### PR TITLE
Ignore prototype properties when iterating over settings

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1210,8 +1210,10 @@ Handsontable.Core = function (rootElement, userSettings) {
 
     if (typeof settings.cell !== 'undefined') {
       for(i in settings.cell) {
-        var cell = settings.cell[i];
-        instance.setCellMetaObject(cell.row, cell.col, cell);
+        if (settings.cell.hasOwnProperty(i)) {
+          var cell = settings.cell[i];
+          instance.setCellMetaObject(cell.row, cell.col, cell);
+        }
       }
     }
 


### PR DESCRIPTION
quick bugfix to avoid including inherited variables when iterating over settings which caused HOT to crash during load.
