### PR TITLE
Fix unintentional fallthrough

### DIFF
--- a/src/editorManager.js
+++ b/src/editorManager.js
@@ -46,8 +46,8 @@
 
                     event.preventDefault();
                     event.stopPropagation();
-                    break;
                   }
+                  break;
 
                 case keyCodes.ARROW_UP:
 


### PR DESCRIPTION
If you type A and ctrl is not down then the case was walling through to the same handler as ARROW_UP. Fixed this issue.
