### PR TITLE
Extend tables to the right when doing autofill

### DIFF
--- a/src/plugins/autofill/autofill.js
+++ b/src/plugins/autofill/autofill.js
@@ -101,17 +101,32 @@ function Autofill(instance) {
     // dragged outside bottom
     if (_this.addingStarted === false && _this.instance.autofill.handle.isDragged > 0 && event.clientY > tableBottom &&
       event.clientX <= tableRight) {
-      _this.instance.mouseDragOutside = true;
+      _this.instance.mouseDragOutsideBottom = true;
       _this.addingStarted = true;
-
     } else {
-      _this.instance.mouseDragOutside = false;
+      _this.instance.mouseDragOutsideBottom = false;
     }
 
-    if (_this.instance.mouseDragOutside) {
+    // dragged outside tableRight
+    if (_this.addingStarted === false && _this.instance.autofill.handle.isDragged > 0 && event.clientY <= tableBottom &&
+      event.clientX > tableRight) {
+      _this.instance.mouseDragOutsideRight = true;
+      _this.addingStarted = true;
+    } else {
+      _this.instance.mouseDragOutsideRight = false;
+    }
+
+    if (_this.instance.mouseDragOutsideBottom) {
       setTimeout(function () {
         _this.addingStarted = false;
         _this.instance.alter('insert_row');
+      }, 200);
+    }
+
+    if (_this.instance.mouseDragOutsideRight) {
+      setTimeout(function () {
+        _this.addingStarted = false;
+        _this.instance.alter('insert_col', _this.instance.countCols());
       }, 200);
     }
   }


### PR DESCRIPTION
Autofill adds already new rows when dragging the autofill-marker below the table. This pull requests add this functionality also for dragging the autofill-marker over the right edge of the table.
This should provide a more consistent experience.
