### PR TITLE
fix for .toLowerCase() error with an empty autoComplete field

### DIFF
--- a/jquery.handsontable.js
+++ b/jquery.handsontable.js
@@ -2134,7 +2134,7 @@ var Handsontable = { //class namespace
             for (var a = 0, alen = priv.settings.autoComplete.length; a < alen; a++) {
               var autoComplete = priv.settings.autoComplete[a];
               var source = autoComplete.source();
-              if (autoComplete.match(changes[c][0], changes[c][1], datamap.getAll)) {
+              if (changes[c][3] && autoComplete.match(changes[c][0], changes[c][1], datamap.getAll)) {
                 var lowercaseVal = changes[c][3].toLowerCase();
                 for (var s = 0, slen = source.length; s < slen; s++) {
                   if (changes[c][3] === source[s]) {


### PR DESCRIPTION
fix for .toLowerCase() error for empty autoComplete field when data was saved to a DB which will return null (I've extended / used the provided PHP - SQLite example)
