### PR TITLE
Update handsontable.d.ts

### DIFF
--- a/handsontable.d.ts
+++ b/handsontable.d.ts
@@ -1521,7 +1521,7 @@ declare namespace Handsontable {
     renderer?: string | renderers.Base;
     rowHeaders?: boolean | any[] | (() => void);
     rowHeaderWidth?: number | any[];
-    rowHeights?: any[] | (() => void) | number | string;
+    rowHeights?: number[] | ((row: number) => number) | number | string;
     search?: boolean;
     selectOptions?: any[];
     skipColumnOnPaste?: boolean;


### PR DESCRIPTION
Adaptation according to https://docs.handsontable.com/3.0.0/Options.html#rowHeights

### Context
It's not possibile to augment the interface with Typescript for the `() => void` type, because it's stricter then `(row: number) => number`. 