### PR TITLE
Fill handle bug fix

### DIFF
--- a/dist/jquery.handsontable.css
+++ b/dist/jquery.handsontable.css
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Tue Aug 27 2013 14:02:35 GMT-0400 (Eastern Daylight Time)
+ * Date: Tue Sep 03 2013 08:47:03 GMT-0400 (Eastern Daylight Time)
  */
 
 .handsontable {

--- a/dist/jquery.handsontable.css
+++ b/dist/jquery.handsontable.css
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Tue Aug 27 2013 12:38:58 GMT+0200 (CEST)
+ * Date: Tue Aug 27 2013 14:02:35 GMT-0400 (Eastern Daylight Time)
  */
 
 .handsontable {

--- a/dist/jquery.handsontable.full.css
+++ b/dist/jquery.handsontable.full.css
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Tue Aug 27 2013 14:02:35 GMT-0400 (Eastern Daylight Time)
+ * Date: Tue Sep 03 2013 08:47:03 GMT-0400 (Eastern Daylight Time)
  */
 
 .handsontable {

--- a/dist/jquery.handsontable.full.css
+++ b/dist/jquery.handsontable.full.css
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Tue Aug 27 2013 12:38:58 GMT+0200 (CEST)
+ * Date: Tue Aug 27 2013 14:02:35 GMT-0400 (Eastern Daylight Time)
  */
 
 .handsontable {

--- a/dist/jquery.handsontable.full.js
+++ b/dist/jquery.handsontable.full.js
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Tue Aug 27 2013 14:02:35 GMT-0400 (Eastern Daylight Time)
+ * Date: Tue Sep 03 2013 08:47:03 GMT-0400 (Eastern Daylight Time)
  */
 /*jslint white: true, browser: true, plusplus: true, indent: 4, maxerr: 50 */
 
@@ -1140,7 +1140,8 @@ Handsontable.Core = function (rootElement, userSettings) {
             break rows;
           }
         }
-		if (data[r][select[1]] === null || data[r][select[3]] === "") {
+        if ((data[r][select[1]] === null || data[r][select[1]] === "" || typeof data[r][select[1]] === "undefined") ||
+            (data[r][select[3]] === null || data[r][select[3]] === "" || typeof data[r][select[3]] === "undefined")) {
 		  maxR = r;
 		}
       }

--- a/dist/jquery.handsontable.full.js
+++ b/dist/jquery.handsontable.full.js
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Tue Aug 27 2013 12:38:58 GMT+0200 (CEST)
+ * Date: Tue Aug 27 2013 14:02:35 GMT-0400 (Eastern Daylight Time)
  */
 /*jslint white: true, browser: true, plusplus: true, indent: 4, maxerr: 50 */
 
@@ -1140,10 +1140,11 @@ Handsontable.Core = function (rootElement, userSettings) {
             break rows;
           }
         }
-        if (!!data[r][select[1] - 1] || !!data[r][select[3] + 1]) {
-          maxR = r;
-        }
+		if (data[r][select[1]] === null || data[r][select[3]] === "") {
+		  maxR = r;
+		}
       }
+	  maxR = (typeof maxR === 'undefined') ? maxR : maxR - priv.settings.minSpareRows;
       if (maxR) {
         instance.view.wt.selections.fill.clear();
         instance.view.wt.selections.fill.add([select[0], select[1]]);

--- a/dist/jquery.handsontable.js
+++ b/dist/jquery.handsontable.js
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Tue Aug 27 2013 14:02:35 GMT-0400 (Eastern Daylight Time)
+ * Date: Tue Sep 03 2013 08:47:03 GMT-0400 (Eastern Daylight Time)
  */
 /*jslint white: true, browser: true, plusplus: true, indent: 4, maxerr: 50 */
 
@@ -1140,7 +1140,8 @@ Handsontable.Core = function (rootElement, userSettings) {
             break rows;
           }
         }
-		if (data[r][select[1]] === null || data[r][select[3]] === "") {
+        if ((data[r][select[1]] === null || data[r][select[1]] === "" || typeof data[r][select[1]] === "undefined") ||
+            (data[r][select[3]] === null || data[r][select[3]] === "" || typeof data[r][select[3]] === "undefined")) {
 		  maxR = r;
 		}
       }

--- a/dist/jquery.handsontable.js
+++ b/dist/jquery.handsontable.js
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Tue Aug 27 2013 12:38:58 GMT+0200 (CEST)
+ * Date: Tue Aug 27 2013 14:02:35 GMT-0400 (Eastern Daylight Time)
  */
 /*jslint white: true, browser: true, plusplus: true, indent: 4, maxerr: 50 */
 
@@ -1140,10 +1140,11 @@ Handsontable.Core = function (rootElement, userSettings) {
             break rows;
           }
         }
