### PR TITLE
add support to beforeValueRender hook for parameters "TD, row, col, prop, value, cellProperties

### DIFF
--- a/handsontable.d.ts
+++ b/handsontable.d.ts
@@ -1553,7 +1553,7 @@ declare namespace Handsontable {
     beforeTouchScroll?: () => void;
     beforeUndo?: (action: object) => void;
     beforeValidate?: (value: any, row: number, prop: string | number, source?: string) => void;
-    beforeValueRender?: (value: any) => void;
+    beforeValueRender?: (TD: Element, row: number, col: number, prop: string|number, value: any, cellProperties: object) => void;
     construct?: () => void;
     hiddenColumn?: (column: number) => void;
     hiddenRow?: (row: number) => void;

--- a/handsontable.d.ts
+++ b/handsontable.d.ts
@@ -1553,7 +1553,7 @@ declare namespace Handsontable {
     beforeTouchScroll?: () => void;
     beforeUndo?: (action: object) => void;
     beforeValidate?: (value: any, row: number, prop: string | number, source?: string) => void;
-    beforeValueRender?: (TD: Element, row: number, col: number, prop: string|number, value: any, cellProperties: object) => void;
+    beforeValueRender?: (value: any, cellProperties: object) => void;
     construct?: () => void;
     hiddenColumn?: (column: number) => void;
     hiddenRow?: (row: number) => void;

--- a/src/tableView.js
+++ b/src/tableView.js
@@ -220,7 +220,7 @@ function TableView(instance) {
       let value = that.instance.getDataAtRowProp(row, prop);
 
       if (that.instance.hasHook('beforeValueRender')) {
-        value = that.instance.runHooks('beforeValueRender', TD, row, col, prop, value, cellProperties);
+        value = that.instance.runHooks('beforeValueRender', value, cellProperties);
       }
 
       that.instance.runHooks('beforeRenderer', TD, row, col, prop, value, cellProperties);

--- a/src/tableView.js
+++ b/src/tableView.js
@@ -220,7 +220,7 @@ function TableView(instance) {
       let value = that.instance.getDataAtRowProp(row, prop);
 
       if (that.instance.hasHook('beforeValueRender')) {
-        value = that.instance.runHooks('beforeValueRender', value);
+        value = that.instance.runHooks('beforeValueRender', TD, row, col, prop, value, cellProperties);
       }
 
       that.instance.runHooks('beforeRenderer', TD, row, col, prop, value, cellProperties);

--- a/test/e2e/Core_render.spec.js
+++ b/test/e2e/Core_render.spec.js
@@ -100,39 +100,15 @@ describe('Core_render', () => {
   });
 
   it('should run beforeValueRender hook', function() {
-    // some primitive i18n function
-    const i18n = (locale) => {
-      if (locale.startsWith('ch')) {
-        return { 'car.brand.bmw': '寶馬', 'car.brand.mercedes': '奔馳', 'car.brand.volkswagen': '大眾汽車'};
-      }
-      return { 'car.brand.bmw': 'BMW', 'car.brand.mercedes': 'Mercedes', 'car.brand.volkswagen': 'Volkswagen'};
-    };
-
-    // assume somewhere we get the user locale
-    const userLocale = 'ch_TW';
-
     handsontable({
-      data: [
-        {brand: 'car.brand.bmw', likes: 100},
-        {brand: 'car.brand.mercedes', likes: 200},
-        {brand: 'car.brand.volkswagen', likes: 150}
-      ],
-      columns: [
-        {data: 'brand'},
-        {data: 'likes', type: 'numeric'},
-      ],
-      beforeValueRender(td, row, col, prop, value, cellProperties) {
-        if (prop === 'brand') {
-          return i18n(userLocale)[value];
-        }
-        return value;
+      data: [['A1', 'B1']],
+      beforeValueRender(value, cellProperties) {
+        return cellProperties.col === 0 ? 'Test' : value;
       }
     });
 
-    // Value is overwritten by beforeValueRender
-    expect(this.$container.find('td:eq(0)')[0].innerHTML).toEqual('寶馬');
-    expect(this.$container.find('td:eq(1)')[0].innerHTML).toEqual('100');
-    expect(this.$container.find('td:eq(2)')[0].innerHTML).toEqual('奔馳');
+    expect(this.$container.find('td:eq(0)')[0].innerHTML).toEqual('Test');
+    expect(this.$container.find('td:eq(0)')[0].innerHTML).toEqual('B1');
   });
 
   it('should run beforeRenderer hook', function() {

--- a/test/e2e/Core_render.spec.js
+++ b/test/e2e/Core_render.spec.js
@@ -108,7 +108,7 @@ describe('Core_render', () => {
     });
 
     expect(this.$container.find('td:eq(0)')[0].innerHTML).toEqual('Test');
-    expect(this.$container.find('td:eq(0)')[0].innerHTML).toEqual('B1');
+    expect(this.$container.find('td:eq(1)')[0].innerHTML).toEqual('B1');
   });
 
   it('should run beforeRenderer hook', function() {

--- a/test/e2e/Core_render.spec.js
+++ b/test/e2e/Core_render.spec.js
@@ -99,6 +99,42 @@ describe('Core_render', () => {
     expect(lastCellProperties.col).toEqual(4);
   });
 
+  it('should run beforeValueRender hook', function() {
+    // some primitive i18n function
+    const i18n = (locale) => {
+      if  (locale.startsWith('ch')) {
+        return { 'car.brand.bmw': '寶馬', 'car.brand.mercedes' : '奔馳', 'car.brand.volkswagen' : '大眾汽車'};
+      }
+      return { 'car.brand.bmw': 'BMW', 'car.brand.mercedes' : 'Mercedes', 'car.brand.volkswagen' : 'Volkswagen'};
+    };
+
+    // assume somewhere we get the user locale
+    const userLocale = 'ch_TW';
+
+    handsontable({
+      data: [
+        {brand: 'car.brand.bmw', likes: 100},
+        {brand: 'car.brand.mercedes', likes: 200},
+        {brand: 'car.brand.volkswagen', likes: 150}
+      ],
+      columns: [
+        {data: 'brand'},
+        {data: 'likes', type: 'numeric'},
+      ],
+      beforeValueRender(td, row, col, prop, value, cellProperties) {
+        if (prop === 'brand') {
+          return i18n(userLocale)[value]
+        }
+        return value
+      }
+    });
+
+    // Value is overwritten by beforeValueRender
+    expect(this.$container.find('td:eq(0)')[0].innerHTML).toEqual('寶馬');
+    expect(this.$container.find('td:eq(1)')[0].innerHTML).toEqual('100');
+    expect(this.$container.find('td:eq(2)')[0].innerHTML).toEqual('奔馳');
+  });
+
   it('should run beforeRenderer hook', function() {
     var lastCellProperties;
 

--- a/test/e2e/Core_render.spec.js
+++ b/test/e2e/Core_render.spec.js
@@ -102,10 +102,10 @@ describe('Core_render', () => {
   it('should run beforeValueRender hook', function() {
     // some primitive i18n function
     const i18n = (locale) => {
-      if  (locale.startsWith('ch')) {
-        return { 'car.brand.bmw': '寶馬', 'car.brand.mercedes' : '奔馳', 'car.brand.volkswagen' : '大眾汽車'};
+      if (locale.startsWith('ch')) {
+        return { 'car.brand.bmw': '寶馬', 'car.brand.mercedes': '奔馳', 'car.brand.volkswagen': '大眾汽車'};
       }
-      return { 'car.brand.bmw': 'BMW', 'car.brand.mercedes' : 'Mercedes', 'car.brand.volkswagen' : 'Volkswagen'};
+      return { 'car.brand.bmw': 'BMW', 'car.brand.mercedes': 'Mercedes', 'car.brand.volkswagen': 'Volkswagen'};
     };
 
     // assume somewhere we get the user locale
@@ -123,9 +123,9 @@ describe('Core_render', () => {
       ],
       beforeValueRender(td, row, col, prop, value, cellProperties) {
         if (prop === 'brand') {
-          return i18n(userLocale)[value]
+          return i18n(userLocale)[value];
         }
-        return value
+        return value;
       }
     });
 

--- a/test/types/handsontable-tests.ts
+++ b/test/types/handsontable-tests.ts
@@ -231,7 +231,7 @@ var hotSettings: Handsontable.GridSettings = {
   beforeTouchScroll: () => {},
   beforeUndo: (action) => {},
   beforeValidate: (value, row, prop, source = 'source') => {},
-  beforeValueRender: (TD, row, col, prop, value, cellProperties) => {},
+  beforeValueRender: (value, cellProperties) => {},
   construct: () => {},
   hiddenColumn: (column) => {},
   hiddenRow: (row) => {},

--- a/test/types/handsontable-tests.ts
+++ b/test/types/handsontable-tests.ts
@@ -231,7 +231,7 @@ var hotSettings: Handsontable.GridSettings = {
   beforeTouchScroll: () => {},
   beforeUndo: (action) => {},
   beforeValidate: (value, row, prop, source = 'source') => {},
-  beforeValueRender: (value) => {},
+  beforeValueRender: (TD, row, col, prop, value, cellProperties) => {},
   construct: () => {},
   hiddenColumn: (column) => {},
   hiddenRow: (row) => {},


### PR DESCRIPTION
### Context
Data return only i18n keys and we want to re-render it with i18n translation. We just want to render the value without using a custom renderer. A "beforeValueRender" hook already exist, but it is insufficient since it only contains 'value' as the parameter. Update the signature with parameters "TD, row, col, prop, value, cellProperties", which is consistent with the 'beforeRenderer' and 'afterRenderer' hooks.

Since the method signature changed, this change is backward incompatible. The choice is either to 
maintain consistency of method signature between similar hooks; or have the signature to be something like this "value, TD, row, col, prop, cellProperties", where value go first, and maintain backward compatibility. I chose the former.

**Update 2018/03/06:** with @swistach suggestion, the method signature changed to "value, cellProperties", which means this change is backward compatible.

### How has this been tested?
A 'should run beforeValueRender hook' e2e test is added to test and illustrate this usage.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):
1. N/A
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [x] My change requires a change to the documentation.
