### PR TITLE
Fix issue #2214

### DIFF
--- a/src/editorManager.js
+++ b/src/editorManager.js
@@ -311,14 +311,12 @@ function EditorManager(instance, priv, selection) {
     col = priv.selRange.highlight.col;
     prop = instance.colToProp(col);
     td = instance.getCell(row, col);
-    originalValue = instance.getDataAtCell(row, col);
     cellProperties = instance.getCellMeta(row, col);
     editorClass = instance.getCellEditor(cellProperties);
 
     if (editorClass) {
       activeEditor = Handsontable.editors.getEditor(editorClass, instance);
       activeEditor.prepare(row, col, prop, td, originalValue, cellProperties);
-
     } else {
       activeEditor = void 0;
     }
@@ -344,6 +342,13 @@ function EditorManager(instance, priv, selection) {
    * @param {DOMEvent} event
    */
   this.openEditor = function(initialValue, event) {
+    if (activeEditor) {
+      activeEditor.originalValue = activeEditor.instance.getDataAtCell(
+        activeEditor.row,
+        activeEditor.col
+      );
+    }
+
     if (activeEditor && !activeEditor.cellProperties.readOnly) {
       activeEditor.beginEditing(initialValue, event);
     } else if (activeEditor && activeEditor.cellProperties.readOnly) {


### PR DESCRIPTION
This bug happens because:
1. setDataAtCell method start validate procedure, validate procedure
   run postAfterValidate hooks and it run some code which close active
   editor and select next cell. Then the next cell is being selected
   fires prepareEditor method https://github.com/handsontable/handsontable/blob/0.19.0/src/editorManager.js#L304
2. prepareEditor method is assigning originalValue, but setDataAtCell
   not set new data yet. Therefore originalValue is storing the previous
   value of cell.

I think originalValue must be assigned right before editor opening.

But this commit also fail two tests: the first in DateEditor because it relies what original value will be assigned in prepareEditor method and second different width (1px) of textarea (openEditor).
