### PR TITLE
Fix selection and context menu type annotations

### DIFF
--- a/handsontable.d.ts
+++ b/handsontable.d.ts
@@ -1561,9 +1561,9 @@ declare namespace Handsontable {
     afterColumnResize?: (currentColumn: number, newSize: number, isDoubleClick: boolean) => void;
     afterColumnSort?: (column: number, order: boolean) => void;
     afterContextMenuDefaultOptions?: (predefinedItems: any[]) => void;
-    afterContextMenuHide?: (context: object) => void;
-    beforeContextMenuShow?: (context: object) => void;
-    afterContextMenuShow?: (context: object) => void;
+    afterContextMenuHide?: (context: Handsontable.plugins.ContextMenu) => void;
+    beforeContextMenuShow?: (context: Handsontable.plugins.ContextMenu) => void;
+    afterContextMenuShow?: (context: Handsontable.plugins.ContextMenu) => void;
     afterCopy?: (data: any[], coords: any[]) => void;
     afterCopyLimit?: (selectedRows: number, selectedColumnds: number, copyRowsLimit: number, copyColumnsLimit: number) => void;
     afterCreateCol?: (index: number, amount: number) => void;

--- a/handsontable.d.ts
+++ b/handsontable.d.ts
@@ -48,8 +48,8 @@ declare namespace _Handsontable {
     getSchema(): object;
     getSelected(): Array<[number, number, number, number]> | undefined;
     getSelectedLast(): number[] | undefined;
-    getSelectedRange(): Range[] | undefined;
-    getSelectedRangeLast(): Range | undefined;
+    getSelectedRange():  Handsontable.wot.CellRange[] | undefined;
+    getSelectedRangeLast(): Handsontable.wot.CellRange | undefined;
     getSettings(): Handsontable.DefaultSettings;
     getSourceData(r?: number, c?: number, r2?: number, c2?: number): any[];
     getSourceDataArray(r?: number, c?: number, r2?: number, c2?: number): any[];


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
1. Type definitions incorrectly say `getSelected()` returns a `Range` which is an object from the DOM, but it should be `CellRange` which is the handsontable object described in the docs. 
2. Type annotation for context menu hooks use `object` which should be `ContextMenu` plugin instance

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Tested with `npm run test:types`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
