### PR TITLE
new test to showcase onChange bug when triggered via 'edit'

### DIFF
--- a/test/jasmine/spec/Core_datachangeSpec.js
+++ b/test/jasmine/spec/Core_datachangeSpec.js
@@ -79,4 +79,39 @@ describe('Core_datachange', function () {
       expect(output).toEqual($container.get(0));
     });
   });
+
+  it('onChange event object should contain documented keys and values when triggered by edit', function () {
+
+    var sampleData = [{
+      col1: 'a',
+      col2: 'b',
+      col3: 'c'
+    }];
+    var event = null;
+
+    runs(function () {
+      $container.handsontable({
+        data: sampleData,
+        onChange: function (e, source) {
+          if ('edit' == source) {
+            event = e.shift();
+          }
+        }
+      });
+      $container.handsontable('setDataAtCell', 0, 0, "test");
+    });
+
+    waitsFor(function () {
+      return (event != null)
+    }, "onChange callback called", 100);
+
+    runs(function () {
+      expect(event[0]).toEqual(0);
+      expect(event[1]).toEqual('col1');
+      expect(event[2]).toEqual('a');
+      expect(event[3]).toEqual('test');
+    });
+  });
+
+
 });


### PR DESCRIPTION
There is a bug and an inconsistency on the data object that is passed as parameter on the callback of the `onChange` event.

I have written this test to illustrate the issues. It is triggered when changing the contents of the table via the `setDataAtCell` method, which results in triggering an `onChange` event with the sourceType of `edit`.

The **_bug**_ is that no previous value is defined, the array index 2 should contain the previous value of the cell before it was changed. The value of that index is `undefined`, which apparently is a bug.

The **_inconsistency**_ is on the `col` field, or array index 1. When the event is triggered with the `setDataAtCell` method (source `type`) the value of the `col` is its numeric representation.

When the event is triggered by the user editing on the table (source `populateFromArray`) then the col has the value that was defined in the data as key.

e.g.

``` javascript
var sampleData = [{
  col1: 'a',
  col2: 'b',
  col3: 'c'
}];

$container.handsontable({
  data: sampleData,
  onChange: function (e, source) {
    // Assume we edit Row 0, Col 0
    //
    // When source == edit, then:
    e.shift() == [0, 0, undefined, 'test'];

    // when source == populateFromArray
    e.shift() == [0, 'col1', 'a', 'test'];        
  }
});
```
