### PR TITLE
non-string-datatypes

### DIFF
--- a/src/editors/baseEditor.js
+++ b/src/editors/baseEditor.js
@@ -106,10 +106,11 @@
     this.instance.view.render();
 
     this.state = Handsontable.EditorState.EDITING;
+    //initialValue = initialValue === undefined ? initialValue : this.originalValue;
+    //initialValue = typeof initialValue == 'string' ? initialValue : this.originalValue;
+    initialValue = (typeof initialValue !== "undefined" && initialValue !== null) ? initialValue : this.originalValue;
 
-    initialValue = typeof initialValue == 'string' ? initialValue : this.originalValue;
-
-    this.setValue(Handsontable.helper.stringify(initialValue));
+    this.setValue(initialValue);
 
     this.open();
     this._opened = true;

--- a/src/editors/textEditor.js
+++ b/src/editors/textEditor.js
@@ -60,10 +60,10 @@
         var isMultipleSelection = !(selected[0] === selected[2] && selected[1] === selected[3]);
         if ((ctrlDown && !isMultipleSelection) || event.altKey) { //if ctrl+enter or alt+enter, add new line
           if(that.isOpened()){
-            that.setValue(that.getValue() + '\n');
+            that.setValue(typeof that.getValue() === string ? that.getValue() + '\n' : that.getValue());
             that.focus();
           } else {
-            that.beginEditing(that.originalValue + '\n')
+            that.beginEditing(typeof that.originalValue === string ? that.originalValue + '\n' : that.originalValue);
           }
           event.stopImmediatePropagation();
         }

--- a/src/plugins/autoColumnSize.js
+++ b/src/plugins/autoColumnSize.js
@@ -60,8 +60,9 @@
       var samples = {};
       var maxLen = 0;
       for (var r = 0; r < rows; r++) {
-        var value = Handsontable.helper.stringify(instance.getDataAtCell(r, col));
-        var len = value.length;
+        var strValue = Handsontable.helper.stringify(instance.getDataAtCell(r, col));
+        var value = instance.getDataAtCell(r, col);
+        var len = strValue.length;
         if (len > maxLen) {
           maxLen = len;
         }


### PR DESCRIPTION
Hey guys,

We´re using Handsontable with complex datatypes (for example, storing multiple selections/Images or a Address validated by Google)

We´ve made 3 changes that might benefit the project as a whole (I´ll split them into 3 pull requests; the current issue in bold)
- **(non-string-datatypes)** There are some instances where non-string datatypes get converted into strings (even when using Renderers, the renderers get strings like "[object Object]")
- (autocorrecting-validators) We modified Validators to be able to correct inputs (like converting date-strings into dates). If the output isn´t boolean, the output of the validator corrects/overwrites the current value
- (copyRenderer) When displaying complex datatypes, using a Renderer works well, however when using copy&paste that fails, so we added a copyRender to be specified in the column.

This allows us to for example store a data as a date object and have it displayed in the format we want. Our other uses include arrays of values and images and geolocation.

The autocorrecting Validators are used like normal ones, but instead of returning true or false, they also can return a value.

The copyRenderer is used like this (in this example, a array of Images is converted into a comma separated list of the images URLs):

``` coffeescript
@columns.push
    data: "name"
    renderer: someRenderer
    copyRenderer:  (cellProperties, value) -> 
            res = []
            if isArray value
                for file in value
                    res.push file.url
            res.join(", ")
```

Do you guys think that would be beneficial for the project in general?

Thanks so much to the Handsontable team and contributors, you´re doing great work! Happy holidays!
