### PR TITLE
autocorrecting-validators

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -748,7 +748,8 @@ Handsontable.Core = function (rootElement, userSettings) {
           instance.validateCell(changes[i][3], cellProperties, (function (i, cellProperties) {
             return function (result) {
               if (typeof result !== 'boolean') {
-                throw new Error("Validation error: result is not boolean");
+                //If the result isn´t boolean, take the returned value as the corrected one
+                changes[i][3] = result;
               }
               if (result === false && cellProperties.allowInvalid === false) {
                 changes.splice(i, 1);         // cancel the change


### PR DESCRIPTION
Hey guys,

We´re using Handsontable with complex datatypes (for example, storing multiple selections/Images or a Address validated by Google)

We´ve made 3 changes that might benefit the project as a whole (I´ll split them into 3 pull requests; the current issue in bold)
-  (non-string-datatypes) There are some instances where non-string datatypes get converted into strings (even when using Renderers, the renderers get strings like "[object Object]")
-  **(autocorrecting-validators)** We modified Validators to be able to correct inputs (like converting date-strings into dates). If the output isn´t boolean, the output of the validator corrects/overwrites the current value
-  (copyRenderer) When displaying complex datatypes, using a Renderer works well, however when using copy&paste that fails, so we added a copyRender to be specified in the column.

This allows us to for example store a data as a date object and have it displayed in the format we want. Our other uses include arrays of values and images and geolocation.

The autocorrecting Validators are used like normal ones, but instead of returning true or false, they also can return a value.

The copyRenderer is used like this (in this example, a array of Images is converted into a comma separated list of the images URLs):

``` coffeescript
@columns.push
    data: "name"
    renderer: someRenderer
    copyRenderer:  (cellProperties, value) -> 
            res = []
            if isArray value
                for file in value
                    res.push file.url
            res.join(", ")
```

Do you guys think that would be beneficial for the project in general?

Thanks so much to the Handsontable team and contributors, you´re doing great work! Happy holidays!
