### PR TITLE
Fix afterSelectionEnd not being fired correctly on mobile

### DIFF
--- a/src/tableView.js
+++ b/src/tableView.js
@@ -84,6 +84,14 @@ function TableView(instance) {
     }
   });
 
+  this.eventManager.addEventListener(document.documentElement, 'touchend', function(event) {
+    setTimeout(function() {
+      if (instance.selection.isInProgress()) {
+        instance.selection.finish();
+      }
+    }, 0);
+  });
+
   this.eventManager.addEventListener(document.documentElement, 'mousedown', function(event) {
     var next = event.target;
     var eventX = event.x || event.clientX;


### PR DESCRIPTION
This commit fixes the issue #2942 where using a hook on afterSelectionEnd didn't work on mobile. To do that, I added an event listener to the `touchend` event, and make it end a selection if there's one. To make sure it is fired after the selection occurs, it's placed in a setTimeout of length 0. Otherwise it would sometimes fire before the selection started.
