### PR TITLE
stop search at instance.rootElement instead of BODY to avoid failures in document fragments

### DIFF
--- a/src/plugins/manualColumnResize/manualColumnResize.js
+++ b/src/plugins/manualColumnResize/manualColumnResize.js
@@ -181,12 +181,11 @@ class ManualColumnResize extends BasePlugin {
    * @returns {Boolean}
    */
   checkIfColumnHeader(element) {
-    if (element.tagName != 'BODY') {
+    if (element != this.hot.rootElement) {
       if (element.parentNode.tagName == 'THEAD') {
         return true;
       } else {
-        element = element.parentNode;
-        return this.checkIfColumnHeader(element);
+        return this.checkIfColumnHeader(element.parentNode);
       }
     }
 


### PR DESCRIPTION
This patch will avoid exceptions when using Handsontable from within a Polymer element, which is bound by a document fragment