### PR TITLE
Fix bug about continuous editing with ime #3500

### DIFF
--- a/src/editors/textEditor.js
+++ b/src/editors/textEditor.js
@@ -153,6 +153,8 @@ TextEditor.prototype.close = function(tdOutside) {
     this.instance.listen(); // don't refocus the table if user focused some cell outside of HT on purpose
   }
   this.instance.removeHook('beforeKeyDown', onBeforeKeyDown);
+
+  this.TEXTAREA.blur();
 };
 
 TextEditor.prototype.focus = function() {


### PR DESCRIPTION
Fix #3500.

The textarea of a editor is still focused after the editor closed, so input from ime streams into the textarea.
The patch calls TEXTAREA.blur() to remove focus when editor closed.
It works well in my environment.
