### PR TITLE
Only calculate duck schema when actually needed

### DIFF
--- a/src/dataMap.js
+++ b/src/dataMap.js
@@ -24,13 +24,7 @@ function DataMap(instance, priv, GridSettings) {
   this.priv = priv;
   this.GridSettings = GridSettings;
   this.dataSource = this.instance.getSettings().data;
-
-  if (this.dataSource[0]) {
-    this.duckSchema = this.recursiveDuckSchema(this.dataSource[0]);
-  }
-  else {
-    this.duckSchema = {};
-  }
+  this.duckSchema = null;
   this.createMap();
 }
 
@@ -145,6 +139,14 @@ DataMap.prototype.getSchema = function () {
     return schema;
   }
 
+  if (this.duckSchema === null) {
+    if (this.dataSource[0]) {
+      this.duckSchema = this.recursiveDuckSchema(this.dataSource[0]);
+    }
+    else {
+      this.duckSchema = {};
+    }
+  }
   return this.duckSchema;
 };
 


### PR DESCRIPTION
Duck schema does not play nicely with a Backbone backend (if does not detect infinite loops in the object structure). It is not used if the schema is explicitly specified, but it is nevertheless generated.

This patch makes sure the duck schema is not calculated when an explicit schema is specified.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/handsontable/handsontable/2475)

<!-- Reviewable:end -->
