### PR TITLE
POC Optimization

### DIFF
--- a/src/renderers/_cellDecorator.js
+++ b/src/renderers/_cellDecorator.js
@@ -4,31 +4,56 @@
 import {addClass, removeClass} from './../helpers/dom/element';
 import {registerRenderer} from './../renderers';
 
-function cellDecorator(instance, TD, row, col, prop, value, cellProperties) {
-  if (cellProperties.className) {
-    if (TD.className) {
-      TD.className = `${TD.className} ${cellProperties.className}`;
-    } else {
-      TD.className = cellProperties.className;
-    }
+function FakeElement(className) {
+  if (className.length) {
+    className += ' ';
   }
+  function add(id) {
+    if (id && className.indexOf(id) < 0) {
+      className += id + ' ';
+    }
+  };
+  function remove(id) {
+    if (id && className.indexOf(id + ' ') >= 0) {
+      className.replace(id + ' ', ' ');
+    }
+  };
+  return {
+    set: function (_) { className = _; },
+    get: function () { return className.trim(); },
+    addClass: add,
+    removeClass: remove,
+    classList: {
+      add: add,
+      remove: remove
+    }
+  };
+}
+
+function cellDecorator(instance, TD, row, col, prop, value, cellProperties) {
+  var fakeTD = FakeElement(TD.className);
+  fakeTD.addClass(cellProperties.className);
 
   if (cellProperties.readOnly) {
-    addClass(TD, cellProperties.readOnlyCellClassName);
+    fakeTD.addClass(cellProperties.readOnlyCellClassName);
   }
 
   if (cellProperties.valid === false && cellProperties.invalidCellClassName) {
-    addClass(TD, cellProperties.invalidCellClassName);
+    fakeTD.addClass(cellProperties.invalidCellClassName);
   } else {
-    removeClass(TD, cellProperties.invalidCellClassName);
+    fakeTD.removeClass(cellProperties.invalidCellClassName);
   }
 
   if (cellProperties.wordWrap === false && cellProperties.noWordWrapClassName) {
-    addClass(TD, cellProperties.noWordWrapClassName);
+    fakeTD.addClass(cellProperties.noWordWrapClassName);
   }
 
   if (!value && cellProperties.placeholder) {
-    addClass(TD, cellProperties.placeholderCellClassName);
+    fakeTD.addClass(cellProperties.placeholderCellClassName);
+  }
+
+  if (TD.className !== fakeTD.get()) {
+    TD.className = fakeTD.get();
   }
 }
 


### PR DESCRIPTION
This is a small POC for an optimization.  

The premise is that changing "className" (and classList) for an element is relatively expensive and is something which is happening a _lot_.

The optimization recommendation is to "pre calculate" the new className and then only apply it once per render cycle per cell.

In my "simple" testing I saw a ~10% speed bump for a cell render (when clicking on the cell) with this change only applied within the cellDecorator, but if this was extended to the whole render cycle (with className only being changed once), I suspect it will have an even greater benefit.
