### PR TITLE
Update documentation of "prop" parameter in propToCol to show that it…

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1902,7 +1902,7 @@ Handsontable.Core = function Core(rootElement, userSettings) {
    *
    * @memberof Core#
    * @function propToCol
-   * @param {String} prop Property name.
+   * @param {String|Number} prop Property name.
    * @returns {Number} Column index.
    */
   this.propToCol = function(prop) {

--- a/src/core.js
+++ b/src/core.js
@@ -1902,7 +1902,7 @@ Handsontable.Core = function Core(rootElement, userSettings) {
    *
    * @memberof Core#
    * @function propToCol
-   * @param {String|Number} prop Property name.
+   * @param {String|Number} prop Property name or column index.
    * @returns {Number} Column index.
    */
   this.propToCol = function(prop) {


### PR DESCRIPTION
… can be a number.

### Context
Documentation is misleading for people using Handsontable from TypeScript. (Because of this the DefinitelyTyped definition of this function used to be incorrect).
The inverse of this function (colToProp) is documented to return String|Number https://docs.handsontable.com/pro/1.8.1/Core.html#colToProp so propToCol should be documented to accept String|Number. The code does accept numbers so no code change is required.

### How has this been tested?
N/A documentation change only

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
- [ x ] My code follows the code style of this project,
- [ x ] My change requires a change to the documentation.
