### PR TITLE
Fix a bug with removing the beginning parts of merged cells. #3473

### DIFF
--- a/src/plugins/mergeCells/cellCoords.js
+++ b/src/plugins/mergeCells/cellCoords.js
@@ -238,7 +238,7 @@ class MergedCellCoords {
         const removedOffset = changeEnd - mergeStart + 1;
         const preRemovedOffset = Math.abs(shiftValue) - removedOffset;
 
-        this[index] -= preRemovedOffset;
+        this[index] -= preRemovedOffset + shiftValue;
         this[span] -= removedOffset;
 
         // removing the middle part of the merge

--- a/src/plugins/mergeCells/test/mergeCells.e2e.js
+++ b/src/plugins/mergeCells/test/mergeCells.e2e.js
@@ -501,6 +501,130 @@ describe('MergeCells', () => {
       expect(mergedCellsCollection[0].row).toEqual(1);
       expect(mergedCellsCollection[1].row).toEqual(3);
     });
+
+    it('should trim the merged cell\'s height, when removing rows between their start and end', () => {
+      const hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(20, 20),
+        mergeCells: [
+          {row: 1, col: 1, rowspan: 5, colspan: 3}
+        ],
+        height: 400,
+        width: 400
+      });
+
+      hot.alter('remove_row', 2, 2);
+
+      let plugin = hot.getPlugin('mergeCells');
+      let mergedCellsCollection = plugin.mergedCellsCollection.mergedCells;
+
+      expect(mergedCellsCollection[0].row).toEqual(1);
+      expect(mergedCellsCollection[0].rowspan).toEqual(3);
+
+      plugin.mergedCellsCollection.clear();
+      plugin.merge(1, 1, 2, 2);
+
+      hot.alter('remove_row', 2, 2);
+
+      expect(mergedCellsCollection[0].row).toEqual(1);
+      expect(mergedCellsCollection[0].rowspan).toEqual(1);
+    });
+
+    it('should trim the merged cell\'s width, when removing columns between their start and end', () => {
+      const hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(20, 20),
+        mergeCells: [
+          {row: 1, col: 1, rowspan: 3, colspan: 5}
+        ],
+        height: 400,
+        width: 400
+      });
+
+      hot.alter('remove_col', 2, 2);
+
+      let plugin = hot.getPlugin('mergeCells');
+      let mergedCellsCollection = plugin.mergedCellsCollection.mergedCells;
+
+      expect(mergedCellsCollection[0].col).toEqual(1);
+      expect(mergedCellsCollection[0].colspan).toEqual(3);
+
+      plugin.mergedCellsCollection.clear();
+      plugin.merge(1, 1, 2, 2);
+
+      hot.alter('remove_col', 2, 2);
+
+      expect(mergedCellsCollection[0].col).toEqual(1);
+      expect(mergedCellsCollection[0].colspan).toEqual(1);
+    });
+
+    it('should shift the `row` of a merged cells, when removing rows consisting it', () => {
+      const hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(20, 20),
+        mergeCells: [
+          {row: 5, col: 5, rowspan: 5, colspan: 3}
+        ],
+        height: 400,
+        width: 400
+      });
+
+      hot.alter('remove_row', 4, 3);
+
+      let plugin = hot.getPlugin('mergeCells');
+      let mergedCellsCollection = plugin.mergedCellsCollection.mergedCells;
+
+      expect(mergedCellsCollection[0].row).toEqual(4);
+      expect(mergedCellsCollection[0].rowspan).toEqual(3);
+
+      plugin.mergedCellsCollection.clear();
+      plugin.merge(1, 1, 2, 2);
+
+      hot.alter('remove_row', 0, 2);
+
+      expect(mergedCellsCollection[0].row).toEqual(0);
+      expect(mergedCellsCollection[0].rowspan).toEqual(1);
+
+      plugin.mergedCellsCollection.clear();
+      plugin.merge(1, 1, 2, 2);
+
+      hot.alter('remove_row', 1, 1);
+
+      expect(mergedCellsCollection[0].row).toEqual(1);
+      expect(mergedCellsCollection[0].rowspan).toEqual(1);
+    });
+
+    it('should shift the `col` of a merged cells, when removing columns consisting it', () => {
+      const hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(20, 20),
+        mergeCells: [
+          {row: 5, col: 5, rowspan: 3, colspan: 5}
+        ],
+        height: 400,
+        width: 400
+      });
+
+      hot.alter('remove_col', 4, 3);
+
+      let plugin = hot.getPlugin('mergeCells');
+      let mergedCellsCollection = plugin.mergedCellsCollection.mergedCells;
+
+      expect(mergedCellsCollection[0].col).toEqual(4);
+      expect(mergedCellsCollection[0].colspan).toEqual(3);
+
+      plugin.mergedCellsCollection.clear();
+      plugin.merge(1, 1, 2, 2);
+
+      hot.alter('remove_col', 0, 2);
+
+      expect(mergedCellsCollection[0].col).toEqual(0);
+      expect(mergedCellsCollection[0].colspan).toEqual(1);
+
+      plugin.mergedCellsCollection.clear();
+      plugin.merge(1, 1, 2, 2);
+
+      hot.alter('remove_col', 1, 1);
+
+      expect(mergedCellsCollection[0].col).toEqual(1);
+      expect(mergedCellsCollection[0].colspan).toEqual(1);
+    });
   });
 
   describe('merged cell candidates validation', () => {


### PR DESCRIPTION
### Context
Removing the "beginnings" of merged cells (top row or left column) was improperly handled in the plugin, this change should fix it.

### How has this been tested?
Added e2e tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):
1. #3473
