### PR TITLE
FIX [editorManager]: Pass the whole event object to moveSelectionAfteRen...

### DIFF
--- a/dist/jquery.handsontable.css
+++ b/dist/jquery.handsontable.css
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Mon Feb 10 2014 14:15:11 GMT+0100 (CET)
+ * Date: Tue Mar 18 2014 15:13:39 GMT+0900 (JST)
  */
 
 .handsontable {

--- a/dist/jquery.handsontable.full.css
+++ b/dist/jquery.handsontable.full.css
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Mon Feb 10 2014 14:15:11 GMT+0100 (CET)
+ * Date: Tue Mar 18 2014 15:13:39 GMT+0900 (JST)
  */
 
 .handsontable {

--- a/dist/jquery.handsontable.full.js
+++ b/dist/jquery.handsontable.full.js
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Mon Feb 10 2014 14:15:11 GMT+0100 (CET)
+ * Date: Tue Mar 18 2014 15:13:39 GMT+0900 (JST)
  */
 /*jslint white: true, browser: true, plusplus: true, indent: 4, maxerr: 50 */
 
@@ -3002,14 +3002,14 @@ Handsontable.TableView.prototype.maximumVisibleElementHeight = function (top) {
                       that.closeEditorAndSaveChanges(ctrlDown);
                     }
 
-                    moveSelectionAfterEnter(event.shiftKey);
+                    moveSelectionAfterEnter(event);
 
                   } else {
 
                     if (instance.getSettings().enterBeginsEditing){
                       that.openEditor();
                     } else {
-                      moveSelectionAfterEnter(event.shiftKey);
+                      moveSelectionAfterEnter(event);
                     }
 
                   }
@@ -3083,8 +3083,9 @@ Handsontable.TableView.prototype.maximumVisibleElementHeight = function (top) {
         $document.off('keydown.handsontable.' + instance.guid);
       });
 