-        if (!!data[r][select[1] - 1] || !!data[r][select[3] + 1]) {
-          maxR = r;
-        }
+		if (data[r][select[1]] === null || data[r][select[3]] === "") {
+		  maxR = r;
+		}
       }
+	  maxR = (typeof maxR === 'undefined') ? maxR : maxR - priv.settings.minSpareRows;
       if (maxR) {
         instance.view.wt.selections.fill.clear();
         instance.view.wt.selections.fill.add([select[0], select[1]]);

--- a/dist_wc/x-handsontable/jquery.handsontable.full.css
+++ b/dist_wc/x-handsontable/jquery.handsontable.full.css
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Tue Aug 27 2013 14:02:35 GMT-0400 (Eastern Daylight Time)
+ * Date: Tue Sep 03 2013 08:47:03 GMT-0400 (Eastern Daylight Time)
  */
 
 .handsontable {

--- a/dist_wc/x-handsontable/jquery.handsontable.full.css
+++ b/dist_wc/x-handsontable/jquery.handsontable.full.css
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Tue Aug 27 2013 12:38:58 GMT+0200 (CEST)
+ * Date: Tue Aug 27 2013 14:02:35 GMT-0400 (Eastern Daylight Time)
  */
 
 .handsontable {

--- a/dist_wc/x-handsontable/jquery.handsontable.full.js
+++ b/dist_wc/x-handsontable/jquery.handsontable.full.js
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Tue Aug 27 2013 14:02:35 GMT-0400 (Eastern Daylight Time)
+ * Date: Tue Sep 03 2013 08:47:03 GMT-0400 (Eastern Daylight Time)
  */
 /*jslint white: true, browser: true, plusplus: true, indent: 4, maxerr: 50 */
 
@@ -1140,7 +1140,8 @@ Handsontable.Core = function (rootElement, userSettings) {
             break rows;
           }
         }
-		if (data[r][select[1]] === null || data[r][select[3]] === "") {
+        if ((data[r][select[1]] === null || data[r][select[1]] === "" || typeof data[r][select[1]] === "undefined") ||
+            (data[r][select[3]] === null || data[r][select[3]] === "" || typeof data[r][select[3]] === "undefined")) {
 		  maxR = r;
 		}
       }

--- a/dist_wc/x-handsontable/jquery.handsontable.full.js
+++ b/dist_wc/x-handsontable/jquery.handsontable.full.js
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Tue Aug 27 2013 12:38:58 GMT+0200 (CEST)
+ * Date: Tue Aug 27 2013 14:02:35 GMT-0400 (Eastern Daylight Time)
  */
 /*jslint white: true, browser: true, plusplus: true, indent: 4, maxerr: 50 */
 
@@ -1140,10 +1140,11 @@ Handsontable.Core = function (rootElement, userSettings) {
             break rows;
           }
         }
-        if (!!data[r][select[1] - 1] || !!data[r][select[3] + 1]) {
-          maxR = r;
-        }
+		if (data[r][select[1]] === null || data[r][select[3]] === "") {
+		  maxR = r;
+		}
       }
