### PR TITLE
Check whether the width/height is NaN in the calculators. #5365

### DIFF
--- a/src/3rdparty/walkontable/src/calculator/viewportColumns.js
+++ b/src/3rdparty/walkontable/src/calculator/viewportColumns.js
@@ -268,7 +268,7 @@ class ViewportColumnsCalculator {
   _getColumnWidth(column) {
     let width = privatePool.get(this).columnWidthFn(column);
 
-    if (width === void 0) {
+    if (isNaN(width)) {
       width = ViewportColumnsCalculator.DEFAULT_WIDTH;
     }
 

--- a/src/3rdparty/walkontable/src/calculator/viewportRows.js
+++ b/src/3rdparty/walkontable/src/calculator/viewportRows.js
@@ -89,7 +89,7 @@ class ViewportRowsCalculator {
     for (let i = 0; i < totalRows; i++) {
       rowHeight = rowHeightFn(i);
 
-      if (rowHeight === undefined) {
+      if (isNaN(rowHeight)) {
         rowHeight = ViewportRowsCalculator.DEFAULT_HEIGHT;
       }
       if (sum <= scrollOffset && !onlyFullyVisible) {

--- a/src/3rdparty/walkontable/test/spec/calculator/viewportColumns.spec.js
+++ b/src/3rdparty/walkontable/test/spec/calculator/viewportColumns.spec.js
@@ -202,4 +202,16 @@ describe('Walkontable.ViewportColumnsCalculator', () => {
     expect(calc.stretchAllColumnsWidth.length).toBe(0);
     expect(calc.needVerifyLastColumnWidth).toBe(true);
   });
+
+  it('should calculate the number of columns based on a default width, ' +
+    'when the width returned from the function is not a number', () => {
+    const calc = new Walkontable.ViewportColumnsCalculator(200, 0, 1000, () => (void 0 + 1));
+    expect(calc.startColumn).toBe(0);
+    expect(calc.startPosition).toBe(0);
+    expect(calc.endColumn).toBe(3);
+
+    const visibleCalc = new Walkontable.ViewportColumnsCalculator(200, 0, 1000, () => (void 0 + 1), null, true);
+    expect(visibleCalc.startColumn).toBe(0);
+    expect(visibleCalc.endColumn).toBe(3);
+  });
 });

--- a/src/3rdparty/walkontable/test/spec/calculator/viewportColumns.spec.js
+++ b/src/3rdparty/walkontable/test/spec/calculator/viewportColumns.spec.js
@@ -5,22 +5,24 @@ describe('Walkontable.ViewportColumnsCalculator', () => {
 
   it('should render first 5 columns in unscrolled container', () => {
     const calc = new Walkontable.ViewportColumnsCalculator(100, 0, 1000, allColumns20);
+    const visibleCalc = new Walkontable.ViewportColumnsCalculator(100, 0, 1000, allColumns20, null, true);
+
     expect(calc.startColumn).toBe(0);
     expect(calc.startPosition).toBe(0);
     expect(calc.endColumn).toBe(4);
 
-    const visibleCalc = new Walkontable.ViewportColumnsCalculator(100, 0, 1000, allColumns20, null, true);
     expect(visibleCalc.startColumn).toBe(0);
     expect(visibleCalc.endColumn).toBe(4);
   });
 
   it('should render 6 columns, starting from 3 in container scrolled to half of fourth column', () => {
     const calc = new Walkontable.ViewportColumnsCalculator(100, 70, 1000, allColumns20);
+    const visibleCalc = new Walkontable.ViewportColumnsCalculator(100, 70, 1000, allColumns20, null, true);
+
     expect(calc.startColumn).toBe(3);
     expect(calc.startPosition).toBe(60);
     expect(calc.endColumn).toBe(8);
 
-    const visibleCalc = new Walkontable.ViewportColumnsCalculator(100, 70, 1000, allColumns20, null, true);
     expect(visibleCalc.startColumn).toBe(4);
     expect(visibleCalc.endColumn).toBe(7);
   });
@@ -30,32 +32,34 @@ describe('Walkontable.ViewportColumnsCalculator', () => {
       calc.startColumn -= 2;
       calc.endColumn += 2;
     };
-
     const calc = new Walkontable.ViewportColumnsCalculator(100, 70, 1000, allColumns20, overrideFn);
+    const visibleCalc = new Walkontable.ViewportColumnsCalculator(100, 70, 1000, allColumns20, null, true);
+
     expect(calc.startColumn).toBe(1);
     expect(calc.startPosition).toBe(20);
     expect(calc.endColumn).toBe(10);
 
-    const visibleCalc = new Walkontable.ViewportColumnsCalculator(100, 70, 1000, allColumns20, null, true);
     expect(visibleCalc.startColumn).toBe(4);
     expect(visibleCalc.endColumn).toBe(7);
   });
 
   it('should return number of rendered columns', () => {
     const calc = new Walkontable.ViewportColumnsCalculator(100, 50, 1000, allColumns20);
+    const visibleCalc = new Walkontable.ViewportColumnsCalculator(100, 50, 1000, allColumns20, null, true);
+
     expect(calc.count).toBe(6);
 
-    const visibleCalc = new Walkontable.ViewportColumnsCalculator(100, 50, 1000, allColumns20, null, true);
     expect(visibleCalc.count).toBe(4);
   });
 
   it('should render all columns if their size is smaller than viewport', () => {
     const calc = new Walkontable.ViewportColumnsCalculator(200, 0, 8, allColumns20);
+    const visibleCalc = new Walkontable.ViewportColumnsCalculator(200, 0, 8, allColumns20, null, true);
+
     expect(calc.startColumn).toBe(0);
     expect(calc.endColumn).toBe(7);
     expect(calc.count).toBe(8);
 
-    const visibleCalc = new Walkontable.ViewportColumnsCalculator(200, 0, 8, allColumns20, null, true);
     expect(visibleCalc.startColumn).toBe(0);
     expect(visibleCalc.endColumn).toBe(7);
     expect(visibleCalc.count).toBe(8);
@@ -63,11 +67,12 @@ describe('Walkontable.ViewportColumnsCalculator', () => {
 
   it('should render all columns if their size is exactly the viewport', () => {
     const calc = new Walkontable.ViewportColumnsCalculator(200, 0, 10, allColumns20);
+    const visibleCalc = new Walkontable.ViewportColumnsCalculator(200, 0, 10, allColumns20, null, true);
+
     expect(calc.startColumn).toBe(0);
     expect(calc.endColumn).toBe(9);
     expect(calc.count).toBe(10);
 
-    const visibleCalc = new Walkontable.ViewportColumnsCalculator(200, 0, 10, allColumns20, null, true);
     expect(visibleCalc.startColumn).toBe(0);
     expect(visibleCalc.endColumn).toBe(9);
     expect(visibleCalc.count).toBe(10);
@@ -75,11 +80,12 @@ describe('Walkontable.ViewportColumnsCalculator', () => {
 
   it('should render all columns if their size is slightly larger than viewport', () => {
     const calc = new Walkontable.ViewportColumnsCalculator(199, 0, 10, allColumns20);
+    const visibleCalc = new Walkontable.ViewportColumnsCalculator(199, 0, 10, allColumns20, null, true);
+
     expect(calc.startColumn).toBe(0);
     expect(calc.endColumn).toBe(9);
     expect(calc.count).toBe(10);
 
-    const visibleCalc = new Walkontable.ViewportColumnsCalculator(199, 0, 10, allColumns20, null, true);
     expect(visibleCalc.startColumn).toBe(0);
     expect(visibleCalc.endColumn).toBe(8);
     expect(visibleCalc.count).toBe(9);
@@ -87,12 +93,13 @@ describe('Walkontable.ViewportColumnsCalculator', () => {
 
   it('should set null values if total columns is 0', () => {
     const calc = new Walkontable.ViewportColumnsCalculator(200, 0, 0, allColumns20);
+    const visibleCalc = new Walkontable.ViewportColumnsCalculator(200, 0, 0, allColumns20, null, true);
+
     expect(calc.startColumn).toBe(null);
     expect(calc.startPosition).toBe(null);
     expect(calc.endColumn).toBe(null);
     expect(calc.count).toBe(0);
 
-    const visibleCalc = new Walkontable.ViewportColumnsCalculator(200, 0, 0, allColumns20, null, true);
     expect(visibleCalc.startColumn).toBe(null);
     expect(visibleCalc.endColumn).toBe(null);
   });
@@ -102,26 +109,27 @@ describe('Walkontable.ViewportColumnsCalculator', () => {
       myCalc.startColumn = 0;
       myCalc.endColumn = 0;
     };
-
     const calc = new Walkontable.ViewportColumnsCalculator(200, 0, 0, allColumns20, overrideFn);
+    const visibleCalc = new Walkontable.ViewportColumnsCalculator(200, 0, 0, allColumns20, null, true);
+
     expect(calc.startColumn).toBe(null);
     expect(calc.startPosition).toBe(null);
     expect(calc.endColumn).toBe(null);
     expect(calc.count).toBe(0);
 
-    const visibleCalc = new Walkontable.ViewportColumnsCalculator(200, 0, 0, allColumns20, null, true);
     expect(visibleCalc.startColumn).toBe(null);
     expect(visibleCalc.endColumn).toBe(null);
   });
 
   it('should scroll backwards if total columns is reached', () => {
     const calc = new Walkontable.ViewportColumnsCalculator(190, 350, 20, allColumns20);
+    const visibleCalc = new Walkontable.ViewportColumnsCalculator(190, 350, 20, allColumns20, null, true);
+
     expect(calc.startColumn).toBe(10);
     expect(calc.startPosition).toBe(200);
     expect(calc.endColumn).toBe(19);
     expect(calc.count).toBe(10);
 
-    const visibleCalc = new Walkontable.ViewportColumnsCalculator(190, 350, 20, allColumns20, null, true);
     expect(visibleCalc.startColumn).toBe(11);
     expect(visibleCalc.endColumn).toBe(19);
   });
@@ -206,11 +214,12 @@ describe('Walkontable.ViewportColumnsCalculator', () => {
   it('should calculate the number of columns based on a default width, ' +
     'when the width returned from the function is not a number', () => {
     const calc = new Walkontable.ViewportColumnsCalculator(200, 0, 1000, () => (void 0 + 1));
+    const visibleCalc = new Walkontable.ViewportColumnsCalculator(200, 0, 1000, () => (void 0 + 1), null, true);
+
     expect(calc.startColumn).toBe(0);
     expect(calc.startPosition).toBe(0);
     expect(calc.endColumn).toBe(3);
 
-    const visibleCalc = new Walkontable.ViewportColumnsCalculator(200, 0, 1000, () => (void 0 + 1), null, true);
     expect(visibleCalc.startColumn).toBe(0);
     expect(visibleCalc.endColumn).toBe(3);
   });

--- a/src/3rdparty/walkontable/test/spec/calculator/viewportRows.spec.js
+++ b/src/3rdparty/walkontable/test/spec/calculator/viewportRows.spec.js
@@ -125,4 +125,16 @@ describe('Walkontable.ViewportRowsCalculator', () => {
     expect(visibleCalc.startRow).toBe(11);
     expect(visibleCalc.endRow).toBe(19);
   });
+
+  it('should calculate the number of rows based on a default height, ' +
+    'when the height returned from the function is not a number', () => {
+    const calc = new Walkontable.ViewportRowsCalculator(100, 0, 1000, () => (void 0 + 1));
+    expect(calc.startRow).toBe(0);
+    expect(calc.startPosition).toBe(0);
+    expect(calc.endRow).toBe(4);
+
+    const visibleCalc = new Walkontable.ViewportRowsCalculator(100, 0, 1000, () => (void 0 + 1), null, true);
+    expect(visibleCalc.startRow).toBe(0);
+    expect(visibleCalc.endRow).toBe(3);
+  });
 });

--- a/src/3rdparty/walkontable/test/spec/calculator/viewportRows.spec.js
+++ b/src/3rdparty/walkontable/test/spec/calculator/viewportRows.spec.js
@@ -5,22 +5,24 @@ describe('Walkontable.ViewportRowsCalculator', () => {
 
   it('should render first 5 rows in unscrolled container', () => {
     const calc = new Walkontable.ViewportRowsCalculator(100, 0, 1000, allRows20);
+    const visibleCalc = new Walkontable.ViewportRowsCalculator(100, 0, 1000, allRows20, null, true);
+
     expect(calc.startRow).toBe(0);
     expect(calc.startPosition).toBe(0);
     expect(calc.endRow).toBe(4);
 
-    const visibleCalc = new Walkontable.ViewportRowsCalculator(100, 0, 1000, allRows20, null, true);
     expect(visibleCalc.startRow).toBe(0);
     expect(visibleCalc.endRow).toBe(4);
   });
 
   it('should render 6 rows, starting from 3 in container scrolled to half of fourth row', () => {
     const calc = new Walkontable.ViewportRowsCalculator(100, 70, 1000, allRows20);
+    const visibleCalc = new Walkontable.ViewportRowsCalculator(100, 70, 1000, allRows20, null, true);
+
     expect(calc.startRow).toBe(3);
     expect(calc.startPosition).toBe(60);
     expect(calc.endRow).toBe(8);
 
-    const visibleCalc = new Walkontable.ViewportRowsCalculator(100, 70, 1000, allRows20, null, true);
     expect(visibleCalc.startRow).toBe(4);
     expect(visibleCalc.endRow).toBe(7);
   });
@@ -30,32 +32,34 @@ describe('Walkontable.ViewportRowsCalculator', () => {
       calc.startRow -= 2;
       calc.endRow += 2;
     };
-
     const calc = new Walkontable.ViewportRowsCalculator(100, 70, 1000, allRows20, overrideFn);
+    const visibleCalc = new Walkontable.ViewportRowsCalculator(100, 70, 1000, allRows20, null, true);
+
     expect(calc.startRow).toBe(1);
     expect(calc.startPosition).toBe(20);
     expect(calc.endRow).toBe(10);
 
-    const visibleCalc = new Walkontable.ViewportRowsCalculator(100, 70, 1000, allRows20, null, true);
     expect(visibleCalc.startRow).toBe(4);
     expect(visibleCalc.endRow).toBe(7);
   });
 
   it('should return number of rendered rows', () => {
     const calc = new Walkontable.ViewportRowsCalculator(100, 50, 1000, allRows20);
+    const visibleCalc = new Walkontable.ViewportRowsCalculator(100, 50, 1000, allRows20, null, true);
+
     expect(calc.count).toBe(6);
 
-    const visibleCalc = new Walkontable.ViewportRowsCalculator(100, 50, 1000, allRows20, null, true);
     expect(visibleCalc.count).toBe(4);
   });
 
   it('should render all rows if their size is smaller than viewport', () => {
     const calc = new Walkontable.ViewportRowsCalculator(200, 0, 8, allRows20);
+    const visibleCalc = new Walkontable.ViewportRowsCalculator(200, 0, 8, allRows20, null, true);
+
     expect(calc.startRow).toBe(0);
     expect(calc.endRow).toBe(7);
     expect(calc.count).toBe(8);
 
-    const visibleCalc = new Walkontable.ViewportRowsCalculator(200, 0, 8, allRows20, null, true);
     expect(visibleCalc.startRow).toBe(0);
     expect(visibleCalc.endRow).toBe(7);
     expect(visibleCalc.count).toBe(8);
@@ -63,11 +67,12 @@ describe('Walkontable.ViewportRowsCalculator', () => {
 
   it('should render all rows if their size is exactly the viewport', () => {
     const calc = new Walkontable.ViewportRowsCalculator(200, 0, 10, allRows20);
+    const visibleCalc = new Walkontable.ViewportRowsCalculator(200, 0, 10, allRows20, null, true);
+
     expect(calc.startRow).toBe(0);
     expect(calc.endRow).toBe(9);
     expect(calc.count).toBe(10);
 
-    const visibleCalc = new Walkontable.ViewportRowsCalculator(200, 0, 10, allRows20, null, true);
     expect(visibleCalc.startRow).toBe(0);
     expect(visibleCalc.endRow).toBe(9);
     expect(visibleCalc.count).toBe(10);
@@ -75,11 +80,12 @@ describe('Walkontable.ViewportRowsCalculator', () => {
 
   it('should render all rows if their size is slightly larger than viewport', () => {
     const calc = new Walkontable.ViewportRowsCalculator(199, 0, 10, allRows20);
+    const visibleCalc = new Walkontable.ViewportRowsCalculator(199, 0, 10, allRows20, null, true);
+
     expect(calc.startRow).toBe(0);
     expect(calc.endRow).toBe(9);
     expect(calc.count).toBe(10);
 
-    const visibleCalc = new Walkontable.ViewportRowsCalculator(199, 0, 10, allRows20, null, true);
     expect(visibleCalc.startRow).toBe(0);
     expect(visibleCalc.endRow).toBe(8);
     expect(visibleCalc.count).toBe(9);
@@ -87,12 +93,13 @@ describe('Walkontable.ViewportRowsCalculator', () => {
 
   it('should set null values if total rows is 0', () => {
     const calc = new Walkontable.ViewportRowsCalculator(200, 0, 0, allRows20);
+    const visibleCalc = new Walkontable.ViewportRowsCalculator(200, 0, 0, allRows20, null, true);
+
     expect(calc.startRow).toBe(null);
     expect(calc.startPosition).toBe(null);
     expect(calc.endRow).toBe(null);
     expect(calc.count).toBe(0);
 
-    const visibleCalc = new Walkontable.ViewportRowsCalculator(200, 0, 0, allRows20, null, true);
     expect(visibleCalc.startRow).toBe(null);
     expect(visibleCalc.endRow).toBe(null);
   });
@@ -102,26 +109,27 @@ describe('Walkontable.ViewportRowsCalculator', () => {
       myCalc.startRow = 0;
       myCalc.endRow = 0;
     };
-
     const calc = new Walkontable.ViewportRowsCalculator(200, 0, 0, allRows20, overrideFn);
+    const visibleCalc = new Walkontable.ViewportRowsCalculator(200, 0, 0, allRows20, null, true);
+
     expect(calc.startRow).toBe(null);
     expect(calc.startPosition).toBe(null);
     expect(calc.endRow).toBe(null);
     expect(calc.count).toBe(0);
 
-    const visibleCalc = new Walkontable.ViewportRowsCalculator(200, 0, 0, allRows20, null, true);
     expect(visibleCalc.startRow).toBe(null);
     expect(visibleCalc.endRow).toBe(null);
   });
 
   it('should scroll backwards if total rows is reached', () => {
     const calc = new Walkontable.ViewportRowsCalculator(190, 350, 20, allRows20);
+    const visibleCalc = new Walkontable.ViewportRowsCalculator(190, 350, 20, allRows20, null, true);
+
     expect(calc.startRow).toBe(10);
     expect(calc.startPosition).toBe(200);
     expect(calc.endRow).toBe(19);
     expect(calc.count).toBe(10);
 
-    const visibleCalc = new Walkontable.ViewportRowsCalculator(190, 350, 20, allRows20, null, true);
     expect(visibleCalc.startRow).toBe(11);
     expect(visibleCalc.endRow).toBe(19);
   });
@@ -129,11 +137,12 @@ describe('Walkontable.ViewportRowsCalculator', () => {
   it('should calculate the number of rows based on a default height, ' +
     'when the height returned from the function is not a number', () => {
     const calc = new Walkontable.ViewportRowsCalculator(100, 0, 1000, () => (void 0 + 1));
+    const visibleCalc = new Walkontable.ViewportRowsCalculator(100, 0, 1000, () => (void 0 + 1), null, true);
+
     expect(calc.startRow).toBe(0);
     expect(calc.startPosition).toBe(0);
     expect(calc.endRow).toBe(4);
 
-    const visibleCalc = new Walkontable.ViewportRowsCalculator(100, 0, 1000, () => (void 0 + 1), null, true);
     expect(visibleCalc.startRow).toBe(0);
     expect(visibleCalc.endRow).toBe(3);
   });


### PR DESCRIPTION
### Context
When the rows calculator gets a `NaN` instead of a `Number` as the row height, it forces the table to render all rows.
For example, setting a `modifyRowHeight` hook with unhandled `undefined` height value, makes a large table virtually unusable.

### Steps to reproduce
<!--- Provide steps to reproduce this issue -->
1. Go to http://jsfiddle.net/js_ziggle/p3om6nue/13/
2. Edit any cell, the number of rendered rows should be around `20`
3. Click the button, it will add a `modifyRowHeight` hook callback
4. Edit any cell and notice the number of rendered rows and the table performance.

### Demo
http://jsfiddle.net/js_ziggle/p3om6nue/12/

### How has this been tested?
Added tests for the calculators.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. #5365 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
