### PR TITLE
Context menu will have minimum width

### DIFF
--- a/src/plugins/contextMenu/contextMenu.css
+++ b/src/plugins/contextMenu/contextMenu.css
@@ -2,7 +2,7 @@
  * Handsontable ContextMenu
  */
 
-.htContextMenu {
+.htContextMenu:not(.htGhostTable) {
   display: none;
   position: absolute;
   z-index: 1060; /* needs to be higher than 1050 - z-index for Twitter Bootstrap modal (#1569) */

--- a/src/plugins/contextMenu/menu.js
+++ b/src/plugins/contextMenu/menu.js
@@ -11,13 +11,15 @@ import {arrayEach, arrayFilter, arrayReduce} from './../../helpers/array';
 import Cursor from './cursor';
 import EventManager from './../../eventManager';
 import {mixin, hasOwnProperty} from './../../helpers/object';
-import {isUndefined} from './../../helpers/mixed';
+import {isUndefined, isDefined} from './../../helpers/mixed';
 import {debounce, isFunction} from './../../helpers/function';
 import {filterSeparators, hasSubMenu, isDisabled, isItemHidden, isSeparator, isSelectionDisabled, normalizeSelection} from './utils';
 import {KEY_CODES} from './../../helpers/unicode';
 import localHooks from './../../mixins/localHooks';
 import {SEPARATOR} from './predefinedItems';
 import {stopImmediatePropagation} from './../../helpers/dom/event';
+
+const MIN_WIDTH = 215;
 
 /**
  * @class Menu
@@ -31,7 +33,8 @@ class Menu {
       name: null,
       className: '',
       keepInViewport: true,
-      standalone: false
+      standalone: false,
+      minWidth: MIN_WIDTH,
     };
     this.eventManager = new EventManager(this);
     this.container = this.createContainer(this.options.name);
@@ -98,6 +101,7 @@ class Menu {
     this.container.style.display = 'block';
 
     const delayedOpenSubMenu = debounce((row) => this.openSubMenu(row), 300);
+    const minWidthOfMenu = this.options.minWidth || MIN_WIDTH;
 
     let filteredItems = arrayFilter(this.menuItems, (item) => isItemHidden(item, this.hot));
 
@@ -106,7 +110,14 @@ class Menu {
     let settings = {
       data: filteredItems,
       colHeaders: false,
-      colWidths: [215],
+      autoColumnSize: true,
+      modifyColWidth(width) {
+        if (isDefined(width) && width < minWidthOfMenu) {
+          return minWidthOfMenu;
+        }
+
+        return width;
+      },
       autoRowSize: false,
       readOnly: true,
       copyPaste: false,

--- a/src/plugins/contextMenu/test/contextMenu.e2e.js
+++ b/src/plugins/contextMenu/test/contextMenu.e2e.js
@@ -79,6 +79,88 @@ describe('ContextMenu', () => {
     ].join(''));
   });
 
+  describe('menu width', () => {
+    it('should display the menu with the minimum width', async () => {
+      handsontable({
+        contextMenu: {
+          items: {
+            custom1: {
+              name: 'a'
+            },
+            custom2: {
+              name: 'b'
+            },
+          }
+        }
+      });
+
+      const $menu = $('.htContextMenu');
+
+      contextMenu();
+
+      await sleep(300);
+
+      expect($menu.find('.wtHider').width()).toEqual(215);
+    });
+
+    it('should expand menu when one of items is wider then default width of the menu', async () => {
+      handsontable({
+        contextMenu: {
+          items: {
+            custom1: {
+              name: 'a'
+            },
+            custom2: {
+              name: 'This is very long text which should expand the context menu...'
+            },
+          }
+        }
+      });
+
+      const $menu = $('.htContextMenu');
+
+      contextMenu();
+
+      await sleep(300);
+
+      expect($menu.find('.wtHider').width()).toBeGreaterThan(215);
+    });
+
+    it('should display a submenu with the minimum width', async () => {
+      handsontable({
+        contextMenu: {
+          items: {
+            custom1: {
+              name: 'a'
+            },
+            custom2: {
+              name() {
+                return 'Menu';
+              },
+              submenu: {
+                items: [{ name: () => 'Submenu' }]
+              }
+            }
+          }
+        }
+      });
+
+      contextMenu();
+
+      await sleep(300);
+
+      const $item = $('.htContextMenu .ht_master .htCore').find('tbody td').not('.htSeparator').eq(1);
+
+      $item.simulate('mouseover');
+
+      await sleep(300);
+
+      const $contextSubMenu = $(`.htContextMenuSub_${$item.text()}`);
+
+      expect($contextSubMenu.find('.wtHider').width()).toEqual(215);
+    });
+  });
+
   describe('menu opening', () => {
     it('should open menu after right click on table cell', () => {
       var hot = handsontable({


### PR DESCRIPTION
### Context
At the start, I've tried to use `AutoColumnSize` plugin. However, it hasn't worked properly because `contextMenu` has CSS which defines it as not displayed at the start. `GhostTable` has drawn a copy of it, but as it hasn't been displayed the width wasn't calculated properly.

After a change which fixed this situation, I've set a minimum of the context menu (it have been fixed so far).

### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
Manual tests on the menu with submenus.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):
1. #4933

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
