### PR TITLE
CopyPaste plugin should support HTML clipboard data.

### DIFF
--- a/src/plugins/copyPaste/utils.js
+++ b/src/plugins/copyPaste/utils.js
@@ -2,6 +2,9 @@ export function arrayToTable(input) {
   const inputLen = input.length;
   const result = ['<table>'];
 
+  const tempElement = document.createElement('div');
+  document.documentElement.appendChild(tempElement);
+
   for (let row = 0; row < inputLen; row += 1) {
     const rowData = input[row];
     const columnsLen = rowData.length;
@@ -12,10 +15,9 @@ export function arrayToTable(input) {
     }
 
     for (let column = 0; column < columnsLen; column += 1) {
-      const tempElement = document.createElement('div');
       tempElement.innerHTML = `${rowData[column]}`;
 
-      columnsResult.push(`<td>${rowData[column].replace(/\n/, '<br>')}</td>`);
+      columnsResult.push(`<td>${tempElement.innerHTML}</td>`);
     }
 
     result.push('<tr>', ...columnsResult, '</tr>');
@@ -24,6 +26,8 @@ export function arrayToTable(input) {
       result.push('</tbody>');
     }
   }
+
+  document.documentElement.removeChild(tempElement);
 
   result.push('</table>');
 
@@ -46,7 +50,7 @@ function htmlTableToArray(table) {
 
     for (let column = 0; column < cellsLen; column += 1) {
       const cell = cells[column];
-      const cellText = cell.textContent.replace(/(<br)(\W)?(>)\n/g, '\n');
+      const cellText = cell.innerHTML;
       newRow.push(cellText);
     }
 
@@ -62,7 +66,7 @@ export function tableToArray(element) {
 
   if (typeof checkElement === 'string') {
     const tempElem = document.createElement('div');
-    tempElem.innerHTML = checkElement;
+    tempElem.innerHTML = checkElement.replace(/\n/g, '');
 
     checkElement = tempElem.querySelector('table');
   }

--- a/src/plugins/copyPaste/utils.js
+++ b/src/plugins/copyPaste/utils.js
@@ -1,0 +1,75 @@
+export function arrayToTable(input) {
+  const inputLen = input.length;
+  const result = ['<table>'];
+
+  for (let row = 0; row < inputLen; row += 1) {
+    const rowData = input[row];
+    const columnsLen = rowData.length;
+    const columnsResult = [];
+
+    if (row === 0) {
+      result.push('<tbody>');
+    }
+
+    for (let column = 0; column < columnsLen; column += 1) {
+      const tempElement = document.createElement('div');
+      tempElement.innerHTML = `${rowData[column]}`;
+
+      columnsResult.push(`<td>${rowData[column].replace(/\n/, '<br>')}</td>`);
+    }
+
+    result.push('<tr>', ...columnsResult, '</tr>');
+
+    if (row + 1 === inputLen) {
+      result.push('</tbody>');
+    }
+  }
+
+  result.push('</table>');
+
+  return result.join('');
+}
+
+export function isHTMLTable(element) {
+  return (element && element.nodeName || '').toLowerCase() === 'table';
+}
+
+function htmlTableToArray(table) {
+  const rows = table.rows;
+  const rowsLen = rows && rows.length;
+  const tempArray = [];
+
+  for (let row = 0; row < rowsLen; row += 1) {
+    const cells = rows[row].cells;
+    const cellsLen = cells.length;
+    const newRow = [];
+
+    for (let column = 0; column < cellsLen; column += 1) {
+      const cell = cells[column];
+      const cellText = cell.textContent.replace(/(<br)(\W)?(>)\n/g, '\n');
+      newRow.push(cellText);
+    }
+
+    tempArray.push(newRow);
+  }
+
+  return tempArray;
+}
+
+export function tableToArray(element) {
+  const result = [];
+  let checkElement = element;
+
+  if (typeof checkElement === 'string') {
+    const tempElem = document.createElement('div');
+    tempElem.innerHTML = checkElement;
+
+    checkElement = tempElem.querySelector('table');
+  }
+
+  if (checkElement && isHTMLTable(checkElement)) {
+    result.push(...htmlTableToArray(checkElement));
+  }
+
+  return result;
+}


### PR DESCRIPTION
### Context
Whole context is described in #4931.

### How has this been tested?
Go through related issues in #4931.

By the way, you can use clipboard viewer to verify clipboard content:
For macOS: [ClipboardViewer](https://developer.apple.com/library/archive/samplecode/ClipboardViewer/Introduction/Intro.html)

### Types of changes
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. #4931