### PR TITLE
Bugfix for vertical scrollbar (wrong height, fixed getHandleSizeRatio)

### DIFF
--- a/src/3rdparty/walkontable/src/scrollbar.js
+++ b/src/3rdparty/walkontable/src/scrollbar.js
@@ -98,7 +98,7 @@ WalkontableScrollbar.prototype.getHandleSizeRatio = function (viewportCount, tot
   if (!totalCount || viewportCount > totalCount || viewportCount == totalCount) {
     return 1;
   }
-  return 1 / totalCount;
+  return viewportCount / totalCount;
 };
 
 WalkontableScrollbar.prototype.prepare = function () {


### PR DESCRIPTION
This patch fixes an issue with the vertical scrollbar which would always be displayed to small. The method "getHandleSizeRatio" has been fixed.