### PR TITLE
Adjust the sort index correctly after row removal.

### DIFF
--- a/src/plugins/columnSorting.js
+++ b/src/plugins/columnSorting.js
@@ -292,6 +292,12 @@ function HandsontableColumnSorting() {
 
   };
 
+  function offsetIndex(delIndices, physicalIndex) {
+    return delIndices.filter(function(el){
+      return el < physicalIndex;
+    }).length;
+  }
+
   this.afterRemoveRow = function(index, amount){
     var instance = this;
 
@@ -299,19 +305,18 @@ function HandsontableColumnSorting() {
       return;
     }
 
-    var physicalRemovedIndex = plugin.translateRow.call(instance, index);
-
-    instance.sortIndex.splice(index, amount);
+    var delSortIndices = instance.sortIndex.splice(index, amount);
+    var delIndices = delSortIndices.map(function(el){ return el[0]; });
+    var minDelIndex = Math.min.apply(null, delIndices);
 
     for(var i = 0; i < instance.sortIndex.length; i++){
-
-      if (instance.sortIndex[i][0] > physicalRemovedIndex){
+      if (instance.sortIndex[i][0] > minDelIndex){
+        var amount = offsetIndex(delIndices, instance.sortIndex[i][0]);
         instance.sortIndex[i][0] -= amount;
       }
     }
 
     saveSortingState.call(instance);
-
   };
 
   this.afterChangeSort = function (changes/*, source*/) {


### PR DESCRIPTION
The way the sort index was adjusted when rows were removed was incorrect
in some cases which caused various side-effects.

A demo of this behaviour can be seen in this fiddle:
http://jsfiddle.net/einarj/Lj3xagn3/

We fixed the issue by correcting the adjustment algorithm in the
columnSorting plugin.
