### PR TITLE
Patch for IE

### DIFF
--- a/src/helpers/dom/element.js
+++ b/src/helpers/dom/element.js
@@ -695,7 +695,11 @@ export function getStyle(element, prop) {
  * @returns {IEElementStyle|CssStyle} Elements computed style object
  */
 export function getComputedStyle(element) {
-  return element.currentStyle || document.defaultView.getComputedStyle(element);
+  if(document.defaultView.getComputedStyle !== '' && document.defaultView.getComputedStyle !== void 0) {
+    return document.defaultView.getComputedStyle(element);
+  } else {
+    return element.currentStyle;
+  }
 }
 
 /**


### PR DESCRIPTION
### Context
In Internet Explorer, in various conditions, when renderAllRows is not possible, scrolling a table will not render rows that were not initially in view.

### How has this been tested?
Tested with various combinations of rows and columns, with renderAllRows set to true and false.

### Types of changes
Bug fix. It is fine to primarily rely on document.defaultView.getComputedStyle.

### Related issue(s):

### Checklist:
- [x ] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.

