### PR TITLE
Adjust the sort index correctly after row removal.

### DIFF
--- a/src/plugins/columnSorting.js
+++ b/src/plugins/columnSorting.js
@@ -299,13 +299,16 @@ function HandsontableColumnSorting() {
       return;
     }
 
-    var physicalRemovedIndex = plugin.translateRow.call(instance, index);
-
-    instance.sortIndex.splice(index, amount);
+    var delSortIndices = instance.sortIndex.splice(index, amount);
+    var delIndicies = delSortIndices.map(function(el){ return el[0]; });
+    var minDelIndex = Math.min(delIndicies);
 
     for(var i = 0; i < instance.sortIndex.length; i++){
+      if (instance.sortIndex[i][0] > minDelIndex){
+        var amount = delIndicies.filter(function(el){
+          return el < instance.sortIndex[i][0];
+        }).length;
 
-      if (instance.sortIndex[i][0] > physicalRemovedIndex){
         instance.sortIndex[i][0] -= amount;
       }
     }


### PR DESCRIPTION
The way the sort index was adjusted when rows were removed was incorrect
in some cases which caused various side-effects.

A demo of this behaviour can be seen in this fiddle: http://jsfiddle.net/einarj/Lj3xagn3/

We fixed the issue by correcting the adjustment algorithm in the
columnSorting plugin.