### PR TITLE
Bugfix for wrong column sorting

### DIFF
--- a/src/plugins/columnSorting.js
+++ b/src/plugins/columnSorting.js
@@ -45,10 +45,10 @@ function HandsontableColumnSorting() {
       if (a[1] === b[1]) {
         return 0;
       }
-      if (a[1] === null) {
+      if (a[1] === null || a[1] === '') {
         return 1;
       }
-      if (b[1] === null) {
+      if (b[1] === null || b[1] === '') {
         return -1;
       }
       if (a[1] < b[1]) return instance.sortOrder ? -1 : 1;


### PR DESCRIPTION
Bugfix for wrong column sorting: It can be reproduced by following steps:
1.) ensure there are many columns so that horizontal scrollbar appears
2.) scroll to the right
3.) sort a column via sort link in column header (for example the first visible column)
The table sorts the very first column, not the first visible column.

See commit 5c50f55
