### PR TITLE
Fix issues #2207 and #1717

### DIFF
--- a/src/eventManager.js
+++ b/src/eventManager.js
@@ -1,6 +1,7 @@
 
 import {polymerWrap, closest} from './helpers/dom/element';
 import {isWebComponentSupportedNatively} from './helpers/browser';
+import {stopImmediatePropagation as _stopImmediatePropagation} from './helpers/dom/event';
 
 /**
  * Event DOM manager for internal use in Handsontable.
@@ -202,9 +203,16 @@ function extendEvent(context, event) {
   let realTarget;
   let target;
   let len;
+  let nativeStopImmediatePropagation;
 
   event.isTargetWebComponent = false;
   event.realTarget = event.target;
+
+  nativeStopImmediatePropagation = event.stopImmediatePropagation;
+  event.stopImmediatePropagation = function() {
+    nativeStopImmediatePropagation.apply(this);
+    _stopImmediatePropagation(this);
+  };
 
   if (!Handsontable.eventManager.isHotTableEnv) {
     return event;


### PR DESCRIPTION
Extend native method `event.stopImmediatePropagation()` to
stop event propagation in Handsontable event manager.

This [example](http://docs.handsontable.com/0.19.0/tutorial-callbacks.html#page-beforeKeyDown) in documentation not work properly because e.stopImmediatePropagation(); actually calling native method. But Handsontable uses it's own event manager and if the fired event will not have property isImmediatePropagationEnabled = false; the event will be propagate to up.