### PR TITLE
afterRowMove hook returns improper target parameter

### DIFF
--- a/src/mixins/arrayMapper.js
+++ b/src/mixins/arrayMapper.js
@@ -1,4 +1,4 @@
-import {arrayEach, arrayReduce, arrayMap, arrayMax} from './../helpers/array';
+import {arrayReduce, arrayMap, arrayMax} from './../helpers/array';
 import {defineGetter} from './../helpers/object';
 import {rangeEach} from './../helpers/number';
 
@@ -11,44 +11,48 @@ const arrayMapper = {
   _arrayMap: [],
 
   /**
-   * Get value by map index.
+   * Get translated index by its physical index.
    *
-   * @param {Number} index Array index.
-   * @return {*} Returns value mapped to passed index.
+   * @param {Number} physicalIndex Physical index.
+   * @return {Number|null} Returns translated index mapped by passed physical index.
    */
-  getValueByIndex(index) {
-    let value;
+  getValueByIndex(physicalIndex) {
+    const length = this._arrayMap.length;
+    let translatedIndex = null;
 
-    // eslint-disable-next-line no-cond-assign, no-return-assign
-    return (value = this._arrayMap[index]) === void 0 ? null : value;
+    if (physicalIndex < length) {
+      translatedIndex = this._arrayMap[physicalIndex];
+    }
+
+    return translatedIndex;
   },
 
   /**
-   * Get map index by its value.
+   * Get physical index by its translated index.
    *
-   * @param {*} value Value to search.
-   * @returns {Number} Returns array index.
+   * @param {*} translatedIndex Value to search.
+   * @returns {Number|null} Returns a physical index of the array mapper.
    */
-  getIndexByValue(value) {
-    let index;
+  getIndexByValue(translatedIndex) {
+    let physicalIndex;
 
     // eslint-disable-next-line no-cond-assign, no-return-assign
-    return (index = this._arrayMap.indexOf(value)) === -1 ? null : index;
+    return (physicalIndex = this._arrayMap.indexOf(translatedIndex)) === -1 ? null : physicalIndex;
   },
 
   /**
    * Insert new items to array mapper starting at passed index. New entries will be a continuation of last value in the array.
    *
-   * @param {Number} index Array index.
+   * @param {Number} physicalIndex Array index.
    * @param {Number} [amount=1] Defines how many items will be created to an array.
    * @returns {Array} Returns added items.
    */
-  insertItems(index, amount = 1) {
+  insertItems(physicalIndex, amount = 1) {
     let newIndex = arrayMax(this._arrayMap) + 1;
     let addedItems = [];
 
     rangeEach(amount - 1, (count) => {
-      addedItems.push(this._arrayMap.splice(index + count, 0, newIndex + count));
+      addedItems.push(this._arrayMap.splice(physicalIndex + count, 0, newIndex + count));
     });
 
     return addedItems;
@@ -57,27 +61,27 @@ const arrayMapper = {
   /**
    * Remove items from array mapper.
    *
-   * @param {Number} index Array index.
+   * @param {Number} physicalIndex Array index.
    * @param {Number} [amount=1] Defines how many items will be created to an array.
    * @returns {Array} Returns removed items.
    */
-  removeItems(index, amount = 1) {
+  removeItems(physicalIndex, amount = 1) {
     let removedItems = [];
 
-    if (Array.isArray(index)) {
+    if (Array.isArray(physicalIndex)) {
       let mapCopy = [].concat(this._arrayMap);
 
       // Sort descending
-      index.sort((a, b) => b - a);
+      physicalIndex.sort((a, b) => b - a);
 
-      removedItems = arrayReduce(index, (acc, item) => {
+      removedItems = arrayReduce(physicalIndex, (acc, item) => {
         this._arrayMap.splice(item, 1);
 
         return acc.concat(mapCopy.slice(item, item + 1));
       }, []);
 
     } else {
-      removedItems = this._arrayMap.splice(index, amount);
+      removedItems = this._arrayMap.splice(physicalIndex, amount);
     }
 
     return removedItems;
@@ -86,11 +90,11 @@ const arrayMapper = {
   /**
    * Unshift items (remove and shift chunk of array to the left).
    *
-   * @param {Number|Array} index Array index or Array of indexes to unshift.
+   * @param {Number|Array} physicalIndex Array index or Array of indexes to unshift.
    * @param {Number} [amount=1] Defines how many items will be removed from an array (when index is passed as number).
    */
-  unshiftItems(index, amount = 1) {
-    let removedItems = this.removeItems(index, amount);
+  unshiftItems(physicalIndex, amount = 1) {
+    let removedItems = this.removeItems(physicalIndex, amount);
 
     function countRowShift(logicalRow) {
       // Todo: compare perf between reduce vs sort->each->brake
@@ -117,21 +121,30 @@ const arrayMapper = {
   /**
    * Shift (right shifting) items starting at passed index.
    *
-   * @param {Number} index Array index.
+   * @param {Number} physicalIndex Array index.
    * @param {Number} [amount=1] Defines how many items will be created to an array.
    */
-  shiftItems(index, amount = 1) {
+  shiftItems(physicalIndex, amount = 1) {
     this._arrayMap = arrayMap(this._arrayMap, (row) => {
-      if (row >= index) {
+      if (row >= physicalIndex) {
         row += amount;
       }
-
       return row;
     });
 
     rangeEach(amount - 1, (count) => {
-      this._arrayMap.splice(index + count, 0, index + count);
+      this._arrayMap.splice(physicalIndex + count, 0, physicalIndex + count);
     });
+  },
+
+  /**
+   * Swap indexes in arrayMapper.
+   *
+   * @param {Number} physicalIndexFrom index to move.
+   * @param {Number} physicalIndexTo index to.
+   */
+  swapIndexes(physicalIndexFrom, physicalIndexTo) {
+    this._arrayMap.splice(physicalIndexTo, 0, ...this._arrayMap.splice(physicalIndexFrom, 1));
   },
 
   /**

--- a/src/plugins/manualColumnFreeze/manualColumnFreeze.js
+++ b/src/plugins/manualColumnFreeze/manualColumnFreeze.js
@@ -129,7 +129,7 @@ class ManualColumnFreeze extends BasePlugin {
     priv.moveByFreeze = true;
     settings.fixedColumnsLeft--;
 
-    this.getMovePlugin().moveColumn(column, returnCol + 1);
+    this.getMovePlugin().moveColumn(column, returnCol);
   }
 
   /**

--- a/src/plugins/manualColumnMove/columnsMapper.js
+++ b/src/plugins/manualColumnMove/columnsMapper.js
@@ -38,25 +38,6 @@ class ColumnsMapper {
   destroy() {
     this._arrayMap = null;
   }
-
-  /**
-   * Moving elements in columnsMapper.
-   *
-   * @param {Number} from Column index to move.
-   * @param {Number} to Target index.
-   */
-  moveColumn(from, to) {
-    let indexToMove = this._arrayMap[from];
-    this._arrayMap[from] = null;
-    this._arrayMap.splice(to, 0, indexToMove);
-  }
-
-  /**
-   * Clearing arrayMap from `null` entries.
-   */
-  clearNull() {
-    this._arrayMap = arrayFilter(this._arrayMap, (i) => i !== null);
-  }
 }
 
 mixin(ColumnsMapper, arrayMapper);

--- a/src/plugins/manualColumnMove/manualColumnMove.js
+++ b/src/plugins/manualColumnMove/manualColumnMove.js
@@ -193,12 +193,9 @@ class ManualColumnMove extends BasePlugin {
         let actualPosition = this.columnsMapper.getIndexByValue(column);
 
         if (actualPosition !== target) {
-          this.columnsMapper.moveColumn(actualPosition, target + index);
+          this.columnsMapper.swapIndexes(actualPosition, target + index);
         }
       });
-
-      // after moving we have to clear columnsMapper from null entries
-      this.columnsMapper.clearNull();
     }
 
     this.hot.runHooks('afterColumnMove', columns, target);
@@ -593,7 +590,6 @@ class ManualColumnMove extends BasePlugin {
   onMouseUp() {
     let priv = privatePool.get(this);
 
-    priv.coordsColumn = void 0;
     priv.pressed = false;
     priv.backlightWidth = 0;
 
@@ -606,7 +602,7 @@ class ManualColumnMove extends BasePlugin {
       return;
     }
 
-    this.moveColumns(priv.columnsToMove, priv.target.col);
+    this.moveColumns(priv.columnsToMove, priv.coordsColumn);
     this.persistentStateSave();
     this.hot.render();
     this.hot.view.wt.wtOverlays.adjustElementsSize(true);

--- a/src/plugins/manualColumnMove/test/columnsMapper.unit.js
+++ b/src/plugins/manualColumnMove/test/columnsMapper.unit.js
@@ -34,33 +34,5 @@ describe('manualColumnMove', () => {
       expect(mapper._arrayMap[4]).toBe(4);
       expect(mapper._arrayMap[5]).toBe(5);
     });
-
-    it('should change order after move action', () => {
-      var mapper = new ColumnsMapper();
-      mapper.createMap(6);
-
-      mapper.moveColumn(1, 0);
-      mapper.clearNull();
-
-      expect(mapper._arrayMap[0]).toBe(1);
-      expect(mapper._arrayMap[1]).toBe(0);
-      expect(mapper._arrayMap[2]).toBe(2);
-      expect(mapper._arrayMap[3]).toBe(3);
-      expect(mapper._arrayMap[4]).toBe(4);
-      expect(mapper._arrayMap[5]).toBe(5);
-    });
-
-    it('should clean from null values', () => {
-      var mapper = new ColumnsMapper();
-      mapper.createMap(6);
-
-      mapper.moveColumn(1, 6);
-      mapper.moveColumn(2, 7);
-      mapper.moveColumn(4, 8);
-
-      mapper.clearNull();
-
-      expect(mapper._arrayMap.length).toBe(6);
-    });
   });
 });

--- a/src/plugins/manualColumnMove/test/manualColumnMove.e2e.js
+++ b/src/plugins/manualColumnMove/test/manualColumnMove.e2e.js
@@ -327,9 +327,9 @@ describe('manualColumnMove', () => {
       $rowsHeaders.eq(1).simulate('mousedown');
       $rowsHeaders.eq(1).simulate('mouseup');
       $rowsHeaders.eq(1).simulate('mousedown');
-      $rowsHeaders.eq(3).simulate('mouseover');
-      $rowsHeaders.eq(3).simulate('mousemove');
-      $rowsHeaders.eq(3).simulate('mouseup');
+      $rowsHeaders.eq(2).simulate('mouseover');
+      $rowsHeaders.eq(2).simulate('mousemove');
+      $rowsHeaders.eq(2).simulate('mouseup');
 
       expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('A1');
       expect(this.$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('C1');
@@ -384,7 +384,7 @@ describe('manualColumnMove', () => {
 
       expect(htCore.find('tbody tr:eq(1) td:eq(0)')[0].className.indexOf('htDimmed')).toBeGreaterThan(-1);
 
-      hot.getPlugin('manualColumnMove').moveColumn(0, 3);
+      hot.getPlugin('manualColumnMove').moveColumn(0, 2);
       hot.render();
 
       expect(htCore.find('tbody tr:eq(1) td:eq(2)')[0].className.indexOf('htDimmed')).toBeGreaterThan(-1);
@@ -408,6 +408,36 @@ describe('manualColumnMove', () => {
       hot.render();
 
       expect(htCore.find('tbody tr:eq(1) td:eq(1)')[0].className.indexOf('htDimmed')).toBeGreaterThan(-1);
+    });
+  });
+
+  describe('callbacks', () => {
+    it('should run `beforeColumnMove` and `afterColumnMove` with proper visual `target` parameter', () => {
+      let targetParameterInsideBeforeColumnMoveCallback;
+      let targetParameterInsideAfterColumnMoveCallback;
+
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(3, 3),
+        colHeaders: true,
+        manualColumnMove: true,
+        beforeColumnMove: (columns, target) => {
+          targetParameterInsideBeforeColumnMoveCallback = target;
+        },
+        afterColumnMove: (columns, target) => {
+          targetParameterInsideAfterColumnMoveCallback = target;
+        }
+      });
+
+      spec().$container.find('thead tr:eq(0) th:eq(0)').simulate('mouseup');
+      spec().$container.find('thead tr:eq(0) th:eq(0)').simulate('mousedown');
+      spec().$container.find('thead tr:eq(0) th:eq(0)').simulate('mousedown');
+
+      spec().$container.find('thead tr:eq(0) th:eq(2)').simulate('mouseover');
+      spec().$container.find('thead tr:eq(0) th:eq(2)').simulate('mousemove');
+      spec().$container.find('thead tr:eq(0) th:eq(2)').simulate('mouseup');
+
+      expect(targetParameterInsideBeforeColumnMoveCallback).toEqual(2);
+      expect(targetParameterInsideAfterColumnMoveCallback).toEqual(2);
     });
   });
 

--- a/src/plugins/manualRowMove/manualRowMove.js
+++ b/src/plugins/manualRowMove/manualRowMove.js
@@ -192,12 +192,9 @@ class ManualRowMove extends BasePlugin {
         let actualPosition = this.rowsMapper.getIndexByValue(row);
 
         if (actualPosition !== target) {
-          this.rowsMapper.moveRow(actualPosition, target + index);
+          this.rowsMapper.swapIndexes(actualPosition, target + index);
         }
       });
-
-      // after moving we have to clear rowsMapper from null entries
-      this.rowsMapper.clearNull();
     }
 
     this.hot.runHooks('afterRowMove', rows, target);
@@ -600,7 +597,6 @@ class ManualRowMove extends BasePlugin {
    */
   onMouseUp() {
     let priv = privatePool.get(this);
-    let target = priv.target.row;
     let rowsLen = priv.rowsToMove.length;
 
     priv.pressed = false;
@@ -612,12 +608,12 @@ class ManualRowMove extends BasePlugin {
       addClass(this.hot.rootElement, CSS_AFTER_SELECTION);
     }
 
-    if (rowsLen < 1 || target === void 0 || priv.rowsToMove.indexOf(target) > -1 ||
-        (priv.rowsToMove[rowsLen - 1] === target - 1)) {
+    if (rowsLen < 1 || priv.target.row === void 0 || priv.rowsToMove.indexOf(priv.target.row) > -1 ||
+        (priv.rowsToMove[rowsLen - 1] === priv.target.row - 1)) {
       return;
     }
 
-    this.moveRows(priv.rowsToMove, target);
+    this.moveRows(priv.rowsToMove, priv.target.coords.row);
 
     this.persistentStateSave();
     this.hot.render();

--- a/src/plugins/manualRowMove/rowsMapper.js
+++ b/src/plugins/manualRowMove/rowsMapper.js
@@ -38,25 +38,6 @@ class RowsMapper {
   destroy() {
     this._arrayMap = null;
   }
-
-  /**
-   * Moving elements in rowsMapper.
-   *
-   * @param {Number} from Row index to move.
-   * @param {Number} to Target index.
-   */
-  moveRow(from, to) {
-    let indexToMove = this._arrayMap[from];
-    this._arrayMap[from] = null;
-    this._arrayMap.splice(to, 0, indexToMove);
-  }
-
-  /**
-   * Clearing arrayMap from `null` entries.
-   */
-  clearNull() {
-    this._arrayMap = arrayFilter(this._arrayMap, (i) => i !== null);
-  }
 }
 
 mixin(RowsMapper, arrayMapper);

--- a/src/plugins/manualRowMove/test/manualRowMove.e2e.js
+++ b/src/plugins/manualRowMove/test/manualRowMove.e2e.js
@@ -356,7 +356,7 @@ describe('manualRowMove', () => {
       });
       $lastHeader.simulate('mouseup');
 
-      expect(targetParameterInsideCallback).toEqual(30);
+      expect(targetParameterInsideCallback).toEqual(29);
     });
 
     it('should run `beforeRowMove` with proper `target` parameter (moving row below last header)', () => {
@@ -382,7 +382,7 @@ describe('manualRowMove', () => {
       });
       $lastHeader.simulate('mouseup');
 
-      expect(targetParameterInsideCallback).toEqual(30);
+      expect(targetParameterInsideCallback).toEqual(29);
     });
 
     it('should run `beforeRowMove` with proper visual `target` parameter', () => {
@@ -469,12 +469,12 @@ describe('manualRowMove', () => {
 
       const $rowsHeaders = spec().$container.find('.ht_clone_left tr th');
 
-      $rowsHeaders.eq(1).simulate('mousedown');
+      $rowsHeaders.eq(2).simulate('mousedown');
+      $rowsHeaders.eq(2).simulate('mouseup');
+      $rowsHeaders.eq(2).simulate('mousedown');
+      $rowsHeaders.eq(1).simulate('mouseover');
+      $rowsHeaders.eq(1).simulate('mousemove');
       $rowsHeaders.eq(1).simulate('mouseup');
-      $rowsHeaders.eq(1).simulate('mousedown');
-      $rowsHeaders.eq(3).simulate('mouseover');
-      $rowsHeaders.eq(3).simulate('mousemove');
-      $rowsHeaders.eq(3).simulate('mouseup');
 
       expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('1');
       expect(spec().$container.find('tbody tr:eq(1) td:eq(0)').text()).toEqual('3');
@@ -551,7 +551,7 @@ describe('manualRowMove', () => {
 
       expect(htCore.find('tbody tr:eq(1) td:eq(0)')[0].className.indexOf('htDimmed')).toBeGreaterThan(-1);
 
-      hot.getPlugin('manualRowMove').moveRow(1, 3);
+      hot.getPlugin('manualRowMove').moveRow(1, 2);
       hot.render();
 
       expect(htCore.find('tbody tr:eq(2) td:eq(0)')[0].className.indexOf('htDimmed')).toBeGreaterThan(-1);
@@ -578,6 +578,36 @@ describe('manualRowMove', () => {
     });
   });
 
+  describe('callbacks', () => {
+    it('should run `beforeRowMove` and `afterRowMove` with proper visual `target` parameter', () => {
+      let targetParameterInsideBeforeRowMoveCallback;
+      let targetParameterInsideAfterRowMoveCallback;
+
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(3, 3),
+        rowHeaders: true,
+        manualRowMove: true,
+        beforeRowMove: (rows, target) => {
+          targetParameterInsideBeforeRowMoveCallback = target;
+        },
+        afterRowMove: (rows, target) => {
+          targetParameterInsideAfterRowMoveCallback = target;
+        }
+      });
+
+      spec().$container.find('tbody tr:eq(0) th:eq(0)').simulate('mouseup');
+      spec().$container.find('tbody tr:eq(0) th:eq(0)').simulate('mousedown');
+      spec().$container.find('tbody tr:eq(0) th:eq(0)').simulate('mousedown');
+
+      spec().$container.find('tbody tr:eq(2) th:eq(0)').simulate('mouseover');
+      spec().$container.find('tbody tr:eq(2) th:eq(0)').simulate('mousemove');
+      spec().$container.find('tbody tr:eq(2) th:eq(0)').simulate('mouseup');
+
+      expect(targetParameterInsideBeforeRowMoveCallback).toEqual(2);
+      expect(targetParameterInsideAfterRowMoveCallback).toEqual(2);
+    });
+  });
+
   describe('undoRedo', () => {
     it('should back changes', () => {
       var hot = handsontable({
@@ -585,7 +615,7 @@ describe('manualRowMove', () => {
         rowHeaders: true,
         manualRowMove: true,
       });
-      hot.getPlugin('manualRowMove').moveRow(1, 4);
+      hot.getPlugin('manualRowMove').moveRow(1, 3);
       hot.render();
 
       expect(hot.getDataAtCell(3, 0)).toBe('A2');
@@ -601,7 +631,7 @@ describe('manualRowMove', () => {
         rowHeaders: true,
         manualRowMove: true,
       });
-      hot.getPlugin('manualRowMove').moveRow(1, 4);
+      hot.getPlugin('manualRowMove').moveRow(1, 3);
       hot.render();
 
       expect(hot.getDataAtCell(3, 0)).toBe('A2');

--- a/src/plugins/manualRowMove/test/rowsMapper.unit.js
+++ b/src/plugins/manualRowMove/test/rowsMapper.unit.js
@@ -34,33 +34,5 @@ describe('manualRowMove', () => {
       expect(mapper._arrayMap[4]).toBe(4);
       expect(mapper._arrayMap[5]).toBe(5);
     });
-
-    it('should change order after move action', () => {
-      var mapper = new RowsMapper();
-      mapper.createMap(6);
-
-      mapper.moveRow(1, 0);
-      mapper.clearNull();
-
-      expect(mapper._arrayMap[0]).toBe(1);
-      expect(mapper._arrayMap[1]).toBe(0);
-      expect(mapper._arrayMap[2]).toBe(2);
-      expect(mapper._arrayMap[3]).toBe(3);
-      expect(mapper._arrayMap[4]).toBe(4);
-      expect(mapper._arrayMap[5]).toBe(5);
-    });
-
-    it('should clean from null values', () => {
-      var mapper = new RowsMapper();
-      mapper.createMap(6);
-
-      mapper.moveRow(1, 6);
-      mapper.moveRow(2, 7);
-      mapper.moveRow(4, 8);
-
-      mapper.clearNull();
-
-      expect(mapper._arrayMap.length).toBe(6);
-    });
   });
 });

--- a/src/plugins/undoRedo/undoRedo.js
+++ b/src/plugins/undoRedo/undoRedo.js
@@ -489,15 +489,8 @@ UndoRedo.RowMoveAction.prototype.undo = function(instance, undoneCallback) {
   let manualRowMove = instance.getPlugin('manualRowMove');
 
   instance.addHookOnce('afterRender', undoneCallback);
-  let mod = this.rows[0] < this.target ? -1 * this.rows.length : 0;
-  let newTarget = this.rows[0] > this.target ? this.rows[0] + this.rows.length : this.rows[0];
-  let newRows = [];
-  let rowsLen = this.rows.length + mod;
 
-  for (let i = mod; i < rowsLen; i++) {
-    newRows.push(this.target + i);
-  }
-  manualRowMove.moveRows(newRows.slice(), newTarget);
+  manualRowMove.moveRows([this.target], this.rows[0]);
   instance.render();
 
   instance.selection.setRangeStartOnly(new CellCoords(this.rows[0], 0));

--- a/test/unit/mixins/arrayMapper.spec.js
+++ b/test/unit/mixins/arrayMapper.spec.js
@@ -1,0 +1,121 @@
+import arrayMapper from 'handsontable/mixins/arrayMapper';
+
+describe('arrayMapper mixin', () => {
+  describe('insertItems', () => {
+    it('should add items to _arrayMap to the given place', () => {
+      arrayMapper._arrayMap = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+      arrayMapper.insertItems(1, 3);
+
+      expect(arrayMapper._arrayMap.length).toBe(13);
+      expect(arrayMapper._arrayMap).toEqual([0, 10, 11, 12, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+      arrayMapper._arrayMap = [1, 6, 3, 4, 5, 7, 8, 9, 0, 2];
+
+      arrayMapper.insertItems(1, 3);
+
+      expect(arrayMapper._arrayMap.length).toBe(13);
+      expect(arrayMapper._arrayMap).toEqual([1, 10, 11, 12, 6, 3, 4, 5, 7, 8, 9, 0, 2]);
+    });
+  });
+
+  describe('removeItems', () => {
+    it('should remove items from _arrayMap and returns removed items', () => {
+      arrayMapper._arrayMap = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+      arrayMapper.removeItems(1, 3);
+
+      expect(arrayMapper._arrayMap.length).toBe(7);
+      expect(arrayMapper._arrayMap).toEqual([0, 4, 5, 6, 7, 8, 9]);
+
+      arrayMapper._arrayMap = [1, 6, 3, 4, 5, 7, 8, 9, 0, 2];
+
+      arrayMapper.removeItems(1, 3);
+
+      expect(arrayMapper._arrayMap.length).toBe(7);
+      expect(arrayMapper._arrayMap).toEqual([1, 5, 7, 8, 9, 0, 2]);
+    });
+  });
+
+  describe('unshiftItems', () => {
+    it('should remove items from _arrayMap', () => {
+      arrayMapper._arrayMap = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+      arrayMapper.unshiftItems(1, 3);
+
+      expect(arrayMapper._arrayMap.length).toBe(7);
+      expect(arrayMapper._arrayMap).toEqual([0, 1, 2, 3, 4, 5, 6]);
+
+      arrayMapper._arrayMap = [1, 6, 3, 4, 5, 7, 8, 9, 0, 2];
+
+      arrayMapper.unshiftItems(1, 3);
+
+      expect(arrayMapper._arrayMap.length).toBe(7);
+      expect(arrayMapper._arrayMap).toEqual([1, 3, 4, 5, 6, 0, 2]);
+    });
+  });
+
+  describe('shiftItems', () => {
+    it('should add items to _arrayMap', () => {
+      arrayMapper._arrayMap = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+      arrayMapper.shiftItems(1, 3);
+
+      expect(arrayMapper._arrayMap.length).toBe(13);
+      expect(arrayMapper._arrayMap).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+
+      arrayMapper._arrayMap = [1, 6, 3, 4, 5, 7, 8, 9, 0, 2];
+
+      arrayMapper.shiftItems(1, 3);
+
+      expect(arrayMapper._arrayMap.length).toBe(13);
+      expect(arrayMapper._arrayMap).toEqual([4, 1, 2, 3, 9, 6, 7, 8, 10, 11, 12, 0, 5]);
+    });
+  });
+
+  describe('Swap indexes', () => {
+    it('should swap given indexes', () => {
+      arrayMapper._arrayMap = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+      arrayMapper.swapIndexes(8, 0);
+      arrayMapper.swapIndexes(3, 1);
+      arrayMapper.swapIndexes(5, 2);
+
+      expect(arrayMapper._arrayMap.length).toBe(10);
+      expect(arrayMapper._arrayMap).toEqual([8, 2, 4, 0, 1, 3, 5, 6, 7, 9]);
+    });
+
+    it('should return to their index', () => {
+      arrayMapper._arrayMap = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+      arrayMapper.swapIndexes(5, 0);
+      arrayMapper.swapIndexes(8, 1);
+
+      expect(arrayMapper._arrayMap.length).toBe(10);
+      expect(arrayMapper._arrayMap).toEqual([5, 8, 0, 1, 2, 3, 4, 6, 7, 9]);
+
+      arrayMapper.swapIndexes(1, 8);
+
+      expect(arrayMapper._arrayMap.length).toBe(10);
+      expect(arrayMapper._arrayMap).toEqual([5, 0, 1, 2, 3, 4, 6, 7, 8, 9]);
+
+      arrayMapper.swapIndexes(0, 5);
+
+      expect(arrayMapper._arrayMap.length).toBe(10);
+      expect(arrayMapper._arrayMap).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    });
+  });
+
+  describe('clearMap', () => {
+    it('should clear _arrayMap', () => {
+      arrayMapper._arrayMap = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+      expect(arrayMapper._arrayMap.length).toBe(10);
+
+      arrayMapper.clearMap();
+
+      expect(arrayMapper._arrayMap.length).toBe(0);
+      expect(arrayMapper._arrayMap).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
###Solution
Replace moveColumn/Row and clearNull by SwapIndexes.

### How has this been tested?
Checked what target values the hooks after/beforeRowMove and after/beforeColumnMove are return.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):
#4501 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
