### PR TITLE
Selection handles DO NOT disappear on the mobile device while trying to drag and drop

### DIFF
--- a/src/3rdparty/walkontable/src/border.js
+++ b/src/3rdparty/walkontable/src/border.js
@@ -481,7 +481,7 @@ class Border {
     }
 
     if (isMobileBrowser()) {
-      this.updateMultipleSelectionHandlesPosition(fromRow, fromColumn, top, left, width, height);
+      this.updateMultipleSelectionHandlesPosition(toRow, toColumn, top, left, width, height);
     }
   }
 

--- a/src/3rdparty/walkontable/src/border.js
+++ b/src/3rdparty/walkontable/src/border.js
@@ -282,7 +282,7 @@ class Border {
     this.selectionHandles.styles.bottomRightHitArea.top = `${parseInt(top + height - (hitAreaWidth / 4), 10)}px`;
     this.selectionHandles.styles.bottomRightHitArea.left = `${parseInt(left + width - (hitAreaWidth / 4), 10)}px`;
 
-    if (this.settings.border.multipleSelectionHandlesVisible && this.settings.border.multipleSelectionHandlesVisible()) {
+    if (this.settings.border.cornerVisible && this.settings.border.cornerVisible()) {
       this.selectionHandles.styles.topLeft.display = 'block';
       this.selectionHandles.styles.topLeftHitArea.display = 'block';
 

--- a/src/selection/highlight/types/area.js
+++ b/src/selection/highlight/types/area.js
@@ -5,7 +5,7 @@ import {Selection} from './../../../3rdparty/walkontable/src';
  *
  * @return {Selection}
  */
-function createHighlight({layerLevel, cornerVisible, multipleSelectionHandlesVisible, areaCornerVisible}) {
+function createHighlight({layerLevel, areaCornerVisible}) {
   const s = new Selection({
     className: 'area',
     markIntersections: true,
@@ -14,7 +14,6 @@ function createHighlight({layerLevel, cornerVisible, multipleSelectionHandlesVis
       width: 1,
       color: '#4b89ff',
       cornerVisible: areaCornerVisible,
-      multipleSelectionHandlesVisible,
     },
   });
 

--- a/src/selection/highlight/types/cell.js
+++ b/src/selection/highlight/types/cell.js
@@ -6,14 +6,13 @@ import {Selection} from './../../../3rdparty/walkontable/src';
  *
  * @return {Selection}
  */
-function createHighlight({cornerVisible, multipleSelectionHandlesVisible, cellCornerVisible}) {
+function createHighlight({cellCornerVisible}) {
   const s = new Selection({
     className: 'current',
     border: {
       width: 2,
       color: '#4b89ff',
       cornerVisible: cellCornerVisible,
-      multipleSelectionHandlesVisible,
     },
   });
 

--- a/src/selection/highlight/types/index.js
+++ b/src/selection/highlight/types/index.js
@@ -9,9 +9,6 @@ import headerHighlight from './header';
 const {
   register,
   getItem,
-  hasItem,
-  getNames,
-  getValues,
 } = staticRegister('highlight/types');
 
 register('area', areaHighlight);

--- a/src/selection/selection.js
+++ b/src/selection/selection.js
@@ -327,10 +327,9 @@ class Selection {
    * Returns `true` if the cell corner should be visible.
    *
    * @private
-   * @param {Number} layerLevel The layer level.
    * @return {Boolean} `true` if the corner element has to be visible, `false` otherwise.
    */
-  isCellCornerVisible(layerLevel) {
+  isCellCornerVisible() {
     return this.settings.fillHandle && !this.tableProps.isEditorOpened() && !this.isMultiple();
   }
 
@@ -341,7 +340,7 @@ class Selection {
    * @return {Boolean} `true` if the corner element has to be visible, `false` otherwise.
    */
   isAreaCornerVisible(layerLevel) {
-    if (layerLevel !== this.selectedRange.ranges.length - 1) {
+    if (Number.isInteger(layerLevel) && layerLevel !== this.selectedRange.ranges.length - 1) {
       return false;
     }
 

--- a/test/e2e/mobile/selection.spec.js
+++ b/test/e2e/mobile/selection.spec.js
@@ -1,0 +1,29 @@
+describe('Selection', () => {
+  const id = 'testContainer';
+
+  beforeEach(function () {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function () {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should show selection handles', async function () {
+    const hot = handsontable({
+      width: 400,
+      height: 400
+    });
+
+    hot.selectCell(1, 1);
+
+    const topLeftSelectionHandle = this.$container.find('.ht_master .htBorders div:last-child .topLeftSelectionHandle')[0];
+    const bottomRightSelectionHandle = this.$container.find('.ht_master .htBorders div:last-child .bottomRightSelectionHandle')[0];
+
+    expect(topLeftSelectionHandle.style.display).toEqual('block');
+    expect(bottomRightSelectionHandle.style.display).toEqual('block');
+  });
+});

--- a/test/e2e/mobile/selection.spec.js
+++ b/test/e2e/mobile/selection.spec.js
@@ -26,4 +26,26 @@ describe('Selection', () => {
     expect(topLeftSelectionHandle.style.display).toEqual('block');
     expect(bottomRightSelectionHandle.style.display).toEqual('block');
   });
+
+  it('should show both selection handles after drag & drop', async function () {
+    const hot = handsontable({
+      width: 400,
+      height: 400
+    });
+
+    hot.selectCell(1, 1);
+
+    await sleep(100);
+
+    this.$container.find('.wtBorder.current.corner').simulate('mousedown');
+    this.$container.find('tbody tr:eq(1) td:eq(2)').simulate('mouseover').simulate('mouseup');
+
+    await sleep(100);
+
+    const topLeftSelectionHandle = this.$container.find('.ht_master .htBorders div:first-child .topLeftSelectionHandle')[0];
+    const bottomRightSelectionHandle = this.$container.find('.ht_master .htBorders div:first-child .bottomRightSelectionHandle')[0];
+
+    expect(topLeftSelectionHandle.style.display).toEqual('block');
+    expect(bottomRightSelectionHandle.style.display).toEqual('block');
+  });
 });


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Two fixes within #4943 issue. The first one is related to changes released within `0.16.0`. The second one is related to release `0.37.0`. Both of them influenced the disappearance of the handlers.

### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
Manual tests with drag & drop on iPad.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):
1. #4943

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
