### PR TITLE
Add export to CustomBorders

### DIFF
--- a/src/plugins/customBorders/customBorders.js
+++ b/src/plugins/customBorders/customBorders.js
@@ -537,3 +537,5 @@ Hooks.getSingleton().add('afterInit', function() {
     this.view.wt.draw(true);
   }
 });
+
+export default CustomBorders;

--- a/test/e2e/publicAPI.spec.js
+++ b/test/e2e/publicAPI.spec.js
@@ -28,6 +28,7 @@ describe('Public API', () => {
       expect(Handsontable.plugins.Comments).toBeFunction();
       expect(Handsontable.plugins.ContextMenu).toBeFunction();
       expect(Handsontable.plugins.CopyPaste).toBeFunction();
+      expect(Handsontable.plugins.CustomBorders).toBeFunction();
       expect(Handsontable.plugins.DragToScroll).toBeFunction();
       expect(Handsontable.plugins.ManualColumnFreeze).toBeFunction();
       expect(Handsontable.plugins.ManualColumnResize).toBeFunction();


### PR DESCRIPTION
rollup.js fails with the following error without it:
```
{ Error: 'default' is not exported by ..\..\node_modules\handsontable\es\plugins\customeBorders\customeBorders.js
    at error (C:\Users\gordon\git\hpcc-js\node_modules\rollup\dist\rollup.js:185:14)
    at Module.error (C:\Users\gordon\git\hpcc-js\node_modules\rollup\dist\rollup.js:8390:3)
    at Module.trace (C:\Users\gordon\git\hpcc-js\node_modules\rollup\dist\rollup.js:8487:10)
    at Module.traceExport (C:\Users\gordon\git\hpcc-js\node_modules\rollup\dist\rollup.js:8526:29)
    at NamespaceVariable.module.getExports.concat.forEach.name (C:\Users\gordon\git\hpcc-js\node_modules\rollup\dist\rollup.js:5561:36)
    at Array.forEach (native)
    at NamespaceVariable (C:\Users\gordon\git\hpcc-js\node_modules\rollup\dist\rollup.js:5560:55)
    at Module.namespace (C:\Users\gordon\git\hpcc-js\node_modules\rollup\dist\rollup.js:8436:31)
    at Module.trace (C:\Users\gordon\git\hpcc-js\node_modules\rollup\dist\rollup.js:8481:24)
    at ModuleScope.findVariable (C:\Users\gordon\git\hpcc-js\node_modules\rollup\dist\rollup.js:8093:22)
    at Identifier.bind (C:\Users\gordon\git\hpcc-js\node_modules\rollup\dist\rollup.js:6996:31)
  code: 'MISSING_EXPORT',
  url: 'https://github.com/rollup/rollup/wiki/Troubleshooting#name-is-not-exported-by-module',
  pos: 1184,
  loc:
   { file: 'C:\\Users\\gordon\\git\\hpcc-js\\node_modules\\handsontable\\es\\plugins\\index.js',
     line: 21,
     column: 7 },
  frame: '19: import Search from \'./search/search\';\n20: import TouchScroll from \'./touchScroll/touchScroll\';\n21: import UndoRedo from \'./undoRedo/undoRedo\';\n           ^\n22: import Base from \'./_base\';' }
```

### Context
RollupJS is unable to bundle the plugin unless it has an export declaration

### How has this been tested?
I added the missing ```export default``` and re-ran rollupjs in my project

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):
1.
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
