### PR TITLE
Functions `countEmptyRows` should work properly from now

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -2977,9 +2977,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
       row;
 
     while (i >= 0) {
-      row = instance.runHooks('modifyRow', i);
-
-      if (instance.isEmptyRow(row)) {
+      if (instance.isEmptyRow(i)) {
         empty++;
 
       } else if (ending) {
@@ -3024,7 +3022,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
    *
    * @memberof Core#
    * @function isEmptyRow
-   * @param {Number} row Row index.
+   * @param {Number} row Visual row index.
    * @returns {Boolean} `true` if the row at the given `row` is empty, `false` otherwise.
    */
   this.isEmptyRow = function(row) {

--- a/src/core.js
+++ b/src/core.js
@@ -13,7 +13,7 @@ import {getPlugin} from './plugins';
 import {getRenderer} from './renderers';
 import {getValidator} from './validators';
 import {randomString} from './helpers/string';
-import {rangeEach} from './helpers/number';
+import {rangeEach, rangeEachReverse} from './helpers/number';
 import TableView from './tableView';
 import DataSource from './dataSource';
 import {translateRowsToColumns, cellMethodLookupFactory, spreadsheetColumnLabel} from './helpers/data';
@@ -2967,26 +2967,22 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
    *
    * @memberof Core#
    * @function countEmptyRows
-   * @param {Boolean} [ending] If `true`, will only count empty rows at the end of the data source.
+   * @param {Boolean} [ending] If `true`, will only count empty rows at the end of the data source
    * @returns {Number} Count empty rows
-   * @fires Hooks#modifyRow
    */
   this.countEmptyRows = function(ending) {
-    var i = instance.countRows() - 1,
-      empty = 0,
-      row;
+    let emptyRows = 0;
 
-    while (i >= 0) {
-      if (instance.isEmptyRow(i)) {
-        empty++;
+    rangeEachReverse(instance.countRows() - 1, (visualIndex) => {
+      if (instance.isEmptyRow(visualIndex)) {
+        emptyRows += 1;
 
-      } else if (ending) {
-        break;
+      } else if (ending === true) {
+        return false;
       }
-      i--;
-    }
+    });
 
-    return empty;
+    return emptyRows;
   };
 
   /**

--- a/src/core.js
+++ b/src/core.js
@@ -2998,19 +2998,19 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
     if (instance.countRows() < 1) {
       return 0;
     }
-    var i = instance.countCols() - 1,
-      empty = 0;
 
-    while (i >= 0) {
-      if (instance.isEmptyCol(i)) {
-        empty++;
-      } else if (ending) {
-        break;
+    let emptyColumns = 0;
+
+    rangeEachReverse(instance.countCols() - 1, (visualIndex) => {
+      if (instance.isEmptyCol(visualIndex)) {
+        emptyColumns += 1;
+
+      } else if (ending === true) {
+        return false;
       }
-      i--;
-    }
+    });
 
-    return empty;
+    return emptyColumns;
   };
 
   /**

--- a/src/helpers/number.js
+++ b/src/helpers/number.js
@@ -42,7 +42,7 @@ export function rangeEach(rangeFrom, rangeTo, iteratee) {
  * A specialized version of `.forEach` defined by ranges iterable in reverse order.
  *
  * @param {Number} rangeFrom The number from start iterate.
- * @param {Number} rangeTo The number where finish iterate or function as a iteratee.
+ * @param {Number|Function} rangeTo The number where finish iterate or function as a iteratee.
  * @param {Function} [iteratee] The function invoked per iteration.
  */
 export function rangeEachReverse(rangeFrom, rangeTo, iteratee) {

--- a/src/helpers/number.js
+++ b/src/helpers/number.js
@@ -42,8 +42,8 @@ export function rangeEach(rangeFrom, rangeTo, iteratee) {
  * A specialized version of `.forEach` defined by ranges iterable in reverse order.
  *
  * @param {Number} rangeFrom The number from start iterate.
- * @param {Number} rangeTo The number where finish iterate.
- * @param {Function} iteratee The function invoked per iteration.
+ * @param {Number} rangeTo The number where finish iterate or function as a iteratee.
+ * @param {Function} [iteratee] The function invoked per iteration.
  */
 export function rangeEachReverse(rangeFrom, rangeTo, iteratee) {
   let index = rangeFrom + 1;

--- a/test/e2e/Core_countEmptyCols.spec.js
+++ b/test/e2e/Core_countEmptyCols.spec.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-multi-spaces */
+/* eslint-disable no-multi-spaces, array-bracket-spacing */
 
 describe('Core_countEmptyCols', () => {
   var id = 'testContainer';
@@ -60,7 +60,7 @@ describe('Core_countEmptyCols', () => {
         [null, null, null, null, null],
         [3,    null, null, null, null],
         [1,    null, null, null, null],
-        [null, null, null, null, 1,  ],
+        [null, null, null, null, 1   ],
       ],
       minSpareCols: 2
     });

--- a/test/e2e/Core_countEmptyCols.spec.js
+++ b/test/e2e/Core_countEmptyCols.spec.js
@@ -1,0 +1,92 @@
+/* eslint-disable no-multi-spaces */
+
+describe('Core_countEmptyCols', () => {
+  var id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should count empty columns properly for empty data set', () => {
+    handsontable({
+      data: []
+    });
+
+    expect(countEmptyCols()).toBe(0);
+  });
+
+  it('should count empty columns properly when using a simple data set', () => {
+    handsontable({
+      data: [
+        [null, null, 1,    null, null, null],
+        [4,    null, null, null, null, null],
+        [null, null, null, null, null, null],
+        [3,    null, null, null, null, null],
+        [1,    null, null, null, null, null],
+        [null, null, null, null, 1,    null],
+      ]
+    });
+
+    expect(countEmptyCols()).toBe(3);
+  });
+
+  it('should count empty columns at the end of the data source properly (optional `ending` parameter)', () => {
+    handsontable({
+      data: [
+        [null, null, 1,    null, null, null],
+        [4,    null, null, null, null, null],
+        [null, null, null, null, null, null],
+        [3,    null, null, null, null, null],
+        [1,    null, null, null, null, null],
+        [null, null, null, null, 1,    null],
+      ]
+    });
+
+    expect(countEmptyCols(true)).toBe(1);
+  });
+
+  it('should count empty columns properly when using `minSpareCols` option', () => {
+    handsontable({
+      data: [
+        [null, null, 1,    null, null],
+        [4,    null, null, null, null],
+        [null, null, null, null, null],
+        [3,    null, null, null, null],
+        [1,    null, null, null, null],
+        [null, null, null, null, 1,  ],
+      ],
+      minSpareCols: 2
+    });
+
+    expect(countEmptyCols()).toBe(4);
+  });
+
+  it('should count empty columns properly when translating columns in the viewport', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(5, 5),
+      modifyCol(row) {
+        return row + 2;
+      }
+    });
+
+    expect(countEmptyCols()).toBe(2);
+  });
+
+  it('should count empty columns properly when translating columns outside the viewport', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(100, 100),
+      modifyCol(column) {
+        return column + 5;
+      }
+    });
+
+    expect(countEmptyCols()).toBe(5);
+  });
+});

--- a/test/e2e/Core_countEmptyRows.spec.js
+++ b/test/e2e/Core_countEmptyRows.spec.js
@@ -20,7 +20,7 @@ describe('Core_countEmptyRows', () => {
         [null],
         [3],
         [1],
-        null,
+        [null],
       ]
     });
 
