### PR TITLE
Allow complex object as table schema.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1467,11 +1467,11 @@ Handsontable.Core = function (rootElement, settings) {
     var rlen;
     priv.isPopulated = false;
     priv.settings.data = data;
-    if ($.isPlainObject(priv.settings.dataSchema) || $.isPlainObject(data[0])) {
-      priv.dataType = 'object';
+    if (priv.settings.dataSchema instanceof Array || data[0]  instanceof Array) {
+      priv.dataType = 'array';
     }
     else {
-      priv.dataType = 'array';
+      priv.dataType = 'object';
     }
     if (data[0]) {
       priv.duckDataSchema = datamap.recursiveDuckSchema(data[0]);


### PR DESCRIPTION
When working in tandem with backbone or other frameworks that supply complex objects. The Jquery isPlainObject and extend can destroy the desired functionality. This change allows use of complex objects as your schema to better tie in with other frameworks.
