### PR TITLE
Allow sorting by clickin the entire header

### DIFF
--- a/src/plugins/columnSorting/columnSorting.js
+++ b/src/plugins/columnSorting/columnSorting.js
@@ -274,6 +274,7 @@ function ColumnSorting() {
   this.getColHeader = function(col, TH) {
     if (this.getSettings().columnSorting && col >= 0) {
       dom.addClass(TH.querySelector('.colHeader'), 'columnSorting');
+      dom.addClass(TH.querySelector('.colHeaderWrapper'), 'columnSorting');
     }
   };
 

--- a/src/tableView.js
+++ b/src/tableView.js
@@ -481,7 +481,7 @@ TableView.prototype.appendColHeader = function(col, TH) {
   var DIV = document.createElement('DIV'),
     SPAN = document.createElement('SPAN');
 
-  DIV.className = 'relative';
+  DIV.className = 'relative colHeaderWrapper';
   SPAN.className = 'colHeader';
 
   if (col > -1) {

--- a/test/jasmine/spec/plugins/columnSortingSpec.js
+++ b/test/jasmine/spec/plugins/columnSortingSpec.js
@@ -8,6 +8,10 @@ describe('ColumnSorting', function () {
 //      this.$container.find('th span.columnSorting:eq(' + columnIndex + ')').click();
       this.$container.find('th span.columnSorting:eq(' + columnIndex + ')').simulate('click');
     }
+
+    this.sortByHeaderWrapper = function(columnIndex) {
+      this.$container.find('th div.colHeaderWrapper:eq(' + columnIndex + ')').simulate('click');
+    }
   });
 
   afterEach(function () {
@@ -1100,4 +1104,17 @@ describe('ColumnSorting', function () {
     expect(getDataAtCol(1)).toEqual(["Ted", "Sid", "Jane", "", "", null]);
 
   });
+
+  it("should be sorted if the header outside the text is clicked", function() {
+    handsontable({
+      data: arrayOfObjects(),
+      colHeaders: true,
+      columnSorting: true
+    });
+
+    this.sortByHeaderWrapper(1);
+
+    expect(this.$container.find('tr td').eq(1).html()).toEqual('Chuck');
+  });
+
 });


### PR DESCRIPTION
This adds the class columnSorting to the div inside the table headers
which will allow the user to sort the columns by clicking the entire
header. Before this commit, the user was forced to click on the header
text for the sorting to take effect.