### PR TITLE
[5.0.2+] htInvalid shifts when row are added/removed

### DIFF
--- a/src/plugins/contextMenu/predefinedItems/removeRow.js
+++ b/src/plugins/contextMenu/predefinedItems/removeRow.js
@@ -26,7 +26,9 @@ export default function removeRowItem() {
       return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_REMOVE_ROW, pluralForm);
     },
     callback() {
-      this.alter('remove_row', transformSelectionToRowDistance(this.getSelected()), null, 'ContextMenu.removeRow');
+      // TODO: Please keep in mind that below `1` may be improper. The table's way of work, before change `f1747b3912ea3b21fe423fd102ca94c87db81379` was restored.
+      // There is still problem when removing more than one row.
+      this.alter('remove_row', transformSelectionToRowDistance(this.getSelected()), 1, 'ContextMenu.removeRow');
     },
     disabled() {
       const selected = getValidSelection(this);

--- a/src/plugins/contextMenu/test/predefinedItems/removeRow.e2e.js
+++ b/src/plugins/contextMenu/test/predefinedItems/removeRow.e2e.js
@@ -90,5 +90,44 @@ describe('ContextMenu', () => {
 
       expect(getDataAtCol(0)).toEqual(['A7']);
     });
+
+    it('should not shift invalid row when removing a single row', async() => {
+      const hot = handsontable({
+        data: [
+          ['aaa', 2],
+          ['bbb', 3],
+          ['ccc', 4],
+          ['ddd', 'string'],
+          ['eee', 6],
+        ],
+        contextMenu: true,
+        columns(column) {
+          if (column === 1) {
+            return {
+              column,
+              type: 'numeric'
+            };
+          }
+
+          return {};
+        }
+      });
+
+      hot.validateCells();
+
+      await sleep(100);
+
+      selectCell(1, 1);
+      contextMenu();
+
+      // "Remove row" item
+      $('.htContextMenu .ht_master .htCore')
+        .find('tbody td')
+        .not('.htSeparator')
+        .eq(4)
+        .simulate('mousedown');
+
+      expect($(hot.getCell(2, 1)).hasClass('htInvalid')).toBeTruthy();
+    });
   });
 });


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Commit https://github.com/handsontable/handsontable/pull/5368/commits/f1747b3912ea3b21fe423fd102ca94c87db81379#diff-7eb52b366866677666470e019283c8eaR282 changed way of work of the Handsontable.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Manual tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #5674

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
