### PR TITLE
AMD Support

### DIFF
--- a/dist/jquery.handsontable.css
+++ b/dist/jquery.handsontable.css
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Thu Sep 05 2013 12:18:23 GMT+0200 (CEST)
+ * Date: Mon Sep 16 2013 15:51:42 GMT-0400 (EDT)
  */
 
 .handsontable {

--- a/dist/jquery.handsontable.full.css
+++ b/dist/jquery.handsontable.full.css
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Thu Sep 05 2013 12:18:23 GMT+0200 (CEST)
+ * Date: Mon Sep 16 2013 15:51:42 GMT-0400 (EDT)
  */
 
 .handsontable {

--- a/dist/jquery.handsontable.full.js
+++ b/dist/jquery.handsontable.full.js
@@ -6,17 +6,36 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Thu Sep 05 2013 12:18:23 GMT+0200 (CEST)
+ * Date: Mon Sep 16 2013 15:51:42 GMT-0400 (EDT)
  */
 /*jslint white: true, browser: true, plusplus: true, indent: 4, maxerr: 50 */
+
+(function(factory){
+
+  // AMD
+  if (typeof define === 'function' && define.amd) {
+    define('handsontable', ['jquery'], factory);
+
+  // CommonJS
+  } else if (typeof require === 'function' && typeof module !== 'undefined' && module.exports) {
+    module.exports = factory(require('jquery'));
+
+  // Global
+  } else {
+    window.Handsontable = factory(window.jQuery);
+  }
+
+}(function($){
+  "use strict";
+
+// Override locally to prevent 3rd party libraries from trying to export
+var define = null;
 
 var Handsontable = { //class namespace
   extension: {}, //extenstion namespace
   helper: {} //helper namespace
 };
 
-(function ($, window, Handsontable) {
-  "use strict";
 Handsontable.activeGuid = null;
 
 /**
@@ -11409,7 +11428,9 @@ if (!Array.prototype.filter) {
   };
 }
 
-})(jQuery, window, Handsontable);
+return Handsontable;
+}));
+
 /* =============================================================
  * bootstrap-typeahead.js v2.3.1
  * http://twitter.github.com/bootstrap/javascript.html#typeahead

--- a/dist/jquery.handsontable.js
+++ b/dist/jquery.handsontable.js
@@ -6,17 +6,36 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Thu Sep 05 2013 12:18:23 GMT+0200 (CEST)
+ * Date: Mon Sep 16 2013 15:51:42 GMT-0400 (EDT)
  */
 /*jslint white: true, browser: true, plusplus: true, indent: 4, maxerr: 50 */
+
+(function(factory){
+
+  // AMD
+  if (typeof define === 'function' && define.amd) {
+    define('handsontable', ['jquery'], factory);
+
+  // CommonJS
+  } else if (typeof require === 'function' && typeof module !== 'undefined' && module.exports) {
+    module.exports = factory(require('jquery'));
+
+  // Global
+  } else {
+    window.Handsontable = factory(window.jQuery);
+  }
+
+}(function($){
+  "use strict";
+
+// Override locally to prevent 3rd party libraries from trying to export
+var define = null;
 
 var Handsontable = { //class namespace
   extension: {}, //extenstion namespace
   helper: {} //helper namespace
 };
 
-(function ($, window, Handsontable) {
-  "use strict";
 Handsontable.activeGuid = null;
 
 /**
@@ -11409,4 +11428,5 @@ if (!Array.prototype.filter) {
   };
 }
 
-})(jQuery, window, Handsontable);
+return Handsontable;
+}));

--- a/dist_wc/x-handsontable/jquery.handsontable.full.css
+++ b/dist_wc/x-handsontable/jquery.handsontable.full.css
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Thu Sep 05 2013 12:18:23 GMT+0200 (CEST)
+ * Date: Mon Sep 16 2013 15:51:42 GMT-0400 (EDT)
  */
 
 .handsontable {

--- a/dist_wc/x-handsontable/jquery.handsontable.full.js
+++ b/dist_wc/x-handsontable/jquery.handsontable.full.js
@@ -6,17 +6,36 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Thu Sep 05 2013 12:18:23 GMT+0200 (CEST)
+ * Date: Mon Sep 16 2013 15:51:42 GMT-0400 (EDT)
  */
 /*jslint white: true, browser: true, plusplus: true, indent: 4, maxerr: 50 */
+
+(function(factory){
+
+  // AMD
+  if (typeof define === 'function' && define.amd) {
+    define('handsontable', ['jquery'], factory);
+
+  // CommonJS
+  } else if (typeof require === 'function' && typeof module !== 'undefined' && module.exports) {
+    module.exports = factory(require('jquery'));
+
+  // Global
+  } else {
+    window.Handsontable = factory(window.jQuery);
+  }
+
+}(function($){
+  "use strict";
+
+// Override locally to prevent 3rd party libraries from trying to export
+var define = null;
 
 var Handsontable = { //class namespace
   extension: {}, //extenstion namespace
   helper: {} //helper namespace
 };
 
-(function ($, window, Handsontable) {
-  "use strict";
 Handsontable.activeGuid = null;
 
 /**
@@ -11409,7 +11428,9 @@ if (!Array.prototype.filter) {
   };
 }
 
-})(jQuery, window, Handsontable);
+return Handsontable;
+}));
+
 /* =============================================================
  * bootstrap-typeahead.js v2.3.1
  * http://twitter.github.com/bootstrap/javascript.html#typeahead

--- a/src/intro.js
+++ b/src/intro.js
@@ -10,10 +10,28 @@
  */
 /*jslint white: true, browser: true, plusplus: true, indent: 4, maxerr: 50 */
 
+(function(factory){
+
+  // AMD
+  if (typeof define === 'function' && define.amd) {
+    define('handsontable', ['jquery'], factory);
+
+  // CommonJS
+  } else if (typeof require === 'function' && typeof module !== 'undefined' && module.exports) {
+    module.exports = factory(require('jquery'));
+
+  // Global
+  } else {
+    window.Handsontable = factory(window.jQuery);
+  }
+
+}(function($){
+  "use strict";
+
+// Override locally to prevent 3rd party libraries from trying to export
+var define = null;
+
 var Handsontable = { //class namespace
   extension: {}, //extenstion namespace
   helper: {} //helper namespace
 };
-
-(function ($, window, Handsontable) {
-  "use strict";

--- a/src/outro.js
+++ b/src/outro.js
@@ -1,1 +1,2 @@
-})(jQuery, window, Handsontable);
+return Handsontable;
+}));


### PR DESCRIPTION
These changes make it possible to use this library with require.js

The issue is that one of the 3rd party libraries that is included in the build tries to call define():
https://github.com/warpech/jquery-handsontable/blob/v0.9.17/dist/jquery.handsontable.js#L11256

Require.js treats the value passed by this call as the Handsontable object instead of using window.Handsontable.

This includes AMD support so that shimming is no longer required. Thanks to @bgrohman for suggesting a better way to handle this. (improves on pull request https://github.com/warpech/jquery-handsontable/pull/873)
