### PR TITLE
Alignment disables undo functionality

### DIFF
--- a/src/plugins/undoRedo/test/UndoRedo.e2e.js
+++ b/src/plugins/undoRedo/test/UndoRedo.e2e.js
@@ -1,5 +1,5 @@
 describe('UndoRedo', () => {
-  var id = 'testContainer';
+  const id = 'testContainer';
 
   beforeEach(function() {
     this.$container = $(`<div id="${id}"></div>`).appendTo('body');
@@ -19,7 +19,7 @@ describe('UndoRedo', () => {
           handsontable({
             data: Handsontable.helper.createSpreadsheetData(2, 2)
           });
-          var HOT = getInstance();
+          const HOT = getInstance();
 
           setDataAtCell(0, 0, 'X1');
           expect(getDataAtCell(0, 0)).toBe('X1');
@@ -32,7 +32,7 @@ describe('UndoRedo', () => {
           handsontable({
             data: Handsontable.helper.createSpreadsheetData(2, 2),
           });
-          var HOT = getInstance();
+          const HOT = getInstance();
 
           setDataAtCell(0, 0, 'X1');
 
@@ -49,7 +49,7 @@ describe('UndoRedo', () => {
         });
 
         it('should undo creation of a single row', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: Handsontable.helper.createSpreadsheetData(2, 2)
           });
 
@@ -65,7 +65,7 @@ describe('UndoRedo', () => {
         });
 
         it('should undo creation of multiple rows', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: Handsontable.helper.createSpreadsheetData(2, 2)
           });
 
@@ -81,7 +81,7 @@ describe('UndoRedo', () => {
         });
 
         it('should undo creation of multiple rows with minSpareRows', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: Handsontable.helper.createSpreadsheetData(2, 1),
             minSpareRows: 2
           });
@@ -100,7 +100,7 @@ describe('UndoRedo', () => {
         });
 
         it('should undo removal of single row', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: Handsontable.helper.createSpreadsheetData(3, 2)
           });
 
@@ -132,7 +132,7 @@ describe('UndoRedo', () => {
         });
 
         it('should undo removal of multiple rows', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: Handsontable.helper.createSpreadsheetData(4, 2)
           });
 
@@ -168,7 +168,7 @@ describe('UndoRedo', () => {
         });
 
         it('should undo creation of a single column (colHeaders: undefined)', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: Handsontable.helper.createSpreadsheetData(2, 3)
           });
 
@@ -184,7 +184,7 @@ describe('UndoRedo', () => {
         });
 
         it('should undo creation of a single column (colHeaders: true)', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: Handsontable.helper.createSpreadsheetData(2, 3),
             colHeaders: true
           });
@@ -204,7 +204,7 @@ describe('UndoRedo', () => {
         });
 
         it('should undo creation of a single column (colHeaders: Array)', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: Handsontable.helper.createSpreadsheetData(2, 3),
             colHeaders: ['Header1', 'Header2', 'Header3']
           });
@@ -224,7 +224,7 @@ describe('UndoRedo', () => {
         });
 
         it('should undo creation of multiple columns (colHeaders: undefined)', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: Handsontable.helper.createSpreadsheetData(2, 2)
           });
 
@@ -240,7 +240,7 @@ describe('UndoRedo', () => {
         });
 
         it('should undo creation of multiple columns (colHeaders: true)', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: Handsontable.helper.createSpreadsheetData(2, 2),
             colHeaders: true
           });
@@ -260,7 +260,7 @@ describe('UndoRedo', () => {
         });
 
         it('should undo creation of multiple columns (colHeaders: Array)', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: Handsontable.helper.createSpreadsheetData(2, 2),
             colHeaders: ['Header1', 'Header2']
           });
@@ -280,7 +280,7 @@ describe('UndoRedo', () => {
         });
 
         it('should undo creation of multiple columns with minSpareCols', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: Handsontable.helper.createSpreadsheetData(1, 1),
             minSpareCols: 2
           });
