### PR TITLE
Fix the selection disappearing when a context menu is triggered

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -72,7 +72,7 @@
     "import/no-unresolved": [
       2,
       {
-        "ignore": ["handsontable"]
+        "ignore": ["handsontable", "walkontable"]
       }
     ],
     "no-mixed-operators": [

--- a/src/plugins/contextMenu/test/contextMenu.e2e.js
+++ b/src/plugins/contextMenu/test/contextMenu.e2e.js
@@ -200,7 +200,6 @@ describe('ContextMenu', () => {
   });
 
   describe('menu disabled', () => {
-
     it('should not open menu after right click', () => {
       var hot = handsontable({
         contextMenu: true,
@@ -1329,7 +1328,6 @@ describe('ContextMenu', () => {
       menu.find('td').not('.htSeparator').eq(8).simulate('mousedown'); // Make read-only
 
       expect(hot.getCellMeta(0, 0).readOnly).toBe(true);
-
     });
 
     it('should make a single selected cell writable, when it\'s set to read-only', () => {
@@ -1353,30 +1351,59 @@ describe('ContextMenu', () => {
       expect(hot.getCellMeta(0, 0).readOnly).toBe(false);
     });
 
-    it('should make a group of selected cells read-only, if all of them are writable', () => {
+    it('should make a range of selected cells read-only, if all of them are writable', () => {
       var hot = handsontable({
         data: Handsontable.helper.createSpreadsheetData(4, 4),
         contextMenu: true,
         height: 100
       });
 
-      for (let i = 0; i < 2; i++) {
-        for (let j = 0; j < 2; j++) {
-          expect(hot.getCellMeta(i, j).readOnly).toEqual(false);
-        }
-      }
+      expect(hot.getCellMeta(0, 0).readOnly).toEqual(false);
+      expect(hot.getCellMeta(0, 1).readOnly).toEqual(false);
+      expect(hot.getCellMeta(1, 0).readOnly).toEqual(false);
+      expect(hot.getCellMeta(1, 1).readOnly).toEqual(false);
 
       selectCell(0, 0, 2, 2);
 
       contextMenu();
-      var menu = $('.htContextMenu .ht_master .htCore tbody');
-      menu.find('td').not('.htSeparator').eq(8).simulate('mousedown');
+      $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(8)
+        .simulate('mousedown');
 
-      for (let i = 0; i < 2; i++) {
-        for (let j = 0; j < 2; j++) {
-          expect(hot.getCellMeta(i, j).readOnly).toEqual(true);
-        }
-      }
+      expect(hot.getCellMeta(0, 0).readOnly).toEqual(true);
+      expect(hot.getCellMeta(0, 1).readOnly).toEqual(true);
+      expect(hot.getCellMeta(1, 0).readOnly).toEqual(true);
+      expect(hot.getCellMeta(1, 1).readOnly).toEqual(true);
+      expect(getSelected()).toEqual([[0, 0, 2, 2]]);
+    });
+
+    it('should make a multiple of selected cells read-only, if all of them are writable', () => {
+      var hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(4, 4),
+        contextMenu: true,
+        height: 100
+      });
+
+      expect(hot.getCellMeta(0, 0).readOnly).toBe(false);
+      expect(hot.getCellMeta(0, 1).readOnly).toBe(false);
+      expect(hot.getCellMeta(1, 0).readOnly).toBe(false);
+      expect(hot.getCellMeta(1, 1).readOnly).toBe(false);
+
+      selectCell(0, 0, 2, 2);
+
+      contextMenu();
+      $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(8)
+        .simulate('mousedown');
+
+      expect(hot.getCellMeta(0, 0).readOnly).toBe(true);
+      expect(hot.getCellMeta(0, 1).readOnly).toBe(true);
+      expect(hot.getCellMeta(1, 0).readOnly).toBe(true);
+      expect(hot.getCellMeta(1, 1).readOnly).toBe(true);
     });
 
     it('should not close menu after clicking on submenu root item', () => {
@@ -1400,11 +1427,10 @@ describe('ContextMenu', () => {
         height: 100
       });
 
-      for (let i = 0; i < 2; i++) {
-        for (let j = 0; j < 2; j++) {
-          expect(hot.getCellMeta(i, j).readOnly).toEqual(false);
-        }
-      }
+      expect(hot.getCellMeta(0, 0).readOnly).toBe(false);
+      expect(hot.getCellMeta(0, 1).readOnly).toBe(false);
+      expect(hot.getCellMeta(1, 0).readOnly).toBe(false);
+      expect(hot.getCellMeta(1, 1).readOnly).toBe(false);
 
       selectCell(2, 2, 0, 0);
 
@@ -1413,11 +1439,10 @@ describe('ContextMenu', () => {
       var menu = $('.htContextMenu .ht_master .htCore tbody');
       menu.find('td').not('.htSeparator').eq(8).simulate('mousedown'); // Make read-only
 
-      for (let i = 0; i < 2; i++) {
-        for (let j = 0; j < 2; j++) {
-          expect(hot.getCellMeta(i, j).readOnly).toEqual(true);
-        }
-      }
+      expect(hot.getCellMeta(0, 0).readOnly).toBe(true);
+      expect(hot.getCellMeta(0, 1).readOnly).toBe(true);
+      expect(hot.getCellMeta(1, 0).readOnly).toBe(true);
+      expect(hot.getCellMeta(1, 1).readOnly).toBe(true);
     });
 
     it('should make a group of selected cells writable if at least one of them is read-only', () => {
@@ -1427,11 +1452,10 @@ describe('ContextMenu', () => {
         height: 100
       });
 
-      for (let i = 0; i < 2; i++) {
-        for (let j = 0; j < 2; j++) {
-          expect(hot.getCellMeta(i, j).readOnly).toEqual(false);
-        }
-      }
+      expect(hot.getCellMeta(0, 0).readOnly).toBe(false);
+      expect(hot.getCellMeta(0, 1).readOnly).toBe(false);
+      expect(hot.getCellMeta(1, 0).readOnly).toBe(false);
+      expect(hot.getCellMeta(1, 1).readOnly).toBe(false);
 
       hot.getCellMeta(1, 1).readOnly = true;
 
@@ -1440,11 +1464,10 @@ describe('ContextMenu', () => {
       contextMenu();
       $('.htContextMenu .ht_master .htCore').find('tbody td').not('.htSeparator').eq(8).simulate('mousedown'); // Make writable
 
-      for (let i = 0; i < 2; i++) {
-        for (let j = 0; j < 2; j++) {
-          expect(hot.getCellMeta(i, j).readOnly).toEqual(false);
-        }
-      }
+      expect(hot.getCellMeta(0, 0).readOnly).toBe(false);
+      expect(hot.getCellMeta(0, 1).readOnly).toBe(false);
+      expect(hot.getCellMeta(1, 0).readOnly).toBe(false);
+      expect(hot.getCellMeta(1, 1).readOnly).toBe(false);
     });
 
     it('should make a group of selected cells writable if at least one of them is read-only (reverse selection)', () => {
@@ -1454,11 +1477,10 @@ describe('ContextMenu', () => {
         height: 100
       });
 
-      for (let i = 0; i < 2; i++) {
-        for (let j = 0; j < 2; j++) {
-          expect(hot.getCellMeta(i, j).readOnly).toEqual(false);
-        }
-      }
+      expect(hot.getCellMeta(0, 0).readOnly).toBe(false);
+      expect(hot.getCellMeta(0, 1).readOnly).toBe(false);
+      expect(hot.getCellMeta(1, 0).readOnly).toBe(false);
+      expect(hot.getCellMeta(1, 1).readOnly).toBe(false);
 
       hot.getCellMeta(1, 1).readOnly = true;
 
@@ -1467,11 +1489,10 @@ describe('ContextMenu', () => {
       contextMenu();
       $('.htContextMenu .ht_master .htCore').find('tbody td').not('.htSeparator').eq(8).simulate('mousedown'); // Make writable
 
-      for (let i = 0; i < 2; i++) {
-        for (let j = 0; j < 2; j++) {
-          expect(hot.getCellMeta(i, j).readOnly).toEqual(false);
-        }
-      }
+      expect(hot.getCellMeta(0, 0).readOnly).toBe(false);
+      expect(hot.getCellMeta(0, 1).readOnly).toBe(false);
+      expect(hot.getCellMeta(1, 0).readOnly).toBe(false);
+      expect(hot.getCellMeta(1, 1).readOnly).toBe(false);
     });
   });
 
@@ -2687,6 +2708,120 @@ describe('ContextMenu', () => {
     });
   });
 
+  describe('selection', () => {
+    it('should not be cleared when a context menu is triggered on a selected single cell', () => {
+      var hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(4, 4),
+        contextMenu: true,
+        height: 100
+      });
+
+      selectCell(0, 0);
+      contextMenu();
+
+      expect($('.htContextMenu').is(':visible')).toBe(true);
+      expect(getSelected()).toEqual([[0, 0, 0, 0]]);
+    });
+
+    it('should not be cleared when a context menu is triggered on a range of selected cells', () => {
+      var hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(4, 4),
+        contextMenu: true,
+        height: 100
+      });
+
+      selectCell(0, 0, 2, 2);
+      contextMenu();
+
+      expect($('.htContextMenu').is(':visible')).toBe(true);
+      expect(getSelected()).toEqual([[0, 0, 2, 2]]);
+    });
+
+    it('should not be cleared when a context menu is triggered on the first layer of the non-contiguous selection', () => {
+      var hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(10, 10),
+        contextMenu: true,
+        height: 200
+      });
+
+      $(getCell(0, 0)).simulate('mousedown');
+      $(getCell(2, 2)).simulate('mouseover');
+      $(getCell(2, 2)).simulate('mouseup');
+
+      keyDown('ctrl');
+
+      $(getCell(2, 2)).simulate('mousedown');
+      $(getCell(7, 2)).simulate('mouseover');
+      $(getCell(7, 2)).simulate('mouseup');
+
+      $(getCell(2, 4)).simulate('mousedown');
+      $(getCell(2, 4)).simulate('mouseover');
+      $(getCell(2, 4)).simulate('mouseup');
+
+      keyUp('ctrl');
+      contextMenu(getCell(0, 0));
+
+      expect($('.htContextMenu').is(':visible')).toBe(true);
+      expect(getSelected()).toEqual([[0, 0, 2, 2], [2, 2, 7, 2], [2, 4, 2, 4]]);
+    });
+
+    it('should not be cleared when a context menu is triggered on the second layer of the non-contiguous selection', () => {
+      var hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(10, 10),
+        contextMenu: true,
+        height: 200
+      });
+
+      $(getCell(0, 0)).simulate('mousedown');
+      $(getCell(2, 2)).simulate('mouseover');
+      $(getCell(2, 2)).simulate('mouseup');
+
+      keyDown('ctrl');
+
+      $(getCell(2, 2)).simulate('mousedown');
+      $(getCell(7, 2)).simulate('mouseover');
+      $(getCell(7, 2)).simulate('mouseup');
+
+      $(getCell(2, 4)).simulate('mousedown');
+      $(getCell(2, 4)).simulate('mouseover');
+      $(getCell(2, 4)).simulate('mouseup');
+
+      keyUp('ctrl');
+      contextMenu(getCell(2, 2));
+
+      expect($('.htContextMenu').is(':visible')).toBe(true);
+      expect(getSelected()).toEqual([[0, 0, 2, 2], [2, 2, 7, 2], [2, 4, 2, 4]]);
+    });
+
+    it('should not be cleared when a context menu is triggered on the last layer of the non-contiguous selection', () => {
+      var hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(10, 10),
+        contextMenu: true,
+        height: 200
+      });
+
+      $(getCell(0, 0)).simulate('mousedown');
+      $(getCell(2, 2)).simulate('mouseover');
+      $(getCell(2, 2)).simulate('mouseup');
+
+      keyDown('ctrl');
+
+      $(getCell(2, 2)).simulate('mousedown');
+      $(getCell(7, 2)).simulate('mouseover');
+      $(getCell(7, 2)).simulate('mouseup');
+
+      $(getCell(2, 4)).simulate('mousedown');
+      $(getCell(2, 4)).simulate('mouseover');
+      $(getCell(2, 4)).simulate('mouseup');
+
+      keyUp('ctrl');
+      contextMenu(getCell(2, 4));
+
+      expect($('.htContextMenu').is(':visible')).toBe(true);
+      expect(getSelected()).toEqual([[0, 0, 2, 2], [2, 2, 7, 2], [2, 4, 2, 4]]);
+    });
+  });
+
   describe('working with multiple tables', () => {
     beforeEach(function () {
       this.$container2 = $(`<div id="${id}-2"></div>`).appendTo('body');
@@ -2813,7 +2948,7 @@ describe('ContextMenu', () => {
   });
 
   describe('context menu with native scroll', () => {
-    beforeEach(function () {
+    beforeEach(function() {
       var wrapper = $('<div></div>').css({
         width: 400,
         height: 200,
@@ -2823,7 +2958,7 @@ describe('ContextMenu', () => {
       this.$wrapper = this.$container.wrap(wrapper).parent();
     });
 
-    afterEach(function () {
+    afterEach(function() {
       if (this.$container) {
         destroy();
         this.$container.remove();
@@ -2842,6 +2977,7 @@ describe('ContextMenu', () => {
       });
 
       contextMenu();
+
       expect($('.htContextMenu').is(':visible')).toBe(true);
     });
 
@@ -2921,8 +3057,8 @@ describe('ContextMenu', () => {
       expect(hot.getPlugin('contextMenu').close).not.toHaveBeenCalled();
     });
 
-    it('should not scroll the window when hovering over context menu items (#1897 reopen)', function () {
-      this.$wrapper.css('overflow', 'visible');
+    it('should not scroll the window when hovering over context menu items (#1897 reopen)', () => {
+      spec().$wrapper.css('overflow', 'visible');
 
       var hot = handsontable({
         data: Handsontable.helper.createSpreadsheetData(403, 303),
@@ -2937,52 +3073,50 @@ describe('ContextMenu', () => {
 
       var cmInstance = hot.getPlugin('contextMenu').menu.hotMenu;
 
+      expect(1).toEqual(1);
+
       cmInstance.selectCell(3, 0);
+
       expect(window.scrollX).toEqual(beginningScrollX);
 
       cmInstance.selectCell(4, 0);
+
       expect(window.scrollX).toEqual(beginningScrollX);
 
       cmInstance.selectCell(6, 0);
+
       expect(window.scrollX).toEqual(beginningScrollX);
     });
   });
 
   describe('afterContextMenuDefaultOptions hook', () => {
     it('should call afterContextMenuDefaultOptions hook with context menu options as the first param', async () => {
-      var options;
+      const cb = jasmine.createSpy();
 
-      var afterContextMenuDefaultOptions = function(options_) {
-        options = options_;
+      cb.and.callFake((options) => {
         options.items.cust1 = {
           name: 'My custom item',
-          callback() {
-          }
+          callback() {}
         };
-      };
+      });
 
-      Handsontable.hooks.add('afterContextMenuDefaultOptions', afterContextMenuDefaultOptions);
+      Handsontable.hooks.add('afterContextMenuDefaultOptions', cb);
 
-      // Hook `afterContextMenuDefaultOptions` is triggered after all plugin will be initialized or with some timeout.
-      // To make test more stable here is a sleep.
-      await sleep(100);
-
-      var hot = handsontable({
+      handsontable({
         contextMenu: true,
         height: 100
       });
 
       contextMenu();
 
-      var $menu = $('.htContextMenu .ht_master .htCore');
+      const $menu = $('.htContextMenu .ht_master .htCore');
 
-      expect(options).toBeDefined();
-      expect(options.items).toBeDefined();
       expect($menu.find('tbody td').text()).toContain('My custom item');
+      expect(cb.calls.count()).toBe(1);
+      expect(cb.calls.argsFor(0)[0].items.cust1.key).toBe('cust1');
+      expect(cb.calls.argsFor(0)[0].items.cust1.name).toBe('My custom item');
 
-      $menu.find('tbody td:eq(0)').simulate('mousedown');
-
-      Handsontable.hooks.remove('afterContextMenuDefaultOptions', afterContextMenuDefaultOptions);
+      Handsontable.hooks.remove('afterContextMenuDefaultOptions', cb);
     });
   });
 

--- a/src/selection/range.js
+++ b/src/selection/range.js
@@ -30,7 +30,7 @@ class SelectionRange {
    * Set coordinates to the class instance. It clears all previously added coordinates and push `coords`
    * to the collection.
    *
-   * @param {CellCoords} coords The CellCoords instance with defined coordinates.
+   * @param {CellCoords} coords The CellCoords instance with defined visual coordinates.
    * @returns {SelectionRange}
    */
   set(coords) {
@@ -43,7 +43,7 @@ class SelectionRange {
   /**
    * Add coordinates to the class instance. The new coordinates are added to the end of the range collection.
    *
-   * @param {CellCoords} coords The CellCoords instance with defined coordinates.
+   * @param {CellCoords} coords The CellCoords instance with defined visual coordinates.
    * @returns {SelectionRange}
    */
   add(coords) {
@@ -55,7 +55,7 @@ class SelectionRange {
   /**
    * Get last added coordinates from ranges, it returns a CellRange instance.
    *
-   * @return {CellCoords|undefined}
+   * @return {CellRange|undefined}
    */
   current() {
     return this.peekByIndex(0);
@@ -64,10 +64,21 @@ class SelectionRange {
   /**
    * Get previously added coordinates from ranges, it returns a CellRange instance.
    *
-   * @return {CellCoords|undefined}
+   * @return {CellRange|undefined}
    */
   previous() {
     return this.peekByIndex(-1);
+  }
+
+  /**
+   * Returns `true` if coords is within selection coords. This method iterates through all selection layers to check if
+   * the coords object is within selection range.
+   *
+   * @param {CellCoords} coords The CellCoords instance with defined visual coordinates.
+   * @returns {Boolean}
+   */
+  includes(coords) {
+    return this.ranges.some((cellRange) => cellRange.includes(coords));
   }
 
   /**
@@ -91,13 +102,13 @@ class SelectionRange {
   }
 
   /**
-   * Peek the coordinates based on the index where that coordinate resides in the collection.
+   * Peek the coordinates based on the offset where that coordinate resides in the collection.
    *
-   * @param {Number} [index=0] An index where the coordinate will be retrieved from.
+   * @param {Number} [offset=0] An offset where the coordinate will be retrieved from.
    * @return {CellRange|undefined}
    */
-  peekByIndex(index = 0) {
-    const rangeIndex = this.size() + index - 1;
+  peekByIndex(offset = 0) {
+    const rangeIndex = this.size() + offset - 1;
     let cellRange;
 
     if (rangeIndex >= 0) {

--- a/src/selection/selection.js
+++ b/src/selection/selection.js
@@ -309,15 +309,14 @@ class Selection {
   }
 
   /**
-   * Returns `true` if coords is within current selection coords. This method only checks the latest
-   * layer of the selection.
+   * Returns `true` if coords is within selection coords. This method iterates through all selection layers to check if
+   * the coords object is within selection range.
    *
-   * @param {CellCoords} coords Visual coordinates to check.
+   * @param {CellCoords} coords The CellCoords instance with defined visual coordinates.
    * @returns {Boolean}
    */
   inInSelection(coords) {
-    // TODO(budnix): This ".includes" should be checked for all layers?
-    return this.isSelected() ? this.selectedRange.current().includes(coords) : false;
+    return this.selectedRange.includes(coords);
   }
 
   /**

--- a/test/unit/selection/range.spec.js
+++ b/test/unit/selection/range.spec.js
@@ -1,0 +1,212 @@
+import SelectionRange from 'handsontable/selection/range';
+import {CellCoords, CellRange} from 'walkontable';
+
+describe('SelectionRange', () => {
+  let selectionRange;
+
+  beforeEach(() => {
+    selectionRange = new SelectionRange();
+  });
+
+  afterEach(() => {
+    selectionRange = null;
+  });
+
+  describe('.constructor', () => {
+    it('should initiate `ranges` as an ampty array', () => {
+      expect(selectionRange.ranges.length).toBe(0);
+    });
+  });
+
+  describe('.isEmpty', () => {
+    it('should return `true` if the size of the ranges is equal to zero', () => {
+      selectionRange.ranges.length = 0;
+
+      expect(selectionRange.isEmpty()).toBe(true);
+    });
+
+    it('should return `false` if the size of the ranges is not equal to zero', () => {
+      selectionRange.ranges.push('x');
+
+      expect(selectionRange.isEmpty()).toBe(false);
+    });
+  });
+
+  describe('.set', () => {
+    it('should reset an array of cell ranges and append new CellRange to this', () => {
+      selectionRange.ranges.push(
+        new CellRange(new CellCoords(4, 4))
+      );
+
+      selectionRange.set(new CellCoords(0, 0));
+      selectionRange.set(new CellCoords(1, 2));
+
+      expect(selectionRange.ranges.length).toBe(1);
+      expect(selectionRange.ranges[0].toObject()).toEqual({
+        from: {col: 2, row: 1},
+        to: {col: 2, row: 1},
+      });
+    });
+  });
+
+  describe('.add', () => {
+    it('should append new CellRange to the ranges array', () => {
+      selectionRange.add(new CellCoords(0, 0));
+      selectionRange.add(new CellCoords(0, 0));
+      selectionRange.add(new CellCoords(1, 2));
+
+      expect(selectionRange.ranges.length).toBe(3);
+      expect(selectionRange.ranges[0].toObject()).toEqual({
+        from: {col: 0, row: 0},
+        to: {col: 0, row: 0},
+      });
+      expect(selectionRange.ranges[1].toObject()).toEqual({
+        from: {col: 0, row: 0},
+        to: {col: 0, row: 0},
+      });
+      expect(selectionRange.ranges[2].toObject()).toEqual({
+        from: {col: 2, row: 1},
+        to: {col: 2, row: 1},
+      });
+    });
+  });
+
+  describe('.current', () => {
+    it('should return `undefined` when an array of ranges is empty', () => {
+      expect(selectionRange.current()).not.toBeDefined();
+    });
+
+    it('should return recently added cell range', () => {
+      selectionRange.ranges.push(
+        new CellRange(new CellCoords(4, 4)),
+        new CellRange(new CellCoords(0, 0)),
+        new CellRange(new CellCoords(1, 2))
+      );
+
+      expect(selectionRange.current().toObject()).toEqual({
+        from: {col: 2, row: 1},
+        to: {col: 2, row: 1},
+      });
+    });
+  });
+
+  describe('.previous', () => {
+    it('should return `undefined` when an array of ranges is empty', () => {
+      expect(selectionRange.previous()).not.toBeDefined();
+    });
+
+    it('should return previously added cell range', () => {
+      selectionRange.ranges.push(
+        new CellRange(new CellCoords(4, 4)),
+        new CellRange(new CellCoords(0, 0)),
+        new CellRange(new CellCoords(1, 2))
+      );
+
+      expect(selectionRange.previous().toObject()).toEqual({
+        from: {col: 0, row: 0},
+        to: {col: 0, row: 0},
+      });
+    });
+  });
+
+  describe('.includes', () => {
+    it('should return `true` if the coords match the selection range', () => {
+      selectionRange.ranges.push(
+        new CellRange(new CellCoords(1, 1), new CellCoords(1, 1), new CellCoords(3, 3)),
+        new CellRange(new CellCoords(11, 11), new CellCoords(11, 11), new CellCoords(11, 11))
+      );
+
+      expect(selectionRange.includes(new CellCoords(1, 2))).toBe(true);
+      expect(selectionRange.includes(new CellCoords(1, 3))).toBe(true);
+      expect(selectionRange.includes(new CellCoords(11, 11))).toBe(true);
+    });
+
+    it('should return `false` if the coords doesn\'t match the selection range', () => {
+      selectionRange.ranges.push(
+        new CellRange(new CellCoords(1, 1), new CellCoords(1, 1), new CellCoords(3, 3)),
+        new CellRange(new CellCoords(11, 11), new CellCoords(11, 11), new CellCoords(11, 11))
+      );
+
+      expect(selectionRange.includes(new CellCoords(1, 4))).toBe(false);
+      expect(selectionRange.includes(new CellCoords(0, 0))).toBe(false);
+      expect(selectionRange.includes(new CellCoords(11, 12))).toBe(false);
+    });
+  });
+
+  describe('.clear', () => {
+    it('should reset the ranges collection', () => {
+      selectionRange.ranges.push(
+        new CellRange(new CellCoords(4, 4)),
+        new CellRange(new CellCoords(0, 0)),
+        new CellRange(new CellCoords(1, 2))
+      );
+
+      selectionRange.clear();
+
+      expect(selectionRange.ranges.length).toBe(0);
+    });
+  });
+
+  describe('.size', () => {
+    it('should return the length/size of the collected ranges', () => {
+      selectionRange.ranges.push(
+        new CellRange(new CellCoords(4, 4)),
+        new CellRange(new CellCoords(0, 0)),
+        new CellRange(new CellCoords(1, 2))
+      );
+
+      expect(selectionRange.size()).toBe(3);
+    });
+  });
+
+  describe('.peekByIndex', () => {
+    it('should return the CellRange object from the end based on the offset argument passed to the method', () => {
+      selectionRange.ranges.push(
+        new CellRange(new CellCoords(4, 4)),
+        new CellRange(new CellCoords(0, 0)),
+        new CellRange(new CellCoords(1, 2))
+      );
+
+      expect(selectionRange.peekByIndex().toObject()).toEqual({
+        from: {col: 2, row: 1},
+        to: {col: 2, row: 1},
+      });
+      expect(selectionRange.peekByIndex(-1).toObject()).toEqual({
+        from: {col: 0, row: 0},
+        to: {col: 0, row: 0},
+      });
+      expect(selectionRange.peekByIndex(-2).toObject()).toEqual({
+        from: {col: 4, row: 4},
+        to: {col: 4, row: 4},
+      });
+      expect(selectionRange.peekByIndex(-4)).not.toBeDefined();
+      expect(selectionRange.peekByIndex(-5)).not.toBeDefined();
+    });
+  });
+
+  it('should have implemented iterator protocol', () => {
+    selectionRange.ranges.push(
+      new CellRange(new CellCoords(4, 4)),
+      new CellRange(new CellCoords(0, 0)),
+      new CellRange(new CellCoords(1, 2))
+    );
+
+    expect(selectionRange[Symbol.iterator]).toBeDefined();
+
+    const ranges = Array.from(selectionRange);
+
+    expect(ranges.length).toBe(3);
+    expect(ranges[0].toObject()).toEqual({
+      from: {col: 4, row: 4},
+      to: {col: 4, row: 4},
+    });
+    expect(ranges[1].toObject()).toEqual({
+      from: {col: 0, row: 0},
+      to: {col: 0, row: 0},
+    });
+    expect(ranges[2].toObject()).toEqual({
+      from: {col: 2, row: 1},
+      to: {col: 2, row: 1},
+    });
+  });
+});


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The implementation of the `.isInSelection` method of the `Selection` class needs to be changed to fix a bug described in the #4816 issue.

### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
This is tested by adding the unit tests to the `SelectionRange` class.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. #4816

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
