### PR TITLE
Fix issues related with broken develop

### DIFF
--- a/src/plugins/autoColumnSize/autoColumnSize.js
+++ b/src/plugins/autoColumnSize/autoColumnSize.js
@@ -166,7 +166,6 @@ class AutoColumnSize extends BasePlugin {
 
     this.addHook('afterLoadData', () => this.onAfterLoadData());
     this.addHook('beforeChange', changes => this.onBeforeChange(changes));
-
     this.addHook('beforeRender', force => this.onBeforeRender(force));
     this.addHook('modifyColWidth', (width, col) => this.getColumnWidth(col, width));
     this.addHook('afterInit', () => this.onAfterInit());
@@ -262,11 +261,14 @@ class AutoColumnSize extends BasePlugin {
         }
       }
     };
+
+    const syncLimit = this.getSyncCalculationLimit();
+
     // sync
-    if (this.firstCalculation && this.getSyncCalculationLimit()) {
-      this.calculateColumnsWidth({ from: 0, to: this.getSyncCalculationLimit() }, rowRange);
+    if (this.firstCalculation && syncLimit >= 0) {
+      this.calculateColumnsWidth({ from: 0, to: syncLimit }, rowRange);
       this.firstCalculation = false;
-      current = this.getSyncCalculationLimit();
+      current = syncLimit + 1;
     }
     // async
     if (current < length) {
@@ -314,7 +316,7 @@ class AutoColumnSize extends BasePlugin {
   getSyncCalculationLimit() {
     /* eslint-disable no-bitwise */
     let limit = AutoColumnSize.SYNC_CALCULATION_LIMIT;
-    const colsLimit = this.hot.countCols();
+    const colsLimit = this.hot.countCols() - 1;
 
     if (isObject(this.hot.getSettings().autoColumnSize)) {
       limit = this.hot.getSettings().autoColumnSize.syncLimit;

--- a/src/plugins/autoRowSize/autoRowSize.js
+++ b/src/plugins/autoRowSize/autoRowSize.js
@@ -229,11 +229,14 @@ class AutoRowSize extends BasePlugin {
         }
       }
     };
+
+    const syncLimit = this.getSyncCalculationLimit();
+
     // sync
-    if (this.firstCalculation && this.getSyncCalculationLimit()) {
-      this.calculateRowsHeight({ from: 0, to: this.getSyncCalculationLimit() }, colRange);
+    if (this.firstCalculation && syncLimit >= 0) {
+      this.calculateRowsHeight({ from: 0, to: syncLimit }, colRange);
       this.firstCalculation = false;
-      current = this.getSyncCalculationLimit();
+      current = syncLimit + 1;
     }
     // async
     if (current < length) {
@@ -282,7 +285,7 @@ class AutoRowSize extends BasePlugin {
   getSyncCalculationLimit() {
     /* eslint-disable no-bitwise */
     let limit = AutoRowSize.SYNC_CALCULATION_LIMIT;
-    const rowsLimit = this.hot.countRows();
+    const rowsLimit = this.hot.countRows() - 1;
 
     if (isObject(this.hot.getSettings().autoRowSize)) {
       limit = this.hot.getSettings().autoRowSize.syncLimit;

--- a/src/utils/ghostTable.js
+++ b/src/utils/ghostTable.js
@@ -310,6 +310,9 @@ class GhostTable {
         const td = d.createElement('td');
         const tr = d.createElement('tr');
 
+        // Indicate that this element is created and supported by GhostTable. It can be useful to
+        // exclude rendering performance costly logic or exclude logic which doesn't work within a hidden table.
+        td.setAttribute('ghost-table', 1);
         renderer(this.hot, td, row, column, this.hot.colToProp(column), string.value, cellProperties);
         tr.appendChild(td);
         fragment.appendChild(tr);


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
This PR fixes issues related to fixes which were merged to the develop branch and they broken tests on that branch.

This PR includes:
 * Fix `syncCalculationLimit` for AutoRowSize plugin which can cause undesired results after #5530 fixes;
 * Fix `syncCalculationLimit` for AutoColumnSize plugin which broken dropdown menu for filters (previously fixed in #5508);
 * Add an attribute to TD element generated by GhostTable which creates an ability to skip renderers' logic when the Handsontable calculates the
   columns' width.

Related changes https://github.com/handsontable/handsontable-pro/pull/175.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Tests are already written so they cover all needed scenarios.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
