### PR TITLE
Fix a minor bug with the column resize handle

### DIFF
--- a/src/plugins/manualColumnResize.js
+++ b/src/plugins/manualColumnResize.js
@@ -73,6 +73,7 @@ function HandsontableManualColumnResize() {
       startOffset = (thOffset - rootOffset) - 6;
 
       resizer.style.left = startOffset + getColumnWidth.call(instance, TH) + 'px';
+      handle.style.height = TH.offsetHeight + 'px';
 
       this.rootElement[0].appendChild(resizer);
     }

--- a/test/jasmine/spec/plugins/manualColumnResizeSpec.js
+++ b/test/jasmine/spec/plugins/manualColumnResizeSpec.js
@@ -122,4 +122,18 @@ describe('manualColumnResize', function () {
     }
 
   });
+
+  it("should make the resize handle the same height as the header", function () {
+    handsontable({
+      colHeaders: ["A Long Header That Will Wrap To Multiple Columns"],
+      manualColumnResize: true
+    })
+
+    var $th = this.$container.find('thead tr:eq(0) th:eq(0)');
+    $th.css('white-space', 'normal'); // Bug only repros if you override the CSS white-space property.
+    $th.trigger('mouseenter');
+
+    var $handle = this.$container.find('.manualColumnResizerHandle');
+    expect($handle.outerHeight()).toEqual($th.outerHeight());
+  })
 });


### PR DESCRIPTION
If you override the CSS white-space property to 'normal', so that text
in the column headers can wrap, and you also enable manual column
resizing, the resize handle does not take up the full height of the
header.

This is a one-line fix for that problem.

(Note: I made the fix in the original src dir, but did not commit the
changes to the generated files. I assume you do that as part of a
build/distribution process. and didn't want them cluttering up the
commit.)
