### PR TITLE
Fix unintentional fallthrough

### DIFF
--- a/src/editors/textEditor.js
+++ b/src/editors/textEditor.js
@@ -68,8 +68,8 @@
       case keyCodes.V:
         if(ctrlDown){
           event.stopImmediatePropagation(); //CTRL+A, CTRL+C, CTRL+V, CTRL+X should only work locally when cell is edited (not in table context)
-          break;
         }
+        break;
       case keyCodes.BACKSPACE:
       case keyCodes.DELETE:
       case keyCodes.HOME:


### PR DESCRIPTION
If you type A, X, C or V and ctrl is not down then the case was walling through to the same handler as BACKPACE, DELETE, HOME, and END. Fixed this issue.
