### PR TITLE
support for dynamic context menu (usage: { build : function () {}})

### DIFF
--- a/src/plugins/contextMenu.js
+++ b/src/plugins/contextMenu.js
@@ -899,6 +899,10 @@
 
     ContextMenuItem.prototype = items;
 
+    if (items.build && typeof items.build === 'function') {
+        items = items.build(this.instance);
+    }
+
     if (items && items.items) {
       items = items.items;
     }


### PR DESCRIPTION
"build" option for context menu allows to create context menu items on the fly. I have not found any other way to implement such functionality. Same functionality is available in jQuery-contextMenu
