### PR TITLE
Adds support for multi-level submenus

### DIFF
--- a/src/plugins/columnSorting/columnSorting.js
+++ b/src/plugins/columnSorting/columnSorting.js
@@ -525,7 +525,9 @@ class ColumnSorting extends BasePlugin {
     if (!this.isSorted()) {
       return;
     }
-
+    if (amount === undefined) {
+      amount = 0;
+    }
     for (var i = 0; i < this.hot.sortIndex.length; i++) {
       if (this.hot.sortIndex[i][0] >= index) {
         this.hot.sortIndex[i][0] += amount;

--- a/src/plugins/contextMenu/commandExecutor.js
+++ b/src/plugins/contextMenu/commandExecutor.js
@@ -35,23 +35,14 @@ class CommandExecutor {
   }
 
   /**
-   * Execute command by its name.
+   * Execute command or command by its name.
    *
-   * @param {String} commandName Command id.
+   * @param {Object} or {String} command or Command id.
    * @param {*} params Arguments passed to command task.
    */
-  execute(commandName, ...params) {
-    let commandSplit = commandName.split(':');
-    commandName = commandSplit[0];
-
-    let subCommandName = commandSplit.length === 2 ? commandSplit[1] : null;
-    let command = this.commands[commandName];
-
-    if (!command) {
-      throw new Error(`Menu command '${commandName}' not exists.`);
-    }
-    if (subCommandName && command.submenu) {
-      command = findSubCommand(subCommandName, command.submenu.items);
+  execute(command, ...params) {
+    if (typeof command === 'string') {
+      command = findCommand(command);
     }
     if (command.disabled === true) {
       return;
@@ -70,25 +61,44 @@ class CommandExecutor {
     if (typeof this.commonCallback === 'function') {
       callbacks.push(this.commonCallback);
     }
-    params.unshift(commandSplit.join(':'));
+    params.unshift(command.key);
     arrayEach(callbacks, (callback) => callback.apply(this.hot, params));
   }
 }
 
-function findSubCommand(subCommandName, subCommands) {
+function findCommand(commandName) {
+  let commandSplit = commandName.split(':');
+  commandName = commandSplit[0];
+
+  let subCommandName = commandSplit.length > 1 ? commandSplit[commandSplit.length - 1] : null;
+  let command = this.commands[commandName];
+
+  if (!command) {
+    throw new Error(`Menu command '${commandName}' not exists.`);
+  }
+  if (subCommandName && command.submenu) {
+    let commands = commandSplit.slice(1);
+    command = findSubCommand(commands, command.submenu.items, commandSplit.slice(0, 2));
+  }
+
+  return command;
+}
+
+function findSubCommand(commands, items, keys) {
   let command;
-
-  arrayEach(subCommands, (cmd) => {
-    let cmds = cmd.key ? cmd.key.split(':') : null;
-
-    if (Array.isArray(cmds) && cmds[1] === subCommandName) {
-      command = cmd;
-
+  arrayEach(items, (item) => {
+    if (item.key === keys.join(':')) {
+      command = item;
       return false;
     }
   });
-
-  return command;
+  if (commands.length > 1) {
+    commands.shift();
+    keys.push(commands[0]);
+    return findSubCommand(commands, command.submenu.items, keys);
+  } else {
+    return command;
+  }
 }
 
 export {CommandExecutor};

--- a/src/plugins/contextMenu/commandExecutor.js
+++ b/src/plugins/contextMenu/commandExecutor.js
@@ -42,7 +42,7 @@ class CommandExecutor {
    */
   execute(command, ...params) {
     if (typeof command === 'string') {
-      command = findCommand(command);
+      command = this.findCommand(command);
     }
     if (command.disabled === true) {
       return;
@@ -64,24 +64,24 @@ class CommandExecutor {
     params.unshift(command.key);
     arrayEach(callbacks, (callback) => callback.apply(this.hot, params));
   }
-}
 
-function findCommand(commandName) {
-  let commandSplit = commandName.split(':');
-  commandName = commandSplit[0];
+  findCommand(commandName) {
+    let commandSplit = commandName.split(':');
+    commandName = commandSplit[0];
 
-  let subCommandName = commandSplit.length > 1 ? commandSplit[commandSplit.length - 1] : null;
-  let command = this.commands[commandName];
+    let subCommandName = commandSplit.length > 1 ? commandSplit[commandSplit.length - 1] : null;
+    let command = this.commands[commandName];
 
-  if (!command) {
-    throw new Error(`Menu command '${commandName}' not exists.`);
+    if (!command) {
+      throw new Error(`Menu command '${commandName}' not exists.`);
+    }
+    if (subCommandName && command.submenu) {
+      let commands = commandSplit.slice(1);
+      command = findSubCommand(commands, command.submenu.items, commandSplit.slice(0, 2));
+    }
+
+    return command;
   }
-  if (subCommandName && command.submenu) {
-    let commands = commandSplit.slice(1);
-    command = findSubCommand(commands, command.submenu.items, commandSplit.slice(0, 2));
-  }
-
-  return command;
 }
 
 function findSubCommand(commands, items, keys) {

--- a/src/plugins/contextMenu/contextMenu.js
+++ b/src/plugins/contextMenu/contextMenu.js
@@ -135,7 +135,7 @@ class ContextMenu extends BasePlugin {
       this.itemsFactory.setPredefinedItems(predefinedItems.items);
       let menuItems = this.itemsFactory.getItems(settings);
 
-      this.menu = new Menu(this.hot, {
+      this.menu = new Menu(this.hot, this.commandExecutor, {
         className: 'htContextMenu',
         keepInViewport: true
       });
@@ -237,7 +237,7 @@ class ContextMenu extends BasePlugin {
    *
    * Or you can execute command registered in settings where `key` is your command name.
    *
-   * @param {String} commandName
+   * @param {Object] or {String} command or command name.
    * @param {*} params
    */
   executeCommand(...params) {

--- a/src/plugins/contextMenu/menu.js
+++ b/src/plugins/contextMenu/menu.js
@@ -23,8 +23,9 @@ import {stopImmediatePropagation} from './../../helpers/dom/event';
  * @plugin ContextMenu
  */
 class Menu {
-  constructor(hotInstance, options) {
+  constructor(hotInstance, commandExecutor, options) {
     this.hot = hotInstance;
+    this.commandExecutor = commandExecutor;
     this.options = options || {
       parent: null,
       name: null,
@@ -143,7 +144,7 @@ class Menu {
       return;
     }
     if (closeParent && this.parentMenu) {
-      this.parentMenu.close();
+      this.parentMenu.close(closeParent);
     } else {
       this.closeAllSubMenus();
       this.container.style.display = 'none';
@@ -177,12 +178,13 @@ class Menu {
       return false;
     }
     let dataItem = this.hotMenu.getSourceDataAtRow(row);
-    let subMenu = new Menu(this.hot, {
+    let subMenu = new Menu(this.hot, this.commandExecutor, {
       parent: this,
       name: dataItem.name,
       className: this.options.className,
       keepInViewport: true
     });
+    subMenu.addLocalHook('executeCommand', (...params) => this.commandExecutor.execute.apply(this.commandExecutor, params));
     subMenu.setMenuItems(dataItem.submenu.items);
     subMenu.open();
     subMenu.setPosition(cell.getBoundingClientRect());
@@ -268,11 +270,7 @@ class Menu {
       autoClose = false;
     }
 
-    this.runLocalHooks('executeCommand', selectedItem.key, normalizedSelection, event);
-
-    if (this.isSubMenu()) {
-      this.parentMenu.runLocalHooks('executeCommand', selectedItem.key, normalizedSelection, event);
-    }
+    this.runLocalHooks('executeCommand', selectedItem, normalizedSelection, event);
 
     if (autoClose) {
       this.close(true);

--- a/src/plugins/search/search.js
+++ b/src/plugins/search/search.js
@@ -22,8 +22,9 @@ Handsontable.Search = function Search(instance) {
 	
     for (var rowIndex = 0; rowIndex < rowCount; rowIndex++) {
       for (var colIndex = 0; colIndex < colCount; colIndex++) {
-  	    var colProperties = instance.getSettings().columns[colIndex];
-		var colQueryMethod = (colProperties.search !== null && typeof colProperties.search == 'object' &&colProperties.search.queryMethod;
+        var colProperties = instance.getSettings().columns[colIndex];
+        var colQueryMethod = 
+          (colProperties.search !== null && typeof colProperties.search == 'object' &&colProperties.search.queryMethod;
 
         var cellData = instance.getDataAtCell(rowIndex, colIndex);
         var cellProperties = instance.getCellMeta(rowIndex, colIndex);

--- a/src/plugins/search/search.js
+++ b/src/plugins/search/search.js
@@ -19,17 +19,17 @@ Handsontable.Search = function Search(instance) {
     if (!queryMethod) {
       queryMethod = Handsontable.Search.global.getDefaultQueryMethod();
     }
-	
+
     for (var rowIndex = 0; rowIndex < rowCount; rowIndex++) {
       for (var colIndex = 0; colIndex < colCount; colIndex++) {
         var colProperties = instance.getSettings().columns[colIndex];
-        var colQueryMethod = 
-          (colProperties.search !== null && typeof colProperties.search == 'object' &&colProperties.search.queryMethod;
+        var colQueryMethod = (colProperties.search !== null && typeof colProperties.search == 'object' &&
+          colProperties.search.queryMethod);
 
         var cellData = instance.getDataAtCell(rowIndex, colIndex);
         var cellProperties = instance.getCellMeta(rowIndex, colIndex);
         var cellCallback = cellProperties.search.callback || callback;
-        var cellQueryMethod = cellProperties.search.queryMethod || colQueryMethod|| queryMethod;
+        var cellQueryMethod = cellProperties.search.queryMethod || colQueryMethod || queryMethod;
         var testResult = cellQueryMethod(queryStr, cellData);
 
         if (testResult) {

--- a/src/plugins/search/search.js
+++ b/src/plugins/search/search.js
@@ -22,14 +22,10 @@ Handsontable.Search = function Search(instance) {
 
     for (var rowIndex = 0; rowIndex < rowCount; rowIndex++) {
       for (var colIndex = 0; colIndex < colCount; colIndex++) {
-        var colProperties = instance.getSettings().columns[colIndex];
-        var colQueryMethod = (colProperties.search !== null && typeof colProperties.search == 'object' &&
-          colProperties.search.queryMethod);
-
         var cellData = instance.getDataAtCell(rowIndex, colIndex);
         var cellProperties = instance.getCellMeta(rowIndex, colIndex);
         var cellCallback = cellProperties.search.callback || callback;
-        var cellQueryMethod = cellProperties.search.queryMethod || colQueryMethod || queryMethod;
+        var cellQueryMethod = cellProperties.search.queryMethod || queryMethod;
         var testResult = cellQueryMethod(queryStr, cellData);
 
         if (testResult) {

--- a/src/plugins/search/search.js
+++ b/src/plugins/search/search.js
@@ -19,13 +19,16 @@ Handsontable.Search = function Search(instance) {
     if (!queryMethod) {
       queryMethod = Handsontable.Search.global.getDefaultQueryMethod();
     }
-
+	
     for (var rowIndex = 0; rowIndex < rowCount; rowIndex++) {
       for (var colIndex = 0; colIndex < colCount; colIndex++) {
+  	    var colProperties = instance.getSettings().columns[colIndex];
+		var colQueryMethod = (colProperties.search !== null && typeof colProperties.search == 'object' &&colProperties.search.queryMethod;
+
         var cellData = instance.getDataAtCell(rowIndex, colIndex);
         var cellProperties = instance.getCellMeta(rowIndex, colIndex);
         var cellCallback = cellProperties.search.callback || callback;
-        var cellQueryMethod = cellProperties.search.queryMethod || queryMethod;
+        var cellQueryMethod = cellProperties.search.queryMethod || colQueryMethod|| queryMethod;
         var testResult = cellQueryMethod(queryStr, cellData);
 
         if (testResult) {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
This change add support for multi-level submenus with the contextMenu plugin.
### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
Tested with the default menu and with this contextMenu definition:
`
contextMenu: {
  callback: function (key, options) {
    console.log(key);
  },
  items: {
    "menu1": {
      name: "menu1",
      submenu: {
        items: [
          {
            name: "submenu11",
            key: "menu1:submenu11",
            disabled: true
          },
          {
            name: "submenu12",
            key: "menu1:submenu12",
            submenu: {
              items: [
                {
                  name: "subsubmenu121",
                  key: "menu1:submenu12:subsubmenu121",
                  callback: function (key, options) {
                    console.log(key+" special callback");
                  }
                }
              ]
            }
          }
        ]
      }
    },
    "menu2": {
      name: "menu2"
    },
    "menu3": {
      name: "menu3"
    }
  }
}
`
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):
1. #3533 
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [x] My change requires a change to the documentation.
