### PR TITLE
bugfix: the default backgroundColor of TextEditor

### DIFF
--- a/src/editors/textEditor.js
+++ b/src/editors/textEditor.js
@@ -394,7 +394,11 @@ TextEditor.prototype.refreshDimensions = function(force = false) {
 
   this.TEXTAREA.style.fontSize = cellComputedStyle.fontSize;
   this.TEXTAREA.style.fontFamily = cellComputedStyle.fontFamily;
-  this.TEXTAREA.style.backgroundColor = backgroundColor ? backgroundColor : getComputedStyle(this.TEXTAREA).backgroundColor;
+  
+  //Record the default backgroundColor of this.TEXTAREA to avoid to be covered by this.TD's backgroundColor.
+  !this.originBackgroundColor && (this.originBackgroundColor = getComputedStyle(this.TEXTAREA).backgroundColor);
+  
+  this.TEXTAREA.style.backgroundColor = backgroundColor ? backgroundColor : this.originBackgroundColor;
 
   this.autoResize.init(this.TEXTAREA, {
     minHeight: Math.min(height, maxHeight),


### PR DESCRIPTION
Fix a bug that the default backgroundColor of the TextEditor will be covered by editing some other table cells, which have their own backgroundColor.

### Context
reproduce steps:
step 1.
![image](https://user-images.githubusercontent.com/9962597/43460841-6d33a20c-9504-11e8-8875-af71f8d3a240.png)

step 2.
![image](https://user-images.githubusercontent.com/9962597/43460783-39e47e9e-9504-11e8-9b83-2da17f2bca1d.png)

step 3.
![image](https://user-images.githubusercontent.com/9962597/43460797-47ad02da-9504-11e8-8ecc-dbdd6e534d07.png)


### How has this been tested?
local demo.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. 
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
