### PR TITLE
ignore elements with nocopypaste class

### DIFF
--- a/src/3rdparty/copypaste.js
+++ b/src/3rdparty/copypaste.js
@@ -99,7 +99,8 @@ CopyPasteClass.prototype.onKeyDown = function (event) {
   if (isCtrlDown) {
     // this is needed by fragmentSelection in Handsontable. Ignore copypaste.js behavior if fragment of cell text is selected
     if (document.activeElement !== this.elTextarea && (this.getSelectionText() !== '' ||
-        ['INPUT', 'SELECT', 'TEXTAREA'].indexOf(document.activeElement.nodeName) !== -1)) {
+        ['INPUT', 'SELECT', 'TEXTAREA'].indexOf(document.activeElement.nodeName) !== -1) ||
+        document.activeElement.className.split(" ").indexOf("nocopypaste") !== -1) {
       return;
     }
 
@@ -288,5 +289,3 @@ CopyPasteClass.prototype.destroy = function () {
 CopyPasteClass.prototype.hasBeenDestroyed = function () {
   return !this.refCounter;
 };
-
-


### PR DESCRIPTION
This fix provides a way to explicitly ignore CopyPaste plugin events on any element which has `nocopypaste` class.

Several wysiwyg plugins like https://github.com/steveathon/bootstrap-wysiwyg initialize their text editor in a `div`.
With the old condition it was impossible to do "Select All" in such editors.
