### PR TITLE
Support for context menu items className

### DIFF
--- a/src/plugins/contextMenu/contextMenu.js
+++ b/src/plugins/contextMenu/contextMenu.js
@@ -606,6 +606,13 @@ ContextMenu.prototype.renderer = function(instance, TD, row, col, prop, value) {
   } else {
     dom.fastInnerHTML(wrapper, value);
   }
+    
+  if (itemHasClassname(item)) {
+    var classNames = item.className.split(' ');
+    for (var i = 0; i < classNames.length; i++) {
+      Handsontable.Dom.addClass(wrapper, classNames[i]);
+    }
+  }
 
   if (itemIsDisabled(item)) {
     dom.addClass(TD, 'htDisabled');
@@ -636,6 +643,10 @@ ContextMenu.prototype.renderer = function(instance, TD, row, col, prop, value) {
 
   function isSubMenu(item) {
     return item.hasOwnProperty('submenu');
+  }
+    
+  function itemHasClassname(item) {
+    return item.hasOwnProperty('className');
   }
 
   function itemIsSeparator(item) {

--- a/src/plugins/contextMenu/test/contextMenu.spec.js
+++ b/src/plugins/contextMenu/test/contextMenu.spec.js
@@ -1425,6 +1425,83 @@ describe('ContextMenu', function () {
       expect(customItem.callback.calls[0].args[0]).toEqual('customItemKey');
 
     });
+      
+    it("should allow className settings in items", function () {
+      var customItem1 = {
+        name: 'Custom item 1',
+        className: 'sample-class',
+        callback: function () {}
+      };
+        
+      var hot = handsontable({
+        contextMenu: {
+          items: {
+            'customItem1' : customItem1 
+          }
+        },
+        height: 100
+      });
+        
+      contextMenu();
+        
+      var $menu = $('.htContextMenu .ht_master .htCore');
+
+      expect($menu.find('tbody td:eq(0) div').hasClass('sample-class')).toBe(true);
+    });
+      
+    it("should allow multiple classNames in a single item", function () {
+      var customItem1 = {
+        name: 'Custom item 1',
+        className: 'sample-class another-class',
+        callback: function () {}
+      };
+        
+      var hot = handsontable({
+        contextMenu: {
+          items: {
+            'customItem1' : customItem1 
+          }
+        },
+        height: 100
+      });
+        
+      contextMenu();
+        
+      var $menu = $('.htContextMenu .ht_master .htCore');
+
+      expect($menu.find('tbody td:eq(0) div').hasClass('sample-class')).toBe(true);
+      expect($menu.find('tbody td:eq(0) div').hasClass('another-class')).toBe(true);
+    });
+      
+    it("should allow classNames for some items only", function () {
+      var customItem1 = {
+        name: 'Custom item 1',
+        className: 'sample-class',
+        callback: function () {}
+      };
+        
+      var customItem2 = {
+        name: 'Custom item 2',
+        callback: function () {}
+      };
+        
+      var hot = handsontable({
+        contextMenu: {
+          items: {
+            'customItem1' : customItem1,
+            'customItem2' : customItem2
+          }
+        },
+        height: 100
+      });
+        
+      contextMenu();
+        
+      var $menu = $('.htContextMenu .ht_master .htCore');
+
+      expect($menu.find('tbody td:eq(0) div').hasClass('sample-class')).toBe(true);
+      expect($menu.find('tbody td:eq(1) div').hasClass('sample-class')).toBe(false);
+    });
 
   });
 


### PR DESCRIPTION
Added support for classNames in contextMenu items.

The contextMenu plugin in the handsontable project is based off this jQuery context menu plugin (http://medialize.github.io/jQuery-contextMenu/docs.html). It is even included in the handsontable docs as source for more customization options.

But "className" support for menu items still isn't available in the master version, so I made it into it. There were 3 tests added to test the feature, as to make sure setting a className for an item works and that it does NOT add it for other items in the menu.

My modification includes the classNames set in the DIV element, child of the TD element that handsontable create for each menu item. I set it this way so it is easier to customize (by applying direct selectors, not inheritance ones, that compromise performance in CSS styling).

My best regards, and keep on working in this awesome project!
