### PR TITLE
[Column sorting] New, inserted columns breaks the table

### DIFF
--- a/src/pluginHooks.js
+++ b/src/pluginHooks.js
@@ -1007,7 +1007,7 @@ const REGISTERED_HOOKS = [
   'persistentStateSave',
 
   /**
-   * Fired by {@link ColumnSorting} and {@link MultiColumnSorting} plugin before sorting the column. If you return `false` value then sorting
+   * Fired by {@link ColumnSorting} and {@link MultiColumnSorting} plugins before sorting the column. If you return `false` value inside callback for hook, then sorting
    * will be not applied by the Handsontable (useful for server-side sorting).
    *
    * This hook is fired when {@link Options#columnSorting} or {@link Options#multiColumnSorting} option is enabled.
@@ -1019,7 +1019,7 @@ const REGISTERED_HOOKS = [
   'beforeColumnSort',
 
   /**
-   * Fired by {@link ColumnSorting} and {@link MultiColumnSorting} plugin after sorting the column. This hook is fired when {@link Options#columnSorting}
+   * Fired by {@link ColumnSorting} and {@link MultiColumnSorting} plugins after sorting the column. This hook is fired when {@link Options#columnSorting}
    * or {@link Options#multiColumnSorting} option is enabled.
    *
    * @event Hooks#afterColumnSort

--- a/src/plugins/columnSorting/columnSorting.js
+++ b/src/plugins/columnSorting/columnSorting.js
@@ -157,6 +157,8 @@ class ColumnSorting extends BasePlugin {
     this.addHook('afterRemoveRow', (index, amount) => this.onAfterRemoveRow(index, amount));
     this.addHook('afterInit', () => this.loadOrSortBySettings());
     this.addHook('afterLoadData', initialLoad => this.onAfterLoadData(initialLoad));
+    this.addHook('afterCreateCol', () => this.onAfterCreateCol());
+    this.addHook('afterRemoveCol', () => this.onAfterRemoveCol());
 
     // TODO: Workaround? It should be refactored / described.
     if (this.hot.view) {
@@ -301,7 +303,7 @@ class ColumnSorting extends BasePlugin {
    *
    *   // const newData = ... // Calculated data set, ie. from an AJAX call.
    *
-   *   this.loadData(newData);
+   *   // this.loadData(newData); // Load new data set.
    *
    *   return false; // The blockade for the default sort action.
    * }```
@@ -571,6 +573,65 @@ class ColumnSorting extends BasePlugin {
   }
 
   /**
+   * Load saved settings or sort by predefined plugin configuration.
+   *
+   * @private
+   */
+  loadOrSortBySettings() {
+    this.columnMetaCache.clear();
+
+    const storedAllSortSettings = this.getAllSavedSortSettings();
+
+    if (isObject(storedAllSortSettings)) {
+      this.sortBySettings(storedAllSortSettings);
+
+    } else {
+      const allSortSettings = this.hot.getSettings().columnSorting;
+
+      this.sortBySettings(allSortSettings);
+    }
+  }
+
+  /**
+   * Sort the table by provided configuration.
+   *
+   * @private
+   * @param {Object} allSortSettings All sort config settings. Object may contain `initialConfig`, `indicator`,
+   * `sortEmptyCells`, `headerAction` and `compareFunctionFactory` properties.
+   */
+  sortBySettings(allSortSettings) {
+    if (isObject(allSortSettings)) {
+      this.columnStatesManager.updateAllColumnsProperties(allSortSettings);
+
+      const initialConfig = allSortSettings.initialConfig;
+
+      if (Array.isArray(initialConfig) || isObject(initialConfig)) {
+        this.sort(initialConfig);
+      }
+
+    } else {
+      // Extra render for headers. Their width may change.
+      this.hot.render();
+    }
+  }
+
+  /**
+   * Enables the ObserveChanges plugin.
+   *
+   * @private
+   */
+  enableObserveChangesPlugin() {
+    const _this = this;
+
+    this.hot._registerTimeout(
+      setTimeout(() => {
+        _this.hot.updateSettings({
+          observeChanges: true
+        });
+      }, 0));
+  }
+
+  /**
    * Callback for `modifyRow` hook. Translates visual row index to the sorted row index.
    *
    * @private
@@ -644,65 +705,6 @@ class ColumnSorting extends BasePlugin {
   }
 
   /**
-   * Load saved settings or sort by predefined plugin configuration.
-   *
-   * @private
-   */
-  loadOrSortBySettings() {
-    this.columnMetaCache.clear();
-
-    const storedAllSortSettings = this.getAllSavedSortSettings();
-
-    if (isObject(storedAllSortSettings)) {
-      this.sortBySettings(storedAllSortSettings);
-
-    } else {
-      const allSortSettings = this.hot.getSettings().columnSorting;
-
-      this.sortBySettings(allSortSettings);
-    }
-  }
-
-  /**
-   * Sort the table by provided configuration.
-   *
-   * @private
-   * @param {Object} allSortSettings All sort config settings. Object may contain `initialConfig`, `indicator`,
-   * `sortEmptyCells`, `headerAction` and `compareFunctionFactory` properties.
-   */
-  sortBySettings(allSortSettings) {
-    if (isObject(allSortSettings)) {
-      this.columnStatesManager.updateAllColumnsProperties(allSortSettings);
-
-      const initialConfig = allSortSettings.initialConfig;
-
-      if (Array.isArray(initialConfig) || isObject(initialConfig)) {
-        this.sort(initialConfig);
-      }
-
-    } else {
-      // Extra render for headers. Their width may change.
-      this.hot.render();
-    }
-  }
-
-  /**
-   * Enables the ObserveChanges plugin.
-   *
-   * @private
-   */
-  enableObserveChangesPlugin() {
-    const _this = this;
-
-    this.hot._registerTimeout(
-      setTimeout(() => {
-        _this.hot.updateSettings({
-          observeChanges: true
-        });
-      }, 0));
-  }
-
-  /**
    * Callback for the `afterLoadData` hook.
    *
    * @private
@@ -739,6 +741,26 @@ class ColumnSorting extends BasePlugin {
    */
   onAfterRemoveRow(removedRows, amount) {
     this.rowsMapper.unshiftItems(removedRows, amount);
+  }
+
+  // TODO: Workaround. Inheriting of non-primitive cell meta values doesn't work. We clear the cache after action which reorganize sequence of columns.
+  /**
+   * Callback for the `afterCreateCol` hook.
+   *
+   * @private
+   */
+  onAfterCreateCol() {
+    this.columnMetaCache.clear();
+  }
+
+  // TODO: Workaround. Inheriting of non-primitive cell meta values doesn't work. We clear the cache after action which reorganize sequence of columns.
+  /**
+   * Callback for the `afterRemoveCol` hook.
+   *
+   * @private
+   */
+  onAfterRemoveCol() {
+    this.columnMetaCache.clear();
   }
 
   /**

--- a/src/plugins/columnSorting/columnSorting.js
+++ b/src/plugins/columnSorting/columnSorting.js
@@ -744,6 +744,7 @@ class ColumnSorting extends BasePlugin {
   }
 
   // TODO: Workaround. Inheriting of non-primitive cell meta values doesn't work. We clear the cache after action which reorganize sequence of columns.
+  // TODO: Remove test named: "should add new columns properly when the `columnSorting` plugin is enabled (inheriting of non-primitive cell meta values)".
   /**
    * Callback for the `afterCreateCol` hook.
    *
@@ -754,6 +755,7 @@ class ColumnSorting extends BasePlugin {
   }
 
   // TODO: Workaround. Inheriting of non-primitive cell meta values doesn't work. We clear the cache after action which reorganize sequence of columns.
+  // TODO: Remove test named: "should add new columns properly when the `columnSorting` plugin is enabled (inheriting of non-primitive cell meta values)".
   /**
    * Callback for the `afterRemoveCol` hook.
    *

--- a/src/plugins/columnSorting/test/columnSorting.e2e.js
+++ b/src/plugins/columnSorting/test/columnSorting.e2e.js
@@ -2579,4 +2579,22 @@ describe('ColumnSorting', () => {
       expect(htCoreWidthAtStart).toBe(newHtCoreWidth);
     });
   });
+
+  // TODO: Remove tests when workaround will be removed.
+  describe('workaround regression check', () => {
+    it('should add new columns properly when the `columnSorting` plugin is enabled (inheriting of non-primitive cell meta values)', () => {
+      spec().$container[0].style.width = 'auto';
+      spec().$container[0].style.height = 'auto';
+
+      handsontable({
+        colHeaders: true,
+        data: Handsontable.helper.createSpreadsheetData(2, 2),
+        columnSorting: true
+      });
+
+      alter('insert_col', 2, 5);
+
+      expect(getHtCore().find('tbody tr').length).toBeLessThan(7);
+    });
+  });
 });

--- a/src/plugins/columnSorting/test/columnSorting.e2e.js
+++ b/src/plugins/columnSorting/test/columnSorting.e2e.js
@@ -2594,7 +2594,7 @@ describe('ColumnSorting', () => {
 
       alter('insert_col', 2, 5);
 
-      expect(getHtCore().find('tbody tr').length).toBeLessThan(7);
+      expect(getHtCore().find('tbody tr:eq(0) td').length).toEqual(7);
     });
   });
 });


### PR DESCRIPTION
### Context
Fixed bug by adding extra listeners on `afterCreateCol`, `afterRemoveCol` hooks.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #5422

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
