### PR TITLE
Fix for duplicated autofill handles between fixed areas. #4920

### DIFF
--- a/src/3rdparty/walkontable/src/border.js
+++ b/src/3rdparty/walkontable/src/border.js
@@ -445,7 +445,14 @@ class Border {
     let cornerVisibleSetting = this.settings.border.cornerVisible;
     cornerVisibleSetting = typeof cornerVisibleSetting === 'function' ? cornerVisibleSetting(this.settings.layerLevel) : cornerVisibleSetting;
 
-    if (isMobileBrowser() || !cornerVisibleSetting) {
+    const hookResult = this.wot.getSetting('onModifyGetCellCoords', toRow, toColumn);
+    let [checkRow, checkCol] = [toRow, toColumn];
+
+    if (hookResult && Array.isArray(hookResult)) {
+      [,, checkRow, checkCol] = hookResult;
+    }
+
+    if (isMobileBrowser() || !cornerVisibleSetting || this.isPartRange(checkRow, checkCol)) {
       this.cornerStyle.display = 'none';
 
     } else {

--- a/src/3rdparty/walkontable/test/spec/border.spec.js
+++ b/src/3rdparty/walkontable/test/spec/border.spec.js
@@ -221,6 +221,41 @@ describe('WalkontableBorder', () => {
     expect($corner.position().left).toBe(95);
   });
 
+  it('should draw only one corner if selection is added between overlays', () => {
+    const wt = new Walkontable.Core({
+      table: $table[0],
+      data: getData,
+      totalRows: 5,
+      totalColumns: 5,
+      fixedColumnsLeft: 2,
+      fixedRowsTop: 2,
+      selections: [
+        new Walkontable.Selection({
+          className: 'current'
+        }),
+        new Walkontable.Selection({
+          className: 'area',
+          border: {
+            cornerVisible() {
+              return true;
+            }
+          }
+        })
+      ],
+    });
+
+    shimSelectionProperties(wt);
+
+    wt.selections.createOrGetArea().add(new Walkontable.CellCoords(0, 0));
+    wt.selections.createOrGetArea().add(new Walkontable.CellCoords(2, 2));
+
+    wt.draw();
+
+    const corners = $container.find('.wtBorder.corner:visible');
+
+    expect(corners.length).toBe(1);
+  });
+
   it('should move the fill handle / corner border to the left, if in the position it would overlap the container (e.g.: far-right)', () => {
     $container.css({
       overflow: 'hidden',

--- a/src/plugins/mergeCells/contextMenuItem/toggleMerge.js
+++ b/src/plugins/mergeCells/contextMenuItem/toggleMerge.js
@@ -18,8 +18,7 @@ export default function toggleMergeItem(plugin) {
       return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_MERGE_CELLS);
     },
     callback() {
-      plugin.toggleMerge(this.getSelectedRangeLast());
-      this.render();
+      plugin.toggleMergeOnSelection();
     },
     disabled() {
       const sel = this.getSelectedLast();

--- a/src/plugins/mergeCells/mergeCells.js
+++ b/src/plugins/mergeCells/mergeCells.js
@@ -280,6 +280,67 @@ class MergeCells extends BasePlugin {
   }
 
   /**
+   *
+   */
+  toggleMergeOnSelection() {
+    const currentRange = this.hot.getSelectedRangeLast();
+
+    if (!currentRange) {
+      return;
+    }
+
+    currentRange.setDirection('NW-SE');
+
+    const {from, to} = currentRange;
+
+    this.toggleMerge(currentRange);
+    this.hot.selectCell(from.row, from.col, to.row, to.col, false);
+  }
+
+  /**
+   * Merge the selection provided as a cell range.
+   *
+   * @param {CellRange} [cellRange] Selection cell range.
+   */
+  mergeSelection(cellRange) {
+    if (!cellRange) {
+      cellRange = this.hot.getSelectedRangeLast();
+
+      if (!cellRange) {
+        return;
+      }
+    }
+
+    cellRange.setDirection('NW-SE');
+
+    const {from, to} = cellRange;
+
+    this.unmergeRange(cellRange, true);
+    this.mergeRange(cellRange);
+    this.hot.selectCell(from.row, from.col, to.row, to.col, false);
+  }
+
+  /**
+   * Merge the selection provided as a cell range.
+   *
+   * @param {CellRange} [cellRange] Selection cell range.
+   */
+  unmergeSelection(cellRange) {
+    if (!cellRange) {
+      cellRange = this.hot.getSelectedRangeLast();
+
+      if (!cellRange) {
+        return;
+      }
+    }
+
+    const {from, to} = cellRange;
+
+    this.unmergeRange(cellRange, true);
+    this.hot.selectCell(from.row, from.col, to.row, to.col, false);
+  }
+
+  /**
    * Merge cells in the provided cell range.
    *
    * @private
@@ -348,20 +409,6 @@ class MergeCells extends BasePlugin {
   }
 
   /**
-   * Merge the selection provided as a cell range.
-   *
-   * @param {CellRange} [cellRange] Selection cell range.
-   */
-  mergeSelection(cellRange) {
-    if (!cellRange) {
-      cellRange = this.hot.getSelectedRangeLast();
-    }
-
-    this.unmergeRange(cellRange, true);
-    this.mergeRange(cellRange);
-  }
-
-  /**
    * Unmerge the selection provided as a cell range. If no cell range is provided, it uses the current selection.
    *
    * @private
@@ -369,9 +416,13 @@ class MergeCells extends BasePlugin {
    * @param {Boolean} [auto=false] `true` if called automatically by the plugin.
    */
   unmergeRange(cellRange, auto = false) {
-    this.hot.runHooks('beforeUnmergeCells', cellRange, auto);
-
     const mergedCells = this.mergedCellsCollection.getWithinRange(cellRange);
+
+    if (!mergedCells) {
+      return;
+    }
+
+    this.hot.runHooks('beforeUnmergeCells', cellRange, auto);
 
     arrayEach(mergedCells, (currentCollection) => {
       this.mergedCellsCollection.remove(currentCollection.row, currentCollection.col);
@@ -597,7 +648,10 @@ class MergeCells extends BasePlugin {
   onModifyGetCellCoords(row, column) {
     const mergeParent = this.mergedCellsCollection.get(row, column);
 
-    return mergeParent ? [mergeParent.row, mergeParent.col] : void 0;
+    return mergeParent ? [
+      mergeParent.row, mergeParent.col,
+      mergeParent.row + mergeParent.rowspan - 1,
+      mergeParent.col + mergeParent.colspan - 1] : void 0;
   }
 
   /**

--- a/src/plugins/mergeCells/mergeCells.js
+++ b/src/plugins/mergeCells/mergeCells.js
@@ -280,7 +280,9 @@ class MergeCells extends BasePlugin {
   }
 
   /**
+   * Merge or unmerge, based on last selected range.
    *
+   * @private
    */
   toggleMergeOnSelection() {
     const currentRange = this.hot.getSelectedRangeLast();
@@ -302,13 +304,9 @@ class MergeCells extends BasePlugin {
    *
    * @param {CellRange} [cellRange] Selection cell range.
    */
-  mergeSelection(cellRange) {
+  mergeSelection(cellRange = this.hot.getSelectedRangeLast()) {
     if (!cellRange) {
-      cellRange = this.hot.getSelectedRangeLast();
-
-      if (!cellRange) {
-        return;
-      }
+      return;
     }
 
     cellRange.setDirection('NW-SE');
@@ -321,17 +319,13 @@ class MergeCells extends BasePlugin {
   }
 
   /**
-   * Merge the selection provided as a cell range.
+   * Unmerge the selection provided as a cell range.
    *
    * @param {CellRange} [cellRange] Selection cell range.
    */
-  unmergeSelection(cellRange) {
+  unmergeSelection(cellRange = this.hot.getSelectedRangeLast()) {
     if (!cellRange) {
-      cellRange = this.hot.getSelectedRangeLast();
-
-      if (!cellRange) {
-        return;
-      }
+      return;
     }
 
     const {from, to} = cellRange;

--- a/src/plugins/mergeCells/test/mergeCells.e2e.js
+++ b/src/plugins/mergeCells/test/mergeCells.e2e.js
@@ -259,6 +259,45 @@ describe('MergeCells', () => {
       selectCell(0, 0);
       expect(getCell(1, 1).className.indexOf('area')).toEqual(-1);
     });
+
+    it('should render fill handle after merge cells', () => {
+      const hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(10, 10),
+        mergeCells: true
+      });
+
+      const plugin = hot.getPlugin('mergeCells');
+      hot.selectCell(0, 0, 2, 2);
+      plugin.mergeSelection();
+
+      expect(spec().$container.find('.wtBorder.current.corner:visible').length).toEqual(1);
+    });
+
+    it('should render fill handle when merge cells is highlighted cell in right bottom corner', () => {
+      const hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(10, 10),
+        mergeCells: [
+          { row: 2, col: 2, rowspan: 2, colspan: 2 }
+        ]
+      });
+
+      hot.selectCell(2, 2, 1, 1);
+
+      expect(spec().$container.find('.wtBorder.corner:visible').length).toEqual(1);
+    });
+
+    it('should render fill handle when cell in right bottom corner is a merged cell', () => {
+      const hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(10, 10),
+        mergeCells: [
+          { row: 2, col: 2, rowspan: 2, colspan: 2 }
+        ]
+      });
+
+      hot.selectCell(1, 1, 2, 2);
+
+      expect(spec().$container.find('.wtBorder.corner:visible').length).toEqual(1);
+    });
   });
 
   describe('merged cells scroll', () => {

--- a/src/selection/selection.js
+++ b/src/selection/selection.js
@@ -1,10 +1,9 @@
 import Highlight, {AREA_TYPE, HEADER_TYPE, CELL_TYPE} from './highlight/highlight';
 import SelectionRange from './range';
-import {CellRange, CellCoords} from './../3rdparty/walkontable/src';
+import {CellCoords} from './../3rdparty/walkontable/src';
 import {isPressedCtrlKey} from './../utils/keyStateObserver';
 import {createObjectPropListener, mixin} from './../helpers/object';
 import {isUndefined} from './../helpers/mixed';
-import {addClass, removeClass} from './../helpers/dom/element';
 import {arrayEach} from './../helpers/array';
 import localHooks from './../mixins/localHooks';
 import Transformation from './transformation';
@@ -327,10 +326,9 @@ class Selection {
    * Returns `true` if the cell corner should be visible.
    *
    * @private
-   * @param {Number} layerLevel The layer level.
    * @return {Boolean} `true` if the corner element has to be visible, `false` otherwise.
    */
-  isCellCornerVisible(layerLevel) {
+  isCellCornerVisible() {
     return this.settings.fillHandle && !this.tableProps.isEditorOpened() && !this.isMultiple();
   }
 
@@ -414,12 +412,12 @@ class Selection {
     // Check if every layer of the coordinates are valid.
     const isValid = !selectionRanges.some((selection) => {
       const [rowStart, columnStart, rowEnd, columnEnd] = selectionSchemaNormalizer(selection);
-      const isValid = isValidCoord(rowStart, countRows) &&
+      const _isValid = isValidCoord(rowStart, countRows) &&
                       isValidCoord(columnStart, countCols) &&
                       isValidCoord(rowEnd, countRows) &&
                       isValidCoord(columnEnd, countCols);
 
-      return !isValid;
+      return !_isValid;
     });
 
     if (isValid) {


### PR DESCRIPTION
### Context
After changes for #4040, fill handle element is visible on each fixed area, if user set fixedRowsTop / fixedColumnsLeft.

### How has this been tested?
1. Select cells from two or more fixed areas.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):
1. #4920

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
