### PR TITLE
Fix middle click scroll behaviour

### DIFF
--- a/src/tableView.js
+++ b/src/tableView.js
@@ -58,6 +58,9 @@ function TableView(instance) {
   instance.container.insertBefore(table, instance.container.firstChild);
 
   this.eventManager.addEventListener(instance.rootElement, 'mousedown', function(event) {
+    if (event.buttons === 4) {
+      return; // Avoid breaking middle click scroll behaviour
+    }
     this.selectionMouseDown = true;
 
     if (!that.isTextSelectionAllowed(event.target)) {


### PR DESCRIPTION
### Context

Middle click scroll is broken, the cursor should become something like in the image below. This doesn't happen because event.preventDefault()
![](http://cdn.ghacks.net/wp-content/uploads/2014/10/mouse-auto-scroll-chrome.jpg)
### How has this been tested?

I added the lines in handsontable.full.js and checked if it worked in my project. I did not build the project or run tests.
### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/2722
### Checklist:
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
