### PR TITLE
Make the `alter` method more stable when group of indexes are used

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -299,7 +299,6 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
           const previousItem = acc[acc.length - 1];
           const [prevIndex, prevAmount] = previousItem;
           const prevLastIndex = prevIndex + prevAmount;
-          const lastIndex = index + amount;
 
           if (index <= prevLastIndex) {
             const amountToAdd = Math.max(amount - (prevLastIndex - index), 0);

--- a/src/core.js
+++ b/src/core.js
@@ -280,18 +280,21 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
 
       const normalizeIndexesGroup = (indexes) => {
         if (indexes.length === 0) {
-          return indexes;
+          return [];
         }
 
+        const sortedIndexes = [...indexes];
+
         // Sort the indexes in ascending order.
-        const sortedIndexes = indexes.sort(([indexA], [indexB]) => {
+        sortedIndexes.sort(([indexA], [indexB]) => {
           if (indexA === indexB) {
             return 0;
           }
 
           return indexA > indexB ? 1 : -1;
         });
-        // Normalize the {index, amount} groups into bigger groups
+
+        // Normalize the {index, amount} groups into bigger groups.
         const normalizedIndexes = arrayReduce(sortedIndexes, (acc, [index, amount]) => {
           const previousItem = acc[acc.length - 1];
           const [prevIndex, prevAmount] = previousItem;
@@ -307,7 +310,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
           }
 
           return acc;
-        }, [indexes[0]]);
+        }, [sortedIndexes[0]]);
 
         return normalizedIndexes;
       };

--- a/src/core.js
+++ b/src/core.js
@@ -279,6 +279,10 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
       }
 
       const normalizeIndexesGroup = (indexes) => {
+        if (indexes.length === 0) {
+          return indexes;
+        }
+
         // Sort the indexes in ascending order.
         const sortedIndexes = indexes.sort(([indexA], [indexB]) => {
           if (indexA === indexB) {
@@ -289,17 +293,13 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
         });
         // Normalize the {index, amount} groups into bigger groups
         const normalizedIndexes = arrayReduce(sortedIndexes, (acc, [index, amount]) => {
-          if (!acc.length) {
-            acc.push([index, amount]);
-          }
-
           const previousItem = acc[acc.length - 1];
           const [prevIndex, prevAmount] = previousItem;
           const prevLastIndex = prevIndex + prevAmount;
           const lastIndex = index + amount;
 
           if (index <= prevLastIndex) {
-            const amountToAdd = amount - (prevLastIndex - index);
+            const amountToAdd = Math.max(amount - (prevLastIndex - index), 0);
 
             previousItem[1] += amountToAdd;
           } else {
@@ -307,7 +307,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
           }
 
           return acc;
-        }, []);
+        }, [indexes[0]]);
 
         return normalizedIndexes;
       };

