### PR TITLE
Establish zero-width top and left cell borders to prevent external stylesheets from impacting cell measurements

### DIFF
--- a/src/css/handsontable.css
+++ b/src/css/handsontable.css
@@ -75,6 +75,8 @@
 
 .handsontable th,
 .handsontable td {
+  border-top-width: 0;
+  border-left-width: 0;
   border-right: 1px solid #CCC;
   border-bottom: 1px solid #CCC;
   height: 22px;


### PR DESCRIPTION
Fixes problem demonstrated [here](http://jsfiddle.net/w2Lzmhwd/1/) where cell measurement is off enough to cause a word wrap