### PR TITLE
Drop dependency on string 'Comment' in menu (handles issue #2042)

### DIFF
--- a/src/plugins/comments.js
+++ b/src/plugins/comments.js
@@ -18,7 +18,7 @@ function Comments(instance) {
 
 			function commentsListener(event) {
         eventManager.removeEventListener(document, 'mouseover');
-        if (!(event.target.className == 'htCommentTextArea' || event.target.innerHTML.indexOf('Comment') != -1)) {
+        if (!(event.target.className == 'htCommentTextArea' || event.target.nodeName.toLowerCase() === "div" /* coming from context menu */))) {
           var value = document.querySelector('.htCommentTextArea').value;
           if (value.trim().length > 1) {
             saveComment(range, value, instance);


### PR DESCRIPTION
The comment-plugin relies on the string 'Comment' to detect if the plugin is called by a context-menu command to add a new comment. When using user-defined context-menu strings without 'Comment' as a part of it (like e.g. 'Kommentar hinzufügen', the german translation for 'add comment'), the comment popup is immediately dismissed and the comment cannot be added.

This commit removes the dependency on the string 'Comment' and checks for the nodeName 'div' instead (the context-menu entry sent as the event.target always comes embedded in a div).

While still not the perfect solution, this improves the situation for cases where other captions are needed in the context-menu entries to trigger the comment-related functionality (such as i18n related stuff).

Handles issue #2042.