### PR TITLE
Add missing .scrollLeft assignment to the bottom-left overlay

### DIFF
--- a/src/3rdparty/walkontable/src/overlays.js
+++ b/src/3rdparty/walkontable/src/overlays.js
@@ -391,6 +391,7 @@ class Overlays {
 
     let topHolder = this.topOverlay.clone.wtTable.holder;
     let leftHolder = this.leftOverlay.clone.wtTable.holder;
+    let bottomOverlay = this.bottomOverlay.needFullRender ? this.bottomOverlay.clone.wtTable.holder : null;
 
     const [scrollLeft, scrollTop] = [this.scrollableElement.scrollLeft, this.scrollableElement.scrollTop];
 
@@ -399,14 +400,14 @@ class Overlays {
 
     if (this.horizontalScrolling) {
       topHolder.scrollLeft = scrollLeft;
+
+      if (bottomOverlay) {
+        bottomOverlay.scrollLeft = scrollLeft;
+      }
     }
 
     if (this.verticalScrolling) {
       leftHolder.scrollTop = scrollTop;
-
-      if (this.bottomOverlay.needFullRender) {
-        this.bottomOverlay.clone.wtTable.holder.scrollLeft = scrollLeft;
-      }
     }
 
     this.refreshAll();

--- a/src/3rdparty/walkontable/src/overlays.js
+++ b/src/3rdparty/walkontable/src/overlays.js
@@ -389,9 +389,8 @@ class Overlays {
       return;
     }
 
-    let topHolder = this.topOverlay.clone.wtTable.holder;
-    let leftHolder = this.leftOverlay.clone.wtTable.holder;
-    let bottomOverlay = this.bottomOverlay.needFullRender ? this.bottomOverlay.clone.wtTable.holder : null;
+    const topHolder = this.topOverlay.clone.wtTable.holder;
+    const leftHolder = this.leftOverlay.clone.wtTable.holder;
 
     const [scrollLeft, scrollTop] = [this.scrollableElement.scrollLeft, this.scrollableElement.scrollTop];
 
@@ -401,8 +400,10 @@ class Overlays {
     if (this.horizontalScrolling) {
       topHolder.scrollLeft = scrollLeft;
 
-      if (bottomOverlay) {
-        bottomOverlay.scrollLeft = scrollLeft;
+      const bottomHolder = this.bottomOverlay.needFullRender ? this.bottomOverlay.clone.wtTable.holder : null;
+
+      if (bottomHolder) {
+        bottomHolder.scrollLeft = scrollLeft;
       }
     }
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
This PR fixes an issue related to PRO feature. The bottom fixed overlay wasn't synchronized with master table scroll.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Tests are added in separate [PR](https://github.com/handsontable/handsontable-pro/pull/96).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #5163 
2. https://github.com/handsontable/handsontable-pro/pull/96

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
