### PR TITLE
Clear the column meta cache after loading new data. #5617

### DIFF
--- a/src/plugins/autoColumnSize/autoColumnSize.js
+++ b/src/plugins/autoColumnSize/autoColumnSize.js
@@ -357,7 +357,7 @@ class AutoColumnSize extends BasePlugin {
   /**
    * Gets the first visible column.
    *
-   * @returns {Number} Returns column index or -1 if table is not rendered.
+   * @returns {Number|null} Returns column index, -1 if table is not rendered or null if there are no columns to base the the calculations on.
    */
   getFirstVisibleColumn() {
     const wot = this.hot.view.wt;
@@ -451,13 +451,19 @@ class AutoColumnSize extends BasePlugin {
   onBeforeRender() {
     const force = this.hot.renderCall;
     const rowsCount = this.hot.countRows();
+    const firstVisibleColumn = this.getFirstVisibleColumn();
+    const lastVisibleColumn = this.getLastVisibleColumn();
+
+    if (firstVisibleColumn === null || lastVisibleColumn === null) {
+      return;
+    }
 
     // Keep last column widths unchanged for situation when all rows was deleted or trimmed (pro #6)
     if (!rowsCount) {
       return;
     }
 
-    this.calculateColumnsWidth({ from: this.getFirstVisibleColumn(), to: this.getLastVisibleColumn() }, void 0, force);
+    this.calculateColumnsWidth({ from: firstVisibleColumn, to: lastVisibleColumn }, void 0, force);
 
     if (this.isNeedRecalculate() && !this.inProgress) {
       this.calculateAllColumnsWidth();

--- a/src/plugins/autoColumnSize/test/autoColumnSize.e2e.js
+++ b/src/plugins/autoColumnSize/test/autoColumnSize.e2e.js
@@ -509,4 +509,18 @@ describe('AutoColumnSize', () => {
 
     expect(cloneTopHider.width()).toEqual(140);
   });
+
+  it('should not calculate any column widths, if there are no columns in the dataset', () => {
+    handsontable({
+      data: [[1, 2]],
+      colHeaders: true,
+    });
+
+    spyOn(getPlugin('autoColumnSize'), 'calculateColumnsWidth').and.callThrough();
+    const calculateColumnsWidth = getPlugin('autoColumnSize').calculateColumnsWidth;
+
+    loadData([[]]);
+
+    expect(calculateColumnsWidth).not.toHaveBeenCalled();
+  });
 });

--- a/src/plugins/autoRowSize/autoRowSize.js
+++ b/src/plugins/autoRowSize/autoRowSize.js
@@ -330,7 +330,7 @@ class AutoRowSize extends BasePlugin {
   /**
    * Get the first visible row.
    *
-   * @returns {Number} Returns row index or -1 if table is not rendered.
+   * @returns {Number|null} Returns row index, -1 if table is not rendered or null if there are no rows to base the the calculations on.
    */
   getFirstVisibleRow() {
     const wot = this.hot.view.wt;
@@ -401,8 +401,14 @@ class AutoRowSize extends BasePlugin {
   onBeforeRender() {
     const force = this.hot.renderCall;
     const fixedRowsBottom = this.hot.getSettings().fixedRowsBottom;
+    const firstVisibleRow = this.getFirstVisibleRow();
+    const lastVisibleRow = this.getLastVisibleRow();
 
-    this.calculateRowsHeight({ from: this.getFirstVisibleRow(), to: this.getLastVisibleRow() }, void 0, force);
+    if (firstVisibleRow === null || lastVisibleRow === null) {
+      return;
+    }
+
+    this.calculateRowsHeight({ from: firstVisibleRow, to: lastVisibleRow }, void 0, force);
 
     // Calculate rows height synchronously for bottom overlay
     if (fixedRowsBottom) {

--- a/src/plugins/autoRowSize/test/autoRowSize.e2e.js
+++ b/src/plugins/autoRowSize/test/autoRowSize.e2e.js
@@ -493,4 +493,19 @@ describe('AutoRowSize', () => {
 
     expect(cloneLeft.height()).toEqual(70);
   });
+
+  it('should not calculate any row heights, if there are no rows in the dataset', () => {
+    handsontable({
+      data: [[1, 2]],
+      colHeaders: true,
+      autoRowSize: true,
+    });
+
+    spyOn(getPlugin('autoRowSize'), 'calculateRowsHeight').and.callThrough();
+    const calculateColumnsWidth = getPlugin('autoRowSize').calculateRowsHeight;
+
+    loadData([]);
+
+    expect(calculateColumnsWidth).not.toHaveBeenCalled();
+  });
 });

--- a/src/plugins/columnSorting/columnSorting.js
+++ b/src/plugins/columnSorting/columnSorting.js
@@ -525,7 +525,12 @@ class ColumnSorting extends BasePlugin {
   rebuildColumnMetaCache() {
     const numberOfColumns = this.hot.countCols();
 
-    rangeEach(numberOfColumns - 1, visualColumnIndex => this.setMergedPluginSettings(visualColumnIndex));
+    if (numberOfColumns === 0) {
+      this.columnMetaCache.clear();
+
+    } else {
+      rangeEach(numberOfColumns - 1, visualColumnIndex => this.setMergedPluginSettings(visualColumnIndex));
+    }
   }
 
   /**

--- a/src/plugins/columnSorting/columnSorting.js
+++ b/src/plugins/columnSorting/columnSorting.js
@@ -735,6 +735,7 @@ class ColumnSorting extends BasePlugin {
    */
   onAfterLoadData(initialLoad) {
     this.rowsMapper.clearMap();
+    this.columnMetaCache.clear();
 
     if (initialLoad === true) {
       // TODO: Workaround? It should be refactored / described.

--- a/src/plugins/columnSorting/columnSorting.js
+++ b/src/plugins/columnSorting/columnSorting.js
@@ -503,10 +503,8 @@ class ColumnSorting extends BasePlugin {
 
     this.blockPluginTranslation = true;
 
-    if (this.columnMetaCache.size === 0) {
-      const numberOfColumns = this.hot.countCols();
-
-      rangeEach(numberOfColumns, visualColumnIndex => this.setMergedPluginSettings(visualColumnIndex));
+    if (this.columnMetaCache.size === 0 || this.columnMetaCache.size < this.hot.countCols()) {
+      this.rebuildColumnMetaCache();
     }
 
     const cellMeta = this.hot.getCellMeta(0, column);
@@ -517,6 +515,17 @@ class ColumnSorting extends BasePlugin {
     cellMetaCopy[this.pluginKey] = this.columnMetaCache.get(this.hot.toPhysicalColumn(column));
 
     return cellMetaCopy;
+  }
+
+  /**
+   * Rebuild the column meta cache for all the columns.
+   *
+   * @private
+   */
+  rebuildColumnMetaCache() {
+    const numberOfColumns = this.hot.countCols();
+
+    rangeEach(numberOfColumns - 1, visualColumnIndex => this.setMergedPluginSettings(visualColumnIndex));
   }
 
   /**

--- a/src/plugins/columnSorting/test/columnSorting.e2e.js
+++ b/src/plugins/columnSorting/test/columnSorting.e2e.js
@@ -658,6 +658,24 @@ describe('ColumnSorting', () => {
     ]);
   });
 
+  it('should clear and generate a new column meta cache after calling `updateSettings` with a new set of data', async() => {
+    handsontable({
+      data: [['test']],
+      columnSorting: true,
+      colHeaders: true
+    });
+
+    const plugin = getPlugin('columnSorting');
+
+    expect(plugin.columnMetaCache.size).toEqual(1);
+
+    updateSettings({
+      data: [['first columns', 'second column', 'third column']]
+    });
+
+    expect(plugin.columnMetaCache.size).toEqual(3);
+  });
+
   describe('isSorted', () => {
     it('should return `false` when plugin is disabled', () => {
       handsontable();


### PR DESCRIPTION
Clear the column meta cache after loading new data to prevent working on an incomplete copy of the column information.

### Related issues:
- #5617 