### PR TITLE
adding sortFunction to columnSorting & pass ctrlKey parameter

### DIFF
--- a/src/plugins/columnSorting.js
+++ b/src/plugins/columnSorting.js
@@ -23,6 +23,7 @@ function HandsontableColumnSorting() {
       } else {
         sortingColumn = sortingSettings.column;
         sortingOrder = sortingSettings.sortOrder;
+        instance.sortFunction = sortingSettings.sortFunction;
       }
       plugin.sortByColumn.call(instance, sortingColumn, sortingOrder);
 
@@ -70,7 +71,7 @@ function HandsontableColumnSorting() {
 
   };
 
-  this.sortByColumn = function (col, order) {
+  this.sortByColumn = function (col, order, optionalCtrlKey) {
     var instance = this;
 
     plugin.setSortingColumn.call(instance, col, order);
@@ -79,7 +80,7 @@ function HandsontableColumnSorting() {
       return;
     }
 
-    Handsontable.hooks.run(instance, 'beforeColumnSort', instance.sortColumn, instance.sortOrder);
+    Handsontable.hooks.run(instance, 'beforeColumnSort', instance.sortColumn, instance.sortOrder, optionalCtrlKey);
 
     plugin.sort.call(instance);
     instance.render();
@@ -123,7 +124,7 @@ function HandsontableColumnSorting() {
     eventManager.addEventListener(instance.rootElement, 'click', function (e){
       if(Handsontable.Dom.hasClass(e.target, 'columnSorting')) {
         var col = getColumn(e.target);
-        plugin.sortByColumn.call(instance, col);
+        plugin.sortByColumn.call(instance, col, undefined, e.ctrlKey);
       }
     });
 
@@ -218,12 +219,17 @@ function HandsontableColumnSorting() {
 
     var colMeta = instance.getCellMeta(0, instance.sortColumn);
     var sortFunction;
-    switch (colMeta.type) {
-      case 'date':
-        sortFunction = dateSort;
-        break;
-      default:
-        sortFunction = defaultSort;
+    if (instance.sortFunction) {
+      sortFunction = instance.sortFunction;
+    }
+    else {
+      switch (colMeta.type) {
+        case 'date':
+          sortFunction = dateSort;
+          break;
+        default:
+          sortFunction = defaultSort;
+      }
     }
 
     this.sortIndex.sort(sortFunction(instance.sortOrder));


### PR DESCRIPTION
- added sortFunction option to columnSorting so that we can pass our custom sorting function
- modified beforeColumnSort callback to get the ctrlKey parameter so that we can check if the user pressed ctrlKey (useful if we want to create our own custom multiple columns sorting)
   [maybe this modifier could be another option - either shift, or alt, or ... instead of just ctrl]
