### PR TITLE
setCellReadOnly(row,col) function/patch to set a particular cell as readonly

### DIFF
--- a/jquery.handsontable.js
+++ b/jquery.handsontable.js
@@ -2391,6 +2391,17 @@ var Handsontable = { //class namespace
     };
 
     /**
+     * Returns value corresponding to params row, col
+     * @param {Number} row
+     * @param {Number} col
+     * @public
+     * @return {string}
+     */
+    this.getDataAtCell = function (row, col) {
+      return datamap.get(row,col);
+    };
+	
+    /**
      * Returns cell meta data object corresponding to params row, col
      * @param {Number} row
      * @param {Number} col
@@ -2411,6 +2422,15 @@ var Handsontable = { //class namespace
 	$td.data("readOnly",true);
     };
 
+	  /**
+	   * Set Cell as Editable
+	   */
+	 this.setCellEditable =  function(rowdata, coldata)
+	   {
+			var $td = $(grid.getCellAtCoords({row: rowdata, col: coldata}));
+            $td.data("readOnly", false);
+	   };
+	   
     /**
      * Returns headers (if they are enabled)
      * @param {Object} obj Instance of rowHeader or colHeader

--- a/src/core.js
+++ b/src/core.js
@@ -2389,7 +2389,17 @@ var Handsontable = { //class namespace
     this.getCell = function (row, col) {
       return grid.getCellAtCoords({row: row, col: col});
     };
-
+	
+    /**
+     * Returns value corresponding to params row, col
+     * @param {Number} row
+     * @param {Number} col
+     * @public
+     * @return {string}
+     */
+    this.getDataAtCell = function (row, col) {
+      return datamap.get(row,col);
+    };
     /**
      * Returns cell meta data object corresponding to params row, col
      * @param {Number} row
@@ -2411,6 +2421,14 @@ var Handsontable = { //class namespace
        $td.data("readOnly",true);
    };
 
+	  /**
+	   * Set Cell as Editable
+	   */
+	 this.setCellEditable =  function(rowdata, coldata)
+	   {
+			var $td = $(grid.getCellAtCoords({row: rowdata, col: coldata}));
+            $td.data("readOnly", false);
+	   };
     /**
      * Returns headers (if they are enabled)
      * @param {Object} obj Instance of rowHeader or colHeader


### PR DESCRIPTION
I have added a small patch/function to set a particular cell as readonly.  Please review and adapt it accordingly.  This patch is made to address the issue [#97](https://github.com/warpech/jquery-handsontable/issues/97)
