### PR TITLE
Handsontable.Dom.fastInnerHTML can accept DOM elements

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -365,7 +365,13 @@ Handsontable.Dom.HTML_CHARACTERS = /(<(.*)>|&(.*);)/;
  * @return {void}
  */
 Handsontable.Dom.fastInnerHTML = function (element, content) {
-  if (this.HTML_CHARACTERS.test(content)) {
+  if (content instanceof HTMLElement) {
+    while(element.firstChild){
+	element.removeChild(element.firstChild);
+    }
+    element.appendChild(content);
+  }
+  else if (this.HTML_CHARACTERS.test(content)) {
     element.innerHTML = content;
   }
   else {


### PR DESCRIPTION
When rendering HTML cells, I sometimes want to send the actual DOM element instead of "raw HTML".
This is particularly important to implement rich-html colHeaders. Simple example:

       var columnNames = ['foo', 'bar'];
        $("#table").handsontable({
            colHeaders: function(col) {
	      var $span = $('<span style="color:red;">');
	      $span.text(columnNames[col]);
	      return $span[0];
	    },
            ...
        });

For this example, the current implementation displays the string "[object HTMLSpanElement]" on the column title. After the changes, the title is show in red as expected.

Yes, I know that this example is simple enough that the current implementation is enough, but I'm working on more complex stuff where it will be needed (I'll need TeX formulas in column headers)