### PR TITLE
pass the validation result into the callback for the validateCells method

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -847,6 +847,7 @@ Handsontable.Core = function Core(rootElement, userSettings) {
 
     return {
       validatorsInQueue: 0,
+      valid: true,
       addValidatorToQueue: function() {
         this.validatorsInQueue++;
         resolved = false;
@@ -855,13 +856,13 @@ Handsontable.Core = function Core(rootElement, userSettings) {
         this.validatorsInQueue = this.validatorsInQueue - 1 < 0 ? 0 : this.validatorsInQueue - 1;
         this.checkIfQueueIsEmpty();
       },
-      onQueueEmpty: function() {
+      onQueueEmpty: function(valid) {
       },
       checkIfQueueIsEmpty: function() {
         /* jshint ignore:start */
         if (this.validatorsInQueue == 0 && resolved == false) {
           resolved = true;
-          this.onQueueEmpty();
+          this.onQueueEmpty(this.valid);
         }
         /* jshint ignore:end */
       }
@@ -2032,7 +2033,13 @@ Handsontable.Core = function Core(rootElement, userSettings) {
       var j = instance.countCols() - 1;
       while (j >= 0) {
         waitingForValidator.addValidatorToQueue();
-        instance.validateCell(instance.getDataAtCell(i, j), instance.getCellMeta(i, j), function() {
+        instance.validateCell(instance.getDataAtCell(i, j), instance.getCellMeta(i, j), function(result) {
+          if (typeof result !== 'boolean') {
+            throw new Error("Validation error: result is not boolean");
+          }
+          if (result === false) {
+            waitingForValidator.valid = false;
+          }
           waitingForValidator.removeValidatorFormQueue();
         }, 'validateCells');
         j--;


### PR DESCRIPTION
This is a straightforward implementation of feature request #2203. The change is to pass in the result of validation when executing the callback provided to `validateCells`. This is particularly useful if you want to verify that all cells are valid before saving the table data, for instance. E.g.,

```js
hot.validateCells(function(valid) {
    if (valid) {
        saveData();
    }
})
```