### PR TITLE
Handsontable breaks copy-pasting text into a contentEditable DIV - This is a fix for this

### DIFF
--- a/src/3rdparty/copypaste.js
+++ b/src/3rdparty/copypaste.js
@@ -81,7 +81,7 @@ CopyPasteClass.prototype.init = function () {
     }
 
     if (isCtrlDown) {
-      if (document.activeElement !== that.elTextarea && (that.getSelectionText() != '' || ['INPUT', 'SELECT', 'TEXTAREA'].indexOf(document.activeElement.nodeName) != -1)) {
+      if (document.activeElement !== that.elTextarea && (that.getSelectionText() != '' || ['INPUT', 'SELECT', 'TEXTAREA'].indexOf(document.activeElement.nodeName) != -1 || $(document.activeElement).prop('contentEditable') === "true")) {
         return; //this is needed by fragmentSelection in Handsontable. Ignore copypaste.js behavior if fragment of cell text is selected
       }
 


### PR DESCRIPTION
If there is a contentEditable DIV and a hansontable on the same page, I can't copy-paste anything into the DIV because handsontable removes the focus from the DIV when pressing the ctrl-key. See the following fiddle for a demonstration: http://jsfiddle.net/mruoss/y5969sbk/1/

This commit adds a check for the contentEditable flag in order to prevent further processing of the keydown event.
