### PR TITLE
Update textEditor.js

### DIFF
--- a/src/editors/textEditor.js
+++ b/src/editors/textEditor.js
@@ -52,7 +52,9 @@
         var isMultipleSelection = !(selected[0] === selected[2] && selected[1] === selected[3]);
         if ((ctrlDown && !isMultipleSelection) || event.altKey) { //if ctrl+enter or alt+enter, add new line
           if(that.isOpened()){
-            that.val(that.val() + '\n');
+            var caretPosition = that.wtDom.getCaretPosition(that.TEXTAREA);
+            that.val(that.val().substr(0, caretPosition) + '\n' + that.val().substr(caretPosition));
+            that.wtDom.setCaretPosition(that.TEXTAREA, caretPosition + 1);
             that.focus();
           } else {
             that.beginEditing(that.originalValue + '\n')


### PR DESCRIPTION
Issue #913
TextArea editor behaviour change. Allows inserting newlines in the middle of the text. 
Previously it was only possible to append newlines to the text inside the TextArea.
