### PR TITLE
allow to use function as colWidths

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -2397,6 +2397,9 @@ Handsontable.Core = function (rootElement, userSettings) {
     else if (Object.prototype.toString.call(priv.settings.colWidths) === '[object Array]' && priv.settings.colWidths[col] !== void 0) {
       return priv.settings.colWidths[col];
     }
+    else if (Object.prototype.toString.call(priv.settings.colWidths) === '[object Function]') {
+      return priv.settings.colWidths(col);
+    }
   };
 
   /**


### PR DESCRIPTION
Documentation suggests that a function can be used for the colWidth option. Unfortunately this seems not to be the case. This patch works for us.
