### PR TITLE
Fix: undo fails with function datasource

### DIFF
--- a/src/plugins/undoRedo/undoRedo.js
+++ b/src/plugins/undoRedo/undoRedo.js
@@ -168,7 +168,7 @@ Handsontable.UndoRedo.ChangeAction = function(changes) {
 };
 helper.inherit(Handsontable.UndoRedo.ChangeAction, Handsontable.UndoRedo.Action);
 Handsontable.UndoRedo.ChangeAction.prototype.undo = function(instance, undoneCallback) {
-  var data = helper.deepClone(this.changes),
+  var data = cloneChanges(this.changes),
     emptyRowsAtTheEnd = instance.countEmptyRows(true),
     emptyColsAtTheEnd = instance.countEmptyCols(true);
 
@@ -197,7 +197,7 @@ Handsontable.UndoRedo.ChangeAction.prototype.undo = function(instance, undoneCal
 
 };
 Handsontable.UndoRedo.ChangeAction.prototype.redo = function(instance, onFinishCallback) {
-  var data = helper.deepClone(this.changes);
+  var data = cloneChanges(this.changes);
 
   for (var i = 0, len = data.length; i < len; i++) {
     data[i].splice(2, 1);
@@ -439,6 +439,20 @@ function removeExposedUndoRedoMethods(instance){
   delete instance.isUndoAvailable;
   delete instance.isRedoAvailable;
   delete instance.clearUndo;
+}
+
+function cloneChanges(changes) {
+  var clone = [];
+  for (var idx = 0; idx < changes.length; idx++) {
+    var change = changes[idx];
+    clone.push([
+      change[0], // row
+      change[1], // property
+      helper.deepClone(change[2]), // oldVal
+      helper.deepClone(change[3])  // newVal
+    ]);
+  }
+  return clone;
 }
 
 Handsontable.hooks.add('afterInit', init);

--- a/test/jasmine/spec/plugins/UndoRedoSpec.js
+++ b/test/jasmine/spec/plugins/UndoRedoSpec.js
@@ -2351,6 +2351,48 @@ describe('UndoRedo', function () {
 
       });
     });
+    
+    describe("Function data", function () {
+
+      function createObjectData() {
+        return [
+          {name: 'Timothy', surname: "Dalton"},
+          {name: 'Sean', surname: "Connery"},
+          {name: 'Roger', surname: "Moore"}
+        ];
+      }
+      
+      function createFunctionColumns() {
+        return ["name", "surname"].map(function (property) {
+          return {
+            data: function (item, value) {
+              if (typeof value === 'undefined') {
+                return item[property];
+              } else {
+                item[property] = value;
+              }
+            }
+          }
+        });
+      }
+
+      it('should undo single change', function () {
+        handsontable({
+          data: createObjectData(),
+          columns: createFunctionColumns(),
+          afterChange: function () {
+            console.log("Event", arguments);
+          }
+        });
+        var HOT = getInstance();
+        
+        setDataAtCell(0, 0, 'Pearce');
+        expect(getDataAtCell(0, 0)).toBe('Pearce');
+
+        HOT.undo();
+        expect(getDataAtCell(0, 0)).toBe('Timothy');
+      });
+    });
   });
 
   describe("plugin features", function () {


### PR DESCRIPTION
Undo uses a deep clone method on the changes being undone. This causes problems when the changed property is represented by a function. There is no need to clone the row number, or the property, though. This PR fixes the problem.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/handsontable/handsontable/2466)

<!-- Reviewable:end -->
