### PR TITLE
Custom menu and submenu width via option settings

### DIFF
--- a/src/plugins/contextMenu.js
+++ b/src/plugins/contextMenu.js
@@ -781,7 +781,7 @@
     function openSubMenu(instance, contextMenu, cell, row) {
       var selectedItem = instance.getData()[row];
       var items = contextMenu.getItems(selectedItem.submenu);
-      var width = selectedItem.submenu.width || defaultOptions.width;
+      var width = selectedItem.submenu.width || this.defaultOptions.width;
       var subMenu = contextMenu.createMenu(selectedItem.name, row);
       var coords = cell.getBoundingClientRect();
 

--- a/src/plugins/contextMenu.js
+++ b/src/plugins/contextMenu.js
@@ -416,7 +416,7 @@
       }
       var menu = this.createMenu();
       var items = this.getItems(settings.contextMenu);
-      var width = settings.contextMenu.width || defaultOptions.width;
+      var width = settings.contextMenu.width || this.defaultOptions.width;
 
       this.show(menu, items, width);
       this.setMenuPosition(event, menu);
@@ -620,7 +620,7 @@
     if (TD.className.indexOf('htSubmenu') != -1) {
       var selectedItem = hot.getData()[coords.row];
       var items = this.getItems(selectedItem.submenu);
-      var width = selectedItem.submenu.width || defaultOptions.width;
+      var width = selectedItem.submenu.width || this.defaultOptions.width;
 
       var subMenu = this.createMenu(selectedItem.name, coords.row);
       var tdCoords = TD.getBoundingClientRect();

--- a/src/plugins/contextMenu.js
+++ b/src/plugins/contextMenu.js
@@ -73,6 +73,7 @@
     });
 
     this.defaultOptions = {
+      width: 200,
       items: [
         {
           key: 'row_above',
@@ -415,8 +416,9 @@
       }
       var menu = this.createMenu();
       var items = this.getItems(settings.contextMenu);
+      var width = settings.contextMenu.width || defaultOptions.width;
 
-      this.show(menu, items);
+      this.show(menu, items, width);
       this.setMenuPosition(event, menu);
 
       $(document).on('mousedown.htContextMenu', Handsontable.helper.proxy(ContextMenu.prototype.closeAll, this));
@@ -471,7 +473,7 @@
     $(document).off('mousedown.htContextMenu');
   };
 
-  ContextMenu.prototype.show = function (menu, items) {
+  ContextMenu.prototype.show = function (menu, items, width) {
     menu.removeAttribute('style');
     menu.style.display = 'block';
 
@@ -485,7 +487,7 @@
     $(menu).handsontable({
       data: items,
       colHeaders: false,
-      colWidths: [200],
+      colWidths: [width],
       readOnly: true,
       copyPaste: false,
       columns: [
@@ -618,11 +620,12 @@
     if (TD.className.indexOf('htSubmenu') != -1) {
       var selectedItem = hot.getData()[coords.row];
       var items = this.getItems(selectedItem.submenu);
+      var width = selectedItem.submenu.width || defaultOptions.width;
 
       var subMenu = this.createMenu(selectedItem.name, coords.row);
       var tdCoords = TD.getBoundingClientRect();
 
-      this.show(subMenu, items);
+      this.show(subMenu, items, width);
       this.setSubMenuPosition(tdCoords, subMenu);
 
     }
@@ -778,10 +781,11 @@
     function openSubMenu(instance, contextMenu, cell, row) {
       var selectedItem = instance.getData()[row];
       var items = contextMenu.getItems(selectedItem.submenu);
+      var width = selectedItem.submenu.width || defaultOptions.width;
       var subMenu = contextMenu.createMenu(selectedItem.name, row);
       var coords = cell.getBoundingClientRect();
 
-      contextMenu.show(subMenu, items);
+      contextMenu.show(subMenu, items, width);
       contextMenu.setSubMenuPosition(coords, subMenu);
       var subMenuInstance = $(subMenu).handsontable('getInstance');
       subMenuInstance.selectCell(0, 0);

--- a/test/jasmine/spec/plugins/contextMenuSpec.js
+++ b/test/jasmine/spec/plugins/contextMenuSpec.js
@@ -2209,5 +2209,100 @@ describe('ContextMenu', function () {
       Handsontable.hooks.remove('afterContextMenuDefaultOptions', afterContextMenuDefaultOptions);
     });
   });
+  
+  describe("custom contextmenu width", function () {
+    it("should open menu and submenu with default width", function () {
+      var hot = handsontable({
+        contextMenu: true
+      });
+
+      expect(hot.contextMenu).toBeDefined();
+
+      expect($('.htContextMenu').is(':visible')).toBe(false);
+
+      contextMenu();
+
+      expect($('.htContextMenu').is(':visible')).toBe(true);
+      expect($('.htContextMenu').width()).toBe(200);
+
+    });
+
+    it("should open menu with custom width and submenu with default width", function () {
+      var hot = handsontable({
+        contextMenu: {
+          width: 400,
+          items: {
+            "test": {
+              name: "test",
+              submenu : {
+                items: {
+                  "sub": {
+                    name: "sub"
+                  }
+                }
+              }
+            }
+          }
+        }
+      });
+
+      expect(hot.contextMenu).toBeDefined();
+      expect($('.htContextMenu').is(':visible')).toBe(false);
+      contextMenu();
+      expect($('.htContextMenu').is(':visible')).toBe(true);
+      expect($('.htContextMenu').width()).toBe(400);
+
+      var item = $('.htContextMenu .ht_master .htCore').find('tbody td').not('.htSeparator').eq(0);
+      item.trigger('mouseover');
+
+      expect(item.text()).toBe('test');
+      expect(item.hasClass('htSubmenu')).toBe(true);
+
+      var contextSubMenu = $('.htContextSubMenu_' + item.text());
+
+      expect(contextSubMenu.length).toEqual(1);
+      expect(contextSubMenu.width()).toBe(200);
+
+    });
+    
+    it("should open menu and submenu with custom width", function () {
+      var hot = handsontable({
+        contextMenu: {
+          width: 400,
+          items: {
+            "test": {
+              name: "test",
+              submenu : {
+                width: 100,
+                items: {
+                  "sub": {
+                    name: "sub"
+                  }
+                }
+              }
+            }
+          }
+        }
+      });
+
+      expect(hot.contextMenu).toBeDefined();
+      expect($('.htContextMenu').is(':visible')).toBe(false);
+      contextMenu();
+      expect($('.htContextMenu').is(':visible')).toBe(true);
+      expect($('.htContextMenu').width()).toBe(400);
+
+      var item = $('.htContextMenu .ht_master .htCore').find('tbody td').not('.htSeparator').eq(0);
+      item.trigger('mouseover');
+
+      expect(item.text()).toBe('test');
+      expect(item.hasClass('htSubmenu')).toBe(true);
+
+      var contextSubMenu = $('.htContextSubMenu_' + item.text());
+
+      expect(contextSubMenu.length).toEqual(1);
+      expect(contextSubMenu.width()).toBe(100);
+
+    });
+  });
 
 });


### PR DESCRIPTION
Replace the static 200px width with additional "width"-options for contextmenu and submenu.
The default width is set to 200px in the defaultOptions.

Usage:

```
contexrmenu: {
  width: Number, 
  items: {
    "menu-item": {
       ...
      submenu: {
        width: Number
      }
   }
}
```

or omit width-option to use defaults.
