### PR TITLE
SelectEditor support for jQuery < 1.8

### DIFF
--- a/src/editors/selectEditor.js
+++ b/src/editors/selectEditor.js
@@ -34,8 +34,11 @@
       }
     }
 
+    // Support for jQuery versions < 1.8 @see http://bugs.jquery.com/ticket/11231
+    var $optionElements = $(optionElements).map(function() {return this.toArray();});
+
     this.select.empty();
-    this.select.append(optionElements);
+    this.select.append($optionElements);
 
   };
 


### PR DESCRIPTION
Fix unusable SelectEditor with a jquery version < 1.8
Source of the bug: http://bugs.jquery.com/ticket/11231, tldr: could not use the jquery .append function with an array prior to version 1.8
