### PR TITLE
Fix afterSelectionEnd not being fired correctly on mobile

### DIFF
--- a/src/tableView.js
+++ b/src/tableView.js
@@ -93,6 +93,14 @@ function TableView(instance) {
     }
   });
 
+  this.eventManager.addEventListener(document.documentElement, 'touchend', function(event) {
+    setTimeout(function() {
+      if (instance.selection.isInProgress()) {
+        instance.selection.finish();
+      }
+    }, 0);
+  });
+
   this.eventManager.addEventListener(document.documentElement, 'mousedown', function(event) {
     var originalTarget = event.target;
     var next = event.target;

--- a/src/tableView.js
+++ b/src/tableView.js
@@ -93,12 +93,10 @@ function TableView(instance) {
     }
   });
 
-  this.eventManager.addEventListener(document.documentElement, 'touchend', function(event) {
-    setTimeout(function() {
-      if (instance.selection.isInProgress()) {
-        instance.selection.finish();
-      }
-    }, 0);
+  this.eventManager.addEventListener(document.documentElement, 'touchend', () => {
+    if (instance.selection.isInProgress()) {
+      instance.selection.finish();
+    }
   });
 
   this.eventManager.addEventListener(document.documentElement, 'mousedown', function(event) {

--- a/test/unit/EventManager.spec.js
+++ b/test/unit/EventManager.spec.js
@@ -140,6 +140,29 @@ describe('EventManager', () => {
     em.clear(window, 'click');
   });
 
+  it('should fire touchend event', () => {
+    var instance = {};
+    var em = new EventManager(instance);
+
+    var test = jasmine.createSpy('test');
+    var test1 = jasmine.createSpy('test1');
+
+    em.addEventListener(window, 'touchend', test);
+    em.addEventListener(window, 'touchend', test1);
+    em.addEventListener(window, 'touchend', test1);
+    em.fireEvent(window, 'touchend');
+
+    expect(test.calls.count()).toEqual(1);
+    expect(test1.calls.count()).toEqual(2);
+
+    em.fireEvent(window, 'touchend');
+
+    expect(test.calls.count()).toEqual(2);
+    expect(test1.calls.count()).toEqual(4);
+
+    em.clear(window, 'touchend');
+  });
+
   it('should remove event by calling function returned from addEvent', () => {
     var instance = {};
     var em = new EventManager(instance);


### PR DESCRIPTION
### Context

The context of the original issue can be found in #2942.
The original pull request can be found here: #2963

Here's in summary of the problem and solution.

The `afterSelectionEnd` event is not working properly on mobile. To fix this, we listen to `touchend` as well.

### How has this been tested?

You can still see problem in action with the original jsfiddle, which uses the current version of Handsontable (0.38.1 as of when this PR was written).

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. #2942 (original issue)
2. #2963 (original PR)

### Checklist:
- [x] My code follows the code style of this project,
