### PR TITLE
Add beforeOnCellMouseDown hook to autoColumnSize to keep widths.

### DIFF
--- a/src/plugins/autoColumnSize/autoColumnSize.js
+++ b/src/plugins/autoColumnSize/autoColumnSize.js
@@ -170,6 +170,7 @@ class AutoColumnSize extends BasePlugin {
     this.addHook('beforeRender', force => this.onBeforeRender(force));
     this.addHook('modifyColWidth', (width, col) => this.getColumnWidth(col, width));
     this.addHook('afterInit', () => this.onAfterInit());
+    this.addHook('beforeOnCellMouseDown', (event, coords) => this.onBeforeOnCellMouseDown(event, coords));
     super.enablePlugin();
   }
 
@@ -266,7 +267,7 @@ class AutoColumnSize extends BasePlugin {
     if (this.firstCalculation && this.getSyncCalculationLimit()) {
       this.calculateColumnsWidth({ from: 0, to: this.getSyncCalculationLimit() }, rowRange);
       this.firstCalculation = false;
-      current = this.getSyncCalculationLimit();
+      current = this.getSyncCalculationLimit() + 1;
     }
     // async
     if (current < length) {
@@ -314,7 +315,7 @@ class AutoColumnSize extends BasePlugin {
   getSyncCalculationLimit() {
     /* eslint-disable no-bitwise */
     let limit = AutoColumnSize.SYNC_CALCULATION_LIMIT;
-    const colsLimit = this.hot.countCols();
+    const colsLimit = this.hot.countCols() - 1;
 
     if (isObject(this.hot.getSettings().autoColumnSize)) {
       limit = this.hot.getSettings().autoColumnSize.syncLimit;
@@ -511,6 +512,17 @@ class AutoColumnSize extends BasePlugin {
     }
 
     return newSize;
+  }
+
+  /**
+  * On before on cell mousedown listener.
+  *
+  * @private
+  */
+  onBeforeOnCellMouseDown(event, coords) {
+    const column = coords.col === -1 ? 0 : coords.col;
+
+    this.calculateColumnsWidth(column, void 0, true);
   }
 
   /**

--- a/src/plugins/autoColumnSize/autoColumnSize.js
+++ b/src/plugins/autoColumnSize/autoColumnSize.js
@@ -170,7 +170,6 @@ class AutoColumnSize extends BasePlugin {
     this.addHook('beforeRender', force => this.onBeforeRender(force));
     this.addHook('modifyColWidth', (width, col) => this.getColumnWidth(col, width));
     this.addHook('afterInit', () => this.onAfterInit());
-    this.addHook('beforeOnCellMouseDown', (event, coords) => this.onBeforeOnCellMouseDown(event, coords));
     super.enablePlugin();
   }
 
@@ -267,7 +266,7 @@ class AutoColumnSize extends BasePlugin {
     if (this.firstCalculation && this.getSyncCalculationLimit()) {
       this.calculateColumnsWidth({ from: 0, to: this.getSyncCalculationLimit() }, rowRange);
       this.firstCalculation = false;
-      current = this.getSyncCalculationLimit() + 1;
+      current = this.getSyncCalculationLimit();
     }
     // async
     if (current < length) {
@@ -315,7 +314,7 @@ class AutoColumnSize extends BasePlugin {
   getSyncCalculationLimit() {
     /* eslint-disable no-bitwise */
     let limit = AutoColumnSize.SYNC_CALCULATION_LIMIT;
-    const colsLimit = this.hot.countCols() - 1;
+    const colsLimit = this.hot.countCols();
 
     if (isObject(this.hot.getSettings().autoColumnSize)) {
       limit = this.hot.getSettings().autoColumnSize.syncLimit;
@@ -512,17 +511,6 @@ class AutoColumnSize extends BasePlugin {
     }
 
     return newSize;
-  }
-
-  /**
-  * On before on cell mousedown listener.
-  *
-  * @private
-  */
-  onBeforeOnCellMouseDown(event, coords) {
-    const column = coords.col === -1 ? 0 : coords.col;
-
-    this.calculateColumnsWidth(column, void 0, true);
   }
 
   /**

--- a/src/plugins/autoColumnSize/autoColumnSize.js
+++ b/src/plugins/autoColumnSize/autoColumnSize.js
@@ -266,7 +266,7 @@ class AutoColumnSize extends BasePlugin {
     if (this.firstCalculation && this.getSyncCalculationLimit()) {
       this.calculateColumnsWidth({ from: 0, to: this.getSyncCalculationLimit() }, rowRange);
       this.firstCalculation = false;
-      current = this.getSyncCalculationLimit() + 1;
+      current = this.getSyncCalculationLimit();
     }
     // async
     if (current < length) {

--- a/src/plugins/autoColumnSize/autoColumnSize.js
+++ b/src/plugins/autoColumnSize/autoColumnSize.js
@@ -314,7 +314,7 @@ class AutoColumnSize extends BasePlugin {
   getSyncCalculationLimit() {
     /* eslint-disable no-bitwise */
     let limit = AutoColumnSize.SYNC_CALCULATION_LIMIT;
-    const colsLimit = this.hot.countCols() - 1;
+    const colsLimit = this.hot.countCols();
 
     if (isObject(this.hot.getSettings().autoColumnSize)) {
       limit = this.hot.getSettings().autoColumnSize.syncLimit;

--- a/src/plugins/autoColumnSize/test/autoColumnSize.e2e.js
+++ b/src/plugins/autoColumnSize/test/autoColumnSize.e2e.js
@@ -482,4 +482,30 @@ describe('AutoColumnSize', () => {
 
     expect(spy.calls.mostRecent().args[5]).toEqual([{ id: 1000 }]);
   });
+
+  it('should not change width and widths after select/click cell', () => {
+    hot = handsontable({
+      data: [
+        ['Canceled'],
+        ['Processing'],
+        ['Processing'],
+        ['Created'],
+        ['Processing'],
+        ['Completed']
+      ],
+      colHeaders: true,
+      rowHeaders: true,
+    });
+
+    const cloneTopHider = spec().$container.find('.ht_clone_top .wtHider');
+    const plugin = hot.getPlugin('autoColumnSize');
+
+    expect(cloneTopHider.width()).toEqual(140);
+    expect(plugin.widths[0]).toEqual(90);
+
+    selectCell(0, 0);
+
+    expect(cloneTopHider.width()).toEqual(140);
+    expect(plugin.widths[0]).toEqual(90);
+  });
 });

--- a/src/plugins/autoColumnSize/test/autoColumnSize.e2e.js
+++ b/src/plugins/autoColumnSize/test/autoColumnSize.e2e.js
@@ -483,8 +483,8 @@ describe('AutoColumnSize', () => {
     expect(spy.calls.mostRecent().args[5]).toEqual([{ id: 1000 }]);
   });
 
-  it('should not change width and widths after select/click cell', () => {
-    const hot = handsontable({
+  it('should not change width after select/click cell', async() => {
+    handsontable({
       data: [
         ['Canceled'],
         ['Processing'],
@@ -497,15 +497,16 @@ describe('AutoColumnSize', () => {
       rowHeaders: true,
     });
 
+    await sleep(300);
+
     const cloneTopHider = spec().$container.find('.ht_clone_top .wtHider');
-    const plugin = hot.getPlugin('autoColumnSize');
 
     expect(cloneTopHider.width()).toEqual(140);
-    expect(plugin.widths[0]).toEqual(90);
 
     selectCell(0, 0);
 
+    await sleep(300);
+
     expect(cloneTopHider.width()).toEqual(140);
-    expect(plugin.widths[0]).toEqual(90);
   });
 });

--- a/src/plugins/autoColumnSize/test/autoColumnSize.e2e.js
+++ b/src/plugins/autoColumnSize/test/autoColumnSize.e2e.js
@@ -484,7 +484,7 @@ describe('AutoColumnSize', () => {
   });
 
   it('should not change width and widths after select/click cell', () => {
-    hot = handsontable({
+    const hot = handsontable({
       data: [
         ['Canceled'],
         ['Processing'],

--- a/src/plugins/columnSorting/test/columnSorting.e2e.js
+++ b/src/plugins/columnSorting/test/columnSorting.e2e.js
@@ -967,7 +967,7 @@ describe('ColumnSorting', () => {
 
       setDataAtCell(0, 0, '19:55', 'edit');
 
-      await 500;
+      await sleep(500);
 
       expect(getDataAtCell(0, 0)).toEqual('7:55:00 pm');
     });

--- a/src/plugins/columnSorting/test/columnSorting.e2e.js
+++ b/src/plugins/columnSorting/test/columnSorting.e2e.js
@@ -965,9 +965,11 @@ describe('ColumnSorting', () => {
         }
       });
 
+      await sleep(100);
+
       setDataAtCell(0, 0, '19:55', 'edit');
 
-      await sleep(500);
+      await sleep(100);
 
       expect(getDataAtCell(0, 0)).toEqual('7:55:00 pm');
     });

--- a/src/plugins/columnSorting/test/columnSorting.e2e.js
+++ b/src/plugins/columnSorting/test/columnSorting.e2e.js
@@ -942,7 +942,7 @@ describe('ColumnSorting', () => {
   });
 
   describe('data type: time', () => {
-    it('should properly rewrite time into correct format after sort', (done) => {
+    it('should properly rewrite time into correct format after sort', async() => {
       handsontable({
         data: [
           ['0:00:01 am'],
@@ -967,10 +967,9 @@ describe('ColumnSorting', () => {
 
       setDataAtCell(0, 0, '19:55', 'edit');
 
-      setTimeout(() => {
-        expect(getDataAtCell(0, 0)).toEqual('7:55:00 pm');
-        done();
-      }, 250);
+      await 500;
+
+      expect(getDataAtCell(0, 0)).toEqual('7:55:00 pm');
     });
   });
 


### PR DESCRIPTION
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #5359

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
