### PR TITLE
Allow 0 as a valid row height

### DIFF
--- a/src/3rdparty/walkontable/src/scrollbarNativeVertical.js
+++ b/src/3rdparty/walkontable/src/scrollbarNativeVertical.js
@@ -65,7 +65,9 @@ WalkontableVerticalScrollbarNative.prototype.onScroll = function () {
 WalkontableVerticalScrollbarNative.prototype.sumCellSizes = function (from, length) {
   var sum = 0, val;
   while (from < length) {
-    sum +=  (val = this.instance.wtTable.getRowHeight(from)) === (void 0) ? this.instance.wtSettings.settings.defaultRowHeight : val; //TODO optimize getSetting, because this is MUCH faster then getSetting
+    //TODO optimize getSetting, because this is MUCH faster then getSetting
+    val = this.instance.wtTable.getRowHeight(from);
+    sum +=  val === (void 0) ? this.instance.wtSettings.settings.defaultRowHeight : val;
     from++;
   }
   return sum;

--- a/src/3rdparty/walkontable/src/scrollbarNativeVertical.js
+++ b/src/3rdparty/walkontable/src/scrollbarNativeVertical.js
@@ -63,9 +63,9 @@ WalkontableVerticalScrollbarNative.prototype.onScroll = function () {
 };
 
 WalkontableVerticalScrollbarNative.prototype.sumCellSizes = function (from, length) {
-  var sum = 0;
+  var sum = 0, val;
   while (from < length) {
-    sum += this.instance.wtTable.getRowHeight(from) || this.instance.wtSettings.settings.defaultRowHeight; //TODO optimize getSetting, because this is MUCH faster then getSetting
+    sum +=  (val = this.instance.wtTable.getRowHeight(from)) === (void 0) ? this.instance.wtSettings.settings.defaultRowHeight : val; //TODO optimize getSetting, because this is MUCH faster then getSetting
     from++;
   }
   return sum;


### PR DESCRIPTION
I'm currently trying to work on a plugin to allow hiding rows. But simply hiding them by applying css alone isn't enough, I also have to convince the virtual native scrollbars that they are not present, by using the "modifyRowHeight" hook. Unfortunately, the way this function is written now, if the the rowheight returned is zero, it will `||` it to `defaultRowHeight` as `0` in js is falsey. Changing `defaultRowHeight` to zero causes plenty of other issue to break so it is best to fix it so that the scrollbar height correctly calculates.
