### PR TITLE
Non-consecutive selection

### DIFF
--- a/.config/development.js
+++ b/.config/development.js
@@ -22,7 +22,7 @@ module.exports.create = function create(envArgs) {
   configBase.forEach(function(c) {
     c.output.filename = PACKAGE_FILENAME + '.js';
 
-    c.devtool = 'cheap-module-source-map';
+    c.devtool = 'source-map';
     // Exclude all external dependencies from 'base' bundle (handsontable.js and handsontable.css files)
     c.externals = {
       numbro: {

--- a/handsontable.d.ts
+++ b/handsontable.d.ts
@@ -3,7 +3,7 @@ declare namespace _Handsontable {
     constructor(element: Element, options: Handsontable.DefaultSettings);
     addHook(key: string, callback: (() => void) | any[]): void;
     addHookOnce(key: string, callback: (() => void) | any[]): void;
-    alter(action: string, index: number, amount?: number, source?: string, keepEmptyRows?: boolean): void;
+    alter(action: 'insert_row' | 'insert_col' | 'remove_row' | 'remove_col', index?: number | Array<[number, number]>, amount?: number, source?: string, keepEmptyRows?: boolean): void;
     clear(): void;
     colOffset(): number;
     colToProp(col: number): string | number;
@@ -20,6 +20,7 @@ declare namespace _Handsontable {
     deselectCell(): void;
     destroy(): void;
     destroyEditor(revertOriginal?: boolean): void;
+    emptySelectedCells(): void;
     getActiveEditor(): object;
     getCell(row: number, col: number, topmost?: boolean): Element;
     getCellEditor(row: number, col: number): object;
@@ -44,8 +45,10 @@ declare namespace _Handsontable {
     getRowHeader(row?: number): any[]|string;
     getRowHeight(row: number): number;
     getSchema(): object;
-    getSelected(): any[];
-    getSelectedRange(): Range;
+    getSelected(): Array<[number, number, number, number]> | undefined;
+    getSelectedLast(): number[] | undefined;
+    getSelectedRange(): Range[] | undefined;
+    getSelectedRangeLast(): Range | undefined;
     getSettings(): object;
     getSourceData(r?: number, c?: number, r2?: number, c2?: number): any[];
     getSourceDataArray(r?: number, c?: number, r2?: number, c2?: number): any[];
@@ -1399,7 +1402,7 @@ declare namespace Handsontable {
     minRows?: number;
     minSpareCols?: number;
     minSpareRows?: number;
-    multiSelect?: boolean;
+    selectionMode?: 'single' | 'range' | 'multiple';
     nestedHeaders?: any[]; // pro
     noWordWrapClassName?: string;
     observeChanges?: boolean;
@@ -1497,10 +1500,10 @@ declare namespace Handsontable {
     afterRowResize?: (currentRow: number, newSize: number, isDoubleClick: boolean) => void;
     afterScrollHorizontally?: () => void;
     afterScrollVertically?: () => void;
-    afterSelection?: (r: number, c: number, r2: number, c2: number) => void;
-    afterSelectionByProp?: (r: number, p: string, r2: number, p2: string) => void;
-    afterSelectionEnd?: (r: number, c: number, r2: number, c2: number) => void;
-    afterSelectionEndByProp?: (r: number, p: string, r2: number, p2: string) => void;
+    afterSelection?: (r: number, c: number, r2: number, c2: number, preventScrolling: object, selectionLayerLevel: number) => void;
+    afterSelectionByProp?: (r: number, p: string, r2: number, p2: string, preventScrolling: object, selectionLayerLevel: number) => void;
+    afterSelectionEnd?: (r: number, c: number, r2: number, c2: number, selectionLayerLevel: number) => void;
+    afterSelectionEndByProp?: (r: number, p: string, r2: number, p2: string, selectionLayerLevel: number) => void;
     afterSetCellMeta?: (row: number, col: number, key: string, value: any) => void;
     afterSetDataAtCell?: (changes: any[], source?: string) => void;
     afterSetDataAtRowProp?: (changes: any[], source?: string) => void;
@@ -1544,8 +1547,8 @@ declare namespace Handsontable {
     beforeRenderer?: (TD: Element, row: number, col: number, prop: string|number, value: string, cellProperties: object) => void;
     beforeRowMove?: (startRow: number, endRow: number) => void;
     beforeRowResize?: (currentRow: number, newSize: number, isDoubleClick: boolean) => any;
-    beforeSetRangeEnd?: (coords: any[]) => void;
-    beforeSetRangeStart?: (coords: any[]) => void;
+    beforeSetRangeEnd?: (coords: wot.CellCoords) => void;
+    beforeSetRangeStart?: (coords: wot.CellCoords) => void;
     beforeStretchingColumnWidth?: (stretchedWidth: number, column: number) => void;
     beforeTouchScroll?: () => void;
     beforeUndo?: (action: object) => void;

--- a/src/3rdparty/walkontable/src/border.js
+++ b/src/3rdparty/walkontable/src/border.js
@@ -255,8 +255,8 @@ class Border {
   }
 
   isPartRange(row, col) {
-    if (this.wot.selections.area.cellRange) {
-      if (row != this.wot.selections.area.cellRange.to.row || col != this.wot.selections.area.cellRange.to.col) {
+    if (this.wot.selections.getArea().cellRange) {
+      if (row != this.wot.selections.getArea().cellRange.to.row || col != this.wot.selections.getArea().cellRange.to.col) {
         return true;
       }
     }
@@ -316,29 +316,15 @@ class Border {
     if (this.disabled) {
       return;
     }
-    var isMultiple,
-      fromTD,
-      toTD,
-      fromOffset,
-      toOffset,
-      containerOffset,
-      top,
-      minTop,
-      left,
-      minLeft,
-      height,
-      width,
-      fromRow,
-      fromColumn,
-      toRow,
-      toColumn,
-      trimmingContainer,
-      cornerOverlappingContainer,
-      ilen;
 
-    ilen = this.wot.wtTable.getRenderedRowsCount();
+    let fromRow;
+    let toRow;
+    let fromColumn;
+    let toColumn;
 
-    for (let i = 0; i < ilen; i++) {
+    const rowsCount = this.wot.wtTable.getRenderedRowsCount();
+
+    for (let i = 0; i < rowsCount; i++) {
       let s = this.wot.wtTable.rowFilter.renderedToSource(i);
 
       if (s >= corners[0] && s <= corners[2]) {
@@ -347,7 +333,7 @@ class Border {
       }
     }
 
-    for (let i = ilen - 1; i >= 0; i--) {
+    for (let i = rowsCount - 1; i >= 0; i--) {
       let s = this.wot.wtTable.rowFilter.renderedToSource(i);
 
       if (s >= corners[0] && s <= corners[2]) {
@@ -356,9 +342,9 @@ class Border {
       }
     }
 
-    ilen = this.wot.wtTable.getRenderedColumnsCount();
+    const columnsCount = this.wot.wtTable.getRenderedColumnsCount();
 
-    for (let i = 0; i < ilen; i++) {
+    for (let i = 0; i < columnsCount; i++) {
       let s = this.wot.wtTable.columnFilter.renderedToSource(i);
 
       if (s >= corners[1] && s <= corners[3]) {
@@ -367,7 +353,7 @@ class Border {
       }
     }
 
-    for (let i = ilen - 1; i >= 0; i--) {
+    for (let i = columnsCount - 1; i >= 0; i--) {
       let s = this.wot.wtTable.columnFilter.renderedToSource(i);
 
       if (s >= corners[1] && s <= corners[3]) {
@@ -380,20 +366,20 @@ class Border {
 
       return;
     }
-    isMultiple = (fromRow !== toRow || fromColumn !== toColumn);
-    fromTD = this.wot.wtTable.getCell(new CellCoords(fromRow, fromColumn));
-    toTD = isMultiple ? this.wot.wtTable.getCell(new CellCoords(toRow, toColumn)) : fromTD;
-    fromOffset = offset(fromTD);
-    toOffset = isMultiple ? offset(toTD) : fromOffset;
-    containerOffset = offset(this.wot.wtTable.TABLE);
+    const isMultiple = (fromRow !== toRow || fromColumn !== toColumn);
+    const fromTD = this.wot.wtTable.getCell(new CellCoords(fromRow, fromColumn));
+    const toTD = isMultiple ? this.wot.wtTable.getCell(new CellCoords(toRow, toColumn)) : fromTD;
+    const fromOffset = offset(fromTD);
+    const toOffset = isMultiple ? offset(toTD) : fromOffset;
+    const containerOffset = offset(this.wot.wtTable.TABLE);
 
-    minTop = fromOffset.top;
-    height = toOffset.top + outerHeight(toTD) - minTop;
-    minLeft = fromOffset.left;
-    width = toOffset.left + outerWidth(toTD) - minLeft;
+    const minTop = fromOffset.top;
+    const minLeft = fromOffset.left;
+    let height = toOffset.top + outerHeight(toTD) - minTop;
+    let width = toOffset.left + outerWidth(toTD) - minLeft;
 
-    top = minTop - containerOffset.top - 1;
-    left = minLeft - containerOffset.left - 1;
+    let top = minTop - containerOffset.top - 1;
+    let left = minLeft - containerOffset.left - 1;
     let style = getComputedStyle(fromTD);
 
     if (parseInt(style.borderTopWidth, 10) > 0) {
@@ -415,7 +401,7 @@ class Border {
     this.leftStyle.height = `${height}px`;
     this.leftStyle.display = 'block';
 
-    let delta = Math.floor(this.settings.border.width / 2);
+    const delta = Math.floor(this.settings.border.width / 2);
 
     this.bottomStyle.top = `${top + height - delta}px`;
     this.bottomStyle.left = `${left}px`;
@@ -438,10 +424,10 @@ class Border {
       // Hide the fill handle, so the possible further adjustments won't force unneeded scrollbars.
       this.cornerStyle.display = 'none';
 
-      trimmingContainer = getTrimmingContainer(this.wot.wtTable.TABLE);
+      const trimmingContainer = getTrimmingContainer(this.wot.wtTable.TABLE);
 
       if (toColumn === this.wot.getSetting('totalColumns') - 1) {
-        cornerOverlappingContainer = toTD.offsetLeft + outerWidth(toTD) + (parseInt(this.cornerDefaultStyle.width, 10) / 2) >= innerWidth(trimmingContainer);
+        const cornerOverlappingContainer = toTD.offsetLeft + outerWidth(toTD) + (parseInt(this.cornerDefaultStyle.width, 10) / 2) >= innerWidth(trimmingContainer);
 
         if (cornerOverlappingContainer) {
           this.cornerStyle.left = `${Math.floor(left + width - 3 - (parseInt(this.cornerDefaultStyle.width, 10) / 2))}px`;
@@ -450,7 +436,7 @@ class Border {
       }
 
       if (toRow === this.wot.getSetting('totalRows') - 1) {
-        cornerOverlappingContainer = toTD.offsetTop + outerHeight(toTD) + (parseInt(this.cornerDefaultStyle.height, 10) / 2) >= innerHeight(trimmingContainer);
+        const cornerOverlappingContainer = toTD.offsetTop + outerHeight(toTD) + (parseInt(this.cornerDefaultStyle.height, 10) / 2) >= innerHeight(trimmingContainer);
 
         if (cornerOverlappingContainer) {
           this.cornerStyle.top = `${Math.floor(top + height - 3 - (parseInt(this.cornerDefaultStyle.height, 10) / 2))}px`;

--- a/src/3rdparty/walkontable/src/border.js
+++ b/src/3rdparty/walkontable/src/border.js
@@ -255,8 +255,10 @@ class Border {
   }
 
   isPartRange(row, col) {
-    if (this.wot.selections.getArea().cellRange) {
-      if (row != this.wot.selections.getArea().cellRange.to.row || col != this.wot.selections.getArea().cellRange.to.col) {
+    const areaSelection = this.wot.selections.createOrGetArea();
+
+    if (areaSelection.cellRange) {
+      if (row != areaSelection.cellRange.to.row || col != areaSelection.cellRange.to.col) {
         return true;
       }
     }

--- a/src/3rdparty/walkontable/src/border.js
+++ b/src/3rdparty/walkontable/src/border.js
@@ -326,7 +326,7 @@ class Border {
 
     const rowsCount = this.wot.wtTable.getRenderedRowsCount();
 
-    for (let i = 0; i < rowsCount; i++) {
+    for (let i = 0; i < rowsCount; i += 1) {
       let s = this.wot.wtTable.rowFilter.renderedToSource(i);
 
       if (s >= corners[0] && s <= corners[2]) {
@@ -335,7 +335,7 @@ class Border {
       }
     }
 
-    for (let i = rowsCount - 1; i >= 0; i--) {
+    for (let i = rowsCount - 1; i >= 0; i -= 1) {
       let s = this.wot.wtTable.rowFilter.renderedToSource(i);
 
       if (s >= corners[0] && s <= corners[2]) {
@@ -346,7 +346,7 @@ class Border {
 
     const columnsCount = this.wot.wtTable.getRenderedColumnsCount();
 
-    for (let i = 0; i < columnsCount; i++) {
+    for (let i = 0; i < columnsCount; i += 1) {
       let s = this.wot.wtTable.columnFilter.renderedToSource(i);
 
       if (s >= corners[1] && s <= corners[3]) {
@@ -355,7 +355,7 @@ class Border {
       }
     }
 
-    for (let i = columnsCount - 1; i >= 0; i--) {
+    for (let i = columnsCount - 1; i >= 0; i -= 1) {
       let s = this.wot.wtTable.columnFilter.renderedToSource(i);
 
       if (s >= corners[1] && s <= corners[3]) {
@@ -374,12 +374,11 @@ class Border {
     const fromOffset = offset(fromTD);
     const toOffset = isMultiple ? offset(toTD) : fromOffset;
     const containerOffset = offset(this.wot.wtTable.TABLE);
-
     const minTop = fromOffset.top;
     const minLeft = fromOffset.left;
+
     let height = toOffset.top + outerHeight(toTD) - minTop;
     let width = toOffset.left + outerWidth(toTD) - minLeft;
-
     let top = minTop - containerOffset.top - 1;
     let left = minLeft - containerOffset.left - 1;
     let style = getComputedStyle(fromTD);

--- a/src/3rdparty/walkontable/src/cell/coords.js
+++ b/src/3rdparty/walkontable/src/cell/coords.js
@@ -92,6 +92,18 @@ class CellCoords {
   isNorthEastOf(testedCoords) {
     return this.row <= testedCoords.row && this.col >= testedCoords.col;
   }
+
+  /**
+   * Convert CellCoords to literla object.
+   *
+   * @return {Object} Returns a literal object with `row` and `col` properties.
+   */
+  toObject() {
+    return {
+      row: this.row,
+      col: this.col,
+    };
+  }
 }
 
 export default CellCoords;

--- a/src/3rdparty/walkontable/src/cell/coords.js
+++ b/src/3rdparty/walkontable/src/cell/coords.js
@@ -94,7 +94,7 @@ class CellCoords {
   }
 
   /**
-   * Convert CellCoords to literla object.
+   * Convert CellCoords to literal object.
    *
    * @return {Object} Returns a literal object with `row` and `col` properties.
    */

--- a/src/3rdparty/walkontable/src/cell/range.js
+++ b/src/3rdparty/walkontable/src/cell/range.js
@@ -15,8 +15,41 @@ class CellRange {
    */
   constructor(highlight, from, to) {
     this.highlight = highlight;
-    this.from = from;
-    this.to = to;
+    this.from = from === void 0 ? highlight : from;
+    this.to = to === void 0 ? highlight : to;
+  }
+
+  /**
+   * Set the new coordinates for highlighting selection.
+   *
+   * @param {CellCoords} coords Coordinates to use.
+   */
+  setHighlight(coords) {
+    this.highlight = coords;
+
+    return this;
+  }
+
+  /**
+   * Set the new coordinates where selection starts from.
+   *
+   * @param {CellCoords} coords Coordinates to use.
+   */
+  setFrom(coords) {
+    this.from = coords;
+
+    return this;
+  }
+
+  /**
+   * Set new coordinates where selection ends from.
+   *
+   * @param {CellCoords} coords Coordinates to use.
+   */
+  setTo(coords) {
+    this.to = coords;
+
+    return this;
   }
 
   /**
@@ -63,12 +96,11 @@ class CellRange {
    * @returns {Boolean}
    */
   includes(cellCoords) {
-    let {row, col} = cellCoords;
-    let topLeft = this.getTopLeftCorner();
-    let bottomRight = this.getBottomRightCorner();
+    const {row, col} = cellCoords;
+    const topLeft = this.getTopLeftCorner();
+    const bottomRight = this.getBottomRightCorner();
 
-    return topLeft.row <= row && bottomRight.row >= row &&
-        topLeft.col <= col && bottomRight.col >= col;
+    return topLeft.row <= row && bottomRight.row >= row && topLeft.col <= col && bottomRight.col >= col;
   }
 
   /**
@@ -128,8 +160,8 @@ class CellRange {
    * @returns {Boolean}
    */
   expand(cellCoords) {
-    let topLeft = this.getTopLeftCorner();
-    let bottomRight = this.getBottomRightCorner();
+    const topLeft = this.getTopLeftCorner();
+    const bottomRight = this.getBottomRightCorner();
 
     if (cellCoords.row < topLeft.row || cellCoords.col < topLeft.col ||
         cellCoords.row > bottomRight.row || cellCoords.col > bottomRight.col) {
@@ -428,6 +460,13 @@ class CellRange {
         }
       }
     }
+  }
+
+  toObject() {
+    return {
+      from: this.from.toObject(),
+      to: this.to.toObject(),
+    };
   }
 }
 

--- a/src/3rdparty/walkontable/src/cell/range.js
+++ b/src/3rdparty/walkontable/src/cell/range.js
@@ -1,22 +1,22 @@
 import CellCoords from './../cell/coords';
 
 /**
- * A cell range is a set of exactly two CellCoords (that can be the same or different)
+ * A cell range is a set of exactly two CellCoords (that can be the same or different).
  *
  * @class CellRange
  */
 class CellRange {
   /**
    * @param {CellCoords} highlight Used to draw bold border around a cell where selection was
-   *                                          started and to edit the cell when you press Enter
-   * @param {CellCoords} from Usually the same as highlight, but in Excel there is distinction - one can change
-   *                                     highlight within a selection
-   * @param {CellCoords} to End selection
+   *                               started and to edit the cell when you press Enter.
+   * @param {CellCoords} [from] Usually the same as highlight, but in Excel there is distinction - one can change
+   *                            highlight within a selection.
+   * @param {CellCoords} [to] End selection.
    */
-  constructor(highlight, from, to) {
+  constructor(highlight, from = highlight, to = highlight) {
     this.highlight = highlight;
-    this.from = from === void 0 ? highlight : from;
-    this.to = to === void 0 ? highlight : to;
+    this.from = from;
+    this.to = to;
   }
 
   /**
@@ -462,6 +462,12 @@ class CellRange {
     }
   }
 
+  /**
+   * Convert CellRange to literal object.
+   *
+   * @return {Object} Returns a literal object with `from` and `to` properties which each of that object
+   *                  contains `row` and `col` keys.
+   */
   toObject() {
     return {
       from: this.from.toObject(),

--- a/src/3rdparty/walkontable/src/event.js
+++ b/src/3rdparty/walkontable/src/event.js
@@ -222,8 +222,8 @@ Event.prototype.parentCell = function(elem) {
     cell.TD = this.instance.wtTable.getCell(cell.coords);
 
   } else if (hasClass(elem, 'wtBorder') && hasClass(elem, 'area')) {
-    if (this.instance.selections.getArea().cellRange) {
-      cell.coords = this.instance.selections.getArea().cellRange.to;
+    if (this.instance.selections.createOrGetArea().cellRange) {
+      cell.coords = this.instance.selections.createOrGetArea().cellRange.to;
       cell.TD = this.instance.wtTable.getCell(cell.coords);
     }
   }

--- a/src/3rdparty/walkontable/src/event.js
+++ b/src/3rdparty/walkontable/src/event.js
@@ -218,12 +218,12 @@ Event.prototype.parentCell = function(elem) {
     cell.TD = TD;
 
   } else if (hasClass(elem, 'wtBorder') && hasClass(elem, 'current')) {
-    cell.coords = this.instance.selections.current.cellRange.highlight; // selections.current is current selected cell
+    cell.coords = this.instance.selections.getCell().cellRange.highlight;
     cell.TD = this.instance.wtTable.getCell(cell.coords);
 
   } else if (hasClass(elem, 'wtBorder') && hasClass(elem, 'area')) {
-    if (this.instance.selections.area.cellRange) {
-      cell.coords = this.instance.selections.area.cellRange.to; // selections.area is area selected cells
+    if (this.instance.selections.getArea().cellRange) {
+      cell.coords = this.instance.selections.getArea().cellRange.to;
       cell.TD = this.instance.wtTable.getCell(cell.coords);
     }
   }

--- a/src/3rdparty/walkontable/src/overlay/top.js
+++ b/src/3rdparty/walkontable/src/overlay/top.js
@@ -10,6 +10,7 @@ import {
   setOverlayPosition,
   resetCssTransform
 } from './../../../../helpers/dom/element';
+import {arrayEach} from './../../../../helpers/array';
 import Overlay from './_base';
 
 /**
@@ -281,12 +282,10 @@ class TopOverlay extends Overlay {
   redrawSelectionBorders(selection) {
     if (selection && selection.cellRange) {
       const border = selection.getBorder(this.wot);
+      const corners = selection.getCorners();
 
-      if (border) {
-        const corners = selection.getCorners();
-        border.disappear();
-        border.appear(corners);
-      }
+      border.disappear();
+      border.appear(corners);
     }
   }
 
@@ -296,9 +295,13 @@ class TopOverlay extends Overlay {
   redrawAllSelectionsBorders() {
     const selections = this.wot.selections;
 
-    this.redrawSelectionBorders(selections.current);
-    this.redrawSelectionBorders(selections.area);
-    this.redrawSelectionBorders(selections.fill);
+    this.redrawSelectionBorders(selections.getCell());
+
+    arrayEach(selections.getAreas(), (area) => {
+      this.redrawSelectionBorders(area);
+    });
+    this.redrawSelectionBorders(selections.getFill());
+
     this.wot.wtTable.wot.wtOverlays.leftOverlay.refresh();
   }
 

--- a/src/3rdparty/walkontable/src/selection.js
+++ b/src/3rdparty/walkontable/src/selection.js
@@ -25,12 +25,11 @@ class Selection {
    * @returns {Border}
    */
   getBorder(wotInstance) {
-    if (this.instanceBorders[wotInstance.guid]) {
-      return this.instanceBorders[wotInstance.guid];
+    if (!this.instanceBorders[wotInstance.guid]) {
+      this.instanceBorders[wotInstance.guid] = new Border(wotInstance, this.settings);
     }
 
-    // where is this returned?
-    this.instanceBorders[wotInstance.guid] = new Border(wotInstance, this.settings);
+    return this.instanceBorders[wotInstance.guid];
   }
 
   /**
@@ -54,6 +53,8 @@ class Selection {
     } else {
       this.cellRange.expand(coords);
     }
+
+    return this;
   }
 
   /**
@@ -86,6 +87,8 @@ class Selection {
    */
   clear() {
     this.cellRange = null;
+
+    return this;
   }
 
   /**
@@ -119,6 +122,8 @@ class Selection {
     if (typeof TD === 'object') {
       addClass(TD, className);
     }
+
+    return this;
   }
 
   /**
@@ -127,11 +132,7 @@ class Selection {
   draw(wotInstance) {
     if (this.isEmpty()) {
       if (this.settings.border) {
-        let border = this.getBorder(wotInstance);
-
-        if (border) {
-          border.disappear();
-        }
+        this.getBorder(wotInstance).disappear();
       }
 
       return;
@@ -210,12 +211,8 @@ class Selection {
     wotInstance.getSetting('onBeforeDrawBorders', corners, this.settings.className);
 
     if (this.settings.border) {
-      let border = this.getBorder(wotInstance);
-
-      if (border) {
-        // warning! border.appear modifies corners!
-        border.appear(corners);
-      }
+      // warning! border.appear modifies corners!
+      this.getBorder(wotInstance).appear(corners);
     }
   }
 }

--- a/src/3rdparty/walkontable/src/selection.js
+++ b/src/3rdparty/walkontable/src/selection.js
@@ -1,4 +1,4 @@
-import {addClass} from './../../../helpers/dom/element';
+import {addClass, hasClass} from './../../../helpers/dom/element';
 import Border from './border';
 import CellCoords from './cell/coords';
 import CellRange from './cell/range';
@@ -15,6 +15,8 @@ class Selection {
     this.settings = settings;
     this.cellRange = cellRange || null;
     this.instanceBorders = {};
+    this.classNames = [this.settings.className];
+    this.classNameGenerator = this.linearClassNameGenerator(this.settings.className, this.settings.layerLevel);
   }
 
   /**
@@ -115,15 +117,61 @@ class Selection {
    * @param {Number} sourceRow Cell row coord
    * @param {Number} sourceColumn Cell column coord
    * @param {String} className Class name
+   * @param {Boolean} [markIntersections=false] If `true`, linear className generator will be used to add CSS classes
+   *                                            in a continuous manner.
    */
-  addClassAtCoords(wotInstance, sourceRow, sourceColumn, className) {
+  addClassAtCoords(wotInstance, sourceRow, sourceColumn, className, markIntersections = false) {
     let TD = wotInstance.wtTable.getCell(new CellCoords(sourceRow, sourceColumn));
 
     if (typeof TD === 'object') {
+      if (markIntersections) {
+        className = this.classNameGenerator(TD);
+
+        if (!this.classNames.includes(className)) {
+          this.classNames.push(className);
+        }
+      }
       addClass(TD, className);
     }
 
     return this;
+  }
+
+  /**
+   * Generate helper for calculating classNames based on previously added base className.
+   * The generated className is always generated as a continuation of the previous className. For example, when
+   * the currently checked element has 'area-2' className the generated new className will be 'area-3'. When
+   * the element doesn't have any classNames than the base className will be returned ('area');
+   *
+   * @param {String} baseClassName Base className to be used.
+   * @param {Number} layerLevelOwner Layer level which the instance of the Selection belongs to.
+   * @return {Function}
+   */
+  linearClassNameGenerator(baseClassName, layerLevelOwner) {
+    // TODO(budnix): Make this recursive function Proper Tail Calls (TCO/PTC) friendly.
+    return function calcClassName(element, previousIndex = -1) {
+      if (layerLevelOwner === 0 || previousIndex === 0) {
+        return baseClassName;
+      }
+
+      let index = previousIndex >= 0 ? previousIndex : layerLevelOwner;
+      let className = baseClassName;
+
+      index--;
+
+      const previousClassName = index === 0 ? baseClassName : `${baseClassName}-${index}`;
+
+      if (hasClass(element, previousClassName)) {
+        const currentLayer = index + 1;
+
+        className = `${baseClassName}-${currentLayer}`;
+
+      } else {
+        className = calcClassName(element, index);
+      }
+
+      return className;
+    };
   }
 
   /**
@@ -193,7 +241,7 @@ class Selection {
         if (sourceRow >= corners[0] && sourceRow <= corners[2] && sourceCol >= corners[1] && sourceCol <= corners[3]) {
           // selected cell
           if (this.settings.className) {
-            this.addClassAtCoords(wotInstance, sourceRow, sourceCol, this.settings.className);
+            this.addClassAtCoords(wotInstance, sourceRow, sourceCol, this.settings.className, this.settings.markIntersections);
           }
         } else if (sourceRow >= corners[0] && sourceRow <= corners[2]) {
           // selection is in this row

--- a/src/3rdparty/walkontable/src/selection.js
+++ b/src/3rdparty/walkontable/src/selection.js
@@ -86,6 +86,8 @@ class Selection {
 
   /**
    * Clears selection
+   *
+   * @returns {Selection}
    */
   clear() {
     this.cellRange = null;
@@ -118,7 +120,8 @@ class Selection {
    * @param {Number} sourceColumn Cell column coord
    * @param {String} className Class name
    * @param {Boolean} [markIntersections=false] If `true`, linear className generator will be used to add CSS classes
-   *                                            in a continuous manner.
+   *                                            in a continuous way.
+   * @returns {Selection}
    */
   addClassAtCoords(wotInstance, sourceRow, sourceColumn, className, markIntersections = false) {
     let TD = wotInstance.wtTable.getCell(new CellCoords(sourceRow, sourceColumn));
@@ -148,7 +151,7 @@ class Selection {
    * @return {Function}
    */
   linearClassNameGenerator(baseClassName, layerLevelOwner) {
-    // TODO(budnix): Make this recursive function Proper Tail Calls (TCO/PTC) friendly.
+    // TODO: Make this recursive function Proper Tail Calls (TCO/PTC) friendly.
     return function calcClassName(element, previousIndex = -1) {
       if (layerLevelOwner === 0 || previousIndex === 0) {
         return baseClassName;

--- a/src/3rdparty/walkontable/src/selection.js
+++ b/src/3rdparty/walkontable/src/selection.js
@@ -160,7 +160,7 @@ class Selection {
       let index = previousIndex >= 0 ? previousIndex : layerLevelOwner;
       let className = baseClassName;
 
-      index--;
+      index -= 1;
 
       const previousClassName = index === 0 ? baseClassName : `${baseClassName}-${index}`;
 

--- a/src/3rdparty/walkontable/src/table.js
+++ b/src/3rdparty/walkontable/src/table.js
@@ -302,6 +302,11 @@ class Table {
     }
   }
 
+  /**
+   * Refresh the table selection by re-rendering Selection instances connected with that instance.
+   *
+   * @param {Boolean} fastDraw If fast drawing is enabled than additionally className clearing is applied.
+   */
   refreshSelections(fastDraw) {
     if (!this.wot.selections) {
       return;
@@ -310,24 +315,42 @@ class Table {
     const len = highlights.length;
 
     if (fastDraw) {
-      // TODO(budnix): Non-consecutive cells feature doubles iteration while removing classNames from the DOM elements.
-      // This line should be optmized to remove specyfied className only once.
+      const classesToRemove = [];
+
       for (let i = 0; i < len; i++) {
-        // there was no rerender, so we need to remove classNames by ourselves
-        if (highlights[i].settings.className) {
-          this.removeClassFromCells(highlights[i].settings.className);
+        const {
+          highlightHeaderClassName,
+          highlightRowClassName,
+          highlightColumnClassName,
+        } = highlights[i].settings;
+        const classNames = highlights[i].classNames;
+        const classNamesLength = classNames.length;
+
+        for (let j = 0; j < classNamesLength; j++) {
+          if (!classesToRemove.includes(classNames[j])) {
+            classesToRemove.push(classNames[j]);
+          }
         }
-        if (highlights[i].settings.highlightHeaderClassName) {
-          this.removeClassFromCells(highlights[i].settings.highlightHeaderClassName);
+
+        if (highlightHeaderClassName && !classesToRemove.includes(highlightHeaderClassName)) {
+          classesToRemove.push(highlightHeaderClassName);
         }
-        if (highlights[i].settings.highlightRowClassName) {
-          this.removeClassFromCells(highlights[i].settings.highlightRowClassName);
+        if (highlightRowClassName && !classesToRemove.includes(highlightRowClassName)) {
+          classesToRemove.push(highlightRowClassName);
         }
-        if (highlights[i].settings.highlightColumnClassName) {
-          this.removeClassFromCells(highlights[i].settings.highlightColumnClassName);
+        if (highlightColumnClassName && !classesToRemove.includes(highlightColumnClassName)) {
+          classesToRemove.push(highlightColumnClassName);
         }
       }
+
+      const classesToRemoveLength = classesToRemove.length;
+
+      for (let i = 0; i < classesToRemoveLength; i++) {
+        // there was no rerender, so we need to remove classNames by ourselves
+        this.removeClassFromCells(classesToRemove[i]);
+      }
     }
+
     for (let i = 0; i < len; i++) {
       highlights[i].draw(this.wot, fastDraw);
     }

--- a/src/3rdparty/walkontable/src/table.js
+++ b/src/3rdparty/walkontable/src/table.js
@@ -306,27 +306,30 @@ class Table {
     if (!this.wot.selections) {
       return;
     }
-    let len = this.wot.selections.length;
+    const highlights = Array.from(this.wot.selections);
+    const len = highlights.length;
 
     if (fastDraw) {
+      // TODO(budnix): Non-consecutive cells feature doubles iteration while removing classNames from the DOM elements.
+      // This line should be optmized to remove specyfied className only once.
       for (let i = 0; i < len; i++) {
         // there was no rerender, so we need to remove classNames by ourselves
-        if (this.wot.selections[i].settings.className) {
-          this.removeClassFromCells(this.wot.selections[i].settings.className);
+        if (highlights[i].settings.className) {
+          this.removeClassFromCells(highlights[i].settings.className);
         }
-        if (this.wot.selections[i].settings.highlightHeaderClassName) {
-          this.removeClassFromCells(this.wot.selections[i].settings.highlightHeaderClassName);
+        if (highlights[i].settings.highlightHeaderClassName) {
+          this.removeClassFromCells(highlights[i].settings.highlightHeaderClassName);
         }
-        if (this.wot.selections[i].settings.highlightRowClassName) {
-          this.removeClassFromCells(this.wot.selections[i].settings.highlightRowClassName);
+        if (highlights[i].settings.highlightRowClassName) {
+          this.removeClassFromCells(highlights[i].settings.highlightRowClassName);
         }
-        if (this.wot.selections[i].settings.highlightColumnClassName) {
-          this.removeClassFromCells(this.wot.selections[i].settings.highlightColumnClassName);
+        if (highlights[i].settings.highlightColumnClassName) {
+          this.removeClassFromCells(highlights[i].settings.highlightColumnClassName);
         }
       }
     }
     for (let i = 0; i < len; i++) {
-      this.wot.selections[i].draw(this.wot, fastDraw);
+      highlights[i].draw(this.wot, fastDraw);
     }
   }
 

--- a/src/3rdparty/walkontable/test/helpers/common.js
+++ b/src/3rdparty/walkontable/test/helpers/common.js
@@ -115,22 +115,23 @@ export function range(from, to) {
 };
 
 /**
- * Rewrite all existing selections from selections[0] etc. to selections.current etc
+ * Rewrite all existing selections from selections[0] etc. to selections.getCell etc
  * @param instance
  * @returns {object} modified instance
  */
 export function shimSelectionProperties(instance) {
   if (instance.selections[0]) {
-    instance.selections.current = instance.selections[0];
+    instance.selections.getCell = () => instance.selections[0];
   }
   if (instance.selections[1]) {
-    instance.selections.area = instance.selections[1];
+    instance.selections.getArea = () => instance.selections[1];
+    instance.selections.getAreas = () => [instance.selections[1]];
   }
   if (instance.selections[2]) {
-    instance.selections.highlight = instance.selections[2];
+    instance.selections.getHeader = () => instance.selections[2];
   }
   if (instance.selections[3]) {
-    instance.selections.fill = instance.selections[3];
+    instance.selections.getFill = () => instance.selections[3];
   }
 
   return instance;

--- a/src/3rdparty/walkontable/test/helpers/common.js
+++ b/src/3rdparty/walkontable/test/helpers/common.js
@@ -124,11 +124,11 @@ export function shimSelectionProperties(instance) {
     instance.selections.getCell = () => instance.selections[0];
   }
   if (instance.selections[1]) {
-    instance.selections.getArea = () => instance.selections[1];
+    instance.selections.createOrGetArea = () => instance.selections[1];
     instance.selections.getAreas = () => [instance.selections[1]];
   }
   if (instance.selections[2]) {
-    instance.selections.getHeader = () => instance.selections[2];
+    instance.selections.createOrGetHeader = () => instance.selections[2];
   }
   if (instance.selections[3]) {
     instance.selections.getFill = () => instance.selections[3];

--- a/src/3rdparty/walkontable/test/spec/border.spec.js
+++ b/src/3rdparty/walkontable/test/spec/border.spec.js
@@ -37,8 +37,8 @@ describe('WalkontableBorder', () => {
         })
       ],
       onCellMouseDown(event, coords, TD) {
-        wt.selections.current.clear();
-        wt.selections.current.add(coords);
+        wt.selections.getCell().clear();
+        wt.selections.getCell().add(coords);
         wt.draw();
       }
     });
@@ -48,10 +48,10 @@ describe('WalkontableBorder', () => {
     var $td1 = $table.find('tbody tr:eq(1) td:eq(0)');
 
     var $td2 = $table.find('tbody tr:eq(2) td:eq(1)');
-    var $top = $(wt.selections.current.getBorder(wt).top);
-    var $right = $(wt.selections.current.getBorder(wt).right);
-    var $bottom = $(wt.selections.current.getBorder(wt).bottom);
-    var $left = $(wt.selections.current.getBorder(wt).left);
+    var $top = $(wt.selections.getCell().getBorder(wt).top);
+    var $right = $(wt.selections.getCell().getBorder(wt).right);
+    var $bottom = $(wt.selections.getCell().getBorder(wt).bottom);
+    var $left = $(wt.selections.getCell().getBorder(wt).left);
 
     $td1.simulate('mousedown');
 
@@ -103,8 +103,8 @@ describe('WalkontableBorder', () => {
         new Walkontable.Selection({})
       ],
       onCellMouseDown(event, coords, TD) {
-        wt.selections.current.clear();
-        wt.selections.current.add(coords);
+        wt.selections.getCell().clear();
+        wt.selections.getCell().add(coords);
         wt.draw();
       }
     });
@@ -113,7 +113,7 @@ describe('WalkontableBorder', () => {
 
     var $td1 = $table.find('tbody tr:eq(1) td:eq(0)');
     var $td2 = $table.find('tbody tr:eq(2) td:eq(1)');
-    var $corner = $(wt.selections.current.getBorder(wt).corner);
+    var $corner = $(wt.selections.getCell().getBorder(wt).corner);
 
     $td1.simulate('mousedown');
 
@@ -153,8 +153,8 @@ describe('WalkontableBorder', () => {
         new Walkontable.Selection({})
       ],
       onCellMouseDown(event, coords, TD) {
-        wt.selections.current.clear();
-        wt.selections.current.add(coords);
+        wt.selections.getCell().clear();
+        wt.selections.getCell().add(coords);
         wt.draw();
       }
     });
@@ -164,7 +164,7 @@ describe('WalkontableBorder', () => {
     var $td1 = $table.find('tbody tr:eq(1) td:eq(0)');
     var $td2 = $table.find('tbody tr:eq(3) td:eq(3)');
     var $td3 = $table.find('tbody tr:eq(2) td:eq(1)');
-    var $corner = $(wt.selections.current.getBorder(wt).corner);
+    var $corner = $(wt.selections.getCell().getBorder(wt).corner);
 
     $td1.simulate('mousedown');
 

--- a/src/3rdparty/walkontable/test/spec/event.spec.js
+++ b/src/3rdparty/walkontable/test/spec/event.spec.js
@@ -377,7 +377,7 @@ describe('WalkontableEvent', () => {
         }
       });
     shimSelectionProperties(wt);
-    wt.selections.current.add(new Walkontable.CellCoords(1, 1));
+    wt.selections.getCell().add(new Walkontable.CellCoords(1, 1));
     wt.draw();
 
     var $td = $table.find('tbody tr:eq(1) td:eq(1)');
@@ -414,7 +414,7 @@ describe('WalkontableEvent', () => {
         }
       });
     shimSelectionProperties(wt);
-    wt.selections.current.add(new Walkontable.CellCoords(1, 1));
+    wt.selections.getCell().add(new Walkontable.CellCoords(1, 1));
     wt.draw();
 
     var $td = $table.find('tbody tr:eq(1) td:eq(1)');
@@ -454,7 +454,7 @@ describe('WalkontableEvent', () => {
         }
       });
     shimSelectionProperties(wt);
-    wt.selections.current.add(new Walkontable.CellCoords(10, 2));
+    wt.selections.getCell().add(new Walkontable.CellCoords(10, 2));
     wt.draw();
 
     var $td = $table.parents('.wtHolder').find('.current.corner');
@@ -483,7 +483,7 @@ describe('WalkontableEvent', () => {
         ]
       });
     shimSelectionProperties(wt);
-    wt.selections.current.add(new Walkontable.CellCoords(10, 2));
+    wt.selections.getCell().add(new Walkontable.CellCoords(10, 2));
     wt.draw();
 
     var $td = $table.parents('.wtHolder').find('.current.corner');

--- a/src/3rdparty/walkontable/test/spec/selection.spec.js
+++ b/src/3rdparty/walkontable/test/spec/selection.spec.js
@@ -34,8 +34,8 @@ describe('Walkontable.Selection', () => {
         })
       ],
       onCellMouseDown(event, coords, TD) {
-        wt.selections.current.clear();
-        wt.selections.current.add(coords);
+        wt.selections.getCell().clear();
+        wt.selections.getCell().add(coords);
         wt.draw();
       }
     });
@@ -75,10 +75,10 @@ describe('Walkontable.Selection', () => {
     });
     shimSelectionProperties(wt);
 
-    wt.selections.area.add(new Walkontable.CellCoords(1, 1));
-    wt.selections.area.add(new Walkontable.CellCoords(1, 2));
-    wt.selections.area.add(new Walkontable.CellCoords(2, 1));
-    wt.selections.area.add(new Walkontable.CellCoords(2, 2));
+    wt.selections.getArea().add(new Walkontable.CellCoords(1, 1));
+    wt.selections.getArea().add(new Walkontable.CellCoords(1, 2));
+    wt.selections.getArea().add(new Walkontable.CellCoords(2, 1));
+    wt.selections.getArea().add(new Walkontable.CellCoords(2, 2));
 
     wt.draw();
 
@@ -103,7 +103,7 @@ describe('Walkontable.Selection', () => {
     });
     shimSelectionProperties(wt);
     wt.draw();
-    wt.selections.current.add(new Walkontable.CellCoords(0, 0));
+    wt.selections.getCell().add(new Walkontable.CellCoords(0, 0));
 
     var $td1 = $table.find('tbody td:eq(0)');
     expect($td1.hasClass('current')).toEqual(false);
@@ -128,8 +128,8 @@ describe('Walkontable.Selection', () => {
         })
       ],
       onCellMouseDown(event, coords, TD) {
-        wt.selections.current.clear();
-        wt.selections.current.add(coords);
+        wt.selections.getCell().clear();
+        wt.selections.getCell().add(coords);
         wt.draw();
       }
     });
@@ -139,7 +139,7 @@ describe('Walkontable.Selection', () => {
     setTimeout(() => {
       var $td1 = $table.find('tbody tr:eq(1) td:eq(0)');
       var $td2 = $table.find('tbody tr:eq(2) td:eq(1)');
-      var $top = $(wt.selections.current.getBorder(wt).top); // cheat... get border for ht_master
+      var $top = $(wt.selections.getCell().getBorder(wt).top); // cheat... get border for ht_master
       $td1.simulate('mousedown');
 
       var pos1 = $top.position();
@@ -174,7 +174,7 @@ describe('Walkontable.Selection', () => {
     shimSelectionProperties(wt);
     wt.draw();
 
-    wt.selections.current.add([20, 0]);
+    wt.selections.getCell().add([20, 0]);
     expect(wt.wtTable.getCoords($table.find('tbody tr:first td:first')[0])).toEqual(new Walkontable.CellCoords(0, 0));
   });
 
@@ -197,13 +197,13 @@ describe('Walkontable.Selection', () => {
     shimSelectionProperties(wt);
     wt.draw();
 
-    wt.selections.current.add(new Walkontable.CellCoords(0, 0));
+    wt.selections.getCell().add(new Walkontable.CellCoords(0, 0));
     wt.draw();
     expect(wt.wtTable.getFirstVisibleRow()).toEqual(0);
     wt.scrollVertical(10).draw();
     expect(wt.wtTable.getFirstVisibleRow()).toEqual(10);
     expect(wt.wtTable.getLastVisibleRow()).toBeAroundValue(17);
-    wt.selections.current.clear();
+    wt.selections.getCell().clear();
     expect(wt.wtTable.getFirstVisibleRow()).toEqual(10);
     expect(wt.wtTable.getLastVisibleRow()).toBeAroundValue(17);
   });
@@ -227,11 +227,11 @@ describe('Walkontable.Selection', () => {
     shimSelectionProperties(wt);
     wt.draw();
 
-    wt.selections.current.add(new Walkontable.CellCoords(0, 0));
-    wt.selections.current.add(new Walkontable.CellCoords(0, 1));
-    wt.selections.current.clear();
+    wt.selections.getCell().add(new Walkontable.CellCoords(0, 0));
+    wt.selections.getCell().add(new Walkontable.CellCoords(0, 1));
+    wt.selections.getCell().clear();
 
-    expect(wt.selections.current.cellRange).toEqual(null);
+    expect(wt.selections.getCell().cellRange).toEqual(null);
   });
 
   it('should highlight cells in selected row & column', () => {
@@ -252,8 +252,8 @@ describe('Walkontable.Selection', () => {
     shimSelectionProperties(wt);
     wt.draw();
 
-    wt.selections.current.add(new Walkontable.CellCoords(0, 0));
-    wt.selections.current.add(new Walkontable.CellCoords(0, 1));
+    wt.selections.getCell().add(new Walkontable.CellCoords(0, 0));
+    wt.selections.getCell().add(new Walkontable.CellCoords(0, 1));
     wt.draw(true);
 
     expect($table.find('.highlightRow').length).toEqual(2);
@@ -282,7 +282,7 @@ describe('Walkontable.Selection', () => {
     shimSelectionProperties(wt);
     wt.draw();
 
-    wt.selections.current.add(new Walkontable.CellCoords(0, 0));
+    wt.selections.getCell().add(new Walkontable.CellCoords(0, 0));
     wt.draw(true);
 
     expect($table.find('.highlightRow').length).toEqual(3);
@@ -305,11 +305,11 @@ describe('Walkontable.Selection', () => {
     shimSelectionProperties(wt);
     wt.draw();
 
-    wt.selections.current.add(new Walkontable.CellCoords(0, 0));
-    wt.selections.current.add(new Walkontable.CellCoords(0, 1));
+    wt.selections.getCell().add(new Walkontable.CellCoords(0, 0));
+    wt.selections.getCell().add(new Walkontable.CellCoords(0, 1));
     wt.draw();
 
-    wt.selections.current.clear();
+    wt.selections.getCell().clear();
     wt.draw();
 
     expect($table.find('.highlightRow').length).toEqual(0);
@@ -340,8 +340,8 @@ describe('Walkontable.Selection', () => {
     shimSelectionProperties(wt);
     wt.draw();
 
-    wt.selections.current.add(new Walkontable.CellCoords(1, 1));
-    wt.selections.current.add(new Walkontable.CellCoords(2, 2));
+    wt.selections.getCell().add(new Walkontable.CellCoords(1, 1));
+    wt.selections.getCell().add(new Walkontable.CellCoords(2, 2));
     wt.draw();
 
     // left side:
@@ -368,7 +368,7 @@ describe('Walkontable.Selection', () => {
     expect($rowHeaders.eq(1).hasClass('highlightRow')).toBe(true);
     expect($rowHeaders.eq(2).hasClass('highlightRow')).toBe(true);
 
-    wt.selections.current.clear();
+    wt.selections.getCell().clear();
     wt.draw();
 
     expect($table.find('.highlightRow').length).toEqual(0);
@@ -397,11 +397,12 @@ describe('Walkontable.Selection', () => {
         ]
       });
       shimSelectionProperties(wt);
-      wt.selections.current.add(new Walkontable.CellCoords(1, 1));
-      wt.selections.current.add(new Walkontable.CellCoords(3, 3));
-      var result = wt.selections.current.replace(new Walkontable.CellCoords(3, 3), new Walkontable.CellCoords(4, 4));
+      wt.selections.getCell().add(new Walkontable.CellCoords(1, 1));
+      wt.selections.getCell().add(new Walkontable.CellCoords(3, 3));
+      var result = wt.selections.getCell().replace(new Walkontable.CellCoords(3, 3), new Walkontable.CellCoords(4, 4));
+
       expect(result).toBe(true);
-      expect(wt.selections.current.getCorners()).toEqual([1, 1, 4, 4]);
+      expect(wt.selections.getCell().getCorners()).toEqual([1, 1, 4, 4]);
     });
   });
 });

--- a/src/3rdparty/walkontable/test/spec/selection.spec.js
+++ b/src/3rdparty/walkontable/test/spec/selection.spec.js
@@ -75,10 +75,10 @@ describe('Walkontable.Selection', () => {
     });
     shimSelectionProperties(wt);
 
-    wt.selections.getArea().add(new Walkontable.CellCoords(1, 1));
-    wt.selections.getArea().add(new Walkontable.CellCoords(1, 2));
-    wt.selections.getArea().add(new Walkontable.CellCoords(2, 1));
-    wt.selections.getArea().add(new Walkontable.CellCoords(2, 2));
+    wt.selections.createOrGetArea().add(new Walkontable.CellCoords(1, 1));
+    wt.selections.createOrGetArea().add(new Walkontable.CellCoords(1, 2));
+    wt.selections.createOrGetArea().add(new Walkontable.CellCoords(2, 1));
+    wt.selections.createOrGetArea().add(new Walkontable.CellCoords(2, 2));
 
     wt.draw();
 

--- a/src/core.js
+++ b/src/core.js
@@ -1275,10 +1275,10 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
    * Returns the last coordinates applied to the table as a an array `[startRow, startCol, endRow, endCol]`.
    *
    * @memberof Core#
-   * @function getSelectedRecently
+   * @function getSelectedLast
    * @returns {Array|undefined} An array of the selection's coordinates.
    */
-  this.getSelectedRecently = function() {
+  this.getSelectedLast = function() {
     const selected = this.getSelected();
     let result;
 
@@ -1307,11 +1307,11 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
   * Returns the last coordinates applied to the table as a CellRange object.
   *
   * @memberof Core#
-  * @function getSelectedRecentlyRange
+  * @function getSelectedRangeLast
   * @since 0.36.0
   * @returns {CellRange|undefined} Selected range object or undefined` if there is no selection.
    */
-  this.getSelectedRecentlyRange = function() {
+  this.getSelectedRangeLast = function() {
     const selectedRange = this.getSelectedRange();
     let result;
 
@@ -1737,7 +1737,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
    * @returns {*} Value of selected cell.
    */
   this.getValue = function() {
-    var sel = instance.getSelectedRecently();
+    var sel = instance.getSelectedLast();
 
     if (GridSettings.prototype.getValue) {
       if (isFunction(GridSettings.prototype.getValue)) {
@@ -3049,13 +3049,13 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
    * @returns {Boolean} `true` if selection was successful, `false` otherwise.
    */
   this.selectCellByProp = function(row, prop, endRow, endProp, scrollToCell) {
-    arguments[1] = datamap.propToCol(arguments[1]);
+    let endColumn;
 
-    if (isDefined(arguments[3])) {
-      arguments[3] = datamap.propToCol(arguments[3]);
+    if (isDefined(endProp)) {
+      endColumn = datamap.propToCol(endProp);
     }
 
-    return instance.selectCell(...arguments);
+    return instance.selectCell(row, datamap.propToCol(prop), endRow, endColumn, scrollToCell);
   };
 
   /**

--- a/src/core.js
+++ b/src/core.js
@@ -261,10 +261,10 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
     this.runHooks('afterDeselect');
   });
   this.selection.addLocalHook('insertRowRequire', (totalRows) => {
-    this.alter('insert_row', totalRows);
+    this.alter('insert_row', totalRows, 1, 'auto');
   });
   this.selection.addLocalHook('insertColRequire', (totalCols) => {
-    this.alter('insert_col', totalCols);
+    this.alter('insert_col', totalCols, 1, 'auto');
   });
 
   grid = {

--- a/src/core.js
+++ b/src/core.js
@@ -147,8 +147,10 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
     const {from, to} = selectionRange.current();
     const selectionLayerLevel = selectionRange.size() - 1;
 
-    this.runHooks('afterSelection', from.row, from.col, to.row, to.col, preventScrolling, selectionLayerLevel);
-    this.runHooks('afterSelectionByProp', from.row, instance.colToProp(from.col), to.row, instance.colToProp(to.col), preventScrolling, selectionLayerLevel);
+    this.runHooks('afterSelection',
+      from.row, from.col, to.row, to.col, preventScrolling, selectionLayerLevel);
+    this.runHooks('afterSelectionByProp',
+      from.row, instance.colToProp(from.col), to.row, instance.colToProp(to.col), preventScrolling, selectionLayerLevel);
 
     let isHeaderSelected = false;
     let areCoordsPositive = true;
@@ -195,8 +197,10 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
     const selectionLayerLevel = cellRanges.length - 1;
     const {from, to} = cellRanges[selectionLayerLevel];
 
-    this.runHooks('afterSelectionEnd', from.row, from.col, to.row, to.col, selectionLayerLevel);
-    this.runHooks('afterSelectionEndByProp', from.row, instance.colToProp(from.col), to.row, instance.colToProp(to.col), selectionLayerLevel);
+    this.runHooks('afterSelectionEnd',
+      from.row, from.col, to.row, to.col, selectionLayerLevel);
+    this.runHooks('afterSelectionEndByProp',
+      from.row, instance.colToProp(from.col), to.row, instance.colToProp(to.col), selectionLayerLevel);
   });
 
   this.selection.addLocalHook('afterIsMultipleSelection', (isMultiple) => {
@@ -760,8 +764,6 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
     this.view = new TableView(this);
     editorManager = new EditorManager(instance, priv, selection, datamap);
 
-    this.editorManager = editorManager;
-
     this.forceFullRender = true; // used when data was changed
 
     instance.runHooks('init');
@@ -1228,9 +1230,13 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
    *
    * Start row and start col are the coordinates of the active cell (where the selection was started).
    *
+   * The version 0.36.0 adds a non-consecutive selection feature. Since this version, the method returns an array of arrays.
+   * Additionally to collect the coordinates of the currently selected area (as it was previously done by the method)
+   * you need to use `getSelectedLast` method.
+   *
    * @memberof Core#
    * @function getSelected
-   * @returns {Array[]} An array of arrays of the selection's indexes.
+   * @returns {Array[]|undefined} An array of arrays of the selection's coordinates.
    */
   this.getSelected = function() { // https://github.com/handsontable/handsontable/issues/44  //cjl
     if (selection.isSelected()) {
@@ -1241,6 +1247,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
   /**
    * Returns the last coordinates applied to the table as a an array `[startRow, startCol, endRow, endCol]`.
    *
+   * @since 0.36.0
    * @memberof Core#
    * @function getSelectedLast
    * @returns {Array|undefined} An array of the selection's coordinates.
@@ -1259,10 +1266,14 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
   /**
    * Returns the current selection as an array of CellRange objects.
    *
+   * The version 0.36.0 adds a non-consecutive selection feature. Since this version, the method returns an array of arrays.
+   * Additionally to collect the coordinates of the currently selected area (as it was previously done by the method)
+   * you need to use `getSelectedRangeLast` method.
+   *
    * @memberof Core#
    * @function getSelectedRange
    * @since 0.11
-   * @returns {CellRange[]} Selected range object or undefined` if there is no selection.
+   * @returns {CellRange[]|undefined} Selected range object or undefined` if there is no selection.
    */
   this.getSelectedRange = function() { // https://github.com/handsontable/handsontable/issues/44  //cjl
     if (selection.isSelected()) {

--- a/src/css/handsontable.css
+++ b/src/css/handsontable.css
@@ -271,15 +271,58 @@
   display:none !important;
 }
 
-.handsontable td.area {
-  background: -moz-linear-gradient(top,  rgba(181,209,255,0.34) 0%, rgba(181,209,255,0.34) 100%); /* FF3.6+ */
-  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(181,209,255,0.34)), color-stop(100%,rgba(181,209,255,0.34))); /* Chrome,Safari4+ */
-  background: -webkit-linear-gradient(top,  rgba(181,209,255,0.34) 0%,rgba(181,209,255,0.34) 100%); /* Chrome10+,Safari5.1+ */
-  background: -o-linear-gradient(top,  rgba(181,209,255,0.34) 0%,rgba(181,209,255,0.34) 100%); /* Opera 11.10+ */
-  background: -ms-linear-gradient(top,  rgba(181,209,255,0.34) 0%,rgba(181,209,255,0.34) 100%); /* IE10+ */
-  background: linear-gradient(to bottom,  rgba(181,209,255,0.34) 0%,rgba(181,209,255,0.34) 100%); /* W3C */
-  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#57b5d1ff', endColorstr='#57b5d1ff',GradientType=0 ); /* IE6-9 */
-  background-color: #fff;
+.handsontable td.area,
+.handsontable td.area-1,
+.handsontable td.area-2,
+.handsontable td.area-3,
+.handsontable td.area-4,
+.handsontable td.area-5,
+.handsontable td.area-6,
+.handsontable td.area-7 {
+  position: relative;
+  background: none;
+  background-color: transparent;
+}
+
+.handsontable td.area:before,
+.handsontable td.area-1:before,
+.handsontable td.area-2:before,
+.handsontable td.area-3:before,
+.handsontable td.area-4:before,
+.handsontable td.area-5:before,
+.handsontable td.area-6:before,
+.handsontable td.area-7:before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: #005eff;
+}
+.handsontable td.area:before {
+  opacity: 0.1;
+}
+.handsontable td.area-1:before {
+  opacity: 0.2;
+}
+.handsontable td.area-2:before {
+  opacity: 0.27;
+}
+.handsontable td.area-3:before {
+  opacity: 0.35;
+}
+.handsontable td.area-4:before {
+  opacity: 0.41;
+}
+.handsontable td.area-5:before {
+  opacity: 0.47;
+}
+.handsontable td.area-6:before {
+  opacity: 0.54;
+}
+.handsontable td.area-7:before {
+  opacity: 0.58;
 }
 
 /* fill handle */

--- a/src/defaultSettings.js
+++ b/src/defaultSettings.js
@@ -1407,8 +1407,9 @@ DefaultSettings.prototype = {
    * Possible values:
    *  * `true` - Disables any type of visual selection (current and area selection),
    *  * `false` - Enables any type of visual selection. This is default value.
-   *  * `current` - Disables the selection of a currently selected cell, the area selection is still present.
-   *  * `area` - Disables the area selection, the currently selected cell selection is still present.
+   *  * `'current'` - Disables the selection of a currently selected cell, the area selection is still present.
+   *  * `'area'` - Disables the area selection, the currently selected cell selection is still present.
+   *  * `'header'` - Disables the headers selection, the currently selected cell selection is still present (available since 0.36.0).
    *
    * @type {Boolean|String|Array}
    * @default false
@@ -1421,7 +1422,7 @@ DefaultSettings.prototype = {
    * ...
    *
    * ...
-   * // as string ('current' or 'area')
+   * // as string ('current', 'area' or 'header')
    * disableVisualSelection: 'current',
    * ...
    *

--- a/src/defaultSettings.js
+++ b/src/defaultSettings.js
@@ -507,12 +507,19 @@ DefaultSettings.prototype = {
   allowRemoveColumn: true,
 
   /**
-   * If true, selection of multiple cells using keyboard or mouse is allowed.
+   * @description
+   * Defines how the table selection reacts. The selection support three different behaviors defined as:
+   *  * `'single'` Only a single cell can be selected.
+   *  * `'contiguous'` Multiple cells within a single range can be selected.
+   *  * `'multiple'` Multiple ranges of cells can be selected.
    *
-   * @type {Boolean}
-   * @default true
+   * [See more](https://docs.handsontable.com/tutorial-selection.html)
+   *
+   * @since 0.36.0
+   * @type {String}
+   * @default 'multiple'
    */
-  multiSelect: true,
+  selectionMode: 'multiple',
 
   /**
    * Enables the fill handle (drag-down and copy-down) functionality, which shows a small rectangle in bottom

--- a/src/defaultSettings.js
+++ b/src/defaultSettings.js
@@ -513,7 +513,8 @@ DefaultSettings.prototype = {
    *  * `'range'` Multiple cells within a single range can be selected.
    *  * `'multiple'` Multiple ranges of cells can be selected.
    *
-   * [See more](https://docs.handsontable.com/tutorial-selection.html)
+   * To see how to interact with selection by getting selected data or change styles of the selected cells go to
+   * [https://docs.handsontable.com/demo-selecting-ranges.html](https://docs.handsontable.com/demo-selecting-ranges.html).
    *
    * @since 0.36.0
    * @type {String}

--- a/src/defaultSettings.js
+++ b/src/defaultSettings.js
@@ -510,7 +510,7 @@ DefaultSettings.prototype = {
    * @description
    * Defines how the table selection reacts. The selection support three different behaviors defined as:
    *  * `'single'` Only a single cell can be selected.
-   *  * `'contiguous'` Multiple cells within a single range can be selected.
+   *  * `'range'` Multiple cells within a single range can be selected.
    *  * `'multiple'` Multiple ranges of cells can be selected.
    *
    * [See more](https://docs.handsontable.com/tutorial-selection.html)

--- a/src/editorManager.js
+++ b/src/editorManager.js
@@ -1,5 +1,5 @@
 import {CellCoords} from './3rdparty/walkontable/src';
-import {KEY_CODES, isMetaKey, isCtrlKey} from './helpers/unicode';
+import {KEY_CODES, isMetaKey, isCtrlMetaKey} from './helpers/unicode';
 import {stopPropagation, stopImmediatePropagation, isImmediatePropagationStopped} from './helpers/dom/event';
 import {getEditorInstance} from './editors';
 import EventManager from './eventManager';
@@ -96,7 +96,7 @@ function EditorManager(instance, priv, selection) {
     ctrlDown = (event.ctrlKey || event.metaKey) && !event.altKey;
 
     if (activeEditor && !activeEditor.isWaiting()) {
-      if (!isMetaKey(event.keyCode) && !isCtrlKey(event.keyCode) && !ctrlDown && !_this.isEditorOpened()) {
+      if (!isMetaKey(event.keyCode) && !isCtrlMetaKey(event.keyCode) && !ctrlDown && !_this.isEditorOpened()) {
         _this.openEditor('', event);
 
         return;

--- a/src/editorManager.js
+++ b/src/editorManager.js
@@ -174,7 +174,7 @@ function EditorManager(instance, priv, selection) {
 
       case KEY_CODES.BACKSPACE:
       case KEY_CODES.DELETE:
-        selection.empty(event);
+        instance.emptySelectedCells();
         _this.prepareEditor();
         event.preventDefault();
         break;
@@ -221,9 +221,9 @@ function EditorManager(instance, priv, selection) {
       case KEY_CODES.HOME:
         selection.setSelectedHeaders(false, false, false);
         if (event.ctrlKey || event.metaKey) {
-          rangeModifier(new CellCoords(0, priv.selRange.from.col));
+          rangeModifier.call(selection, new CellCoords(0, selection.selectedRange.current().from.col));
         } else {
-          rangeModifier(new CellCoords(priv.selRange.from.row, 0));
+          rangeModifier.call(selection, new CellCoords(selection.selectedRange.current().from.row, 0));
         }
         event.preventDefault(); // don't scroll the window
         stopPropagation(event);
@@ -232,9 +232,9 @@ function EditorManager(instance, priv, selection) {
       case KEY_CODES.END:
         selection.setSelectedHeaders(false, false, false);
         if (event.ctrlKey || event.metaKey) {
-          rangeModifier(new CellCoords(instance.countRows() - 1, priv.selRange.from.col));
+          rangeModifier.call(selection, new CellCoords(instance.countRows() - 1, selection.selectedRange.current().from.col));
         } else {
-          rangeModifier(new CellCoords(priv.selRange.from.row, instance.countCols() - 1));
+          rangeModifier.call(selection, new CellCoords(selection.selectedRange.current().from.row, instance.countCols() - 1));
         }
         event.preventDefault(); // don't scroll the window
         stopPropagation(event);
@@ -330,8 +330,8 @@ function EditorManager(instance, priv, selection) {
 
       return;
     }
-    row = priv.selRange.highlight.row;
-    col = priv.selRange.highlight.col;
+    row = instance.selection.selectedRange.current().highlight.row;
+    col = instance.selection.selectedRange.current().highlight.col;
     prop = instance.colToProp(col);
     td = instance.getCell(row, col);
 

--- a/src/editors/_baseEditor.js
+++ b/src/editors/_baseEditor.js
@@ -79,7 +79,7 @@ BaseEditor.prototype.saveValue = function(value, ctrlDown) {
 
   // if ctrl+enter and multiple cells selected, behave like Excel (finish editing and apply to all cells)
   if (ctrlDown) {
-    selection = this.instance.getSelected();
+    selection = this.instance.getSelectedRecently();
 
     if (selection[0] > selection[2]) {
       tmp = selection[0];

--- a/src/editors/_baseEditor.js
+++ b/src/editors/_baseEditor.js
@@ -79,7 +79,7 @@ BaseEditor.prototype.saveValue = function(value, ctrlDown) {
 
   // if ctrl+enter and multiple cells selected, behave like Excel (finish editing and apply to all cells)
   if (ctrlDown) {
-    selection = this.instance.getSelectedRecently();
+    selection = this.instance.getSelectedLast();
 
     if (selection[0] > selection[2]) {
       tmp = selection[0];

--- a/src/editors/autocompleteEditor.js
+++ b/src/editors/autocompleteEditor.js
@@ -421,7 +421,9 @@ AutocompleteEditor.prototype.stripValuesIfNeeded = function (values) {
 };
 
 AutocompleteEditor.prototype.allowKeyEventPropagation = function(keyCode) {
-  let selected = {row: this.htEditor.getSelectedRange() ? this.htEditor.getSelectedRange().from.row : -1};
+  const selectedRange = this.htEditor.getSelectedRecentlyRange();
+
+  let selected = {row: selectedRange ? selectedRange.from.row : -1};
   let allowed = false;
 
   if (keyCode === KEY_CODES.ARROW_DOWN && selected.row > 0 && selected.row < this.htEditor.countRows() - 1) {

--- a/src/editors/autocompleteEditor.js
+++ b/src/editors/autocompleteEditor.js
@@ -421,7 +421,7 @@ AutocompleteEditor.prototype.stripValuesIfNeeded = function (values) {
 };
 
 AutocompleteEditor.prototype.allowKeyEventPropagation = function(keyCode) {
-  const selectedRange = this.htEditor.getSelectedRecentlyRange();
+  const selectedRange = this.htEditor.getSelectedRangeLast();
 
   let selected = {row: selectedRange ? selectedRange.from.row : -1};
   let allowed = false;

--- a/src/editors/dateEditor.js
+++ b/src/editors/dateEditor.js
@@ -107,7 +107,7 @@ class DateEditor extends TextEditor {
   close() {
     this._opened = false;
     this.instance._registerTimeout(setTimeout(() => {
-      this.instance.selection.refreshBorders();
+      this.instance._refreshBorders();
     }, 0));
 
     super.close();

--- a/src/editors/handsontableEditor.js
+++ b/src/editors/handsontableEditor.js
@@ -67,27 +67,27 @@ var onBeforeKeyDown = function(event) {
   var selectedRow;
 
   if (event.keyCode == KEY_CODES.ARROW_DOWN) {
-    if (!innerHOT.getSelected() && !innerHOT.flipped) {
+    if (!innerHOT.getSelectedRecently() && !innerHOT.flipped) {
       rowToSelect = 0;
-    } else if (innerHOT.getSelected()) {
+    } else if (innerHOT.getSelectedRecently()) {
       if (innerHOT.flipped) {
-        rowToSelect = innerHOT.getSelected()[0] + 1;
+        rowToSelect = innerHOT.getSelectedRecently()[0] + 1;
       } else if (!innerHOT.flipped) {
-        selectedRow = innerHOT.getSelected()[0];
+        selectedRow = innerHOT.getSelectedRecently()[0];
         var lastRow = innerHOT.countRows() - 1;
         rowToSelect = Math.min(lastRow, selectedRow + 1);
       }
     }
   } else if (event.keyCode == KEY_CODES.ARROW_UP) {
-    if (!innerHOT.getSelected() && innerHOT.flipped) {
+    if (!innerHOT.getSelectedRecently() && innerHOT.flipped) {
       rowToSelect = innerHOT.countRows() - 1;
 
-    } else if (innerHOT.getSelected()) {
+    } else if (innerHOT.getSelectedRecently()) {
       if (innerHOT.flipped) {
-        selectedRow = innerHOT.getSelected()[0];
+        selectedRow = innerHOT.getSelectedRecently()[0];
         rowToSelect = Math.max(0, selectedRow - 1);
       } else {
-        selectedRow = innerHOT.getSelected()[0];
+        selectedRow = innerHOT.getSelectedRecently()[0];
         rowToSelect = selectedRow - 1;
       }
     }
@@ -159,7 +159,7 @@ HandsontableEditor.prototype.finishEditing = function(isCancelled, ctrlDown) {
     this.instance.listen(); // return the focus to the parent HOT instance
   }
 
-  if (this.htEditor && this.htEditor.getSelected()) {
+  if (this.htEditor && this.htEditor.getSelectedRecently()) {
     var value = this.htEditor.getInstance().getValue();
 
     if (value !== void 0) { // if the value is undefined then it means we don't want to set the value

--- a/src/editors/handsontableEditor.js
+++ b/src/editors/handsontableEditor.js
@@ -67,27 +67,27 @@ var onBeforeKeyDown = function(event) {
   var selectedRow;
 
   if (event.keyCode == KEY_CODES.ARROW_DOWN) {
-    if (!innerHOT.getSelectedRecently() && !innerHOT.flipped) {
+    if (!innerHOT.getSelectedLast() && !innerHOT.flipped) {
       rowToSelect = 0;
-    } else if (innerHOT.getSelectedRecently()) {
+    } else if (innerHOT.getSelectedLast()) {
       if (innerHOT.flipped) {
-        rowToSelect = innerHOT.getSelectedRecently()[0] + 1;
+        rowToSelect = innerHOT.getSelectedLast()[0] + 1;
       } else if (!innerHOT.flipped) {
-        selectedRow = innerHOT.getSelectedRecently()[0];
+        selectedRow = innerHOT.getSelectedLast()[0];
         var lastRow = innerHOT.countRows() - 1;
         rowToSelect = Math.min(lastRow, selectedRow + 1);
       }
     }
   } else if (event.keyCode == KEY_CODES.ARROW_UP) {
-    if (!innerHOT.getSelectedRecently() && innerHOT.flipped) {
+    if (!innerHOT.getSelectedLast() && innerHOT.flipped) {
       rowToSelect = innerHOT.countRows() - 1;
 
-    } else if (innerHOT.getSelectedRecently()) {
+    } else if (innerHOT.getSelectedLast()) {
       if (innerHOT.flipped) {
-        selectedRow = innerHOT.getSelectedRecently()[0];
+        selectedRow = innerHOT.getSelectedLast()[0];
         rowToSelect = Math.max(0, selectedRow - 1);
       } else {
-        selectedRow = innerHOT.getSelectedRecently()[0];
+        selectedRow = innerHOT.getSelectedLast()[0];
         rowToSelect = selectedRow - 1;
       }
     }
@@ -159,7 +159,7 @@ HandsontableEditor.prototype.finishEditing = function(isCancelled, ctrlDown) {
     this.instance.listen(); // return the focus to the parent HOT instance
   }
 
-  if (this.htEditor && this.htEditor.getSelectedRecently()) {
+  if (this.htEditor && this.htEditor.getSelectedLast()) {
     var value = this.htEditor.getInstance().getValue();
 
     if (value !== void 0) { // if the value is undefined then it means we don't want to set the value

--- a/src/editors/mobileTextEditor.js
+++ b/src/editors/mobileTextEditor.js
@@ -143,7 +143,8 @@ MobileTextEditor.prototype.close = function() {
 };
 
 MobileTextEditor.prototype.scrollToView = function() {
-  var coords = this.instance.getSelectedRange().highlight;
+  var coords = this.instance.getSelectedRecentlyRange().highlight;
+
   this.instance.view.scrollViewport(coords);
 };
 
@@ -162,7 +163,7 @@ MobileTextEditor.prototype.updateEditorPosition = function(x, y) {
     this.editorContainer.style.left = `${x}px`;
 
   } else {
-    var selection = this.instance.getSelected(),
+    var selection = this.instance.getSelectedRecently(),
       selectedCell = this.instance.getCell(selection[0], selection[1]);
 
     // cache sizes
@@ -210,7 +211,7 @@ MobileTextEditor.prototype.updateEditorPosition = function(x, y) {
 };
 
 MobileTextEditor.prototype.updateEditorData = function() {
-  var selected = this.instance.getSelected(),
+  var selected = this.instance.getSelectedRecently(),
     selectedValue = this.instance.getDataAtCell(selected[0], selected[1]);
 
   this.row = selected[0];

--- a/src/editors/mobileTextEditor.js
+++ b/src/editors/mobileTextEditor.js
@@ -143,7 +143,7 @@ MobileTextEditor.prototype.close = function() {
 };
 
 MobileTextEditor.prototype.scrollToView = function() {
-  var coords = this.instance.getSelectedRecentlyRange().highlight;
+  var coords = this.instance.getSelectedRangeLast().highlight;
 
   this.instance.view.scrollViewport(coords);
 };
@@ -163,7 +163,7 @@ MobileTextEditor.prototype.updateEditorPosition = function(x, y) {
     this.editorContainer.style.left = `${x}px`;
 
   } else {
-    var selection = this.instance.getSelectedRecently(),
+    var selection = this.instance.getSelectedLast(),
       selectedCell = this.instance.getCell(selection[0], selection[1]);
 
     // cache sizes
@@ -211,7 +211,7 @@ MobileTextEditor.prototype.updateEditorPosition = function(x, y) {
 };
 
 MobileTextEditor.prototype.updateEditorData = function() {
-  var selected = this.instance.getSelectedRecently(),
+  var selected = this.instance.getSelectedLast(),
     selectedValue = this.instance.getDataAtCell(selected[0], selected[1]);
 
   this.row = selected[0];

--- a/src/editors/selectEditor.js
+++ b/src/editors/selectEditor.js
@@ -183,11 +183,11 @@ SelectEditor.prototype.refreshDimensions = function() {
     default:
       break;
   }
-  if (this.instance.getSelected()[0] === 0) {
+  if (this.instance.getSelectedRecently()[0] === 0) {
     editTop += 1;
   }
 
-  if (this.instance.getSelected()[1] === 0) {
+  if (this.instance.getSelectedRecently()[1] === 0) {
     editLeft += 1;
   }
 

--- a/src/editors/selectEditor.js
+++ b/src/editors/selectEditor.js
@@ -183,11 +183,11 @@ SelectEditor.prototype.refreshDimensions = function() {
     default:
       break;
   }
-  if (this.instance.getSelectedRecently()[0] === 0) {
+  if (this.instance.getSelectedLast()[0] === 0) {
     editTop += 1;
   }
 
-  if (this.instance.getSelectedRecently()[1] === 0) {
+  if (this.instance.getSelectedLast()[1] === 0) {
     editLeft += 1;
   }
 

--- a/src/editors/textEditor.js
+++ b/src/editors/textEditor.js
@@ -94,7 +94,7 @@ var onBeforeKeyDown = function onBeforeKeyDown(event) {
       break;
 
     case KEY_CODES.ENTER:
-      var selected = that.instance.getSelected();
+      var selected = that.instance.getSelectedRecently();
       var isMultipleSelection = !(selected[0] === selected[2] && selected[1] === selected[3]);
       if ((ctrlDown && !isMultipleSelection) || event.altKey) { // if ctrl+enter or alt+enter, add new line
         if (that.isOpened()) {
@@ -300,12 +300,12 @@ TextEditor.prototype.refreshDimensions = function() {
       break;
   }
 
-  if (colHeadersCount && this.instance.getSelected()[0] === 0 ||
-      (settings.fixedRowsBottom && this.instance.getSelected()[0] === totalRowsCount - settings.fixedRowsBottom)) {
+  if (colHeadersCount && this.instance.getSelectedRecently()[0] === 0 ||
+      (settings.fixedRowsBottom && this.instance.getSelectedRecently()[0] === totalRowsCount - settings.fixedRowsBottom)) {
     editTop += 1;
   }
 
-  if (this.instance.getSelected()[1] === 0) {
+  if (this.instance.getSelectedRecently()[1] === 0) {
     editLeft += 1;
   }
 

--- a/src/editors/textEditor.js
+++ b/src/editors/textEditor.js
@@ -94,7 +94,7 @@ var onBeforeKeyDown = function onBeforeKeyDown(event) {
       break;
 
     case KEY_CODES.ENTER:
-      var selected = that.instance.getSelectedRecently();
+      var selected = that.instance.getSelectedLast();
       var isMultipleSelection = !(selected[0] === selected[2] && selected[1] === selected[3]);
       if ((ctrlDown && !isMultipleSelection) || event.altKey) { // if ctrl+enter or alt+enter, add new line
         if (that.isOpened()) {
@@ -300,12 +300,12 @@ TextEditor.prototype.refreshDimensions = function() {
       break;
   }
 
-  if (colHeadersCount && this.instance.getSelectedRecently()[0] === 0 ||
-      (settings.fixedRowsBottom && this.instance.getSelectedRecently()[0] === totalRowsCount - settings.fixedRowsBottom)) {
+  if (colHeadersCount && this.instance.getSelectedLast()[0] === 0 ||
+      (settings.fixedRowsBottom && this.instance.getSelectedLast()[0] === totalRowsCount - settings.fixedRowsBottom)) {
     editTop += 1;
   }
 
-  if (this.instance.getSelectedRecently()[1] === 0) {
+  if (this.instance.getSelectedLast()[1] === 0) {
     editLeft += 1;
   }
 

--- a/src/helpers/array.js
+++ b/src/helpers/array.js
@@ -123,17 +123,30 @@ export function arrayMap(array, iteratee) {
  *
  * {@link https://github.com/lodash/lodash/blob/master/lodash.js}
  *
- * @param {Array} array The array to iterate over.
+ * @param {Array|*} array The array to iterate over or an any element with implemented iterator protocol.
  * @param {Function} iteratee The function invoked per iteration.
  * @returns {Array} Returns `array`.
  */
 export function arrayEach(array, iteratee) {
-  let index = -1,
-    length = array.length;
+  let index = -1;
 
-  while (++index < length) {
-    if (iteratee(array[index], index, array) === false) {
-      break;
+  if (Array.isArray(array)) {
+    const length = array.length;
+
+    while (++index < length) {
+      if (iteratee(array[index], index, array) === false) {
+        break;
+      }
+    }
+  } else if (array[Symbol.iterator]) {
+    const iterable = array[Symbol.iterator]();
+
+    for (let variable of iterable) {
+      index++;
+
+      if (iteratee(variable, index, iterable) === false) {
+        break;
+      }
     }
   }
 

--- a/src/helpers/array.js
+++ b/src/helpers/array.js
@@ -54,14 +54,19 @@ export function pivot(arr) {
  * @returns {*} Returns the accumulated value.
  */
 export function arrayReduce(array, iteratee, accumulator, initFromArray) {
-  let index = -1,
-    length = array.length;
+  let index = -1;
+  let iterable = array;
+
+  if (!Array.isArray(array)) {
+    iterable = Array.from(array);
+  }
+  const length = iterable.length;
 
   if (initFromArray && length) {
-    accumulator = array[++index];
+    accumulator = iterable[++index];
   }
   while (++index < length) {
-    accumulator = iteratee(accumulator, array[index], index, array);
+    accumulator = iteratee(accumulator, iterable[index], index, iterable);
   }
 
   return accumulator;
@@ -78,15 +83,20 @@ export function arrayReduce(array, iteratee, accumulator, initFromArray) {
  * @returns {Array} Returns the new filtered array.
  */
 export function arrayFilter(array, predicate) {
-  let index = -1,
-    length = array.length,
-    resIndex = -1,
-    result = [];
+  let index = -1;
+  let iterable = array;
+
+  if (!Array.isArray(array)) {
+    iterable = Array.from(array);
+  }
+  const length = iterable.length;
+  const result = [];
+  let resIndex = -1;
 
   while (++index < length) {
-    let value = array[index];
+    const value = iterable[index];
 
-    if (predicate(value, index, array)) {
+    if (predicate(value, index, iterable)) {
       result[++resIndex] = value;
     }
   }
@@ -103,15 +113,21 @@ export function arrayFilter(array, predicate) {
  * @returns {Array} Returns the new filtered array.
  */
 export function arrayMap(array, iteratee) {
-  let index = -1,
-    length = array.length,
-    resIndex = -1,
-    result = [];
+  let index = -1;
+  let iterable = array;
+
+  if (!Array.isArray(array)) {
+    iterable = Array.from(array);
+  }
+
+  const length = iterable.length;
+  const result = [];
+  let resIndex = -1;
 
   while (++index < length) {
-    let value = array[index];
+    const value = iterable[index];
 
-    result[++resIndex] = iteratee(value, index, array);
+    result[++resIndex] = iteratee(value, index, iterable);
   }
 
   return result;
@@ -129,24 +145,17 @@ export function arrayMap(array, iteratee) {
  */
 export function arrayEach(array, iteratee) {
   let index = -1;
+  let iterable = array;
 
-  if (Array.isArray(array)) {
-    const length = array.length;
+  if (!Array.isArray(array)) {
+    iterable = Array.from(array);
+  }
 
-    while (++index < length) {
-      if (iteratee(array[index], index, array) === false) {
-        break;
-      }
-    }
-  } else if (array[Symbol.iterator]) {
-    const iterable = array[Symbol.iterator]();
+  const length = iterable.length;
 
-    for (let variable of iterable) {
-      index++;
-
-      if (iteratee(variable, index, iterable) === false) {
-        break;
-      }
+  while (++index < length) {
+    if (iteratee(iterable[index], index, iterable) === false) {
+      break;
     }
   }
 

--- a/src/helpers/array.js
+++ b/src/helpers/array.js
@@ -89,6 +89,7 @@ export function arrayFilter(array, predicate) {
   if (!Array.isArray(array)) {
     iterable = Array.from(array);
   }
+
   const length = iterable.length;
   const result = [];
   let resIndex = -1;

--- a/src/helpers/unicode.js
+++ b/src/helpers/unicode.js
@@ -11,8 +11,8 @@ export const KEY_CODES = {
   END: 35,
   ENTER: 13,
   ESCAPE: 27,
-  CONTROL_LEFT: 91,
-  COMMAND_LEFT: 17,
+  CONTROL: 17,
+  COMMAND_LEFT: 91,
   COMMAND_RIGHT: 93,
   ALT: 18,
   HOME: 36,
@@ -105,7 +105,7 @@ export function isMetaKey(keyCode) {
  * @returns {Boolean}
  */
 export function isCtrlKey(keyCode) {
-  return [KEY_CODES.CONTROL_LEFT, 224, KEY_CODES.COMMAND_LEFT, KEY_CODES.COMMAND_RIGHT].indexOf(keyCode) !== -1;
+  return [KEY_CODES.CONTROL, 224, KEY_CODES.COMMAND_LEFT, KEY_CODES.COMMAND_RIGHT].indexOf(keyCode) !== -1;
 }
 
 /**

--- a/src/helpers/unicode.js
+++ b/src/helpers/unicode.js
@@ -14,6 +14,7 @@ export const KEY_CODES = {
   CONTROL: 17,
   COMMAND_LEFT: 91,
   COMMAND_RIGHT: 93,
+  COMMAND_FIREFOX: 224,
   ALT: 18,
   HOME: 36,
   PAGE_DOWN: 34,
@@ -101,11 +102,33 @@ export function isMetaKey(keyCode) {
 }
 
 /**
- * @param {Number} keyCode
+ * Checks if passed key code is ctrl or cmd key. Depends on what OS the code runs it check key code based on
+ * different meta key codes.
+ *
+ * @param {Number} keyCode Key code to check.
  * @returns {Boolean}
  */
 export function isCtrlKey(keyCode) {
-  return [KEY_CODES.CONTROL, 224, KEY_CODES.COMMAND_LEFT, KEY_CODES.COMMAND_RIGHT].indexOf(keyCode) !== -1;
+  const keys = [];
+
+  if (window.navigator.platform.includes('Mac')) {
+    keys.push(KEY_CODES.COMMAND_LEFT, KEY_CODES.COMMAND_RIGHT, KEY_CODES.COMMAND_FIREFOX);
+  } else {
+    keys.push(KEY_CODES.CONTROL);
+  }
+
+  return keys.includes(keyCode);
+}
+
+/**
+ * Checks if passed key code is ctrl or cmd key. This helper checks if the key code matches to meta keys
+ * regardless of the OS on which it is running.
+ *
+ * @param {Number} keyCode Key code to check.
+ * @returns {Boolean}
+ */
+export function isCtrlMetaKey(keyCode) {
+  return [KEY_CODES.CONTROL, KEY_CODES.COMMAND_LEFT, KEY_CODES.COMMAND_RIGHT, KEY_CODES.COMMAND_FIREFOX].includes(keyCode);
 }
 
 /**

--- a/src/pluginHooks.js
+++ b/src/pluginHooks.js
@@ -765,7 +765,7 @@ const REGISTERED_HOOKS = [
    * Callback fired before setting range is started.
    *
    * @event Hooks#beforeSetRangeStart
-   * @param {Array} coords CellCoords array.
+   * @param {CellCoords} coords CellCoords instance.
    */
   'beforeSetRangeStart',
 
@@ -773,7 +773,7 @@ const REGISTERED_HOOKS = [
    * Callback fired before setting range is ended.
    *
    * @event Hooks#beforeSetRangeEnd
-   * @param {Array} coords CellCoords array.
+   * @param {CellCoords} coords CellCoords instance.
    */
   'beforeSetRangeEnd',
 

--- a/src/pluginHooks.js
+++ b/src/pluginHooks.js
@@ -406,12 +406,12 @@ const REGISTERED_HOOKS = [
    * @param {Number} r2 Selection end visual row index.
    * @param {Number} c2 Selection end visual column index.
    * @param {Object} preventScrolling Object with `value` property where its value change will be observed.
+   * @param {Number} selectionLayerLevel The number which indicates what selection layer is currently modified.
    *    * @example
    * ```js
    * handsontable({
-   *   afterSelection: function (r, c, r2, c2, preventScrolling) {
+   *   afterSelection: function (r, c, r2, c2, preventScrolling, selectionLayerLevel) {
    *     // setting if prevent scrolling after selection
-   *
    *     preventScrolling.value = true;
    *   }
    * })
@@ -428,12 +428,12 @@ const REGISTERED_HOOKS = [
    * @param {Number} r2 Selection end visual row index.
    * @param {String} p2 Selection end data source object property name.
    * @param {Object} preventScrolling Object with `value` property where its value change will be observed.
+   * @param {Number} selectionLayerLevel The number which indicates what selection layer is currently modified.
    *    * @example
    * ```js
    * handsontable({
-   *   afterSelectionByProp: function (r, c, r2, c2, preventScrolling) {
+   *   afterSelectionByProp: function (r, c, r2, c2, preventScrolling, selectionLayerLevel) {
    *     // setting if prevent scrolling after selection
-   *
    *     preventScrolling.value = true;
    *   }
    * })
@@ -449,6 +449,7 @@ const REGISTERED_HOOKS = [
    * @param {Number} c Selection start visual column index.
    * @param {Number} r2 Selection end visual row index.
    * @param {Number} c2 Selection end visual column index.
+   * @param {Number} selectionLayerLevel The number which indicates what selection layer is currently modified.
    */
   'afterSelectionEnd',
 
@@ -461,6 +462,7 @@ const REGISTERED_HOOKS = [
    * @param {String} p Selection start data source object property index.
    * @param {Number} r2 Selection end visual row index.
    * @param {String} p2 Selection end data source object property index.
+   * @param {Number} selectionLayerLevel The number which indicates what selection layer is currently modified.
    */
   'afterSelectionEndByProp',
 

--- a/src/plugins/autofill/autofill.js
+++ b/src/plugins/autofill/autofill.js
@@ -125,8 +125,8 @@ class Autofill extends BasePlugin {
    */
   getSelectionData() {
     const selRange = {
-      from: this.hot.getSelectedRange().from,
-      to: this.hot.getSelectedRange().to,
+      from: this.hot.getSelectedRecentlyRange().from,
+      to: this.hot.getSelectedRecentlyRange().to,
     };
 
     return this.hot.getData(selRange.from.row, selRange.from.col, selRange.to.row, selRange.to.col);
@@ -235,8 +235,8 @@ class Autofill extends BasePlugin {
    */
 
   getCoordsOfDragAndDropBorders(coordsOfSelection) {
-    const topLeftCorner = this.hot.getSelectedRange().getTopLeftCorner();
-    const bottomRightCorner = this.hot.getSelectedRange().getBottomRightCorner();
+    const topLeftCorner = this.hot.getSelectedRecentlyRange().getTopLeftCorner();
+    const bottomRightCorner = this.hot.getSelectedRecentlyRange().getBottomRightCorner();
     let coords;
 
     if (this.directions.includes(DIRECTIONS.vertical) &&
@@ -288,7 +288,7 @@ class Autofill extends BasePlugin {
    */
   addNewRowIfNeeded() {
     if (this.hot.selection.highlight.getFill().cellRange && this.addingStarted === false && this.autoInsertRow) {
-      const cornersOfSelectedCells = this.hot.getSelected();
+      const cornersOfSelectedCells = this.hot.getSelectedRecently();
       const cornersOfSelectedDragArea = this.hot.selection.highlight.getFill().getCorners();
       const nrOfTableRows = this.hot.countRows();
 
@@ -308,7 +308,7 @@ class Autofill extends BasePlugin {
    */
   getCornersOfSelectedCells() {
     if (this.hot.selection.isMultiple()) {
-      return this.hot.selection.highlight.getArea().getCorners();
+      return this.hot.selection.highlight.createOrGetArea().getCorners();
 
     }
     return this.hot.selection.highlight.getCell().getCorners();
@@ -424,8 +424,8 @@ class Autofill extends BasePlugin {
   redrawBorders(coords) {
     this.hot.selection.highlight.getFill()
       .clear()
-      .add(this.hot.getSelectedRange().from)
-      .add(this.hot.getSelectedRange().to)
+      .add(this.hot.getSelectedRecentlyRange().from)
+      .add(this.hot.getSelectedRecentlyRange().to)
       .add(coords);
 
     this.hot.view.render();

--- a/src/plugins/autofill/autofill.js
+++ b/src/plugins/autofill/autofill.js
@@ -139,11 +139,11 @@ class Autofill extends BasePlugin {
    * @returns {Boolean} reports if fill was applied.
    */
   fillIn() {
-    if (this.hot.view.wt.selections.fill.isEmpty()) {
+    if (this.hot.selection.highlight.getFill().isEmpty()) {
       return false;
     }
 
-    const cornersOfSelectionAndDragAreas = this.hot.view.wt.selections.fill.getCorners();
+    const cornersOfSelectionAndDragAreas = this.hot.selection.highlight.getFill().getCorners();
 
     this.resetSelectionOfDraggedArea();
 
@@ -202,7 +202,7 @@ class Autofill extends BasePlugin {
 
     } else {
       // reset to avoid some range bug
-      this.hot.selection.refreshBorders();
+      this.hot._refreshBorders();
     }
 
     return true;
@@ -287,9 +287,9 @@ class Autofill extends BasePlugin {
    * @private
    */
   addNewRowIfNeeded() {
-    if (this.hot.view.wt.selections.fill.cellRange && this.addingStarted === false && this.autoInsertRow) {
+    if (this.hot.selection.highlight.getFill().cellRange && this.addingStarted === false && this.autoInsertRow) {
       const cornersOfSelectedCells = this.hot.getSelected();
-      const cornersOfSelectedDragArea = this.hot.view.wt.selections.fill.getCorners();
+      const cornersOfSelectedDragArea = this.hot.selection.highlight.getFill().getCorners();
       const nrOfTableRows = this.hot.countRows();
 
       if (cornersOfSelectedCells[2] < nrOfTableRows - 1 && cornersOfSelectedDragArea[2] === nrOfTableRows - 1) {
@@ -308,10 +308,10 @@ class Autofill extends BasePlugin {
    */
   getCornersOfSelectedCells() {
     if (this.hot.selection.isMultiple()) {
-      return this.hot.view.wt.selections.area.getCorners();
+      return this.hot.selection.highlight.getArea().getCorners();
 
     }
-    return this.hot.view.wt.selections.current.getCorners();
+    return this.hot.selection.highlight.getCell().getCorners();
 
   }
 
@@ -355,15 +355,16 @@ class Autofill extends BasePlugin {
    * @param {Number} rowIndex
    */
   addSelectionFromStartAreaToSpecificRowIndex(selectStartArea, rowIndex) {
-    this.hot.view.wt.selections.fill.clear();
-    this.hot.view.wt.selections.fill.add(new CellCoords(
-      selectStartArea[0],
-      selectStartArea[1])
-    );
-    this.hot.view.wt.selections.fill.add(new CellCoords(
-      rowIndex,
-      selectStartArea[3])
-    );
+    this.hot.selection.highlight.getFill()
+      .clear()
+      .add(new CellCoords(
+        selectStartArea[0],
+        selectStartArea[1])
+      )
+      .add(new CellCoords(
+        rowIndex,
+        selectStartArea[3])
+      );
   }
 
   /**
@@ -411,7 +412,7 @@ class Autofill extends BasePlugin {
   resetSelectionOfDraggedArea() {
     this.handleDraggedCells = 0;
 
-    this.hot.view.wt.selections.fill.clear();
+    this.hot.selection.highlight.getFill().clear();
   }
 
   /**
@@ -421,10 +422,12 @@ class Autofill extends BasePlugin {
    * @param {CellCoords} coords `CellCoords` coord object.
    */
   redrawBorders(coords) {
-    this.hot.view.wt.selections.fill.clear();
-    this.hot.view.wt.selections.fill.add(this.hot.getSelectedRange().from);
-    this.hot.view.wt.selections.fill.add(this.hot.getSelectedRange().to);
-    this.hot.view.wt.selections.fill.add(coords);
+    this.hot.selection.highlight.getFill()
+      .clear()
+      .add(this.hot.getSelectedRange().from)
+      .add(this.hot.getSelectedRange().to)
+      .add(coords);
+
     this.hot.view.render();
   }
 

--- a/src/plugins/autofill/autofill.js
+++ b/src/plugins/autofill/autofill.js
@@ -125,8 +125,8 @@ class Autofill extends BasePlugin {
    */
   getSelectionData() {
     const selRange = {
-      from: this.hot.getSelectedRecentlyRange().from,
-      to: this.hot.getSelectedRecentlyRange().to,
+      from: this.hot.getSelectedRangeLast().from,
+      to: this.hot.getSelectedRangeLast().to,
     };
 
     return this.hot.getData(selRange.from.row, selRange.from.col, selRange.to.row, selRange.to.col);
@@ -235,8 +235,8 @@ class Autofill extends BasePlugin {
    */
 
   getCoordsOfDragAndDropBorders(coordsOfSelection) {
-    const topLeftCorner = this.hot.getSelectedRecentlyRange().getTopLeftCorner();
-    const bottomRightCorner = this.hot.getSelectedRecentlyRange().getBottomRightCorner();
+    const topLeftCorner = this.hot.getSelectedRangeLast().getTopLeftCorner();
+    const bottomRightCorner = this.hot.getSelectedRangeLast().getBottomRightCorner();
     let coords;
 
     if (this.directions.includes(DIRECTIONS.vertical) &&
@@ -288,7 +288,7 @@ class Autofill extends BasePlugin {
    */
   addNewRowIfNeeded() {
     if (this.hot.selection.highlight.getFill().cellRange && this.addingStarted === false && this.autoInsertRow) {
-      const cornersOfSelectedCells = this.hot.getSelectedRecently();
+      const cornersOfSelectedCells = this.hot.getSelectedLast();
       const cornersOfSelectedDragArea = this.hot.selection.highlight.getFill().getCorners();
       const nrOfTableRows = this.hot.countRows();
 
@@ -424,8 +424,8 @@ class Autofill extends BasePlugin {
   redrawBorders(coords) {
     this.hot.selection.highlight.getFill()
       .clear()
-      .add(this.hot.getSelectedRecentlyRange().from)
-      .add(this.hot.getSelectedRecentlyRange().to)
+      .add(this.hot.getSelectedRangeLast().from)
+      .add(this.hot.getSelectedRangeLast().to)
       .add(coords);
 
     this.hot.view.render();

--- a/src/plugins/comments/comments.js
+++ b/src/plugins/comments/comments.js
@@ -431,7 +431,7 @@ class Comments extends BasePlugin {
    * @returns {Boolean}
    */
   checkSelectionCommentsConsistency() {
-    const selected = this.hot.getSelectedRange();
+    const selected = this.hot.getSelectedRecentlyRange();
 
     if (!selected) {
       return false;
@@ -618,7 +618,7 @@ class Comments extends BasePlugin {
    */
   onContextMenuAddComment() {
     this.displaySwitch.cancelHiding();
-    let coords = this.hot.getSelectedRange();
+    let coords = this.hot.getSelectedRecentlyRange();
 
     this.contextMenuEvent = true;
     this.setRange({
@@ -637,13 +637,14 @@ class Comments extends BasePlugin {
    * Context Menu's "remove comment" callback.
    *
    * @private
-   * @param {Object} selection The current selection.
    */
-  onContextMenuRemoveComment(selection) {
+  onContextMenuRemoveComment() {
     this.contextMenuEvent = true;
 
-    for (let i = selection.start.row; i <= selection.end.row; i++) {
-      for (let j = selection.start.col; j <= selection.end.col; j++) {
+    let {from, to} = this.hot.getSelectedRecentlyRange();
+
+    for (let i = from.row; i <= to.row; i++) {
+      for (let j = from.col; j <= to.col; j++) {
         this.removeCommentAtCell(i, j, false);
       }
     }
@@ -655,13 +656,14 @@ class Comments extends BasePlugin {
    * Context Menu's "make comment read-only" callback.
    *
    * @private
-   * @param {Object} selection The current selection.
    */
-  onContextMenuMakeReadOnly(selection) {
+  onContextMenuMakeReadOnly() {
     this.contextMenuEvent = true;
 
-    for (let i = selection.start.row; i <= selection.end.row; i++) {
-      for (let j = selection.start.col; j <= selection.end.col; j++) {
+    let {from, to} = this.hot.getSelectedRecentlyRange();
+
+    for (let i = from.row; i <= to.row; i++) {
+      for (let j = from.col; j <= to.col; j++) {
         let currentState = !!this.getCommentMeta(i, j, META_READONLY);
 
         this.updateCommentMeta(i, j, {[META_READONLY]: !currentState});
@@ -691,7 +693,7 @@ class Comments extends BasePlugin {
         },
         callback: () => this.onContextMenuAddComment(),
         disabled() {
-          return !(this.getSelected() && !this.selection.selectedHeader.corner);
+          return !(this.getSelectedRecently() && !this.selection.selectedHeader.corner);
         }
       },
       {
@@ -699,14 +701,14 @@ class Comments extends BasePlugin {
         name() {
           return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_REMOVE_COMMENT);
         },
-        callback: (key, selection) => this.onContextMenuRemoveComment(selection),
+        callback: () => this.onContextMenuRemoveComment(),
         disabled: () => this.hot.selection.selectedHeader.corner
       },
       {
         key: 'commentsReadOnly',
         name() {
           let label = this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_READ_ONLY_COMMENT);
-          let hasProperty = checkSelectionConsistency(this.getSelectedRange(), (row, col) => {
+          let hasProperty = checkSelectionConsistency(this.getSelectedRecentlyRange(), (row, col) => {
             let readOnlyProperty = this.getCellMeta(row, col)[META_COMMENT];
             if (readOnlyProperty) {
               readOnlyProperty = readOnlyProperty[META_READONLY];
@@ -723,7 +725,7 @@ class Comments extends BasePlugin {
 
           return label;
         },
-        callback: (key, selection) => this.onContextMenuMakeReadOnly(selection),
+        callback: () => this.onContextMenuMakeReadOnly(),
         disabled: () => this.hot.selection.selectedHeader.corner || !this.checkSelectionCommentsConsistency()
       }
     );

--- a/src/plugins/comments/comments.js
+++ b/src/plugins/comments/comments.js
@@ -431,7 +431,7 @@ class Comments extends BasePlugin {
    * @returns {Boolean}
    */
   checkSelectionCommentsConsistency() {
-    const selected = this.hot.getSelectedRecentlyRange();
+    const selected = this.hot.getSelectedRangeLast();
 
     if (!selected) {
       return false;
@@ -618,7 +618,7 @@ class Comments extends BasePlugin {
    */
   onContextMenuAddComment() {
     this.displaySwitch.cancelHiding();
-    let coords = this.hot.getSelectedRecentlyRange();
+    let coords = this.hot.getSelectedRangeLast();
 
     this.contextMenuEvent = true;
     this.setRange({
@@ -641,7 +641,7 @@ class Comments extends BasePlugin {
   onContextMenuRemoveComment() {
     this.contextMenuEvent = true;
 
-    let {from, to} = this.hot.getSelectedRecentlyRange();
+    let {from, to} = this.hot.getSelectedRangeLast();
 
     for (let i = from.row; i <= to.row; i++) {
       for (let j = from.col; j <= to.col; j++) {
@@ -660,7 +660,7 @@ class Comments extends BasePlugin {
   onContextMenuMakeReadOnly() {
     this.contextMenuEvent = true;
 
-    let {from, to} = this.hot.getSelectedRecentlyRange();
+    let {from, to} = this.hot.getSelectedRangeLast();
 
     for (let i = from.row; i <= to.row; i++) {
       for (let j = from.col; j <= to.col; j++) {
@@ -693,7 +693,7 @@ class Comments extends BasePlugin {
         },
         callback: () => this.onContextMenuAddComment(),
         disabled() {
-          return !(this.getSelectedRecently() && !this.selection.selectedHeader.corner);
+          return !(this.getSelectedLast() && !this.selection.selectedHeader.corner);
         }
       },
       {
@@ -708,7 +708,7 @@ class Comments extends BasePlugin {
         key: 'commentsReadOnly',
         name() {
           let label = this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_READ_ONLY_COMMENT);
-          let hasProperty = checkSelectionConsistency(this.getSelectedRecentlyRange(), (row, col) => {
+          let hasProperty = checkSelectionConsistency(this.getSelectedRangeLast(), (row, col) => {
             let readOnlyProperty = this.getCellMeta(row, col)[META_COMMENT];
             if (readOnlyProperty) {
               readOnlyProperty = readOnlyProperty[META_READONLY];

--- a/src/plugins/contextMenu/menu.js
+++ b/src/plugins/contextMenu/menu.js
@@ -131,7 +131,7 @@ class Menu {
     this.hot.getSettings().outsideClickDeselects = false;
     this.hotMenu = new Core(this.container, settings);
     this.hotMenu.addHook('afterInit', () => this.onAfterInit());
-    this.hotMenu.addHook('afterSelection', (r, c, r2, c2, preventScrolling) => this.onAfterSelection(r, c, r2, c2, preventScrolling));
+    this.hotMenu.addHook('afterSelection', (...args) => this.onAfterSelection(...args));
     this.hotMenu.init();
     this.hotMenu.listen();
     this.blockMainTableCallbacks();
@@ -660,13 +660,10 @@ class Menu {
   /**
    * On after selection listener.
    *
-   * @param {Number} r Selection start row index.
-   * @param {Number} c Selection start column index.
-   * @param {Number} r2 Selection end row index.
-   * @param {Number} c2 Selection end column index.
+   * @param {Array} selectedCells An array with selection coords.
    * @param {Object} preventScrolling Object with `value` property where its value change will be observed.
    */
-  onAfterSelection(r, c, r2, c2, preventScrolling) {
+  onAfterSelection(selectedCells, preventScrolling) {
     if (this.keyEvent === false) {
       preventScrolling.value = true;
     }

--- a/src/plugins/contextMenu/menu.js
+++ b/src/plugins/contextMenu/menu.js
@@ -252,18 +252,18 @@ class Menu {
    * @param {Event} [event]
    */
   executeCommand(event) {
-    if (!this.isOpened() || !this.hotMenu.getSelected()) {
+    if (!this.isOpened() || !this.hotMenu.getSelectedRecently()) {
       return;
     }
-    const selectedItem = this.hotMenu.getSourceDataAtRow(this.hotMenu.getSelected()[0]);
+    const selectedItem = this.hotMenu.getSourceDataAtRow(this.hotMenu.getSelectedRecently()[0]);
 
     this.runLocalHooks('select', selectedItem, event);
 
     if (selectedItem.isCommand === false || selectedItem.name === SEPARATOR) {
       return;
     }
-    const selRange = this.hot.getSelectedRange();
-    const normalizedSelection = selRange ? normalizeSelection(selRange) : {};
+    const selRanges = this.hot.getSelectedRange();
+    const normalizedSelection = selRanges ? normalizeSelection(selRanges) : [];
     let autoClose = true;
 
     // Don't close context menu if item is disabled or it has submenu
@@ -567,7 +567,7 @@ class Menu {
    * @param {Event} event
    */
   onBeforeKeyDown(event) {
-    let selection = this.hotMenu.getSelected();
+    let selection = this.hotMenu.getSelectedRecently();
     let stopEvent = false;
     this.keyEvent = true;
 

--- a/src/plugins/contextMenu/menu.js
+++ b/src/plugins/contextMenu/menu.js
@@ -667,7 +667,7 @@ class Menu {
    * @param {Object} preventScrolling Object with `value` property where its value change will be observed.
    * @param {Number} selectionLayerLevel The number which indicates what selection layer is currently modified.
    */
-  onAfterSelection(r, c, r2, c2, preventScrolling, selectionLayer) {
+  onAfterSelection(r, c, r2, c2, preventScrolling) {
     if (this.keyEvent === false) {
       preventScrolling.value = true;
     }

--- a/src/plugins/contextMenu/menu.js
+++ b/src/plugins/contextMenu/menu.js
@@ -660,10 +660,14 @@ class Menu {
   /**
    * On after selection listener.
    *
-   * @param {Array} selectedCells An array with selection coords.
+   * @param {Number} r Selection start row index.
+   * @param {Number} c Selection start column index.
+   * @param {Number} r2 Selection end row index.
+   * @param {Number} c2 Selection end column index.
    * @param {Object} preventScrolling Object with `value` property where its value change will be observed.
+   * @param {Number} selectionLayerLevel The number which indicates what selection layer is currently modified.
    */
-  onAfterSelection(selectedCells, preventScrolling) {
+  onAfterSelection(r, c, r2, c2, preventScrolling, selectionLayer) {
     if (this.keyEvent === false) {
       preventScrolling.value = true;
     }

--- a/src/plugins/contextMenu/menu.js
+++ b/src/plugins/contextMenu/menu.js
@@ -252,10 +252,10 @@ class Menu {
    * @param {Event} [event]
    */
   executeCommand(event) {
-    if (!this.isOpened() || !this.hotMenu.getSelectedRecently()) {
+    if (!this.isOpened() || !this.hotMenu.getSelectedLast()) {
       return;
     }
-    const selectedItem = this.hotMenu.getSourceDataAtRow(this.hotMenu.getSelectedRecently()[0]);
+    const selectedItem = this.hotMenu.getSourceDataAtRow(this.hotMenu.getSelectedLast()[0]);
 
     this.runLocalHooks('select', selectedItem, event);
 
@@ -567,7 +567,7 @@ class Menu {
    * @param {Event} event
    */
   onBeforeKeyDown(event) {
-    let selection = this.hotMenu.getSelectedRecently();
+    let selection = this.hotMenu.getSelectedLast();
     let stopEvent = false;
     this.keyEvent = true;
 

--- a/src/plugins/contextMenu/predefinedItems/alignment.js
+++ b/src/plugins/contextMenu/predefinedItems/alignment.js
@@ -34,13 +34,13 @@ export default function alignmentItem() {
             return label;
           },
           callback() {
-            let range = this.getSelectedRange();
-            let stateBefore = getAlignmentClasses(range, (row, col) => this.getCellMeta(row, col).className);
-            let type = 'horizontal';
-            let alignment = 'htLeft';
+            const selectedRange = this.getSelectedRange();
+            const stateBefore = getAlignmentClasses(selectedRange, (row, col) => this.getCellMeta(row, col).className);
+            const type = 'horizontal';
+            const alignment = 'htLeft';
 
-            this.runHooks('beforeCellAlignment', stateBefore, range, type, alignment);
-            align(range, type, alignment, (row, col) => this.getCellMeta(row, col),
+            this.runHooks('beforeCellAlignment', stateBefore, selectedRange, type, alignment);
+            align(selectedRange, type, alignment, (row, col) => this.getCellMeta(row, col),
               (row, col, key, value) => this.setCellMeta(row, col, key, value));
             this.render();
           },
@@ -64,14 +64,14 @@ export default function alignmentItem() {
 
             return label;
           },
-          callback() {
-            let range = this.getSelectedRange();
-            let stateBefore = getAlignmentClasses(range, (row, col) => this.getCellMeta(row, col).className);
+          callback(key, selection) {
+            const selectedRange = this.getSelectedRange();
+            let stateBefore = getAlignmentClasses(selectedRange, (row, col) => this.getCellMeta(row, col).className);
             let type = 'horizontal';
             let alignment = 'htCenter';
 
-            this.runHooks('beforeCellAlignment', stateBefore, range, type, alignment);
-            align(range, type, alignment, (row, col) => this.getCellMeta(row, col),
+            this.runHooks('beforeCellAlignment', stateBefore, selectedRange, type, alignment);
+            align(selectedRange, type, alignment, (row, col) => this.getCellMeta(row, col),
               (row, col, key, value) => this.setCellMeta(row, col, key, value));
             this.render();
           },
@@ -96,13 +96,13 @@ export default function alignmentItem() {
             return label;
           },
           callback() {
-            let range = this.getSelectedRange();
-            let stateBefore = getAlignmentClasses(range, (row, col) => this.getCellMeta(row, col).className);
+            const selectedRange = this.getSelectedRange();
+            let stateBefore = getAlignmentClasses(selectedRange, (row, col) => this.getCellMeta(row, col).className);
             let type = 'horizontal';
             let alignment = 'htRight';
 
-            this.runHooks('beforeCellAlignment', stateBefore, range, type, alignment);
-            align(range, type, alignment, (row, col) => this.getCellMeta(row, col),
+            this.runHooks('beforeCellAlignment', stateBefore, selectedRange, type, alignment);
+            align(selectedRange, type, alignment, (row, col) => this.getCellMeta(row, col),
               (row, col, key, value) => this.setCellMeta(row, col, key, value));
             this.render();
           },
@@ -127,13 +127,13 @@ export default function alignmentItem() {
             return label;
           },
           callback() {
-            let range = this.getSelectedRange();
-            let stateBefore = getAlignmentClasses(range, (row, col) => this.getCellMeta(row, col).className);
+            const selectedRange = this.getSelectedRange();
+            let stateBefore = getAlignmentClasses(selectedRange, (row, col) => this.getCellMeta(row, col).className);
             let type = 'horizontal';
             let alignment = 'htJustify';
 
-            this.runHooks('beforeCellAlignment', stateBefore, range, type, alignment);
-            align(range, type, alignment, (row, col) => this.getCellMeta(row, col),
+            this.runHooks('beforeCellAlignment', stateBefore, selectedRange, type, alignment);
+            align(selectedRange, type, alignment, (row, col) => this.getCellMeta(row, col),
               (row, col, key, value) => this.setCellMeta(row, col, key, value));
             this.render();
           },
@@ -160,13 +160,13 @@ export default function alignmentItem() {
             return label;
           },
           callback() {
-            let range = this.getSelectedRange();
-            let stateBefore = getAlignmentClasses(range, (row, col) => this.getCellMeta(row, col).className);
+            const selectedRange = this.getSelectedRange();
+            let stateBefore = getAlignmentClasses(selectedRange, (row, col) => this.getCellMeta(row, col).className);
             let type = 'vertical';
             let alignment = 'htTop';
 
-            this.runHooks('beforeCellAlignment', stateBefore, range, type, alignment);
-            align(range, type, alignment, (row, col) => this.getCellMeta(row, col),
+            this.runHooks('beforeCellAlignment', stateBefore, selectedRange, type, alignment);
+            align(selectedRange, type, alignment, (row, col) => this.getCellMeta(row, col),
               (row, col, key, value) => this.setCellMeta(row, col, key, value));
             this.render();
           },
@@ -191,13 +191,13 @@ export default function alignmentItem() {
             return label;
           },
           callback() {
-            let range = this.getSelectedRange();
-            let stateBefore = getAlignmentClasses(range, (row, col) => this.getCellMeta(row, col).className);
+            const selectedRange = this.getSelectedRange();
+            let stateBefore = getAlignmentClasses(selectedRange, (row, col) => this.getCellMeta(row, col).className);
             let type = 'vertical';
             let alignment = 'htMiddle';
 
-            this.runHooks('beforeCellAlignment', stateBefore, range, type, alignment);
-            align(range, type, alignment, (row, col) => this.getCellMeta(row, col),
+            this.runHooks('beforeCellAlignment', stateBefore, selectedRange, type, alignment);
+            align(selectedRange, type, alignment, (row, col) => this.getCellMeta(row, col),
               (row, col, key, value) => this.setCellMeta(row, col, key, value));
             this.render();
           },
@@ -222,13 +222,13 @@ export default function alignmentItem() {
             return label;
           },
           callback() {
-            let range = this.getSelectedRange();
-            let stateBefore = getAlignmentClasses(range, (row, col) => this.getCellMeta(row, col).className);
+            const selectedRange = this.getSelectedRange();
+            let stateBefore = getAlignmentClasses(selectedRange, (row, col) => this.getCellMeta(row, col).className);
             let type = 'vertical';
             let alignment = 'htBottom';
 
-            this.runHooks('beforeCellAlignment', stateBefore, range, type, alignment);
-            align(range, type, alignment, (row, col) => this.getCellMeta(row, col),
+            this.runHooks('beforeCellAlignment', stateBefore, selectedRange, type, alignment);
+            align(selectedRange, type, alignment, (row, col) => this.getCellMeta(row, col),
               (row, col, key, value) => this.setCellMeta(row, col, key, value));
             this.render();
           },

--- a/src/plugins/contextMenu/predefinedItems/clearColumn.js
+++ b/src/plugins/contextMenu/predefinedItems/clearColumn.js
@@ -11,22 +11,23 @@ export default function clearColumnItem() {
     },
 
     callback(key, selection) {
-      let column = selection.start.col;
+      let column = selection[0].start.col;
 
       if (this.countRows()) {
-        this.populateFromArray(0, column, [[null]], Math.max(selection.start.row, selection.end.row), column, 'ContextMenu.clearColumn');
+        this.populateFromArray(0, column, [[null]], Math.max(selection[0].start.row, selection[0].end.row), column, 'ContextMenu.clearColumn');
       }
     },
     disabled() {
-      let selected = getValidSelection(this);
+      const selected = getValidSelection(this);
 
       if (!selected) {
         return true;
       }
-      let entireRowSelection = [selected[0], 0, selected[0], this.countCols() - 1];
-      let rowSelected = entireRowSelection.join(',') === selected.join(',');
+      const [startRow, startColumn, endRow, endColumn] = selected[0];
+      const entireRowSelection = [startRow, 0, endRow, this.countCols() - 1];
+      const rowSelected = entireRowSelection.join(',') === selected.join(',');
 
-      return selected[1] < 0 || this.countCols() >= this.getSettings().maxCols || rowSelected;
+      return startColumn < 0 || this.countCols() >= this.getSettings().maxCols || rowSelected;
     }
   };
 }

--- a/src/plugins/contextMenu/predefinedItems/clearColumn.js
+++ b/src/plugins/contextMenu/predefinedItems/clearColumn.js
@@ -9,7 +9,6 @@ export default function clearColumnItem() {
     name() {
       return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_CLEAR_COLUMN);
     },
-
     callback(key, selection) {
       let column = selection[0].start.col;
 

--- a/src/plugins/contextMenu/predefinedItems/columnLeft.js
+++ b/src/plugins/contextMenu/predefinedItems/columnLeft.js
@@ -9,8 +9,10 @@ export default function columnLeftItem() {
     name() {
       return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_INSERT_LEFT);
     },
-    callback(key, selection) {
-      this.alter('insert_col', selection[0].start.col, 1, 'ContextMenu.columnLeft');
+    callback(key, normalizedSelection) {
+      const latestSelection = normalizedSelection[Math.max(normalizedSelection.length - 1, 0)];
+
+      this.alter('insert_col', latestSelection.start.col, 1, 'ContextMenu.columnLeft');
     },
     disabled() {
       const selected = getValidSelection(this);
@@ -19,9 +21,6 @@ export default function columnLeftItem() {
         return true;
       }
       if (!this.isColumnModificationAllowed()) {
-        return true;
-      }
-      if (selected.length > 1) {
         return true;
       }
       const [startRow, startColumn, endRow, endColumn] = selected[0];

--- a/src/plugins/contextMenu/predefinedItems/columnLeft.js
+++ b/src/plugins/contextMenu/predefinedItems/columnLeft.js
@@ -10,10 +10,10 @@ export default function columnLeftItem() {
       return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_INSERT_LEFT);
     },
     callback(key, selection) {
-      this.alter('insert_col', selection.start.col, 1, 'ContextMenu.columnLeft');
+      this.alter('insert_col', selection[0].start.col, 1, 'ContextMenu.columnLeft');
     },
     disabled() {
-      let selected = getValidSelection(this);
+      const selected = getValidSelection(this);
 
       if (!selected) {
         return true;
@@ -21,11 +21,15 @@ export default function columnLeftItem() {
       if (!this.isColumnModificationAllowed()) {
         return true;
       }
-      let entireRowSelection = [selected[0], 0, selected[0], this.countCols() - 1];
-      let rowSelected = entireRowSelection.join(',') === selected.join(',');
-      let onlyOneColumn = this.countCols() === 1;
+      if (selected.length > 1) {
+        return true;
+      }
+      const [startRow, startColumn, endRow, endColumn] = selected[0];
+      const entireRowSelection = [startRow, 0, endRow, this.countCols() - 1];
+      const rowSelected = entireRowSelection.join(',') === selected.join(',');
+      const onlyOneColumn = this.countCols() === 1;
 
-      return selected[1] < 0 || this.countCols() >= this.getSettings().maxCols || (!onlyOneColumn && rowSelected);
+      return startColumn < 0 || this.countCols() >= this.getSettings().maxCols || (!onlyOneColumn && rowSelected);
     },
     hidden() {
       return !this.getSettings().allowInsertColumn;

--- a/src/plugins/contextMenu/predefinedItems/columnRight.js
+++ b/src/plugins/contextMenu/predefinedItems/columnRight.js
@@ -11,10 +11,10 @@ export default function columnRightItem() {
     },
 
     callback(key, selection) {
-      this.alter('insert_col', selection.end.col + 1, 1, 'ContextMenu.columnRight');
+      this.alter('insert_col', selection[0].end.col + 1, 1, 'ContextMenu.columnRight');
     },
     disabled() {
-      let selected = getValidSelection(this);
+      const selected = getValidSelection(this);
 
       if (!selected) {
         return true;
@@ -22,11 +22,15 @@ export default function columnRightItem() {
       if (!this.isColumnModificationAllowed()) {
         return true;
       }
-      let entireRowSelection = [selected[0], 0, selected[0], this.countCols() - 1];
-      let rowSelected = entireRowSelection.join(',') === selected.join(',');
-      let onlyOneColumn = this.countCols() === 1;
+      if (selected.length > 1) {
+        return true;
+      }
+      const [startRow, startColumn, endRow, endColumn] = selected[0];
+      const entireRowSelection = [startRow, 0, endRow, this.countCols() - 1];
+      const rowSelected = entireRowSelection.join(',') === selected.join(',');
+      const onlyOneColumn = this.countCols() === 1;
 
-      return selected[1] < 0 || this.countCols() >= this.getSettings().maxCols || (!onlyOneColumn && rowSelected);
+      return startColumn < 0 || this.countCols() >= this.getSettings().maxCols || (!onlyOneColumn && rowSelected);
     },
     hidden() {
       return !this.getSettings().allowInsertColumn;

--- a/src/plugins/contextMenu/predefinedItems/columnRight.js
+++ b/src/plugins/contextMenu/predefinedItems/columnRight.js
@@ -9,9 +9,10 @@ export default function columnRightItem() {
     name() {
       return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_INSERT_RIGHT);
     },
+    callback(key, normalizedSelection) {
+      const latestSelection = normalizedSelection[Math.max(normalizedSelection.length - 1, 0)];
 
-    callback(key, selection) {
-      this.alter('insert_col', selection[0].end.col + 1, 1, 'ContextMenu.columnRight');
+      this.alter('insert_col', latestSelection.end.col + 1, 1, 'ContextMenu.columnRight');
     },
     disabled() {
       const selected = getValidSelection(this);
@@ -20,9 +21,6 @@ export default function columnRightItem() {
         return true;
       }
       if (!this.isColumnModificationAllowed()) {
-        return true;
-      }
-      if (selected.length > 1) {
         return true;
       }
       const [startRow, startColumn, endRow, endColumn] = selected[0];

--- a/src/plugins/contextMenu/predefinedItems/readOnly.js
+++ b/src/plugins/contextMenu/predefinedItems/readOnly.js
@@ -1,4 +1,5 @@
 import {checkSelectionConsistency, markLabelAsSelected} from './../utils';
+import {arrayEach} from './../../../helpers/array';
 import * as C from './../../../i18n/constants';
 
 export const KEY = 'make_read_only';
@@ -17,12 +18,15 @@ export default function readOnlyItem() {
       return label;
     },
     callback() {
-      let range = this.getSelectedRange();
-      let atLeastOneReadOnly = checkSelectionConsistency(range, (row, col) => this.getCellMeta(row, col).readOnly);
+      const ranges = this.getSelectedRange();
+      const atLeastOneReadOnly = checkSelectionConsistency(ranges, (row, col) => this.getCellMeta(row, col).readOnly);
 
-      range.forAll((row, col) => {
-        this.setCellMeta(row, col, 'readOnly', !atLeastOneReadOnly);
+      arrayEach(ranges, (range) => {
+        range.forAll((row, col) => {
+          this.setCellMeta(row, col, 'readOnly', !atLeastOneReadOnly);
+        });
       });
+
       this.render();
     },
     disabled() {

--- a/src/plugins/contextMenu/predefinedItems/redo.js
+++ b/src/plugins/contextMenu/predefinedItems/redo.js
@@ -8,7 +8,6 @@ export default function redoItem() {
     name() {
       return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_REDO);
     },
-
     callback() {
       this.redo();
     },

--- a/src/plugins/contextMenu/predefinedItems/removeColumn.js
+++ b/src/plugins/contextMenu/predefinedItems/removeColumn.js
@@ -1,4 +1,5 @@
 import {getValidSelection} from './../utils';
+import {arrayEach} from './../../../helpers/array';
 import * as C from './../../../i18n/constants';
 
 export const KEY = 'remove_col';
@@ -10,27 +11,35 @@ export default function removeColumnItem() {
       const selection = this.getSelected();
       let pluralForm = 0;
 
-      if (Array.isArray(selection)) {
-        const [, fromColumn, , toColumn] = selection;
-
-        if (fromColumn - toColumn !== 0) {
+      if (selection) {
+        if (selection.length > 1) {
           pluralForm = 1;
+        } else {
+          const [, fromColumn, , toColumn] = selection[0];
+
+          if (fromColumn - toColumn !== 0) {
+            pluralForm = 1;
+          }
         }
       }
 
       return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_REMOVE_COLUMN, pluralForm);
     },
-
     callback(key, selection) {
-      let amount = selection.end.col - selection.start.col + 1;
+      const [{start, end}] = selection;
+      const amount = end.col - start.col + 1;
 
-      this.alter('remove_col', selection.start.col, amount, 'ContextMenu.removeColumn');
+      this.alter('remove_col', start.col, amount, 'ContextMenu.removeColumn');
     },
     disabled() {
       const selected = getValidSelection(this);
       const totalColumns = this.countCols();
 
-      return !selected || this.selection.selectedHeader.rows || this.selection.selectedHeader.corner ||
+      if (!selected || selected.length > 1) {
+        return true;
+      }
+
+      return this.selection.selectedHeader.rows || this.selection.selectedHeader.corner ||
              !this.isColumnModificationAllowed() || !totalColumns;
     },
     hidden() {

--- a/src/plugins/contextMenu/predefinedItems/removeColumn.js
+++ b/src/plugins/contextMenu/predefinedItems/removeColumn.js
@@ -1,5 +1,6 @@
 import {getValidSelection} from './../utils';
 import {arrayEach} from './../../../helpers/array';
+import {transformSelectionToColumnDistance} from './../../../selection/utils';
 import * as C from './../../../i18n/constants';
 
 export const KEY = 'remove_col';
@@ -25,17 +26,14 @@ export default function removeColumnItem() {
 
       return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_REMOVE_COLUMN, pluralForm);
     },
-    callback(key, selection) {
-      const [{start, end}] = selection;
-      const amount = end.col - start.col + 1;
-
-      this.alter('remove_col', start.col, amount, 'ContextMenu.removeColumn');
+    callback() {
+      this.alter('remove_col', transformSelectionToColumnDistance(this.getSelected()), null, 'ContextMenu.removeColumn');
     },
     disabled() {
       const selected = getValidSelection(this);
       const totalColumns = this.countCols();
 
-      if (!selected || selected.length > 1) {
+      if (!selected) {
         return true;
       }
 

--- a/src/plugins/contextMenu/predefinedItems/removeRow.js
+++ b/src/plugins/contextMenu/predefinedItems/removeRow.js
@@ -1,4 +1,5 @@
 import {getValidSelection} from './../utils';
+import {arrayEach} from './../../../helpers/array';
 import * as C from './../../../i18n/constants';
 
 export const KEY = 'remove_row';
@@ -10,26 +11,35 @@ export default function removeRowItem() {
       const selection = this.getSelected();
       let pluralForm = 0;
 
-      if (Array.isArray(selection)) {
-        const [fromRow, , toRow] = selection;
-
-        if (fromRow - toRow !== 0) {
+      if (selection) {
+        if (selection.length > 1) {
           pluralForm = 1;
+        } else {
+          const [fromRow, , toRow] = selection[0];
+
+          if (fromRow - toRow !== 0) {
+            pluralForm = 1;
+          }
         }
       }
 
       return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_REMOVE_ROW, pluralForm);
     },
     callback(key, selection) {
-      let amount = selection.end.row - selection.start.row + 1;
+      const [{start, end}] = selection;
+      const amount = end.row - start.row + 1;
 
-      this.alter('remove_row', selection.start.row, amount, 'ContextMenu.removeRow');
+      this.alter('remove_row', start.row, amount, 'ContextMenu.removeRow');
     },
     disabled() {
       const selected = getValidSelection(this);
       const totalRows = this.countRows();
 
-      return !selected || this.selection.selectedHeader.cols || this.selection.selectedHeader.corner || !totalRows;
+      if (!selected || selected.length > 1) {
+        return true;
+      }
+
+      return this.selection.selectedHeader.cols || this.selection.selectedHeader.corner || !totalRows;
     },
     hidden() {
       return !this.getSettings().allowRemoveRow;

--- a/src/plugins/contextMenu/predefinedItems/removeRow.js
+++ b/src/plugins/contextMenu/predefinedItems/removeRow.js
@@ -1,5 +1,6 @@
 import {getValidSelection} from './../utils';
 import {arrayEach} from './../../../helpers/array';
+import {transformSelectionToRowDistance} from './../../../selection/utils';
 import * as C from './../../../i18n/constants';
 
 export const KEY = 'remove_row';
@@ -25,17 +26,14 @@ export default function removeRowItem() {
 
       return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_REMOVE_ROW, pluralForm);
     },
-    callback(key, selection) {
-      const [{start, end}] = selection;
-      const amount = end.row - start.row + 1;
-
-      this.alter('remove_row', start.row, amount, 'ContextMenu.removeRow');
+    callback() {
+      this.alter('remove_row', transformSelectionToRowDistance(this.getSelected()), null, 'ContextMenu.removeRow');
     },
     disabled() {
       const selected = getValidSelection(this);
       const totalRows = this.countRows();
 
-      if (!selected || selected.length > 1) {
+      if (!selected) {
         return true;
       }
 

--- a/src/plugins/contextMenu/predefinedItems/rowAbove.js
+++ b/src/plugins/contextMenu/predefinedItems/rowAbove.js
@@ -9,14 +9,15 @@ export default function rowAboveItem() {
     name() {
       return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_ROW_ABOVE);
     },
+    callback(key, normalizedSelection) {
+      const latestSelection = normalizedSelection[Math.max(normalizedSelection.length - 1, 0)];
 
-    callback(key, selection) {
-      this.alter('insert_row', selection[0].start.row, 1, 'ContextMenu.rowAbove');
+      this.alter('insert_row', latestSelection.start.row, 1, 'ContextMenu.rowAbove');
     },
     disabled() {
       let selected = getValidSelection(this);
 
-      if (!selected || selected.length > 1) {
+      if (!selected) {
         return true;
       }
 

--- a/src/plugins/contextMenu/predefinedItems/rowAbove.js
+++ b/src/plugins/contextMenu/predefinedItems/rowAbove.js
@@ -11,12 +11,16 @@ export default function rowAboveItem() {
     },
 
     callback(key, selection) {
-      this.alter('insert_row', selection.start.row, 1, 'ContextMenu.rowAbove');
+      this.alter('insert_row', selection[0].start.row, 1, 'ContextMenu.rowAbove');
     },
     disabled() {
       let selected = getValidSelection(this);
 
-      return !selected || this.selection.selectedHeader.cols || this.countRows() >= this.getSettings().maxRows;
+      if (!selected || selected.length > 1) {
+        return true;
+      }
+
+      return this.selection.selectedHeader.cols || this.countRows() >= this.getSettings().maxRows;
     },
     hidden() {
       return !this.getSettings().allowInsertRow;

--- a/src/plugins/contextMenu/predefinedItems/rowBelow.js
+++ b/src/plugins/contextMenu/predefinedItems/rowBelow.js
@@ -9,14 +9,15 @@ export default function rowBelowItem() {
     name() {
       return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_ROW_BELOW);
     },
+    callback(key, normalizedSelection) {
+      const latestSelection = normalizedSelection[Math.max(normalizedSelection.length - 1, 0)];
 
-    callback(key, selection) {
-      this.alter('insert_row', selection[0].end.row + 1, 1, 'ContextMenu.rowBelow');
+      this.alter('insert_row', latestSelection.end.row + 1, 1, 'ContextMenu.rowBelow');
     },
     disabled() {
       let selected = getValidSelection(this);
 
-      if (!selected || selected.length > 1) {
+      if (!selected) {
         return true;
       }
 

--- a/src/plugins/contextMenu/predefinedItems/rowBelow.js
+++ b/src/plugins/contextMenu/predefinedItems/rowBelow.js
@@ -11,12 +11,16 @@ export default function rowBelowItem() {
     },
 
     callback(key, selection) {
-      this.alter('insert_row', selection.end.row + 1, 1, 'ContextMenu.rowBelow');
+      this.alter('insert_row', selection[0].end.row + 1, 1, 'ContextMenu.rowBelow');
     },
     disabled() {
       let selected = getValidSelection(this);
 
-      return !selected || this.selection.selectedHeader.cols || this.countRows() >= this.getSettings().maxRows;
+      if (!selected || selected.length > 1) {
+        return true;
+      }
+
+      return this.selection.selectedHeader.cols || this.countRows() >= this.getSettings().maxRows;
     },
     hidden() {
       return !this.getSettings().allowInsertRow;

--- a/src/plugins/contextMenu/predefinedItems/undo.js
+++ b/src/plugins/contextMenu/predefinedItems/undo.js
@@ -8,7 +8,6 @@ export default function undoItem() {
     name() {
       return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_UNDO);
     },
-
     callback() {
       this.undo();
     },

--- a/src/plugins/contextMenu/test/contextMenu.e2e.js
+++ b/src/plugins/contextMenu/test/contextMenu.e2e.js
@@ -1878,7 +1878,7 @@ describe('ContextMenu', () => {
 
         keyDownUp('arrow_down');
 
-        expect(menuHot.getSelected()).toEqual([0, 0, 0, 0]);
+        expect(menuHot.getSelected()).toEqual([[0, 0, 0, 0]]);
       });
 
       it('should scroll down, when user hits ARROW_DOWN for item in menu below the viewport', () => {
@@ -2091,7 +2091,7 @@ describe('ContextMenu', () => {
 
         keyDownUp('arrow_down');
 
-        expect(menuHot.getSelected()).toEqual([2, 0, 2, 0]);
+        expect(menuHot.getSelected()).toEqual([[2, 0, 2, 0]]);
       });
 
       it('should NOT select any items in menu, when user hits ARROW_DOWN and there is no items enabled', () => {
@@ -2144,7 +2144,7 @@ describe('ContextMenu', () => {
 
         keyDownUp('arrow_up');
 
-        expect(menuHot.getSelected()).toEqual([2, 0, 2, 0]);
+        expect(menuHot.getSelected()).toEqual([[2, 0, 2, 0]]);
       });
 
       it('should select the last NOT DISABLED item in menu, when user hits ARROW_UP', () => {
@@ -2174,7 +2174,7 @@ describe('ContextMenu', () => {
 
         keyDownUp('arrow_up');
 
-        expect(menuHot.getSelected()).toEqual([0, 0, 0, 0]);
+        expect(menuHot.getSelected()).toEqual([[0, 0, 0, 0]]);
       });
 
       it('should NOT select any items in menu, when user hits ARROW_UP and there is no items enabled', () => {
@@ -2234,15 +2234,15 @@ describe('ContextMenu', () => {
 
         keyDownUp('arrow_down');
 
-        expect(menuHot.getSelected()).toEqual([0, 0, 0, 0]);
+        expect(menuHot.getSelected()).toEqual([[0, 0, 0, 0]]);
 
         keyDownUp('arrow_down');
 
-        expect(menuHot.getSelected()).toEqual([1, 0, 1, 0]);
+        expect(menuHot.getSelected()).toEqual([[1, 0, 1, 0]]);
 
         keyDownUp('arrow_down');
 
-        expect(menuHot.getSelected()).toEqual([2, 0, 2, 0]);
+        expect(menuHot.getSelected()).toEqual([[2, 0, 2, 0]]);
       });
 
       it('should select next item (skipping disabled items) when user hits ARROW_DOWN', () => {
@@ -2269,11 +2269,11 @@ describe('ContextMenu', () => {
 
         keyDownUp('arrow_down');
 
-        expect(menuHot.getSelected()).toEqual([0, 0, 0, 0]);
+        expect(menuHot.getSelected()).toEqual([[0, 0, 0, 0]]);
 
         keyDownUp('arrow_down');
 
-        expect(menuHot.getSelected()).toEqual([2, 0, 2, 0]);
+        expect(menuHot.getSelected()).toEqual([[2, 0, 2, 0]]);
       });
 
       it('should select next item (skipping separators) when user hits ARROW_DOWN', () => {
@@ -2300,15 +2300,15 @@ describe('ContextMenu', () => {
 
         keyDownUp('arrow_down');
 
-        expect(menuHot.getSelected()).toEqual([0, 0, 0, 0]);
+        expect(menuHot.getSelected()).toEqual([[0, 0, 0, 0]]);
 
         keyDownUp('arrow_down');
 
-        expect(menuHot.getSelected()).toEqual([2, 0, 2, 0]);
+        expect(menuHot.getSelected()).toEqual([[2, 0, 2, 0]]);
 
         keyDownUp('arrow_down');
 
-        expect(menuHot.getSelected()).toEqual([3, 0, 3, 0]);
+        expect(menuHot.getSelected()).toEqual([[3, 0, 3, 0]]);
       });
 
       it('should not change selection when last item is selected and user hits ARROW_DOWN', () => {
@@ -2334,19 +2334,19 @@ describe('ContextMenu', () => {
 
         keyDownUp('arrow_down');
 
-        expect(menuHot.getSelected()).toEqual([0, 0, 0, 0]);
+        expect(menuHot.getSelected()).toEqual([[0, 0, 0, 0]]);
 
         keyDownUp('arrow_down');
 
-        expect(menuHot.getSelected()).toEqual([1, 0, 1, 0]);
+        expect(menuHot.getSelected()).toEqual([[1, 0, 1, 0]]);
 
         keyDownUp('arrow_down');
 
-        expect(menuHot.getSelected()).toEqual([2, 0, 2, 0]);
+        expect(menuHot.getSelected()).toEqual([[2, 0, 2, 0]]);
 
         keyDownUp('arrow_down');
 
-        expect(menuHot.getSelected()).toEqual([2, 0, 2, 0]);
+        expect(menuHot.getSelected()).toEqual([[2, 0, 2, 0]]);
       });
 
       it('should not change selection when last enabled item is selected and user hits ARROW_DOWN', () => {
@@ -2373,15 +2373,15 @@ describe('ContextMenu', () => {
 
         keyDownUp('arrow_down');
 
-        expect(menuHot.getSelected()).toEqual([0, 0, 0, 0]);
+        expect(menuHot.getSelected()).toEqual([[0, 0, 0, 0]]);
 
         keyDownUp('arrow_down');
 
-        expect(menuHot.getSelected()).toEqual([1, 0, 1, 0]);
+        expect(menuHot.getSelected()).toEqual([[1, 0, 1, 0]]);
 
         keyDownUp('arrow_down');
 
-        expect(menuHot.getSelected()).toEqual([1, 0, 1, 0]);
+        expect(menuHot.getSelected()).toEqual([[1, 0, 1, 0]]);
       });
 
       it('should select next item when user hits ARROW_UP', () => {
@@ -2407,15 +2407,15 @@ describe('ContextMenu', () => {
 
         keyDownUp('arrow_up');
 
-        expect(menuHot.getSelected()).toEqual([2, 0, 2, 0]);
+        expect(menuHot.getSelected()).toEqual([[2, 0, 2, 0]]);
 
         keyDownUp('arrow_up');
 
-        expect(menuHot.getSelected()).toEqual([1, 0, 1, 0]);
+        expect(menuHot.getSelected()).toEqual([[1, 0, 1, 0]]);
 
         keyDownUp('arrow_up');
 
-        expect(menuHot.getSelected()).toEqual([0, 0, 0, 0]);
+        expect(menuHot.getSelected()).toEqual([[0, 0, 0, 0]]);
       });
 
       it('should select next item (skipping disabled items) when user hits ARROW_UP', () => {
@@ -2442,11 +2442,11 @@ describe('ContextMenu', () => {
 
         keyDownUp('arrow_up');
 
-        expect(menuHot.getSelected()).toEqual([2, 0, 2, 0]);
+        expect(menuHot.getSelected()).toEqual([[2, 0, 2, 0]]);
 
         keyDownUp('arrow_up');
 
-        expect(menuHot.getSelected()).toEqual([0, 0, 0, 0]);
+        expect(menuHot.getSelected()).toEqual([[0, 0, 0, 0]]);
       });
 
       it('should select next item (skipping separators) when user hits ARROW_UP', () => {
@@ -2473,15 +2473,15 @@ describe('ContextMenu', () => {
 
         keyDownUp('arrow_up');
 
-        expect(menuHot.getSelected()).toEqual([3, 0, 3, 0]);
+        expect(menuHot.getSelected()).toEqual([[3, 0, 3, 0]]);
 
         keyDownUp('arrow_up');
 
-        expect(menuHot.getSelected()).toEqual([2, 0, 2, 0]);
+        expect(menuHot.getSelected()).toEqual([[2, 0, 2, 0]]);
 
         keyDownUp('arrow_up');
 
-        expect(menuHot.getSelected()).toEqual([0, 0, 0, 0]);
+        expect(menuHot.getSelected()).toEqual([[0, 0, 0, 0]]);
       });
 
       it('should not change selection when first item is selected and user hits ARROW_UP', () => {
@@ -2507,19 +2507,19 @@ describe('ContextMenu', () => {
 
         keyDownUp('arrow_up');
 
-        expect(menuHot.getSelected()).toEqual([2, 0, 2, 0]);
+        expect(menuHot.getSelected()).toEqual([[2, 0, 2, 0]]);
 
         keyDownUp('arrow_up');
 
-        expect(menuHot.getSelected()).toEqual([1, 0, 1, 0]);
+        expect(menuHot.getSelected()).toEqual([[1, 0, 1, 0]]);
 
         keyDownUp('arrow_up');
 
-        expect(menuHot.getSelected()).toEqual([0, 0, 0, 0]);
+        expect(menuHot.getSelected()).toEqual([[0, 0, 0, 0]]);
 
         keyDownUp('arrow_up');
 
-        expect(menuHot.getSelected()).toEqual([0, 0, 0, 0]);
+        expect(menuHot.getSelected()).toEqual([[0, 0, 0, 0]]);
       });
 
       it('should not change selection when first enabled item is selected and user hits ARROW_UP', () => {
@@ -2546,15 +2546,15 @@ describe('ContextMenu', () => {
 
         keyDownUp('arrow_up');
 
-        expect(menuHot.getSelected()).toEqual([2, 0, 2, 0]);
+        expect(menuHot.getSelected()).toEqual([[2, 0, 2, 0]]);
 
         keyDownUp('arrow_up');
 
-        expect(menuHot.getSelected()).toEqual([1, 0, 1, 0]);
+        expect(menuHot.getSelected()).toEqual([[1, 0, 1, 0]]);
 
         keyDownUp('arrow_up');
 
-        expect(menuHot.getSelected()).toEqual([1, 0, 1, 0]);
+        expect(menuHot.getSelected()).toEqual([[1, 0, 1, 0]]);
       });
 
       it('should perform a selected item action, when user hits ENTER', () => {
@@ -2577,7 +2577,7 @@ describe('ContextMenu', () => {
 
         keyDownUp('arrow_down');
 
-        expect(menuHot.getSelected()).toEqual([0, 0, 0, 0]);
+        expect(menuHot.getSelected()).toEqual([[0, 0, 0, 0]]);
 
         expect(itemAction).not.toHaveBeenCalled();
 
@@ -2747,7 +2747,7 @@ describe('ContextMenu', () => {
           selected = hot.getSelected();
         }
 
-        var cell = hot.getCell(selected[0], selected[1]);
+        var cell = hot.getCell(selected[0][0], selected[0][1]);
         var cellOffset = $(cell).offset();
 
         $(cell).simulate('contextmenu', {
@@ -2801,7 +2801,7 @@ describe('ContextMenu', () => {
           selected = hot.getSelected();
         }
 
-        var cell = hot.getCell(selected[0], selected[1]);
+        var cell = hot.getCell(selected[0][0], selected[0][1]);
         var cellOffset = $(cell).offset();
 
         $(cell).simulate('contextmenu', {
@@ -2949,7 +2949,7 @@ describe('ContextMenu', () => {
   });
 
   describe('afterContextMenuDefaultOptions hook', () => {
-    it('should call afterContextMenuDefaultOptions hook with context menu options as the first param', () => {
+    it('should call afterContextMenuDefaultOptions hook with context menu options as the first param', async () => {
       var options;
 
       var afterContextMenuDefaultOptions = function(options_) {
@@ -2962,6 +2962,10 @@ describe('ContextMenu', () => {
       };
 
       Handsontable.hooks.add('afterContextMenuDefaultOptions', afterContextMenuDefaultOptions);
+
+      // Hook `afterContextMenuDefaultOptions` is triggered after all plugin will be initialized or with some timeout.
+      // To make test more stable here is a sleep.
+      await sleep(100);
 
       var hot = handsontable({
         contextMenu: true,

--- a/src/plugins/contextMenu/utils.js
+++ b/src/plugins/contextMenu/utils.js
@@ -1,12 +1,13 @@
-import {arrayEach} from './../../helpers/array';
+import {arrayEach, arrayMap} from './../../helpers/array';
+import {rangeEach} from './../../helpers/number';
 import {hasClass} from './../../helpers/dom/element';
 import {KEY as SEPARATOR} from './predefinedItems/separator';
 
-export function normalizeSelection(selRange) {
-  return {
-    start: selRange.getTopLeftCorner(),
-    end: selRange.getBottomRightCorner()
-  };
+export function normalizeSelection(selRanges) {
+  return arrayMap(selRanges, (range) => ({
+    start: range.getTopLeftCorner(),
+    end: range.getBottomRightCorner()
+  }));
 }
 
 export function isSeparator(cell) {
@@ -69,31 +70,35 @@ export function prepareHorizontalAlignClass(className, alignment) {
   return className;
 }
 
-export function getAlignmentClasses(range, callback) {
+export function getAlignmentClasses(ranges, callback) {
   const classes = {};
 
-  for (let row = range.from.row; row <= range.to.row; row++) {
-    for (let col = range.from.col; col <= range.to.col; col++) {
-      if (!classes[row]) {
-        classes[row] = [];
+  arrayEach(ranges, ({from, to}) => {
+    for (let row = from.row; row <= to.row; row++) {
+      for (let col = from.col; col <= to.col; col++) {
+        if (!classes[row]) {
+          classes[row] = [];
+        }
+        classes[row][col] = callback(row, col);
       }
-      classes[row][col] = callback(row, col);
     }
-  }
+  });
 
   return classes;
 }
 
-export function align(range, type, alignment, cellDescriptor, propertySetter) {
-  if (range.from.row == range.to.row && range.from.col == range.to.col) {
-    applyAlignClassName(range.from.row, range.from.col, type, alignment, cellDescriptor, propertySetter);
-  } else {
-    for (let row = range.from.row; row <= range.to.row; row++) {
-      for (let col = range.from.col; col <= range.to.col; col++) {
-        applyAlignClassName(row, col, type, alignment, cellDescriptor, propertySetter);
+export function align(ranges, type, alignment, cellDescriptor, propertySetter) {
+  arrayEach(ranges, ({from, to}) => {
+    if (from.row == to.row && from.col == to.col) {
+      applyAlignClassName(from.row, from.col, type, alignment, cellDescriptor, propertySetter);
+    } else {
+      for (let row = from.row; row <= to.row; row++) {
+        for (let col = from.col; col <= to.col; col++) {
+          applyAlignClassName(row, col, type, alignment, cellDescriptor, propertySetter);
+        }
       }
     }
-  }
+  });
 }
 
 function applyAlignClassName(row, col, type, alignment, cellDescriptor, propertySetter) {
@@ -111,10 +116,10 @@ function applyAlignClassName(row, col, type, alignment, cellDescriptor, property
   propertySetter(row, col, 'className', className);
 }
 
-export function checkSelectionConsistency(range, comparator) {
+export function checkSelectionConsistency(ranges, comparator) {
   let result = false;
 
-  if (range) {
+  arrayEach(ranges, (range) => {
     range.forAll((row, col) => {
       if (comparator(row, col)) {
         result = true;
@@ -122,7 +127,9 @@ export function checkSelectionConsistency(range, comparator) {
         return false;
       }
     });
-  }
+
+    return result;
+  });
 
   return result;
 }

--- a/src/plugins/contextMenu/utils.js
+++ b/src/plugins/contextMenu/utils.js
@@ -119,17 +119,19 @@ function applyAlignClassName(row, col, type, alignment, cellDescriptor, property
 export function checkSelectionConsistency(ranges, comparator) {
   let result = false;
 
-  arrayEach(ranges, (range) => {
-    range.forAll((row, col) => {
-      if (comparator(row, col)) {
-        result = true;
+  if (Array.isArray(ranges)) {
+    arrayEach(ranges, (range) => {
+      range.forAll((row, col) => {
+        if (comparator(row, col)) {
+          result = true;
 
-        return false;
-      }
+          return false;
+        }
+      });
+
+      return result;
     });
-
-    return result;
-  });
+  }
 
   return result;
 }

--- a/src/plugins/copyPaste/contextMenuItem/copy.js
+++ b/src/plugins/copyPaste/contextMenuItem/copy.js
@@ -10,7 +10,13 @@ export default function copyItem(copyPastePlugin) {
       copyPastePlugin.copy();
     },
     disabled() {
-      return !copyPastePlugin.hot.getSelected();
+      const selected = this.getSelected();
+
+      if (!selected || selected.length > 1) {
+        return true;
+      }
+
+      return false;
     },
     hidden: false
   };

--- a/src/plugins/copyPaste/contextMenuItem/cut.js
+++ b/src/plugins/copyPaste/contextMenuItem/cut.js
@@ -10,7 +10,13 @@ export default function cutItem(copyPastePlugin) {
       copyPastePlugin.cut();
     },
     disabled() {
-      return !copyPastePlugin.hot.getSelected();
+      const selected = this.getSelected();
+
+      if (!selected || selected.length > 1) {
+        return true;
+      }
+
+      return false;
     },
     hidden: false
   };

--- a/src/plugins/copyPaste/copyPaste.js
+++ b/src/plugins/copyPaste/copyPaste.js
@@ -164,20 +164,19 @@ class CopyPaste extends BasePlugin {
    * @memberof CopyPaste#
    */
   setCopyableText() {
-    let selRange = this.hot.getSelectedRange();
+    const selRange = this.hot.getSelectedRecentlyRange();
 
     if (!selRange) {
       return;
     }
-
-    let topLeft = selRange.getTopLeftCorner();
-    let bottomRight = selRange.getBottomRightCorner();
-    let startRow = topLeft.row;
-    let startCol = topLeft.col;
-    let endRow = bottomRight.row;
-    let endCol = bottomRight.col;
-    let finalEndRow = Math.min(endRow, startRow + this.rowsLimit - 1);
-    let finalEndCol = Math.min(endCol, startCol + this.columnsLimit - 1);
+    const topLeft = selRange.getTopLeftCorner();
+    const bottomRight = selRange.getBottomRightCorner();
+    const startRow = topLeft.row;
+    const startCol = topLeft.col;
+    const endRow = bottomRight.row;
+    const endCol = bottomRight.col;
+    const finalEndRow = Math.min(endRow, startRow + this.rowsLimit - 1);
+    const finalEndCol = Math.min(endCol, startCol + this.columnsLimit - 1);
 
     this.copyableRanges.length = 0;
 
@@ -242,9 +241,9 @@ class CopyPaste extends BasePlugin {
    * @returns {Array} Returns array of arrays which will be copied into clipboard.
    */
   getRangedData(ranges) {
-    let dataSet = [];
-    let copyableRows = [];
-    let copyableColumns = [];
+    const dataSet = [];
+    const copyableRows = [];
+    const copyableColumns = [];
 
     // Count all copyable rows and columns
     arrayEach(ranges, (range) => {
@@ -429,7 +428,7 @@ class CopyPaste extends BasePlugin {
       return;
     }
 
-    let selected = this.hot.getSelected();
+    let selected = this.hot.getSelectedRecently();
     let coordsFrom = new CellCoords(selected[0], selected[1]);
     let coordsTo = new CellCoords(selected[2], selected[3]);
     let cellRange = new CellRange(coordsFrom, coordsFrom, coordsTo);

--- a/src/plugins/copyPaste/copyPaste.js
+++ b/src/plugins/copyPaste/copyPaste.js
@@ -386,7 +386,7 @@ class CopyPaste extends BasePlugin {
         window.clipboardData.setData('Text', value);
       }
 
-      this.hot.selection.empty();
+      this.hot.emptySelectedCells();
       this.hot.runHooks('afterCut', rangedData, this.copyableRanges);
     }
 

--- a/src/plugins/copyPaste/copyPaste.js
+++ b/src/plugins/copyPaste/copyPaste.js
@@ -164,7 +164,7 @@ class CopyPaste extends BasePlugin {
    * @memberof CopyPaste#
    */
   setCopyableText() {
-    const selRange = this.hot.getSelectedRecentlyRange();
+    const selRange = this.hot.getSelectedRangeLast();
 
     if (!selRange) {
       return;
@@ -428,7 +428,7 @@ class CopyPaste extends BasePlugin {
       return;
     }
 
-    let selected = this.hot.getSelectedRecently();
+    let selected = this.hot.getSelectedLast();
     let coordsFrom = new CellCoords(selected[0], selected[1]);
     let coordsTo = new CellCoords(selected[2], selected[3]);
     let cellRange = new CellRange(coordsFrom, coordsFrom, coordsTo);

--- a/src/plugins/copyPaste/test/copyPaste.e2e.js
+++ b/src/plugins/copyPaste/test/copyPaste.e2e.js
@@ -147,7 +147,7 @@ describe('CopyPaste', () => {
       expect(copyPasteTextarea.value.length).toEqual(0);
 
       selectCell(0, 0, 1, 1);
-      keyDownUp(Handsontable.helper.KEY_CODES.CONTROL_LEFT);
+      keyDownUp(Handsontable.helper.KEY_CODES.CONTROL);
 
       expect(copyPasteTextarea.value).toEqual('A\t1\nB\t2');
     });

--- a/src/plugins/copyPaste/test/copyPaste.e2e.js
+++ b/src/plugins/copyPaste/test/copyPaste.e2e.js
@@ -115,7 +115,7 @@ describe('CopyPaste', () => {
       $(document.activeElement).simulate('keydown', {keyCode: Handsontable.helper.KEY_CODES.A, ctrlKey: true});
 
       setTimeout(() => {
-        expect(getSelected()).toEqual([0, 0, 1, 1]);
+        expect(getSelected()).toEqual([[0, 0, 1, 1]]);
         expect(copyPasteTextarea.value).toEqual('A1\tB1\nA2\tB2');
         done();
       }, 10);
@@ -533,7 +533,7 @@ describe('CopyPaste', () => {
       spec().$container.find('tbody tr:eq(1) td:eq(0)').simulate('mousedown');
       spec().$container.find('tbody tr:eq(1) td:eq(0)').simulate('mouseup');
 
-      expect(getSelected()).toEqual([1, 0, 1, 0]);
+      expect(getSelected()).toEqual([[1, 0, 1, 0]]);
 
       $('html').simulate('mousedown').simulate('mouseup');
 

--- a/src/plugins/customBorders/customBorders.js
+++ b/src/plugins/customBorders/customBorders.js
@@ -1,5 +1,6 @@
 import Hooks from './../../pluginHooks';
 import {hasOwnProperty} from './../../helpers/object';
+import {arrayEach} from './../../helpers/array';
 import {CellRange, Selection} from './../../3rdparty/walkontable/src';
 import * as C from './../../i18n/constants';
 
@@ -81,13 +82,17 @@ var init = function() {
  * @returns {Number}
  */
 var getSettingIndex = function(className) {
-  for (var i = 0; i < instance.view.wt.selections.length; i++) {
-    if (instance.view.wt.selections[i].settings.className == className) {
-      return i;
-    }
-  }
+  let index = -1;
 
-  return -1;
+  arrayEach(instance.selection.highlight.borders, (selection, i) => {
+    if (selection.settings.className == className) {
+      index = i;
+
+      return false;
+    }
+  });
+
+  return index;
 };
 
 /** *
@@ -104,9 +109,9 @@ var insertBorderIntoSettings = function(border) {
   var index = getSettingIndex(border.className);
 
   if (index >= 0) {
-    instance.view.wt.selections[index] = selection;
+    instance.selection.highlight.borders[index] = selection;
   } else {
-    instance.view.wt.selections.push(selection);
+    instance.selection.highlight.borders.push(selection);
   }
 };
 

--- a/src/plugins/manualColumnFreeze/contextMenuItem/freezeColumn.js
+++ b/src/plugins/manualColumnFreeze/contextMenuItem/freezeColumn.js
@@ -6,8 +6,8 @@ export default function freezeColumnItem(manualColumnFreezePlugin) {
     name() {
       return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_FREEZE_COLUMN);
     },
-    callback() {
-      let selectedColumn = this.getSelectedRange().from.col;
+    callback(key, selected) {
+      const [{start: {col: selectedColumn}}] = selected;
 
       manualColumnFreezePlugin.freezeColumn(selectedColumn);
 
@@ -21,7 +21,10 @@ export default function freezeColumnItem(manualColumnFreezePlugin) {
       if (selection === void 0) {
         hide = true;
 
-      } else if ((selection.from.col !== selection.to.col) || (selection.from.col <= this.getSettings().fixedColumnsLeft - 1)) {
+      } else if (selection.length > 1) {
+        hide = true;
+
+      } else if ((selection[0].from.col !== selection[0].to.col) || (selection[0].from.col <= this.getSettings().fixedColumnsLeft - 1)) {
         hide = true;
       }
 

--- a/src/plugins/manualColumnFreeze/contextMenuItem/unfreezeColumn.js
+++ b/src/plugins/manualColumnFreeze/contextMenuItem/unfreezeColumn.js
@@ -6,8 +6,8 @@ export default function unfreezeColumnItem(manualColumnFreezePlugin) {
     name() {
       return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_UNFREEZE_COLUMN);
     },
-    callback() {
-      let selectedColumn = this.getSelectedRange().from.col;
+    callback(key, selected) {
+      const [{start: {col: selectedColumn}}] = selected;
 
       manualColumnFreezePlugin.unfreezeColumn(selectedColumn);
 
@@ -21,7 +21,10 @@ export default function unfreezeColumnItem(manualColumnFreezePlugin) {
       if (selection === void 0) {
         hide = true;
 
-      } else if ((selection.from.col !== selection.to.col) || selection.from.col >= this.getSettings().fixedColumnsLeft) {
+      } else if (selection.length > 1) {
+        hide = true;
+
+      } else if ((selection[0].from.col !== selection[0].to.col) || selection[0].from.col >= this.getSettings().fixedColumnsLeft) {
         hide = true;
       }
 

--- a/src/plugins/manualColumnMove/manualColumnMove.js
+++ b/src/plugins/manualColumnMove/manualColumnMove.js
@@ -466,7 +466,7 @@ class ManualColumnMove extends BasePlugin {
   onBeforeOnCellMouseDown(event, coords, TD, blockCalculations) {
     let wtTable = this.hot.view.wt.wtTable;
     let isHeaderSelection = this.hot.selection.selectedHeader.cols;
-    let selection = this.hot.getSelectedRecentlyRange();
+    let selection = this.hot.getSelectedRangeLast();
     let priv = privatePool.get(this);
     let isSortingElement = event.realTarget.className.indexOf('columnSorting') > -1;
 
@@ -561,7 +561,7 @@ class ManualColumnMove extends BasePlugin {
    * @param {Object} blockCalculations Object which contains information about blockCalculation for row, column or cells.
    */
   onBeforeOnCellMouseOver(event, coords, TD, blockCalculations) {
-    let selectedRange = this.hot.getSelectedRecentlyRange();
+    let selectedRange = this.hot.getSelectedRangeLast();
     let priv = privatePool.get(this);
 
     if (!selectedRange || !priv.pressed) {

--- a/src/plugins/manualColumnMove/manualColumnMove.js
+++ b/src/plugins/manualColumnMove/manualColumnMove.js
@@ -466,7 +466,7 @@ class ManualColumnMove extends BasePlugin {
   onBeforeOnCellMouseDown(event, coords, TD, blockCalculations) {
     let wtTable = this.hot.view.wt.wtTable;
     let isHeaderSelection = this.hot.selection.selectedHeader.cols;
-    let selection = this.hot.getSelectedRange();
+    let selection = this.hot.getSelectedRecentlyRange();
     let priv = privatePool.get(this);
     let isSortingElement = event.realTarget.className.indexOf('columnSorting') > -1;
 
@@ -561,7 +561,7 @@ class ManualColumnMove extends BasePlugin {
    * @param {Object} blockCalculations Object which contains information about blockCalculation for row, column or cells.
    */
   onBeforeOnCellMouseOver(event, coords, TD, blockCalculations) {
-    let selectedRange = this.hot.getSelectedRange();
+    let selectedRange = this.hot.getSelectedRecentlyRange();
     let priv = privatePool.get(this);
 
     if (!selectedRange || !priv.pressed) {

--- a/src/plugins/manualColumnResize/manualColumnResize.js
+++ b/src/plugins/manualColumnResize/manualColumnResize.js
@@ -147,7 +147,7 @@ class ManualColumnResize extends BasePlugin {
       this.selectedCols = [];
 
       if (this.hot.selection.isSelected() && this.hot.selection.selectedHeader.cols) {
-        let {from, to} = this.hot.getSelectedRange();
+        let {from, to} = this.hot.getSelectedRecentlyRange();
         let start = from.col;
         let end = to.col;
 

--- a/src/plugins/manualColumnResize/manualColumnResize.js
+++ b/src/plugins/manualColumnResize/manualColumnResize.js
@@ -147,7 +147,7 @@ class ManualColumnResize extends BasePlugin {
       this.selectedCols = [];
 
       if (this.hot.selection.isSelected() && this.hot.selection.selectedHeader.cols) {
-        let {from, to} = this.hot.getSelectedRecentlyRange();
+        let {from, to} = this.hot.getSelectedRangeLast();
         let start = from.col;
         let end = to.col;
 

--- a/src/plugins/manualRowMove/manualRowMove.js
+++ b/src/plugins/manualRowMove/manualRowMove.js
@@ -308,7 +308,7 @@ class ManualRowMove extends BasePlugin {
    * @returns {Array}
    */
   prepareRowsToMoving() {
-    let selection = this.hot.getSelectedRange();
+    let selection = this.hot.getSelectedRecentlyRange();
     let selectedRows = [];
 
     if (!selection) {
@@ -485,7 +485,7 @@ class ManualRowMove extends BasePlugin {
   onBeforeOnCellMouseDown(event, coords, TD, blockCalculations) {
     let wtTable = this.hot.view.wt.wtTable;
     let isHeaderSelection = this.hot.selection.selectedHeader.rows;
-    let selection = this.hot.getSelectedRange();
+    let selection = this.hot.getSelectedRecentlyRange();
     let priv = privatePool.get(this);
 
     if (!selection || !isHeaderSelection || priv.pressed || event.button !== 0) {
@@ -569,7 +569,7 @@ class ManualRowMove extends BasePlugin {
    * @param {Object} blockCalculations Object which contains information about blockCalculation for row, column or cells.
    */
   onBeforeOnCellMouseOver(event, coords, TD, blockCalculations) {
-    let selectedRange = this.hot.getSelectedRange();
+    let selectedRange = this.hot.getSelectedRecentlyRange();
     let priv = privatePool.get(this);
 
     if (!selectedRange || !priv.pressed) {

--- a/src/plugins/manualRowMove/manualRowMove.js
+++ b/src/plugins/manualRowMove/manualRowMove.js
@@ -308,7 +308,7 @@ class ManualRowMove extends BasePlugin {
    * @returns {Array}
    */
   prepareRowsToMoving() {
-    let selection = this.hot.getSelectedRecentlyRange();
+    let selection = this.hot.getSelectedRangeLast();
     let selectedRows = [];
 
     if (!selection) {
@@ -485,7 +485,7 @@ class ManualRowMove extends BasePlugin {
   onBeforeOnCellMouseDown(event, coords, TD, blockCalculations) {
     let wtTable = this.hot.view.wt.wtTable;
     let isHeaderSelection = this.hot.selection.selectedHeader.rows;
-    let selection = this.hot.getSelectedRecentlyRange();
+    let selection = this.hot.getSelectedRangeLast();
     let priv = privatePool.get(this);
 
     if (!selection || !isHeaderSelection || priv.pressed || event.button !== 0) {
@@ -569,7 +569,7 @@ class ManualRowMove extends BasePlugin {
    * @param {Object} blockCalculations Object which contains information about blockCalculation for row, column or cells.
    */
   onBeforeOnCellMouseOver(event, coords, TD, blockCalculations) {
-    let selectedRange = this.hot.getSelectedRecentlyRange();
+    let selectedRange = this.hot.getSelectedRangeLast();
     let priv = privatePool.get(this);
 
     if (!selectedRange || !priv.pressed) {

--- a/src/plugins/manualRowResize/manualRowResize.js
+++ b/src/plugins/manualRowResize/manualRowResize.js
@@ -141,7 +141,7 @@ class ManualRowResize extends BasePlugin {
       this.selectedRows = [];
 
       if (this.hot.selection.isSelected() && this.hot.selection.selectedHeader.rows) {
-        let {from, to} = this.hot.getSelectedRange();
+        let {from, to} = this.hot.getSelectedRecentlyRange();
         let start = from.row;
         let end = to.row;
 

--- a/src/plugins/manualRowResize/manualRowResize.js
+++ b/src/plugins/manualRowResize/manualRowResize.js
@@ -141,7 +141,7 @@ class ManualRowResize extends BasePlugin {
       this.selectedRows = [];
 
       if (this.hot.selection.isSelected() && this.hot.selection.selectedHeader.rows) {
-        let {from, to} = this.hot.getSelectedRecentlyRange();
+        let {from, to} = this.hot.getSelectedRangeLast();
         let start = from.row;
         let end = to.row;
 

--- a/src/plugins/mergeCells/mergeCells.js
+++ b/src/plugins/mergeCells/mergeCells.js
@@ -356,7 +356,7 @@ var onBeforeKeyDown = function(event) {
 
   if (ctrlDown) {
     if (event.keyCode === 77) { // CTRL + M
-      this.mergeCells.mergeOrUnmergeSelection(this.getSelectedRange());
+      this.mergeCells.mergeOrUnmergeSelection(this.getSelectedRecentlyRange());
       this.render();
       stopImmediatePropagation(event);
     }
@@ -372,7 +372,7 @@ var addMergeActionsToContextMenu = function(defaultOptions) {
   defaultOptions.items.push({
     key: 'mergeCells',
     name() {
-      var sel = this.getSelected();
+      var sel = this.getSelectedRecentlyRange();
       var info = this.mergeCells.mergedCellInfoCollection.getInfo(sel[0], sel[1]);
 
       if (info) {
@@ -382,7 +382,7 @@ var addMergeActionsToContextMenu = function(defaultOptions) {
       return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_MERGE_CELLS);
     },
     callback() {
-      this.mergeCells.mergeOrUnmergeSelection(this.getSelectedRange());
+      this.mergeCells.mergeOrUnmergeSelection(this.getSelectedRecentlyRange());
       this.render();
     },
     disabled() {
@@ -401,7 +401,7 @@ var modifyTransformFactory = function(hook) {
   return function(delta) {
     var mergeCellsSetting = this.getSettings().mergeCells;
     if (mergeCellsSetting) {
-      var currentSelectedRange = this.getSelectedRange();
+      var currentSelectedRange = this.getSelectedRecentlyRange();
       this.mergeCells.modifyTransform(hook, currentSelectedRange, delta);
 
       if (hook === 'modifyTransformEnd') {
@@ -433,7 +433,7 @@ var beforeSetRangeEnd = function(coords) {
   this.lastDesiredCoords = null; // unset lastDesiredCoords when selection is changed with mouse
   var mergeCellsSetting = this.getSettings().mergeCells;
   if (mergeCellsSetting) {
-    var selRange = this.getSelectedRange();
+    var selRange = this.getSelectedRecentlyRange();
     selRange.highlight = new CellCoords(selRange.highlight.row, selRange.highlight.col); // clone in case we will modify its reference
     selRange.to = coords;
 
@@ -468,7 +468,7 @@ var beforeDrawAreaBorders = function(corners, className) {
   if (className && className == 'area') {
     var mergeCellsSetting = this.getSettings().mergeCells;
     if (mergeCellsSetting) {
-      var selRange = this.getSelectedRange();
+      var selRange = this.getSelectedRecentlyRange();
       var startRange = new CellRange(selRange.from, selRange.from, selRange.from);
       var stopRange = new CellRange(selRange.to, selRange.to, selRange.to);
 
@@ -556,7 +556,7 @@ var afterViewportColumnCalculatorOverride = function(calc) {
 var isMultipleSelection = function(isMultiple) {
   if (isMultiple && this.mergeCells) {
     var mergedCells = this.mergeCells.mergedCellInfoCollection,
-      selectionRange = this.getSelectedRange();
+      selectionRange = this.getSelectedRecentlyRange();
 
     for (var group in mergedCells) {
       if (selectionRange.highlight.row == mergedCells[group].row &&

--- a/src/plugins/mergeCells/mergeCells.js
+++ b/src/plugins/mergeCells/mergeCells.js
@@ -356,7 +356,7 @@ var onBeforeKeyDown = function(event) {
 
   if (ctrlDown) {
     if (event.keyCode === 77) { // CTRL + M
-      this.mergeCells.mergeOrUnmergeSelection(this.getSelectedRecentlyRange());
+      this.mergeCells.mergeOrUnmergeSelection(this.getSelectedRangeLast());
       this.render();
       stopImmediatePropagation(event);
     }
@@ -372,7 +372,7 @@ var addMergeActionsToContextMenu = function(defaultOptions) {
   defaultOptions.items.push({
     key: 'mergeCells',
     name() {
-      var sel = this.getSelectedRecentlyRange();
+      var sel = this.getSelectedRangeLast();
       var info = this.mergeCells.mergedCellInfoCollection.getInfo(sel[0], sel[1]);
 
       if (info) {
@@ -382,7 +382,7 @@ var addMergeActionsToContextMenu = function(defaultOptions) {
       return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_MERGE_CELLS);
     },
     callback() {
-      this.mergeCells.mergeOrUnmergeSelection(this.getSelectedRecentlyRange());
+      this.mergeCells.mergeOrUnmergeSelection(this.getSelectedRangeLast());
       this.render();
     },
     disabled() {
@@ -401,7 +401,7 @@ var modifyTransformFactory = function(hook) {
   return function(delta) {
     var mergeCellsSetting = this.getSettings().mergeCells;
     if (mergeCellsSetting) {
-      var currentSelectedRange = this.getSelectedRecentlyRange();
+      var currentSelectedRange = this.getSelectedRangeLast();
       this.mergeCells.modifyTransform(hook, currentSelectedRange, delta);
 
       if (hook === 'modifyTransformEnd') {
@@ -433,7 +433,7 @@ var beforeSetRangeEnd = function(coords) {
   this.lastDesiredCoords = null; // unset lastDesiredCoords when selection is changed with mouse
   var mergeCellsSetting = this.getSettings().mergeCells;
   if (mergeCellsSetting) {
-    var selRange = this.getSelectedRecentlyRange();
+    var selRange = this.getSelectedRangeLast();
     selRange.highlight = new CellCoords(selRange.highlight.row, selRange.highlight.col); // clone in case we will modify its reference
     selRange.to = coords;
 
@@ -468,7 +468,7 @@ var beforeDrawAreaBorders = function(corners, className) {
   if (className && className == 'area') {
     var mergeCellsSetting = this.getSettings().mergeCells;
     if (mergeCellsSetting) {
-      var selRange = this.getSelectedRecentlyRange();
+      var selRange = this.getSelectedRangeLast();
       var startRange = new CellRange(selRange.from, selRange.from, selRange.from);
       var stopRange = new CellRange(selRange.to, selRange.to, selRange.to);
 
@@ -556,7 +556,7 @@ var afterViewportColumnCalculatorOverride = function(calc) {
 var isMultipleSelection = function(isMultiple) {
   if (isMultiple && this.mergeCells) {
     var mergedCells = this.mergeCells.mergedCellInfoCollection,
-      selectionRange = this.getSelectedRecentlyRange();
+      selectionRange = this.getSelectedRangeLast();
 
     for (var group in mergedCells) {
       if (selectionRange.highlight.row == mergedCells[group].row &&

--- a/src/plugins/mergeCells/test/canMergeRange.e2e.js
+++ b/src/plugins/mergeCells/test/canMergeRange.e2e.js
@@ -134,13 +134,13 @@ describe('MergeCells', () => {
 
       hot.selectCell(0, 0);
 
-      expect(hot.getSelected()).toEqual([0, 0, 0, 3]);
+      expect(hot.getSelected()).toEqual([[0, 0, 0, 3]]);
 
       deselectCell();
 
       hot.selectCell(0, 1);
 
-      expect(hot.getSelected()).toEqual([0, 0, 0, 3]);
+      expect(hot.getSelected()).toEqual([[0, 0, 0, 3]]);
     });
 
     it('should always make a rectangular selection, when selecting merged and not merged cells', function() {
@@ -166,20 +166,20 @@ describe('MergeCells', () => {
 
       hot.selectCell(0, 0);
 
-      expect(hot.getSelected()).toEqual([0, 0, 0, 0]);
+      expect(hot.getSelected()).toEqual([[0, 0, 0, 0]]);
 
       deselectCell();
 
       hot.selectCell(0, 0, 1, 1);
 
-      expect(hot.getSelected()).not.toEqual([0, 0, 1, 1]);
-      expect(hot.getSelected()).toEqual([0, 0, 2, 3]);
+      expect(hot.getSelected()).not.toEqual([[0, 0, 1, 1]]);
+      expect(hot.getSelected()).toEqual([[0, 0, 2, 3]]);
 
       deselectCell();
 
       hot.selectCell(0, 1, 1, 1);
 
-      expect(hot.getSelected()).toEqual([0, 1, 2, 3]);
+      expect(hot.getSelected()).toEqual([[0, 1, 2, 3]]);
     });
 
     it('should not switch the selection start point when selecting from non-merged cells to merged cells', () => {
@@ -193,23 +193,23 @@ describe('MergeCells', () => {
 
       $(hot.getCell(6, 6)).simulate('mousedown');
 
-      expect(hot.getSelectedRange().from.col).toEqual(6);
-      expect(hot.getSelectedRange().from.row).toEqual(6);
+      expect(hot.getSelectedRecentlyRange().from.col).toEqual(6);
+      expect(hot.getSelectedRecentlyRange().from.row).toEqual(6);
 
       $(hot.getCell(1, 1)).simulate('mouseenter');
 
-      expect(hot.getSelectedRange().from.col).toEqual(6);
-      expect(hot.getSelectedRange().from.row).toEqual(6);
+      expect(hot.getSelectedRecentlyRange().from.col).toEqual(6);
+      expect(hot.getSelectedRecentlyRange().from.row).toEqual(6);
 
       $(hot.getCell(3, 3)).simulate('mouseenter');
 
-      expect(hot.getSelectedRange().from.col).toEqual(6);
-      expect(hot.getSelectedRange().from.row).toEqual(6);
+      expect(hot.getSelectedRecentlyRange().from.col).toEqual(6);
+      expect(hot.getSelectedRecentlyRange().from.row).toEqual(6);
 
       $(hot.getCell(4, 4)).simulate('mouseenter');
 
-      expect(hot.getSelectedRange().from.col).toEqual(6);
-      expect(hot.getSelectedRange().from.row).toEqual(6);
+      expect(hot.getSelectedRecentlyRange().from.col).toEqual(6);
+      expect(hot.getSelectedRecentlyRange().from.row).toEqual(6);
 
     });
 
@@ -222,16 +222,16 @@ describe('MergeCells', () => {
       });
 
       hot.selectCell(5, 5, 5, 2);
-      expect(hot.getSelectedRange().getDirection()).toEqual('SE-NW');
+      expect(hot.getSelectedRecentlyRange().getDirection()).toEqual('SE-NW');
 
       hot.selectCell(4, 4, 2, 5);
-      expect(hot.getSelectedRange().getDirection()).toEqual('SW-NE');
+      expect(hot.getSelectedRecentlyRange().getDirection()).toEqual('SW-NE');
 
       hot.selectCell(4, 4, 5, 7);
-      expect(hot.getSelectedRange().getDirection()).toEqual('NW-SE');
+      expect(hot.getSelectedRecentlyRange().getDirection()).toEqual('NW-SE');
 
       hot.selectCell(4, 5, 7, 5);
-      expect(hot.getSelectedRange().getDirection()).toEqual('NE-SW');
+      expect(hot.getSelectedRecentlyRange().getDirection()).toEqual('NE-SW');
     });
 
     it('should not add an area class to the selected cell if a single merged cell is selected', () => {

--- a/src/plugins/mergeCells/test/canMergeRange.e2e.js
+++ b/src/plugins/mergeCells/test/canMergeRange.e2e.js
@@ -193,23 +193,23 @@ describe('MergeCells', () => {
 
       $(hot.getCell(6, 6)).simulate('mousedown');
 
-      expect(hot.getSelectedRecentlyRange().from.col).toEqual(6);
-      expect(hot.getSelectedRecentlyRange().from.row).toEqual(6);
+      expect(hot.getSelectedRangeLast().from.col).toEqual(6);
+      expect(hot.getSelectedRangeLast().from.row).toEqual(6);
 
       $(hot.getCell(1, 1)).simulate('mouseenter');
 
-      expect(hot.getSelectedRecentlyRange().from.col).toEqual(6);
-      expect(hot.getSelectedRecentlyRange().from.row).toEqual(6);
+      expect(hot.getSelectedRangeLast().from.col).toEqual(6);
+      expect(hot.getSelectedRangeLast().from.row).toEqual(6);
 
       $(hot.getCell(3, 3)).simulate('mouseenter');
 
-      expect(hot.getSelectedRecentlyRange().from.col).toEqual(6);
-      expect(hot.getSelectedRecentlyRange().from.row).toEqual(6);
+      expect(hot.getSelectedRangeLast().from.col).toEqual(6);
+      expect(hot.getSelectedRangeLast().from.row).toEqual(6);
 
       $(hot.getCell(4, 4)).simulate('mouseenter');
 
-      expect(hot.getSelectedRecentlyRange().from.col).toEqual(6);
-      expect(hot.getSelectedRecentlyRange().from.row).toEqual(6);
+      expect(hot.getSelectedRangeLast().from.col).toEqual(6);
+      expect(hot.getSelectedRangeLast().from.row).toEqual(6);
 
     });
 
@@ -222,16 +222,16 @@ describe('MergeCells', () => {
       });
 
       hot.selectCell(5, 5, 5, 2);
-      expect(hot.getSelectedRecentlyRange().getDirection()).toEqual('SE-NW');
+      expect(hot.getSelectedRangeLast().getDirection()).toEqual('SE-NW');
 
       hot.selectCell(4, 4, 2, 5);
-      expect(hot.getSelectedRecentlyRange().getDirection()).toEqual('SW-NE');
+      expect(hot.getSelectedRangeLast().getDirection()).toEqual('SW-NE');
 
       hot.selectCell(4, 4, 5, 7);
-      expect(hot.getSelectedRecentlyRange().getDirection()).toEqual('NW-SE');
+      expect(hot.getSelectedRangeLast().getDirection()).toEqual('NW-SE');
 
       hot.selectCell(4, 5, 7, 5);
-      expect(hot.getSelectedRecentlyRange().getDirection()).toEqual('NE-SW');
+      expect(hot.getSelectedRangeLast().getDirection()).toEqual('NE-SW');
     });
 
     it('should not add an area class to the selected cell if a single merged cell is selected', () => {

--- a/src/plugins/multipleSelectionHandles/multipleSelectionHandles.js
+++ b/src/plugins/multipleSelectionHandles/multipleSelectionHandles.js
@@ -86,7 +86,7 @@ class MultipleSelectionHandles extends BasePlugin {
       let selectedRange;
 
       if (hasClass(event.target, 'topLeftSelectionHandle-HitArea')) {
-        selectedRange = _this.hot.getSelectedRange();
+        selectedRange = _this.hot.getSelectedRecentlyRange();
 
         _this.dragged.push('topLeft');
 
@@ -100,7 +100,7 @@ class MultipleSelectionHandles extends BasePlugin {
         return false;
 
       } else if (hasClass(event.target, 'bottomRightSelectionHandle-HitArea')) {
-        selectedRange = _this.hot.getSelectedRange();
+        selectedRange = _this.hot.getSelectedRecentlyRange();
 
         _this.dragged.push('bottomRight');
 
@@ -164,7 +164,7 @@ class MultipleSelectionHandles extends BasePlugin {
           targetCoords.col = 0;
         }
 
-        selectedRange = _this.hot.getSelectedRange();
+        selectedRange = _this.hot.getSelectedRecentlyRange();
         rangeWidth = selectedRange.getWidth();
         rangeHeight = selectedRange.getHeight();
         rangeDirection = selectedRange.getDirection();

--- a/src/plugins/multipleSelectionHandles/multipleSelectionHandles.js
+++ b/src/plugins/multipleSelectionHandles/multipleSelectionHandles.js
@@ -86,7 +86,7 @@ class MultipleSelectionHandles extends BasePlugin {
       let selectedRange;
 
       if (hasClass(event.target, 'topLeftSelectionHandle-HitArea')) {
-        selectedRange = _this.hot.getSelectedRecentlyRange();
+        selectedRange = _this.hot.getSelectedRangeLast();
 
         _this.dragged.push('topLeft');
 
@@ -100,7 +100,7 @@ class MultipleSelectionHandles extends BasePlugin {
         return false;
 
       } else if (hasClass(event.target, 'bottomRightSelectionHandle-HitArea')) {
-        selectedRange = _this.hot.getSelectedRecentlyRange();
+        selectedRange = _this.hot.getSelectedRangeLast();
 
         _this.dragged.push('bottomRight');
 
@@ -164,7 +164,7 @@ class MultipleSelectionHandles extends BasePlugin {
           targetCoords.col = 0;
         }
 
-        selectedRange = _this.hot.getSelectedRecentlyRange();
+        selectedRange = _this.hot.getSelectedRangeLast();
         rangeWidth = selectedRange.getWidth();
         rangeHeight = selectedRange.getHeight();
         rangeDirection = selectedRange.getDirection();

--- a/src/plugins/observeChanges/observeChanges.js
+++ b/src/plugins/observeChanges/observeChanges.js
@@ -106,7 +106,7 @@ class ObserveChanges extends BasePlugin {
           }
         },
         replace: (patch) => {
-          this.hot.runHooks('afterChange', [patch.row, patch.col, null, patch.value], sourceName);
+          this.hot.runHooks('afterChange', [[patch.row, patch.col, null, patch.value]], sourceName);
         },
       };
 

--- a/src/plugins/observeChanges/test/observeChanges.e2e.js
+++ b/src/plugins/observeChanges/test/observeChanges.e2e.js
@@ -458,7 +458,7 @@ describe('HandsontableObserveChanges', () => {
 
         setTimeout(() => {
           expect(afterChangeCallback.calls.count()).toEqual(1);
-          expect(afterChangeCallback).toHaveBeenCalledWith([0, 0, null, 'new string'], 'ObserveChanges.change', undefined, undefined, undefined, undefined);
+          expect(afterChangeCallback).toHaveBeenCalledWith([[0, 0, null, 'new string']], 'ObserveChanges.change', undefined, undefined, undefined, undefined);
           done();
         }, 200);
       });
@@ -544,7 +544,7 @@ describe('HandsontableObserveChanges', () => {
 
         setTimeout(() => {
           expect(afterChangeCallback.calls.count()).toEqual(1);
-          expect(afterChangeCallback).toHaveBeenCalledWith([0, 'prop0', null, 'new string'], 'ObserveChanges.change', undefined, undefined, undefined, undefined);
+          expect(afterChangeCallback).toHaveBeenCalledWith([[0, 'prop0', null, 'new string']], 'ObserveChanges.change', undefined, undefined, undefined, undefined);
           done();
         }, 200);
       });

--- a/src/plugins/undoRedo/test/UndoRedo.e2e.js
+++ b/src/plugins/undoRedo/test/UndoRedo.e2e.js
@@ -2196,7 +2196,6 @@ describe('UndoRedo', () => {
             expect(finish).toBe(true);
           }
         }
-
       });
 
       it('should redo a sequence of aligning cells', () => {

--- a/src/plugins/undoRedo/undoRedo.js
+++ b/src/plugins/undoRedo/undoRedo.js
@@ -2,7 +2,7 @@
  * Handsontable UndoRedo class
  */
 import Hooks from './../../pluginHooks';
-import {arrayMap} from './../../helpers/array';
+import {arrayMap, arrayEach} from './../../helpers/array';
 import {rangeEach} from './../../helpers/number';
 import {inherit, deepClone} from './../../helpers/object';
 import {stopImmediatePropagation} from './../../helpers/dom/event';
@@ -429,11 +429,14 @@ UndoRedo.CellAlignmentAction.prototype.undo = function(instance, undoneCallback)
   if (!instance.getPlugin('contextMenu').isEnabled()) {
     return;
   }
-  for (var row = this.range.from.row; row <= this.range.to.row; row++) {
-    for (var col = this.range.from.col; col <= this.range.to.col; col++) {
-      instance.setCellMeta(row, col, 'className', this.stateBefore[row][col] || ' htLeft');
+
+  arrayEach(this.range, ({from, to}) => {
+    for (var row = from.row; row <= to.row; row++) {
+      for (var col = from.col; col <= to.col; col++) {
+        instance.setCellMeta(row, col, 'className', this.stateBefore[row][col] || ' htLeft');
+      }
     }
-  }
+  });
 
   instance.addHookOnce('afterRender', undoneCallback);
   instance.render();
@@ -442,8 +445,10 @@ UndoRedo.CellAlignmentAction.prototype.redo = function(instance, undoneCallback)
   if (!instance.getPlugin('contextMenu').isEnabled()) {
     return;
   }
-  instance.selectCell(this.range.from.row, this.range.from.col, this.range.to.row, this.range.to.col);
-  instance.getPlugin('contextMenu').executeCommand(`alignment:${this.alignment.replace('ht', '').toLowerCase()}`);
+  arrayEach(this.range, ({from, to}) => {
+    instance.selectCell(from.row, from.col, to.row, to.col);
+    instance.getPlugin('contextMenu').executeCommand(`alignment:${this.alignment.replace('ht', '').toLowerCase()}`);
+  });
 
   instance.addHookOnce('afterRender', undoneCallback);
   instance.render();

--- a/src/renderers/checkboxRenderer.js
+++ b/src/renderers/checkboxRenderer.js
@@ -119,7 +119,7 @@ function checkboxRenderer(instance, TD, row, col, prop, value, cellProperties) {
    * @param {Boolean} [uncheckCheckbox=false]
    */
   function changeSelectedCheckboxesState(uncheckCheckbox = false) {
-    const selRange = instance.getSelectedRange();
+    const selRange = instance.getSelectedRecentlyRange();
 
     if (!selRange) {
       return;
@@ -177,7 +177,7 @@ function checkboxRenderer(instance, TD, row, col, prop, value, cellProperties) {
    * @param {Function} callback
    */
   function eachSelectedCheckboxCell(callback) {
-    const selRange = instance.getSelectedRange();
+    const selRange = instance.getSelectedRecentlyRange();
 
     if (!selRange) {
       return;

--- a/src/renderers/checkboxRenderer.js
+++ b/src/renderers/checkboxRenderer.js
@@ -119,7 +119,7 @@ function checkboxRenderer(instance, TD, row, col, prop, value, cellProperties) {
    * @param {Boolean} [uncheckCheckbox=false]
    */
   function changeSelectedCheckboxesState(uncheckCheckbox = false) {
-    const selRange = instance.getSelectedRecentlyRange();
+    const selRange = instance.getSelectedRangeLast();
 
     if (!selRange) {
       return;
@@ -177,7 +177,7 @@ function checkboxRenderer(instance, TD, row, col, prop, value, cellProperties) {
    * @param {Function} callback
    */
   function eachSelectedCheckboxCell(callback) {
-    const selRange = instance.getSelectedRecentlyRange();
+    const selRange = instance.getSelectedRangeLast();
 
     if (!selRange) {
       return;

--- a/src/selection/highlight/highlight.js
+++ b/src/selection/highlight/highlight.js
@@ -137,7 +137,7 @@ class Highlight {
     if (this.areas.has(layerLevel)) {
       area = this.areas.get(layerLevel);
     } else {
-      area = createHighlight(AREA_TYPE, this.options);
+      area = createHighlight(AREA_TYPE, {layerLevel, ...this.options});
 
       this.areas.set(layerLevel, area);
     }
@@ -167,7 +167,7 @@ class Highlight {
     if (this.headers.has(layerLevel)) {
       header = this.headers.get(layerLevel);
     } else {
-      header = createHighlight(HEADER_TYPE, this.options);
+      header = createHighlight(HEADER_TYPE, {...this.options});
 
       this.headers.set(layerLevel, header);
     }

--- a/src/selection/highlight/highlight.js
+++ b/src/selection/highlight/highlight.js
@@ -1,0 +1,169 @@
+import {createHighlight} from './types';
+import {arrayEach} from './../../helpers/array';
+
+class Highlight {
+  constructor(options) {
+    /**
+     * Options passed to the Walkontable Selection class.
+     *
+     * @type {Object}
+     */
+    this.options = options;
+    /**
+     * The property which describes which layer level of the visual selection will be modified.
+     * This option is valid only for `area` and `header` highlight types which occurs multiple times on
+     * the table (as a non-consecutive selection).
+     *
+     * An order of the layers is the same as the order of added new non-consecutive selections.
+     *
+     * @type {Number}
+     * @default 0
+     */
+    this.layerLevel = 0;
+    /**
+     * `cell` highlight object which describes attributes for the currently selected cell.
+     * It can only occur only once on the table.
+     *
+     * @type {Selection}
+     */
+    this.cell = createHighlight('cell', options);
+    /**
+     * `fill` highlight object which describes attributes for the borders for autofill functionality.
+     * It can only occur only once on the table.
+     *
+     * @type {Selection}
+     */
+    this.fill = createHighlight('fill', options);
+    /**
+     * Collection of the `area` highlights. That objects describes attributes for the borders and selection of
+     * the multiple selected cells. It can occur multiple times on the table.
+     *
+     * @type {Map.<number, Selection>}
+     */
+    this.areas = new Map();
+    /**
+     * Collection of the `header` highlights. That objects describes attributes for the selection of
+     * the multiple selected rows and columns in the table header. It can occur multiple times on the table.
+     *
+     * @type {Map.<number, Selection>}
+     */
+    this.headers = new Map();
+    /**
+     * The temporary property, holder for borders added through CustomBorders plugin.
+     *
+     * @type {Selection[]}
+     */
+    this.borders = [];
+  }
+
+  /**
+   * Set a new layer level to make access to the desire `area` and `header` highlights.
+   *
+   * @param {Number} [level=0] Layer level to use.
+   */
+  useLayerLevel(level = 0) {
+    this.layerLevel = level;
+  }
+
+  /**
+   * Get Walkontable Selection instance created for controlling highlight of the currently selected/edited cell.
+   *
+   * @return {Selection}
+   */
+  getCell() {
+    return this.cell;
+  }
+
+  /**
+   * Get Walkontable Selection instance created for controlling highlight of the autofill functionality.
+   *
+   * @return {Selection}
+   */
+  getFill() {
+    return this.fill;
+  }
+
+  /**
+   * Get Walkontable Selection instance created for controlling highlight of the multiple selected cells.
+   *
+   * @return {Selection}
+   */
+  getArea() {
+    let area;
+    const layerLevel = this.layerLevel;
+
+    if (this.areas.has(layerLevel)) {
+      area = this.areas.get(layerLevel);
+    } else {
+      area = createHighlight('area', this.options);
+
+      this.areas.set(layerLevel, area);
+    }
+
+    return area;
+  }
+
+  /**
+   * Get all Walkontable Selection instances which describes the state of the visual highlight of the cells.
+   *
+   * @return {Selection[]}
+   */
+  getAreas() {
+    return [...this.areas.values()];
+  }
+
+  /**
+   * Get Walkontable Selection instance created for controlling highlight of the multiple selected header cells.
+   *
+   * @return {Selection}
+   */
+  getHeader() {
+    let header;
+    const layerLevel = this.layerLevel;
+
+    if (this.headers.has(layerLevel)) {
+      header = this.headers.get(layerLevel);
+    } else {
+      header = createHighlight('header', this.options);
+
+      this.headers.set(layerLevel, header);
+    }
+
+    return header;
+  }
+
+  /**
+   * Get all Walkontable Selection instances which describes the state of the visual highlight of the header cells.
+   *
+   * @return {Selection[]}
+   */
+  getHeaders() {
+    return [...this.headers.values()];
+  }
+
+  /**
+   * Perform cleaning visual highlights of the whole table.
+   *
+   * @return {[type]}
+   */
+  clear() {
+    this.cell.clear();
+    this.fill.clear();
+
+    arrayEach(Array.from(this.areas.entries()), ([, area]) => {
+      area.clear();
+    });
+    arrayEach(Array.from(this.headers.entries()), ([, header]) => {
+      header.clear();
+    });
+  }
+
+  /**
+   * This object can be iterate over using `for of` syntax or using internal `arrayEach` helper.
+   */
+  [Symbol.iterator]() {
+    return [this.cell, ...this.areas.values(), ...this.headers.values(), this.fill, ...this.borders][Symbol.iterator]();
+  }
+}
+
+export default Highlight;

--- a/src/selection/highlight/highlight.js
+++ b/src/selection/highlight/highlight.js
@@ -17,6 +17,9 @@ export const HEADER_TYPE = 'header';
  *    that type should be created to manage not-consecutive selection;
  *  - `header` can occur multiple times. This type is designed to highlight only headers. Like `area` type it
  *    can appear with multiple highlights (accessed under different level layers).
+ *
+ * @class Highlight
+ * @util
  */
 class Highlight {
   constructor(options) {

--- a/src/selection/highlight/types/area.js
+++ b/src/selection/highlight/types/area.js
@@ -5,12 +5,14 @@ import {Selection} from './../../../3rdparty/walkontable/src';
  *
  * @return {Selection}
  */
-function createHighlight({cornerVisible, multipleSelectionHandlesVisible, areaCornerVisible}) {
+function createHighlight({layerLevel, cornerVisible, multipleSelectionHandlesVisible, areaCornerVisible}) {
   const s = new Selection({
     className: 'area',
+    markIntersections: true,
+    layerLevel: Math.min(layerLevel, 7),
     border: {
       width: 1,
-      color: '#89AFF9',
+      color: '#4b89ff',
       cornerVisible: areaCornerVisible,
       multipleSelectionHandlesVisible,
     },

--- a/src/selection/highlight/types/area.js
+++ b/src/selection/highlight/types/area.js
@@ -1,0 +1,22 @@
+import {Selection} from './../../../3rdparty/walkontable/src';
+
+/**
+ * Creates the new instance of Selection responsible for highlighting area of the selected multiple cells.
+ *
+ * @return {Selection}
+ */
+function createHighlight({cornerVisible, multipleSelectionHandlesVisible, areaCornerVisible}) {
+  const s = new Selection({
+    className: 'area',
+    border: {
+      width: 1,
+      color: '#89AFF9',
+      cornerVisible: areaCornerVisible,
+      multipleSelectionHandlesVisible,
+    },
+  });
+
+  return s;
+}
+
+export default createHighlight;

--- a/src/selection/highlight/types/cell.js
+++ b/src/selection/highlight/types/cell.js
@@ -11,7 +11,7 @@ function createHighlight({cornerVisible, multipleSelectionHandlesVisible, cellCo
     className: 'current',
     border: {
       width: 2,
-      color: '#5292F7',
+      color: '#4b89ff',
       cornerVisible: cellCornerVisible,
       multipleSelectionHandlesVisible,
     },

--- a/src/selection/highlight/types/cell.js
+++ b/src/selection/highlight/types/cell.js
@@ -1,0 +1,23 @@
+import {Selection} from './../../../3rdparty/walkontable/src';
+
+/**
+ * Creates the new instance of Selection responsible for highlighting currently selected cell. This type of selection
+ * can present on the table only one at the time.
+ *
+ * @return {Selection}
+ */
+function createHighlight({cornerVisible, multipleSelectionHandlesVisible, cellCornerVisible}) {
+  const s = new Selection({
+    className: 'current',
+    border: {
+      width: 2,
+      color: '#5292F7',
+      cornerVisible: cellCornerVisible,
+      multipleSelectionHandlesVisible,
+    },
+  });
+
+  return s;
+}
+
+export default createHighlight;

--- a/src/selection/highlight/types/fill.js
+++ b/src/selection/highlight/types/fill.js
@@ -1,0 +1,21 @@
+import {Selection} from './../../../3rdparty/walkontable/src';
+
+/**
+ * Creates the new instance of Selection, responsible for highlighting cells which are covered by fill handle
+ * functionality. This type of selection can present on the table only one at the time.
+ *
+ * @return {Selection}
+ */
+function createHighlight() {
+  const s = new Selection({
+    className: 'fill',
+    border: {
+      width: 1,
+      color: 'red',
+    },
+  });
+
+  return s;
+}
+
+export default createHighlight;

--- a/src/selection/highlight/types/fill.js
+++ b/src/selection/highlight/types/fill.js
@@ -11,7 +11,7 @@ function createHighlight() {
     className: 'fill',
     border: {
       width: 1,
-      color: 'red',
+      color: '#ff0000',
     },
   });
 

--- a/src/selection/highlight/types/header.js
+++ b/src/selection/highlight/types/header.js
@@ -1,0 +1,20 @@
+import {Selection} from './../../../3rdparty/walkontable/src';
+
+/**
+ * Creates the new instance of Selection, responsible for highlighting row and column headers. This type of selection
+ * can occur multiple times.
+ *
+ * @return {Selection}
+ */
+function createHighlight({headerClassName, rowClassName, columnClassName}) {
+  const s = new Selection({
+    className: 'highlight',
+    highlightHeaderClassName: headerClassName,
+    highlightRowClassName: rowClassName,
+    highlightColumnClassName: columnClassName,
+  });
+
+  return s;
+}
+
+export default createHighlight;

--- a/src/selection/highlight/types/index.js
+++ b/src/selection/highlight/types/index.js
@@ -1,0 +1,28 @@
+/* eslint-disable import/prefer-default-export */
+import staticRegister from './../../../utils/staticRegister';
+
+import areaHighlight from './area';
+import cellHighlight from './cell';
+import fillHighlight from './fill';
+import headerHighlight from './header';
+
+const {
+  register,
+  getItem,
+  hasItem,
+  getNames,
+  getValues,
+} = staticRegister('highlight/types');
+
+register('area', areaHighlight);
+register('cell', cellHighlight);
+register('fill', fillHighlight);
+register('header', headerHighlight);
+
+function createHighlight(highlightType, options) {
+  return getItem(highlightType)(options);
+}
+
+export {
+  createHighlight,
+};

--- a/src/selection/index.js
+++ b/src/selection/index.js
@@ -1,0 +1,7 @@
+import Highlight from './highlight/highlight';
+import Selection from './selection';
+
+export {
+  Highlight,
+  Selection,
+};

--- a/src/selection/range.js
+++ b/src/selection/range.js
@@ -1,14 +1,35 @@
 import {CellRange} from './../3rdparty/walkontable/src';
 
+/**
+ * The SelectionRange class is a simple CellRanges collection designed for easy manipulation of the multiple
+ * consecutive and non-consecutive selections.
+ */
 class SelectionRange {
   constructor() {
+    /**
+     * List of all CellRanges added to the class instance.
+     *
+     * @type {CellRange[]}
+     */
     this.ranges = [];
   }
 
+  /**
+   * Check if selected range is empty.
+   *
+   * @return {Boolean}
+   */
   isEmpty() {
-    return this.ranges.length === 0;
+    return this.size() === 0;
   }
 
+  /**
+   * Set coordinates to the class instance. It clears all previously added coordinates and push `coords`
+   * to the collection.
+   *
+   * @param {CellCoords} coords The CellCoords instance with defined coordinates.
+   * @returns {SelectionRange}
+   */
   set(coords) {
     this.clear();
     this.ranges.push(new CellRange(coords));
@@ -16,24 +37,71 @@ class SelectionRange {
     return this;
   }
 
+  /**
+   * Add coordinates to the class instance. The new coordinates are added to the end of the range collection.
+   *
+   * @param {CellCoords} coords The CellCoords instance with defined coordinates.
+   * @returns {SelectionRange}
+   */
   add(coords) {
     this.ranges.push(new CellRange(coords));
 
     return this;
   }
 
+  /**
+   * Get last added coordinates from ranges, it returns a CellRange instance.
+   *
+   * @return {CellCoords|undefined}
+   */
   current() {
-    return this.ranges[Math.max(this.size() - 1, 0)];
+    return this.peekByIndex(0);
   }
 
+  /**
+   * Get previously added coordinates from ranges, it returns a CellRange instance.
+   *
+   * @return {CellCoords|undefined}
+   */
+  previous() {
+    return this.peekByIndex(-1);
+  }
+
+  /**
+   * Clear collection.
+   *
+   * @return {SelectionRange}
+   */
   clear() {
     this.ranges.length = 0;
 
     return this;
   }
 
+  /**
+   * Get count of added all coordinates added to the selection.
+   *
+   * @return {Number}
+   */
   size() {
     return this.ranges.length;
+  }
+
+  /**
+   * Peek the coordinates based on the index where that coordinate resides in the collection.
+   *
+   * @param {Number} [index=0] An index where the coordinate will be retrieved from.
+   * @return {CellRange|undefined}
+   */
+  peekByIndex(index = 0) {
+    const rangeIndex = this.size() + index - 1;
+    let cellRange;
+
+    if (rangeIndex >= 0) {
+      cellRange = this.ranges[rangeIndex];
+    }
+
+    return cellRange;
   }
 
   [Symbol.iterator]() {

--- a/src/selection/range.js
+++ b/src/selection/range.js
@@ -1,0 +1,44 @@
+import {CellRange} from './../3rdparty/walkontable/src';
+
+class SelectionRange {
+  constructor() {
+    this.ranges = [];
+  }
+
+  isEmpty() {
+    return this.ranges.length === 0;
+  }
+
+  set(coords) {
+    this.clear();
+    this.ranges.push(new CellRange(coords));
+
+    return this;
+  }
+
+  add(coords) {
+    this.ranges.push(new CellRange(coords));
+
+    return this;
+  }
+
+  current() {
+    return this.ranges[Math.max(this.size() - 1, 0)];
+  }
+
+  clear() {
+    this.ranges.length = 0;
+
+    return this;
+  }
+
+  size() {
+    return this.ranges.length;
+  }
+
+  [Symbol.iterator]() {
+    return this.ranges[Symbol.iterator]();
+  }
+}
+
+export default SelectionRange;

--- a/src/selection/range.js
+++ b/src/selection/range.js
@@ -3,6 +3,9 @@ import {CellRange} from './../3rdparty/walkontable/src';
 /**
  * The SelectionRange class is a simple CellRanges collection designed for easy manipulation of the multiple
  * consecutive and non-consecutive selections.
+ *
+ * @class SelectionRange
+ * @util
  */
 class SelectionRange {
   constructor() {

--- a/src/selection/selection.js
+++ b/src/selection/selection.js
@@ -1,0 +1,269 @@
+import Highlight from './highlight/highlight';
+import SelectionRange from './range';
+import {CellRange, CellCoords} from './../3rdparty/walkontable/src';
+import {isPressed} from './../utils/keyStateObserver';
+import {createObjectPropListener, mixin} from './../helpers/object';
+import {addClass, removeClass} from './../helpers/dom/element';
+import {arrayEach} from './../helpers/array';
+import localHooks from './../mixins/localHooks';
+import Transformation from './transformation';
+
+class Selection {
+  constructor(settings, tableProps) {
+    this.settings = settings;
+    this.tableProps = tableProps;
+    this.inProgress = false;
+    this.selectedHeader = {
+      cols: false,
+      rows: false,
+      corner: false,
+    };
+
+    this.selectedRange = new SelectionRange();
+    this.highlight = new Highlight({
+      headerClassName: settings.currentHeaderClassName,
+      rowClassName: settings.currentRowClassName,
+      columnClassName: settings.currentColClassName,
+      cellCornerVisible: () => this.settings.fillHandle && !this.tableProps.isEditorOpened() && !this.isMultiple(),
+      areaCornerVisible: () => this.settings.fillHandle && !this.tableProps.isEditorOpened() && this.isMultiple(),
+    });
+    this.transformation = new Transformation(this.selectedRange, {
+      countRows: () => this.tableProps.countRows(),
+      countCols: () => this.tableProps.countCols(),
+      fixedRowsBottom: () => settings.fixedRowsBottom,
+      minSpareRows: () => settings.minSpareRows,
+      minSpareCols: () => settings.minSpareCols,
+      autoWrapRow: () => settings.autoWrapRow,
+      autoWrapCol: () => settings.autoWrapCol,
+    });
+
+    this.transformation.addLocalHook('beforeTransformStart', (...args) => this.runLocalHooks('beforeModifyTransformStart', ...args));
+    this.transformation.addLocalHook('afterTransformStart', (...args) => this.runLocalHooks('afterModifyTransformStart', ...args));
+    this.transformation.addLocalHook('beforeTransformEnd', (...args) => this.runLocalHooks('beforeModifyTransformEnd', ...args));
+    this.transformation.addLocalHook('afterTransformEnd', (...args) => this.runLocalHooks('afterModifyTransformEnd', ...args));
+    this.transformation.addLocalHook('insertRowRequire', (...args) => this.runLocalHooks('insertRowRequire', ...args));
+    this.transformation.addLocalHook('insertColRequire', (...args) => this.runLocalHooks('insertColRequire', ...args));
+  }
+
+  getSelectedRange() {
+    return this.selectedRange;
+  }
+
+  /**
+   * @param {Boolean} [rows=false]
+   * @param {Boolean} [cols=false]
+   * @param {Boolean} [corner=false]
+   */
+  setSelectedHeaders(rows = false, cols = false, corner = false) {
+    this.selectedHeader.rows = rows;
+    this.selectedHeader.cols = cols;
+    this.selectedHeader.corner = corner;
+  }
+
+  /**
+   * Sets inProgress to `true`. This enables onSelectionEnd and onSelectionEndByProp to function as desired.
+   */
+  begin() {
+    this.inProgress = true;
+  }
+
+  /**
+   * Sets inProgress to `false`. Triggers onSelectionEnd and onSelectionEndByProp.
+   */
+  finish() {
+    this.runLocalHooks('afterSelectionFinished', this.selectedRange);
+    this.inProgress = false;
+  }
+
+  /**
+   * @returns {Boolean}
+   */
+  isInProgress() {
+    return this.inProgress;
+  }
+
+  /**
+   * Starts selection range on given coordinate object.
+   *
+   * @param {CellCoords} coords Visual coords.
+   * @param keepEditorOpened
+   */
+  setRangeStart(coords, keepEditorOpened) {
+    if (!isPressed('COMMAND_LEFT')) {
+      this.selectedRange.clear();
+    }
+
+    this.runLocalHooks('beforeSetRangeStart', coords);
+    this.selectedRange.add(coords);
+
+    this.setRangeEnd(coords, null, keepEditorOpened);
+  }
+
+  /**
+   * Starts selection range on given td object.
+   *
+   * @param {CellCoords} coords Visual coords.
+   * @param keepEditorOpened
+   */
+  setRangeStartOnly(coords) {
+    if (!isPressed('COMMAND_LEFT')) {
+      this.selectedRange.clear();
+    }
+
+    this.runLocalHooks('beforeSetRangeStartOnly', coords);
+    this.selectedRange.add(coords);
+  }
+
+  /**
+   * Ends selection range on given td object.
+   *
+   * @param {CellCoords} coords Visual coords.
+   * @param {Boolean} [scrollToCell=true] If `true`, viewport will be scrolled to range end
+   * @param {Boolean} [keepEditorOpened] If `true`, cell editor will be still opened after changing selection range
+   */
+  setRangeEnd(coords, scrollToCell = true, keepEditorOpened = false) {
+    if (this.selectedRange.isEmpty()) {
+      return;
+    }
+
+    this.runLocalHooks('beforeSetRangeEnd', coords);
+    this.begin();
+
+    const cellRange = this.selectedRange.current();
+
+    cellRange.setTo(new CellCoords(coords.row, coords.col));
+
+    if (!this.settings.multiSelect) {
+      cellRange.setFrom(coords);
+    }
+
+    let disableVisualSelection = this.settings.disableVisualSelection;
+
+    if (typeof disableVisualSelection === 'string') {
+      disableVisualSelection = [disableVisualSelection];
+    }
+
+    // set up current selection
+    this.highlight.getCell().clear();
+
+    if (disableVisualSelection === false ||
+        Array.isArray(disableVisualSelection) && disableVisualSelection.indexOf('current') === -1) {
+      this.highlight.getCell().add(this.selectedRange.current().highlight);
+    }
+
+    const highlightLayerLevel = this.selectedRange.size() - 1;
+
+    // If the next layer level is lower than previous then clear all area and header highlights. The new
+    // selection is performing.
+    if (highlightLayerLevel < this.highlight.layerLevel) {
+      arrayEach(this.highlight.getAreas(), (area) => {
+        area.clear();
+      });
+      arrayEach(this.highlight.getHeaders(), (header) => {
+        header.clear();
+      });
+    }
+
+    this.highlight.useLayerLevel(highlightLayerLevel);
+
+    this.highlight.getArea().clear();
+    this.highlight.getHeader().clear();
+
+    if ((disableVisualSelection === false ||
+        Array.isArray(disableVisualSelection) && disableVisualSelection.indexOf('area') === -1) && this.isMultiple()) {
+      this.highlight.getArea()
+        .add(cellRange.from)
+        .add(cellRange.to);
+    }
+    this.highlight.getHeader()
+      .add(cellRange.from)
+      .add(cellRange.to);
+
+    this.runLocalHooks('afterSetRangeEnd', coords, scrollToCell, keepEditorOpened);
+  }
+
+  /**
+   * Returns information if we have a multiselection.
+   *
+   * @returns {Boolean}
+   */
+  isMultiple() {
+    const isMultipleListener = createObjectPropListener(!this.selectedRange.current().isSingle());
+
+    this.runLocalHooks('afterIsMultipleSelection', isMultipleListener);
+
+    return isMultipleListener.value;
+  }
+
+  /**
+   * Selects cell relative to current cell (if possible).
+   */
+  transformStart(rowDelta, colDelta, force, keepEditorOpened) {
+    const newCoords = this.transformation.transformStart(rowDelta, colDelta, force);
+
+    this.setRangeStart(newCoords, keepEditorOpened);
+  }
+
+  /**
+   * Sets selection end cell relative to current selection end cell (if possible).
+   */
+  transformEnd(rowDelta, colDelta) {
+    const newCoords = this.transformation.transformEnd(rowDelta, colDelta);
+
+    this.setRangeEnd(newCoords, true);
+  }
+
+  /**
+   * Returns `true` if currently there is a selection on screen, `false` otherwise.
+   *
+   * @returns {Boolean}
+   */
+  isSelected() {
+    return !this.selectedRange.isEmpty();
+  }
+
+  /**
+   * Returns `true` if coords is within current selection coords.
+   *
+   * @param {CellCoords} coords
+   * @returns {Boolean}
+   */
+  inInSelection(coords) {
+    if (!this.isSelected()) {
+      return false;
+    }
+
+    // TODO(budnix): `includes` in all ranges need to be implemented not only current one.
+    return this.selectedRange.current().includes(coords);
+  }
+
+  /**
+   * Deselects all selected cells
+   */
+  deselect() {
+    if (!this.isSelected()) {
+      return;
+    }
+    this.inProgress = false;
+    this.selectedRange.clear();
+    this.highlight.clear();
+
+    this.runLocalHooks('afterDeselect');
+  }
+
+  /**
+   * Select all cells
+   */
+  selectAll() {
+    if (!this.settings.multiSelect) {
+      return;
+    }
+    this.setSelectedHeaders(true, true, true);
+    this.setRangeStart(new CellCoords(0, 0));
+    this.setRangeEnd(new CellCoords(this.tableProps.countRows() - 1, this.tableProps.countCols() - 1), false);
+  }
+}
+
+mixin(Selection, localHooks);
+
+export default Selection;

--- a/src/selection/selection.js
+++ b/src/selection/selection.js
@@ -10,7 +10,8 @@ import localHooks from './../mixins/localHooks';
 import Transformation from './transformation';
 
 /**
- * [Selection description]
+ * @class Selection
+ * @util
  */
 class Selection {
   constructor(settings, tableProps) {

--- a/src/selection/selection.js
+++ b/src/selection/selection.js
@@ -143,11 +143,12 @@ class Selection {
     const isMultipleMode = this.settings.selectionMode === 'multiple';
     const isMultipleSelection = isUndefined(multipleSelection) ? isPressedCtrlKey() : multipleSelection;
 
+    this.runLocalHooks('beforeSetRangeStart', coords);
+
     if (!isMultipleMode || (isMultipleMode && !isMultipleSelection)) {
       this.selectedRange.clear();
     }
 
-    this.runLocalHooks('beforeSetRangeStart', coords);
     this.selectedRange.add(coords);
     this.setRangeEnd(coords, null, keepEditorOpened);
   }
@@ -164,11 +165,12 @@ class Selection {
     const isMultipleMode = this.settings.selectionMode === 'multiple';
     const isMultipleSelection = isUndefined(multipleSelection) ? isPressedCtrlKey() : multipleSelection;
 
+    this.runLocalHooks('beforeSetRangeStartOnly', coords);
+
     if (!isMultipleMode || (isMultipleMode && !isMultipleSelection)) {
       this.selectedRange.clear();
     }
 
-    this.runLocalHooks('beforeSetRangeStartOnly', coords);
     this.selectedRange.add(coords);
   }
 

--- a/src/selection/selection.js
+++ b/src/selection/selection.js
@@ -117,7 +117,7 @@ class Selection {
    * Indicate that selection process finished. It sets internaly `.inProgress` property to `false`.
    */
   finish() {
-    this.runLocalHooks('afterSelectionFinished', this.selectedRange);
+    this.runLocalHooks('afterSelectionFinished', Array.from(this.selectedRange));
     this.inProgress = false;
   }
 

--- a/src/selection/selection.js
+++ b/src/selection/selection.js
@@ -243,6 +243,7 @@ class Selection {
         }
       }
     }
+
     if (this.highlight.isEnabledFor(HEADER_TYPE)) {
       if (this.settings.selectionMode === 'single') {
         headerHighlight.add(cellRange.highlight);

--- a/src/selection/transformation.js
+++ b/src/selection/transformation.js
@@ -2,14 +2,36 @@ import {CellCoords} from './../3rdparty/walkontable/src';
 import {mixin} from './../helpers/object';
 import localHooks from './../mixins/localHooks';
 
+/**
+ * The Transformation class implements algorithms for transforming coordinates based on current settings
+ * passed to the Handsontable.
+ *
+ * Transformation is always applied relative to the current selection.
+ */
 class Transformation {
   constructor(range, options) {
+    /**
+     * Instance of the SelectionRange, holder for coordinates applied to the table.
+     *
+     * @type {SelectionRange}
+     */
     this.range = range;
+    /**
+     * Additional options which define the state of the settings which can infer transformation.
+     *
+     * @type {Object}
+     */
     this.options = options;
   }
 
   /**
    * Selects cell relative to current cell (if possible).
+   *
+   * @param {Number} rowDelta Rows number to move, value can be passed as negative number.
+   * @param {Number} colDelta Columns number to move, value can be passed as negative number.
+   * @param {Boolean} force If `true` the new rows/columns will be created if necessary. Otherwise, row/column will
+   *                        be created according to `minSpareRows/minSpareCols` settings of Handsontable.
+   * @returns {CellCoords}
    */
   transformStart(rowDelta, colDelta, force) {
     const delta = new CellCoords(rowDelta, colDelta);
@@ -81,6 +103,10 @@ class Transformation {
 
   /**
    * Sets selection end cell relative to current selection end cell (if possible).
+   *
+   * @param {Number} rowDelta Rows number to move, value can be passed as negative number.
+   * @param {Number} colDelta Columns number to move, value can be passed as negative number.
+   * @returns {CellCoords}
    */
   transformEnd(rowDelta, colDelta) {
     const delta = new CellCoords(rowDelta, colDelta);

--- a/src/selection/transformation.js
+++ b/src/selection/transformation.js
@@ -1,0 +1,122 @@
+import {CellCoords} from './../3rdparty/walkontable/src';
+import {mixin} from './../helpers/object';
+import localHooks from './../mixins/localHooks';
+
+class Transformation {
+  constructor(range, options) {
+    this.range = range;
+    this.options = options;
+  }
+
+  /**
+   * Selects cell relative to current cell (if possible).
+   */
+  transformStart(rowDelta, colDelta, force) {
+    const delta = new CellCoords(rowDelta, colDelta);
+
+    this.runLocalHooks('beforeTransformStart', delta);
+
+    let totalRows = this.options.countRows();
+    let totalCols = this.options.countCols();
+    const fixedRowsBottom = this.options.fixedRowsBottom();
+    const minSpareRows = this.options.minSpareRows();
+    const minSpareCols = this.options.minSpareCols();
+    const autoWrapRow = this.options.autoWrapRow();
+    const autoWrapCol = this.options.autoWrapCol();
+    const highlightCoords = this.range.current().highlight;
+
+    if (highlightCoords.row + rowDelta > totalRows - 1) {
+      if (force && minSpareRows > 0 && !(fixedRowsBottom && highlightCoords.row >= totalRows - fixedRowsBottom - 1)) {
+        this.runLocalHooks('insertRowRequire', totalRows);
+        totalRows = this.options.countRows();
+
+      } else if (autoWrapCol) {
+        delta.row = 1 - totalRows;
+        delta.col = highlightCoords.col + delta.col == totalCols - 1 ? 1 - totalCols : 1;
+      }
+    } else if (autoWrapCol && highlightCoords.row + delta.row < 0 && highlightCoords.col + delta.col >= 0) {
+      delta.row = totalRows - 1;
+      delta.col = highlightCoords.col + delta.col == 0 ? totalCols - 1 : -1;
+    }
+
+    if (highlightCoords.col + delta.col > totalCols - 1) {
+      if (force && minSpareCols > 0) {
+        this.runLocalHooks('insertColRequire', totalRows);
+        totalCols = this.options.countCols();
+
+      } else if (autoWrapRow) {
+        delta.row = highlightCoords.row + delta.row == totalRows - 1 ? 1 - totalRows : 1;
+        delta.col = 1 - totalCols;
+      }
+    } else if (autoWrapRow && highlightCoords.col + delta.col < 0 && highlightCoords.row + delta.row >= 0) {
+      delta.row = highlightCoords.row + delta.row == 0 ? totalRows - 1 : -1;
+      delta.col = totalCols - 1;
+    }
+
+    const coords = new CellCoords(highlightCoords.row + delta.row, highlightCoords.col + delta.col);
+    let rowTransformDir = 0;
+    let colTransformDir = 0;
+
+    if (coords.row < 0) {
+      rowTransformDir = -1;
+      coords.row = 0;
+
+    } else if (coords.row > 0 && coords.row >= totalRows) {
+      rowTransformDir = 1;
+      coords.row = totalRows - 1;
+    }
+
+    if (coords.col < 0) {
+      colTransformDir = -1;
+      coords.col = 0;
+
+    } else if (coords.col > 0 && coords.col >= totalCols) {
+      colTransformDir = 1;
+      coords.col = totalCols - 1;
+    }
+    this.runLocalHooks('afterTransformStart', coords, rowTransformDir, colTransformDir);
+
+    return coords;
+  }
+
+  /**
+   * Sets selection end cell relative to current selection end cell (if possible).
+   */
+  transformEnd(rowDelta, colDelta) {
+    const delta = new CellCoords(rowDelta, colDelta);
+
+    this.runLocalHooks('beforeTransformEnd', delta);
+
+    const totalRows = this.options.countRows();
+    const totalCols = this.options.countCols();
+    const cellRange = this.range.current();
+    const coords = new CellCoords(cellRange.to.row + delta.row, cellRange.to.col + delta.col);
+    let rowTransformDir = 0;
+    let colTransformDir = 0;
+
+    if (coords.row < 0) {
+      rowTransformDir = -1;
+      coords.row = 0;
+
+    } else if (coords.row > 0 && coords.row >= totalRows) {
+      rowTransformDir = 1;
+      coords.row = totalRows - 1;
+    }
+
+    if (coords.col < 0) {
+      colTransformDir = -1;
+      coords.col = 0;
+
+    } else if (coords.col > 0 && coords.col >= totalCols) {
+      colTransformDir = 1;
+      coords.col = totalCols - 1;
+    }
+    this.runLocalHooks('afterTransformEnd', coords, rowTransformDir, colTransformDir);
+
+    return coords;
+  }
+}
+
+mixin(Transformation, localHooks);
+
+export default Transformation;

--- a/src/selection/transformation.js
+++ b/src/selection/transformation.js
@@ -7,6 +7,9 @@ import localHooks from './../mixins/localHooks';
  * passed to the Handsontable.
  *
  * Transformation is always applied relative to the current selection.
+ *
+ * @class Transformation
+ * @util
  */
 class Transformation {
   constructor(range, options) {

--- a/src/selection/utils.js
+++ b/src/selection/utils.js
@@ -1,0 +1,158 @@
+import {CellRange} from './../3rdparty/walkontable/src';
+import {arrayEach, arrayReduce} from './../helpers/array';
+
+const SELECTION_TYPE_ARRAY = 'array';
+const SELECTION_TYPE_OBJECT = 'object';
+const SELECTION_TYPES = [SELECTION_TYPE_OBJECT, SELECTION_TYPE_ARRAY];
+
+/**
+ * Detect data structure, a holder for coordinates for selection functionality.
+ *
+ * @param {Array[]|CellRange[]} selectionRanges An array of selected ranges. This type of data is produced by
+ *                                              `hot.getSelected()` and `hot.getSelectedRange()` methods.
+ * @returns {String|undefined} It returns strings: `array` or `object` depends on from what method the selection data is
+ *                            provided. If data type is unrecognized than it returns `undefined`.
+ */
+export function detectSelectionType(selectionRanges) {
+  let result;
+
+  if (selectionRanges.length) {
+    const firstItem = selectionRanges[0];
+
+    if (Array.isArray(firstItem)) {
+      result = SELECTION_TYPE_ARRAY;
+
+    } else if (firstItem instanceof CellRange) {
+      result = SELECTION_TYPE_OBJECT;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Factory function designed for normalization data schema from different data structures of the selection ranges.
+ *
+ * @param {String} type Selection type which will be processed.
+ * @returns {Array} Returns normalized data about selected range as an array: `[rowStart, columnStart, rowEnd, columnEnd]`.
+ */
+export function normalizeSelectionFactory(type) {
+  if (!SELECTION_TYPES.includes(type)) {
+    throw new Error('Unsupported selection ranges data type was provided.');
+  }
+
+  return function(selection) {
+    const isObjectType = type === SELECTION_TYPE_OBJECT;
+    const rowStart = isObjectType ? selection.from.row : selection[0];
+    const columnStart = isObjectType ? selection.from.col : selection[1];
+    const rowEnd = isObjectType ? selection.to.row : selection[2];
+    const columnEnd = isObjectType ? selection.to.col : selection[3];
+
+    return [
+      Math.min(rowStart, rowEnd),
+      Math.min(columnStart, columnEnd),
+      Math.max(rowStart, rowEnd),
+      Math.max(columnStart, columnEnd),
+    ];
+  };
+}
+
+/**
+ * Function transform selection ranges (produced by `hot.getSelected()` and `hot.getSelectedRange()`) to normalized
+ * data structure. It merges repeated ranges into consecutive coordinates. The returned structure
+ * contains an array of arrays. The single item contains at index 0 visual column index from the selection was
+ * started and at index 1 distance as a count of selected columns.
+ *
+ * @param {Array[]|CellRange[]} selectionRanges Selection ranges produced by Handsontable.
+ * @return {Array[]} Returns an array of arrays with ranges defines in that schema:
+ *                   `[[visualColumnStart, distance], [visualColumnStart, distance], ...]`.
+ *                   The column distances are always created starting from the left (zero index) to the
+ *                   right (the latest column index).
+ */
+export function transformSelectionToColumnDistance(selectionRanges) {
+  const selectionType = detectSelectionType(selectionRanges);
+
+  if (!selectionType) {
+    return [];
+  }
+
+  const selectionSchemaNormalizer = normalizeSelectionFactory(selectionType);
+  const unorderedIndexes = new Set();
+
+  // Iterate through all ranges and collect all column indexes which are not saved yet.
+  arrayEach(selectionRanges, (selection) => {
+    const [, columnStart,, columnEnd] = selectionSchemaNormalizer(selection);
+    const amount = columnEnd - columnStart + 1;
+
+    arrayEach(Array.from(new Array(amount), (_, i) => columnStart + i), (index) => {
+      if (!unorderedIndexes.has(index)) {
+        unorderedIndexes.add(index);
+      }
+    });
+  });
+
+  // Sort indexes in ascending order to easily detecting non-consecutive columns.
+  const orderedIndexes = Array.from(unorderedIndexes).sort((a, b) => a - b);
+  const normalizedColumnRanges = arrayReduce(orderedIndexes, (acc, visualColumnIndex, index, array) => {
+    if (index !== 0 && visualColumnIndex === array[index - 1] + 1) {
+      acc[acc.length - 1][1]++;
+
+    } else {
+      acc.push([visualColumnIndex, 1]);
+    }
+
+    return acc;
+  }, []);
+
+  return normalizedColumnRanges;
+}
+
+/**
+ * Function transform selection ranges (produced by `hot.getSelected()` and `hot.getSelectedRange()`) to normalized
+ * data structure. It merges repeated ranges into consecutive coordinates. The returned structure
+ * contains an array of arrays. The single item contains at index 0 visual column index from the selection was
+ * started and at index 1 distance as a count of selected columns.
+ *
+ * @param {Array[]|CellRange[]} selectionRanges Selection ranges produced by Handsontable.
+ * @return {Array[]} Returns an array of arrays with ranges defines in that schema:
+ *                   `[[visualColumnStart, distance], [visualColumnStart, distance], ...]`.
+ *                   The column distances are always created starting from the left (zero index) to the
+ *                   right (the latest column index).
+ */
+export function transformSelectionToRowDistance(selectionRanges) {
+  const selectionType = detectSelectionType(selectionRanges);
+
+  if (!selectionType) {
+    return [];
+  }
+
+  const selectionSchemaNormalizer = normalizeSelectionFactory(selectionType);
+  const unorderedIndexes = new Set();
+
+  // Iterate through all ranges and collect all column indexes which are not saved yet.
+  arrayEach(selectionRanges, (selection) => {
+    const [rowStart,, rowEnd] = selectionSchemaNormalizer(selection);
+    const amount = rowEnd - rowStart + 1;
+
+    arrayEach(Array.from(new Array(amount), (_, i) => rowStart + i), (index) => {
+      if (!unorderedIndexes.has(index)) {
+        unorderedIndexes.add(index);
+      }
+    });
+  });
+
+  // Sort indexes in ascending order to easily detecting non-consecutive columns.
+  const orderedIndexes = Array.from(unorderedIndexes).sort((a, b) => a - b);
+  const normalizedRowRanges = arrayReduce(orderedIndexes, (acc, rowIndex, index, array) => {
+    if (index !== 0 && rowIndex === array[index - 1] + 1) {
+      acc[acc.length - 1][1]++;
+
+    } else {
+      acc.push([rowIndex, 1]);
+    }
+
+    return acc;
+  }, []);
+
+  return normalizedRowRanges;
+}

--- a/src/tableView.js
+++ b/src/tableView.js
@@ -13,7 +13,7 @@ import {
 import {isChrome, isSafari} from './helpers/browser';
 import EventManager from './eventManager';
 import {stopPropagation, isImmediatePropagationStopped, isRightClick, isLeftClick} from './helpers/dom/event';
-import Walkontable, {CellCoords, Selection} from './3rdparty/walkontable/src';
+import Walkontable, {CellCoords} from './3rdparty/walkontable/src';
 
 /**
  * Handsontable TableView constructor
@@ -162,55 +162,6 @@ function TableView(instance) {
     }
   };
 
-  var selections = [
-    new Selection({
-      className: 'current',
-      border: {
-        width: 2,
-        color: '#5292F7',
-        // style: 'solid', // not used
-        cornerVisible: function() {
-          return that.settings.fillHandle && !that.isCellEdited() && !instance.selection.isMultiple();
-        },
-        multipleSelectionHandlesVisible: function() {
-          return !that.isCellEdited() && !instance.selection.isMultiple();
-        },
-      },
-    }),
-    new Selection({
-      className: 'area',
-      border: {
-        width: 1,
-        color: '#89AFF9',
-        // style: 'solid', // not used
-        cornerVisible: function() {
-          return that.settings.fillHandle && !that.isCellEdited() && instance.selection.isMultiple();
-        },
-        multipleSelectionHandlesVisible: function() {
-          return !that.isCellEdited() && instance.selection.isMultiple();
-        },
-      },
-    }),
-    new Selection({
-      className: 'highlight',
-      highlightHeaderClassName: that.settings.currentHeaderClassName,
-      highlightRowClassName: that.settings.currentRowClassName,
-      highlightColumnClassName: that.settings.currentColClassName,
-    }),
-    new Selection({
-      className: 'fill',
-      border: {
-        width: 1,
-        color: 'red',
-        // style: 'solid' // not used
-      },
-    }),
-  ];
-  selections.current = selections[0];
-  selections.area = selections[1];
-  selections.highlight = selections[2];
-  selections.fill = selections[3];
-
   var walkontableConfig = {
     debug: function() {
       return that.settings.debug;
@@ -277,7 +228,7 @@ function TableView(instance) {
       that.instance.runHooks('afterRenderer', TD, row, col, prop, value, cellProperties);
 
     },
-    selections: selections,
+    selections: that.instance.selection.highlight,
     hideBorderOnMouseDownOver: function() {
       return that.settings.fragmentSelection;
     },
@@ -417,7 +368,7 @@ function TableView(instance) {
         return;
       }
 
-      if (event.button === 0 && isMouseDown) {
+      if (isLeftClick(event) && isMouseDown) {
         if (coords.row >= 0 && coords.col >= 0) { // is not a header
           if (instance.selection.selectedHeader.cols && !blockCalculations.column) {
             instance.selection.setRangeEnd(new CellCoords(instance.countRows() - 1, coords.col), false);

--- a/src/tableView.js
+++ b/src/tableView.js
@@ -250,7 +250,7 @@ function TableView(instance) {
         return;
       }
 
-      let actualSelection = instance.getSelectedRange();
+      let actualSelection = instance.getSelectedRecentlyRange();
       let selection = instance.selection;
       let selectedHeader = selection.selectedHeader;
 
@@ -568,7 +568,7 @@ TableView.prototype.isTextSelectionAllowed = function(el) {
  * @returns {Boolean}
  */
 TableView.prototype.isSelectedOnlyCell = function() {
-  var [row, col, rowEnd, colEnd] = this.instance.getSelected() || [];
+  var [row, col, rowEnd, colEnd] = this.instance.getSelectedRecently() || [];
 
   return row !== void 0 && row === rowEnd && col === colEnd;
 };

--- a/src/tableView.js
+++ b/src/tableView.js
@@ -250,7 +250,7 @@ function TableView(instance) {
         return;
       }
 
-      let actualSelection = instance.getSelectedRecentlyRange();
+      let actualSelection = instance.getSelectedRangeLast();
       let selection = instance.selection;
       let selectedHeader = selection.selectedHeader;
 
@@ -568,7 +568,7 @@ TableView.prototype.isTextSelectionAllowed = function(el) {
  * @returns {Boolean}
  */
 TableView.prototype.isSelectedOnlyCell = function() {
-  var [row, col, rowEnd, colEnd] = this.instance.getSelectedRecently() || [];
+  var [row, col, rowEnd, colEnd] = this.instance.getSelectedLast() || [];
 
   return row !== void 0 && row === rowEnd && col === colEnd;
 };

--- a/src/utils/keyStateObserver.js
+++ b/src/utils/keyStateObserver.js
@@ -1,0 +1,43 @@
+/* eslint-disable import/prefer-default-export */
+import EventManager from '../eventManager';
+import {isCtrlKey, isKey} from '../helpers/unicode';
+import {arrayEach, arrayReduce} from '../helpers/array';
+
+const eventManager = new EventManager();
+const pressedKeys = new Set();
+let observeCount = 0;
+
+function startObserving() {
+  if (observeCount === 0) {
+    eventManager.addEventListener(document.documentElement, 'keydown', (event) => {
+      if (!pressedKeys.has(event.keyCode)) {
+        pressedKeys.add(event.keyCode);
+      }
+    });
+    eventManager.addEventListener(document.documentElement, 'keyup', (event) => {
+      if (pressedKeys.has(event.keyCode)) {
+        pressedKeys.delete(event.keyCode);
+      }
+    });
+  }
+  observeCount++;
+}
+
+function stopObserving() {
+  observeCount--;
+
+  if (observeCount === 0) {
+    eventManager.clearEvents();
+    pressedKeys.clear();
+  }
+}
+
+function isPressed(keyCodes) {
+  return Array.from(pressedKeys.values()).some((_keyCode) => isKey(_keyCode, keyCodes));
+}
+
+export {
+  isPressed,
+  startObserving,
+  stopObserving,
+};

--- a/src/utils/keyStateObserver.js
+++ b/src/utils/keyStateObserver.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/prefer-default-export */
 import EventManager from '../eventManager';
 import {isCtrlKey, isKey} from '../helpers/unicode';
 import {arrayEach, arrayReduce} from '../helpers/array';
@@ -7,6 +6,9 @@ const eventManager = new EventManager();
 const pressedKeys = new Set();
 let observeCount = 0;
 
+/**
+ * Begins observing keyboard keys states.
+ */
 function startObserving() {
   if (observeCount === 0) {
     eventManager.addEventListener(document.documentElement, 'keydown', (event) => {
@@ -23,6 +25,9 @@ function startObserving() {
   observeCount++;
 }
 
+/**
+ * Stops observing keyboard keys states and clear all previously saved states.
+ */
 function stopObserving() {
   observeCount--;
 
@@ -32,11 +37,27 @@ function stopObserving() {
   }
 }
 
+/**
+ * Checks if provided keyCode or keyCodes are pressed.
+ *
+ * @param {String} keyCodes The key codes passed as a string defined in helpers/unicode.js file delimited with '|'.
+ * @return {Boolean}
+ */
 function isPressed(keyCodes) {
   return Array.from(pressedKeys.values()).some((_keyCode) => isKey(_keyCode, keyCodes));
 }
 
+/**
+ * Checks if ctrl keys are pressed.
+ *
+ * @return {Boolean}
+ */
+function isPressedCtrlKey() {
+  return Array.from(pressedKeys.values()).some((_keyCode) => isCtrlKey(_keyCode));
+}
+
 export {
+  isPressedCtrlKey,
   isPressed,
   startObserving,
   stopObserving,

--- a/src/utils/keyStateObserver.js
+++ b/src/utils/keyStateObserver.js
@@ -11,14 +11,19 @@ let observeCount = 0;
  */
 function startObserving() {
   if (observeCount === 0) {
-    eventManager.addEventListener(document.documentElement, 'keydown', (event) => {
+    eventManager.addEventListener(document, 'keydown', (event) => {
       if (!pressedKeys.has(event.keyCode)) {
         pressedKeys.add(event.keyCode);
       }
     });
-    eventManager.addEventListener(document.documentElement, 'keyup', (event) => {
+    eventManager.addEventListener(document, 'keyup', (event) => {
       if (pressedKeys.has(event.keyCode)) {
         pressedKeys.delete(event.keyCode);
+      }
+    });
+    eventManager.addEventListener(document, 'visibilitychange', (event) => {
+      if (document.hidden) {
+        pressedKeys.clear();
       }
     });
   }

--- a/src/utils/keyStateObserver.js
+++ b/src/utils/keyStateObserver.js
@@ -1,16 +1,16 @@
 import EventManager from '../eventManager';
-import {isCtrlKey, isKey} from '../helpers/unicode';
+import {isCtrlMetaKey, isKey} from '../helpers/unicode';
 import {arrayEach, arrayReduce} from '../helpers/array';
 
 const eventManager = new EventManager();
 const pressedKeys = new Set();
-let observeCount = 0;
+let refCount = 0;
 
 /**
  * Begins observing keyboard keys states.
  */
 function startObserving() {
-  if (observeCount === 0) {
+  if (refCount === 0) {
     eventManager.addEventListener(document, 'keydown', (event) => {
       if (!pressedKeys.has(event.keyCode)) {
         pressedKeys.add(event.keyCode);
@@ -21,25 +21,36 @@ function startObserving() {
         pressedKeys.delete(event.keyCode);
       }
     });
-    eventManager.addEventListener(document, 'visibilitychange', (event) => {
+    eventManager.addEventListener(document, 'visibilitychange', () => {
       if (document.hidden) {
         pressedKeys.clear();
       }
     });
   }
-  observeCount++;
+
+  refCount++;
 }
 
 /**
  * Stops observing keyboard keys states and clear all previously saved states.
  */
 function stopObserving() {
-  observeCount--;
-
-  if (observeCount === 0) {
-    eventManager.clearEvents();
-    pressedKeys.clear();
+  if (refCount > 0) {
+    refCount--;
   }
+
+  if (refCount === 0) {
+    _resetState();
+  }
+}
+
+/**
+ * Remove all listeners attached to the DOM and clear all previously saved states.
+ */
+function _resetState() {
+  eventManager.clearEvents();
+  pressedKeys.clear();
+  refCount = 0;
 }
 
 /**
@@ -58,12 +69,24 @@ function isPressed(keyCodes) {
  * @return {Boolean}
  */
 function isPressedCtrlKey() {
-  return Array.from(pressedKeys.values()).some((_keyCode) => isCtrlKey(_keyCode));
+  return Array.from(pressedKeys.values()).some((_keyCode) => isCtrlMetaKey(_keyCode));
+}
+
+/**
+ * Returns reference count. Useful for debugging and testing purposes.
+ *
+ * @constructor
+ * @return {[type]}
+ */
+function _getRefCount() {
+  return refCount;
 }
 
 export {
-  isPressedCtrlKey,
+  _getRefCount,
+  _resetState,
   isPressed,
+  isPressedCtrlKey,
   startObserving,
   stopObserving,
 };

--- a/src/utils/keyStateObserver.js
+++ b/src/utils/keyStateObserver.js
@@ -75,8 +75,7 @@ function isPressedCtrlKey() {
 /**
  * Returns reference count. Useful for debugging and testing purposes.
  *
- * @constructor
- * @return {[type]}
+ * @return {Number}
  */
 function _getRefCount() {
   return refCount;

--- a/src/utils/keyStateObserver.js
+++ b/src/utils/keyStateObserver.js
@@ -28,7 +28,7 @@ function startObserving() {
     });
   }
 
-  refCount++;
+  refCount += 1;
 }
 
 /**
@@ -36,7 +36,7 @@ function startObserving() {
  */
 function stopObserving() {
   if (refCount > 0) {
-    refCount--;
+    refCount -= 1;
   }
 
   if (refCount === 0) {

--- a/test/e2e/Core_alter.spec.js
+++ b/test/e2e/Core_alter.spec.js
@@ -66,6 +66,28 @@ describe('Core_alter', () => {
       expect(getData().length).toEqual(5); // new row should be added by keepEmptyRows
     });
 
+    it('should support removing multiple rows at once', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(15, 5),
+      });
+      // [[rowPhysicalIndex, amountRowsToRemove] ...]
+      alter('remove_row', [[1, 3], [3, 1], [3, 3], [4, 3]]);
+      // It remove rows as follow:
+      //     1--------3
+      // A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15
+      //             3-1
+      // A1, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15
+      //             3---------3
+      // A1, A5, A6, A8, A9, A10, A11, A12, A13, A14, A15
+      //                  4-----------3
+      // A1, A5, A6, A11, A12, A13, A14, A15
+      //
+      // Result: A1, A5, A6, A11, A15
+
+      expect(getDataAtCol(0)).toEqual(['A1', 'A5', 'A6', 'A11', 'A15']);
+      expect(getData().length).toBe(5);
+    });
+
     it('should fire beforeRemoveRow event before removing row', () => {
       var onBeforeRemoveRow = jasmine.createSpy('onBeforeRemoveRow');
 
@@ -386,6 +408,28 @@ describe('Core_alter', () => {
 
       expect(countCols()).toEqual(5);
       expect(this.$container.find('tr:eq(1) td:last').html()).toEqual('e');
+    });
+
+    it('should support removing multiple columns at once', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 15),
+      });
+      // [[columnPhysicalIndex, amountColumnsToRemove] ...]
+      alter('remove_col', [[1, 3], [3, 1], [3, 3], [4, 3]]);
+      // It remove columns as follow:
+      //     1--------3
+      // A1, B1, C1, D1, E1, F1, G1, H1, I1, J1, K1, L1, M1, N1, O1
+      //             3-1
+      // A1, E1, F1, G1, H1, I1, J1, K1, L1, M1, N1, O1
+      //             3--------3
+      // A1, E1, F1, H1, I1, J1, K1, L1, M1, N1, O1
+      //                 4--------3
+      // A1, E1, F1, K1, L1, M1, N1, O1
+      //
+      // Result: A1, E1, F1, K1, O1
+
+      expect(getDataAtRow(0)).toEqual(['A1', 'E1', 'F1', 'K1', 'O1']);
+      expect(getData()[0].length).toBe(5);
     });
 
     it('should fire beforeRemoveCol event before removing col', () => {

--- a/test/e2e/Core_alter.spec.js
+++ b/test/e2e/Core_alter.spec.js
@@ -804,8 +804,10 @@ describe('Core_alter', () => {
       alter('insert_row', 2);
 
       const selected = getSelected();
-      expect(selected[0]).toEqual(3);
-      expect(selected[2]).toEqual(3);
+
+      expect(selected[0][0]).toBe(3);
+      expect(selected[0][2]).toBe(3);
+      expect(selected.length).toBe(1);
     });
 
     it('should shift the cell meta according to the new row layout', () => {

--- a/test/e2e/Core_beforeKeyDown.spec.js
+++ b/test/e2e/Core_beforeKeyDown.spec.js
@@ -64,8 +64,8 @@ describe('Core_beforeKeyDown', () => {
 
     keyDown('arrow_right');
 
-    expect(getSelected()).toEqual([0, 0, 0, 0]);
-    expect(getSelected()).not.toEqual([0, 1, 0, 1]);
+    expect(getSelected()).toEqual([[0, 0, 0, 0]]);
+    expect(getSelected()).not.toEqual([[0, 1, 0, 1]]);
   });
 
   it('should overwrite default behavior of delete key, but not this of right arrow', () => {
@@ -89,7 +89,7 @@ describe('Core_beforeKeyDown', () => {
     keyDown('arrow_right');
 
     expect(getData().length).toEqual(3);
-    expect(getSelected()).toEqual([0, 1, 0, 1]);
+    expect(getSelected()).toEqual([[0, 1, 0, 1]]);
   });
 
   it('should run beforeKeyDown hook in cell editor handler', () => {

--- a/test/e2e/Core_destroyEditor.spec.js
+++ b/test/e2e/Core_destroyEditor.spec.js
@@ -40,7 +40,7 @@ describe('Core_destroyEditor', () => {
     keyDownUp('enter');
 
     destroyEditor();
-    expect(getSelected()).toEqual([1, 1, 1, 1]);
+    expect(getSelected()).toEqual([[1, 1, 1, 1]]);
   });
 
   it('should revert original value when param set to true', () => {

--- a/test/e2e/Core_getCellMeta.spec.js
+++ b/test/e2e/Core_getCellMeta.spec.js
@@ -73,7 +73,7 @@ describe('Core_getCellMeta', () => {
     selectCell(0, 0);
     expect(getCellMeta(0, 0).readOnly).toBe(true);
     keyDown('enter');
-    expect(getSelected()).toEqual([1, 0, 1, 0]);
+    expect(getSelected()).toEqual([[1, 0, 1, 0]]);
 
   });
 

--- a/test/e2e/Core_loadData.spec.js
+++ b/test/e2e/Core_loadData.spec.js
@@ -297,7 +297,7 @@ describe('Core_loadData', () => {
     loadData(data2);
 
     expect(countRows()).toBe(data2.length);
-    expect(getSelected()).toEqual([4, 0, 4, 0]);
+    expect(getSelected()).toEqual([[4, 0, 4, 0]]);
   });
 
   it('should remove grid rows if new data source has less of them (with minSpareRows)', () => {
@@ -330,7 +330,7 @@ describe('Core_loadData', () => {
     loadData(data2);
 
     expect(countRows()).toBe(6); // +1 because of minSpareRows
-    expect(getSelected()).toEqual([5, 0, 5, 0]);
+    expect(getSelected()).toEqual([[5, 0, 5, 0]]);
   });
 
   it('loading empty data should remove all rows', () => {
@@ -356,7 +356,7 @@ describe('Core_loadData', () => {
     loadData(data2);
 
     expect(countRows()).toBe(0);
-    expect(getSelected()).toBe(void 0);
+    expect(getSelected()).toBeUndefined();
   });
 
   it('should only have as many columns as in settings', () => {

--- a/test/e2e/Core_navigation.spec.js
+++ b/test/e2e/Core_navigation.spec.js
@@ -21,7 +21,7 @@ describe('Core_navigation', () => {
     selectCell(0, 0);
     keyDown('arrow_right');
 
-    expect(getSelected()).toEqual([0, 1, 0, 1]);
+    expect(getSelected()).toEqual([[0, 1, 0, 1]]);
   });
 
   it('should move to the previous cell', () => {
@@ -33,7 +33,7 @@ describe('Core_navigation', () => {
     selectCell(1, 2);
     keyDown('arrow_left');
 
-    expect(getSelected()).toEqual([1, 1, 1, 1]);
+    expect(getSelected()).toEqual([[1, 1, 1, 1]]);
   });
 
   it('should move to the cell above', () => {
@@ -45,7 +45,7 @@ describe('Core_navigation', () => {
     selectCell(1, 2);
     keyDown('arrow_up');
 
-    expect(getSelected()).toEqual([0, 2, 0, 2]);
+    expect(getSelected()).toEqual([[0, 2, 0, 2]]);
   });
 
   it('should move to the cell below', () => {
@@ -57,7 +57,7 @@ describe('Core_navigation', () => {
     selectCell(1, 2);
     keyDown('arrow_down');
 
-    expect(getSelected()).toEqual([2, 2, 2, 2]);
+    expect(getSelected()).toEqual([[2, 2, 2, 2]]);
   });
 
   describe('autoWrap disabled', () => {
@@ -71,7 +71,7 @@ describe('Core_navigation', () => {
       selectCell(0, 4);
       keyDown('arrow_right');
 
-      expect(getSelected()).toEqual([0, 4, 0, 4]);
+      expect(getSelected()).toEqual([[0, 4, 0, 4]]);
     });
 
     it('should NOT move to the previous cell, if already at the first cell in row', () => {
@@ -84,7 +84,7 @@ describe('Core_navigation', () => {
       selectCell(1, 0);
       keyDown('arrow_left');
 
-      expect(getSelected()).toEqual([1, 0, 1, 0]);
+      expect(getSelected()).toEqual([[1, 0, 1, 0]]);
     });
 
     it('should NOT move to the cell below, if already at the last cell in column', () => {
@@ -97,7 +97,7 @@ describe('Core_navigation', () => {
       selectCell(4, 0);
       keyDown('arrow_down');
 
-      expect(getSelected()).toEqual([4, 0, 4, 0]);
+      expect(getSelected()).toEqual([[4, 0, 4, 0]]);
     });
 
     it('should NOT move to the cell above, if already at the first cell in column', () => {
@@ -110,7 +110,7 @@ describe('Core_navigation', () => {
       selectCell(0, 1);
       keyDown('arrow_up');
 
-      expect(getSelected()).toEqual([0, 1, 0, 1]);
+      expect(getSelected()).toEqual([[0, 1, 0, 1]]);
     });
 
   });
@@ -126,7 +126,7 @@ describe('Core_navigation', () => {
       selectCell(0, 4);
       keyDown('arrow_right');
 
-      expect(getSelected()).toEqual([1, 0, 1, 0]);
+      expect(getSelected()).toEqual([[1, 0, 1, 0]]);
     });
 
     it('should move to the first cell of the previous row, if already at the first cell in row', () => {
@@ -139,7 +139,7 @@ describe('Core_navigation', () => {
       selectCell(1, 0);
       keyDown('arrow_left');
 
-      expect(getSelected()).toEqual([0, 4, 0, 4]);
+      expect(getSelected()).toEqual([[0, 4, 0, 4]]);
     });
 
     it('should move to the first cell of the next column, if already at the last cell in column', () => {
@@ -152,7 +152,7 @@ describe('Core_navigation', () => {
       selectCell(4, 1);
       keyDown('arrow_down');
 
-      expect(getSelected()).toEqual([0, 2, 0, 2]);
+      expect(getSelected()).toEqual([[0, 2, 0, 2]]);
     });
 
     it('should move to the last cell of the previous column, if already at the first cell in column', () => {
@@ -165,7 +165,7 @@ describe('Core_navigation', () => {
       selectCell(0, 1);
       keyDown('arrow_up');
 
-      expect(getSelected()).toEqual([4, 0, 4, 0]);
+      expect(getSelected()).toEqual([[4, 0, 4, 0]]);
     });
 
     it('should move to the first cell of the first row, after trying to get to the next cell in row, being already at the last cell in table', () => {
@@ -178,7 +178,7 @@ describe('Core_navigation', () => {
       selectCell(4, 4);
       keyDown('arrow_right');
 
-      expect(getSelected()).toEqual([0, 0, 0, 0]);
+      expect(getSelected()).toEqual([[0, 0, 0, 0]]);
     });
 
     it('should move to the first cell of the first row, after trying to get to the next cell in column, being already at the last cell in table', () => {
@@ -191,7 +191,7 @@ describe('Core_navigation', () => {
       selectCell(4, 4);
       keyDown('arrow_down');
 
-      expect(getSelected()).toEqual([0, 0, 0, 0]);
+      expect(getSelected()).toEqual([[0, 0, 0, 0]]);
     });
 
     it('should move to the last cell of the last row, after trying to get to the previous cell in row, being already at the first cell in table', () => {
@@ -204,7 +204,7 @@ describe('Core_navigation', () => {
       selectCell(0, 0);
       keyDown('arrow_left');
 
-      expect(getSelected()).toEqual([4, 4, 4, 4]);
+      expect(getSelected()).toEqual([[4, 4, 4, 4]]);
     });
 
     it('should move to the last cell of the last row, after trying to get to the previous cell in column, being already at the first cell in table', () => {
@@ -217,7 +217,7 @@ describe('Core_navigation', () => {
       selectCell(0, 0);
       keyDown('arrow_up');
 
-      expect(getSelected()).toEqual([4, 4, 4, 4]);
+      expect(getSelected()).toEqual([[4, 4, 4, 4]]);
     });
 
     it('should traverse whole table by constantly selecting next cell in row', () => {
@@ -231,12 +231,12 @@ describe('Core_navigation', () => {
 
       for (var row = 0, rlen = countRows(); row < rlen; row++) {
         for (var col = 0, clen = countCols(); col < clen; col++) {
-          expect(getSelected()).toEqual([row, col, row, col]);
+          expect(getSelected()).toEqual([[row, col, row, col]]);
           keyDown('arrow_right');
         }
       }
 
-      expect(getSelected()).toEqual([0, 0, 0, 0]);
+      expect(getSelected()).toEqual([[0, 0, 0, 0]]);
     });
 
     it('should traverse whole table by constantly selecting previous cell in row', () => {
@@ -250,12 +250,12 @@ describe('Core_navigation', () => {
 
       for (var row = countRows() - 1; row >= 0; row--) {
         for (var col = countCols() - 1; col >= 0; col--) {
-          expect(getSelected()).toEqual([row, col, row, col]);
+          expect(getSelected()).toEqual([[row, col, row, col]]);
           keyDown('arrow_left');
         }
       }
 
-      expect(getSelected()).toEqual([4, 4, 4, 4]);
+      expect(getSelected()).toEqual([[4, 4, 4, 4]]);
     });
 
     it('should traverse whole table by constantly selecting next cell in column', () => {
@@ -269,12 +269,12 @@ describe('Core_navigation', () => {
 
       for (var col = 0, clen = countCols(); col < clen; col++) {
         for (var row = 0, rlen = countRows(); row < rlen; row++) {
-          expect(getSelected()).toEqual([row, col, row, col]);
+          expect(getSelected()).toEqual([[row, col, row, col]]);
           keyDown('arrow_down');
         }
       }
 
-      expect(getSelected()).toEqual([0, 0, 0, 0]);
+      expect(getSelected()).toEqual([[0, 0, 0, 0]]);
     });
 
     it('should traverse whole table by constantly selecting previous cell in column', () => {
@@ -288,12 +288,12 @@ describe('Core_navigation', () => {
 
       for (var col = countCols() - 1; col >= 0; col--) {
         for (var row = countRows() - 1; row >= 0; row--) {
-          expect(getSelected()).toEqual([row, col, row, col]);
+          expect(getSelected()).toEqual([[row, col, row, col]]);
           keyDown('arrow_up');
         }
       }
 
-      expect(getSelected()).toEqual([4, 4, 4, 4]);
+      expect(getSelected()).toEqual([[4, 4, 4, 4]]);
     });
   });
 });

--- a/test/e2e/Core_onKeyDown.spec.js
+++ b/test/e2e/Core_onKeyDown.spec.js
@@ -17,14 +17,14 @@ describe('Core_onKeyDown', () => {
     handsontable();
     selectCell(0, 0);
     keyDownUp('tab');
-    expect(getSelected()).toEqual([0, 1, 0, 1]);
+    expect(getSelected()).toEqual([[0, 1, 0, 1]]);
   });
 
   it('should advance to previous cell when shift+TAB is pressed', () => {
     handsontable();
     selectCell(1, 1);
     keyDownUp('shift+tab');
-    expect(getSelected()).toEqual([1, 0, 1, 0]);
+    expect(getSelected()).toEqual([[1, 0, 1, 0]]);
   });
 
   describe('while editing (quick edit mode)', () => {
@@ -37,7 +37,7 @@ describe('Core_onKeyDown', () => {
       keyProxy().val('Ted');
       keyDownUp('tab');
       expect(getData()[1][1]).toEqual('Ted');
-      expect(getSelected()).toEqual([1, 2, 1, 2]);
+      expect(getSelected()).toEqual([[1, 2, 1, 2]]);
     });
 
     it('should finish editing and advance to lower cell when enter is pressed', () => {
@@ -49,7 +49,7 @@ describe('Core_onKeyDown', () => {
       keyProxy().val('Ted');
       keyDownUp('enter');
       expect(getData()[1][1]).toEqual('Ted');
-      expect(getSelected()).toEqual([2, 1, 2, 1]);
+      expect(getSelected()).toEqual([[2, 1, 2, 1]]);
     });
 
     it('should finish editing and advance to higher cell when shift+enter is pressed', () => {
@@ -61,7 +61,7 @@ describe('Core_onKeyDown', () => {
       keyProxy().val('Ted');
       keyDownUp('shift+enter');
       expect(getData()[1][1]).toEqual('Ted');
-      expect(getSelected()).toEqual([0, 1, 0, 1]);
+      expect(getSelected()).toEqual([[0, 1, 0, 1]]);
     });
 
     it('should finish editing and advance to lower cell when down arrow is pressed', () => {
@@ -72,7 +72,7 @@ describe('Core_onKeyDown', () => {
       keyProxy().val('Ted');
       keyDownUp('arrow_down');
       expect(getData()[1][1]).toEqual('Ted');
-      expect(getSelected()).toEqual([2, 1, 2, 1]);
+      expect(getSelected()).toEqual([[2, 1, 2, 1]]);
     });
 
     it('should finish editing and advance to higher cell when up arrow is pressed', () => {
@@ -83,7 +83,7 @@ describe('Core_onKeyDown', () => {
       keyProxy().val('Ted');
       keyDownUp('arrow_up');
       expect(getData()[1][1]).toEqual('Ted');
-      expect(getSelected()).toEqual([0, 1, 0, 1]);
+      expect(getSelected()).toEqual([[0, 1, 0, 1]]);
     });
 
     it('should finish editing and advance to right cell when right arrow is pressed', () => {
@@ -97,7 +97,7 @@ describe('Core_onKeyDown', () => {
       keyDownUp('arrow_right');
       keyDownUp('arrow_right');
       expect(getData()[1][1]).toEqual('Ted');
-      expect(getSelected()).toEqual([1, 4, 1, 4]);
+      expect(getSelected()).toEqual([[1, 4, 1, 4]]);
     });
 
     it('should finish editing and advance to left cell when left arrow is pressed', () => {
@@ -113,7 +113,7 @@ describe('Core_onKeyDown', () => {
       keyDownUp('arrow_left');
       keyDownUp('arrow_left');
       expect(getData()[1][1]).toEqual('Ted');
-      expect(getSelected()).toEqual([1, 0, 1, 0]);
+      expect(getSelected()).toEqual([[1, 0, 1, 0]]);
     });
 
     it('should finish editing and advance to lower cell when enter is pressed (with sync validator)', (done) => {
@@ -137,7 +137,7 @@ describe('Core_onKeyDown', () => {
       setTimeout(() => {
         expect(onAfterValidate).toHaveBeenCalled();
         expect(getData()[1][1]).toEqual('Ted');
-        expect(getSelected()).toEqual([2, 1, 2, 1]);
+        expect(getSelected()).toEqual([[2, 1, 2, 1]]);
         done();
       }, 200);
     });
@@ -164,7 +164,7 @@ describe('Core_onKeyDown', () => {
       setTimeout(() => {
         expect(onAfterValidate).toHaveBeenCalled();
         expect(getData()[1][1]).toEqual('Ted');
-        expect(getSelected()).toEqual([2, 1, 2, 1]);
+        expect(getSelected()).toEqual([[2, 1, 2, 1]]);
         done();
       }, 200);
     });
@@ -180,7 +180,7 @@ describe('Core_onKeyDown', () => {
       keyProxy().val('Ted');
       keyDownUp('tab');
       expect(getData()[1][1]).toEqual('Ted');
-      expect(getSelected()).toEqual([1, 2, 1, 2]);
+      expect(getSelected()).toEqual([[1, 2, 1, 2]]);
     });
 
     it('should finish editing and advance to lower cell when enter is pressed', () => {
@@ -192,7 +192,7 @@ describe('Core_onKeyDown', () => {
       keyProxy().val('Ted');
       keyDownUp('enter');
       expect(getData()[1][1]).toEqual('Ted');
-      expect(getSelected()).toEqual([2, 1, 2, 1]);
+      expect(getSelected()).toEqual([[2, 1, 2, 1]]);
     });
 
     it('should finish editing and advance to higher cell when shift+enter is pressed', () => {
@@ -204,7 +204,7 @@ describe('Core_onKeyDown', () => {
       keyProxy().val('Ted');
       keyDownUp('shift+enter');
       expect(getData()[1][1]).toEqual('Ted');
-      expect(getSelected()).toEqual([0, 1, 0, 1]);
+      expect(getSelected()).toEqual([[0, 1, 0, 1]]);
     });
 
     it('shouldn\'t finish editing and advance to lower cell when down arrow is pressed', () => {
@@ -215,7 +215,7 @@ describe('Core_onKeyDown', () => {
       keyProxy().val('Ted');
       keyDownUp('arrow_down');
       expect(getData()[1][1]).toEqual(null);
-      expect(getSelected()).toEqual([1, 1, 1, 1]);
+      expect(getSelected()).toEqual([[1, 1, 1, 1]]);
     });
 
     it('shouldn\'t finish editing and advance to higher cell when up arrow is pressed', () => {
@@ -226,7 +226,7 @@ describe('Core_onKeyDown', () => {
       keyProxy().val('Ted');
       keyDownUp('arrow_up');
       expect(getData()[1][1]).toEqual(null);
-      expect(getSelected()).toEqual([1, 1, 1, 1]);
+      expect(getSelected()).toEqual([[1, 1, 1, 1]]);
     });
 
     it('shouldn\'t finish editing and advance to right cell when right arrow is pressed', () => {
@@ -240,7 +240,7 @@ describe('Core_onKeyDown', () => {
       keyDownUp('arrow_right');
       keyDownUp('arrow_right');
       expect(getData()[1][1]).toEqual(null);
-      expect(getSelected()).toEqual([1, 1, 1, 1]);
+      expect(getSelected()).toEqual([[1, 1, 1, 1]]);
     });
 
     it('shouldn\'t finish editing and advance to left cell when left arrow is pressed', () => {
@@ -254,7 +254,7 @@ describe('Core_onKeyDown', () => {
       keyDownUp('arrow_left');
       keyDownUp('arrow_left');
       expect(getData()[1][1]).toEqual(null);
-      expect(getSelected()).toEqual([1, 1, 1, 1]);
+      expect(getSelected()).toEqual([[1, 1, 1, 1]]);
     });
 
     it('should finish editing and advance to lower cell when enter is pressed (with sync validator)', (done) => {
@@ -278,7 +278,7 @@ describe('Core_onKeyDown', () => {
       setTimeout(() => {
         expect(onAfterValidate).toHaveBeenCalled();
         expect(getData()[1][1]).toEqual('Ted');
-        expect(getSelected()).toEqual([2, 1, 2, 1]);
+        expect(getSelected()).toEqual([[2, 1, 2, 1]]);
         done();
       }, 200);
     });
@@ -305,7 +305,7 @@ describe('Core_onKeyDown', () => {
       setTimeout(() => {
         expect(onAfterValidate).toHaveBeenCalled();
         expect(getData()[1][1]).toEqual('Ted');
-        expect(getSelected()).toEqual([2, 1, 2, 1]);
+        expect(getSelected()).toEqual([[2, 1, 2, 1]]);
         done();
       }, 200);
     });

--- a/test/e2e/Core_selection.spec.js
+++ b/test/e2e/Core_selection.spec.js
@@ -13,30 +13,36 @@ describe('Core_selection', () => {
   });
 
   it('should call onSelection callback', () => {
-    var output = null;
+    let output = null;
 
     handsontable({
-      afterSelection(r, c) {
-        output = [r, c];
+      afterSelection(selectedCells) {
+        output = selectedCells;
       }
     });
     selectCell(1, 2);
 
-    expect(output[0]).toEqual(1);
-    expect(output[1]).toEqual(2);
+    expect(output.length).toBe(1);
+    expect(output[0].from.row).toBe(1);
+    expect(output[0].from.col).toBe(2);
+    expect(output[0].to.row).toBe(1);
+    expect(output[0].to.col).toBe(2);
   });
 
   it('should trigger selection event', () => {
-    var output = null;
+    let output = null;
 
     handsontable();
-    Handsontable.hooks.add('afterSelection', (r, c) => {
-      output = [r, c];
+    Handsontable.hooks.add('afterSelection', (selectedCells) => {
+      output = selectedCells;
     });
     selectCell(1, 2);
 
-    expect(output[0]).toEqual(1);
-    expect(output[1]).toEqual(2);
+    expect(output.length).toBe(1);
+    expect(output[0].from.row).toBe(1);
+    expect(output[0].from.col).toBe(2);
+    expect(output[0].to.row).toBe(1);
+    expect(output[0].to.col).toBe(2);
   });
 
   it('this.rootElement should point to handsontable rootElement (onSelection)', function() {

--- a/test/e2e/Core_selection.spec.js
+++ b/test/e2e/Core_selection.spec.js
@@ -120,14 +120,14 @@ describe('Core_selection', () => {
       clientY: verticalScrollbarCoords.y
     });
 
-    expect(getSelected()).toEqual([0, 0, 0, 0]);
+    expect(getSelected()).toEqual([[0, 0, 0, 0]]);
 
     $(hot.view.wt.wtTable.holder).simulate('mousedown', {
       clientX: horizontalScrollbarCoords.x,
       clientY: horizontalScrollbarCoords.y
     });
 
-    expect(getSelected()).toEqual([0, 0, 0, 0]);
+    expect(getSelected()).toEqual([[0, 0, 0, 0]]);
   });
 
   it('should not deselect currently selected cell', () => {
@@ -138,7 +138,7 @@ describe('Core_selection', () => {
 
     $('html').simulate('mousedown');
 
-    expect(getSelected()).toEqual([0, 0, 0, 0]);
+    expect(getSelected()).toEqual([[0, 0, 0, 0]]);
   });
 
   it('should allow to focus on external input and hold current selection informations', () => {
@@ -153,7 +153,7 @@ describe('Core_selection', () => {
     textarea.focus();
 
     expect(document.activeElement.id).toEqual('test_textarea');
-    expect(getSelected()).toEqual([0, 0, 0, 0]);
+    expect(getSelected()).toEqual([[0, 0, 0, 0]]);
     textarea.remove();
   });
 
@@ -184,7 +184,7 @@ describe('Core_selection', () => {
     expect(document.activeElement).toBe(document.getElementById('test_textarea'));
 
     // should preserve selection, close editor and save changes
-    expect(getSelected()).toEqual([0, 0, 0, 0]);
+    expect(getSelected()).toEqual([[0, 0, 0, 0]]);
     expect(getDataAtCell(0, 0)).toBeNull();
 
     textarea.remove();
@@ -219,7 +219,7 @@ describe('Core_selection', () => {
     expect(document.activeElement).toBe(document.getElementById('test_textarea'));
 
     // should preserve selection, close editor and save changes
-    expect(getSelected()).toEqual([0, 0, 0, 0]);
+    expect(getSelected()).toEqual([[0, 0, 0, 0]]);
     expect(getDataAtCell(0, 0)).toEqual('Foo');
 
     textarea.remove();
@@ -254,7 +254,7 @@ describe('Core_selection', () => {
     expect(document.activeElement).toBe(document.getElementById('test_textarea'));
 
     // should NOT preserve selection
-    expect(getSelected()).toEqual(undefined);
+    expect(getSelected()).toBeUndefined();
     expect(getDataAtCell(0, 0)).toEqual('Foo');
 
     textarea.remove();
@@ -289,7 +289,7 @@ describe('Core_selection', () => {
     expect(document.activeElement).toBe(document.getElementById('test_textarea'));
 
     // should preserve selection, close editor and save changes
-    expect(getSelected()).toEqual([0, 0, 0, 0]);
+    expect(getSelected()).toEqual([[0, 0, 0, 0]]);
     expect(getDataAtCell(0, 0)).toEqual('Foo');
 
     textarea.remove();
@@ -303,7 +303,7 @@ describe('Core_selection', () => {
     selectCell(0, 0);
     keyDownUp('arrow_left');
 
-    expect(getSelected()).toEqual([0, 0, 0, 0]);
+    expect(getSelected()).toEqual([[0, 0, 0, 0]]);
   });
 
   it('should fix start range if provided is out of bounds (to the top)', () => {
@@ -314,7 +314,7 @@ describe('Core_selection', () => {
     selectCell(0, 0);
     keyDownUp('arrow_up');
 
-    expect(getSelected()).toEqual([0, 0, 0, 0]);
+    expect(getSelected()).toEqual([[0, 0, 0, 0]]);
   });
 
   it('should fix start range if provided is out of bounds (to the right)', () => {
@@ -325,7 +325,7 @@ describe('Core_selection', () => {
     selectCell(0, 4);
     keyDownUp('arrow_right');
 
-    expect(getSelected()).toEqual([0, 4, 0, 4]);
+    expect(getSelected()).toEqual([[0, 4, 0, 4]]);
   });
 
   it('should fix start range if provided is out of bounds (to the bottom)', () => {
@@ -336,7 +336,7 @@ describe('Core_selection', () => {
     selectCell(4, 0);
     keyDownUp('arrow_down');
 
-    expect(getSelected()).toEqual([4, 0, 4, 0]);
+    expect(getSelected()).toEqual([[4, 0, 4, 0]]);
   });
 
   it('should fix end range if provided is out of bounds (to the left)', () => {
@@ -348,7 +348,7 @@ describe('Core_selection', () => {
     keyDownUp('shift+arrow_left');
     keyDownUp('shift+arrow_left');
 
-    expect(getSelected()).toEqual([0, 1, 0, 0]);
+    expect(getSelected()).toEqual([[0, 1, 0, 0]]);
   });
 
   it('should fix end range if provided is out of bounds (to the top)', () => {
@@ -360,7 +360,7 @@ describe('Core_selection', () => {
     keyDownUp('shift+arrow_up');
     keyDownUp('shift+arrow_up');
 
-    expect(getSelected()).toEqual([1, 0, 0, 0]);
+    expect(getSelected()).toEqual([[1, 0, 0, 0]]);
   });
 
   it('should fix end range if provided is out of bounds (to the right)', () => {
@@ -372,7 +372,7 @@ describe('Core_selection', () => {
     keyDownUp('shift+arrow_right');
     keyDownUp('shift+arrow_right');
 
-    expect(getSelected()).toEqual([0, 3, 0, 4]);
+    expect(getSelected()).toEqual([[0, 3, 0, 4]]);
   });
 
   it('should fix end range if provided is out of bounds (to the bottom)', () => {
@@ -385,7 +385,7 @@ describe('Core_selection', () => {
     keyDownUp('shift+arrow_down');
     keyDownUp('shift+arrow_down');
 
-    expect(getSelected()).toEqual([3, 0, 4, 0]);
+    expect(getSelected()).toEqual([[3, 0, 4, 0]]);
   });
 
   it('should select multiple cells', () => {
@@ -395,7 +395,7 @@ describe('Core_selection', () => {
     });
     selectCell(3, 0, 4, 1);
 
-    expect(getSelected()).toEqual([3, 0, 4, 1]);
+    expect(getSelected()).toEqual([[3, 0, 4, 1]]);
   });
 
   it('should call onSelectionEnd as many times as onSelection when `selectCell` is called', () => {
@@ -433,7 +433,7 @@ describe('Core_selection', () => {
     keyDownUp('shift+arrow_down'); // makes tick++
     keyDownUp('shift+arrow_down'); // makes tick++
 
-    expect(getSelected()).toEqual([3, 0, 4, 0]);
+    expect(getSelected()).toEqual([[3, 0, 4, 0]]);
     expect(tick).toEqual(4);
   });
 
@@ -451,7 +451,7 @@ describe('Core_selection', () => {
     keyDown('shift+arrow_down');
     keyDownUp('shift+arrow_down'); // makes tick++
 
-    expect(getSelected()).toEqual([3, 0, 4, 0]);
+    expect(getSelected()).toEqual([[3, 0, 4, 0]]);
     expect(tick).toEqual(2);
   });
 
@@ -468,7 +468,7 @@ describe('Core_selection', () => {
     this.$container.find('.ht_clone_top tr:eq(0) th:eq(4)').simulate('mousedown', {shiftKey: true});
     this.$container.find('.ht_clone_top tr:eq(0) th:eq(4)').simulate('mouseup');
 
-    expect(getSelected()).toEqual([0, 1, 4, 4]);
+    expect(getSelected()).toEqual([[0, 1, 4, 4]]);
 
   });
 
@@ -485,7 +485,7 @@ describe('Core_selection', () => {
     this.$container.find('.ht_clone_left tr:eq(4) th:eq(0)').simulate('mousedown', {shiftKey: true});
     this.$container.find('.ht_clone_left tr:eq(4) th:eq(0)').simulate('mouseup');
 
-    expect(getSelected()).toEqual([1, 0, 4, 4]);
+    expect(getSelected()).toEqual([[1, 0, 4, 4]]);
 
   });
 
@@ -502,7 +502,7 @@ describe('Core_selection', () => {
     this.$container.find('.ht_clone_top tr:eq(0) th:eq(4)').simulate('mousedown', {shiftKey: true});
     this.$container.find('.ht_clone_top tr:eq(0) th:eq(4)').simulate('mouseup');
 
-    expect(getSelected()).toEqual([0, 1, 4, 4]);
+    expect(getSelected()).toEqual([[0, 1, 4, 4]]);
 
   });
 
@@ -518,7 +518,7 @@ describe('Core_selection', () => {
     this.$container.find('.ht_clone_left tr:eq(4) th:eq(0)').simulate('mousedown', {shiftKey: true});
     this.$container.find('.ht_clone_left tr:eq(4) th:eq(0)').simulate('mouseup');
 
-    expect(getSelected()).toEqual([1, 0, 4, 4]);
+    expect(getSelected()).toEqual([[1, 0, 4, 4]]);
 
   });
 
@@ -534,7 +534,7 @@ describe('Core_selection', () => {
     this.$container.find('.ht_clone_top tr:eq(0) th:eq(4)').simulate('mousedown', {shiftKey: true});
     this.$container.find('.ht_clone_top tr:eq(0) th:eq(4)').simulate('mouseup');
 
-    expect(getSelected()).toEqual([0, 1, 4, 4]);
+    expect(getSelected()).toEqual([[0, 1, 4, 4]]);
   });
 
   it('should call onSelection while user selects cells with mouse; onSelectionEnd when user finishes selection', function() {
@@ -557,7 +557,7 @@ describe('Core_selection', () => {
 
     this.$container.find('tr:eq(1) td:eq(3)').simulate('mouseup');
 
-    expect(getSelected()).toEqual([0, 0, 1, 3]);
+    expect(getSelected()).toEqual([[0, 0, 1, 3]]);
     expect(tick).toEqual(3);
     expect(tickEnd).toEqual(1);
   });
@@ -576,7 +576,7 @@ describe('Core_selection', () => {
     this.$container.find('.ht_clone_left tr:eq(0) th:eq(1)').simulate('mouseover');
     this.$container.find('.ht_clone_left tr:eq(0) th:eq(1)').simulate('mouseup');
 
-    expect(getSelected()).toEqual([0, 1, 4, 1]);
+    expect(getSelected()).toEqual([[0, 1, 4, 1]]);
   });
 
   it('should move focus to selected cell', () => {
@@ -629,7 +629,7 @@ describe('Core_selection', () => {
 
     this.$container.find('thead th:eq(0)').simulate('mousedown');
 
-    expect(getSelected()).toEqual([0, 0, 49, 0]);
+    expect(getSelected()).toEqual([[0, 0, 49, 0]]);
     expect(hot.selection.selectedHeader.rows).toBe(false);
     expect(hot.selection.selectedHeader.cols).toBe(true);
     expect(hot.selection.selectedHeader.corner).toBe(false);
@@ -663,7 +663,7 @@ describe('Core_selection', () => {
 
     this.$container.find('.ht_master thead th:eq(1)').simulate('mousedown');
 
-    expect(getSelected()).toEqual([0, 0, 49, 0]);
+    expect(getSelected()).toEqual([[0, 0, 49, 0]]);
     expect(hot.selection.selectedHeader.rows).toBe(false);
     expect(hot.selection.selectedHeader.cols).toBe(true);
     expect(hot.selection.selectedHeader.corner).toBe(false);
@@ -686,7 +686,7 @@ describe('Core_selection', () => {
     this.$container.find('.ht_master thead th:eq(2)').simulate('mousedown');
     this.$container.find('.ht_master thead th:eq(2)').simulate('mouseup');
 
-    expect(getSelected()).toEqual([0, 1, 49, 1]);
+    expect(getSelected()).toEqual([[0, 1, 49, 1]]);
     expect(hot.selection.selectedHeader.rows).toBe(false);
     expect(hot.selection.selectedHeader.cols).toBe(true);
     expect(hot.selection.selectedHeader.corner).toBe(false);
@@ -713,7 +713,7 @@ describe('Core_selection', () => {
     }, 30);
 
     setTimeout(() => {
-      expect(getSelected()).toEqual([12, 11, 10, 11]);
+      expect(getSelected()).toEqual([[12, 11, 10, 11]]);
       done();
     }, 60);
   });
@@ -739,7 +739,7 @@ describe('Core_selection', () => {
     }, 30);
 
     setTimeout(() => {
-      expect(getSelected()).toEqual([12, 11, 12, 10]);
+      expect(getSelected()).toEqual([[12, 11, 12, 10]]);
       done();
     }, 60);
   });
@@ -841,7 +841,7 @@ describe('Core_selection', () => {
 
     this.$container.find('tr:eq(2) th:eq(0)').simulate('mousedown');
 
-    expect(getSelected()).toEqual([1, 0, 1, 4]);
+    expect(getSelected()).toEqual([[1, 0, 1, 4]]);
     expect(hot.selection.selectedHeader.rows).toBe(true);
     expect(hot.selection.selectedHeader.cols).toBe(false);
     expect(hot.selection.selectedHeader.corner).toBe(false);
@@ -872,9 +872,9 @@ describe('Core_selection', () => {
     });
 
     this.$container.find('tr:eq(2) th:eq(0)').simulate('mousedown');
-    expect(getSelected()).toEqual([1, 0, 1, 4]);
+    expect(getSelected()).toEqual([[1, 0, 1, 4]]);
     this.$container.find('tr:eq(3) th:eq(0)').simulate('mousedown');
-    expect(getSelected()).toEqual([2, 0, 2, 4]);
+    expect(getSelected()).toEqual([[2, 0, 2, 4]]);
   });
 
   it('should select a cell in a newly added row after automatic row adding, triggered by editing a cell in the last row with minSpareRows > 0, ' +
@@ -896,7 +896,7 @@ describe('Core_selection', () => {
 
     setTimeout(() => {
       expect(countRows()).toEqual(6);
-      expect(getSelected()).toEqual([5, 0, 5, 0]);
+      expect(getSelected()).toEqual([[5, 0, 5, 0]]);
     }, 200);
 
     setTimeout(() => {
@@ -917,7 +917,7 @@ describe('Core_selection', () => {
     });
     keyDown('arrow_down');
 
-    expect(getSelected()).toEqual([2, 1, 2, 1]);
+    expect(getSelected()).toEqual([[2, 1, 2, 1]]);
   });
 
   it('should change selected coords by modifying coords object via `modifyTransformEnd` hook', () => {
@@ -933,7 +933,7 @@ describe('Core_selection', () => {
     });
     keyDown('shift+arrow_down');
 
-    expect(getSelected()).toEqual([0, 0, 2, 2]);
+    expect(getSelected()).toEqual([[0, 0, 2, 2]]);
   });
 
   it('should indicate is coords is out of bounds via `afterModifyTransformStart` hook', () => {
@@ -1022,12 +1022,12 @@ describe('Core_selection', () => {
     cells.eq(18).simulate('mouseover');
     cells.eq(18).simulate('mouseup');
 
-    expect(hot.getSelected()).toEqual([1, 1, 3, 3]);
+    expect(hot.getSelected()).toEqual([[1, 1, 3, 3]]);
 
     cells.eq(16).simulate('mousedown');
     cells.eq(16).simulate('mouseup');
 
-    expect(hot.getSelected()).toEqual([3, 1, 3, 1]);
+    expect(hot.getSelected()).toEqual([[3, 1, 3, 1]]);
   });
 
   it('should select the first row after corner header is clicked', function() {
@@ -1040,7 +1040,7 @@ describe('Core_selection', () => {
 
     this.$container.find('thead').find('th').eq(0).simulate('mousedown');
 
-    expect(getSelected()).toEqual([0, 0, 0, 0]);
+    expect(getSelected()).toEqual([[0, 0, 0, 0]]);
     expect(hot.selection.selectedHeader.rows).toBe(false);
     expect(hot.selection.selectedHeader.cols).toBe(false);
     expect(hot.selection.selectedHeader.corner).toBe(true);

--- a/test/e2e/Core_selection.spec.js
+++ b/test/e2e/Core_selection.spec.js
@@ -16,33 +16,35 @@ describe('Core_selection', () => {
     let output = null;
 
     handsontable({
-      afterSelection(selectedCells) {
-        output = selectedCells;
+      afterSelection(row, column, rowEnd, columnEnd, preventScrolling, selectionLayerLevel) {
+        output = {row, column, rowEnd, columnEnd, preventScrolling, selectionLayerLevel};
       }
     });
     selectCell(1, 2);
 
-    expect(output.length).toBe(1);
-    expect(output[0].from.row).toBe(1);
-    expect(output[0].from.col).toBe(2);
-    expect(output[0].to.row).toBe(1);
-    expect(output[0].to.col).toBe(2);
+    expect(output.row).toBe(1);
+    expect(output.column).toBe(2);
+    expect(output.rowEnd).toBe(1);
+    expect(output.columnEnd).toBe(2);
+    expect(output.preventScrolling.value).toBe(false);
+    expect(output.selectionLayerLevel).toBe(0);
   });
 
   it('should trigger selection event', () => {
     let output = null;
 
     handsontable();
-    Handsontable.hooks.add('afterSelection', (selectedCells) => {
-      output = selectedCells;
+    Handsontable.hooks.add('afterSelection', (row, column, rowEnd, columnEnd, preventScrolling, selectionLayerLevel) => {
+      output = {row, column, rowEnd, columnEnd, preventScrolling, selectionLayerLevel};
     });
     selectCell(1, 2);
 
-    expect(output.length).toBe(1);
-    expect(output[0].from.row).toBe(1);
-    expect(output[0].from.col).toBe(2);
-    expect(output[0].to.row).toBe(1);
-    expect(output[0].to.col).toBe(2);
+    expect(output.row).toBe(1);
+    expect(output.column).toBe(2);
+    expect(output.rowEnd).toBe(1);
+    expect(output.columnEnd).toBe(2);
+    expect(output.preventScrolling.value).toBe(false);
+    expect(output.selectionLayerLevel).toBe(0);
   });
 
   it('this.rootElement should point to handsontable rootElement (onSelection)', function() {

--- a/test/e2e/Core_setDataAtCell.spec.js
+++ b/test/e2e/Core_setDataAtCell.spec.js
@@ -81,7 +81,7 @@ describe('Core_setDataAtCell', () => {
     }, 200);
   });
 
-  it('should paste not more rows than maxRows', (done) => {
+  it('should paste not more rows than maxRows', async () => {
     handsontable({
       minSpareRows: 1,
       minRows: 5,
@@ -90,11 +90,10 @@ describe('Core_setDataAtCell', () => {
     selectCell(4, 0);
     triggerPaste('1\n2\n3\n4\n5\n6\n7\n8\n9\n10');
 
-    setTimeout(() => {
-      expect(countRows()).toEqual(10);
-      expect(getDataAtCell(9, 0)).toEqual('6');
-      done();
-    }, 200);
+    await sleep(200);
+
+    expect(countRows()).toEqual(10);
+    expect(getDataAtCell(9, 0)).toEqual('6');
   });
 
   it('should paste not more cols than maxCols', (done) => {

--- a/test/e2e/Core_validate.spec.js
+++ b/test/e2e/Core_validate.spec.js
@@ -1532,10 +1532,10 @@ describe('Core_validate', () => {
 
     setTimeout(() => {
       expect(isEditorVisible()).toBe(false);
-      expect(getSelected()).toEqual([3, 0, 3, 0]);
+      expect(getSelected()).toEqual([[3, 0, 3, 0]]);
 
       keyDownUp('arrow_up');
-      expect(getSelected()).toEqual([2, 0, 2, 0]);
+      expect(getSelected()).toEqual([[2, 0, 2, 0]]);
       done();
     }, 400);
   });
@@ -1565,16 +1565,16 @@ describe('Core_validate', () => {
     document.activeElement.value = '999';
     keyDownUp('enter');
 
-    expect(getSelected()).toEqual([3, 0, 3, 0]);
+    expect(getSelected()).toEqual([[3, 0, 3, 0]]);
 
     keyDownUp('arrow_down');
     keyDownUp('arrow_down');
     expect(isEditorVisible()).toBe(true);
-    expect(getSelected()).toEqual([5, 0, 5, 0]);
+    expect(getSelected()).toEqual([[5, 0, 5, 0]]);
 
     setTimeout(() => {
       expect(isEditorVisible()).toBe(false);
-      expect(getSelected()).toEqual([5, 0, 5, 0]); // only enterMove and first arrow_down is performed
+      expect(getSelected()).toEqual([[5, 0, 5, 0]]); // only enterMove and first arrow_down is performed
       done();
     }, 200);
   });
@@ -1605,16 +1605,16 @@ describe('Core_validate', () => {
     document.activeElement.value = '999';
     keyDownUp('enter');
 
-    expect(getSelected()).toEqual([3, 0, 3, 0]);
+    expect(getSelected()).toEqual([[3, 0, 3, 0]]);
 
     keyDownUp('arrow_up');
     keyDownUp('arrow_up');
     expect(isEditorVisible()).toBe(true);
-    expect(getSelected()).toEqual([1, 0, 1, 0]);
+    expect(getSelected()).toEqual([[1, 0, 1, 0]]);
 
     setTimeout(() => {
       expect(isEditorVisible()).toBe(false);
-      expect(getSelected()).toEqual([1, 0, 1, 0]);
+      expect(getSelected()).toEqual([[1, 0, 1, 0]]);
       done();
     }, 200);
   });
@@ -1644,16 +1644,16 @@ describe('Core_validate', () => {
     keyDownUp('enter');
     document.activeElement.value = '999';
     keyDownUp('enter'); // should be accepted but only after 100 ms
-    expect(getSelected()).toEqual([3, 0, 3, 0]);
+    expect(getSelected()).toEqual([[3, 0, 3, 0]]);
 
     keyDownUp('arrow_right');
     keyDownUp('arrow_right');
     expect(isEditorVisible()).toBe(true);
-    expect(getSelected()).toEqual([3, 2, 3, 2]);
+    expect(getSelected()).toEqual([[3, 2, 3, 2]]);
 
     setTimeout(() => {
       expect(isEditorVisible()).toBe(false);
-      expect(getSelected()).toEqual([3, 2, 3, 2]);
+      expect(getSelected()).toEqual([[3, 2, 3, 2]]);
       done();
     }, 200);
   });
@@ -1683,7 +1683,7 @@ describe('Core_validate', () => {
     keyDownUp('enter');
     document.activeElement.value = '999';
     keyDownUp('enter'); // should be accepted but only after 100 ms
-    expect(getSelected()).toEqual([3, 2, 3, 2]);
+    expect(getSelected()).toEqual([[3, 2, 3, 2]]);
 
     this.$container.simulate('keydown', {keyCode: Handsontable.helper.KEY_CODES.ARROW_LEFT});
     this.$container.simulate('keyup', {keyCode: Handsontable.helper.KEY_CODES.ARROW_LEFT});
@@ -1691,11 +1691,11 @@ describe('Core_validate', () => {
     this.$container.simulate('keyup', {keyCode: Handsontable.helper.KEY_CODES.ARROW_LEFT});
 
     expect(isEditorVisible()).toBe(true);
-    expect(getSelected()).toEqual([3, 0, 3, 0]);
+    expect(getSelected()).toEqual([[3, 0, 3, 0]]);
 
     setTimeout(() => {
       expect(isEditorVisible()).toBe(false);
-      expect(getSelected()).toEqual([3, 0, 3, 0]);
+      expect(getSelected()).toEqual([[3, 0, 3, 0]]);
       done();
     }, 200);
   });

--- a/test/e2e/Core_view.spec.js
+++ b/test/e2e/Core_view.spec.js
@@ -26,7 +26,7 @@ describe('Core_view', () => {
     keyDown('arrow_down');
     keyDown('arrow_down');
 
-    expect(getSelected()).toEqual([4, 0, 4, 0]);
+    expect(getSelected()).toEqual([[4, 0, 4, 0]]);
 
     keyDown('enter');
 
@@ -98,7 +98,7 @@ describe('Core_view', () => {
     htCore.find('tr:eq(3) td:eq(0)').simulate('mousedown');
 
     expect(hot.rootElement.querySelector('.wtHolder').scrollTop).toBeGreaterThan(scrollTop);
-    expect(getSelected()).toEqual([3, 0, 3, 0]);
+    expect(getSelected()).toEqual([[3, 0, 3, 0]]);
   });
 
   it('should scroll viewport without cell selection', function() {
@@ -317,7 +317,7 @@ describe('Core_view', () => {
 
     keyDown('arrow_right');
 
-    expect(getSelected()).toEqual([39, 1, 39, 1]);
+    expect(getSelected()).toEqual([[39, 1, 39, 1]]);
     expect($(window).scrollTop()).toEqual(lastScroll);
   });
 

--- a/test/e2e/FillHandle.spec.js
+++ b/test/e2e/FillHandle.spec.js
@@ -275,7 +275,7 @@ describe('FillHandle', () => {
     this.$container.find('tr:eq(2) td:eq(0)').simulate('mouseover');
     this.$container.find('.wtBorder.corner').simulate('mouseup');
 
-    expect(getSelected()).toEqual([0, 0, 2, 0]);
+    expect(getSelected()).toEqual([[0, 0, 2, 0]]);
     expect(getDataAtCell(1, 0)).toEqual('test');
   });
 
@@ -303,7 +303,7 @@ describe('FillHandle', () => {
     this.$container.find('tr:eq(2) td:eq(0)').simulate('mouseover');
     this.$container.find('tr:eq(2) td:eq(0)').simulate('mouseup');
 
-    expect(getSelected()).toEqual([1, 1, 2, 1]);
+    expect(getSelected()).toEqual([[1, 1, 2, 1]]);
     expect(getDataAtCell(2, 1)).toEqual('test');
 
     document.body.removeChild($table[0]);

--- a/test/e2e/editors/autocompleteEditor.spec.js
+++ b/test/e2e/editors/autocompleteEditor.spec.js
@@ -1304,7 +1304,7 @@ describe('AutocompleteEditor', () => {
           ['black']
         ]);
 
-        var selected = innerHot.getSelected();
+        var selected = innerHot.getSelected()[0];
         var selectedData = innerHot.getDataAtCell(selected[0], selected[1]);
 
         expect(selectedData).toEqual('blue');
@@ -1362,7 +1362,7 @@ describe('AutocompleteEditor', () => {
           ['black']
         ]);
 
-        var selected = innerHot.getSelected();
+        var selected = innerHot.getSelected()[0];
         var selectedData = innerHot.getDataAtCell(selected[0], selected[1]);
 
         expect(selectedData).toEqual('blue');
@@ -1816,7 +1816,7 @@ describe('AutocompleteEditor', () => {
         var ac = hot.getActiveEditor();
         var innerHot = ac.htEditor;
 
-        expect(innerHot.getSelected()).toEqual([1, 0, 1, 0]);
+        expect(innerHot.getSelected()).toEqual([[1, 0, 1, 0]]);
         done();
       }, 400);
     });
@@ -2702,7 +2702,7 @@ describe('AutocompleteEditor', () => {
     setTimeout(() => {
       keyDownUp('arrow_up');
 
-      expect(getSelected()).toEqual([0, 0, 0, 0]);
+      expect(getSelected()).toEqual([[0, 0, 0, 0]]);
       done();
     }, 200);
   });
@@ -2735,7 +2735,7 @@ describe('AutocompleteEditor', () => {
     setTimeout(() => {
       keyDownUp('arrow_right');
 
-      expect(getSelected()).toEqual([1, 1, 1, 1]);
+      expect(getSelected()).toEqual([[1, 1, 1, 1]]);
       done();
     }, 200);
   });
@@ -2770,7 +2770,7 @@ describe('AutocompleteEditor', () => {
     setTimeout(() => {
       keyDownUp('arrow_left');
 
-      expect(getSelected()).toEqual([1, 0, 1, 0]);
+      expect(getSelected()).toEqual([[1, 0, 1, 0]]);
       done();
     }, 200);
   });
@@ -2802,7 +2802,7 @@ describe('AutocompleteEditor', () => {
     setTimeout(() => {
       keyDownUp('arrow_down');
 
-      expect(getSelected()).toEqual([1, 0, 1, 0]);
+      expect(getSelected()).toEqual([[1, 0, 1, 0]]);
       done();
     }, 200);
   });
@@ -2840,7 +2840,7 @@ describe('AutocompleteEditor', () => {
     setTimeout(() => {
       keyDownUp('arrow_down');
 
-      expect(getSelected()).toEqual([2, 0, 2, 0]);
+      expect(getSelected()).toEqual([[2, 0, 2, 0]]);
       done();
     }, 200);
   });
@@ -2872,7 +2872,7 @@ describe('AutocompleteEditor', () => {
     setTimeout(() => {
       keyDownUp('arrow_down');
 
-      expect(getSelected()).toEqual([1, 0, 1, 0]);
+      expect(getSelected()).toEqual([[1, 0, 1, 0]]);
       done();
     }, 200);
   });
@@ -2901,15 +2901,15 @@ describe('AutocompleteEditor', () => {
     setTimeout(() => {
       keyDownUp('arrow_down');
 
-      expect(hot.getActiveEditor().htEditor.getSelected()).toEqual([0, 0, 0, 0]);
+      expect(hot.getActiveEditor().htEditor.getSelected()).toEqual([[0, 0, 0, 0]]);
 
       keyDownUp('arrow_down');
 
-      expect(hot.getActiveEditor().htEditor.getSelected()).toEqual([1, 0, 1, 0]);
+      expect(hot.getActiveEditor().htEditor.getSelected()).toEqual([[1, 0, 1, 0]]);
 
       keyDownUp('arrow_down');
 
-      expect(hot.getActiveEditor().htEditor.getSelected()).toEqual([2, 0, 2, 0]);
+      expect(hot.getActiveEditor().htEditor.getSelected()).toEqual([[2, 0, 2, 0]]);
       done();
     }, 200);
   });
@@ -2938,19 +2938,19 @@ describe('AutocompleteEditor', () => {
     setTimeout(() => {
       hot.getActiveEditor().htEditor.selectCell(2, 0);
 
-      expect(hot.getActiveEditor().htEditor.getSelected()).toEqual([2, 0, 2, 0]);
+      expect(hot.getActiveEditor().htEditor.getSelected()).toEqual([[2, 0, 2, 0]]);
 
       keyDownUp('arrow_up');
 
-      expect(hot.getActiveEditor().htEditor.getSelected()).toEqual([1, 0, 1, 0]);
+      expect(hot.getActiveEditor().htEditor.getSelected()).toEqual([[1, 0, 1, 0]]);
 
       keyDownUp('arrow_up');
 
-      expect(hot.getActiveEditor().htEditor.getSelected()).toEqual([0, 0, 0, 0]);
+      expect(hot.getActiveEditor().htEditor.getSelected()).toEqual([[0, 0, 0, 0]]);
 
       keyDownUp('arrow_up');
 
-      expect(hot.getActiveEditor().htEditor.getSelected()).toEqual([0, 0, 0, 0]);
+      expect(hot.getActiveEditor().htEditor.getSelected()).toEqual([[0, 0, 0, 0]]);
       done();
     }, 200);
   });
@@ -3020,7 +3020,7 @@ describe('AutocompleteEditor', () => {
       keyDownUp('arrow_up');
       keyDownUp('arrow_up');
 
-      expect(getSelected()).toEqual([0, 0, 0, 0]);
+      expect(getSelected()).toEqual([[0, 0, 0, 0]]);
       done();
     }, 200);
   });

--- a/test/e2e/editors/handsontableEditor.spec.js
+++ b/test/e2e/editors/handsontableEditor.spec.js
@@ -175,14 +175,14 @@ describe('HandsontableEditor', () => {
           handsontable: {
             colHeaders: ['Marque', 'Country', 'Parent company'],
             data: getManufacturerData(),
-            afterSelection() {
-              selections.push(['inner', arguments[0]]); // arguments[0] is selection start row
+            afterSelection(selectedCells) {
+              selections.push(['inner', selectedCells[0].from.row]);
             }
           }
         }
       ],
-      afterSelection() {
-        selections.push(['outer', arguments[0]]); // arguments[0] is selection start row
+      afterSelection(selectedCells) {
+        selections.push(['outer', selectedCells[0].from.row]);
       }
     });
     expect(selections.length).toBe(0);

--- a/test/e2e/editors/handsontableEditor.spec.js
+++ b/test/e2e/editors/handsontableEditor.spec.js
@@ -162,7 +162,7 @@ describe('HandsontableEditor', () => {
     keyDownUp('arrow_down');
     keyDownUp('arrow_down');
 
-    expect(getSelected()).toEqual([4, 0, 4, 0]);
+    expect(getSelected()).toEqual([[4, 0, 4, 0]]);
   });
 
   it('should focus the TD after HT editor is prepared, finished (by keyboard) and destroyed', () => {
@@ -226,7 +226,7 @@ describe('HandsontableEditor', () => {
       var ht = hot.getActiveEditor();
       var innerHot = ht.htEditor;
 
-      expect(innerHot.getSelected()).toEqual([0, 0, 0, 0]);
+      expect(innerHot.getSelected()).toEqual([[0, 0, 0, 0]]);
     });
 
     it('should hide textarea', () => {

--- a/test/e2e/editors/handsontableEditor.spec.js
+++ b/test/e2e/editors/handsontableEditor.spec.js
@@ -175,14 +175,14 @@ describe('HandsontableEditor', () => {
           handsontable: {
             colHeaders: ['Marque', 'Country', 'Parent company'],
             data: getManufacturerData(),
-            afterSelection(selectedCells) {
-              selections.push(['inner', selectedCells[0].from.row]);
+            afterSelection(row) {
+              selections.push(['inner', row]);
             }
           }
         }
       ],
-      afterSelection(selectedCells) {
-        selections.push(['outer', selectedCells[0].from.row]);
+      afterSelection(row) {
+        selections.push(['outer', row]);
       }
     });
     expect(selections.length).toBe(0);

--- a/test/e2e/editors/noEditor.spec.js
+++ b/test/e2e/editors/noEditor.spec.js
@@ -24,7 +24,7 @@ describe('noEditor', () => {
     keyDown('enter');
     selection = getSelected();
 
-    expect(selection).toEqual([2, 2, 2, 2]);
+    expect(selection).toEqual([[2, 2, 2, 2]]);
     expect(isEditorVisible()).toEqual(false);
   });
 
@@ -40,7 +40,7 @@ describe('noEditor', () => {
     keyDown('enter');
     selection = getSelected();
 
-    expect(selection).toEqual([2, 2, 2, 2]);
+    expect(selection).toEqual([[2, 2, 2, 2]]);
   });
 
   it('shouldn\'t move down when enterBeginsEditing equals false', () => {
@@ -55,7 +55,7 @@ describe('noEditor', () => {
     keyDown('enter');
     selection = getSelected();
 
-    expect(selection).toEqual([3, 2, 3, 2]);
+    expect(selection).toEqual([[3, 2, 3, 2]]);
     expect(isEditorVisible()).toEqual(false);
   });
 

--- a/test/e2e/editors/textEditor.spec.js
+++ b/test/e2e/editors/textEditor.spec.js
@@ -22,7 +22,8 @@ describe('TextEditor', () => {
     keyDown('enter');
 
     var selection = getSelected();
-    expect(selection).toEqual([2, 2, 2, 2]);
+
+    expect(selection).toEqual([[2, 2, 2, 2]]);
     expect(isEditorVisible()).toEqual(true);
   });
 
@@ -36,7 +37,7 @@ describe('TextEditor', () => {
     keyDown('enter');
 
     var selection = getSelected();
-    expect(selection).toEqual([3, 2, 3, 2]);
+    expect(selection).toEqual([[3, 2, 3, 2]]);
   });
 
   it('should move down when enterBeginsEditing equals false', () => {
@@ -48,7 +49,7 @@ describe('TextEditor', () => {
     keyDown('enter');
 
     var selection = getSelected();
-    expect(selection).toEqual([3, 2, 3, 2]);
+    expect(selection).toEqual([[3, 2, 3, 2]]);
     expect(isEditorVisible()).toEqual(false);
   });
 
@@ -512,7 +513,7 @@ describe('TextEditor', () => {
     }); // CTRL+A should NOT select all table when cell is edited
 
     var selection = getSelected();
-    expect(selection).toEqual([2, 2, 2, 2]);
+    expect(selection).toEqual([[2, 2, 2, 2]]);
     expect(isEditorVisible()).toEqual(true);
   });
 
@@ -610,7 +611,7 @@ describe('TextEditor', () => {
     this.$container2.find('tbody tr:eq(0) td:eq(0)').simulate('mouseup');
 
     expect(hot1.getSelected()).toBeUndefined();
-    expect(hot2.getSelected()).toEqual([0, 0, 0, 0]);
+    expect(hot2.getSelected()).toEqual([[0, 0, 0, 0]]);
 
     // Open editor in HOT2
     keyDown('enter');

--- a/test/e2e/renderers/checkboxRenderer.spec.js
+++ b/test/e2e/renderers/checkboxRenderer.spec.js
@@ -77,7 +77,7 @@ describe('CheckboxRenderer', () => {
 
     setTimeout(() => {
       expect(spy.test.calls.count()).toBe(0);
-      expect(hot.getSelected()).toEqual([2, 0, 2, 0]);
+      expect(hot.getSelected()).toEqual([[2, 0, 2, 0]]);
 
       done();
     }, 100);
@@ -95,7 +95,7 @@ describe('CheckboxRenderer', () => {
 
     this.$container.find('td label').eq(2).simulate('mousedown');
 
-    expect(hot.getSelected()).toEqual([2, 0, 2, 0]);
+    expect(hot.getSelected()).toEqual([[2, 0, 2, 0]]);
   });
 
   it('should reverse selection in checkboxes', function() {

--- a/test/helpers/common.js
+++ b/test/helpers/common.js
@@ -83,11 +83,11 @@ export function getCorrespondingOverlay(cell, container) {
  */
 export function contextMenu(cell) {
   var hot = spec().$container.data('handsontable');
-  var selected = hot.getSelected();
+  var selected = hot.getSelectedRecently();
 
   if (!selected) {
     hot.selectCell(0, 0);
-    selected = hot.getSelected();
+    selected = hot.getSelectedRecently();
   }
   if (!cell) {
     cell = getCell(selected[0], selected[1]);

--- a/test/helpers/common.js
+++ b/test/helpers/common.js
@@ -83,11 +83,11 @@ export function getCorrespondingOverlay(cell, container) {
  */
 export function contextMenu(cell) {
   var hot = spec().$container.data('handsontable');
-  var selected = hot.getSelectedRecently();
+  var selected = hot.getSelectedLast();
 
   if (!selected) {
     hot.selectCell(0, 0);
-    selected = hot.getSelectedRecently();
+    selected = hot.getSelectedLast();
   }
   if (!cell) {
     cell = getCell(selected[0], selected[1]);

--- a/test/helpers/common.js
+++ b/test/helpers/common.js
@@ -223,7 +223,11 @@ export function handsontableKeyTriggerFactory(type) {
           break;
 
         case 'ctrl':
-          ev.keyCode = 17;
+          if (window.navigator.platform.includes('Mac')) {
+            ev.keyCode = 91;
+          } else {
+            ev.keyCode = 17;
+          }
           break;
 
         case 'shift':
@@ -377,10 +381,15 @@ export const addHook = handsontableMethodFactory('addHook');
 export const alter = handsontableMethodFactory('alter');
 export const colToProp = handsontableMethodFactory('colToProp');
 export const countCols = handsontableMethodFactory('countCols');
+export const countEmptyCols = handsontableMethodFactory('countEmptyCols');
+export const countEmptyRows = handsontableMethodFactory('countEmptyRows');
 export const countRows = handsontableMethodFactory('countRows');
+export const countSourceCols = handsontableMethodFactory('countSourceCols');
+export const countSourceRows = handsontableMethodFactory('countSourceRows');
 export const deselectCell = handsontableMethodFactory('deselectCell');
 export const destroy = handsontableMethodFactory('destroy');
 export const destroyEditor = handsontableMethodFactory('destroyEditor');
+export const emptySelectedCells = handsontableMethodFactory('emptySelectedCells');
 export const getActiveEditor = handsontableMethodFactory('getActiveEditor');
 export const getCell = handsontableMethodFactory('getCell');
 export const getCellEditor = handsontableMethodFactory('getCellEditor');
@@ -401,6 +410,9 @@ export const getDataType = handsontableMethodFactory('getDataType');
 export const getInstance = handsontableMethodFactory('getInstance');
 export const getRowHeader = handsontableMethodFactory('getRowHeader');
 export const getSelected = handsontableMethodFactory('getSelected');
+export const getSelectedLast = handsontableMethodFactory('getSelectedLast');
+export const getSelectedRange = handsontableMethodFactory('getSelectedRange');
+export const getSelectedRangeLast = handsontableMethodFactory('getSelectedRangeLast');
 export const getSourceData = handsontableMethodFactory('getSourceData');
 export const getSourceDataArray = handsontableMethodFactory('getSourceDataArray');
 export const getSourceDataAtCell = handsontableMethodFactory('getSourceDataAtCell');
@@ -420,10 +432,6 @@ export const spliceCellsMeta = handsontableMethodFactory('spliceCellsMeta');
 export const spliceCol = handsontableMethodFactory('spliceCol');
 export const spliceRow = handsontableMethodFactory('spliceRow');
 export const updateSettings = handsontableMethodFactory('updateSettings');
-export const countSourceRows = handsontableMethodFactory('countSourceRows');
-export const countSourceCols = handsontableMethodFactory('countSourceCols');
-export const countEmptyRows = handsontableMethodFactory('countEmptyRows');
-export const countEmptyCols = handsontableMethodFactory('countEmptyCols');
 
 /**
  * Returns column width for HOT container

--- a/test/types/handsontable-tests.ts
+++ b/test/types/handsontable-tests.ts
@@ -83,7 +83,7 @@ var hotSettings: Handsontable.GridSettings = {
   minRows: 123,
   minSpareCols: 123,
   minSpareRows: 123,
-  multiSelect: true,
+  selectionMode: 'single',
   nestedHeaders: [],
   noWordWrapClassName: 'foo',
   observeChanges: true,
@@ -179,10 +179,10 @@ var hotSettings: Handsontable.GridSettings = {
   afterRowResize: (currentRow, newSize, isDoubleClick) => {},
   afterScrollHorizontally: () => {},
   afterScrollVertically: () => {},
-  afterSelection: (r, c, r2, c2) => {},
-  afterSelectionByProp: (r, p, r2, p2) => {},
-  afterSelectionEnd: (r, c, r2, c2) => {},
-  afterSelectionEndByProp: (r, p, r2, p2) => {},
+  afterSelection: (r, c, r2, c2, preventScrolling, selectionLayerLevel) => {},
+  afterSelectionByProp: (r, p, r2, p2, preventScrolling, selectionLayerLevel) => {},
+  afterSelectionEnd: (r, c, r2, c2, selectionLayerLevel) => {},
+  afterSelectionEndByProp: (r, p, r2, p2, selectionLayerLevel) => {},
   afterSetCellMeta: (row, col, key, value) => {},
   afterSetDataAtCell: (changes, source) => {},
   afterSetDataAtRowProp: (changes, source) => {},
@@ -278,6 +278,7 @@ function test_HandsontableMethods() {
   hot.deselectCell();
   hot.destroy();
   hot.destroyEditor(true);
+  hot.emptySelectedCells();
   hot.getActiveEditor();
   hot.getCell(123, 123, true);
   hot.getCellEditor(123, 123);
@@ -302,7 +303,9 @@ function test_HandsontableMethods() {
   hot.getRowHeight(123);
   hot.getSchema();
   hot.getSelected();
+  hot.getSelectedLast();
   hot.getSelectedRange();
+  hot.getSelectedRangeLast();
   hot.getSettings();
   hot.getSourceData(123, 123, 123, 123);
   hot.getSourceDataAtCell(123, 123);

--- a/test/unit/helpers/Unicode.spec.js
+++ b/test/unit/helpers/Unicode.spec.js
@@ -1,5 +1,6 @@
 import {
   isKey,
+  isCtrlMetaKey,
 } from 'handsontable/helpers/unicode';
 
 describe('Unicode helper', () => {
@@ -26,6 +27,23 @@ describe('Unicode helper', () => {
       expect(isKey(37, 'ARROW_RIGHT|ARROW_UP|ARROW_BOTTOM')).toBe(false);
       expect(isKey('39', 'ARROW_RIGHT|ARROW_UP|ARROW_BOTTOM')).toBe(false);
       expect(isKey(116, 'ARROW_RIGHT|ARROW_UP|ARROW_BOTTOM')).toBe(false);
+    });
+  });
+
+  //
+  // Handsontable.helper.isCtrlMetaKey
+  //
+  describe('isCtrlMetaKey', () => {
+    it('should return `true` when CTRL/CMD key is pressed', () => {
+      expect(isCtrlMetaKey(17)).toBe(true);
+      expect(isCtrlMetaKey(91)).toBe(true);
+      expect(isCtrlMetaKey(93)).toBe(true);
+      expect(isCtrlMetaKey(224)).toBe(true);
+
+      expect(isCtrlMetaKey()).toBe(false);
+      expect(isCtrlMetaKey(223)).toBe(false);
+      expect(isCtrlMetaKey(1)).toBe(false);
+      expect(isCtrlMetaKey(16)).toBe(false);
     });
   });
 });

--- a/test/unit/utils/keyStateObserver.spec.js
+++ b/test/unit/utils/keyStateObserver.spec.js
@@ -1,0 +1,158 @@
+import {
+  _getRefCount,
+  _resetState,
+  isPressed,
+  isPressedCtrlKey,
+  startObserving,
+  stopObserving,
+} from 'handsontable/utils/keyStateObserver';
+
+describe('keyStateObserver', () => {
+  afterEach(() => {
+    _resetState();
+  });
+
+  describe('.startObserving', () => {
+    it('should internally keep calls count to make the dom listener removable', () => {
+      startObserving();
+      startObserving();
+      startObserving();
+      startObserving();
+
+      expect(_getRefCount()).toBe(4);
+    });
+  });
+
+  describe('.stopObserving', () => {
+    it('should internally keep calls count to make the dom listener removable', () => {
+      startObserving();
+      startObserving();
+      startObserving();
+      startObserving();
+
+      expect(_getRefCount()).toBe(4);
+
+      stopObserving();
+      stopObserving();
+      stopObserving();
+      stopObserving();
+      stopObserving();
+      stopObserving();
+
+      expect(_getRefCount()).toBe(0);
+    });
+
+    it('should reset all key states after the last stopObserving function is called', () => {
+      startObserving();
+
+      expect(isPressed('ENTER')).toBe(false);
+      expect(isPressed('BACKSPACE')).toBe(false);
+      expect(isPressedCtrlKey()).toBe(false);
+
+      document.dispatchEvent(new KeyboardEvent('keydown', {keyCode: 13}));
+      document.dispatchEvent(new KeyboardEvent('keydown', {keyCode: 8}));
+      document.dispatchEvent(new KeyboardEvent('keydown', {keyCode: 91}));
+
+      expect(isPressed('ENTER')).toBe(true);
+      expect(isPressed('BACKSPACE')).toBe(true);
+      expect(isPressedCtrlKey()).toBe(true);
+
+      stopObserving();
+
+      expect(isPressed('ENTER')).toBe(false);
+      expect(isPressed('BACKSPACE')).toBe(false);
+      expect(isPressedCtrlKey()).toBe(false);
+    });
+  });
+
+  describe('.isPressedCtrlKey', () => {
+    it('should return `true` when CTRL key is pressed', () => {
+      startObserving();
+
+      expect(isPressedCtrlKey()).toBe(false);
+
+      document.dispatchEvent(new KeyboardEvent('keydown', {keyCode: 17}));
+
+      expect(isPressedCtrlKey()).toBe(true);
+
+      document.dispatchEvent(new KeyboardEvent('keyup', {keyCode: 17}));
+
+      expect(isPressedCtrlKey()).toBe(false);
+    });
+
+    it('should return `true` when left CMD key is pressed', () => {
+      startObserving();
+
+      expect(isPressedCtrlKey()).toBe(false);
+
+      document.dispatchEvent(new KeyboardEvent('keydown', {keyCode: 91}));
+
+      expect(isPressedCtrlKey()).toBe(true);
+
+      document.dispatchEvent(new KeyboardEvent('keyup', {keyCode: 91}));
+
+      expect(isPressedCtrlKey()).toBe(false);
+    });
+
+    it('should return `true` when right CMD key is pressed', () => {
+      startObserving();
+
+      expect(isPressedCtrlKey()).toBe(false);
+
+      document.dispatchEvent(new KeyboardEvent('keydown', {keyCode: 93}));
+
+      expect(isPressedCtrlKey()).toBe(true);
+
+      document.dispatchEvent(new KeyboardEvent('keyup', {keyCode: 93}));
+
+      expect(isPressedCtrlKey()).toBe(false);
+    });
+
+    it('should return `true` when CMD key is pressed (macOS on FF)', () => {
+      startObserving();
+
+      expect(isPressedCtrlKey()).toBe(false);
+
+      document.dispatchEvent(new KeyboardEvent('keydown', {keyCode: 224}));
+
+      expect(isPressedCtrlKey()).toBe(true);
+
+      document.dispatchEvent(new KeyboardEvent('keyup', {keyCode: 224}));
+
+      expect(isPressedCtrlKey()).toBe(false);
+    });
+  });
+
+  describe('.isPressed', () => {
+    it('should return `true` when ENTER key is pressed', () => {
+      startObserving();
+
+      expect(isPressed('ENTER')).toBe(false);
+
+      document.dispatchEvent(new KeyboardEvent('keydown', {keyCode: 13}));
+
+      expect(isPressed('ENTER')).toBe(true);
+
+      document.dispatchEvent(new KeyboardEvent('keyup', {keyCode: 13}));
+
+      expect(isPressed('ENTER')).toBe(false);
+    });
+
+    it('should return `true` when multiple expected keys are pressed', () => {
+      startObserving();
+
+      expect(isPressed('ENTER|BACKSPACE')).toBe(false);
+
+      document.dispatchEvent(new KeyboardEvent('keydown', {keyCode: 13}));
+
+      expect(isPressed('ENTER|BACKSPACE')).toBe(true);
+
+      document.dispatchEvent(new KeyboardEvent('keyup', {keyCode: 13}));
+      document.dispatchEvent(new KeyboardEvent('keydown', {keyCode: 8}));
+
+      expect(isPressed('ENTER|BACKSPACE')).toBe(true);
+
+      document.dispatchEvent(new KeyboardEvent('keyup', {keyCode: 8}));
+    });
+  });
+});


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
This PR extends the functionality of the how cell selection works. The code contains changes which allow selecting non-consecutive cells like in the regularly excel/google spreadsheet app. 

That is why the new setting was implemented `selectionMode` which can be set as:
 - `'single'`: Only a single cell can be selected.
 - `'range'`: Multiple cells within a single range can be selected.
 - `'multiple'`: Multiple ranges of cells can be selected.

The default value is set to `'multiple'`.

The multiple selections are triggered by pressing the CTRL/CMD key.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):
1. #4708

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [x] My change requires a change to the documentation.
