### PR TITLE
bugfix: autocomplete non case sensitive filtering #1799

### DIFF
--- a/src/editors/autocompleteEditor.js
+++ b/src/editors/autocompleteEditor.js
@@ -164,12 +164,15 @@
     var indexOfValue;
     var charsLeft;
 
+    var caseSensitive = this.cellProperties.filteringCaseSensitive;
+    var searchedValue = caseSensitive ? this.getValue() : this.getValue().toLowerCase();
 
     for(var i = 0, len = this.choices.length; i < len; i++){
       currentItem = this.choices[i];
 
       if(valueLength > 0){
-        indexOfValue = currentItem.indexOf(this.getValue())
+        var comparedItem = caseSensitive ? currentItem : currentItem.toLowerCase();
+        indexOfValue = comparedItem.indexOf(searchedValue);
       } else {
         indexOfValue = currentItem === this.getValue() ? 0 : -1;
       }


### PR DESCRIPTION
When using strict = true, autocomplete hightlight an element but don't select it on enter key.
It is working with autocomplete based on array but not with Ajax.

To test it you can use the 3rd example of the autocomplete demo :
On the first column input "peu" Peugeot will be highlighted but not selected before the fix.
