### PR TITLE
Selection by headers should scroll viewport.

### DIFF
--- a/src/3rdparty/walkontable/src/core.js
+++ b/src/3rdparty/walkontable/src/core.js
@@ -137,14 +137,14 @@ class Walkontable {
   }
 
   /**
-   * Scrolls the viewport to a cell (rerenders if needed)
+   * Scrolls the viewport to a cell (rerenders if needed).
    *
    * @param {CellCoords} coords
    * @param {Boolean} [snapToTop]
    * @param {Boolean} [snapToRight]
    * @param {Boolean} [snapToBottom]
    * @param {Boolean} [snapToLeft]
-   * @returns {Walkontable}
+   * @returns {Boolean}
    */
   scrollViewport(coords, snapToTop, snapToRight, snapToBottom, snapToLeft) {
     return this.wtScroll.scrollViewport(coords, snapToTop, snapToRight, snapToBottom, snapToLeft);
@@ -156,7 +156,7 @@ class Walkontable {
    * @param {Number} column Visual column index.
    * @param {Boolean} [snapToRight]
    * @param {Boolean} [snapToLeft]
-   * @returns {Walkontable}
+   * @returns {Boolean}
    */
   scrollViewportHorizontally(column, snapToRight, snapToLeft) {
     return this.wtScroll.scrollViewportHorizontally(column, snapToRight, snapToLeft);
@@ -168,7 +168,7 @@ class Walkontable {
    * @param {Number} row Visual row index.
    * @param {Boolean} [snapToTop]
    * @param {Boolean} [snapToBottom]
-   * @returns {Walkontable}
+   * @returns {Boolean}
    */
   scrollViewportVertically(row, snapToTop, snapToBottom) {
     return this.wtScroll.scrollViewportVertically(row, snapToTop, snapToBottom);

--- a/src/3rdparty/walkontable/src/core.js
+++ b/src/3rdparty/walkontable/src/core.js
@@ -137,41 +137,41 @@ class Walkontable {
   }
 
   /**
-   * Scroll the viewport to a row at the given index in the data source
-   *
-   * @param {Number} row
-   * @returns {Walkontable}
-   */
-  scrollVertical(row) {
-    this.wtOverlays.topOverlay.scrollTo(row);
-    this.getSetting('onScrollVertically');
-
-    return this;
-  }
-
-  /**
-   * Scroll the viewport to a column at the given index in the data source
-   *
-   * @param {Number} column
-   * @returns {Walkontable}
-   */
-  scrollHorizontal(column) {
-    this.wtOverlays.leftOverlay.scrollTo(column);
-    this.getSetting('onScrollHorizontally');
-
-    return this;
-  }
-
-  /**
    * Scrolls the viewport to a cell (rerenders if needed)
    *
    * @param {CellCoords} coords
+   * @param {Boolean} [snapToTop]
+   * @param {Boolean} [snapToRight]
+   * @param {Boolean} [snapToBottom]
+   * @param {Boolean} [snapToLeft]
    * @returns {Walkontable}
    */
-  scrollViewport(coords) {
-    this.wtScroll.scrollViewport(coords);
+  scrollViewport(coords, snapToTop, snapToRight, snapToBottom, snapToLeft) {
+    return this.wtScroll.scrollViewport(coords, snapToTop, snapToRight, snapToBottom, snapToLeft);
+  }
 
-    return this;
+  /**
+   * Scrolls the viewport to a column (rerenders if needed).
+   *
+   * @param {Number} column Visual column index.
+   * @param {Boolean} [snapToRight]
+   * @param {Boolean} [snapToLeft]
+   * @returns {Walkontable}
+   */
+  scrollViewportHorizontally(column, snapToRight, snapToLeft) {
+    return this.wtScroll.scrollViewportHorizontally(column, snapToRight, snapToLeft);
+  }
+
+  /**
+   * Scrolls the viewport to a row (rerenders if needed).
+   *
+   * @param {Number} row Visual row index.
+   * @param {Boolean} [snapToTop]
+   * @param {Boolean} [snapToBottom]
+   * @returns {Walkontable}
+   */
+  scrollViewportVertically(row, snapToTop, snapToBottom) {
+    return this.wtScroll.scrollViewportVertically(row, snapToTop, snapToBottom);
   }
 
   /**

--- a/src/3rdparty/walkontable/src/overlay/left.js
+++ b/src/3rdparty/walkontable/src/overlay/left.js
@@ -78,14 +78,22 @@ class LeftOverlay extends Overlay {
    * Sets the main overlay's horizontal scroll position
    *
    * @param {Number} pos
+   *
+   * @returns {Boolean}
    */
   setScrollPosition(pos) {
-    if (this.mainTableScrollableElement === window) {
-      window.scrollTo(pos, getWindowScrollTop());
+    let result = false;
 
-    } else {
+    if (this.mainTableScrollableElement === window && window.scrollX !== pos) {
+      window.scrollTo(pos, getWindowScrollTop());
+      result = true;
+
+    } else if (this.mainTableScrollableElement.scrollLeft !== pos) {
       this.mainTableScrollableElement.scrollLeft = pos;
+      result = true;
     }
+
+    return result;
   }
 
   /**
@@ -217,6 +225,8 @@ class LeftOverlay extends Overlay {
    *
    * @param sourceCol {Number} Column index which you want to scroll to
    * @param [beyondRendered=false] {Boolean} if `true`, scrolls according to the bottom edge (top edge is by default)
+   *
+   * @returns {Boolean}
    */
   scrollTo(sourceCol, beyondRendered) {
     let newX = this.getTableParentOffset();
@@ -236,7 +246,7 @@ class LeftOverlay extends Overlay {
     }
     newX += scrollbarCompensation;
 
-    this.setScrollPosition(newX);
+    return this.setScrollPosition(newX);
   }
 
   /**

--- a/src/3rdparty/walkontable/src/overlay/left.js
+++ b/src/3rdparty/walkontable/src/overlay/left.js
@@ -25,7 +25,7 @@ class LeftOverlay extends Overlay {
   }
 
   /**
-   * Checks if overlay should be fully rendered
+   * Checks if overlay should be fully rendered.
    *
    * @returns {Boolean}
    */
@@ -34,7 +34,7 @@ class LeftOverlay extends Overlay {
   }
 
   /**
-   * Updates the left overlay position
+   * Updates the left overlay position.
    */
   resetFixedPosition() {
     if (!this.needFullRender || !this.wot.wtTable.holder.parentNode) {
@@ -70,15 +70,13 @@ class LeftOverlay extends Overlay {
       resetCssTransform(overlayRoot);
     }
     this.adjustHeaderBordersPosition(headerPosition);
-
     this.adjustElementsSize();
   }
 
   /**
-   * Sets the main overlay's horizontal scroll position
+   * Sets the main overlay's horizontal scroll position.
    *
    * @param {Number} pos
-   *
    * @returns {Boolean}
    */
   setScrollPosition(pos) {
@@ -97,18 +95,18 @@ class LeftOverlay extends Overlay {
   }
 
   /**
-   * Triggers onScroll hook callback
+   * Triggers onScroll hook callback.
    */
   onScroll() {
     this.wot.getSetting('onScrollVertically');
   }
 
   /**
-   * Calculates total sum cells width
+   * Calculates total sum cells width.
    *
-   * @param {Number} from Column index which calculates started from
-   * @param {Number} to Column index where calculation is finished
-   * @returns {Number} Width sum
+   * @param {Number} from Column index which calculates started from.
+   * @param {Number} to Column index where calculation is finished.
+   * @returns {Number} Width sum.
    */
   sumCellSizes(from, to) {
     let sum = 0;
@@ -169,7 +167,7 @@ class LeftOverlay extends Overlay {
   }
 
   /**
-   * Adjust overlay root childs size
+   * Adjust overlay root childs size.
    */
   adjustRootChildrenSize() {
     let scrollbarWidth = getScrollbarWidth();
@@ -184,7 +182,7 @@ class LeftOverlay extends Overlay {
   }
 
   /**
-   * Adjust the overlay dimensions and position
+   * Adjust the overlay dimensions and position.
    */
   applyToDOM() {
     let total = this.wot.getSetting('totalColumns');
@@ -209,7 +207,7 @@ class LeftOverlay extends Overlay {
   }
 
   /**
-   * Synchronize calculated top position to an element
+   * Synchronize calculated top position to an element.
    */
   syncOverlayOffset() {
     if (typeof this.wot.wtViewport.rowsRenderCalculator.startPosition === 'number') {
@@ -221,11 +219,10 @@ class LeftOverlay extends Overlay {
   }
 
   /**
-   * Scrolls horizontally to a column at the left edge of the viewport
+   * Scrolls horizontally to a column at the left edge of the viewport.
    *
-   * @param sourceCol {Number} Column index which you want to scroll to
-   * @param [beyondRendered=false] {Boolean} if `true`, scrolls according to the bottom edge (top edge is by default)
-   *
+   * @param {Number} sourceCol  Column index which you want to scroll to.
+   * @param {Boolean} [beyondRendered]  if `true`, scrolls according to the bottom edge (top edge is by default).
    * @returns {Boolean}
    */
   scrollTo(sourceCol, beyondRendered) {
@@ -244,13 +241,14 @@ class LeftOverlay extends Overlay {
     } else {
       newX += this.sumCellSizes(this.wot.getSetting('fixedColumnsLeft'), sourceCol);
     }
+
     newX += scrollbarCompensation;
 
     return this.setScrollPosition(newX);
   }
 
   /**
-   * Gets table parent left position
+   * Gets table parent left position.
    *
    * @returns {Number}
    */
@@ -266,18 +264,18 @@ class LeftOverlay extends Overlay {
   }
 
   /**
-   * Gets the main overlay's horizontal scroll position
+   * Gets the main overlay's horizontal scroll position.
    *
-   * @returns {Number} Main table's vertical scroll position
+   * @returns {Number} Main table's vertical scroll position.
    */
   getScrollPosition() {
     return getScrollLeft(this.mainTableScrollableElement);
   }
 
   /**
-   * Adds css classes to hide the header border's header (cell-selection border hiding issue)
+   * Adds css classes to hide the header border's header (cell-selection border hiding issue).
    *
-   * @param {Number} position Header X position if trimming container is window or scroll top if not
+   * @param {Number} position Header X position if trimming container is window or scroll top if not.
    */
   adjustHeaderBordersPosition(position) {
     const masterParent = this.wot.wtTable.holder.parentNode;

--- a/src/3rdparty/walkontable/src/overlay/top.js
+++ b/src/3rdparty/walkontable/src/overlay/top.js
@@ -26,7 +26,7 @@ class TopOverlay extends Overlay {
   }
 
   /**
-   * Checks if overlay should be fully rendered
+   * Checks if overlay should be fully rendered.
    *
    * @returns {Boolean}
    */
@@ -35,7 +35,7 @@ class TopOverlay extends Overlay {
   }
 
   /**
-   * Updates the top overlay position
+   * Updates the top overlay position.
    */
   resetFixedPosition() {
     if (!this.needFullRender || !this.wot.wtTable.holder.parentNode) {
@@ -72,15 +72,13 @@ class TopOverlay extends Overlay {
     }
 
     this.adjustHeaderBordersPosition(headerPosition);
-
     this.adjustElementsSize();
   }
 
   /**
-   * Sets the main overlay's vertical scroll position
+   * Sets the main overlay's vertical scroll position.
    *
    * @param {Number} pos
-   *
    * @returns {Boolean}
    */
   setScrollPosition(pos) {
@@ -99,18 +97,18 @@ class TopOverlay extends Overlay {
   }
 
   /**
-   * Triggers onScroll hook callback
+   * Triggers onScroll hook callback.
    */
   onScroll() {
     this.wot.getSetting('onScrollHorizontally');
   }
 
   /**
-   * Calculates total sum cells height
+   * Calculates total sum cells height.
    *
-   * @param {Number} from Row index which calculates started from
-   * @param {Number} to Row index where calculation is finished
-   * @returns {Number} Height sum
+   * @param {Number} from Row index which calculates started from.
+   * @param {Number} to Row index where calculation is finished.
+   * @returns {Number} Height sum.
    */
   sumCellSizes(from, to) {
     let sum = 0;
@@ -173,7 +171,7 @@ class TopOverlay extends Overlay {
   }
 
   /**
-   * Adjust overlay root childs size
+   * Adjust overlay root childs size.
    */
   adjustRootChildrenSize() {
     let scrollbarWidth = getScrollbarWidth();
@@ -188,7 +186,7 @@ class TopOverlay extends Overlay {
   }
 
   /**
-   * Adjust the overlay dimensions and position
+   * Adjust the overlay dimensions and position.
    */
   applyToDOM() {
     let total = this.wot.getSetting('totalRows');
@@ -214,7 +212,7 @@ class TopOverlay extends Overlay {
   }
 
   /**
-   * Synchronize calculated left position to an element
+   * Synchronize calculated left position to an element.
    */
   syncOverlayOffset() {
     if (typeof this.wot.wtViewport.columnsRenderCalculator.startPosition === 'number') {
@@ -226,11 +224,10 @@ class TopOverlay extends Overlay {
   }
 
   /**
-   * Scrolls vertically to a row
+   * Scrolls vertically to a row.
    *
-   * @param sourceRow {Number} Row index which you want to scroll to
-   * @param [bottomEdge=false] {Boolean} if `true`, scrolls according to the bottom edge (top edge is by default)
-   *
+   * @param {Number} sourceRow Row index which you want to scroll to.
+   * @param {Boolean} [bottomEdge] if `true`, scrolls according to the bottom edge (top edge is by default).
    * @returns {Boolean}
    */
   scrollTo(sourceRow, bottomEdge) {
@@ -262,7 +259,7 @@ class TopOverlay extends Overlay {
   }
 
   /**
-   * Gets table parent top position
+   * Gets table parent top position.
    *
    * @returns {Number}
    */
@@ -276,18 +273,18 @@ class TopOverlay extends Overlay {
   }
 
   /**
-   * Gets the main overlay's vertical scroll position
+   * Gets the main overlay's vertical scroll position.
    *
-   * @returns {Number} Main table's vertical scroll position
+   * @returns {Number} Main table's vertical scroll position.
    */
   getScrollPosition() {
     return getScrollTop(this.mainTableScrollableElement);
   }
 
   /**
-   * Redraw borders of selection
+   * Redraw borders of selection.
    *
-   * @param {WalkontableSelection} selection Selection for redraw
+   * @param {WalkontableSelection} selection Selection for redraw.
    */
   redrawSelectionBorders(selection) {
     if (selection && selection.cellRange) {
@@ -300,7 +297,7 @@ class TopOverlay extends Overlay {
   }
 
   /**
-   * Redrawing borders of all selections
+   * Redrawing borders of all selections.
    */
   redrawAllSelectionsBorders() {
     const selections = this.wot.selections;
@@ -316,9 +313,9 @@ class TopOverlay extends Overlay {
   }
 
   /**
-   * Adds css classes to hide the header border's header (cell-selection border hiding issue)
+   * Adds css classes to hide the header border's header (cell-selection border hiding issue).
    *
-   * @param {Number} position Header Y position if trimming container is window or scroll top if not
+   * @param {Number} position Header Y position if trimming container is window or scroll top if not.
    */
   adjustHeaderBordersPosition(position) {
     const masterParent = this.wot.wtTable.holder.parentNode;

--- a/src/3rdparty/walkontable/src/overlay/top.js
+++ b/src/3rdparty/walkontable/src/overlay/top.js
@@ -80,14 +80,22 @@ class TopOverlay extends Overlay {
    * Sets the main overlay's vertical scroll position
    *
    * @param {Number} pos
+   *
+   * @returns {Boolean}
    */
   setScrollPosition(pos) {
-    if (this.mainTableScrollableElement === window) {
-      window.scrollTo(getWindowScrollLeft(), pos);
+    let result = false;
 
-    } else {
+    if (this.mainTableScrollableElement === window && window.scrollY !== pos) {
+      window.scrollTo(getWindowScrollLeft(), pos);
+      result = true;
+
+    } else if (this.mainTableScrollableElement.scrollTop !== pos) {
       this.mainTableScrollableElement.scrollTop = pos;
+      result = true;
     }
+
+    return result;
   }
 
   /**
@@ -222,6 +230,8 @@ class TopOverlay extends Overlay {
    *
    * @param sourceRow {Number} Row index which you want to scroll to
    * @param [bottomEdge=false] {Boolean} if `true`, scrolls according to the bottom edge (top edge is by default)
+   *
+   * @returns {Boolean}
    */
   scrollTo(sourceRow, bottomEdge) {
     let newY = this.getTableParentOffset();
@@ -248,7 +258,7 @@ class TopOverlay extends Overlay {
     }
     newY += scrollbarCompensation;
 
-    this.setScrollPosition(newY);
+    return this.setScrollPosition(newY);
   }
 
   /**

--- a/src/3rdparty/walkontable/src/scroll.js
+++ b/src/3rdparty/walkontable/src/scroll.js
@@ -22,13 +22,14 @@ class Scroll {
   }
 
   /**
-   * Scrolls viewport to a cell by minimum number of cells
+   * Scrolls viewport to a cell.
    *
    * @param {CellCoords} coords
    * @param {Boolean} [snapToTop]
    * @param {Boolean} [snapToRight]
    * @param {Boolean} [snapToBottom]
    * @param {Boolean} [snapToLeft]
+   * @returns {Boolean}
    */
   scrollViewport(coords, snapToTop, snapToRight, snapToBottom, snapToLeft) {
     const scrolledHorizontally = this.scrollViewportHorizontally(coords.col, snapToRight, snapToLeft);
@@ -38,12 +39,11 @@ class Scroll {
   }
 
   /**
-   * Scrolls viewport to a column by minimum number of columns.
+   * Scrolls viewport to a column.
    *
    * @param {Number} column Visual column index.
    * @param {Boolean} [snapToRight]
    * @param {Boolean} [snapToLeft]
-   *
    * @returns {Boolean}
    */
   scrollViewportHorizontally(column, snapToRight, snapToLeft) {
@@ -70,11 +70,12 @@ class Scroll {
   }
 
   /**
-   * Scrolls viewport to a row by minimum number of rows.
+   * Scrolls viewport to a row.
    *
    * @param {Number} row Visual row index.
    * @param {Boolean} [snapToTop]
    * @param {Boolean} [snapToBottom]
+   * @returns {Boolean}
    */
   scrollViewportVertically(row, snapToTop, snapToBottom) {
     if (!this.wot.drawn) {

--- a/src/3rdparty/walkontable/src/scroll.js
+++ b/src/3rdparty/walkontable/src/scroll.js
@@ -25,43 +25,79 @@ class Scroll {
    * Scrolls viewport to a cell by minimum number of cells
    *
    * @param {CellCoords} coords
+   * @param {Boolean} [snapToTop]
+   * @param {Boolean} [snapToRight]
+   * @param {Boolean} [snapToBottom]
+   * @param {Boolean} [snapToLeft]
    */
-  scrollViewport(coords) {
+  scrollViewport(coords, snapToTop, snapToRight, snapToBottom, snapToLeft) {
+    const scrolledHorizontally = this.scrollViewportHorizontally(coords.col, snapToRight, snapToLeft);
+    const scrolledVertically = this.scrollViewportVertically(coords.row, snapToTop, snapToBottom);
+
+    return scrolledHorizontally || scrolledVertically;
+  }
+
+  /**
+   * Scrolls viewport to a column by minimum number of columns.
+   *
+   * @param {Number} column Visual column index.
+   * @param {Boolean} [snapToRight]
+   * @param {Boolean} [snapToLeft]
+   *
+   * @returns {Boolean}
+   */
+  scrollViewportHorizontally(column, snapToRight, snapToLeft) {
     if (!this.wot.drawn) {
-      return;
+      return false;
     }
 
     const {
-      topOverlay,
-      leftOverlay,
-      totalRows,
-      totalColumns,
-      fixedRowsTop,
-      fixedRowsBottom,
       fixedColumnsLeft,
+      leftOverlay,
+      totalColumns,
     } = this._getVariables();
+    let result = false;
 
-    if (coords.row < 0 || coords.row > Math.max(totalRows - 1, 0)) {
-      throw new Error(`row ${coords.row} does not exist`);
+    if (column >= 0 && column <= Math.max(totalColumns - 1, 0)) {
+      if (column >= fixedColumnsLeft && (column < this.getFirstVisibleColumn() || snapToLeft)) {
+        result = leftOverlay.scrollTo(column);
+      } else if (column > this.getLastVisibleColumn() || snapToRight) {
+        result = leftOverlay.scrollTo(column, true);
+      }
     }
 
-    if (coords.col < 0 || coords.col > Math.max(totalColumns - 1, 0)) {
-      throw new Error(`column ${coords.col} does not exist`);
+    return result;
+  }
+
+  /**
+   * Scrolls viewport to a row by minimum number of rows.
+   *
+   * @param {Number} row Visual row index.
+   * @param {Boolean} [snapToTop]
+   * @param {Boolean} [snapToBottom]
+   */
+  scrollViewportVertically(row, snapToTop, snapToBottom) {
+    if (!this.wot.drawn) {
+      return false;
     }
 
-    if (coords.row >= fixedRowsTop && coords.row < this.getFirstVisibleRow()) {
-      topOverlay.scrollTo(coords.row);
+    const {
+      fixedRowsBottom,
+      fixedRowsTop,
+      topOverlay,
+      totalRows,
+    } = this._getVariables();
+    let result = false;
 
-    } else if (coords.row > this.getLastVisibleRow() && coords.row < totalRows - fixedRowsBottom) {
-      topOverlay.scrollTo(coords.row, true);
+    if (row >= 0 && row <= Math.max(totalRows - 1, 0)) {
+      if (row >= fixedRowsTop && (row < this.getFirstVisibleRow() || snapToTop)) {
+        result = topOverlay.scrollTo(row);
+      } else if ((row > this.getLastVisibleRow() && row < totalRows - fixedRowsBottom) || snapToBottom) {
+        result = topOverlay.scrollTo(row, true);
+      }
     }
 
-    if (coords.col >= fixedColumnsLeft && coords.col < this.getFirstVisibleColumn()) {
-      leftOverlay.scrollTo(coords.col);
-
-    } else if (coords.col > this.getLastVisibleColumn()) {
-      leftOverlay.scrollTo(coords.col, true);
-    }
+    return result;
   }
 
   /**

--- a/src/3rdparty/walkontable/test/spec/scroll.spec.js
+++ b/src/3rdparty/walkontable/test/spec/scroll.spec.js
@@ -1,8 +1,8 @@
 describe('WalkontableScroll', () => {
-  var $table,
-    $container,
-    $wrapper,
-    debug = false;
+  let debug = false;
+  let $container;
+  let $wrapper;
+  let $table;
 
   beforeEach(() => {
     $wrapper = $('<div></div>').css({overflow: 'hidden'});
@@ -24,13 +24,17 @@ describe('WalkontableScroll', () => {
 
   describe('scroll', () => {
     it('should scroll to last column when rowHeaders is not in use', () => {
-      var wt = new Walkontable.Core({
+      const wt = new Walkontable.Core({
         table: $table[0],
         data: getData,
         totalRows: getTotalRows,
         totalColumns: getTotalColumns
       });
-      wt.draw().scrollHorizontal(999).draw();
+
+      wt.draw();
+      wt.scrollViewportHorizontally(getTotalColumns() - 1);
+      wt.draw();
+
       expect($table.find('tbody tr:eq(0) td:last')[0].innerHTML).toBe('c');
     });
 
@@ -39,7 +43,7 @@ describe('WalkontableScroll', () => {
         return i + 1;
       }
 
-      var wt = new Walkontable.Core({
+      const wt = new Walkontable.Core({
         table: $table[0],
         data: getData,
         totalRows: getTotalRows,
@@ -51,16 +55,20 @@ describe('WalkontableScroll', () => {
           TH.innerHTML = plusOne(row);
         }]
       });
-      wt.draw().scrollHorizontal(999).draw();
+
+      wt.draw();
+      wt.scrollViewportHorizontally(getTotalColumns() - 1);
+      wt.draw();
+
       expect($table.find('tbody tr:eq(0) td:last')[0].innerHTML).toBe('c');
     });
 
-    it('scroll not scroll the viewport if all rows are visible', function() {
-      this.data.splice(5);
+    it('scroll not scroll the viewport if all rows are visible', () => {
+      spec().data.splice(5);
 
       $wrapper.height(201).width(100);
 
-      var wt = new Walkontable.Core({
+      const wt = new Walkontable.Core({
         table: $table[0],
         data: getData,
         totalRows: getTotalRows,
@@ -71,122 +79,150 @@ describe('WalkontableScroll', () => {
 
       expect(wt.wtTable.getVisibleRowsCount()).toEqual(5);
 
-      wt.scrollVertical(999).draw();
+      wt.scrollViewportVertically(getTotalRows() - 1);
+      wt.draw();
+
       expect(wt.wtTable.getCoords($table.find('tbody tr:eq(0) td:eq(0)')[0])).toEqual(new Walkontable.CellCoords(0, 0));
     });
 
     it('scroll horizontal should take totalColumns if it is smaller than width', () => {
-      var wt = new Walkontable.Core({
+      const wt = new Walkontable.Core({
         table: $table[0],
         data: getData,
         totalRows: getTotalRows,
         totalColumns: getTotalColumns
       });
-      wt.draw().scrollHorizontal(999).draw();
+
+      wt.draw();
+      wt.scrollViewportHorizontally(getTotalColumns() - 1);
+      wt.draw();
+
       expect(wt.wtTable.getCoords($table.find('tbody tr:eq(0) td:eq(0)')[0])).toEqual(new Walkontable.CellCoords(0, 0));
     });
 
-    it('scroll vertical should scroll to first row if given number smaller than 0', () => {
-      var wt = new Walkontable.Core({
+    it('scroll vertical should return `false` if given number smaller than 0', () => {
+      const wt = new Walkontable.Core({
         table: $table[0],
         data: getData,
         totalRows: getTotalRows,
         totalColumns: getTotalColumns
       });
-      wt.draw().scrollVertical(-1).draw();
-      expect(wt.wtTable.getCoords($table.find('tbody tr:first td:first')[0])).toEqual(new Walkontable.CellCoords(0, 0));
+
+      wt.draw();
+
+      expect(wt.scrollViewportVertically(-1)).toBe(false);
     });
 
-    it('scroll vertical should scroll to last row if given number bigger than totalRows', function() {
-      this.data.splice(20, this.data.length - 20);
+    it('scroll vertical should return `false` if given number bigger than totalRows', () => {
+      spec().data.splice(20, spec().data.length - 20);
 
-      var wt = new Walkontable.Core({
+      const wt = new Walkontable.Core({
         table: $table[0],
         data: getData,
         totalRows: getTotalRows,
         totalColumns: getTotalColumns
       });
-      wt.draw().scrollVertical(999).draw();
-      expect(wt.wtTable.getCoords($table.find('tbody tr:last td:first')[0])).toEqual(new Walkontable.CellCoords(19, 0));
+
+      wt.draw();
+
+      expect(wt.scrollViewportVertically(999)).toBe(false);
     });
 
-    it('scroll horizontal should scroll to first row if given number smaller than 0', () => {
-
-      var wt = new Walkontable.Core({
+    it('scroll horizontal should return `false` if given number smaller than 0', () => {
+      const wt = new Walkontable.Core({
         table: $table[0],
         data: getData,
         totalRows: getTotalRows,
         totalColumns: getTotalColumns
       });
-      wt.draw().scrollHorizontal(-1).draw();
-      expect(wt.wtTable.getCoords($table.find('tbody tr:first td:first')[0])).toEqual(new Walkontable.CellCoords(0, 0));
+
+      wt.draw();
+
+      expect(wt.scrollViewportHorizontally(-1)).toBe(false);
     });
 
-    it('scroll horizontal should scroll to last row if given number bigger than totalRows', () => {
-      var wt = new Walkontable.Core({
+    it('scroll horizontal should return `false` if given number bigger than totalRows', () => {
+      const wt = new Walkontable.Core({
         table: $table[0],
         data: getData,
         totalRows: getTotalRows,
         totalColumns: getTotalColumns
       });
-      wt.draw().scrollHorizontal(999).draw();
-      expect(wt.wtTable.getCoords($table.find('tbody tr:first td:last')[0])).toEqual(new Walkontable.CellCoords(0, 3));
+
+      wt.draw();
+
+      expect(wt.scrollViewportHorizontally(999)).toBe(false);
     });
 
     it('scroll viewport to a cell that is visible should do nothing', () => {
-
       $wrapper.height(201).width(120);
-      var wt = new Walkontable.Core({
+
+      const wt = new Walkontable.Core({
         table: $table[0],
         data: getData,
         totalRows: getTotalRows,
         totalColumns: getTotalColumns
       });
+
       wt.draw();
-      var tmp = wt.getViewport();
-      wt.scrollViewport(new Walkontable.CellCoords(0, 1)).draw();
+
+      const tmp = wt.getViewport();
+
+      wt.scrollViewport(new Walkontable.CellCoords(0, 1));
+      wt.draw();
+
       expect(wt.getViewport()).toEqual(tmp);
     });
 
     it('scroll viewport to a cell on far right should make it visible on right edge', () => {
       $wrapper.width(125).height(201);
 
-      var wt = new Walkontable.Core({
+      const wt = new Walkontable.Core({
         table: $table[0],
         data: getData,
         totalRows: getTotalRows,
         totalColumns: getTotalColumns
       });
+
       wt.draw();
-      var height = $wrapper[0].clientHeight;
-      var visibleRowCount = Math.floor(height / 23);
-      wt.scrollViewport(new Walkontable.CellCoords(0, 2)).draw();
+
+      const height = $wrapper[0].clientHeight;
+      const visibleRowCount = Math.floor(height / 23);
+
+      wt.scrollViewport(new Walkontable.CellCoords(0, 2));
+      wt.draw();
+
       expect(wt.getViewport()).toEqual([0, 1, visibleRowCount - 1, 2]);
     });
 
     it('scroll viewport to a cell on far left should make it visible on left edge', () => {
       $wrapper.width(100).height(201);
 
-      var wt = new Walkontable.Core({
+      const wt = new Walkontable.Core({
         table: $table[0],
         data: getData,
         totalRows: getTotalRows,
         totalColumns: getTotalColumns
       });
+
       wt.draw();
-      var height = $wrapper[0].clientHeight;
-      var visibleRowCount = Math.floor(height / 23);
-      wt.scrollViewport(new Walkontable.CellCoords(0, 3)).draw();
+
+      const height = $wrapper[0].clientHeight;
+      const visibleRowCount = Math.floor(height / 23);
+
+      wt.scrollViewport(new Walkontable.CellCoords(0, 3));
+      wt.draw();
       expect(wt.getViewport()).toEqual([0, 3, visibleRowCount - 1, 3]);
 
-      wt.scrollViewport(new Walkontable.CellCoords(0, 1)).draw();
+      wt.scrollViewport(new Walkontable.CellCoords(0, 1));
+      wt.draw();
       expect(wt.getViewport()).toEqual([0, 1, visibleRowCount - 1, 1]);
     });
 
     it('scroll viewport to a cell on far left should make it visible on left edge (with row header)', () => {
       $wrapper.width(140).height(201);
 
-      var wt = new Walkontable.Core({
+      const wt = new Walkontable.Core({
         table: $table[0],
         data: getData,
         totalRows: getTotalRows,
@@ -195,19 +231,23 @@ describe('WalkontableScroll', () => {
           TH.innerHTML = row + 1;
         }]
       });
+
       wt.draw();
 
-      var height = $wrapper[0].clientHeight;
-      var visibleRowCount = Math.floor(height / 23);
+      const height = $wrapper[0].clientHeight;
+      const visibleRowCount = Math.floor(height / 23);
 
-      wt.scrollViewport(new Walkontable.CellCoords(0, 3)).draw();
+      wt.scrollViewport(new Walkontable.CellCoords(0, 3));
+      wt.draw();
       expect(wt.getViewport()).toEqual([0, 3, visibleRowCount - 1, 3]);
-      wt.scrollViewport(new Walkontable.CellCoords(0, 1)).draw();
+
+      wt.scrollViewport(new Walkontable.CellCoords(0, 1));
+      wt.draw();
       expect(wt.wtTable.getFirstVisibleColumn()).toEqual(1);
     });
 
     it('scroll viewport to a cell on far right should make it visible on right edge (with row header)', () => {
-      var wt = new Walkontable.Core({
+      const wt = new Walkontable.Core({
         table: $table[0],
         data: getData,
         totalRows: getTotalRows,
@@ -216,22 +256,28 @@ describe('WalkontableScroll', () => {
           TH.innerHTML = row + 1;
         }]
       });
-      wt.draw().scrollViewport(new Walkontable.CellCoords(0, 2)).draw();
+
+      wt.draw();
+      wt.scrollViewport(new Walkontable.CellCoords(0, 2));
+      wt.draw();
+
       expect(wt.wtTable.getCoords($table.find('tbody tr:first td:last')[0])).toEqual(new Walkontable.CellCoords(0, 3));
     });
 
     it('scroll viewport to a cell on far bottom should make it visible on bottom edge', () => {
       $wrapper.width(125).height(201);
 
-      var wt = new Walkontable.Core({
+      const wt = new Walkontable.Core({
         table: $table[0],
         data: getData,
         totalRows: getTotalRows,
         totalColumns: getTotalColumns
       });
+
+      wt.draw();
+      wt.scrollViewport(new Walkontable.CellCoords(12, 0));
       wt.draw();
 
-      wt.scrollViewport(new Walkontable.CellCoords(12, 0)).draw();
       expect(wt.getViewport()[0]).toBeAroundValue(5);
       expect(wt.getViewport()[1]).toBeAroundValue(0);
       expect(wt.getViewport()[2]).toBeAroundValue(12);
@@ -241,96 +287,111 @@ describe('WalkontableScroll', () => {
     it('scroll viewport to a cell on far top should make it visible on top edge', () => {
       $wrapper.width(100).height(201);
 
-      var wt = new Walkontable.Core({
+      const wt = new Walkontable.Core({
         table: $table[0],
         data: getData,
         totalRows: getTotalRows,
         totalColumns: getTotalColumns
       });
+
       wt.draw();
-      wt.scrollViewport(new Walkontable.CellCoords(20, 0)).draw();
-      wt.scrollViewport(new Walkontable.CellCoords(12, 0)).draw();
+      wt.scrollViewport(new Walkontable.CellCoords(20, 0));
+      wt.draw();
+      wt.scrollViewport(new Walkontable.CellCoords(12, 0));
+      wt.draw();
 
       expect(wt.wtTable.getCoords($table.find('tbody tr:first td:first')[0])).toEqual(new Walkontable.CellCoords(12, 0));
     });
 
-    it('scroll viewport to a cell that does not exist (vertically) should throw an error', function() {
-      this.data.splice(20, this.data.length - 20);
+    it('scroll viewport to a cell that does not exist (vertically) should return `false`', () => {
+      spec().data.splice(20, spec().data.length - 20);
 
-      expect(() => {
-        $wrapper.width(100).height(201);
-        var wt = new Walkontable.Core({
-          table: $table[0],
-          data: getData,
-          totalRows: getTotalRows,
-          totalColumns: getTotalColumns
-        });
-        wt.draw();
-        wt.scrollViewport(new Walkontable.CellCoords(40, 0)).draw();
-      }).toThrow();
+      $wrapper.width(100).height(201);
 
-    });
-
-    it('scroll viewport to a cell that does not exist (horizontally) should throw an error', () => {
-      expect(() => {
-        $wrapper.width(100).height(201);
-        var wt = new Walkontable.Core({
-          table: $table[0],
-          data: getData,
-          totalRows: getTotalRows,
-          totalColumns: getTotalColumns
-        });
-        wt.draw();
-        wt.scrollViewport(new Walkontable.CellCoords(0, 40)).draw();
-      }).toThrow();
-    });
-
-    it('remove row from the last scroll page should scroll viewport a row up if needed', function() {
-
-      $wrapper.width(100).height(210);
-
-      var wt = new Walkontable.Core({
+      const wt = new Walkontable.Core({
         table: $table[0],
         data: getData,
         totalRows: getTotalRows,
         totalColumns: getTotalColumns
       });
-      wt.draw().scrollViewport(new Walkontable.CellCoords(getTotalRows() - 1, 0)).draw();
 
-      var originalViewportStartRow = wt.getViewport()[0];
+      wt.draw();
 
-      this.data.splice(getTotalRows() - 4, 1); // remove row at index 96
+      expect(wt.scrollViewport(new Walkontable.CellCoords(40, 0))).toBe(false);
+    });
+
+    it('scroll viewport to a cell that does not exist (horizontally) should return `false`', () => {
+      $wrapper.width(100).height(201);
+
+      const wt = new Walkontable.Core({
+        table: $table[0],
+        data: getData,
+        totalRows: getTotalRows,
+        totalColumns: getTotalColumns
+      });
+
+      wt.draw();
+
+      expect(wt.scrollViewport(new Walkontable.CellCoords(0, 40))).toBe(false);
+    });
+
+    it('remove row from the last scroll page should scroll viewport a row up if needed', () => {
+      $wrapper.width(100).height(210);
+
+      const wt = new Walkontable.Core({
+        table: $table[0],
+        data: getData,
+        totalRows: getTotalRows,
+        totalColumns: getTotalColumns
+      });
+
+      wt.draw();
+      wt.scrollViewport(new Walkontable.CellCoords(getTotalRows() - 1, 0));
+      wt.draw();
+
+      const originalViewportStartRow = wt.getViewport()[0];
+
+      spec().data.splice(getTotalRows() - 4, 1); // remove row at index 96
       wt.draw();
 
       expect(originalViewportStartRow - 1).toEqual(wt.getViewport()[0]);
     });
 
-    it('should scroll to last row if smaller data source is loaded that does not have currently displayed row', function() {
+    it('should scroll to last row if smaller data source is loaded that does not have currently displayed row', () => {
       $wrapper.width(100).height(260);
-      var wt = new Walkontable.Core({
+
+      const wt = new Walkontable.Core({
         table: $table[0],
         data: getData,
         totalRows: getTotalRows,
         totalColumns: getTotalColumns
       });
+
       wt.draw();
-      wt.scrollVertical(50).draw();
-      this.data.splice(30, this.data.length - 30);
+      wt.scrollViewportVertically(50);
       wt.draw();
+      spec().data.splice(30, spec().data.length - 30);
+      wt.draw();
+
       expect($table.find('tbody tr').length).toBeGreaterThan(9);
     });
 
     it('should scroll to last column if smaller data source is loaded that does not have currently displayed column', () => {
       createDataArray(20, 100);
-      var wt = new Walkontable.Core({
+
+      const wt = new Walkontable.Core({
         table: $table[0],
         data: getData,
         totalRows: getTotalRows,
         totalColumns: getTotalColumns
       });
-      wt.draw().scrollHorizontal(50).draw();
+
+      wt.draw();
+      wt.scrollViewportHorizontally(50);
+      wt.draw();
       createDataArray(100, 30);
       wt.draw();
+
       expect($table.find('tbody tr:first td').length).toBeGreaterThan(3);
     });
 
@@ -342,25 +403,29 @@ describe('WalkontableScroll', () => {
       }
 
       $wrapper.width(260).height(201);
-      var wt = new Walkontable.Core({
+
+      const wt = new Walkontable.Core({
         table: $table[0],
         data: getData,
         totalRows: getTotalRows,
         totalColumns: getTotalColumns
       });
+
       wt.draw();
-      wt.scrollVertical(20).draw();
+      wt.scrollViewportVertically(getTotalRows() - 1);
+      wt.draw();
+
       expect($table.find('tbody tr:last td:first')[0]).toBe(wt.wtTable.getCell(new Walkontable.CellCoords(this.data.length - 1, 0))); // last rendered row should be last data row
     });
 
-    xit('should scroll to last row with very high rows (respecting fixedRows)', function() {
+    xit('should scroll to last row with very high rows (respecting fixedRows)', () => {
       createDataArray(20, 100);
 
-      for (var i = 0, ilen = this.data.length; i < ilen; i++) {
-        this.data[i][0] += '\n this \nis \na \nmultiline \ncell';
+      for (var i = 0, ilen = spec().data.length; i < ilen; i++) {
+        spec().data[i][0] += '\n this \nis \na \nmultiline \ncell';
       }
 
-      var wt = new Walkontable.Core({
+      const wt = new Walkontable.Core({
         table: $table[0],
         data: getData,
         totalRows: getTotalRows,
@@ -368,34 +433,41 @@ describe('WalkontableScroll', () => {
         fixedRowsTop: 2
       });
 
-      wt.draw().scrollVertical(2000).draw();
+      wt.draw();
+      wt.scrollViewportVertically(2000);
+      wt.draw();
 
       expect($table.find('tbody tr:eq(0) td:first')[0]).toBe(wt.wtTable.getCell(new Walkontable.CellCoords(0, 0))); // first rendered row should fixed row 0
       expect($table.find('tbody tr:eq(1) td:first')[0]).toBe(wt.wtTable.getCell(new Walkontable.CellCoords(1, 0))); // second rendered row should fixed row 1
       expect($table.find('tbody tr:eq(2) td:first')[0]).toBe(wt.wtTable.getCell(new Walkontable.CellCoords(2, 0))); // third rendered row should fixed row 1
-      expect($table.find('tbody tr:last td:first')[0]).toBe(wt.wtTable.getCell(new Walkontable.CellCoords(this.data.length - 1, 0))); // last rendered row should be last data row
+      expect($table.find('tbody tr:last td:first')[0]).toBe(wt.wtTable.getCell(new Walkontable.CellCoords(spec().data.length - 1, 0))); // last rendered row should be last data row
     });
 
     it('should scroll to last column with very wide cells', () => {
       createDataArray(20, 100);
       $wrapper.width(260).height(201);
 
-      var wt = new Walkontable.Core({
+      const wt = new Walkontable.Core({
         table: $table[0],
         data: getData,
         totalRows: getTotalRows,
         totalColumns: getTotalColumns
       });
-      wt.draw().scrollHorizontal(50).draw();
+
+      wt.draw();
+      wt.scrollViewportHorizontally(50);
+      wt.draw();
       createDataArray(100, 30);
       wt.draw();
+
       expect($table.find('tbody tr:first td').length).toBeGreaterThan(3);
     });
 
     it('should scroll the desired cell to the bottom edge even if it\'s located in a fixed column', (done) => {
       createDataArray(20, 100);
       $wrapper.width(260).height(201);
-      var wt = new Walkontable.Core({
+
+      const wt = new Walkontable.Core({
         table: $table[0],
         data: getData,
         totalRows: getTotalRows,
@@ -403,7 +475,9 @@ describe('WalkontableScroll', () => {
         fixedColumnsLeft: 2
       });
 
-      wt.draw().scrollViewport(new Walkontable.CellCoords(8, 1)).draw();
+      wt.draw();
+      wt.scrollViewport(new Walkontable.CellCoords(8, 1));
+      wt.draw();
 
       setTimeout(() => {
         expect(wt.wtTable.getLastVisibleRow()).toBe(8);
@@ -415,10 +489,10 @@ describe('WalkontableScroll', () => {
       createDataArray(100, 100);
       $wrapper.width(260).height(201);
 
-      var topOverlayCallback = jasmine.createSpy('topOverlayCallback');
-      var leftOverlayCallback = jasmine.createSpy('leftOverlayCallback');
+      const topOverlayCallback = jasmine.createSpy('topOverlayCallback');
+      const leftOverlayCallback = jasmine.createSpy('leftOverlayCallback');
 
-      var wt = new Walkontable.Core({
+      const wt = new Walkontable.Core({
         table: $table[0],
         data: getData,
         totalRows: getTotalRows,
@@ -426,16 +500,16 @@ describe('WalkontableScroll', () => {
         fixedColumnsLeft: 2,
         fixedRowsTop: 2
       });
-
-      var masterHolder = wt.wtTable.holder;
-      var leftOverlayHolder = wt.wtOverlays.leftOverlay.clone.wtTable.holder;
-      var topOverlayHolder = wt.wtOverlays.topOverlay.clone.wtTable.holder;
+      const masterHolder = wt.wtTable.holder;
+      const leftOverlayHolder = wt.wtOverlays.leftOverlay.clone.wtTable.holder;
+      const topOverlayHolder = wt.wtOverlays.topOverlay.clone.wtTable.holder;
 
       topOverlayHolder.addEventListener('scroll', topOverlayCallback);
       leftOverlayHolder.addEventListener('scroll', leftOverlayCallback);
 
       wt.draw();
-      wt.scrollViewport(new Walkontable.CellCoords(50, 50)).draw();
+      wt.scrollViewport(new Walkontable.CellCoords(50, 50));
+      wt.draw();
 
       setTimeout(() => {
         expect(topOverlayCallback.calls.count()).toEqual(1);
@@ -454,10 +528,10 @@ describe('WalkontableScroll', () => {
       createDataArray(100, 100);
       $wrapper.width(260).height(201);
 
-      var scrollHorizontally = jasmine.createSpy('scrollHorizontal');
-      var scrollVertically = jasmine.createSpy('scrollVertically');
+      const scrollHorizontally = jasmine.createSpy('scrollHorizontal');
+      const scrollVertically = jasmine.createSpy('scrollVertically');
 
-      var wt = new Walkontable.Core({
+      const wt = new Walkontable.Core({
         table: $table[0],
         data: getData,
         totalRows: getTotalRows,
@@ -484,10 +558,10 @@ describe('WalkontableScroll', () => {
       createDataArray(100, 100);
       $wrapper.width(260).height(201);
 
-      var scrollHorizontally = jasmine.createSpy('scrollHorizontal');
-      var scrollVertically = jasmine.createSpy('scrollVertically');
+      const scrollHorizontally = jasmine.createSpy('scrollHorizontal');
+      const scrollVertically = jasmine.createSpy('scrollVertically');
 
-      var wt = new Walkontable.Core({
+      const wt = new Walkontable.Core({
         table: $table[0],
         data: getData,
         totalRows: getTotalRows,
@@ -506,21 +580,21 @@ describe('WalkontableScroll', () => {
       setTimeout(() => {
         expect(scrollVertically.calls.count()).toEqual(0);
         expect(scrollHorizontally.calls.count()).toEqual(1);
+
         done();
       }, 50);
     });
 
     // Commented due to PhantomJS WheelEvent problem.
     // Throws an error: TypeError: '[object WheelEventConstructor]' is not a constructor
-    xit('should scroll the table when the `wheel` event is triggered on the corner overlay', () => {
+    xit('should scroll the table when the `wheel` event is triggered on the corner overlay', (done) => {
       createDataArray(100, 100);
       $wrapper.width(260).height(201);
 
-      var masterCallback = jasmine.createSpy('masterCallback');
-      var topCallback = jasmine.createSpy('topCallback');
-      var leftCallback = jasmine.createSpy('leftCallback');
-
-      var wt = new Walkontable.Core({
+      const masterCallback = jasmine.createSpy('masterCallback');
+      const topCallback = jasmine.createSpy('topCallback');
+      const leftCallback = jasmine.createSpy('leftCallback');
+      const wt = new Walkontable.Core({
         table: $table[0],
         data: getData,
         totalRows: getTotalRows,
@@ -531,16 +605,16 @@ describe('WalkontableScroll', () => {
 
       wt.draw();
 
-      var topLeftCornerOverlayHolder = wt.wtOverlays.topLeftCornerOverlay.clone.wtTable.holder;
-      var topHolder = wt.wtOverlays.topOverlay.clone.wtTable.holder;
-      var leftHolder = wt.wtOverlays.leftOverlay.clone.wtTable.holder;
-      var masterHolder = wt.wtTable.holder;
+      const topLeftCornerOverlayHolder = wt.wtOverlays.topLeftCornerOverlay.clone.wtTable.holder;
+      const topHolder = wt.wtOverlays.topOverlay.clone.wtTable.holder;
+      const leftHolder = wt.wtOverlays.leftOverlay.clone.wtTable.holder;
+      const masterHolder = wt.wtTable.holder;
 
       masterHolder.addEventListener('scroll', masterCallback);
       topHolder.addEventListener('scroll', topCallback);
       leftHolder.addEventListener('scroll', leftCallback);
 
-      var wheelEvent = new WheelEvent('wheel', {
+      let wheelEvent = new WheelEvent('wheel', {
         deltaX: 400
       });
 
@@ -548,9 +622,7 @@ describe('WalkontableScroll', () => {
 
       wt.draw();
 
-      waits(20);
-
-      runs(() => {
+      setTimeout(() => {
         expect(masterCallback.callCount).toEqual(1);
         expect(topCallback.callCount).toEqual(1);
         expect(leftCallback.callCount).toEqual(0);
@@ -561,113 +633,132 @@ describe('WalkontableScroll', () => {
 
         topLeftCornerOverlayHolder.dispatchEvent(wheelEvent);
         wt.draw();
-      });
+      }, 20);
 
-      waits(20);
-
-      runs(() => {
+      setTimeout(() => {
         expect(masterCallback.callCount).toEqual(2);
         expect(topCallback.callCount).toEqual(1);
         expect(leftCallback.callCount).toEqual(1);
-      });
+        done();
+      }, 40);
     });
   });
 
   describe('scrollViewport - horizontally', () => {
-
     beforeEach(() => {
       $wrapper.width(201).height(201);
     });
 
-    it('should scroll to last column on the right', function() {
-      this.data = createSpreadsheetData(10, 10);
+    it('should scroll to last column on the right', () => {
+      spec().data = createSpreadsheetData(10, 10);
 
       $wrapper.width(201).height(201);
-      var wt = new Walkontable.Core({
+      const wt = new Walkontable.Core({
         table: $table[0],
         data: getData,
         totalRows: getTotalRows,
         totalColumns: getTotalColumns,
         columnWidth: 50
       });
+
       wt.draw();
       expect(wt.wtTable.getLastVisibleColumn()).toEqual(2);
-      wt.scrollViewport(new Walkontable.CellCoords(0, 9)).draw();
+
+      wt.scrollViewport(new Walkontable.CellCoords(0, 9));
+      wt.draw();
       expect(wt.wtTable.getLastVisibleColumn()).toEqual(9);
     });
 
-    it('should not scroll back to a column that is in viewport', function() {
-      this.data = createSpreadsheetData(10, 10);
+    it('should not scroll back to a column that is in viewport', () => {
+      spec().data = createSpreadsheetData(10, 10);
 
-      var wt = new Walkontable.Core({
+      const wt = new Walkontable.Core({
         table: $table[0],
         data: getData,
         totalRows: getTotalRows,
         totalColumns: getTotalColumns,
         columnWidth: 50
       });
+
       wt.draw();
       expect(wt.wtTable.getLastVisibleColumn()).toEqual(2);
-      wt.scrollViewport(new Walkontable.CellCoords(0, 9)).draw();
+
+      wt.scrollViewport(new Walkontable.CellCoords(0, 9));
+      wt.draw();
       expect(wt.wtTable.getLastVisibleColumn()).toEqual(9);
 
-      wt.scrollViewport(new Walkontable.CellCoords(0, 9)).draw();
+      wt.scrollViewport(new Walkontable.CellCoords(0, 9));
+      wt.draw();
       expect(wt.wtTable.getLastVisibleColumn()).toEqual(9); // nothing changed
 
-      wt.scrollViewport(new Walkontable.CellCoords(0, 8)).draw();
+      wt.scrollViewport(new Walkontable.CellCoords(0, 8));
+      wt.draw();
       expect(wt.wtTable.getLastVisibleColumn()).toEqual(9); // nothing changed
 
-      wt.scrollViewport(new Walkontable.CellCoords(0, 7)).draw();
+      wt.scrollViewport(new Walkontable.CellCoords(0, 7));
+      wt.draw();
       expect(wt.wtTable.getLastVisibleColumn()).toEqual(9); // nothing changed
     });
 
-    it('should scroll back to a column that is before viewport', function() {
-      this.data = createSpreadsheetData(10, 10);
+    it('should scroll back to a column that is before viewport', () => {
+      spec().data = createSpreadsheetData(10, 10);
 
-      var wt = new Walkontable.Core({
+      const wt = new Walkontable.Core({
         table: $table[0],
         data: getData,
         totalRows: getTotalRows,
         totalColumns: getTotalColumns,
         columnWidth: 50
       });
+
       wt.draw();
       expect(wt.wtTable.getLastVisibleColumn()).toEqual(2);
-      wt.scrollViewport(new Walkontable.CellCoords(0, 9)).draw();
+
+      wt.scrollViewport(new Walkontable.CellCoords(0, 9));
+      wt.draw();
       expect(wt.wtTable.getLastVisibleColumn()).toEqual(9);
 
-      wt.draw().scrollViewport(new Walkontable.CellCoords(0, 3)).draw();
+      wt.draw();
+      wt.scrollViewport(new Walkontable.CellCoords(0, 3));
+      wt.draw();
       expect(wt.wtTable.getLastVisibleColumn()).toEqual(5);
 
-      wt.draw().scrollViewport(new Walkontable.CellCoords(0, 4)).draw();
+      wt.draw();
+      wt.scrollViewport(new Walkontable.CellCoords(0, 4));
+      wt.draw();
       expect(wt.wtTable.getLastVisibleColumn()).toEqual(5);// nothing changed
 
-      wt.scrollViewport(new Walkontable.CellCoords(0, 9)).draw();
+      wt.scrollViewport(new Walkontable.CellCoords(0, 9));
+      wt.draw();
       expect(wt.wtTable.getLastVisibleColumn()).toEqual(9);
     });
 
-    it('should scroll to a column that is after viewport', function() {
-      this.data = createSpreadsheetData(10, 10);
+    it('should scroll to a column that is after viewport', () => {
+      spec().data = createSpreadsheetData(10, 10);
 
-      var wt = new Walkontable.Core({
+      const wt = new Walkontable.Core({
         table: $table[0],
         data: getData,
         totalRows: getTotalRows,
         totalColumns: getTotalColumns,
         columnWidth: 50
       });
+
       wt.draw();
-      wt.scrollViewport(new Walkontable.CellCoords(0, 2)).draw();
+      wt.scrollViewport(new Walkontable.CellCoords(0, 2));
+      wt.draw();
       expect(wt.wtTable.getLastVisibleColumn()).toEqual(2);
 
-      wt.draw().scrollViewport(new Walkontable.CellCoords(0, 4)).draw();
+      wt.draw();
+      wt.scrollViewport(new Walkontable.CellCoords(0, 4));
+      wt.draw();
       expect(wt.wtTable.getLastVisibleColumn()).toEqual(4);
     });
 
-    it('should scroll to a wide column that is after viewport', function() {
-      this.data = createSpreadsheetData(10, 10);
+    it('should scroll to a wide column that is after viewport', () => {
+      spec().data = createSpreadsheetData(10, 10);
 
-      var wt = new Walkontable.Core({
+      const wt = new Walkontable.Core({
         table: $table[0],
         data: getData,
         totalRows: getTotalRows,
@@ -684,15 +775,17 @@ describe('WalkontableScroll', () => {
       wt.draw();
       expect(wt.wtTable.getLastVisibleColumn()).toEqual(2);
       expect(wt.wtTable.getFirstVisibleColumn()).toEqual(0);
-      wt.scrollViewport(new Walkontable.CellCoords(0, 3)).draw();
+
+      wt.scrollViewport(new Walkontable.CellCoords(0, 3));
+      wt.draw();
       expect(wt.wtTable.getLastVisibleColumn()).toEqual(3);
       expect(wt.wtTable.getFirstVisibleColumn()).toEqual(2);
     });
 
-    xit('should scroll to a very wide column that is after viewport', function() {
-      this.data = createSpreadsheetData(10, 10);
+    xit('should scroll to a very wide column that is after viewport', () => {
+      spec().data = createSpreadsheetData(10, 10);
 
-      var wt = new Walkontable.Core({
+      const wt = new Walkontable.Core({
         table: $table[0],
         data: getData,
         totalRows: getTotalRows,
@@ -727,10 +820,10 @@ describe('WalkontableScroll', () => {
       expect(wt.wtTable.getFirstVisibleColumn()).toEqual(3);
     });
 
-    xit('should scroll to a very wide column that is after viewport (with fixedColumnsLeft)', function() {
-      this.data = createSpreadsheetData(1, 10);
+    xit('should scroll to a very wide column that is after viewport (with fixedColumnsLeft)', () => {
+      spec().data = createSpreadsheetData(1, 10);
 
-      var wt = new Walkontable.Core({
+      const wt = new Walkontable.Core({
         table: $table[0],
         data: getData,
         totalRows: getTotalRows,
@@ -746,34 +839,40 @@ describe('WalkontableScroll', () => {
       });
 
       wt.draw();
-      wt.scrollViewport(new Walkontable.CellCoords(0, 3)).draw();
+      wt.scrollViewport(new Walkontable.CellCoords(0, 3));
+      wt.draw();
       expect(wt.wtTable.getLastVisibleColumn()).toEqual(3);
 
-      wt.draw().scrollViewport(new Walkontable.CellCoords(0, 2)).draw();
+      wt.draw();
+      wt.scrollViewport(new Walkontable.CellCoords(0, 2));
+      wt.draw();
       expect(wt.wtTable.getFirstVisibleColumn()).toBeGreaterThan(2);
       expect(wt.wtTable.getLastVisibleColumn()).toBeGreaterThan(2);
 
-      wt.draw().scrollViewport(new Walkontable.CellCoords(0, 3)).draw();
+      wt.draw();
+      wt.scrollViewport(new Walkontable.CellCoords(0, 3));
+      wt.draw();
       expect(wt.wtTable.getLastVisibleColumn()).toEqual(3);
 
-      wt.draw().scrollViewport(new Walkontable.CellCoords(0, 4)).draw();
+      wt.draw();
+      wt.scrollViewport(new Walkontable.CellCoords(0, 4));
+      wt.draw();
       expect(wt.wtTable.getLastVisibleColumn()).toEqual(4);
     });
   });
 
   describe('scrollViewport - vertically', () => {
-
     beforeEach(() => {
       $wrapper.width(201).height(201);
     });
 
-    xit('should scroll to a very high row that is after viewport', function() {
-      this.data = createSpreadsheetData(20, 1);
+    xit('should scroll to a very high row that is after viewport', () => {
+      spec().data = createSpreadsheetData(20, 1);
 
-      var txt = 'Very very very very very very very very very very very very very very very very very long text.';
-      this.data[4][0] = txt;
+      const txt = 'Very very very very very very very very very very very very very very very very very long text.';
+      spec().data[4][0] = txt;
 
-      var wt = new Walkontable.Core({
+      const wt = new Walkontable.Core({
         table: $table[0],
         data: getData,
         totalRows: getTotalRows,
@@ -783,47 +882,62 @@ describe('WalkontableScroll', () => {
       wt.draw();
       expect(wt.wtTable.getFirstVisibleRow()).toEqual(0);
 
-      wt.scrollViewport(new Walkontable.CellCoords(4, 0)).draw();
+      wt.scrollViewport(new Walkontable.CellCoords(4, 0));
+      wt.draw();
       expect(wt.wtTable.getLastVisibleRow()).toEqual(4);
 
-      wt.draw().scrollViewport(new Walkontable.CellCoords(5, 0)).draw();
+      wt.draw();
+      wt.scrollViewport(new Walkontable.CellCoords(5, 0));
+      wt.draw();
       expect(wt.wtTable.getLastVisibleRow()).toEqual(5);
 
-      wt.draw().scrollViewport(new Walkontable.CellCoords(4, 0)).draw();
+      wt.draw();
+      wt.scrollViewport(new Walkontable.CellCoords(4, 0));
+      wt.draw();
       expect(wt.wtTable.getFirstVisibleRow()).toEqual(4);
 
-      wt.draw().scrollViewport(new Walkontable.CellCoords(3, 0)).draw();
+      wt.draw();
+      wt.scrollViewport(new Walkontable.CellCoords(3, 0));
+      wt.draw();
       expect(wt.wtTable.getFirstVisibleRow()).toEqual(3);
     });
 
-    xit('should scroll to a very high row that is after viewport (at the end)', function() {
-      this.data = createSpreadsheetData(20, 1);
+    xit('should scroll to a very high row that is after viewport (at the end)', () => {
+      spec().data = createSpreadsheetData(20, 1);
 
-      var txt = 'Very very very very very very very very very very very very very very very very very long text.';
-      this.data[19][0] = txt;
+      const txt = 'Very very very very very very very very very very very very very very very very very long text.';
+      spec().data[19][0] = txt;
 
-      var wt = new Walkontable.Core({
+      const wt = new Walkontable.Core({
         table: $table[0],
         data: getData,
         totalRows: getTotalRows,
         totalColumns: getTotalColumns
       });
 
-      wt.draw().scrollViewport(new Walkontable.CellCoords(18, 0)).draw();
+      wt.draw();
+      wt.scrollViewport(new Walkontable.CellCoords(18, 0));
+      wt.draw();
       expect($table.find('tbody tr').length).toBe(2);
       expect($table.find('tbody tr:eq(0) td:eq(0)').html()).toBe('A18');
       expect($table.find('tbody tr:eq(1) td:eq(0)').html()).toBe(txt);
 
-      wt.draw().scrollViewport(new Walkontable.CellCoords(19, 0)).draw();
+      wt.draw();
+      wt.scrollViewport(new Walkontable.CellCoords(19, 0));
+      wt.draw();
       expect($table.find('tbody tr').length).toBe(1);
       expect($table.find('tbody tr:eq(0) td:eq(0)').html()).toBe(txt); // scrolled down
 
-      wt.draw().scrollViewport(new Walkontable.CellCoords(18, 0)).draw();
+      wt.draw();
+      wt.scrollViewport(new Walkontable.CellCoords(18, 0));
+      wt.draw();
       expect($table.find('tbody tr').length).toBe(2);
       expect($table.find('tbody tr:eq(0) td:eq(0)').html()).toBe('A18'); // scrolled up
       expect($table.find('tbody tr:eq(1) td:eq(0)').html()).toBe(txt);
 
-      wt.draw().scrollViewport(new Walkontable.CellCoords(17, 0)).draw();
+      wt.draw();
+      wt.scrollViewport(new Walkontable.CellCoords(17, 0));
+      wt.draw();
       expect($table.find('tbody tr').length).toBe(3);
       expect($table.find('tbody tr:eq(0) td:eq(0)').html()).toBe('A17'); // scrolled up
       expect($table.find('tbody tr:eq(1) td:eq(0)').html()).toBe('A18');

--- a/src/3rdparty/walkontable/test/spec/selection.spec.js
+++ b/src/3rdparty/walkontable/test/spec/selection.spec.js
@@ -143,21 +143,25 @@ describe('Walkontable.Selection', () => {
   });
 
   it('should not scroll the viewport after selection is cleared', () => {
-    var wt = new Walkontable.Core({
+    const wt = new Walkontable.Core({
       table: $table[0],
       data: getData,
       totalRows: getTotalRows,
       totalColumns: getTotalColumns,
       selections: createSelectionController(),
     });
+
     wt.draw();
 
     wt.selections.getCell().add(new Walkontable.CellCoords(0, 0));
     wt.draw();
     expect(wt.wtTable.getFirstVisibleRow()).toEqual(0);
-    wt.scrollVertical(10).draw();
+
+    wt.scrollViewportVertically(17);
+    wt.draw();
     expect(wt.wtTable.getFirstVisibleRow()).toEqual(10);
     expect(wt.wtTable.getLastVisibleRow()).toBeAroundValue(17);
+
     wt.selections.getCell().clear();
     expect(wt.wtTable.getFirstVisibleRow()).toEqual(10);
     expect(wt.wtTable.getLastVisibleRow()).toBeAroundValue(17);

--- a/src/3rdparty/walkontable/test/spec/settings/stretchH.spec.js
+++ b/src/3rdparty/walkontable/test/spec/settings/stretchH.spec.js
@@ -137,7 +137,7 @@ describe('stretchH option', () => {
     $wrapper.width(400).height(201);
     spec().data[0][19] = 'longer text';
 
-    var wt = new Walkontable.Core({
+    const wt = new Walkontable.Core({
       table: $table[0],
       data: getData,
       totalRows: getTotalRows,
@@ -150,11 +150,12 @@ describe('stretchH option', () => {
         return index === 19 ? 100 : 50;
       }
     });
+
     wt.draw();
-    wt.scrollHorizontal(19);
+    wt.scrollViewportHorizontally(19);
     wt.draw();
 
-    var wtHider = $table.parents('.wtHider');
+    const wtHider = $table.parents('.wtHider');
 
     expect(wtHider.find('col:eq(6)').width()).toBe(100);
   });

--- a/src/3rdparty/walkontable/test/spec/table.spec.js
+++ b/src/3rdparty/walkontable/test/spec/table.spec.js
@@ -413,7 +413,7 @@ describe('WalkontableTable', () => {
     wt.draw();
     var oldCount = count;
 
-    wt.scrollVertical(8);
+    wt.scrollViewportVertically(8);
     wt.draw(true);
     expect(count).not.toBeGreaterThan(oldCount);
   });
@@ -437,11 +437,11 @@ describe('WalkontableTable', () => {
     wt.draw();
     var oldCount = count;
 
-    wt.scrollVertical(10);
+    wt.scrollViewportVertically(10);
     wt.draw(true);
     expect(count).not.toBeGreaterThan(oldCount);
 
-    wt.scrollVertical(11);
+    wt.scrollViewportVertically(getTotalRows() - 1);
     wt.draw(true);
     expect(count).toBeGreaterThan(oldCount);
   });
@@ -466,7 +466,7 @@ describe('WalkontableTable', () => {
     wt.draw();
     var oldCount = count;
 
-    wt.scrollHorizontal(8);
+    wt.scrollViewportHorizontally(8);
     wt.draw(true);
 
     expect(count).not.toBeGreaterThan(oldCount);
@@ -493,11 +493,11 @@ describe('WalkontableTable', () => {
     wt.draw();
     var oldCount = count;
 
-    wt.scrollHorizontal(10);
+    wt.scrollViewportHorizontally(10);
     wt.draw(true);
     expect(count).not.toBeGreaterThan(oldCount);
 
-    wt.scrollHorizontal(11);
+    wt.scrollViewportHorizontally(11);
     wt.draw(true);
     expect(count).toBeGreaterThan(oldCount);
   });
@@ -555,7 +555,7 @@ describe('WalkontableTable', () => {
         totalColumns: getTotalColumns
       });
       wt.draw();
-      wt.scrollVertical(7);
+      wt.scrollViewportVertically(7);
       wt.draw();
 
       expect(wt.wtTable.isLastRowFullyVisible()).toEqual(true);

--- a/src/plugins/columnSorting/test/columnSorting.e2e.js
+++ b/src/plugins/columnSorting/test/columnSorting.e2e.js
@@ -7,10 +7,10 @@ describe('ColumnSorting', () => {
     this.$container = $(`<div id="${id}" style="overflow: auto; width: 300px; height: 200px;"></div>`).appendTo('body');
 
     this.sortByClickOnColumnHeader = function(columnIndex) {
-      const element = this.$container.find(`th span.columnSorting:eq(${columnIndex})`);
+      const element = this.$container.data('handsontable').view.wt.wtTable.getColumnHeader(columnIndex).querySelector('span.columnSorting');
 
-      element.simulate('mousedown');
-      element.simulate('mouseup');
+      $(element).simulate('mousedown');
+      $(element).simulate('mouseup');
     };
   });
 
@@ -974,7 +974,7 @@ describe('ColumnSorting', () => {
     });
   });
 
-  it('should properly sort numeric data', function() {
+  it('should properly sort numeric data', async () => {
     handsontable({
       data: [
         ['Mercedes', 'A 160', '01/14/2006', '6999.9999'],
@@ -997,15 +997,18 @@ describe('ColumnSorting', () => {
       columnSorting: true
     });
 
-    this.sortByClickOnColumnHeader(3);
+    spec().sortByClickOnColumnHeader(3);
+    await sleep(50);
 
     expect(getDataAtCol(3)).toEqual(['6999.9999', '7000', 8330, '8330', 8333, 30500, '33900']);
 
-    this.sortByClickOnColumnHeader(3);
+    spec().sortByClickOnColumnHeader(3);
+    await sleep(50);
 
     expect(getDataAtCol(3)).toEqual(['33900', 30500, 8333, 8330, '8330', '7000', '6999.9999']);
 
-    this.sortByClickOnColumnHeader(3);
+    spec().sortByClickOnColumnHeader(3);
+    await sleep(50);
 
     expect(getDataAtCol(3)).toEqual(['6999.9999', 8330, '8330', 8333, '33900', '7000', 30500]);
   });

--- a/src/plugins/manualColumnMove/manualColumnMove.js
+++ b/src/plugins/manualColumnMove/manualColumnMove.js
@@ -366,7 +366,7 @@ class ManualColumnMove extends BasePlugin {
       // unfortunately first column is bigger than rest
       tdOffsetLeft += priv.target.TD.offsetWidth;
 
-      if (priv.target.col > lastVisible) {
+      if (priv.target.col > lastVisible && lastVisible < priv.countCols) {
         this.hot.scrollViewportTo(void 0, lastVisible + 1, void 0, true);
       }
 
@@ -374,12 +374,12 @@ class ManualColumnMove extends BasePlugin {
       // elsewhere on table
       priv.target.col = priv.coordsColumn;
 
-      if (priv.target.col <= firstVisible && priv.target.col >= priv.fixedColumns) {
+      if (priv.target.col <= firstVisible && priv.target.col >= priv.fixedColumns && firstVisible > 0) {
         this.hot.scrollViewportTo(void 0, firstVisible - 1);
       }
     }
 
-    if (priv.target.col <= firstVisible && priv.target.col >= priv.fixedColumns) {
+    if (priv.target.col <= firstVisible && priv.target.col >= priv.fixedColumns && firstVisible > 0) {
       this.hot.scrollViewportTo(void 0, firstVisible - 1);
     }
 

--- a/src/tableView.js
+++ b/src/tableView.js
@@ -514,6 +514,7 @@ TableView.prototype.getCellAtCoords = function(coords, topmost) {
  * @param {Boolean} [snapToRight]
  * @param {Boolean} [snapToBottom]
  * @param {Boolean} [snapToLeft]
+ * @returns {Boolean}
  */
 TableView.prototype.scrollViewport = function(coords, snapToTop, snapToRight, snapToBottom, snapToLeft) {
   return this.wt.scrollViewport(coords, snapToTop, snapToRight, snapToBottom, snapToLeft);
@@ -525,6 +526,7 @@ TableView.prototype.scrollViewport = function(coords, snapToTop, snapToRight, sn
  * @param {Number} column Visual column index.
  * @param {Boolean} [snapToLeft]
  * @param {Boolean} [snapToRight]
+ * @returns {Boolean}
  */
 TableView.prototype.scrollViewportHorizontally = function(column, snapToRight, snapToLeft) {
   return this.wt.scrollViewportHorizontally(column, snapToRight, snapToLeft);
@@ -533,9 +535,10 @@ TableView.prototype.scrollViewportHorizontally = function(column, snapToRight, s
 /**
  * Scroll viewport to a row.
  *
- * @param {Number} row Visual row index
+ * @param {Number} row Visual row index.
  * @param {Boolean} [snapToTop]
  * @param {Boolean} [snapToBottom]
+ * @returns {Boolean}
  */
 TableView.prototype.scrollViewportVertically = function(row, snapToTop, snapToBottom) {
   return this.wt.scrollViewportVertically(row, snapToTop, snapToBottom);

--- a/src/tableView.js
+++ b/src/tableView.js
@@ -507,12 +507,38 @@ TableView.prototype.getCellAtCoords = function(coords, topmost) {
 };
 
 /**
- * Scroll viewport to selection.
+ * Scroll viewport to a cell.
  *
  * @param {CellCoords} coords
+ * @param {Boolean} [snapToTop]
+ * @param {Boolean} [snapToRight]
+ * @param {Boolean} [snapToBottom]
+ * @param {Boolean} [snapToLeft]
  */
-TableView.prototype.scrollViewport = function(coords) {
-  this.wt.scrollViewport(coords);
+TableView.prototype.scrollViewport = function(coords, snapToTop, snapToRight, snapToBottom, snapToLeft) {
+  return this.wt.scrollViewport(coords, snapToTop, snapToRight, snapToBottom, snapToLeft);
+};
+
+/**
+ * Scroll viewport to a column.
+ *
+ * @param {Number} column Visual column index.
+ * @param {Boolean} [snapToLeft]
+ * @param {Boolean} [snapToRight]
+ */
+TableView.prototype.scrollViewportHorizontally = function(column, snapToRight, snapToLeft) {
+  return this.wt.scrollViewportHorizontally(column, snapToRight, snapToLeft);
+};
+
+/**
+ * Scroll viewport to a row.
+ *
+ * @param {Number} row Visual row index
+ * @param {Boolean} [snapToTop]
+ * @param {Boolean} [snapToBottom]
+ */
+TableView.prototype.scrollViewportVertically = function(row, snapToTop, snapToBottom) {
+  return this.wt.scrollViewportVertically(row, snapToTop, snapToBottom);
 };
 
 /**

--- a/test/e2e/Core_selection.spec.js
+++ b/test/e2e/Core_selection.spec.js
@@ -526,7 +526,7 @@ describe('Core_selection', () => {
     });
 
     hot.render();
-    hot.view.wt.scrollHorizontal(20);
+    hot.scrollViewportTo(void 0, hot.countCols() - 1);
 
     spec().$container.find('.ht_master thead th:eq(2)').simulate('mousedown');
     spec().$container.find('.ht_master thead th:eq(2)').simulate('mouseup');
@@ -545,7 +545,7 @@ describe('Core_selection', () => {
   });
 
   it('should set the selection end to the first visible row, when dragging the selection from a cell to a column header', (done) => {
-    var hot = handsontable({
+    const hot = handsontable({
       width: 200,
       height: 200,
       startRows: 20,
@@ -554,9 +554,7 @@ describe('Core_selection', () => {
       rowHeaders: true
     });
 
-    hot.view.wt.scrollVertical(10);
-    hot.view.wt.scrollHorizontal(10);
-
+    hot.scrollViewportTo(10, 10);
     hot.render();
 
     setTimeout(() => {
@@ -596,8 +594,7 @@ describe('Core_selection', () => {
       rowHeaders: true
     });
 
-    hot.view.wt.scrollVertical(10);
-    hot.view.wt.scrollHorizontal(10);
+    hot.scrollViewportTo(10, 10);
 
     hot.render();
 

--- a/test/e2e/Core_selection.spec.js
+++ b/test/e2e/Core_selection.spec.js
@@ -1,5 +1,5 @@
 describe('Core_selection', () => {
-  var id = 'testContainer';
+  const id = 'testContainer';
 
   beforeEach(function() {
     this.$container = $(`<div id="${id}"></div>`).appendTo('body');
@@ -54,7 +54,7 @@ describe('Core_selection', () => {
   });
 
   it('should focus external textarea when clicked during editing', () => {
-    var textarea = $('<input type="text">').prependTo($('body'));
+    const textarea = $('<input type="text">').prependTo($('body'));
 
     handsontable();
     selectCell(0, 0);
@@ -189,8 +189,8 @@ describe('Core_selection', () => {
   });
 
   it('should call onSelectionEnd as many times as onSelection when `selectCell` is called', () => {
-    var tick = 0,
-      tickEnd = 0;
+    let tick = 0;
+    let tickEnd = 0;
 
     handsontable({
       startRows: 5,
@@ -210,7 +210,8 @@ describe('Core_selection', () => {
   });
 
   it('should call onSelectionEnd when user finishes selection by releasing SHIFT key (3 times)', () => {
-    var tick = 0;
+    let tick = 0;
+
     handsontable({
       startRows: 5,
       startCols: 5,
@@ -228,7 +229,8 @@ describe('Core_selection', () => {
   });
 
   it('should call onSelectionEnd when user finishes selection by releasing SHIFT key (1 time)', () => {
-    var tick = 0;
+    let tick = 0;
+
     handsontable({
       startRows: 5,
       startCols: 5,
@@ -245,58 +247,56 @@ describe('Core_selection', () => {
     expect(tick).toEqual(2);
   });
 
-  it('should select columns by click on header with SHIFT key', function() {
+  it('should select columns by click on header with SHIFT key', () => {
     handsontable({
       startRows: 5,
       startCols: 5,
       colHeaders: true
     });
 
-    this.$container.find('.ht_clone_top tr:eq(0) th:eq(1)').simulate('mousedown');
-    this.$container.find('.ht_clone_top tr:eq(0) th:eq(1)').simulate('mouseup');
+    spec().$container.find('.ht_clone_top tr:eq(0) th:eq(1)').simulate('mousedown');
+    spec().$container.find('.ht_clone_top tr:eq(0) th:eq(1)').simulate('mouseup');
 
-    this.$container.find('.ht_clone_top tr:eq(0) th:eq(4)').simulate('mousedown', {shiftKey: true});
-    this.$container.find('.ht_clone_top tr:eq(0) th:eq(4)').simulate('mouseup');
+    spec().$container.find('.ht_clone_top tr:eq(0) th:eq(4)').simulate('mousedown', {shiftKey: true});
+    spec().$container.find('.ht_clone_top tr:eq(0) th:eq(4)').simulate('mouseup');
 
     expect(getSelected()).toEqual([[0, 1, 4, 4]]);
-
   });
 
-  it('should select rows by click on header with SHIFT key', function() {
+  it('should select rows by click on header with SHIFT key', () => {
     handsontable({
       startRows: 5,
       startCols: 5,
       rowHeaders: true
     });
 
-    this.$container.find('.ht_clone_left tr:eq(1) th:eq(0)').simulate('mousedown');
-    this.$container.find('.ht_clone_left tr:eq(1) th:eq(0)').simulate('mouseup');
+    spec().$container.find('.ht_clone_left tr:eq(1) th:eq(0)').simulate('mousedown');
+    spec().$container.find('.ht_clone_left tr:eq(1) th:eq(0)').simulate('mouseup');
 
-    this.$container.find('.ht_clone_left tr:eq(4) th:eq(0)').simulate('mousedown', {shiftKey: true});
-    this.$container.find('.ht_clone_left tr:eq(4) th:eq(0)').simulate('mouseup');
+    spec().$container.find('.ht_clone_left tr:eq(4) th:eq(0)').simulate('mousedown', {shiftKey: true});
+    spec().$container.find('.ht_clone_left tr:eq(4) th:eq(0)').simulate('mouseup');
 
     expect(getSelected()).toEqual([[1, 0, 4, 4]]);
-
   });
 
-  it('should select columns by click on header with SHIFT key', function() {
+  it('should select columns by click on header with SHIFT key', () => {
     handsontable({
       startRows: 5,
       startCols: 5,
       colHeaders: true
     });
 
-    this.$container.find('.ht_clone_top tr:eq(0) th:eq(1)').simulate('mousedown');
-    this.$container.find('.ht_clone_top tr:eq(0) th:eq(1)').simulate('mouseup');
+    spec().$container.find('.ht_clone_top tr:eq(0) th:eq(1)').simulate('mousedown');
+    spec().$container.find('.ht_clone_top tr:eq(0) th:eq(1)').simulate('mouseup');
 
-    this.$container.find('.ht_clone_top tr:eq(0) th:eq(4)').simulate('mousedown', {shiftKey: true});
-    this.$container.find('.ht_clone_top tr:eq(0) th:eq(4)').simulate('mouseup');
+    spec().$container.find('.ht_clone_top tr:eq(0) th:eq(4)').simulate('mousedown', {shiftKey: true});
+    spec().$container.find('.ht_clone_top tr:eq(0) th:eq(4)').simulate('mouseup');
 
     expect(getSelected()).toEqual([[0, 1, 4, 4]]);
 
   });
 
-  it('should change selection after click on row header with SHIFT key', function() {
+  it('should change selection after click on row header with SHIFT key', () => {
     handsontable({
       startRows: 5,
       startCols: 5,
@@ -305,14 +305,14 @@ describe('Core_selection', () => {
 
     selectCell(1, 1, 3, 3);
 
-    this.$container.find('.ht_clone_left tr:eq(4) th:eq(0)').simulate('mousedown', {shiftKey: true});
-    this.$container.find('.ht_clone_left tr:eq(4) th:eq(0)').simulate('mouseup');
+    spec().$container.find('.ht_clone_left tr:eq(4) th:eq(0)').simulate('mousedown', {shiftKey: true});
+    spec().$container.find('.ht_clone_left tr:eq(4) th:eq(0)').simulate('mouseup');
 
     expect(getSelected()).toEqual([[1, 0, 4, 4]]);
 
   });
 
-  it('should change selection after click on column header with SHIFT key', function() {
+  it('should change selection after click on column header with SHIFT key', () => {
     handsontable({
       startRows: 5,
       startCols: 5,
@@ -321,15 +321,16 @@ describe('Core_selection', () => {
 
     selectCell(1, 1, 3, 3);
 
-    this.$container.find('.ht_clone_top tr:eq(0) th:eq(4)').simulate('mousedown', {shiftKey: true});
-    this.$container.find('.ht_clone_top tr:eq(0) th:eq(4)').simulate('mouseup');
+    spec().$container.find('.ht_clone_top tr:eq(0) th:eq(4)').simulate('mousedown', {shiftKey: true});
+    spec().$container.find('.ht_clone_top tr:eq(0) th:eq(4)').simulate('mouseup');
 
     expect(getSelected()).toEqual([[0, 1, 4, 4]]);
   });
 
-  it('should call onSelection while user selects cells with mouse; onSelectionEnd when user finishes selection', function() {
-    var tick = 0,
-      tickEnd = 0;
+  it('should call onSelection while user selects cells with mouse; onSelectionEnd when user finishes selection', () => {
+    let tick = 0;
+    let tickEnd = 0;
+
     handsontable({
       startRows: 5,
       startCols: 5,
@@ -341,18 +342,18 @@ describe('Core_selection', () => {
       }
     });
 
-    this.$container.find('tr:eq(0) td:eq(0)').simulate('mousedown');
-    this.$container.find('tr:eq(0) td:eq(1)').simulate('mouseover');
-    this.$container.find('tr:eq(1) td:eq(3)').simulate('mouseover');
+    spec().$container.find('tr:eq(0) td:eq(0)').simulate('mousedown');
+    spec().$container.find('tr:eq(0) td:eq(1)').simulate('mouseover');
+    spec().$container.find('tr:eq(1) td:eq(3)').simulate('mouseover');
 
-    this.$container.find('tr:eq(1) td:eq(3)').simulate('mouseup');
+    spec().$container.find('tr:eq(1) td:eq(3)').simulate('mouseup');
 
     expect(getSelected()).toEqual([[0, 0, 1, 3]]);
     expect(tick).toEqual(3);
     expect(tickEnd).toEqual(1);
   });
 
-  it('should properly select columns, when the user moves the cursor over column headers across two overlays', function() {
+  it('should properly select columns, when the user moves the cursor over column headers across two overlays', () => {
     handsontable({
       startRows: 5,
       startCols: 5,
@@ -360,17 +361,18 @@ describe('Core_selection', () => {
       fixedColumnsLeft: 2
     });
 
-    this.$container.find('.ht_clone_left tr:eq(0) th:eq(1)').simulate('mousedown');
-    this.$container.find('.ht_clone_left tr:eq(0) th:eq(1)').simulate('mouseover');
-    this.$container.find('.ht_clone_top tr:eq(0) th:eq(2)').simulate('mouseover');
-    this.$container.find('.ht_clone_left tr:eq(0) th:eq(1)').simulate('mouseover');
-    this.$container.find('.ht_clone_left tr:eq(0) th:eq(1)').simulate('mouseup');
+    spec().$container.find('.ht_clone_left tr:eq(0) th:eq(1)').simulate('mousedown');
+    spec().$container.find('.ht_clone_left tr:eq(0) th:eq(1)').simulate('mouseover');
+    spec().$container.find('.ht_clone_top tr:eq(0) th:eq(2)').simulate('mouseover');
+    spec().$container.find('.ht_clone_left tr:eq(0) th:eq(1)').simulate('mouseover');
+    spec().$container.find('.ht_clone_left tr:eq(0) th:eq(1)').simulate('mouseup');
 
     expect(getSelected()).toEqual([[0, 1, 4, 1]]);
   });
 
   it('should move focus to selected cell', () => {
-    var $input = $('<input>').appendTo(document.body);
+    const $input = $('<input>').appendTo(document.body);
+
     handsontable({
       startRows: 5,
       startCols: 5
@@ -385,24 +387,18 @@ describe('Core_selection', () => {
 
   // This test should cover the #893 case, but it always passes. It seems like the keydown event (with CTRL key pressed) isn't delivered.
   it('should not move focus from outside elements on CTRL keydown event, when no cell is selected', () => {
-    var $input = $('<input type="text"/>');
+    const $input = $('<input type="text"/>');
+
     $('body').append($input);
-
     handsontable();
-
     selectCell(0, 0);
 
     expect(document.activeElement.nodeName).toBeInArray(['TEXTAREA', 'BODY', 'HTML']);
 
     $input.focus();
-
     expect(document.activeElement.nodeName).toBe('INPUT');
 
-    // var keyDownEvent = $.Event('keydown', {ctrlKey: true, metaKey: true});
-    // $input.trigger(keyDownEvent);
-
     $input.simulate('keydown', {ctrlKey: true, metaKey: true});
-
     expect(document.activeElement.nodeName).toBe('INPUT');
 
     $input.remove();
@@ -466,8 +462,8 @@ describe('Core_selection', () => {
       `).toBeMatchToSelectionPattern();
   });
 
-  it('should not overwrite background color of the cells with custom CSS classes', function() {
-    var hot = handsontable({
+  it('should not overwrite background color of the cells with custom CSS classes', () => {
+    handsontable({
       width: 300,
       height: 150,
       startRows: 5,
@@ -482,8 +478,8 @@ describe('Core_selection', () => {
     expect(window.getComputedStyle(getCell(1, 1))['background-color']).toBe('rgb(255, 0, 0)');
   });
 
-  it('should select the entire column after column header is clicked (in fixed rows/cols corner)', function() {
-    var hot = handsontable({
+  it('should select the entire column after column header is clicked (in fixed rows/cols corner)', () => {
+    handsontable({
       width: 200,
       height: 100,
       startRows: 10,
@@ -494,7 +490,7 @@ describe('Core_selection', () => {
       fixedColumnsLeft: 2
     });
 
-    this.$container.find('.ht_master thead th:eq(1)').simulate('mousedown');
+    spec().$container.find('.ht_master thead th:eq(1)').simulate('mousedown');
 
     expect(getSelected()).toEqual([[0, 0, 9, 0]]);
     expect(`
@@ -544,7 +540,31 @@ describe('Core_selection', () => {
       `).toBeMatchToSelectionPattern();
   });
 
-  it('should set the selection end to the first visible row, when dragging the selection from a cell to a column header', (done) => {
+  it('should scroll viewport after partially visible column\'s header is clicked, without vertical scroll manipulation', () => {
+    const hot = handsontable({
+      width: 200,
+      height: 100,
+      startRows: 40,
+      startCols: 40,
+      colWidths: 73,
+      colHeaders: true,
+      rowHeaders: true,
+    });
+
+    const mainHolder = hot.view.wt.wtTable.holder;
+
+    mainHolder.scrollTop = 200;
+
+    const firstLastVisibleColumn = hot.view.wt.wtTable.getLastVisibleColumn();
+    let headerElement = hot.view.wt.wtTable.getColumnHeader(firstLastVisibleColumn + 1);
+
+    $(headerElement).simulate('mousedown');
+
+    expect(hot.view.wt.wtTable.getLastVisibleColumn()).toBe(firstLastVisibleColumn + 1);
+    expect(mainHolder.scrollTop).toBe(200);
+  });
+
+  it('should set the selection end to the first visible row, when dragging the selection from a cell to a column header', async () => {
     const hot = handsontable({
       width: 200,
       height: 200,
@@ -557,15 +577,14 @@ describe('Core_selection', () => {
     hot.scrollViewportTo(10, 10);
     hot.render();
 
-    setTimeout(() => {
-      $(getCell(12, 11)).simulate('mousedown');
-      spec().$container.find('.ht_clone_top thead th:eq(2)').simulate('mouseover');
-    }, 30);
+    await sleep(30);
 
-    setTimeout(() => {
-      expect(getSelected()).toEqual([[12, 11, 10, 11]]);
-      done();
-    }, 60);
+    $(getCell(12, 11)).simulate('mousedown');
+    spec().$container.find('.ht_clone_top thead th:eq(2)').simulate('mouseover');
+
+    await sleep(30);
+
+    expect(getSelected()).toEqual([[12, 11, 10, 11]]);
   });
 
   it('should render selection borders with set proper z-indexes', () => {
@@ -584,8 +603,8 @@ describe('Core_selection', () => {
     expect(Handsontable.dom.getComputedStyle(hot.rootElement.querySelector('.ht_master .htBorders .area')).zIndex).toBe('8');
   });
 
-  it('should set the selection end to the first visible column, when dragging the selection from a cell to a row header', (done) => {
-    var hot = handsontable({
+  it('should set the selection end to the first visible column, when dragging the selection from a cell to a row header', async () => {
+    const hot = handsontable({
       width: 200,
       height: 200,
       startRows: 20,
@@ -595,29 +614,28 @@ describe('Core_selection', () => {
     });
 
     hot.scrollViewportTo(10, 10);
-
     hot.render();
 
-    setTimeout(() => {
-      $(getCell(12, 11)).simulate('mousedown');
-      spec().$container.find('.ht_clone_left tbody th:eq(12)').simulate('mouseover');
-    }, 30);
+    await sleep(30);
 
-    setTimeout(() => {
-      expect(getSelected()).toEqual([[12, 11, 12, 10]]);
-      done();
-    }, 60);
+    $(getCell(12, 11)).simulate('mousedown');
+    spec().$container.find('.ht_clone_left tbody th:eq(12)').simulate('mouseover');
+
+    await sleep(30);
+
+    expect(getSelected()).toEqual([[12, 11, 12, 10]]);
   });
 
-  it('should allow to scroll the table when a whole column is selected and table is longer than it\'s container', function(done) {
-    var errCount = 0;
+  it('should allow to scroll the table when a whole column is selected and table is longer than it\'s container', async () => {
+    let errCount = 0;
+
     $(window).on('error.selectionTest', () => {
       errCount++;
     });
 
-    var onAfterScrollVertically = jasmine.createSpy('onAfterScrollVertically');
+    const onAfterScrollVertically = jasmine.createSpy('onAfterScrollVertically');
 
-    var hot = handsontable({
+    const hot = handsontable({
       height: 100,
       width: 300,
       startRows: 100,
@@ -627,25 +645,24 @@ describe('Core_selection', () => {
       afterScrollVertically: onAfterScrollVertically
     });
 
-    var mainHolder = hot.view.wt.wtTable.holder;
+    const mainHolder = hot.view.wt.wtTable.holder;
 
     mainHolder.scrollTop = 0;
 
-    this.$container.find('thead tr:eq(0) th:eq(2)').simulate('mousedown');
-    this.$container.find('thead tr:eq(0) th:eq(2)').simulate('mouseup');
+    spec().$container.find('thead tr:eq(0) th:eq(2)').simulate('mousedown');
+    spec().$container.find('thead tr:eq(0) th:eq(2)').simulate('mouseup');
 
     mainHolder.scrollTop = 120;
 
-    setTimeout(() => {
-      expect(errCount).toEqual(0); // expect no errors to be thrown
+    await sleep(100);
 
-      $(window).off('error.selectionTest');
-      done();
-    }, 100);
+    expect(errCount).toEqual(0); // expect no errors to be thrown
+
+    $(window).off('error.selectionTest');
   });
 
   it('should scroll to the end of the selection, when selecting cells using the keyboard', () => {
-    var hot = handsontable({
+    const hot = handsontable({
       height: 300,
       width: 300,
       startRows: 50,
@@ -656,12 +673,13 @@ describe('Core_selection', () => {
       fixedColumnsLeft: 2
     });
 
-    var mainHolder = hot.view.wt.wtTable.holder;
+    const mainHolder = hot.view.wt.wtTable.holder;
 
     mainHolder.scrollTop = 100;
     selectCell(1, 3);
     keyDownUp('arrow_down');
     expect(mainHolder.scrollTop).toEqual(0);
+
     mainHolder.scrollTop = 100;
     selectCell(1, 3);
     keyDownUp('shift+arrow_down');
@@ -671,40 +689,91 @@ describe('Core_selection', () => {
     selectCell(3, 1);
     keyDownUp('arrow_right');
     expect(mainHolder.scrollLeft).toEqual(0);
+
     mainHolder.scrollLeft = 100;
     selectCell(3, 1);
     keyDownUp('shift+arrow_right');
     expect(mainHolder.scrollLeft).toEqual(0);
 
-    var lastVisibleColumn = hot.view.wt.wtTable.getLastVisibleColumn();
+    const lastVisibleColumn = hot.view.wt.wtTable.getLastVisibleColumn();
     selectCell(3, lastVisibleColumn);
     keyDownUp('arrow_right');
     expect(hot.view.wt.wtTable.getLastVisibleColumn()).toEqual(lastVisibleColumn + 1);
+
     keyDownUp('arrow_right');
     expect(hot.view.wt.wtTable.getLastVisibleColumn()).toEqual(lastVisibleColumn + 2);
+
     keyDownUp('shift+arrow_right');
     expect(hot.view.wt.wtTable.getLastVisibleColumn()).toEqual(lastVisibleColumn + 3);
 
-    var lastVisibleRow = hot.view.wt.wtTable.getLastVisibleRow();
+    const lastVisibleRow = hot.view.wt.wtTable.getLastVisibleRow();
     selectCell(lastVisibleRow, 3);
     keyDownUp('arrow_down');
     expect(hot.view.wt.wtTable.getLastVisibleRow()).toEqual(lastVisibleRow + 1);
+
     keyDownUp('arrow_down');
     expect(hot.view.wt.wtTable.getLastVisibleRow()).toEqual(lastVisibleRow + 2);
+
     keyDownUp('shift+arrow_down');
     expect(hot.view.wt.wtTable.getLastVisibleRow()).toEqual(lastVisibleRow + 3);
-
   });
 
-  it('should select the entire row after row header is clicked', function() {
-    var hot = handsontable({
+  it('should scroll to the last selected row or column of the selection, when user uses the keyboard', () => {
+    const hot = handsontable({
+      height: 300,
+      width: 300,
+      startRows: 50,
+      startCols: 50,
+      colHeaders: true,
+      rowHeaders: true,
+      fixedRowsTop: 2,
+      fixedColumnsLeft: 2
+    });
+
+    const mainHolder = hot.view.wt.wtTable.holder;
+    const lastVisibleColumn = hot.view.wt.wtTable.getLastVisibleColumn();
+    const lastVisibleRow = hot.view.wt.wtTable.getLastVisibleRow();
+    const rowHeader = hot.view.wt.wtTable.getRowHeader(lastVisibleRow);
+    const columnHeader = hot.view.wt.wtTable.getColumnHeader(lastVisibleColumn);
+
+    $(columnHeader).simulate('mousedown');
+    $(columnHeader).simulate('mouseup');
+    keyDownUp('shift+arrow_right');
+    expect(hot.view.wt.wtTable.getLastVisibleColumn()).toEqual(lastVisibleColumn + 1);
+
+    keyDownUp('shift+arrow_right');
+    expect(hot.view.wt.wtTable.getLastVisibleColumn()).toEqual(lastVisibleColumn + 2);
+
+    keyDownUp('shift+arrow_right');
+    expect(hot.view.wt.wtTable.getLastVisibleColumn()).toEqual(lastVisibleColumn + 3);
+
+    const scrollLeft = mainHolder.scrollLeft;
+    expect(scrollLeft).toBeGreaterThan(0);
+    expect(mainHolder.scrollTop).toBe(0);
+
+    $(rowHeader).simulate('mousedown');
+    $(rowHeader).simulate('mouseup');
+    keyDownUp('shift+arrow_down');
+    expect(hot.view.wt.wtTable.getLastVisibleRow()).toEqual(lastVisibleRow + 1);
+
+    keyDownUp('shift+arrow_down');
+    expect(hot.view.wt.wtTable.getLastVisibleRow()).toEqual(lastVisibleRow + 2);
+
+    keyDownUp('shift+arrow_down');
+    expect(hot.view.wt.wtTable.getLastVisibleRow()).toEqual(lastVisibleRow + 3);
+    expect(mainHolder.scrollLeft).toBe(scrollLeft);
+    expect(mainHolder.scrollTop).toBeGreaterThan(0);
+  });
+
+  it('should select the entire row after row header is clicked', () => {
+    handsontable({
       startRows: 5,
       startCols: 5,
       colHeaders: true,
       rowHeaders: true
     });
 
-    this.$container.find('tr:eq(2) th:eq(0)').simulate('mousedown');
+    spec().$container.find('tr:eq(2) th:eq(0)').simulate('mousedown');
 
     expect(getSelected()).toEqual([[1, 0, 1, 4]]);
     expect(`
@@ -718,7 +787,31 @@ describe('Core_selection', () => {
       `).toBeMatchToSelectionPattern();
   });
 
-  it('should select the entire row of a partially fixed table after row header is clicked', function() {
+  it('should scroll viewport after partially visible row\'s header is clicked, without horizontal scroll manipulation', () => {
+    const hot = handsontable({
+      width: 200,
+      height: 100,
+      startRows: 40,
+      startCols: 40,
+      rowHeights: 27,
+      colHeaders: true,
+      rowHeaders: true,
+    });
+
+    const mainHolder = hot.view.wt.wtTable.holder;
+
+    mainHolder.scrollLeft = 200;
+
+    const firstLastVisibleRow = hot.view.wt.wtTable.getLastVisibleRow();
+    let headerElement = hot.view.wt.wtTable.getRowHeader(firstLastVisibleRow + 1);
+
+    $(headerElement).simulate('mousedown');
+
+    expect(hot.view.wt.wtTable.getLastVisibleRow()).toBe(firstLastVisibleRow + 1);
+    expect(mainHolder.scrollLeft).toBe(200);
+  });
+
+  it('should select the entire row of a partially fixed table after row header is clicked', () => {
     handsontable({
       startRows: 5,
       startCols: 5,
@@ -728,37 +821,31 @@ describe('Core_selection', () => {
       fixedColumnsLeft: 2
     });
 
-    this.$container.find('tr:eq(2) th:eq(0)').simulate('mousedown');
+    spec().$container.find('tr:eq(2) th:eq(0)').simulate('mousedown');
     expect(getSelected()).toEqual([[1, 0, 1, 4]]);
-    this.$container.find('tr:eq(3) th:eq(0)').simulate('mousedown');
+
+    spec().$container.find('tr:eq(3) th:eq(0)').simulate('mousedown');
     expect(getSelected()).toEqual([[2, 0, 2, 4]]);
   });
 
   it('should select a cell in a newly added row after automatic row adding, triggered by editing a cell in the last row with minSpareRows > 0, ' +
-    'unless editing happened within the fixed bottom rows', (done) => {
-    var hot = handsontable({
+    'unless editing happened within the fixed bottom rows', async () => {
+    handsontable({
       startRows: 5,
       startCols: 2,
       minSpareRows: 1
     });
 
-    setTimeout(() => {
-      selectCell(4, 0);
-      keyDownUp('enter');
-    }, 10);
+    await sleep(10);
+    selectCell(4, 0);
+    keyDownUp('enter');
 
-    setTimeout(() => {
-      keyDownUp('enter');
-    }, 100);
+    await sleep(90);
+    keyDownUp('enter');
 
-    setTimeout(() => {
-      expect(countRows()).toEqual(6);
-      expect(getSelected()).toEqual([[5, 0, 5, 0]]);
-    }, 200);
-
-    setTimeout(() => {
-      done();
-    }, 250);
+    await sleep(100);
+    expect(countRows()).toEqual(6);
+    expect(getSelected()).toEqual([[5, 0, 5, 0]]);
   });
 
   it('should select a cell which one was added automatically by minSpareCols', () => {
@@ -782,10 +869,11 @@ describe('Core_selection', () => {
   });
 
   it('should change selected coords by modifying coords object via `modifyTransformStart` hook', () => {
-    var hot = handsontable({
+    const hot = handsontable({
       startRows: 5,
       startCols: 5
     });
+
     selectCell(0, 0);
 
     hot.addHook('modifyTransformStart', (coords) => {
@@ -798,10 +886,11 @@ describe('Core_selection', () => {
   });
 
   it('should change selected coords by modifying coords object via `modifyTransformEnd` hook', () => {
-    var hot = handsontable({
+    const hot = handsontable({
       startRows: 5,
       startCols: 5
     });
+
     selectCell(0, 0);
 
     hot.addHook('modifyTransformEnd', (coords) => {
@@ -814,16 +903,15 @@ describe('Core_selection', () => {
   });
 
   it('should indicate is coords is out of bounds via `afterModifyTransformStart` hook', () => {
-    var spy = jasmine.createSpy();
-
-    var hot = handsontable({
+    const spy = jasmine.createSpy();
+    const hot = handsontable({
       startRows: 5,
       startCols: 5,
       autoWrapCol: false,
       autoWrapRow: false
     });
-    hot.addHook('afterModifyTransformStart', spy);
 
+    hot.addHook('afterModifyTransformStart', spy);
     selectCell(2, 0);
     keyDownUp('arrow_left');
 
@@ -853,14 +941,13 @@ describe('Core_selection', () => {
   });
 
   it('should indicate is coords is out of bounds via `afterModifyTransformEnd` hook', () => {
-    var spy = jasmine.createSpy();
-
-    var hot = handsontable({
+    const spy = jasmine.createSpy();
+    const hot = handsontable({
       startRows: 5,
       startCols: 5
     });
-    hot.addHook('afterModifyTransformEnd', spy);
 
+    hot.addHook('afterModifyTransformEnd', spy);
     selectCell(2, 0);
     keyDownUp('shift+arrow_left');
 
@@ -890,12 +977,11 @@ describe('Core_selection', () => {
   });
 
   it('should change selection after left mouse button on one of selected cell', () => {
-    var hot = handsontable({
+    const hot = handsontable({
       startRows: 5,
       startCols: 5
     });
-
-    var cells = $('.ht_master.handsontable td');
+    const cells = $('.ht_master.handsontable td');
 
     cells.eq(6).simulate('mousedown');
     cells.eq(18).simulate('mouseover');
@@ -931,8 +1017,8 @@ describe('Core_selection', () => {
       `).toBeMatchToSelectionPattern();
   });
 
-  it('should redraw selection when option `colHeaders` is set and user scrolled', function (done) {
-    var hot = handsontable({
+  it('should redraw selection when option `colHeaders` is set and user scrolled', async () => {
+    const hot = handsontable({
       startRows: 20,
       startCols: 20,
       colHeaders: true,
@@ -940,30 +1026,28 @@ describe('Core_selection', () => {
       width: 400,
       height: 200
     });
-    var cellVerticalPosition;
-    var borderOffsetInPixels = 1;
-    var topBorder;
+    let cellVerticalPosition;
+    let borderOffsetInPixels = 1;
+    let topBorder;
 
     selectCell(5, 5);
     hot.view.wt.wtOverlays.topOverlay.scrollTo(2);
 
-    setTimeout(function () {
-      cellVerticalPosition = hot.getCell(5, 5).offsetTop;
-      topBorder = $('.wtBorder.current')[0];
-      expect(topBorder.offsetTop).toEqual(cellVerticalPosition - borderOffsetInPixels);
-      hot.view.wt.wtOverlays.topOverlay.scrollTo(0);
-    }, 100);
+    await sleep(100);
 
-    setTimeout(function () {
-      cellVerticalPosition = hot.getCell(5, 5).offsetTop;
-      topBorder = $('.wtBorder.current')[0];
-      expect(topBorder.offsetTop).toEqual(cellVerticalPosition - borderOffsetInPixels);
-      done();
-    }, 200);
+    cellVerticalPosition = hot.getCell(5, 5).offsetTop;
+    topBorder = $('.wtBorder.current')[0];
+    expect(topBorder.offsetTop).toEqual(cellVerticalPosition - borderOffsetInPixels);
+    hot.view.wt.wtOverlays.topOverlay.scrollTo(0);
+
+    await sleep(100);
+    cellVerticalPosition = hot.getCell(5, 5).offsetTop;
+    topBorder = $('.wtBorder.current')[0];
+    expect(topBorder.offsetTop).toEqual(cellVerticalPosition - borderOffsetInPixels);
   });
 
-  it('should redraw selection on `leftOverlay` when options `colHeaders` and `fixedColumnsLeft` are set, and user scrolled', function (done) {
-    var hot = handsontable({
+  it('should redraw selection on `leftOverlay` when options `colHeaders` and `fixedColumnsLeft` are set, and user scrolled', async () => {
+    const hot = handsontable({
       fixedColumnsLeft: 2,
       startRows: 20,
       startCols: 20,
@@ -972,26 +1056,23 @@ describe('Core_selection', () => {
       width: 400,
       height: 200
     });
-    var cellVerticalPosition;
-    var borderOffsetInPixels = 1;
-    var topBorder;
+    let cellVerticalPosition;
+    let borderOffsetInPixels = 1;
+    let topBorder;
 
     selectCell(1, 0);
     hot.view.wt.wtOverlays.topOverlay.scrollTo(5);
 
-    setTimeout(function () {
-      cellVerticalPosition = hot.getCell(1, 0).offsetTop;
-      topBorder = $('.wtBorder.current')[0];
-      expect(topBorder.offsetTop).toEqual(cellVerticalPosition - borderOffsetInPixels);
-      hot.view.wt.wtOverlays.topOverlay.scrollTo(0);
-    }, 100);
+    await sleep(100);
+    cellVerticalPosition = hot.getCell(1, 0).offsetTop;
+    topBorder = $('.wtBorder.current')[0];
+    expect(topBorder.offsetTop).toEqual(cellVerticalPosition - borderOffsetInPixels);
+    hot.view.wt.wtOverlays.topOverlay.scrollTo(0);
 
-    setTimeout(function () {
-      cellVerticalPosition = hot.getCell(1, 0).offsetTop;
-      topBorder = $('.wtBorder.current')[0];
-      expect(topBorder.offsetTop).toEqual(cellVerticalPosition - borderOffsetInPixels);
-      done();
-    }, 200);
+    await sleep(100);
+    cellVerticalPosition = hot.getCell(1, 0).offsetTop;
+    topBorder = $('.wtBorder.current')[0];
+    expect(topBorder.offsetTop).toEqual(cellVerticalPosition - borderOffsetInPixels);
   });
 
   describe('multiple selection mode', () => {

--- a/test/e2e/Core_view.spec.js
+++ b/test/e2e/Core_view.spec.js
@@ -139,15 +139,9 @@ describe('Core_view', () => {
       height: 100
     });
 
-    expect(() => {
-      hot1.view.scrollViewport({row: -1, col: 0});
-    }).toThrow();
-    expect(() => {
-      hot1.view.scrollViewport({row: 0, col: -1});
-    }).toThrow();
-    expect(() => {
-      hot1.view.scrollViewport({row: -1, col: -1});
-    }).toThrow();
+    expect(hot1.view.scrollViewport({row: -1, col: 0})).toBe(false);
+    expect(hot1.view.scrollViewport({row: 0, col: -1})).toBe(false);
+    expect(hot1.view.scrollViewport({row: -1, col: -1})).toBe(false);
   });
 
   it('should scroll viewport, respecting fixed rows', function() {

--- a/test/e2e/editors/textEditor.spec.js
+++ b/test/e2e/editors/textEditor.spec.js
@@ -1038,7 +1038,7 @@ describe('TextEditor', () => {
 
     expect($editorInput.outerWidth()).toEqual(hot.view.wt.wtTable.holder.clientWidth - $editedCell.position().left + 1);
 
-    hot.view.wt.scrollHorizontal(3);
+    hot.scrollViewportTo(void 0, 3);
     hot.render();
 
     expect($editorInput.width() + $editorInput.offset().left).toBeLessThan(hot.view.wt.wtTable.holder.clientWidth);


### PR DESCRIPTION
### Context
A table should be scrolled to the new end of a selection by a header, if it was out of the viewport.

### How has this been tested?
1. Select last visible row/column
2. Press <kbd>SHIFT</kbd> + <kbd>&#x25BC;</kbd> or <kbd>&#x25B6;</kbd>

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)

### Related issue(s):
1. #3560