### PR TITLE
add afterGetRowHeader event

### DIFF
--- a/src/css/jquery.handsontable.css
+++ b/src/css/jquery.handsontable.css
@@ -68,14 +68,18 @@
   height: 22px;
   empty-cells: show;
   line-height: 21px;
-  padding: 0 4px 0 4px;
-  /* top, bottom padding different than 0 is handled poorly by FF with HTML5 doctype */
+  padding: 0;
   background-color: #FFF;
   vertical-align: top;
   overflow: hidden;
   outline-width: 0;
   white-space: pre-line;
   /* preserve new line character in cell */
+}
+
+.handsontable td {
+  padding: 0 4px 0 4px;
+  /* top, bottom padding different than 0 is handled poorly by FF with HTML5 doctype */
 }
 
 .handsontable td.htInvalid {
@@ -134,7 +138,7 @@
   background-color: #CCC;
 }
 
-.handsontable thead th .relative {
+.handsontable th .relative {
   position: relative;
   padding: 2px 4px;
 }

--- a/src/pluginHooks.js
+++ b/src/pluginHooks.js
@@ -27,6 +27,7 @@ Handsontable.PluginHookClass = (function () {
       afterValidate: [],
       afterGetCellMeta: [],
       afterGetColHeader: [],
+      afterGetRowHeader: [],
       afterGetColWidth: [],
       afterDestroy: [],
       afterRemoveRow: [],

--- a/src/tableView.js
+++ b/src/tableView.js
@@ -358,16 +358,22 @@ Handsontable.TableView.prototype.scrollViewport = function (coords) {
  * @param TH
  */
 Handsontable.TableView.prototype.appendRowHeader = function (row, TH) {
-  if (row > -1) {
-    this.wt.wtDom.fastInnerHTML(TH, this.instance.getRowHeader(row));
+  var DIV = document.createElement('DIV')
+    , SPAN = document.createElement('SPAN');
+
+  DIV.className = 'relative';
+  SPAN.className = 'colHeader';
+
+  if (row < 0) {
+      this.wt.wtDom.fastInnerText(DIV, '\u00A0');
+  } else {
+      this.wt.wtDom.fastInnerHTML(SPAN, this.instance.getRowHeader(row));
+      DIV.appendChild(SPAN);
   }
-  else {
-    var DIV = document.createElement('DIV');
-    DIV.className = 'relative';
-    this.wt.wtDom.fastInnerText(DIV, '\u00A0');
-    this.wt.wtDom.empty(TH);
-    TH.appendChild(DIV);
-  }
+
+  this.wt.wtDom.empty(TH);
+  TH.appendChild(DIV);
+
   this.instance.PluginHooks.run('afterGetRowHeader', row, TH);
 };
 

--- a/src/tableView.js
+++ b/src/tableView.js
@@ -368,6 +368,7 @@ Handsontable.TableView.prototype.appendRowHeader = function (row, TH) {
     this.wt.wtDom.empty(TH);
     TH.appendChild(DIV);
   }
+  this.instance.PluginHooks.run('afterGetRowHeader', row, TH);
 };
 
 /**


### PR DESCRIPTION
This adds an event to the rowHeader mechanism, similar to the one used for column headers. This is needed to implement row moving.

This PR also adjusts the row header structure to match that of the column header. This way plugins get exactly the same input data to work on from both events.
