### PR TITLE
On triggerPaste without string, try clipboard APIs, fall back to help modal (fixes #3078)

### DIFF
--- a/lib/copyPaste/copyPaste.js
+++ b/lib/copyPaste/copyPaste.js
@@ -38,6 +38,7 @@ CopyPasteClass.prototype.init = function () {
   this.copyCallbacks = [];
   this.cutCallbacks = [];
   this.pasteCallbacks = [];
+  this.failedPasteCallbacks = [];
 
   // this.listenerElement = document.documentElement;
   parent = document.body;
@@ -124,10 +125,10 @@ CopyPasteClass.prototype.onKeyDown = function(event) {
     if (document.activeElement !== this.elTextarea && (this.getSelectionText() !== '' || isActiveElementEditable())) {
       return;
     }
-    this.selectNodeText(this.elTextarea);
+    this.selectPasteNode();
     setTimeout(function() {
       if (document.activeElement !== _this.elTextarea) {
-        _this.selectNodeText(_this.elTextarea);
+        _this.selectPasteNode();
       }
     }, 0);
   }
@@ -144,8 +145,8 @@ CopyPasteClass.prototype.onKeyDown = function(event) {
 
     } else if (event.keyCode === 86) {
       setTimeout(function () {
-        _this.triggerPaste(event);
-      }, 0);
+        _this.triggerPaste(event, _this.elTextarea.value);
+      }, 50);
     }
   }
 };
