### PR TITLE
Fix typo in AutoColumnSize typescript definition and add test (develop branch).

### DIFF
--- a/handsontable.d.ts
+++ b/handsontable.d.ts
@@ -621,7 +621,7 @@ declare namespace Handsontable {
       firstCalculation: boolean;
       ghostTable: GhostTable;
       inProgress: boolean;
-      sampleGenerator: SamplesGenerator;
+      samplesGenerator: SamplesGenerator;
       widths: any[];
 
       calculateAllColumnsWidth(rowRange?: number | object): void;

--- a/test/types/methods.types.ts
+++ b/test/types/methods.types.ts
@@ -124,3 +124,5 @@ const trimeRows: Handsontable.plugins.TrimRows = hot.getPlugin('trimRows');
 const formulas: Handsontable.plugins.Formulas = hot.getPlugin('formulas');
 const ganttChart: Handsontable.plugins.GanttChart = hot.getPlugin('ganttChart');
 const nestedRows: Handsontable.plugins.NestedRows = hot.getPlugin('nestedRows');
+
+autoColumnSize.samplesGenerator.setSampleCount(5);


### PR DESCRIPTION
### Context
This has the same changes as #5325, but it it is targeted at the `develop` branch instead. This solves the problem raised in #5324. It's a simple typo in `handsontable.d.ts`. 

### How has this been tested?
I've used this change in the context of a project that leverages handsontable, and it works correctly.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- New feature or improvement (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Additional language file or change to the existing one (translations)

### Related issue(s):
1. #5324 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
-  My change requires a change to the documentation.
