### PR TITLE
Fix fillHandle bug.

### DIFF
--- a/src/plugins/autofill.js
+++ b/src/plugins/autofill.js
@@ -20,7 +20,7 @@
       wtOnCellMouseOver;
 
     $(this.instance.$table).off('mouseup.' + instance.guid).on('mouseup.' + instance.guid, function (event) {
-      if (instance.autofill.handle && instance.autofill.handle.isDragged) {
+      if (instance.autofill && instance.autofill.handle && instance.autofill.handle.isDragged) {
         if (instance.autofill.handle.isDragged > 1) {
           instance.autofill.apply();
         }


### PR DESCRIPTION
When fillHandle setting is disabled, clicking on table cells caused `Uncaught TypeError: Cannot read property 'handle' of undefined`. There was a missing `instance.autofill` check in autofill plugin.
