### PR TITLE
(issue #1550) Fixed losing focus in external contenteditable elements when pressing ctrl.

### DIFF
--- a/src/3rdparty/copypaste.js
+++ b/src/3rdparty/copypaste.js
@@ -99,7 +99,8 @@ CopyPasteClass.prototype.onKeyDown = function (event) {
   if (isCtrlDown) {
     // this is needed by fragmentSelection in Handsontable. Ignore copypaste.js behavior if fragment of cell text is selected
     if (document.activeElement !== this.elTextarea && (this.getSelectionText() !== '' ||
-        ['INPUT', 'SELECT', 'TEXTAREA'].indexOf(document.activeElement.nodeName) !== -1)) {
+        ['INPUT', 'SELECT', 'TEXTAREA'].indexOf(document.activeElement.nodeName) !== -1 ||
+        document.activeElement.isContentEditable)) {
       return;
     }
 


### PR DESCRIPTION
Sorry for the lack of a unit test. The simulated ctrl keydown event fired by the keyDownUp helper didn't reproduce the bug that can be seen in the browser.