### PR TITLE
Add freeze_column to context_menu documentation

### DIFF
--- a/demo/contextmenu.html
+++ b/demo/contextmenu.html
@@ -163,6 +163,7 @@
         <li><b>clear_column</b> (designed for <a href="dropdownmenu.html">Dropdown Menu</a>)</li>
         <li><b>borders</b> (only with <a href="custom_borders.html">Custom Borders</a> turned on)</li>
         <li><b>commentsAddEdit</b>, <b>commentsRemove</b> (only with <a href="comments.html">Comments</a> turned on)</li>
+        <li><b>freeze_column</b>, <b>unfreeze_column</b> (only with <a href="column_freeze.html">Column Freezing</a> turned on)</li>
       </ul>
 
       <div id="example2"></div>


### PR DESCRIPTION
### Context
This attribute, `column_freeze` is not listed in the available attributes for the context menu.
I had to guess on what to add when I wanted to do something like:
```javascript
            var settings = {
              manualColumnFreeze: true,
              contextMenu: true,
              contextMenu: ['freeze_column', 'alignment']
            }
```
### How has this been tested?
added it to a handsontable and context menu showed only those options
![screen shot 2017-02-01 at 2 42 12 pm](https://cloud.githubusercontent.com/assets/13190980/22529752/7d5e01c4-e88d-11e6-850d-bc0c70f0ed49.png)

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):
1.
2.
3.

### Checklist:
- [ ] My code follows the code style of this project,
- [x] My change requires a change to the documentation.
