### PR TITLE
Update jquery.handsontable.full.css

### DIFF
--- a/dist/jquery.handsontable.full.css
+++ b/dist/jquery.handsontable.full.css
@@ -58,7 +58,7 @@
 }
 
 .handsontable col.rowHeader {
-  width: 50px;
+  width: 30px;
 }
 
 .handsontable th,
@@ -452,8 +452,9 @@ ul.context-menu-list li {
   position: absolute;
 }
 
+/* The outline of the context menu is looking bad */
 .handsontable .htContextMenu table.htCore {
-  outline: 1px solid #bbb;
+  outline: 0px solid #bbb;
 }
 
 .handsontable .htContextMenu table tbody tr td {


### PR DESCRIPTION
This change decreases the default row headers width to 30px
Then the context menu outline is not needed
