### PR TITLE
Extend SampleGenerator class

### DIFF
--- a/src/plugins/autoColumnSize/autoColumnSize.js
+++ b/src/plugins/autoColumnSize/autoColumnSize.js
@@ -94,7 +94,32 @@ class AutoColumnSize extends BasePlugin {
      * @private
      * @type {SamplesGenerator}
      */
-    this.samplesGenerator = new SamplesGenerator((row, col) => (this.hot.getCellMeta(row, col).spanned ? '' : this.hot.getDataAtCell(row, col)));
+    this.samplesGenerator = new SamplesGenerator((row, column) => {
+      const cellMeta = this.hot.getCellMeta(row, column);
+      let cellValue = '';
+
+      if (!cellMeta.spanned) {
+        cellValue = this.hot.getDataAtCell(row, column);
+      }
+
+      let bundleCountSeed = 0;
+
+      if (cellMeta.label) {
+        const {value: labelValue, property: labelProperty} = cellMeta.label;
+        let labelText = '';
+
+        if (labelValue) {
+          labelText = typeof labelValue === 'function' ? labelValue(row, column, this.hot.colToProp(column), cellValue) : labelValue;
+
+        } else if (labelProperty) {
+          labelText = this.hot.getDataAtRowProp(row, labelProperty);
+        }
+
+        bundleCountSeed = labelText.length;
+      }
+
+      return {value: cellValue, bundleCountSeed};
+    });
     /**
      * `true` only if the first calculation was performed
      *
@@ -184,7 +209,7 @@ class AutoColumnSize extends BasePlugin {
       if (force || (this.widths[col] === void 0 && !this.hot._getColWidthFromSettings(col))) {
         const samples = this.samplesGenerator.generateColumnSamples(col, rowRange);
 
-        samples.forEach((sample, col) => this.ghostTable.addColumn(col, sample));
+        arrayEach(samples, ([column, sample]) => this.ghostTable.addColumn(column, sample));
       }
     });
 

--- a/src/plugins/autoRowSize/autoRowSize.js
+++ b/src/plugins/autoRowSize/autoRowSize.js
@@ -89,15 +89,16 @@ class AutoRowSize extends BasePlugin {
      * @type {SamplesGenerator}
      */
     this.samplesGenerator = new SamplesGenerator((row, col) => {
+      let cellValue;
+
       if (row >= 0) {
-        return this.hot.getDataAtCell(row, col);
+        cellValue = this.hot.getDataAtCell(row, col);
 
       } else if (row === -1) {
-        return this.hot.getColHeader(col);
-
+        cellValue = this.hot.getColHeader(col);
       }
-      return null;
 
+      return {value: cellValue};
     });
     /**
      * `true` if only the first calculation was performed.
@@ -183,9 +184,7 @@ class AutoRowSize extends BasePlugin {
       if (force || this.heights[row] === void 0) {
         const samples = this.samplesGenerator.generateRowSamples(row, colRange);
 
-        samples.forEach((sample, row) => {
-          this.ghostTable.addRow(row, sample);
-        });
+        arrayEach(samples, ([row, sample]) => this.ghostTable.addRow(row, sample));
       }
     });
     if (this.ghostTable.rows.length) {

--- a/src/utils/samplesGenerator.js
+++ b/src/utils/samplesGenerator.js
@@ -130,22 +130,18 @@ class SamplesGenerator {
    * @returns {Map}
    */
   generateSample(type, range, specifierValue) {
+    if (type !== 'row' && type !== 'col') {
+      throw new Error('Unsupported sample type');
+    }
+
     const samples = new Map();
-    let sampledValues = [];
-    let length;
+    const computedKey = type === 'row' ? 'col' : 'row';
+    const sampledValues = [];
 
     rangeEach(range.from, range.to, (index) => {
-      let value;
-
-      if (type === 'row') {
-        value = this.dataFactory(specifierValue, index);
-
-      } else if (type === 'col') {
-        value = this.dataFactory(index, specifierValue);
-
-      } else {
-        throw new Error('Unsupported sample type');
-      }
+      const {value, bundleCountSeed} = type === 'row' ? this.dataFactory(specifierValue, index) : this.dataFactory(index, specifierValue);
+      const hasCustomBundleSeed = bundleCountSeed > 0;
+      let length;
 
       if (isObject(value)) {
         length = Object.keys(value).length;
@@ -157,20 +153,22 @@ class SamplesGenerator {
         length = stringify(value).length;
       }
 
+      if (hasCustomBundleSeed) {
+        length += bundleCountSeed;
+      }
+
       if (!samples.has(length)) {
         samples.set(length, {
           needed: this.getSampleCount(),
           strings: [],
         });
       }
-      let sample = samples.get(length);
+      const sample = samples.get(length);
 
       if (sample.needed) {
-        let duplicate = sampledValues.indexOf(value) > -1;
+        const duplicate = sampledValues.indexOf(value) > -1;
 
-        if (!duplicate || this.allowDuplicates) {
-          let computedKey = type === 'row' ? 'col' : 'row';
-
+        if (!duplicate || this.allowDuplicates || hasCustomBundleSeed) {
           sample.strings.push({value, [computedKey]: index});
           sampledValues.push(value);
           sample.needed--;

--- a/test/unit/utils/samplesGenerator.spec.js
+++ b/test/unit/utils/samplesGenerator.spec.js
@@ -71,7 +71,9 @@ describe('SamplesGenerator', () => {
         ['AA', {id: 2}, 'C', [1, 2, 3, 4, 5], 123456789],
       ];
 
-      return data[row][col];
+      return {
+        value: data[row][col]
+      };
     });
 
     spyOn(sg, 'dataFactory').and.callThrough();
@@ -87,6 +89,57 @@ describe('SamplesGenerator', () => {
     expect(result.get(2).strings).toEqual([{value: 'AA', col: 0}]);
   });
 
+  it('should generate row sample with limited generated items (when the data source contains the same values)', () => {
+    const sg = new SamplesGenerator((row, col) => {
+      const data = [
+        [true, true, true, true, true, true, true, true, true, true],
+      ];
+
+      return {
+        value: data[row][col]
+      };
+    });
+
+    spyOn(sg, 'dataFactory').and.callThrough();
+
+    const result = sg.generateSample('row', {from: 0, to: 9}, 0);
+
+    expect(result.size).toBe(1);
+    expect(result.get(4).strings).toEqual([{col: 0, value: true}]);
+  });
+
+  it('should generate row sample controlled by `bundleCountSeed` (in case of collecting more samples despite their repeatability)', () => {
+    let seedIndex = 0;
+    const sg = new SamplesGenerator((row, col) => {
+      const data = [
+        [true, true, true, true, true, true, true, true, true, true],
+      ];
+
+      seedIndex += 1;
+
+      return {
+        value: data[row][col],
+        bundleCountSeed: seedIndex,
+      };
+    });
+
+    spyOn(sg, 'dataFactory').and.callThrough();
+
+    const result = sg.generateSample('row', {from: 0, to: 9}, 0);
+
+    expect(result.size).toBe(10);
+    expect(result.get(5).strings).toEqual([{col: 0, value: true}]);
+    expect(result.get(6).strings).toEqual([{col: 1, value: true}]);
+    expect(result.get(7).strings).toEqual([{col: 2, value: true}]);
+    expect(result.get(8).strings).toEqual([{col: 3, value: true}]);
+    expect(result.get(9).strings).toEqual([{col: 4, value: true}]);
+    expect(result.get(10).strings).toEqual([{col: 5, value: true}]);
+    expect(result.get(11).strings).toEqual([{col: 6, value: true}]);
+    expect(result.get(12).strings).toEqual([{col: 7, value: true}]);
+    expect(result.get(13).strings).toEqual([{col: 8, value: true}]);
+    expect(result.get(14).strings).toEqual([{col: 9, value: true}]);
+  });
+
   it('should generate column sample', () => {
     var sg = new SamplesGenerator((row, col) => {
       var data = [
@@ -97,7 +150,9 @@ describe('SamplesGenerator', () => {
         [{id: 1}, {id: 2}, {id: 3}, {id: 4}],
       ];
 
-      return data[row][col];
+      return {
+        value: data[row][col]
+      };
     });
 
     spyOn(sg, 'dataFactory').and.callThrough();
@@ -111,5 +166,74 @@ describe('SamplesGenerator', () => {
     expect(result.size).toBe(3);
     expect(result.get(1).strings).toEqual([{value: 'D', row: 1}, {value: [4], row: 3}, {value: {id: 4}, row: 4}]);
     expect(result.get(2).strings).toEqual([{value: 44, row: 0}]);
+  });
+
+  it('should generate column sample with limited generated items (when the data source contains the same values)', () => {
+    const sg = new SamplesGenerator((row, col) => {
+      const data = [
+        [true],
+        [true],
+        [true],
+        [true],
+        [true],
+        [true],
+        [true],
+        [true],
+        [true],
+        [true],
+      ];
+
+      return {
+        value: data[row][col]
+      };
+    });
+
+    spyOn(sg, 'dataFactory').and.callThrough();
+
+    const result = sg.generateSample('col', {from: 0, to: 9}, 0);
+
+    expect(result.size).toBe(1);
+    expect(result.get(4).strings).toEqual([{row: 0, value: true}]);
+  });
+
+  it('should generate column sample controlled by `bundleCountSeed` (in case of collecting more samples despite their repeatability)', () => {
+    let seedIndex = 0;
+    const sg = new SamplesGenerator((row, col) => {
+      const data = [
+        [true],
+        [true],
+        [true],
+        [true],
+        [true],
+        [true],
+        [true],
+        [true],
+        [true],
+        [true],
+      ];
+
+      seedIndex += 1;
+
+      return {
+        value: data[row][col],
+        bundleCountSeed: seedIndex,
+      };
+    });
+
+    spyOn(sg, 'dataFactory').and.callThrough();
+
+    const result = sg.generateSample('col', {from: 0, to: 9}, 0);
+
+    expect(result.size).toBe(10);
+    expect(result.get(5).strings).toEqual([{row: 0, value: true}]);
+    expect(result.get(6).strings).toEqual([{row: 1, value: true}]);
+    expect(result.get(7).strings).toEqual([{row: 2, value: true}]);
+    expect(result.get(8).strings).toEqual([{row: 3, value: true}]);
+    expect(result.get(9).strings).toEqual([{row: 4, value: true}]);
+    expect(result.get(10).strings).toEqual([{row: 5, value: true}]);
+    expect(result.get(11).strings).toEqual([{row: 6, value: true}]);
+    expect(result.get(12).strings).toEqual([{row: 7, value: true}]);
+    expect(result.get(13).strings).toEqual([{row: 8, value: true}]);
+    expect(result.get(14).strings).toEqual([{row: 9, value: true}]);
   });
 });


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Extends the `SampleGenerator` class for `bundleCountSeed` feature (returned in data provider function) which could be used to control the cell data uniqueness. This feature is implemented in `AutoRowSize` and `AutoColumnSize` plugin which incorrectly calculates the width of the checkbox cell types with enabled labels. 

Now, the label values control the uniqueness of the cell data hence `SampleGenerator` generates more samples for the checkbox values and the width is calculated properly.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Tested manually.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #3437

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
