### PR TITLE
Add option: renderAllColumns

### DIFF
--- a/src/3rdparty/walkontable/src/settings.js
+++ b/src/3rdparty/walkontable/src/settings.js
@@ -62,6 +62,7 @@ function WalkontableSettings(instance, settings) {
     scrollbarHeight: 10,
 
     renderAllRows: false,
+    renderAllColumns: false,
     groups: false
   };
 

--- a/src/3rdparty/walkontable/src/viewport.js
+++ b/src/3rdparty/walkontable/src/viewport.js
@@ -234,7 +234,13 @@ WalkontableViewport.prototype.createRowsCalculator = function (visible) {
 WalkontableViewport.prototype.createColumnsCalculator = function (visible) {
   this.columnHeaderHeight = NaN;
 
-  var width = this.getViewportWidth();
+  var width;
+  if (this.instance.wtSettings.settings.renderAllColumns) {
+    width = Infinity;
+  }
+  else {
+    width = this.getViewportWidth();
+  }
 
   var pos = this.instance.wtScrollbars.horizontal.getScrollPosition() - this.instance.wtScrollbars.vertical.getTableParentOffset();
   if (pos < 0) {

--- a/src/tableView.js
+++ b/src/tableView.js
@@ -184,6 +184,7 @@ Handsontable.TableView = function (instance) {
       return that.settings.fixedRowsTop;
     },
     renderAllRows: that.settings.renderAllRows,
+    renderAllColumns: that.settings.renderAllColumns,
     rowHeaders: function () {
       var arr = [];
       if(instance.hasRowHeaders()) {


### PR DESCRIPTION
Hi everyone,

I have been using handsontable for a while, and it is my first contribution to this project.

There is already an option to render all columns, it can be useful when you want all the table to be in the DOM or when you want to avoid lags on scrolling. But there is not an option to render all rows. It can be useful and it had been to me. So I just added this feature the same way the option renderAllRows is implemented.
