### PR TITLE
Remove CSS properties which overwrite cells background color

### DIFF
--- a/.config/test-e2e.js
+++ b/.config/test-e2e.js
@@ -42,6 +42,7 @@ module.exports.create = function create(envArgs) {
         externalCssFiles: [
           'lib/normalize.css',
           '../dist/handsontable.css',
+          'helpers/common.css',
         ],
         externalJsFiles: [
           '../test/lib/phantom-reporter.js',

--- a/.config/test-production.js
+++ b/.config/test-production.js
@@ -27,6 +27,7 @@ module.exports.create = function create(envArgs) {
         externalCssFiles: [
           'lib/normalize.css',
           '../dist/handsontable.full.min.css',
+          'helpers/common.css',
         ],
         externalJsFiles: [
           '../test/lib/phantom-reporter.js',

--- a/src/css/handsontable.css
+++ b/src/css/handsontable.css
@@ -280,8 +280,6 @@
 .handsontable td.area-6,
 .handsontable td.area-7 {
   position: relative;
-  background: none;
-  background-color: transparent;
 }
 
 .handsontable td.area:before,

--- a/test/e2e/Core_selection.spec.js
+++ b/test/e2e/Core_selection.spec.js
@@ -786,6 +786,22 @@ describe('Core_selection', () => {
     expect(this.$container.hasClass('ht__selection--columns')).toBeTruthy();
   });
 
+  it('should not overwrite background color of the cells with custom CSS classes', function() {
+    var hot = handsontable({
+      width: 300,
+      height: 150,
+      startRows: 5,
+      startCols: 5,
+      cells: (row, col) => (row === 1 && col === 1 ? {className: 'red-background'} : void 0)
+    });
+
+    $(getCell(0, 0)).simulate('mousedown');
+    $(getCell(4, 4)).simulate('mouseover');
+    $(getCell(4, 4)).simulate('mouseup');
+
+    expect(window.getComputedStyle(getCell(1, 1))['background-color']).toBe('rgb(255, 0, 0)');
+  });
+
   it('should select the entire column after column header is clicked (in fixed rows/cols corner)', function() {
     var hot = handsontable({
       width: 200,

--- a/test/helpers/common.css
+++ b/test/helpers/common.css
@@ -1,0 +1,3 @@
+.red-background {
+  background-color: #ff0000 !important;
+}


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
This PR fixes the background color of the cells which are overwritten by selection. The selection CSS classes are modified to not overwrite the cell `background`.

### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
This has been testing by attaching custom CSS to the cells. The tests added to this feature checks if the selection doesn't remove `background-color` from the cells using `window.getComputedStyles` function.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. #4812

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [x] My change requires a change to the documentation.
