### PR TITLE
bug fix: make sorting columns work when left columns are hidden

### DIFF
--- a/src/plugins/columnSorting.js
+++ b/src/plugins/columnSorting.js
@@ -134,7 +134,7 @@ function HandsontableColumnSorting() {
 
     function getColumn(target) {
       var TH = Handsontable.Dom.closest(target, 'TH');
-      return Handsontable.Dom.index(TH) - countRowHeaders();
+      return TH.col;
     }
   };
 
@@ -260,6 +260,7 @@ function HandsontableColumnSorting() {
   this.getColHeader = function (col, TH) {
     if (this.getSettings().columnSorting && col >= 0) {
       Handsontable.Dom.addClass(TH.querySelector('.colHeader'), 'columnSorting');
+      TH.col = col;
     }
   };
 


### PR DESCRIPTION
Make sorting columns work when left columns are hidden.
I don't think that this is the best fix, but we can't rely on "walking" through the DOM since when columns are hidden, their THs are not in the DOM
