### PR TITLE
Fix comment positioning when HoT is nested in a scrollable element

### DIFF
--- a/src/plugins/comments/comments.js
+++ b/src/plugins/comments/comments.js
@@ -396,7 +396,8 @@ class Comments extends BasePlugin {
     let cellOffset = offset(TD);
     let scrollOffset = this.scrollOffset(this.hot.rootElement);
     let lastColWidth = this.hot.view.wt.wtTable.getStretchedColumnWidth(column);
-    let cellTopOffset = cellOffset.top < 0 ? 0 : cellOffset.top;
+    let cellTopOffset = cellOffset.top - scrollOffset.top;
+    cellTopOffset = cellTopOffset < 0 ? 0 : cellTopOffset;
     let cellLeftOffset = cellOffset.left - scrollOffset.left;
 
     if (this.hot.view.wt.wtViewport.hasVerticalScroll() && scrollableElement !== window) {

--- a/src/plugins/comments/comments.js
+++ b/src/plugins/comments/comments.js
@@ -394,9 +394,10 @@ class Comments extends BasePlugin {
     const row = this.range.from.row;
     const column = this.range.from.col;
     let cellOffset = offset(TD);
+    let scrollOffset = this.scrollOffset(this.hot.rootElement);
     let lastColWidth = this.hot.view.wt.wtTable.getStretchedColumnWidth(column);
     let cellTopOffset = cellOffset.top < 0 ? 0 : cellOffset.top;
-    let cellLeftOffset = cellOffset.left;
+    let cellLeftOffset = cellOffset.left - scrollOffset.left;
 
     if (this.hot.view.wt.wtViewport.hasVerticalScroll() && scrollableElement !== window) {
       cellTopOffset -= this.hot.view.wt.wtOverlays.topOverlay.getScrollPosition();
@@ -421,6 +422,28 @@ class Comments extends BasePlugin {
     this.editor.setReadOnlyState(readOnly);
 
     this.editor.setPosition(x, y);
+  }
+
+  /**
+   * Find the recursive scroll offset distance between an element and the
+   * closest fixed element, or the document body.
+   *
+   * @private
+   * @param {Element} element The element to check from.
+   * @returns {Object}
+   */
+  scrollOffset(element) {
+    let scrollTop = 0;
+    let scrollLeft = 0;
+    while (element && element != document.documentElement && element != document.body) {
+      scrollTop += element.scrollTop;
+      scrollLeft += element.scrollLeft;
+      if (element.style.position == 'fixed') {
+        break;
+      }
+    }
+
+    return {left: scrollLeft, top: scrollTop};
   }
 
   /**


### PR DESCRIPTION
### Context
Handsontable does not account for scrollable elements it is nested within, which means that it misaligns comments when outer elements are scrolled. Fix this by summing the amount of scrollLeft and scrollTop and subtracting them from comment position. 

Thorough change description:
Add a new method to the comments plugin which computes the scroll distance (left, top) between the Handsontable element and the document body // nearest parent element with position: fixed, whichever comes first. Employ this method to offset comment text boxes to render them in the correct location while still respecting existing placement logic.

### How has this been tested?
Tested with modifications on an internal build. Can fork + update jsfiddle if there's some external hosting I can use to show a modified handsontable.full.js.

You can repro the error here: http://jsfiddle.net/5h11bfsx/
In the demo area:
1. Hover over comment in C11.
2. Observe that comment appears to right of cell, as expected.
3. Drag right (outer div) scrollbar until C11 is at top of demo area, but still visible.
4. Hover over comment in C11.
5. Observe that comment appears in middle of screen, and not beside C11.
6. Hover over C21.
7. Observe that comment appears beneath table, as opposed to beside C21.

I noticed that the contributions doc asked to add a test. I'm having a difficult time running tests on my end (I run the right npm commands, get to a terminal which displays info followed by many ......., but cannot access the local browser test instances) // am unsure how to simulate scrolling in this test environment. Advice would be heavily appreciated!

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):
1.

### Checklist:
- [ ] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.

Unsure if my code conforms to the project style fully as the link in the contributing section leads to a Wiki with no coding guidelines as far as I can tell. Perhaps I missed something obvious, feel free to link me.
