### PR TITLE
add custom column sorting function to column options

### DIFF
--- a/src/plugins/columnSorting.js
+++ b/src/plugins/columnSorting.js
@@ -202,12 +202,16 @@ function HandsontableColumnSorting() {
 
     var colMeta = instance.getCellMeta(0, instance.sortColumn);
     var sortFunction;
-    switch (colMeta.type) {
-      case 'date':
-        sortFunction = dateSort;
-        break;
-      default:
-        sortFunction = defaultSort;
+    if (typeof colMeta.sorter != 'undefined') {
+      sortFunction = colMeta.sorter;
+    } else {
+      switch (colMeta.type) {
+        case 'date':
+          sortFunction = dateSort;
+          break;
+        default:
+          sortFunction = defaultSort;
+      }
     }
 
     this.sortIndex.sort(sortFunction(instance.sortOrder));

--- a/test/jasmine/spec/plugins/columnSortingSpec.js
+++ b/test/jasmine/spec/plugins/columnSortingSpec.js
@@ -903,4 +903,51 @@ describe('ColumnSorting', function () {
     expect(this.$container.find('tbody tr:eq(5) td:eq(1)').text()).toEqual('J');
 
   });
+
+  it("should use column sort function from the column options", function () {
+    var hot = handsontable({
+      data: [
+        [1, 'B'],
+        [0, 'D'],
+        [3, 'A'],
+        [2, 'C']
+      ],
+      columns: [
+        {},
+        {
+          // sort the second column by the reverse inital ordering instead of the data
+          sorter: function(sortOrder) {
+            return function (a, b) {
+              if (a[0] === b[0]) {
+               return 0;
+              }
+              if (a[0] === null) {
+                return 1;
+              }
+              if (b[0] === null) {
+                return -1;
+              }
+              if (a[0] < b[0]) return sortOrder ? 1 : -1;
+              if (a[0] > b[0]) return sortOrder ? -1 : 1;
+              return 0;
+            };
+          }
+        }
+      ],
+      columnSorting: {
+        column: 1
+      }
+    });
+
+    expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('2');
+    expect(this.$container.find('tbody tr:eq(1) td:eq(0)').text()).toEqual('3');
+    expect(this.$container.find('tbody tr:eq(2) td:eq(0)').text()).toEqual('0');
+    expect(this.$container.find('tbody tr:eq(3) td:eq(0)').text()).toEqual('1');
+
+    expect(this.$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('C');
+    expect(this.$container.find('tbody tr:eq(1) td:eq(1)').text()).toEqual('A');
+    expect(this.$container.find('tbody tr:eq(2) td:eq(1)').text()).toEqual('D');
+    expect(this.$container.find('tbody tr:eq(3) td:eq(1)').text()).toEqual('B');
+  });
+
 });


### PR DESCRIPTION
This change adds a new column option 'sorter' that can be used to provide a custom sort function that's used instead of the default when sorting the by that column.

A use case is when a column is an enum style value and the logical sort order of that enum is different from the lexicographical order of the values.

The sort function takes a sortOrder and returns a comparison function that takes two arrays of (row index, cell value) and returns an int (same as the sort function used internally by HandsontableColumnSorting).
