### PR TITLE
Fix unresponsive selection

### DIFF
--- a/src/3rdparty/walkontable/src/event.js
+++ b/src/3rdparty/walkontable/src/event.js
@@ -6,6 +6,7 @@ import {
 } from './../../../helpers/dom/element';
 import { partial } from './../../../helpers/function';
 import { isTouchSupported } from './../../../helpers/feature';
+import { isMobileBrowser } from './../../../helpers/browser';
 import EventManager from './../../../eventManager';
 
 const privatePool = new WeakMap();
@@ -52,23 +53,9 @@ class Event {
     this.eventManager.addEventListener(this.instance.wtTable.TABLE, 'mouseover', event => this.onMouseOver(event));
     this.eventManager.addEventListener(this.instance.wtTable.TABLE, 'mouseout', event => this.onMouseOut(event));
 
-    if (isTouchSupported()) {
-      const onTouchStartProxy = (event) => {
-        const priv = privatePool.get(this);
-
-        priv.selectedCellBeforeTouchEnd = this.instance.selections.getCell().cellRange;
-        this.instance.touchApplied = true;
-
-        this.onTouchStart(event);
-      };
-      const onTouchEndProxy = (event) => {
-        this.instance.touchApplied = false;
-
-        this.onTouchEnd(event);
-      };
-
-      this.eventManager.addEventListener(this.instance.wtTable.holder, 'touchstart', event => onTouchStartProxy(event));
-      this.eventManager.addEventListener(this.instance.wtTable.holder, 'touchend', event => onTouchEndProxy(event));
+    const touchEvents = () => {
+      this.eventManager.addEventListener(this.instance.wtTable.holder, 'touchstart', event => this.onTouchStart(event));
+      this.eventManager.addEventListener(this.instance.wtTable.holder, 'touchend', event => this.onTouchEnd(event));
 
       if (!this.instance.momentumScrolling) {
         this.instance.momentumScrolling = {};
@@ -89,10 +76,22 @@ class Event {
           }
         }, 200);
       });
+    }
 
-    } else {
+    const mouseEvents = () => {
       this.eventManager.addEventListener(this.instance.wtTable.holder, 'mouseup', event => this.onMouseUp(event));
       this.eventManager.addEventListener(this.instance.wtTable.holder, 'mousedown', event => this.onMouseDown(event));
+    }
+
+    if (isMobileBrowser()) {
+      touchEvents();
+    } else {
+      // PC like devices which support both methods (touchscreen and ability to plug-in mouse).
+      if (isTouchSupported()) {
+        touchEvents();
+      }
+
+      mouseEvents();
     }
 
     this.eventManager.addEventListener(window, 'resize', () => {
@@ -297,6 +296,11 @@ class Event {
    * @param {MouseEvent} event
    */
   onTouchStart(event) {
+    const priv = privatePool.get(this);
+
+    priv.selectedCellBeforeTouchEnd = this.instance.selections.getCell().cellRange;
+    this.instance.touchApplied = true;
+
     this.onMouseDown(event);
   }
 
@@ -309,6 +313,8 @@ class Event {
   onTouchEnd(event) {
     const excludeTags = ['A', 'BUTTON', 'INPUT'];
     const target = event.target;
+
+    this.instance.touchApplied = false;
 
     // When the standard event was performed on the link element (a cell which contains HTML `a` element) then here
     // we check if it should be canceled. Click is blocked in a situation when the element is rendered outside

--- a/src/3rdparty/walkontable/src/event.js
+++ b/src/3rdparty/walkontable/src/event.js
@@ -53,7 +53,7 @@ class Event {
     this.eventManager.addEventListener(this.instance.wtTable.TABLE, 'mouseover', event => this.onMouseOver(event));
     this.eventManager.addEventListener(this.instance.wtTable.TABLE, 'mouseout', event => this.onMouseOut(event));
 
-    const touchEvents = () => {
+    const initTouchEvents = () => {
       this.eventManager.addEventListener(this.instance.wtTable.holder, 'touchstart', event => this.onTouchStart(event));
       this.eventManager.addEventListener(this.instance.wtTable.holder, 'touchend', event => this.onTouchEnd(event));
 
@@ -78,20 +78,20 @@ class Event {
       });
     };
 
-    const mouseEvents = () => {
+    const initMouseEvents = () => {
       this.eventManager.addEventListener(this.instance.wtTable.holder, 'mouseup', event => this.onMouseUp(event));
       this.eventManager.addEventListener(this.instance.wtTable.holder, 'mousedown', event => this.onMouseDown(event));
     };
 
     if (isMobileBrowser()) {
-      touchEvents();
+      initTouchEvents();
     } else {
       // PC like devices which support both methods (touchscreen and ability to plug-in mouse).
       if (isTouchSupported()) {
-        touchEvents();
+        initTouchEvents();
       }
 
-      mouseEvents();
+      initMouseEvents();
     }
 
     this.eventManager.addEventListener(window, 'resize', () => {

--- a/src/3rdparty/walkontable/src/event.js
+++ b/src/3rdparty/walkontable/src/event.js
@@ -76,12 +76,12 @@ class Event {
           }
         }, 200);
       });
-    }
+    };
 
     const mouseEvents = () => {
       this.eventManager.addEventListener(this.instance.wtTable.holder, 'mouseup', event => this.onMouseUp(event));
       this.eventManager.addEventListener(this.instance.wtTable.holder, 'mousedown', event => this.onMouseDown(event));
-    }
+    };
 
     if (isMobileBrowser()) {
       touchEvents();


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
This fix resolves an issue about not abling select a cell or edit a cell on devices which support both input methods (a touchscreen with an ability to plug in a mouse).

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Tested on iOS and Android emulator (to make sure that this change does not break that functionality for mobile devices). Additionally, issue owner confirmed that this PR resolves the issue https://github.com/handsontable/handsontable/issues/5669#issuecomment-447828700.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/5669

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
