### PR TITLE
Fix for textarea onpaste default action prevention. Fixes #3123

### DIFF
--- a/lib/copyPaste/copyPaste.js
+++ b/lib/copyPaste/copyPaste.js
@@ -75,7 +75,7 @@ CopyPasteClass.prototype.init = function () {
         }
         this.value = clipboardContents;
 
-        return false;
+        event.preventDefault();
       }
     };
     style = this.elTextarea.style;

--- a/src/plugins/copyPaste/test/copyPaste.spec.js
+++ b/src/plugins/copyPaste/test/copyPaste.spec.js
@@ -14,9 +14,13 @@ describe('CopyPaste', function () {
 
   it("should remove additional new line from copied text (only safari)", function () {
     var getData = jasmine.createSpy().andReturn('a\nb\n\n');
+    var preventDefault = jasmine.createSpy();
     var hot = handsontable();
 
-    $('.copyPaste')[0].onpaste({clipboardData: {getData: getData}});
+    $('.copyPaste')[0].onpaste(
+      {clipboardData: {getData: getData},
+      preventDefault: preventDefault
+    });
 
     if (Handsontable.helper.isSafari()) {
       expect($('.copyPaste')[0].value).toEqual('a\nb\n');
@@ -26,6 +30,8 @@ describe('CopyPaste', function () {
       expect($('.copyPaste')[0].value).toBe('a\nb\n\n');
       expect(getData).toHaveBeenCalledWith('Text');
     }
+
+    expect(preventDefault).toHaveBeenCalled();
   });
 
 


### PR DESCRIPTION
There are two ways to prevent the default action of a dom event (such as clicking on a button, or pasting text into a textarea). You can either ```return false``` or do ```event.preventDefault()``` in the event handler.

The first way, while supported by most browsers is not in the standard, while the second is currently the accepted proper way to prevent the default action. 

This changes textarea.onpaste event handler to use the second method. As a nice side effect this makes Handsontable compatible with Angular2. 