### PR TITLE
Improved editor manager to prevent editors leak.

### DIFF
--- a/src/editors/index.js
+++ b/src/editors/index.js
@@ -52,8 +52,8 @@ export function RegisteredEditor(editorClass) {
     return instances[hotInstance.guid];
   };
 
-  Hooks.getSingleton().add('afterDestroy', function() {
-    instances = {};
+  Hooks.getSingleton().add('afterDestroy', () => {
+    instances[this.guid] = null;
   });
 }
 

--- a/src/editors/index.js
+++ b/src/editors/index.js
@@ -52,7 +52,7 @@ export function RegisteredEditor(editorClass) {
     return instances[hotInstance.guid];
   };
 
-  Hooks.getSingleton().add('afterDestroy', () => {
+  Hooks.getSingleton().add('afterDestroy', function() {
     instances[this.guid] = null;
   });
 }

--- a/src/plugins/contextMenu/test/contextMenu.e2e.js
+++ b/src/plugins/contextMenu/test/contextMenu.e2e.js
@@ -3085,6 +3085,30 @@ describe('ContextMenu', () => {
     });
   });
 
+  describe('context menu with disabled `allowInvalid`', () => {
+    it('should not close invalid cell', async () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(10, 10),
+        contextMenu: true,
+        validator: (value, callback) => callback(false),
+        allowInvalid: false
+      });
+
+      selectCell(0, 0);
+      keyDownUp('enter');
+
+      contextMenu(getCell(2, 2));
+
+      await sleep(100);
+
+      contextMenu(getCell(2, 2));
+
+      await sleep(100);
+
+      expect(getActiveEditor().isOpened()).toBe(true);
+    });
+  });
+
   describe('context menu with native scroll', () => {
     beforeEach(function() {
       var wrapper = $('<div></div>').css({

--- a/test/e2e/editors/handsontableEditor.spec.js
+++ b/test/e2e/editors/handsontableEditor.spec.js
@@ -59,6 +59,36 @@ describe('HandsontableEditor', () => {
     expect(this.$container.find('.handsontableEditor')[0].offsetTop).toEqual(this.$container.find('.handsontableInput')[0].offsetHeight);
   });
 
+  it('should prepare the editor only once per instance', function() {
+    handsontable({
+      columns: [
+        {
+          type: 'handsontable',
+          handsontable: {
+            colHeaders: ['Marque', 'Country', 'Parent company'],
+            data: getManufacturerData()
+          }
+        }
+      ]
+    });
+
+    selectCell(0, 0);
+
+    keyDownUp('enter');
+    keyDownUp('enter');
+    keyDownUp('enter');
+    keyDownUp('enter');
+    keyDownUp('enter');
+    keyDownUp('enter');
+    keyDownUp('enter');
+    keyDownUp('enter');
+    keyDownUp('enter');
+    keyDownUp('enter');
+    keyDownUp('enter');
+    keyDownUp('enter');
+    expect(this.$container.find('.handsontableEditor').length).toEqual(1);
+  });
+
   it('should destroy the editor when Esc is pressed', function() {
     handsontable({
       columns: [


### PR DESCRIPTION
### Context
Editor registration works improperly. Reference to the editor is removing, but DOM element is still present. In result of this behaviour, a new editor is created and added to DOM.

### How has this been tested?
Follow "Steps to reproduce" from #4551.

### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)

### Related issue(s):
1. #4551
