### PR TITLE
Fix Focus lost from contenteditable on Ctrl/Cmd

### DIFF
--- a/src/3rdparty/copypaste.js
+++ b/src/3rdparty/copypaste.js
@@ -95,7 +95,7 @@ CopyPasteClass.prototype.onKeyDown = function(event) {
       element = element.shadowRoot.activeElement;
     }
 
-    return ['INPUT', 'SELECT', 'TEXTAREA'].indexOf(element.nodeName) > -1;
+    return ['INPUT', 'SELECT', 'TEXTAREA'].indexOf(element.nodeName) > -1 || element.contentEditable === 'true';
   }
 
   // mac


### PR DESCRIPTION
Same issue as described in #893 for non-input elements with contentEditable set to true on the same page with Handsontable. contentEditable is used for pretty much any modern WYSIWYG editor.