### PR TITLE
issue-3381: preventing validation occurring prior to 'beforeChange'

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -999,6 +999,8 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
   }
 
   function validateChanges(changes, source, callback) {
+    verifyChanges(); 
+ 
     var waitingForValidator = new ValidatorsQueue();
     waitingForValidator.onQueueEmpty = resolve;
 
@@ -1062,6 +1064,10 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
     waitingForValidator.checkIfQueueIsEmpty();
 
     function resolve() {
+      callback(); // called when async validators are resolved and beforeChange was not async 
+    } 
+ 
+    function verifyChanges() { 
       var beforeChangeResult;
 
       if (changes.length) {
@@ -1072,7 +1078,6 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
           changes.splice(0, changes.length); // invalidate all changes (remove everything from array)
         }
       }
-      callback(); // called when async validators are resolved and beforeChange was not async
     }
   }
 

--- a/test/e2e/Core_validate.spec.js
+++ b/test/e2e/Core_validate.spec.js
@@ -502,6 +502,87 @@ describe('Core_validate', () => {
       done();
     }, 200);
   });
+  
+  it('should not add class name `htInvalid` for cancelled changes - on edit', (done) => { 
+    var onAfterValidate = jasmine.createSpy('onAfterValidate'); 
+ 
+    handsontable({ 
+      data: Handsontable.helper.createSpreadsheetData(2, 2), 
+      validator(value, callb) { 
+        if (value == 'test') { 
+          callb(false); 
+        } else { 
+          callb(true); 
+        } 
+      }, 
+      afterValidate: onAfterValidate, 
+      beforeChange: function() { 
+        return false; 
+      } 
+    }); 
+ 
+    setDataAtCell(0, 0, 'test'); 
+
+    setTimeout(() => { 
+      // establishing that validation was not called
+      expect(onAfterValidate).not.toHaveBeenCalled(); 
+      // and that the changed value was cleared
+      expect(getDataAtCell(0, 0)).not.toEqual('test'); 
+      // and that the cell is not marked invalid
+      expect(spec().$container.find('td.htInvalid').length).toEqual(0); 
+      expect(spec().$container.find('tr:eq(0) td:eq(0)').hasClass('htInvalid')).toEqual(false); 
+      done(); 
+    }, 500); 
+  }); 
+ 
+  
+    it('should not remove class name `htInvalid` for cancelled changes - on edit', (done) => {
+      var onAfterValidate = jasmine.createSpy('onAfterValidate');
+      var allowChange = true;
+  
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(2, 2),
+        validator: function (value, callb) {
+          if (value == 'test') {
+            callb(false);
+          }
+          else {
+            callb(true);
+          }
+        },
+        afterValidate: onAfterValidate,
+        beforeChange: function() {
+          return allowChange;
+        }
+      });
+
+      setDataAtCell(0, 0, 'test');
+
+      setTimeout(() => {
+        // establishing that validation was called and the cell was set to invalid
+        expect(onAfterValidate).toHaveBeenCalled(); 
+        expect(getDataAtCell(0, 0)).toEqual('test');
+        expect(onAfterValidate.calls.count()).toEqual(1);
+        expect(spec().$container.find('td.htInvalid').length).toEqual(1);
+        expect(spec().$container.find('tr:eq(0) td:eq(0)').hasClass('htInvalid')).toEqual(true);
+        
+        // setting flag to have 'beforeChange' reject changes, then change value
+        allowChange = false;
+        setDataAtCell(0, 0, 'test2');
+
+        setTimeout(() => {
+          // establishing that the value was rejected
+          expect(getDataAtCell(0, 0)).toEqual('test');
+          // and that validation was not called a second time
+          expect(onAfterValidate.calls.count()).toEqual(1);
+          // and that the cell is still marked invalid
+          expect(spec().$container.find('td.htInvalid').length).toEqual(1);
+          expect(spec().$container.find('tr:eq(0) td:eq(0)').hasClass('htInvalid')).toEqual(true);
+          done();          
+        }, 500);
+      }, 500);
+    });
+  
 
   it('should add class name `htInvalid` to a cell without removing other classes', (done) => {
     var onAfterValidate = jasmine.createSpy('onAfterValidate');


### PR DESCRIPTION
### Context
Issue described in https://github.com/handsontable/handsontable/issues/3381. Validation happens on changes before the potential cancelling of those changes in the `beforeChange` event. This means that the table may sometimes show validation unrelated to the actual data in the table.

### How has this been tested?
New tests in `Core_validate.spec.js`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):
1. 3381
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
