### PR TITLE
DropdownEditor beforeValidate hook should convert property to column

### DIFF
--- a/src/editors/dropdownEditor.js
+++ b/src/editors/dropdownEditor.js
@@ -15,7 +15,8 @@ class DropdownEditor extends AutocompleteEditor {
   }
 }
 
-Handsontable.hooks.add('beforeValidate', function(value, row, col, source) {
+Handsontable.hooks.add('beforeValidate', function(value, row, prop, source) {
+  let col = this.propToCol(prop);
   let cellMeta = this.getCellMeta(row, col);
 
   if (cellMeta.editor === Handsontable.editors.DropdownEditor) {

--- a/test/jasmine/spec/editors/dropdownEditorSpec.js
+++ b/test/jasmine/spec/editors/dropdownEditorSpec.js
@@ -96,4 +96,17 @@ describe('DropdownEditor', function() {
 
   });
 
+  it("should convert property to column in beforeValidate hook", function() {
+    var cellsSpy = jasmine.createSpy('cellsSpy');
+    handsontable({
+      columns: [
+        {data: 'id', type: 'numeric'}
+      ],
+      cells: cellsSpy
+    });
+
+    setDataAtCell(0, 0, 'foo');
+    expect(cellsSpy).not.toHaveBeenCalledWith(0,'id','id')
+  })
+
 });


### PR DESCRIPTION
DropdownEditor was trying to call getCellMeta with (col, prop) in its beforeValidate hook, leading to the property instead of the column being passed to the cells option.