### PR TITLE
make double click fillhandle work with data key value pairs

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1143,11 +1143,23 @@ Handsontable.Core = function (rootElement, userSettings) {
       data = datamap.getAll();
       rows : for (r = select[2] + 1; r < instance.countRows(); r++) {
         for (c = select[1]; c <= select[3]; c++) {
+
+        	// data[r] could be an object literal
+        	if (Handsontable.helper.isObject(data[r])) {
+        	  c = Handsontable.helper.getNthKey(data[r], c);
+        	}
+
           if (data[r][c]) {
             break rows;
           }
         }
-        if (!!data[r][select[1] - 1] || !!data[r][select[3] + 1]) {
+        var cells = [select[1] - 1, select[3] + 1];
+        if (Handsontable.helper.isObject(data[r])) {
+          cells[0] = Handsontable.helper.getNthKey(data[r], cells[0]);
+          cells[1] = Handsontable.helper.getNthKey(data[r], cells[1]);
+        }
+
+        if (!!data[r][cells[0]] || !!data[r][cells[1]]) {
           maxR = r;
         }
       }

--- a/src/editorManager.js
+++ b/src/editorManager.js
@@ -318,6 +318,8 @@
     this.setCopyableText = function () {
 
       var selection = instance.getSelected();
+      if (!selection) return;
+
       var settings = instance.getSettings();
       var copyRowsLimit = settings.copyRowsLimit;
       var copyColsLimit = settings.copyColsLimit;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -241,6 +241,22 @@ Handsontable.helper.extendArray = function (arr, extension) {
 };
 
 /**
+ * Get nth object key
+ * @param {Object} obj
+ * @param {Number} n
+ * @return {String} key
+ */
+Handsontable.helper.getNthKey = function(obj, n) {
+  var i = 0;
+  for (var key in obj) {
+    if (!obj.hasOwnProperty(key)) continue;
+    if (n == i) return key;
+    i++;
+  }
+  return null;
+};
+
+/**
  * Returns cell renderer or editor function directly or through lookup map
  */
 Handsontable.helper.getCellMethod = function (methodName, methodFunction) {

--- a/src/renderers/checkboxRenderer.js
+++ b/src/renderers/checkboxRenderer.js
@@ -73,8 +73,6 @@ Handsontable.CheckboxRenderer = function (instance, TD, row, col, prop, value, c
 
     instance.addHook('beforeKeyDown', function(event){
        if(event.keyCode == 32){
-         event.stopImmediatePropagation();
-         event.preventDefault();
 
          var selection = instance.getSelected();
          var cell, checkbox, cellProperties;
@@ -95,6 +93,9 @@ Handsontable.CheckboxRenderer = function (instance, TD, row, col, prop, value, c
              checkbox = cell.querySelectorAll('input[type=checkbox]');
 
              if(checkbox.length > 0 && !cellProperties.readOnly){
+               event.stopImmediatePropagation();
+               event.preventDefault();
+
                for(var i = 0, len = checkbox.length; i < len; i++){
                  checkbox[i].checked = !checkbox[i].checked;
                  $(checkbox[i]).trigger('change');


### PR DESCRIPTION
Double click fillhandle didn't work for data array's in following format because it was only compatible with array indexes.

```
data [
    {
        img: 'imagename.jpg',
        title: 'some title',
    },
    {
        img: 'imagename2.jpg',
        title: 'some title 2',
    }   
]
```
