### PR TITLE
SheetClip should properly parse multiline text on Windows

### DIFF
--- a/lib/SheetClip/SheetClip.js
+++ b/lib/SheetClip/SheetClip.js
@@ -27,7 +27,7 @@
     parse: function (str) {
       var r, rLen, rows, arr = [], a = 0, c, cLen, multiline, last;
 
-      rows = str.split('\n');
+      rows = str.replace(/\r\n|\r|\n/g, "\n").split("\n");
 
       if (rows.length > 1 && rows[rows.length - 1] === '') {
         rows.pop();

--- a/lib/SheetClip/SheetClip.js
+++ b/lib/SheetClip/SheetClip.js
@@ -27,7 +27,7 @@
     parse: function (str) {
       var r, rLen, rows, arr = [], a = 0, c, cLen, multiline, last;
 
-      rows = str.replace(/\r\n|\r|\n/g, "\n").split("\n");
+      rows = str.replace(/\r\n|\r/g, '\n').split('\n');
 
       if (rows.length > 1 && rows[rows.length - 1] === '') {
         rows.pop();

--- a/src/plugins/copyPaste/test/copyPaste.e2e.js
+++ b/src/plugins/copyPaste/test/copyPaste.e2e.js
@@ -707,5 +707,20 @@ describe('CopyPaste', () => {
 
       expect(getDataAtCol(1)).toEqual(['{""""}', '{""""}{""""}', '{""""}{""""}{""""}']);
     });
+
+    it('should properly parse newline in text/plain on Windows', () => {
+      const afterChangeSpy = jasmine.createSpy('afterChange');
+
+      handsontable({
+        afterChange: afterChangeSpy,
+      });
+
+      selectCell(0, 0);
+
+      triggerPaste('Kia\r\nNissan\r\nToyota');
+
+      expect(afterChangeSpy)
+        .toHaveBeenCalledWith([[0, 0, null, 'Kia'], [1, 0, null, 'Nissan'], [2, 0, null, 'Toyota']], 'CopyPaste.paste', void 0, void 0, void 0, void 0);
+    });
   });
 });


### PR DESCRIPTION
### Context
Only `\n` triggers creating a new row.
Older MacOS uses CR and Windows uses CRLF, so we are not compatible with these OS.
This change adds support for CR and CRLF systems.

### How has this been tested?
Use this demo: https://jsfiddle.net/vw1pteor/
Expected result:
```
[
  [0,0,null,"Test"],
  [1,0,null,"Test 2"],
  [2,0,null,"Test 3"],
  [3,0,null,"Test 4"]
]
```

### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)

### Related issue(s):
1. #5477