### PR TITLE
Prevent the mobile browser from displaying the keyboard on every cell selection.

### DIFF
--- a/src/plugins/copyPaste/focusableElement.js
+++ b/src/plugins/copyPaste/focusableElement.js
@@ -1,6 +1,7 @@
 import EventManager from './../../eventManager';
 import localHooks from './../../mixins/localHooks';
 import { mixin } from './../../helpers/object';
+import { isMobileBrowser } from './../../helpers/browser';
 
 /**
  * @class FocusableWrapper
@@ -70,7 +71,10 @@ class FocusableWrapper {
   focus() {
     // Add an empty space to texarea. It is necessary for safari to enable "copy" command from menu bar.
     this.mainElement.value = ' ';
-    this.mainElement.select();
+
+    if (!isMobileBrowser()) {
+      this.mainElement.select();
+    }
   }
 }
 

--- a/test/e2e/mobile/selection.spec.js
+++ b/test/e2e/mobile/selection.spec.js
@@ -20,8 +20,8 @@ describe('Selection', () => {
 
     hot.selectCell(1, 1);
 
-    const topLeftSelectionHandle = spec().$container.find('.ht_master .htBorders div:last-child .topLeftSelectionHandle')[0];
-    const bottomRightSelectionHandle = spec().$container.find('.ht_master .htBorders div:last-child .bottomRightSelectionHandle')[0];
+    const topLeftSelectionHandle = spec().$container.find('.ht_master .htBorders div:first-child .topLeftSelectionHandle')[0];
+    const bottomRightSelectionHandle = spec().$container.find('.ht_master .htBorders div:first-child .bottomRightSelectionHandle')[0];
 
     expect(topLeftSelectionHandle.style.display).toEqual('block');
     expect(bottomRightSelectionHandle.style.display).toEqual('block');
@@ -42,10 +42,28 @@ describe('Selection', () => {
 
     await sleep(100);
 
-    const topLeftSelectionHandle = spec().$container.find('.ht_master .htBorders div:first-child .topLeftSelectionHandle')[0];
-    const bottomRightSelectionHandle = spec().$container.find('.ht_master .htBorders div:first-child .bottomRightSelectionHandle')[0];
+    const topLeftSelectionHandle = spec().$container.find('.ht_master .htBorders div:last-child .topLeftSelectionHandle')[0];
+    const bottomRightSelectionHandle = spec().$container.find('.ht_master .htBorders div:last-child .bottomRightSelectionHandle')[0];
 
     expect(topLeftSelectionHandle.style.display).toEqual('block');
     expect(bottomRightSelectionHandle.style.display).toEqual('block');
+  });
+
+  it('should not call the `select` method on the "focusable" textarea when selecting a cell', async() => {
+    const hot = handsontable({
+      data: [['test']],
+      width: 400,
+      height: 400
+    });
+
+    hot.selectCell(0, 0);
+
+    const copyPastePlugin = hot.getPlugin('copyPaste');
+    const focusableElement = copyPastePlugin.focusableElement.getFocusableElement();
+    spyOn(focusableElement, 'select');
+
+    hot.selectCell(0, 0);
+
+    expect(focusableElement.select).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
- Fix mobile tests
- Prevent the mobile browser from displaying the keyboard on every cell selection.
 #5479 

*Note:* Added a mobile test case, should be testes on a mobile device.