### PR TITLE
+ Add in SelectCell, kev/value functionality

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -71,6 +71,7 @@ module.exports = function (grunt) {
         'src/renderers/numericRenderer.js',
         'src/renderers/passwordRenderer.js',
         'src/renderers/htmlRenderer.js',
+        'src/renderers/selectRenderer.js',
 
         'src/editors/baseEditor.js',
         'src/editors/textEditor.js',

--- a/src/cellTypes.js
+++ b/src/cellTypes.js
@@ -47,6 +47,12 @@ Handsontable.DropdownCell = {
   validator: Handsontable.AutocompleteValidator
 };
 
+Handsontable.SelectCell = {
+    editor: Handsontable.editors.SelectEditor,
+    renderer: Handsontable.renderers.SelectRenderer, 
+    validator: Handsontable.AutocompleteValidator
+};
+
 //here setup the friendly aliases that are used by cellProperties.type
 Handsontable.cellTypes = {
   text: Handsontable.TextCell,
@@ -56,7 +62,8 @@ Handsontable.cellTypes = {
   autocomplete: Handsontable.AutocompleteCell,
   handsontable: Handsontable.HandsontableCell,
   password: Handsontable.PasswordCell,
-  dropdown: Handsontable.DropdownCell
+  dropdown: Handsontable.DropdownCell,
+  select: Handsontable.SelectCell
 };
 
 //here setup the friendly aliases that are used by cellProperties.renderer and cellProperties.editor

--- a/src/editors/selectEditor.js
+++ b/src/editors/selectEditor.js
@@ -14,41 +14,26 @@
 
 
     var selectOptions = this.cellProperties.selectOptions;
+    var selectKey = this.cellProperties.selectKey;
+    var selectText = this.cellProperties.selectText;
     var options;
 
-    if (typeof selectOptions == 'function'){
-      options =  this.prepareOptions(selectOptions(this.row, this.col, this.prop))
+    if (typeof selectOptions == 'function') {
+        options = selectOptions(this.row, this.col, this.prop);
     } else {
-      options =  this.prepareOptions(selectOptions);
+        options = selectOptions;
     }
 
     Handsontable.Dom.empty(this.select);
 
-    for (var option in options){
-      if (options.hasOwnProperty(option)){
-        var optionElement = document.createElement('OPTION');
-        optionElement.value = option;
-        Handsontable.Dom.fastInnerHTML(optionElement, options[option]);
-        this.select.appendChild(optionElement);
-      }
+    if(options !== undefined && options.length !== undefined){
+        for (var i = 0; i < options.length; i++){      
+            var optionElement = document.createElement('OPTION');
+            optionElement.value = selectKey !== undefined ? options[i][selectKey] : options[i];
+            Handsontable.Dom.fastInnerHTML(optionElement, selectText !== undefined ? options[i][selectText] : options[i]);
+            this.select.appendChild(optionElement);      
+        }
     }
-  };
-
-  SelectEditor.prototype.prepareOptions = function(optionsToPrepare){
-
-    var preparedOptions = {};
-
-    if (Handsontable.helper.isArray(optionsToPrepare)){
-      for(var i = 0, len = optionsToPrepare.length; i < len; i++){
-        preparedOptions[optionsToPrepare[i]] = optionsToPrepare[i];
-      }
-    }
-    else if (typeof optionsToPrepare == 'object') {
-      preparedOptions = optionsToPrepare;
-    }
-
-    return preparedOptions;
-
   };
 
   SelectEditor.prototype.getValue = function () {

--- a/src/renderers/selectRenderer.js
+++ b/src/renderers/selectRenderer.js
@@ -1,0 +1,24 @@
+(function(Handosntable){
+
+  'use strict';
+
+  var SelectRenderer = function (instance, TD, row, col, prop, value, cellProperties) {
+        if (!(value == null || value == "")){
+            var txtValue = value;
+
+            for (var i = 0; i < cellProperties.selectOptions.length; i++) {
+                if (cellProperties.selectOptions[i][cellProperties.selectKey] == value) {
+                    txtValue = cellProperties.selectOptions[i][cellProperties.selectText];
+                    break;
+                }
+            }
+        }
+        
+        Handsontable.renderers.TextRenderer(instance, TD, row, col, prop, txtValue, cellProperties);
+  };
+
+  Handosntable.SelectRenderer = SelectRenderer;
+  Handosntable.renderers.SelectRenderer = SelectRenderer;
+  Handosntable.renderers.registerRenderer('select', SelectRenderer);
+
+})(Handsontable);

--- a/test/jasmine/SpecRunner.html
+++ b/test/jasmine/SpecRunner.html
@@ -174,6 +174,8 @@
   
   <script src="spec/validators/numericValidatorSpec.js"></script>
   
+  <script src="../../src/plugins/dragToScroll/test/dragToScroll.spec.js"></script>
+  
 
 
   <script src="lib/jasmine/reporter.js"></script>

--- a/test/jasmine/spec/editors/selectEditorSpec.js
+++ b/test/jasmine/spec/editors/selectEditorSpec.js
@@ -71,17 +71,19 @@ describe('selectEditor', function () {
   });
 
   it("should populate select with given options (object)", function () {
-    var options = {
-      'mit' : 'Misubishi',
-      'che' : 'Chevrolet',
-      'lam' : 'Lamborgini'
-    };
+    var options = [
+      {key:'mit', value:'Misubishi'},
+      {key:'che', value:'Chevrolet'},
+      {key:'lam', value:'Lamborgini'}
+    ];
 
     handsontable({
       columns: [
         {
           editor: 'select',
-          selectOptions: options
+          selectOptions: options,
+		  selectKey:"key",
+		  selectText:"value"
         }
       ]
     });
@@ -137,18 +139,20 @@ describe('selectEditor', function () {
 
   it("should populate select with given options (function:object)", function () {
     var options = function () {
-      return {
-        'mit' : 'Misubishi',
-        'che' : 'Chevrolet',
-        'lam' : 'Lamborgini'
-      }
+      return [
+      {key:'mit', value:'Misubishi'},
+      {key:'che', value:'Chevrolet'},
+      {key:'lam', value:'Lamborgini'}
+	  ];
     };
 
     handsontable({
       columns: [
         {
           editor: 'select',
-          selectOptions: options
+          selectOptions: options,
+		  selectKey:"key",
+		  selectText:"value"
         }
       ]
     });


### PR DESCRIPTION
Changes in SelectEditor, fixes undesirable sort by key, added key/value properties.

Main reason for this change is re-sorting SelectEditor items by key (id).
E.g. { 1:"Basic", 3:"C", 6:"C#", 5:"Java", 2:"Pascal", 4:"Python" } (sorted by name) 
becomes [Basic, Pascal, C, Python, Java, C#] (sorted by id/year).

Another reason is reusability. Developer can reuse object and specify key/value properties.
E.g. 
var langs = [
{id:1, year:1964, name:"Basic"},
{id:3, year:1972, name:"C"},
{id:6, year:2000, name:"C#"},
{id:5, year:1995, name:"Java"},
{id:2, year:1970, name:"Pascal"},
{id:4, year:1991, name:"Python"}
];
handsontable({
  columns: [{
      editor: 'select',
      selectOptions: langs,
      selectKey:"id",
      selectText:"name"
    }]
});

This way, elements will not be sorted again by id, backend is in charge for sorting!

In HOT documentation http://handsontable.com/demo/selectEditor.html, only array is officially supported. This change also supports arrays.There is no backward compatibility issues.
