### PR TITLE
Fix: minSpareCols should works with new selection transformation. #4986

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1106,7 +1106,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
       changes.push([
         input[i][0],
         prop,
-        dataSource.getAtCell(input[i][0], input[i][1]),
+        dataSource.getAtCell(recordTranslator.toPhysicalRow(input[i][0]), input[i][1]),
         input[i][2],
       ]);
     }

--- a/src/core.js
+++ b/src/core.js
@@ -1106,7 +1106,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
       changes.push([
         input[i][0],
         prop,
-        dataSource.getAtCell(recordTranslator.toPhysicalRow(input[i][0]), input[i][1]),
+        dataSource.getAtCell(input[i][0], input[i][1]),
         input[i][2],
       ]);
     }

--- a/src/selection/transformation.js
+++ b/src/selection/transformation.js
@@ -66,7 +66,7 @@ class Transformation {
 
     if (highlightCoords.col + delta.col > totalCols - 1) {
       if (force && minSpareCols > 0) {
-        this.runLocalHooks('insertColRequire', totalRows);
+        this.runLocalHooks('insertColRequire', totalCols);
         totalCols = this.options.countCols();
 
       } else if (autoWrapRow) {

--- a/test/e2e/Core_selection.spec.js
+++ b/test/e2e/Core_selection.spec.js
@@ -940,6 +940,26 @@ describe('Core_selection', () => {
     }, 250);
   });
 
+  it('should select a cell which one was added automatically by minSpareCols', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(1, 5),
+      minSpareCols: 1,
+    });
+
+    selectCell(0, 5);
+    keyDownUp('tab');
+
+    expect(countCols()).toEqual(7);
+    expect(getSelected()).toEqual([[0, 6, 0, 6]]);
+    expect(getDataAtCell(0, 0)).toEqual('A1');
+    expect(getDataAtCell(0, 1)).toEqual('B1');
+    expect(getDataAtCell(0, 2)).toEqual('C1');
+    expect(getDataAtCell(0, 3)).toEqual('D1');
+    expect(getDataAtCell(0, 4)).toEqual('E1');
+    expect(getDataAtCell(0, 5)).toBeNull();
+    expect(getDataAtCell(0, 6)).toBeNull();
+  });
+
   it('should change selected coords by modifying coords object via `modifyTransformStart` hook', () => {
     var hot = handsontable({
       startRows: 5,


### PR DESCRIPTION
### Context
Our recent refactor of the selection mechanism cause the issue with inserting columns automatically by `minSpareCols`.

### How has this been tested?
1. Create Handsontable with below settings:
```
{
   data: Handsontable.helper.createSpreadsheetData(1, 5),
   minSpareCols: 1
}
```
2. Select the most right cell.
3. Change selection by <kbd>TAB</kbd>

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. #4986