### PR TITLE
ESLINT - prefer-arrow-callback

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -57,7 +57,6 @@
     "object-shorthand": 1,
     "one-var": 0,
     "padded-blocks": 0,
-    "prefer-arrow-callback": 1,
     "prefer-const": 0,
     "prefer-rest-params": 1,
     "prefer-spread": 1,

--- a/src/plugins/autoColumnSize/test/autoColumnSize.e2e.js
+++ b/src/plugins/autoColumnSize/test/autoColumnSize.e2e.js
@@ -18,14 +18,14 @@ describe('AutoColumnSize', () => {
     ];
   };
 
-  it('should apply auto size by default', function() {
+  it('should apply auto size by default', () => {
     handsontable({
       data: arrayOfObjects()
     });
 
-    var width0 = colWidth(this.$container, 0);
-    var width1 = colWidth(this.$container, 1);
-    var width2 = colWidth(this.$container, 2);
+    var width0 = colWidth(spec().$container, 0);
+    var width1 = colWidth(spec().$container, 1);
+    var width2 = colWidth(spec().$container, 2);
 
     expect(width0).toBeLessThan(width1);
     expect(width1).toBeLessThan(width2);
@@ -56,7 +56,7 @@ describe('AutoColumnSize', () => {
     expect([216, 229, 247, 260, 261]).toEqual(jasmine.arrayContaining([colWidth(spec().$container, 2)]));
   });
 
-  it('should correctly detect column widths with colHeaders', function() {
+  it('should correctly detect column widths with colHeaders', () => {
     handsontable({
       data: arrayOfObjects(),
       autoColumnSize: true,
@@ -67,10 +67,10 @@ describe('AutoColumnSize', () => {
       ]
     });
 
-    expect([149, 155, 174, 178]).toEqual(jasmine.arrayContaining([colWidth(this.$container, 0)]));
+    expect([149, 155, 174, 178]).toEqual(jasmine.arrayContaining([colWidth(spec().$container, 0)]));
   });
 
-  it('should correctly detect column widths after update colHeaders when headers were passed as an array', function() {
+  it('should correctly detect column widths after update colHeaders when headers were passed as an array', () => {
     handsontable({
       data: arrayOfObjects(),
       autoColumnSize: true,
@@ -81,15 +81,15 @@ describe('AutoColumnSize', () => {
       ]
     });
 
-    expect([50, 51, 53]).toEqual(jasmine.arrayContaining([colWidth(this.$container, 0)]));
+    expect([50, 51, 53]).toEqual(jasmine.arrayContaining([colWidth(spec().$container, 0)]));
 
     updateSettings({colHeaders: ['Identifier Longer text', 'Identifier Longer and longer text']});
 
-    expect([149, 155, 174, 178]).toEqual(jasmine.arrayContaining([colWidth(this.$container, 0)]));
-    expect([226, 235, 263, 270]).toEqual(jasmine.arrayContaining([colWidth(this.$container, 1)]));
+    expect([149, 155, 174, 178]).toEqual(jasmine.arrayContaining([colWidth(spec().$container, 0)]));
+    expect([226, 235, 263, 270]).toEqual(jasmine.arrayContaining([colWidth(spec().$container, 1)]));
   });
 
-  it('should correctly detect column widths after update colHeaders when headers were passed as a string', function() {
+  it('should correctly detect column widths after update colHeaders when headers were passed as a string', () => {
     handsontable({
       data: arrayOfObjects(),
       autoColumnSize: true,
@@ -100,15 +100,15 @@ describe('AutoColumnSize', () => {
       ]
     });
 
-    expect([50, 51, 53]).toEqual(jasmine.arrayContaining([colWidth(this.$container, 0)]));
+    expect([50, 51, 53]).toEqual(jasmine.arrayContaining([colWidth(spec().$container, 0)]));
 
     updateSettings({colHeaders: 'Identifier Longer text'});
 
-    expect([149, 155, 174, 178]).toEqual(jasmine.arrayContaining([colWidth(this.$container, 0)]));
-    expect([149, 155, 174, 178]).toEqual(jasmine.arrayContaining([colWidth(this.$container, 1)]));
+    expect([149, 155, 174, 178]).toEqual(jasmine.arrayContaining([colWidth(spec().$container, 0)]));
+    expect([149, 155, 174, 178]).toEqual(jasmine.arrayContaining([colWidth(spec().$container, 1)]));
   });
 
-  it('should correctly detect column widths after update colHeaders when headers were passed as a function', function() {
+  it('should correctly detect column widths after update colHeaders when headers were passed as a function', () => {
     handsontable({
       data: arrayOfObjects(),
       autoColumnSize: true,
@@ -119,7 +119,7 @@ describe('AutoColumnSize', () => {
       ]
     });
 
-    expect([50, 51, 53]).toEqual(jasmine.arrayContaining([colWidth(this.$container, 0)]));
+    expect([50, 51, 53]).toEqual(jasmine.arrayContaining([colWidth(spec().$container, 0)]));
 
     updateSettings({
       colHeaders(index) {
@@ -127,11 +127,11 @@ describe('AutoColumnSize', () => {
       },
     });
 
-    expect([149, 155, 174, 178]).toEqual(jasmine.arrayContaining([colWidth(this.$container, 0)]));
-    expect([226, 235, 263, 270]).toEqual(jasmine.arrayContaining([colWidth(this.$container, 1)]));
+    expect([149, 155, 174, 178]).toEqual(jasmine.arrayContaining([colWidth(spec().$container, 0)]));
+    expect([226, 235, 263, 270]).toEqual(jasmine.arrayContaining([colWidth(spec().$container, 1)]));
   });
 
-  it('should correctly detect column width with colHeaders and the useHeaders option set to false (not taking the header widths into calculation)', function() {
+  it('should correctly detect column width with colHeaders and the useHeaders option set to false (not taking the header widths into calculation)', () => {
     handsontable({
       data: [
         {id: 'ab'}
@@ -145,10 +145,10 @@ describe('AutoColumnSize', () => {
       ]
     });
 
-    expect(colWidth(this.$container, 0)).toBe(50);
+    expect(colWidth(spec().$container, 0)).toBe(50);
   });
 
-  it('should correctly detect column width with columns.title', function() {
+  it('should correctly detect column width with columns.title', () => {
     handsontable({
       data: arrayOfObjects(),
       autoColumnSize: true,
@@ -157,10 +157,10 @@ describe('AutoColumnSize', () => {
       ]
     });
 
-    expect([68, 70, 71, 80, 82]).toEqual(jasmine.arrayContaining([colWidth(this.$container, 0)]));
+    expect([68, 70, 71, 80, 82]).toEqual(jasmine.arrayContaining([colWidth(spec().$container, 0)]));
   });
 
-  it('should correctly detect column widths after update columns.title', function() {
+  it('should correctly detect column widths after update columns.title', () => {
     handsontable({
       data: arrayOfObjects(),
       autoColumnSize: true,
@@ -175,7 +175,7 @@ describe('AutoColumnSize', () => {
       ],
     });
 
-    expect([174, 182, 183, 208, 213]).toEqual(jasmine.arrayContaining([colWidth(this.$container, 0)]));
+    expect([174, 182, 183, 208, 213]).toEqual(jasmine.arrayContaining([colWidth(spec().$container, 0)]));
   });
 
   // https://github.com/handsontable/handsontable/issues/2684
@@ -195,7 +195,7 @@ describe('AutoColumnSize', () => {
     expect([68, 70, 71, 80, 82]).toEqual(jasmine.arrayContaining([colWidth(spec().$container, 0)]));
   });
 
-  it('should not wrap the cell values when the whole column has values with the same length', function() {
+  it('should not wrap the cell values when the whole column has values with the same length', () => {
     handsontable({
       data: [
         {
@@ -222,7 +222,7 @@ describe('AutoColumnSize', () => {
       ]
     });
 
-    expect([93]).toEqual(jasmine.arrayContaining([colWidth(this.$container, 0)]));
+    expect([93]).toEqual(jasmine.arrayContaining([colWidth(spec().$container, 0)]));
     expect(rowHeight(spec().$container, 0)).toBe(24);
     expect(rowHeight(spec().$container, 1)).toBe(23);
     expect(rowHeight(spec().$container, 2)).toBe(23);
@@ -253,14 +253,14 @@ describe('AutoColumnSize', () => {
     expect([216, 229, 247, 260, 261]).toEqual(jasmine.arrayContaining([colWidth(spec().$container, 2)]));
   });
 
-  it('should be possible to disable plugin using updateSettings', function() {
+  it('should be possible to disable plugin using updateSettings', () => {
     handsontable({
       data: arrayOfObjects()
     });
 
-    var width0 = colWidth(this.$container, 0);
-    var width1 = colWidth(this.$container, 1);
-    var width2 = colWidth(this.$container, 2);
+    var width0 = colWidth(spec().$container, 0);
+    var width1 = colWidth(spec().$container, 1);
+    var width2 = colWidth(spec().$container, 2);
 
     expect(width0).toBeLessThan(width1);
     expect(width1).toBeLessThan(width2);
@@ -269,23 +269,23 @@ describe('AutoColumnSize', () => {
       autoColumnSize: false
     });
 
-    width0 = colWidth(this.$container, 0);
-    width1 = colWidth(this.$container, 1);
-    width2 = colWidth(this.$container, 2);
+    width0 = colWidth(spec().$container, 0);
+    width1 = colWidth(spec().$container, 1);
+    width2 = colWidth(spec().$container, 2);
 
     expect(width0).toEqual(width1);
     expect(width0).toEqual(width2);
     expect(width1).toEqual(width2);
   });
 
-  it('should apply disabling/enabling plugin using updateSettings, only to a particular HOT instance', function() {
-    this.$container2 = $(`<div id="${id}-2"></div>`).appendTo('body');
+  it('should apply disabling/enabling plugin using updateSettings, only to a particular HOT instance', () => {
+    spec().$container2 = $(`<div id="${id}-2"></div>`).appendTo('body');
 
     handsontable({
       data: arrayOfObjects()
     });
 
-    this.$container2.handsontable({
+    spec().$container2.handsontable({
       data: arrayOfObjects()
     });
 
@@ -294,13 +294,13 @@ describe('AutoColumnSize', () => {
       2: []
     };
 
-    widths[1][0] = colWidth(this.$container, 0);
-    widths[1][1] = colWidth(this.$container, 1);
-    widths[1][2] = colWidth(this.$container, 2);
+    widths[1][0] = colWidth(spec().$container, 0);
+    widths[1][1] = colWidth(spec().$container, 1);
+    widths[1][2] = colWidth(spec().$container, 2);
 
-    widths[2][0] = colWidth(this.$container2, 0);
-    widths[2][1] = colWidth(this.$container2, 1);
-    widths[2][2] = colWidth(this.$container2, 2);
+    widths[2][0] = colWidth(spec().$container2, 0);
+    widths[2][1] = colWidth(spec().$container2, 1);
+    widths[2][2] = colWidth(spec().$container2, 2);
 
     expect(widths[1][0]).toBeLessThan(widths[1][1]);
     expect(widths[1][1]).toBeLessThan(widths[1][2]);
@@ -312,13 +312,13 @@ describe('AutoColumnSize', () => {
       autoColumnSize: false
     });
 
-    widths[1][0] = colWidth(this.$container, 0);
-    widths[1][1] = colWidth(this.$container, 1);
-    widths[1][2] = colWidth(this.$container, 2);
+    widths[1][0] = colWidth(spec().$container, 0);
+    widths[1][1] = colWidth(spec().$container, 1);
+    widths[1][2] = colWidth(spec().$container, 2);
 
-    widths[2][0] = colWidth(this.$container2, 0);
-    widths[2][1] = colWidth(this.$container2, 1);
-    widths[2][2] = colWidth(this.$container2, 2);
+    widths[2][0] = colWidth(spec().$container2, 0);
+    widths[2][1] = colWidth(spec().$container2, 1);
+    widths[2][2] = colWidth(spec().$container2, 2);
 
     expect(widths[1][0]).toEqual(widths[1][1]);
     expect(widths[1][0]).toEqual(widths[1][2]);
@@ -327,19 +327,19 @@ describe('AutoColumnSize', () => {
     expect(widths[2][0]).toBeLessThan(widths[2][1]);
     expect(widths[2][1]).toBeLessThan(widths[2][2]);
 
-    this.$container2.handsontable('destroy');
-    this.$container2.remove();
+    spec().$container2.handsontable('destroy');
+    spec().$container2.remove();
   });
 
-  it('should be possible to enable plugin using updateSettings', function() {
+  it('should be possible to enable plugin using updateSettings', () => {
     handsontable({
       data: arrayOfObjects(),
       autoColumnSize: false
     });
 
-    var width0 = colWidth(this.$container, 0);
-    var width1 = colWidth(this.$container, 1);
-    var width2 = colWidth(this.$container, 2);
+    var width0 = colWidth(spec().$container, 0);
+    var width1 = colWidth(spec().$container, 1);
+    var width2 = colWidth(spec().$container, 2);
 
     expect(width0).toEqual(width1);
     expect(width0).toEqual(width2);
@@ -349,9 +349,9 @@ describe('AutoColumnSize', () => {
       autoColumnSize: true
     });
 
-    width0 = colWidth(this.$container, 0);
-    width1 = colWidth(this.$container, 1);
-    width2 = colWidth(this.$container, 2);
+    width0 = colWidth(spec().$container, 0);
+    width1 = colWidth(spec().$container, 1);
+    width2 = colWidth(spec().$container, 2);
 
     expect(width0).toBeLessThan(width1);
     expect(width1).toBeLessThan(width2);
@@ -386,7 +386,7 @@ describe('AutoColumnSize', () => {
     $container2.remove();
   });
 
-  it('should consider CSS class of the <table> element (e.g. when used with Bootstrap)', function() {
+  it('should consider CSS class of the <table> element (e.g. when used with Bootstrap)', () => {
     var $style = $('<style>.htCore.big-table td {font-size: 32px}</style>').appendTo('head');
 
     handsontable({
@@ -394,11 +394,11 @@ describe('AutoColumnSize', () => {
       autoColumnSize: true
     });
 
-    var width = colWidth(this.$container, 0);
+    var width = colWidth(spec().$container, 0);
 
-    this.$container.find('table').addClass('big-table');
+    spec().$container.find('table').addClass('big-table');
     render();
-    expect(colWidth(this.$container, 0)).toBeGreaterThan(width);
+    expect(colWidth(spec().$container, 0)).toBeGreaterThan(width);
 
     $style.remove();
   });
@@ -411,7 +411,7 @@ describe('AutoColumnSize', () => {
     expect(document.querySelector('.htAutoSize')).toBe(null);
   });
 
-  it('should not trigger autoColumnSize when column width is defined (through colWidths)', function() {
+  it('should not trigger autoColumnSize when column width is defined (through colWidths)', () => {
     handsontable({
       data: arrayOfObjects(),
       autoColumnSize: true,
@@ -423,10 +423,10 @@ describe('AutoColumnSize', () => {
 
     setDataAtCell(0, 0, 'LongLongLongLong');
 
-    expect(colWidth(this.$container, 0)).toBe(70);
+    expect(colWidth(spec().$container, 0)).toBe(70);
   });
 
-  it('should not trigger autoColumnSize when column width is defined (through columns.width)', function() {
+  it('should not trigger autoColumnSize when column width is defined (through columns.width)', () => {
     handsontable({
       data: arrayOfObjects(),
       autoColumnSize: true,
@@ -443,10 +443,10 @@ describe('AutoColumnSize', () => {
 
     setDataAtCell(0, 0, 'LongLongLongLong');
 
-    expect(colWidth(this.$container, 0)).toBe(70);
+    expect(colWidth(spec().$container, 0)).toBe(70);
   });
 
-  it('should consider renderer that uses conditional formatting for specific row & column index', function() {
+  it('should consider renderer that uses conditional formatting for specific row & column index', () => {
     var data = arrayOfObjects();
     data.push({id: '2', name: 'Rocket Man', lastName: 'In a tin can'});
     handsontable({
@@ -465,7 +465,7 @@ describe('AutoColumnSize', () => {
       }
     });
 
-    expect(colWidth(this.$container, 0)).toBeGreaterThan(colWidth(this.$container, 1));
+    expect(colWidth(spec().$container, 0)).toBeGreaterThan(colWidth(spec().$container, 1));
   });
 
   it('should\'t serialize value if it is array (nested data sources)', () => {

--- a/src/plugins/autoRowSize/test/autoRowSize.e2e.js
+++ b/src/plugins/autoRowSize/test/autoRowSize.e2e.js
@@ -27,14 +27,14 @@ describe('AutoRowSize', () => {
     ];
   }
 
-  it('should apply auto size by default', function() {
+  it('should apply auto size by default', () => {
     handsontable({
       data: arrayOfObjects()
     });
 
-    var height0 = rowHeight(this.$container, 0);
-    var height1 = rowHeight(this.$container, 1);
-    var height2 = rowHeight(this.$container, 2);
+    var height0 = rowHeight(spec().$container, 0);
+    var height1 = rowHeight(spec().$container, 1);
+    var height2 = rowHeight(spec().$container, 2);
 
     expect(height0).toBeLessThan(height1);
     expect(height1).toBeLessThan(height2);
@@ -174,33 +174,31 @@ describe('AutoRowSize', () => {
     });
   });
 
-  it('should correctly detect row height when table is hidden on init (display: none)', function(done) {
-    this.$container.css('display', 'none');
+  it('should correctly detect row height when table is hidden on init (display: none)', async () => {
+    spec().$container.css('display', 'none');
     var hot = handsontable({
       data: arrayOfObjects(),
       rowHeaders: true,
       autoRowSize: true
     });
 
-    setTimeout(() => {
-      spec().$container.css('display', 'block');
-      hot.render();
+    await sleep(200);
+    spec().$container.css('display', 'block');
+    hot.render();
 
-      expect(rowHeight(spec().$container, 0)).toBe(24);
-      expect(rowHeight(spec().$container, 1)).toBe(43);
-      expect([106, 127]).toEqual(jasmine.arrayContaining([rowHeight(spec().$container, 2)]));
-      done();
-    }, 200);
+    expect(rowHeight(spec().$container, 0)).toBe(24);
+    expect(rowHeight(spec().$container, 1)).toBe(43);
+    expect([106, 127]).toEqual(jasmine.arrayContaining([rowHeight(spec().$container, 2)]));
   });
 
-  it('should be possible to disable plugin using updateSettings', function() {
+  it('should be possible to disable plugin using updateSettings', () => {
     var hot = handsontable({
       data: arrayOfObjects()
     });
 
-    var height0 = rowHeight(this.$container, 0);
-    var height1 = rowHeight(this.$container, 1);
-    var height2 = rowHeight(this.$container, 2);
+    var height0 = rowHeight(spec().$container, 0);
+    var height1 = rowHeight(spec().$container, 1);
+    var height2 = rowHeight(spec().$container, 2);
 
     expect(height0).toBeLessThan(height1);
     expect(height1).toBeLessThan(height2);
@@ -210,7 +208,7 @@ describe('AutoRowSize', () => {
     });
     hot.setDataAtCell(0, 0, 'A\nB\nC');
 
-    var height4 = rowHeight(this.$container, 0);
+    var height4 = rowHeight(spec().$container, 0);
 
     expect(height4).toBeGreaterThan(height0);
   });
@@ -276,7 +274,7 @@ describe('AutoRowSize', () => {
     $container2.remove();
   });
 
-  it('should consider CSS class of the <table> element (e.g. when used with Bootstrap)', function() {
+  it('should consider CSS class of the <table> element (e.g. when used with Bootstrap)', () => {
     var $style = $('<style>.htCore.big-table td {font-size: 32px;line-height: 1.1}</style>').appendTo('head');
 
     var hot = handsontable({
@@ -285,7 +283,7 @@ describe('AutoRowSize', () => {
     });
     var height = parseInt(hot.getCell(2, 0).style.height, 10);
 
-    this.$container.find('table').addClass('big-table');
+    spec().$container.find('table').addClass('big-table');
     hot.getPlugin('autoRowSize').clearCache();
     render();
     expect(parseInt(hot.getCell(2, 0).style.height, 10)).toBeGreaterThan(height);

--- a/src/plugins/autofill/test/autofill.e2e.js
+++ b/src/plugins/autofill/test/autofill.e2e.js
@@ -49,7 +49,7 @@ describe('AutoFill', () => {
     expect(Handsontable.dom.getComputedStyle(hot.rootElement.querySelector('.ht_master .htBorders .fill')).zIndex).toBe('6');
   });
 
-  it('should not change cell value (drag vertically when fillHandle option is set to `horizontal`)', function() {
+  it('should not change cell value (drag vertically when fillHandle option is set to `horizontal`)', () => {
     handsontable({
       data: [
         [1, 2, 3, 4, 5, 6],
@@ -61,13 +61,13 @@ describe('AutoFill', () => {
     });
 
     selectCell(0, 0);
-    this.$container.find('.wtBorder.current.corner').simulate('mousedown');
-    this.$container.find('tbody tr:eq(1) td:eq(0)').simulate('mouseover').simulate('mouseup');
+    spec().$container.find('.wtBorder.current.corner').simulate('mousedown');
+    spec().$container.find('tbody tr:eq(1) td:eq(0)').simulate('mouseover').simulate('mouseup');
 
     expect(getDataAtCell(1, 0)).toEqual(7);
   });
 
-  it('should not change cell value (drag horizontally when fillHandle option is set to `vertical`)', function() {
+  it('should not change cell value (drag horizontally when fillHandle option is set to `vertical`)', () => {
     handsontable({
       data: [
         [1, 2, 3, 4, 5, 6],
@@ -79,13 +79,13 @@ describe('AutoFill', () => {
     });
 
     selectCell(0, 0);
-    this.$container.find('.wtBorder.current.corner').simulate('mousedown');
-    this.$container.find('tbody tr:eq(0) td:eq(1)').simulate('mouseover').simulate('mouseup');
+    spec().$container.find('.wtBorder.current.corner').simulate('mousedown');
+    spec().$container.find('tbody tr:eq(0) td:eq(1)').simulate('mouseover').simulate('mouseup');
 
     expect(getDataAtCell(0, 1)).toEqual(2);
   });
 
-  it('should work properly when fillHandle option is set to object with property `direction` set to `vertical`)', function() {
+  it('should work properly when fillHandle option is set to object with property `direction` set to `vertical`)', () => {
     handsontable({
       data: [
         [1, 2, 3, 4, 5, 6],
@@ -99,19 +99,19 @@ describe('AutoFill', () => {
     });
 
     selectCell(0, 0);
-    this.$container.find('.wtBorder.current.corner').simulate('mousedown');
-    this.$container.find('tbody tr:eq(0) td:eq(1)').simulate('mouseover').simulate('mouseup');
+    spec().$container.find('.wtBorder.current.corner').simulate('mousedown');
+    spec().$container.find('tbody tr:eq(0) td:eq(1)').simulate('mouseover').simulate('mouseup');
 
     expect(getDataAtCell(0, 1)).toEqual(2);
 
     selectCell(0, 0);
-    this.$container.find('.wtBorder.current.corner').simulate('mousedown');
-    this.$container.find('tbody tr:eq(1) td:eq(0)').simulate('mouseover').simulate('mouseup');
+    spec().$container.find('.wtBorder.current.corner').simulate('mousedown');
+    spec().$container.find('tbody tr:eq(1) td:eq(0)').simulate('mouseover').simulate('mouseup');
 
     expect(getDataAtCell(1, 0)).toEqual(1);
   });
 
-  it('should work properly when fillHandle option is set to object with property `direction` set to `horizontal`)', function() {
+  it('should work properly when fillHandle option is set to object with property `direction` set to `horizontal`)', () => {
     handsontable({
       data: [
         [1, 2, 3, 4, 5, 6],
@@ -125,19 +125,19 @@ describe('AutoFill', () => {
     });
 
     selectCell(0, 0);
-    this.$container.find('.wtBorder.current.corner').simulate('mousedown');
-    this.$container.find('tbody tr:eq(0) td:eq(1)').simulate('mouseover').simulate('mouseup');
+    spec().$container.find('.wtBorder.current.corner').simulate('mousedown');
+    spec().$container.find('tbody tr:eq(0) td:eq(1)').simulate('mouseover').simulate('mouseup');
 
     expect(getDataAtCell(0, 1)).toEqual(1);
 
     selectCell(0, 0);
-    this.$container.find('.wtBorder.current.corner').simulate('mousedown');
-    this.$container.find('tbody tr:eq(1) td:eq(0)').simulate('mouseover').simulate('mouseup');
+    spec().$container.find('.wtBorder.current.corner').simulate('mousedown');
+    spec().$container.find('tbody tr:eq(1) td:eq(0)').simulate('mouseover').simulate('mouseup');
 
     expect(getDataAtCell(1, 0)).toEqual(7);
   });
 
-  it('should not change cell value (drag when fillHandle is set to `false`)', function() {
+  it('should not change cell value (drag when fillHandle is set to `false`)', () => {
     handsontable({
       data: [
         [1, 2, 3, 4, 5, 6],
@@ -151,21 +151,21 @@ describe('AutoFill', () => {
     // checking drag vertically - should not change cell value
 
     selectCell(0, 0);
-    this.$container.find('.wtBorder.current.corner').simulate('mousedown');
-    this.$container.find('tbody tr:eq(0) td:eq(1)').simulate('mouseover').simulate('mouseup');
+    spec().$container.find('.wtBorder.current.corner').simulate('mousedown');
+    spec().$container.find('tbody tr:eq(0) td:eq(1)').simulate('mouseover').simulate('mouseup');
 
     expect(getDataAtCell(0, 1)).toEqual(2);
 
     // checking drag horizontally - should not change cell value
 
     selectCell(0, 0);
-    this.$container.find('.wtBorder.current.corner').simulate('mousedown');
-    this.$container.find('tbody tr:eq(0) td:eq(1)').simulate('mouseover').simulate('mouseup');
+    spec().$container.find('.wtBorder.current.corner').simulate('mousedown');
+    spec().$container.find('tbody tr:eq(0) td:eq(1)').simulate('mouseover').simulate('mouseup');
 
     expect(getDataAtCell(0, 1)).toEqual(2);
   });
 
-  it('should work properly when using updateSettings', function() {
+  it('should work properly when using updateSettings', () => {
     handsontable({
       data: [
         [1, 2, 3, 4, 5, 6],
@@ -181,8 +181,8 @@ describe('AutoFill', () => {
     // checking drag vertically - should change cell value
 
     selectCell(0, 0);
-    this.$container.find('.wtBorder.current.corner').simulate('mousedown');
-    this.$container.find('tbody tr:eq(0) td:eq(1)').simulate('mouseover').simulate('mouseup');
+    spec().$container.find('.wtBorder.current.corner').simulate('mousedown');
+    spec().$container.find('tbody tr:eq(0) td:eq(1)').simulate('mouseover').simulate('mouseup');
 
     expect(getDataAtCell(0, 1)).toEqual(2);
 
@@ -191,16 +191,16 @@ describe('AutoFill', () => {
     // checking drag vertically - should not change cell value
 
     selectCell(0, 1);
-    this.$container.find('.wtBorder.current.corner').simulate('mousedown');
-    this.$container.find('tbody tr:eq(1) td:eq(1)').simulate('mouseover').simulate('mouseup');
+    spec().$container.find('.wtBorder.current.corner').simulate('mousedown');
+    spec().$container.find('tbody tr:eq(1) td:eq(1)').simulate('mouseover').simulate('mouseup');
 
     expect(getDataAtCell(1, 1)).toEqual(8);
 
     // checking drag horizontally - should not change cell value
 
     selectCell(0, 1);
-    this.$container.find('.wtBorder.current.corner').simulate('mousedown');
-    this.$container.find('tbody tr:eq(0) td:eq(2)').simulate('mouseover').simulate('mouseup');
+    spec().$container.find('.wtBorder.current.corner').simulate('mousedown');
+    spec().$container.find('tbody tr:eq(0) td:eq(2)').simulate('mouseover').simulate('mouseup');
 
     expect(getDataAtCell(0, 2)).toEqual(3);
   });
@@ -273,7 +273,7 @@ describe('AutoFill', () => {
     expect(isFillHandleVisible()).toBe(true);
   });
 
-  it('should add custom value after autofill', function() {
+  it('should add custom value after autofill', () => {
     handsontable({
       data: [
         [1, 2, 3, 4, 5, 6],
@@ -287,18 +287,18 @@ describe('AutoFill', () => {
     });
     selectCell(0, 0);
 
-    this.$container.find('.wtBorder.corner').simulate('mousedown');
-    this.$container.find('tr:eq(1) td:eq(0)').simulate('mouseover');
-    this.$container.find('tr:eq(2) td:eq(0)').simulate('mouseover');
-    this.$container.find('.wtBorder.corner').simulate('mouseup');
+    spec().$container.find('.wtBorder.corner').simulate('mousedown');
+    spec().$container.find('tr:eq(1) td:eq(0)').simulate('mouseover');
+    spec().$container.find('tr:eq(2) td:eq(0)').simulate('mouseover');
+    spec().$container.find('.wtBorder.corner').simulate('mouseup');
 
     expect(getSelected()).toEqual([[0, 0, 2, 0]]);
     expect(getDataAtCell(1, 0)).toEqual('test');
   });
 
-  it('should use correct cell coordinates also when Handsontable is used inside a TABLE (#355)', function() {
+  it('should use correct cell coordinates also when Handsontable is used inside a TABLE (#355)', () => {
     var $table = $('<table><tr><td></td></tr></table>').appendTo('body');
-    this.$container.appendTo($table.find('td'));
+    spec().$container.appendTo($table.find('td'));
 
     handsontable({
       data: [
@@ -313,17 +313,17 @@ describe('AutoFill', () => {
     });
     selectCell(1, 1);
 
-    this.$container.find('.wtBorder.current.corner').simulate('mousedown');
-    this.$container.find('tr:eq(1) td:eq(0)').simulate('mouseover');
-    this.$container.find('tr:eq(2) td:eq(0)').simulate('mouseover');
-    this.$container.find('tr:eq(2) td:eq(0)').simulate('mouseup');
+    spec().$container.find('.wtBorder.current.corner').simulate('mousedown');
+    spec().$container.find('tr:eq(1) td:eq(0)').simulate('mouseover');
+    spec().$container.find('tr:eq(2) td:eq(0)').simulate('mouseover');
+    spec().$container.find('tr:eq(2) td:eq(0)').simulate('mouseup');
 
     expect(getSelected()).toEqual([[1, 1, 2, 1]]);
     expect(getDataAtCell(2, 1)).toEqual('test');
 
     document.body.removeChild($table[0]);
   });
-  it('should fill cells below until the end of content in the neighbouring column with current cell\'s data', function() {
+  it('should fill cells below until the end of content in the neighbouring column with current cell\'s data', () => {
     handsontable({
       data: [
         [1, 2, 3, 4, 5, 6],
@@ -334,7 +334,7 @@ describe('AutoFill', () => {
     });
 
     selectCell(1, 3);
-    var fillHandle = this.$container.find('.wtBorder.current.corner')[0];
+    var fillHandle = spec().$container.find('.wtBorder.current.corner')[0];
     mouseDoubleClick(fillHandle);
 
     expect(getDataAtCell(2, 3)).toEqual(null);
@@ -348,7 +348,7 @@ describe('AutoFill', () => {
 
   });
 
-  it('should fill cells below until the end of content in the neighbouring column with the currently selected area\'s data', function() {
+  it('should fill cells below until the end of content in the neighbouring column with the currently selected area\'s data', () => {
     handsontable({
       data: [
         [1, 2, 3, 4, 5, 6],
@@ -359,7 +359,7 @@ describe('AutoFill', () => {
     });
 
     selectCell(1, 3, 1, 4);
-    var fillHandle = this.$container.find('.wtBorder.area.corner')[0];
+    var fillHandle = spec().$container.find('.wtBorder.area.corner')[0];
     mouseDoubleClick(fillHandle);
 
     expect(getDataAtCell(2, 3)).toEqual(null);
@@ -377,7 +377,7 @@ describe('AutoFill', () => {
 
   });
 
-  it('should add new row after dragging the handle to the last table row', function(done) {
+  it('should add new row after dragging the handle to the last table row', async () => {
     var hot = handsontable({
       data: [
         [1, 2, 'test', 4, 5, 6],
@@ -390,24 +390,21 @@ describe('AutoFill', () => {
 
     selectCell(0, 2);
 
-    this.$container.find('.wtBorder.current.corner').simulate('mousedown');
-    this.$container.find('tr:last-child td:eq(2)').simulate('mouseover');
+    spec().$container.find('.wtBorder.current.corner').simulate('mousedown');
+    spec().$container.find('tr:last-child td:eq(2)').simulate('mouseover');
 
     expect(hot.countRows()).toBe(4);
 
-    setTimeout(() => {
-      expect(hot.countRows()).toBe(5);
+    await sleep(300);
+    expect(hot.countRows()).toBe(5);
 
-      spec().$container.find('tr:last-child td:eq(2)').simulate('mouseover');
-    }, 300);
+    spec().$container.find('tr:last-child td:eq(2)').simulate('mouseover');
 
-    setTimeout(() => {
-      expect(hot.countRows()).toBe(6);
-      done();
-    }, 600);
+    await sleep(300);
+    expect(hot.countRows()).toBe(6);
   });
 
-  it('should add new row after dragging the handle to the last table row (autoInsertRow as true)', function(done) {
+  it('should add new row after dragging the handle to the last table row (autoInsertRow as true)', async () => {
     var hot = handsontable({
       data: [
         [1, 2, 'test', 4, 5, 6],
@@ -422,24 +419,21 @@ describe('AutoFill', () => {
 
     selectCell(0, 2);
 
-    this.$container.find('.wtBorder.current.corner').simulate('mousedown');
-    this.$container.find('tr:last-child td:eq(2)').simulate('mouseover');
+    spec().$container.find('.wtBorder.current.corner').simulate('mousedown');
+    spec().$container.find('tr:last-child td:eq(2)').simulate('mouseover');
 
     expect(hot.countRows()).toBe(4);
 
-    setTimeout(() => {
-      expect(hot.countRows()).toBe(5);
+    await sleep(300);
+    expect(hot.countRows()).toBe(5);
 
-      spec().$container.find('tr:last-child td:eq(2)').simulate('mouseover');
-    }, 300);
+    spec().$container.find('tr:last-child td:eq(2)').simulate('mouseover');
 
-    setTimeout(() => {
-      expect(hot.countRows()).toBe(6);
-      done();
-    }, 600);
+    await sleep(300);
+    expect(hot.countRows()).toBe(6);
   });
 
-  it('should add new row after dragging the handle to the last table row (autoInsertRow as true, vertical)', function(done) {
+  it('should add new row after dragging the handle to the last table row (autoInsertRow as true, vertical)', async () => {
     var hot = handsontable({
       data: [
         [1, 2, 'test', 4, 5, 6],
@@ -455,24 +449,21 @@ describe('AutoFill', () => {
 
     selectCell(0, 2);
 
-    this.$container.find('.wtBorder.current.corner').simulate('mousedown');
-    this.$container.find('tr:last-child td:eq(2)').simulate('mouseover');
+    spec().$container.find('.wtBorder.current.corner').simulate('mousedown');
+    spec().$container.find('tr:last-child td:eq(2)').simulate('mouseover');
 
     expect(hot.countRows()).toBe(4);
 
-    setTimeout(() => {
-      expect(hot.countRows()).toBe(5);
+    await sleep(300);
+    expect(hot.countRows()).toBe(5);
 
-      spec().$container.find('tr:last-child td:eq(2)').simulate('mouseover');
-    }, 300);
+    spec().$container.find('tr:last-child td:eq(2)').simulate('mouseover');
 
-    setTimeout(() => {
-      expect(hot.countRows()).toBe(6);
-      done();
-    }, 600);
+    await sleep(300);
+    expect(hot.countRows()).toBe(6);
   });
 
-  it('should not add new row after dragging the handle to the last table row (autoInsertRow as true, horizontal)', function(done) {
+  it('should not add new row after dragging the handle to the last table row (autoInsertRow as true, horizontal)', async () => {
     var hot = handsontable({
       data: [
         [1, 2, 'test', 4, 5, 6],
@@ -488,24 +479,23 @@ describe('AutoFill', () => {
 
     selectCell(0, 2);
 
-    this.$container.find('.wtBorder.current.corner').simulate('mousedown');
-    this.$container.find('tr:last-child td:eq(2)').simulate('mouseover');
+    spec().$container.find('.wtBorder.current.corner').simulate('mousedown');
+    spec().$container.find('tr:last-child td:eq(2)').simulate('mouseover');
 
     expect(hot.countRows()).toBe(4);
 
-    setTimeout(() => {
-      expect(hot.countRows()).toBe(4);
+    await sleep(300);
 
-      spec().$container.find('tr:last-child td:eq(2)').simulate('mouseover');
-    }, 300);
+    expect(hot.countRows()).toBe(4);
 
-    setTimeout(() => {
-      expect(hot.countRows()).toBe(4);
-      done();
-    }, 600);
+    spec().$container.find('tr:last-child td:eq(2)').simulate('mouseover');
+
+    await sleep(300);
+
+    expect(hot.countRows()).toBe(4);
   });
 
-  it('should not add new row after dragging the handle below the viewport when `autoInsertRow` is disabled', function(done) {
+  it('should not add new row after dragging the handle below the viewport when `autoInsertRow` is disabled', async () => {
     var hot = handsontable({
       data: [
         [1, 2, 'test', 4, 5, 6],
@@ -520,9 +510,9 @@ describe('AutoFill', () => {
 
     selectCell(0, 2);
 
-    this.$container.find('.wtBorder.current.corner').simulate('mousedown');
+    spec().$container.find('.wtBorder.current.corner').simulate('mousedown');
     var ev = {};
-    var $lastRow = this.$container.find('tr:last-child td:eq(2)');
+    var $lastRow = spec().$container.find('tr:last-child td:eq(2)');
 
     expect(hot.countRows()).toBe(4);
 
@@ -531,20 +521,19 @@ describe('AutoFill', () => {
 
     $(document.documentElement).simulate('mousemove', ev);
 
-    setTimeout(() => {
-      expect(hot.countRows()).toBe(4);
+    await sleep(300);
 
-      ev.clientY = $lastRow.offset().top + 150;
-      $(document.documentElement).simulate('mousemove', ev);
-    }, 300);
+    expect(hot.countRows()).toBe(4);
 
-    setTimeout(() => {
-      expect(hot.countRows()).toBe(4);
-      done();
-    }, 600);
+    ev.clientY = $lastRow.offset().top + 150;
+    $(document.documentElement).simulate('mousemove', ev);
+
+    await sleep(300);
+
+    expect(hot.countRows()).toBe(4);
   });
 
-  it('should not add new rows if the current number of rows reaches the maxRows setting', function(done) {
+  it('should not add new rows if the current number of rows reaches the maxRows setting', async () => {
     var hot = handsontable({
       data: [
         [1, 2, 'test', 4, 5, 6],
@@ -560,24 +549,23 @@ describe('AutoFill', () => {
 
     selectCell(0, 2);
 
-    this.$container.find('.wtBorder.current.corner').simulate('mousedown');
-    this.$container.find('tr:last-child td:eq(2)').simulate('mouseover');
+    spec().$container.find('.wtBorder.current.corner').simulate('mousedown');
+    spec().$container.find('tr:last-child td:eq(2)').simulate('mouseover');
 
     expect(hot.countRows()).toBe(4);
 
-    setTimeout(() => {
-      expect(hot.countRows()).toBe(5);
+    await sleep(200);
 
-      spec().$container.find('tr:last-child td:eq(2)').simulate('mouseover');
-    }, 200);
+    expect(hot.countRows()).toBe(5);
 
-    setTimeout(() => {
-      expect(hot.countRows()).toBe(5);
-      done();
-    }, 400);
+    spec().$container.find('tr:last-child td:eq(2)').simulate('mouseover');
+
+    await sleep(200);
+
+    expect(hot.countRows()).toBe(5);
   });
 
-  it('should add new row after dragging the handle below the viewport', function(done) {
+  it('should add new row after dragging the handle below the viewport', async () => {
     var hot = handsontable({
       data: [
         [1, 2, 'test', 4, 5, 6],
@@ -592,9 +580,9 @@ describe('AutoFill', () => {
 
     selectCell(0, 2);
 
-    this.$container.find('.wtBorder.current.corner').simulate('mousedown');
+    spec().$container.find('.wtBorder.current.corner').simulate('mousedown');
     var ev = {};
-    var $lastRow = this.$container.find('tr:last-child td:eq(2)');
+    var $lastRow = spec().$container.find('tr:last-child td:eq(2)');
 
     expect(hot.countRows()).toBe(4);
 
@@ -603,20 +591,19 @@ describe('AutoFill', () => {
 
     $(document.documentElement).simulate('mousemove', ev);
 
-    setTimeout(() => {
-      expect(hot.countRows()).toBe(5);
+    await sleep(300);
 
-      ev.clientY = $lastRow.offset().top + 150;
-      $(document.documentElement).simulate('mousemove', ev);
-    }, 300);
+    expect(hot.countRows()).toBe(5);
 
-    setTimeout(() => {
-      expect(hot.countRows()).toBe(6);
-      done();
-    }, 600);
+    ev.clientY = $lastRow.offset().top + 150;
+    $(document.documentElement).simulate('mousemove', ev);
+
+    await sleep(300);
+
+    expect(hot.countRows()).toBe(6);
   });
 
-  it('should fill cells when dragging the handle to the headers', function() {
+  it('should fill cells when dragging the handle to the headers', () => {
     handsontable({
       data: [
         [1, 2, 3, 4, 5, 6],
@@ -632,12 +619,12 @@ describe('AutoFill', () => {
 
     selectCell(2, 2);
 
-    this.$container.find('.wtBorder.current.corner').simulate('mousedown');
+    spec().$container.find('.wtBorder.current.corner').simulate('mousedown');
 
     var errors = 0;
 
     try {
-      this.$container.find('thead tr:first-child th:eq(2)').simulate('mouseover').simulate('mouseup');
+      spec().$container.find('thead tr:first-child th:eq(2)').simulate('mouseover').simulate('mouseup');
     } catch (err) {
       errors++;
     }
@@ -651,12 +638,12 @@ describe('AutoFill', () => {
     // row headers:
     selectCell(2, 2);
 
-    this.$container.find('.wtBorder.current.corner').simulate('mousedown');
+    spec().$container.find('.wtBorder.current.corner').simulate('mousedown');
 
     errors = 0;
 
     try {
-      this.$container.find('tbody tr:nth(2) th:first-child').simulate('mouseover').simulate('mouseup');
+      spec().$container.find('tbody tr:nth(2) th:first-child').simulate('mouseover').simulate('mouseup');
     } catch (err) {
       errors++;
     }
@@ -667,7 +654,7 @@ describe('AutoFill', () => {
     expect($('.fill').filter(function() { return $(this).css('display') !== 'none'; }).length).toEqual(0); // check if fill selection is refreshed
   });
 
-  it('should not add a new row if dragging from the last row upwards or sideways', function(done) {
+  it('should not add a new row if dragging from the last row upwards or sideways', async () => {
     var mouseOverSpy = jasmine.createSpy('mouseOverSpy');
     var hot = handsontable({
       data: [
@@ -681,32 +668,30 @@ describe('AutoFill', () => {
 
     selectCell(3, 2);
 
-    this.$container.find('.wtBorder.current.corner').simulate('mousedown');
-    this.$container.find('tr:nth-child(3) td:eq(2)').simulate('mouseover');
+    spec().$container.find('.wtBorder.current.corner').simulate('mousedown');
+    spec().$container.find('tr:nth-child(3) td:eq(2)').simulate('mouseover');
 
-    setTimeout(() => {
-      expect(hot.countRows()).toBe(4);
+    await sleep(300);
+    expect(hot.countRows()).toBe(4);
 
-      selectCell(3, 2);
-      spec().$container.find('.wtBorder.current.corner').simulate('mousedown');
-      spec().$container.find('tr:nth-child(4) td:eq(3)').simulate('mouseover');
-    }, 300);
+    selectCell(3, 2);
+    spec().$container.find('.wtBorder.current.corner').simulate('mousedown');
+    spec().$container.find('tr:nth-child(4) td:eq(3)').simulate('mouseover');
 
-    setTimeout(() => {
-      expect(hot.countRows()).toBe(4);
+    await sleep(200);
 
-      selectCell(3, 2);
-      spec().$container.find('.wtBorder.current.corner').simulate('mousedown');
-      spec().$container.find('tr:nth-child(4) td:eq(1)').simulate('mouseover');
-    }, 500);
+    expect(hot.countRows()).toBe(4);
 
-    setTimeout(() => {
-      expect(hot.countRows()).toBe(4);
-      done();
-    }, 700);
+    selectCell(3, 2);
+    spec().$container.find('.wtBorder.current.corner').simulate('mousedown');
+    spec().$container.find('tr:nth-child(4) td:eq(1)').simulate('mouseover');
+
+    await sleep(200);
+
+    expect(hot.countRows()).toBe(4);
   });
 
-  it('should add new row after dragging the handle below the viewport', function(done) {
+  it('should add new row after dragging the handle below the viewport', async () => {
     var hot = handsontable({
       data: [
         [1, 2, 'test', 4, 5, 6],
@@ -721,9 +706,9 @@ describe('AutoFill', () => {
 
     selectCell(0, 2);
 
-    this.$container.find('.wtBorder.current.corner').simulate('mousedown');
+    spec().$container.find('.wtBorder.current.corner').simulate('mousedown');
     var ev = {};
-    var $lastRow = this.$container.find('tr:last-child td:eq(2)');
+    var $lastRow = spec().$container.find('tr:last-child td:eq(2)');
 
     expect(hot.countRows()).toBe(4);
 
@@ -732,20 +717,19 @@ describe('AutoFill', () => {
 
     $(document.documentElement).simulate('mousemove', ev);
 
-    setTimeout(() => {
-      expect(hot.countRows()).toBe(5);
+    await sleep(300);
 
-      ev.clientY = $lastRow.offset().top + 150;
-      $(document.documentElement).simulate('mousemove', ev);
-    }, 300);
+    expect(hot.countRows()).toBe(5);
 
-    setTimeout(() => {
-      expect(hot.countRows()).toBe(6);
-      done();
-    }, 600);
+    ev.clientY = $lastRow.offset().top + 150;
+    $(document.documentElement).simulate('mousemove', ev);
+
+    await sleep(300);
+
+    expect(hot.countRows()).toBe(6);
   });
 
-  it('should not add new row after dragging the handle below the viewport (direction is set to horizontal)', function(done) {
+  it('should not add new row after dragging the handle below the viewport (direction is set to horizontal)', async () => {
     var hot = handsontable({
       data: [
         [1, 2, 'test', 4, 5, 6],
@@ -761,9 +745,9 @@ describe('AutoFill', () => {
 
     selectCell(0, 2);
 
-    this.$container.find('.wtBorder.current.corner').simulate('mousedown');
+    spec().$container.find('.wtBorder.current.corner').simulate('mousedown');
     var ev = {};
-    var $lastRow = this.$container.find('tr:last-child td:eq(2)');
+    var $lastRow = spec().$container.find('tr:last-child td:eq(2)');
 
     expect(hot.countRows()).toBe(4);
 
@@ -772,13 +756,12 @@ describe('AutoFill', () => {
 
     $(document.documentElement).simulate('mousemove', ev);
 
-    setTimeout(() => {
-      expect(hot.countRows()).toBe(4);
-      done();
-    }, 300);
+    await sleep(300);
+
+    expect(hot.countRows()).toBe(4);
   });
 
-  it('should populate the filled data in the correct order, when dragging the fill handle upwards', function() {
+  it('should populate the filled data in the correct order, when dragging the fill handle upwards', () => {
     handsontable({
       data: [
         [null, null, null, null],
@@ -795,13 +778,13 @@ describe('AutoFill', () => {
     expect(JSON.stringify(getData(0, 1, 3, 2))).toEqual(JSON.stringify([[null, null], [null, null], [null, null], [null, null]]));
 
     selectCell(4, 1, 6, 2);
-    this.$container.find('.wtBorder.area.corner').simulate('mousedown');
+    spec().$container.find('.wtBorder.area.corner').simulate('mousedown');
     $(getCell(0, 2, true)).simulate('mouseover').simulate('mouseup');
 
     expect(JSON.stringify(getData(0, 1, 3, 2))).toEqual(JSON.stringify([[0, 5], [2, 3], [1, 4], [0, 5]]));
   });
 
-  it('should populate the filled data in the correct order, when dragging the fill handle towards left', function() {
+  it('should populate the filled data in the correct order, when dragging the fill handle towards left', () => {
     handsontable({
       data: [
         [null, null, null, null, null, null, null, null],
@@ -814,7 +797,7 @@ describe('AutoFill', () => {
     expect(JSON.stringify(getData(1, 1, 2, 4))).toEqual(JSON.stringify([[null, null, null, null], [null, null, null, null]]));
 
     selectCell(1, 5, 2, 7);
-    this.$container.find('.wtBorder.area.corner').simulate('mousedown');
+    spec().$container.find('.wtBorder.area.corner').simulate('mousedown');
     $(getCell(2, 1, true)).simulate('mouseover').simulate('mouseup');
 
     expect(JSON.stringify(getData(1, 1, 2, 4))).toEqual(JSON.stringify([[2, 0, 1, 2], [5, 3, 4, 5]]));

--- a/src/plugins/columnSorting/test/columnSorting.e2e.js
+++ b/src/plugins/columnSorting/test/columnSorting.e2e.js
@@ -63,7 +63,7 @@ describe('ColumnSorting', () => {
     expect(htCore.find('tbody tr:eq(0) td:eq(3)').text()).toEqual('5');
   });
 
-  it('should display sortIndicator properly after changing column order', function() {
+  it('should display sortIndicator properly after changing column order', () => {
     const modifyCol = (column) => {
       if (column === 0) {
         return 1;
@@ -92,7 +92,7 @@ describe('ColumnSorting', () => {
     // changing column order: 0 <-> 1
     updateSettings({modifyCol});
 
-    const sortedColumn = this.$container.find('th span.columnSorting')[1];
+    const sortedColumn = spec().$container.find('th span.columnSorting')[1];
     const afterValue = window.getComputedStyle(sortedColumn, ':after').getPropertyValue('content');
 
     expect(afterValue.indexOf(blackUpPointingTriangle)).toBeGreaterThan(-1);
@@ -193,7 +193,7 @@ describe('ColumnSorting', () => {
     this.sortByClickOnColumnHeader(0);
     this.sortByClickOnColumnHeader(0);
 
-    expect(this.$container.find('tr td').first().html()).toEqual('10');
+    expect(spec().$container.find('tr td').first().html()).toEqual('10');
   });
 
   it('should remove specified row from sorted table and NOT sort the table again', function() {
@@ -1037,20 +1037,20 @@ describe('ColumnSorting', () => {
       removeRowPlugin: true // this plugin ads an extra row header, so now we have 2 instead of 1
     });
 
-    expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('1');
+    expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('1');
 
     this.sortByClickOnColumnHeader(0); // sort by first column
 
-    expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('0');
+    expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('0');
 
-    expect(this.$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('D');
+    expect(spec().$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('D');
 
     this.sortByClickOnColumnHeader(1); // sort by second column
 
-    expect(this.$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('A');
+    expect(spec().$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('A');
   });
 
-  it('should allow to define sorting column and order during initialization', function() {
+  it('should allow to define sorting column and order during initialization', () => {
     handsontable({
       data: [
         [1, 'B'],
@@ -1065,11 +1065,11 @@ describe('ColumnSorting', () => {
       }
     });
 
-    expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('0');
-    expect(this.$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('D');
+    expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('0');
+    expect(spec().$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('D');
   });
 
-  it('should allow to change sorting column with updateSettings', function() {
+  it('should allow to change sorting column with updateSettings', () => {
     handsontable({
       data: [
         [1, 'B'],
@@ -1084,8 +1084,8 @@ describe('ColumnSorting', () => {
       }
     });
 
-    expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('0');
-    expect(this.$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('D');
+    expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('0');
+    expect(spec().$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('D');
 
     updateSettings({
       columnSorting: {
@@ -1094,11 +1094,11 @@ describe('ColumnSorting', () => {
       }
     });
 
-    expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('3');
-    expect(this.$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('A');
+    expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('3');
+    expect(spec().$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('A');
   });
 
-  it('should allow to change sorting order with updateSettings', function() {
+  it('should allow to change sorting order with updateSettings', () => {
     handsontable({
       data: [
         [1, 'B'],
@@ -1113,7 +1113,7 @@ describe('ColumnSorting', () => {
       }
     });
 
-    expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('0');
+    expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('0');
 
     updateSettings({
       columnSorting: {
@@ -1122,7 +1122,7 @@ describe('ColumnSorting', () => {
       }
     });
 
-    expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('3');
+    expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('3');
   });
 
   it('should allow to change if sorting empty cells with updateSettings', () => {
@@ -1232,7 +1232,7 @@ describe('ColumnSorting', () => {
     ]);
   });
 
-  it('should reset column sorting with updateSettings', function() {
+  it('should reset column sorting with updateSettings', () => {
     handsontable({
       data: [
         [1, 'B'],
@@ -1247,16 +1247,16 @@ describe('ColumnSorting', () => {
       }
     });
 
-    expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('0');
+    expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('0');
 
     updateSettings({
       columnSorting: void 0
     });
 
-    expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('1');
+    expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('1');
   });
 
-  it('should sort table using plugin API method', function() {
+  it('should sort table using plugin API method', () => {
     handsontable({
       data: [
         [1, 'B'],
@@ -1267,20 +1267,20 @@ describe('ColumnSorting', () => {
       columnSorting: true
     });
 
-    expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('1');
-    expect(this.$container.find('tbody tr:eq(1) td:eq(0)').text()).toEqual('0');
-    expect(this.$container.find('tbody tr:eq(2) td:eq(0)').text()).toEqual('3');
-    expect(this.$container.find('tbody tr:eq(3) td:eq(0)').text()).toEqual('2');
+    expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('1');
+    expect(spec().$container.find('tbody tr:eq(1) td:eq(0)').text()).toEqual('0');
+    expect(spec().$container.find('tbody tr:eq(2) td:eq(0)').text()).toEqual('3');
+    expect(spec().$container.find('tbody tr:eq(3) td:eq(0)').text()).toEqual('2');
 
     getPlugin('columnSorting').sort(0, 'asc');
 
-    expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('0');
-    expect(this.$container.find('tbody tr:eq(1) td:eq(0)').text()).toEqual('1');
-    expect(this.$container.find('tbody tr:eq(2) td:eq(0)').text()).toEqual('2');
-    expect(this.$container.find('tbody tr:eq(3) td:eq(0)').text()).toEqual('3');
+    expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('0');
+    expect(spec().$container.find('tbody tr:eq(1) td:eq(0)').text()).toEqual('1');
+    expect(spec().$container.find('tbody tr:eq(2) td:eq(0)').text()).toEqual('2');
+    expect(spec().$container.find('tbody tr:eq(3) td:eq(0)').text()).toEqual('3');
   });
 
-  it('should reset column sorting with updateSettings', function() {
+  it('should reset column sorting with updateSettings', () => {
     handsontable({
       data: [
         [1, 'B'],
@@ -1295,13 +1295,13 @@ describe('ColumnSorting', () => {
       }
     });
 
-    expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('0');
+    expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('0');
 
     updateSettings({
       columnSorting: void 0
     });
 
-    expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('1');
+    expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('1');
   });
 
   it('should fire beforeColumnSort event before sorting data', function() {
@@ -1316,10 +1316,10 @@ describe('ColumnSorting', () => {
     });
 
     this.beforeColumnSortHandler = function() {
-      expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('2');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('4');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('3');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('2');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('4');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('3');
     };
 
     spyOn(this, 'beforeColumnSortHandler');
@@ -1606,7 +1606,7 @@ describe('ColumnSorting', () => {
     }, 2000); // 2s delayed needs for safari env
   });
 
-  it('should apply sorting when there are two tables and only one has sorting enabled and has been already sorted (#1020)', function() {
+  it('should apply sorting when there are two tables and only one has sorting enabled and has been already sorted (#1020)', () => {
     handsontable({
       data: [
         [1, 'B'],
@@ -1619,19 +1619,19 @@ describe('ColumnSorting', () => {
       }
     });
 
-    this.$container2 = $(`<div id="${id}-2"></div>`).appendTo('body');
-    this.$container2.handsontable();
-    this.$container2.handsontable('getInstance');
+    spec().$container2 = $(`<div id="${id}-2"></div>`).appendTo('body');
+    spec().$container2.handsontable();
+    spec().$container2.handsontable('getInstance');
 
     selectCell(0, 1);
     keyDown('enter');
     expect($('.handsontableInput').val()).toEqual('A');
 
-    this.$container2.handsontable('destroy');
-    this.$container2.remove();
+    spec().$container2.handsontable('destroy');
+    spec().$container2.remove();
   });
 
-  it('should reset sorting after loading new data', function() {
+  it('should reset sorting after loading new data', () => {
     handsontable({
       data: [
         [1, 'B'],
@@ -1642,17 +1642,17 @@ describe('ColumnSorting', () => {
       columnSorting: true
     });
 
-    expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('1');
-    expect(this.$container.find('tbody tr:eq(1) td:eq(0)').text()).toEqual('0');
-    expect(this.$container.find('tbody tr:eq(2) td:eq(0)').text()).toEqual('3');
-    expect(this.$container.find('tbody tr:eq(3) td:eq(0)').text()).toEqual('2');
+    expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('1');
+    expect(spec().$container.find('tbody tr:eq(1) td:eq(0)').text()).toEqual('0');
+    expect(spec().$container.find('tbody tr:eq(2) td:eq(0)').text()).toEqual('3');
+    expect(spec().$container.find('tbody tr:eq(3) td:eq(0)').text()).toEqual('2');
 
     getPlugin('columnSorting').sort(0, 'asc');
 
-    expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('0');
-    expect(this.$container.find('tbody tr:eq(1) td:eq(0)').text()).toEqual('1');
-    expect(this.$container.find('tbody tr:eq(2) td:eq(0)').text()).toEqual('2');
-    expect(this.$container.find('tbody tr:eq(3) td:eq(0)').text()).toEqual('3');
+    expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('0');
+    expect(spec().$container.find('tbody tr:eq(1) td:eq(0)').text()).toEqual('1');
+    expect(spec().$container.find('tbody tr:eq(2) td:eq(0)').text()).toEqual('2');
+    expect(spec().$container.find('tbody tr:eq(3) td:eq(0)').text()).toEqual('3');
 
     loadData([
       [50, 'E'],
@@ -1663,16 +1663,16 @@ describe('ColumnSorting', () => {
       [20, 'H']
     ]);
 
-    expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('50');
-    expect(this.$container.find('tbody tr:eq(1) td:eq(0)').text()).toEqual('10');
-    expect(this.$container.find('tbody tr:eq(2) td:eq(0)').text()).toEqual('30');
-    expect(this.$container.find('tbody tr:eq(3) td:eq(0)').text()).toEqual('60');
-    expect(this.$container.find('tbody tr:eq(4) td:eq(0)').text()).toEqual('40');
-    expect(this.$container.find('tbody tr:eq(5) td:eq(0)').text()).toEqual('20');
+    expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('50');
+    expect(spec().$container.find('tbody tr:eq(1) td:eq(0)').text()).toEqual('10');
+    expect(spec().$container.find('tbody tr:eq(2) td:eq(0)').text()).toEqual('30');
+    expect(spec().$container.find('tbody tr:eq(3) td:eq(0)').text()).toEqual('60');
+    expect(spec().$container.find('tbody tr:eq(4) td:eq(0)').text()).toEqual('40');
+    expect(spec().$container.find('tbody tr:eq(5) td:eq(0)').text()).toEqual('20');
 
   });
 
-  it('should reset sorting after loading new data (default sorting column and order set)', function() {
+  it('should reset sorting after loading new data (default sorting column and order set)', () => {
     handsontable({
       data: [
         [1, 'B'],
@@ -1686,22 +1686,22 @@ describe('ColumnSorting', () => {
       }
     });
 
-    expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('3');
-    expect(this.$container.find('tbody tr:eq(1) td:eq(0)').text()).toEqual('1');
-    expect(this.$container.find('tbody tr:eq(2) td:eq(0)').text()).toEqual('2');
-    expect(this.$container.find('tbody tr:eq(3) td:eq(0)').text()).toEqual('0');
+    expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('3');
+    expect(spec().$container.find('tbody tr:eq(1) td:eq(0)').text()).toEqual('1');
+    expect(spec().$container.find('tbody tr:eq(2) td:eq(0)').text()).toEqual('2');
+    expect(spec().$container.find('tbody tr:eq(3) td:eq(0)').text()).toEqual('0');
 
-    expect(this.$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('A');
-    expect(this.$container.find('tbody tr:eq(1) td:eq(1)').text()).toEqual('B');
-    expect(this.$container.find('tbody tr:eq(2) td:eq(1)').text()).toEqual('C');
-    expect(this.$container.find('tbody tr:eq(3) td:eq(1)').text()).toEqual('D');
+    expect(spec().$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('A');
+    expect(spec().$container.find('tbody tr:eq(1) td:eq(1)').text()).toEqual('B');
+    expect(spec().$container.find('tbody tr:eq(2) td:eq(1)').text()).toEqual('C');
+    expect(spec().$container.find('tbody tr:eq(3) td:eq(1)').text()).toEqual('D');
 
     getPlugin('columnSorting').sort(0, 'asc');
 
-    expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('0');
-    expect(this.$container.find('tbody tr:eq(1) td:eq(0)').text()).toEqual('1');
-    expect(this.$container.find('tbody tr:eq(2) td:eq(0)').text()).toEqual('2');
-    expect(this.$container.find('tbody tr:eq(3) td:eq(0)').text()).toEqual('3');
+    expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('0');
+    expect(spec().$container.find('tbody tr:eq(1) td:eq(0)').text()).toEqual('1');
+    expect(spec().$container.find('tbody tr:eq(2) td:eq(0)').text()).toEqual('2');
+    expect(spec().$container.find('tbody tr:eq(3) td:eq(0)').text()).toEqual('3');
 
     loadData([
       [50, 'E'],
@@ -1712,19 +1712,19 @@ describe('ColumnSorting', () => {
       [20, 'H']
     ]);
 
-    expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('50');
-    expect(this.$container.find('tbody tr:eq(1) td:eq(0)').text()).toEqual('30');
-    expect(this.$container.find('tbody tr:eq(2) td:eq(0)').text()).toEqual('10');
-    expect(this.$container.find('tbody tr:eq(3) td:eq(0)').text()).toEqual('20');
-    expect(this.$container.find('tbody tr:eq(4) td:eq(0)').text()).toEqual('60');
-    expect(this.$container.find('tbody tr:eq(5) td:eq(0)').text()).toEqual('40');
+    expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('50');
+    expect(spec().$container.find('tbody tr:eq(1) td:eq(0)').text()).toEqual('30');
+    expect(spec().$container.find('tbody tr:eq(2) td:eq(0)').text()).toEqual('10');
+    expect(spec().$container.find('tbody tr:eq(3) td:eq(0)').text()).toEqual('20');
+    expect(spec().$container.find('tbody tr:eq(4) td:eq(0)').text()).toEqual('60');
+    expect(spec().$container.find('tbody tr:eq(5) td:eq(0)').text()).toEqual('40');
 
-    expect(this.$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('E');
-    expect(this.$container.find('tbody tr:eq(1) td:eq(1)').text()).toEqual('F');
-    expect(this.$container.find('tbody tr:eq(2) td:eq(1)').text()).toEqual('G');
-    expect(this.$container.find('tbody tr:eq(3) td:eq(1)').text()).toEqual('H');
-    expect(this.$container.find('tbody tr:eq(4) td:eq(1)').text()).toEqual('I');
-    expect(this.$container.find('tbody tr:eq(5) td:eq(1)').text()).toEqual('J');
+    expect(spec().$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('E');
+    expect(spec().$container.find('tbody tr:eq(1) td:eq(1)').text()).toEqual('F');
+    expect(spec().$container.find('tbody tr:eq(2) td:eq(1)').text()).toEqual('G');
+    expect(spec().$container.find('tbody tr:eq(3) td:eq(1)').text()).toEqual('H');
+    expect(spec().$container.find('tbody tr:eq(4) td:eq(1)').text()).toEqual('I');
+    expect(spec().$container.find('tbody tr:eq(5) td:eq(1)').text()).toEqual('J');
 
   });
 
@@ -1941,7 +1941,7 @@ describe('ColumnSorting', () => {
 
     this.sortByClickOnColumnHeader(1);
 
-    let sortedColumn = this.$container.find('th span.columnSorting')[1];
+    let sortedColumn = spec().$container.find('th span.columnSorting')[1];
     let afterValue = window.getComputedStyle(sortedColumn, ':after').getPropertyValue('content');
 
     expect(afterValue === '' || afterValue === 'none').toBe(true);
@@ -1957,20 +1957,20 @@ describe('ColumnSorting', () => {
     this.sortByClickOnColumnHeader(1);
 
     // descending (updateSettings doesn't reset sorting stack)
-    sortedColumn = this.$container.find('th span.columnSorting')[1];
+    sortedColumn = spec().$container.find('th span.columnSorting')[1];
     afterValue = window.getComputedStyle(sortedColumn, ':after').getPropertyValue('content');
     expect(afterValue.indexOf(blackDownPointingTriangle)).toBeGreaterThan(-1);
 
     this.sortByClickOnColumnHeader(1);
 
-    sortedColumn = this.$container.find('th span.columnSorting')[1];
+    sortedColumn = spec().$container.find('th span.columnSorting')[1];
     afterValue = window.getComputedStyle(sortedColumn, ':after').getPropertyValue('content');
     expect(afterValue === '' || afterValue === 'none').toBe(true);
 
     this.sortByClickOnColumnHeader(1);
 
     // ascending
-    sortedColumn = this.$container.find('th span.columnSorting')[1];
+    sortedColumn = spec().$container.find('th span.columnSorting')[1];
     afterValue = window.getComputedStyle(sortedColumn, ':after').getPropertyValue('content');
 
     expect(afterValue.indexOf(blackUpPointingTriangle)).toBeGreaterThan(-1);
@@ -1990,25 +1990,25 @@ describe('ColumnSorting', () => {
 
     this.sortByClickOnColumnHeader(0);
 
-    sortedColumn = this.$container.find('th span.columnSorting')[0];
+    sortedColumn = spec().$container.find('th span.columnSorting')[0];
     afterValue = window.getComputedStyle(sortedColumn, ':after').getPropertyValue('content');
     expect(afterValue === '' || afterValue === 'none').toBe(true);
 
     this.sortByClickOnColumnHeader(1);
 
     // descending
-    sortedColumn = this.$container.find('th span.columnSorting')[1];
+    sortedColumn = spec().$container.find('th span.columnSorting')[1];
     afterValue = window.getComputedStyle(sortedColumn, ':after').getPropertyValue('content');
     expect(afterValue === '' || afterValue === 'none').toBe(true);
 
     this.sortByClickOnColumnHeader(2);
 
-    sortedColumn = this.$container.find('th span.columnSorting')[2];
+    sortedColumn = spec().$container.find('th span.columnSorting')[2];
     afterValue = window.getComputedStyle(sortedColumn, ':after').getPropertyValue('content');
     expect(afterValue.indexOf(blackUpPointingTriangle)).toBeGreaterThan(-1);
   });
 
-  it('should change sorting indicator state on every plugin API method call (continuously for the same column)', function() {
+  it('should change sorting indicator state on every plugin API method call (continuously for the same column)', () => {
     handsontable({
       data: [
         [1, 'Ted', 'Right'],
@@ -2025,39 +2025,39 @@ describe('ColumnSorting', () => {
     getPlugin('columnSorting').sort(1);
 
     // ascending
-    let sortedColumn = this.$container.find('th span.columnSorting')[1];
+    let sortedColumn = spec().$container.find('th span.columnSorting')[1];
     let afterValue = window.getComputedStyle(sortedColumn, ':after').getPropertyValue('content');
     expect(afterValue.indexOf(blackUpPointingTriangle)).toBeGreaterThan(-1);
 
     getPlugin('columnSorting').sort(1);
 
     // descending
-    sortedColumn = this.$container.find('th span.columnSorting')[1];
+    sortedColumn = spec().$container.find('th span.columnSorting')[1];
     afterValue = window.getComputedStyle(sortedColumn, ':after').getPropertyValue('content');
     expect(afterValue.indexOf(blackDownPointingTriangle)).toBeGreaterThan(-1);
 
     getPlugin('columnSorting').sort(1);
 
-    sortedColumn = this.$container.find('th span.columnSorting')[1];
+    sortedColumn = spec().$container.find('th span.columnSorting')[1];
     afterValue = window.getComputedStyle(sortedColumn, ':after').getPropertyValue('content');
     expect(afterValue === '' || afterValue === 'none').toBe(true);
 
     getPlugin('columnSorting').sort(1);
 
     // ascending
-    sortedColumn = this.$container.find('th span.columnSorting')[1];
+    sortedColumn = spec().$container.find('th span.columnSorting')[1];
     afterValue = window.getComputedStyle(sortedColumn, ':after').getPropertyValue('content');
     expect(afterValue.indexOf(blackUpPointingTriangle)).toBeGreaterThan(-1);
 
     getPlugin('columnSorting').sort(1);
 
     // descending
-    sortedColumn = this.$container.find('th span.columnSorting')[1];
+    sortedColumn = spec().$container.find('th span.columnSorting')[1];
     afterValue = window.getComputedStyle(sortedColumn, ':after').getPropertyValue('content');
     expect(afterValue.indexOf(blackDownPointingTriangle)).toBeGreaterThan(-1);
   });
 
-  it('should change sorting indicator state on every plugin API method (calling for different columns)', function() {
+  it('should change sorting indicator state on every plugin API method (calling for different columns)', () => {
     handsontable({
       data: [
         [1, 'Ted', 'Right'],
@@ -2074,47 +2074,47 @@ describe('ColumnSorting', () => {
     getPlugin('columnSorting').sort(1);
 
     // ascending
-    let sortedColumn = this.$container.find('th span.columnSorting')[1];
+    let sortedColumn = spec().$container.find('th span.columnSorting')[1];
     let afterValue = window.getComputedStyle(sortedColumn, ':after').getPropertyValue('content');
     expect(afterValue.indexOf(blackUpPointingTriangle)).toBeGreaterThan(-1);
 
     getPlugin('columnSorting').sort(2);
 
     // ascending
-    sortedColumn = this.$container.find('th span.columnSorting')[2];
+    sortedColumn = spec().$container.find('th span.columnSorting')[2];
     afterValue = window.getComputedStyle(sortedColumn, ':after').getPropertyValue('content');
     expect(afterValue.indexOf(blackUpPointingTriangle)).toBeGreaterThan(-1);
 
     getPlugin('columnSorting').sort(1);
 
     // ascending
-    sortedColumn = this.$container.find('th span.columnSorting')[1];
+    sortedColumn = spec().$container.find('th span.columnSorting')[1];
     afterValue = window.getComputedStyle(sortedColumn, ':after').getPropertyValue('content');
     expect(afterValue.indexOf(blackUpPointingTriangle)).toBeGreaterThan(-1);
 
     getPlugin('columnSorting').sort(2, 'desc');
 
     // descending
-    sortedColumn = this.$container.find('th span.columnSorting')[2];
+    sortedColumn = spec().$container.find('th span.columnSorting')[2];
     afterValue = window.getComputedStyle(sortedColumn, ':after').getPropertyValue('content');
     expect(afterValue.indexOf(blackDownPointingTriangle)).toBeGreaterThan(-1);
 
     getPlugin('columnSorting').sort(2, 'desc');
 
     // descending
-    sortedColumn = this.$container.find('th span.columnSorting')[2];
+    sortedColumn = spec().$container.find('th span.columnSorting')[2];
     afterValue = window.getComputedStyle(sortedColumn, ':after').getPropertyValue('content');
     expect(afterValue.indexOf(blackDownPointingTriangle)).toBeGreaterThan(-1);
 
     getPlugin('columnSorting').sort(2, 'asc');
 
     // ascending
-    sortedColumn = this.$container.find('th span.columnSorting')[2];
+    sortedColumn = spec().$container.find('th span.columnSorting')[2];
     afterValue = window.getComputedStyle(sortedColumn, ':after').getPropertyValue('content');
     expect(afterValue.indexOf(blackUpPointingTriangle)).toBeGreaterThan(-1);
   });
 
-  it('should change sorting indicator state when initial column sorting was provided', function() {
+  it('should change sorting indicator state when initial column sorting was provided', () => {
     handsontable({
       data: [
         [1, 'Ted', 'Right'],
@@ -2132,35 +2132,35 @@ describe('ColumnSorting', () => {
     });
 
     // descending
-    let sortedColumn = this.$container.find('th span.columnSorting')[1];
+    let sortedColumn = spec().$container.find('th span.columnSorting')[1];
     let afterValue = window.getComputedStyle(sortedColumn, ':after').getPropertyValue('content');
     expect(afterValue.indexOf(blackDownPointingTriangle)).toBeGreaterThan(-1);
 
     getPlugin('columnSorting').sort(1);
 
     // default
-    sortedColumn = this.$container.find('th span.columnSorting')[1];
+    sortedColumn = spec().$container.find('th span.columnSorting')[1];
     afterValue = window.getComputedStyle(sortedColumn, ':after').getPropertyValue('content');
     expect(afterValue === '' || afterValue === 'none').toBe(true);
 
     getPlugin('columnSorting').sort(1);
 
     // ascending
-    sortedColumn = this.$container.find('th span.columnSorting')[1];
+    sortedColumn = spec().$container.find('th span.columnSorting')[1];
     afterValue = window.getComputedStyle(sortedColumn, ':after').getPropertyValue('content');
     expect(afterValue.indexOf(blackUpPointingTriangle)).toBeGreaterThan(-1);
 
     getPlugin('columnSorting').sort(1);
 
     // descending
-    sortedColumn = this.$container.find('th span.columnSorting')[1];
+    sortedColumn = spec().$container.find('th span.columnSorting')[1];
     afterValue = window.getComputedStyle(sortedColumn, ':after').getPropertyValue('content');
     expect(afterValue.indexOf(blackDownPointingTriangle)).toBeGreaterThan(-1);
 
     getPlugin('columnSorting').sort(1);
 
     // default
-    sortedColumn = this.$container.find('th span.columnSorting')[1];
+    sortedColumn = spec().$container.find('th span.columnSorting')[1];
     afterValue = window.getComputedStyle(sortedColumn, ':after').getPropertyValue('content');
     expect(afterValue === '' || afterValue === 'none').toBe(true);
   });

--- a/src/plugins/comments/test/comments.e2e.js
+++ b/src/plugins/comments/test/comments.e2e.js
@@ -37,7 +37,7 @@ describe('Comments', () => {
     });
   });
 
-  describe('updateSettings', function () {
+  describe('updateSettings', () => {
     it('should change delay, after which comment is showed #4323', (done) => {
       const rows = 10;
       const columns = 10;
@@ -93,7 +93,7 @@ describe('Comments', () => {
     });
   });
 
-  describe('Displaying comment after `mouseover` event', function () {
+  describe('Displaying comment after `mouseover` event', () => {
     it('should display comment after predefined delay when custom `displayDelay` ' +
       'option of `comments` plugin wasn\'t set', (done) => {
       const rows = 10;
@@ -327,7 +327,7 @@ describe('Comments', () => {
     expect(readOnly).toEqual(true);
   });
 
-  it('should not close the comment editor immediately after opening #4323', (done) => {
+  it('should not close the comment editor immediately after opening #4323', async () => {
     const hot = handsontable({
       data: Handsontable.helper.createSpreadsheetData(4, 4),
       contextMenu: true,
@@ -352,10 +352,9 @@ describe('Comments', () => {
 
     const editor = hot.getPlugin('comments').editor.getInputElement();
 
-    setTimeout(function () {
-      expect($(editor).parents('.htComments')[0].style.display).toEqual('block');
-      done();
-    }, 300);
+    await sleep(300);
+
+    expect($(editor).parents('.htComments')[0].style.display).toEqual('block');
   });
 
   describe('Using the Context Menu', () => {

--- a/src/plugins/comments/test/displaySwitch.unit.js
+++ b/src/plugins/comments/test/displaySwitch.unit.js
@@ -168,7 +168,7 @@ describe('Comments', () => {
   });
 
   describe('DisplaySwitch.cancelHiding', () => {
-    it('should not call function after delay', function () {
+    it('should not call function after delay', () => {
       const displaySwitch = new DisplaySwitch(700);
       const onHide = jasmine.createSpy('onHide');
 
@@ -184,7 +184,7 @@ describe('Comments', () => {
       expect(onHide).not.toHaveBeenCalled();
     });
 
-    it('should set timer value to `null`', function () {
+    it('should set timer value to `null`', () => {
       const displaySwitch = new DisplaySwitch(700);
       const onHide = jasmine.createSpy('onHide');
 

--- a/src/plugins/contextMenu/test/contextMenu.e2e.js
+++ b/src/plugins/contextMenu/test/contextMenu.e2e.js
@@ -353,7 +353,7 @@ describe('ContextMenu', () => {
   });
 
   describe('menu closing', () => {
-    it('should close menu after click', function () {
+    it('should close menu after click', () => {
       handsontable({
         contextMenu: true,
         height: 100
@@ -363,7 +363,7 @@ describe('ContextMenu', () => {
 
       expect($('.htContextMenu').is(':visible')).toBe(true);
 
-      mouseDown(this.$container);
+      mouseDown(spec().$container);
 
       expect($('.htContextMenu').is(':visible')).toBe(false);
     });
@@ -1977,7 +1977,7 @@ describe('ContextMenu', () => {
       expect($menu.find('tbody td:eq(4)').hasClass('htDisabled')).toBe(false);
     });
 
-    it('should disable Remove col in context menu when rows are selected by headers', function() {
+    it('should disable Remove col in context menu when rows are selected by headers', () => {
       handsontable({
         contextMenu: ['remove_col', 'remove_row'],
         height: 100,
@@ -1985,7 +1985,7 @@ describe('ContextMenu', () => {
         rowHeaders: true
       });
 
-      const $rowsHeaders = this.$container.find('.ht_clone_left tr th');
+      const $rowsHeaders = spec().$container.find('.ht_clone_left tr th');
 
       $rowsHeaders.eq(1).simulate('mousedown');
       $rowsHeaders.eq(2).simulate('mouseover');

--- a/src/plugins/contextMenu/test/predefinedItems/alignment.e2e.js
+++ b/src/plugins/contextMenu/test/predefinedItems/alignment.e2e.js
@@ -1,4 +1,4 @@
-describe('ContextMenu', function () {
+describe('ContextMenu', () => {
   var id = 'testContainer';
 
   beforeEach(function () {
@@ -12,8 +12,8 @@ describe('ContextMenu', function () {
     }
   });
 
-  describe('alignment', function() {
-    it('should align text left', function (done) {
+  describe('alignment', () => {
+    it('should align text left', async () => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(4, 4),
         contextMenu: true,
@@ -25,18 +25,17 @@ describe('ContextMenu', function () {
       var item = $('.htContextMenu .ht_master .htCore').find('tbody td').not('.htSeparator').eq(9);
       item.simulate('mouseover');
 
-      setTimeout(function () {
-        var contextSubMenu = $(`.htContextMenuSub_${item.text()}`);
-        var button = contextSubMenu.find('.ht_master .htCore tbody td').not('.htSeparator').eq(0);
-        button.simulate('mousedown'); // Text left
+      await sleep(350);
 
-        expect(getCellMeta(0, 0).className).toEqual('htLeft');
-        expect(getCell(0, 0).className).toContain('htLeft');
-        done();
-      }, 350);
+      var contextSubMenu = $(`.htContextMenuSub_${item.text()}`);
+      var button = contextSubMenu.find('.ht_master .htCore tbody td').not('.htSeparator').eq(0);
+      button.simulate('mousedown'); // Text left
+
+      expect(getCellMeta(0, 0).className).toEqual('htLeft');
+      expect(getCell(0, 0).className).toContain('htLeft');
     });
 
-    it('should align text center', function (done) {
+    it('should align text center', async () => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(4, 4),
         contextMenu: true,
@@ -48,18 +47,16 @@ describe('ContextMenu', function () {
       var item = $('.htContextMenu .ht_master .htCore').find('tbody td').not('.htSeparator').eq(9);
       item.simulate('mouseover');
 
-      setTimeout(function () {
-        var contextSubMenu = $(`.htContextMenuSub_${item.text()}`);
-        var button = contextSubMenu.find('.ht_master .htCore tbody td').not('.htSeparator').eq(1);
+      await sleep(350);
+      var contextSubMenu = $(`.htContextMenuSub_${item.text()}`);
+      var button = contextSubMenu.find('.ht_master .htCore tbody td').not('.htSeparator').eq(1);
 
-        button.simulate('mousedown'); // Text center
-        expect(getCellMeta(0, 0).className).toEqual('htCenter');
-        expect(getCell(0, 0).className).toContain('htCenter');
-        done();
-      }, 350);
+      button.simulate('mousedown'); // Text center
+      expect(getCellMeta(0, 0).className).toEqual('htCenter');
+      expect(getCell(0, 0).className).toContain('htCenter');
     });
 
-    it('should align text right', function (done) {
+    it('should align text right', async () => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(4, 4),
         contextMenu: true,
@@ -71,18 +68,16 @@ describe('ContextMenu', function () {
       var item = $('.htContextMenu .ht_master .htCore').find('tbody td').not('.htSeparator').eq(9);
       item.simulate('mouseover');
 
-      setTimeout(function () {
-        var contextSubMenu = $(`.htContextMenuSub_${item.text()}`);
-        var button = contextSubMenu.find('.ht_master .htCore tbody td').not('.htSeparator').eq(2);
+      await sleep(350);
+      var contextSubMenu = $(`.htContextMenuSub_${item.text()}`);
+      var button = contextSubMenu.find('.ht_master .htCore tbody td').not('.htSeparator').eq(2);
 
-        button.simulate('mousedown'); // Text right
-        expect(getCellMeta(0, 0).className).toEqual('htRight');
-        expect(getCell(0, 0).className).toContain('htRight');
-        done();
-      }, 350);
+      button.simulate('mousedown'); // Text right
+      expect(getCellMeta(0, 0).className).toEqual('htRight');
+      expect(getCell(0, 0).className).toContain('htRight');
     });
 
-    it('should justify text', function (done) {
+    it('should justify text', async () => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(4, 4),
         contextMenu: true,
@@ -94,19 +89,18 @@ describe('ContextMenu', function () {
       var item = $('.htContextMenu .ht_master .htCore').find('tbody td').not('.htSeparator').eq(9);
       item.simulate('mouseover');
 
-      setTimeout(function () {
-        var contextSubMenu = $(`.htContextMenuSub_${item.text()}`);
-        var button = contextSubMenu.find('.ht_master .htCore tbody td').not('.htSeparator').eq(3);
+      await sleep(350);
 
-        button.simulate('mousedown'); // Text justify
-        deselectCell();
-        expect(getCellMeta(0, 0).className).toEqual('htJustify');
-        expect(getCell(0, 0).className).toContain('htJustify');
-        done();
-      }, 350); // menu opens after 300ms
+      var contextSubMenu = $(`.htContextMenuSub_${item.text()}`);
+      var button = contextSubMenu.find('.ht_master .htCore tbody td').not('.htSeparator').eq(3);
+
+      button.simulate('mousedown'); // Text justify
+      deselectCell();
+      expect(getCellMeta(0, 0).className).toEqual('htJustify');
+      expect(getCell(0, 0).className).toContain('htJustify');
     });
 
-    it('should vertical align text top', function (done) {
+    it('should vertical align text top', async () => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(4, 4),
         contextMenu: true,
@@ -118,19 +112,17 @@ describe('ContextMenu', function () {
       var item = $('.htContextMenu .ht_master .htCore').find('tbody td').not('.htSeparator').eq(9);
       item.simulate('mouseover');
 
-      setTimeout(function () {
-        var contextSubMenu = $(`.htContextMenuSub_${item.text()}`);
-        var button = contextSubMenu.find('.ht_master .htCore tbody td').not('.htSeparator').eq(4);
+      await sleep(350);
+      var contextSubMenu = $(`.htContextMenuSub_${item.text()}`);
+      var button = contextSubMenu.find('.ht_master .htCore tbody td').not('.htSeparator').eq(4);
 
-        button.simulate('mousedown'); // Text top
-        deselectCell();
-        expect(getCellMeta(0, 0).className).toEqual('htTop');
-        expect(getCell(0, 0).className).toContain('htTop');
-        done();
-      }, 350); // menu opens after 300ms
+      button.simulate('mousedown'); // Text top
+      deselectCell();
+      expect(getCellMeta(0, 0).className).toEqual('htTop');
+      expect(getCell(0, 0).className).toContain('htTop');
     });
 
-    it('should vertical align text middle', function (done) {
+    it('should vertical align text middle', async () => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(4, 4),
         contextMenu: true,
@@ -142,19 +134,17 @@ describe('ContextMenu', function () {
       var item = $('.htContextMenu .ht_master .htCore').find('tbody td').not('.htSeparator').eq(9);
       item.simulate('mouseover');
 
-      setTimeout(function () {
-        var contextSubMenu = $(`.htContextMenuSub_${item.text()}`);
-        var button = contextSubMenu.find('.ht_master .htCore tbody td').not('.htSeparator').eq(5);
+      await sleep(350);
+      var contextSubMenu = $(`.htContextMenuSub_${item.text()}`);
+      var button = contextSubMenu.find('.ht_master .htCore tbody td').not('.htSeparator').eq(5);
 
-        button.simulate('mousedown'); // Text middle
-        deselectCell();
-        expect(getCellMeta(0, 0).className).toEqual('htMiddle');
-        expect(getCell(0, 0).className).toContain('htMiddle');
-        done();
-      }, 350); // menu opens after 300ms
+      button.simulate('mousedown'); // Text middle
+      deselectCell();
+      expect(getCellMeta(0, 0).className).toEqual('htMiddle');
+      expect(getCell(0, 0).className).toContain('htMiddle');
     });
 
-    it('should vertical align text bottom', function (done) {
+    it('should vertical align text bottom', async () => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(4, 4),
         contextMenu: true,
@@ -165,18 +155,16 @@ describe('ContextMenu', function () {
       var item = $('.htContextMenu .ht_master .htCore').find('tbody td').not('.htSeparator').eq(9);
       item.simulate('mouseover');
 
-      setTimeout(function () {
-        var contextSubMenu = $(`.htContextMenuSub_${item.text()}`);
-        var button = contextSubMenu.find('.ht_master .htCore tbody td').not('.htSeparator').eq(6);
-        button.simulate('mousedown'); // Text bottom
-        deselectCell();
-        expect(getCellMeta(0, 0).className).toEqual('htBottom');
-        expect(getCell(0, 0).className).toContain('htBottom');
-        done();
-      }, 350); // menu opens after 300ms
+      await sleep(350);
+      var contextSubMenu = $(`.htContextMenuSub_${item.text()}`);
+      var button = contextSubMenu.find('.ht_master .htCore tbody td').not('.htSeparator').eq(6);
+      button.simulate('mousedown'); // Text bottom
+      deselectCell();
+      expect(getCellMeta(0, 0).className).toEqual('htBottom');
+      expect(getCell(0, 0).className).toContain('htBottom');
     });
 
-    it('should trigger `afterSetCellMeta` callback after changing alignment by context menu', function (done) {
+    it('should trigger `afterSetCellMeta` callback after changing alignment by context menu', async () => {
       var afterSetCellMetaCallback = jasmine.createSpy('afterSetCellMetaCallback');
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(5, 5),
@@ -191,14 +179,12 @@ describe('ContextMenu', function () {
       var item = $('.htContextMenu .ht_master .htCore').find('tbody td').not('.htSeparator').eq(9);
       item.simulate('mouseover');
 
-      setTimeout(function () {
-        var contextSubMenu = $(`.htContextMenuSub_${item.text()}`);
-        var button = contextSubMenu.find('.ht_master .htCore tbody td').not('.htSeparator').eq(2);
-        button.simulate('mousedown'); // Text bottom
-        deselectCell();
-        expect(afterSetCellMetaCallback).toHaveBeenCalledWith(2, 3, 'className', 'htRight', undefined, undefined);
-        done();
-      }, 350); // menu opens after 300ms
+      await sleep(350);
+      var contextSubMenu = $(`.htContextMenuSub_${item.text()}`);
+      var button = contextSubMenu.find('.ht_master .htCore tbody td').not('.htSeparator').eq(2);
+      button.simulate('mousedown'); // Text bottom
+      deselectCell();
+      expect(afterSetCellMetaCallback).toHaveBeenCalledWith(2, 3, 'className', 'htRight', undefined, undefined);
     });
   });
 });

--- a/src/plugins/contextMenu/test/predefinedItems/removeColumn.e2e.js
+++ b/src/plugins/contextMenu/test/predefinedItems/removeColumn.e2e.js
@@ -1,4 +1,4 @@
-describe('ContextMenu', function () {
+describe('ContextMenu', () => {
   var id = 'testContainer';
 
   beforeEach(function () {
@@ -12,8 +12,8 @@ describe('ContextMenu', function () {
     }
   });
 
-  describe('remove columns', function() {
-    it('should execute action when single cell is selected', async function() {
+  describe('remove columns', () => {
+    it('should execute action when single cell is selected', () => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(5, 5),
         contextMenu: true,
@@ -32,7 +32,7 @@ describe('ContextMenu', function () {
       expect(getDataAtRow(0)).toEqual(['A1', 'B1', 'D1', 'E1']);
     });
 
-    it('should execute action when range of the cells are selected', async function() {
+    it('should execute action when range of the cells are selected', () => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(5, 5),
         contextMenu: true,
@@ -51,7 +51,7 @@ describe('ContextMenu', function () {
       expect(getDataAtRow(0)).toEqual(['A1', 'B1']);
     });
 
-    it('should execute action when multiple cells are selected', async function() {
+    it('should execute action when multiple cells are selected', () => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(8, 5),
         contextMenu: true,

--- a/src/plugins/contextMenu/test/predefinedItems/removeRow.e2e.js
+++ b/src/plugins/contextMenu/test/predefinedItems/removeRow.e2e.js
@@ -1,4 +1,4 @@
-describe('ContextMenu', function () {
+describe('ContextMenu', () => {
   var id = 'testContainer';
 
   beforeEach(function () {
@@ -12,8 +12,8 @@ describe('ContextMenu', function () {
     }
   });
 
-  describe('remove rows', function() {
-    it('should execute action when single cell is selected', async function() {
+  describe('remove rows', () => {
+    it('should execute action when single cell is selected', () => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(5, 5),
         contextMenu: true,
@@ -32,7 +32,7 @@ describe('ContextMenu', function () {
       expect(getDataAtCol(0)).toEqual(['A1', 'A2', 'A4', 'A5']);
     });
 
-    it('should execute action when range of the cells are selected', async function() {
+    it('should execute action when range of the cells are selected', () => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(5, 5),
         contextMenu: true,
@@ -51,7 +51,7 @@ describe('ContextMenu', function () {
       expect(getDataAtCol(0)).toEqual(['A1', 'A2']);
     });
 
-    it('should execute action when multiple cells are selected', async function() {
+    it('should execute action when multiple cells are selected', () => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(8, 5),
         contextMenu: true,

--- a/src/plugins/copyPaste/test/copyPaste.e2e.js
+++ b/src/plugins/copyPaste/test/copyPaste.e2e.js
@@ -90,7 +90,7 @@ describe('CopyPaste', () => {
       }
     });
 
-    it('should disable copyPaste only in particular table', function() {
+    it('should disable copyPaste only in particular table', () => {
       const hot1 = handsontable();
       const hot2 = spec().$container2.handsontable({ copyPaste: false }).handsontable('getInstance');
 
@@ -98,7 +98,7 @@ describe('CopyPaste', () => {
       expect(hot2.getPlugin('CopyPaste').focusableElement).toBeUndefined();
     });
 
-    it('should not create HandsontableCopyPaste element until the table will be selected', function() {
+    it('should not create HandsontableCopyPaste element until the table will be selected', () => {
       handsontable();
       spec().$container2.handsontable();
 
@@ -118,7 +118,7 @@ describe('CopyPaste', () => {
       expect(document.activeElement).toBe(hot2.getActiveEditor().TEXTAREA);
     });
 
-    it('should destroy HandsontableCopyPaste element as long as at least one table has copyPaste enabled', function() {
+    it('should destroy HandsontableCopyPaste element as long as at least one table has copyPaste enabled', () => {
       const hot1 = handsontable({editor: false});
       const hot2 = spec().$container2.handsontable({editor: false}).handsontable('getInstance');
 
@@ -136,7 +136,7 @@ describe('CopyPaste', () => {
       expect($('#HandsontableCopyPaste').length).toBe(0);
     });
 
-    it('should not touch focusable element borrowed from cell editors', function() {
+    it('should not touch focusable element borrowed from cell editors', () => {
       const hot1 = handsontable();
       const hot2 = spec().$container2.handsontable().handsontable('getInstance');
 

--- a/src/plugins/manualColumnMove/test/manualColumnMove.e2e.js
+++ b/src/plugins/manualColumnMove/test/manualColumnMove.e2e.js
@@ -13,20 +13,20 @@ describe('manualColumnMove', () => {
   });
 
   describe('init', () => {
-    it('should change column order at init', function() {
+    it('should change column order at init', () => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(10, 10),
         manualColumnMove: [1, 2, 0]
       });
 
-      expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('B1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('C1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('A1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('B1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('C1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('A1');
     });
   });
 
   describe('persistentState', () => {
-    it('should load data from cache after initialization of new Handsontable instance', function(done) {
+    it('should load data from cache after initialization of new Handsontable instance', () => {
       var hot = handsontable({
         data: Handsontable.helper.createSpreadsheetData(10, 10),
         manualColumnMove: true,
@@ -40,8 +40,8 @@ describe('manualColumnMove', () => {
       manualColumnMovePlugin.persistentStateSave();
 
       hot.destroy();
-      this.$container.remove();
-      this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+      spec().$container.remove();
+      spec().$container = $(`<div id="${id}"></div>`).appendTo('body');
 
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(10, 10),
@@ -50,7 +50,6 @@ describe('manualColumnMove', () => {
       });
 
       expect(getDataAtCell(0, 0)).toEqual(dataAt0x2Cell);
-      done();
     });
 
     it('should work with updateSettings properly', () => {
@@ -72,7 +71,7 @@ describe('manualColumnMove', () => {
   });
 
   describe('updateSettings', () => {
-    it('should be enabled after specifying it in updateSettings config', function() {
+    it('should be enabled after specifying it in updateSettings config', () => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(10, 10),
         colHeaders: true
@@ -82,59 +81,59 @@ describe('manualColumnMove', () => {
         manualColumnMove: true
       });
 
-      this.$container.find('thead tr:eq(0) th:eq(0)').simulate('mousedown');
-      this.$container.find('thead tr:eq(0) th:eq(0)').simulate('mouseup');
+      spec().$container.find('thead tr:eq(0) th:eq(0)').simulate('mousedown');
+      spec().$container.find('thead tr:eq(0) th:eq(0)').simulate('mouseup');
 
-      expect(this.$container.hasClass('after-selection--columns')).toBeGreaterThan(0);
+      expect(spec().$container.hasClass('after-selection--columns')).toBeGreaterThan(0);
     });
 
-    it('should change the default column order with updateSettings', function() {
+    it('should change the default column order with updateSettings', () => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(10, 10),
         manualColumnMove: true
       });
 
-      expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('A1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('B1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('C1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('A1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('B1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('C1');
 
       updateSettings({
         manualColumnMove: [2, 1, 0]
       });
 
-      expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('C1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('B1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('A1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('C1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('B1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('A1');
     });
 
-    it('should change column order with updateSettings', function() {
+    it('should change column order with updateSettings', () => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(10, 10),
         manualColumnMove: [1, 2, 0]
       });
 
-      expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('B1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('C1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('A1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('B1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('C1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('A1');
 
       updateSettings({
         manualColumnMove: [2, 1, 0]
       });
 
-      expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('C1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('B1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('A1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('C1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('B1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('A1');
     });
 
-    it('should update columnsMapper when updateSettings change numbers of columns', function() {
+    it('should update columnsMapper when updateSettings change numbers of columns', () => {
       var hot = handsontable({
         data: Handsontable.helper.createSpreadsheetData(10, 10),
         manualColumnMove: true
       });
 
-      expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('A1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('B1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('C1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('A1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('B1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('C1');
 
       hot.getPlugin('manualColumnMove').moveColumn(2, 0);
 
@@ -146,33 +145,33 @@ describe('manualColumnMove', () => {
         ]
       });
 
-      expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('B1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('C1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('A1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('B1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('C1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('A1');
     });
 
-    it('should reset column order with updateSettings when undefined is passed', function() {
+    it('should reset column order with updateSettings when undefined is passed', () => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(10, 10),
         manualColumnMove: [1, 2, 0]
       });
 
-      expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('B1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('C1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('A1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('B1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('C1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('A1');
 
       updateSettings({
         manualColumnMove: void 0
       });
 
-      expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('A1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('B1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('C1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('A1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('B1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('C1');
     });
   });
 
-  describe('loadData', function() {
-    it('should increase numbers of columns if it is necessary', function() {
+  describe('loadData', () => {
+    it('should increase numbers of columns if it is necessary', () => {
       var hot = handsontable({
         data: Handsontable.helper.createSpreadsheetData(5, 5),
         manualColumnMove: true
@@ -184,7 +183,7 @@ describe('manualColumnMove', () => {
       expect(hot.getPlugin('manualColumnMove').columnsMapper.__arrayMap.length).toEqual(10);
     });
 
-    it('should decrease numbers of columns if it is necessary', function() {
+    it('should decrease numbers of columns if it is necessary', () => {
       var hot = handsontable({
         data: Handsontable.helper.createSpreadsheetData(5, 5),
         manualColumnMove: true
@@ -198,45 +197,45 @@ describe('manualColumnMove', () => {
   });
 
   describe('moving', () => {
-    it('should move column by API', function () {
+    it('should move column by API', () => {
       var hot = handsontable({
         data: Handsontable.helper.createSpreadsheetData(10, 10),
         colHeaders: true,
         manualColumnMove: true
       });
 
-      expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('A1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('B1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('C1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('A1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('B1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('C1');
 
       hot.getPlugin('manualColumnMove').moveColumn(2, 0);
       hot.render();
 
-      expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('C1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('A1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('B1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('C1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('A1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('B1');
     });
 
-    it('should move many columns by API', function() {
+    it('should move many columns by API', () => {
       var hot = handsontable({
         data: Handsontable.helper.createSpreadsheetData(10, 10),
         colHeaders: true,
         manualColumnMove: true
       });
 
-      expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('A1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('B1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('C1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('A1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('B1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('C1');
 
       hot.getPlugin('manualColumnMove').moveColumns([7, 9, 8], 0);
       hot.render();
 
-      expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('H1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('J1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('I1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('H1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('J1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('I1');
     });
 
-    it('should trigger an beforeColumnMove event before column move', function() {
+    it('should trigger an beforeColumnMove event before column move', () => {
       var beforeMoveColumnCallback = jasmine.createSpy('beforeMoveColumnCallback');
 
       var hot = handsontable({
@@ -246,24 +245,24 @@ describe('manualColumnMove', () => {
         beforeColumnMove: beforeMoveColumnCallback
       });
 
-      expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('A1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('B1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('C1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('A1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('B1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('C1');
 
       hot.getPlugin('manualColumnMove').moveColumns([8, 9, 7], 0);
       hot.render();
 
-      expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('I1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('J1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('H1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('I1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('J1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('H1');
 
       expect(beforeMoveColumnCallback).toHaveBeenCalledWith([8, 9, 7], 0, void 0, void 0, void 0, void 0);
     });
 
-    it('should trigger an afterColumnMove event after column move', function() {
+    it('should trigger an afterColumnMove event after column move', () => {
       var afterMoveColumnCallback = jasmine.createSpy('afterMoveColumnCallback');
 
-      this.$container.height(150);
+      spec().$container.height(150);
 
       var hot = handsontable({
         data: Handsontable.helper.createSpreadsheetData(10, 10),
@@ -272,32 +271,32 @@ describe('manualColumnMove', () => {
         afterColumnMove: afterMoveColumnCallback
       });
 
-      expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('A1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('B1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('C1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('A1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('B1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('C1');
 
       hot.getPlugin('manualColumnMove').moveColumns([8, 9, 7], 0);
       hot.render();
 
-      expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('I1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('J1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('H1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('I1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('J1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('H1');
 
       expect(afterMoveColumnCallback).toHaveBeenCalledWith([8, 9, 7], 0, void 0, void 0, void 0, void 0);
     });
 
-    it('should move the second column to the first column', function() {
+    it('should move the second column to the first column', () => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(10, 10),
         colHeaders: true,
         manualColumnMove: true
       });
 
-      expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('A1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('B1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('C1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('A1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('B1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('C1');
 
-      var $rowsHeaders = this.$container.find('.ht_clone_top tr th');
+      var $rowsHeaders = spec().$container.find('.ht_clone_top tr th');
 
       $rowsHeaders.eq(1).simulate('mousedown');
       $rowsHeaders.eq(1).simulate('mouseup');
@@ -306,23 +305,23 @@ describe('manualColumnMove', () => {
       $rowsHeaders.eq(0).simulate('mousemove');
       $rowsHeaders.eq(0).simulate('mouseup');
 
-      expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('B1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('A1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('C1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('B1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('A1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('C1');
     });
 
-    it('should move the second row to the third row', function() {
+    it('should move the second row to the third row', () => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(10, 10),
         colHeaders: true,
         manualColumnMove: true
       });
 
-      expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('A1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('B1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('C1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('A1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('B1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('C1');
 
-      var $rowsHeaders = this.$container.find('.ht_clone_top tr th');
+      var $rowsHeaders = spec().$container.find('.ht_clone_top tr th');
 
       $rowsHeaders.eq(1).simulate('mousedown');
       $rowsHeaders.eq(1).simulate('mouseup');
@@ -331,9 +330,9 @@ describe('manualColumnMove', () => {
       $rowsHeaders.eq(3).simulate('mousemove');
       $rowsHeaders.eq(3).simulate('mouseup');
 
-      expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('A1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('C1');
-      expect(this.$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('B1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('A1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('C1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('B1');
     });
 
     it('should properly scrolling viewport if mouse is over part-visible cell', (done) => {

--- a/src/plugins/manualColumnMove/test/manualColumnMoveUI.e2e.js
+++ b/src/plugins/manualColumnMove/test/manualColumnMoveUI.e2e.js
@@ -14,39 +14,39 @@ describe('manualColumnMove', () => {
   });
 
   describe('UI', () => {
-    it('should append UI elements to wtHider after click on row header', function() {
+    it('should append UI elements to wtHider after click on row header', () => {
       handsontable({
         data: arrayOfArrays.slice(),
         colHeaders: true,
         manualColumnMove: true
       });
 
-      var $headerTH = this.$container.find('thead tr:eq(0) th:eq(0)');
+      var $headerTH = spec().$container.find('thead tr:eq(0) th:eq(0)');
       $headerTH.simulate('mousedown');
       $headerTH.simulate('mouseup');
       $headerTH.simulate('mousedown');
 
-      expect(this.$container.find('.ht__manualColumnMove--guideline').length).toBe(1);
-      expect(this.$container.find('.ht__manualColumnMove--backlight').length).toBe(1);
+      expect(spec().$container.find('.ht__manualColumnMove--guideline').length).toBe(1);
+      expect(spec().$container.find('.ht__manualColumnMove--backlight').length).toBe(1);
     });
 
-    it('should part of UI elements be visible on dragging action', function() {
+    it('should part of UI elements be visible on dragging action', () => {
       handsontable({
         data: arrayOfArrays.slice(),
         colHeaders: true,
         manualColumnMove: true
       });
 
-      var $headerTH = this.$container.find('thead tr:eq(0) th:eq(0)');
+      var $headerTH = spec().$container.find('thead tr:eq(0) th:eq(0)');
       $headerTH.simulate('mousedown');
       $headerTH.simulate('mouseup');
       $headerTH.simulate('mousedown');
 
-      expect(this.$container.find('.ht__manualColumnMove--guideline:visible').length).toBe(0);
-      expect(this.$container.find('.ht__manualColumnMove--backlight:visible').length).toBe(1);
+      expect(spec().$container.find('.ht__manualColumnMove--guideline:visible').length).toBe(0);
+      expect(spec().$container.find('.ht__manualColumnMove--backlight:visible').length).toBe(1);
     });
 
-    it('should all of UI elements be visible on dragging action', function() {
+    it('should all of UI elements be visible on dragging action', () => {
       handsontable({
         data: arrayOfArrays.slice(),
         colHeaders: true,
@@ -54,9 +54,9 @@ describe('manualColumnMove', () => {
       });
 
       var $headers = [
-        this.$container.find('thead tr:eq(0) th:eq(0)'),
-        this.$container.find('thead tr:eq(0) th:eq(1)'),
-        this.$container.find('thead tr:eq(0) th:eq(2)'),
+        spec().$container.find('thead tr:eq(0) th:eq(0)'),
+        spec().$container.find('thead tr:eq(0) th:eq(1)'),
+        spec().$container.find('thead tr:eq(0) th:eq(2)'),
       ];
 
       $headers[0].simulate('mousedown');
@@ -65,11 +65,11 @@ describe('manualColumnMove', () => {
       $headers[1].simulate('mouseover');
       $headers[2].simulate('mouseover');
 
-      expect(this.$container.find('.ht__manualColumnMove--guideline:visible').length).toBe(1);
-      expect(this.$container.find('.ht__manualColumnMove--backlight:visible').length).toBe(1);
+      expect(spec().$container.find('.ht__manualColumnMove--guideline:visible').length).toBe(1);
+      expect(spec().$container.find('.ht__manualColumnMove--backlight:visible').length).toBe(1);
     });
 
-    it('should set properly width for the backlight element when stretchH is enabled', function() {
+    it('should set properly width for the backlight element when stretchH is enabled', () => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(30, 5),
         width: 600,
@@ -78,15 +78,15 @@ describe('manualColumnMove', () => {
         manualColumnMove: true
       });
 
-      var $headerTH = this.$container.find('thead tr:eq(0) th:eq(1)');
+      var $headerTH = spec().$container.find('thead tr:eq(0) th:eq(1)');
       $headerTH.simulate('mousedown');
       $headerTH.simulate('mouseup');
       $headerTH.simulate('mousedown');
 
-      expect(this.$container.find('.ht__manualColumnMove--backlight')[0].offsetWidth).toBe($headerTH[0].offsetWidth);
+      expect(spec().$container.find('.ht__manualColumnMove--backlight')[0].offsetWidth).toBe($headerTH[0].offsetWidth);
     });
 
-    it('should set properly width for the backlight element when stretchH is enabled and column order was changed', function() {
+    it('should set properly width for the backlight element when stretchH is enabled and column order was changed', () => {
       handsontable({
         data: [
           {id: 1, flag: 'EUR', currencyCode: 'EUR', currency: 'Euro', level: 0.9033, units: 'EUR / USD', asOf: '08/19/2015', onedChng: 0.0026},
@@ -106,14 +106,14 @@ describe('manualColumnMove', () => {
         ]
       });
 
-      var $headerTH = this.$container.find('thead tr:eq(0) th:eq(6)');
+      var $headerTH = spec().$container.find('thead tr:eq(0) th:eq(6)');
       $headerTH.simulate('mousedown');
       $headerTH.simulate('mouseup');
       $headerTH.simulate('mousedown');
       $headerTH.simulate('mouseup');
       $headerTH.simulate('mousedown');
 
-      expect(this.$container.find('.ht__manualColumnMove--backlight')[0].offsetWidth).toBe($headerTH[0].offsetWidth);
+      expect(spec().$container.find('.ht__manualColumnMove--backlight')[0].offsetWidth).toBe($headerTH[0].offsetWidth);
     });
 
     it('should set proper left position of the backlight element when colWidths is undefined', () => {
@@ -151,7 +151,7 @@ describe('manualColumnMove', () => {
       expect(spec().$container.find('.ht__manualColumnMove--backlight')[0].offsetLeft).toBe(150);
     });
 
-    it('should not run moving ui if mousedown was fired on sorting element', function() {
+    it('should not run moving ui if mousedown was fired on sorting element', () => {
       handsontable({
         data: arrayOfArrays.slice(),
         colHeaders: true,
@@ -159,7 +159,7 @@ describe('manualColumnMove', () => {
         columnSorting: true
       });
 
-      var $headerTH = this.$container.find('thead tr:eq(0) th:eq(6)');
+      var $headerTH = spec().$container.find('thead tr:eq(0) th:eq(6)');
       var $summaryElement = $headerTH.find('.columnSorting');
 
       $headerTH.simulate('mousedown');
@@ -167,7 +167,7 @@ describe('manualColumnMove', () => {
       $headerTH.simulate('mousedown');
       $headerTH.simulate('mouseup');
 
-      var $backlight = this.$container.find('.ht__manualColumnMove--backlight')[0];
+      var $backlight = spec().$container.find('.ht__manualColumnMove--backlight')[0];
       $summaryElement.simulate('mousedown');
 
       var displayProp = $backlight.currentStyle ? $backlight.currentStyle.display : getComputedStyle($backlight, null).display;

--- a/src/plugins/manualColumnResize/test/manualColumnResize.e2e.js
+++ b/src/plugins/manualColumnResize/test/manualColumnResize.e2e.js
@@ -12,17 +12,17 @@ describe('manualColumnResize', () => {
     }
   });
 
-  it('should change column widths at init', function() {
+  it('should change column widths at init', () => {
     handsontable({
       manualColumnResize: [100, 150, 180]
     });
 
-    expect(colWidth(this.$container, 0)).toBe(100);
-    expect(colWidth(this.$container, 1)).toBe(150);
-    expect(colWidth(this.$container, 2)).toBe(180);
+    expect(colWidth(spec().$container, 0)).toBe(100);
+    expect(colWidth(spec().$container, 1)).toBe(150);
+    expect(colWidth(spec().$container, 2)).toBe(180);
   });
 
-  it('should be enabled after specifying it in updateSettings config', function() {
+  it('should be enabled after specifying it in updateSettings config', () => {
     handsontable({
       data: [
         {id: 1, name: 'Ted', lastName: 'Right'},
@@ -36,85 +36,85 @@ describe('manualColumnResize', () => {
 
     updateSettings({manualColumnResize: true});
 
-    this.$container.find('thead tr:eq(0) th:eq(0)').simulate('mouseover');
+    spec().$container.find('thead tr:eq(0) th:eq(0)').simulate('mouseover');
 
     expect($('.manualColumnResizer').size()).toBeGreaterThan(0);
   });
 
-  it('should change the default column widths with updateSettings', function() {
+  it('should change the default column widths with updateSettings', () => {
     handsontable({
       manualColumnResize: true
     });
 
-    expect(colWidth(this.$container, 0)).toBe(50);
-    expect(colWidth(this.$container, 1)).toBe(50);
-    expect(colWidth(this.$container, 2)).toBe(50);
+    expect(colWidth(spec().$container, 0)).toBe(50);
+    expect(colWidth(spec().$container, 1)).toBe(50);
+    expect(colWidth(spec().$container, 2)).toBe(50);
 
     updateSettings({
       manualColumnResize: [60, 50, 80]
     });
 
-    expect(colWidth(this.$container, 0)).toBe(60);
-    expect(colWidth(this.$container, 1)).toBe(50);
-    expect(colWidth(this.$container, 2)).toBe(80);
+    expect(colWidth(spec().$container, 0)).toBe(60);
+    expect(colWidth(spec().$container, 1)).toBe(50);
+    expect(colWidth(spec().$container, 2)).toBe(80);
   });
 
-  it('should change column widths with updateSettings', function() {
+  it('should change column widths with updateSettings', () => {
     handsontable({
       manualColumnResize: [100, 150, 180]
     });
 
-    expect(colWidth(this.$container, 0)).toBe(100);
-    expect(colWidth(this.$container, 1)).toBe(150);
-    expect(colWidth(this.$container, 2)).toBe(180);
+    expect(colWidth(spec().$container, 0)).toBe(100);
+    expect(colWidth(spec().$container, 1)).toBe(150);
+    expect(colWidth(spec().$container, 2)).toBe(180);
 
     updateSettings({
       manualColumnResize: [60, 50, 80]
     });
 
-    expect(colWidth(this.$container, 0)).toBe(60);
-    expect(colWidth(this.$container, 1)).toBe(50);
-    expect(colWidth(this.$container, 2)).toBe(80);
+    expect(colWidth(spec().$container, 0)).toBe(60);
+    expect(colWidth(spec().$container, 1)).toBe(50);
+    expect(colWidth(spec().$container, 2)).toBe(80);
   });
 
-  it('should reset column widths when undefined is passed', function() {
+  it('should reset column widths when undefined is passed', () => {
     handsontable({
       manualColumnResize: [100, 150, 180]
     });
 
-    expect(colWidth(this.$container, 0)).toBe(100);
-    expect(colWidth(this.$container, 1)).toBe(150);
-    expect(colWidth(this.$container, 2)).toBe(180);
+    expect(colWidth(spec().$container, 0)).toBe(100);
+    expect(colWidth(spec().$container, 1)).toBe(150);
+    expect(colWidth(spec().$container, 2)).toBe(180);
 
     updateSettings({
       manualColumnResize: void 0
     });
 
-    expect(colWidth(this.$container, 0)).toBe(50);
-    expect(colWidth(this.$container, 1)).toBe(50);
-    expect(colWidth(this.$container, 2)).toBe(50);
+    expect(colWidth(spec().$container, 0)).toBe(50);
+    expect(colWidth(spec().$container, 1)).toBe(50);
+    expect(colWidth(spec().$container, 2)).toBe(50);
   });
 
-  it('should not reset column widths when `true` is passed', function() {
+  it('should not reset column widths when `true` is passed', () => {
     handsontable({
       manualColumnResize: [100, 150, 180]
     });
 
-    expect(colWidth(this.$container, 0)).toBe(100);
-    expect(colWidth(this.$container, 1)).toBe(150);
-    expect(colWidth(this.$container, 2)).toBe(180);
+    expect(colWidth(spec().$container, 0)).toBe(100);
+    expect(colWidth(spec().$container, 1)).toBe(150);
+    expect(colWidth(spec().$container, 2)).toBe(180);
 
     updateSettings({
       manualColumnResize: true
     });
 
-    expect(colWidth(this.$container, 0)).toBe(100);
-    expect(colWidth(this.$container, 1)).toBe(150);
-    expect(colWidth(this.$container, 2)).toBe(180);
+    expect(colWidth(spec().$container, 0)).toBe(100);
+    expect(colWidth(spec().$container, 1)).toBe(150);
+    expect(colWidth(spec().$container, 2)).toBe(180);
   });
 
-  it('should resize (narrowing) appropriate columns, even when stretchH `all` is enabled', function() {
-    this.$container.css('width', '910px');
+  it('should resize (narrowing) appropriate columns, even when stretchH `all` is enabled', () => {
+    spec().$container.css('width', '910px');
     handsontable({
       colHeaders: true,
       manualColumnResize: true,
@@ -123,7 +123,7 @@ describe('manualColumnResize', () => {
 
     resizeColumn(1, 65);
 
-    var $columnHeaders = this.$container.find('thead tr:eq(1) th');
+    var $columnHeaders = spec().$container.find('thead tr:eq(1) th');
 
     expect($columnHeaders.eq(0).width()).toBe(209);
     expect($columnHeaders.eq(1).width()).toBe(64);
@@ -132,8 +132,8 @@ describe('manualColumnResize', () => {
     expect($columnHeaders.eq(4).width()).toBe(211);
   });
 
-  it('should resize (extending) appropriate columns, even when stretchH `all` is enabled', function() {
-    this.$container.css('width', '910px');
+  it('should resize (extending) appropriate columns, even when stretchH `all` is enabled', () => {
+    spec().$container.css('width', '910px');
     handsontable({
       colHeaders: true,
       manualColumnResize: true,
@@ -142,7 +142,7 @@ describe('manualColumnResize', () => {
 
     resizeColumn(1, 400);
 
-    var $columnHeaders = this.$container.find('thead tr:eq(1) th');
+    var $columnHeaders = spec().$container.find('thead tr:eq(1) th');
 
     expect($columnHeaders.eq(0).width()).toBe(125);
     expect($columnHeaders.eq(1).width()).toBe(399);
@@ -151,72 +151,70 @@ describe('manualColumnResize', () => {
     expect($columnHeaders.eq(4).width()).toBe(128);
   });
 
-  it('should resize (narrowing) selected columns', function(done) {
+  it('should resize (narrowing) selected columns', async () => {
     handsontable({
       data: Handsontable.helper.createSpreadsheetData(10, 20),
       colHeaders: true,
       manualColumnResize: true
     });
 
-    var $columnHeaders = this.$container.find('thead tr:eq(0) th');
-    var $colHeader = this.$container.find('thead tr:eq(0) th:eq(1)');
+    var $columnHeaders = spec().$container.find('thead tr:eq(0) th');
+    var $colHeader = spec().$container.find('thead tr:eq(0) th:eq(1)');
     $colHeader.simulate('mouseover');
 
-    var $resizer = this.$container.find('.manualColumnResizer');
+    var $resizer = spec().$container.find('.manualColumnResizer');
     var resizerPosition = $resizer.position();
 
-    this.$container.find('tr:eq(0) th:eq(1)').simulate('mousedown');
-    this.$container.find('tr:eq(0) th:eq(2)').simulate('mouseover');
-    this.$container.find('tr:eq(0) th:eq(3)').simulate('mouseover');
-    this.$container.find('tr:eq(0) th:eq(3)').simulate('mousemove');
-    this.$container.find('tr:eq(0) th:eq(3)').simulate('mouseup');
+    spec().$container.find('tr:eq(0) th:eq(1)').simulate('mousedown');
+    spec().$container.find('tr:eq(0) th:eq(2)').simulate('mouseover');
+    spec().$container.find('tr:eq(0) th:eq(3)').simulate('mouseover');
+    spec().$container.find('tr:eq(0) th:eq(3)').simulate('mousemove');
+    spec().$container.find('tr:eq(0) th:eq(3)').simulate('mouseup');
 
     $resizer.simulate('mousedown', {clientX: resizerPosition.left});
-    $resizer.simulate('mousemove', {clientX: this.$container.find('tr:eq(0) th:eq(1)').position().left + 29});
+    $resizer.simulate('mousemove', {clientX: spec().$container.find('tr:eq(0) th:eq(1)').position().left + 29});
     $resizer.simulate('mouseup');
 
-    setTimeout(() => {
-      expect($columnHeaders.eq(1).width()).toBe(33);
-      expect($columnHeaders.eq(2).width()).toBe(34);
-      expect($columnHeaders.eq(3).width()).toBe(34);
-      done();
-    }, 1000);
+    await sleep(1000);
+
+    expect($columnHeaders.eq(1).width()).toBe(33);
+    expect($columnHeaders.eq(2).width()).toBe(34);
+    expect($columnHeaders.eq(3).width()).toBe(34);
   });
 
-  it('should resize (expanding) selected columns', function(done) {
+  it('should resize (expanding) selected columns', async () => {
     handsontable({
       data: Handsontable.helper.createSpreadsheetData(10, 20),
       colHeaders: true,
       manualColumnResize: true
     });
 
-    var $columnHeaders = this.$container.find('thead tr:eq(0) th');
-    var $colHeader = this.$container.find('thead tr:eq(0) th:eq(1)');
+    var $columnHeaders = spec().$container.find('thead tr:eq(0) th');
+    var $colHeader = spec().$container.find('thead tr:eq(0) th:eq(1)');
     $colHeader.simulate('mouseover');
 
-    var $resizer = this.$container.find('.manualColumnResizer');
+    var $resizer = spec().$container.find('.manualColumnResizer');
     var resizerPosition = $resizer.position();
 
-    this.$container.find('tr:eq(0) th:eq(1)').simulate('mousedown');
-    this.$container.find('tr:eq(0) th:eq(2)').simulate('mouseover');
-    this.$container.find('tr:eq(0) th:eq(3)').simulate('mouseover');
-    this.$container.find('tr:eq(0) th:eq(3)').simulate('mousemove');
-    this.$container.find('tr:eq(0) th:eq(3)').simulate('mouseup');
+    spec().$container.find('tr:eq(0) th:eq(1)').simulate('mousedown');
+    spec().$container.find('tr:eq(0) th:eq(2)').simulate('mouseover');
+    spec().$container.find('tr:eq(0) th:eq(3)').simulate('mouseover');
+    spec().$container.find('tr:eq(0) th:eq(3)').simulate('mousemove');
+    spec().$container.find('tr:eq(0) th:eq(3)').simulate('mouseup');
 
     $resizer.simulate('mousedown', {clientX: resizerPosition.left});
-    $resizer.simulate('mousemove', {clientX: this.$container.find('tr:eq(0) th:eq(1)').position().left + 150});
+    $resizer.simulate('mousemove', {clientX: spec().$container.find('tr:eq(0) th:eq(1)').position().left + 150});
     $resizer.simulate('mouseup');
 
-    setTimeout(() => {
-      expect($columnHeaders.eq(1).width()).toBe(154);
-      expect($columnHeaders.eq(2).width()).toBe(155);
-      expect($columnHeaders.eq(3).width()).toBe(155);
-      done();
-    }, 1000);
+    await sleep(1000);
+
+    expect($columnHeaders.eq(1).width()).toBe(154);
+    expect($columnHeaders.eq(2).width()).toBe(155);
+    expect($columnHeaders.eq(3).width()).toBe(155);
   });
 
-  it('should resize appropriate columns to calculated stretch width after double click on column handler when stretchH is set as `all`', function(done) {
-    this.$container.css('width', '910px');
+  it('should resize appropriate columns to calculated stretch width after double click on column handler when stretchH is set as `all`', async () => {
+    spec().$container.css('width', '910px');
     handsontable({
       colHeaders: true,
       manualColumnResize: true,
@@ -225,7 +223,7 @@ describe('manualColumnResize', () => {
 
     resizeColumn(1, 65);
 
-    var $columnHeaders = this.$container.find('thead tr:eq(1) th');
+    var $columnHeaders = spec().$container.find('thead tr:eq(1) th');
 
     expect($columnHeaders.eq(0).width()).toBe(209);
     expect($columnHeaders.eq(1).width()).toBe(64);
@@ -237,7 +235,7 @@ describe('manualColumnResize', () => {
 
     $th.simulate('mouseover');
 
-    var $resizer = this.$container.find('.manualColumnResizer');
+    var $resizer = spec().$container.find('.manualColumnResizer');
     var resizerPosition = $resizer.position();
 
     $resizer.simulate('mousedown', {clientX: resizerPosition.left});
@@ -246,18 +244,17 @@ describe('manualColumnResize', () => {
     $resizer.simulate('mousedown', {clientX: resizerPosition.left});
     $resizer.simulate('mouseup');
 
-    setTimeout(() => {
-      expect($columnHeaders.eq(0).width()).toBe(180);
-      expect($columnHeaders.eq(1).width()).toBe(181);
-      expect($columnHeaders.eq(2).width()).toBe(181);
-      expect($columnHeaders.eq(3).width()).toBe(181);
-      expect($columnHeaders.eq(4).width()).toBe(181);
-      done();
-    }, 1000);
+    await sleep(1000);
+
+    expect($columnHeaders.eq(0).width()).toBe(180);
+    expect($columnHeaders.eq(1).width()).toBe(181);
+    expect($columnHeaders.eq(2).width()).toBe(181);
+    expect($columnHeaders.eq(3).width()).toBe(181);
+    expect($columnHeaders.eq(4).width()).toBe(181);
   });
 
-  it('should resize appropriate columns to calculated autoColumnSize width after double click on column handler when stretchH is set as `last`', function(done) {
-    this.$container.css('width', '910px');
+  it('should resize appropriate columns to calculated autoColumnSize width after double click on column handler when stretchH is set as `last`', async () => {
+    spec().$container.css('width', '910px');
     handsontable({
       colHeaders: true,
       manualColumnResize: true,
@@ -266,7 +263,7 @@ describe('manualColumnResize', () => {
 
     resizeColumn(0, 65);
 
-    var $columnHeaders = this.$container.find('thead tr:eq(0) th');
+    var $columnHeaders = spec().$container.find('thead tr:eq(0) th');
 
     expect($columnHeaders.eq(0).width()).toBe(63);
     expect($columnHeaders.eq(1).width()).toBe(48);
@@ -278,7 +275,7 @@ describe('manualColumnResize', () => {
 
     $th.simulate('mouseover');
 
-    var $resizer = this.$container.find('.manualColumnResizer');
+    var $resizer = spec().$container.find('.manualColumnResizer');
     var resizerPosition = $resizer.position();
 
     $resizer.simulate('mousedown', {clientX: resizerPosition.left});
@@ -287,14 +284,13 @@ describe('manualColumnResize', () => {
     $resizer.simulate('mousedown', {clientX: resizerPosition.left});
     $resizer.simulate('mouseup');
 
-    setTimeout(() => {
-      expect($columnHeaders.eq(0).width()).toBeAroundValue(19);
-      expect($columnHeaders.eq(1).width()).toBe(48);
-      expect($columnHeaders.eq(2).width()).toBe(49);
-      expect($columnHeaders.eq(3).width()).toBe(49);
-      expect($columnHeaders.eq(4).width()).toBeAroundValue(738);
-      done();
-    }, 1000);
+    await sleep(1000);
+
+    expect($columnHeaders.eq(0).width()).toBeAroundValue(19);
+    expect($columnHeaders.eq(1).width()).toBe(48);
+    expect($columnHeaders.eq(2).width()).toBe(49);
+    expect($columnHeaders.eq(3).width()).toBe(49);
+    expect($columnHeaders.eq(4).width()).toBeAroundValue(738);
   });
 
   it('should resize appropriate columns, even if the column order was changed with manualColumnMove plugin', function() {
@@ -304,7 +300,7 @@ describe('manualColumnResize', () => {
       manualColumnResize: true
     });
 
-    var $columnHeaders = this.$container.find('thead tr:eq(0) th');
+    var $columnHeaders = spec().$container.find('thead tr:eq(0) th');
     var initialColumnWidths = [];
 
     $columnHeaders.each(function() {
@@ -324,7 +320,7 @@ describe('manualColumnResize', () => {
     }
   });
 
-  it('should trigger an afterColumnResize event after column size changes', function() {
+  it('should trigger an afterColumnResize event after column size changes', () => {
     var afterColumnResizeCallback = jasmine.createSpy('afterColumnResizeCallback');
 
     handsontable({
@@ -334,15 +330,15 @@ describe('manualColumnResize', () => {
       afterColumnResize: afterColumnResizeCallback
     });
 
-    expect(colWidth(this.$container, 0)).toEqual(50);
+    expect(colWidth(spec().$container, 0)).toEqual(50);
 
     resizeColumn(0, 100);
 
     expect(afterColumnResizeCallback).toHaveBeenCalledWith(0, 100, void 0, void 0, void 0, void 0);
-    expect(colWidth(this.$container, 0)).toEqual(100);
+    expect(colWidth(spec().$container, 0)).toEqual(100);
   });
 
-  it('should not trigger an afterColumnResize event if column size does not change (mouseMove event width delta = 0)', function() {
+  it('should not trigger an afterColumnResize event if column size does not change (mouseMove event width delta = 0)', () => {
     var afterColumnResizeCallback = jasmine.createSpy('afterColumnResizeCallback');
 
     handsontable({
@@ -352,15 +348,15 @@ describe('manualColumnResize', () => {
       afterColumnResize: afterColumnResizeCallback
     });
 
-    expect(colWidth(this.$container, 0)).toEqual(50);
+    expect(colWidth(spec().$container, 0)).toEqual(50);
 
     resizeColumn(0, 50);
 
     expect(afterColumnResizeCallback).not.toHaveBeenCalled();
-    expect(colWidth(this.$container, 0)).toEqual(50);
+    expect(colWidth(spec().$container, 0)).toEqual(50);
   });
 
-  it('should not trigger an afterColumnResize event if column size does not change (no mouseMove event)', function() {
+  it('should not trigger an afterColumnResize event if column size does not change (no mouseMove event)', () => {
     var afterColumnResizeCallback = jasmine.createSpy('afterColumnResizeCallback');
 
     handsontable({
@@ -370,22 +366,22 @@ describe('manualColumnResize', () => {
       afterColumnResize: afterColumnResizeCallback
     });
 
-    expect(colWidth(this.$container, 0)).toEqual(50);
+    expect(colWidth(spec().$container, 0)).toEqual(50);
 
-    var $th = this.$container.find('thead tr:eq(0) th:eq(0)');
+    var $th = spec().$container.find('thead tr:eq(0) th:eq(0)');
     $th.simulate('mouseover');
 
-    var $resizer = this.$container.find('.manualColumnResizer');
+    var $resizer = spec().$container.find('.manualColumnResizer');
     var resizerPosition = $resizer.position();
 
     $resizer.simulate('mousedown', {clientX: resizerPosition.left});
     $resizer.simulate('mouseup');
 
     expect(afterColumnResizeCallback).not.toHaveBeenCalled();
-    expect(colWidth(this.$container, 0)).toEqual(50);
+    expect(colWidth(spec().$container, 0)).toEqual(50);
   });
 
-  it('should trigger an afterColumnResize after column size changes, after double click', function(done) {
+  it('should trigger an afterColumnResize after column size changes, after double click', async () => {
     var afterColumnResizeCallback = jasmine.createSpy('afterColumnResizeCallback');
 
     handsontable({
@@ -395,13 +391,13 @@ describe('manualColumnResize', () => {
       afterColumnResize: afterColumnResizeCallback
     });
 
-    expect(colWidth(this.$container, 0)).toEqual(50);
+    expect(colWidth(spec().$container, 0)).toEqual(50);
 
-    var $th = this.$container.find('thead tr:eq(0) th:eq(0)');
+    var $th = spec().$container.find('thead tr:eq(0) th:eq(0)');
 
     $th.simulate('mouseover');
 
-    var $resizer = this.$container.find('.manualColumnResizer');
+    var $resizer = spec().$container.find('.manualColumnResizer');
     var resizerPosition = $resizer.position();
 
     $resizer.simulate('mousedown', {clientX: resizerPosition.left});
@@ -410,17 +406,16 @@ describe('manualColumnResize', () => {
     $resizer.simulate('mousedown', {clientX: resizerPosition.left});
     $resizer.simulate('mouseup');
 
-    setTimeout(() => {
-      expect(afterColumnResizeCallback.calls.count()).toEqual(1);
-      expect(afterColumnResizeCallback.calls.argsFor(0)[0]).toEqual(0);
-      // All modern browsers returns width = 25px, but IE8 seems to compute width differently and returns 24px
-      expect(afterColumnResizeCallback.calls.argsFor(0)[1]).toBeInArray([30, 31, 32, 24, 25]);
-      expect(colWidth(spec().$container, 0)).toBeInArray([30, 31, 32, 24, 25]);
-      done();
-    }, 1000);
+    await sleep(1000);
+
+    expect(afterColumnResizeCallback.calls.count()).toEqual(1);
+    expect(afterColumnResizeCallback.calls.argsFor(0)[0]).toEqual(0);
+    // All modern browsers returns width = 25px, but IE8 seems to compute width differently and returns 24px
+    expect(afterColumnResizeCallback.calls.argsFor(0)[1]).toBeInArray([30, 31, 32, 24, 25]);
+    expect(colWidth(spec().$container, 0)).toBeInArray([30, 31, 32, 24, 25]);
   });
 
-  it('should autosize column after double click (when initial width is not defined)', function(done) {
+  it('should autosize column after double click (when initial width is not defined)', async () => {
     handsontable({
       data: Handsontable.helper.createSpreadsheetData(3, 3),
       colHeaders: true,
@@ -428,13 +423,13 @@ describe('manualColumnResize', () => {
       columns: [{width: 100}, {width: 200}, {}]
     });
 
-    expect(colWidth(this.$container, 0)).toEqual(100);
-    expect(colWidth(this.$container, 1)).toEqual(200);
-    expect(colWidth(this.$container, 2)).toEqual(50);
+    expect(colWidth(spec().$container, 0)).toEqual(100);
+    expect(colWidth(spec().$container, 1)).toEqual(200);
+    expect(colWidth(spec().$container, 2)).toEqual(50);
 
     resizeColumn(2, 300);
 
-    var $resizer = this.$container.find('.manualColumnResizer');
+    var $resizer = spec().$container.find('.manualColumnResizer');
     var resizerPosition = $resizer.position();
 
     $resizer.simulate('mousedown', {clientX: resizerPosition.left});
@@ -443,13 +438,12 @@ describe('manualColumnResize', () => {
     $resizer.simulate('mousedown', {clientX: resizerPosition.left});
     $resizer.simulate('mouseup');
 
-    setTimeout(() => {
-      expect(colWidth(spec().$container, 2)).toBeAroundValue(29, 3);
-      done();
-    }, 1000);
+    await sleep(1000);
+
+    expect(colWidth(spec().$container, 2)).toBeAroundValue(29, 3);
   });
 
-  it('should autosize selected columns after double click on handler', function(done) {
+  it('should autosize selected columns after double click on handler', async () => {
     handsontable({
       data: Handsontable.helper.createSpreadsheetData(9, 9),
       colHeaders: true,
@@ -458,31 +452,30 @@ describe('manualColumnResize', () => {
 
     resizeColumn(2, 300);
 
-    this.$container.find('thead tr:eq(0) th:eq(1)').simulate('mousedown');
-    this.$container.find('thead tr:eq(0) th:eq(2)').simulate('mouseover');
-    this.$container.find('thead tr:eq(0) th:eq(3)').simulate('mouseover');
-    this.$container.find('thead tr:eq(0) th:eq(3)').simulate('mousemove');
-    this.$container.find('thead tr:eq(0) th:eq(3)').simulate('mouseup');
+    spec().$container.find('thead tr:eq(0) th:eq(1)').simulate('mousedown');
+    spec().$container.find('thead tr:eq(0) th:eq(2)').simulate('mouseover');
+    spec().$container.find('thead tr:eq(0) th:eq(3)').simulate('mouseover');
+    spec().$container.find('thead tr:eq(0) th:eq(3)').simulate('mousemove');
+    spec().$container.find('thead tr:eq(0) th:eq(3)').simulate('mouseup');
 
     var $resizer = spec().$container.find('.manualColumnResizer');
     var resizerPosition = $resizer.position();
 
-    setTimeout(() => {
-      $resizer.simulate('mousedown', {clientX: resizerPosition.left});
-      $resizer.simulate('mouseup');
-      $resizer.simulate('mousedown', {clientX: resizerPosition.left});
-      $resizer.simulate('mouseup');
-    }, 600);
+    await sleep(600);
 
-    setTimeout(() => {
-      expect(colWidth(spec().$container, 1)).toBeAroundValue(32, 2);
-      expect(colWidth(spec().$container, 2)).toBeAroundValue(32, 2);
-      expect(colWidth(spec().$container, 3)).toBeAroundValue(32, 2);
-      done();
-    }, 1200);
+    $resizer.simulate('mousedown', {clientX: resizerPosition.left});
+    $resizer.simulate('mouseup');
+    $resizer.simulate('mousedown', {clientX: resizerPosition.left});
+    $resizer.simulate('mouseup');
+
+    await sleep(600);
+
+    expect(colWidth(spec().$container, 1)).toBeAroundValue(32, 2);
+    expect(colWidth(spec().$container, 2)).toBeAroundValue(32, 2);
+    expect(colWidth(spec().$container, 3)).toBeAroundValue(32, 2);
   });
 
-  it('should adjust resize handles position after table size changed', function() {
+  it('should adjust resize handles position after table size changed', () => {
     var maxed = false;
 
     handsontable({
@@ -494,11 +487,11 @@ describe('manualColumnResize', () => {
       }
     });
 
-    this.$container.find('thead th:eq(0)').simulate('mouseover');
+    spec().$container.find('thead th:eq(0)').simulate('mouseover');
 
-    var handle = this.$container.find('.manualColumnResizer');
+    var handle = spec().$container.find('.manualColumnResizer');
     var handleBox = handle[0].getBoundingClientRect();
-    var th0 = this.$container.find('thead th:eq(0)');
+    var th0 = spec().$container.find('thead th:eq(0)');
     var thBox = th0[0].getBoundingClientRect();
 
     expect(handleBox.left + handleBox.width).toEqual(thBox.left + thBox.width - 1);
@@ -506,14 +499,14 @@ describe('manualColumnResize', () => {
     maxed = true;
 
     render();
-    this.$container.find('thead th:eq(0)').simulate('mouseover');
+    spec().$container.find('thead th:eq(0)').simulate('mouseover');
 
     handleBox = handle[0].getBoundingClientRect();
     thBox = th0[0].getBoundingClientRect();
     expect(handleBox.left + handleBox.width).toEqual(thBox.left + thBox.width - 1);
   });
 
-  it('should display the resize handle in the correct place after the table has been scrolled', function() {
+  it('should display the resize handle in the correct place after the table has been scrolled', () => {
     var hot = handsontable({
       data: Handsontable.helper.createSpreadsheetData(10, 20),
       colHeaders: true,
@@ -524,9 +517,9 @@ describe('manualColumnResize', () => {
 
     var mainHolder = hot.view.wt.wtTable.holder;
 
-    var $colHeader = this.$container.find('.ht_clone_top thead tr:eq(0) th:eq(2)');
+    var $colHeader = spec().$container.find('.ht_clone_top thead tr:eq(0) th:eq(2)');
     $colHeader.simulate('mouseover');
-    var $handle = this.$container.find('.manualColumnResizer');
+    var $handle = spec().$container.find('.manualColumnResizer');
     $handle[0].style.background = 'red';
 
     expect($colHeader.offset().left + $colHeader.width() - 5).toBeCloseTo($handle.offset().left, 0);
@@ -535,14 +528,14 @@ describe('manualColumnResize', () => {
     $(mainHolder).scrollLeft(200);
     hot.render();
 
-    $colHeader = this.$container.find('.ht_clone_top thead tr:eq(0) th:eq(3)');
+    $colHeader = spec().$container.find('.ht_clone_top thead tr:eq(0) th:eq(3)');
     $colHeader.simulate('mouseover');
     expect($colHeader.offset().left + $colHeader.width() - 5).toBeCloseTo($handle.offset().left, 0);
     expect($colHeader.offset().top).toBeCloseTo($handle.offset().top, 0);
   });
 
   describe('handle and guide', () => {
-    it('should display the resize handle in the proper position and with a proper size', function() {
+    it('should display the resize handle in the proper position and with a proper size', () => {
       handsontable({
         data: [
           {id: 1, name: 'Ted', lastName: 'Right'},
@@ -555,7 +548,7 @@ describe('manualColumnResize', () => {
         manualColumnResize: true
       });
 
-      var $headerTH = this.$container.find('thead tr:eq(0) th:eq(1)');
+      var $headerTH = spec().$container.find('thead tr:eq(0) th:eq(1)');
       $headerTH.simulate('mouseover');
 
       var $handle = $('.manualColumnResizer');

--- a/src/plugins/manualRowResize/test/manualRowResize.e2e.js
+++ b/src/plugins/manualRowResize/test/manualRowResize.e2e.js
@@ -13,18 +13,18 @@ describe('manualRowResize', () => {
     }
   });
 
-  it('should change row heights at init', function() {
+  it('should change row heights at init', () => {
     handsontable({
       rowHeaders: true,
       manualRowResize: [50, 40, 100]
     });
 
-    expect(rowHeight(this.$container, 0)).toEqual(51);
-    expect(rowHeight(this.$container, 1)).toEqual(40);
-    expect(rowHeight(this.$container, 2)).toEqual(100);
+    expect(rowHeight(spec().$container, 0)).toEqual(51);
+    expect(rowHeight(spec().$container, 1)).toEqual(40);
+    expect(rowHeight(spec().$container, 2)).toEqual(100);
   });
 
-  it('should be enabled after specifying it in updateSettings config', function() {
+  it('should be enabled after specifying it in updateSettings config', () => {
     handsontable({
       data: [
         {id: 1, name: 'Ted', lastName: 'Right'},
@@ -38,102 +38,102 @@ describe('manualRowResize', () => {
 
     updateSettings({manualRowResize: true});
 
-    this.$container.find('tbody tr:eq(0) th:eq(0)').simulate('mouseover');
+    spec().$container.find('tbody tr:eq(0) th:eq(0)').simulate('mouseover');
 
     expect($('.manualRowResizer').size()).toBeGreaterThan(0);
   });
 
-  it('should change the default row height with updateSettings', function() {
+  it('should change the default row height with updateSettings', () => {
     handsontable({
       manualRowResize: true
     });
 
-    expect(rowHeight(this.$container, 0)).toEqual(defaultRowHeight + 2); // + Double border
-    expect(rowHeight(this.$container, 1)).toEqual(defaultRowHeight + 1); // + Single border
-    expect(rowHeight(this.$container, 2)).toEqual(defaultRowHeight + 1); // + Single border
+    expect(rowHeight(spec().$container, 0)).toEqual(defaultRowHeight + 2); // + Double border
+    expect(rowHeight(spec().$container, 1)).toEqual(defaultRowHeight + 1); // + Single border
+    expect(rowHeight(spec().$container, 2)).toEqual(defaultRowHeight + 1); // + Single border
 
     updateSettings({
       manualRowResize: [60, 50, 80]
     });
 
-    expect(rowHeight(this.$container, 0)).toEqual(61);
-    expect(rowHeight(this.$container, 1)).toEqual(50);
-    expect(rowHeight(this.$container, 2)).toEqual(80);
+    expect(rowHeight(spec().$container, 0)).toEqual(61);
+    expect(rowHeight(spec().$container, 1)).toEqual(50);
+    expect(rowHeight(spec().$container, 2)).toEqual(80);
   });
 
-  it('should change the row height with updateSettings', function() {
+  it('should change the row height with updateSettings', () => {
     handsontable({
       manualRowResize: [60, 50, 80]
     });
 
-    expect(rowHeight(this.$container, 0)).toEqual(61);
-    expect(rowHeight(this.$container, 1)).toEqual(50);
-    expect(rowHeight(this.$container, 2)).toEqual(80);
+    expect(rowHeight(spec().$container, 0)).toEqual(61);
+    expect(rowHeight(spec().$container, 1)).toEqual(50);
+    expect(rowHeight(spec().$container, 2)).toEqual(80);
 
     updateSettings({
       manualRowResize: [30, 80, 100]
     });
 
-    expect(rowHeight(this.$container, 0)).toEqual(31);
-    expect(rowHeight(this.$container, 1)).toEqual(80);
-    expect(rowHeight(this.$container, 2)).toEqual(100);
+    expect(rowHeight(spec().$container, 0)).toEqual(31);
+    expect(rowHeight(spec().$container, 1)).toEqual(80);
+    expect(rowHeight(spec().$container, 2)).toEqual(100);
   });
 
-  it('should not change the row height when `true` is passing', function() {
+  it('should not change the row height when `true` is passing', () => {
     handsontable({
       manualRowResize: [60, 50, 80]
     });
 
-    expect(rowHeight(this.$container, 0)).toEqual(61);
-    expect(rowHeight(this.$container, 1)).toEqual(50);
-    expect(rowHeight(this.$container, 2)).toEqual(80);
+    expect(rowHeight(spec().$container, 0)).toEqual(61);
+    expect(rowHeight(spec().$container, 1)).toEqual(50);
+    expect(rowHeight(spec().$container, 2)).toEqual(80);
 
     updateSettings({
       manualRowResize: true
     });
 
-    expect(rowHeight(this.$container, 0)).toEqual(61);
-    expect(rowHeight(this.$container, 1)).toEqual(50);
-    expect(rowHeight(this.$container, 2)).toEqual(80);
+    expect(rowHeight(spec().$container, 0)).toEqual(61);
+    expect(rowHeight(spec().$container, 1)).toEqual(50);
+    expect(rowHeight(spec().$container, 2)).toEqual(80);
   });
 
-  it('should change the row height to defaults when undefined is passed', function() {
+  it('should change the row height to defaults when undefined is passed', () => {
     handsontable({
       manualRowResize: [60, 50, 80]
     });
 
-    expect(rowHeight(this.$container, 0)).toEqual(61);
-    expect(rowHeight(this.$container, 1)).toEqual(50);
-    expect(rowHeight(this.$container, 2)).toEqual(80);
+    expect(rowHeight(spec().$container, 0)).toEqual(61);
+    expect(rowHeight(spec().$container, 1)).toEqual(50);
+    expect(rowHeight(spec().$container, 2)).toEqual(80);
 
     updateSettings({
       manualRowResize: void 0
     });
 
-    expect(rowHeight(this.$container, 0)).toEqual(defaultRowHeight + 2); // + Double border
-    expect(rowHeight(this.$container, 1)).toEqual(defaultRowHeight + 1); // + Single border
-    expect(rowHeight(this.$container, 2)).toEqual(defaultRowHeight + 1); // + Single border
+    expect(rowHeight(spec().$container, 0)).toEqual(defaultRowHeight + 2); // + Double border
+    expect(rowHeight(spec().$container, 1)).toEqual(defaultRowHeight + 1); // + Single border
+    expect(rowHeight(spec().$container, 2)).toEqual(defaultRowHeight + 1); // + Single border
   });
 
-  it('should reset row height', function() {
+  it('should reset row height', () => {
     handsontable({
       manualRowResize: true
     });
 
-    expect(rowHeight(this.$container, 0)).toEqual(defaultRowHeight + 2);
-    expect(rowHeight(this.$container, 1)).toEqual(defaultRowHeight + 1);
-    expect(rowHeight(this.$container, 2)).toEqual(defaultRowHeight + 1);
+    expect(rowHeight(spec().$container, 0)).toEqual(defaultRowHeight + 2);
+    expect(rowHeight(spec().$container, 1)).toEqual(defaultRowHeight + 1);
+    expect(rowHeight(spec().$container, 2)).toEqual(defaultRowHeight + 1);
 
     updateSettings({
       manualRowResize: true
     });
 
-    expect(rowHeight(this.$container, 0)).toEqual(defaultRowHeight + 2);
-    expect(rowHeight(this.$container, 1)).toEqual(defaultRowHeight + 1);
-    expect(rowHeight(this.$container, 2)).toEqual(defaultRowHeight + 1);
+    expect(rowHeight(spec().$container, 0)).toEqual(defaultRowHeight + 2);
+    expect(rowHeight(spec().$container, 1)).toEqual(defaultRowHeight + 1);
+    expect(rowHeight(spec().$container, 2)).toEqual(defaultRowHeight + 1);
   });
 
-  it('should trigger afterRowResize event after row height changes', function() {
+  it('should trigger afterRowResize event after row height changes', () => {
     var afterRowResizeCallback = jasmine.createSpy('afterRowResizeCallback');
 
     handsontable({
@@ -143,14 +143,14 @@ describe('manualRowResize', () => {
       afterRowResize: afterRowResizeCallback
     });
 
-    expect(rowHeight(this.$container, 0)).toEqual(defaultRowHeight + 2);
+    expect(rowHeight(spec().$container, 0)).toEqual(defaultRowHeight + 2);
 
     resizeRow(0, 100);
     expect(afterRowResizeCallback).toHaveBeenCalledWith(0, 100, false, void 0, void 0, void 0);
-    expect(rowHeight(this.$container, 0)).toEqual(101);
+    expect(rowHeight(spec().$container, 0)).toEqual(101);
   });
 
-  it('should not trigger afterRowResize event if row height does not change (delta = 0)', function() {
+  it('should not trigger afterRowResize event if row height does not change (delta = 0)', () => {
     var afterRowResizeCallback = jasmine.createSpy('afterRowResizeCallback');
 
     handsontable({
@@ -160,14 +160,14 @@ describe('manualRowResize', () => {
       afterRowResize: afterRowResizeCallback
     });
 
-    expect(rowHeight(this.$container, 0)).toEqual(defaultRowHeight + 2);
+    expect(rowHeight(spec().$container, 0)).toEqual(defaultRowHeight + 2);
 
     resizeRow(0, defaultRowHeight);
     expect(afterRowResizeCallback).not.toHaveBeenCalled();
-    expect(rowHeight(this.$container, 0)).toEqual(defaultRowHeight + 2);
+    expect(rowHeight(spec().$container, 0)).toEqual(defaultRowHeight + 2);
   });
 
-  it('should not trigger afterRowResize event after if row height does not change (no mousemove event)', function() {
+  it('should not trigger afterRowResize event after if row height does not change (no mousemove event)', () => {
     var afterRowResizeCallback = jasmine.createSpy('afterRowResizeCallback');
 
     handsontable({
@@ -177,12 +177,12 @@ describe('manualRowResize', () => {
       afterRowResize: afterRowResizeCallback
     });
 
-    expect(rowHeight(this.$container, 0)).toEqual(defaultRowHeight + 2);
+    expect(rowHeight(spec().$container, 0)).toEqual(defaultRowHeight + 2);
 
-    var $th = this.$container.find('tbody tr:eq(0) th:eq(0)');
+    var $th = spec().$container.find('tbody tr:eq(0) th:eq(0)');
     $th.simulate('mouseover');
 
-    var $resizer = this.$container.find('.manualRowResizer');
+    var $resizer = spec().$container.find('.manualRowResizer');
     var resizerPosition = $resizer.position();
 
     $resizer.simulate('mousedown', {
@@ -192,10 +192,10 @@ describe('manualRowResize', () => {
     $resizer.simulate('mouseup');
 
     expect(afterRowResizeCallback).not.toHaveBeenCalled();
-    expect(rowHeight(this.$container, 0)).toEqual(defaultRowHeight + 2);
+    expect(rowHeight(spec().$container, 0)).toEqual(defaultRowHeight + 2);
   });
 
-  it('should trigger an afterRowResize after row size changes, after double click', function(done) {
+  it('should trigger an afterRowResize after row size changes, after double click', async () => {
     var afterRowResizeCallback = jasmine.createSpy('afterRowResizeCallback');
 
     handsontable({
@@ -206,12 +206,12 @@ describe('manualRowResize', () => {
       afterRowResize: afterRowResizeCallback
     });
 
-    expect(rowHeight(this.$container, 0)).toEqual(defaultRowHeight + 2);
+    expect(rowHeight(spec().$container, 0)).toEqual(defaultRowHeight + 2);
 
-    var $th = this.$container.find('tbody tr:eq(2) th:eq(0)');
+    var $th = spec().$container.find('tbody tr:eq(2) th:eq(0)');
     $th.simulate('mouseover');
 
-    var $resizer = this.$container.find('.manualRowResizer');
+    var $resizer = spec().$container.find('.manualRowResizer');
     var resizerPosition = $resizer.position();
 
     $resizer.simulate('mousedown', {
@@ -224,15 +224,14 @@ describe('manualRowResize', () => {
     });
     $resizer.simulate('mouseup');
 
-    setTimeout(() => {
-      expect(afterRowResizeCallback.calls.count()).toEqual(1);
-      expect(afterRowResizeCallback.calls.argsFor(0)[0]).toEqual(2);
-      expect(afterRowResizeCallback.calls.argsFor(0)[1]).toEqual(defaultRowHeight + 1);
-      expect(rowHeight(spec().$container, 2)).toEqual(defaultRowHeight + 1);
-      done();
-    }, 1000);
+    await sleep(1000);
+
+    expect(afterRowResizeCallback.calls.count()).toEqual(1);
+    expect(afterRowResizeCallback.calls.argsFor(0)[0]).toEqual(2);
+    expect(afterRowResizeCallback.calls.argsFor(0)[1]).toEqual(defaultRowHeight + 1);
+    expect(rowHeight(spec().$container, 2)).toEqual(defaultRowHeight + 1);
   });
-  it('should not trigger afterRowResize event after if row height does not change (no dblclick event)', function() {
+  it('should not trigger afterRowResize event after if row height does not change (no dblclick event)', () => {
     var afterRowResizeCallback = jasmine.createSpy('afterRowResizeCallback');
 
     handsontable({
@@ -242,12 +241,12 @@ describe('manualRowResize', () => {
       afterRowResize: afterRowResizeCallback
     });
 
-    expect(rowHeight(this.$container, 0)).toEqual(defaultRowHeight + 2);
+    expect(rowHeight(spec().$container, 0)).toEqual(defaultRowHeight + 2);
 
-    var $th = this.$container.find('tbody tr:eq(2) th:eq(0)');
+    var $th = spec().$container.find('tbody tr:eq(2) th:eq(0)');
     $th.simulate('mouseover');
 
-    var $resizer = this.$container.find('.manualRowResizer');
+    var $resizer = spec().$container.find('.manualRowResizer');
     var resizerPosition = $resizer.position();
 
     $resizer.simulate('mousedown', {
@@ -256,9 +255,9 @@ describe('manualRowResize', () => {
     $resizer.simulate('mouseup');
 
     expect(afterRowResizeCallback).not.toHaveBeenCalled();
-    expect(rowHeight(this.$container, 0)).toEqual(defaultRowHeight + 2);
+    expect(rowHeight(spec().$container, 0)).toEqual(defaultRowHeight + 2);
   });
-  it('should display the resize handle in the correct place after the table has been scrolled', function() {
+  it('should display the resize handle in the correct place after the table has been scrolled', () => {
     var hot = handsontable({
       data: Handsontable.helper.createSpreadsheetData(20, 20),
       rowHeaders: true,
@@ -269,9 +268,9 @@ describe('manualRowResize', () => {
 
     var mainHolder = hot.view.wt.wtTable.holder;
 
-    var $rowHeader = this.$container.find('.ht_clone_left tbody tr:eq(2) th:eq(0)');
+    var $rowHeader = spec().$container.find('.ht_clone_left tbody tr:eq(2) th:eq(0)');
     $rowHeader.simulate('mouseover');
-    var $handle = this.$container.find('.manualRowResizer');
+    var $handle = spec().$container.find('.manualRowResizer');
     $handle[0].style.background = 'red';
 
     expect($rowHeader.offset().left).toBeCloseTo($handle.offset().left, 0);
@@ -280,13 +279,13 @@ describe('manualRowResize', () => {
     $(mainHolder).scrollTop(200);
     $(mainHolder).scroll();
 
-    $rowHeader = this.$container.find('.ht_clone_left tbody tr:eq(2) th:eq(0)');
+    $rowHeader = spec().$container.find('.ht_clone_left tbody tr:eq(2) th:eq(0)');
     $rowHeader.simulate('mouseover');
     expect($rowHeader.offset().left).toBeCloseTo($handle.offset().left, 0);
     expect($rowHeader.offset().top + $rowHeader.height() - 5).toBeCloseTo($handle.offset().top, 0);
   });
 
-  it('should autosize selected rows after double click on handler', function(done) {
+  it('should autosize selected rows after double click on handler', async () => {
     handsontable({
       data: Handsontable.helper.createSpreadsheetData(9, 9),
       rowHeaders: true,
@@ -295,31 +294,30 @@ describe('manualRowResize', () => {
 
     resizeRow(2, 300);
 
-    var $resizer = this.$container.find('.manualRowResizer');
+    var $resizer = spec().$container.find('.manualRowResizer');
     var resizerPosition = $resizer.position();
 
-    this.$container.find('.ht_clone_left tbody tr:eq(1) th:eq(0)').simulate('mousedown');
-    this.$container.find('.ht_clone_left tbody tr:eq(2) th:eq(0)').simulate('mouseover');
-    this.$container.find('.ht_clone_left tbody tr:eq(3) th:eq(0)').simulate('mouseover');
-    this.$container.find('.ht_clone_left tbody tr:eq(3) th:eq(0)').simulate('mousemove');
-    this.$container.find('.ht_clone_left tbody tr:eq(3) th:eq(0)').simulate('mouseup');
+    spec().$container.find('.ht_clone_left tbody tr:eq(1) th:eq(0)').simulate('mousedown');
+    spec().$container.find('.ht_clone_left tbody tr:eq(2) th:eq(0)').simulate('mouseover');
+    spec().$container.find('.ht_clone_left tbody tr:eq(3) th:eq(0)').simulate('mouseover');
+    spec().$container.find('.ht_clone_left tbody tr:eq(3) th:eq(0)').simulate('mousemove');
+    spec().$container.find('.ht_clone_left tbody tr:eq(3) th:eq(0)').simulate('mouseup');
 
-    setTimeout(() => {
-      $resizer.simulate('mousedown', {clientY: resizerPosition.top});
-      $resizer.simulate('mouseup');
-      $resizer.simulate('mousedown', {clientY: resizerPosition.top});
-      $resizer.simulate('mouseup');
-    }, 600);
+    await sleep(600);
 
-    setTimeout(() => {
-      expect(rowHeight(spec().$container, 1)).toBeAroundValue(24);
-      expect(rowHeight(spec().$container, 2)).toBeAroundValue(24);
-      expect(rowHeight(spec().$container, 3)).toBeAroundValue(24);
-      done();
-    }, 1600);
+    $resizer.simulate('mousedown', {clientY: resizerPosition.top});
+    $resizer.simulate('mouseup');
+    $resizer.simulate('mousedown', {clientY: resizerPosition.top});
+    $resizer.simulate('mouseup');
+
+    await sleep(1000);
+
+    expect(rowHeight(spec().$container, 1)).toBeAroundValue(24);
+    expect(rowHeight(spec().$container, 2)).toBeAroundValue(24);
+    expect(rowHeight(spec().$container, 3)).toBeAroundValue(24);
   });
 
-  it('should resize (expanding and narrowing) selected rows', function(done) {
+  it('should resize (expanding and narrowing) selected rows', async () => {
     handsontable({
       data: Handsontable.helper.createSpreadsheetData(10, 20),
       rowHeaders: true,
@@ -328,8 +326,8 @@ describe('manualRowResize', () => {
 
     resizeRow(2, 60);
 
-    var $rowsHeaders = this.$container.find('.ht_clone_left tr th');
-    this.$container.find('.ht_clone_left tbody tr:eq(1) th:eq(0)').simulate('mouseover');
+    var $rowsHeaders = spec().$container.find('.ht_clone_left tr th');
+    spec().$container.find('.ht_clone_left tbody tr:eq(1) th:eq(0)').simulate('mouseover');
 
     $rowsHeaders.eq(1).simulate('mousedown');
     $rowsHeaders.eq(2).simulate('mouseover');
@@ -337,33 +335,31 @@ describe('manualRowResize', () => {
     $rowsHeaders.eq(3).simulate('mousemove');
     $rowsHeaders.eq(3).simulate('mouseup');
 
-    var $resizer = this.$container.find('.manualRowResizer');
+    var $resizer = spec().$container.find('.manualRowResizer');
     var resizerPosition = $resizer.position();
 
-    setTimeout(() => {
-      $resizer.simulate('mousedown', {clientY: resizerPosition.top});
-      $resizer.simulate('mousemove', {clientY: resizerPosition.top - $rowsHeaders.eq(3).height() + 80});
-      $resizer.simulate('mouseup');
+    await sleep(600);
+    $resizer.simulate('mousedown', {clientY: resizerPosition.top});
+    $resizer.simulate('mousemove', {clientY: resizerPosition.top - $rowsHeaders.eq(3).height() + 80});
+    $resizer.simulate('mouseup');
 
-      expect($rowsHeaders.eq(1).height()).toEqual(80);
-      expect($rowsHeaders.eq(2).height()).toEqual(80);
-      expect($rowsHeaders.eq(3).height()).toEqual(80);
-    }, 600);
+    expect($rowsHeaders.eq(1).height()).toEqual(80);
+    expect($rowsHeaders.eq(2).height()).toEqual(80);
+    expect($rowsHeaders.eq(3).height()).toEqual(80);
 
-    setTimeout(() => {
-      $resizer.simulate('mousedown', {clientY: resizerPosition.top});
-      $resizer.simulate('mousemove', {clientY: resizerPosition.top - $rowsHeaders.eq(3).height() + 35});
-      $resizer.simulate('mouseup');
+    await sleep(1200);
 
-      expect($rowsHeaders.eq(1).height()).toEqual(35);
-      expect($rowsHeaders.eq(2).height()).toEqual(35);
-      expect($rowsHeaders.eq(3).height()).toEqual(35);
-      done();
-    }, 1800);
+    $resizer.simulate('mousedown', {clientY: resizerPosition.top});
+    $resizer.simulate('mousemove', {clientY: resizerPosition.top - $rowsHeaders.eq(3).height() + 35});
+    $resizer.simulate('mouseup');
+
+    expect($rowsHeaders.eq(1).height()).toEqual(35);
+    expect($rowsHeaders.eq(2).height()).toEqual(35);
+    expect($rowsHeaders.eq(3).height()).toEqual(35);
   });
 
   describe('handle and guide', () => {
-    it('should display the resize handle in the proper position and with a proper size', function() {
+    it('should display the resize handle in the proper position and with a proper size', () => {
       handsontable({
         data: [
           {id: 1, name: 'Ted', lastName: 'Right'},
@@ -376,7 +372,7 @@ describe('manualRowResize', () => {
         manualRowResize: true
       });
 
-      var $headerTH = this.$container.find('tbody tr:eq(1) th:eq(0)');
+      var $headerTH = spec().$container.find('tbody tr:eq(1) th:eq(0)');
       $headerTH.simulate('mouseover');
 
       var $handle = $('.manualRowResizer');

--- a/src/plugins/mergeCells/test/mergeCells.e2e.js
+++ b/src/plugins/mergeCells/test/mergeCells.e2e.js
@@ -129,7 +129,7 @@ describe('MergeCells', () => {
   });
 
   describe('merged cells selection', () => {
-    it('should select the whole range of cells which form a merged cell', function() {
+    it('should select the whole range of cells which form a merged cell', () => {
       const hot = handsontable({
         data: Handsontable.helper.createSpreadsheetObjectData(4, 4),
         mergeCells: [
@@ -142,7 +142,7 @@ describe('MergeCells', () => {
         ]
       });
 
-      let $table = this.$container.find('table.htCore');
+      let $table = spec().$container.find('table.htCore');
       let $td = $table.find('tr:eq(0) td:eq(0)');
 
       expect($td.attr('rowspan')).toEqual('1');
@@ -161,7 +161,7 @@ describe('MergeCells', () => {
       expect(hot.getSelectedLast()).toEqual([0, 0, 0, 3]);
     });
 
-    it('should always make a rectangular selection, when selecting merged and not merged cells', function() {
+    it('should always make a rectangular selection, when selecting merged and not merged cells', () => {
       const hot = handsontable({
         data: Handsontable.helper.createSpreadsheetObjectData(4, 4),
         mergeCells: [
@@ -174,7 +174,7 @@ describe('MergeCells', () => {
         ]
       });
 
-      let $table = this.$container.find('table.htCore');
+      let $table = spec().$container.find('table.htCore');
       let $td = $table.find('tr:eq(1) td:eq(1)');
 
       expect($td.attr('rowspan')).toEqual('2');
@@ -540,7 +540,7 @@ describe('MergeCells', () => {
       expect(hot.countRenderedCols()).toBe(39);
     });
 
-    it('should render whole merged cell even when most columns are not in the viewport - scrolled to the right', function() {
+    it('should render whole merged cell even when most columns are not in the viewport - scrolled to the right', () => {
       const hot = handsontable({
         data: Handsontable.helper.createSpreadsheetObjectData(5, 40),
         mergeCells: [
@@ -551,7 +551,7 @@ describe('MergeCells', () => {
         width: 400
       });
 
-      this.$container.scrollLeft(99999);
+      spec().$container.scrollLeft(99999);
       hot.render();
 
       expect(hot.countRenderedCols()).toBe(39);

--- a/src/plugins/mergeCells/test/selection.e2e.js
+++ b/src/plugins/mergeCells/test/selection.e2e.js
@@ -86,7 +86,7 @@ describe('MergeCells Selection', () => {
   });
 
   it('should make the entirely selected merged cells have the same background color as a regular selected area, when ' +
-    'selecting entire columns or rows (using multiple selection layers)', function() {
+    'selecting entire columns or rows (using multiple selection layers)', () => {
     handsontable({
       data: Handsontable.helper.createSpreadsheetObjectData(10, 5),
       mergeCells: [
@@ -110,10 +110,10 @@ describe('MergeCells Selection', () => {
       getCell(3, -1, true),
     ];
     const columnHeaders = [
-      this.$container.find('.ht_clone_top tr:eq(0) th:eq(1)'),
-      this.$container.find('.ht_clone_top tr:eq(0) th:eq(2)'),
-      this.$container.find('.ht_clone_top tr:eq(0) th:eq(3)'),
-      this.$container.find('.ht_clone_top tr:eq(0) th:eq(4)'),
+      spec().$container.find('.ht_clone_top tr:eq(0) th:eq(1)'),
+      spec().$container.find('.ht_clone_top tr:eq(0) th:eq(2)'),
+      spec().$container.find('.ht_clone_top tr:eq(0) th:eq(3)'),
+      spec().$container.find('.ht_clone_top tr:eq(0) th:eq(4)'),
     ];
 
     deselectCell();

--- a/src/plugins/undoRedo/test/UndoRedo.e2e.js
+++ b/src/plugins/undoRedo/test/UndoRedo.e2e.js
@@ -748,8 +748,8 @@ describe('UndoRedo', () => {
           expect(getDataAtCell(3, 1)).toEqual('B4');
         });
 
-        it('should undo changes only for table where the change actually took place', function() {
-          this.$container2 = $(`<div id="${id}-2"></div>`).appendTo('body');
+        it('should undo changes only for table where the change actually took place', () => {
+          spec().$container2 = $(`<div id="${id}-2"></div>`).appendTo('body');
 
           const hot1 = handsontable({
             data: [
@@ -759,7 +759,7 @@ describe('UndoRedo', () => {
             ]
           });
 
-          this.$container2.handsontable({
+          spec().$container2.handsontable({
             data: [
               ['A'],
               ['B'],
@@ -767,7 +767,7 @@ describe('UndoRedo', () => {
             ]
           });
 
-          const hot2 = this.$container2.handsontable('getInstance');
+          const hot2 = spec().$container2.handsontable('getInstance');
 
           hot1.setDataAtCell(0, 0, 4);
           expect(hot1.getDataAtCell(0, 0)).toEqual(4);
@@ -782,7 +782,7 @@ describe('UndoRedo', () => {
           expect(hot1.getDataAtCell(0, 0)).toEqual(1);
 
           hot2.destroy();
-          this.$container2.remove();
+          spec().$container2.remove();
         });
 
         it('should return the right amount after undo removal of single column', () => {
@@ -1361,8 +1361,8 @@ describe('UndoRedo', () => {
           expect(getDataAtCell(0, 1)).toEqual('B1');
         });
 
-        it('should redo changes only for table where the change actually took place', function() {
-          this.$container2 = $(`<div id="${id}-2"></div>`).appendTo('body');
+        it('should redo changes only for table where the change actually took place', () => {
+          spec().$container2 = $(`<div id="${id}-2"></div>`).appendTo('body');
 
           const hot1 = handsontable({
             data: [
@@ -1372,7 +1372,7 @@ describe('UndoRedo', () => {
             ]
           });
 
-          this.$container2.handsontable({
+          spec().$container2.handsontable({
             data: [
               ['A'],
               ['B'],
@@ -1380,7 +1380,7 @@ describe('UndoRedo', () => {
             ]
           });
 
-          const hot2 = this.$container2.handsontable('getInstance');
+          const hot2 = spec().$container2.handsontable('getInstance');
 
           hot1.setDataAtCell(0, 0, 4);
           expect(hot1.getDataAtCell(0, 0)).toEqual(4);
@@ -1399,7 +1399,7 @@ describe('UndoRedo', () => {
           expect(hot2.getDataAtCell(0, 0)).toEqual('A');
 
           hot2.destroy();
-          this.$container2.remove();
+          spec().$container2.remove();
         });
       });
     });
@@ -2386,7 +2386,7 @@ describe('UndoRedo', () => {
     });
 
     describe('Keyboard shortcuts', () => {
-      it('should undo single change after hitting CTRL+Z', function() {
+      it('should undo single change after hitting CTRL+Z', () => {
         handsontable({
           data: Handsontable.helper.createSpreadsheetData(2, 2)
         });
@@ -2394,11 +2394,11 @@ describe('UndoRedo', () => {
         selectCell(0, 0);
         setDataAtCell(0, 0, 'new value');
 
-        this.$container.simulate('keydown', {ctrlKey: true, keyCode: 'Z'.charCodeAt(0)});
+        spec().$container.simulate('keydown', {ctrlKey: true, keyCode: 'Z'.charCodeAt(0)});
         expect(getDataAtCell(0, 0)).toBe('A1');
       });
 
-      it('should redo single change after hitting CTRL+Y', function() {
+      it('should redo single change after hitting CTRL+Y', () => {
         handsontable({
           data: Handsontable.helper.createSpreadsheetData(2, 2)
         });
@@ -2412,12 +2412,12 @@ describe('UndoRedo', () => {
         HOT.undo();
         expect(getDataAtCell(0, 0)).toBe('A1');
 
-        this.$container.simulate('keydown', {ctrlKey: true, keyCode: 'Y'.charCodeAt(0)});
+        spec().$container.simulate('keydown', {ctrlKey: true, keyCode: 'Y'.charCodeAt(0)});
 
         expect(getDataAtCell(0, 0)).toBe('new value');
       });
 
-      it('should redo single change after hitting CTRL+SHIFT+Z', function() {
+      it('should redo single change after hitting CTRL+SHIFT+Z', () => {
         handsontable({
           data: Handsontable.helper.createSpreadsheetData(2, 2)
         });
@@ -2431,7 +2431,7 @@ describe('UndoRedo', () => {
         HOT.undo();
         expect(getDataAtCell(0, 0)).toBe('A1');
 
-        this.$container.simulate('keydown', {ctrlKey: true, shiftKey: true, keyCode: 'Z'.charCodeAt(0)});
+        spec().$container.simulate('keydown', {ctrlKey: true, shiftKey: true, keyCode: 'Z'.charCodeAt(0)});
 
         expect(getDataAtCell(0, 0)).toBe('new value');
       });

--- a/test/e2e/ColHeader.spec.js
+++ b/test/e2e/ColHeader.spec.js
@@ -12,20 +12,18 @@ describe('ColHeader', () => {
     }
   });
 
-  it('should not show col headers by default', function() {
-    var that = this;
+  it('should not show col headers by default', () => {
     handsontable();
 
-    expect(that.$container.find('thead th').length).toEqual(0);
+    expect(spec().$container.find('thead th').length).toEqual(0);
   });
 
-  it('should show col headers if true', function() {
-    var that = this;
+  it('should show col headers if true', () => {
     handsontable({
       colHeaders: true
     });
 
-    expect(that.$container.find('thead th').length).toBeGreaterThan(0);
+    expect(spec().$container.find('thead th').length).toBeGreaterThan(0);
   });
 
   it('should show default columns headers labelled A-(Z * n)', () => {
@@ -99,13 +97,12 @@ describe('ColHeader', () => {
     expect($.trim(ths.eq(4).text())).toEqual('E');
   });
 
-  it('should not show col headers if false', function() {
-    var that = this;
+  it('should not show col headers if false', () => {
     handsontable({
       colHeaders: false
     });
 
-    expect(that.$container.find('th.htColHeader').length).toEqual(0);
+    expect(spec().$container.find('th.htColHeader').length).toEqual(0);
   });
 
   it('should hide columns headers after updateSettings', () => {
@@ -317,7 +314,7 @@ describe('ColHeader', () => {
     expect(topHeaderExample.height()).toEqual(masterHeaderExample.height());
   });
 
-  it('should allow defining custom column header height using the columnHeaderHeight config option', function() {
+  it('should allow defining custom column header height using the columnHeaderHeight config option', () => {
     var hot = handsontable({
       startCols: 3,
       colHeaders: true,
@@ -326,10 +323,10 @@ describe('ColHeader', () => {
 
     hot.render();
 
-    expect(this.$container.find('th').eq(0).height()).toEqual(40);
+    expect(spec().$container.find('th').eq(0).height()).toEqual(40);
   });
 
-  it('should allow defining custom column header heights using the columnHeaderHeight config option, when multiple column header levels are defined', function() {
+  it('should allow defining custom column header heights using the columnHeaderHeight config option, when multiple column header levels are defined', () => {
     var hot = handsontable({
       startCols: 3,
       colHeaders: true,
@@ -355,7 +352,7 @@ describe('ColHeader', () => {
     });
     hot.render();
 
-    expect(this.$container.find('.handsontable.ht_clone_top tr:nth-child(1) th:nth-child(1)').height()).toEqual(45);
-    expect(this.$container.find('.handsontable.ht_clone_top tr:nth-child(2) th:nth-child(1)').height()).toEqual(65);
+    expect(spec().$container.find('.handsontable.ht_clone_top tr:nth-child(1) th:nth-child(1)').height()).toEqual(45);
+    expect(spec().$container.find('.handsontable.ht_clone_top tr:nth-child(2) th:nth-child(1)').height()).toEqual(65);
   });
 });

--- a/test/e2e/Core_alter.spec.js
+++ b/test/e2e/Core_alter.spec.js
@@ -209,7 +209,7 @@ describe('Core_alter', () => {
       expect(countCols()).toEqual(4);
     });
 
-    it('should remove one row if amount parameter is empty', function() {
+    it('should remove one row if amount parameter is empty', () => {
       handsontable({
         data: [
           ['a1', 'a2', 'a3'],
@@ -222,11 +222,11 @@ describe('Core_alter', () => {
       alter('remove_row', 1);
 
       expect(countRows()).toEqual(4);
-      expect(this.$container.find('tr:eq(0) td:eq(0)').html()).toEqual('a1');
-      expect(this.$container.find('tr:eq(1) td:eq(1)').html()).toEqual('c2');
+      expect(spec().$container.find('tr:eq(0) td:eq(0)').html()).toEqual('a1');
+      expect(spec().$container.find('tr:eq(1) td:eq(1)').html()).toEqual('c2');
     });
 
-    it('should remove as many rows as given in the amount parameter', function() {
+    it('should remove as many rows as given in the amount parameter', () => {
       handsontable({
         data: [
           ['a1', 'a2', 'a3'],
@@ -239,8 +239,8 @@ describe('Core_alter', () => {
       alter('remove_row', 1, 3);
 
       expect(countRows()).toEqual(2);
-      expect(this.$container.find('tr:eq(0) td:eq(0)').html()).toEqual('a1');
-      expect(this.$container.find('tr:eq(1) td:eq(1)').html()).toEqual('e2');
+      expect(spec().$container.find('tr:eq(0) td:eq(0)').html()).toEqual('a1');
+      expect(spec().$container.find('tr:eq(1) td:eq(1)').html()).toEqual('e2');
     });
 
     it('should not remove more rows that exist', () => {
@@ -485,7 +485,7 @@ describe('Core_alter', () => {
       });
     });
 
-    it('should remove one column if amount parameter is empty', function() {
+    it('should remove one column if amount parameter is empty', () => {
       handsontable({
         data: [
           ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'],
@@ -495,11 +495,11 @@ describe('Core_alter', () => {
       alter('remove_col', 1);
 
       expect(countCols()).toEqual(7);
-      expect(this.$container.find('tr:eq(0) td:eq(0)').html()).toEqual('a');
-      expect(this.$container.find('tr:eq(1) td:eq(1)').html()).toEqual('c');
+      expect(spec().$container.find('tr:eq(0) td:eq(0)').html()).toEqual('a');
+      expect(spec().$container.find('tr:eq(1) td:eq(1)').html()).toEqual('c');
     });
 
-    it('should remove as many columns as given in the amount parameter', function() {
+    it('should remove as many columns as given in the amount parameter', () => {
       handsontable({
         data: [
           ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'],
@@ -509,11 +509,11 @@ describe('Core_alter', () => {
       alter('remove_col', 1, 3);
 
       expect(countCols()).toEqual(5);
-      expect(this.$container.find('tr:eq(0) td:eq(0)').html()).toEqual('a');
-      expect(this.$container.find('tr:eq(1) td:eq(1)').html()).toEqual('e');
+      expect(spec().$container.find('tr:eq(0) td:eq(0)').html()).toEqual('a');
+      expect(spec().$container.find('tr:eq(1) td:eq(1)').html()).toEqual('e');
     });
 
-    it('should not remove more columns that exist', function() {
+    it('should not remove more columns that exist', () => {
       handsontable({
         data: [
           ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'],
@@ -523,10 +523,10 @@ describe('Core_alter', () => {
       alter('remove_col', 6, 3);
 
       expect(countCols()).toEqual(6);
-      expect(this.$container.find('tr:eq(1) td:last').html()).toEqual('f');
+      expect(spec().$container.find('tr:eq(1) td:last').html()).toEqual('f');
     });
 
-    it('should remove one column from end if no parameters are given', function() {
+    it('should remove one column from end if no parameters are given', () => {
       handsontable({
         data: [
           ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'],
@@ -536,10 +536,10 @@ describe('Core_alter', () => {
       alter('remove_col');
 
       expect(countCols()).toEqual(7);
-      expect(this.$container.find('tr:eq(1) td:last').html()).toEqual('g');
+      expect(spec().$container.find('tr:eq(1) td:last').html()).toEqual('g');
     });
 
-    it('should remove amount of columns from end if index parameter is not given', function() {
+    it('should remove amount of columns from end if index parameter is not given', () => {
       handsontable({
         data: [
           ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'],
@@ -549,7 +549,7 @@ describe('Core_alter', () => {
       alter('remove_col', null, 3);
 
       expect(countCols()).toEqual(5);
-      expect(this.$container.find('tr:eq(1) td:last').html()).toEqual('e');
+      expect(spec().$container.find('tr:eq(1) td:last').html()).toEqual('e');
     });
 
     it('should fire beforeRemoveCol event before removing col', () => {
@@ -615,8 +615,8 @@ describe('Core_alter', () => {
       expect(getCellMeta(0, 1).someValue).toEqual([0, 2]);
     });
 
-    it('should remove column when not all rows are visible in the viewport', function() {
-      this.$container.css({
+    it('should remove column when not all rows are visible in the viewport', () => {
+      spec().$container.css({
         height: '100',
         overflow: 'auto'
       });
@@ -713,7 +713,7 @@ describe('Core_alter', () => {
   });
 
   describe('insert row', () => {
-    it('should insert row at given index', function() {
+    it('should insert row at given index', () => {
       handsontable({
         data: [
           ['a1', 'a2', 'a3'],
@@ -726,7 +726,7 @@ describe('Core_alter', () => {
       alter('insert_row', 1);
 
       expect(countRows()).toEqual(6);
-      expect(this.$container.find('tr:eq(2) td:eq(0)').html()).toEqual('b1');
+      expect(spec().$container.find('tr:eq(2) td:eq(0)').html()).toEqual('b1');
     });
 
     it('should fire the beforeCreateRow hook before creating a row', () => {
@@ -845,7 +845,7 @@ describe('Core_alter', () => {
       expect(getDataAtCell(4, 2)).toEqual(null);
     });
 
-    it('should insert the amount of rows at given index', function() {
+    it('should insert the amount of rows at given index', () => {
       handsontable({
         data: [
           ['a1', 'a2', 'a3'],
@@ -859,9 +859,9 @@ describe('Core_alter', () => {
 
       expect(countRows()).toEqual(8);
 
-      expect(this.$container.find('tr:eq(1) td:eq(0)').html()).toEqual('');
+      expect(spec().$container.find('tr:eq(1) td:eq(0)').html()).toEqual('');
 
-      expect(this.$container.find('tr:eq(4) td:eq(0)').html()).toEqual('b1');
+      expect(spec().$container.find('tr:eq(4) td:eq(0)').html()).toEqual('b1');
     });
 
     it('should insert the amount of rows at the end if index is not given', () => {
@@ -896,7 +896,7 @@ describe('Core_alter', () => {
       expect(countRows()).toEqual(7);
     });
 
-    it('when amount parameter is used, should not insert more rows than allowed by maxRows', function() {
+    it('when amount parameter is used, should not insert more rows than allowed by maxRows', () => {
       handsontable({
         data: [
           ['a1', 'a2', 'a3'],
@@ -910,7 +910,7 @@ describe('Core_alter', () => {
       alter('insert_row', 1, 10);
 
       expect(countRows()).toEqual(10);
-      expect(this.$container.find('tr:eq(6) td:eq(0)').html()).toEqual('b1');
+      expect(spec().$container.find('tr:eq(6) td:eq(0)').html()).toEqual('b1');
     });
 
     it('should not add more source rows than defined in maxRows when trimming rows using the modifyRow hook', () => {
@@ -1000,7 +1000,7 @@ describe('Core_alter', () => {
   });
 
   describe('insert column', () => {
-    it('should insert column at given index', function() {
+    it('should insert column at given index', () => {
       handsontable({
         data: [
           ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'],
@@ -1010,10 +1010,10 @@ describe('Core_alter', () => {
       alter('insert_col', 1);
 
       expect(countCols()).toEqual(9);
-      expect(this.$container.find('tr:eq(1) td:eq(2)').html()).toEqual('b');
+      expect(spec().$container.find('tr:eq(1) td:eq(2)').html()).toEqual('b');
     });
 
-    it('should insert column at the end if index is not given', function() {
+    it('should insert column at the end if index is not given', () => {
       handsontable({
         data: [
           ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'],
@@ -1023,10 +1023,10 @@ describe('Core_alter', () => {
       alter('insert_col');
 
       expect(countCols()).toEqual(9);
-      expect(this.$container.find('tr:eq(1) td:eq(7)').html()).toEqual('h');
+      expect(spec().$container.find('tr:eq(1) td:eq(7)').html()).toEqual('h');
     });
 
-    it('should insert the amount of columns at given index', function() {
+    it('should insert the amount of columns at given index', () => {
       handsontable({
         data: [
           ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'],
@@ -1036,10 +1036,10 @@ describe('Core_alter', () => {
       alter('insert_col', 1, 3);
 
       expect(countCols()).toEqual(11);
-      expect(this.$container.find('tr:eq(1) td:eq(4)').html()).toEqual('b');
+      expect(spec().$container.find('tr:eq(1) td:eq(4)').html()).toEqual('b');
     });
 
-    it('should insert the amount of columns at the end if index is not given', function() {
+    it('should insert the amount of columns at the end if index is not given', () => {
       handsontable({
         data: [
           ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'],
@@ -1049,11 +1049,11 @@ describe('Core_alter', () => {
       alter('insert_col', null, 3);
 
       expect(countCols()).toEqual(11);
-      expect(this.$container.find('tr:eq(1) td:eq(7)').html()).toEqual('h');
+      expect(spec().$container.find('tr:eq(1) td:eq(7)').html()).toEqual('h');
 
-      expect(this.$container.find('tr:eq(1) td:eq(8)').html()).toEqual('');
-      expect(this.$container.find('tr:eq(1) td:eq(9)').html()).toEqual('');
-      expect(this.$container.find('tr:eq(1) td:eq(10)').html()).toEqual('');
+      expect(spec().$container.find('tr:eq(1) td:eq(8)').html()).toEqual('');
+      expect(spec().$container.find('tr:eq(1) td:eq(9)').html()).toEqual('');
+      expect(spec().$container.find('tr:eq(1) td:eq(10)').html()).toEqual('');
     });
 
     it('should insert not more cols than maxCols', () => {
@@ -1068,7 +1068,7 @@ describe('Core_alter', () => {
       expect(countCols()).toEqual(7);
     });
 
-    it('should not insert more columns than allowed by maxCols, when amount parameter is used', function() {
+    it('should not insert more columns than allowed by maxCols, when amount parameter is used', () => {
       handsontable({
         data: [
           ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'],
@@ -1079,9 +1079,9 @@ describe('Core_alter', () => {
       alter('insert_col', 1, 10);
 
       expect(countCols()).toEqual(10);
-      expect(this.$container.find('tr:eq(1) td:eq(1)').html()).toEqual('');
-      expect(this.$container.find('tr:eq(1) td:eq(2)').html()).toEqual('');
-      expect(this.$container.find('tr:eq(1) td:eq(3)').html()).toEqual('b');
+      expect(spec().$container.find('tr:eq(1) td:eq(1)').html()).toEqual('');
+      expect(spec().$container.find('tr:eq(1) td:eq(2)').html()).toEqual('');
+      expect(spec().$container.find('tr:eq(1) td:eq(3)').html()).toEqual('b');
     });
 
     it('should fire callback on create col', () => {
@@ -1144,8 +1144,8 @@ describe('Core_alter', () => {
 
     });
 
-    it('should stretch the table after adding another column (if stretching is set to \'all\')', function() {
-      this.$container.css({
+    it('should stretch the table after adding another column (if stretching is set to \'all\')', () => {
+      spec().$container.css({
         width: 500,
       });
 

--- a/test/e2e/Core_beforechange.spec.js
+++ b/test/e2e/Core_beforechange.spec.js
@@ -12,7 +12,7 @@ describe('Core_beforechange', () => {
     }
   });
 
-  it('this.rootElement should point to handsontable rootElement', function() {
+  it('this.rootElement should point to handsontable rootElement', () => {
     var output = null;
 
     handsontable({
@@ -22,7 +22,7 @@ describe('Core_beforechange', () => {
     });
     setDataAtCell(0, 0, 'test');
 
-    expect(output).toEqual(this.$container[0]);
+    expect(output).toEqual(spec().$container[0]);
   });
 
   it('should remove change from stack', () => {

--- a/test/e2e/Core_count.spec.js
+++ b/test/e2e/Core_count.spec.js
@@ -20,8 +20,8 @@ describe('Core_count', () => {
       expect(instance.countVisibleRows()).toEqual(4);
     });
 
-    it('should return -1 if table is not rendered', function() {
-      this.$container.remove();
+    it('should return -1 if table is not rendered', () => {
+      spec().$container.remove();
       var instance = handsontable({
         data: Handsontable.helper.createSpreadsheetData(10, 10),
         width: 100
@@ -49,8 +49,8 @@ describe('Core_count', () => {
       expect(instance.countRenderedRows()).toEqual(25);
     });
 
-    it('should return -1 if table is not rendered', function() {
-      this.$container.remove();
+    it('should return -1 if table is not rendered', () => {
+      spec().$container.remove();
       var instance = handsontable({
         data: Handsontable.helper.createSpreadsheetData(10, 10),
         width: 100
@@ -68,8 +68,8 @@ describe('Core_count', () => {
       expect(instance.countVisibleCols()).toEqual(10);
     });
 
-    it('should return -1 if table is not rendered', function() {
-      this.$container.remove();
+    it('should return -1 if table is not rendered', () => {
+      spec().$container.remove();
       var instance = handsontable({
         data: Handsontable.helper.createSpreadsheetData(10, 10),
         width: 100

--- a/test/e2e/Core_datachange.spec.js
+++ b/test/e2e/Core_datachange.spec.js
@@ -75,9 +75,9 @@ describe('Core_datachange', () => {
     expect(output[0][3]).toEqual('test');
   });
 
-  it('this.rootElement should point to handsontable rootElement', function() {
+  it('this.rootElement should point to handsontable rootElement', () => {
     var output = null;
-    var $container = this.$container;
+    var $container = spec().$container;
 
     handsontable({
       afterChange() {
@@ -89,9 +89,9 @@ describe('Core_datachange', () => {
     expect(output).toEqual($container[0]);
   });
 
-  it('onChange should be triggered after data is rendered to DOM (init)', function() {
+  it('onChange should be triggered after data is rendered to DOM (init)', () => {
     var output = null;
-    var $container = this.$container;
+    var $container = spec().$container;
 
     handsontable({
       data: [
@@ -107,9 +107,9 @@ describe('Core_datachange', () => {
     expect(output).toEqual('Joe Red');
   });
 
-  it('onChange should be triggered after data is rendered to DOM (setDataAtCell)', function() {
+  it('onChange should be triggered after data is rendered to DOM (setDataAtCell)', () => {
     var output = null;
-    var $container = this.$container;
+    var $container = spec().$container;
 
     handsontable({
       data: [

--- a/test/e2e/Core_destroyEditor.spec.js
+++ b/test/e2e/Core_destroyEditor.spec.js
@@ -54,8 +54,8 @@ describe('Core_destroyEditor', () => {
     expect(getDataAtCell(1, 1)).toEqual(null);
   });
 
-  it('should not destroy editor on scroll', function() {
-    this.$container.css({
+  it('should not destroy editor on scroll', () => {
+    spec().$container.css({
       width: 200,
       height: 100
     });
@@ -71,7 +71,7 @@ describe('Core_destroyEditor', () => {
 
     expect(editor.is(':visible')).toBe(true);
 
-    this.$container.scroll();
+    spec().$container.scroll();
 
     expect(editor.is(':visible')).toBe(true);
 

--- a/test/e2e/Core_getCellMeta.spec.js
+++ b/test/e2e/Core_getCellMeta.spec.js
@@ -145,7 +145,7 @@ describe('Core_getCellMeta', () => {
     expect(_this.instance).toBe(HOT);
   });
 
-  it('should get proper cellProperties when order of displayed rows is different than order of stored data', function() {
+  it('should get proper cellProperties when order of displayed rows is different than order of stored data', () => {
     handsontable({
       data: [
         ['C'],
@@ -164,14 +164,14 @@ describe('Core_getCellMeta', () => {
       }
     });
 
-    expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('C');
-    expect(this.$container.find('tbody tr:eq(0) td:eq(0)').hasClass('htDimmed')).toBe(false);
+    expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('C');
+    expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').hasClass('htDimmed')).toBe(false);
 
-    expect(this.$container.find('tbody tr:eq(1) td:eq(0)').text()).toEqual('A');
-    expect(this.$container.find('tbody tr:eq(1) td:eq(0)').hasClass('htDimmed')).toBe(true);
+    expect(spec().$container.find('tbody tr:eq(1) td:eq(0)').text()).toEqual('A');
+    expect(spec().$container.find('tbody tr:eq(1) td:eq(0)').hasClass('htDimmed')).toBe(true);
 
-    expect(this.$container.find('tbody tr:eq(2) td:eq(0)').text()).toEqual('B');
-    expect(this.$container.find('tbody tr:eq(2) td:eq(0)').hasClass('htDimmed')).toBe(false);
+    expect(spec().$container.find('tbody tr:eq(2) td:eq(0)').text()).toEqual('B');
+    expect(spec().$container.find('tbody tr:eq(2) td:eq(0)').hasClass('htDimmed')).toBe(false);
 
     // Column sorting changes the order of displayed rows while keeping table data unchanged
     updateSettings({
@@ -181,14 +181,14 @@ describe('Core_getCellMeta', () => {
       }
     });
 
-    expect(this.$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('A');
-    expect(this.$container.find('tbody tr:eq(0) td:eq(0)').hasClass('htDimmed')).toBe(true);
+    expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('A');
+    expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').hasClass('htDimmed')).toBe(true);
 
-    expect(this.$container.find('tbody tr:eq(1) td:eq(0)').text()).toEqual('B');
-    expect(this.$container.find('tbody tr:eq(1) td:eq(0)').hasClass('htDimmed')).toBe(false);
+    expect(spec().$container.find('tbody tr:eq(1) td:eq(0)').text()).toEqual('B');
+    expect(spec().$container.find('tbody tr:eq(1) td:eq(0)').hasClass('htDimmed')).toBe(false);
 
-    expect(this.$container.find('tbody tr:eq(2) td:eq(0)').text()).toEqual('C');
-    expect(this.$container.find('tbody tr:eq(2) td:eq(0)').hasClass('htDimmed')).toBe(false);
+    expect(spec().$container.find('tbody tr:eq(2) td:eq(0)').text()).toEqual('C');
+    expect(spec().$container.find('tbody tr:eq(2) td:eq(0)').hasClass('htDimmed')).toBe(false);
   });
 
   it('should call `beforeGetCellMeta` plugin hook with visual indexes as parameters', () => {

--- a/test/e2e/Core_init.spec.js
+++ b/test/e2e/Core_init.spec.js
@@ -12,17 +12,17 @@ describe('Core_init', () => {
     }
   });
 
-  it('should respect startRows and startCols when no data is provided', function() {
-    this.$container.remove();
-    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  it('should respect startRows and startCols when no data is provided', () => {
+    spec().$container.remove();
+    spec().$container = $(`<div id="${id}"></div>`).appendTo('body');
     handsontable();
 
     expect(countRows()).toEqual(5); // as given in README.md
     expect(countCols()).toEqual(5); // as given in README.md
   });
 
-  it('should respect width provided in inline style', function() {
-    this.$container.css({
+  it('should respect width provided in inline style', () => {
+    spec().$container.css({
       overflow: 'auto',
       width: '200px'
     });
@@ -32,34 +32,34 @@ describe('Core_init', () => {
       ]
     });
 
-    expect(this.$container.width()).toEqual(200);
+    expect(spec().$container.width()).toEqual(200);
   });
 
-  it('should respect width provided in CSS class', function() {
+  it('should respect width provided in CSS class', () => {
     $('<style>.myTable {overflow: auto; width: 200px}</style>').appendTo('head');
-    this.$container.addClass('myTable');
+    spec().$container.addClass('myTable');
     handsontable({
       data: [
         ['ABC', 'ABC', 'ABC', 'ABC', 'ABC', 'ABC', 'ABC', 'ABC', 'ABC']
       ]
     });
 
-    expect(this.$container.width()).toEqual(200);
+    expect(spec().$container.width()).toEqual(200);
   });
 
-  it('should construct when container is not appended to document', function() {
-    this.$container.remove();
+  it('should construct when container is not appended to document', () => {
+    spec().$container.remove();
     handsontable();
     expect(getData()).toBeTruthy();
   });
 
-  xit('should create table even if is launched inside custom element', function() {
+  xit('should create table even if is launched inside custom element', () => {
     // TODO: When we'll update phantomjs, then we should try to run this test case.
-    this.$container = $(`<hot-table><div id="${id}"></div></hot-table>`).appendTo('body');
+    spec().$container = $(`<hot-table><div id="${id}"></div></hot-table>`).appendTo('body');
     handsontable();
 
     expect(() => {
-      mouseOver(this.$container.find('tr:eq(0) td:eq(1)'));
+      mouseOver(spec().$container.find('tr:eq(0) td:eq(1)'));
     }).not.toThrow();
   });
 });

--- a/test/e2e/Core_keepEmptyRows.spec.js
+++ b/test/e2e/Core_keepEmptyRows.spec.js
@@ -41,7 +41,7 @@ describe('Core_keepEmptyRows', () => {
     ];
   };
 
-  it('should remove columns if needed', function() {
+  it('should remove columns if needed', () => {
     handsontable({
       data: arrayOfNestedObjects(),
       columns: [
@@ -50,10 +50,10 @@ describe('Core_keepEmptyRows', () => {
       ]
     });
 
-    expect(this.$container.find('tbody tr:first td').length).toEqual(2);
+    expect(spec().$container.find('tbody tr:first td').length).toEqual(2);
   });
 
-  it('should remove columns if needed when columns is a function', function() {
+  it('should remove columns if needed when columns is a function', () => {
     handsontable({
       data: arrayOfNestedObjects(),
       columns(column) {
@@ -73,10 +73,10 @@ describe('Core_keepEmptyRows', () => {
       }
     });
 
-    expect(this.$container.find('tbody tr:first td').length).toEqual(2);
+    expect(spec().$container.find('tbody tr:first td').length).toEqual(2);
   });
 
-  it('should create columns if needed', function() {
+  it('should create columns if needed', () => {
     handsontable({
       data: arrayOfNestedObjects(),
       columns: [
@@ -89,10 +89,10 @@ describe('Core_keepEmptyRows', () => {
       ]
     });
 
-    expect(this.$container.find('tbody tr:first td').length).toEqual(6);
+    expect(spec().$container.find('tbody tr:first td').length).toEqual(6);
   });
 
-  it('should create columns if needed when columns is a function', function() {
+  it('should create columns if needed when columns is a function', () => {
     handsontable({
       data: arrayOfNestedObjects(),
       columns(column) {
@@ -123,7 +123,7 @@ describe('Core_keepEmptyRows', () => {
       }
     });
 
-    expect(this.$container.find('tbody tr:first td').length).toEqual(6);
+    expect(spec().$container.find('tbody tr:first td').length).toEqual(6);
   });
 
   it('should create spare cols and rows on init (array data source)', () => {
@@ -141,7 +141,7 @@ describe('Core_keepEmptyRows', () => {
     expect(countCells()).toEqual(36);
   });
 
-  it('should create spare cols and rows on init (object data source)', function() {
+  it('should create spare cols and rows on init (object data source)', () => {
     handsontable({
       data: arrayOfNestedObjects(),
       minRows: 4,
@@ -150,7 +150,7 @@ describe('Core_keepEmptyRows', () => {
 
     expect(countRows()).toEqual(4);
     expect(countCols()).toEqual(6); // because arrayOfNestedObjects has 6 nested properites and they should be figured out if dataSchema/columns is not given
-    expect(this.$container.find('tbody tr:first td:last').text()).toEqual('City Name');
+    expect(spec().$container.find('tbody tr:first td:last').text()).toEqual('City Name');
   });
 
   it('should create new row when last cell in last row is edited', () => {

--- a/test/e2e/Core_loadData.spec.js
+++ b/test/e2e/Core_loadData.spec.js
@@ -547,18 +547,18 @@ describe('Core_loadData', () => {
     expect(getCellMeta(0, 0).foo).toBeUndefined();
   });
 
-  it('should clear cell properties after loadData, but before rendering new data', function() {
+  it('should clear cell properties after loadData, but before rendering new data', () => {
     handsontable();
     loadData(arrayOfArrays());
 
     getCellMeta(0, 0).valid = false;
     render();
 
-    expect(this.$container.find('tbody tr:eq(0) td:eq(0)').hasClass('htInvalid')).toEqual(true);
+    expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').hasClass('htInvalid')).toEqual(true);
 
     loadData(arrayOfArrays());
 
-    expect(this.$container.find('tbody tr:eq(0) td:eq(0)').hasClass('htInvalid')).toEqual(false);
+    expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').hasClass('htInvalid')).toEqual(false);
 
   });
 

--- a/test/e2e/Core_removeCellMeta.spec.js
+++ b/test/e2e/Core_removeCellMeta.spec.js
@@ -52,7 +52,7 @@ describe('Core_removeCellMeta', () => {
     expect(getCellMeta(0, 0).key).toBeUndefined();
   });
 
-  it('should trigger `beforeRemoveCellMeta` hook with proper parameters', function () {
+  it('should trigger `beforeRemoveCellMeta` hook with proper parameters', () => {
     const beforeRemoveCellMeta = jasmine.createSpy('beforeRemoveCellMeta');
 
     handsontable({
@@ -70,7 +70,7 @@ describe('Core_removeCellMeta', () => {
     expect(beforeRemoveCellMeta).toHaveBeenCalledWith(0, 0, 'key', 'value', undefined, undefined);
   });
 
-  it('should trigger `afterRemoveCellMeta` hook with proper parameters - case 1 (removed `key` existed)', function () {
+  it('should trigger `afterRemoveCellMeta` hook with proper parameters - case 1 (removed `key` existed)', () => {
     const afterRemoveCellMeta = jasmine.createSpy('afterRemoveCellMeta');
 
     handsontable({
@@ -88,7 +88,7 @@ describe('Core_removeCellMeta', () => {
     expect(afterRemoveCellMeta).toHaveBeenCalledWith(0, 0, 'key', 'value', undefined, undefined);
   });
 
-  it('should trigger `afterRemoveCellMeta` hook with proper parameters - case 2  (removed `key` not existed)', function () {
+  it('should trigger `afterRemoveCellMeta` hook with proper parameters - case 2  (removed `key` not existed)', () => {
     const afterRemoveCellMeta = jasmine.createSpy('afterRemoveCellMeta');
 
     handsontable({
@@ -151,7 +151,7 @@ describe('Core_removeCellMeta', () => {
     expect(colInsideHook).toEqual(1);
   });
 
-  it('should block removing cell meta when hook `beforeRemoveCellMeta` return false', function () {
+  it('should block removing cell meta when hook `beforeRemoveCellMeta` return false', () => {
     handsontable({
       beforeRemoveCellMeta: function (row, col) {
         if (row === 0 && col === 0) {

--- a/test/e2e/Core_render.spec.js
+++ b/test/e2e/Core_render.spec.js
@@ -12,7 +12,7 @@ describe('Core_render', () => {
     }
   });
 
-  it('all cells should get green background', function() {
+  it('all cells should get green background', () => {
     function greenCell(instance, td) {
       Handsontable.renderers.TextRenderer.apply(this, arguments);
       td.style.backgroundColor = 'green';
@@ -35,13 +35,13 @@ describe('Core_render', () => {
       }
     });
 
-    var $tds = this.$container.find('.htCore tbody td');
+    var $tds = spec().$container.find('.htCore tbody td');
     $tds.each(function() {
       expect(this.style.backgroundColor).toEqual('green');
     });
   });
 
-  it('render should update border dimensions', function() {
+  it('render should update border dimensions', () => {
     var data = [
       ['a', 'b'],
       ['c', 'd']
@@ -59,8 +59,8 @@ describe('Core_render', () => {
     data[1][1] = 'dddddddddddddddddddd';
     render();
 
-    var $td = this.$container.find('.htCore tbody tr:eq(1) td:eq(1)');
-    expect(this.$container.find('.wtBorder.current').width()).toBeGreaterThan($td.width());
+    var $td = spec().$container.find('.htCore tbody tr:eq(1) td:eq(1)');
+    expect(spec().$container.find('.wtBorder.current').width()).toBeGreaterThan($td.width());
   });
 
   it('should not render table twice', () => {
@@ -79,7 +79,7 @@ describe('Core_render', () => {
     expect(counter).toEqual(2); // 1 from load and 1 from populateFromArray
   });
 
-  it('should run afterRenderer hook', function() {
+  it('should run afterRenderer hook', () => {
     var lastCellProperties;
 
     handsontable({
@@ -94,12 +94,12 @@ describe('Core_render', () => {
       }
     });
 
-    expect(this.$container.find('td:eq(0)')[0].innerHTML).toEqual('Changed by plugin');
+    expect(spec().$container.find('td:eq(0)')[0].innerHTML).toEqual('Changed by plugin');
     expect(lastCellProperties.row).toEqual(1);
     expect(lastCellProperties.col).toEqual(4);
   });
 
-  it('should run beforeValueRender hook', function() {
+  it('should run beforeValueRender hook', () => {
     handsontable({
       data: [['A1', 'B1']],
       beforeValueRender(value, cellProperties) {
@@ -107,11 +107,11 @@ describe('Core_render', () => {
       }
     });
 
-    expect(this.$container.find('td:eq(0)')[0].innerHTML).toEqual('Test');
-    expect(this.$container.find('td:eq(1)')[0].innerHTML).toEqual('B1');
+    expect(spec().$container.find('td:eq(0)')[0].innerHTML).toEqual('Test');
+    expect(spec().$container.find('td:eq(1)')[0].innerHTML).toEqual('B1');
   });
 
-  it('should run beforeRenderer hook', function() {
+  it('should run beforeRenderer hook', () => {
     var lastCellProperties;
 
     handsontable({
@@ -123,7 +123,7 @@ describe('Core_render', () => {
     });
 
     // Value is overwritten by text renderer
-    expect(this.$container.find('td:eq(0)')[0].innerHTML).toEqual('1');
+    expect(spec().$container.find('td:eq(0)')[0].innerHTML).toEqual('1');
     expect(lastCellProperties.row).toEqual(1);
     expect(lastCellProperties.col).toEqual(4);
   });

--- a/test/e2e/Core_update.spec.js
+++ b/test/e2e/Core_update.spec.js
@@ -104,7 +104,7 @@ describe('Core_updateSettings', () => {
     }).not.toThrow();
   });
 
-  it('should not reset columns types to text', function() {
+  it('should not reset columns types to text', () => {
     handsontable({
       data: [[1, true]],
       columns: [
@@ -113,7 +113,7 @@ describe('Core_updateSettings', () => {
       ]
     });
 
-    const td = this.$container.find('td');
+    const td = spec().$container.find('td');
 
     expect(td.eq(0).text()).toEqual('1');
     expect(td.eq(1).text()).toEqual('');
@@ -124,7 +124,7 @@ describe('Core_updateSettings', () => {
     expect(td.eq(1).text()).toEqual('');
   });
 
-  it('should not reset columns types to text when columns is a function', function() {
+  it('should not reset columns types to text when columns is a function', () => {
     handsontable({
       data: [[1, true]],
       columns(column) {
@@ -141,7 +141,7 @@ describe('Core_updateSettings', () => {
       }
     });
 
-    const td = this.$container.find('td');
+    const td = spec().$container.find('td');
 
     expect(td.eq(0).text()).toEqual('1');
     expect(td.eq(1).text()).toEqual('');
@@ -430,52 +430,52 @@ describe('Core_updateSettings', () => {
     expect(getCellValidator(0, 0)).toBeUndefined();
   });
 
-  it('should allow updating the table height', function() {
+  it('should allow updating the table height', () => {
     handsontable({
       startRows: 22,
       startCols: 5
     });
 
-    const initialHeight = parseInt(this.$container[0].style.height, 10);
+    const initialHeight = parseInt(spec().$container[0].style.height, 10);
 
     updateSettings({
       height: 300
     });
 
-    expect(parseInt(this.$container[0].style.height, 10)).toEqual(300);
-    expect(parseInt(this.$container[0].style.height, 10)).not.toEqual(initialHeight);
+    expect(parseInt(spec().$container[0].style.height, 10)).toEqual(300);
+    expect(parseInt(spec().$container[0].style.height, 10)).not.toEqual(initialHeight);
   });
 
-  it('should not reset the table height, when the updateSettings config object doesn\'t have any height specified', function() {
+  it('should not reset the table height, when the updateSettings config object doesn\'t have any height specified', () => {
     handsontable({
       startRows: 22,
       startCols: 5,
       height: 300
     });
 
-    const initialHeight = this.$container[0].style.height;
+    const initialHeight = spec().$container[0].style.height;
 
     updateSettings({
       rowHeaders: true
     });
 
-    expect(parseInt(this.$container[0].style.height, 10)).toEqual(parseInt(initialHeight, 10));
+    expect(parseInt(spec().$container[0].style.height, 10)).toEqual(parseInt(initialHeight, 10));
   });
 
-  it('should allow resetting the table height', function() {
+  it('should allow resetting the table height', () => {
     handsontable({
       startRows: 22,
       startCols: 5,
       height: 300
     });
 
-    const initialHeight = this.$container[0].style.height;
+    const initialHeight = spec().$container[0].style.height;
 
     updateSettings({
       height: null
     });
 
-    expect(parseInt(this.$container[0].style.height, 10)).not.toEqual(parseInt(initialHeight, 10));
+    expect(parseInt(spec().$container[0].style.height, 10)).not.toEqual(parseInt(initialHeight, 10));
   });
 
   it('should allow updating the stretching type', () => {
@@ -504,7 +504,7 @@ describe('Core_updateSettings', () => {
     expect(hot.view.wt.getSetting('stretchH')).toEqual('last');
   });
 
-  it('should change colHeader\'s row height if is needed', function() {
+  it('should change colHeader\'s row height if is needed', () => {
     handsontable({
       colHeaders: true,
       rowHeaders: true
@@ -512,17 +512,17 @@ describe('Core_updateSettings', () => {
 
     const rowHeights = [];
 
-    rowHeights.push(this.$container.find('.ht_clone_top_left_corner thead th')[0].clientHeight);
+    rowHeights.push(spec().$container.find('.ht_clone_top_left_corner thead th')[0].clientHeight);
     updateSettings({
       colHeaders: ['A<br/>A']
     });
 
-    rowHeights.push(this.$container.find('.ht_clone_top_left_corner thead th')[0].clientHeight);
+    rowHeights.push(spec().$container.find('.ht_clone_top_left_corner thead th')[0].clientHeight);
 
     expect(rowHeights[0]).toBeLessThan(rowHeights[1]);
   });
 
-  it('should not overwrite properties (created by columns defined as function) of cells below the viewport by updateSettings #4029', function() {
+  it('should not overwrite properties (created by columns defined as function) of cells below the viewport by updateSettings #4029', () => {
     let rows = 50;
     const columns = 2;
 
@@ -568,7 +568,7 @@ describe('Core_updateSettings', () => {
     expect(getCellMeta(rows, 1).readOnly).toEqual(false);
   });
 
-  it('should not overwrite properties (created by columns defined as array) of cells below the viewport by updateSettings #4029', function() {
+  it('should not overwrite properties (created by columns defined as array) of cells below the viewport by updateSettings #4029', () => {
     let rows = 50;
     const columns = 2;
 

--- a/test/e2e/Core_validate.spec.js
+++ b/test/e2e/Core_validate.spec.js
@@ -630,7 +630,7 @@ describe('Core_validate', () => {
     expect(spec().$container.find('td:not(.htInvalid)').length).toEqual(4);
   });
 
-  it('should add class name `htInvalid` to an cell that does not validate - when we trigger validateCell', function(done) {
+  it('should add class name `htInvalid` to an cell that does not validate - when we trigger validateCell', async () => {
     var onAfterValidate = jasmine.createSpy('onAfterValidate');
     var hot = handsontable({
       data: Handsontable.helper.createSpreadsheetData(2, 2),
@@ -640,15 +640,14 @@ describe('Core_validate', () => {
       afterValidate: onAfterValidate
     });
 
-    expect(this.$container.find('td:not(.htInvalid)').length).toEqual(4);
+    expect(spec().$container.find('td:not(.htInvalid)').length).toEqual(4);
 
     hot.validateCell(hot.getDataAtCell(1, 1), hot.getCellMeta(1, 1), () => {});
 
-    setTimeout(() => {
-      expect(spec().$container.find('td.htInvalid').length).toEqual(1);
-      expect(spec().$container.find('td:not(.htInvalid)').length).toEqual(3);
-      done();
-    }, 200);
+    await sleep(200);
+
+    expect(spec().$container.find('td.htInvalid').length).toEqual(1);
+    expect(spec().$container.find('td:not(.htInvalid)').length).toEqual(3);
   });
 
   it('should remove class name `htInvalid` from an cell that does validate - when we change validator rules', (done) => {
@@ -1600,7 +1599,7 @@ describe('Core_validate', () => {
     }, 200);
   });
 
-  it('should not allow keyboard movement until cell is validated (move LEFT)', function(done) {
+  it('should not allow keyboard movement until cell is validated (move LEFT)', async () => {
     var onAfterValidate = jasmine.createSpy('onAfterValidate');
 
     hot = handsontable({
@@ -1627,19 +1626,18 @@ describe('Core_validate', () => {
     keyDownUp('enter'); // should be accepted but only after 100 ms
     expect(getSelected()).toEqual([[3, 2, 3, 2]]);
 
-    this.$container.simulate('keydown', {keyCode: Handsontable.helper.KEY_CODES.ARROW_LEFT});
-    this.$container.simulate('keyup', {keyCode: Handsontable.helper.KEY_CODES.ARROW_LEFT});
-    this.$container.simulate('keydown', {keyCode: Handsontable.helper.KEY_CODES.ARROW_LEFT});
-    this.$container.simulate('keyup', {keyCode: Handsontable.helper.KEY_CODES.ARROW_LEFT});
+    spec().$container.simulate('keydown', {keyCode: Handsontable.helper.KEY_CODES.ARROW_LEFT});
+    spec().$container.simulate('keyup', {keyCode: Handsontable.helper.KEY_CODES.ARROW_LEFT});
+    spec().$container.simulate('keydown', {keyCode: Handsontable.helper.KEY_CODES.ARROW_LEFT});
+    spec().$container.simulate('keyup', {keyCode: Handsontable.helper.KEY_CODES.ARROW_LEFT});
 
     expect(isEditorVisible()).toBe(true);
     expect(getSelected()).toEqual([[3, 0, 3, 0]]);
 
-    setTimeout(() => {
-      expect(isEditorVisible()).toBe(false);
-      expect(getSelected()).toEqual([[3, 0, 3, 0]]);
-      done();
-    }, 200);
+    await sleep(200);
+
+    expect(isEditorVisible()).toBe(false);
+    expect(getSelected()).toEqual([[3, 0, 3, 0]]);
   });
 
   it('should not validate cell if editing has been canceled', (done) => {

--- a/test/e2e/Core_view.spec.js
+++ b/test/e2e/Core_view.spec.js
@@ -12,9 +12,9 @@ describe('Core_view', () => {
     }
   });
 
-  it('should focus cell after viewport is scrolled using down arrow', function() {
-    this.$container[0].style.width = '400px';
-    this.$container[0].style.height = '60px';
+  it('should focus cell after viewport is scrolled using down arrow', () => {
+    spec().$container[0].style.width = '400px';
+    spec().$container[0].style.height = '60px';
 
     handsontable({
       startRows: 20
@@ -56,10 +56,10 @@ describe('Core_view', () => {
     expect(scrollableElement.scrollTop).toBeGreaterThan(initialScrollTop);
   });
 
-  it('should not render "undefined" class name', function() {
-    this.$container[0].style.width = '501px';
-    this.$container[0].style.height = '100px';
-    this.$container[0].style.overflow = 'hidden';
+  it('should not render "undefined" class name', () => {
+    spec().$container[0].style.width = '501px';
+    spec().$container[0].style.height = '100px';
+    spec().$container[0].style.overflow = 'hidden';
 
     handsontable({
       startRows: 10,
@@ -72,12 +72,12 @@ describe('Core_view', () => {
 
     selectCell(0, 0);
 
-    expect(this.$container.find('.undefined').length).toBe(0);
+    expect(spec().$container.find('.undefined').length).toBe(0);
   });
 
-  it('should scroll viewport when partially visible cell is clicked', function() {
-    this.$container[0].style.width = '400px';
-    this.$container[0].style.height = '60px';
+  it('should scroll viewport when partially visible cell is clicked', () => {
+    spec().$container[0].style.width = '400px';
+    spec().$container[0].style.height = '60px';
 
     var hot = handsontable({
       data: Handsontable.helper.createSpreadsheetData(10, 3),
@@ -88,8 +88,8 @@ describe('Core_view', () => {
     var scrollTop = hot.rootElement.querySelector('.wtHolder').scrollTop;
 
     expect(scrollTop).toBe(0);
-    expect(this.$container.height()).toEqual(60);
-    expect(this.$container.find('.wtHolder .wtHider').height()).toBeGreaterThan(60);
+    expect(spec().$container.height()).toEqual(60);
+    expect(spec().$container.find('.wtHolder .wtHider').height()).toBeGreaterThan(60);
 
     expect(htCore.find('tr:eq(0) td:eq(0)').html()).toEqual('A1');
     expect(htCore.find('tr:eq(1) td:eq(0)').html()).toEqual('A2');
@@ -101,8 +101,8 @@ describe('Core_view', () => {
     expect(getSelected()).toEqual([[3, 0, 3, 0]]);
   });
 
-  it('should scroll viewport without cell selection', function() {
-    this.$container[0].style.width = '400px';
+  it('should scroll viewport without cell selection', () => {
+    spec().$container[0].style.width = '400px';
 
     var hot1 = handsontable({
       data: Handsontable.helper.createSpreadsheetData(20, 20),
@@ -111,15 +111,15 @@ describe('Core_view', () => {
 
     hot1.scrollViewportTo(10, 10);
 
-    var wtHolder = this.$container.find('.ht_master .wtHolder');
+    var wtHolder = spec().$container.find('.ht_master .wtHolder');
 
     expect(wtHolder[0].scrollTop).toEqual(230);
     expect(wtHolder[0].scrollLeft).toEqual(500);
 
   });
 
-  it('should not throw error while scrolling viewport to 0, 0 (empty data)', function() {
-    this.$container[0].style.width = '400px';
+  it('should not throw error while scrolling viewport to 0, 0 (empty data)', () => {
+    spec().$container[0].style.width = '400px';
 
     var hot1 = handsontable({
       data: [],
@@ -131,8 +131,8 @@ describe('Core_view', () => {
     }).not.toThrow();
   });
 
-  it('should throw error while scrolling viewport below 0 (empty data)', function() {
-    this.$container[0].style.width = '400px';
+  it('should throw error while scrolling viewport below 0 (empty data)', () => {
+    spec().$container[0].style.width = '400px';
 
     var hot1 = handsontable({
       data: [],
@@ -144,9 +144,9 @@ describe('Core_view', () => {
     expect(hot1.view.scrollViewport({row: -1, col: -1})).toBe(false);
   });
 
-  it('should scroll viewport, respecting fixed rows', function() {
-    this.$container[0].style.width = '400px';
-    this.$container[0].style.height = '60px';
+  it('should scroll viewport, respecting fixed rows', () => {
+    spec().$container[0].style.width = '400px';
+    spec().$container[0].style.height = '60px';
 
     var hot = handsontable({
       data: Handsontable.helper.createSpreadsheetData(10, 9),
@@ -172,9 +172,9 @@ describe('Core_view', () => {
     expect(hot.rootElement.querySelector('.wtHolder').scrollTop).toBeGreaterThan(scrollTop);
   });
 
-  it('should enable to change fixedRowsTop with updateSettings', function() {
-    this.$container[0].style.width = '400px';
-    this.$container[0].style.height = '60px';
+  it('should enable to change fixedRowsTop with updateSettings', () => {
+    spec().$container[0].style.width = '400px';
+    spec().$container[0].style.height = '60px';
 
     var HOT = handsontable({
       data: Handsontable.helper.createSpreadsheetData(10, 9),
@@ -218,9 +218,9 @@ describe('Core_view', () => {
     expect(htCore.find('tr:eq(3) td:eq(0)').html()).toEqual('A4');
   });
 
-  it('should scroll viewport, respecting fixed columns', function() {
-    this.$container[0].style.width = '200px';
-    this.$container[0].style.height = '100px';
+  it('should scroll viewport, respecting fixed columns', () => {
+    spec().$container[0].style.width = '200px';
+    spec().$container[0].style.height = '100px';
 
     handsontable({
       data: Handsontable.helper.createSpreadsheetData(10, 9),
@@ -228,7 +228,7 @@ describe('Core_view', () => {
     });
 
     var htCore = getHtCore();
-    var leftClone = this.$container.find('.ht_clone_left');
+    var leftClone = spec().$container.find('.ht_clone_left');
 
     expect(leftClone.find('tr:eq(0) td').length).toEqual(1);
     expect(leftClone.find('tr:eq(0) td:eq(0)').html()).toEqual('A1');
@@ -252,9 +252,9 @@ describe('Core_view', () => {
 
   });
 
-  it('should enable to change fixedColumnsLeft with updateSettings', function() {
-    this.$container[0].style.width = '200px';
-    this.$container[0].style.height = '100px';
+  it('should enable to change fixedColumnsLeft with updateSettings', () => {
+    spec().$container[0].style.width = '200px';
+    spec().$container[0].style.height = '100px';
 
     var HOT = handsontable({
       data: Handsontable.helper.createSpreadsheetData(10, 9),
@@ -263,7 +263,7 @@ describe('Core_view', () => {
 
     selectCell(0, 0);
 
-    var leftClone = this.$container.find('.ht_clone_left');
+    var leftClone = spec().$container.find('.ht_clone_left');
 
     expect(leftClone.find('tr:eq(0) td').length).toEqual(1);
     expect(leftClone.find('tr:eq(0) td:eq(0)').html()).toEqual('A1');
@@ -315,37 +315,36 @@ describe('Core_view', () => {
     expect($(window).scrollTop()).toEqual(lastScroll);
   });
 
-  it('should not shrink table when width and height is not specified for container', function(done) {
+  it('should not shrink table when width and height is not specified for container', async () => {
     var initHeight;
 
-    this.$container[0].style.overflow = 'hidden';
-    this.$container.wrap('<div style="width: 50px;"></div>');
+    spec().$container[0].style.overflow = 'hidden';
+    spec().$container.wrap('<div style="width: 50px;"></div>');
     handsontable({
       startRows: 10,
       startCols: 10
     });
 
-    setTimeout(() => {
-      initHeight = spec().$container.height();
-    }, 250);
+    await sleep(250);
 
-    setTimeout(() => {
-      expect(spec().$container.height()).toEqual(initHeight);
-      done();
-    }, 500);
+    initHeight = spec().$container.height();
+
+    await sleep(250);
+
+    expect(spec().$container.height()).toEqual(initHeight);
   });
 
-  it('should allow height to be a number', function() {
+  it('should allow height to be a number', () => {
     handsontable({
       startRows: 10,
       startCols: 10,
       height: 107
     });
 
-    expect(this.$container.height()).toEqual(107);
+    expect(spec().$container.height()).toEqual(107);
   });
 
-  it('should allow height to be a function', function() {
+  it('should allow height to be a function', () => {
     handsontable({
       startRows: 10,
       startCols: 10,
@@ -354,20 +353,20 @@ describe('Core_view', () => {
       }
     });
 
-    expect(this.$container.height()).toEqual(107);
+    expect(spec().$container.height()).toEqual(107);
   });
 
-  it('should allow width to be a number', function() {
+  it('should allow width to be a number', () => {
     handsontable({
       startRows: 10,
       startCols: 10,
       width: 107,
     });
 
-    expect(this.$container.width()).toEqual(107); // rootElement is full width but this should do the trick
+    expect(spec().$container.width()).toEqual(107); // rootElement is full width but this should do the trick
   });
 
-  it('should allow width to be a function', function() {
+  it('should allow width to be a function', () => {
     handsontable({
       startRows: 10,
       startCols: 10,
@@ -376,13 +375,13 @@ describe('Core_view', () => {
       }
     });
 
-    expect(this.$container.width()).toEqual(107); // rootElement is full width but this should do the trick
+    expect(spec().$container.width()).toEqual(107); // rootElement is full width but this should do the trick
   });
 
-  it('should fire beforeRender event after table has been scrolled', function(done) {
-    this.$container[0].style.width = '400px';
-    this.$container[0].style.height = '60px';
-    this.$container[0].style.overflow = 'hidden';
+  it('should fire beforeRender event after table has been scrolled', async () => {
+    spec().$container[0].style.width = '400px';
+    spec().$container[0].style.height = '60px';
+    spec().$container[0].style.overflow = 'hidden';
 
     var hot = handsontable({
       data: Handsontable.helper.createSpreadsheetData(100, 3)
@@ -391,18 +390,17 @@ describe('Core_view', () => {
     var beforeRenderCallback = jasmine.createSpy('beforeRenderCallback');
 
     hot.addHook('beforeRender', beforeRenderCallback);
-    this.$container.find('.ht_master .wtHolder').scrollTop(1000);
+    spec().$container.find('.ht_master .wtHolder').scrollTop(1000);
 
-    setTimeout(() => {
-      expect(beforeRenderCallback.calls.count()).toBe(1);
-      done();
-    }, 200);
+    await sleep(200);
+
+    expect(beforeRenderCallback.calls.count()).toBe(1);
   });
 
-  it('should fire afterRender event after table has been scrolled', function(done) {
-    this.$container[0].style.width = '400px';
-    this.$container[0].style.height = '60px';
-    this.$container[0].style.overflow = 'hidden';
+  it('should fire afterRender event after table has been scrolled', async () => {
+    spec().$container[0].style.width = '400px';
+    spec().$container[0].style.height = '60px';
+    spec().$container[0].style.overflow = 'hidden';
 
     var hot = handsontable({
       data: Handsontable.helper.createSpreadsheetData(20, 3)
@@ -410,18 +408,17 @@ describe('Core_view', () => {
 
     var afterRenderCallback = jasmine.createSpy('afterRenderCallback');
     hot.addHook('afterRender', afterRenderCallback);
-    this.$container.find('.ht_master .wtHolder').first().scrollTop(1000);
+    spec().$container.find('.ht_master .wtHolder').first().scrollTop(1000);
 
-    setTimeout(() => {
-      expect(afterRenderCallback.calls.count()).toBe(1);
-      done();
-    }, 200);
+    await sleep(200);
+
+    expect(afterRenderCallback.calls.count()).toBe(1);
   });
 
-  it('should fire afterRender event after table physically rendered', function(done) {
-    this.$container[0].style.width = '400px';
-    this.$container[0].style.height = '60px';
-    this.$container[0].style.overflow = 'hidden';
+  it('should fire afterRender event after table physically rendered', async () => {
+    spec().$container[0].style.width = '400px';
+    spec().$container[0].style.height = '60px';
+    spec().$container[0].style.overflow = 'hidden';
 
     var hot = handsontable({
       data: Handsontable.helper.createSpreadsheetData(20, 3)
@@ -431,14 +428,12 @@ describe('Core_view', () => {
       hot.view.wt.wtTable.holder.style.overflow = 'scroll';
       hot.view.wt.wtTable.holder.style.width = '220px';
     });
-    this.$container.find('.ht_master .wtHolder').first().scrollTop(1000);
+    spec().$container.find('.ht_master .wtHolder').first().scrollTop(1000);
 
-    setTimeout(() => {
-      // after afterRender hook triggered element style shouldn't changed
-      expect(hot.view.wt.wtTable.holder.style.overflow).toBe('scroll');
-      expect(hot.view.wt.wtTable.holder.style.width).toBe('220px');
-      done();
-    }, 100);
+    await sleep(100);
+    // after afterRender hook triggered element style shouldn't changed
+    expect(hot.view.wt.wtTable.holder.style.overflow).toBe('scroll');
+    expect(hot.view.wt.wtTable.holder.style.width).toBe('220px');
   });
 
   // TODO fix these tests - https://github.com/handsontable/handsontable/issues/1559
@@ -506,7 +501,7 @@ describe('Core_view', () => {
       expect(hot.getCell(1, 2).clientHeight).toEqual(hot.getCell(1, 1).clientHeight);
     });
 
-    it('should be the same as the row heights in the main table (after scroll)', function() {
+    it('should be the same as the row heights in the main table (after scroll)', () => {
       var myData = Handsontable.helper.createSpreadsheetData(20, 4);
       myData[1][3] = 'very\nlong\ntext';
       myData[5][3] = 'very\nlong\ntext';
@@ -528,13 +523,13 @@ describe('Core_view', () => {
       $(mainHolder).scrollTop(200);
       hot.render();
 
-      var masterTD = this.$container.find('.ht_master tbody tr:eq(5) td:eq(1)')[0];
-      var cloneTD = this.$container.find('.ht_clone_left tbody tr:eq(5) td:eq(1)')[0];
+      var masterTD = spec().$container.find('.ht_master tbody tr:eq(5) td:eq(1)')[0];
+      var cloneTD = spec().$container.find('.ht_clone_left tbody tr:eq(5) td:eq(1)')[0];
 
       expect(cloneTD.clientHeight).toEqual(masterTD.clientHeight);
     });
 
-    it('should be the same as the row heights in the main table (after scroll, in corner)', function() {
+    it('should be the same as the row heights in the main table (after scroll, in corner)', () => {
       var myData = Handsontable.helper.createSpreadsheetData(20, 4);
       myData[1][3] = 'very\nlong\ntext';
       myData[5][3] = 'very\nlong\ntext';
@@ -554,17 +549,17 @@ describe('Core_view', () => {
       var rowHeight = hot.getCell(1, 3).clientHeight;
       var mainHolder = hot.view.wt.wtTable.holder;
 
-      expect(this.$container.find('.ht_clone_top_left_corner tbody tr:eq(1) td:eq(1)')[0].clientHeight).toEqual(rowHeight);
+      expect(spec().$container.find('.ht_clone_top_left_corner tbody tr:eq(1) td:eq(1)')[0].clientHeight).toEqual(rowHeight);
 
       $(mainHolder).scrollTop(200);
       hot.render();
 
-      expect(this.$container.find('.ht_clone_top_left_corner tbody tr:eq(1) td:eq(1)')[0].clientHeight).toEqual(rowHeight);
+      expect(spec().$container.find('.ht_clone_top_left_corner tbody tr:eq(1) td:eq(1)')[0].clientHeight).toEqual(rowHeight);
     });
   });
 
   describe('fixed column widths', () => {
-    it('should set the columns width correctly after changes made during updateSettings', function() {
+    it('should set the columns width correctly after changes made during updateSettings', () => {
       var hot = handsontable({
         startRows: 2,
         fixedColumnsLeft: 2,
@@ -585,7 +580,7 @@ describe('Core_view', () => {
         }]
       });
 
-      var leftClone = this.$container.find('.ht_clone_left');
+      var leftClone = spec().$container.find('.ht_clone_left');
 
       expect(Handsontable.dom.outerWidth(leftClone.find('tbody tr:nth-child(1) td:nth-child(2)')[0])).toEqual(80);
 
@@ -604,7 +599,7 @@ describe('Core_view', () => {
       expect(Handsontable.dom.outerWidth(leftClone.find('tbody tr:nth-child(1) td:nth-child(2)')[0])).toEqual(80);
     });
 
-    it('should set the columns width correctly after changes made during updateSettings when columns is a function', function() {
+    it('should set the columns width correctly after changes made during updateSettings when columns is a function', () => {
       var hot = handsontable({
         startCols: 7,
         startRows: 2,
@@ -635,7 +630,7 @@ describe('Core_view', () => {
         }
       });
 
-      var leftClone = this.$container.find('.ht_clone_left');
+      var leftClone = spec().$container.find('.ht_clone_left');
 
       expect(Handsontable.dom.outerWidth(leftClone.find('tbody tr:nth-child(1) td:nth-child(2)')[0])).toEqual(80);
 
@@ -656,8 +651,8 @@ describe('Core_view', () => {
   });
 
   describe('stretchH', () => {
-    it('should stretch all visible columns with the ratio appropriate to the container\'s width', function() {
-      this.$container[0].style.width = '300px';
+    it('should stretch all visible columns with the ratio appropriate to the container\'s width', () => {
+      spec().$container[0].style.width = '300px';
 
       var hot = handsontable({
           startRows: 5,
@@ -667,7 +662,7 @@ describe('Core_view', () => {
           stretchH: 'all'
         }),
         rowHeaderWidth = hot.view.wt.wtViewport.getRowHeaderWidth(),
-        expectedCellWidth = (parseInt(this.$container[0].style.width, 10) - rowHeaderWidth) / 5;
+        expectedCellWidth = (parseInt(spec().$container[0].style.width, 10) - rowHeaderWidth) / 5;
 
       expect(getCell(0, 0).offsetWidth).toEqual(expectedCellWidth);
       expect(getCell(0, 1).offsetWidth).toEqual(expectedCellWidth);
@@ -675,8 +670,8 @@ describe('Core_view', () => {
       expect(getCell(0, 3).offsetWidth).toEqual(expectedCellWidth);
       expect(getCell(0, 4).offsetWidth).toEqual(expectedCellWidth);
 
-      this.$container[0].style.width = '';
-      this.$container.wrap('<div class="temp_wrapper" style="width:400px;"></div>');
+      spec().$container[0].style.width = '';
+      spec().$container.wrap('<div class="temp_wrapper" style="width:400px;"></div>');
       hot.render();
 
       expectedCellWidth = (parseInt($('.temp_wrapper')[0].style.width, 10) - rowHeaderWidth) / 5;
@@ -687,13 +682,13 @@ describe('Core_view', () => {
       expect(getCell(0, 3).offsetWidth).toEqual(expectedCellWidth);
       expect(getCell(0, 4).offsetWidth).toEqual(expectedCellWidth);
 
-      this.$container.unwrap();
+      spec().$container.unwrap();
     });
 
-    it('should stretch all visible columns with overflow hidden', function() {
-      this.$container[0].style.width = '501px';
-      this.$container[0].style.height = '100px';
-      this.$container[0].style.overflow = 'hidden';
+    it('should stretch all visible columns with overflow hidden', () => {
+      spec().$container[0].style.width = '501px';
+      spec().$container[0].style.height = '100px';
+      spec().$container[0].style.overflow = 'hidden';
 
       handsontable({
         startRows: 10,
@@ -704,8 +699,8 @@ describe('Core_view', () => {
         stretchH: 'all'
       });
 
-      var masterTH = this.$container[0].querySelectorAll('.ht_master thead tr th');
-      var overlayTH = this.$container[0].querySelectorAll('.ht_clone_top thead tr th');
+      var masterTH = spec().$container[0].querySelectorAll('.ht_master thead tr th');
+      var overlayTH = spec().$container[0].querySelectorAll('.ht_clone_top thead tr th');
 
       expect(masterTH[0].offsetWidth).toEqual(50);
       expect(overlayTH[0].offsetWidth).toEqual(50);
@@ -719,10 +714,10 @@ describe('Core_view', () => {
       expect(masterTH[5].offsetWidth).toEqual(overlayTH[5].offsetWidth);
     });
 
-    it('should respect stretched widths returned in beforeStretchingColumnWidth hook', function() {
-      this.$container[0].style.width = '501px';
-      this.$container[0].style.height = '100px';
-      this.$container[0].style.overflow = 'hidden';
+    it('should respect stretched widths returned in beforeStretchingColumnWidth hook', () => {
+      spec().$container[0].style.width = '501px';
+      spec().$container[0].style.height = '100px';
+      spec().$container[0].style.overflow = 'hidden';
 
       var callbackSpy = jasmine.createSpy();
 
@@ -743,7 +738,7 @@ describe('Core_view', () => {
         beforeStretchingColumnWidth: callbackSpy
       });
 
-      var $columnHeaders = this.$container.find('thead tr:eq(0) th');
+      var $columnHeaders = spec().$container.find('thead tr:eq(0) th');
 
       expect($columnHeaders.eq(0).width()).toEqual(48);
       expect($columnHeaders.eq(1).width()).toEqual(73);

--- a/test/e2e/PluginHooks.spec.js
+++ b/test/e2e/PluginHooks.spec.js
@@ -222,7 +222,7 @@ describe('PluginHooks', () => {
     expect(i).toEqual(1);
   });
 
-  it('should mark the hook callbacks added with Handsontable initialization', function() {
+  it('should mark the hook callbacks added with Handsontable initialization', () => {
     var fn = function() {};
     var fn2 = function() {};
 
@@ -236,7 +236,7 @@ describe('PluginHooks', () => {
     expect(fn2.initialHook).toEqual(void 0);
   });
 
-  it('should mark the hook callbacks added using the updateSettings method', function() {
+  it('should mark the hook callbacks added using the updateSettings method', () => {
     var fn = function() {};
     var fn2 = function() {};
 
@@ -253,7 +253,7 @@ describe('PluginHooks', () => {
   });
 
   it('should replace the existing hook callbacks, if they\'re updated using the updateSettings method (when there was a hook ' +
-     'already declared in the initialization)', function() {
+     'already declared in the initialization)', () => {
     var fn = function() {};
     var fn2 = function() {};
 
@@ -282,7 +282,7 @@ describe('PluginHooks', () => {
     expect(hot.pluginHookBucket.afterGetCellMeta.length).toEqual(initialCallbackCount);
   });
 
-  it('should replace the existing hook callbacks, if they\'re updated using the updateSettings method', function() {
+  it('should replace the existing hook callbacks, if they\'re updated using the updateSettings method', () => {
     var fn = function() {};
     var fn2 = function() {};
 
@@ -317,7 +317,7 @@ describe('PluginHooks', () => {
     expect(hot.pluginHookBucket.afterGetCellMeta.length).toEqual(initialCallbackCount);
   });
 
-  it('should NOT replace existing hook callbacks, if the\'re added using the addHook method', function() {
+  it('should NOT replace existing hook callbacks, if the\'re added using the addHook method', () => {
     var fn = function() {};
     var fn2 = function() {};
 
@@ -329,13 +329,9 @@ describe('PluginHooks', () => {
 
     var initialCallbackCount = hot.pluginHookBucket.afterGetCellMeta.length;
 
-    hot.addHook('afterGetCellMeta', function() {
-      return { a: 'another function' };
-    });
+    hot.addHook('afterGetCellMeta', () => ({ a: 'another function' }));
 
-    hot.addHook('afterGetCellMeta', function() {
-      return { a: 'yet another function' };
-    });
+    hot.addHook('afterGetCellMeta', () => ({ a: 'yet another function' }));
 
     hot.addHook('afterGetCellMeta', fn2);
 

--- a/test/e2e/RowHeader.spec.js
+++ b/test/e2e/RowHeader.spec.js
@@ -28,7 +28,7 @@ describe('RowHeader', () => {
     expect(that.$container.find('tbody th').length).toBeGreaterThan(0);
   });
 
-  it('should show row headers numbered 1-10 by default', function() {
+  it('should show row headers numbered 1-10 by default', () => {
     var startRows = 5;
     handsontable({
       startRows,
@@ -44,7 +44,7 @@ describe('RowHeader', () => {
     expect($.trim(ths.eq(4).text())).toEqual('5');
   });
 
-  it('should show row headers with custom label', function() {
+  it('should show row headers with custom label', () => {
     var startRows = 5;
     handsontable({
       startRows,
@@ -60,7 +60,7 @@ describe('RowHeader', () => {
     expect($.trim(ths.eq(4).text())).toEqual('5');
   });
 
-  it('should not show row headers if false', function() {
+  it('should not show row headers if false', () => {
     handsontable({
       rowHeaders: false
     });
@@ -154,18 +154,18 @@ describe('RowHeader', () => {
 
   });
 
-  it('should allow defining custom row header width using the rowHeaderWidth config option', function() {
+  it('should allow defining custom row header width using the rowHeaderWidth config option', () => {
     handsontable({
       startCols: 3,
       rowHeaders: true,
       rowHeaderWidth: 150
     });
 
-    expect(this.$container.find('th').eq(0).outerWidth()).toEqual(150);
-    expect(this.$container.find('col').first().css('width')).toEqual('150px');
+    expect(spec().$container.find('th').eq(0).outerWidth()).toEqual(150);
+    expect(spec().$container.find('col').first().css('width')).toEqual('150px');
   });
 
-  it('should allow defining custom column header heights using the columnHeaderHeight config option, when multiple column header levels are defined', function() {
+  it('should allow defining custom column header heights using the columnHeaderHeight config option, when multiple column header levels are defined', () => {
     var hot = handsontable({
       startCols: 3,
       rowHeaders: true,
@@ -191,10 +191,10 @@ describe('RowHeader', () => {
     });
     hot.render();
 
-    expect(this.$container.find('.handsontable.ht_clone_left tr:nth-child(1) th:nth-child(1)').outerWidth()).toEqual(66);
-    expect(this.$container.find('.handsontable.ht_clone_left tr:nth-child(1) th:nth-child(2)').outerWidth()).toEqual(96);
+    expect(spec().$container.find('.handsontable.ht_clone_left tr:nth-child(1) th:nth-child(1)').outerWidth()).toEqual(66);
+    expect(spec().$container.find('.handsontable.ht_clone_left tr:nth-child(1) th:nth-child(2)').outerWidth()).toEqual(96);
 
-    expect(this.$container.find('col').first().css('width')).toEqual('66px');
-    expect(this.$container.find('col').eq(1).css('width')).toEqual('96px');
+    expect(spec().$container.find('col').first().css('width')).toEqual('66px');
+    expect(spec().$container.find('col').eq(1).css('width')).toEqual('96px');
   });
 });

--- a/test/e2e/core/setCellMeta.spec.js
+++ b/test/e2e/core/setCellMeta.spec.js
@@ -59,7 +59,7 @@ describe('Core.setCellMeta', () => {
     expect(cellMeta.className).toEqual(className);
   });
 
-  it('should set correct meta classNames for cells using cell in configuration', function() {
+  it('should set correct meta classNames for cells using cell in configuration', () => {
     const classNames = [
       'htCenter htTop',
       'htRight htBottom'
@@ -72,11 +72,11 @@ describe('Core.setCellMeta', () => {
       ]
     });
 
-    expect(this.$container.find('tbody tr:eq(0) td:eq(0)')[0].className).toEqual(classNames[0]);
-    expect(this.$container.find('tbody tr:eq(1) td:eq(1)')[0].className).toEqual(classNames[1]);
+    expect(spec().$container.find('tbody tr:eq(0) td:eq(0)')[0].className).toEqual(classNames[0]);
+    expect(spec().$container.find('tbody tr:eq(1) td:eq(1)')[0].className).toEqual(classNames[1]);
   });
 
-  it('should change cell meta data with updateSettings when the cell option is defined', function() {
+  it('should change cell meta data with updateSettings when the cell option is defined', () => {
     const classNames = [
       'htCenter htTop',
       'htRight htBottom'
@@ -89,15 +89,15 @@ describe('Core.setCellMeta', () => {
       ]
     });
 
-    expect(this.$container.find('tbody tr:eq(0) td:eq(0)')[0].className).toEqual(classNames[0]);
-    expect(this.$container.find('tbody tr:eq(1) td:eq(1)')[0].className).toEqual(classNames[1]);
+    expect(spec().$container.find('tbody tr:eq(0) td:eq(0)')[0].className).toEqual(classNames[0]);
+    expect(spec().$container.find('tbody tr:eq(1) td:eq(1)')[0].className).toEqual(classNames[1]);
 
     updateSettings({
       cell: []
     });
 
-    expect(this.$container.find('tbody tr:eq(0) td:eq(0)')[0].className).toEqual('');
-    expect(this.$container.find('tbody tr:eq(1) td:eq(1)')[0].className).toEqual('');
+    expect(spec().$container.find('tbody tr:eq(0) td:eq(0)')[0].className).toEqual('');
+    expect(spec().$container.find('tbody tr:eq(1) td:eq(1)')[0].className).toEqual('');
 
     updateSettings({
       cell: [
@@ -106,8 +106,8 @@ describe('Core.setCellMeta', () => {
       ]
     });
 
-    expect(this.$container.find('tbody tr:eq(0) td:eq(0)')[0].className).toEqual(classNames[1]);
-    expect(this.$container.find('tbody tr:eq(1) td:eq(1)')[0].className).toEqual(classNames[0]);
+    expect(spec().$container.find('tbody tr:eq(0) td:eq(0)')[0].className).toEqual(classNames[1]);
+    expect(spec().$container.find('tbody tr:eq(1) td:eq(1)')[0].className).toEqual(classNames[0]);
   });
 
   it('should call `afterSetCellMeta` plugin hook with visual indexes as parameters', () => {

--- a/test/e2e/editors/autocompleteEditor.spec.js
+++ b/test/e2e/editors/autocompleteEditor.spec.js
@@ -2484,7 +2484,7 @@ describe('AutocompleteEditor', () => {
     }, 200);
   });
 
-  it('should add a scrollbar to the autocomplete dropdown, only if number of displayed choices exceeds 10', function(done) {
+  it('should add a scrollbar to the autocomplete dropdown, only if number of displayed choices exceeds 10', async () => {
     var hot = handsontable({
       data: [
         ['', 'two', 'three'],
@@ -2502,7 +2502,7 @@ describe('AutocompleteEditor', () => {
       ]
     });
 
-    this.$container.css({
+    spec().$container.css({
       height: 600
     });
 
@@ -2513,22 +2513,21 @@ describe('AutocompleteEditor', () => {
 
     var dropdownHolder = hot.getActiveEditor().htEditor.view.wt.wtTable.holder;
 
-    setTimeout(() => {
-      expect(dropdownHolder.scrollHeight).toBeGreaterThan(dropdownHolder.clientHeight);
+    await sleep(30);
 
-      keyDownUp('esc');
+    expect(dropdownHolder.scrollHeight).toBeGreaterThan(dropdownHolder.clientHeight);
 
-      hot.getSettings().columns[0].source = hot.getSettings().columns[0].source.slice(0).splice(3);
-      hot.updateSettings({});
+    keyDownUp('esc');
 
-      selectCell(0, 0);
-      $(getCell(0, 0)).find('.htAutocompleteArrow').simulate('mousedown');
-    }, 30);
+    hot.getSettings().columns[0].source = hot.getSettings().columns[0].source.slice(0).splice(3);
+    hot.updateSettings({});
 
-    setTimeout(() => {
-      expect(dropdownHolder.scrollHeight > dropdownHolder.clientHeight).toBe(false);
-      done();
-    }, 60);
+    selectCell(0, 0);
+    $(getCell(0, 0)).find('.htAutocompleteArrow').simulate('mousedown');
+
+    await sleep(30);
+
+    expect(dropdownHolder.scrollHeight > dropdownHolder.clientHeight).toBe(false);
   });
 
   it('should not close editor on scrolling', async () => {

--- a/test/e2e/editors/handsontableEditor.spec.js
+++ b/test/e2e/editors/handsontableEditor.spec.js
@@ -23,7 +23,7 @@ describe('HandsontableEditor', () => {
     ];
   }
 
-  it('should create an editor that is a Handsontable instance', function() {
+  it('should create an editor that is a Handsontable instance', () => {
     handsontable({
       columns: [
         {
@@ -38,10 +38,10 @@ describe('HandsontableEditor', () => {
     selectCell(2, 0);
 
     keyDownUp('enter');
-    expect(this.$container.find('.handsontableEditor:visible').length).toEqual(1);
+    expect(spec().$container.find('.handsontableEditor:visible').length).toEqual(1);
   });
 
-  it('should create an editor directly below the textarea element', function() {
+  it('should create an editor directly below the textarea element', () => {
     handsontable({
       columns: [
         {
@@ -56,10 +56,10 @@ describe('HandsontableEditor', () => {
     selectCell(2, 0);
 
     keyDownUp('enter');
-    expect(this.$container.find('.handsontableEditor')[0].offsetTop).toEqual(this.$container.find('.handsontableInput')[0].offsetHeight);
+    expect(spec().$container.find('.handsontableEditor')[0].offsetTop).toEqual(spec().$container.find('.handsontableInput')[0].offsetHeight);
   });
 
-  it('should prepare the editor only once per instance', function() {
+  it('should prepare the editor only once per instance', () => {
     handsontable({
       columns: [
         {
@@ -86,10 +86,10 @@ describe('HandsontableEditor', () => {
     keyDownUp('enter');
     keyDownUp('enter');
     keyDownUp('enter');
-    expect(this.$container.find('.handsontableEditor').length).toEqual(1);
+    expect(spec().$container.find('.handsontableEditor').length).toEqual(1);
   });
 
-  it('should reuse the container and display them after select the same or different cell', function() {
+  it('should reuse the container and display them after select the same or different cell', () => {
     handsontable({
       columns: [
         {
@@ -105,33 +105,33 @@ describe('HandsontableEditor', () => {
     selectCell(0, 0);
     keyDownUp('enter');
 
-    let container = this.$container.find('.handsontableEditor')[0];
+    let container = spec().$container.find('.handsontableEditor')[0];
 
     expect(container.clientHeight).toBeGreaterThan(2);
 
     selectCell(0, 0);
     keyDownUp('enter');
 
-    container = this.$container.find('.handsontableEditor')[0];
+    container = spec().$container.find('.handsontableEditor')[0];
 
     expect(container.clientHeight).toBeGreaterThan(2);
 
     selectCell(1, 0);
     keyDownUp('enter');
 
-    container = this.$container.find('.handsontableEditor')[0];
+    container = spec().$container.find('.handsontableEditor')[0];
 
     expect(container.clientHeight).toBeGreaterThan(2);
 
     selectCell(1, 0);
     keyDownUp('enter');
 
-    container = this.$container.find('.handsontableEditor')[0];
+    container = spec().$container.find('.handsontableEditor')[0];
 
     expect(container.clientHeight).toBeGreaterThan(2);
   });
 
-  it('should destroy the editor when Esc is pressed', function() {
+  it('should destroy the editor when Esc is pressed', () => {
     handsontable({
       columns: [
         {
@@ -147,7 +147,7 @@ describe('HandsontableEditor', () => {
 
     keyDownUp('enter');
     keyDownUp('esc');
-    expect(this.$container.find('.handsontableEditor:visible').length).toEqual(0);
+    expect(spec().$container.find('.handsontableEditor:visible').length).toEqual(0);
   });
 
   // see https://github.com/handsontable/handsontable/issues/3380
@@ -177,7 +177,7 @@ describe('HandsontableEditor', () => {
     window.onerror = prevError;
   });
 
-  it('Enter pressed in nested HT should set the value and hide the editor', function() {
+  it('Enter pressed in nested HT should set the value and hide the editor', () => {
     handsontable({
       columns: [
         {
@@ -194,7 +194,7 @@ describe('HandsontableEditor', () => {
     keyDownUp('enter');
     keyDownUp('arrow_down');
     keyDownUp('enter');
-    expect(this.$container.find('.handsontableEditor:visible').length).toEqual(0);
+    expect(spec().$container.find('.handsontableEditor:visible').length).toEqual(0);
     expect(getDataAtCell(2, 0)).toEqual('BMW');
   });
 

--- a/test/e2e/editors/index.spec.js
+++ b/test/e2e/editors/index.spec.js
@@ -76,7 +76,7 @@ describe('editors', () => {
     expect(getEditor('myEditor')).toBe(MyEditor);
   });
 
-  it('should reset previous value when printable character was entered to selected, non-empty cell', async function () {
+  it('should reset previous value when printable character was entered to selected, non-empty cell', async () => {
     handsontable({
       data: [
         {id: 10, name: 'Cup'},

--- a/test/e2e/editors/noEditor.spec.js
+++ b/test/e2e/editors/noEditor.spec.js
@@ -126,7 +126,7 @@ describe('noEditor', () => {
     }, 200);
   });
 
-  it('should not open editor after pressing a printable character', function() {
+  it('should not open editor after pressing a printable character', () => {
     handsontable({
       data: Handsontable.helper.createSpreadsheetData(3, 3),
       editor: false
@@ -135,12 +135,12 @@ describe('noEditor', () => {
 
     expect(isEditorVisible()).toBe(false);
 
-    this.$container.simulate('keydown', {keyCode: 'a'.charCodeAt(0)});
+    spec().$container.simulate('keydown', {keyCode: 'a'.charCodeAt(0)});
 
     expect(isEditorVisible()).toBe(false);
   });
 
-  it('should not open editor after pressing a printable character with shift key', function() {
+  it('should not open editor after pressing a printable character with shift key', () => {
     handsontable({
       data: Handsontable.helper.createSpreadsheetData(3, 3),
       editor: false
@@ -149,7 +149,7 @@ describe('noEditor', () => {
 
     expect(isEditorVisible()).toBe(false);
 
-    this.$container.simulate('keydown', {keyCode: 'a'.charCodeAt(0), shiftKey: true});
+    spec().$container.simulate('keydown', {keyCode: 'a'.charCodeAt(0), shiftKey: true});
 
     expect(isEditorVisible()).toBe(false);
   });

--- a/test/e2e/editors/numericEditor.spec.js
+++ b/test/e2e/editors/numericEditor.spec.js
@@ -652,7 +652,7 @@ describe('NumericEditor', () => {
       }, 100);
     };
 
-    it('Moving from numeric editor to text editor', function(done) {
+    it('Moving from numeric editor to text editor', (done) => {
       handsontable({
         data: [
           {id: 1, name: 'Ted', lastName: 'Right', money: 0}
@@ -670,12 +670,12 @@ describe('NumericEditor', () => {
         moveFromCol: 3,
         moveToRow: 0,
         moveToCol: 0,
-        $container: this.$container,
+        $container: spec().$container,
         doneFunc: done
       });
     });
 
-    it('Moving from text editor to numeric editor', function(done) {
+    it('Moving from text editor to numeric editor', (done) => {
       handsontable({
         data: [
           {id: 1, name: 'Ted', lastName: 'Right', money: 0}
@@ -693,7 +693,7 @@ describe('NumericEditor', () => {
         moveFromCol: 1,
         moveToRow: 0,
         moveToCol: 3,
-        $container: this.$container,
+        $container: spec().$container,
         doneFunc: done
       });
     });

--- a/test/e2e/editors/textEditor.spec.js
+++ b/test/e2e/editors/textEditor.spec.js
@@ -569,7 +569,7 @@ describe('TextEditor', () => {
     expect(editor.focus).toHaveBeenCalled();
   });
 
-  it('editor size should not exceed the viewport after text edit', function() {
+  it('editor size should not exceed the viewport after text edit', () => {
     handsontable({
       data: Handsontable.helper.createSpreadsheetData(10, 5),
       width: 200,
@@ -586,20 +586,20 @@ describe('TextEditor', () => {
     keyDownUp(32); // space - trigger textarea resize
 
     var $textarea = $(document.activeElement);
-    var $wtHider = this.$container.find('.wtHider');
+    var $wtHider = spec().$container.find('.wtHider');
 
-    expect($textarea.offset().left + $textarea.outerWidth()).not.toBeGreaterThan($wtHider.offset().left + this.$container.outerWidth());
+    expect($textarea.offset().left + $textarea.outerWidth()).not.toBeGreaterThan($wtHider.offset().left + spec().$container.outerWidth());
     expect($textarea.offset().top + $textarea.outerHeight()).not.toBeGreaterThan($wtHider.offset().top + $wtHider.outerHeight());
   });
 
   it('should open editor after selecting cell in another table and hitting enter', function() {
-    this.$container2 = $(`<div id="${id}-2"></div>`).appendTo('body');
+    spec().$container2 = $(`<div id="${id}-2"></div>`).appendTo('body');
 
     var hot1 = handsontable();
     var hot2 = handsontable2.call(this);
 
-    this.$container.find('tbody tr:eq(0) td:eq(0)').simulate('mousedown');
-    this.$container.find('tbody tr:eq(0) td:eq(0)').simulate('mouseup');
+    spec().$container.find('tbody tr:eq(0) td:eq(0)').simulate('mousedown');
+    spec().$container.find('tbody tr:eq(0) td:eq(0)').simulate('mouseup');
 
     // Open editor in HOT1
     keyDown('enter');
@@ -611,8 +611,8 @@ describe('TextEditor', () => {
 
     expect(isEditorVisible($(hot1.getActiveEditor().TEXTAREA))).toBe(false);
 
-    this.$container2.find('tbody tr:eq(0) td:eq(0)').simulate('mousedown');
-    this.$container2.find('tbody tr:eq(0) td:eq(0)').simulate('mouseup');
+    spec().$container2.find('tbody tr:eq(0) td:eq(0)').simulate('mousedown');
+    spec().$container2.find('tbody tr:eq(0) td:eq(0)').simulate('mouseup');
 
     expect(hot1.getSelected()).toBeUndefined();
     expect(hot2.getSelected()).toEqual([[0, 0, 0, 0]]);
@@ -622,11 +622,11 @@ describe('TextEditor', () => {
 
     expect(isEditorVisible($(hot2.getActiveEditor().TEXTAREA))).toBe(true);
 
-    this.$container2.handsontable('destroy');
-    this.$container2.remove();
+    spec().$container2.handsontable('destroy');
+    spec().$container2.remove();
 
     function handsontable2(options) {
-      var container = this.$container2;
+      var container = spec().$container2;
 
       container.handsontable(options);
       container[0].focus(); // otherwise TextEditor tests do not pass in IE8
@@ -635,7 +635,7 @@ describe('TextEditor', () => {
     }
   });
 
-  it('should open editor after pressing a printable character', function() {
+  it('should open editor after pressing a printable character', () => {
     handsontable({
       data: Handsontable.helper.createSpreadsheetData(3, 3)
     });
@@ -644,14 +644,14 @@ describe('TextEditor', () => {
 
     expect(isEditorVisible()).toBe(false);
 
-    this.$container.simulate('keydown', {
+    spec().$container.simulate('keydown', {
       keyCode: 'A'.charCodeAt(0)
     });
 
     expect(isEditorVisible()).toBe(true);
   });
 
-  it('should open editor after pressing a printable character with shift key', function() {
+  it('should open editor after pressing a printable character with shift key', () => {
     handsontable({
       data: Handsontable.helper.createSpreadsheetData(3, 3)
     });
@@ -660,7 +660,7 @@ describe('TextEditor', () => {
 
     expect(isEditorVisible()).toBe(false);
 
-    this.$container.simulate('keydown', {
+    spec().$container.simulate('keydown', {
       keyCode: 'A'.charCodeAt(0),
       shiftKey: true
     });
@@ -668,7 +668,7 @@ describe('TextEditor', () => {
     expect(isEditorVisible()).toBe(true);
   });
 
-  it('should be able to open editor after clearing cell data with DELETE', function() {
+  it('should be able to open editor after clearing cell data with DELETE', () => {
     handsontable({
       data: Handsontable.helper.createSpreadsheetData(3, 3)
     });
@@ -677,17 +677,17 @@ describe('TextEditor', () => {
 
     expect(isEditorVisible()).toBe(false);
 
-    this.$container.simulate('keydown', {
+    spec().$container.simulate('keydown', {
       keyCode: 46
     });
-    this.$container.simulate('keydown', {
+    spec().$container.simulate('keydown', {
       keyCode: 'A'.charCodeAt(0)
     });
 
     expect(isEditorVisible()).toBe(true);
   });
 
-  it('should be able to open editor after clearing cell data with BACKSPACE', function() {
+  it('should be able to open editor after clearing cell data with BACKSPACE', () => {
     handsontable({
       data: Handsontable.helper.createSpreadsheetData(3, 3)
     });
@@ -696,10 +696,10 @@ describe('TextEditor', () => {
 
     expect(isEditorVisible()).toBe(false);
 
-    this.$container.simulate('keydown', {
+    spec().$container.simulate('keydown', {
       keyCode: 8 // backspace
     });
-    this.$container.simulate('keydown', {
+    spec().$container.simulate('keydown', {
       keyCode: 'A'.charCodeAt(0)
     });
 
@@ -931,8 +931,8 @@ describe('TextEditor', () => {
     expect(top).toEqual($inputHolder.offset().top + 1);
   });
 
-  it('should display editor with the proper size, when the edited column is beyond the tables container', function() {
-    this.$container.css('overflow', '');
+  it('should display editor with the proper size, when the edited column is beyond the tables container', () => {
+    spec().$container.css('overflow', '');
     var hot = handsontable({
       data: Handsontable.helper.createSpreadsheetData(3, 9)
     });
@@ -968,8 +968,8 @@ describe('TextEditor', () => {
 
   });
 
-  it('should render the text without trimming out the whitespace, if trimWhitespace is set to false', function() {
-    this.$container.css('overflow', '');
+  it('should render the text without trimming out the whitespace, if trimWhitespace is set to false', () => {
+    spec().$container.css('overflow', '');
     var hot = handsontable({
       data: Handsontable.helper.createSpreadsheetData(3, 9),
       trimWhitespace: false

--- a/test/e2e/mobile/selection.spec.js
+++ b/test/e2e/mobile/selection.spec.js
@@ -12,7 +12,7 @@ describe('Selection', () => {
     }
   });
 
-  it('should show selection handles', async function() {
+  it('should show selection handles', () => {
     const hot = handsontable({
       width: 400,
       height: 400
@@ -20,14 +20,14 @@ describe('Selection', () => {
 
     hot.selectCell(1, 1);
 
-    const topLeftSelectionHandle = this.$container.find('.ht_master .htBorders div:last-child .topLeftSelectionHandle')[0];
-    const bottomRightSelectionHandle = this.$container.find('.ht_master .htBorders div:last-child .bottomRightSelectionHandle')[0];
+    const topLeftSelectionHandle = spec().$container.find('.ht_master .htBorders div:last-child .topLeftSelectionHandle')[0];
+    const bottomRightSelectionHandle = spec().$container.find('.ht_master .htBorders div:last-child .bottomRightSelectionHandle')[0];
 
     expect(topLeftSelectionHandle.style.display).toEqual('block');
     expect(bottomRightSelectionHandle.style.display).toEqual('block');
   });
 
-  it('should show both selection handles after drag & drop', async function() {
+  it('should show both selection handles after drag & drop', async () => {
     const hot = handsontable({
       width: 400,
       height: 400
@@ -37,13 +37,13 @@ describe('Selection', () => {
 
     await sleep(100);
 
-    this.$container.find('.wtBorder.current.corner').simulate('mousedown');
-    this.$container.find('tbody tr:eq(1) td:eq(2)').simulate('mouseover').simulate('mouseup');
+    spec().$container.find('.wtBorder.current.corner').simulate('mousedown');
+    spec().$container.find('tbody tr:eq(1) td:eq(2)').simulate('mouseover').simulate('mouseup');
 
     await sleep(100);
 
-    const topLeftSelectionHandle = this.$container.find('.ht_master .htBorders div:first-child .topLeftSelectionHandle')[0];
-    const bottomRightSelectionHandle = this.$container.find('.ht_master .htBorders div:first-child .bottomRightSelectionHandle')[0];
+    const topLeftSelectionHandle = spec().$container.find('.ht_master .htBorders div:first-child .topLeftSelectionHandle')[0];
+    const bottomRightSelectionHandle = spec().$container.find('.ht_master .htBorders div:first-child .bottomRightSelectionHandle')[0];
 
     expect(topLeftSelectionHandle.style.display).toEqual('block');
     expect(bottomRightSelectionHandle.style.display).toEqual('block');

--- a/test/e2e/renderers/checkboxRenderer.spec.js
+++ b/test/e2e/renderers/checkboxRenderer.spec.js
@@ -55,7 +55,7 @@ describe('CheckboxRenderer', () => {
     expect($(getRenderedContent(2, 0)).prop('checked')).toBe(true);
   });
 
-  it('should select cell after checkbox click', function(done) {
+  it('should select cell after checkbox click', async () => {
     var spy = jasmine.createSpyObj('error', ['test']);
     window.onerror = function() {
       spy.test();
@@ -75,15 +75,13 @@ describe('CheckboxRenderer', () => {
     spec().$container.find(':checkbox').eq(2).simulate('mouseup');
     spec().$container.find(':checkbox').eq(2).simulate('click');
 
-    setTimeout(() => {
-      expect(spy.test.calls.count()).toBe(0);
-      expect(hot.getSelected()).toEqual([[2, 0, 2, 0]]);
+    await sleep(100);
 
-      done();
-    }, 100);
+    expect(spy.test.calls.count()).toBe(0);
+    expect(hot.getSelected()).toEqual([[2, 0, 2, 0]]);
   });
 
-  it('should select cell after label click', function() {
+  it('should select cell after label click', () => {
     var hot = handsontable({
       data: [[true], [false], [true]],
       columns: [
@@ -93,12 +91,12 @@ describe('CheckboxRenderer', () => {
 
     hot.selectCell(0, 0);
 
-    this.$container.find('td label').eq(2).simulate('mousedown');
+    spec().$container.find('td label').eq(2).simulate('mousedown');
 
     expect(hot.getSelected()).toEqual([[2, 0, 2, 0]]);
   });
 
-  it('should reverse selection in checkboxes', function() {
+  it('should reverse selection in checkboxes', () => {
     handsontable({
       data: [[true], [false], [true]],
       columns: [
@@ -106,14 +104,14 @@ describe('CheckboxRenderer', () => {
       ]
     });
 
-    this.$container.find(':checkbox').eq(0).simulate('click');
-    this.$container.find(':checkbox').eq(1).simulate('click');
-    this.$container.find(':checkbox').eq(2).simulate('click');
+    spec().$container.find(':checkbox').eq(0).simulate('click');
+    spec().$container.find(':checkbox').eq(1).simulate('click');
+    spec().$container.find(':checkbox').eq(2).simulate('click');
 
     expect(getData()).toEqual([[false], [true], [false]]);
   });
 
-  it('shouldn\'t uncheck checkboxes', function() {
+  it('shouldn\'t uncheck checkboxes', () => {
     handsontable({
       data: [[true], [true], [true]],
       columns: [
@@ -121,12 +119,12 @@ describe('CheckboxRenderer', () => {
       ]
     });
 
-    this.$container.find(':checkbox').trigger('click');
+    spec().$container.find(':checkbox').trigger('click');
 
     expect(getData()).toEqual([[true], [true], [true]]);
   });
 
-  it('should check single box after hitting space', function() {
+  it('should check single box after hitting space', () => {
     handsontable({
       data: [[true], [true], [true]],
       columns: [
@@ -137,7 +135,7 @@ describe('CheckboxRenderer', () => {
     var afterChangeCallback = jasmine.createSpy('afterChangeCallback');
     addHook('afterChange', afterChangeCallback);
 
-    var checkboxes = this.$container.find(':checkbox');
+    var checkboxes = spec().$container.find(':checkbox');
 
     expect(checkboxes.eq(0).prop('checked')).toBe(true);
     expect(checkboxes.eq(1).prop('checked')).toBe(true);
@@ -146,13 +144,13 @@ describe('CheckboxRenderer', () => {
 
     selectCell(0, 0);
 
-    //  this.$container.find(':checkbox').eq(0).simulate('click');
-    //  this.$container.simulate('keydown',{
+    //  spec().$container.find(':checkbox').eq(0).simulate('click');
+    //  spec().$container.simulate('keydown',{
     //    keyCode: 32
     //  });
     keyDown('space');
 
-    checkboxes = this.$container.find(':checkbox');
+    checkboxes = spec().$container.find(':checkbox');
 
     expect(checkboxes.eq(0).prop('checked')).toBe(false);
     expect(checkboxes.eq(1).prop('checked')).toBe(true);
@@ -162,7 +160,7 @@ describe('CheckboxRenderer', () => {
     expect(afterChangeCallback).toHaveBeenCalledWith([[0, 0, true, false]], 'edit', undefined, undefined, undefined, undefined);
   });
 
-  it('should not check single box after hitting space, if cell is readOnly', function() {
+  it('should not check single box after hitting space, if cell is readOnly', () => {
     handsontable({
       data: [[true], [true], [true]],
       columns: [
@@ -173,7 +171,7 @@ describe('CheckboxRenderer', () => {
     var afterChangeCallback = jasmine.createSpy('afterChangeCallback');
     addHook('afterChange', afterChangeCallback);
 
-    var checkboxes = this.$container.find(':checkbox');
+    var checkboxes = spec().$container.find(':checkbox');
 
     expect(checkboxes.eq(0).prop('checked')).toBe(true);
     expect(checkboxes.eq(1).prop('checked')).toBe(true);
@@ -184,7 +182,7 @@ describe('CheckboxRenderer', () => {
 
     keyDown('space');
 
-    checkboxes = this.$container.find(':checkbox');
+    checkboxes = spec().$container.find(':checkbox');
 
     expect(checkboxes.eq(0).prop('checked')).toBe(true);
     expect(checkboxes.eq(1).prop('checked')).toBe(true);
@@ -193,7 +191,7 @@ describe('CheckboxRenderer', () => {
     expect(afterChangeCallback).not.toHaveBeenCalled();
   });
 
-  it('should not check single box after hitting space, if last column is readOnly (#3562)', function() {
+  it('should not check single box after hitting space, if last column is readOnly (#3562)', () => {
     handsontable({
       data: [[true, true], [false, false], [true, true]],
       columns: [
@@ -211,7 +209,7 @@ describe('CheckboxRenderer', () => {
     selectCell(1, 1);
     keyDown('space');
 
-    var checkboxes = this.$container.find(':checkbox');
+    var checkboxes = spec().$container.find(':checkbox');
 
     // column 0
     expect(checkboxes.eq(0).prop('checked')).toBe(false);
@@ -264,7 +262,7 @@ describe('CheckboxRenderer', () => {
     expect(getDataAtCell(199, 0)).toEqual(true);
   });
 
-  it('should reverse checkboxes state after hitting space, when multiple cells are selected', function() {
+  it('should reverse checkboxes state after hitting space, when multiple cells are selected', () => {
     handsontable({
       data: [[true], [false], [true]],
       columns: [
@@ -275,7 +273,7 @@ describe('CheckboxRenderer', () => {
     var afterChangeCallback = jasmine.createSpy('afterChangeCallback');
     addHook('afterChange', afterChangeCallback);
 
-    var checkboxes = this.$container.find(':checkbox');
+    var checkboxes = spec().$container.find(':checkbox');
 
     expect(checkboxes.eq(0).prop('checked')).toBe(true);
     expect(checkboxes.eq(1).prop('checked')).toBe(false);
@@ -286,7 +284,7 @@ describe('CheckboxRenderer', () => {
 
     keyDown('space');
 
-    checkboxes = this.$container.find(':checkbox');
+    checkboxes = spec().$container.find(':checkbox');
 
     expect(checkboxes.eq(0).prop('checked')).toBe(false);
     expect(checkboxes.eq(1).prop('checked')).toBe(true);
@@ -296,7 +294,7 @@ describe('CheckboxRenderer', () => {
     expect(afterChangeCallback).toHaveBeenCalledWith([[0, 0, true, false], [1, 0, false, true], [2, 0, true, false]], 'edit', undefined, undefined, undefined, undefined);
   });
 
-  it('should reverse checkboxes state after hitting space, when multiple cells are selected and selStart > selEnd', function() {
+  it('should reverse checkboxes state after hitting space, when multiple cells are selected and selStart > selEnd', () => {
     handsontable({
       data: [[true], [false], [true]],
       columns: [
@@ -307,7 +305,7 @@ describe('CheckboxRenderer', () => {
     var afterChangeCallback = jasmine.createSpy('afterChangeCallback');
     addHook('afterChange', afterChangeCallback);
 
-    var checkboxes = this.$container.find(':checkbox');
+    var checkboxes = spec().$container.find(':checkbox');
 
     expect(checkboxes.eq(0).prop('checked')).toBe(true);
     expect(checkboxes.eq(1).prop('checked')).toBe(false);
@@ -318,7 +316,7 @@ describe('CheckboxRenderer', () => {
 
     keyDown('space');
 
-    checkboxes = this.$container.find(':checkbox');
+    checkboxes = spec().$container.find(':checkbox');
 
     expect(checkboxes.eq(0).prop('checked')).toBe(false);
     expect(checkboxes.eq(1).prop('checked')).toBe(true);
@@ -370,7 +368,7 @@ describe('CheckboxRenderer', () => {
     expect(getDataAtCell(0, 0)).toBe(false);
   });
 
-  it('should change checkbox state from checked to unchecked after hitting ENTER', function() {
+  it('should change checkbox state from checked to unchecked after hitting ENTER', () => {
     handsontable({
       data: [[true], [true], [true]],
       columns: [
@@ -381,7 +379,7 @@ describe('CheckboxRenderer', () => {
     var afterChangeCallback = jasmine.createSpy('afterChangeCallback');
     addHook('afterChange', afterChangeCallback);
 
-    var checkboxes = this.$container.find(':checkbox');
+    var checkboxes = spec().$container.find(':checkbox');
 
     expect(checkboxes.eq(0).prop('checked')).toBe(true);
     expect(checkboxes.eq(1).prop('checked')).toBe(true);
@@ -392,7 +390,7 @@ describe('CheckboxRenderer', () => {
 
     keyDown('enter');
 
-    checkboxes = this.$container.find(':checkbox');
+    checkboxes = spec().$container.find(':checkbox');
 
     expect(checkboxes.eq(0).prop('checked')).toBe(false);
     expect(checkboxes.eq(1).prop('checked')).toBe(true);
@@ -402,7 +400,7 @@ describe('CheckboxRenderer', () => {
     expect(afterChangeCallback).toHaveBeenCalledWith([[0, 0, true, false]], 'edit', undefined, undefined, undefined, undefined);
   });
 
-  it('should change checkbox state from checked to unchecked after hitting ENTER using custom check/uncheck templates', function() {
+  it('should change checkbox state from checked to unchecked after hitting ENTER using custom check/uncheck templates', () => {
     handsontable({
       data: [['yes'], ['yes'], ['no']],
       columns: [
@@ -417,7 +415,7 @@ describe('CheckboxRenderer', () => {
     var afterChangeCallback = jasmine.createSpy('afterChangeCallback');
     addHook('afterChange', afterChangeCallback);
 
-    var checkboxes = this.$container.find(':checkbox');
+    var checkboxes = spec().$container.find(':checkbox');
 
     expect(checkboxes.eq(0).prop('checked')).toBe(true);
     expect(checkboxes.eq(1).prop('checked')).toBe(true);
@@ -428,7 +426,7 @@ describe('CheckboxRenderer', () => {
 
     keyDown('enter');
 
-    checkboxes = this.$container.find(':checkbox');
+    checkboxes = spec().$container.find(':checkbox');
 
     expect(checkboxes.eq(0).prop('checked')).toBe(false);
     expect(checkboxes.eq(1).prop('checked')).toBe(true);
@@ -438,7 +436,7 @@ describe('CheckboxRenderer', () => {
     expect(afterChangeCallback).toHaveBeenCalledWith([[0, 0, 'yes', 'no']], 'edit', undefined, undefined, undefined, undefined);
   });
 
-  it('should change checkbox state from checked to unchecked after hitting ENTER using custom check/uncheck templates in numeric format', function() {
+  it('should change checkbox state from checked to unchecked after hitting ENTER using custom check/uncheck templates in numeric format', () => {
     handsontable({
       data: [[1], [1], [0]],
       columns: [
@@ -453,7 +451,7 @@ describe('CheckboxRenderer', () => {
     var afterChangeCallback = jasmine.createSpy('afterChangeCallback');
     addHook('afterChange', afterChangeCallback);
 
-    var checkboxes = this.$container.find(':checkbox');
+    var checkboxes = spec().$container.find(':checkbox');
 
     expect(checkboxes.eq(0).prop('checked')).toBe(true);
     expect(checkboxes.eq(1).prop('checked')).toBe(true);
@@ -464,7 +462,7 @@ describe('CheckboxRenderer', () => {
 
     keyDown('enter');
 
-    checkboxes = this.$container.find(':checkbox');
+    checkboxes = spec().$container.find(':checkbox');
 
     expect(checkboxes.eq(0).prop('checked')).toBe(false);
     expect(checkboxes.eq(1).prop('checked')).toBe(true);
@@ -474,7 +472,7 @@ describe('CheckboxRenderer', () => {
     expect(afterChangeCallback).toHaveBeenCalledWith([[0, 0, 1, 0]], 'edit', undefined, undefined, undefined, undefined);
   });
 
-  it('should change checkbox state to unchecked after hitting DELETE', function() {
+  it('should change checkbox state to unchecked after hitting DELETE', () => {
     handsontable({
       data: [[true], [false], [true]],
       columns: [
@@ -485,7 +483,7 @@ describe('CheckboxRenderer', () => {
     var afterChangeCallback = jasmine.createSpy('afterChangeCallback');
     addHook('afterChange', afterChangeCallback);
 
-    var checkboxes = this.$container.find(':checkbox');
+    var checkboxes = spec().$container.find(':checkbox');
 
     expect(checkboxes.eq(0).prop('checked')).toBe(true);
     expect(checkboxes.eq(1).prop('checked')).toBe(false);
@@ -497,7 +495,7 @@ describe('CheckboxRenderer', () => {
     selectCell(0, 1);
     keyDown('delete');
 
-    checkboxes = this.$container.find(':checkbox');
+    checkboxes = spec().$container.find(':checkbox');
 
     expect(checkboxes.eq(0).prop('checked')).toBe(false);
     expect(checkboxes.eq(1).prop('checked')).toBe(false);
@@ -508,7 +506,7 @@ describe('CheckboxRenderer', () => {
     expect(afterChangeCallback).toHaveBeenCalledWith([[0, 0, true, false]], 'edit', undefined, undefined, undefined, undefined);
   });
 
-  it('should change checkbox notte to unchecked after hitting BACKSPACE', function() {
+  it('should change checkbox notte to unchecked after hitting BACKSPACE', () => {
     handsontable({
       data: [[true], [false], [true]],
       columns: [
@@ -519,7 +517,7 @@ describe('CheckboxRenderer', () => {
     var afterChangeCallback = jasmine.createSpy('afterChangeCallback');
     addHook('afterChange', afterChangeCallback);
 
-    var checkboxes = this.$container.find(':checkbox');
+    var checkboxes = spec().$container.find(':checkbox');
 
     expect(checkboxes.eq(0).prop('checked')).toBe(true);
     expect(checkboxes.eq(1).prop('checked')).toBe(false);
@@ -531,7 +529,7 @@ describe('CheckboxRenderer', () => {
     selectCell(0, 1);
     keyDown('backspace');
 
-    checkboxes = this.$container.find(':checkbox');
+    checkboxes = spec().$container.find(':checkbox');
 
     expect(checkboxes.eq(0).prop('checked')).toBe(false);
     expect(checkboxes.eq(1).prop('checked')).toBe(false);

--- a/test/e2e/settings/colWidths.spec.js
+++ b/test/e2e/settings/colWidths.spec.js
@@ -14,39 +14,39 @@ describe('settings', () => {
     });
 
     describe('defined in constructor', () => {
-      it('should consider colWidths provided as number', function() {
+      it('should consider colWidths provided as number', () => {
         handsontable({
           colWidths: 123
         });
 
-        expect(colWidth(this.$container, 0)).toBe(123);
+        expect(colWidth(spec().$container, 0)).toBe(123);
       });
 
-      it('should consider colWidths provided as string', function() {
+      it('should consider colWidths provided as string', () => {
         handsontable({
           colWidths: '123'
         });
 
-        expect(colWidth(this.$container, 0)).toBe(123);
+        expect(colWidth(spec().$container, 0)).toBe(123);
       });
 
-      it('should consider colWidths provided as array of numbers', function() {
+      it('should consider colWidths provided as array of numbers', () => {
         handsontable({
           colWidths: [123]
         });
 
-        expect(colWidth(this.$container, 0)).toBe(123);
+        expect(colWidth(spec().$container, 0)).toBe(123);
       });
 
-      it('should consider colWidths provided as array of strings', function() {
+      it('should consider colWidths provided as array of strings', () => {
         handsontable({
           colWidths: ['123']
         });
 
-        expect(colWidth(this.$container, 0)).toBe(123);
+        expect(colWidth(spec().$container, 0)).toBe(123);
       });
 
-      it('should consider colWidth provided as function that returns number', function() {
+      it('should consider colWidth provided as function that returns number', () => {
         handsontable({
           colWidths(index) {
             if (index === 0) {
@@ -56,10 +56,10 @@ describe('settings', () => {
           }
         });
 
-        expect(colWidth(this.$container, 0)).toBe(123);
+        expect(colWidth(spec().$container, 0)).toBe(123);
       });
 
-      it('should consider colWidth provided as function that returns string', function() {
+      it('should consider colWidth provided as function that returns string', () => {
         handsontable({
           colWidths(index) {
             if (index === 0) {
@@ -69,48 +69,48 @@ describe('settings', () => {
           }
         });
 
-        expect(colWidth(this.$container, 0)).toBe(123);
+        expect(colWidth(spec().$container, 0)).toBe(123);
       });
     });
 
     describe('defined in updateSettings', () => {
-      it('should consider colWidths provided as number', function() {
+      it('should consider colWidths provided as number', () => {
         handsontable();
         updateSettings({
           colWidths: 123
         });
 
-        expect(colWidth(this.$container, 0)).toBe(123);
+        expect(colWidth(spec().$container, 0)).toBe(123);
       });
 
-      it('should consider colWidths provided as string', function() {
+      it('should consider colWidths provided as string', () => {
         handsontable();
         updateSettings({
           colWidths: '123'
         });
 
-        expect(colWidth(this.$container, 0)).toBe(123);
+        expect(colWidth(spec().$container, 0)).toBe(123);
       });
 
-      it('should consider colWidths provided as array of numbers', function() {
+      it('should consider colWidths provided as array of numbers', () => {
         handsontable();
         updateSettings({
           colWidths: [123]
         });
 
-        expect(colWidth(this.$container, 0)).toBe(123);
+        expect(colWidth(spec().$container, 0)).toBe(123);
       });
 
-      it('should consider colWidths provided as array of strings', function() {
+      it('should consider colWidths provided as array of strings', () => {
         handsontable();
         updateSettings({
           colWidths: ['123']
         });
 
-        expect(colWidth(this.$container, 0)).toBe(123);
+        expect(colWidth(spec().$container, 0)).toBe(123);
       });
 
-      it('should consider colWidth provided as function that returns number', function() {
+      it('should consider colWidth provided as function that returns number', () => {
         handsontable();
         updateSettings({
           colWidths(index) {
@@ -121,10 +121,10 @@ describe('settings', () => {
           }
         });
 
-        expect(colWidth(this.$container, 0)).toBe(123);
+        expect(colWidth(spec().$container, 0)).toBe(123);
       });
 
-      it('should consider colWidth provided as function that returns string', function() {
+      it('should consider colWidth provided as function that returns string', () => {
         handsontable();
         updateSettings({
           colWidths(index) {
@@ -135,12 +135,12 @@ describe('settings', () => {
           }
         });
 
-        expect(colWidth(this.$container, 0)).toBe(123);
+        expect(colWidth(spec().$container, 0)).toBe(123);
       });
     });
 
     describe('defined in columns', () => {
-      it('should consider width provided as number', function() {
+      it('should consider width provided as number', () => {
         handsontable({
           columns: [
             {
@@ -149,10 +149,10 @@ describe('settings', () => {
           ]
         });
 
-        expect(colWidth(this.$container, 0)).toBe(123);
+        expect(colWidth(spec().$container, 0)).toBe(123);
       });
 
-      it('should consider width provided as string', function() {
+      it('should consider width provided as string', () => {
         handsontable({
           columns: [
             {
@@ -161,10 +161,10 @@ describe('settings', () => {
           ]
         });
 
-        expect(colWidth(this.$container, 0)).toBe(123);
+        expect(colWidth(spec().$container, 0)).toBe(123);
       });
 
-      it('should consider width provided as array of numbers', function() {
+      it('should consider width provided as array of numbers', () => {
         handsontable({
           columns: [
             {
@@ -173,10 +173,10 @@ describe('settings', () => {
           ]
         });
 
-        expect(colWidth(this.$container, 0)).toBe(123);
+        expect(colWidth(spec().$container, 0)).toBe(123);
       });
 
-      it('should consider width provided as array of strings', function() {
+      it('should consider width provided as array of strings', () => {
         handsontable({
           columns: [
             {
@@ -185,10 +185,10 @@ describe('settings', () => {
           ]
         });
 
-        expect(colWidth(this.$container, 0)).toBe(123);
+        expect(colWidth(spec().$container, 0)).toBe(123);
       });
 
-      it('should consider width provided as function that returns number', function() {
+      it('should consider width provided as function that returns number', () => {
         handsontable({
           columns: [
             {
@@ -202,10 +202,10 @@ describe('settings', () => {
           ]
         });
 
-        expect(colWidth(this.$container, 0)).toBe(123);
+        expect(colWidth(spec().$container, 0)).toBe(123);
       });
 
-      it('should consider width provided as function that returns string', function() {
+      it('should consider width provided as function that returns string', () => {
         handsontable({
           columns: [
             {
@@ -219,12 +219,12 @@ describe('settings', () => {
           ]
         });
 
-        expect(colWidth(this.$container, 0)).toBe(123);
+        expect(colWidth(spec().$container, 0)).toBe(123);
       });
     });
 
     describe('defined in cells', () => {
-      it('should consider width provided as number', function() {
+      it('should consider width provided as number', () => {
         handsontable({
           cells(row, col) {
             if (col === 0) {
@@ -233,10 +233,10 @@ describe('settings', () => {
           }
         });
 
-        expect(colWidth(this.$container, 0)).toBe(123);
+        expect(colWidth(spec().$container, 0)).toBe(123);
       });
 
-      it('should consider width provided as string', function() {
+      it('should consider width provided as string', () => {
         handsontable({
           cells(row, col) {
             if (col === 0) {
@@ -245,7 +245,7 @@ describe('settings', () => {
           }
         });
 
-        expect(colWidth(this.$container, 0)).toBe(123);
+        expect(colWidth(spec().$container, 0)).toBe(123);
       });
     });
   });

--- a/test/e2e/settings/currentHeaderClassName.spec.js
+++ b/test/e2e/settings/currentHeaderClassName.spec.js
@@ -13,7 +13,7 @@ describe('settings', () => {
   });
 
   describe('currentHeaderClassName', () => {
-    it('should apply default currentHeaderClassName to cells in row where there is a selection', function() {
+    it('should apply default currentHeaderClassName to cells in row where there is a selection', () => {
       handsontable({
         rowHeaders: true,
         colHeaders: true,
@@ -22,10 +22,10 @@ describe('settings', () => {
 
       selectCell(2, 2);
 
-      expect(this.$container.find('.ht_master th.ht__highlight').length).toEqual(2);
+      expect(spec().$container.find('.ht_master th.ht__highlight').length).toEqual(2);
     });
 
-    it('should apply default currentHeaderClassName from cells after deselection', function() {
+    it('should apply default currentHeaderClassName from cells after deselection', () => {
       handsontable({
         rowHeaders: true,
         colHeaders: true,
@@ -35,9 +35,9 @@ describe('settings', () => {
       selectCell(2, 2);
       deselectCell();
 
-      expect(this.$container.find('.ht_master th.ht__highlight').length).toEqual(0);
+      expect(spec().$container.find('.ht_master th.ht__highlight').length).toEqual(0);
     });
-    it('should apply custom currentHeaderClassName to cells in row where there is a selection', function() {
+    it('should apply custom currentHeaderClassName to cells in row where there is a selection', () => {
       handsontable({
         rowHeaders: true,
         colHeaders: true,
@@ -47,7 +47,7 @@ describe('settings', () => {
 
       selectCell(2, 2);
 
-      expect(this.$container.find('.ht_master th.currentHeaderClassName').length).toEqual(2);
+      expect(spec().$container.find('.ht_master th.currentHeaderClassName').length).toEqual(2);
     });
   });
 });

--- a/test/e2e/settings/currentRowClassName.spec.js
+++ b/test/e2e/settings/currentRowClassName.spec.js
@@ -13,7 +13,7 @@ describe('settings', () => {
   });
 
   describe('currentRowClassName', () => {
-    it('should apply currentRowClassName to cells in row where there is a selection', function() {
+    it('should apply currentRowClassName to cells in row where there is a selection', () => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(5, 7),
         currentRowClassName: 'currentRowClassName'
@@ -21,10 +21,10 @@ describe('settings', () => {
 
       selectCell(2, 2);
 
-      expect(this.$container.find('td.currentRowClassName').length).toEqual(6);
+      expect(spec().$container.find('td.currentRowClassName').length).toEqual(6);
     });
 
-    it('should apply currentRowClassName from cells after deselection', function() {
+    it('should apply currentRowClassName from cells after deselection', () => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(5, 7),
         currentRowClassName: 'currentRowClassName'
@@ -33,12 +33,12 @@ describe('settings', () => {
       selectCell(2, 2);
       deselectCell();
 
-      expect(this.$container.find('td.currentRowClassName').length).toEqual(0);
+      expect(spec().$container.find('td.currentRowClassName').length).toEqual(0);
     });
   });
 
   describe('currentColClassName', () => {
-    it('should apply currentColClassName to cells in row where there is a selection', function() {
+    it('should apply currentColClassName to cells in row where there is a selection', () => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(5, 7),
         currentColClassName: 'currentColClassName'
@@ -46,10 +46,10 @@ describe('settings', () => {
 
       selectCell(2, 2);
 
-      expect(this.$container.find('td.currentColClassName').length).toEqual(4);
+      expect(spec().$container.find('td.currentColClassName').length).toEqual(4);
     });
 
-    it('should remove currentColClassName from cells after deselection', function() {
+    it('should remove currentColClassName from cells after deselection', () => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(5, 7),
         currentColClassName: 'currentColClassName'
@@ -58,7 +58,7 @@ describe('settings', () => {
       selectCell(2, 2);
       deselectCell();
 
-      expect(this.$container.find('td.currentColClassName').length).toEqual(0);
+      expect(spec().$container.find('td.currentColClassName').length).toEqual(0);
     });
   });
 });

--- a/test/e2e/settings/fragmentSelection.spec.js
+++ b/test/e2e/settings/fragmentSelection.spec.js
@@ -72,32 +72,32 @@ describe('settings', () => {
     }
 
     describe('constructor', () => {
-      it('should disallow fragmentSelection when set to false', function() {
+      it('should disallow fragmentSelection when set to false', () => {
         handsontable({
           data: Handsontable.helper.createSpreadsheetData(4, 4),
           fragmentSelection: false
         });
 
-        selectElementText(this.$container.find('tr:eq(0) td:eq(1)')[0], 3);
+        selectElementText(spec().$container.find('tr:eq(0) td:eq(1)')[0], 3);
 
-        mouseDown(this.$container.find('tr:eq(0) td:eq(3)'));
-        mouseUp(this.$container.find('tr:eq(0) td:eq(3)'));
+        mouseDown(spec().$container.find('tr:eq(0) td:eq(3)'));
+        mouseUp(spec().$container.find('tr:eq(0) td:eq(3)'));
 
         var sel = getSelected();
 
         expect(sel).toEqual(' '); // copyPaste has selected space in textarea
       });
 
-      xit('should allow fragmentSelection when set to true', function() {
+      xit('should allow fragmentSelection when set to true', () => {
         // We have to try another way to simulate text selection.
         handsontable({
           data: Handsontable.helper.createSpreadsheetData(4, 4),
           fragmentSelection: true
         });
-        selectElementText(this.$container.find('td')[1], 3);
+        selectElementText(spec().$container.find('td')[1], 3);
 
-        mouseDown(this.$container.find('tr:eq(0) td:eq(3)'));
-        mouseUp(this.$container.find('tr:eq(0) td:eq(3)'));
+        mouseDown(spec().$container.find('tr:eq(0) td:eq(3)'));
+        mouseUp(spec().$container.find('tr:eq(0) td:eq(3)'));
 
         var sel = getSelected();
         sel = sel.replace(/\s/g, ''); // tabs and spaces between <td>s are inconsistent in browsers, so let's ignore them
@@ -105,42 +105,42 @@ describe('settings', () => {
         expect(sel).toEqual('B1C1D1');
       });
 
-      xit('should allow fragmentSelection from one cell when set to `cell`', function() {
+      xit('should allow fragmentSelection from one cell when set to `cell`', () => {
         // We have to try another way to simulate text selection.
         handsontable({
           data: Handsontable.helper.createSpreadsheetData(4, 4),
           fragmentSelection: 'cell'
         });
-        selectElementText(this.$container.find('td')[1], 1);
+        selectElementText(spec().$container.find('td')[1], 1);
 
-        mouseDown(this.$container.find('tr:eq(0) td:eq(1)'));
-        mouseUp(this.$container.find('tr:eq(0) td:eq(1)'));
+        mouseDown(spec().$container.find('tr:eq(0) td:eq(1)'));
+        mouseUp(spec().$container.find('tr:eq(0) td:eq(1)'));
 
         expect(getSelected().replace(/\s/g, '')).toEqual('B1');
       });
 
-      it('should disallow fragmentSelection from one cell when set to `cell` and when user selects adjacent cell', function() {
+      it('should disallow fragmentSelection from one cell when set to `cell` and when user selects adjacent cell', () => {
         handsontable({
           data: Handsontable.helper.createSpreadsheetData(4, 4),
           fragmentSelection: 'cell'
         });
-        selectElementText(this.$container.find('td')[1], 1);
+        selectElementText(spec().$container.find('td')[1], 1);
 
-        mouseDown(this.$container.find('tr:eq(0) td:eq(1)'));
-        mouseOver(this.$container.find('tr:eq(0) td:eq(2)'));
-        mouseMove(this.$container.find('tr:eq(0) td:eq(2)'));
-        mouseUp(this.$container.find('tr:eq(0) td:eq(2)'));
+        mouseDown(spec().$container.find('tr:eq(0) td:eq(1)'));
+        mouseOver(spec().$container.find('tr:eq(0) td:eq(2)'));
+        mouseMove(spec().$container.find('tr:eq(0) td:eq(2)'));
+        mouseUp(spec().$container.find('tr:eq(0) td:eq(2)'));
 
         expect(getSelected()).toEqual(' '); // copyPaste has selected space in textarea
       });
 
-      it('should disallow fragmentSelection of Handsontable chrome (anything that is not table) when set to false', function() {
+      it('should disallow fragmentSelection of Handsontable chrome (anything that is not table) when set to false', () => {
         handsontable({
           data: Handsontable.helper.createSpreadsheetData(4, 4),
           fragmentSelection: false
         });
         var $div = $('<div style="position: absolute; top: 0; left: 0">Text</div>');
-        this.$container.append($div);
+        spec().$container.append($div);
         selectElementText($div[0], 1);
 
         mouseDown($div);
@@ -149,13 +149,13 @@ describe('settings', () => {
         expect(sel).toEqual(false);
       });
 
-      it('should disallow fragmentSelection of Handsontable chrome (anything that is not table) when set to true', function() {
+      it('should disallow fragmentSelection of Handsontable chrome (anything that is not table) when set to true', () => {
         handsontable({
           data: Handsontable.helper.createSpreadsheetData(4, 4),
           fragmentSelection: true
         });
         var $div = $('<div style="position: absolute; top: 0; left: 0">Text</div>');
-        this.$container.append($div);
+        spec().$container.append($div);
         selectElementText($div[0], 1);
 
         mouseDown($div);
@@ -166,32 +166,32 @@ describe('settings', () => {
     });
 
     describe('dynamic', () => {
-      it('should disallow fragmentSelection when set to false', function() {
+      it('should disallow fragmentSelection when set to false', () => {
         handsontable({
           data: Handsontable.helper.createSpreadsheetData(4, 4),
           fragmentSelection: true
         });
         updateSettings({fragmentSelection: false});
-        selectElementText(this.$container.find('tr:eq(0) td:eq(1)')[0], 3);
+        selectElementText(spec().$container.find('tr:eq(0) td:eq(1)')[0], 3);
 
-        mouseDown(this.$container.find('tr:eq(0) td:eq(3)'));
-        mouseUp(this.$container.find('tr:eq(0) td:eq(3)'));
+        mouseDown(spec().$container.find('tr:eq(0) td:eq(3)'));
+        mouseUp(spec().$container.find('tr:eq(0) td:eq(3)'));
 
         var sel = getSelected();
         expect(sel).toEqual(' '); // copyPaste has selected space in textarea
       });
 
-      xit('should allow fragmentSelection when set to true', function() {
+      xit('should allow fragmentSelection when set to true', () => {
         // We have to try another way to simulate text selection.
         handsontable({
           data: Handsontable.helper.createSpreadsheetData(4, 4),
           fragmentSelection: false
         });
         updateSettings({fragmentSelection: true});
-        selectElementText(this.$container.find('td')[1], 3);
+        selectElementText(spec().$container.find('td')[1], 3);
 
-        mouseDown(this.$container.find('tr:eq(0) td:eq(3)'));
-        mouseUp(this.$container.find('tr:eq(0) td:eq(3)'));
+        mouseDown(spec().$container.find('tr:eq(0) td:eq(3)'));
+        mouseUp(spec().$container.find('tr:eq(0) td:eq(3)'));
 
         var sel = getSelected();
         sel = sel.replace(/\s/g, ''); // tabs and spaces between <td>s are inconsistent in browsers, so let's ignore them

--- a/test/unit/helpers/TemplateLiteralTag.spec.js
+++ b/test/unit/helpers/TemplateLiteralTag.spec.js
@@ -1,7 +1,7 @@
 import {toSingleLine} from 'handsontable/helpers/templateLiteralTag';
 
 describe('Helpers for template literals', () => {
-  describe('toSingleLine', function () {
+  describe('toSingleLine', () => {
     it('should strip two line string (string with whitespace at end of first line and indention at second one)', () => {
       const text = toSingleLine`Hello world 
         Hello world`;


### PR DESCRIPTION
### Context
Necessary changes to remove `prefer-arrow-callback` from our custom `.eslintrc`.

### How has this been tested?
1. `npm run lint`
2. should be error-free

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. #4536