### PR TITLE
#1074 stretchH mode should not trigger horizontal scrollbars

### DIFF
--- a/dist/jquery.handsontable.css
+++ b/dist/jquery.handsontable.css
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Tue Oct 01 2013 13:17:18 GMT+0200 (Central European Daylight Time)
+ * Date: Thu Oct 03 2013 12:25:34 GMT-0700 (PDT)
  */
 
 .handsontable {

--- a/dist/jquery.handsontable.css
+++ b/dist/jquery.handsontable.css
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Thu Oct 03 2013 12:25:34 GMT-0700 (PDT)
+ * Date: Thu Oct 03 2013 15:12:25 GMT-0700 (PDT)
  */
 
 .handsontable {

--- a/dist/jquery.handsontable.full.css
+++ b/dist/jquery.handsontable.full.css
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Tue Oct 01 2013 13:17:18 GMT+0200 (Central European Daylight Time)
+ * Date: Thu Oct 03 2013 12:25:34 GMT-0700 (PDT)
  */
 
 .handsontable {

--- a/dist/jquery.handsontable.full.css
+++ b/dist/jquery.handsontable.full.css
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Thu Oct 03 2013 12:25:34 GMT-0700 (PDT)
+ * Date: Thu Oct 03 2013 15:12:25 GMT-0700 (PDT)
  */
 
 .handsontable {

--- a/dist/jquery.handsontable.full.js
+++ b/dist/jquery.handsontable.full.js
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Thu Oct 03 2013 12:25:34 GMT-0700 (PDT)
+ * Date: Thu Oct 03 2013 15:12:25 GMT-0700 (PDT)
  */
 /*jslint white: true, browser: true, plusplus: true, indent: 4, maxerr: 50 */
 
@@ -8070,7 +8070,7 @@ WalkontableCellStrategy.prototype.countVisible = function () {
 };
 
 WalkontableCellStrategy.prototype.isLastIncomplete = function () {
-  return this.remainingSize > 0;
+  return this.remainingSize >= 0;
 };
 /**
  * WalkontableClassNameList
@@ -9410,9 +9410,6 @@ WalkontableHorizontalScrollbar.prototype.readSettings = function () {
   this.offset = this.instance.getSetting('offsetColumn');
   this.total = this.instance.getSetting('totalColumns');
   this.visibleCount = this.instance.wtTable.columnStrategy.countVisible();
-  if(this.visibleCount > 1 && this.instance.wtTable.columnStrategy.isLastIncomplete()) {
-    this.visibleCount--;
-  }
   this.handlePosition = parseInt(this.handleStyle.left, 10);
   this.sliderSize = parseInt(this.sliderStyle.width, 10);
   this.fixedCount = this.instance.getSetting('fixedColumnsLeft');

--- a/dist/jquery.handsontable.full.js
+++ b/dist/jquery.handsontable.full.js
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Tue Oct 01 2013 13:17:18 GMT+0200 (Central European Daylight Time)
+ * Date: Thu Oct 03 2013 12:25:34 GMT-0700 (PDT)
  */
 /*jslint white: true, browser: true, plusplus: true, indent: 4, maxerr: 50 */
 
@@ -8070,7 +8070,7 @@ WalkontableCellStrategy.prototype.countVisible = function () {
 };
 
 WalkontableCellStrategy.prototype.isLastIncomplete = function () {
-  return this.remainingSize >= 0;
+  return this.remainingSize > 0;
 };
 /**
  * WalkontableClassNameList

--- a/dist/jquery.handsontable.js
+++ b/dist/jquery.handsontable.js
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Thu Oct 03 2013 12:25:34 GMT-0700 (PDT)
+ * Date: Thu Oct 03 2013 15:12:25 GMT-0700 (PDT)
  */
 /*jslint white: true, browser: true, plusplus: true, indent: 4, maxerr: 50 */
 
@@ -8070,7 +8070,7 @@ WalkontableCellStrategy.prototype.countVisible = function () {
 };
 
 WalkontableCellStrategy.prototype.isLastIncomplete = function () {
-  return this.remainingSize > 0;
+  return this.remainingSize >= 0;
 };
 /**
  * WalkontableClassNameList
@@ -9410,9 +9410,6 @@ WalkontableHorizontalScrollbar.prototype.readSettings = function () {
   this.offset = this.instance.getSetting('offsetColumn');
   this.total = this.instance.getSetting('totalColumns');
   this.visibleCount = this.instance.wtTable.columnStrategy.countVisible();
-  if(this.visibleCount > 1 && this.instance.wtTable.columnStrategy.isLastIncomplete()) {
-    this.visibleCount--;
-  }
   this.handlePosition = parseInt(this.handleStyle.left, 10);
   this.sliderSize = parseInt(this.sliderStyle.width, 10);
   this.fixedCount = this.instance.getSetting('fixedColumnsLeft');

--- a/dist/jquery.handsontable.js
+++ b/dist/jquery.handsontable.js
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Tue Oct 01 2013 13:17:18 GMT+0200 (Central European Daylight Time)
+ * Date: Thu Oct 03 2013 12:25:34 GMT-0700 (PDT)
  */
 /*jslint white: true, browser: true, plusplus: true, indent: 4, maxerr: 50 */
 
@@ -8070,7 +8070,7 @@ WalkontableCellStrategy.prototype.countVisible = function () {
 };
 
 WalkontableCellStrategy.prototype.isLastIncomplete = function () {
-  return this.remainingSize >= 0;
+  return this.remainingSize > 0;
 };
 /**
  * WalkontableClassNameList

--- a/dist_wc/x-handsontable/jquery.handsontable.full.css
+++ b/dist_wc/x-handsontable/jquery.handsontable.full.css
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Tue Oct 01 2013 13:17:18 GMT+0200 (Central European Daylight Time)
+ * Date: Thu Oct 03 2013 12:25:34 GMT-0700 (PDT)
  */
 
 .handsontable {

--- a/dist_wc/x-handsontable/jquery.handsontable.full.css
+++ b/dist_wc/x-handsontable/jquery.handsontable.full.css
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Thu Oct 03 2013 12:25:34 GMT-0700 (PDT)
+ * Date: Thu Oct 03 2013 15:12:25 GMT-0700 (PDT)
  */
 
 .handsontable {

--- a/dist_wc/x-handsontable/jquery.handsontable.full.js
+++ b/dist_wc/x-handsontable/jquery.handsontable.full.js
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Thu Oct 03 2013 12:25:34 GMT-0700 (PDT)
+ * Date: Thu Oct 03 2013 15:12:25 GMT-0700 (PDT)
  */
 /*jslint white: true, browser: true, plusplus: true, indent: 4, maxerr: 50 */
 
@@ -8070,7 +8070,7 @@ WalkontableCellStrategy.prototype.countVisible = function () {
 };
 
 WalkontableCellStrategy.prototype.isLastIncomplete = function () {
-  return this.remainingSize > 0;
+  return this.remainingSize >= 0;
 };
 /**
  * WalkontableClassNameList
@@ -9410,9 +9410,6 @@ WalkontableHorizontalScrollbar.prototype.readSettings = function () {
   this.offset = this.instance.getSetting('offsetColumn');
   this.total = this.instance.getSetting('totalColumns');
   this.visibleCount = this.instance.wtTable.columnStrategy.countVisible();
-  if(this.visibleCount > 1 && this.instance.wtTable.columnStrategy.isLastIncomplete()) {
-    this.visibleCount--;
-  }
   this.handlePosition = parseInt(this.handleStyle.left, 10);
   this.sliderSize = parseInt(this.sliderStyle.width, 10);
   this.fixedCount = this.instance.getSetting('fixedColumnsLeft');

--- a/dist_wc/x-handsontable/jquery.handsontable.full.js
+++ b/dist_wc/x-handsontable/jquery.handsontable.full.js
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Tue Oct 01 2013 13:17:18 GMT+0200 (Central European Daylight Time)
+ * Date: Thu Oct 03 2013 12:25:34 GMT-0700 (PDT)
  */
 /*jslint white: true, browser: true, plusplus: true, indent: 4, maxerr: 50 */
 
@@ -8070,7 +8070,7 @@ WalkontableCellStrategy.prototype.countVisible = function () {
 };
 
 WalkontableCellStrategy.prototype.isLastIncomplete = function () {
-  return this.remainingSize >= 0;
+  return this.remainingSize > 0;
 };
 /**
  * WalkontableClassNameList

--- a/src/3rdparty/walkontable/src/cellStrategy.js
+++ b/src/3rdparty/walkontable/src/cellStrategy.js
@@ -18,5 +18,5 @@ WalkontableCellStrategy.prototype.countVisible = function () {
 };
 
 WalkontableCellStrategy.prototype.isLastIncomplete = function () {
-  return this.remainingSize >= 0;
+  return this.remainingSize > 0;
 };

--- a/src/3rdparty/walkontable/src/cellStrategy.js
+++ b/src/3rdparty/walkontable/src/cellStrategy.js
@@ -18,5 +18,5 @@ WalkontableCellStrategy.prototype.countVisible = function () {
 };
 
 WalkontableCellStrategy.prototype.isLastIncomplete = function () {
-  return this.remainingSize > 0;
+  return this.remainingSize >= 0;
 };

--- a/src/3rdparty/walkontable/src/scrollbar.js
+++ b/src/3rdparty/walkontable/src/scrollbar.js
@@ -233,9 +233,6 @@ WalkontableHorizontalScrollbar.prototype.readSettings = function () {
   this.offset = this.instance.getSetting('offsetColumn');
   this.total = this.instance.getSetting('totalColumns');
   this.visibleCount = this.instance.wtTable.columnStrategy.countVisible();
-  if(this.visibleCount > 1 && this.instance.wtTable.columnStrategy.isLastIncomplete()) {
-    this.visibleCount--;
-  }
   this.handlePosition = parseInt(this.handleStyle.left, 10);
   this.sliderSize = parseInt(this.sliderStyle.width, 10);
   this.fixedCount = this.instance.getSetting('fixedColumnsLeft');

--- a/src/3rdparty/walkontable/test/jasmine/spec/rowStrategy.spec.js
+++ b/src/3rdparty/walkontable/test/jasmine/spec/rowStrategy.spec.js
@@ -22,6 +22,33 @@ describe('WalkontableRowStrategy', function () {
     expect(strategy.cellSizes).toEqual([25, 25, 25, 25]);
   });
 
+  it("should show 4 cells if container size is 99", function () {
+    source = [0, 1, 2, 5, 6, 7, 8, 9, 10];
+    var strategy = new WalkontableRowStrategy(99, allCells25);
+    for (var i = 0; i < source.length; i++) {
+      strategy.add(i);
+    }
+    expect(strategy.cellCount).toEqual(4);
+  });
+  
+  it("should show 4 cells if container size is 100", function () {
+    source = [0, 1, 2, 5, 6, 7, 8, 9, 10];
+    var strategy = new WalkontableRowStrategy(100, allCells25);
+    for (var i = 0; i < source.length; i++) {
+      strategy.add(i);
+    }
+    expect(strategy.cellCount).toEqual(4);
+  });
+  
+  it("should show 5 cells if container size is 101", function () {
+	    source = [0, 1, 2, 5, 6, 7, 8, 9, 10];
+	    var strategy = new WalkontableRowStrategy(101, allCells25);
+	    for (var i = 0; i < source.length; i++) {
+	      strategy.add(i);
+	    }
+	    expect(strategy.cellCount).toEqual(5);
+	  });
+  
   it("should show all cells if containerSize is Infinity", function () {
     source = [0, 1, 2, 5, 6, 7, 8, 9, 10];
     var strategy = new WalkontableRowStrategy(Infinity, allCells25);


### PR DESCRIPTION
This addresses #1074.
Since stretch modes set availableSize to 0 after stretching is completed, the horizontal scroll check thinks that the stretched cells overflow the available space.

Changed check to > 0 instead of >= 0
