### PR TITLE
Validator failure incorrectly highlights inner div on autocomplete and date cell types

### DIFF
--- a/dist/jquery.handsontable.css
+++ b/dist/jquery.handsontable.css
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Tue Oct 01 2013 13:17:18 GMT+0200 (Central European Daylight Time)
+ * Date: Tue Oct 01 2013 11:54:46 GMT-0700 (PDT)
  */
 
 .handsontable {

--- a/dist/jquery.handsontable.full.css
+++ b/dist/jquery.handsontable.full.css
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Tue Oct 01 2013 13:17:18 GMT+0200 (Central European Daylight Time)
+ * Date: Tue Oct 01 2013 11:54:46 GMT-0700 (PDT)
  */
 
 .handsontable {

--- a/dist/jquery.handsontable.full.js
+++ b/dist/jquery.handsontable.full.js
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Tue Oct 01 2013 13:17:18 GMT+0200 (Central European Daylight Time)
+ * Date: Tue Oct 01 2013 11:54:46 GMT-0700 (PDT)
  */
 /*jslint white: true, browser: true, plusplus: true, indent: 4, maxerr: 50 */
 
@@ -3633,7 +3633,9 @@ Handsontable.AutocompleteRenderer = function (instance, TD, row, col, prop, valu
     instance.rootElement.on('mouseup', '.htAutocompleteArrow', instance.acArrowListener); //this way we don't bind event listener to each arrow. We rely on propagation instead
   }
 
-  Handsontable.TextRenderer(instance, TEXT, row, col, prop, value, cellProperties);
+  Handsontable.TextRenderer(instance, TD, row, col, prop, value, cellProperties);
+  var escaped = Handsontable.helper.stringify(value);
+  instance.view.wt.wtDom.fastInnerText(TEXT, escaped);
 
   if (!TEXT.firstChild) { //http://jsperf.com/empty-node-if-needed
     //otherwise empty fields appear borderless in demo/renderers.html (IE)

--- a/dist/jquery.handsontable.js
+++ b/dist/jquery.handsontable.js
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Tue Oct 01 2013 13:17:18 GMT+0200 (Central European Daylight Time)
+ * Date: Tue Oct 01 2013 11:54:46 GMT-0700 (PDT)
  */
 /*jslint white: true, browser: true, plusplus: true, indent: 4, maxerr: 50 */
 
@@ -3633,7 +3633,9 @@ Handsontable.AutocompleteRenderer = function (instance, TD, row, col, prop, valu
     instance.rootElement.on('mouseup', '.htAutocompleteArrow', instance.acArrowListener); //this way we don't bind event listener to each arrow. We rely on propagation instead
   }
 
-  Handsontable.TextRenderer(instance, TEXT, row, col, prop, value, cellProperties);
+  Handsontable.TextRenderer(instance, TD, row, col, prop, value, cellProperties);
+  var escaped = Handsontable.helper.stringify(value);
+  instance.view.wt.wtDom.fastInnerText(TEXT, escaped);
 
   if (!TEXT.firstChild) { //http://jsperf.com/empty-node-if-needed
     //otherwise empty fields appear borderless in demo/renderers.html (IE)

--- a/dist_wc/x-handsontable/jquery.handsontable.full.css
+++ b/dist_wc/x-handsontable/jquery.handsontable.full.css
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Tue Oct 01 2013 13:17:18 GMT+0200 (Central European Daylight Time)
+ * Date: Tue Oct 01 2013 11:54:46 GMT-0700 (PDT)
  */
 
 .handsontable {

--- a/dist_wc/x-handsontable/jquery.handsontable.full.js
+++ b/dist_wc/x-handsontable/jquery.handsontable.full.js
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Tue Oct 01 2013 13:17:18 GMT+0200 (Central European Daylight Time)
+ * Date: Tue Oct 01 2013 11:54:46 GMT-0700 (PDT)
  */
 /*jslint white: true, browser: true, plusplus: true, indent: 4, maxerr: 50 */
 
@@ -3633,7 +3633,9 @@ Handsontable.AutocompleteRenderer = function (instance, TD, row, col, prop, valu
     instance.rootElement.on('mouseup', '.htAutocompleteArrow', instance.acArrowListener); //this way we don't bind event listener to each arrow. We rely on propagation instead
   }
 
-  Handsontable.TextRenderer(instance, TEXT, row, col, prop, value, cellProperties);
+  Handsontable.TextRenderer(instance, TD, row, col, prop, value, cellProperties);
+  var escaped = Handsontable.helper.stringify(value);
+  instance.view.wt.wtDom.fastInnerText(TEXT, escaped);
 
   if (!TEXT.firstChild) { //http://jsperf.com/empty-node-if-needed
     //otherwise empty fields appear borderless in demo/renderers.html (IE)

--- a/src/renderers/autocompleteRenderer.js
+++ b/src/renderers/autocompleteRenderer.js
@@ -28,7 +28,9 @@ Handsontable.AutocompleteRenderer = function (instance, TD, row, col, prop, valu
     instance.rootElement.on('mouseup', '.htAutocompleteArrow', instance.acArrowListener); //this way we don't bind event listener to each arrow. We rely on propagation instead
   }
 
-  Handsontable.TextRenderer(instance, TEXT, row, col, prop, value, cellProperties);
+  Handsontable.TextRenderer(instance, TD, row, col, prop, value, cellProperties);
+  var escaped = Handsontable.helper.stringify(value);
+  instance.view.wt.wtDom.fastInnerText(TEXT, escaped);
 
   if (!TEXT.firstChild) { //http://jsperf.com/empty-node-if-needed
     //otherwise empty fields appear borderless in demo/renderers.html (IE)

--- a/test/jasmine/spec/editors/autocompleteEditorSpec.js
+++ b/test/jasmine/spec/editors/autocompleteEditorSpec.js
@@ -624,4 +624,29 @@ describe('AutocompleteEditor', function () {
     expect(getDataAtCol(2)).toEqual(['yellow', 'red', 'blue']);
   });
 
+  it('should add class name `htInvalid` to a cell that does not validate - on validateCells', function () {
+    var hot = handsontable({
+      autoComplete: getAutocompleteConfig(false),
+      data: [
+        ['yellow'],
+        ['red'],
+        ['blue']
+      ],
+      validator: function (value, callb) {
+        if (value == "yellow") {
+          callb(false)
+        }
+        else {
+          callb(true)
+        }
+      }
+    });
+
+    hot.validateCells(function () {
+      hot.render();
+    });
+
+    expect(this.$container.find('td.htInvalid').length).toEqual(1);
+    expect(this.$container.find('td:not(.htInvalid)').length).toEqual(2);
+  });
 });

--- a/test/jasmine/spec/editors/dateEditorSpec.js
+++ b/test/jasmine/spec/editors/dateEditorSpec.js
@@ -1,4 +1,4 @@
-describe('TextEditor', function () {
+describe('DateEditor', function () {
   var id = 'testContainer';
 
   beforeEach(function () {
@@ -130,5 +130,32 @@ describe('TextEditor', function () {
 
     expect($('.htDatepickerHolder').is(':visible')).toBe(false);
 
+  });
+
+  it('should add class name `htInvalid` to a cell that does not validate - on validateCells', function () {
+    var hot = handsontable({
+      data: getDates(),
+      columns: [
+        {
+          type: 'date',
+          dateFormat: 'mm/dd/yy'
+        }
+      ],
+      validator: function (value, callb) {
+        if (value == "12/01/2008") {
+          callb(false)
+        }
+        else {
+          callb(true)
+        }
+      }
+    });
+
+    hot.validateCells(function () {
+      hot.render();
+    });
+
+    expect(this.$container.find('td.htInvalid').length).toEqual(1);
+    expect(this.$container.find('td:not(.htInvalid)').length).toEqual(4);
   });
 });


### PR DESCRIPTION
Date and Autocomplete fields will not highlight properly in the case of validation failures because classes are being added to the inner &lt;div&gt; element instead of the the cell.

This pull request fixes the problem by making sure htDimmed and invalidCellClassName are applied to the cell instead, making them consistent with other cell types.
### Now with unit tests

Unit tests added for autocompleteEditorSpec and dateEditorSpec per instructions in #1073
