### PR TITLE
Agreene/fix formula change on click

### DIFF
--- a/test/e2e/Core_setDataAtCell.spec.js
+++ b/test/e2e/Core_setDataAtCell.spec.js
@@ -240,6 +240,25 @@ describe('Core_setDataAtCell', () => {
     expect(getDataAtCell(0, 0)).toEqual('foo bar');
   });
 
+  it('should trigger `afterSetDataAtCell` hook with formattedChanges', () => {
+    var _changes;
+    var _source;
+
+    handsontable({
+      type: 'numeric',
+      afterSetDataAtCell(changes, source) {
+        _changes = changes;
+        _source = source;
+      }
+    });
+
+    setDataAtCell(0, 0, '1', 'customSource');
+
+    expect(_changes).toEqual([[0, 0, null, 1]]);
+    expect(_source).toBe('customSource');
+    expect(getDataAtCell(0, 0)).toEqual(1);
+  });
+
   it('should modify value on the fly using `afterSetDataAtCell` hook', () => {
     handsontable({
       data: [['a', 'b', 'c'], [1, 2, 3]],

--- a/test/e2e/Core_setDataAtCell.spec.js
+++ b/test/e2e/Core_setDataAtCell.spec.js
@@ -240,7 +240,7 @@ describe('Core_setDataAtCell', () => {
     expect(getDataAtCell(0, 0)).toEqual('foo bar');
   });
 
-  it('should trigger `afterSetDataAtCell` hook with formattedChanges', () => {
+  it('should trigger `afterSetDataAtCell` hook with formatted changes', () => {
     var _changes;
     var _source;
 
@@ -255,8 +255,6 @@ describe('Core_setDataAtCell', () => {
     setDataAtCell(0, 0, '1', 'customSource');
 
     expect(_changes).toEqual([[0, 0, null, 1]]);
-    expect(_source).toBe('customSource');
-    expect(getDataAtCell(0, 0)).toEqual(1);
   });
 
   it('should modify value on the fly using `afterSetDataAtCell` hook', () => {


### PR DESCRIPTION
### Context
This is a fix for the bug reported [here](https://forum.handsontable.com/t/gl-99-not-working-appropriately-with-complex-formulas/1043/6). Basically when clicking on cells that are referenced by certain formulas the formula value changes. This is because the formula listener for 'afterSetCellData` is getting the changes before they are formatted into numbers.

### How has this been tested?
I tested locally to see if the formula values stopped updating when they shouldn't be and ran the test suite and it passed

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
