### PR TITLE
Changed bower.json to use "lite" version. Fixes #2582.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "handsontable",
   "description": "Spreadsheet-like data grid editor that provides copy/paste functionality compatible with Excel/Google Docs",
   "version": "0.15.0",
-  "main": ["./dist/handsontable.full.js", "./dist/handsontable.full.css"],
+  "main": ["./dist/handsontable.js", "./dist/handsontable.css"],
   "homepage": "http://handsontable.com/",
   "repository": {
     "type": "git",


### PR DESCRIPTION
You shouldn't include the dependencies in the files listed in the `main` stanza because Bower's already managing the dependencies and doing so causes duplication. See #2582.