### PR TITLE
Excel like sorting

### DIFF
--- a/src/plugins/columnSorting.js
+++ b/src/plugins/columnSorting.js
@@ -45,10 +45,10 @@ function HandsontableColumnSorting() {
       if (a[1] === b[1]) {
         return 0;
       }
-      if (a[1] === null) {
+      if (a[1] === null || a[1] === '') {
         return 1;
       }
-      if (b[1] === null) {
+      if (b[1] === null || b[1] === '') {
         return -1;
       }
       if (a[1] < b[1]) return instance.sortOrder ? -1 : 1;


### PR DESCRIPTION
Feature: Excel like sorting. Excel or Google Table ignore empty fields when sorting the column so that empty fields remain always at the bottom of table.

See commit 0e797b6
