### PR TITLE
Bug fix when copy cell (carriage return).

### DIFF
--- a/src/3rdparty/sheetclip.js
+++ b/src/3rdparty/sheetclip.js
@@ -79,7 +79,9 @@
             str += val;
           }
         }
-        str += '\n';
+        if (arr.length > 1 && r < rlen) {
+          str += '\n';
+        }
       }
       return str;
     }

--- a/test/jasmine/spec/plugins/copyPasteSpec.js
+++ b/test/jasmine/spec/plugins/copyPasteSpec.js
@@ -116,7 +116,7 @@ describe('CopyPaste plugin', function () {
       selectCell(0, 0);
       keyDownUp(Handsontable.helper.keyCode.CONTROL_LEFT);
 
-      expect(copyPasteTextarea.val()).toEqual('A0\n');
+      expect(copyPasteTextarea.val()).toEqual('A0');
 
     });
 
@@ -132,7 +132,7 @@ describe('CopyPaste plugin', function () {
       selectCell(0, 0);
       keyDownUp(Handsontable.helper.keyCode.COMMAND_LEFT);
 
-      expect(copyPasteTextarea.val()).toEqual('A0\n');
+      expect(copyPasteTextarea.val()).toEqual('A0');
 
     });
 
@@ -148,7 +148,7 @@ describe('CopyPaste plugin', function () {
       selectCell(0, 0);
       keyDownUp(Handsontable.helper.keyCode.COMMAND_RIGHT);
 
-      expect(copyPasteTextarea.val()).toEqual('A0\n');
+      expect(copyPasteTextarea.val()).toEqual('A0');
 
     });
 

--- a/test/jasmine/spec/settings/copyableSpec.js
+++ b/test/jasmine/spec/settings/copyableSpec.js
@@ -29,7 +29,7 @@ describe('settings', function () {
         ]
       });
 
-      expect(getCopyableData(0, 0, 0, 2)).toMatch('Joe\t\tJack\n');
+      expect(getCopyableData(0, 0, 0, 2)).toMatch('Joe\t\tJack');
     });
 
     it("with copyable=true, CTRL+C should copy the password value", function () {
@@ -50,7 +50,7 @@ describe('settings', function () {
         ]
       });
 
-      expect(getCopyableData(0, 0, 0, 2)).toMatch('Joe\tSecret\tJack\n');
+      expect(getCopyableData(0, 0, 0, 2)).toMatch('Joe\tSecret\tJack');
     });
 
     it("with copyable=false, CTRL+C should NOT copy the password value", function () {
@@ -71,7 +71,7 @@ describe('settings', function () {
         ]
       });
 
-      expect(getCopyableData(0, 0, 0, 2)).toMatch('Joe\t\tJack\n');
+      expect(getCopyableData(0, 0, 0, 2)).toMatch('Joe\t\tJack');
     });
 
   });


### PR DESCRIPTION
Bug fix:
- When copying the cell to notepad was added carriage return.

Example:
http://jsfiddle.net/dixso/YrGrV/4/
