### PR TITLE
Don't stop scrolling on column headers #3090

### DIFF
--- a/src/3rdparty/walkontable/src/overlays.js
+++ b/src/3rdparty/walkontable/src/overlays.js
@@ -234,7 +234,7 @@ class Overlays {
           overlay = 'bottomLeft';
         }
 
-        if ((overlay == 'top' && deltaY !== 0) ||
+        if ((overlay == 'top' && deltaY !== 0 && this.wot.getSetting('scrollColHeaders')) ||
           (overlay == 'left' && deltaX !== 0) ||
           (overlay == 'bottom' && deltaY !== 0) ||
           ((overlay === 'topLeft' || overlay === 'bottomLeft') && (deltaY !== 0 || deltaX !== 0))) {
@@ -526,7 +526,7 @@ class Overlays {
       }
 
       // "fake" scroll value calculated from the mousewheel event
-      if (fakeScrollValue !== null) {
+      if (fakeScrollValue !== null && this.wot.getSetting('scrollColHeaders')) {
         scrollValueChanged = true;
         masterVertical.scrollTop += fakeScrollValue;
       }

--- a/src/defaultSettings.js
+++ b/src/defaultSettings.js
@@ -2075,6 +2075,27 @@ DefaultSettings.prototype = {
    * @default: false
    */
   filteringCaseSensitive: false,
+
+  /**
+   * If defined as 'true', scrolling on the column header scrolls the table. Otherwise
+   * the scroll event is allowed to bubble up to parent elements.
+   *
+   * @type {Boolean}
+   * @default: true
+   */
+  scrollColHeaders: true,
+
+  /**
+   * If defined as 'true', an alternative scrolling implementation is enabled for browsers other than
+   * Chrome and Safari. This compatibility mode fixes the scroll sync issue #2350 on IE9. However,
+   * up-to-date browsers (tested with Firefox 57, Chrome 62, Safari 11 and IE 11) work fine with the default
+   * implementation, so disabling this compatibility mode makes the up-to-date browsers work more alike, especially
+   * Firefox when trying to scroll the page on the column header.
+   *
+   * @type {Boolean}
+   * @default: true
+   */
+  scrollCompatibilityMode: true,
 };
 
 export default DefaultSettings;

--- a/src/tableView.js
+++ b/src/tableView.js
@@ -533,6 +533,9 @@ function TableView(instance) {
     columnHeaderHeight: function() {
       const columnHeaderHeight = instance.runHooks('modifyColumnHeaderHeight');
       return that.settings.columnHeaderHeight || columnHeaderHeight;
+    },
+    scrollColHeaders: function() {
+      return that.settings.scrollColHeaders;
     }
   };
 
@@ -541,7 +544,7 @@ function TableView(instance) {
   this.wt = new Walkontable(walkontableConfig);
   this.activeWt = this.wt;
 
-  if (!isChrome() && !isSafari()) {
+  if (!isChrome() && !isSafari() && this.settings.scrollCompatibilityMode) {
     this.eventManager.addEventListener(instance.rootElement, 'wheel', (event) => {
       event.preventDefault();
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
See issue #3090 and these fiddles:
- current version: http://jsfiddle.net/c7exz88L/ (using the library from the handsontable.com)
- fixed version:    http://jsfiddle.net/c7exz88L/1/ (using a library built from this pull request)

We are using Handsontable in a scrolling container. When the scrolling is started above the table the container stops scrolling when column headers reach the mouse position. If the scrolling is started on top of column headers, the table will scroll to the end, but won't continue scrolling the container after that. This happens in Firefox, Chrome and IE, but not in Safari.

Like suggested by alexgann in the original issue, I kept the original behaviour intact and added a new configuration parameter scrollColHeaders. It's set to true by default, but setting it to false fixes this issue in Chrome.

I found a separate peace of code in tableView.js affecting this in Firefox and IE. This code was added in a  commit referencing the issue #2350, which was about fixing the scrolling in an old IE. In my use case it's enough to support the latest browsers, so simply added an another configuration parameter scrollCompatibilityMode. When it's set to true, the fix for #2350 is enabled, but the fix for #3090 doesn't work in Firefox and IE. Setting it to false makes the fix for #3090 to work also in Firefox and IE, but probably reintroduces #2350 on older browsers.

### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
I tested these manually on Safari 11, Firefox 57, Chrome 62 (in OSX High Sierra) and IE11 (in Windows 7) using the linked fiddles.

I have no idea how to write automatic tests for this and I don't have access to the latest Windows at the moment, so I haven't tested this in Edge.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

I added configuration options to keep the original behaviour by default. I leave it for you to decide if you want to apply these changes by default (set to false) or even change to code only to this new behaviour (delete the code blocks that were made configurable).

### Related issue(s):
1. #2350
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [x] My change requires a change to the documentation.

I guess it would be good to mention these new configuration options in the documentation.