### PR TITLE
Remove external modules from jsdoc @dependencies tag

### DIFF
--- a/src/editors/dateEditor.js
+++ b/src/editors/dateEditor.js
@@ -12,7 +12,7 @@ import TextEditor from './textEditor';
  * @private
  * @editor DateEditor
  * @class DateEditor
- * @dependencies TextEditor moment pikaday
+ * @dependencies TextEditor
  */
 class DateEditor extends TextEditor {
   /**

--- a/src/plugins/columnSorting/columnSorting.js
+++ b/src/plugins/columnSorting/columnSorting.js
@@ -80,7 +80,7 @@ const REPLACE_COLUMN_CONFIG_STRATEGY = 'replace';
  *   }
  * }]```
  *
- * @dependencies ObserveChanges moment
+ * @dependencies ObserveChanges
  */
 class ColumnSorting extends BasePlugin {
   constructor(hotInstance) {

--- a/src/renderers/numericRenderer.js
+++ b/src/renderers/numericRenderer.js
@@ -7,7 +7,6 @@ import { isNumeric } from './../helpers/number';
  *
  * @private
  * @renderer NumericRenderer
- * @dependencies numbro
  * @param {Object} instance Handsontable instance
  * @param {Element} TD Table cell where to render
  * @param {Number} row

--- a/src/validators/dateValidator.js
+++ b/src/validators/dateValidator.js
@@ -7,7 +7,6 @@ import { getEditorInstance } from '../editors';
  *
  * @private
  * @validator DateValidator
- * @dependencies moment
  * @param {*} value - Value of edited cell
  * @param {Function} callback - Callback called with validation result
  */

--- a/src/validators/timeValidator.js
+++ b/src/validators/timeValidator.js
@@ -12,7 +12,6 @@ const STRICT_FORMATS = [
  *
  * @private
  * @validator TimeValidator
- * @dependencies moment
  * @param {*} value - Value of edited cell
  * @param {Function} callback - Callback called with validation result
  */


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
[hot-builder](https://github.com/handsontable/hot-builder) no more supports 3rd parties dependencies defined as jsdoc tag @dependencies. This PR removes all unsupported modules.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
To test this PR clone the repo and try to build it using the latest version of hot-builder. Command to build files looks like `hot-builder build -i cloned-handsontable/ -o hot-dist/`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #5287

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
