### PR TITLE
Updated style setters based on proper css style

### DIFF
--- a/src/helpers/feature.js
+++ b/src/helpers/feature.js
@@ -66,9 +66,9 @@ let _hasCaptionProblem;
 
 function detectCaptionProblem() {
   const TABLE = document.createElement('TABLE');
-  TABLE.style.borderSpacing = 0;
-  TABLE.style.borderWidth = 0;
-  TABLE.style.padding = 0;
+  TABLE.style.borderSpacing = '0';
+  TABLE.style.borderWidth = '0';
+  TABLE.style.padding = '0';
   const TBODY = document.createElement('TBODY');
   TABLE.appendChild(TBODY);
   TBODY.appendChild(document.createElement('TR'));
@@ -77,8 +77,8 @@ function detectCaptionProblem() {
 
   const CAPTION = document.createElement('CAPTION');
   CAPTION.innerHTML = 'c<br>c<br>c<br>c';
-  CAPTION.style.padding = 0;
-  CAPTION.style.margin = 0;
+  CAPTION.style.padding = '0';
+  CAPTION.style.margin = '0';
   TABLE.insertBefore(CAPTION, TBODY);
 
   document.body.appendChild(TABLE);


### PR DESCRIPTION
Work continued from #5291.

> ### Description
> In the `detectCaptionProblem` function, a table element is created with default values for border spacing, width and padding.
> Following CSSStyle, these values should be strings, not numbers.
> There is a problem with Jest when a HotTable is generated since it goes through this element creation, and Jest does a `v.toLowerCase()` on the border-spacing (which is a number at that point).
> 
> The `detectCaptionProblem` function should assign values to the style like this:
> 
> ```
>   TABLE.style.borderSpacing = '0';
>   TABLE.style.borderWidth = '0';
>   TABLE.style.padding = '0';
> ```

