### PR TITLE
Allow non strict format dates

### DIFF
--- a/src/editors/dateEditor.js
+++ b/src/editors/dateEditor.js
@@ -28,6 +28,7 @@ class DateEditor extends TextEditor {
     this.datePicker = null;
     this.datePickerStyle = null;
     this.defaultDateFormat = 'DD/MM/YYYY';
+    this.defaultDateFormatStrict = true;
     this.isCellEdited = false;
     this.parentDestroyed = false;
 
@@ -146,6 +147,7 @@ class DateEditor extends TextEditor {
 
     let offset = this.TD.getBoundingClientRect();
     let dateFormat = this.cellProperties.dateFormat || this.defaultDateFormat;
+    let dateFormatStrict = this.cellProperties.dateFormatStrict || this.defaultDateFormatStrict;
     let datePickerConfig = this.$datePicker.config();
     let dateStr;
     let isMouseDown = this.instance.view.isMouseDown();
@@ -160,7 +162,7 @@ class DateEditor extends TextEditor {
     if (this.originalValue) {
       dateStr = this.originalValue;
 
-      if (moment(dateStr, dateFormat, true).isValid()) {
+d      if (moment(dateStr, dateFormat, dateFormatStrict).isValid()) {
         this.$datePicker.setMoment(moment(dateStr, dateFormat), true);
       }
       if (!isMeta && !isMouseDown) {
@@ -173,7 +175,7 @@ class DateEditor extends TextEditor {
 
         datePickerConfig.defaultDate = dateStr;
 
-        if (moment(dateStr, dateFormat, true).isValid()) {
+        if (moment(dateStr, dateFormat, dateFormatStrict).isValid()) {
           this.$datePicker.setMoment(moment(dateStr, dateFormat), true);
         }
 


### PR DESCRIPTION
Related with #3235

My dates looks like this: 14/02/2016 [INVALID].
Which means I need to treat somehow the date before opening the datepicker, or tell moment.js that the format is valid and it should still parse it.

I found out handsontable forces the format to be strictly the same as the one provided in the datepickerconfig format, which in my case would be DD-MM-YYYY.
But that wouldn't allow DD-MM-YYY string.

[Reproduction online of the issue](http://jsfiddle.net/7u1kxjLe/32/)
