### PR TITLE
Fix inserting column from context menu when table only has one column

### DIFF
--- a/src/plugins/contextMenu/predefinedItems.js
+++ b/src/plugins/contextMenu/predefinedItems.js
@@ -112,8 +112,9 @@ const _predefinedItems = {
       }
       let entireRowSelection = [selected[0], 0, selected[0], this.countCols() - 1];
       let rowSelected = entireRowSelection.join(',') == selected.join(',');
+      let onlyOneColumn = this.countCols() == 1;
 
-      return selected[1] < 0 || this.countCols() >= this.getSettings().maxCols || rowSelected;
+      return selected[1] < 0 || this.countCols() >= this.getSettings().maxCols || (!onlyOneColumn && rowSelected);
     },
     hidden: function() {
       return !this.getSettings().allowInsertColumn;
@@ -137,8 +138,9 @@ const _predefinedItems = {
       }
       let entireRowSelection = [selected[0], 0, selected[0], this.countCols() - 1];
       let rowSelected = entireRowSelection.join(',') == selected.join(',');
+      let onlyOneColumn = this.countCols() == 1;
 
-      return selected[1] < 0 || this.countCols() >= this.getSettings().maxCols || rowSelected;
+      return selected[1] < 0 || this.countCols() >= this.getSettings().maxCols || (!onlyOneColumn && rowSelected);
     },
     hidden: function() {
       return !this.getSettings().allowInsertColumn;

--- a/src/plugins/contextMenu/test/contextMenu.spec.js
+++ b/src/plugins/contextMenu/test/contextMenu.spec.js
@@ -1495,6 +1495,24 @@ describe('ContextMenu', function () {
       expect($menu.find('tbody td:eq(4)').hasClass('htDisabled')).toBe(true);
 
     });
+
+    it('should NOT disable Insert col in context menu when only one column exists', function () {
+      var hot = handsontable({
+        data: [['single col']],
+        contextMenu: true,
+        maxCols: 10,
+        height: 100
+      });
+
+      selectCell(0, 0);
+      contextMenu();
+      var $menu = $('.htContextMenu .ht_master .htCore');
+
+      expect($menu.find('tbody td:eq(3)').text()).toEqual('Insert column on the left');
+      expect($menu.find('tbody td:eq(3)').hasClass('htDisabled')).toBe(false);
+      expect($menu.find('tbody td:eq(4)').text()).toEqual('Insert column on the right');
+      expect($menu.find('tbody td:eq(4)').hasClass('htDisabled')).toBe(false);
+    });
   });
 
   describe("custom options", function () {


### PR DESCRIPTION
As reported at #3095, currently when a table has only one column accessing the context menu does not allow for a new column to be inserted:

<img width="249" alt="cannot-insert-column" src="https://cloud.githubusercontent.com/assets/301630/13280263/a112264a-db28-11e5-8fa7-777f721c4c18.png">

This is due to a check being made to ensure that a new column cannot be added if an entire row has been selected, which is returning a false positive when there's only one column in the row.

To fix this the check described above is skipped if the table only has one column:
<img width="268" alt="fixed" src="https://cloud.githubusercontent.com/assets/301630/13280277/b8a93aaa-db28-11e5-8370-a14228650c96.png">
