### PR TITLE
ESLINT - newline-per-chained-call

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,7 +18,7 @@
     "import/extensions": 0,
     "import/no-extraneous-dependencies": 0,
     "new-cap": 2,
-    "newline-per-chained-call": 1,
+    "newline-per-chained-call": 0,
     "no-eq-null": 2,
     "no-irregular-whitespace": 2,
     "no-mixed-spaces-and-tabs": 2,


### PR DESCRIPTION
### Context
Necessary changes to turn off warnings of `newline-per-chained-call` in our custom `.eslintrc`.

### How has this been tested?
1. `npm run lint`
2. should be warning-free

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. #4536