### PR TITLE
Fix TypeError in observeChanges Plugin

### DIFF
--- a/src/plugins/observeChanges/observeChanges.js
+++ b/src/plugins/observeChanges/observeChanges.js
@@ -106,7 +106,7 @@ class ObserveChanges extends BasePlugin {
           }
         },
         replace: (patch) => {
-          this.hot.runHooks('afterChange', [patch.row, patch.col, null, patch.value], sourceName);
+          this.hot.runHooks('afterChange', [[patch.row, patch.col, null, patch.value]], sourceName);
         },
       };
 

--- a/src/plugins/observeChanges/test/observeChanges.e2e.js
+++ b/src/plugins/observeChanges/test/observeChanges.e2e.js
@@ -458,7 +458,7 @@ describe('HandsontableObserveChanges', () => {
 
         setTimeout(() => {
           expect(afterChangeCallback.calls.count()).toEqual(1);
-          expect(afterChangeCallback).toHaveBeenCalledWith([0, 0, null, 'new string'], 'ObserveChanges.change', undefined, undefined, undefined, undefined);
+          expect(afterChangeCallback).toHaveBeenCalledWith([[0, 0, null, 'new string']], 'ObserveChanges.change', undefined, undefined, undefined, undefined);
           done();
         }, 200);
       });
@@ -544,7 +544,7 @@ describe('HandsontableObserveChanges', () => {
 
         setTimeout(() => {
           expect(afterChangeCallback.calls.count()).toEqual(1);
-          expect(afterChangeCallback).toHaveBeenCalledWith([0, 'prop0', null, 'new string'], 'ObserveChanges.change', undefined, undefined, undefined, undefined);
+          expect(afterChangeCallback).toHaveBeenCalledWith([[0, 'prop0', null, 'new string']], 'ObserveChanges.change', undefined, undefined, undefined, undefined);
           done();
         }, 200);
       });


### PR DESCRIPTION
### Context
The problem, along with a demo, is in the linked issue.

The short version is, the `afterChange` hook is receiving a 1D array here, when the API expects a 2D array. This results in an uncaught `TypeError`

### How has this been tested?
Updated the expectations in related specs

### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/4637

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
