### PR TITLE
make sure context menu is above the table after the table was rendered

### DIFF
--- a/src/css/jquery.handsontable.css
+++ b/src/css/jquery.handsontable.css
@@ -478,6 +478,7 @@ ul.context-menu-list li {
 .htContextMenu {
   display: none;
   position: absolute;
+  z-index: 1000;
 }
 
 .htContextMenu .ht_clone_top,


### PR DESCRIPTION
I have tried most of the show case of handsontable on your website and I cannot find the bug. However, I found the bug in my situation. I pretty much used the example of your backbone.js integration example. The only difference is that I have a data backend hence the handsontable rendering happens multiple times after its initial setup. Then I have this ugly bug ( https://www.dropbox.com/s/5ozycqm6tlbptit/bug.png ). The bug is reproducible in IE 8, Latest Chrome and Firefox 23. The way to fix it is to add a big enough z-indx to htContextMenu.

I am sorry that I don't know how to write a test case for this visual bug.
