### PR TITLE
Set null on empty 'checkbox' type cell

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -658,7 +658,7 @@ Handsontable.Core = function (rootElement, userSettings) {
       for (r = topLeft.row; r <= bottomRight.row; r++) {
         for (c = topLeft.col; c <= bottomRight.col; c++) {
           if (!instance.getCellMeta(r, c).readOnly) {
-            changes.push([r, c, '']);
+            changes.push([r, c, instance.getCellMeta(r, c).type === 'checkbox' ? null : '']);
           }
         }
       }


### PR DESCRIPTION
Fix issue on backspace 'checkbox' type cell. See [video](https://drive.google.com/file/d/0B3qx7vYOOTkUN2drR18wYUtDU1k/view?usp=sharing)
