### PR TITLE
Allow user to clear sorting

### DIFF
--- a/src/plugins/columnSorting/columnSorting.js
+++ b/src/plugins/columnSorting/columnSorting.js
@@ -207,7 +207,7 @@ class ColumnSorting extends BasePlugin {
       sortingState.sortOrder = this.hot.sortOrder;
     }
 
-    if (hasOwnProperty(sortingState, 'sortColumn') || hasOwnProperty(sortingState, 'sortOrder')) {
+    if (hasOwnProperty(sortingState, 'sortColumn') && hasOwnProperty(sortingState, 'sortOrder')) {
       this.hot.runHooks('persistentStateSave', 'columnSorting', sortingState);
     }
 


### PR DESCRIPTION
Sort state should not persist on the next page load if the user clears the sort order. `sortColumn` would be present, but `sortOrder` would not, triggering the hook, which restores the previous `sortOrder` value.

- [x] Signed CLA
- [x] Changed base branch to `develop`
- [x] Rebased
- [ ] Add/update tests