### PR TITLE
Selection corner should be positioned correctly even if a window is a trimming container. #4961

### DIFF
--- a/src/3rdparty/walkontable/src/border.js
+++ b/src/3rdparty/walkontable/src/border.js
@@ -464,10 +464,17 @@ class Border {
       // Hide the fill handle, so the possible further adjustments won't force unneeded scrollbars.
       this.cornerStyle.display = 'none';
 
-      const trimmingContainer = getTrimmingContainer(this.wot.wtTable.TABLE);
+      let trimmingContainer = getTrimmingContainer(this.wot.wtTable.TABLE);
+      const trimToWindow = trimmingContainer === window;
+
+      if (trimToWindow) {
+        trimmingContainer = document.documentElement;
+      }
 
       if (toColumn === this.wot.getSetting('totalColumns') - 1) {
-        const cornerOverlappingContainer = toTD.offsetLeft + outerWidth(toTD) + (parseInt(this.cornerDefaultStyle.width, 10) / 2) >= innerWidth(trimmingContainer);
+        const toTdOffsetLeft = trimToWindow ? toTD.getBoundingClientRect().left : toTD.offsetLeft;
+        const cornerRightEdge = toTdOffsetLeft + outerWidth(toTD) + (parseInt(this.cornerDefaultStyle.width, 10) / 2);
+        const cornerOverlappingContainer = cornerRightEdge >= innerWidth(trimmingContainer);
 
         if (cornerOverlappingContainer) {
           this.cornerStyle.left = `${Math.floor(left + width - 3 - (parseInt(this.cornerDefaultStyle.width, 10) / 2))}px`;
@@ -476,7 +483,9 @@ class Border {
       }
 
       if (toRow === this.wot.getSetting('totalRows') - 1) {
-        const cornerOverlappingContainer = toTD.offsetTop + outerHeight(toTD) + (parseInt(this.cornerDefaultStyle.height, 10) / 2) >= innerHeight(trimmingContainer);
+        const toTdOffsetTop = trimToWindow ? toTD.getBoundingClientRect().top : toTD.offsetTop;
+        const cornerBottomEdge = toTdOffsetTop + outerHeight(toTD) + (parseInt(this.cornerDefaultStyle.height, 10) / 2);
+        const cornerOverlappingContainer = cornerBottomEdge >= innerHeight(trimmingContainer);
 
         if (cornerOverlappingContainer) {
           this.cornerStyle.top = `${Math.floor(top + height - 3 - (parseInt(this.cornerDefaultStyle.height, 10) / 2))}px`;

--- a/src/3rdparty/walkontable/test/spec/border.spec.js
+++ b/src/3rdparty/walkontable/test/spec/border.spec.js
@@ -259,7 +259,7 @@ describe('WalkontableBorder', () => {
   it('should move the fill handle / corner border to the left, if in the position it would overlap the container (e.g.: far-right)', () => {
     $container.css({
       overflow: 'hidden',
-      width: '200px'
+      width: '200px',
     });
     const wt = new Walkontable.Core({
       table: $table[0],
@@ -315,6 +315,55 @@ describe('WalkontableBorder', () => {
     expect($corner.position().top).toBe(65);
     expect($corner.position().left).toBe(95);
     expect($container[0].clientWidth === $container[0].scrollWidth).toBe(true);
+  });
+
+  it('should move the fill handle / corner border to the top, if in the position it would overlap the container (e.g.: far-bottom)', () => {
+    $container.css({
+      overflow: 'hidden',
+      height: 'auto',
+      marginTop: '2000px',
+    });
+
+    const wt = new Walkontable.Core({
+      table: $table[0],
+      data: getData,
+      totalRows: 5,
+      totalColumns: 1,
+      selections: [
+        new Walkontable.Selection({
+          border: {
+            width: 2,
+            color: 'green',
+            cornerVisible() {
+              return true;
+            }
+          }
+        }),
+        new Walkontable.Selection({})
+      ],
+      onCellMouseDown(event, coords, TD) {
+        wt.selections.getCell().clear();
+        wt.selections.getCell().add(coords);
+        wt.draw();
+      }
+    });
+
+    shimSelectionProperties(wt);
+    wt.draw();
+
+    const $td = $table.find('tbody tr:last-of-type td:last-of-type');
+    const $corner = $(wt.selections.getCell().getBorder(wt).corner);
+
+    $td.simulate('mousedown');
+
+    wt.draw();
+
+    expect($corner.css('width')).toBe('6px');
+    expect($corner.css('height')).toBe('6px');
+    expect($table.css('height')).toBe('116px');
+    expect($corner.position().top).toBe(109); // table.height - corner.height - corner.borderTop
+    expect($corner.position().left).toBe(45);
+    expect($container[0].clientHeight === $container[0].scrollHeight).toBe(true);
   });
 
 });

--- a/src/3rdparty/walkontable/test/spec/border.spec.js
+++ b/src/3rdparty/walkontable/test/spec/border.spec.js
@@ -365,5 +365,4 @@ describe('WalkontableBorder', () => {
     expect($corner.position().left).toBe(45);
     expect($container[0].clientHeight === $container[0].scrollHeight).toBe(true);
   });
-
 });

--- a/src/3rdparty/walkontable/test/spec/border.spec.js
+++ b/src/3rdparty/walkontable/test/spec/border.spec.js
@@ -365,4 +365,56 @@ describe('WalkontableBorder', () => {
     expect($corner.position().left).toBe(45);
     expect($container[0].clientHeight === $container[0].scrollHeight).toBe(true);
   });
+
+  it('should move the corner border to the top-left, if is not enough area on the bottom-right corner of container', () => {
+    $container.css({
+      overflow: 'hidden',
+      height: 'auto',
+      width: '50px',
+      marginTop: '2000px',
+      marginLeft: '2000px',
+    });
+
+    const wt = new Walkontable.Core({
+      table: $table[0],
+      data: getData,
+      totalRows: 1,
+      totalColumns: 1,
+      selections: [
+        new Walkontable.Selection({
+          border: {
+            width: 2,
+            color: 'green',
+            cornerVisible() {
+              return true;
+            }
+          }
+        }),
+        new Walkontable.Selection({})
+      ],
+      onCellMouseDown(event, coords, TD) {
+        wt.selections.getCell().clear();
+        wt.selections.getCell().add(coords);
+        wt.draw();
+      }
+    });
+
+    shimSelectionProperties(wt);
+    wt.draw();
+
+    const $td = $table.find('tbody tr:last-of-type td:last-of-type');
+    const $corner = $(wt.selections.getCell().getBorder(wt).corner);
+
+    $td.simulate('mousedown');
+
+    wt.draw();
+
+    expect($corner.css('width')).toBe('6px');
+    expect($corner.css('height')).toBe('6px');
+    expect($table.css('height')).toBe('24px');
+    expect($corner.position().top).toBe(17); // table.height - corner.height - corner.borderTop
+    expect($corner.position().left).toBe(43);
+    expect($container[0].clientHeight === $container[0].scrollHeight).toBe(true);
+    expect($container[0].clientWidth === $container[0].scrollWidth).toBe(true);
+  });
 });

--- a/src/tableView.js
+++ b/src/tableView.js
@@ -189,14 +189,13 @@ function TableView(instance) {
       return that.settings.minSpareRows;
     },
     renderAllRows: that.settings.renderAllRows,
-    rowHeaders: function() {
+    rowHeaders() {
       let headerRenderers = [];
 
       if (instance.hasRowHeaders()) {
-        headerRenderers.push(function(row, TH) {
-          that.appendRowHeader(row, TH);
-        });
+        headerRenderers.push((row, TH) => that.appendRowHeader(row, TH));
       }
+
       instance.runHooks('afterGetRowHeaderRenderers', headerRenderers);
 
       return headerRenderers;


### PR DESCRIPTION
### Context
In the case when a user tries to select the last cell in the last row and table is trimmed by the window, then `walkontable.border.corner` is positioned incorrectly.

### How has this been tested?
Use this example: https://jsfiddle.net/hgxa1vj0/

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. #4961
