### PR TITLE
Make contextMenu predefined items actually use the predefined items

### DIFF
--- a/src/plugins/contextMenu/contextMenu.js
+++ b/src/plugins/contextMenu/contextMenu.js
@@ -126,7 +126,7 @@ class ContextMenu extends BasePlugin {
 
     const settings = this.hot.getSettings().contextMenu;
     let predefinedItems = {
-      items: this.itemsFactory.getItems(settings)
+      items: this.itemsFactory.getItems(true)
     };
     this.registerEvents();
 


### PR DESCRIPTION
Fetching the predefined items for the context menu currently fetches the items defined in the settings provided by the user. This change makes it _actually fetch the predefined items_.

This caused an issue when defining custom context menus while using the ContextMenuCopyPaste plugin - adding `"copy"` or `"paste"` would display "null" in the context menu (despite this, the functionality would sometimes work?).