### PR TITLE
Fix issue #2719

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1466,6 +1466,7 @@ Handsontable.Core = function Core(rootElement, userSettings) {
    */
   this.updateSettings = function(settings, init) {
     var i, clen;
+    var settingName;
 
     if (typeof settings.rows !== 'undefined') {
       throw new Error('"rows" setting is no longer supported. do you mean startRows, minRows or maxRows?');
@@ -1487,6 +1488,17 @@ Handsontable.Core = function Core(rootElement, userSettings) {
           if (!init && settings.hasOwnProperty(i)) {
             GridSettings.prototype[i] = settings[i];
           }
+        }
+      }
+    }
+
+    // Some settings like `stretch` effective only when saved in walkontable instance
+    // so update it there
+    // allso update only settings which has `string` class
+    if (init !== true) {
+      for (settingName in settings) {
+        if (typeof instance.view.wt.wtSettings.defaults[settingName] === 'string') {
+          instance.view.wt.update(settingName, settings[settingName]);
         }
       }
     }


### PR DESCRIPTION
This issue happens because when Handsontable decide should it
stretch column or not it read settings from walkontable instance https://github.com/handsontable/handsontable/blob/0.19.0/src/3rdparty/walkontable/src/viewport.js#L67 ,
but Handsontable.updateSettings() function not update them.
