### PR TITLE
Enabling row menus when 1 row exists (#1853)

### DIFF
--- a/src/plugins/contextMenu.js
+++ b/src/plugins/contextMenu.js
@@ -85,7 +85,7 @@
               entireColumnSelection = [0, selected[1], this.view.wt.wtTable.getRowStrategy().cellCount - 1, selected[1]],
               columnSelected = entireColumnSelection.join(',') == selected.join(',');
 
-            return selected[0] < 0 || this.countRows() >= this.getSettings().maxRows || columnSelected;
+            return selected[0] < 0 || this.countRows() >= this.getSettings().maxRows || (columnSelected && this.countRows() > 1);
           }
         },
         {
@@ -99,7 +99,7 @@
               entireColumnSelection = [0, selected[1], this.view.wt.wtTable.getRowStrategy().cellCount - 1, selected[1]],
               columnSelected = entireColumnSelection.join(',') == selected.join(',');
 
-            return this.getSelected()[0] < 0 || this.countRows() >= this.getSettings().maxRows || columnSelected;
+            return this.getSelected()[0] < 0 || this.countRows() >= this.getSettings().maxRows || (columnSelected && this.countRows() > 1);
           }
         },
         ContextMenu.SEPARATOR,


### PR DESCRIPTION
Updating the context menus for adding and removing rows such that they still appear enabled when only one row exists (#1853)
