### PR TITLE
Fixes uncaught TypeError while selecting invalid cell #5119 #5258 #5128

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -921,7 +921,9 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
                 changes.splice(index, 1); // cancel the change
                 cellPropertiesReference.valid = true; // we cancelled the change, so cell value is still valid
                 const cell = instance.getCell(cellPropertiesReference.visualRow, cellPropertiesReference.visualCol);
-                removeClass(cell, instance.getSettings().invalidCellClassName);
+                if (cell !== null) {
+                  removeClass(cell, instance.getSettings().invalidCellClassName);
+                }
                 // index -= 1;
               }
               waitingForValidator.removeValidatorFormQueue();

--- a/test/e2e/Core_validate.spec.js
+++ b/test/e2e/Core_validate.spec.js
@@ -1324,6 +1324,36 @@ describe('Core_validate', () => {
     }, 200);
   });
 
+  it('should not attempt to remove the htInvalid class if the validated cell is no longer rendered', (done) => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(20, 2),
+      columnSorting: {
+        column: 0,
+        sortOrder: 'desc'
+      },
+      allowInvalid: false,
+      validator(value, callback) {
+        setTimeout(() => {
+          callback(value.length === 2);
+        }, 100);
+      },
+      height: 40
+    });
+
+    selectCell(0, 0);
+    keyDown('enter');
+
+    document.activeElement.value = 'Ted';
+
+    selectCell(19, 0);
+
+    setTimeout(() => {
+      const $cell = $(getCell(0, 0));
+      expect($cell.hasClass('htInvalid')).toEqual(false);
+      done();
+    }, 200);
+  });
+
   it('should close the editor and save the new value if validation fails and allowInvalid is set to "true"', (done) => {
     let validationResult;
 


### PR DESCRIPTION
If the cell wasn't rendered then it would return back null and would try and remove the class of a null object which would throw an exception. Added a basic null check.

### Context
<!--- Why is this change required? What problem does it solve? -->
Was throwing an error when attempting to validated an invalid cell that wasn't rendered with `allowInvalid` set to `false`. Solves three issues which seem to be duplicates of each other: #5119 #5258 #5128 

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Manually tested as well as added an e2e test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #5119 
2. #5258 
3. #5128 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
