### PR TITLE
Add option to disable moveable rows/columns

### DIFF
--- a/src/plugins/manualColumnMove/manualColumnMove.js
+++ b/src/plugins/manualColumnMove/manualColumnMove.js
@@ -46,7 +46,7 @@ function ManualColumnMove() {
     currentTH = TH;
 
     var col = this.view.wt.wtTable.getCoords(TH).col; //getCoords returns WalkontableCellCoords
-    if (col >= 0) { //if not row header
+    if (col >= 0 && this.disabledColumns.indexOf(col) === -1) { //if not column header
       currentCol = col;
       var box = currentTH.getBoundingClientRect();
       startOffset = box.left;
@@ -121,9 +121,14 @@ function ManualColumnMove() {
         if (th) {
           if (pressed) {
             var col = instance.view.wt.wtTable.getCoords(th).col;
-            if (col >= 0) { //not TH above row header
-              endCol = col;
-              refreshHandlePosition(e.target, endCol - startCol);
+            if (col >= 0) { //not TH in front of header
+				if (instance.disabledColumns.indexOf(col) === -1 ||
+                  col == startCol ||
+                  col < startCol && instance.disabledColumns.indexOf(col - 1) === -1 ||
+                  col > startCol && instance.disabledColumns.indexOf(col + 1) === -1) {
+                  endCol = col;
+                  refreshHandlePosition(e.target, endCol - startCol);
+              }
             }
           } else {
             setupHandlePosition.call(instance, th);
@@ -197,6 +202,10 @@ function ManualColumnMove() {
 
     if (manualColMoveEnabled) {
       var initialManualColumnPositions = this.getSettings().manualColumnMove;
+      this.disabledColumns = instance.getSettings().manualColumnMoveDisable;
+      if (!Array.isArray(this.disabledColumns)) {
+        this.disabledColumns = [];
+      }
 
       var loadedManualColumnPositions = loadManualColumnPositions.call(instance);
 

--- a/src/plugins/manualRowMove/manualRowMove.js
+++ b/src/plugins/manualRowMove/manualRowMove.js
@@ -53,7 +53,7 @@ function ManualRowMove() {
     currentTH = TH;
 
     var row = this.view.wt.wtTable.getCoords(TH).row; //getCoords returns WalkontableCellCoords
-    if (row >= 0) { //if not row header
+    if (row >= 0 && this.disabledRows.indexOf(row) === -1) { //if not row header
       currentRow = row;
       var box = currentTH.getBoundingClientRect();
       startOffset = box.top;
@@ -127,8 +127,14 @@ function ManualRowMove() {
         var th = getTHFromTargetElement(e.target);
         if (th) {
           if (pressed) {
-            endRow = instance.view.wt.wtTable.getCoords(th).row;
-            refreshHandlePosition(th, endRow - startRow);
+            var currentRow = instance.view.wt.wtTable.getCoords(th).row;
+              if (instance.disabledRows.indexOf(currentRow) === -1 ||
+                  currentRow == startRow ||
+                  currentRow < startRow && instance.disabledRows.indexOf(currentRow - 1) === -1 ||
+                  currentRow > startRow && instance.disabledRows.indexOf(currentRow + 1) === -1) {
+                  refreshHandlePosition(th, currentRow - startRow);
+                  endRow = currentRow;
+              }
           } else {
             setupHandlePosition.call(instance, th);
           }
@@ -199,6 +205,10 @@ function ManualRowMove() {
 
     if (manualRowMoveEnabled) {
       var initialManualRowPositions = instance.getSettings().manualRowMove;
+      this.disabledRows = instance.getSettings().manualRowMoveDisable;
+      if (!Array.isArray(this.disabledRows)) {
+        this.disabledRows = [];
+      }
       var loadedManualRowPostions = loadManualRowPositions.call(instance);
 
       // update plugin usages count for manualColumnPositions


### PR DESCRIPTION
In some occasions, e.g. when using `manualRowMove` together with `mergeCells`, it may be desirable to disable some rows for moving.

In order to be backwards compatible with existing options, a new option is introduced: `manualRowMoveDisable`. This option expects an array of ints/rownumbers which should be disabled for moving.

A row which has been disabled will not show the move handle and will not be moveable by itself. If there are two disabled rows directly next to each other, then it will not be possible to move another row between those two disabled rows.

The respective changes have been add for columns.
