### PR TITLE
Missing language changes

### DIFF
--- a/.config/languages-development.js
+++ b/.config/languages-development.js
@@ -36,9 +36,6 @@ function getEntryJsFiles() {
 
 const ruleForSnippetsInjection = {
   test: /\.js$/,
-  include: [
-    path.resolve(__dirname, '../', SOURCE_LANGUAGES_DIRECTORY),
-  ],
   loader: StringReplacePlugin.replace({
     replacements: [
       {
@@ -69,6 +66,7 @@ module.exports.create = function create() {
       path: path.resolve(__dirname, '../' + OUTPUT_LANGUAGES_DIRECTORY),
       libraryTarget: 'umd',
       filename: '[name].js',
+      // Workaround below: Without this option webpack would export all language packs as globals
       libraryExport: '___',
       umdNamedDefine: true
     },

--- a/src/i18n/languages/index.js
+++ b/src/i18n/languages/index.js
@@ -1,9 +1,13 @@
 /* eslint-disable import/prefer-default-export */
 
+import deCH from './de-CH';
+import deDE from './de-DE';
 import enUS from './en-US';
 import plPL from './pl-PL';
 
 export {
+  deCH,
+  deDE,
   enUS,
   plPL
 };


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
- Added missing documentation annotation
- Removed unnecessary `webpack` config key 
- Added new language packs to `/src/i18n/languages/index.js` file

### How has this been tested?
I've run `build:languages` npm script. No significant differences between actual files and newly created were noticed.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [x] My change requires a change to the documentation.
