### PR TITLE
Added beforeCopy and beforePaste hooks

### DIFF
--- a/src/dataMap.js
+++ b/src/dataMap.js
@@ -574,7 +574,9 @@ DataMap.prototype.getText = function(start, end) {
  * @returns {String}
  */
 DataMap.prototype.getCopyableText = function(start, end) {
-  return SheetClip.stringify(this.getRange(start, end, this.DESTINATION_CLIPBOARD_GENERATOR));
+  var range = this.getRange(start, end, this.DESTINATION_CLIPBOARD_GENERATOR);
+  var proceed = Handsontable.hooks.run(this.instance, 'beforeCopy', range);
+  return proceed ? SheetClip.stringify(range) : false;
 };
 
 export {DataMap};

--- a/src/pluginHooks.js
+++ b/src/pluginHooks.js
@@ -678,6 +678,33 @@ const REGISTERED_HOOKS = [
    * @param {Boolean} isDoubleClick Flag that determines whether there was a double-click.
    */
   'afterRowResize',
+
+  /**
+   * Allow application to modify the content being copied. To cancel the whole copy operation return false.
+   * You can modify the 'range' object as you see fit.
+   *
+   * @event Hooks#beforeCopy
+   * @since 0.18
+   * @param {Object} range
+   * @returns false if you want to cancel out of copy operation
+   */
+    'beforeCopy',
+
+  /**
+   * Allow application to modify the content being pasted. To cancel the whole paste operation return false.
+   * You can modify the 'inputArray' as you see fit.
+   *
+   * @event Hooks#beforePaste
+   * @since 0.18
+   * @param {Array} inputArray
+   * @param {Number} startRow
+   * @param {Number} startCol
+   * @param {Number} endRow
+   * @param {Number} endCol
+   * @param {String} pasteMode
+   * @returns false if you want to cancel out of paste operation
+   */
+    'beforePaste'
 ];
 
 import {arrayEach} from './helpers/array';

--- a/src/plugins/copyPaste/copyPaste.js
+++ b/src/plugins/copyPaste/copyPaste.js
@@ -87,7 +87,11 @@ function CopyPastePlugin(instance) {
       }
     });
 
-    instance.populateFromArray(areaStart.row, areaStart.col, inputArray, areaEnd.row, areaEnd.col, 'paste', instance.getSettings().pasteMode);
+    // If hook returns false don't proceed with paste.
+    var proceed = Handsontable.hooks.run(instance, 'beforePaste', inputArray, areaStart.row, areaStart.col, areaEnd.row, areaEnd.col, instance.getSettings().pasteMode);
+    if (proceed) {
+      instance.populateFromArray(areaStart.row, areaStart.col, inputArray, areaEnd.row, areaEnd.col, 'paste', instance.getSettings().pasteMode);
+    }
   }
 
   function onBeforeKeyDown(event) {

--- a/test/jasmine/spec/Core_copySpec.js
+++ b/test/jasmine/spec/Core_copySpec.js
@@ -101,4 +101,55 @@ describe('Core_copy', function () {
       expect(hot.getDataAtCell(1, 3)).toEqual('12');
     });
   });
+
+  it('beforePaste hook should be called', function () {
+    var hot = handsontable({
+      data: arrayOfArrays(),
+      beforePaste: function(inputArray, startRow, startCol, endRow, endCol, pasteMode) {
+        inputArray[0][3] = 'Ford';
+        inputArray[1][2] = '14';
+      }
+    });
+    $('textarea.copyPaste').val('\tRenault\tBMW\tFiat\tJaguar\n2008\t10\t11\t12\t13\n');
+
+    selectCell(0, 0, countRows() - 1, countCols() - 1); //selectAll
+    keyDownUp('ctrl+v');
+    waits(200);
+
+    runs(function() {
+      expect(hot.getDataAtCell(0, 0)).toEqual('');
+      expect(hot.getDataAtCell(0, 1)).toEqual('Renault');
+      expect(hot.getDataAtCell(0, 2)).toEqual('BMW');
+      expect(hot.getDataAtCell(0, 3)).toEqual('Ford');
+      expect(hot.getDataAtCell(1, 0)).toEqual('2008');
+      expect(hot.getDataAtCell(1, 1)).toEqual('10');
+      expect(hot.getDataAtCell(1, 2)).toEqual('14');
+      expect(hot.getDataAtCell(1, 3)).toEqual('12');
+    });
+  });
+
+  it('paste should be canceled when returning false from beforePaste hook', function () {
+    var hot = handsontable({
+      data: arrayOfArrays(),
+      beforePaste: function(/* inputArray, startRow, startCol, endRow, endCol, pasteMode */) {
+        return false;
+      }
+    });
+    $('textarea.copyPaste').val('\tRenault\tBMW\tFiat\tJaguar\n2008\t10\t11\t12\t13\n');
+
+    selectCell(0, 0, countRows() - 1, countCols() - 1); //selectAll
+    keyDownUp('ctrl+v');
+    waits(200);
+
+    runs(function() {
+      expect(hot.getDataAtCell(0, 0)).toEqual('');
+      expect(hot.getDataAtCell(0, 1)).toEqual('Kia');
+      expect(hot.getDataAtCell(0, 2)).toEqual('Nissan');
+      expect(hot.getDataAtCell(0, 3)).toEqual('Toyota');
+      expect(hot.getDataAtCell(1, 0)).toEqual('2008');
+      expect(hot.getDataAtCell(1, 1)).toEqual(10);
+      expect(hot.getDataAtCell(1, 2)).toEqual(11);
+      expect(hot.getDataAtCell(1, 3)).toEqual(12);
+    });
+  });
 });

--- a/test/jasmine/spec/core/getCopyableTextSpec.js
+++ b/test/jasmine/spec/core/getCopyableTextSpec.js
@@ -31,4 +31,28 @@ describe('Core.getCopyableText', function () {
     expect(getCopyableText(0, 0)).toBe('\n');
     expect(getCopyableText(0, 0, 1, 2)).toBe('\t\t\n\t\t\n');
   });
+
+  it('beforeCopy should be called and allowed to change data being copied', function () {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(5, 5),
+      copyable: true,
+      beforeCopy: function(range) {
+        range[0][0] = 'Tabasco';
+      }
+    });
+
+    expect(getCopyableText(0, 0)).toBe('Tabasco\n'); //SheetClip.stringify will add new line.
+  });
+
+  it('copy should be canceled if beforeCopy returns false', function () {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(5, 5),
+      copyable: true,
+      beforeCopy: function(/* range */) {
+        return false;
+      }
+    });
+
+    expect(getCopyableText(0, 0)).toBe(false);
+  });
 });


### PR DESCRIPTION
Copy/paste plugin leaves few things to be desired. It doesn't work on non-primitive types resulting in [object Object] being copied, and maybe even more importantly it copies all the columns. Sometimes this is not acceptable.

To allow developer more control over copy/paste operation I have created two new hooks, beforeCopy and beforePaste allowing developer to:
1. cancel out of these operations entirely, and 
2. modify the content being copied and pasted
