### PR TITLE
Mention in `rowHeights` docs that it enforces minimum heights

### DIFF
--- a/src/defaultSettings.js
+++ b/src/defaultSettings.js
@@ -229,6 +229,8 @@ DefaultSettings.prototype = {
    * Defines row heights in pixels. Accepts numbers, strings (that will be converted into a number),
    * array of numbers (if you want to define row height separately for each row) or a
    * function (if you want to set row height dynamically on each render).
+   * If the ManualRowResize or AutoRowSize plugins are enabled, this is also the minimum height that can be set
+   * via either of those two plugins.
    * Height should be equal or greater than 23px. Table is rendered incorrectly if height is less than 23px.
    *
    * @type {Array|Function|Number|String}


### PR DESCRIPTION
As mentioned in #3301, `rowHeights` sets the minimum row height when using manual or automatic row resize. This fact is not currently mentioned in the docs, but this PR fixes that.

This is a documentation only PR and I have signed my CLA.