### PR TITLE
Avoid deleting whole table when click "remove_row" in the context menu.

### DIFF
--- a/src/plugins/contextMenu/predefinedItems.js
+++ b/src/plugins/contextMenu/predefinedItems.js
@@ -168,6 +168,11 @@ const _predefinedItems = {
       if (!selected) {
         return true;
       }
+      
+      if(selected[2] == this.countRows()-1){
+        return true;
+      }
+      
       let entireColumnSelection = [0, selected[1], this.countRows() - 1, selected[1]];
 
       return entireColumnSelection.join(',') === selected.join(',');
@@ -192,6 +197,9 @@ const _predefinedItems = {
         return true;
       }
       if (!this.isColumnModificationAllowed()) {
+        return true;
+      }
+      if(selected[3] == this.countCols()-1){
         return true;
       }
       let entireRowSelection = [selected[0], 0, selected[0], this.countCols() - 1];


### PR DESCRIPTION
if i select some rows ,and click "remove_col" in the context menu,i may delete the whole table, maybe we should prevent this.
