### PR TITLE
Fix bug in manual column move

### DIFF
--- a/src/plugins/manualColumnMove.js
+++ b/src/plugins/manualColumnMove.js
@@ -72,6 +72,7 @@ function HandsontableManualColumnMove() {
       var mover = e.currentTarget;
       var TH = instance.view.wt.wtDom.closest(mover, 'TH');
       startCol = instance.view.wt.wtDom.index(TH) + instance.colOffset();
+      endCol = startCol;
       pressed = true;
       startX = e.pageX;
 

--- a/test/jasmine/spec/plugins/manualColumnMoveSpec.js
+++ b/test/jasmine/spec/plugins/manualColumnMoveSpec.js
@@ -177,4 +177,35 @@ describe('manualColumnMove', function () {
       $secondColHeader.trigger('mouseup');
     }
   });
+
+  it("should not move the column if you click the handle without dragging", function () {
+    handsontable({
+      data: [
+        {id: 1, name: "Ted", lastName: "Right"},
+      ],
+      colHeaders: true,
+      manualColumnMove: true
+    });
+
+    expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('1');
+    expect(this.$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('Ted');
+    expect(this.$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('Right');
+
+    selectCell(0, 0);
+
+    var $colHeader = this.$container.find('thead tr:eq(0) th:eq(2)');
+    var $manualColumnMover = $colHeader.find('.manualColumnMover');
+
+    //Grab the column
+    var mouseDownEvent = $.Event('mousedown');
+    mouseDownEvent.pageX = $manualColumnMover.position().left;
+    $manualColumnMover.trigger(mouseDownEvent);
+
+    //Drop it without dragging
+    $colHeader.trigger('mouseup');
+
+    expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('1');
+    expect(this.$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('Ted');
+    expect(this.$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('Right');
+  })
 });


### PR DESCRIPTION
Repro for this bug:
1. Enable manualColumnMove
2. Click on the move tab of a column, but don't drag it

Expected: column is not moved

Actual: column can be moved to an arbitrary location

If this is the first time that move-column has been invoked since the
table was initialized, the afterColumnMove callback is actually invoked
with a newIndex parameter of undefined or NaN.

The cause is that endCol is not initialized unless the move tab is
dragged into a different cell. The simple fix is to always initialize
endCol = startCol as soon as we start dragging.
