### PR TITLE
Define correct number of values and types for afterChange hook

### DIFF
--- a/handsontable.d.ts
+++ b/handsontable.d.ts
@@ -1557,7 +1557,7 @@ declare namespace Handsontable {
     afterAddChild?: (parent: object, element: object | void, index: number | void) => void;
     afterBeginEdting?: (row: number, column: number) => void;
     afterCellMetaReset?: () => void;
-    afterChange?: (changes: any[], source: string) => void;
+    afterChange?: (changes: [number, number, string, number | string][], source: string) => void;
     afterChangesObserved?: () => void;
     afterColumnMove?: (startColumn: number, endColumn: number) => void;
     afterColumnResize?: (currentColumn: number, newSize: number, isDoubleClick: boolean) => void;


### PR DESCRIPTION
### Context
The `afterChange` hook identified the input `changes` as `any[]` in the `handsontable.d.ts`. This does not clearly communicate the number of values in each row nor their type. This change addresses the issue by supplying the type `[number, number, string, number | string][]` for the `changes` input.

### How has this been tested?
I tested this in an existing production application and by printing the types out to the browser console using:

``` javascript
console.log(typeof changes[0][0], typeof changes[0][1], typeof changes[0][2], typeof changes[0][3])
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
