### PR TITLE
Handsontable shouldn't scroll container after cell selection.

### DIFF
--- a/src/helpers/dom/element.js
+++ b/src/helpers/dom/element.js
@@ -656,20 +656,19 @@ export function getTrimmingContainer(base) {
   while (el && el.style && document.body !== el) {
     if (el.style.overflow !== 'visible' && el.style.overflow !== '') {
       return el;
-
-    } else if (window.getComputedStyle) {
-      const computedStyle = getComputedStyle(el);
-      const allowedProperties = ['scroll', 'hidden', 'auto'];
-      const property = computedStyle.getPropertyValue('overflow');
-      const propertyY = computedStyle.getPropertyValue('overflow-y');
-      const propertyX = computedStyle.getPropertyValue('overflow-x');
-
-      if (allowedProperties.includes(property) || allowedProperties.includes(propertyY) || allowedProperties.includes(propertyX)) {
-        return el;
-      }
-
-      el = el.parentNode;
     }
+
+    const computedStyle = getComputedStyle(el);
+    const allowedProperties = ['scroll', 'hidden', 'auto'];
+    const property = computedStyle.getPropertyValue('overflow');
+    const propertyY = computedStyle.getPropertyValue('overflow-y');
+    const propertyX = computedStyle.getPropertyValue('overflow-x');
+
+    if (allowedProperties.includes(property) || allowedProperties.includes(propertyY) || allowedProperties.includes(propertyX)) {
+      return el;
+    }
+
+    el = el.parentNode;
   }
 
   return window;

--- a/src/helpers/dom/element.js
+++ b/src/helpers/dom/element.js
@@ -658,14 +658,18 @@ export function getTrimmingContainer(base) {
       return el;
 
     } else if (window.getComputedStyle) {
-      const computedStyle = window.getComputedStyle(el);
+      const computedStyle = getComputedStyle(el);
+      const allowedProperties = ['scroll', 'hidden', 'auto'];
+      const property = computedStyle.getPropertyValue('overflow');
+      const propertyY = computedStyle.getPropertyValue('overflow-y');
+      const propertyX = computedStyle.getPropertyValue('overflow-x');
 
-      if (computedStyle.getPropertyValue('overflow') !== 'visible' && computedStyle.getPropertyValue('overflow') !== '') {
+      if (allowedProperties.includes(property) || allowedProperties.includes(propertyY) || allowedProperties.includes(propertyX)) {
         return el;
       }
-    }
 
-    el = el.parentNode;
+      el = el.parentNode;
+    }
   }
 
   return window;

--- a/src/plugins/contextMenu/test/contextMenu.e2e.js
+++ b/src/plugins/contextMenu/test/contextMenu.e2e.js
@@ -3341,19 +3341,17 @@ describe('ContextMenu', () => {
 
       const cmInstance = getPlugin('contextMenu').menu.hotMenu;
 
-      expect(1).toEqual(1);
-
       cmInstance.selectCell(3, 0);
 
-      expect(window.scrollX).toEqual(beginningScrollX);
+      expect(window.scrollX).toBe(beginningScrollX);
 
       cmInstance.selectCell(4, 0);
 
-      expect(window.scrollX).toEqual(beginningScrollX);
+      expect(window.scrollX).toBe(beginningScrollX);
 
       cmInstance.selectCell(6, 0);
 
-      expect(window.scrollX).toEqual(beginningScrollX);
+      expect(window.scrollX).toBe(beginningScrollX);
     });
   });
 


### PR DESCRIPTION
### Context
In Edge/IE, CSS instructions for `overlay-y` and `overlay-x` are not attached in `overflow`.

### How has this been tested?
Use configuration of the example: http://jsfiddle.net/m0e5y3qg/6/

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. #4656
