### PR TITLE
Autocomplete editor popup no longer limited by column size.

### DIFF
--- a/src/editors/autocompleteEditor.js
+++ b/src/editors/autocompleteEditor.js
@@ -72,7 +72,6 @@
     var that = this;
 
     choicesListHot.updateSettings({
-      'colWidths': [Handsontable.Dom.outerWidth(this.TEXTAREA) - 2],
       afterRenderer: function (TD, row, col, prop, value) {
         var caseSensitive = this.getCellMeta(row, col).filteringCaseSensitive === true;
 


### PR DESCRIPTION
This is one way to address issue #2335.

If there are better ways that you suggest, I'd be happy to try implementing them in another PR.