### PR TITLE
TextEditor.refreshValue should use physical row index.

### DIFF
--- a/src/editors/textEditor.js
+++ b/src/editors/textEditor.js
@@ -282,7 +282,8 @@ TextEditor.prototype.getEditedCell = function() {
 };
 
 TextEditor.prototype.refreshValue = function() {
-  const sourceData = this.instance.getSourceDataAtCell(this.row, this.prop);
+  const physicalRow = this.instance.toPhysicalRow(this.row);
+  const sourceData = this.instance.getSourceDataAtCell(physicalRow, this.col);
   this.originalValue = sourceData;
 
   this.setValue(sourceData);

--- a/test/e2e/editors/textEditor.spec.js
+++ b/test/e2e/editors/textEditor.spec.js
@@ -63,6 +63,20 @@ describe('TextEditor', () => {
     expect(keyProxy().val()).toEqual('string');
   });
 
+  it('should render proper value after cell coords manipulation', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(5, 5),
+      modifyRow(row) { return row === 4 ? 0 : row + 1; },
+      modifyCol(column) { return column === 4 ? 0 : column + 1; },
+    });
+
+    selectCell(0, 0);
+    getActiveEditor().beginEditing();
+    getActiveEditor().refreshValue();
+
+    expect(getActiveEditor().originalValue).toEqual('B2');
+  });
+
   it('should render textarea editor with tabindex=-1 attribute', async() => {
     const hot = handsontable();
 


### PR DESCRIPTION
### Context
`TextEditor.refreshValue` uses `getSourceDataAtCell` which needs physical row index instead of visual row index. 

### How has this been tested?
Use below code:
```
var hot = new Handsontable(document.querySelector('#container'), {
  data: Handsontable.helper.createSpreadsheetData(5, 5),
  modifyRow: (row) => row === 4 ? 0 : row + 1,
  modifyCol: (column) => column === 4 ? 0 : column + 1,
});
    
hot.selectCell(0, 0);
hot.setDataAtCell(0, 0, 'AAAA');
```
and after init press <kbd>ENTER</kbd>

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. #4289