### PR TITLE
Unification of function calls inside `editorManager` and corresponding changes

### DIFF
--- a/src/editorManager.js
+++ b/src/editorManager.js
@@ -269,8 +269,8 @@ function EditorManager(instance, priv, selection) {
 
     function onDblClick(event, coords, elem) {
       // may be TD or TH
-      if (elem.nodeName == 'TD') {
-        _this.openEditor();
+      if (elem.nodeName === 'TD') {
+        _this.openEditor(null, event);
 
         if (activeEditor) {
           activeEditor.enableFullEditMode();
@@ -364,12 +364,12 @@ function EditorManager(instance, priv, selection) {
    *
    * @function openEditor
    * @memberof! Handsontable.EditorManager#
-   * @param {String} initialValue
+   * @param {null|String} newInitialValue new value from which editor will start if handled property it's not the `null`.
    * @param {DOMEvent} event
    */
-  this.openEditor = function(initialValue, event) {
+  this.openEditor = function(newInitialValue, event) {
     if (activeEditor && !activeEditor.cellProperties.readOnly) {
-      activeEditor.beginEditing(initialValue, event);
+      activeEditor.beginEditing(newInitialValue, event);
     } else if (activeEditor && activeEditor.cellProperties.readOnly) {
 
       // move the selection after opening the editor with ENTER key

--- a/src/editors/_baseEditor.js
+++ b/src/editors/_baseEditor.js
@@ -98,16 +98,16 @@ BaseEditor.prototype.saveValue = function(value, ctrlDown) {
   this.instance.populateFromArray(selection[0], selection[1], value, selection[2], selection[3], 'edit');
 };
 
-BaseEditor.prototype.beginEditing = function(initialValue, event) {
-  if (this.state != EditorState.VIRGIN) {
+BaseEditor.prototype.beginEditing = function(newInitialValue, event) {
+  if (this.state !== EditorState.VIRGIN) {
     return;
   }
   this.instance.view.scrollViewport(new CellCoords(this.row, this.col));
   this.instance.view.render();
   this.state = EditorState.EDITING;
 
-  initialValue = typeof initialValue == 'string' ? initialValue : this.originalValue;
-  this.setValue(stringify(initialValue));
+  newInitialValue = typeof newInitialValue === 'string' ? newInitialValue : this.originalValue;
+  this.setValue(stringify(newInitialValue));
 
   this.open(event);
   this._opened = true;

--- a/src/editors/checkboxEditor.js
+++ b/src/editors/checkboxEditor.js
@@ -8,8 +8,11 @@ import {hasClass} from './../helpers/dom/element';
  */
 class CheckboxEditor extends BaseEditor {
   beginEditing(initialValue, event) {
-    // editorManager return double click event as undefined
-    if (event === void 0) {
+    // Just some events connected with checkbox editor are delegated here. Some `keydown` events like `enter` and `space` key press
+    // are handled inside `checkboxRenderer`. Some events come here from `editorManager`. Below `if` statement was created by author
+    // for purpose of handling only `doubleclick` event which may be done on a cell with checkbox.
+
+    if (event.type === 'mouseup') {
       let checkbox = this.TD.querySelector('input[type="checkbox"]');
 
       if (!hasClass(checkbox, 'htBadValue')) {

--- a/src/editors/numericEditor.js
+++ b/src/editors/numericEditor.js
@@ -4,15 +4,7 @@ import TextEditor from './textEditor';
  * @private
  * @editor NumericEditor
  * @class NumericEditor
- * @dependencies TextEditor numbro
  */
-class NumericEditor extends TextEditor {
-  beginEditing(initialValue, event) {
-    // There is a problem with `initialValue` property which gets other value when we press `enter`, other when we perform the double click.
-    // It was discovered within #4706. Property `event` should be probably removed, but now it's handled by `open` function of `BaseEditor`
-    // (called inside inherited `beginEditing` function).
-    super.beginEditing(this.originalValue, event);
-  }
-}
+class NumericEditor extends TextEditor {}
 
 export default NumericEditor;

--- a/test/e2e/editors/index.spec.js
+++ b/test/e2e/editors/index.spec.js
@@ -76,4 +76,36 @@ describe('editors', () => {
 
     expect(getEditor('myEditor')).toBe(MyEditor);
   });
+
+  it('should reset previous value when printable character was entered to selected, non-empty cell', async function () {
+    handsontable({
+      data: [
+        {id: 10, name: 'Cup'},
+        {id: 23, name: 'Newspaper'},
+        {id: 31, name: 'Car'}
+      ],
+      columns: [
+        {data: 'id', type: 'numeric'},
+        {data: 'name'},
+      ]
+    });
+
+    selectCell(0, 0);
+    keyDownUp('1'.charCodeAt(0));
+
+    destroyEditor();
+
+    await sleep(100);
+
+    expect(getCell(0, 0).innerHTML).not.toEqual('10');
+
+    selectCell(0, 1);
+    keyDownUp('a'.charCodeAt(0));
+
+    destroyEditor();
+
+    await sleep(100);
+
+    expect(getCell(1, 0).innerHTML).not.toEqual('Cup');
+  });
 });

--- a/test/e2e/renderers/checkboxRenderer.spec.js
+++ b/test/e2e/renderers/checkboxRenderer.spec.js
@@ -620,6 +620,25 @@ describe('CheckboxRenderer', () => {
     expect(afterChangeCallback.calls.count()).toEqual(0);
   });
 
+  it('should not change checkbox state after hitting F2 key', () => {
+    const onAfterChange = jasmine.createSpy('afterChangeCallback');
+
+    handsontable({
+      data: [[false], [true], [true]],
+      columns: [
+        {type: 'checkbox'}
+      ],
+      onAfterChange
+    });
+
+    selectCell(0, 0);
+    keyDown('f2');
+
+    expect(getDataAtCell(0, 0)).toBe(false);
+
+    expect(onAfterChange.calls.count()).toEqual(0);
+  });
+
   it('should not change checkbox state after hitting other keys then SPACE, ENTER, DELETE or BACKSPACE', () => {
     handsontable({
       data: [[false], [true], [true]],


### PR DESCRIPTION
### Solution
Function `openEditor` will be used consistently inside `EditorManager`. We will call it with below attributes:

- f2 `keydown` -> `null`, `event`
- enter `keydown` -> `null`, `event`
- `doubleclick` -> ~~undefined, undefined~~ -> `null`, `event`
- `keydown` on selected cell -> `''` (empty string), `event`

### How has this been tested?
I've tested fix with the table containing cells of type `text`, `checkbox` and `numeric`.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s): #4738

### Checklist:
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
