### PR TITLE
Fix a bug with text editor showing the wrong value #4289

### DIFF
--- a/src/editors/textEditor.js
+++ b/src/editors/textEditor.js
@@ -240,10 +240,10 @@ TextEditor.prototype.getEditedCell = function() {
 };
 
 TextEditor.prototype.refreshValue = function() {
-  let sourceData = this.instance.getSourceDataAtCell(this.row, this.prop);
-  this.originalValue = sourceData;
+  let cellData = this.instance.getDataAtCell(this.row, this.prop);
+  this.originalValue = cellData;
 
-  this.setValue(sourceData);
+  this.setValue(cellData);
   this.refreshDimensions();
 };
 

--- a/test/e2e/editors/textEditor.spec.js
+++ b/test/e2e/editors/textEditor.spec.js
@@ -407,6 +407,43 @@ describe('TextEditor', () => {
     expect(keyProxy().val()).toEqual('2012');
   });
 
+  it('should render correct value in textarea after row order changed and new values set (#4289)', () => {
+    var hot = handsontable({
+      data: [
+        [1, 'Tom'],
+        [2, 'Cage']
+      ],
+      columnSorting: true
+    });
+
+    hot.sort(0, false);
+    hot.render();
+
+    selectCell(0, 0);
+
+    setDataAtCell(1, 1, 'Frank');
+
+    keyDown('enter');
+    expect(keyProxy().val()).toEqual('2');
+    keyDown('enter');
+
+    expect(hot.getDataAtCell(0, 0)).toEqual('2');
+
+    selectCell(1, 0);
+    keyDown('enter');
+    expect(keyProxy().val()).toEqual('1');
+    keyDown('enter');
+
+    expect(hot.getDataAtCell(1, 0)).toEqual('1');
+
+    selectCell(1, 1);
+    keyDown('enter');
+    expect(keyProxy().val()).toEqual('Frank');
+    keyDown('enter');
+
+    expect(hot.getDataAtCell(1, 1)).toEqual('Frank');
+  });
+
   it('should open editor after hitting F2', () => {
     handsontable();
     selectCell(2, 2);


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Updating cell values programmatically after a column sort will cause the currently selected cell to show a different value in the editable text area during cell edit than what was previously visible in that cell. The text editor needs to respect the current visual row order when refreshing it's value. 

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
End-to-End tests added.
Original problem can be seen here: http://jsfiddle.net/kd98wn2x/1/

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #4289
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
