### PR TITLE
Fix & change of behaviour after touch on a cell with link

### DIFF
--- a/src/3rdparty/walkontable/src/event.js
+++ b/src/3rdparty/walkontable/src/event.js
@@ -153,11 +153,11 @@ function Event(instance) {
   };
 
   var onTouchEnd = function(event) {
-    const excludeTags = ['A'];
+    const excludeTags = ['A', 'BUTTON', 'INPUT'];
     const target = event.target;
 
     // touched link which was placed inside a cell (a cell with DOM `a` element) WILL NOT trigger the below function calls
-    // and as consequence will behave as standard (open link).
+    // and as consequence will behave as standard (open the link).
     if (selectedCellWasTouched(target) === false || excludeTags.includes(target.tagName) === false) {
       event.preventDefault();
       onMouseUp(event);

--- a/src/3rdparty/walkontable/src/event.js
+++ b/src/3rdparty/walkontable/src/event.js
@@ -14,6 +14,7 @@ import EventManager from './../../../eventManager';
 function Event(instance) {
   const that = this;
   const eventManager = new EventManager(instance);
+  let selectedCellBeforeTouchEnd;
 
   this.instance = instance;
 
@@ -57,11 +58,7 @@ function Event(instance) {
     that.instance.touchMoving = true;
   };
 
-  var longTouchTimeout;
-
   var onTouchStart = function(event) {
-    var container = this;
-
     eventManager.addEventListener(this, 'touchmove', onTouchMove);
 
     // Prevent cell selection when scrolling with touch event - not the best solution performance-wise
@@ -141,14 +138,30 @@ function Event(instance) {
     }
   };
 
+  const selectedCellWasTouched = (touchTarget) => {
+    const cellUnderFinger = that.parentCell(touchTarget);
+    const coordsOfCellUnderFinger = cellUnderFinger.coords;
+
+    if (selectedCellBeforeTouchEnd && coordsOfCellUnderFinger) {
+      const [rowTouched, rowSelected] = [coordsOfCellUnderFinger.row, selectedCellBeforeTouchEnd.from.row];
+      const [colTouched, colSelected] = [coordsOfCellUnderFinger.col, selectedCellBeforeTouchEnd.from.col];
+
+      return rowTouched === rowSelected && colTouched === colSelected;
+    }
+
+    return false;
+  };
+
   var onTouchEnd = function(event) {
-    clearTimeout(longTouchTimeout);
-    // that.instance.longTouch == void 0;
+    const excludeTags = ['A'];
+    const target = event.target;
 
-    event.preventDefault();
-    onMouseUp(event);
-
-    // eventManager.removeEventListener(that.instance.wtTable.holder, "mouseup", onMouseUp);
+    // touched link which was placed inside a cell (a cell with DOM `a` element) WILL NOT trigger the below function calls
+    // and as consequence will behave as standard (open link).
+    if (selectedCellWasTouched(target) === false || excludeTags.includes(target.tagName) === false) {
+      event.preventDefault();
+      onMouseUp(event);
+    }
   };
 
   eventManager.addEventListener(this.instance.wtTable.holder, 'mousedown', onMouseDown);
@@ -161,6 +174,8 @@ function Event(instance) {
     var classSelector = `.${this.instance.wtTable.holder.parentNode.className.split(' ').join('.')}`;
 
     eventManager.addEventListener(this.instance.wtTable.holder, 'touchstart', (event) => {
+      selectedCellBeforeTouchEnd = instance.selections.getCell().cellRange;
+
       that.instance.touchApplied = true;
       if (isChildOf(event.target, classSelector)) {
         onTouchStart.call(event.target, event);

--- a/test/e2e/mobile/events.spec.js
+++ b/test/e2e/mobile/events.spec.js
@@ -32,4 +32,64 @@ describe('Events', () => {
     expect(getSelected()).toBeDefined();
     expect(afterOnCellMouseDown).toHaveBeenCalled();
   });
+
+  it('should block default action related to link touch and translate from the touch to click on a cell', async () => {
+    const hot = handsontable({
+      data: [['<a href="#justForTest">click me!</a>'], []],
+      rowHeaders: true,
+      colHeaders: true,
+      width: 600,
+      height: 400,
+      columns: [
+        {
+          renderer: 'html'
+        }
+      ]
+    });
+    const onCellMouseUp = spyOn(hot.view.wt.wtSettings.settings, 'onCellMouseUp');
+
+    const cell = hot.getCell(0, 0);
+
+    triggerTouchEvent('touchstart', cell.firstChild);
+
+    await sleep(100);
+
+    triggerTouchEvent('touchend', cell.firstChild);
+
+    await sleep(100);
+
+    expect(onCellMouseUp).toHaveBeenCalled();
+  });
+
+  it('should trigger default action related link touch and do not translate from the touch to click on a cell', async () => {
+    const hot = handsontable({
+      data: [['<a href="#justForTest">click me!</a>'], []],
+      rowHeaders: true,
+      colHeaders: true,
+      width: 600,
+      height: 400,
+      columns: [
+        {
+          renderer: 'html'
+        }
+      ]
+    });
+    const onCellMouseUp = spyOn(hot.view.wt.wtSettings.settings, 'onCellMouseUp');
+
+    const cell = hot.getCell(0, 0);
+
+    hot.selectCell(0, 0);
+
+    await sleep(100);
+
+    triggerTouchEvent('touchstart', cell.firstChild);
+
+    await sleep(100);
+
+    triggerTouchEvent('touchend', cell.firstChild);
+
+    await sleep(100);
+
+    expect(onCellMouseUp).not.toHaveBeenCalled();
+  });
 });

--- a/test/e2e/mobile/events.spec.js
+++ b/test/e2e/mobile/events.spec.js
@@ -75,7 +75,7 @@ describe('Events', () => {
     expect(onCellMouseUp).toHaveBeenCalled();
   });
 
-  it('should trigger default action related link touch and do not translate from the touch to click on a cell', async () => {
+  it('should trigger default action related to link touch and do not translate from the touch to click on a cell', async () => {
     const hot = handsontable({
       data: [['<a href="#justForTest">click me!</a>'], []],
       rowHeaders: true,

--- a/test/e2e/mobile/events.spec.js
+++ b/test/e2e/mobile/events.spec.js
@@ -50,6 +50,20 @@ describe('Events', () => {
 
     const cell = hot.getCell(0, 0);
 
+    // performing touch on not selected cell
+    triggerTouchEvent('touchstart', cell.firstChild);
+
+    await sleep(100);
+
+    triggerTouchEvent('touchend', cell.firstChild);
+
+    await sleep(100);
+
+    // selecting cell other than the one with link
+    hot.selectCell(1, 0);
+
+    await sleep(100);
+
     triggerTouchEvent('touchstart', cell.firstChild);
 
     await sleep(100);
@@ -83,19 +97,7 @@ describe('Events', () => {
 
     await sleep(100);
 
-    triggerTouchEvent('touchstart', cell.firstChild);
-
-    await sleep(100);
-
-    triggerTouchEvent('touchend', cell.firstChild);
-
-    await sleep(100);
-
-    // selecting cell other than the one with link
-    hot.selectCell(1, 0);
-
-    await sleep(100);
-
+    // performing touch on selected cell
     triggerTouchEvent('touchstart', cell.firstChild);
 
     await sleep(100);

--- a/test/e2e/mobile/events.spec.js
+++ b/test/e2e/mobile/events.spec.js
@@ -78,7 +78,21 @@ describe('Events', () => {
 
     const cell = hot.getCell(0, 0);
 
+    // selecting cell with link
     hot.selectCell(0, 0);
+
+    await sleep(100);
+
+    triggerTouchEvent('touchstart', cell.firstChild);
+
+    await sleep(100);
+
+    triggerTouchEvent('touchend', cell.firstChild);
+
+    await sleep(100);
+
+    // selecting cell other than the one with link
+    hot.selectCell(1, 0);
 
     await sleep(100);
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Touch on the link inside a cell hasn't worked, because inside `onTouchEnd` (inside `event.js` file) `preventDefault` function was called on the `event` object. 

The behavior of touch on such cell change. From now it should be selected at first. After that touched link element will execute default action (i.e. redirect to another webpage). Other tags inside cell i.e. `<video>`, `canvas` could work in the same way in the future. 

### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
Manual tests on iPad with set `html` editor for a column and `a` DOM element inside the column's cell.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):
1. #4570  

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [x] My change requires a change to the documentation.