--- a/src/plugins/contextMenu/test/predefinedItems/removeColumn.e2e.js
+++ b/src/plugins/contextMenu/test/predefinedItems/removeColumn.e2e.js
@@ -1,0 +1,90 @@
+describe('ContextMenu', function () {
+  var id = 'testContainer';
+
+  beforeEach(function () {
+    this.$container = $('<div id="' + id + '"></div>').appendTo('body');
+  });
+
+  afterEach(function () {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  describe('remove columns', function() {
+    it('should execute action when single cell is selected', async function() {
+      var hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        contextMenu: true,
+      });
+
+      selectCell(2, 2);
+      contextMenu();
+
+      // "Remove column" item
+      $('.htContextMenu .ht_master .htCore')
+        .find('tbody td')
+        .not('.htSeparator')
+        .eq(5)
+        .simulate('mousedown');
+
+      expect(getDataAtRow(0)).toEqual(['A1', 'B1', 'D1', 'E1']);
+    });
+
+    it('should execute action when range of the cells are selected', async function() {
+      var hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        contextMenu: true,
+      });
+
+      selectCell(2, 2, 4, 4);
+      contextMenu();
+
+      // "Remove column" item
+      $('.htContextMenu .ht_master .htCore')
+        .find('tbody td')
+        .not('.htSeparator')
+        .eq(5)
+        .simulate('mousedown');
+
+      expect(getDataAtRow(0)).toEqual(['A1', 'B1']);
+    });
+
+    it('should execute action when multiple cells are selected', async function() {
+      var hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(8, 5),
+        contextMenu: true,
+      });
+
+      $(getCell(0, 0)).simulate('mousedown');
+      $(getCell(1, 0)).simulate('mouseover');
+      $(getCell(1, 0)).simulate('mouseup');
+
+      keyDown('ctrl');
+
+      $(getCell(2, 1)).simulate('mousedown');
+      $(getCell(2, 1)).simulate('mouseover');
+      $(getCell(2, 1)).simulate('mouseup');
+
+      $(getCell(0, 3)).simulate('mousedown');
+      $(getCell(5, 3)).simulate('mouseover');
+      $(getCell(5, 3)).simulate('mouseup');
+
+      $(getCell(7, 4)).simulate('mousedown');
+      $(getCell(7, 4)).simulate('mouseover');
+      $(getCell(7, 4)).simulate('mouseup');
+
+      contextMenu();
+
+      // "Remove column" item
+      $('.htContextMenu .ht_master .htCore')
+        .find('tbody td')
+        .not('.htSeparator')
+        .eq(5)
+        .simulate('mousedown');
+
+      expect(getDataAtRow(0)).toEqual(['C1']);
+    });
+  });
+});

--- a/src/plugins/contextMenu/test/predefinedItems/removeRow.e2e.js
+++ b/src/plugins/contextMenu/test/predefinedItems/removeRow.e2e.js
@@ -1,0 +1,94 @@
+describe('ContextMenu', function () {
+  var id = 'testContainer';
+
+  beforeEach(function () {
+    this.$container = $('<div id="' + id + '"></div>').appendTo('body');
+  });
+
+  afterEach(function () {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  describe('remove rows', function() {
+    it('should execute action when single cell is selected', async function() {
+      var hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        contextMenu: true,
+      });
+
+      selectCell(2, 2);
+      contextMenu();
+
+      // "Remove row" item
+      $('.htContextMenu .ht_master .htCore')
+        .find('tbody td')
+        .not('.htSeparator')
+        .eq(4)
+        .simulate('mousedown');
+
+      expect(getDataAtCol(0)).toEqual(['A1', 'A2', 'A4', 'A5']);
+    });
+
+    it('should execute action when range of the cells are selected', async function() {
+      var hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        contextMenu: true,
+      });
+
+      selectCell(2, 2, 4, 4);
+      contextMenu();
+
+      // "Remove row" item
+      $('.htContextMenu .ht_master .htCore')
+        .find('tbody td')
+        .not('.htSeparator')
+        .eq(4)
+        .simulate('mousedown');
+
+      expect(getDataAtCol(0)).toEqual(['A1', 'A2']);
+    });
+
+    it('should execute action when multiple cells are selected', async function() {
+      var hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(8, 5),
+        contextMenu: true,
+      });
+
+      $(getCell(0, 0)).simulate('mousedown');
+      $(getCell(1, 0)).simulate('mouseover');
+      $(getCell(1, 0)).simulate('mouseup');
+
+      keyDown('ctrl');
+
+      $(getCell(2, 1)).simulate('mousedown');
+      $(getCell(2, 1)).simulate('mouseover');
+      $(getCell(2, 1)).simulate('mouseup');
+
+      $(getCell(0, 3)).simulate('mousedown');
+      $(getCell(5, 3)).simulate('mouseover');
+      $(getCell(5, 3)).simulate('mouseup');
+
+      $(getCell(5, 0)).simulate('mousedown');
+      $(getCell(5, 4)).simulate('mouseover');
+      $(getCell(5, 4)).simulate('mouseup');
+
+      $(getCell(7, 4)).simulate('mousedown');
+      $(getCell(7, 4)).simulate('mouseover');
+      $(getCell(7, 4)).simulate('mouseup');
+
+      contextMenu();
+
+      // "Remove row" item
+      $('.htContextMenu .ht_master .htCore')
+        .find('tbody td')
+        .not('.htSeparator')
+        .eq(4)
+        .simulate('mousedown');
+
+      expect(getDataAtCol(0)).toEqual(['A7']);
+    });
+  });
+});

