### PR TITLE
Only call getValue once, when trimWhitespace is true

### DIFF
--- a/src/editors/_baseEditor.js
+++ b/src/editors/_baseEditor.js
@@ -162,7 +162,8 @@ BaseEditor.prototype.finishEditing = function(restoreOriginalValue, ctrlDown, ca
       // String.prototype.trim is defined in Walkontable polyfill.js
       val = [
         // We trim only string values
-        [typeof this.getValue() === 'string' ? String.prototype.trim.call(this.getValue() || '') : this.getValue()]];
+        var value = this.getValue();
+        [typeof value === 'string' ? String.prototype.trim.call(value || '') : value]];
     } else {
       val = [
         [this.getValue()]


### PR DESCRIPTION
This is only an optimization change, without side effects.