### PR TITLE
Remove hook `beforeKeyDown` when close autocompleteEditor, not when finish editing.

### DIFF
--- a/src/editors/autocompleteEditor.js
+++ b/src/editors/autocompleteEditor.js
@@ -307,9 +307,6 @@ AutocompleteEditor.prototype.setDropdownHeight = function(height) {
 };
 
 AutocompleteEditor.prototype.finishEditing = function(restoreOriginalValue, ...args) {
-  if (!restoreOriginalValue) {
-    this.instance.removeHook('beforeKeyDown', onBeforeKeyDown);
-  }
   HandsontableEditor.prototype.finishEditing.apply(this, [restoreOriginalValue, ...args]);
 };
 
@@ -431,6 +428,11 @@ AutocompleteEditor.prototype.allowKeyEventPropagation = function(keyCode) {
   }
 
   return allowed;
+};
+
+AutocompleteEditor.prototype.close = function(...args) {
+  this.instance.removeHook('beforeKeyDown', onBeforeKeyDown);
+  HandsontableEditor.prototype.close.apply(this, args);
 };
 
 AutocompleteEditor.prototype.discardEditor = function(...args) {


### PR DESCRIPTION
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #3374 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
