### PR TITLE
[Column sorting] New, inserted row breaks the table data

### DIFF
--- a/src/plugins/columnSorting/columnSorting.js
+++ b/src/plugins/columnSorting/columnSorting.js
@@ -490,6 +490,9 @@ class ColumnSorting extends BasePlugin {
   // TODO: Workaround. Inheriting of non-primitive cell meta values doesn't work. Instead of getting properties from
   // column meta we call this function.
   getFirstCellSettings(column) {
+    // TODO: Remove test named: "should not break the dataset when inserted new row" (#5431).
+    const actualBlockTranslationFlag = this.blockPluginTranslation;
+
     this.blockPluginTranslation = true;
 
     if (this.columnMetaCache.size === 0) {
@@ -500,7 +503,7 @@ class ColumnSorting extends BasePlugin {
 
     const cellMeta = this.hot.getCellMeta(0, column);
 
-    this.blockPluginTranslation = false;
+    this.blockPluginTranslation = actualBlockTranslationFlag;
 
     const cellMetaCopy = Object.create(cellMeta);
     cellMetaCopy.columnSorting = this.columnMetaCache.get(this.hot.toPhysicalColumn(column));

--- a/src/plugins/columnSorting/test/columnSorting.e2e.js
+++ b/src/plugins/columnSorting/test/columnSorting.e2e.js
@@ -2579,4 +2579,24 @@ describe('ColumnSorting', () => {
       expect(htCoreWidthAtStart).toBe(newHtCoreWidth);
     });
   });
+
+  // TODO: Remove tests when workaround will be removed.
+  describe('workaround regression check', () => {
+    it('should not break the dataset when inserted new row', () => {
+      handsontable({
+        colHeaders: true,
+        data: Handsontable.helper.createSpreadsheetData(3, 3),
+        columnSorting: true
+      });
+
+      alter('insert_row', 2);
+
+      expect(getData()).toEqual([
+        ['A1', 'B1', 'C1'],
+        ['A2', 'B2', 'C2'],
+        [null, null, null],
+        ['A3', 'B3', 'C3']
+      ]);
+    });
+  });
 });

--- a/src/plugins/columnSorting/test/columnSorting.e2e.js
+++ b/src/plugins/columnSorting/test/columnSorting.e2e.js
@@ -2598,7 +2598,7 @@ describe('ColumnSorting', () => {
         ['A3', 'B3', 'C3']
       ]);
     });
-    
+
     it('should add new columns properly when the `columnSorting` plugin is enabled (inheriting of non-primitive cell meta values)', () => {
       spec().$container[0].style.width = 'auto';
       spec().$container[0].style.height = 'auto';


### PR DESCRIPTION
### Context
Using `getFirstCellSettings` won't change plugin's `blockPluginTranslation` flag.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #5431

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
