### PR TITLE
Convert AutocompleteEditor to ES6

### DIFF
--- a/src/editors/autocompleteEditor.js
+++ b/src/editors/autocompleteEditor.js
@@ -41,7 +41,7 @@ function onBeforeKeyDown(event) {
   }
 }
 
-export default class AutocompleteEditor extends HandsontableEditor {
+class AutocompleteEditor extends HandsontableEditor {
 
   /**
    * @private
@@ -440,3 +440,5 @@ AutocompleteEditor.sortByRelevance = function(value, choices, caseSensitive) {
 
   return result;
 };
+
+export default AutocompleteEditor;


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Converted to ES6 per https://github.com/handsontable/handsontable/issues/5403
- Use `class` and `extends HandstontableEditor`
- Replace overridden method's use of `HandsontableEditor.foo.apply(this, ...args)` with `super.foo(...args)`
- Moved global `skipOne` and `onBeforeKeyDown` to top of file

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
`npm test`
Same comment as previous PR: some e2e tests are failing from `develop` branch related to scrolling, changes here didn't appear to cause any new failures.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/5403
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
