### PR TITLE
Issue #4400 Fixed ObserveChanges plugin memory leak

### DIFF
--- a/lib/jsonpatch/json-patch-duplex.js
+++ b/lib/jsonpatch/json-patch-duplex.js
@@ -330,8 +330,7 @@ var jsonpatch;
             generate(observer);
             clearTimeout(observer.next);
             removeObserverFromMirror(mirror, observer);
-            if (mirror.observers.length === 0)
-            {
+            if (mirror.observers.length === 0) {
                 beforeDict.splice(beforeDict.indexOf(mirror), 1);
             }
             if (typeof window !== 'undefined') {

--- a/lib/jsonpatch/json-patch-duplex.js
+++ b/lib/jsonpatch/json-patch-duplex.js
@@ -330,7 +330,10 @@ var jsonpatch;
             generate(observer);
             clearTimeout(observer.next);
             removeObserverFromMirror(mirror, observer);
-            beforeDict.splice(beforeDict.indexOf(mirror), 1);
+            if (mirror.observers.length === 0)
+            {
+                beforeDict.splice(beforeDict.indexOf(mirror), 1);
+            }
             if (typeof window !== 'undefined') {
                 if (window.removeEventListener) {
                     window.removeEventListener('mousedown', fastCheck);

--- a/lib/jsonpatch/json-patch-duplex.js
+++ b/lib/jsonpatch/json-patch-duplex.js
@@ -330,6 +330,7 @@ var jsonpatch;
             generate(observer);
             clearTimeout(observer.next);
             removeObserverFromMirror(mirror, observer);
+            beforeDict.splice(beforeDict.indexOf(mirror), 1);
             if (typeof window !== 'undefined') {
                 if (window.removeEventListener) {
                     window.removeEventListener('mousedown', fastCheck);


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Fixes #4400 - ObserveChanges plugin causing a memory leak (which as actually caused by the JSON patch library)

### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
Tested it locally in our own project and ensured all Handsontable tests still pass.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):
1. #4400 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
