### PR TITLE
Add cloneFactory setting for cloning cells

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -506,7 +506,8 @@ Handsontable.Core = function Core(rootElement, userSettings) {
 
                   /* jshint -W073 */
                   if (isObjectEquals(orgValueSchema, valueSchema)) {
-                    value = deepClone(value);
+                    const cloneFactory = instance.getSettings().cloneFactory;
+                    value = cloneFactory(value);
                   } else {
                     pushData = false;
                   }
@@ -5199,5 +5200,17 @@ DefaultSettings.prototype = {
    * @default: false
    */
   filteringCaseSensitive: false,
+
+  /**
+   * @description
+   * The function used to clone cells when performing operations like autofill.
+   *
+   * @type {Function}
+   * @param {Object} cell
+   * @returns {Object}
+   * @default A function which takes a deep clone of JSON-compatible properties (i.e. it ignores functions, does not
+   * preserve prototypes, etc).
+   */
+  cloneFactory: deepClone
 };
 Handsontable.DefaultSettings = DefaultSettings;


### PR DESCRIPTION
Hi,

I've been butting up against the issue described in #3744 again, but in a slightly different way. I want to add a toString method on all objects backing the cells (so that copying from handsontable, e.g. into Excel, gives something more informative than "[Object object]"), but because of the deepClone operation (which uses JSON de/serialization), the toString method gets dropped when autofilling, etc.

I realised I could kill two birds with one stone by adding a "clone factory" as a setting to handsontable. That way, I can take control of cloning my cells and use my constructor and not only will all my cells have my toString method, but their schemas will match as well (thus working around my problem in #3744).

I think there should perhaps be a longer-term solution to #3744, but for now this would, I think, satisfy me, personally.

Does a "clone factory" sound sensible? Could it be merged? Happy to hear any feedback or many any fixes required.

Thanks,
Rowan
