### PR TITLE
Fix for issue #1796

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -3,7 +3,7 @@
  * It is recommended for Handsontable plugins and renderers, because it is much faster than jQuery
  * @type {Object}
  */
-if(!window.Handsontable) {
+if(typeof Handsontable === 'undefined') {
   var Handsontable = {}; //required because Walkontable test suite uses this class directly
 }
 Handsontable.Dom = {};


### PR DESCRIPTION
Checking whether window.Handsontable is defined will overwrite the "Handsontable" variable when including handsontable with commonjs.
