### PR TITLE
bugfix: Ctrl-A throws error when no selection (#1800)

### DIFF
--- a/src/plugins/copyPaste.js
+++ b/src/plugins/copyPaste.js
@@ -46,20 +46,21 @@
     };
 
     function onBeforeKeyDown (event) {
-      if (Handsontable.helper.isCtrlKey(event.keyCode) && instance.getSelected()) {
-        //when CTRL is pressed, prepare selectable text in textarea
-        //http://stackoverflow.com/questions/3902635/how-does-one-capture-a-macs-command-key-via-javascript
-        plugin.setCopyableText();
-        event.stopImmediatePropagation();
-        return;
+      if (instance.getSelected()) {
+        if (Handsontable.helper.isCtrlKey(event.keyCode)) {
+          //when CTRL is pressed, prepare selectable text in textarea
+          //http://stackoverflow.com/questions/3902635/how-does-one-capture-a-macs-command-key-via-javascript
+          plugin.setCopyableText();
+          event.stopImmediatePropagation();
+          return;
+        }
+
+        var ctrlDown = (event.ctrlKey || event.metaKey) && !event.altKey; //catch CTRL but not right ALT (which in some systems triggers ALT+CTRL)
+
+        if (event.keyCode == Handsontable.helper.keyCode.A && ctrlDown) {
+          instance._registerTimeout(setTimeout(Handsontable.helper.proxy(plugin.setCopyableText, plugin), 0));
+        }
       }
-
-      var ctrlDown = (event.ctrlKey || event.metaKey) && !event.altKey; //catch CTRL but not right ALT (which in some systems triggers ALT+CTRL)
-
-      if (event.keyCode == Handsontable.helper.keyCode.A && ctrlDown) {
-        instance._registerTimeout(setTimeout(Handsontable.helper.proxy(plugin.setCopyableText, plugin), 0));
-      }
-
     }
 
     this.destroy = function () {


### PR DESCRIPTION
The problem was occuring when the table had no selected cell, therefore we can't see it as not selected.
Another way to solve this issue is to unsubscribe the keydown event when the user focus somewhere else but this is the better way to keep it simple.

Tested on Firefox 32, IE 9 and Chrome 37
