### PR TITLE
Fix for bug that prevents columns from being uniquely looked up by property

### DIFF
--- a/demo/backbone.html
+++ b/demo/backbone.html
@@ -140,9 +140,9 @@
               dataSchema: makeCar,
               contextMenu: true,
               columns: [
-                attr("make"),
-                attr("model"),
-                attr("year")
+                  { data: createAttrFn("make") },
+                  { data: createAttrFn("model") },
+                  { data: createAttrFn("year"), type:'numeric', allowInvalid: false }
               ],
               colHeaders: ["Make", "Model", "Year"]
               //minSpareRows: 1 //see notes on the left for `minSpareRows`
@@ -160,15 +160,14 @@
             // you'll have to make something like these until there is a better
             // way to use the string notation, i.e. "bb:make"!
 
-            // normally, you'd get these from the server with .fetch()
-            function attr(attr) {
-              // this lets us remember `attr` for when when it is get/set
-              return {data: function (car, value) {
-                if (_.isUndefined(value)) {
-                  return car.get(attr);
+            function createAttrFn(attr,columnName) {
+                columnName = typeof columnName === 'undefined' ? attr : columnName;
+                return function(car,value) {
+                  if ( typeof car === 'undefined' ) return columnName;
+                  if ( _.isUndefined(value) ) return car.get(attr);
+                  car.set(attr, value);
                 }
-                car.set(attr, value);
-              }};
+
             }
 
             // just setting `dataSchema: CarModel` would be great, but it is non-

--- a/demo/datasources.html
+++ b/demo/datasources.html
@@ -65,6 +65,7 @@
         <li><a href="#dataschema">object data source (custom data schema)</a></li>
         <li><a href="#propertyschema">function data source and schema (to reach where arrays and objects can't
           reach)</a></li>
+        <li><a href="#propertyschemaValidations">function data source and schema with validations enabled</a></li>
       </ul>
 
       <p>Please take note that Handsontable will change the original data source. More about this here: <a
@@ -367,11 +368,12 @@
           dataSchema: model,
           startRows: 5,
           startCols: 3,
-          colHeaders: ['ID', 'Name', 'Address'],
+          colHeaders: ['ID', 'Name', 'Address1','Address2'],
           columns: [
             {data: property("id")},
             {data: property("name")},
-            {data: property("address")}
+            {data: property("address",'MyAddressColumn1')},
+            {data: property("address",'MyAddressColumn2')}
           ],
           minSpareRows: 1
         });
@@ -398,8 +400,11 @@
           return _pub;
         }
 
