### PR TITLE
Added setting dragDownCreatesRows

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -4376,6 +4376,11 @@ DefaultSettings.prototype = {
    *
    * @type {Boolean}
    */
-  renderAllRows: void 0
+  renderAllRows: void 0,
+
+  /**
+   * If this setting is true, drag-down will create new rows once it reaches the last row.
+   */
+  dragDownCreatesRows: true
 };
 Handsontable.DefaultSettings = DefaultSettings;

--- a/src/plugins/autofill/autofill.js
+++ b/src/plugins/autofill/autofill.js
@@ -109,7 +109,7 @@ function Autofill(instance) {
       _this.instance.mouseDragOutside = false;
     }
 
-    if (_this.instance.mouseDragOutside) {
+    if (_this.instance.mouseDragOutside && _this.instance.getSettings().dragDownCreatesRows) {
       setTimeout(function() {
         _this.addingStarted = false;
         _this.instance.alter('insert_row');
@@ -309,7 +309,7 @@ Autofill.prototype.checkIfNewRowNeeded = function() {
     tableRows = this.instance.countRows(),
     that = this;
 
-  if (this.instance.view.wt.selections.fill.cellRange && this.addingStarted === false) {
+  if (this.instance.getSettings().dragDownCreatesRows && this.instance.view.wt.selections.fill.cellRange && this.addingStarted === false) {
     selection = this.instance.getSelected();
     fillCorners = this.instance.view.wt.selections.fill.getCorners();
 

--- a/test/jasmine/spec/FillHandleSpec.js
+++ b/test/jasmine/spec/FillHandleSpec.js
@@ -391,5 +391,37 @@ describe('FillHandle', function () {
 
   });
 
+  it('should not add new rows if dragDownCreateRow is false', function () {
+    var hot = handsontable({
+      data: [
+        [1, 2, "test", 4, 5, 6],
+        [1, 2, 3, 4, 5, 6],
+        [1, 2, 3, 4, 5, 6],
+        [1, 2, 3, 4, 5, 6]
+      ],
+      dragDownCreatesRows: false
+    });
+
+    selectCell(0, 2);
+
+    this.$container.find('.wtBorder.current.corner').simulate('mousedown');
+    this.$container.find('tr:last-child td:eq(2)').simulate('mouseover');
+
+    expect(hot.countRows()).toBe(4);
+    waits(300);
+
+    runs(function () {
+      expect(hot.countRows()).toBe(4);
+
+      this.$container.find('tr:last-child td:eq(2)').simulate('mouseover');
+
+      waits(300);
+
+      runs(function () {
+        expect(hot.countRows()).toBe(4);
+      });
+
+    });
+  });
 });
 


### PR DESCRIPTION
This setting allows developer to prevent HOT from creating new rows on drag-down.

Defaulting it to true to keep it compatible with existing functionality which is to create new rows.
