### PR TITLE
Prevent Safari from reopening closed tab when undoing

### DIFF
--- a/src/plugins/undoRedo.js
+++ b/src/plugins/undoRedo.js
@@ -304,10 +304,12 @@
     if(ctrlDown){
       if (event.keyCode === 89 || (event.shiftKey && event.keyCode === 90)) { //CTRL + Y or CTRL + SHIFT + Z
         instance.undoRedo.redo();
+        event.preventDefault();
         event.stopImmediatePropagation();
       }
       else if (event.keyCode === 90) { //CTRL + Z
         instance.undoRedo.undo();
+        event.preventDefault();
         event.stopImmediatePropagation();
       }
     }


### PR DESCRIPTION
Safari(8.x at least), uses cmd-z to reopen a recently closed tab. Adding `event.preventDefault()` to the listener prevents this from happening.
