### PR TITLE
Fix event handler leak when showing comment popups (fixes #1790)

### DIFF
--- a/src/plugins/comments.js
+++ b/src/plugins/comments.js
@@ -69,7 +69,8 @@ function Comments(instance) {
     },
     commentsMouseOverListener = function (event) {
         if(event.target.className.indexOf('htCommentCell') != -1) {
-						unBindMouseEvent();
+            eventManager.removeEventListener(document, 'mouseover');
+            unBindMouseEvent();
             var coords = instance.view.wt.wtTable.getCoords(event.target);
             var range = {
                 from: new WalkontableCellCoords(coords.row, coords.col)


### PR DESCRIPTION
The mouseover event handler is not properly released when an existing comment is shown (line 71 detects an existing comment). Another mouseover handler gets added later on inside showComment (which calls placeCommentBox, which calls bindMouseEvent, which adds the additional handler). This leads to multiple event handlers adding up to a large chain and slowing down the browser[1] until anoother cell is clicked (and the handlers are reset). This commit adds the missing handler release (fixes issue #1790).

[1] IE11 even crashes after a couple of fast mouse moves between cells with existing comments, see demo page