### PR TITLE
Fix vertical scrolling on IE when the table auto-detects its height

### DIFF
--- a/src/helpers/dom/element.js
+++ b/src/helpers/dom/element.js
@@ -709,7 +709,11 @@ export function getStyle(element, prop) {
  * @returns {IEElementStyle|CssStyle} Elements computed style object
  */
 export function getComputedStyle(element) {
-  return element.currentStyle || document.defaultView.getComputedStyle(element);
+  if(document.defaultView.getComputedStyle !== '' && document.defaultView.getComputedStyle !== void 0) {
+    return document.defaultView.getComputedStyle(element);
+  } else {
+    return element.currentStyle;
+  }
 }
 
 /**

--- a/src/helpers/dom/element.js
+++ b/src/helpers/dom/element.js
@@ -709,7 +709,7 @@ export function getStyle(element, prop) {
  * @returns {IEElementStyle|CssStyle} Elements computed style object
  */
 export function getComputedStyle(element) {
-  if(document.defaultView.getComputedStyle !== '' && document.defaultView.getComputedStyle !== void 0) {
+  if (document.defaultView.getComputedStyle !== '' && document.defaultView.getComputedStyle !== void 0) {
     return document.defaultView.getComputedStyle(element);
   } else {
     return element.currentStyle;

--- a/test/e2e/Dom.spec.js
+++ b/test/e2e/Dom.spec.js
@@ -483,7 +483,7 @@ describe('Handsontable.Dom', () => {
       element.style.fontSize = '12pt';
       document.body.appendChild(element);
 
-      var computed = Handsontable.dom.getComputedStyle();
+      var computed = Handsontable.dom.getComputedStyle(element);
 
       expect(computed.fontSize).toBe('16px');
     });

--- a/test/e2e/Dom.spec.js
+++ b/test/e2e/Dom.spec.js
@@ -474,4 +474,18 @@ describe('Handsontable.Dom', () => {
     });
   });
 
+  //
+  // Handsontable.dom.getComputedStyle
+  //
+  describe('getComputedStyle', () => {
+    it('should return a computed style', () => {
+      var element = document.createElement('div');
+      element.style.fontSize = '12pt';
+      document.body.appendChild(element);
+
+      var computed = Handsontable.dom.getComputedStyle();
+
+      expect(computed.fontSize).toBe('16px');
+    });
+  });
 });


### PR DESCRIPTION
### Context

I would like to restore an old patch that was provided by @samuellapointe back in 2015.  Here's the original context of the original issue (#2942):

> The issue (#2924) was in a project where I had to let a table fill a container, it didn't create scrollbars on IE. It's related to how the table selects its height according to the computed style. The previous behavior first checked if element.currentStyle returned a style, otherwise it used document.defaultView.getComputedStyle. However, element.currentStyle returns incorrect width and height values: auto. Since IE9+ is compatible with document.defaultView.getComputedStyle, I set it to first check if that function exists, and if so, use it. Otherwise, use element.currentStyle. This means the bug is fixed on IE9+ but it will still happen on previous versions.

Context of the original PR (#2663)

>This commit fixes the issue #2942 where using a hook on afterSelectionEnd didn't work on mobile. To do that, I added an event listener to the touchend event, and make it end a selection if there's one. To make sure it is fired after the selection occurs, it's placed in a setTimeout of length 0. Otherwise it would sometimes fire before the selection started.

### How has this been tested?
See in the description above.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. #2942
2. #2924 
3. #2963 (PR)

### Checklist:
- [x] My code follows the code style of this project (I'm pretty sure it does)
