### PR TITLE
Column sorting will work for formulas and `isSorted` will work properly

### DIFF
--- a/src/plugins/columnSorting/columnSorting.js
+++ b/src/plugins/columnSorting/columnSorting.js
@@ -79,7 +79,7 @@ class ColumnSorting extends BasePlugin {
      */
     this.sortEmptyCells = false;
     // It blocks the plugin translation, this flag is checked inside `onModifyRow` listener.
-    this.blockPluginTranslation = false;
+    this.blockPluginTranslation = true;
   }
 
   /**

--- a/src/plugins/columnSorting/columnSorting.js
+++ b/src/plugins/columnSorting/columnSorting.js
@@ -78,7 +78,12 @@ class ColumnSorting extends BasePlugin {
      * @type {Boolean}
      */
     this.sortEmptyCells = false;
-    // It blocks the plugin translation, this flag is checked inside `onModifyRow` listener.
+    /**
+     * It blocks the plugin translation, this flag is checked inside `onModifyRow` listener.
+     *
+     * @private
+     * @type {boolean}
+     */
     this.blockPluginTranslation = true;
   }
 
@@ -311,6 +316,7 @@ class ColumnSorting extends BasePlugin {
   /**
    * Get sort function for the particular column basing on its column meta.
    *
+   * @private
    * @param {Object} columnMeta
    * @returns {Function}
    */

--- a/src/plugins/columnSorting/test/columnSorting.e2e.js
+++ b/src/plugins/columnSorting/test/columnSorting.e2e.js
@@ -540,6 +540,86 @@ describe('ColumnSorting', () => {
     ]);
   });
 
+  describe('isSorted', () => {
+    it('should return `false` when plugin is disabled', () => {
+      const hot = handsontable();
+
+      expect(hot.getPlugin('columnSorting').isSorted()).toBeFalsy();
+    });
+
+    it('should return `false` when plugin is enabled and the table was not sorted #1', () => {
+      const hot = handsontable({
+        columnSorting: true
+      });
+
+      expect(hot.getPlugin('columnSorting').isSorted()).toBeFalsy();
+    });
+
+    it('should return `false` when plugin is enabled and the table was not sorted #2', () => {
+      const hot = handsontable({
+        data: [
+          ['Citroen1', 'C4 Coupe', null],
+          ['Mercedes1', 'A 160', '12/01/2008'],
+          ['Mercedes2', 'A 160', '01/14/2006'],
+        ],
+        columnSorting: {
+          column: 1,
+          sortOrder: 'none'
+        }
+      });
+
+      expect(hot.getPlugin('columnSorting').isSorted()).toBeFalsy();
+    });
+
+    it('should return `true` when plugin is enabled and the table was sorted', () => {
+      const hot = handsontable({
+        data: [
+          ['Citroen1', 'C4 Coupe', null],
+          ['Mercedes1', 'A 160', '12/01/2008'],
+          ['Mercedes2', 'A 160', '01/14/2006'],
+        ],
+        columnSorting: {
+          column: 1,
+          sortOrder: 'asc'
+        }
+      });
+
+      expect(hot.getPlugin('columnSorting').isSorted()).toBeTruthy();
+    });
+
+    it('should be handled properly when using the `updateSettings`', () => {
+      const hot = handsontable({
+        data: [
+          ['Citroen1', 'C4 Coupe', null],
+          ['Mercedes1', 'A 160', '12/01/2008'],
+          ['Mercedes2', 'A 160', '01/14/2006'],
+        ],
+        columnSorting: {
+          column: 1,
+          sortOrder: 'asc'
+        }
+      });
+
+      hot.updateSettings({
+        columnSorting: {
+          column: 1,
+          sortOrder: 'none'
+        }
+      });
+
+      expect(hot.getPlugin('columnSorting').isSorted()).toBeFalsy();
+
+      hot.updateSettings({
+        columnSorting: {
+          column: 1,
+          sortOrder: 'desc'
+        }
+      });
+
+      expect(hot.getPlugin('columnSorting').isSorted()).toBeTruthy();
+    });
+  });
+
   describe('data type: date', () => {
     it('should place empty strings, null and undefined values at proper position when `sortEmptyCells` ' +
       'option is enabled and `column` property of `columnSorting` option is set', function() {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
1. Issue #5014 has been merged, but some tests for Handsontable Pro aren't passing. Not passing tests were related to refactoring of `columnSorting` plugin. Method of creating an array of indexes and data (a variable is named now `indexesWithData`) for purpose of sorting has been changed. 

It was **unsuccessful attempt** to remove flag blocking translation (before refactor `sortingEnabled` variable, now, after revert  `blockPluginTranslation` variable)

2. After API changes documentation was updated and I've discovered that function `isSorted` is useless. I've fixed that and wrote some tests.

Changes in the documentation: https://github.com/handsontable/docs/commit/1d61e8bc7998df31ca97679fddcfdfdfbaa7193e and corresponding https://github.com/handsontable/docs-pro/commit/7cf16c7c743b1d2df22b4d262beb8d7332e9004f

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Modified tests for Handsontable Pro (https://github.com/handsontable/handsontable-pro/pull/70) are passing again.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #5014

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [x] My change requires a change to the documentation.
