### PR TITLE
Provide the alter arguments to the afterChange hook

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -510,7 +510,14 @@ Handsontable.Core = function (rootElement, userSettings) {
           changes.push([r, c, oldData[r] ? oldData[r][c] : null, newData[r][c]]);
         }
       }
-      instance.PluginHooks.run('afterChange', changes, source || action);
+      
+      var alterArguments = {
+        index: index,
+        amount: amount,
+        source: source,
+        keepEmptyRows: keepEmptyRows
+      };
+      instance.PluginHooks.run('afterChange', changes, source || action, alterArguments);
       if (!keepEmptyRows) {
         grid.adjustRowsAndCols(); //makes sure that we did not add rows that will be removed in next refresh
       }


### PR DESCRIPTION
On a user inserting a new row (from the context menu) I needed to tell the server to shift the data at index X by rows Y.

I couldn't find a way to get X and Y from a hook, but the proposed change provides the arguments given to grid.alter to any callbacks.

This removes the need to calculate which rows have changed based on the changes array.

Alternatively, what about firing more specific events? Something like:
instance.PluginHook.runHooks('alter:insertRow', index, amount);
instance.PluginHook.runHooks('alter:insertCol', index, amount);
.. etc ..
