### PR TITLE
Support sorting checkbox columns

### DIFF
--- a/src/plugins/columnSorting/columnSorting.js
+++ b/src/plugins/columnSorting/columnSorting.js
@@ -420,6 +420,19 @@ class ColumnSorting extends BasePlugin {
   }
 
   /**
+   * Boolean sorting algorithm.
+   *
+   * @param {Boolean} sortOrder Sorting order (`true` for ascending, `false` for descending).
+   * @param {Object} columnMeta Column meta object.
+   * @returns {Function} The compare function.
+   */
+  booleanSort(sortOrder, columnMeta) {
+    return function(a, b) {
+      return sortOrder ? (b[1] - a[1]) : (a[1] - b[1]);
+    };
+  }
+
+  /**
    * Perform the sorting.
    */
   sort() {
@@ -461,6 +474,9 @@ class ColumnSorting extends BasePlugin {
           break;
         case 'numeric':
           sortFunction = this.numericSort;
+          break;
+        case 'checkbox':
+          sortFunction = this.booleanSort;
           break;
         default:
           sortFunction = this.defaultSort;


### PR DESCRIPTION
### Context
Reopened from #4036. CLA is signed and PR is rebased to `develop`.

Checkbox columns cannot be sorted, as booleans cannot be effectively compared with < or >. They can however be subtracted from each other.
```javascript
>> true > false
<< true
>> false < true
<< true
>> true - false
<< 1
>> false - true
<< -1
```

### How has this been tested?
Created table with checkbox fields and ColumnSort enabled.. Checked some boxes. Sorted columns.

### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. N/A

### Checklist:
- [X] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.