### PR TITLE
sort boolean columns using subtraction

### DIFF
--- a/src/plugins/columnSorting/columnSorting.js
+++ b/src/plugins/columnSorting/columnSorting.js
@@ -420,6 +420,45 @@ class ColumnSorting extends BasePlugin {
   }
 
   /**
+   * Boolean sorting algorithm.
+   *
+   * @param {Boolean} sortOrder Sorting order (`true` for ascending, `false` for descending).
+   * @param {Object} columnMeta Column meta object.
+   * @returns {Function} The compare function.
+   */
+  booleanSort(sortOrder, columnMeta) {
+    return function(a, b) {
+      if (a[1] !== true && a[1] !== false && b[1] !== true && b[1] !== false) {
+        return 0;
+      }
+
+      if (columnMeta.columnSorting.sortEmptyCells) {
+        if (isEmpty(a[1])) {
+          return sortOrder ? -1 : 1;
+        }
+
+        if (isEmpty(b[1])) {
+          return sortOrder ? 1 : -1;
+        }
+      }
+
+      if (!!a[1] !== a[1]) {
+        return 1;
+      }
+
+      if (!!b[1] !== b[1]) {
+        return -1;
+      }
+
+      if (!!a[1] === !!b[1]) {
+        return 0;
+      }
+
+      return sortOrder ? (a[1] - b[1]) : (b[1] - a[1]);
+    };
+  }
+
+  /**
    * Perform the sorting.
    */
   sort() {
@@ -461,6 +500,9 @@ class ColumnSorting extends BasePlugin {
           break;
         case 'numeric':
           sortFunction = this.numericSort;
+          break;
+        case 'checkbox':
+          sortFunction = this.booleanSort;
           break;
         default:
           sortFunction = this.defaultSort;

--- a/src/plugins/columnSorting/test/columnSorting.e2e.js
+++ b/src/plugins/columnSorting/test/columnSorting.e2e.js
@@ -1083,6 +1083,68 @@ describe('ColumnSorting', () => {
     expect(hot.getDataAtCol(0)).toEqual([3, 1, 6, 8, 2, 4, 7]);
   });
 
+  it('should sort checkboxes properly #4047', () => {
+    var myData = [
+      {a: false, b: 2, c: 3},
+      {a: true, b: 11, c: -4},
+      {a: false, b: 10, c: 11}
+    ];
+
+    function customIsEmptyRow(row) {
+      var data = this.getSourceData();
+      return data[row].isNew;
+    }
+
+    handsontable({
+      data: myData,
+      rowHeaders: true,
+      colHeaders: ['A', 'B', 'C'],
+      columns: [
+        {data: 'a', type: 'checkbox'},
+        {data: 'b', type: 'text'},
+        {data: 'c', type: 'text'}
+      ],
+      dataSchema: {isNew: true, a: false}, // default for a to avoid #bad value#
+      columnSorting: true,
+      minSpareRows: 3,
+      isEmptyRow: customIsEmptyRow
+    });
+
+    // ASC
+    updateSettings({
+      columnSorting: {
+        column: 0,
+        sortOrder: true
+      }
+    });
+
+    expect(getData()).toEqual([
+      [false, 2, 3],
+      [false, 10, 11],
+      [true, 11, -4],
+      [false, null, null],
+      [false, null, null],
+      [false, null, null]
+    ]);
+
+    // DSC
+    updateSettings({
+      columnSorting: {
+        column: 0,
+        sortOrder: false
+      }
+    });
+
+    expect(getData()).toEqual([
+      [true, 11, -4],
+      [false, 2, 3],
+      [false, 10, 11],
+      [false, null, null],
+      [false, null, null],
+      [false, null, null]
+    ]);
+  });
+
   it('should NOT sort spare rows', () => {
     var myData = [
       {a: 'aaa', b: 2, c: 3},


### PR DESCRIPTION
Since boolean values cannot be compared with > or < this adds a new booleanSort() algorithm for checkbox columns.

Followup to patch by @brandond in #4036, and #4261.
Test by @wszymanski in 0e57854ad3621bc0e779b95989587b0f67ba310f