### PR TITLE
Prevent declaring out-of-bounds merged cells. #4887

### DIFF
--- a/src/plugins/mergeCells/cellCoords.js
+++ b/src/plugins/mergeCells/cellCoords.js
@@ -1,4 +1,5 @@
 import {CellCoords, CellRange} from '../../3rdparty/walkontable/src/index';
+import {toSingleLine} from './../../helpers/templateLiteralTag';
 
 /**
  * The `MergedCellCoords` class represents a single merged cell.
@@ -47,9 +48,11 @@ class MergedCellCoords {
    * @return {String}
    */
   static NEGATIVE_VALUES_WARNING(newMergedCell) {
-    return 'The merged cell declared with ' +
-      `{row: ${newMergedCell.row}, col: ${newMergedCell.col}, rowspan: ${newMergedCell.rowspan}, colspan: ${newMergedCell.colspan}} ` +
-      'contains negative values, which is not supported. It will not be added to the collection.';
+    return toSingleLine([
+      `The merged cell declared with {row: ${newMergedCell.row}, col: ${newMergedCell.col}, rowspan: 
+    ${newMergedCell.rowspan}, colspan: ${newMergedCell.colspan}} contains negative values, which is not supported. It 
+    will not be added to the collection.`
+    ]);
   }
 
   /**
@@ -59,8 +62,10 @@ class MergedCellCoords {
    * @return {String}
    */
   static IS_OUT_OF_BOUNDS_WARNING(newMergedCell) {
-    return `The merged cell declared at [${newMergedCell.row}, ${newMergedCell.col}] is positioned ` +
-      '(or positioned partially) outside of the table range. It was not added to the table, please fix your setup.';
+    return toSingleLine([
+      `The merged cell declared at [${newMergedCell.row}, ${newMergedCell.col}] is positioned (or positioned partially) 
+       outside of the table range. It was not added to the table, please fix your setup.`
+    ]);
   }
 
   /**
@@ -70,8 +75,10 @@ class MergedCellCoords {
    * @return {String}
    */
   static IS_SINGLE_CELL(newMergedCell) {
-    return `The merged cell declared at [${newMergedCell.row}, ${newMergedCell.col}] ` +
-      'has both "rowspan" and "colspan" declared as "1", which makes it a single cell. It cannot be added to the collection.';
+    return toSingleLine([
+      `The merged cell declared at [${newMergedCell.row}, ${newMergedCell.col}] has both "rowspan" 
+     and "colspan" declared as "1", which makes it a single cell. It cannot be added to the collection.`
+    ]);
   }
 
   /**
@@ -81,8 +88,10 @@ class MergedCellCoords {
    * @return {String}
    */
   static ZERO_SPAN_WARNING(newMergedCell) {
-    return `The merged cell declared at [${newMergedCell.row}, ${newMergedCell.col}] ` +
-      'has "rowspan" or "colspan" declared as "0", which is not supported. It cannot be added to the collection.';
+    return toSingleLine([
+      `The merged cell declared at [${newMergedCell.row}, ${newMergedCell.col}] has "rowspan" or "colspan" declared as 
+      "0", which is not supported. It cannot be added to the collection.`
+    ]);
   }
 
   /**

--- a/src/plugins/mergeCells/cellCoords.js
+++ b/src/plugins/mergeCells/cellCoords.js
@@ -48,11 +48,9 @@ class MergedCellCoords {
    * @return {String}
    */
   static NEGATIVE_VALUES_WARNING(newMergedCell) {
-    return toSingleLine([
-      `The merged cell declared with {row: ${newMergedCell.row}, col: ${newMergedCell.col}, rowspan: 
+    return toSingleLine`The merged cell declared with {row: ${newMergedCell.row}, col: ${newMergedCell.col}, rowspan: 
     ${newMergedCell.rowspan}, colspan: ${newMergedCell.colspan}} contains negative values, which is not supported. It 
-    will not be added to the collection.`
-    ]);
+    will not be added to the collection.`;
   }
 
   /**
@@ -62,10 +60,8 @@ class MergedCellCoords {
    * @return {String}
    */
   static IS_OUT_OF_BOUNDS_WARNING(newMergedCell) {
-    return toSingleLine([
-      `The merged cell declared at [${newMergedCell.row}, ${newMergedCell.col}] is positioned (or positioned partially) 
-       outside of the table range. It was not added to the table, please fix your setup.`
-    ]);
+    return toSingleLine`The merged cell declared at [${newMergedCell.row}, ${newMergedCell.col}] is positioned (or positioned partially) 
+       outside of the table range. It was not added to the table, please fix your setup.`;
   }
 
   /**
@@ -75,10 +71,8 @@ class MergedCellCoords {
    * @return {String}
    */
   static IS_SINGLE_CELL(newMergedCell) {
-    return toSingleLine([
-      `The merged cell declared at [${newMergedCell.row}, ${newMergedCell.col}] has both "rowspan" 
-     and "colspan" declared as "1", which makes it a single cell. It cannot be added to the collection.`
-    ]);
+    return toSingleLine`The merged cell declared at [${newMergedCell.row}, ${newMergedCell.col}] has both "rowspan" 
+     and "colspan" declared as "1", which makes it a single cell. It cannot be added to the collection.`;
   }
 
   /**
@@ -88,10 +82,8 @@ class MergedCellCoords {
    * @return {String}
    */
   static ZERO_SPAN_WARNING(newMergedCell) {
-    return toSingleLine([
-      `The merged cell declared at [${newMergedCell.row}, ${newMergedCell.col}] has "rowspan" or "colspan" declared as 
-      "0", which is not supported. It cannot be added to the collection.`
-    ]);
+    return toSingleLine`The merged cell declared at [${newMergedCell.row}, ${newMergedCell.col}] has "rowspan" or "colspan" declared as 
+      "0", which is not supported. It cannot be added to the collection.`;
   }
 
   /**

--- a/src/plugins/mergeCells/cellCoords.js
+++ b/src/plugins/mergeCells/cellCoords.js
@@ -56,6 +56,11 @@ class MergedCellCoords {
       'has both "rowspan" and "colspan" declared as "1", which makes it a single cell. It cannot be added to the collection.';
   }
 
+  static ZERO_SPAN_WARNING(newMergedCell) {
+    return `The merged cell declared at [${newMergedCell.row}, ${newMergedCell.col}] ` +
+      'has both "rowspan" and "colspan" declared as "0", which is not supported. It cannot be added to the collection.';
+  }
+
   /**
    * Check whether the values provided for a merged cell contain any negative values.
    *
@@ -75,6 +80,17 @@ class MergedCellCoords {
    */
   static isSingleCell(mergedCellInfo) {
     return mergedCellInfo.colspan === 1 && mergedCellInfo.rowspan === 1;
+  }
+
+  /**
+   * Check whether the provided merged cell information object contains a rowspan and colspan of 0.
+   *
+   * @private
+   * @param {Object} mergedCellInfo An object with `row`, `col`, `rowspan` and `colspan` properties.
+   * @return {Boolean}
+   */
+  static containsZeroSpan(mergedCellInfo) {
+    return mergedCellInfo.colspan === 0 && mergedCellInfo.rowspan === 0;
   }
 
   /**

--- a/src/plugins/mergeCells/cellCoords.js
+++ b/src/plugins/mergeCells/cellCoords.js
@@ -40,6 +40,60 @@ class MergedCellCoords {
     this.removed = false;
   }
 
+  static NEGATIVE_VALUES_WARNING(newMergedCell) {
+    return 'The merged cell declared with ' +
+      `{row: ${newMergedCell.row}, col: ${newMergedCell.col}, rowspan: ${newMergedCell.rowspan}, colspan: ${newMergedCell.colspan}} ` +
+      'contains negative values, which is not supported. It will not be added to the collection.';
+  }
+
+  static IS_OUT_OF_BOUNDS_WARNING(newMergedCell) {
+    return `The merged cell declared at [${newMergedCell.row}, ${newMergedCell.col}] is positioned ` +
+      '(or positioned partially) outside of the table range. It was not added to the table, please fix your setup.';
+  }
+
+  static IS_SINGLE_CELL(newMergedCell) {
+    return `The merged cell declared at [${newMergedCell.row}, ${newMergedCell.col}] ` +
+      'has both "rowspan" and "colspan" declared as "1", which makes it a single cell. It cannot be added to the collection.';
+  }
+
+  /**
+   * Check whether the values provided for a merged cell contain any negative values.
+   *
+   * @param {Object} mergedCellInfo Object containing the `row`, `col`, `rowspan` and `colspan` properties.
+   * @return {Boolean}
+   */
+  static containsNegativeValues(mergedCellInfo) {
+    return mergedCellInfo.row < 0 || mergedCellInfo.col < 0 || mergedCellInfo.rowspan < 0 || mergedCellInfo.colspan < 0;
+  }
+
+  /**
+   * Check whether the provided merged cell information object represents a single cell.
+   *
+   * @private
+   * @param {Object} mergedCellInfo An object with `row`, `col`, `rowspan` and `colspan` properties.
+   * @return {Boolean}
+   */
+  static isSingleCell(mergedCellInfo) {
+    return mergedCellInfo.colspan === 1 && mergedCellInfo.rowspan === 1;
+  }
+
+  /**
+   * Check whether the provided merged cell object is to be declared out of bounds of the table.
+   *
+   * @param {Object} mergeCell Object containing the `row`, `col`, `rowspan` and `colspan` properties.
+   * @param {Number} rowCount Number of rows in the table.
+   * @param {Number} columnCount Number of rows in the table.
+   * @return {Boolean}
+   */
+  static isOutOfBounds(mergeCell, rowCount, columnCount) {
+    return mergeCell.row < 0 ||
+      mergeCell.col < 0 ||
+      mergeCell.row >= rowCount ||
+      mergeCell.row + mergeCell.rowspan - 1 >= rowCount ||
+      mergeCell.col >= columnCount ||
+      mergeCell.col + mergeCell.colspan - 1 >= columnCount;
+  }
+
   /**
    * Sanitize (prevent from going outside the boundaries) the merged cell.
    *

--- a/src/plugins/mergeCells/cellCoords.js
+++ b/src/plugins/mergeCells/cellCoords.js
@@ -40,22 +40,46 @@ class MergedCellCoords {
     this.removed = false;
   }
 
+  /**
+   * Get a warning message for when the declared merged cell data contains negative values.
+   *
+   * @param {Object} newMergedCell Object containg information about the merged cells that was about to be added.
+   * @return {String}
+   */
   static NEGATIVE_VALUES_WARNING(newMergedCell) {
     return 'The merged cell declared with ' +
       `{row: ${newMergedCell.row}, col: ${newMergedCell.col}, rowspan: ${newMergedCell.rowspan}, colspan: ${newMergedCell.colspan}} ` +
       'contains negative values, which is not supported. It will not be added to the collection.';
   }
 
+  /**
+   * Get a warning message for when the declared merged cell data contains values exceeding the table limits.
+   *
+   * @param {Object} newMergedCell Object containg information about the merged cells that was about to be added.
+   * @return {String}
+   */
   static IS_OUT_OF_BOUNDS_WARNING(newMergedCell) {
     return `The merged cell declared at [${newMergedCell.row}, ${newMergedCell.col}] is positioned ` +
       '(or positioned partially) outside of the table range. It was not added to the table, please fix your setup.';
   }
 
+  /**
+   * Get a warning message for when the declared merged cell data represents a single cell.
+   *
+   * @param {Object} newMergedCell Object containg information about the merged cells that was about to be added.
+   * @return {String}
+   */
   static IS_SINGLE_CELL(newMergedCell) {
     return `The merged cell declared at [${newMergedCell.row}, ${newMergedCell.col}] ` +
       'has both "rowspan" and "colspan" declared as "1", which makes it a single cell. It cannot be added to the collection.';
   }
 
+  /**
+   * Get a warning message for when the declared merged cell data contains "colspan" or "rowspan", that equals 0.
+   *
+   * @param {Object} newMergedCell Object containg information about the merged cells that was about to be added.
+   * @return {String}
+   */
   static ZERO_SPAN_WARNING(newMergedCell) {
     return `The merged cell declared at [${newMergedCell.row}, ${newMergedCell.col}] ` +
       'has "rowspan" or "colspan" declared as "0", which is not supported. It cannot be added to the collection.';

--- a/src/plugins/mergeCells/cellCoords.js
+++ b/src/plugins/mergeCells/cellCoords.js
@@ -58,7 +58,7 @@ class MergedCellCoords {
 
   static ZERO_SPAN_WARNING(newMergedCell) {
     return `The merged cell declared at [${newMergedCell.row}, ${newMergedCell.col}] ` +
-      'has both "rowspan" and "colspan" declared as "0", which is not supported. It cannot be added to the collection.';
+      'has "rowspan" or "colspan" declared as "0", which is not supported. It cannot be added to the collection.';
   }
 
   /**
@@ -83,14 +83,14 @@ class MergedCellCoords {
   }
 
   /**
-   * Check whether the provided merged cell information object contains a rowspan and colspan of 0.
+   * Check whether the provided merged cell information object contains a rowspan or colspan of 0.
    *
    * @private
    * @param {Object} mergedCellInfo An object with `row`, `col`, `rowspan` and `colspan` properties.
    * @return {Boolean}
    */
   static containsZeroSpan(mergedCellInfo) {
-    return mergedCellInfo.colspan === 0 && mergedCellInfo.rowspan === 0;
+    return mergedCellInfo.colspan === 0 || mergedCellInfo.rowspan === 0;
   }
 
   /**

--- a/src/plugins/mergeCells/cellsCollection.js
+++ b/src/plugins/mergeCells/cellsCollection.js
@@ -37,11 +37,6 @@ class MergedCellsCollection {
       'declared merged cell. The overlapping merged cell was not added to the table, please fix your setup.';
   }
 
-  static IS_OUT_OF_BOUNDS_WARNING(newMergedCell) {
-    return `The merged cell declared at [${newMergedCell.row}, ${newMergedCell.col}] is positioned ` +
-      '(or positioned partially) outside of the table range. It was not added to the table, please fix your setup.';
-  }
-
   /**
    * Get a merged cell from the container, based on the provided arguments. You can provide either the "starting coordinates"
    * of a merged cell, or any coordinates from the body of the merged cell.
@@ -139,10 +134,9 @@ class MergedCellsCollection {
     const colspan = mergedCellInfo.colspan;
     const newMergedCell = new MergedCellCoords(row, column, rowspan, colspan);
     const alreadyExists = this.get(row, column);
-    const isOutOfBounds = this.isOutOfBounds(newMergedCell);
     const isOverlapping = this.isOverlapping(newMergedCell);
 
-    if (!alreadyExists && !isOverlapping && !isOutOfBounds) {
+    if (!alreadyExists && !isOverlapping) {
       if (this.hot) {
         newMergedCell.normalize(this.hot);
       }
@@ -150,11 +144,6 @@ class MergedCellsCollection {
       mergedCells.push(newMergedCell);
 
       return newMergedCell;
-
-    } else if (!alreadyExists && isOutOfBounds) {
-      console.warn(MergedCellsCollection.IS_OUT_OF_BOUNDS_WARNING(newMergedCell));
-
-      return false;
     }
 
     console.warn(MergedCellsCollection.IS_OVERLAPPING_WARNING(newMergedCell));
@@ -241,24 +230,6 @@ class MergedCellsCollection {
     });
 
     return result;
-  }
-
-  /**
-   * Check whether the provided merged cell object is to be declared out of bounds of the table.
-   *
-   * @param {Object} mergeCell Object representing the dimensions of a merged cell.
-   * @return {Boolean}
-   */
-  isOutOfBounds(mergeCell) {
-    const rowCount = this.hot.countRows();
-    const columnCount = this.hot.countCols();
-
-    return mergeCell.row < 0 ||
-      mergeCell.col < 0 ||
-      mergeCell.row > rowCount ||
-      mergeCell.row + mergeCell.rowspan - 1 > rowCount ||
-      mergeCell.col > columnCount ||
-      mergeCell.col + mergeCell.colspan - 1 > columnCount;
   }
 
   /**

--- a/src/plugins/mergeCells/cellsCollection.js
+++ b/src/plugins/mergeCells/cellsCollection.js
@@ -3,6 +3,7 @@ import {CellCoords, CellRange} from '../../3rdparty/walkontable/src/index';
 import {rangeEach} from '../../helpers/number';
 import {arrayEach} from '../../helpers/array';
 import {applySpanProperties} from './utils';
+import {toSingleLine} from './../../helpers/templateLiteralTag';
 
 /**
  * Defines a container object for the merged cells.
@@ -39,8 +40,9 @@ class MergedCellsCollection {
    * @return {String}
    */
   static IS_OVERLAPPING_WARNING(newMergedCell) {
-    return `The merged cell declared at [${newMergedCell.row}, ${newMergedCell.col}] overlaps with the other ` +
-      'declared merged cell. The overlapping merged cell was not added to the table, please fix your setup.';
+    return toSingleLine([
+      `The merged cell declared at [${newMergedCell.row}, ${newMergedCell.col}] overlaps with the other declared merged 
+      cell. The overlapping merged cell was not added to the table, please fix your setup.`]);
   }
 
   /**

--- a/src/plugins/mergeCells/cellsCollection.js
+++ b/src/plugins/mergeCells/cellsCollection.js
@@ -40,9 +40,8 @@ class MergedCellsCollection {
    * @return {String}
    */
   static IS_OVERLAPPING_WARNING(newMergedCell) {
-    return toSingleLine([
-      `The merged cell declared at [${newMergedCell.row}, ${newMergedCell.col}] overlaps with the other declared merged 
-      cell. The overlapping merged cell was not added to the table, please fix your setup.`]);
+    return toSingleLine`The merged cell declared at [${newMergedCell.row}, ${newMergedCell.col}] overlaps with the other declared merged 
+      cell. The overlapping merged cell was not added to the table, please fix your setup.`;
   }
 
   /**

--- a/src/plugins/mergeCells/cellsCollection.js
+++ b/src/plugins/mergeCells/cellsCollection.js
@@ -32,6 +32,12 @@ class MergedCellsCollection {
     this.hot = plugin.hot;
   }
 
+  /**
+   * Get a warning message for when the declared merged cell data overlaps already existing merged cells.
+   *
+   * @param {Object} newMergedCell Object containg information about the merged cells that was about to be added.
+   * @return {String}
+   */
   static IS_OVERLAPPING_WARNING(newMergedCell) {
     return `The merged cell declared at [${newMergedCell.row}, ${newMergedCell.col}] overlaps with the other ` +
       'declared merged cell. The overlapping merged cell was not added to the table, please fix your setup.';

--- a/src/plugins/mergeCells/contextMenuItem/toggleMerge.js
+++ b/src/plugins/mergeCells/contextMenuItem/toggleMerge.js
@@ -1,14 +1,18 @@
 import * as C from '../../../i18n/constants';
+import MergedCellCoords from '../cellCoords';
 
 export default function toggleMergeItem(plugin) {
   return {
     key: 'mergeCells',
     name() {
       const sel = this.getSelectedLast();
-      const info = plugin.mergedCellsCollection.get(sel[0], sel[1]);
 
-      if (info.row === sel[0] && info.col === sel[1] && info.row + info.rowspan - 1 === sel[2] && info.col + info.colspan - 1 === sel[3]) {
-        return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_UNMERGE_CELLS);
+      if (sel) {
+        const info = plugin.mergedCellsCollection.get(sel[0], sel[1]);
+
+        if (info.row === sel[0] && info.col === sel[1] && info.row + info.rowspan - 1 === sel[2] && info.col + info.colspan - 1 === sel[3]) {
+          return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_UNMERGE_CELLS);
+        }
       }
 
       return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_MERGE_CELLS);
@@ -18,7 +22,20 @@ export default function toggleMergeItem(plugin) {
       this.render();
     },
     disabled() {
-      return this.selection.selectedHeader.corner;
+      const sel = this.getSelectedLast();
+
+      if (!sel) {
+        return true;
+      }
+
+      const isSingleCell = MergedCellCoords.isSingleCell({
+        row: sel[0],
+        col: sel[1],
+        rowspan: sel[2] - sel[0] + 1,
+        colspan: sel[3] - sel[1] + 1
+      });
+
+      return isSingleCell || this.selection.selectedHeader.corner;
     },
     hidden: false
   };

--- a/src/plugins/mergeCells/mergeCells.js
+++ b/src/plugins/mergeCells/mergeCells.js
@@ -166,6 +166,11 @@ class MergeCells extends BasePlugin {
       console.warn(MergedCellCoords.IS_SINGLE_CELL(setting));
 
       valid = false;
+
+    } else if (MergedCellCoords.containsZeroSpan(setting)) {
+      console.warn(MergedCellCoords.ZERO_SPAN_WARNING(setting));
+
+      valid = false;
     }
 
     return valid;

--- a/src/plugins/mergeCells/mergeCells.js
+++ b/src/plugins/mergeCells/mergeCells.js
@@ -4,6 +4,7 @@ import {registerPlugin} from './../../plugins';
 import {stopImmediatePropagation} from './../../helpers/dom/event';
 import {CellCoords, CellRange} from './../../3rdparty/walkontable/src';
 import MergedCellsCollection from './cellsCollection';
+import MergedCellCoords from './cellCoords';
 import AutofillCalculations from './calculations/autofill';
 import SelectionCalculations from './calculations/selection';
 import toggleMergeItem from './contextMenuItem/toggleMerge';
@@ -138,6 +139,39 @@ class MergeCells extends BasePlugin {
   }
 
   /**
+   * Validate a single setting object, represented by a single merged cell information object.
+   *
+   * @private
+   * @param {Object} setting An object with `row`, `col`, `rowspan` and `colspan` properties.
+   * @return {Boolean}
+   */
+  validateSetting(setting) {
+    let valid = true;
+
+    if (!setting) {
+      return false;
+    }
+
+    if (MergedCellCoords.containsNegativeValues(setting)) {
+      console.warn(MergedCellCoords.NEGATIVE_VALUES_WARNING(setting));
+
+      valid = false;
+
+    } else if (MergedCellCoords.isOutOfBounds(setting, this.hot.countRows(), this.hot.countCols())) {
+      console.warn(MergedCellCoords.IS_OUT_OF_BOUNDS_WARNING(setting));
+
+      valid = false;
+
+    } else if (MergedCellCoords.isSingleCell(setting)) {
+      console.warn(MergedCellCoords.IS_SINGLE_CELL(setting));
+
+      valid = false;
+    }
+
+    return valid;
+  }
+
+  /**
    * Generate the merged cells from the settings provided to the plugin.
    *
    * @private
@@ -148,6 +182,10 @@ class MergeCells extends BasePlugin {
       let populationArgumentsList = [];
 
       arrayEach(settings, (setting) => {
+        if (!this.validateSetting(setting)) {
+          return;
+        }
+
         const highlight = new CellCoords(setting.row, setting.col);
         const rangeEnd = new CellCoords(setting.row + setting.rowspan - 1, setting.col + setting.colspan - 1);
         const mergeRange = new CellRange(highlight, highlight, rangeEnd);
@@ -228,10 +266,12 @@ class MergeCells extends BasePlugin {
    * Returns `true` if a range is mergeable.
    *
    * @private
-   * @param {CellRange} cellRange Cell range to test.
+   * @param {Object} newMergedCellInfo Merged cell information object to test.
+   * @param {Boolean} [auto=false] `true` if triggered at initialization.
+   * @returns {Boolean}
    */
-  canMergeRange(cellRange) {
-    return !cellRange.isSingle();
+  canMergeRange(newMergedCellInfo, auto = false) {
+    return auto ? true : this.validateSetting(newMergedCellInfo);
   }
 
   /**
@@ -246,11 +286,6 @@ class MergeCells extends BasePlugin {
    * @fires Hooks#afterMergeCells
    */
   mergeRange(cellRange, auto = false, preventPopulation = false) {
-    if (!this.canMergeRange(cellRange)) {
-      return false;
-    }
-
-    // normalize top left corner
     const topLeft = cellRange.getTopLeftCorner();
     const bottomRight = cellRange.getBottomRightCorner();
     const mergeParent = {
@@ -261,6 +296,10 @@ class MergeCells extends BasePlugin {
     };
     const clearedData = [];
     let populationInfo = null;
+
+    if (!this.canMergeRange(mergeParent, auto)) {
+      return false;
+    }
 
     this.hot.runHooks('beforeMergeCells', cellRange, auto);
 

--- a/src/plugins/mergeCells/test/autofillCalculations.unit.js
+++ b/src/plugins/mergeCells/test/autofillCalculations.unit.js
@@ -185,7 +185,7 @@ describe('MergeCells-Autofill calculations', () => {
         countRows: () => 100,
       };
       const instance = new AutofillCalculations({
-        mergedCellsCollection: new MergedCellsCollection(hotMock),
+        mergedCellsCollection: new MergedCellsCollection({hot: hotMock}),
         hot: hotMock
       });
 

--- a/src/plugins/mergeCells/test/cellsCollection.unit.js
+++ b/src/plugins/mergeCells/test/cellsCollection.unit.js
@@ -83,42 +83,6 @@ describe('MergeCells', () => {
         expect(mergedCellsCollection.mergedCells[1].row).toEqual(20);
         expect(mergedCellsCollection.mergedCells[1].col).toEqual(21);
       });
-
-      it('should not add new merged cells and throw an appropriate warning, if the merged cell is out of the range of the table', () => {
-        const warnSpy = spyOn(console, 'warn');
-
-        const mergedCellsCollection = new MergedCellsCollection({hot: hotMock});
-        const newMergedCells = [
-          {
-            row: 0,
-            col: 1,
-            rowspan: 3,
-            colspan: 4
-          },
-          {
-            row: 5,
-            col: 8,
-            rowspan: 3,
-            colspan: 4
-          },
-          {
-            row: 20,
-            col: 21,
-            rowspan: 300,
-            colspan: 4
-          }];
-
-        mergedCellsCollection.add(newMergedCells[0]);
-        mergedCellsCollection.add(newMergedCells[1]);
-        mergedCellsCollection.add(newMergedCells[2]);
-
-        expect(warnSpy).toHaveBeenCalledWith(MergedCellsCollection.IS_OUT_OF_BOUNDS_WARNING(newMergedCells[2]));
-        expect(mergedCellsCollection.mergedCells.length).toEqual(2);
-        expect(mergedCellsCollection.mergedCells[0].row).toEqual(0);
-        expect(mergedCellsCollection.mergedCells[0].col).toEqual(1);
-        expect(mergedCellsCollection.mergedCells[1].row).toEqual(5);
-        expect(mergedCellsCollection.mergedCells[1].col).toEqual(8);
-      });
     });
 
     describe('`remove` method', () => {

--- a/src/plugins/mergeCells/test/cellsCollection.unit.js
+++ b/src/plugins/mergeCells/test/cellsCollection.unit.js
@@ -2,9 +2,16 @@ import MergedCellsCollection from '../cellsCollection';
 
 describe('MergeCells', () => {
   describe('MergedCellsCollection', () => {
+    const hotMock = {
+      render: () => {
+      },
+      countCols: () => 100,
+      countRows: () => 100,
+    };
+
     describe('`add` method', () => {
       it('should add a merged cell object to the array of merged cells', () => {
-        const mergedCellsCollection = new MergedCellsCollection({hot: null});
+        const mergedCellsCollection = new MergedCellsCollection({hot: hotMock});
 
         mergedCellsCollection.add({
           row: 0,
@@ -39,11 +46,84 @@ describe('MergeCells', () => {
         expect(mergedCellsCollection.mergedCells[2].rowspan).toEqual(3);
         expect(mergedCellsCollection.mergedCells[2].colspan).toEqual(4);
       });
+
+      it('should not add new merged cells and throw an appropriate warning, if the merged cell is overlapping any other ' +
+        'previously declared merged cell', () => {
+        const warnSpy = spyOn(console, 'warn');
+
+        const mergedCellsCollection = new MergedCellsCollection({hot: hotMock});
+        const newMergedCells = [
+          {
+            row: 0,
+            col: 1,
+            rowspan: 3,
+            colspan: 4
+          },
+          {
+            row: 1,
+            col: 2,
+            rowspan: 3,
+            colspan: 4
+          },
+          {
+            row: 20,
+            col: 21,
+            rowspan: 3,
+            colspan: 4
+          }];
+
+        mergedCellsCollection.add(newMergedCells[0]);
+        mergedCellsCollection.add(newMergedCells[1]);
+        mergedCellsCollection.add(newMergedCells[2]);
+
+        expect(warnSpy).toHaveBeenCalledWith(MergedCellsCollection.IS_OVERLAPPING_WARNING(newMergedCells[1]));
+        expect(mergedCellsCollection.mergedCells.length).toEqual(2);
+        expect(mergedCellsCollection.mergedCells[0].row).toEqual(0);
+        expect(mergedCellsCollection.mergedCells[0].col).toEqual(1);
+        expect(mergedCellsCollection.mergedCells[1].row).toEqual(20);
+        expect(mergedCellsCollection.mergedCells[1].col).toEqual(21);
+      });
+
+      it('should not add new merged cells and throw an appropriate warning, if the merged cell is out of the range of the table', () => {
+        const warnSpy = spyOn(console, 'warn');
+
+        const mergedCellsCollection = new MergedCellsCollection({hot: hotMock});
+        const newMergedCells = [
+          {
+            row: 0,
+            col: 1,
+            rowspan: 3,
+            colspan: 4
+          },
+          {
+            row: 5,
+            col: 8,
+            rowspan: 3,
+            colspan: 4
+          },
+          {
+            row: 20,
+            col: 21,
+            rowspan: 300,
+            colspan: 4
+          }];
+
+        mergedCellsCollection.add(newMergedCells[0]);
+        mergedCellsCollection.add(newMergedCells[1]);
+        mergedCellsCollection.add(newMergedCells[2]);
+
+        expect(warnSpy).toHaveBeenCalledWith(MergedCellsCollection.IS_OUT_OF_BOUNDS_WARNING(newMergedCells[2]));
+        expect(mergedCellsCollection.mergedCells.length).toEqual(2);
+        expect(mergedCellsCollection.mergedCells[0].row).toEqual(0);
+        expect(mergedCellsCollection.mergedCells[0].col).toEqual(1);
+        expect(mergedCellsCollection.mergedCells[1].row).toEqual(5);
+        expect(mergedCellsCollection.mergedCells[1].col).toEqual(8);
+      });
     });
 
     describe('`remove` method', () => {
       it('should remove a merged cell object from the array of merged cells by passing the starting coordinates', () => {
-        const mergedCellsCollection = new MergedCellsCollection({hot: null});
+        const mergedCellsCollection = new MergedCellsCollection({hot: hotMock});
 
         mergedCellsCollection.add({
           row: 0,
@@ -78,7 +158,7 @@ describe('MergeCells', () => {
       });
 
       it('should remove a merged cell object from the array of merged cells by passing the coordinates from the middle of the merged cell', () => {
-        const mergedCellsCollection = new MergedCellsCollection({hot: null});
+        const mergedCellsCollection = new MergedCellsCollection({hot: hotMock});
 
         mergedCellsCollection.add({
           row: 0,
@@ -115,7 +195,7 @@ describe('MergeCells', () => {
 
     describe('`get` method', () => {
       it('should get a merged cell object from the array of merged cells by passing the starting coordinates', () => {
-        const mergedCellsCollection = new MergedCellsCollection({hot: null});
+        const mergedCellsCollection = new MergedCellsCollection({hot: hotMock});
 
         mergedCellsCollection.add({
           row: 0,
@@ -145,7 +225,7 @@ describe('MergeCells', () => {
       });
 
       it('should get a merged cell object from the array of merged cells by passing coordinates from the middle of the merged cell', () => {
-        const mergedCellsCollection = new MergedCellsCollection({hot: null});
+        const mergedCellsCollection = new MergedCellsCollection({hot: hotMock});
 
         mergedCellsCollection.add({
           row: 0,
@@ -177,7 +257,7 @@ describe('MergeCells', () => {
 
     describe('`getByRange` method', () => {
       it('should get a merged cell object from the array of merged cells by passing coordinates from the middle of the merged cell', () => {
-        const mergedCellsCollection = new MergedCellsCollection({hot: null});
+        const mergedCellsCollection = new MergedCellsCollection({hot: hotMock});
 
         mergedCellsCollection.add({
           row: 0,
@@ -218,7 +298,7 @@ describe('MergeCells', () => {
 
     describe('`getWithinRange` method', () => {
       it('should get an array of merged cells within the provided range', () => {
-        const mergedCellsCollection = new MergedCellsCollection({hot: null});
+        const mergedCellsCollection = new MergedCellsCollection({hot: hotMock});
 
         mergedCellsCollection.add({
           row: 0,
@@ -265,7 +345,7 @@ describe('MergeCells', () => {
 
     describe('`shiftCollections` method', () => {
       it('should shift all the appropriate merged cells in the provided direction', () => {
-        const mergedCellsCollection = new MergedCellsCollection({hot: null});
+        const mergedCellsCollection = new MergedCellsCollection({hot: hotMock});
 
         mergedCellsCollection.add({
           row: 0,
@@ -325,7 +405,7 @@ describe('MergeCells', () => {
       });
 
       it('should resize the merged cell (and shift the merged cells that follow) if the change happened inside a merged cell', () => {
-        const mergedCellsCollection = new MergedCellsCollection({hot: null});
+        const mergedCellsCollection = new MergedCellsCollection({hot: hotMock});
 
         mergedCellsCollection.add({
           row: 0,
@@ -376,7 +456,7 @@ describe('MergeCells', () => {
 
     describe('`isOverlapping` method', () => {
       it('should return whether the provided merged cell overlaps with the others in the merged cell', () => {
-        const mergedCellsCollection = new MergedCellsCollection({hot: null});
+        const mergedCellsCollection = new MergedCellsCollection({hot: hotMock});
 
         mergedCellsCollection.add({
           row: 0,

--- a/src/plugins/mergeCells/test/mergeCells.e2e.js
+++ b/src/plugins/mergeCells/test/mergeCells.e2e.js
@@ -14,7 +14,7 @@ describe('MergeCells', () => {
 
   describe('mergeCells option', () => {
     it('should merge cell in startup', () => {
-      let hot = handsontable({
+      const hot = handsontable({
         data: Handsontable.helper.createSpreadsheetObjectData(10, 5),
         mergeCells: [
           {row: 0, col: 0, rowspan: 2, colspan: 2}
@@ -29,7 +29,7 @@ describe('MergeCells', () => {
 
   describe('mergeCells updateSettings', () => {
     it('should allow to overwrite the initial settings using the updateSettings method', () => {
-      let hot = handsontable({
+      const hot = handsontable({
         data: Handsontable.helper.createSpreadsheetObjectData(10, 10),
         mergeCells: [
           {row: 0, col: 0, rowspan: 2, colspan: 2}
@@ -56,7 +56,7 @@ describe('MergeCells', () => {
     });
 
     it('should allow resetting the merged cells by changing it to an empty array', () => {
-      let hot = handsontable({
+      const hot = handsontable({
         data: Handsontable.helper.createSpreadsheetObjectData(10, 10),
         mergeCells: [
           {row: 0, col: 0, rowspan: 2, colspan: 2}
@@ -76,7 +76,7 @@ describe('MergeCells', () => {
     });
 
     it('should allow resetting and turning off the mergeCells plugin by changing mergeCells to \'false\'', () => {
-      let hot = handsontable({
+      const hot = handsontable({
         data: Handsontable.helper.createSpreadsheetObjectData(10, 10),
         mergeCells: [
           {row: 0, col: 0, rowspan: 2, colspan: 2}
@@ -99,7 +99,7 @@ describe('MergeCells', () => {
 
   describe('mergeCells copy', () => {
     it('should not copy text of cells that are merged into another cell', () => {
-      let hot = handsontable({
+      const hot = handsontable({
         data: Handsontable.helper.createSpreadsheetObjectData(10, 5),
         mergeCells: [
           {row: 0, col: 0, rowspan: 2, colspan: 2}
@@ -112,7 +112,7 @@ describe('MergeCells', () => {
   describe('merged cells selection', () => {
 
     it('should select the whole range of cells which form a merged cell', function() {
-      let hot = handsontable({
+      const hot = handsontable({
         data: Handsontable.helper.createSpreadsheetObjectData(4, 4),
         mergeCells: [
           {
@@ -144,7 +144,7 @@ describe('MergeCells', () => {
     });
 
     it('should always make a rectangular selection, when selecting merged and not merged cells', function() {
-      let hot = handsontable({
+      const hot = handsontable({
         data: Handsontable.helper.createSpreadsheetObjectData(4, 4),
         mergeCells: [
           {
@@ -183,7 +183,7 @@ describe('MergeCells', () => {
     });
 
     it('should not switch the selection start point when selecting from non-merged cells to merged cells', () => {
-      let hot = handsontable({
+      const hot = handsontable({
         data: Handsontable.helper.createSpreadsheetObjectData(10, 10),
         mergeCells: [
           {row: 1, col: 1, rowspan: 3, colspan: 3},
@@ -214,7 +214,7 @@ describe('MergeCells', () => {
     });
 
     it('should select cells in the correct direction when changing selections around a merged range', () => {
-      let hot = handsontable({
+      const hot = handsontable({
         data: Handsontable.helper.createSpreadsheetObjectData(10, 10),
         mergeCells: [
           {row: 4, col: 4, rowspan: 2, colspan: 2}
@@ -263,7 +263,7 @@ describe('MergeCells', () => {
 
   describe('merged cells scroll', () => {
     it('getCell should return merged cell parent', () => {
-      let hot = handsontable({
+      const hot = handsontable({
         data: Handsontable.helper.createSpreadsheetObjectData(10, 5),
         mergeCells: [
           {row: 0, col: 0, rowspan: 2, colspan: 2}
@@ -279,7 +279,7 @@ describe('MergeCells', () => {
     });
 
     it('should scroll viewport to beginning of a merged cell when it\'s clicked', () => {
-      let hot = handsontable({
+      const hot = handsontable({
         data: Handsontable.helper.createSpreadsheetObjectData(10, 5),
         mergeCells: [
           {row: 5, col: 0, rowspan: 2, colspan: 2}
@@ -316,7 +316,7 @@ describe('MergeCells', () => {
     });
 
     it('should render whole merged cell even when most rows are not in the viewport - scrolled to top', () => {
-      let hot = handsontable({
+      const hot = handsontable({
         data: Handsontable.helper.createSpreadsheetObjectData(40, 5),
         mergeCells: [
           {row: 1, col: 0, rowspan: 21, colspan: 2},
@@ -330,7 +330,7 @@ describe('MergeCells', () => {
     });
 
     it('should render whole merged cell even when most rows are not in the viewport - scrolled to bottom', () => {
-      let hot = handsontable({
+      const hot = handsontable({
         data: Handsontable.helper.createSpreadsheetObjectData(40, 5),
         mergeCells: [
           {row: 1, col: 0, rowspan: 21, colspan: 2},
@@ -349,7 +349,7 @@ describe('MergeCells', () => {
     });
 
     it('should render whole merged cell even when most columns are not in the viewport - scrolled to the left', () => {
-      let hot = handsontable({
+      const hot = handsontable({
         data: Handsontable.helper.createSpreadsheetObjectData(5, 40),
         mergeCells: [
           {row: 0, col: 1, rowspan: 2, colspan: 21},
@@ -363,7 +363,7 @@ describe('MergeCells', () => {
     });
 
     it('should render whole merged cell even when most columns are not in the viewport - scrolled to the right', function() {
-      let hot = handsontable({
+      const hot = handsontable({
         data: Handsontable.helper.createSpreadsheetObjectData(5, 40),
         mergeCells: [
           {row: 0, col: 1, rowspan: 2, colspan: 21},
@@ -383,7 +383,7 @@ describe('MergeCells', () => {
 
   describe('merge cells shift', () => {
     it('should shift the merged cells right, when inserting a column on the left side of them', () => {
-      let hot = handsontable({
+      const hot = handsontable({
         data: Handsontable.helper.createSpreadsheetData(20, 20),
         mergeCells: [
           {row: 1, col: 1, rowspan: 2, colspan: 2},
@@ -403,7 +403,7 @@ describe('MergeCells', () => {
     });
 
     it('should shift the merged cells left, when removing a column on the left side of them', () => {
-      let hot = handsontable({
+      const hot = handsontable({
         data: Handsontable.helper.createSpreadsheetData(20, 20),
         mergeCells: [
           {row: 1, col: 1, rowspan: 2, colspan: 2},
@@ -424,7 +424,7 @@ describe('MergeCells', () => {
     });
 
     it('should shift the merged cells down, when inserting rows above them', () => {
-      let hot = handsontable({
+      const hot = handsontable({
         data: Handsontable.helper.createSpreadsheetData(20, 20),
         mergeCells: [
           {row: 1, col: 1, rowspan: 2, colspan: 2},
@@ -444,7 +444,7 @@ describe('MergeCells', () => {
     });
 
     it('should shift the merged cells up, when removing rows above them', () => {
-      let hot = handsontable({
+      const hot = handsontable({
         data: Handsontable.helper.createSpreadsheetData(20, 20),
         mergeCells: [
           {row: 1, col: 1, rowspan: 2, colspan: 2},
@@ -464,9 +464,130 @@ describe('MergeCells', () => {
     });
   });
 
+  describe('merged cell candidates validation', () => {
+    it('should check if the provided merged cell information object contains negative values, and if so, do not add it ' +
+      'to the collection and throw an appropriate warning', () => {
+      const warnSpy = spyOn(console, 'warn');
+      const newMergedCells = [
+        {
+          row: 0,
+          col: 1,
+          rowspan: 3,
+          colspan: 4
+        },
+        {
+          row: -5,
+          col: 8,
+          rowspan: 3,
+          colspan: 4
+        },
+        {
+          row: 20,
+          col: -21,
+          rowspan: 3,
+          colspan: 4
+        },
+        {
+          row: 200,
+          col: 210,
+          rowspan: -3,
+          colspan: 4
+        },
+        {
+          row: 220,
+          col: 220,
+          rowspan: 3,
+          colspan: -4
+        }];
+      const hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(20, 20),
+        mergeCells: newMergedCells
+      });
+
+      expect(warnSpy).toHaveBeenCalledWith('The merged cell declared with {row: -5, col: 8, rowspan: 3, colspan: 4} ' +
+        'contains negative values, which is not supported. It will not be added to the collection.');
+      expect(warnSpy).toHaveBeenCalledWith('The merged cell declared with {row: 20, col: -21, rowspan: 3, colspan: 4} ' +
+        'contains negative values, which is not supported. It will not be added to the collection.');
+      expect(warnSpy).toHaveBeenCalledWith('The merged cell declared with {row: 200, col: 210, rowspan: -3, colspan: 4} ' +
+        'contains negative values, which is not supported. It will not be added to the collection.');
+      expect(warnSpy).toHaveBeenCalledWith('The merged cell declared with {row: 220, col: 220, rowspan: 3, colspan: -4} ' +
+        'contains negative values, which is not supported. It will not be added to the collection.');
+
+      expect(hot.getPlugin('mergeCells').mergedCellsCollection.mergedCells.length).toEqual(1);
+    });
+
+    it('should check if the provided merged cell information object represents a single cell, and if so, do not add it ' +
+      'to the collection and throw an appropriate warning', () => {
+      const warnSpy = spyOn(console, 'warn');
+      const newMergedCells = [
+        {
+          row: 0,
+          col: 1,
+          rowspan: 3,
+          colspan: 4
+        },
+        {
+          row: 5,
+          col: 8,
+          rowspan: 1,
+          colspan: 1
+        },
+        {
+          row: 20,
+          col: 21,
+          rowspan: 3,
+          colspan: 4
+        }
+      ];
+      const hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(30, 30),
+        mergeCells: newMergedCells
+      });
+
+      expect(warnSpy).toHaveBeenCalledWith('The merged cell declared at [5, 8] has both "rowspan" and "colspan" ' +
+        'declared as "1", which makes it a single cell. It cannot be added to the collection.');
+      expect(hot.getPlugin('mergeCells').mergedCellsCollection.mergedCells.length).toEqual(2);
+    });
+
+    it('should check if the provided merged cell information object contains merged declared out of bounds, and if so, ' +
+      'do not add it to the collection and throw an appropriate warning', () => {
+      const warnSpy = spyOn(console, 'warn');
+      const newMergedCells = [
+        {
+          row: 0,
+          col: 1,
+          rowspan: 3,
+          colspan: 4
+        },
+        {
+          row: 17,
+          col: 17,
+          rowspan: 5,
+          colspan: 5
+        },
+        {
+          row: 20,
+          col: 21,
+          rowspan: 3,
+          colspan: 4
+        }
+      ];
+      const hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(20, 20),
+        mergeCells: newMergedCells
+      });
+
+      expect(warnSpy).toHaveBeenCalledWith('The merged cell declared at [17, 17] is positioned ' +
+        '(or positioned partially) outside of the table range. It was not added to the table, please fix your setup.');
+      expect(warnSpy).toHaveBeenCalledWith('The merged cell declared at [20, 21] is positioned ' +
+        '(or positioned partially) outside of the table range. It was not added to the table, please fix your setup.');
+      expect(hot.getPlugin('mergeCells').mergedCellsCollection.mergedCells.length).toEqual(1);
+    });
+  });
+
   xdescribe('canMergeRange', () => {
     it('should return false if start and end cell is the same', () => {
-      let hot = handsontable({
+      const hot = handsontable({
         data: Handsontable.helper.createSpreadsheetObjectData(10, 5)
       });
       let mergeCells = new Handsontable.plugins.MergeCells(hot);
@@ -483,7 +604,7 @@ describe('MergeCells', () => {
     });
 
     it('should return true for 2 consecutive cells in the same column', () => {
-      let hot = handsontable({
+      const hot = handsontable({
         data: Handsontable.helper.createSpreadsheetObjectData(10, 5)
       });
       let mergeCells = new Handsontable.plugins.MergeCells(hot);
@@ -500,7 +621,7 @@ describe('MergeCells', () => {
     });
 
     it('should return true for 2 consecutive cells in the same row', () => {
-      let hot = handsontable({
+      const hot = handsontable({
         data: Handsontable.helper.createSpreadsheetObjectData(10, 5)
       });
       let mergeCells = hot.getPlugin('mergeCells');
@@ -517,7 +638,7 @@ describe('MergeCells', () => {
     });
 
     it('should return true for 4 neighboring cells', () => {
-      let hot = handsontable({
+      const hot = handsontable({
         data: Handsontable.helper.createSpreadsheetObjectData(10, 5)
       });
       let mergeCells = hot.getPlugin('mergeCells');
@@ -716,7 +837,7 @@ describe('MergeCells', () => {
   describe('Validation', () => {
     it('should not hide the merged cells after validating the table', (done) => {
       let onAfterValidate = jasmine.createSpy('onAfterValidate');
-      let hot = handsontable({
+      const hot = handsontable({
         data: Handsontable.helper.createSpreadsheetData(10, 10),
         mergeCells: [
           {row: 5, col: 4, rowspan: 2, colspan: 2},
@@ -752,7 +873,7 @@ describe('MergeCells', () => {
 
   describe('Entire row/column selection', () => {
     it('should be possible to select a single entire column, when there\'s a merged cell in it', () => {
-      let hot = handsontable({
+      const hot = handsontable({
         data: Handsontable.helper.createSpreadsheetData(10, 10),
         mergeCells: [
           {row: 5, col: 4, rowspan: 2, colspan: 5}
@@ -768,7 +889,7 @@ describe('MergeCells', () => {
     });
 
     it('should be possible to select a single entire row, when there\'s a merged cell in it', () => {
-      let hot = handsontable({
+      const hot = handsontable({
         data: Handsontable.helper.createSpreadsheetData(10, 10),
         mergeCells: [
           {row: 5, col: 4, rowspan: 5, colspan: 2}
@@ -786,7 +907,7 @@ describe('MergeCells', () => {
 
   describe('Undo/Redo', () => {
     it('should not be possible to remove initially declared merged cells by calling the \'Undo\' action.', () => {
-      let hot = handsontable({
+      const hot = handsontable({
         data: Handsontable.helper.createSpreadsheetData(10, 10),
         mergeCells: [
           {row: 5, col: 4, rowspan: 2, colspan: 5},

--- a/src/plugins/mergeCells/test/mergeCells.e2e.js
+++ b/src/plugins/mergeCells/test/mergeCells.e2e.js
@@ -516,6 +516,34 @@ describe('MergeCells', () => {
       expect(hot.getPlugin('mergeCells').mergedCellsCollection.mergedCells.length).toEqual(1);
     });
 
+    it('should check if the provided merged cell information object has rowspan and colspan declared as 0, and if so, do not add it ' +
+      'to the collection and throw an appropriate warning', () => {
+      const warnSpy = spyOn(console, 'warn');
+      const newMergedCells = [
+        {
+          row: 0,
+          col: 1,
+          rowspan: 3,
+          colspan: 4
+        },
+        {
+          row: 6,
+          col: 6,
+          rowspan: 0,
+          colspan: 0
+        }
+      ];
+      const hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(20, 20),
+        mergeCells: newMergedCells
+      });
+
+      expect(warnSpy).toHaveBeenCalledWith('The merged cell declared at [6, 6] has both "rowspan" and ' +
+        '"colspan" declared as "0", which is not supported. It cannot be added to the collection.');
+
+      expect(hot.getPlugin('mergeCells').mergedCellsCollection.mergedCells.length).toEqual(1);
+    });
+
     it('should check if the provided merged cell information object represents a single cell, and if so, do not add it ' +
       'to the collection and throw an appropriate warning', () => {
       const warnSpy = spyOn(console, 'warn');

--- a/src/plugins/mergeCells/test/mergeCells.e2e.js
+++ b/src/plugins/mergeCells/test/mergeCells.e2e.js
@@ -531,6 +531,12 @@ describe('MergeCells', () => {
           col: 6,
           rowspan: 0,
           colspan: 0
+        },
+        {
+          row: 9,
+          col: 9,
+          rowspan: 1,
+          colspan: 0
         }
       ];
       const hot = handsontable({
@@ -538,7 +544,9 @@ describe('MergeCells', () => {
         mergeCells: newMergedCells
       });
 
-      expect(warnSpy).toHaveBeenCalledWith('The merged cell declared at [6, 6] has both "rowspan" and ' +
+      expect(warnSpy).toHaveBeenCalledWith('The merged cell declared at [6, 6] has "rowspan" or ' +
+        '"colspan" declared as "0", which is not supported. It cannot be added to the collection.');
+      expect(warnSpy).toHaveBeenCalledWith('The merged cell declared at [9, 9] has "rowspan" or ' +
         '"colspan" declared as "0", which is not supported. It cannot be added to the collection.');
 
       expect(hot.getPlugin('mergeCells').mergedCellsCollection.mergedCells.length).toEqual(1);


### PR DESCRIPTION
### Context
Added an additional check to make sure the newly declared merged cells are not beyond the range of the table. If they are, they're not added + there's a appropriate warning being thrown in the console.

### How has this been tested?
* Added tests for merged cells being out of bounds
* Added tests for merged cells overlapping each other

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):
1. #4887
