### PR TITLE
[FIX] Issue-4162

### DIFF
--- a/src/renderers/checkboxRenderer.js
+++ b/src/renderers/checkboxRenderer.js
@@ -98,6 +98,9 @@ function checkboxRenderer(instance, TD, row, col, prop, value, cellProperties, .
     const switchOffKeys = 'DELETE|BACKSPACE';
     const isKeyCode = partial(isKey, event.keyCode);
 
+    if (!instance.getSettings().enterBeginsEditing && isKeyCode('ENTER')) {
+      return;
+    }
     if (isKeyCode(`${toggleKeys}|${switchOffKeys}`) && !isImmediatePropagationStopped(event)) {
       eachSelectedCheckboxCell(() => {
         stopImmediatePropagation(event);

--- a/test/e2e/renderers/checkboxRenderer.spec.js
+++ b/test/e2e/renderers/checkboxRenderer.spec.js
@@ -400,6 +400,72 @@ describe('CheckboxRenderer', () => {
     expect(afterChangeCallback).toHaveBeenCalledWith([[0, 0, true, false]], 'edit', undefined, undefined, undefined, undefined);
   });
 
+  it('should move down without changing checkbox state when enterBeginsEditing equals false', () => {
+    handsontable({
+      enterBeginsEditing: false,
+      data: [[true], [false], [true]],
+      columns: [
+        { type: 'checkbox' }
+      ]
+    });
+
+    const afterChangeCallback = jasmine.createSpy('afterChangeCallback');
+    addHook('afterChange', afterChangeCallback);
+
+    let checkboxes = spec().$container.find(':checkbox');
+
+    expect(checkboxes.eq(0).prop('checked')).toBe(true);
+    expect(checkboxes.eq(1).prop('checked')).toBe(false);
+    expect(checkboxes.eq(2).prop('checked')).toBe(true);
+    expect(getData()).toEqual([[true], [false], [true]]);
+
+    selectCell(0, 0);
+
+    keyDown('enter');
+
+    checkboxes = spec().$container.find(':checkbox');
+    const selection = getSelected();
+    expect(selection).toEqual([[1, 0, 1, 0]]);
+    expect(checkboxes.eq(0).prop('checked')).toBe(true);
+    expect(checkboxes.eq(1).prop('checked')).toBe(false);
+    expect(checkboxes.eq(2).prop('checked')).toBe(true);
+    expect(getData()).toEqual([[true], [false], [true]]);
+    expect(afterChangeCallback.calls.count()).toEqual(0);
+  });
+
+  it('should begin editing and changing checkbox state when enterBeginsEditing equals true', () => {
+    handsontable({
+      enterBeginsEditing: true,
+      data: [[true], [false], [true]],
+      columns: [
+        { type: 'checkbox' }
+      ]
+    });
+
+    const afterChangeCallback = jasmine.createSpy('afterChangeCallback');
+    addHook('afterChange', afterChangeCallback);
+
+    let checkboxes = spec().$container.find(':checkbox');
+
+    expect(checkboxes.eq(0).prop('checked')).toBe(true);
+    expect(checkboxes.eq(1).prop('checked')).toBe(false);
+    expect(checkboxes.eq(2).prop('checked')).toBe(true);
+    expect(getData()).toEqual([[true], [false], [true]]);
+
+    selectCell(0, 0);
+
+    keyDown('enter');
+
+    checkboxes = spec().$container.find(':checkbox');
+    const selection = getSelected();
+    expect(selection).toEqual([[0, 0, 0, 0]]);
+    expect(checkboxes.eq(0).prop('checked')).toBe(false);
+    expect(checkboxes.eq(1).prop('checked')).toBe(false);
+    expect(checkboxes.eq(2).prop('checked')).toBe(true);
+    expect(getData()).toEqual([[false], [false], [true]]);
+    expect(afterChangeCallback.calls.count()).toEqual(1);
+  });
+
   it('should change checkbox state from checked to unchecked after hitting ENTER using custom check/uncheck templates', () => {
     handsontable({
       data: [['yes'], ['yes'], ['no']],


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Block an ability to change a checkbox state via ENTER key when enterBeginsEditing option is set to false.
Better explanation in issue #4162 

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Tested it on some of the demos to ensure that it working proper without affecting others.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/4162

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
