### PR TITLE
Fix selection background for the cells with multiline values

### DIFF
--- a/src/css/handsontable.css
+++ b/src/css/handsontable.css
@@ -298,8 +298,24 @@
   left: 0;
   right: 0;
   bottom: 0;
+  bottom: -100%\9; /* Fix for IE9 to spread the ":before" pseudo element to 100% height of the parent element */
   background: #005eff;
 }
+
+/* Fix for IE10 and IE11 to spread the ":before" pseudo element to 100% height of the parent element */
+@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+  .handsontable td.area:before,
+  .handsontable td.area-1:before,
+  .handsontable td.area-2:before,
+  .handsontable td.area-3:before,
+  .handsontable td.area-4:before,
+  .handsontable td.area-5:before,
+  .handsontable td.area-6:before,
+  .handsontable td.area-7:before {
+    bottom: -100%;
+  }
+}
+
 .handsontable td.area:before {
   opacity: 0.1;
 }


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The selection doesn't work correctly for IE9 to IE11. To fix the issue CSS properties are added which are only valid for IE9, IE10, and IE11. Those properties spread the pseudo element to the 100% of the parent height.

### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
It was tested on most popular browsers including IE9, IE10, IE11 and Edge.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. #4806

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [x] My change requires a change to the documentation.
