### PR TITLE
Issue #5124 Autocomplete arrow now prepended to TD element

### DIFF
--- a/src/renderers/autocompleteRenderer.js
+++ b/src/renderers/autocompleteRenderer.js
@@ -41,14 +41,14 @@ function autocompleteRenderer(instance, TD, row, col, prop, value, cellPropertie
     getRenderer('text').apply(this, arguments);
   }
 
-  TD.insertBefore(ARROW, TD.firstChild);
-  addClass(TD, 'htAutocomplete');
-
   if (!TD.firstChild) { // http://jsperf.com/empty-node-if-needed
     // otherwise empty fields appear borderless in demo/renderers.html (IE)
     TD.appendChild(document.createTextNode(String.fromCharCode(160))); // workaround for https://github.com/handsontable/handsontable/issues/1946
     // this is faster than innerHTML. See: https://github.com/handsontable/handsontable/wiki/JavaScript-&-DOM-performance-tips
   }
+
+  TD.insertBefore(ARROW, TD.firstChild);
+  addClass(TD, 'htAutocomplete');
 
   if (!instance.acArrowListener) {
     var eventManager = new EventManager(instance);

--- a/src/renderers/autocompleteRenderer.js
+++ b/src/renderers/autocompleteRenderer.js
@@ -41,7 +41,7 @@ function autocompleteRenderer(instance, TD, row, col, prop, value, cellPropertie
     getRenderer('text').apply(this, arguments);
   }
 
-  TD.prepend(ARROW);
+  TD.insertBefore(ARROW, TD.firstChild);
   addClass(TD, 'htAutocomplete');
 
   if (!TD.firstChild) { // http://jsperf.com/empty-node-if-needed

--- a/src/renderers/autocompleteRenderer.js
+++ b/src/renderers/autocompleteRenderer.js
@@ -41,7 +41,7 @@ function autocompleteRenderer(instance, TD, row, col, prop, value, cellPropertie
     getRenderer('text').apply(this, arguments);
   }
 
-  TD.appendChild(ARROW);
+  TD.prepend(ARROW);
   addClass(TD, 'htAutocomplete');
 
   if (!TD.firstChild) { // http://jsperf.com/empty-node-if-needed

--- a/test/e2e/renderers/autocompleteRenderer.spec.js
+++ b/test/e2e/renderers/autocompleteRenderer.spec.js
@@ -63,4 +63,14 @@ describe('AutocompleteRenderer', () => {
 
     expect(hot.getActiveEditor().isOpened()).toBe(true);
   });
+
+  it('should prepend the autocomplete arrow at the start of the cell element (#5124)', () => {
+    var hot = handsontable({
+      type: 'autocomplete'
+    });
+
+    var $contents = $(getCell(0, 0)).contents();
+
+    expect($contents.eq(0).hasClass('htAutocompleteArrow')).toBe(true);
+  });
 });


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Solves issue #5124. Does this by using `prepend` instead of `appendChild` which will put it at the start of the TD HTML content but still maintain its position on the right side of the cell. This allows `white-space: nowrap` to be used and not have the arrow wrap onto the next line.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Created an e2e test as well as manual testing inside of our own project.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #5124 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
