### PR TITLE
Added beforeCellCopy hook to deal with copy formatted cell values

### DIFF
--- a/src/dataMap.js
+++ b/src/dataMap.js
@@ -418,7 +418,8 @@
    */
   Handsontable.DataMap.prototype.getCopyable = function (row, prop) {
     if (copyableLookup.call(this.instance, row, this.propToCol(prop))) {
-      return this.get(row, prop);
+      var cellValue = this.get(row, prop);
+      return Handsontable.hooks.run(this.instance, 'beforeCellCopy', cellValue, row, prop);
     }
     return '';
   };

--- a/src/pluginHooks.js
+++ b/src/pluginHooks.js
@@ -18,6 +18,7 @@ Handsontable.PluginHookClass = (function () {
       beforeKeyDown: [],
       beforeOnCellMouseDown: [],
       beforeTouchScroll: [],
+      beforeCellCopy : [],
       afterInit : [],
       afterLoadData : [],
       afterUpdateSettings: [],

--- a/test/jasmine/spec/Core_copySpec.js
+++ b/test/jasmine/spec/Core_copySpec.js
@@ -63,4 +63,25 @@ describe('Core_copy', function () {
     keyDownUp('ctrl');
     expect(result).toEqual([4, 5, 2, 2]);
   });
+
+  it('should copy to clipboard the original value when there is no beforeCellCopy callback', function (){
+    handsontable({
+      data : arrayOfArrays()
+    });
+
+    var result = getCopyableData(1, 1, 1, 1); // select '2008'/'Kia'
+    expect(result).toBe('10\n');
+  });
+
+  it('should call beforeCellCopy callback before copy a cell value to clipboard', function (){
+    handsontable({
+      data: arrayOfArrays(),
+      beforeCellCopy : function (value, row, col){
+        return "cell{row=" + row + ",col=" + col + ",value=" + value + "}";
+      }
+    });
+
+    var result = getCopyableData(1, 1, 1, 1); // select '2008'/'Kia'
+    expect(result).toBe("cell{row=1,col=1,value=10}\n");
+  });
 });


### PR DESCRIPTION
Previously I changed handsontable source to call a new hook on dataMap.getCopyable method.

```
Handsontable.DataMap.prototype.getCopyable = function (row, prop) {
    if (copyableLookup.call(this.instance, row, this.propToCol(prop))) {
      var cellValue = this.get(row, prop);
      return Handsontable.hooks.run(this.instance, 'beforeCellCopy', cellValue, row, prop);
    }
    return '';
  };
```

I made this change to solve #1729 issue. But I hadn't understood how Handsontable team works with Git-flow and I had created a wrong pull request.
I think this time is correct ; )