+	  maxR = (typeof maxR === 'undefined') ? maxR : maxR - priv.settings.minSpareRows;
       if (maxR) {
         instance.view.wt.selections.fill.clear();
         instance.view.wt.selections.fill.add([select[0], select[1]]);

--- a/src/core.js
+++ b/src/core.js
@@ -1121,7 +1121,8 @@ Handsontable.Core = function (rootElement, userSettings) {
             break rows;
           }
         }
-		if (data[r][select[1]] === null || data[r][select[3]] === "") {
+        if ((data[r][select[1]] === null || data[r][select[1]] === "" || typeof data[r][select[1]] === "undefined") ||
+            (data[r][select[3]] === null || data[r][select[3]] === "" || typeof data[r][select[3]] === "undefined")) {
 		  maxR = r;
 		}
       }

--- a/src/core.js
+++ b/src/core.js
@@ -1121,10 +1121,11 @@ Handsontable.Core = function (rootElement, userSettings) {
             break rows;
           }
         }
-        if (!!data[r][select[1] - 1] || !!data[r][select[3] + 1]) {
-          maxR = r;
-        }
+		if (data[r][select[1]] === null || data[r][select[3]] === "") {
+		  maxR = r;
+		}
       }
+	  maxR = (typeof maxR === 'undefined') ? maxR : maxR - priv.settings.minSpareRows;
       if (maxR) {
         instance.view.wt.selections.fill.clear();
         instance.view.wt.selections.fill.add([select[0], select[1]]);

--- a/test/jasmine/spec/FillHandleSpec.js
+++ b/test/jasmine/spec/FillHandleSpec.js
@@ -146,7 +146,7 @@ describe('FillHandle', function () {
         ["", "", "test", "", "", ""],
         ["", "", "", "", "", ""],
         ["", "", null, "", "", ""],
-        ["", "", null, "", "", ""]
+        ["", "", , "", "", ""]
       ]
     });
     selectCell(0, 2);
