### PR TITLE
Fix table rendering in Chrome 68+

### DIFF
--- a/src/3rdparty/walkontable/src/viewport.js
+++ b/src/3rdparty/walkontable/src/viewport.js
@@ -87,7 +87,7 @@ class Viewport {
     if (trimmingContainer !== window) {
       overflow = getStyle(this.instance.wtOverlays.leftOverlay.trimmingContainer, 'overflow');
 
-      if (overflow === 'scroll' || overflow === 'hidden' || overflow === 'auto') {
+      if (overflow && (overflow.startsWith('scroll') || overflow.startsWith('hidden') || overflow.startsWith('auto'))) {
         // this is used in `scroll.html`
         // TODO test me
         return Math.max(width, trimmingContainer.clientWidth);


### PR DESCRIPTION
In Chrome 68, `document.defaultView.getComputedStyle(element)` of a hidden element
will return `hidden auto` instead of `hidden` as it did in Chrome 67. This means
that we now need to match the start of the css attribute value, and not an exact match on
the entire css value.

### Context
In Chrome 68, `document.defaultView.getComputedStyle(element)` of a hidden element
will return `hidden auto` instead of `hidden` as it did in Chrome 67. This means
that we now need to match the start of the css attribute value, and not an exact match on
the entire css value. 

The table has erratic behavior if it can't measure its width. 

### How has this been tested?
I've tested this by integrating the forked fix into my application, and running it against Chrome 67 and Chrome 68. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
