### PR TITLE
Update Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ If you use a CommonJS compatible environment you can use the `require` function 
 ```javascript
 var handsontable = require('handsontable');
 ```
+To grab all dependencies following an NPM install, you can use this for CommonJS modules
+```javascript
+var handsontable = require('handsontable/dist/handsontable.full');
+```
+
 To bundle Handsontable with [Browserify](http://browserify.org) you must specify the module names of all required modules:
 
 `browserify main.js -o bundle.js -r moment -r pikaday -r zeroclipboard -r numbro`


### PR DESCRIPTION
Preventing issue on installation of Cannot find module 'numbro' for those using Webpack

### Context
<!--- Why is this change required? What problem does it solve? -->
A number of fresh installs of handsontables are getting less than the complete set of dependent modules required to get up and running.

### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
Documentation change.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):
1.
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project,
- [X] My change requires a change to the documentation.
