### PR TITLE
Property `numericFormat` definitely not used for formatting input

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1026,7 +1026,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
    * Get parsed number from numeric string.
    *
    * @param {String} numericData Float (separated by a dot or a comma) or integer.
-   * @returns {Number} Number if we get data in "float like" or "integer like" format, not changed value otherwise.
+   * @returns {Number} Number if we get data in parsable format, not changed value otherwise.
    */
   function getParsedNumber(numericData) {
     // Unifying "float like" string. Change from value with comma determiner to value with dot determiner,
@@ -1040,22 +1040,31 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
     return numericData;
   }
 
+  /**
+   * Checks if given value is numeric.
+   *
+   * @param {String} value Checked value.
+   * @returns {Boolean}
+   */
+  function isNumericData(value) {
+    return value.length > 0 && /^-?[\d\s]*(\.|,)?\d*$/.test(value);
+  }
+
   function validateChanges(changes, source, callback) {
-    var waitingForValidator = new ValidatorsQueue();
+    const waitingForValidator = new ValidatorsQueue();
+
     waitingForValidator.onQueueEmpty = resolve;
 
-    for (var i = changes.length - 1; i >= 0; i--) {
+    for (let i = changes.length - 1; i >= 0; i--) {
       if (changes[i] === null) {
         changes.splice(i, 1);
       } else {
-        var row = changes[i][0];
-        var col = datamap.propToCol(changes[i][1]);
-        var cellProperties = instance.getCellMeta(row, col);
+        const [row, prop, , newValue] = changes[i];
+        const col = datamap.propToCol(prop);
+        const cellProperties = instance.getCellMeta(row, col);
 
-        if (cellProperties.type === 'numeric' && typeof changes[i][3] === 'string') {
-          if (changes[i][3].length > 0 && /^-?[\d\s]*(\.|,)?\d*$/.test(changes[i][3])) {
-            changes[i][3] = getParsedNumber(changes[i][3]);
-          }
+        if (cellProperties.type === 'numeric' && typeof newValue === 'string' && isNumericData(newValue)) {
+          changes[i][3] = getParsedNumber(newValue);
         }
 
         /* eslint-disable no-loop-func */

--- a/src/core.js
+++ b/src/core.js
@@ -1040,18 +1040,9 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
     return numericData;
   }
 
-  /**
-   * Checks if given value is numeric.
-   *
-   * @param {String} value Checked value.
-   * @returns {Boolean}
-   */
-  function isNumericData(value) {
-    return value.length > 0 && /^-?[\d\s]*(\.|,)?\d*$/.test(value);
-  }
-
   function validateChanges(changes, source, callback) {
     const waitingForValidator = new ValidatorsQueue();
+    const isNumericData = (value) => value.length > 0 && /^-?[\d\s]*(\.|,)?\d*$/.test(value);
 
     waitingForValidator.onQueueEmpty = resolve;
 

--- a/src/defaultSettings.js
+++ b/src/defaultSettings.js
@@ -1581,7 +1581,7 @@ DefaultSettings.prototype = {
    * - pattern, which is handled by `numbro` for purpose of formatting numbers to desired pattern. List of supported patterns can be found [here](http://numbrojs.com/format.html#numbers).
    * - culture, which is handled by `numbro` for purpose of formatting currencies. Examples showing how it works can be found [here](http://numbrojs.com/format.html#currency). List of supported cultures can be found [here](http://numbrojs.com/languages.html#supported-languages).
    *
-   * Note: Please keep in mind that this option is used only to format the displayed output! It has no effect on the input data provided for the cell. Numbers can be entered to the table only as floats (separated by a dot or a comma) or integers, and are stored in the dataset in the same way.
+   * Note: Please keep in mind that this option is used only to format the displayed output! It has no effect on the input data provided for the cell. Numbers can be entered to the table only as floats (separated by a dot or a comma) or integers, and are stored in the dataset as JavaScript numbers.
    *
    * Since 0.26.0 Handsontable uses [numbro](http://numbrojs.com/) as a main library for numbers formatting.
    *

--- a/src/defaultSettings.js
+++ b/src/defaultSettings.js
@@ -1581,7 +1581,7 @@ DefaultSettings.prototype = {
    * - pattern, which is handled by `numbro` for purpose of formatting numbers to desired pattern. List of supported patterns can be found [here](http://numbrojs.com/format.html#numbers).
    * - culture, which is handled by `numbro` for purpose of formatting currencies. Examples showing how it works can be found [here](http://numbrojs.com/format.html#currency). List of supported cultures can be found [here](http://numbrojs.com/languages.html#supported-languages).
    *
-   * Note: Please keep in mind that this option is used only to format the displayed output! It has no effect on the input data provided for the cell. Numbers can be entered to the table only as floats (separated by a dot or a comma) or integers, and are stored in the dataset as JavaScript numbers.
+   * Note: Please keep in mind that this option is used only to format the displayed output! It has no effect on the input data provided for the cell. The numeric data can be entered to the table only as floats (separated by a dot or a comma) or integers, and are stored in the source dataset as JavaScript numbers.
    *
    * Since 0.26.0 Handsontable uses [numbro](http://numbrojs.com/) as a main library for numbers formatting.
    *

--- a/src/defaultSettings.js
+++ b/src/defaultSettings.js
@@ -1581,7 +1581,7 @@ DefaultSettings.prototype = {
    * - pattern, which is handled by `numbro` for purpose of formatting numbers to desired pattern. List of supported patterns can be found [here](http://numbrojs.com/format.html#numbers).
    * - culture, which is handled by `numbro` for purpose of formatting currencies. Examples showing how it works can be found [here](http://numbrojs.com/format.html#currency). List of supported cultures can be found [here](http://numbrojs.com/languages.html#supported-languages).
    *
-   * Note: Please keep in mind that this option is used only to format the displayed output! It has no effect on the input data provided for the cell. The numeric data can be entered to the table only as floats (separated by a dot or a comma) or integers, and are stored in the source dataset as JavaScript numbers.
+   * __Note:__ Please keep in mind that this option is used only to format the displayed output! It has no effect on the input data provided for the cell. The numeric data can be entered to the table only as floats (separated by a dot or a comma) or integers, and are stored in the source dataset as JavaScript numbers.
    *
    * Since 0.26.0 Handsontable uses [numbro](http://numbrojs.com/) as a main library for numbers formatting.
    *

--- a/src/defaultSettings.js
+++ b/src/defaultSettings.js
@@ -1581,6 +1581,8 @@ DefaultSettings.prototype = {
    * - pattern, which is handled by `numbro` for purpose of formatting numbers to desired pattern. List of supported patterns can be found [here](http://numbrojs.com/format.html#numbers).
    * - culture, which is handled by `numbro` for purpose of formatting currencies. Examples showing how it works can be found [here](http://numbrojs.com/format.html#currency). List of supported cultures can be found [here](http://numbrojs.com/languages.html#supported-languages).
    *
+   * Note: Please keep in mind that this option is used only to format the displayed output! It has no effect on the input data provided for the cell. Numbers can be entered to the table only as floats (separated by a dot or a comma) or integers, and are stored in the dataset in the same way.
+   *
    * Since 0.26.0 Handsontable uses [numbro](http://numbrojs.com/) as a main library for numbers formatting.
    *
    * @example

--- a/src/editors/numericEditor.js
+++ b/src/editors/numericEditor.js
@@ -1,4 +1,3 @@
-import numbro from 'numbro';
 import TextEditor from './textEditor';
 
 /**
@@ -8,23 +7,8 @@ import TextEditor from './textEditor';
  * @dependencies TextEditor numbro
  */
 class NumericEditor extends TextEditor {
-  /**
-   * @param {*} initialValue
-   */
-  beginEditing(initialValue) {
-    if (typeof initialValue === 'undefined' && this.originalValue) {
-      const decimalDelimiter = numbro.cultureData().delimiters.decimal;
-      const numericFormat = this.cellProperties.numericFormat;
-      const cellCulture = numericFormat && numericFormat.culture;
-
-      if (typeof cellCulture !== 'undefined') {
-        numbro.culture(cellCulture);
-      }
-
-      initialValue = (`${this.originalValue}`).replace('.', decimalDelimiter);
-    }
-
-    super.beginEditing(initialValue);
+  beginEditing() {
+    super.beginEditing(this.originalValue);
   }
 }
 

--- a/src/editors/numericEditor.js
+++ b/src/editors/numericEditor.js
@@ -8,8 +8,8 @@ import TextEditor from './textEditor';
  */
 class NumericEditor extends TextEditor {
   beginEditing(initialValue, event) {
-    // There is problem with `initialValue` property which get other value when we press `enter`, other when we perform double click.
-    // It was described within #4706. Property `event` should be probably removed, but now it's handled by `open` function of `BaseEditor`
+    // There is a problem with `initialValue` property which gets other value when we press `enter`, other when we perform the double click.
+    // It was discovered within #4706. Property `event` should be probably removed, but now it's handled by `open` function of `BaseEditor`
     // (called inside inherited `beginEditing` function).
     super.beginEditing(this.originalValue, event);
   }

--- a/src/editors/numericEditor.js
+++ b/src/editors/numericEditor.js
@@ -7,8 +7,11 @@ import TextEditor from './textEditor';
  * @dependencies TextEditor numbro
  */
 class NumericEditor extends TextEditor {
-  beginEditing() {
-    super.beginEditing(this.originalValue);
+  beginEditing(initialValue, event) {
+    // There is problem with `initialValue` property which get other value when we press `enter`, other when we perform double click.
+    // It was described within #4706. Property `event` should be probably removed, but now it's handled by `open` function of `BaseEditor`
+    // (called inside inherited `beginEditing` function).
+    super.beginEditing(this.originalValue, event);
   }
 }
 

--- a/test/e2e/editors/numericEditor.spec.js
+++ b/test/e2e/editors/numericEditor.spec.js
@@ -411,6 +411,117 @@ describe('NumericEditor', () => {
     expect(getCell(2, 3).innerHTML).toEqual('$2,456.22');
   });
 
+  it('should display values as "float like" string with dot as determiner after pressing enter ' +
+    'and not change value after closing editor', async () => {
+    handsontable({
+      data: [
+        {id: 1, price_eur: 222.5, price_pln: 1222.6, price_aud: 1333.5}
+      ],
+      columns: [
+        {data: 'id', type: 'numeric'},
+        {data: 'price_eur', type: 'numeric'},
+        {data: 'price_pln', type: 'numeric', numericFormat: {pattern: '$0,0.00', culture: 'en-US'}},
+        {data: 'price_aud', type: 'numeric', numericFormat: {pattern: '$0,0.00', culture: 'de-DE'}}
+      ]
+    });
+
+    selectCell(0, 1);
+    keyDown('enter');
+
+    await sleep(100);
+
+    expect(document.activeElement.value).toEqual('222.5');
+
+    // closing editor
+    keyDown('enter');
+
+    await sleep(100);
+
+    expect(getDataAtCell(0, 1)).toEqual(222.5);
+
+    selectCell(0, 2);
+    keyDown('enter');
+
+    await sleep(100);
+
+    expect(document.activeElement.value).toEqual('1222.6');
+
+    // closing editor
+    keyDown('enter');
+
+    await sleep(100);
+
+    expect(getDataAtCell(0, 2)).toEqual(1222.6);
+
+    selectCell(0, 3);
+    keyDown('enter');
+
+    await sleep(100);
+
+    expect(document.activeElement.value).toEqual('1333.5');
+
+    // closing editor
+    keyDown('enter');
+
+    await sleep(100);
+
+    expect(getDataAtCell(0, 3)).toEqual(1333.5);
+  });
+
+  it('should display values as "float like" string with dot as determiner after double click ' +
+    'and not change value after closing editor', async () => {
+    handsontable({
+      data: [
+        {id: 1, price_eur: 222.5, price_pln: 1222.6, price_aud: 1333.5}
+      ],
+      columns: [
+        {data: 'id', type: 'numeric'},
+        {data: 'price_eur', type: 'numeric'},
+        {data: 'price_pln', type: 'numeric', numericFormat: {pattern: '$0,0.00', culture: 'en-US'}},
+        {data: 'price_aud', type: 'numeric', numericFormat: {pattern: '$0,0.00', culture: 'de-DE'}}
+      ]
+    });
+
+    mouseDoubleClick(getCell(0, 1));
+
+    await sleep(100);
+
+    expect(document.activeElement.value).toEqual('222.5');
+
+    // closing editor
+    keyDown('enter');
+
+    await sleep(100);
+
+    expect(getDataAtCell(0, 1)).toEqual(222.5);
+
+    mouseDoubleClick(getCell(0, 2));
+
+    await sleep(100);
+
+    expect(document.activeElement.value).toEqual('1222.6');
+
+    // closing editor
+    keyDown('enter');
+
+    await sleep(100);
+
+    expect(getDataAtCell(0, 2)).toEqual(1222.6);
+
+    mouseDoubleClick(getCell(0, 3));
+
+    await sleep(100);
+
+    expect(document.activeElement.value).toEqual('1333.5');
+
+    // closing editor
+    keyDown('enter');
+
+    await sleep(100);
+
+    expect(getDataAtCell(0, 3)).toEqual(1333.5);
+  });
+
   it('should mark text as invalid without removing when using `setDataAtCell`', async () => {
     const hot = handsontable({
       data: arrayOfObjects(),

--- a/test/e2e/editors/numericEditor.spec.js
+++ b/test/e2e/editors/numericEditor.spec.js
@@ -49,7 +49,7 @@ describe('NumericEditor', () => {
     expect(getDataAtCell(2, 0)).toEqual(999);
   });
 
-  it('should not convert "float like" formatted input value to number (object data source) #4706', async () => {
+  it('should not convert formatted "float like" input value to number (object data source) #4706', async () => {
     handsontable({
       data: arrayOfObjects(),
       columns: [
@@ -209,10 +209,12 @@ describe('NumericEditor', () => {
       data: arrayOfObjects(),
       columns: [
         {data: 'id', type: 'numeric'},
-        {data: 'name'},
+        {data: 'price', type: 'numeric', numericFormat: {pattern: '$0,0.00', culture: 'de-DE'}},
         {data: 'lastName'}
       ]
     });
+
+    // Column with default formatting
 
     selectCell(0, 0);
     keyDown('enter');
@@ -239,6 +241,35 @@ describe('NumericEditor', () => {
 
     destroyEditor();
 
+    // Column with specified formatting
+
+    await sleep(100);
+
+    selectCell(0, 1);
+    keyDown('enter');
+
+    document.activeElement.value = '12aaa34';
+
+    destroyEditor();
+
+    await sleep(100);
+
+    selectCell(1, 1);
+    keyDown('enter');
+
+    document.activeElement.value = 'aaa34';
+
+    destroyEditor();
+
+    await sleep(100);
+
+    selectCell(2, 1);
+    keyDown('enter');
+
+    document.activeElement.value = '12aaa';
+
+    destroyEditor();
+
     await sleep(100);
 
     expect($(getCell(0, 0)).hasClass('htInvalid')).toBe(true);
@@ -249,6 +280,15 @@ describe('NumericEditor', () => {
 
     expect($(getCell(2, 0)).hasClass('htInvalid')).toBe(true);
     expect(getDataAtCell(2, 0)).toEqual('12aaa');
+
+    expect($(getCell(0, 1)).hasClass('htInvalid')).toBe(true);
+    expect(getDataAtCell(0, 1)).toEqual('12aaa34');
+
+    expect($(getCell(1, 1)).hasClass('htInvalid')).toBe(true);
+    expect(getDataAtCell(1, 1)).toEqual('aaa34');
+
+    expect($(getCell(2, 1)).hasClass('htInvalid')).toBe(true);
+    expect(getDataAtCell(2, 1)).toEqual('12aaa');
   });
 
   it('should display a string in a format \'$X,XXX.XX\' when using language=en, appropriate format in column settings and \'XXXX.XX\' as ' +

--- a/test/e2e/editors/numericEditor.spec.js
+++ b/test/e2e/editors/numericEditor.spec.js
@@ -27,17 +27,14 @@ describe('NumericEditor', () => {
     ];
   };
 
-  it('should convert "integer like" input value to number (object data source)', (done) => {
-    const onAfterValidate = jasmine.createSpy('onAfterValidate');
-
+  it('should convert "integer like" input value to number (object data source)', async () => {
     handsontable({
       data: arrayOfObjects(),
       columns: [
         {data: 'id', type: 'numeric'},
         {data: 'name'},
         {data: 'lastName'}
-      ],
-      afterValidate: onAfterValidate
+      ]
     });
     selectCell(2, 0);
 
@@ -46,16 +43,13 @@ describe('NumericEditor', () => {
 
     destroyEditor();
 
-    setTimeout(() => {
-      expect(typeof getDataAtCell(2, 0)).toEqual('number');
-      expect(getDataAtCell(2, 0)).toEqual(999);
-      done();
-    }, 100);
+    await sleep(100);
+
+    expect(typeof getDataAtCell(2, 0)).toEqual('number');
+    expect(getDataAtCell(2, 0)).toEqual(999);
   });
 
   it('should not convert "float like" formatted input value to number (object data source) #4706', async () => {
-    const onAfterValidate = jasmine.createSpy('onAfterValidate');
-
     handsontable({
       data: arrayOfObjects(),
       columns: [
@@ -63,8 +57,7 @@ describe('NumericEditor', () => {
         {data: 'price_eur', type: 'numeric'},
         {data: 'price_pln', type: 'numeric', numericFormat: {pattern: '$0,0.00', culture: 'en-US'}},
         {data: 'price_aud', type: 'numeric', numericFormat: {pattern: '$0,0.00', culture: 'de-DE'}}
-      ],
-      afterValidate: onAfterValidate
+      ]
     });
 
     selectCell(0, 1);
@@ -129,17 +122,14 @@ describe('NumericEditor', () => {
     expect(getDataAtCell(1, 3)).toEqual('400,000.5');
   });
 
-  it('should convert "float like" input value with dot as determiner to number (object data source)', (done) => {
-    const onAfterValidate = jasmine.createSpy('onAfterValidate');
-
+  it('should convert "float like" input value with dot as determiner to number (object data source)', async () => {
     handsontable({
       data: arrayOfObjects(),
       columns: [
         {data: 'id', type: 'numeric'},
         {data: 'price'},
         {data: 'lastName'}
-      ],
-      afterValidate: onAfterValidate
+      ]
     });
     selectCell(2, 0);
 
@@ -148,24 +138,20 @@ describe('NumericEditor', () => {
 
     destroyEditor();
 
-    setTimeout(() => {
-      expect(typeof getDataAtCell(2, 0)).toEqual('number');
-      expect(getDataAtCell(2, 0)).toEqual(77.7);
-      done();
-    }, 100);
+    await sleep(100);
+
+    expect(typeof getDataAtCell(2, 0)).toEqual('number');
+    expect(getDataAtCell(2, 0)).toEqual(77.7);
   });
 
-  it('should convert "float like" input value with comma as determiner to number (object data source)', (done) => {
-    const onAfterValidate = jasmine.createSpy('onAfterValidate');
-
+  it('should convert "float like" input value with comma as determiner to number (object data source)', async () => {
     handsontable({
       data: arrayOfObjects(),
       columns: [
         {data: 'id', type: 'numeric'},
         {data: 'name'},
         {data: 'lastName'}
-      ],
-      afterValidate: onAfterValidate
+      ]
     });
     selectCell(2, 0);
 
@@ -174,24 +160,20 @@ describe('NumericEditor', () => {
 
     destroyEditor();
 
-    setTimeout(() => {
-      expect(typeof getDataAtCell(2, 0)).toEqual('number');
-      expect(getDataAtCell(2, 0)).toEqual(77.7);
-      done();
-    }, 100);
+    await sleep(100);
+
+    expect(typeof getDataAtCell(2, 0)).toEqual('number');
+    expect(getDataAtCell(2, 0)).toEqual(77.7);
   });
 
-  it('should convert "float like" input without leading zero to a float', (done) => {
-    const onAfterValidate = jasmine.createSpy('onAfterValidate');
-
+  it('should convert "float like" input without leading zero to a float', async () => {
     handsontable({
       data: arrayOfObjects(),
       columns: [
         {data: 'id', type: 'numeric'},
         {data: 'name'},
         {data: 'lastName'}
-      ],
-      afterValidate: onAfterValidate
+      ]
     });
 
     selectCell(2, 0);
@@ -199,16 +181,14 @@ describe('NumericEditor', () => {
 
     document.activeElement.value = '.74';
 
-    onAfterValidate.calls.reset();
     destroyEditor();
 
-    setTimeout(() => {
-      expect(getDataAtCell(2, 0)).toEqual(0.74);
-      done();
-    }, 100);
+    await sleep(100);
+
+    expect(getDataAtCell(2, 0)).toEqual(0.74);
   });
 
-  it('should apply changes to editor after validation', (done) => {
+  it('should apply changes to editor after validation', async () => {
     handsontable({
       data: arrayOfObjects(),
       columns: [
@@ -219,23 +199,19 @@ describe('NumericEditor', () => {
     selectCell(0, 0);
     keyDown('delete');
 
-    setTimeout(() => {
-      expect(getActiveEditor().originalValue).toEqual('');
-      done();
-    }, 100);
+    await sleep(100);
+
+    expect(getActiveEditor().originalValue).toEqual('');
   });
 
   it('should not validate string input data containing numbers ', async () => {
-    const onAfterValidate = jasmine.createSpy('onAfterValidate');
-
     handsontable({
       data: arrayOfObjects(),
       columns: [
         {data: 'id', type: 'numeric'},
         {data: 'name'},
         {data: 'lastName'}
-      ],
-      afterValidate: onAfterValidate
+      ]
     });
 
     selectCell(0, 0);
@@ -276,17 +252,14 @@ describe('NumericEditor', () => {
   });
 
   it('should display a string in a format \'$X,XXX.XX\' when using language=en, appropriate format in column settings and \'XXXX.XX\' as ' +
-     'an input string', (done) => {
-    const onAfterValidate = jasmine.createSpy('onAfterValidate');
-
+     'an input string', async () => {
     handsontable({
       data: arrayOfObjects(),
       columns: [
         {data: 'id', type: 'numeric', numericFormat: {pattern: '$0,0.00', culture: 'en-US'}},
         {data: 'name'},
         {data: 'lastName'}
-      ],
-      afterValidate: onAfterValidate
+      ]
     });
     selectCell(2, 0);
 
@@ -294,27 +267,22 @@ describe('NumericEditor', () => {
 
     document.activeElement.value = '2456.22';
 
-    onAfterValidate.calls.reset();
     destroyEditor();
 
-    setTimeout(() => {
-      expect(getCell(2, 0).innerHTML).toEqual('$2,456.22');
-      done();
-    }, 100);
+    await sleep(100);
+
+    expect(getCell(2, 0).innerHTML).toEqual('$2,456.22');
   });
 
   it('should display a string in a format \'X.XXX,XX €\' when using language=de, appropriate format in column settings and \'XXXX,XX\' as an ' +
-     'input string (that comes from manual input)', (done) => {
-    const onAfterValidate = jasmine.createSpy('onAfterValidate');
-
+     'input string (that comes from manual input)', async () => {
     handsontable({
       data: arrayOfObjects(),
       columns: [
         {data: 'id', type: 'numeric', numericFormat: {pattern: '0,0.00 $', culture: 'de-DE'}},
         {data: 'name'},
         {data: 'lastName'}
-      ],
-      afterValidate: onAfterValidate
+      ]
     });
     selectCell(2, 0);
 
@@ -322,17 +290,15 @@ describe('NumericEditor', () => {
 
     document.activeElement.value = '2456,22';
 
-    onAfterValidate.calls.reset();
     destroyEditor();
 
-    setTimeout(() => {
-      expect(getCell(2, 0).innerHTML).toEqual('2.456,22 €');
-      done();
-    }, 100);
+    await sleep(100);
+
+    expect(getCell(2, 0).innerHTML).toEqual('2.456,22 €');
   });
 
   it('should display a string in a format \'X.XXX,XX €\' when using language=de, appropriate format in column settings and \'XXXX.XX\' as an ' +
-     'input string (that comes from paste)', (done) => {
+     'input string (that comes from paste)', async () => {
     const onAfterValidate = jasmine.createSpy('onAfterValidate');
 
     handsontable({
@@ -350,19 +316,15 @@ describe('NumericEditor', () => {
 
     document.activeElement.value = '2456.22';
 
-    onAfterValidate.calls.reset();
     destroyEditor();
 
-    setTimeout(() => {
-      expect(getCell(2, 0).innerHTML).toEqual('2.456,22 €');
-      done();
-    }, 100);
+    await sleep(100);
+
+    expect(getCell(2, 0).innerHTML).toEqual('2.456,22 €');
   });
 
   it('should display a string in a format \'X XXX,XX €\' when using language=de, appropriate format in column settings and \'XXXX,XX\' as an ' +
-     'input string and ignore not needed zeros at the end', (done) => {
-    const onAfterValidate = jasmine.createSpy('onAfterValidate');
-
+     'input string and ignore not needed zeros at the end', async () => {
     handsontable({
       data: [
         {id: 1, name: 'Ted', lastName: 'Right', money: 0},
@@ -381,38 +343,35 @@ describe('NumericEditor', () => {
         {data: 'name'},
         {data: 'lastName'},
         {data: 'money', type: 'numeric', numericFormat: {pattern: '$0,0.00', culture: 'en-US'}}
-      ],
-      afterValidate: onAfterValidate
+      ]
     });
 
     selectCell(2, 0);
 
-    function manuallySetValueTo(val) {
-      keyDown('enter');
+    keyDown('enter');
 
-      document.activeElement.value = val;
+    document.activeElement.value = '2456,220';
 
-      onAfterValidate.calls.reset();
-      destroyEditor();
-    }
+    destroyEditor();
 
-    manuallySetValueTo('2456,220');
+    await sleep(100);
 
-    setTimeout(() => {
-      expect(getCell(2, 0).innerHTML).toEqual('2.456,22 €');
+    expect(getCell(2, 0).innerHTML).toEqual('2.456,22 €');
 
-      deselectCell();
-      selectCell(2, 3);
-      manuallySetValueTo('2456.220');
-    }, 100);
+    selectCell(2, 3);
 
-    setTimeout(() => {
-      expect(getCell(2, 3).innerHTML).toEqual('$2,456.22');
-      done();
-    }, 200);
+    keyDown('enter');
+
+    document.activeElement.value = '2456.220';
+
+    destroyEditor();
+
+    await sleep(100);
+
+    expect(getCell(2, 3).innerHTML).toEqual('$2,456.22');
   });
 
-  it('should mark text as invalid without removing when using `setDataAtCell`', (done) => {
+  it('should mark text as invalid without removing when using `setDataAtCell`', async () => {
     const hot = handsontable({
       data: arrayOfObjects(),
       columns: [
@@ -424,16 +383,13 @@ describe('NumericEditor', () => {
 
     hot.setDataAtCell(0, 0, 'abc');
 
-    setTimeout(() => {
-      expect(hot.getDataAtCell(0, 0)).toEqual('abc');
-      expect($(getCell(0, 0)).hasClass('htInvalid')).toBe(true);
-      done();
-    }, 200);
+    await sleep(200);
+
+    expect(hot.getDataAtCell(0, 0)).toEqual('abc');
+    expect($(getCell(0, 0)).hasClass('htInvalid')).toBe(true);
   });
 
-  it('should allow custom validator', (done) => {
-    const onAfterValidate = jasmine.createSpy('onAfterValidate');
-
+  it('should allow custom validator', async () => {
     handsontable({
       data: arrayOfObjects(),
       allowInvalid: false,
@@ -447,8 +403,7 @@ describe('NumericEditor', () => {
         },
         {data: 'name'},
         {data: 'lastName'}
-      ],
-      afterValidate: onAfterValidate
+      ]
     });
     selectCell(2, 0);
 
@@ -457,19 +412,17 @@ describe('NumericEditor', () => {
 
     destroyEditor();
 
-    setTimeout(() => {
-      expect(getDataAtCell(2, 0)).not.toEqual(99); // should be ignored
+    await sleep(100);
 
-      document.activeElement.value = '999';
+    expect(getDataAtCell(2, 0)).not.toEqual(99); // should be ignored
 
-      onAfterValidate.calls.reset();
-      destroyEditor();
-    }, 100);
+    document.activeElement.value = '999';
 
-    setTimeout(() => {
-      expect(getDataAtCell(2, 0)).toEqual(999);
-      done();
-    }, 200);
+    destroyEditor();
+
+    await sleep(100);
+
+    expect(getDataAtCell(2, 0)).toEqual(999);
   });
 
   // Input element can not lose the focus while entering new characters. It breaks IME editor functionality for Asian users.

--- a/test/e2e/renderers/numericRenderer.spec.js
+++ b/test/e2e/renderers/numericRenderer.spec.js
@@ -53,7 +53,7 @@ describe('NumericRenderer', () => {
     }, 200);
   });
 
-  it('should try to render string as numeral', (done) => {
+  it('should not try to render string as numeral', (done) => {
     handsontable({
       cells() {
         return {
@@ -66,7 +66,7 @@ describe('NumericRenderer', () => {
     setDataAtCell(2, 2, '123 simple test');
 
     setTimeout(() => {
-      expect(getCell(2, 2).innerHTML).toEqual('$123.00');
+      expect(getCell(2, 2).innerHTML).toEqual('123 simple test');
       done();
     }, 100);
   });


### PR DESCRIPTION
### Solution
We definitely **not** use property `numericFormat` for formatting input from now.

### How has this been tested?
I've tested fix with every case described in issue and also with `autofill` and `copy & paste` features.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s): #4706

### Checklist:
- [x] My code follows the code style of this project,
- [x] My change requires a change to the documentation.
