### PR TITLE
clear currentRowClassName and currentColumnClassName when refreshing selections. 

### DIFF
--- a/src/3rdparty/walkontable.js
+++ b/src/3rdparty/walkontable.js
@@ -1827,8 +1827,15 @@ WalkontableTable.prototype.refreshPositions = function (selectionsOnly) {
 };
 
 WalkontableTable.prototype.refreshSelections = function (selectionsOnly) {
-  var r;
+  var r, i, ilen, TDs
+      , currentRowClassName = this.instance.getSetting("currentRowClassName")
+      , currentColumnClassName = this.instance.getSetting("currentColumnClassName");
   if (this.instance.selections) {
+      TDs = this.instance.wtTable.TABLE.getElementsByTagName('TD');
+      for (i = 0, ilen = TDs.length; i < ilen; i++) {
+        this.instance.wtDom.removeClass(TDs[i], currentRowClassName);
+        this.instance.wtDom.removeClass(TDs[i], currentColumnClassName);
+      }
     for (r in this.instance.selections) {
       if (this.instance.selections.hasOwnProperty(r)) {
         this.instance.selections[r].draw(selectionsOnly);


### PR DESCRIPTION
Without this if you outside click and outsideClickDeselects
= true, then the selection is removed but the currentRowClassName and
the currentColumnClassName are still on the previously selected row and column.

You can reproduce on http://handsontable.com/demo/current.html by clicking on a cell and then outside clicking.
