### PR TITLE
Delete duplicate beforeValueRender jsdoc

### DIFF
--- a/src/pluginHooks.js
+++ b/src/pluginHooks.js
@@ -1120,14 +1120,6 @@ const REGISTERED_HOOKS = [
   'afterModifyTransformEnd',
 
   /**
-   * Fired before rendering a cell value.
-   *
-   * @event Hooks#beforeValueRender
-   * @param {Mixed} value The rendered value.
-   */
-  'beforeValueRender',
-
-  /**
    * Fired inside the `viewportRowCalculatorOverride` method. Allows modifying the row calculator parameters.
    *
    * @event Hooks#afterViewportRowCalculatorOverride


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The beforeValueRender event is documented twice, this commit removes one.

[pluginHooks.js#L702](https://github.com/handsontable/handsontable/blob/f7288f2a64c39142226206f81768ef60d8480279/src/pluginHooks.js#L702)

[pluginHooks.js#L1122](https://github.com/handsontable/handsontable/blob/f7288f2a64c39142226206f81768ef60d8480279/src/pluginHooks.js#L1122)

### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
untested

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):
1.
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project,
- [x] My change requires a change to the documentation.
