### PR TITLE
BugFix: Can add new line at the bottom of table without exception after table was sorted

### DIFF
--- a/src/plugins/columnSorting.js
+++ b/src/plugins/columnSorting.js
@@ -59,7 +59,10 @@ function HandsontableColumnSorting() {
 
   this.translateRow = function (getVars) {
     if (sortingEnabled && this.sortIndex && this.sortIndex.length) {
-      getVars.row = this.sortIndex[getVars.row][0];
+      var row = this.sortIndex[getVars.row];
+      if (row) {
+        getVars.row = row[0];
+      }
     }
   };
 


### PR DESCRIPTION
Steps to reproduce the exception/bug:
1.) Sort the table via sort link in column header
2.) Jump to last populated row via CTRL+END
3.) Enter new row
