### PR TITLE
Add class to context menu entries

### DIFF
--- a/src/plugins/contextMenu/contextMenu.js
+++ b/src/plugins/contextMenu/contextMenu.js
@@ -601,6 +601,8 @@ ContextMenu.prototype.renderer = function(instance, TD, row, col, prop, value) {
   dom.empty(TD);
   TD.appendChild(wrapper);
 
+  Handsontable.Dom.addClass(wrapper, item.key);
+
   if (itemIsSeparator(item)) {
     dom.addClass(TD, 'htSeparator');
   } else {


### PR DESCRIPTION
Add a class to every line in the context menu, so they can be styled individually (e.g. by adding an icon).
