### PR TITLE
 ESLINT - consistent-return

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,7 +11,7 @@
   "rules": {
     "class-methods-use-this": 0,
     "comma-dangle": 0,
-    "consistent-return": 1,
+    "consistent-return": 0,
     "dot-notation": 2,
     "eol-last": 2,
     "func-names": 0,


### PR DESCRIPTION
### Context
Necessary changes to turn off warnings of `consistent-return` in our custom `.eslintrc`.

### How has this been tested?
1. `npm run lint`
2. should be warning-free

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. #4536