@@ -299,7 +299,7 @@ describe('UndoRedo', () => {
         });
 
         it('should undo removal of single column (colHeaders: undefined)', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: Handsontable.helper.createSpreadsheetData(2, 3)
           });
 
@@ -331,7 +331,7 @@ describe('UndoRedo', () => {
         });
 
         it('should undo removal of single column (colHeaders: true)', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: Handsontable.helper.createSpreadsheetData(2, 2),
             colHeaders: true
           });
@@ -364,7 +364,7 @@ describe('UndoRedo', () => {
         });
 
         it('should undo removal of single column (colHeaders: Array)', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: Handsontable.helper.createSpreadsheetData(2, 2),
             colHeaders: ['Header1', 'Header2']
           });
@@ -397,7 +397,7 @@ describe('UndoRedo', () => {
         });
 
         it('should undo removal of multiple columns (colHeaders: undefined)', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: Handsontable.helper.createSpreadsheetData(2, 4)
           });
 
@@ -437,7 +437,7 @@ describe('UndoRedo', () => {
         });
 
         it('should undo removal of multiple columns (colHeaders: true)', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: Handsontable.helper.createSpreadsheetData(2, 4),
             colHeaders: true
           });
@@ -481,7 +481,7 @@ describe('UndoRedo', () => {
         });
 
         it('should undo removal of multiple columns (colHeaders: Array)', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: Handsontable.helper.createSpreadsheetData(2, 4),
             colHeaders: ['Header1', 'Header2', 'Header3', 'Header4']
           });
@@ -525,7 +525,7 @@ describe('UndoRedo', () => {
         });
 
         it('should undo removal of multiple columns (with a used manualColumnMove)', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: Handsontable.helper.createSpreadsheetData(2, 7),
             manualColumnMove: [3, 2, 0, 6, 1, 5, 4]
           });