--- a/test/e2e/Core_alter.spec.js
+++ b/test/e2e/Core_alter.spec.js
@@ -51,6 +51,72 @@ describe('Core_alter', () => {
   };
 
   describe('remove row', () => {
+    describe('multiple items at once', () => {
+      it('should remove rows when index groups are passed in ascending order', () => {
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(15, 5),
+        });
+        // [[rowVisualIndex, amountRowsToRemove] ...]
+        alter('remove_row', [[1, 3], [5, 1], [7, 3], [11, 2]]);
+        // It remove rows as follow:
+        //     1--------3      5-1     7---------3       11-----2
+        // A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15
+        //
+        // Result: A1, A5, A7, A11, A14, A15
+
+        expect(getDataAtCol(0)).toEqual(['A1', 'A5', 'A7', 'A11', 'A14', 'A15']);
+        expect(getData().length).toBe(6);
+      });
+
+      it('should remove rows when index groups are passed in descending order', () => {
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(15, 5),
+        });
+        // [[rowVisualIndex, amountRowsToRemove] ...]
+        alter('remove_row', [[11, 2], [7, 3], [5, 1], [1, 3]]);
+        // It remove rows as follow:
+        //     1--------3      5-1     7---------3       11-----2
+        // A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15
+        //
+        // Result: A1, A5, A7, A11, A14, A15
+
+        expect(getDataAtCol(0)).toEqual(['A1', 'A5', 'A7', 'A11', 'A14', 'A15']);
+        expect(getData().length).toBe(6);
+      });
+
+      it('should remove rows when index groups are passed as intersecting values', () => {
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(15, 5),
+        });
+        // [[rowVisualIndex, amountRowsToRemove] ...]
+        alter('remove_row', [[1, 3], [4, 2], [5, 5], [11, 1]]);
+        // It remove rows as follow:
+        //     1---------------------------------9       11-1
+        // A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15
+        //
+        // Result: A1, A11, A13, A14, A15
+
+        expect(getDataAtCol(0)).toEqual(['A1', 'A11', 'A13', 'A14', 'A15']);
+        expect(getData().length).toBe(5);
+      });
+
+      it('should remove rows when index groups are passed as intersecting values (placed randomly)', () => {
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(15, 5),
+        });
+        // [[rowVisualIndex, amountRowsToRemove] ...]
+        alter('remove_row', [[4, 2], [11, 1], [5, 5], [1, 3]]);
+        // It remove rows as follow:
+        //     1---------------------------------9       11-1
+        // A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15
+        //
+        // Result: A1, A11, A13, A14, A15
+
+        expect(getDataAtCol(0)).toEqual(['A1', 'A11', 'A13', 'A14', 'A15']);
+        expect(getData().length).toBe(5);
+      });
+    });
+
     it('should remove row', () => {
       handsontable({
         minRows: 5,
@@ -64,28 +130,6 @@ describe('Core_alter', () => {
 
       expect(getDataAtCell(1, 1)).toEqual('Joan'); // Joan should be moved up
       expect(getData().length).toEqual(5); // new row should be added by keepEmptyRows
-    });
-
-    it('should support removing multiple rows at once', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(15, 5),
-      });
-      // [[rowPhysicalIndex, amountRowsToRemove] ...]
-      alter('remove_row', [[1, 3], [3, 1], [3, 3], [4, 3]]);
-      // It remove rows as follow:
-      //     1--------3
-      // A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15
-      //             3-1
-      // A1, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15
-      //             3---------3
-      // A1, A5, A6, A8, A9, A10, A11, A12, A13, A14, A15
-      //                  4-----------3
-      // A1, A5, A6, A11, A12, A13, A14, A15
-      //
-      // Result: A1, A5, A6, A11, A15
-
-      expect(getDataAtCol(0)).toEqual(['A1', 'A5', 'A6', 'A11', 'A15']);
-      expect(getData().length).toBe(5);
     });
 
     it('should fire beforeRemoveRow event before removing row', () => {
@@ -343,6 +387,72 @@ describe('Core_alter', () => {
   });
 
   describe('remove column', () => {
+    describe('multiple items at once', () => {
+      it('should remove columns when index groups are passed in ascending order', () => {
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(5, 15),
+        });
+        // [[columnVisualIndex, amountColumnsToRemove] ...]
+        alter('remove_col', [[1, 3], [5, 1], [7, 3], [11, 2]]);
+        // It remove columns as follow:
+        //     1--------3      5-1     7--------3      11---2
+        // A1, B1, C1, D1, E1, F1, G1, H1, I1, J1, K1, L1, M1, N1, O1
+        //
+        // Result: A1, E1, G1, K1, N1, O1
+
+        expect(getDataAtRow(0)).toEqual(['A1', 'E1', 'G1', 'K1', 'N1', 'O1']);
+        expect(getData()[0].length).toBe(6);
+      });
+
+      it('should remove columns when index groups are passed in descending order', () => {
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(5, 15),
+        });
+        // [[columnVisualIndex, amountColumnsToRemove] ...]
+        alter('remove_col', [[11, 2], [7, 3], [5, 1], [1, 3]]);
+        // It remove columns as follow:
+        //     1--------3      5-1     7--------3      11---2
+        // A1, B1, C1, D1, E1, F1, G1, H1, I1, J1, K1, L1, M1, N1, O1
+        //
+        // Result: A1, E1, G1, K1, N1, O1
+
+        expect(getDataAtRow(0)).toEqual(['A1', 'E1', 'G1', 'K1', 'N1', 'O1']);
+        expect(getData()[0].length).toBe(6);
+      });
+
+      it('should remove columns when index groups are passed as intersecting values', () => {
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(5, 15),
+        });
+        // [[columnVisualIndex, amountColumnsToRemove] ...]
+        alter('remove_col', [[1, 3], [4, 2], [5, 5], [11, 1]]);
+        // It remove columns as follow:
+        //     1--------------------------------9     11-1
+        // A1, B1, C1, D1, E1, F1, G1, H1, I1, J1, K1, L1, M1, N1, O1
+        //
+        // Result: A1, K1, M1, N1, O1
+
+        expect(getDataAtRow(0)).toEqual(['A1', 'K1', 'M1', 'N1', 'O1']);
+        expect(getData()[0].length).toBe(5);
+      });
+
+      it('should remove columns when index groups are passed as intersecting values (placed randomly)', () => {
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(5, 15),
+        });
+        // [[columnVisualIndex, amountColumnsToRemove] ...]
+        alter('remove_col', [[4, 2], [11, 1], [5, 5], [1, 3]]);
+        // It remove columns as follow:
+        //     1--------------------------------9     11-1
+        // A1, B1, C1, D1, E1, F1, G1, H1, I1, J1, K1, L1, M1, N1, O1
+        //
+        // Result: A1, K1, M1, N1, O1
+
+        expect(getDataAtRow(0)).toEqual(['A1', 'K1', 'M1', 'N1', 'O1']);
+        expect(getData()[0].length).toBe(5);
+      });
+    });
+
     it('should remove one column if amount parameter is empty', function() {
       handsontable({
         data: [
@@ -408,28 +518,6 @@ describe('Core_alter', () => {
 
       expect(countCols()).toEqual(5);
       expect(this.$container.find('tr:eq(1) td:last').html()).toEqual('e');
-    });
-
-    it('should support removing multiple columns at once', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 15),
-      });
-      // [[columnPhysicalIndex, amountColumnsToRemove] ...]
-      alter('remove_col', [[1, 3], [3, 1], [3, 3], [4, 3]]);
-      // It remove columns as follow:
-      //     1--------3
-      // A1, B1, C1, D1, E1, F1, G1, H1, I1, J1, K1, L1, M1, N1, O1
-      //             3-1
-      // A1, E1, F1, G1, H1, I1, J1, K1, L1, M1, N1, O1
-      //             3--------3
-      // A1, E1, F1, H1, I1, J1, K1, L1, M1, N1, O1
-      //                 4--------3
-      // A1, E1, F1, K1, L1, M1, N1, O1
-      //
-      // Result: A1, E1, F1, K1, O1
-
-      expect(getDataAtRow(0)).toEqual(['A1', 'E1', 'F1', 'K1', 'O1']);
-      expect(getData()[0].length).toBe(5);
     });
 
     it('should fire beforeRemoveCol event before removing col', () => {

--- a/test/e2e/Core_alter.spec.js
+++ b/test/e2e/Core_alter.spec.js
@@ -100,6 +100,22 @@ describe('Core_alter', () => {
         expect(getData().length).toBe(5);
       });
 
+      it('should remove rows when index groups are passed as intersecting values (the second scenario)', () => {
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(15, 5),
+        });
+        // [[rowVisualIndex, amountRowsToRemove] ...]
+        alter('remove_row', [[1, 3], [2, 1], [5, 2]]);
+        // It remove columns as follow:
+        //     1--------3      5----2
+        // A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15
+        //
+        // Result: A1, A5, A8, A9, A10, A11, A12, A13, A14, A15
+
+        expect(getDataAtCol(0)).toEqual(['A1', 'A5', 'A8', 'A9', 'A10', 'A11', 'A12', 'A13', 'A14', 'A15']);
+        expect(getData().length).toBe(10);
+      });
+
       it('should remove rows when index groups are passed as intersecting values (placed randomly)', () => {
         handsontable({
           data: Handsontable.helper.createSpreadsheetData(15, 5),
@@ -434,6 +450,22 @@ describe('Core_alter', () => {
 
         expect(getDataAtRow(0)).toEqual(['A1', 'K1', 'M1', 'N1', 'O1']);
         expect(getData()[0].length).toBe(5);
+      });
+
+      it('should remove columns when index groups are passed as intersecting values (the second scenario)', () => {
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(5, 15),
+        });
+        // [[columnVisualIndex, amountColumnsToRemove] ...]
+        alter('remove_col', [[1, 3], [2, 1], [5, 2]]);
+        // It remove columns as follow:
+        //     1--------3      5----2
+        // A1, B1, C1, D1, E1, F1, G1, H1, I1, J1, K1, L1, M1, N1, O1
+        //
+        // Result: A1, E1, H1
+
+        expect(getDataAtRow(0)).toEqual(['A1', 'E1', 'H1', 'I1', 'J1', 'K1', 'L1', 'M1', 'N1', 'O1']);
+        expect(getData()[0].length).toBe(10);
       });
 
       it('should remove columns when index groups are passed as intersecting values (placed randomly)', () => {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
To make the `hot.alter` method less buggy the normalization algorithm for a group of indexes is added. This change allows passing unordered with intersection indexes to the `hot.alter` method.

### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
This was tested by removing rows and columns through API using several combinations of the group of the indexes. Since 0.36.0 the `alter` method supports removing rows and columns using an array of arrays like `[[index, amount], [index, amount]...]` but only in an orderly manner.

This PR extends that method in how the group of the indexes should be created and support passing them in an unordered way. Additionally, the normalization internally tries to simplify the passed collection by grouping the collection into continuous values.

For instance, this group `[[11, 1], [4, 2], [5, 5], [1, 3]]` will be transformed to `[[1, 9], [11, 1]]`.
```
                 5-------5
input:   1---3 4-2             11
rows:  1 2 3 4 5 6 7 8 9 10 11 12 13 14
output: [[1, 9], [11, 1]]
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. #4815

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [x] My change requires a change to the documentation.
