### PR TITLE
Add export to UndoRedo plugin

### DIFF
--- a/src/plugins/undoRedo/undoRedo.js
+++ b/src/plugins/undoRedo/undoRedo.js
@@ -631,3 +631,5 @@ hook.register('beforeUndo');
 hook.register('afterUndo');
 hook.register('beforeRedo');
 hook.register('afterRedo');
+
+export default UndoRedo;

--- a/test/e2e/publicAPI.spec.js
+++ b/test/e2e/publicAPI.spec.js
@@ -34,6 +34,7 @@ describe('Public API', () => {
       expect(Handsontable.plugins.ManualRowResize).toBeFunction();
       expect(Handsontable.plugins.MultipleSelectionHandles).toBeFunction();
       expect(Handsontable.plugins.TouchScroll).toBeFunction();
+      expect(Handsontable.plugins.UndoRedo).toBeFunction();
     });
   });
 


### PR DESCRIPTION
rollupjs complains without it.

### Context
RollupJS is unable to bundle the plugin unless it has an export declaration - all the other plugins have a default export, so this (and customBorders) appears to be a simple omission.

### How has this been tested?
I added the missing ```export default``` and re-ran rollupjs in my project

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):
1.
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