@@ -168,9 +168,9 @@ describe('FillHandle', function () {
     handsontable({
       data: [
         ["", "test 1", "test 2", "test 3", "test 4", "test 5"],
+        ["", null, null, null, null, null],
         ["", "", "", "", "", ""],
-        ["", "", "", "", "", ""],
-        ["", "", "", "", "", ""]
+        ["", , , , , ]
       ]
     });
     selectCell(0, 1);

--- a/test/jasmine/spec/FillHandleSpec.js
+++ b/test/jasmine/spec/FillHandleSpec.js
@@ -137,4 +137,82 @@ describe('FillHandle', function () {
 
     document.body.removeChild($table[0]);
   });
+  
+  it('should fill proceeding empty or null rows within selected cell column with value from selected cell', function () {
+    var ev;
+
+    handsontable({
+      data: [
+        ["", "", "test", "", "", ""],
+        ["", "", "", "", "", ""],
+        ["", "", null, "", "", ""],
+        ["", "", null, "", "", ""]
+      ]
+    });
+    selectCell(0, 2);
+	
+	var fillHandle = this.$container.find('.wtBorder.corner')[0]; //fill handle
+	$(fillHandle).trigger("mousedown");
+	$(fillHandle).trigger("mouseup");
+	$(fillHandle).trigger("mousedown");
+	$(fillHandle).trigger("mouseup");
+
+    expect(getDataAtCell(1, 2)).toEqual("test");
+	expect(getDataAtCell(2, 2)).toEqual("test");
+	expect(getDataAtCell(3, 2)).toEqual("test");
+  });
+  
+  it("should fill proceeding empty or null rows within selected cell columns with values from selected cells", function () {
+    var ev;
+
+    handsontable({
+      data: [
+        ["", "test 1", "test 2", "test 3", "test 4", "test 5"],
+        ["", "", "", "", "", ""],
+        ["", "", "", "", "", ""],
+        ["", "", "", "", "", ""]
+      ]
+    });
+    selectCell(0, 1);
+
+    this.$container.find('tr:eq(0) td:eq(1)').trigger("mousedown");
+    this.$container.find('tr:eq(0) td:eq(2)').trigger("mouseenter");
+    this.$container.find('tr:eq(0) td:eq(3)').trigger("mouseenter");
+    this.$container.find('tr:eq(0) td:eq(4)').trigger("mouseenter");
+    this.$container.find('tr:eq(0) td:eq(5)').trigger("mouseenter");
+	this.$container.find('tr:eq(0) td:eq(5)').trigger("mouseup");
+
+	// Validate selected cells
+	expect(getSelected()).toEqual([0, 1, 0, 5]);
+	
+	var fillHandle = this.$container.find('.wtBorder.corner')[0]; //fill handle
+	$(fillHandle).trigger("mousedown");
+	$(fillHandle).trigger("mouseup");
+	$(fillHandle).trigger("mousedown");
+	$(fillHandle).trigger("mouseup");
+
+	// Validate selected cells after autofill
+    expect(getSelected()).toEqual([0, 1, 3, 5]);
+	
+	// Validate row 2
+    expect(getDataAtCell(1, 1)).toEqual("test 1");
+	expect(getDataAtCell(1, 2)).toEqual("test 2");
+	expect(getDataAtCell(1, 3)).toEqual("test 3");
+	expect(getDataAtCell(1, 4)).toEqual("test 4");
+	expect(getDataAtCell(1, 5)).toEqual("test 5");
+
+	// Validate row 3
+	expect(getDataAtCell(2, 1)).toEqual("test 1");
+	expect(getDataAtCell(2, 2)).toEqual("test 2");
+	expect(getDataAtCell(2, 3)).toEqual("test 3");
+	expect(getDataAtCell(2, 4)).toEqual("test 4");
+	expect(getDataAtCell(2, 5)).toEqual("test 5");
+
+	// Validate row 4
+	expect(getDataAtCell(3, 1)).toEqual("test 1");
+	expect(getDataAtCell(3, 2)).toEqual("test 2");
+	expect(getDataAtCell(3, 3)).toEqual("test 3");
+	expect(getDataAtCell(3, 4)).toEqual("test 4");
+	expect(getDataAtCell(3, 5)).toEqual("test 5");
+  });
 });


### PR DESCRIPTION
The double-click event on the fill handle is buggy, even on the demo
page. The problem seems to be two-fold. First, it only works when the
column to the left or the column to the right of the highlighted cell is
populated with data. The problem is in the selectAdjacent function. It
correctly calculates the highlighted cell, but incorrectly calculates
the proceeding rows to fill. Instead of looking at the cells that
proceed in the highlighted cell's column, it looks at the cells that
proceed in the column to the left and the column to the right of the
highlighted cell's column. This can be seen in the following if
statement:

if (!!data[r][select[1] - 1] || !!data[r][select[3] + 1]) {
maxR = r;
}

In the if condition, it looks at the correct row, but the incorrect
column by substracting 1 and adding 1 to the column part of the array.
Again, it's looking at the columns to the left and right of the
highlighted cell's column. But even if that's corrected by removing the
subtraction/addition, the second part of the problem is that by using !!
to convert or cast the value of the cell, a null or empty value will
return false, as you know. But it seems that we should be specifically
looking for null or empty cells to calculate the rows to fill. So I
found that the solution to this problem was to validate that the
returned value of a given cell was null or empty:

if (data[r][select[1]] === null || data[r][select[3]] === "") {
maxR = r;
}

In addition, to account for spare rows, I added the following statement
before the block of code that fills the cells:

maxR = (typeof maxR === 'undefined') ? maxR : maxR -
priv.settings.minSpareRows;
if (maxR) {
...
}

Making this change to my local copy of jquery.handsontable.full.js
allowed the double-click event on the fill handle to behave as expected.
This also works when multiple cells are highlighted.
