### PR TITLE
bugfix-#1185: Editor focus after validation stuck on previously invalid cell

### DIFF
--- a/src/editorManager.js
+++ b/src/editorManager.js
@@ -351,6 +351,10 @@
         return;
       }
 
+      if (pendingPrepare){
+        pendingPrepare = false;
+      }
+
       var row = priv.selStart.row();
       var col = priv.selStart.col();
       var prop = instance.colToProp(col);


### PR DESCRIPTION
After failed validation, editor is being prepared as the result of "selectCell" call in "baseEditor -> discardEditor()". This causes "baseEditor -> _closeCallback()" to be reset to empty function but "editorManager -> pendingPrepare" variable is never reset to "false". This lead to unexpected behavior once validation passes again - when going out of editor by selecting different cell (TAB or mouse click), editor focus was still in the previously selected cell, not the one that is visually selected.

Fixed by setting "false" value to "editorManager -> pendingPrepare" if it is set to true and "editorManager -> activeEditor" is not waiting.
