### PR TITLE
Support sorting checkbox columns

### DIFF
--- a/src/plugins/columnSorting/columnSorting.js
+++ b/src/plugins/columnSorting/columnSorting.js
@@ -367,6 +367,19 @@ class ColumnSorting extends BasePlugin {
   }
 
   /**
+   * Boolean sorting algorithm.
+   *
+   * @param {Boolean} sortOrder Sorting order (`true` for ascending, `false` for descending).
+   * @param {Object} columnMeta Column meta object.
+   * @returns {Function} The compare function.
+   */
+  booleanSort(sortOrder, columnMeta) {
+    return function(a, b) {
+      return sortOrder ? (b[1] - a[1]) : (a[1] - b[1]);
+    };
+  }
+
+  /**
    * Perform the sorting.
    */
   sort() {
@@ -407,6 +420,9 @@ class ColumnSorting extends BasePlugin {
           break;
         case 'numeric':
           sortFunction = this.numericSort;
+          break;
+        case 'checkbox':
+          sortFunction = this.booleanSort;
           break;
         default:
           sortFunction = this.defaultSort;

--- a/src/plugins/columnSorting/test/columnSorting.spec.js
+++ b/src/plugins/columnSorting/test/columnSorting.spec.js
@@ -575,7 +575,7 @@ describe('ColumnSorting', function() {
     var myData = [
       {a: false, b: 2, c: 3},
       {a: true, b: 11, c: -4},
-      {a: false, b: 10, c: 11}
+      {a: true, b: 10, c: 11}
     ];
 
     function customIsEmptyRow(row) {
@@ -600,7 +600,7 @@ describe('ColumnSorting', function() {
 
     expect(this.$container.find('tbody tr:eq(0) td:eq(0) :checkbox').is(':checked')).toBe(false);
     expect(this.$container.find('tbody tr:eq(1) td:eq(0) :checkbox').is(':checked')).toBe(true);
-    expect(this.$container.find('tbody tr:eq(2) td:eq(0) :checkbox').is(':checked')).toBe(false);
+    expect(this.$container.find('tbody tr:eq(2) td:eq(0) :checkbox').is(':checked')).toBe(true);
     expect(this.$container.find('tbody tr:eq(3) td:eq(0) :checkbox').is(':checked')).toBe(false); //spare row
 
     updateSettings({
@@ -610,9 +610,9 @@ describe('ColumnSorting', function() {
       }
     });
 
-    expect(this.$container.find('tbody tr:eq(0) td:eq(0) :checkbox').is(':checked')).toBe(false);
-    expect(this.$container.find('tbody tr:eq(1) td:eq(0) :checkbox').is(':checked')).toBe(false);
-    expect(this.$container.find('tbody tr:eq(2) td:eq(0) :checkbox').is(':checked')).toBe(true);
+    expect(this.$container.find('tbody tr:eq(0) td:eq(0) :checkbox').is(':checked')).toBe(true);
+    expect(this.$container.find('tbody tr:eq(1) td:eq(0) :checkbox').is(':checked')).toBe(true);
+    expect(this.$container.find('tbody tr:eq(2) td:eq(0) :checkbox').is(':checked')).toBe(false);
     expect(this.$container.find('tbody tr:eq(3) td:eq(0) :checkbox').is(':checked')).toBe(false); //spare row
   });
 


### PR DESCRIPTION
### Context
Checkbox columns cannot be sorted, as booleans cannot be effectively compared with < or >. They can however be subtracted from each other.
```javascript
>> true > false
<< true
>> false < true
<< true
>> true - false
<< 1
>> false - true
<< -1
```

### How has this been tested?
Created table with checkbox fields and ColumnSort enabled.. Checked some boxes. Sorted columns.

### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. N/A

### Checklist:
- [X] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.