@@ -153,13 +154,13 @@ CopyPasteClass.prototype.onKeyDown = function(event) {
 //http://jsperf.com/textara-selection
 //http://stackoverflow.com/questions/1502385/how-can-i-make-this-code-work-in-ie
 /**
- * Select all text contains in passed node element
+ * Select all text in our hidden text box, in preparation for a browser paste event
  *
  * @param {Element} element
  */
-CopyPasteClass.prototype.selectNodeText = function(element) {
-  if (element) {
-    element.select();
+CopyPasteClass.prototype.selectPasteNode = function() {
+  if (this.elTextarea) {
+    this.elTextarea.select();
   }
 };
 
@@ -192,7 +193,7 @@ CopyPasteClass.prototype.copyable = function(string) {
     throw new Error('copyable requires string parameter');
   }
   this.elTextarea.value = string;
-  this.selectNodeText(this.elTextarea);
+  this.selectPasteNode();
 };
 
 /*CopyPasteClass.prototype.onCopy = function (fn) {
@@ -218,33 +219,34 @@ CopyPasteClass.prototype.onPaste = function(callback) {
 };
 
 /**
+ * Add function callback to onFailedPaste event
+ *
+ * @param {Function} callback
+ */
+CopyPasteClass.prototype.onFailedPaste = function(callback) {
+  this.failedPasteCallbacks.push(callback);
+}
+
+/**
  * Remove callback from all events
  *
  * @param {Function} callback
  * @returns {Boolean}
  */
 CopyPasteClass.prototype.removeCallback = function(callback) {
-  var i, len;
+  var callbackArrays = [
+    this.copyCallbacks,
+    this.cutCallbacks,
+    this.pasteCallbacks,
+    this.failedPasteCallbacks
+  ];
+  for (var a = 0; a < callbackArrays.length; a++) {
+    for (var i = 0, len = callbackArrays[a].length; i < len; i++) {
+      if (callbackArrays[a][i] === callback) {
+        callbackArrays[a].splice(i, 1);
 
-  for (i = 0, len = this.copyCallbacks.length; i < len; i++) {
-    if (this.copyCallbacks[i] === callback) {
-      this.copyCallbacks.splice(i, 1);
-
-      return true;
-    }
-  }
-  for (i = 0, len = this.cutCallbacks.length; i < len; i++) {
-    if (this.cutCallbacks[i] === callback) {
-      this.cutCallbacks.splice(i, 1);
-
-      return true;
-    }
-  }
-  for (i = 0, len = this.pasteCallbacks.length; i < len; i++) {
-    if (this.pasteCallbacks[i] === callback) {
-      this.pasteCallbacks.splice(i, 1);
-
-      return true;
+        return true;
+      }
     }
   }
 
@@ -279,14 +281,49 @@ CopyPasteClass.prototype.triggerPaste = function(event, string) {
 
   if (_this.pasteCallbacks) {
     setTimeout(function () {
-      var val = string || _this.elTextarea.value;
+      if (string === null || string === undefined) {
+        // No string was supplied, so try to trigger a paste event directly.
+        if (window.clipboardData) {
+          // Internet Explorer's odd implementation of w3c clipboard API
+          string = window.clipboardData.getData('Text');
+        } else if (window.queryCommandSupported && window.queryCommandSupported('paste')) {
+          // w3c execCommand API
+          _this.selectPasteNode();
+          var result = document.execCommand("paste");
+          if (result === true) {
+            setTimeout(function () {
+              _this.triggerPaste(event, _this.elTextarea.value);
+            }, 50);
+          } else {
+            // Paste command was available but did not succeed, this is known to happen in
+            // Firefox versions < 41.
+            _this.triggerFailedPaste(event);
+          }
+          return;
+        } else {
+          _this.triggerFailedPaste(event);
+          return;
+        }
+      }
 
       for (var i = 0, len = _this.pasteCallbacks.length; i < len; i++) {
-        _this.pasteCallbacks[i](val, event);
+        _this.pasteCallbacks[i](string, event);
       }
     }, 50);
   }
 };
+
+/**
+ * Trigger failed paste event; this means that user must manually paste from their browser UI
+ *
+ * @param {DOMEvent} event
+ * @param {String} string
+ */
+CopyPasteClass.prototype.triggerFailedPaste = function(event) {
+  for (var i = 0, len = this.failedPasteCallbacks.length; i < len; i++) {
+    this.failedPasteCallbacks[i](event);
+  }
+}
 
 /**
  * Destroy instance

--- a/src/css/handsontable.css
+++ b/src/css/handsontable.css
@@ -694,6 +694,50 @@ thead .htCollapseButton:after {
   overflow-y: hidden;
 }
 
+.handsontable > .helpModalWrapper {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.6);
+  z-index: 1000;
+}
+
+.handsontable > .helpModalWrapper > .helpModal {
+  position: absolute;
+  min-width: 200px;
+  width: 50%;
+  margin-left: auto;
+  margin-right: auto;
+  top: 40%;
+  left: 25%;
+  border: 1px solid black;
+  border-radius: 5px;
+  padding: 20px;
+  background-color: white;
+  z-index: 1001;
+  text-align: center;
+}
+
+.handsontable > .helpModalWrapper > .helpModal > .helpModalKeys {
+  font-size: 1.6em;
+  margin-top: 1em;
+  vertical-align: 90%;
+}
+
+.handsontable > .helpModalWrapper > .helpModal > .helpModalKeys > .helpModalKey {
+  display: inline-block;
+  padding: 10px;
+  margin: 0 5px;
+  font-size: 1.2em;
+  font-family: monospace;
+  font-weight: bold;
+  border: 1px solid gray;
+  border-radius: 3px;
+  background-color: beige;
+  box-shadow: inset 0 0 10px #000;
+}
 
 /*WalkontableDebugOverlay*/
 

--- a/src/plugins/copyPaste/test/copyPaste.e2e.js
+++ b/src/plugins/copyPaste/test/copyPaste.e2e.js
@@ -59,16 +59,49 @@ describe('CopyPaste', () => {
     }, 100);
   });
 
+  it('should show help modal when triggerPaste called with no string and no browser clipboard API', (done) => {
+    var hot = handsontable();
+    expect($('.helpModalWrapper').css('display')).toEqual('none');
+    hot.copyPaste.triggerPaste();
+
+    setTimeout(() => {
+      expect($('.helpModalWrapper').css('display')).toEqual('block');
+      done();
+    }, 100);
+  });
+
+  it('should hide the help modal when a non-control key is typed', () => {
+    var hot = handsontable();
+    hot.copyPaste.showHelpModal();
+    selectCell(0, 0);
+    expect($('.helpModalWrapper').css('display')).toEqual('block');
+    keyDownUp(Handsontable.helper.KEY_CODES.CONTROL_LEFT);
+    expect($('.helpModalWrapper').css('display')).toEqual('block');
+    keyDownUp(Handsontable.helper.KEY_CODES.COMMAND_LEFT);
+    expect($('.helpModalWrapper').css('display')).toEqual('block');
+    keyDownUp(Handsontable.helper.KEY_CODES.A);
+    expect($('.helpModalWrapper').css('display')).toEqual('none');
+  });
+
+  it('should hide the help modal when its fill-wrapper is clicked', () => {
+    var hot = handsontable();
+    hot.copyPaste.showHelpModal();
+    selectCell(0, 0);
+    expect($('.helpModalWrapper').css('display')).toEqual('block');
+    $('.helpModalWrapper').simulate('click');
+    expect($('.helpModalWrapper').css('display')).toEqual('none');
+  });
+
   describe('enabling/disabing plugin', () => {
     it('should enable copyPaste by default', () => {
-
       var hot = handsontable();
 
       expect(hot.copyPaste).toBeDefined();
     });
 
-    it('should create copyPaste div if enabled', () => {
+    it('should create copyPaste and helpModalWrapper divs if enabled', () => {
       expect($('#CopyPasteDiv').length).toEqual(0);
+      expect($('.helpModalWrapper').length).toEqual(0);
 
       var hot = handsontable();
 
@@ -76,10 +109,12 @@ describe('CopyPaste', () => {
       keyDownUp(Handsontable.helper.KEY_CODES.CONTROL_LEFT); // copyPaste div isn't created until you click CTRL
 
       expect($('#CopyPasteDiv').length).toEqual(1);
+      expect($('.helpModalWrapper').length).toEqual(1);
     });
 
-    it('should not create copyPaste div if disabled', () => {
+    it('should not create copyPaste and helpModalWrapper divs if disabled', () => {
       expect($('#CopyPasteDiv').length).toEqual(0);
+      expect($('.helpModalWrapper').length).toEqual(0);
 
       var hot = handsontable({
         copyPaste: false
@@ -89,6 +124,7 @@ describe('CopyPaste', () => {
       keyDownUp(Handsontable.helper.KEY_CODES.CONTROL_LEFT);
 
       expect($('#CopyPasteDiv').length).toEqual(0);
+      expect($('.helpModalWrapper').length).toEqual(0);
     });
 
     it('should not create copyPaste property if plugin is disabled', () => {
@@ -111,8 +147,9 @@ describe('CopyPaste', () => {
       expect(hot.copyPaste).toBe(null);
     });
 
-    it('should remove copyPaste div if plugin has been disabled using updateSetting', () => {
+    it('should remove copyPaste and helpModalWrapper divs if plugin has been disabled using updateSetting', () => {
       expect($('#CopyPasteDiv').length).toEqual(0);
+      expect($('.helpModalWrapper').length).toEqual(0);
 
       var hot = handsontable();
 
@@ -120,17 +157,20 @@ describe('CopyPaste', () => {
       keyDownUp(Handsontable.helper.KEY_CODES.CONTROL_LEFT);
 
       expect($('#CopyPasteDiv').length).toEqual(1);
+      expect($('.helpModalWrapper').length).toEqual(1);
 
       updateSettings({
         copyPaste: false
       });
 
       expect($('#CopyPasteDiv').length).toEqual(0);
+      expect($('.helpModalWrapper').length).toEqual(0);
 
       selectCell(0, 0);
       keyDownUp(Handsontable.helper.KEY_CODES.CONTROL_LEFT);
 
       expect($('#CopyPasteDiv').length).toEqual(0);
+      expect($('.helpModalWrapper').length).toEqual(0);
     });
   });
 
@@ -303,9 +343,18 @@ describe('CopyPaste', () => {
 
       it('should create only one CopyPasteDiv regardless of the number of tables', function() {
         var hot1 = handsontable();
-        var hot2 = this.$container2.handsontable();
+        var hot2 = this.$container2.handsontable().handsontable('getInstance');
 
         expect($('#CopyPasteDiv').length).toEqual(1);
+      });
+
+      it('should create a helpModalWrapper for each table', function () {
+        var hot1 = handsontable();
+        var hot2 = this.$container2.handsontable().handsontable('getInstance');
+
+        expect($('.helpModalWrapper').length).toEqual(2);
+        expect($(hot1.rootElement).find('.helpModalWrapper').length).toEqual(1);
+        expect($(hot2.rootElement).find('.helpModalWrapper').length).toEqual(1);
       });
 
       it('should leave CopyPasteDiv as long as at least one table has copyPaste enabled', function() {
@@ -325,6 +374,19 @@ describe('CopyPaste', () => {
         });
 
         expect($('#CopyPasteDiv').length).toEqual(0);
+      });
+
+      it('should remove helpModalWrapper only from tables which disable the plugin', function () {
+        var hot1 = handsontable();
+        var hot2 = this.$container2.handsontable().handsontable('getInstance');
+
+        hot1.updateSettings({
+          copyPaste: false
+        });
+
+        expect($('.helpModalWrapper').length).toEqual(1);
+        expect($(hot1.rootElement).find('.helpModalWrapper').length).toEqual(0);
+        expect($(hot2.rootElement).find('.helpModalWrapper').length).toEqual(1);
       });
     });
   });


### PR DESCRIPTION
Fixes #3078, see further discussion there.

This PR ultimately is to fix the paste context menu item. As it is now, it just re-pastes _whatever was previously pasted via CTRL+V_.

In CopyPasteClass, when triggerPaste is called, it now expects to be given a string with the text that was pasted. If this is not given, it attempts to use one of the (few) known ways of directly accessing the clipboard or triggering a true paste vent. If that doesn't work, then it emits a new event: failedPaste.

The copy paste plugin receives this event and uses it to show a modal to the user, which tells them that they must use the CTRL+V shortcut (or on Mac, Clover+V) to paste. The modal disappears if HOT is clicked on, if any non-control key is pressed, or if an actual clipboard event occurs (e.g. they select Paste from the browser's edit menu).
