### PR TITLE
Overloaded definitions for setDataAtCell and setDataAtRowProp

### DIFF
--- a/handsontable.d.ts
+++ b/handsontable.d.ts
@@ -81,8 +81,10 @@ declare namespace _Handsontable {
     selectRows(startRow: number, endRow?: number): boolean;
     setCellMeta(row: number, col: number, key: string, val: string): void;
     setCellMetaObject(row: number, col: number, prop: object): void;
-    setDataAtCell(row: number | Array<[number,number,any]>, col: number, value: string | object, source?: string): void;
-    setDataAtRowProp(row: number | any[], prop: string, value: string, source?: string): void;
+    setDataAtCell(row: number, col: number, value: string | object, source?: string): void;
+    setDataAtCell(row: Array<[number, number, string | object]>, source?: string): void;
+    setDataAtRowProp(row: number, prop: string, value: string, source?: string): void;
+    setDataAtRowProp(row: Array<[number, string, string]>, source?: string): void;
     spliceCol(col: number, index: number, amount: number, elements?: any): void;
     spliceRow(row: number, index: number, amount: number, elements?: any): void;
     toPhysicalColumn(column: number): number;

--- a/handsontable.d.ts
+++ b/handsontable.d.ts
@@ -81,10 +81,10 @@ declare namespace _Handsontable {
     selectRows(startRow: number, endRow?: number): boolean;
     setCellMeta(row: number, col: number, key: string, val: string): void;
     setCellMetaObject(row: number, col: number, prop: object): void;
-    setDataAtCell(row: number, col: number, value: string | object, source?: string): void;
-    setDataAtCell(row: Array<[number, number, string | object]>, source?: string): void;
-    setDataAtRowProp(row: number, prop: string, value: string, source?: string): void;
-    setDataAtRowProp(row: Array<[number, string, string]>, source?: string): void;
+    setDataAtCell(row: number, col: string | number, value: any, source?: string): void;
+    setDataAtCell(changes: Array<[number, string | number, any]>, source?: string): void;
+    setDataAtRowProp(row: number, prop: string, value: any, source?: string): void;
+    setDataAtRowProp(changes: Array<[number, string | number, any]>, source?: string): void;
     spliceCol(col: number, index: number, amount: number, elements?: any): void;
     spliceRow(row: number, index: number, amount: number, elements?: any): void;
     toPhysicalColumn(column: number): number;

--- a/test/types/methods.types.ts
+++ b/test/types/methods.types.ts
@@ -87,9 +87,9 @@ hot.setCellMeta(123, 123, 'foo', 'foo');
 hot.setCellMetaObject(123, 123, {});
 hot.setDataAtCell(123, 123, 'foo', 'foo');
 hot.setDataAtCell(123, 123, {myProperty: 'foo'}, 'foo');
-hot.setDataAtCell([[123, 123, 'foo'], [123, 123, {myProperty: 'foo'}]], 'foo')
+hot.setDataAtCell([[123, 123, 'foo'], [123, 123, {myProperty: 'foo'}]], 'foo');
 hot.setDataAtRowProp(123, 'foo', 'foo', 'foo');
-hot.setDataAtRowProp([[123, 'foo', 'foo'], [123, 'foo', 'foo']], 'foo')
+hot.setDataAtRowProp([[123, 'foo', 'foo'], [123, 'foo', 'foo']], 'foo');
 hot.spliceCol(123, 123, 123, 'foo');
 hot.spliceRow(123, 123, 123, 'foo');
 hot.unlisten();

--- a/test/types/methods.types.ts
+++ b/test/types/methods.types.ts
@@ -87,7 +87,9 @@ hot.setCellMeta(123, 123, 'foo', 'foo');
 hot.setCellMetaObject(123, 123, {});
 hot.setDataAtCell(123, 123, 'foo', 'foo');
 hot.setDataAtCell(123, 123, {myProperty: 'foo'}, 'foo');
+hot.setDataAtCell([[123, 123, 'foo'], [123, 123, {myProperty: 'foo'}]], 'foo')
 hot.setDataAtRowProp(123, 'foo', 'foo', 'foo');
+hot.setDataAtRowProp([[123, 'foo', 'foo'], [123, 'foo', 'foo']], 'foo')
 hot.spliceCol(123, 123, 123, 'foo');
 hot.spliceRow(123, 123, 123, 'foo');
 hot.unlisten();


### PR DESCRIPTION
### Context
The current TypeScript definitions for `setDataAtCell` and `setDataAtRowProp` require additional parameters that are not required when using the `any[]` overload. This change provides the proper overloads for TypeScript to correctly type check use of these methods.

Replaces #4818 

### How has this been tested?
1. I verified that use of the additional parameters for `column` and `value` were ignored when providing an array of values to update.
2. I changed the `handsontable.d.ts` declaration file in place in my project with the provided changes, built, and re-ran the application after clearing my cache.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):
1.
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
