### PR TITLE
validate scientific notation in numeric cells

### DIFF
--- a/src/validators/numericValidator.js
+++ b/src/validators/numericValidator.js
@@ -17,6 +17,6 @@ export default function numericValidator(value, callback) {
     callback(false);
 
   } else {
-    callback(/^-?\d*(\.|,)?\d*$/.test(value));
+    callback(/^\s*[+-]?\s*(?:(?:\d+(?:\.\d+)?(?:e[+-]?\d+)?)|(?:0x[a-f\d]+))\s*$/i.test(value));
   }
 };

--- a/test/e2e/validators/numericValidator.spec.js
+++ b/test/e2e/validators/numericValidator.spec.js
@@ -111,6 +111,49 @@ describe('numericValidator', () => {
     }, 100);
   });
 
+  it('should validate large-number scientific notation', (done) => {
+    var onAfterValidate = jasmine.createSpy('onAfterValidate');
+
+    handsontable({
+      data: arrayOfObjects(),
+      columns: [
+        {data: 'id', type: 'numeric'},
+        {data: 'name'},
+        {data: 'lastName'}
+      ],
+      afterValidate: onAfterValidate
+    });
+
+    setDataAtCell(2, 0, '1e+23');
+
+    setTimeout(() => {
+      expect(onAfterValidate).toHaveBeenCalledWith(true, 1e+23, 2, 'id', undefined, undefined);
+      done();
+    }, 100);
+  });
+
+
+  it('should validate small-number scientific notation', (done) => {
+    var onAfterValidate = jasmine.createSpy('onAfterValidate');
+
+    handsontable({
+      data: arrayOfObjects(),
+      columns: [
+        {data: 'id', type: 'numeric'},
+        {data: 'name'},
+        {data: 'lastName'}
+      ],
+      afterValidate: onAfterValidate
+    });
+
+    setDataAtCell(2, 0, '1e-23');
+
+    setTimeout(() => {
+      expect(onAfterValidate).toHaveBeenCalledWith(true, 1e-23, 2, 'id', undefined, undefined);
+      done();
+    }, 100);
+  });
+
   describe('allowEmpty', () => {
     it('should not validate an empty string when allowEmpty is set as `false`', (done) => {
       var onAfterValidate = jasmine.createSpy('onAfterValidate');


### PR DESCRIPTION
### Context
Scientific notation should be validated true in numeric cells.

### How has this been tested?
Verified scientific notation properly passes regexp.
Note: this regexp is from your own isNumeric function; not by me.

### Types of changes
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. 2030

### Checklist:
- [X ] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
