### PR TITLE
fix instance.dataType checker inside loadData()

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1022,7 +1022,7 @@ Handsontable.Core = function (rootElement, userSettings) {
     priv.isPopulated = false;
     GridSettings.prototype.data = data;
 
-    if (priv.settings.dataSchema instanceof Array || data[0]  instanceof Array) {
+    if (Handsontable.helper.isArray(priv.settings.dataSchema) || Handsontable.helper.isArray(data[0])) {
       instance.dataType = 'array';
     }
     else if (typeof priv.settings.dataSchema === 'function') {


### PR DESCRIPTION
Inside loadData, the "instanceof" checker was being used to set the instance.dataType property to either 'obj' or 'array'. Unfortunately, this breaks when a pseudoclassical constructor builds an instantiation settings object with a data property that is an array. Instanceof will instead register the data property as an object, breaking the table in some instances. 

Array.isArray is instead better able to accurately note the type of the data property. I've used the provided polyfill/shim helper Handsontable.helper.isArray already found in the code base. 

The bug that I'm referring to cant be reproduced in a jsfiddle. alert(constructed.data instanceof array) correctly alerts true, even though it is definitely being incorrectly noted as an array inside handsontable. The exact point of break I was finding in my own project was in src/core 1742, which did not like that my data array was being noted as instance.dataType === 'obj'. The jsfiddle table doesnt break, but this is definitely the bug breaking it in my project. The instanceof being a poor type checker is the problem. 

src/core 1025 now: 
if (Handsontable.helper.isArray(priv.settings.dataSchema) || Handsontable.helper.isArray(data[0])) {

src/core 1025 formerly:
if (priv.settings.dataSchema instanceof Array || data[0]  instanceof Array) {
