### PR TITLE
Minor syntax-fix in demo/web_component/toolkit/platform/CustomElements/workbench/webkitCustomElements.html

### DIFF
--- a/demo/web_component/toolkit/platform/CustomElements/workbench/webkitCustomElements.html
+++ b/demo/web_component/toolkit/platform/CustomElements/workbench/webkitCustomElements.html
@@ -9,7 +9,7 @@ license that can be found in the LICENSE file.
     <title>CustomElements Workbench</title>
     <meta charset="UTF-8">
   </head>
-  <body
+  <body>
     <x-foo>XFoo One</x-foo>
     <script>
       XFoo = document.webkitRegister('x-foo', {


### PR DESCRIPTION
In file demo/web_component/toolkit/platform/CustomElements/workbench/webkitCustomElements.html the opening body-tag was 

&lt;body

instead of 

&lt;body&gt;

BR
Jens
