### PR TITLE
Legend Refreshing

### DIFF
--- a/jquery.handsontable.js
+++ b/jquery.handsontable.js
@@ -32,7 +32,8 @@ var Handsontable = { //class namespace
       hasLegend: null,
       lastAutoComplete: null,
       undoRedo: null,
-      extensions: {}
+      extensions: {},
+      legendDirty: null
     };
 
     var lastChange = '';


### PR DESCRIPTION
Added code to update the legend when you call updateSettings with legend
data.  The refreshLegend function is also publically available in case
it needs to be called manually.
Manually called:
$('#handsontable_id').data('handsontable').refreshLegend();

Issue #90 (labeled as a question) would be resolved with this code as
the legend is updated on the table if you update it with updateSettings.

Issue #70 (labeled as a bug) would not be resolved with this code as I
didn't want to assume I knew the best fix for this.  A workaround
however does exist with this code as you can call refreshLegend to
update the column you are editing in the onChange function.
