### PR TITLE
Feature/issue 3897

### DIFF
--- a/src/plugins/manualColumnFreeze/manualColumnFreeze.js
+++ b/src/plugins/manualColumnFreeze/manualColumnFreeze.js
@@ -77,6 +77,9 @@ class ManualColumnFreeze extends BasePlugin {
     this.disablePlugin();
     this.enablePlugin();
 
+    if (!this.manualColumnMovePlugin.isEnabled()) {
+      this.manualColumnMovePlugin.adjustColumnSize();
+    }
     super.updatePlugin();
   }
 

--- a/src/plugins/manualColumnFreeze/test/manualColumnFreeze.spec.js
+++ b/src/plugins/manualColumnFreeze/test/manualColumnFreeze.spec.js
@@ -37,6 +37,25 @@ describe("manualColumnFreeze", function () {
 
       expect(movePlugin.columnsMapper.getValueByIndex(0)).toEqual(5);
     });
+
+    it("should still freeze columns as table size expands", function () {
+      var hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(3, 3),
+        manualColumnFreeze: true
+      });
+
+      hot.updateSettings({
+        data: Handsontable.helper.createSpreadsheetData(10, 10)
+      });
+      
+      var plugin = hot.getPlugin('manualColumnFreeze');
+      var movePlugin = hot.getPlugin('manualColumnMove');
+
+      plugin.freezeColumn(5);
+
+      expect(movePlugin.columnsMapper.getValueByIndex(0)).toEqual(5);
+    });
+
   });
 
   describe("unfreezeColumn", function () {
@@ -69,6 +88,7 @@ describe("manualColumnFreeze", function () {
       expect(movePlugin.columnsMapper.getValueByIndex(1)).toEqual(2);
       expect(movePlugin.columnsMapper.getValueByIndex(2)).toEqual(0);
     });
+
   });
 
   describe("functionality", function () {

--- a/src/plugins/manualColumnMove/manualColumnMove.js
+++ b/src/plugins/manualColumnMove/manualColumnMove.js
@@ -670,11 +670,10 @@ class ManualColumnMove extends BasePlugin {
   }
 
   /**
-   * `afterPluginsInitialized` hook callback.
+   * `adjustColumnSize` -- called to adjust size of columnsMapper
    *
-   * @private
    */
-  onAfterPluginsInitialized() {
+  adjustColumnSize() {
     let countCols = this.hot.countCols();
     let columnsMapperLen = this.columnsMapper._arrayMap.length;
 
@@ -698,7 +697,15 @@ class ManualColumnMove extends BasePlugin {
 
       this.columnsMapper.removeItems(columnsToRemove);
     }
+  }
 
+  /**
+   * `afterPluginsInitialized` hook callback.
+   *
+   * @private
+   */
+  onAfterPluginsInitialized() {
+    this.adjustColumnSize();
     this.initialSettings();
     this.backlight.build();
     this.guideline.build();


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
see #3897 
This resolves so that if number of columns increases, manualColumnFreeze continues to work even if manualColumnMove plugin is disabled

### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
See additional specs

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):
1. #3897
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