-      function moveSelectionAfterEnter(shiftKey){
-        var enterMoves = typeof priv.settings.enterMoves === 'function' ? priv.settings.enterMoves(event) : priv.settings.enterMoves;
+      function moveSelectionAfterEnter(evt){
+        var shiftKey = evt.shiftKey;
+        var enterMoves = typeof priv.settings.enterMoves === 'function' ? priv.settings.enterMoves(evt) : priv.settings.enterMoves;
 
         if (shiftKey) {
           selection.transformStart(-enterMoves.row, -enterMoves.col); //move selection up

--- a/dist/jquery.handsontable.js
+++ b/dist/jquery.handsontable.js
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Mon Feb 10 2014 14:15:11 GMT+0100 (CET)
+ * Date: Tue Mar 18 2014 15:13:39 GMT+0900 (JST)
  */
 /*jslint white: true, browser: true, plusplus: true, indent: 4, maxerr: 50 */
 
@@ -3002,14 +3002,14 @@ Handsontable.TableView.prototype.maximumVisibleElementHeight = function (top) {
                       that.closeEditorAndSaveChanges(ctrlDown);
                     }
 
-                    moveSelectionAfterEnter(event.shiftKey);
+                    moveSelectionAfterEnter(event);
 
                   } else {
 
                     if (instance.getSettings().enterBeginsEditing){
                       that.openEditor();
                     } else {
-                      moveSelectionAfterEnter(event.shiftKey);
+                      moveSelectionAfterEnter(event);
                     }
 
                   }
@@ -3083,8 +3083,9 @@ Handsontable.TableView.prototype.maximumVisibleElementHeight = function (top) {
         $document.off('keydown.handsontable.' + instance.guid);
       });
 
-      function moveSelectionAfterEnter(shiftKey){
-        var enterMoves = typeof priv.settings.enterMoves === 'function' ? priv.settings.enterMoves(event) : priv.settings.enterMoves;
+      function moveSelectionAfterEnter(evt){
+        var shiftKey = evt.shiftKey;
+        var enterMoves = typeof priv.settings.enterMoves === 'function' ? priv.settings.enterMoves(evt) : priv.settings.enterMoves;
 
         if (shiftKey) {
           selection.transformStart(-enterMoves.row, -enterMoves.col); //move selection up

--- a/dist_wc/handsontable-table/jquery.handsontable.full.css
+++ b/dist_wc/handsontable-table/jquery.handsontable.full.css
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Mon Feb 10 2014 14:15:11 GMT+0100 (CET)
+ * Date: Tue Mar 18 2014 15:13:39 GMT+0900 (JST)
  */
 
 .handsontable {

--- a/dist_wc/handsontable-table/jquery.handsontable.full.js
+++ b/dist_wc/handsontable-table/jquery.handsontable.full.js
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  * http://handsontable.com/
  *
- * Date: Mon Feb 10 2014 14:15:11 GMT+0100 (CET)
+ * Date: Tue Mar 18 2014 15:13:39 GMT+0900 (JST)
  */
 /*jslint white: true, browser: true, plusplus: true, indent: 4, maxerr: 50 */
 
@@ -3002,14 +3002,14 @@ Handsontable.TableView.prototype.maximumVisibleElementHeight = function (top) {
                       that.closeEditorAndSaveChanges(ctrlDown);
                     }
 
-                    moveSelectionAfterEnter(event.shiftKey);
+                    moveSelectionAfterEnter(event);
 
                   } else {
 
                     if (instance.getSettings().enterBeginsEditing){
                       that.openEditor();
                     } else {
-                      moveSelectionAfterEnter(event.shiftKey);
+                      moveSelectionAfterEnter(event);
                     }
 
                   }
@@ -3083,8 +3083,9 @@ Handsontable.TableView.prototype.maximumVisibleElementHeight = function (top) {
         $document.off('keydown.handsontable.' + instance.guid);
       });
 
-      function moveSelectionAfterEnter(shiftKey){
-        var enterMoves = typeof priv.settings.enterMoves === 'function' ? priv.settings.enterMoves(event) : priv.settings.enterMoves;
+      function moveSelectionAfterEnter(evt){
+        var shiftKey = evt.shiftKey;
+        var enterMoves = typeof priv.settings.enterMoves === 'function' ? priv.settings.enterMoves(evt) : priv.settings.enterMoves;
 
         if (shiftKey) {
           selection.transformStart(-enterMoves.row, -enterMoves.col); //move selection up

--- a/src/editorManager.js
+++ b/src/editorManager.js
@@ -125,14 +125,14 @@
                       that.closeEditorAndSaveChanges(ctrlDown);
                     }
 
-                    moveSelectionAfterEnter(event.shiftKey);
+                    moveSelectionAfterEnter(event);
 
                   } else {
 
                     if (instance.getSettings().enterBeginsEditing){
                       that.openEditor();
                     } else {
-                      moveSelectionAfterEnter(event.shiftKey);
+                      moveSelectionAfterEnter(event);
                     }
 
                   }
@@ -206,8 +206,9 @@
         $document.off('keydown.handsontable.' + instance.guid);
       });
 
-      function moveSelectionAfterEnter(shiftKey){
-        var enterMoves = typeof priv.settings.enterMoves === 'function' ? priv.settings.enterMoves(event) : priv.settings.enterMoves;
+      function moveSelectionAfterEnter(evt){
+        var shiftKey = evt.shiftKey;
+        var enterMoves = typeof priv.settings.enterMoves === 'function' ? priv.settings.enterMoves(evt) : priv.settings.enterMoves;
 
         if (shiftKey) {
           selection.transformStart(-enterMoves.row, -enterMoves.col); //move selection up


### PR DESCRIPTION
IE and Chrome define a window.event variable, but that variable is not in Firefox.
The function `moveSelectionAfterEnter` uses the undefined variable `event`. This is a problem in Firefox.
See this jsfiddle as an example:

http://jsfiddle.net/nhatcher/C5fA4/
