### PR TITLE
Bugfix to reenable support for multiple comments (fixes issue #2014)

### DIFF
--- a/src/plugins/comments.js
+++ b/src/plugins/comments.js
@@ -32,7 +32,7 @@ function Comments(instance) {
     },
     unBindMouseEvent = function () {
       eventManager.removeEventListener(document, 'mousedown');
-      eventManager.addEventListener(document, 'mousedown', Handsontable.helper.proxy(commentsMouseOverListener));
+      eventManager.addEventListener(document, 'mouseover', Handsontable.helper.proxy(commentsMouseOverListener));
     },
     placeCommentBox = function (range, commentBox) {
       var TD = instance.view.wt.wtTable.getCell(range.from),


### PR DESCRIPTION
The comments-plugin lost the ability to create more than a single comment. The mouseover-handler was not properly re-enabled after showing a comment.

This bug might have been introduced during the jquery dependency removal process and the introduction of the eventManager. This commit fixes the problem (see issue #2014).