-        function property(attr) {
+        function property(attr,columnName) {
+          columnName = typeof columnName === 'undefined' ? attr : columnName;
+
           return function (row, value) {
+            if (typeof row === 'undefined' ) return columnName; 
             return row.attr(attr, value);
           }
         }
@@ -407,6 +412,94 @@
     </div>
   </div>
 </div>
+
+
+"rowLayout">
+  <div class="descLayout">
+    <div class="pad" data-jsfiddle="example7">
+      <a name="propertyschema"></a>
+
+      <h2>Function data source and schema with validations eanbled</h2>
+
+
+
+      <div id="example7"></div>
+
+      <p>
+        <button name="dump" data-dump="#example7" title="Prints current data source to Firebug/Chrome Dev Tools">Dump
+          data to console
+        </button>
+      </p>
+    </div>
+  </div>
+
+  <div class="codeLayout">
+    <div class="pad">
+      <div class="jsFiddle">
+        <button class="jsFiddleLink" data-runfiddle="example7">Edit in jsFiddle</button>
+      </div>
+
+      <script data-jsfiddle="example7">
+
+        var $container = $("#example7");
+        $container.handsontable({
+          data: [
+            model({id: 1, name: "Ted Right", address: ""}),
+            model({id: 2, name: "Frank Honest", address: ""}),
+            model({id: 3, name: "Joan Well", address: ""})
+          ],
+          dataSchema: model,
+          startRows: 5,
+          startCols: 4,
+          //colHeaders: ['ID', 'Name', 'Address1','Address2'],
+          columns: [
+            {data: property("id"), type: 'numeric', allowInvalid: false, title: 'ID'},
+            {data: property("name"), title: 'Name' },
+            {data: property("address",'MyAddressColumn1'), title: 'Address 1' },
+            {data: property("address",'MyAddressColumn2'), title: 'Address 2' }
+          ],
+          minSpareRows: 1
+        });
+
+        function model(opts) {
+          var _pub = {},
+            _priv = $.extend({
+              id: undefined,
+              name: undefined,
+              address: undefined
+            }, opts);
+
+          _pub.attr = function (attr, val) {
+            if (typeof val === 'undefined') {
+              window.console && console.log("\t\tGET the", attr, "value of", _pub);
+              return _priv[attr];
+            }
+            window.console && console.log("SET the", attr, "value of", _pub);
+            _priv[attr] = val;
+
+            return _pub;
+          };
+
+          return _pub;
+        }
+
+        function property(attr,columnName) {
+          columnName = typeof columnName === 'undefined' ? attr : columnName;
+
+          return function (row, value) {
+            if (typeof row === 'undefined' ) return columnName; 
+            return row.attr(attr, value);
+          }
+        }
+      </script>
+    </div>
+  </div>
+</div>
+
+
+
+
+
 
 <div class="rowLayout">
   <div class="descLayout noMargin">

--- a/demo/datasources.html
+++ b/demo/datasources.html
@@ -414,13 +414,13 @@
 </div>
 
 
-"rowLayout">
+<div class="rowLayout">
   <div class="descLayout">
     <div class="pad" data-jsfiddle="example7">
-      <a name="propertyschema"></a>
+      <a name="propertyschemaValidations"></a>
 
-      <h2>Function data source and schema with validations eanbled</h2>
-
+      <h2>Function data source and schema with validations enabled</h2>
+      <p>Note: This will not work without the factory function being like so and/or without my patch to core.js</p>
 
 
       <div id="example7"></div>

--- a/dist/jquery.handsontable.css
+++ b/dist/jquery.handsontable.css
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Thu Nov 14 2013 11:22:27 GMT-0800 (PST)
+ * Date: Thu Nov 14 2013 11:43:32 GMT-0800 (PST)
  */
 
 .handsontable {

--- a/dist/jquery.handsontable.css
+++ b/dist/jquery.handsontable.css
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Thu Nov 14 2013 12:27:22 GMT-0800 (PST)
+ * Date: Thu Nov 14 2013 13:11:48 GMT-0800 (PST)
  */
 
 .handsontable {

--- a/dist/jquery.handsontable.css
+++ b/dist/jquery.handsontable.css
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Wed Oct 30 2013 03:16:48 GMT+0100 (Central European Standard Time)
+ * Date: Thu Nov 14 2013 10:55:16 GMT-0800 (PST)
  */
 
 .handsontable {

--- a/dist/jquery.handsontable.css
+++ b/dist/jquery.handsontable.css
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Thu Nov 14 2013 11:43:32 GMT-0800 (PST)
+ * Date: Thu Nov 14 2013 12:27:22 GMT-0800 (PST)
  */
 
 .handsontable {

--- a/dist/jquery.handsontable.css
+++ b/dist/jquery.handsontable.css
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Thu Nov 14 2013 10:55:16 GMT-0800 (PST)
+ * Date: Thu Nov 14 2013 11:22:27 GMT-0800 (PST)
  */
 
 .handsontable {

--- a/dist/jquery.handsontable.full.css
+++ b/dist/jquery.handsontable.full.css
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Thu Nov 14 2013 11:22:27 GMT-0800 (PST)
+ * Date: Thu Nov 14 2013 11:43:32 GMT-0800 (PST)
  */
 
 .handsontable {

--- a/dist/jquery.handsontable.full.css
+++ b/dist/jquery.handsontable.full.css
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Thu Nov 14 2013 12:27:22 GMT-0800 (PST)
+ * Date: Thu Nov 14 2013 13:11:48 GMT-0800 (PST)
  */
 
 .handsontable {

--- a/dist/jquery.handsontable.full.css
+++ b/dist/jquery.handsontable.full.css
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Wed Oct 30 2013 03:16:48 GMT+0100 (Central European Standard Time)
+ * Date: Thu Nov 14 2013 10:55:16 GMT-0800 (PST)
  */
 
 .handsontable {

--- a/dist/jquery.handsontable.full.css
+++ b/dist/jquery.handsontable.full.css
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Thu Nov 14 2013 11:43:32 GMT-0800 (PST)
+ * Date: Thu Nov 14 2013 12:27:22 GMT-0800 (PST)
  */
 
 .handsontable {

--- a/dist/jquery.handsontable.full.css
+++ b/dist/jquery.handsontable.full.css
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Thu Nov 14 2013 10:55:16 GMT-0800 (PST)
+ * Date: Thu Nov 14 2013 11:22:27 GMT-0800 (PST)
  */
 
 .handsontable {

--- a/dist/jquery.handsontable.full.js
+++ b/dist/jquery.handsontable.full.js
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Thu Nov 14 2013 11:43:32 GMT-0800 (PST)
+ * Date: Thu Nov 14 2013 12:27:22 GMT-0800 (PST)
  */
 /*jslint white: true, browser: true, plusplus: true, indent: 4, maxerr: 50 */
 
@@ -123,6 +123,15 @@ Handsontable.Core = function (rootElement, userSettings) {
     // to identify the column when its row property is undefined 
     getPropLookupKey: function(prop) {
         return typeof prop !== 'function' ? prop : (prop() || prop); // is prop() is undefined, just use the fn text
+    },
+
+    // return the actual property (especially functions) with the given property key (the field or given column name)
+    getPropertyByKey: function(propKey) {
+        var col = priv.propToCol[propKey];
+        if ( typeof col === 'undefined') {
+            throw "Could not lookup column by property key "+propKey;
+        }
+        return priv.colToProp[col];
     },
 
 
@@ -1998,6 +2007,15 @@ Handsontable.Core = function (rootElement, userSettings) {
     return datamap.colToProp(col);
   };
 
+  /**
+   * Returns the actual property (especially functions) with a property key (column name or field)
+   * @param {String} propKey
+   * @public
+   * @return value (mixed data type -- this may be a fn or a string defining a field)
+   */
+  this.getPropertyByKey = function(propKey) {
+    return datamap.getPropertyByKey(propKey);
+  };
   /**
    * Returns column number associated with property name
    * @param {String} prop

--- a/dist/jquery.handsontable.full.js
+++ b/dist/jquery.handsontable.full.js
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Thu Nov 14 2013 10:55:16 GMT-0800 (PST)
+ * Date: Thu Nov 14 2013 11:22:27 GMT-0800 (PST)
  */
 /*jslint white: true, browser: true, plusplus: true, indent: 4, maxerr: 50 */
 

--- a/dist/jquery.handsontable.full.js
+++ b/dist/jquery.handsontable.full.js
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Wed Oct 30 2013 03:16:48 GMT+0100 (Central European Standard Time)
+ * Date: Thu Nov 14 2013 10:55:16 GMT-0800 (PST)
  */
 /*jslint white: true, browser: true, plusplus: true, indent: 4, maxerr: 50 */
 
@@ -114,6 +114,18 @@ Handsontable.Core = function (rootElement, userSettings) {
       return lastCol;
     },
 
+
+
+    // generate a unique signature for column properties, especially those that are defined as functions
+    // currently, in the main branch, properties that are defined as function as keyed by the function text.
+    // This generates collisions since typically the same accessor function is used for multiple columns (albeit with different behaviors as defined by the closure variables)
+    // NOTE: this assumes that the accessor function is configured to return the field name or some other unique string
+    // to identify the column when its row property is undefined 
+    getPropLookupKey: function(prop) {
+        return typeof prop !== 'function' ? prop : (prop() || prop); // is prop() is undefined, just use the fn text
+    },
+
+
     createMap: function () {
       if (typeof datamap.getSchema() === "undefined") {
         throw new Error("trying to create `columns` definition but you didnt' provide `schema` nor `data`");
@@ -124,13 +136,14 @@ Handsontable.Core = function (rootElement, userSettings) {
       if (priv.settings.columns) {
         for (i = 0, ilen = priv.settings.columns.length; i < ilen; i++) {
           priv.colToProp[i] = priv.settings.columns[i].data;
-          priv.propToCol[priv.settings.columns[i].data] = i;
+          priv.propToCol[datamap.getPropLookupKey(priv.settings.columns[i].data)] = i;
         }
       }
       else {
         datamap.recursiveDuckColumns(schema);
       }
     },
+    
 
     colToProp: function (col) {
       col = Handsontable.PluginHooks.execute(instance, 'modifyCol', col);
@@ -143,9 +156,10 @@ Handsontable.Core = function (rootElement, userSettings) {
     },
 
     propToCol: function (prop) {
-      var col;
-      if (typeof priv.propToCol[prop] !== 'undefined') {
-        col = priv.propToCol[prop];
+      var col,
+          propKey = datamap.getPropLookupKey(prop);
+      if (typeof priv.propToCol[propKey] !== 'undefined') {
+        col = priv.propToCol[propKey];
       }
       else {
         col = prop;

--- a/dist/jquery.handsontable.full.js
+++ b/dist/jquery.handsontable.full.js
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Thu Nov 14 2013 12:27:22 GMT-0800 (PST)
+ * Date: Thu Nov 14 2013 13:11:48 GMT-0800 (PST)
  */
 /*jslint white: true, browser: true, plusplus: true, indent: 4, maxerr: 50 */
 

--- a/dist/jquery.handsontable.full.js
+++ b/dist/jquery.handsontable.full.js
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Thu Nov 14 2013 11:22:27 GMT-0800 (PST)
+ * Date: Thu Nov 14 2013 11:43:32 GMT-0800 (PST)
  */
 /*jslint white: true, browser: true, plusplus: true, indent: 4, maxerr: 50 */
 

--- a/dist/jquery.handsontable.js
+++ b/dist/jquery.handsontable.js
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Thu Nov 14 2013 11:43:32 GMT-0800 (PST)
+ * Date: Thu Nov 14 2013 12:27:22 GMT-0800 (PST)
  */
 /*jslint white: true, browser: true, plusplus: true, indent: 4, maxerr: 50 */
 
@@ -123,6 +123,15 @@ Handsontable.Core = function (rootElement, userSettings) {
     // to identify the column when its row property is undefined 
     getPropLookupKey: function(prop) {
         return typeof prop !== 'function' ? prop : (prop() || prop); // is prop() is undefined, just use the fn text
+    },
+
+    // return the actual property (especially functions) with the given property key (the field or given column name)
+    getPropertyByKey: function(propKey) {
+        var col = priv.propToCol[propKey];
+        if ( typeof col === 'undefined') {
+            throw "Could not lookup column by property key "+propKey;
+        }
+        return priv.colToProp[col];
     },
 
 
@@ -1998,6 +2007,15 @@ Handsontable.Core = function (rootElement, userSettings) {
     return datamap.colToProp(col);
   };
 
+  /**
+   * Returns the actual property (especially functions) with a property key (column name or field)
+   * @param {String} propKey
+   * @public
+   * @return value (mixed data type -- this may be a fn or a string defining a field)
+   */
+  this.getPropertyByKey = function(propKey) {
+    return datamap.getPropertyByKey(propKey);
+  };
   /**
    * Returns column number associated with property name
    * @param {String} prop

--- a/dist/jquery.handsontable.js
+++ b/dist/jquery.handsontable.js
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Thu Nov 14 2013 10:55:16 GMT-0800 (PST)
+ * Date: Thu Nov 14 2013 11:22:27 GMT-0800 (PST)
  */
 /*jslint white: true, browser: true, plusplus: true, indent: 4, maxerr: 50 */
 

--- a/dist/jquery.handsontable.js
+++ b/dist/jquery.handsontable.js
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Wed Oct 30 2013 03:16:48 GMT+0100 (Central European Standard Time)
+ * Date: Thu Nov 14 2013 10:55:16 GMT-0800 (PST)
  */
 /*jslint white: true, browser: true, plusplus: true, indent: 4, maxerr: 50 */
 
@@ -114,6 +114,18 @@ Handsontable.Core = function (rootElement, userSettings) {
       return lastCol;
     },
 
+
+
+    // generate a unique signature for column properties, especially those that are defined as functions
+    // currently, in the main branch, properties that are defined as function as keyed by the function text.
+    // This generates collisions since typically the same accessor function is used for multiple columns (albeit with different behaviors as defined by the closure variables)
+    // NOTE: this assumes that the accessor function is configured to return the field name or some other unique string
+    // to identify the column when its row property is undefined 
+    getPropLookupKey: function(prop) {
+        return typeof prop !== 'function' ? prop : (prop() || prop); // is prop() is undefined, just use the fn text
+    },
+
+
     createMap: function () {
       if (typeof datamap.getSchema() === "undefined") {
         throw new Error("trying to create `columns` definition but you didnt' provide `schema` nor `data`");
@@ -124,13 +136,14 @@ Handsontable.Core = function (rootElement, userSettings) {
       if (priv.settings.columns) {
         for (i = 0, ilen = priv.settings.columns.length; i < ilen; i++) {
           priv.colToProp[i] = priv.settings.columns[i].data;
-          priv.propToCol[priv.settings.columns[i].data] = i;
+          priv.propToCol[datamap.getPropLookupKey(priv.settings.columns[i].data)] = i;
         }
       }
       else {
         datamap.recursiveDuckColumns(schema);
       }
     },
+    
 
     colToProp: function (col) {
       col = Handsontable.PluginHooks.execute(instance, 'modifyCol', col);
@@ -143,9 +156,10 @@ Handsontable.Core = function (rootElement, userSettings) {
     },
 
     propToCol: function (prop) {
-      var col;
-      if (typeof priv.propToCol[prop] !== 'undefined') {
-        col = priv.propToCol[prop];
+      var col,
+          propKey = datamap.getPropLookupKey(prop);
+      if (typeof priv.propToCol[propKey] !== 'undefined') {
+        col = priv.propToCol[propKey];
       }
       else {
         col = prop;

--- a/dist/jquery.handsontable.js
+++ b/dist/jquery.handsontable.js
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Thu Nov 14 2013 12:27:22 GMT-0800 (PST)
+ * Date: Thu Nov 14 2013 13:11:48 GMT-0800 (PST)
  */
 /*jslint white: true, browser: true, plusplus: true, indent: 4, maxerr: 50 */
 

--- a/dist/jquery.handsontable.js
+++ b/dist/jquery.handsontable.js
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Thu Nov 14 2013 11:22:27 GMT-0800 (PST)
+ * Date: Thu Nov 14 2013 11:43:32 GMT-0800 (PST)
  */
 /*jslint white: true, browser: true, plusplus: true, indent: 4, maxerr: 50 */
 

--- a/dist_wc/handsontable-table/jquery.handsontable.full.css
+++ b/dist_wc/handsontable-table/jquery.handsontable.full.css
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Thu Nov 14 2013 11:22:27 GMT-0800 (PST)
+ * Date: Thu Nov 14 2013 11:43:32 GMT-0800 (PST)
  */
 
 .handsontable {

--- a/dist_wc/handsontable-table/jquery.handsontable.full.css
+++ b/dist_wc/handsontable-table/jquery.handsontable.full.css
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Thu Nov 14 2013 12:27:22 GMT-0800 (PST)
+ * Date: Thu Nov 14 2013 13:11:48 GMT-0800 (PST)
  */
 
 .handsontable {

--- a/dist_wc/handsontable-table/jquery.handsontable.full.css
+++ b/dist_wc/handsontable-table/jquery.handsontable.full.css
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Wed Oct 30 2013 03:16:48 GMT+0100 (Central European Standard Time)
+ * Date: Thu Nov 14 2013 10:55:16 GMT-0800 (PST)
  */
 
 .handsontable {

--- a/dist_wc/handsontable-table/jquery.handsontable.full.css
+++ b/dist_wc/handsontable-table/jquery.handsontable.full.css
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Thu Nov 14 2013 11:43:32 GMT-0800 (PST)
+ * Date: Thu Nov 14 2013 12:27:22 GMT-0800 (PST)
  */
 
 .handsontable {

--- a/dist_wc/handsontable-table/jquery.handsontable.full.css
+++ b/dist_wc/handsontable-table/jquery.handsontable.full.css
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Thu Nov 14 2013 10:55:16 GMT-0800 (PST)
+ * Date: Thu Nov 14 2013 11:22:27 GMT-0800 (PST)
  */
 
 .handsontable {

--- a/dist_wc/handsontable-table/jquery.handsontable.full.js
+++ b/dist_wc/handsontable-table/jquery.handsontable.full.js
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Thu Nov 14 2013 11:43:32 GMT-0800 (PST)
+ * Date: Thu Nov 14 2013 12:27:22 GMT-0800 (PST)
  */
 /*jslint white: true, browser: true, plusplus: true, indent: 4, maxerr: 50 */
 
@@ -123,6 +123,15 @@ Handsontable.Core = function (rootElement, userSettings) {
     // to identify the column when its row property is undefined 
     getPropLookupKey: function(prop) {
         return typeof prop !== 'function' ? prop : (prop() || prop); // is prop() is undefined, just use the fn text
+    },
+
+    // return the actual property (especially functions) with the given property key (the field or given column name)
+    getPropertyByKey: function(propKey) {
+        var col = priv.propToCol[propKey];
+        if ( typeof col === 'undefined') {
+            throw "Could not lookup column by property key "+propKey;
+        }
+        return priv.colToProp[col];
     },
 
 
@@ -1998,6 +2007,15 @@ Handsontable.Core = function (rootElement, userSettings) {
     return datamap.colToProp(col);
   };
 
+  /**
+   * Returns the actual property (especially functions) with a property key (column name or field)
+   * @param {String} propKey
+   * @public
+   * @return value (mixed data type -- this may be a fn or a string defining a field)
+   */
+  this.getPropertyByKey = function(propKey) {
+    return datamap.getPropertyByKey(propKey);
+  };
   /**
    * Returns column number associated with property name
    * @param {String} prop

--- a/dist_wc/handsontable-table/jquery.handsontable.full.js
+++ b/dist_wc/handsontable-table/jquery.handsontable.full.js
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Thu Nov 14 2013 10:55:16 GMT-0800 (PST)
+ * Date: Thu Nov 14 2013 11:22:27 GMT-0800 (PST)
  */
 /*jslint white: true, browser: true, plusplus: true, indent: 4, maxerr: 50 */
 

--- a/dist_wc/handsontable-table/jquery.handsontable.full.js
+++ b/dist_wc/handsontable-table/jquery.handsontable.full.js
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Wed Oct 30 2013 03:16:48 GMT+0100 (Central European Standard Time)
+ * Date: Thu Nov 14 2013 10:55:16 GMT-0800 (PST)
  */
 /*jslint white: true, browser: true, plusplus: true, indent: 4, maxerr: 50 */
 
@@ -114,6 +114,18 @@ Handsontable.Core = function (rootElement, userSettings) {
       return lastCol;
     },
 
+
+
+    // generate a unique signature for column properties, especially those that are defined as functions
+    // currently, in the main branch, properties that are defined as function as keyed by the function text.
+    // This generates collisions since typically the same accessor function is used for multiple columns (albeit with different behaviors as defined by the closure variables)
+    // NOTE: this assumes that the accessor function is configured to return the field name or some other unique string
+    // to identify the column when its row property is undefined 
+    getPropLookupKey: function(prop) {
+        return typeof prop !== 'function' ? prop : (prop() || prop); // is prop() is undefined, just use the fn text
+    },
+
+
     createMap: function () {
       if (typeof datamap.getSchema() === "undefined") {
         throw new Error("trying to create `columns` definition but you didnt' provide `schema` nor `data`");
@@ -124,13 +136,14 @@ Handsontable.Core = function (rootElement, userSettings) {
       if (priv.settings.columns) {
         for (i = 0, ilen = priv.settings.columns.length; i < ilen; i++) {
           priv.colToProp[i] = priv.settings.columns[i].data;
-          priv.propToCol[priv.settings.columns[i].data] = i;
+          priv.propToCol[datamap.getPropLookupKey(priv.settings.columns[i].data)] = i;
         }
       }
       else {
         datamap.recursiveDuckColumns(schema);
       }
     },
+    
 
     colToProp: function (col) {
       col = Handsontable.PluginHooks.execute(instance, 'modifyCol', col);
@@ -143,9 +156,10 @@ Handsontable.Core = function (rootElement, userSettings) {
     },
 
     propToCol: function (prop) {
-      var col;
-      if (typeof priv.propToCol[prop] !== 'undefined') {
-        col = priv.propToCol[prop];
+      var col,
+          propKey = datamap.getPropLookupKey(prop);
+      if (typeof priv.propToCol[propKey] !== 'undefined') {
+        col = priv.propToCol[propKey];
       }
       else {
         col = prop;

--- a/dist_wc/handsontable-table/jquery.handsontable.full.js
+++ b/dist_wc/handsontable-table/jquery.handsontable.full.js
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Thu Nov 14 2013 12:27:22 GMT-0800 (PST)
+ * Date: Thu Nov 14 2013 13:11:48 GMT-0800 (PST)
  */
 /*jslint white: true, browser: true, plusplus: true, indent: 4, maxerr: 50 */
 

--- a/dist_wc/handsontable-table/jquery.handsontable.full.js
+++ b/dist_wc/handsontable-table/jquery.handsontable.full.js
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Thu Nov 14 2013 11:22:27 GMT-0800 (PST)
+ * Date: Thu Nov 14 2013 11:43:32 GMT-0800 (PST)
  */
 /*jslint white: true, browser: true, plusplus: true, indent: 4, maxerr: 50 */
 

--- a/src/core.js
+++ b/src/core.js
@@ -106,6 +106,15 @@ Handsontable.Core = function (rootElement, userSettings) {
         return typeof prop !== 'function' ? prop : (prop() || prop); // is prop() is undefined, just use the fn text
     },
 
+    // return the actual property (especially functions) with the given property key (the field or given column name)
+    getPropertyByKey: function(propKey) {
+        var col = priv.propToCol[propKey];
+        if ( typeof col === 'undefined') {
+            throw "Could not lookup column by property key "+propKey;
+        }
+        return priv.colToProp[col];
+    },
+
 
     createMap: function () {
       if (typeof datamap.getSchema() === "undefined") {
@@ -1979,6 +1988,15 @@ Handsontable.Core = function (rootElement, userSettings) {
     return datamap.colToProp(col);
   };
 
+  /**
+   * Returns the actual property (especially functions) with a property key (column name or field)
+   * @param {String} propKey
+   * @public
+   * @return value (mixed data type -- this may be a fn or a string defining a field)
+   */
+  this.getPropertyByKey = function(propKey) {
+    return datamap.getPropertyByKey(propKey);
+  };
   /**
    * Returns column number associated with property name
    * @param {String} prop

--- a/test/jasmine/spec/Core_loadDataSpec.js
+++ b/test/jasmine/spec/Core_loadDataSpec.js
@@ -363,9 +363,9 @@ describe('Core_loadData', function () {
     handsontable({
       data: cars,
       columns: [
-        attr("make"),
-        attr("model"),
-        attr("year")
+        { data: createAttrFn("make") },
+        { data: createAttrFn("model") },
+        { data: createAttrFn("year") }
       ]
     });
 
@@ -377,16 +377,26 @@ describe('Core_loadData', function () {
       return removed;
     }
 
-    // normally, you'd get these from the server with .fetch()
-    function attr(attr) {
-      // this lets us remember `attr` for when when it is get/set
-      return {data: function (car, value) {
-        if (_.isUndefined(value)) {
-          return car.get(attr);
+    function createAttrFn(attr,columnName) {
+        columnName = typeof columnName === 'undefined' ? attr : columnName;
+        return function(car,value) {
+          if ( typeof car === 'undefined' ) return columnName;
+          if ( _.isUndefined(value) ) return car.get(attr);
+          car.set(attr, value);
         }
-        car.set(attr, value);
-      }};
+
     }
+
+    // // normally, you'd get these from the server with .fetch()
+    // function attr(attr) {
+    //   // this lets us remember `attr` for when when it is get/set
+    //   return {data: function (car, value) {
+    //     if (_.isUndefined(value)) {
+    //       return car.get(attr);
+    //     }
+    //     car.set(attr, value);
+    //   }};
+    // }
 
     expect(countRows()).toBe(3);
   });

--- a/test/jasmine/spec/Core_setDataAtCellSpec.js
+++ b/test/jasmine/spec/Core_setDataAtCellSpec.js
@@ -333,13 +333,15 @@ describe('Core_setDataAtCell', function () {
     setDataAtCell(1, 1, 'Something Else');
     expect(getDataAtCell(1, 1)).toEqual('Something Else');
 
-    // verify we can reference explicitly named column
-    expect(getDataAtRowProp(1,"MyAddress2","Frank's house"));
-    expect(getDataAtRowProp(1,"MyAddress1","Frank's house"));
-
     // verify we can reference implicitly named columns (via the property text)
-    expect(getDataAtRowProp(2,'name','Joan Well'));
-    expect(getDataAtRowProp(2,'id',3));
+    expect(getDataAtRowProp(2,getPropertyByKey('name'))).toEqual('Joan Well');
+    expect(getDataAtRowProp(2,getPropertyByKey('id'))).toEqual(3);
+
+
+    // verify we can reference explicitly named column
+    expect(getDataAtRowProp(1,getPropertyByKey("MyAddress2"))).toEqual("Frank's house");
+    expect(getDataAtRowProp(1,getPropertyByKey("MyAddress1"))).toEqual("Frank's house");
+
 
   });
 

--- a/test/jasmine/spec/Core_setDataAtCellSpec.js
+++ b/test/jasmine/spec/Core_setDataAtCellSpec.js
@@ -278,6 +278,72 @@ describe('Core_setDataAtCell', function () {
     expect(getDataAtCell(1, 1)).toEqual('Something Else');
   });
 
+
+
+  //https://handsontable.com/demo/datasources.html
+  it('should be able to properly reference function datasource columns by property or column name', function () {
+    handsontable({
+      data: [
+        model({id: 1, name: "Ted Right", address: ""}),
+        model({id: 2, name: "Frank Honest", address: "Frank's house"}),
+        model({id: 3, name: "Joan Well", address: "Joan's house"})
+      ],
+      dataSchema: model,
+      startRows: 5,
+      startCols: 3,
+      colHeaders: ['ID', 'Name', 'Address'],
+      columns: [
+        {data: createAttrFn("id")},
+        {data: createAttrFn("name")},
+        {data: createAttrFn("address","MyAddress2")},
+        {data: createAttrFn("address","MyAddress1")}
+      ],
+      minSpareRows: 1
+    });
+
+    function model(opts) {
+      var _pub = {},
+        _priv = $.extend({
+          id: undefined,
+          name: undefined,
+          address: undefined
+        }, opts);
+
+      _pub.attr = function (attr, val) {
+        if (typeof val === 'undefined') {
+          return _priv[attr];
+        }
+        _priv[attr] = val;
+
+        return _pub;
+      };
+
+      return _pub;
+    }
+
+    function createAttrFn(attr,columnName) {
+        columnName = typeof columnName === 'undefined' ? attr : columnName;
+        return function(row,value) {
+          if ( typeof row === 'undefined' ) return columnName;
+          return row.attr(attr, value);
+        }
+    }
+
+    expect(getDataAtCell(1, 1)).toEqual('Frank Honest');
+    setDataAtCell(1, 1, 'Something Else');
+    expect(getDataAtCell(1, 1)).toEqual('Something Else');
+
+    // verify we can reference explicitly named column
+    expect(getDataAtRowProp(1,"MyAddress2","Frank's house"));
+    expect(getDataAtRowProp(1,"MyAddress1","Frank's house"));
+
+    // verify we can reference implicitly named columns (via the property text)
+    expect(getDataAtRowProp(2,'name','Joan Well'));
+    expect(getDataAtRowProp(2,'id',3));
+
+  });
+
+
   it('should accept changes array as 1st param and source as 2nd param', function () {
     var callCount = 0
       , lastSource = '';

--- a/test/jasmine/spec/Core_setDataAtCellSpec.js
+++ b/test/jasmine/spec/Core_setDataAtCellSpec.js
@@ -231,9 +231,9 @@ describe('Core_setDataAtCell', function () {
       startCols: 3,
       colHeaders: ['ID', 'Name', 'Address'],
       columns: [
-        {data: property("id")},
-        {data: property("name")},
-        {data: property("address")}
+        {data: createAttrFn("id")},
+        {data: createAttrFn("name")},
+        {data: createAttrFn("address")}
       ],
       minSpareRows: 1
     });
@@ -258,11 +258,20 @@ describe('Core_setDataAtCell', function () {
       return _pub;
     }
 
-    function property(attr) {
-      return function (row, value) {
-        return row.attr(attr, value);
-      }
+    function createAttrFn(attr,columnName) {
+        columnName = typeof columnName === 'undefined' ? attr : columnName;
+        return function(row,value) {
+          if ( typeof row === 'undefined' ) return columnName;
+          return row.attr(attr, value);
+        }
     }
+
+    // function property(attr) {
+
+    //   return function (row, value) {
+    //     return row.attr(attr, value);
+    //   }
+    // }
 
     expect(getDataAtCell(1, 1)).toEqual('Frank Honest');
     setDataAtCell(1, 1, 'Something Else');

--- a/test/jasmine/spec/SpecHelper.js
+++ b/test/jasmine/spec/SpecHelper.js
@@ -251,6 +251,7 @@ var getCell = handsontableMethodFactory('getCell');
 var getCellMeta = handsontableMethodFactory('getCellMeta');
 var getData = handsontableMethodFactory('getData');
 var getDataAtCell = handsontableMethodFactory('getDataAtCell');
+var getPropertyByKey = handsontableMethodFactory('getPropertyByKey');
 var getDataAtRowProp = handsontableMethodFactory('getDataAtRowProp');
 var getDataAtRow = handsontableMethodFactory('getDataAtRow');
 var getDataAtCol = handsontableMethodFactory('getDataAtCol');


### PR DESCRIPTION
This is a patch to fix a bug that prevents HOT from being able to uniquely lookup columns by the property when the data property is defined as a function (and probably some other instances as well).   The core issue is that HOT creates a lookup table using the defined property and when that property is a function it uses the function's text as the key.  With the functional data source method the user is virtually certain to re-use the same accessor function and this results in collisions.  This problem certainly manifests itself when the user enables  cell validation or sets allowInvalid = false (i.e., it thinks it's editing the wrong column and tries to set the wrong values).

<u>Examples</u>

<a href="http://jsfiddle.net/plaak/vAQKC/17/">Standard functional example</a>
<a href="http://jsfiddle.net/plaak/EsHG3/26/">Backbone example</a> 

You can try out my <a href="http://rawgithub.com/laakmann/jquery-handsontable/master/demo/datasources.html">patched version here</a>

Note: I should add that this requires the user to modify their factory function slightly so that when the returned function is subsequently called without the row parameter being defined (i.e., it's undefined) it will return the field name being get/set by the function or some other string to uniquely identify the column.  

<u>Something like so:</u>

```
function createAttrFn(attr,columnName) {
    columnName = typeof columnName === 'undefined' ? attr : columnName;
    return function(row,value) {
      if ( typeof row === 'undefined' ) return columnName;
      return row.attr(attr, value);
    }
}
```
