### PR TITLE
Problems using contextMenu in Container without Id

### DIFF
--- a/jquery.handsontable.js
+++ b/jquery.handsontable.js
@@ -1825,7 +1825,7 @@
         }
 
         $.contextMenu({
-          selector: container.attr('id') ? ("#" + container.attr('id')) : "." + container[0].className.replace(/[\s]+/g, ' .'),
+          selector: container.attr('id') ? ("#" + container.attr('id')) : "." + container[0].className.replace(/[\s]+/g, '.'),
           trigger: 'right',
           callback: onContextClick,
           items: items


### PR DESCRIPTION
Hi warpech,

First of all, thanks for all your job! I think the library is terrific.

I found a problem using contextMenu.

I'm using more than one class for my table and contextMenu wasn't working, diving I found the problem, the selector that handsontable send to $.contextMenu in line 1828

https://github.com/raultm/jquery-handsontable/blob/master/jquery.handsontable.js#L1828

Example

<table class="classOne classTwo">

Handson table created ".classOne .classTwo" so contextMenu try to find an element with .classTwo inside an element with .classOne.

I've remove the blank space so now the selector is ".classOne.classTwo" and contextMenu look for an element with both classes.

If there are more than two classes works too.

Bye
