### PR TITLE
Focus on created editor should not scroll window

### DIFF
--- a/src/editors/textEditor.js
+++ b/src/editors/textEditor.js
@@ -73,10 +73,12 @@ TextEditor.prototype.hideEditableElement = function() {
   this.textareaParentStyle.top = '-9999px';
   this.textareaParentStyle.left = '-9999px';
   this.textareaParentStyle.zIndex = '-1';
+  this.textareaParentStyle.position = 'fixed';
 };
 
 TextEditor.prototype.showEditableElement = function() {
   this.textareaParentStyle.zIndex = this.holderZIndex >= 0 ? this.holderZIndex : '';
+  this.textareaParentStyle.position = '';
 };
 
 TextEditor.prototype.getValue = function() {

--- a/test/e2e/editors/textEditor.spec.js
+++ b/test/e2e/editors/textEditor.spec.js
@@ -53,6 +53,53 @@ describe('TextEditor', () => {
     expect(isEditorVisible()).toEqual(false);
   });
 
+  it('should create editor holder after cell selection', () => {
+    handsontable({
+      editor: 'text',
+    });
+
+    const container = spec().$container;
+
+    expect(container.find('.handsontableInputHolder').length).toBe(0);
+
+    selectCell(0, 0);
+
+    expect(container.find('.handsontableInputHolder').length).toBe(1);
+  });
+
+  it('should prepare editor with proper styles after selection', () => {
+    handsontable({
+      editor: 'text',
+    });
+
+    selectCell(0, 0);
+
+    const { left, position, top, zIndex } = spec().$container.find('.handsontableInputHolder').css(['left', 'position', 'top', 'zIndex']);
+
+    expect(left).toBe('-9999px');
+    expect(position).toBe('fixed');
+    expect(top).toBe('-9999px');
+    expect(zIndex).toBe('-1');
+  });
+
+  it('should change editor\'s CSS properties during switching to being visible', () => {
+    handsontable({
+      editor: 'text',
+    });
+
+    selectCell(0, 0);
+    keyDownUp('enter');
+
+    const cell = getCell(0, 0);
+    const [cellOffsetTop, cellOffsetLeft] = [cell.offsetTop, cell.offsetLeft];
+    const { left, position, top, zIndex } = spec().$container.find('.handsontableInputHolder').css(['left', 'position', 'top', 'zIndex']);
+
+    expect(parseInt(left, 10)).toBeAroundValue(cellOffsetLeft);
+    expect(position).toBe('absolute');
+    expect(parseInt(top, 10)).toBeAroundValue(cellOffsetTop);
+    expect(zIndex).not.toBe('-1');
+  });
+
   it('should render string in textarea', () => {
     handsontable();
     setDataAtCell(2, 2, 'string');


### PR DESCRIPTION
### Context
During creating an editor within `mousedown` event callback, the browser's trying scroll to the new active element.

### How has this been tested?
Use Firefox to test.
1. Initialise Handsontable instance in container with added margin's eg.: `margin: 1200px;`
2. Scroll to Handsontable
3. Select one of the visible cells

__Result__: the window's viewport should stay in the same place as before cell selection.

### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)

### Related issue(s):
1. #5220