### PR TITLE
Check for attachEvent on the element instead of the window. Fixes #4386

### DIFF
--- a/lib/autoResize/autoResize.js
+++ b/lib/autoResize/autoResize.js
@@ -18,14 +18,14 @@ function autoResize() {
     text = document.createTextNode(''),
     span = document.createElement('SPAN'),
     observe = function (element, event, handler) {
-      if (window.attachEvent) {
+      if (element.attachEvent) {
         element.attachEvent('on' + event, handler);
       } else {
         element.addEventListener(event, handler, false);
       }
     },
     unObserve = function (element, event, handler) {
-      if (window.removeEventListener) {
+      if (element.removeEventListener) {
         element.removeEventListener(event, handler, false);
       } else {
         element.detachEvent('on' + event, handler);

--- a/test/e2e/editors/textEditor.spec.js
+++ b/test/e2e/editors/textEditor.spec.js
@@ -1100,4 +1100,16 @@ describe('TextEditor', () => {
       done();
     }, 150);
   });
+
+  it('should not throw an exception when window.attachEvent is defined but the text area does not have attachEvent', (done) => {
+    var hot = handsontable();
+    window.attachEvent = true;
+    selectCell(1, 1);
+
+    expect(() => {
+      hot.getActiveEditor().autoResize.init(hot.getActiveEditor().TEXTAREA);
+    }).not.toThrow();
+
+    done();
+  });
 });


### PR DESCRIPTION
### Context
If another library modifies window to have an 'attachEvent' method, but the rest of the elements on the page don't have the method, this will lead to a false positive, causing an exception to be thrown when the autoResize method tries to access the 'attachEvent' method on the element. Erring on the side of caution, the code should validate that the element has the attachEvent method before invoking it.

### How has this been tested?
Added a unit test that verifies that autoResize will check the element instead of the window to determine whether or not to call attachEvent.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
