### PR TITLE
Adding ability to prevent drag-down from creating new rows, adding beforeCopy and beforePaste hooks

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -3964,5 +3964,10 @@ DefaultSettings.prototype = {
    * @type {Boolean}
    */
   strict: void 0,
+
+  /**
+   * If this setting is true, drag-down will create new rows once it reaches the last row.
+   */
+  dragDownCreateRow: true
 };
 Handsontable.DefaultSettings = DefaultSettings;

--- a/src/dataMap.js
+++ b/src/dataMap.js
@@ -578,7 +578,9 @@ DataMap.prototype.getText = function (start, end) {
  * @returns {String}
  */
 DataMap.prototype.getCopyableText = function (start, end) {
-  return SheetClip.stringify(this.getRange(start, end, this.DESTINATION_CLIPBOARD_GENERATOR));
+  var range = this.getRange(start, end, this.DESTINATION_CLIPBOARD_GENERATOR);
+  var proceed = Handsontable.hooks.run(this.instance, 'beforeCopy', range);
+  return proceed ? SheetClip.stringify(range) : false;
 };
 
 export {DataMap};

--- a/src/pluginHooks.js
+++ b/src/pluginHooks.js
@@ -554,7 +554,34 @@ const REGISTERED_HOOKS = [
   /**
    * @event Hooks#persistentStateSave
    */
-  "persistentStateSave"
+  "persistentStateSave",
+
+  /**
+   * Allow application to modify the content being copied. To cancel the whole copy operation return falsy value.
+   * You can modify the 'range' object as you see fit.
+   *
+   * @event Hooks#beforeCopy
+   * @since 0.18
+   * @param {Object} range
+   * @returns falsy if you want to cancel out of copy operation
+   */
+  "beforeCopy",
+
+  /**
+   * Allow application to modify the content being pasted. To cancel the whole paste operation return falsy value.
+   * You can modify the 'inputArray' as you see fit.
+   *
+   * @event Hooks#beforePaste
+   * @since 0.18
+   * @param {Array} inputArray
+   * @param {Number} startRow
+   * @param {Number} startCol
+   * @param {Number} endRow
+   * @param {Number} endCol
+   * @param {String} pasteMode
+   * @returns falsy if you want to cancel out of paste operation
+   */
+  "beforePaste"
 ];
 
 import {EventManager} from './eventManager';

--- a/src/plugins/autofill/autofill.js
+++ b/src/plugins/autofill/autofill.js
@@ -109,7 +109,7 @@ function Autofill(instance) {
       _this.instance.mouseDragOutside = false;
     }
 
-    if (_this.instance.mouseDragOutside) {
+    if (_this.instance.mouseDragOutside && _this.instance.getSettings().minSpareRows > 0 ) {
       setTimeout(function () {
         _this.addingStarted = false;
         _this.instance.alter('insert_row');
@@ -309,7 +309,7 @@ Autofill.prototype.checkIfNewRowNeeded = function () {
     tableRows = this.instance.countRows(),
     that = this;
 
-  if (this.instance.view.wt.selections.fill.cellRange && this.addingStarted === false) {
+  if (this.instance.getSettings().minSpareRows > 0 && this.instance.view.wt.selections.fill.cellRange && this.addingStarted === false) {
     selection = this.instance.getSelected();
     fillCorners = this.instance.view.wt.selections.fill.getCorners();
 

--- a/src/plugins/autofill/autofill.js
+++ b/src/plugins/autofill/autofill.js
@@ -109,7 +109,7 @@ function Autofill(instance) {
       _this.instance.mouseDragOutside = false;
     }
 
-    if (_this.instance.mouseDragOutside && _this.instance.getSettings().minSpareRows > 0 ) {
+    if (_this.instance.mouseDragOutside && _this.instance.getSettings().dragDownCreateRow ) {
       setTimeout(function () {
         _this.addingStarted = false;
         _this.instance.alter('insert_row');
@@ -309,7 +309,7 @@ Autofill.prototype.checkIfNewRowNeeded = function () {
     tableRows = this.instance.countRows(),
     that = this;
 
-  if (this.instance.getSettings().minSpareRows > 0 && this.instance.view.wt.selections.fill.cellRange && this.addingStarted === false) {
+  if (this.instance.getSettings().dragDownCreateRow && this.instance.view.wt.selections.fill.cellRange && this.addingStarted === false) {
     selection = this.instance.getSelected();
     fillCorners = this.instance.view.wt.selections.fill.getCorners();
 

--- a/src/plugins/copyPaste/copyPaste.js
+++ b/src/plugins/copyPaste/copyPaste.js
@@ -65,7 +65,11 @@ function CopyPastePlugin(instance) {
       }
     });
 
-    instance.populateFromArray(areaStart.row, areaStart.col, inputArray, areaEnd.row, areaEnd.col, 'paste', instance.getSettings().pasteMode);
+    // If hook returns true don't proceed with paste.
+    var proceed = Handsontable.hooks.run(instance, 'beforePaste', inputArray, areaStart.row, areaStart.col, areaEnd.row, areaEnd.col, instance.getSettings().pasteMode);
+    if(proceed) {
+      instance.populateFromArray(areaStart.row, areaStart.col, inputArray, areaEnd.row, areaEnd.col, 'paste', instance.getSettings().pasteMode);
+    }
   }
 
   function onBeforeKeyDown(event) {
@@ -141,10 +145,13 @@ function CopyPastePlugin(instance) {
     var finalEndRow = Math.min(endRow, startRow + copyRowsLimit - 1);
     var finalEndCol = Math.min(endCol, startCol + copyColsLimit - 1);
 
-    instance.copyPaste.copyPasteInstance.copyable(instance.getCopyableData(startRow, startCol, finalEndRow, finalEndCol));
-
-    if (endRow !== finalEndRow || endCol !== finalEndCol) {
-      Handsontable.hooks.run(instance, "afterCopyLimit", endRow - startRow + 1, endCol - startCol + 1, copyRowsLimit, copyColsLimit);
+    var data = instance.getCopyableData(startRow, startCol, finalEndRow, finalEndCol);
+    // Don't proceed if getCopyableData returns falsy value.
+    if(data) {
+      instance.copyPaste.copyPasteInstance.copyable(data);
+      if (endRow !== finalEndRow || endCol !== finalEndCol) {
+        Handsontable.hooks.run(instance, "afterCopyLimit", endRow - startRow + 1, endCol - startCol + 1, copyRowsLimit, copyColsLimit);
+      }
     }
   };
 }

--- a/test/jasmine/spec/FillHandleSpec.js
+++ b/test/jasmine/spec/FillHandleSpec.js
@@ -249,6 +249,39 @@ describe('FillHandle', function () {
     });
   });
 
+  it('should not add new rows if dragDownCreateRow is false', function () {
+    var hot = handsontable({
+      data: [
+        [1, 2, "test", 4, 5, 6],
+        [1, 2, 3, 4, 5, 6],
+        [1, 2, 3, 4, 5, 6],
+        [1, 2, 3, 4, 5, 6]
+      ],
+      dragDownCreateRow: false
+    });
+
+    selectCell(0, 2);
+
+    this.$container.find('.wtBorder.current.corner').simulate('mousedown');
+    this.$container.find('tr:last-child td:eq(2)').simulate('mouseover');
+
+    expect(hot.countRows()).toBe(4);
+    waits(300);
+
+    runs(function () {
+      expect(hot.countRows()).toBe(4);
+
+      this.$container.find('tr:last-child td:eq(2)').simulate('mouseover');
+
+      waits(300);
+
+      runs(function () {
+        expect(hot.countRows()).toBe(4);
+      });
+
+    });
+  });
+
   it('should add new row after dragging the handle below the viewport', function () {
     var hot = handsontable({
       data: [


### PR DESCRIPTION
I have added the ability to prevent drag-down from creating new rows. This is useful in cases where developer wants to have fix number of rows but still wants the fill-handle functionality.

One might think to use 'maxRows' in this scenario but that may not be an option (for example the rows are created elsewhere, outside of handsontable).

I have added 'dragDownCreateRow' setting and defaulted it to true which is current default functionality.

Autofill.js checks this setting and skips adding rows if the setting is false.