### PR TITLE
Convert BaseEditor to use ES6 class and arrow function scope

### DIFF
--- a/src/editors/_baseEditor.js
+++ b/src/editors/_baseEditor.js
@@ -12,258 +12,242 @@ export const EditorState = {
  * @util
  * @class BaseEditor
  */
-function BaseEditor(instance) {
-  this.instance = instance;
-  this.state = EditorState.VIRGIN;
-
-  this._opened = false;
-  this._fullEditMode = false;
-  this._closeCallback = null;
-
-  this.init();
-}
-
-BaseEditor.prototype._fireCallbacks = function(result) {
-  if (this._closeCallback) {
-    this._closeCallback(result);
-    this._closeCallback = null;
-  }
-};
-
-BaseEditor.prototype.init = function() {};
-
-BaseEditor.prototype.getValue = function() {
-  throw Error('Editor getValue() method unimplemented');
-};
-
-BaseEditor.prototype.setValue = function() {
-  throw Error('Editor setValue() method unimplemented');
-};
-
-BaseEditor.prototype.open = function() {
-  throw Error('Editor open() method unimplemented');
-};
-
-BaseEditor.prototype.close = function() {
-  throw Error('Editor close() method unimplemented');
-};
-
-BaseEditor.prototype.prepare = function(row, col, prop, td, originalValue, cellProperties) {
-  this.TD = td;
-  this.row = row;
-  this.col = col;
-  this.prop = prop;
-  this.originalValue = originalValue;
-  this.cellProperties = cellProperties;
-  this.state = EditorState.VIRGIN;
-};
-
-BaseEditor.prototype.extend = function() {
-  const baseClass = this.constructor;
-
-  function Editor(...args) {
-    baseClass.apply(this, args);
-  }
-
-  function inherit(Child, Parent) {
-    function Bridge() {}
-    Bridge.prototype = Parent.prototype;
-    Child.prototype = new Bridge();
-    Child.prototype.constructor = Child;
-
-    return Child;
-  }
-
-  return inherit(Editor, baseClass);
-};
-
-BaseEditor.prototype.saveValue = function(value, ctrlDown) {
-  let selection;
-  let tmp;
-
-  // if ctrl+enter and multiple cells selected, behave like Excel (finish editing and apply to all cells)
-  if (ctrlDown) {
-    selection = this.instance.getSelectedLast();
-
-    if (selection[0] > selection[2]) {
-      tmp = selection[0];
-      selection[0] = selection[2];
-      selection[2] = tmp;
-    }
-    if (selection[1] > selection[3]) {
-      tmp = selection[1];
-      selection[1] = selection[3];
-      selection[3] = tmp;
-    }
-  } else {
-    selection = [this.row, this.col, null, null];
-  }
-
-  this.instance.populateFromArray(selection[0], selection[1], value, selection[2], selection[3], 'edit');
-};
-
-BaseEditor.prototype.beginEditing = function(newInitialValue, event) {
-  if (this.state !== EditorState.VIRGIN) {
-    return;
-  }
-  this.instance.view.scrollViewport(new CellCoords(this.row, this.col));
-  this.state = EditorState.EDITING;
-
-  // Set the editor value only in the full edit mode. In other mode the focusable element has to be empty,
-  // otherwise IME (editor for Asia users) doesn't work.
-  if (this.isInFullEditMode()) {
-    const stringifiedInitialValue = typeof newInitialValue === 'string' ? newInitialValue : stringify(this.originalValue);
-
-    this.setValue(stringifiedInitialValue);
-  }
-
-  this.open(event);
-  this._opened = true;
-  this.focus();
-
-  // only rerender the selections (FillHandle should disappear when beginediting is triggered)
-  this.instance.view.render();
-
-  this.instance.runHooks('afterBeginEditing', this.row, this.col);
-};
-
-BaseEditor.prototype.finishEditing = function(restoreOriginalValue, ctrlDown, callback) {
-  const _this = this;
-  let val;
-
-  if (callback) {
-    const previousCloseCallback = this._closeCallback;
-
-    this._closeCallback = function(result) {
-      if (previousCloseCallback) {
-        previousCloseCallback(result);
-      }
-
-      callback(result);
-      _this.instance.view.render();
-    };
-  }
-
-  if (this.isWaiting()) {
-    return;
-  }
-
-  if (this.state === EditorState.VIRGIN) {
-    this.instance._registerTimeout(() => {
-      _this._fireCallbacks(true);
-    });
-
-    return;
-  }
-
-  if (this.state === EditorState.EDITING) {
-    if (restoreOriginalValue) {
-      this.cancelChanges();
-      this.instance.view.render();
-
-      return;
-    }
-
-    const value = this.getValue();
-
-    if (this.instance.getSettings().trimWhitespace) {
-      // We trim only string values
-      val = [
-        [typeof value === 'string' ? String.prototype.trim.call(value || '') : value]
-      ];
-    } else {
-      val = [
-        [value]
-      ];
-    }
-
-    this.state = EditorState.WAITING;
-    this.saveValue(val, ctrlDown);
-
-    if (this.instance.getCellValidator(this.cellProperties)) {
-      this.instance.addHookOnce('postAfterValidate', (result) => {
-        _this.state = EditorState.FINISHED;
-        _this.discardEditor(result);
-      });
-    } else {
-      this.state = EditorState.FINISHED;
-      this.discardEditor(true);
-    }
-  }
-};
-
-BaseEditor.prototype.cancelChanges = function() {
-  this.state = EditorState.FINISHED;
-  this.discardEditor();
-};
-
-BaseEditor.prototype.discardEditor = function(result) {
-  if (this.state !== EditorState.FINISHED) {
-    return;
-  }
-
-  // validator was defined and failed
-  if (result === false && this.cellProperties.allowInvalid !== true) {
-    this.instance.selectCell(this.row, this.col);
-    this.focus();
-    this.state = EditorState.EDITING;
-    this._fireCallbacks(false);
-
-  } else {
-    this.close();
+export default class BaseEditor {
+  constructor(instance) {
+    this.instance = instance;
+    this.state = EditorState.VIRGIN;
+  
     this._opened = false;
     this._fullEditMode = false;
+    this._closeCallback = null;
+  
+    this.init();
+  }
+
+  _fireCallbacks(result) {
+    if (this._closeCallback) {
+      this._closeCallback(result);
+      this._closeCallback = null;
+    }
+  }
+
+  init() {}
+
+  getValue() {
+    throw Error('Editor getValue() method unimplemented');
+  }
+
+  setValue() {
+    throw Error('Editor setValue() method unimplemented');
+  }
+
+  open() {
+    throw Error('Editor open() method unimplemented');
+  }
+
+  close() {
+    throw Error('Editor close() method unimplemented');
+  }
+
+  prepare(row, col, prop, td, originalValue, cellProperties) {
+    this.TD = td;
+    this.row = row;
+    this.col = col;
+    this.prop = prop;
+    this.originalValue = originalValue;
+    this.cellProperties = cellProperties;
     this.state = EditorState.VIRGIN;
-    this._fireCallbacks(true);
-  }
-};
-
-/**
- * Switch editor into full edit mode. In this state navigation keys don't close editor. This mode is activated
- * automatically after hit ENTER or F2 key on the cell or while editing cell press F2 key.
- */
-BaseEditor.prototype.enableFullEditMode = function() {
-  this._fullEditMode = true;
-};
-
-/**
- * Checks if editor is in full edit mode.
- *
- * @returns {Boolean}
- */
-BaseEditor.prototype.isInFullEditMode = function() {
-  return this._fullEditMode;
-};
-
-BaseEditor.prototype.isOpened = function() {
-  return this._opened;
-};
-
-BaseEditor.prototype.isWaiting = function() {
-  return this.state === EditorState.WAITING;
-};
-
-BaseEditor.prototype.checkEditorSection = function() {
-  const totalRows = this.instance.countRows();
-  let section = '';
-
-  if (this.row < this.instance.getSettings().fixedRowsTop) {
-    if (this.col < this.instance.getSettings().fixedColumnsLeft) {
-      section = 'top-left-corner';
-    } else {
-      section = 'top';
-    }
-  } else if (this.instance.getSettings().fixedRowsBottom && this.row >= totalRows - this.instance.getSettings().fixedRowsBottom) {
-    if (this.col < this.instance.getSettings().fixedColumnsLeft) {
-      section = 'bottom-left-corner';
-    } else {
-      section = 'bottom';
-    }
-  } else if (this.col < this.instance.getSettings().fixedColumnsLeft) {
-    section = 'left';
   }
 
-  return section;
-};
+  extend() {
+    return class Editor extends BaseEditor { }
+  }
 
-export default BaseEditor;
+  saveValue(value, ctrlDown) {
+    let selection;
+    let tmp;
+  
+    // if ctrl+enter and multiple cells selected, behave like Excel (finish editing and apply to all cells)
+    if (ctrlDown) {
+      selection = this.instance.getSelectedLast();
+  
+      if (selection[0] > selection[2]) {
+        tmp = selection[0];
+        selection[0] = selection[2];
+        selection[2] = tmp;
+      }
+      if (selection[1] > selection[3]) {
+        tmp = selection[1];
+        selection[1] = selection[3];
+        selection[3] = tmp;
+      }
+    } else {
+      selection = [this.row, this.col, null, null];
+    }
+  
+    this.instance.populateFromArray(selection[0], selection[1], value, selection[2], selection[3], 'edit');
+  }
+
+  beginEditing(newInitialValue, event) {
+    if (this.state !== EditorState.VIRGIN) {
+      return;
+    }
+    this.instance.view.scrollViewport(new CellCoords(this.row, this.col));
+    this.state = EditorState.EDITING;
+  
+    // Set the editor value only in the full edit mode. In other mode the focusable element has to be empty,
+    // otherwise IME (editor for Asia users) doesn't work.
+    if (this.isInFullEditMode()) {
+      const stringifiedInitialValue = typeof newInitialValue === 'string' ? newInitialValue : stringify(this.originalValue);
+  
+      this.setValue(stringifiedInitialValue);
+    }
+  
+    this.open(event);
+    this._opened = true;
+    this.focus();
+  
+    // only rerender the selections (FillHandle should disappear when beginediting is triggered)
+    this.instance.view.render();
+  
+    this.instance.runHooks('afterBeginEditing', this.row, this.col);
+  }
+
+  finishEditing(restoreOriginalValue, ctrlDown, callback) {
+    let val;
+  
+    if (callback) {
+      const previousCloseCallback = this._closeCallback;
+  
+      this._closeCallback = (result) => {
+        if (previousCloseCallback) {
+          previousCloseCallback(result);
+        }
+  
+        callback(result);
+        this.instance.view.render();
+      };
+    }
+  
+    if (this.isWaiting()) {
+      return;
+    }
+  
+    if (this.state === EditorState.VIRGIN) {
+      this.instance._registerTimeout(() => {
+        this._fireCallbacks(true);
+      });
+  
+      return;
+    }
+  
+    if (this.state === EditorState.EDITING) {
+      if (restoreOriginalValue) {
+        this.cancelChanges();
+        this.instance.view.render();
+  
+        return;
+      }
+  
+      const value = this.getValue();
+  
+      if (this.instance.getSettings().trimWhitespace) {
+        // We trim only string values
+        val = [
+          [typeof value === 'string' ? String.prototype.trim.call(value || '') : value]
+        ];
+      } else {
+        val = [
+          [value]
+        ];
+      }
+  
+      this.state = EditorState.WAITING;
+      this.saveValue(val, ctrlDown);
+  
+      if (this.instance.getCellValidator(this.cellProperties)) {
+        this.instance.addHookOnce('postAfterValidate', (result) => {
+          this.state = EditorState.FINISHED;
+          this.discardEditor(result);
+        });
+      } else {
+        this.state = EditorState.FINISHED;
+        this.discardEditor(true);
+      }
+    }
+  }
+
+  cancelChanges() {
+    this.state = EditorState.FINISHED;
+    this.discardEditor();
+  }
+
+  discardEditor(result) {
+    if (this.state !== EditorState.FINISHED) {
+      return;
+    }
+  
+    // validator was defined and failed
+    if (result === false && this.cellProperties.allowInvalid !== true) {
+      this.instance.selectCell(this.row, this.col);
+      this.focus();
+      this.state = EditorState.EDITING;
+      this._fireCallbacks(false);
+  
+    } else {
+      this.close();
+      this._opened = false;
+      this._fullEditMode = false;
+      this.state = EditorState.VIRGIN;
+      this._fireCallbacks(true);
+    }
+  }
+
+  /**
+   * Switch editor into full edit mode. In this state navigation keys don't close editor. This mode is activated
+   * automatically after hit ENTER or F2 key on the cell or while editing cell press F2 key.
+   */
+  enableFullEditMode() {
+    this._fullEditMode = true;
+  }
+
+  /**
+   * Checks if editor is in full edit mode.
+   *
+   * @returns {Boolean}
+   */
+  isInFullEditMode() {
+    return this._fullEditMode;
+  }
+
+  isOpened() {
+    return this._opened;
+  }
+
+  isWaiting() {
+    return this.state === EditorState.WAITING;
+  }
+
+  checkEditorSection() {
+    const totalRows = this.instance.countRows();
+    let section = '';
+  
+    if (this.row < this.instance.getSettings().fixedRowsTop) {
+      if (this.col < this.instance.getSettings().fixedColumnsLeft) {
+        section = 'top-left-corner';
+      } else {
+        section = 'top';
+      }
+    } else if (this.instance.getSettings().fixedRowsBottom && this.row >= totalRows - this.instance.getSettings().fixedRowsBottom) {
+      if (this.col < this.instance.getSettings().fixedColumnsLeft) {
+        section = 'bottom-left-corner';
+      } else {
+        section = 'bottom';
+      }
+    } else if (this.col < this.instance.getSettings().fixedColumnsLeft) {
+      section = 'left';
+    }
+  
+    return section;
+  }
+}

--- a/src/editors/_baseEditor.js
+++ b/src/editors/_baseEditor.js
@@ -16,11 +16,11 @@ export default class BaseEditor {
   constructor(instance) {
     this.instance = instance;
     this.state = EditorState.VIRGIN;
-  
+
     this._opened = false;
     this._fullEditMode = false;
     this._closeCallback = null;
-  
+
     this.init();
   }
 
@@ -60,17 +60,17 @@ export default class BaseEditor {
   }
 
   extend() {
-    return class Editor extends BaseEditor { }
+    return class Editor extends BaseEditor { };
   }
 
   saveValue(value, ctrlDown) {
     let selection;
     let tmp;
-  
+
     // if ctrl+enter and multiple cells selected, behave like Excel (finish editing and apply to all cells)
     if (ctrlDown) {
       selection = this.instance.getSelectedLast();
-  
+
       if (selection[0] > selection[2]) {
         tmp = selection[0];
         selection[0] = selection[2];
@@ -84,7 +84,7 @@ export default class BaseEditor {
     } else {
       selection = [this.row, this.col, null, null];
     }
-  
+
     this.instance.populateFromArray(selection[0], selection[1], value, selection[2], selection[3], 'edit');
   }
 
@@ -94,63 +94,63 @@ export default class BaseEditor {
     }
     this.instance.view.scrollViewport(new CellCoords(this.row, this.col));
     this.state = EditorState.EDITING;
-  
+
     // Set the editor value only in the full edit mode. In other mode the focusable element has to be empty,
     // otherwise IME (editor for Asia users) doesn't work.
     if (this.isInFullEditMode()) {
       const stringifiedInitialValue = typeof newInitialValue === 'string' ? newInitialValue : stringify(this.originalValue);
-  
+
       this.setValue(stringifiedInitialValue);
     }
-  
+
     this.open(event);
     this._opened = true;
     this.focus();
-  
+
     // only rerender the selections (FillHandle should disappear when beginediting is triggered)
     this.instance.view.render();
-  
+
     this.instance.runHooks('afterBeginEditing', this.row, this.col);
   }
 
   finishEditing(restoreOriginalValue, ctrlDown, callback) {
     let val;
-  
+
     if (callback) {
       const previousCloseCallback = this._closeCallback;
-  
+
       this._closeCallback = (result) => {
         if (previousCloseCallback) {
           previousCloseCallback(result);
         }
-  
+
         callback(result);
         this.instance.view.render();
       };
     }
-  
+
     if (this.isWaiting()) {
       return;
     }
-  
+
     if (this.state === EditorState.VIRGIN) {
       this.instance._registerTimeout(() => {
         this._fireCallbacks(true);
       });
-  
+
       return;
     }
-  
+
     if (this.state === EditorState.EDITING) {
       if (restoreOriginalValue) {
         this.cancelChanges();
         this.instance.view.render();
-  
+
         return;
       }
-  
+
       const value = this.getValue();
-  
+
       if (this.instance.getSettings().trimWhitespace) {
         // We trim only string values
         val = [
@@ -161,10 +161,10 @@ export default class BaseEditor {
           [value]
         ];
       }
-  
+
       this.state = EditorState.WAITING;
       this.saveValue(val, ctrlDown);
-  
+
       if (this.instance.getCellValidator(this.cellProperties)) {
         this.instance.addHookOnce('postAfterValidate', (result) => {
           this.state = EditorState.FINISHED;
@@ -186,14 +186,14 @@ export default class BaseEditor {
     if (this.state !== EditorState.FINISHED) {
       return;
     }
-  
+
     // validator was defined and failed
     if (result === false && this.cellProperties.allowInvalid !== true) {
       this.instance.selectCell(this.row, this.col);
       this.focus();
       this.state = EditorState.EDITING;
       this._fireCallbacks(false);
-  
+
     } else {
       this.close();
       this._opened = false;
@@ -231,7 +231,7 @@ export default class BaseEditor {
   checkEditorSection() {
     const totalRows = this.instance.countRows();
     let section = '';
-  
+
     if (this.row < this.instance.getSettings().fixedRowsTop) {
       if (this.col < this.instance.getSettings().fixedColumnsLeft) {
         section = 'top-left-corner';
@@ -247,7 +247,7 @@ export default class BaseEditor {
     } else if (this.col < this.instance.getSettings().fixedColumnsLeft) {
       section = 'left';
     }
-  
+
     return section;
   }
 }

--- a/src/editors/_baseEditor.js
+++ b/src/editors/_baseEditor.js
@@ -12,7 +12,7 @@ export const EditorState = {
  * @util
  * @class BaseEditor
  */
-export default class BaseEditor {
+class BaseEditor {
   constructor(instance) {
     this.instance = instance;
     this.state = EditorState.VIRGIN;
@@ -251,3 +251,5 @@ export default class BaseEditor {
     return section;
   }
 }
+
+export default BaseEditor;

--- a/src/editors/_baseEditor.js
+++ b/src/editors/_baseEditor.js
@@ -60,7 +60,7 @@ class BaseEditor {
   }
 
   extend() {
-    return class Editor extends BaseEditor { };
+    return (class Editor extends this.constructor {});
   }
 
   saveValue(value, ctrlDown) {


### PR DESCRIPTION
### Context
ES5 to ES6 conversion per https://github.com/handsontable/handsontable/issues/5403

Github's diff viewer is unfortunately pretty noisy, the changes were:
- Converted `BaseEditor` constructor function and prototype functions to use ES6 `class` - this was a pure copy paste with no re-ordering or changes except listed below.
- Changed the `extend` method to simply return `class Editor extends BaseEditor {}`
- Replaced `_this` with `this` in arrow functions

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
`npm test`
I branched from `develop` and found that before changes there are some `e2e` failures when run locally. This PR did not seem to introduce any new ones.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/5403
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
