### PR TITLE
Use bootstraps @brand-danger color for htInvalid cell invalid style.

### DIFF
--- a/plugins/bootstrap/handsontable.bootstrap.css
+++ b/plugins/bootstrap/handsontable.bootstrap.css
@@ -56,3 +56,8 @@
 .table-striped > tbody > tr:nth-of-type(even) {
   background-color: #FFF;
 }
+
+.handsontable .table td.htInvalid {
+  color: #fff;
+  background-color: #d9534f;
+}


### PR DESCRIPTION
If you're using the Bootstrap integration, the handontable invalid cell style should match the Bootstrap 'danger' color, which is defined in `bootstrap/variables.less` file as:

``` less
@brand-danger:          #d9534f;
```
