### PR TITLE
Default style to dataTable child elements.

### DIFF
--- a/jquery.handsontable.css
+++ b/jquery.handsontable.css
@@ -8,6 +8,13 @@
   font-size: 13px;
 }
 
+.dataTable * {
+  box-sizing: content-box;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  vertical-align: middle;
+}
+
 .dataTable table {
   border-collapse: separate;
   position: relative;


### PR DESCRIPTION
Forces the values that the script expects when calculating where to
place elements. This fixes problems where you use something like
`* { box-sizing: border-box;  }`
