### PR TITLE
Fix scroll issue

### DIFF
--- a/src/editors/textEditor.js
+++ b/src/editors/textEditor.js
@@ -70,8 +70,6 @@ TextEditor.prototype.prepare = function(row, col, prop, td, originalValue, cellP
 };
 
 TextEditor.prototype.hideEditableElement = function() {
-  this.textareaParentStyle.top = '-9999px';
-  this.textareaParentStyle.left = '-9999px';
   this.textareaParentStyle.zIndex = '-1';
 };
 


### PR DESCRIPTION
### Context
Fixes an issue causing Handson Table to scroll to the top of the page.
The issue seems to be caused by the paste event being fired before the
copy/paste plugin is enabled. When this happens, the text editor
placeholder element receives focus. Since the text editor placeholder
element was being set to -9999 top and left, this was causing the screen
to scroll to the top. Not setting a top and left value fixes the issue.

### How has this been tested?
I wasn't able to get an E2E test working to test the fix. I couldn't figure out how to access Puppeteer in the E2E test and the [`triggerPaste`](https://github.com/handsontable/handsontable/blob/638c3aa0303af292b3e685046f53e6e9ea17208c/test/helpers/common.js#L368) helper defined in copy paste event didn't work in reproducing the issue that I'm encountering since it invokes the paste callback directly instead of firing a paste event.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. #5350

### Checklist:
- [X] My code follows the code style of this project,
