### PR TITLE
Fix vertical scrolling on IE when the table auto-detects its height

### DIFF
--- a/src/helpers/dom/element.js
+++ b/src/helpers/dom/element.js
@@ -636,7 +636,7 @@ export function getStyle(element, prop) {
  * @returns {IEElementStyle|CssStyle} Elements computed style object
  */
 export function getComputedStyle(element) {
-  if(document.defaultView.getComputedStyle !== '' && document.defaultView.getComputedStyle !== void 0) {
+  if (document.defaultView.getComputedStyle !== '' && document.defaultView.getComputedStyle !== void 0) {
     return document.defaultView.getComputedStyle(element);
   } else {
     return element.currentStyle;

--- a/src/helpers/dom/element.js
+++ b/src/helpers/dom/element.js
@@ -636,7 +636,11 @@ export function getStyle(element, prop) {
  * @returns {IEElementStyle|CssStyle} Elements computed style object
  */
 export function getComputedStyle(element) {
-  return element.currentStyle || document.defaultView.getComputedStyle(element);
+  if(document.defaultView.getComputedStyle !== '' && document.defaultView.getComputedStyle !== void 0) {
+    return document.defaultView.getComputedStyle(element);
+  } else {
+    return element.currentStyle;
+  }
 }
 
 /**


### PR DESCRIPTION
The issue (#2924) was in a project where I had to let a table fill a container, it didn't create scrollbars on IE. It's related to how the table selects its height according to the computed style. The previous behavior first checked if `element.currentStyle` returned a style, otherwise it used `document.defaultView.getComputedStyle`. However, `element.currentStyle` returns incorrect width and height values: `auto`. Since IE9+ is compatible with `document.defaultView.getComputedStyle`, I set it to first check if that function exists, and if so, use it. Otherwise, use `element.currentStyle`. This means the bug is fixed on IE9+ but it will still happen on previous versions.
