### PR TITLE
insert_row: Added check for valid index

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -141,6 +141,9 @@ Handsontable.Core = function Core(rootElement, userSettings) {
           if (instance.getSettings().maxRows === instance.countSourceRows()) {
             return;
           }
+          if (typeof index !== 'number' || index >= instance.countSourceRows()) {
+            index = instance.countSourceRows();
+          }
           delta = datamap.createRow(index, amount, source);
           spliceWith(priv.cellSettings, index, amount, 'array');
 


### PR DESCRIPTION
### Context
Previously, 'insert_row' without specifying an index would add the row at the bottom, but would insert the settings at the top. (This was because `datamap.createRow` would do the `index` check, but `spliceWith` wouldn't, (making it call `splice` with arguments: `undefined, 0, []`, thus inserting `[]` at the start)).

### How has this been tested?
I have tested with the automated tests, and using it (specifically autofill drag).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
