### PR TITLE
Allow '.' in property names

### DIFF
--- a/src/dataMap.js
+++ b/src/dataMap.js
@@ -396,8 +396,9 @@ DataMap.prototype.spliceRow = function(row, index, amount/*, elements...*/) {
  */
 DataMap.prototype.get = function(row, prop) {
   row = Handsontable.hooks.run(this.instance, 'modifyRow', row);
-
-  if (typeof prop === 'string' && prop.indexOf('.') > -1) {
+  if (this.dataSource[row] && this.dataSource[row].hasOwnProperty && this.dataSource[row].hasOwnProperty(prop)) {
+    return this.dataSource[row][prop];
+  } else if (typeof prop === 'string' && prop.indexOf('.') > -1) {
     var sliced = prop.split('.');
     var out = this.dataSource[row];
 
@@ -430,9 +431,6 @@ DataMap.prototype.get = function(row, prop) {
     return prop(this.dataSource.slice(row, row + 1)[0]);
 
   }
-  if (this.dataSource[row] && this.dataSource[row].hasOwnProperty && this.dataSource[row].hasOwnProperty(prop)) {
-    return this.dataSource[row][prop];
-  }
 
   return null;
 };
@@ -463,8 +461,9 @@ DataMap.prototype.getCopyable = function(row, prop) {
  */
 DataMap.prototype.set = function(row, prop, value, source) {
   row = Handsontable.hooks.run(this.instance, 'modifyRow', row, source || 'datamapGet');
-
-  if (typeof prop === 'string' && prop.indexOf('.') > -1) {
+  if (this.dataSource[row] && this.dataSource[row].hasOwnProperty && this.dataSource[row].hasOwnProperty(prop)) {
+    this.dataSource[row][prop] = value;
+  } else if (typeof prop === 'string' && prop.indexOf('.') > -1) {
     var sliced = prop.split('.');
     var out = this.dataSource[row];
     for (var i = 0, ilen = sliced.length - 1; i < ilen; i++) {


### PR DESCRIPTION
Simple change in program flow to allow '.' (period) in a property name.

This way, if a data set has a property of "Misc. Item", it'll find and get/set it.  Currently, dataMap assumes all '.' mean nested properties and tries to find data['Misc'][' Item'] which won't exist.

When dot notation is being used as intended, it'll fall through the hasOwnProperty condition and work normally.