### PR TITLE
Changed 'module.exports' on 'export default'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -166,4 +166,4 @@ arrayHelpers.arrayEach(Object.getOwnPropertyNames(plugins), (pluginName) => {
 Handsontable.plugins.registerPlugin = registerPlugin;
 
 // Export Handsontable
-module.exports = Handsontable;
+export default Handsontable;


### PR DESCRIPTION
### Context
Webpack has some problems when you mix `import` and `module.exports` (webpack/webpack/issues/4039)

### How has this been tested?


### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):
1. https://github.com/webpack/webpack/issues/4039  

### Checklist:
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
