### PR TITLE
Loosening the relationship between modules

### DIFF
--- a/src/editors/autocompleteEditor.js
+++ b/src/editors/autocompleteEditor.js
@@ -117,11 +117,15 @@ AutocompleteEditor.prototype.open = function(...args) {
     autoColumnSize: true,
     modifyColWidth(width, col) {
       // workaround for <strong> text overlapping the dropdown, not really accurate
-      const autoWidths = this.getPlugin('autoColumnSize').widths;
+      const autoColumnSize = this.getPlugin('autoColumnSize');
       let columnWidth = width;
 
-      if (autoWidths[col]) {
-        columnWidth = autoWidths[col];
+      if (autoColumnSize) {
+        const autoWidths = autoColumnSize.widths;
+
+        if (autoWidths[col]) {
+          columnWidth = autoWidths[col];
+        }
       }
 
       return trimDropdown ? columnWidth : columnWidth + 15;

--- a/src/plugins/filters/filters.js
+++ b/src/plugins/filters/filters.js
@@ -23,7 +23,7 @@ import './filters.css';
 /**
  * @plugin Filters
  * @pro
- * @dependencies DropdownMenu TrimRows
+ * @dependencies DropdownMenu TrimRows HiddenRows
  *
  * @description
  * The plugin allows filtering the table data either by the built-in component or with the API.

--- a/src/plugins/multiColumnSorting/multiColumnSorting.js
+++ b/src/plugins/multiColumnSorting/multiColumnSorting.js
@@ -18,6 +18,7 @@ registerRootComparator(PLUGIN_KEY, rootComparator);
 
 /**
  * @plugin MultiColumnSorting
+ * @dependencies ColumnSorting
  * @pro
  *
  * @description


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
This PR fixes a code which was dependent on `AutoColumnSize` plugin which may not exist. This fixes throwing error while editing cell value when Handsontable was built without the mentioned plugin.

Additionally, added missing dependencies to jsdoc (used by hot-builder).

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Tested locally. Tests are not included, due to the Handsontable always includes all plugins.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/hot-builder/pull/30

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
