### PR TITLE
Put moment before pikaday in bower.json, to correct ordering through Bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -38,8 +38,8 @@
   ],
   "dependencies": {
     "zeroclipboard": ">=2.1.6",
-    "pikaday": "1.3.0",
-    "moment": "2.9.0"
+    "moment": "2.9.0",
+    "pikaday": "1.3.0"
   },
   "devDependencies": {
     "chroma-js": "~0.5.6"


### PR DESCRIPTION
I've had an issue with Bower loading moment.js after Pikaday when both are pulled as dependencies from handsontable. This breaks Pikaday as it doesn't detect moment.js properly, and therefore doesn't handle the value initialization correctly. Switching the order in bower.json does seem to get the generated order more correct -- and there isn't a good reason I can see why moment.js should be after Pikaday. 