### PR TITLE
YUI Compressor compliance

### DIFF
--- a/jquery.handsontable.js
+++ b/jquery.handsontable.js
@@ -4245,7 +4245,7 @@ Handsontable.PluginHooks.push('afterInit', createContextMenu);
       if (config.minWidth !== 'original' || config.maxWidth !== 'original') {
         this.wClone = $('<div/>').width('auto').css({
           whiteSpace: 'nowrap',
-          float: 'left'
+          'float': 'left'
         });
         this.clones = this.clones.add(this.wClone);
       }

--- a/src/3rdparty/jquery.autoresize.js
+++ b/src/3rdparty/jquery.autoresize.js
@@ -125,7 +125,7 @@
       if (config.minWidth !== 'original' || config.maxWidth !== 'original') {
         this.wClone = $('<div/>').width('auto').css({
           whiteSpace: 'nowrap',
-          float: 'left'
+          'float': 'left'
         });
         this.clones = this.clones.add(this.wClone);
       }


### PR DESCRIPTION
Hi,

I use YUI Compressor on my project. The compression of jquery.handsontable.js fails because of the use of the reserve keyword `float` as a map key in the autoresize third party library. 

I checked the original lib (https://github.com/alexbardas/jQuery.fn.autoResize/blob/master/jquery.autoresize.js) but it is quite different. 

This pull request is no big deal but it's still a little improvement. 

Keep up the good work,

Nicolas
