### PR TITLE
Add `allowEmpty` option to `AutocompleteEditor`

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1328,7 +1328,7 @@ Handsontable.Core = function (rootElement, settings) {
 
     for (var i = changes.length - 1; i >= 0; i--) {
       var cellProperties = self.getCellMeta(changes[i][0], datamap.propToCol(changes[i][1]));
-      if (cellProperties.strict && cellProperties.source) {
+      if (cellProperties.strict && cellProperties.source && !(cellProperties.allowEmpty && changes[i][3] === "")) {
         $.isFunction(cellProperties.source) ? cellProperties.source(changes[i][3], process(i)) : process(i)(cellProperties.source);
       }
     }

--- a/test/jasmine/spec/editors/autocompleteEditorSpec.js
+++ b/test/jasmine/spec/editors/autocompleteEditorSpec.js
@@ -388,6 +388,24 @@ describe('AutocompleteEditor', function () {
 
   });
 
+  it('strict mode and allowEmpty returns does not trigger validation for empty string', function () {
+    handsontable({
+      data: [ ['one', 'two'] ],
+      columns: [
+        {
+          type: Handsontable.AutocompleteCell,
+          source: ['Acura', 'BMW', 'Bentley'],
+          strict: true,
+          allowEmpty: true
+        },
+        { type: 'text'}
+      ]
+    });
+    setDataAtCell(0, 0, '');
+
+    expect(getData()).toEqual([ ['', 'two'] ]);
+  });
+
   it('typing in textarea should refresh the lookup list', function () {
     runs(function () {
       handsontable({


### PR DESCRIPTION
Hi,

> This option will allow to empty the content of a `strict`
> autocomplete cell, this way the user does not get stuck with
> something he means to remove.

I think this feature could be helpful for everyone. What do you think?

Thanks again for this awesome plugin. 1 000 000 OpenSource points to you!
