### PR TITLE
Fix incorrect state when editing non-writable cells

### DIFF
--- a/jquery.handsontable.js
+++ b/jquery.handsontable.js
@@ -1499,12 +1499,16 @@
           return;
         }
 
+        var td = grid.getCellAtCoords(priv.selStart),
+            $td = $(td);
+
+        if (!grid.isCellWriteable($td)) {
+          return;
+        }
+
         if (priv.fillHandle) {
           autofill.hideHandle();
         }
-
-        var td = grid.getCellAtCoords(priv.selStart),
-            $td = $(td);
 
         priv.isCellEdited = true;
         lastChange = '';
@@ -1513,10 +1517,6 @@
           highlight.off();
           priv.selEnd = priv.selStart;
           highlight.on();
-        }
-
-        if (!grid.isCellWriteable($td)) {
-          return;
         }
 
         if (useOriginalValue) {


### PR DESCRIPTION
When attempting to edit at non-writable cell, some state is changed before checking if the cell is writable. In case the cell is read-only, the change to the state isn't reverted, and the cell editing logic is left in an incorrect state - i.e. the priv.isCellEdited remains true, as well as any multiple cell selection being cleared.

This bugfix moves the writable check before the change in state, so that it is never done unless the cell is indeed writable.