@@ -35,11 +35,11 @@ describe('Core_countEmptyRows', () => {
         [null],
         [3],
         [1],
-        null,
-        null,
-        null,
-        null,
-        null,
+        [null],
+        [null],
+        [null],
+        [null],
+        [null],
       ]
     });
 

--- a/test/e2e/Core_countEmptyRows.spec.js
+++ b/test/e2e/Core_countEmptyRows.spec.js
@@ -1,0 +1,85 @@
+describe('Core_countEmptyRows', () => {
+  var id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should count empty rows properly when using a simple data set', () => {
+    handsontable({
+      data: [
+        [null],
+        [4],
+        [null],
+        [3],
+        [1],
+        null,
+      ]
+    });
+
+    expect(countEmptyRows()).toBe(3);
+  });
+
+  it('should count empty rows properly when using `minSpareRows` option', () => {
+    handsontable({
+      data: [
+        [null],
+        [4],
+        [null],
+        [3],
+        [1],
+      ],
+      minSpareRows: 2
+    });
+
+    expect(countEmptyRows()).toBe(4);
+  });
+
+  it('should count empty rows properly when translating rows in the viewport', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(5, 5),
+      modifyRow(row) {
+        return row + 2;
+      }
+    });
+
+    expect(countEmptyRows()).toBe(2);
+  });
+
+  it('should count empty rows properly when translating rows below the viewport', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(1000, 1000),
+      modifyRow(row) {
+        return row + 5;
+      }
+    });
+
+    expect(countEmptyRows()).toBe(5);
+  });
+
+  it('should count empty rows properly when trimming rows', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(10, 10),
+      modifyRow(row) {
+        if (row === 9 || row === 8) {
+          return null;
+        }
+
+        if (row >= 2) {
+          return row + 2;
+        }
+
+        return row;
+      }
+    });
+
+    expect(countEmptyRows()).toBe(0);
+  });
+});

--- a/test/e2e/Core_countEmptyRows.spec.js
+++ b/test/e2e/Core_countEmptyRows.spec.js
@@ -27,6 +27,25 @@ describe('Core_countEmptyRows', () => {
     expect(countEmptyRows()).toBe(3);
   });
 
+  it('should count empty rows at the end of the data source properly (optional `ending` parameter)', () => {
+    handsontable({
+      data: [
+        [null],
+        [4],
+        [null],
+        [3],
+        [1],
+        null,
+        null,
+        null,
+        null,
+        null,
+      ]
+    });
+
+    expect(countEmptyRows(true)).toBe(5);
+  });
+
   it('should count empty rows properly when using `minSpareRows` option', () => {
     handsontable({
       data: [
@@ -55,7 +74,7 @@ describe('Core_countEmptyRows', () => {
 
   it('should count empty rows properly when translating rows below the viewport', () => {
     handsontable({
-      data: Handsontable.helper.createSpreadsheetData(1000, 1000),
+      data: Handsontable.helper.createSpreadsheetData(100, 100),
       modifyRow(row) {
         return row + 5;
       }
@@ -64,7 +83,7 @@ describe('Core_countEmptyRows', () => {
     expect(countEmptyRows()).toBe(5);
   });
 
-  it('should count empty rows properly when trimming rows', () => {
+  it('should count empty rows properly when rows was trimmed', () => {
     handsontable({
       data: Handsontable.helper.createSpreadsheetData(10, 10),
       modifyRow(row) {


### PR DESCRIPTION
### Context
Function `countEmptyRows` hasn't worked properly. It has passed the physical index to `isEmptyRow` function while it works on visual indexes. Analogous, `countEmptyCols` doesn’t work like that and it should work properly.

### How has this been tested?
Added tests both for `countEmptyRows` and `countEmptyCols` & checked fix on the original issue.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):
1. #4170 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
