### PR TITLE
Apply cellDecorator for CheckboxRenderer. Set opacity for readOnly checkbox

### DIFF
--- a/src/css/handsontable.css
+++ b/src/css/handsontable.css
@@ -384,6 +384,10 @@ AutocompleteRenderer down arrow
 CheckboxRenderer
 */
 
+.handsontable .htDimmed .htCheckboxRendererInput {
+  opacity: 0.5;
+}
+
 .handsontable .htCheckboxRendererInput.noValue {
   opacity: 0.5;
 }

--- a/src/renderers/checkboxRenderer.js
+++ b/src/renderers/checkboxRenderer.js
@@ -19,6 +19,8 @@
 
   var CheckboxRenderer = function (instance, TD, row, col, prop, value, cellProperties) {
 
+    Handsontable.renderers.cellDecorator.apply(this, arguments);
+
     var eventManager = Handsontable.eventManager(instance);
 
     if (typeof cellProperties.checkedTemplate === "undefined") {


### PR DESCRIPTION
Fix issue that readOnly not applied to checkbox. Make readOnly checkboxes look like disabled. 