### PR TITLE
Support dataSchema callback for array-based data

### DIFF
--- a/src/dataMap.js
+++ b/src/dataMap.js
@@ -173,9 +173,13 @@ DataMap.prototype.createRow = function (index, amount, createdAutomatically) {
   while (numberOfCreatedRows < amount && this.instance.countRows() < maxRows) {
 
     if (this.instance.dataType === 'array') {
-      row = [];
-      for (var c = 0; c < colCount; c++) {
-        row.push(null);
+      if (this.instance.getSettings().dataSchema) {
+        row = JSON.parse(JSON.stringify(this.getSchema()));  // Clone template array
+      } else {        
+        row = [];
+        for (var c = 0; c < colCount; c++) {
+          row.push(null);
+        }
       }
 
     } else if (this.instance.dataType === 'function') {


### PR DESCRIPTION
Added 4 lines of code to support the dataSchema setting when using an array-based data source.  The dataSchema setting can be a template array or a callback function that returns an array.  In either case, the array will be cloned.