### PR TITLE
Added samplingRatio and allowSampleDuplicates options to the AutoColumnSize plugin

### DIFF
--- a/src/plugins/autoColumnSize/autoColumnSize.js
+++ b/src/plugins/autoColumnSize/autoColumnSize.js
@@ -137,6 +137,8 @@ class AutoColumnSize extends BasePlugin {
       this.ghostTable.setSetting('useHeaders', setting.useHeaders);
     }
 
+    this.setSamplingOptions();
+
     this.addHook('afterLoadData', () => this.onAfterLoadData());
     this.addHook('beforeChange', (changes) => this.onBeforeChange(changes));
 

--- a/src/plugins/autoColumnSize/test/autoColumnSize.e2e.js
+++ b/src/plugins/autoColumnSize/test/autoColumnSize.e2e.js
@@ -195,6 +195,41 @@ describe('AutoColumnSize', () => {
     expect([68, 70, 71, 80, 82]).toEqual(jasmine.arrayContaining([colWidth(spec().$container, 0)]));
   });
 
+  it('should not wrap the cell values when the whole column has values with the same length', function() {
+    handsontable({
+      data:  [
+        {
+          units: 'EUR / USD'
+        },
+        {
+          units: 'JPY / USD'
+        },
+        {
+          units: 'GBP / USD'
+        },
+        {
+          units: 'MXN / USD'
+        },
+        {
+          units: 'ARS / USD'
+        }
+      ],
+      autoColumnSize: {
+        samplingRatio: 5,
+      },
+      columns: [
+        {data: 'units'},
+      ]
+    });
+
+    expect([93]).toEqual(jasmine.arrayContaining([colWidth(this.$container, 0)]));
+    expect(rowHeight(spec().$container, 0)).toBe(24);
+    expect(rowHeight(spec().$container, 1)).toBe(23);
+    expect(rowHeight(spec().$container, 2)).toBe(23);
+    expect(rowHeight(spec().$container, 3)).toBe(23);
+    expect(rowHeight(spec().$container, 4)).toBe(23);
+  });
+
   it('should keep last columns width unchanged if all rows was removed', async () => {
     var hot = handsontable({
       data: arrayOfObjects(),

--- a/src/plugins/autoColumnSize/test/autoColumnSize.e2e.js
+++ b/src/plugins/autoColumnSize/test/autoColumnSize.e2e.js
@@ -197,7 +197,7 @@ describe('AutoColumnSize', () => {
 
   it('should not wrap the cell values when the whole column has values with the same length', function() {
     handsontable({
-      data:  [
+      data: [
         {
           units: 'EUR / USD'
         },


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Added missing `setSamplingOptions` method call to the `AutoColumnSize` plugin.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Added manually + added new tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #4888

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
