### PR TITLE
Scientific notation in numeric editor should be validate properly

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -893,7 +893,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
 
   function validateChanges(changes, source, callback) {
     const waitingForValidator = new ValidatorsQueue();
-    const isNumericData = value => value.length > 0 && /^-?[\d\s]*(\.|,)?\d*$/.test(value);
+    const isNumericData = value => value.length > 0 && /^\s*[+-.]?\s*(?:(?:\d+(?:(\.|,)\d+)?(?:e[+-]?\d+)?)|(?:0x[a-f\d]+))\s*$/.test(value);
 
     waitingForValidator.onQueueEmpty = resolve;
 

--- a/src/validators/numericValidator.js
+++ b/src/validators/numericValidator.js
@@ -7,7 +7,7 @@
  * @param {*} callback - Callback called with validation result
  */
 
-import {isNumeric} from './../helpers/number';
+import { isNumeric } from './../helpers/number';
 
 export default function numericValidator(value, callback) {
   let valueToValidate = value;

--- a/src/validators/numericValidator.js
+++ b/src/validators/numericValidator.js
@@ -6,6 +6,9 @@
  * @param {*} value - Value of edited cell
  * @param {*} callback - Callback called with validation result
  */
+
+import {isNumeric} from './../helpers/number';
+
 export default function numericValidator(value, callback) {
   let valueToValidate = value;
 
@@ -19,6 +22,6 @@ export default function numericValidator(value, callback) {
     callback(false);
 
   } else {
-    callback(/^-?\d*(\.|,)?\d*$/.test(valueToValidate));
+    callback(isNumeric(value));
   }
 }

--- a/test/e2e/validators/numericValidator.spec.js
+++ b/test/e2e/validators/numericValidator.spec.js
@@ -112,14 +112,14 @@ describe('numericValidator', () => {
   });
 
   it('should validate large-number scientific notation', (done) => {
-    var onAfterValidate = jasmine.createSpy('onAfterValidate');
+    const onAfterValidate = jasmine.createSpy('onAfterValidate');
 
     handsontable({
       data: arrayOfObjects(),
       columns: [
-        {data: 'id', type: 'numeric'},
-        {data: 'name'},
-        {data: 'lastName'}
+        { data: 'id', type: 'numeric' },
+        { data: 'name' },
+        { data: 'lastName' }
       ],
       afterValidate: onAfterValidate
     });
@@ -132,16 +132,15 @@ describe('numericValidator', () => {
     }, 100);
   });
 
-
   it('should validate small-number scientific notation', (done) => {
-    var onAfterValidate = jasmine.createSpy('onAfterValidate');
+    const onAfterValidate = jasmine.createSpy('onAfterValidate');
 
     handsontable({
       data: arrayOfObjects(),
       columns: [
-        {data: 'id', type: 'numeric'},
-        {data: 'name'},
-        {data: 'lastName'}
+        { data: 'id', type: 'numeric' },
+        { data: 'name' },
+        { data: 'lastName' }
       ],
       afterValidate: onAfterValidate
     });

--- a/test/e2e/validators/numericValidator.spec.js
+++ b/test/e2e/validators/numericValidator.spec.js
@@ -111,6 +111,49 @@ describe('numericValidator', () => {
     }, 100);
   });
 
+  it('should validate large-number scientific notation', (done) => {
+    var onAfterValidate = jasmine.createSpy('onAfterValidate');
+
+    handsontable({
+      data: arrayOfObjects(),
+      columns: [
+        {data: 'id', type: 'numeric'},
+        {data: 'name'},
+        {data: 'lastName'}
+      ],
+      afterValidate: onAfterValidate
+    });
+
+    setDataAtCell(2, 0, '1e+23');
+
+    setTimeout(() => {
+      expect(onAfterValidate).toHaveBeenCalledWith(true, 1e+23, 2, 'id', undefined, undefined);
+      done();
+    }, 100);
+  });
+
+
+  it('should validate small-number scientific notation', (done) => {
+    var onAfterValidate = jasmine.createSpy('onAfterValidate');
+
+    handsontable({
+      data: arrayOfObjects(),
+      columns: [
+        {data: 'id', type: 'numeric'},
+        {data: 'name'},
+        {data: 'lastName'}
+      ],
+      afterValidate: onAfterValidate
+    });
+
+    setDataAtCell(2, 0, '1e-23');
+
+    setTimeout(() => {
+      expect(onAfterValidate).toHaveBeenCalledWith(true, 1e-23, 2, 'id', undefined, undefined);
+      done();
+    }, 100);
+  });
+
   describe('allowEmpty', () => {
     it('should not validate an empty string when allowEmpty is set as `false`', (done) => {
       const onAfterValidate = jasmine.createSpy('onAfterValidate');


### PR DESCRIPTION
### Context
Current regex marks scientific notation as incorrect numeric value.

This PR is based on #5259.

### How has this been tested?
Use configuration from https://jsfiddle.net/d406brcp/
Result: Cells shouldn't be highlighted as invalid.

### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)

### Related issue(s):
1. #2030
