### PR TITLE
Protect against stack overflow in deepObjectSize

### DIFF
--- a/src/helpers/object.js
+++ b/src/helpers/object.js
@@ -296,7 +296,10 @@ export function deepObjectSize(object) {
   if (!isObject(object)) {
     return 0;
   }
+  let recursMax = 10;
   let recursObjLen = function(obj) {
+    if (!recursMax) return 0;
+    recursMax--;
     let result = 0;
 
     if (isObject(obj)) {
@@ -307,6 +310,7 @@ export function deepObjectSize(object) {
       result++;
     }
 
+    recursMax++;
     return result;
   };
 


### PR DESCRIPTION
### Context
When Handsontable is bound to complex objects for rows, it may generate stack overflow exceptions. The logic inside Handsontable sometimes wants to walk deep iteration over row level objects, and that can be expensive or have cyclical references.

The change limits the depth of iteration,

### How has this been tested?
Ran with the updated code and seen it not break anymore. Tried with flat data row objects too.