### PR TITLE
Fix for #645

### DIFF
--- a/src/3rdparty/walkontable/src/scroll.js
+++ b/src/3rdparty/walkontable/src/scroll.js
@@ -48,7 +48,7 @@ WalkontableScroll.prototype.scrollHorizontal = function (delta) {
 
   if (total > 0) {
     newOffset = this.scrollLogic(delta, offset, total, fixedCount, maxSize, function (col) {
-      if (col - offset < fixedCount) {
+      if (col - offset < fixedCount && col - offset >= 0) {
         return instance.getSetting('columnWidth', col - offset);
       }
       else {


### PR DESCRIPTION
This fixes the case when the horizontal scroll bar will not allow you to scroll to see the last column when using fixed columns. This is for Issue #645.
