### PR TITLE
Fix null MouseEvent path on safari

### DIFF
--- a/src/eventManager.js
+++ b/src/eventManager.js
@@ -34,7 +34,7 @@ function eventManager(instance) {
       return event;
     }
     event = dom.polymerWrap(event);
-    len = event.path.length;
+    len = event.path ? event.path.length : 0;
 
     while (len --) {
       if (event.path[len].nodeName === componentName) {


### PR DESCRIPTION
Safari 8.0.5 on OS X Yosemite throws error for null event.path