### PR TITLE
Add support for column specific queryMethods in search plugin

### DIFF
--- a/src/plugins/search/search.js
+++ b/src/plugins/search/search.js
@@ -22,8 +22,9 @@ Handsontable.Search = function Search(instance) {
 	
     for (var rowIndex = 0; rowIndex < rowCount; rowIndex++) {
       for (var colIndex = 0; colIndex < colCount; colIndex++) {
-  	    var colProperties = instance.getSettings().columns[colIndex];
-		var colQueryMethod = (colProperties.search !== null && typeof colProperties.search == 'object' &&colProperties.search.queryMethod;
+        var colProperties = instance.getSettings().columns[colIndex];
+        var colQueryMethod = 
+          (colProperties.search !== null && typeof colProperties.search == 'object' &&colProperties.search.queryMethod;
 
         var cellData = instance.getDataAtCell(rowIndex, colIndex);
         var cellProperties = instance.getCellMeta(rowIndex, colIndex);

--- a/src/plugins/search/search.js
+++ b/src/plugins/search/search.js
@@ -19,13 +19,16 @@ Handsontable.Search = function Search(instance) {
     if (!queryMethod) {
       queryMethod = Handsontable.Search.global.getDefaultQueryMethod();
     }
-
+	
     for (var rowIndex = 0; rowIndex < rowCount; rowIndex++) {
       for (var colIndex = 0; colIndex < colCount; colIndex++) {
+  	    var colProperties = instance.getSettings().columns[colIndex];
+		var colQueryMethod = (colProperties.search !== null && typeof colProperties.search == 'object' &&colProperties.search.queryMethod;
+
         var cellData = instance.getDataAtCell(rowIndex, colIndex);
         var cellProperties = instance.getCellMeta(rowIndex, colIndex);
         var cellCallback = cellProperties.search.callback || callback;
-        var cellQueryMethod = cellProperties.search.queryMethod || queryMethod;
+        var cellQueryMethod = cellProperties.search.queryMethod || colQueryMethod|| queryMethod;
         var testResult = cellQueryMethod(queryStr, cellData);
 
         if (testResult) {


### PR DESCRIPTION
### Context
The search plugin doesn't provide full support for [Cascading Configuration](http://docs.handsontable.com/pro/1.8.2/Options.html). There is support for a global, a search specific and a cell specific search function but there is no support for a column specific search function.
Example: 
This is needed for example for locale specific numerical columns (with Numbro) where a numerical data value of let's say 1.5 is rendered 1,5 and the user would also search for values using the comma instead of the dot. To support this kind of search a column specific search functions is needed that formats the data value to the rendered value prior to making the comparison with the search value.

### How has this been tested?
Tested with global, cell and column specific searches.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):
1. #3986
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [x] My change requires a change to the documentation.
