### PR TITLE
datePickerConfig override from cellProperties

### DIFF
--- a/src/editors/dateEditor.js
+++ b/src/editors/dateEditor.js
@@ -174,6 +174,12 @@ class DateEditor extends TextEditor {
     this.$datePicker._onInputFocus = function() {};
     datePickerConfig.format = dateFormat;
 
+    if (this.cellProperties.datePickerConfig != undefined) {
+      for (var attrname in this.cellProperties.datePickerConfig) { 
+        datePickerConfig[attrname] = this.cellProperties.datePickerConfig[attrname]; 
+      }
+    }
+
     if (this.originalValue) {
       dateStr = this.originalValue;
 


### PR DESCRIPTION
Added a way of passing configuration options to date picker from cell. Suppose I wanted to pass disableWeekends:true to pickaday - I couldn't before. Now I can!