### PR TITLE
replacing reference to non-existent Exception with Error

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1397,7 +1397,7 @@ Handsontable.Core = function (rootElement, settings) {
 
     for (i = 0, ilen = input.length; i < ilen; i++) {
       if (typeof input[i][1] !== 'number') {
-        throw new Exception('Method `setDataAtCell` accepts row and column number as its parameters. If you want to use object property name, use method `setDataAtRowProp`');
+        throw new Error('Method `setDataAtCell` accepts row and column number as its parameters. If you want to use object property name, use method `setDataAtRowProp`');
       }
       prop = datamap.colToProp(input[i][1]);
       changes.push([


### PR DESCRIPTION
One liner.

While doing some stuff with this method in `master` (which worked in 0.8.10) ran across this problem.

The error message was informative, and still got to me, but I imagine the Error in question was interesting, and not the missing reference!
