### PR TITLE
Correct calculated position of the editor when preventOverflow is 'horizontal'

### DIFF
--- a/src/editors/textEditor.js
+++ b/src/editors/textEditor.js
@@ -298,13 +298,11 @@ TextEditor.prototype.refreshDimensions = function(force = false) {
 
   const currentOffset = offset(this.TD);
   const containerOffset = offset(this.instance.rootElement);
-  const scrollableContainer = this.instance.view.wt.wtOverlays.topOverlay.mainTableScrollableElement;
+  const scrollableContainerTop = this.instance.view.wt.wtOverlays.topOverlay.mainTableScrollableElement;
+  const scrollableContainerLeft = this.instance.view.wt.wtOverlays.leftOverlay.mainTableScrollableElement;
   const totalRowsCount = this.instance.countRows();
-  const containerScrollTop = scrollableContainer !== window ?
-    scrollableContainer.scrollTop : 0;
-  const containerScrollLeft = scrollableContainer !== window ?
-    scrollableContainer.scrollLeft : 0;
-
+  const containerScrollTop = scrollableContainerTop !== window ? scrollableContainerTop.scrollTop : 0;
+  const containerScrollLeft = scrollableContainerLeft !== window ? scrollableContainerLeft.scrollLeft : 0;
   const editorSection = this.checkEditorSection();
 
   const scrollTop = ['', 'left'].includes(editorSection) ? containerScrollTop : 0;
@@ -371,8 +369,8 @@ TextEditor.prototype.refreshDimensions = function(force = false) {
   const cellLeftOffset = this.TD.offsetLeft + firstColumnOffset - horizontalScrollPosition;
 
   const width = innerWidth(this.TD) - 8;
-  const actualVerticalScrollbarWidth = hasVerticalScrollbar(scrollableContainer) ? scrollbarWidth : 0;
-  const actualHorizontalScrollbarWidth = hasHorizontalScrollbar(scrollableContainer) ? scrollbarWidth : 0;
+  const actualVerticalScrollbarWidth = hasVerticalScrollbar(scrollableContainerTop) ? scrollbarWidth : 0;
+  const actualHorizontalScrollbarWidth = hasHorizontalScrollbar(scrollableContainerLeft) ? scrollbarWidth : 0;
   const maxWidth = this.instance.view.maximumVisibleElementWidth(cellLeftOffset) - 9 - actualVerticalScrollbarWidth;
   const height = this.TD.scrollHeight + 1;
   const maxHeight = Math.max(this.instance.view.maximumVisibleElementHeight(cellTopOffset) - actualHorizontalScrollbarWidth, 23);

--- a/test/e2e/editors/textEditor.spec.js
+++ b/test/e2e/editors/textEditor.spec.js
@@ -882,6 +882,51 @@ describe('TextEditor', () => {
     $(mainHolder).scrollTop(1000);
   });
 
+  it('should open editor at the same coordinates as the edited cell if preventOverflow is set as horizontal after the table had been scrolled', async() => {
+    spec().$container[0].style = 'width: 400px';
+
+    const hot = handsontable({
+      data: Handsontable.helper.createSpreadsheetData(30, 30),
+      preventOverflow: 'horizontal',
+      fixedColumnsLeft: 2,
+      fixedRowsTop: 2,
+      rowHeaders: true,
+      colHeaders: true,
+    });
+
+    const $holder = $(hot.view.wt.wtTable.holder);
+    $holder.scrollTop(100);
+    $holder.scrollLeft(100);
+
+    hot.render();
+
+    await sleep(50);
+    // corner
+    selectCell(1, 1);
+    keyDownUp(Handsontable.helper.KEY_CODES.ENTER);
+    const $inputHolder = $('.handsontableInputHolder');
+    expect($(getCell(1, 1, true)).offset().left).toEqual($inputHolder.offset().left + 1);
+    expect($(getCell(1, 1, true)).offset().top).toEqual($inputHolder.offset().top + 1);
+
+    // top
+    selectCell(1, 4);
+    keyDownUp(Handsontable.helper.KEY_CODES.ENTER);
+    expect($(getCell(1, 4, true)).offset().left).toEqual($inputHolder.offset().left + 1);
+    expect($(getCell(1, 4, true)).offset().top).toEqual($inputHolder.offset().top + 1);
+
+    // left
+    selectCell(4, 1);
+    keyDownUp(Handsontable.helper.KEY_CODES.ENTER);
+    expect($(getCell(4, 1, true)).offset().left).toEqual($inputHolder.offset().left + 1);
+    expect($(getCell(4, 1, true)).offset().top).toEqual($inputHolder.offset().top + 1);
+
+    // non-fixed
+    selectCell(4, 4);
+    keyDownUp(Handsontable.helper.KEY_CODES.ENTER);
+    expect($(getCell(4, 4, true)).offset().left).toEqual($inputHolder.offset().left + 1);
+    expect($(getCell(4, 4, true)).offset().top).toEqual($inputHolder.offset().top + 1);
+  });
+
   it('should open editor at the same coordinates as the edited cell after the table had been scrolled (corner)', () => {
     const hot = handsontable({
       data: Handsontable.helper.createSpreadsheetData(16, 8),


### PR DESCRIPTION
### Context
`refeshDimension` calculates the editor's position improperly when `preventOverflow: horizontal`

### How has this been tested?
1. Use configuration from #5073.
2. Scroll table horizontally.
3. Open editor.

### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)

### Related issue(s):
1. #5073