@@ -548,7 +548,7 @@ describe('UndoRedo', () => {
           handsontable({
             data: Handsontable.helper.createSpreadsheetData(2, 2)
           });
-          var HOT = getInstance();
+          const HOT = getInstance();
 
           setDataAtCell(0, 0, 'X1');
           setDataAtCell(1, 0, 'X2');
@@ -595,7 +595,7 @@ describe('UndoRedo', () => {
           handsontable({
             data: Handsontable.helper.createSpreadsheetData(2, 2),
           });
-          var HOT = getInstance();
+          const HOT = getInstance();
 
           setDataAtCell(0, 0, 'X1');
           setDataAtCell(1, 0, 'X2');
@@ -657,7 +657,7 @@ describe('UndoRedo', () => {
         });
 
         it('should undo multiple row creations', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: Handsontable.helper.createSpreadsheetData(2, 2)
           });
 
@@ -687,7 +687,7 @@ describe('UndoRedo', () => {
         });
 
         it('should undo multiple row removals', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: Handsontable.helper.createSpreadsheetData(4, 2)
           });
 
@@ -751,7 +751,7 @@ describe('UndoRedo', () => {
         it('should undo changes only for table where the change actually took place', function() {
           this.$container2 = $(`<div id="${id}-2"></div>`).appendTo('body');
 
-          var hot1 = handsontable({
+          const hot1 = handsontable({
             data: [
               [1],
               [2],
@@ -767,7 +767,7 @@ describe('UndoRedo', () => {
             ]
           });
 
-          var hot2 = this.$container2.handsontable('getInstance');
+          const hot2 = this.$container2.handsontable('getInstance');
 
           hot1.setDataAtCell(0, 0, 4);
           expect(hot1.getDataAtCell(0, 0)).toEqual(4);
@@ -827,7 +827,7 @@ describe('UndoRedo', () => {
           handsontable({
             data: Handsontable.helper.createSpreadsheetData(2, 2)
           });
-          var HOT = getInstance();
+          const HOT = getInstance();
 
           setDataAtCell(0, 0, 'new value');
 
@@ -844,7 +844,7 @@ describe('UndoRedo', () => {
           handsontable({
             data: Handsontable.helper.createSpreadsheetData(2, 2),
           });
-          var HOT = getInstance();
+          const HOT = getInstance();
 
           setDataAtCell(0, 0, 'new value');
 
@@ -867,7 +867,7 @@ describe('UndoRedo', () => {
         });
 
         it('should redo creation of a single row', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: Handsontable.helper.createSpreadsheetData(2, 2)
           });
 
@@ -887,7 +887,7 @@ describe('UndoRedo', () => {
         });
 
         it('should redo creation of multiple rows', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: Handsontable.helper.createSpreadsheetData(2, 2)
           });
 
@@ -907,7 +907,7 @@ describe('UndoRedo', () => {
         });
 
         it('should redo removal of single row', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: Handsontable.helper.createSpreadsheetData(3, 2)
           });
 
@@ -947,7 +947,7 @@ describe('UndoRedo', () => {
         });
 
         it('should redo removal of multiple rows', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: Handsontable.helper.createSpreadsheetData(4, 2)
           });
 
@@ -991,7 +991,7 @@ describe('UndoRedo', () => {
         });
 
         it('should redo creation of a single column', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: Handsontable.helper.createSpreadsheetData(2, 2)
           });
 
@@ -1011,7 +1011,7 @@ describe('UndoRedo', () => {
         });
 
         it('should redo creation of multiple columns', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: Handsontable.helper.createSpreadsheetData(2, 2)
           });
 
@@ -1031,7 +1031,7 @@ describe('UndoRedo', () => {
         });
 
         it('should redo removal of single column', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: Handsontable.helper.createSpreadsheetData(2, 2)
           });
 
@@ -1067,7 +1067,7 @@ describe('UndoRedo', () => {
         });
 
         it('should redo removal of multiple columns', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: Handsontable.helper.createSpreadsheetData(2, 4)
           });
 
@@ -1122,7 +1122,7 @@ describe('UndoRedo', () => {
           handsontable({
             data: Handsontable.helper.createSpreadsheetData(2, 2)
           });
-          var HOT = getInstance();
+          const HOT = getInstance();
 
           setDataAtCell(0, 0, 'X1');
           setDataAtCell(1, 0, 'X2');
@@ -1176,7 +1176,7 @@ describe('UndoRedo', () => {
         });
 
         it('should redo multiple changes in cell with validator', (done) => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: Handsontable.helper.createSpreadsheetData(2, 2),
           });
 
@@ -1261,7 +1261,7 @@ describe('UndoRedo', () => {
         });
 
         it('should redo multiple row creations', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: Handsontable.helper.createSpreadsheetData(2, 2)
           });
 
@@ -1298,7 +1298,7 @@ describe('UndoRedo', () => {
         });
 
         it('should undo multiple row removals', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: Handsontable.helper.createSpreadsheetData(4, 2)
           });
 
@@ -1364,7 +1364,7 @@ describe('UndoRedo', () => {
         it('should redo changes only for table where the change actually took place', function() {
           this.$container2 = $(`<div id="${id}-2"></div>`).appendTo('body');
 
-          var hot1 = handsontable({
+          const hot1 = handsontable({
             data: [
               [1],
               [2],
@@ -1380,7 +1380,7 @@ describe('UndoRedo', () => {
             ]
           });
 
-          var hot2 = this.$container2.handsontable('getInstance');
+          const hot2 = this.$container2.handsontable('getInstance');
 
           hot1.setDataAtCell(0, 0, 4);
           expect(hot1.getDataAtCell(0, 0)).toEqual(4);
@@ -1419,7 +1419,7 @@ describe('UndoRedo', () => {
           handsontable({
             data: createObjectData()
           });
-          var HOT = getInstance();
+          const HOT = getInstance();
 
           setDataAtRowProp(0, 0, 'Pearce');
           expect(getDataAtRowProp(0, 0)).toBe('Pearce');
@@ -1432,7 +1432,7 @@ describe('UndoRedo', () => {
           handsontable({
             data: createObjectData(),
           });
-          var HOT = getInstance();
+          const HOT = getInstance();
 
           setDataAtRowProp(0, 0, 'Pearce');
 
@@ -1449,7 +1449,7 @@ describe('UndoRedo', () => {
         });
 
         it('should undo creation of a single row', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: createObjectData().slice(0, 2)
           });
 
@@ -1465,7 +1465,7 @@ describe('UndoRedo', () => {
         });
 
         it('should undo creation of multiple rows', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: createObjectData().slice(0, 2)
           });
 
@@ -1481,7 +1481,7 @@ describe('UndoRedo', () => {
         });
 
         it('should undo removal of single row', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: createObjectData().slice(0, 2)
           });
 
@@ -1509,7 +1509,7 @@ describe('UndoRedo', () => {
         });
 
         it('should undo removal of multiple rows', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: createObjectData()
           });
 
@@ -1546,7 +1546,7 @@ describe('UndoRedo', () => {
           handsontable({
             data: createObjectData().slice(0, 2)
           });
-          var HOT = getInstance();
+          const HOT = getInstance();
 
           setDataAtRowProp(0, 'name', 'Pierce');
           setDataAtRowProp(0, 'surname', 'Brosnan');
@@ -1593,7 +1593,7 @@ describe('UndoRedo', () => {
           handsontable({
             data: createObjectData().slice(0, 2),
           });
-          var HOT = getInstance();
+          const HOT = getInstance();
 
           setDataAtRowProp(0, 'name', 'Pierce');
           setDataAtRowProp(0, 'surname', 'Brosnan');
@@ -1655,7 +1655,7 @@ describe('UndoRedo', () => {
         });
 
         it('should undo multiple row creations', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: createObjectData().slice(0, 2)
           });
 
@@ -1686,7 +1686,7 @@ describe('UndoRedo', () => {
         });
 
         it('should undo multiple row removals', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: createObjectData()
           });
 
@@ -1738,7 +1738,7 @@ describe('UndoRedo', () => {
           handsontable({
             data: createObjectData()
           });
-          var HOT = getInstance();
+          const HOT = getInstance();
 
           setDataAtRowProp(0, 0, 'Pearce');
           expect(getDataAtRowProp(0, 0)).toBe('Pearce');
@@ -1754,7 +1754,7 @@ describe('UndoRedo', () => {
           handsontable({
             data: createObjectData(),
           });
-          var HOT = getInstance();
+          const HOT = getInstance();
 
           setDataAtRowProp(0, 0, 'Pearce');
 
@@ -1777,7 +1777,7 @@ describe('UndoRedo', () => {
         });
 
         it('should redo creation of a single row', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: createObjectData().slice(0, 2)
           });
 
@@ -1797,7 +1797,7 @@ describe('UndoRedo', () => {
         });
 
         it('should redo creation of multiple rows', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: createObjectData().slice(0, 2)
           });
 
@@ -1817,7 +1817,7 @@ describe('UndoRedo', () => {
         });
 
         it('should redo removal of single row', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: createObjectData().slice(0, 2)
           });
 
@@ -1853,7 +1853,7 @@ describe('UndoRedo', () => {
         });
 
         it('should redo removal of multiple rows', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: createObjectData()
           });
 
@@ -1900,7 +1900,7 @@ describe('UndoRedo', () => {
           handsontable({
             data: createObjectData().slice(0, 2)
           });
-          var HOT = getInstance();
+          const HOT = getInstance();
 
           setDataAtRowProp(0, 'name', 'Pierce');
           setDataAtRowProp(0, 'surname', 'Brosnan');
@@ -1957,7 +1957,7 @@ describe('UndoRedo', () => {
           handsontable({
             data: createObjectData().slice(0, 2),
           });
-          var HOT = getInstance();
+          const HOT = getInstance();
 
           setDataAtRowProp(0, 'name', 'Pierce');
           setDataAtRowProp(0, 'surname', 'Brosnan');
@@ -2040,7 +2040,7 @@ describe('UndoRedo', () => {
         });
 
         it('should redo multiple row creations', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: createObjectData().slice(0, 2)
           });
 
@@ -2077,7 +2077,7 @@ describe('UndoRedo', () => {
         });
 
         it('should undo multiple row removals', () => {
-          var HOT = handsontable({
+          const HOT = handsontable({
             data: createObjectData()
           });
 
@@ -2132,7 +2132,7 @@ describe('UndoRedo', () => {
   describe('plugin features', () => {
     describe('cell alignment', () => {
       it('should undo a sequence of aligning cells', () => {
-        var hot = handsontable({
+        const hot = handsontable({
           data: Handsontable.helper.createSpreadsheetData(9, 9),
           contextMenu: true,
           colWidths: [50, 50, 50, 50, 50, 50, 50, 50, 50],
@@ -2159,7 +2159,7 @@ describe('UndoRedo', () => {
         selectCell(0, 6, 8, 8);
         hot.getPlugin('contextMenu').executeCommand('alignment:bottom');
 
-        var cellMeta = hot.getCellMeta(0, 0);
+        let cellMeta = hot.getCellMeta(0, 0);
         expect(cellMeta.className.indexOf('htCenter')).toBeGreaterThan(-1);
         expect(cellMeta.className.indexOf('htMiddle')).toBeGreaterThan(-1);
 
@@ -2225,9 +2225,9 @@ describe('UndoRedo', () => {
         hot.undo();
 
         // check if all cells are either non-adjusted or adjusted to the left (as default)
-        var finish;
-        for (var i = 0; i < 9; i++) {
-          for (var j = 0; j < 9; j++) {
+        let finish;
+        for (let i = 0; i < 9; i++) {
+          for (let j = 0; j < 9; j++) {
             cellMeta = hot.getCellMeta(i, j);
             finish = cellMeta.className === void 0 || cellMeta.className.trim() === '' || cellMeta.className.trim() === 'htLeft';
             expect(finish).toBe(true);
@@ -2236,7 +2236,7 @@ describe('UndoRedo', () => {
       });
 
       it('should redo a sequence of aligning cells', () => {
-        var hot = handsontable({
+        const hot = handsontable({
           data: Handsontable.helper.createSpreadsheetData(9, 9),
           contextMenu: true,
           colWidths: [50, 50, 50, 50, 50, 50, 50, 50, 50],
@@ -2263,7 +2263,7 @@ describe('UndoRedo', () => {
         selectCell(0, 6, 8, 8);
         hot.getPlugin('contextMenu').executeCommand('alignment:bottom');
 
-        var cellMeta = hot.getCellMeta(0, 0);
+        let cellMeta = hot.getCellMeta(0, 0);
         expect(cellMeta.className.indexOf('htCenter')).toBeGreaterThan(-1);
         expect(cellMeta.className.indexOf('htMiddle')).toBeGreaterThan(-1);
 
@@ -2294,9 +2294,9 @@ describe('UndoRedo', () => {
         hot.undo();
 
         // check if all cells are either non-adjusted or adjusted to the left (as default)
-        var finish;
-        for (var i = 0; i < 9; i++) {
-          for (var j = 0; j < 9; j++) {
+        let finish;
+        for (let i = 0; i < 9; i++) {
+          for (let j = 0; j < 9; j++) {
             cellMeta = hot.getCellMeta(i, j);
             finish = cellMeta.className === void 0 || cellMeta.className.trim() === '' || cellMeta.className.trim() === 'htLeft';
             expect(finish).toBe(true);
@@ -2342,7 +2342,7 @@ describe('UndoRedo', () => {
     });
 
     it('should exposed new methods when plugin is enabled', () => {
-      var hot = handsontable({
+      const hot = handsontable({
         undo: false
       });
 
@@ -2364,7 +2364,7 @@ describe('UndoRedo', () => {
     });
 
     it('should remove exposed methods when plugin is disbaled', () => {
-      var hot = handsontable({
+      const hot = handsontable({
         undo: true
       });
 
@@ -2390,7 +2390,7 @@ describe('UndoRedo', () => {
         handsontable({
           data: Handsontable.helper.createSpreadsheetData(2, 2)
         });
-        var HOT = getInstance();
+        const HOT = getInstance();
 
         selectCell(0, 0);
         setDataAtCell(0, 0, 'new value');
@@ -2403,7 +2403,7 @@ describe('UndoRedo', () => {
         handsontable({
           data: Handsontable.helper.createSpreadsheetData(2, 2)
         });
-        var HOT = getInstance();
+        const HOT = getInstance();
 
         selectCell(0, 0);
         setDataAtCell(0, 0, 'new value');
@@ -2422,7 +2422,7 @@ describe('UndoRedo', () => {
         handsontable({
           data: Handsontable.helper.createSpreadsheetData(2, 2)
         });
-        var HOT = getInstance();
+        const HOT = getInstance();
 
         selectCell(0, 0);
         setDataAtCell(0, 0, 'new value');
@@ -2441,11 +2441,11 @@ describe('UndoRedo', () => {
 
   describe('Hooks', () => {
     it('should fire a `beforeUndo` hook after the undo process begins', (done) => {
-      var beforeUndoSpy = jasmine.createSpy('beforeUndo');
-      var hot = handsontable({
+      const beforeUndoSpy = jasmine.createSpy('beforeUndo');
+      const hot = handsontable({
         data: Handsontable.helper.createSpreadsheetData(2, 2),
       });
-      var hookData = null;
+      let hookData = null;
 
       hot.addHook('beforeUndo', beforeUndoSpy);
       hot.addHook('beforeUndo', (data) => {
@@ -2468,11 +2468,11 @@ describe('UndoRedo', () => {
     });
 
     it('should fire a `beforeRedo` hook before the redo process begins', (done) => {
-      var beforeRedoSpy = jasmine.createSpy('beforeRedo');
-      var hot = handsontable({
+      const beforeRedoSpy = jasmine.createSpy('beforeRedo');
+      const hot = handsontable({
         data: Handsontable.helper.createSpreadsheetData(2, 2),
       });
-      var hookData = null;
+      let hookData = null;
 
       hot.addHook('beforeRedo', beforeRedoSpy);
       hot.addHook('beforeRedo', (data) => {
@@ -2496,11 +2496,11 @@ describe('UndoRedo', () => {
     });
 
     it('should fire a `afterRedo` hook after the redo process begins', (done) => {
-      var afterRedoSpy = jasmine.createSpy('afterRedo');
-      var hot = handsontable({
+      const afterRedoSpy = jasmine.createSpy('afterRedo');
+      const hot = handsontable({
         data: Handsontable.helper.createSpreadsheetData(2, 2),
       });
-      var hookData = null;
+      let hookData = null;
 
       hot.addHook('beforeRedo', afterRedoSpy);
       hot.addHook('beforeRedo', (data) => {

--- a/src/plugins/undoRedo/undoRedo.js
+++ b/src/plugins/undoRedo/undoRedo.js
@@ -7,6 +7,7 @@ import {rangeEach} from './../../helpers/number';
 import {inherit, deepClone} from './../../helpers/object';
 import {stopImmediatePropagation} from './../../helpers/dom/event';
 import {CellCoords} from './../../3rdparty/walkontable/src';
+import {align} from './../contextMenu/utils';
 
 /**
  * @description
@@ -455,14 +456,8 @@ UndoRedo.CellAlignmentAction.prototype.undo = function(instance, undoneCallback)
   instance.render();
 };
 UndoRedo.CellAlignmentAction.prototype.redo = function(instance, undoneCallback) {
-  arrayEach(this.range, ({from, to}) => {
-    for (var row = from.row; row <= to.row; row += 1) {
-      for (var col = from.col; col <= to.col; col += 1) {
-        var className = this.stateBefore[row][col] ? `${this.stateBefore[row][col]} ${this.alignment}` : `${this.alignment}`;
-        instance.setCellMeta(row, col, 'className', className);
-      }
-    }
-  });
+  align(this.range, this.type, this.alignment, (row, col) => instance.getCellMeta(row, col),
+    (row, col, key, value) => instance.setCellMeta(row, col, key, value));
 
   instance.addHookOnce('afterRender', undoneCallback);
   instance.render();

--- a/src/plugins/undoRedo/undoRedo.js
+++ b/src/plugins/undoRedo/undoRedo.js
@@ -444,8 +444,8 @@ UndoRedo.CellAlignmentAction = function(stateBefore, range, type, alignment) {
 };
 UndoRedo.CellAlignmentAction.prototype.undo = function(instance, undoneCallback) {
   arrayEach(this.range, ({from, to}) => {
-    for (var row = from.row; row <= to.row; row++) {
-      for (var col = from.col; col <= to.col; col++) {
+    for (var row = from.row; row <= to.row; row += 1) {
+      for (var col = from.col; col <= to.col; col += 1) {
         instance.setCellMeta(row, col, 'className', this.stateBefore[row][col] || ' htLeft');
       }
     }
@@ -456,8 +456,12 @@ UndoRedo.CellAlignmentAction.prototype.undo = function(instance, undoneCallback)
 };
 UndoRedo.CellAlignmentAction.prototype.redo = function(instance, undoneCallback) {
   arrayEach(this.range, ({from, to}) => {
-    instance.selectCell(from.row, from.col, to.row, to.col);
-    instance.getPlugin('contextMenu').executeCommand(`alignment:${this.alignment.replace('ht', '').toLowerCase()}`);
+    for (var row = from.row; row <= to.row; row += 1) {
+      for (var col = from.col; col <= to.col; col += 1) {
+        var className = this.stateBefore[row][col] ? `${this.stateBefore[row][col]} ${this.alignment}` : `${this.alignment}`;
+        instance.setCellMeta(row, col, 'className', className);
+      }
+    }
   });
 
   instance.addHookOnce('afterRender', undoneCallback);

--- a/src/plugins/undoRedo/undoRedo.js
+++ b/src/plugins/undoRedo/undoRedo.js
@@ -443,10 +443,6 @@ UndoRedo.CellAlignmentAction = function(stateBefore, range, type, alignment) {
   this.alignment = alignment;
 };
 UndoRedo.CellAlignmentAction.prototype.undo = function(instance, undoneCallback) {
-  if (!instance.getPlugin('contextMenu').isEnabled()) {
-    return;
-  }
-
   arrayEach(this.range, ({from, to}) => {
     for (var row = from.row; row <= to.row; row++) {
       for (var col = from.col; col <= to.col; col++) {
@@ -459,9 +455,6 @@ UndoRedo.CellAlignmentAction.prototype.undo = function(instance, undoneCallback)
   instance.render();
 };
 UndoRedo.CellAlignmentAction.prototype.redo = function(instance, undoneCallback) {
-  if (!instance.getPlugin('contextMenu').isEnabled()) {
-    return;
-  }
   arrayEach(this.range, ({from, to}) => {
     instance.selectCell(from.row, from.col, to.row, to.col);
     instance.getPlugin('contextMenu').executeCommand(`alignment:${this.alignment.replace('ht', '').toLowerCase()}`);

--- a/src/plugins/undoRedo/undoRedo.js
+++ b/src/plugins/undoRedo/undoRedo.js
@@ -445,8 +445,8 @@ UndoRedo.CellAlignmentAction = function(stateBefore, range, type, alignment) {
 };
 UndoRedo.CellAlignmentAction.prototype.undo = function(instance, undoneCallback) {
   arrayEach(this.range, ({from, to}) => {
-    for (var row = from.row; row <= to.row; row += 1) {
-      for (var col = from.col; col <= to.col; col += 1) {
+    for (let row = from.row; row <= to.row; row += 1) {
+      for (let col = from.col; col <= to.col; col += 1) {
         instance.setCellMeta(row, col, 'className', this.stateBefore[row][col] || ' htLeft');
       }
     }


### PR DESCRIPTION
### Context
When change the alignment from the `dropdownMenu` then it's impossible to revert the changes using `ctrl+z`. Removing an unnecessary test to enable contextMenu, because changes can be made without using it.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):
1. #3319
2. https://github.com/handsontable/handsontable-pro/issues/47

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
