### PR TITLE
Async validation should not throw an exception.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1063,8 +1063,12 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
       value = instance.runHooks('beforeValidate', value, cellProperties.visualRow, cellProperties.prop, source);
 
       // To provide consistent behaviour, validation should be always asynchronous
-      instance._registerTimeout(setTimeout(() => {
+      instance._registerImmediate(() => {
+        console.log('validateCell._registerImmediate');
         validator.call(cellProperties, value, (valid) => {
+          if (!instance) {
+            return false;
+          }
           // eslint-disable-next-line no-param-reassign
           valid = instance.runHooks('afterValidate', valid, value, cellProperties.visualRow, cellProperties.prop, source);
           cellProperties.valid = valid;
@@ -1072,14 +1076,14 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
           done(valid);
           instance.runHooks('postAfterValidate', valid, value, cellProperties.visualRow, cellProperties.prop, source);
         });
-      }, 0));
+      });
 
     } else {
       // resolve callback even if validator function was not found
-      instance._registerTimeout(setTimeout(() => {
+      instance._registerImmediate(() => {
         cellProperties.valid = true;
         done(cellProperties.valid, false);
-      }, 0));
+      });
     }
   };
 

--- a/src/core.js
+++ b/src/core.js
@@ -1066,7 +1066,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
       instance._registerImmediate(() => {
         validator.call(cellProperties, value, (valid) => {
           if (!instance) {
-            return false;
+            return;
           }
           // eslint-disable-next-line no-param-reassign
           valid = instance.runHooks('afterValidate', valid, value, cellProperties.visualRow, cellProperties.prop, source);

--- a/src/core.js
+++ b/src/core.js
@@ -1064,7 +1064,6 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
 
       // To provide consistent behaviour, validation should be always asynchronous
       instance._registerImmediate(() => {
-        console.log('validateCell._registerImmediate');
         validator.call(cellProperties, value, (valid) => {
           if (!instance) {
             return false;

--- a/test/e2e/Core_validate.spec.js
+++ b/test/e2e/Core_validate.spec.js
@@ -1295,7 +1295,7 @@ describe('Core_validate', () => {
     }, 200);
   });
 
-  it('should remove htInvalid class properly after cancelling change, when physical indexes are not equal to visual indexes', (done) => {
+  it('should remove htInvalid class properly after cancelling change, when physical indexes are not equal to visual indexes', async() => {
     handsontable({
       data: Handsontable.helper.createSpreadsheetData(5, 2),
       columnSorting: {
@@ -1317,11 +1317,10 @@ describe('Core_validate', () => {
 
     keyDown('enter');
 
-    setTimeout(() => {
-      const $cell = $(getCell(0, 0));
-      expect($cell.hasClass('htInvalid')).toEqual(false);
-      done();
-    }, 200);
+    await sleep(300);
+
+    const $cell = $(getCell(0, 0));
+    expect($cell.hasClass('htInvalid')).toEqual(false);
   });
 
   it('should not attempt to remove the htInvalid class if the validated cell is no longer rendered', (done) => {

--- a/test/e2e/Core_validate.spec.js
+++ b/test/e2e/Core_validate.spec.js
@@ -27,6 +27,27 @@ describe('Core_validate', () => {
     ];
   };
 
+  it('should not throw an exception if the instance was destroyed in the meantime when validator was called', (done) => {
+    const hot = handsontable({
+      data: arrayOfObjects(),
+      validator(value, callback) {
+        setTimeout(() => {
+          callback(true);
+        }, 300);
+      }
+    });
+
+    expect(async() => {
+      hot.validateCells();
+      await sleep(100);
+
+      hot.destroy();
+      await sleep(500);
+      spec().$container.remove();
+      done();
+    }).not.toThrow();
+  });
+
   it('should call beforeValidate', () => {
     let fired = null;
 

--- a/test/e2e/Core_validate.spec.js
+++ b/test/e2e/Core_validate.spec.js
@@ -27,25 +27,22 @@ describe('Core_validate', () => {
     ];
   };
 
-  it('should not throw an exception if the instance was destroyed in the meantime when validator was called', (done) => {
+  it('should not throw an exception if the instance was destroyed in the meantime when validator was called', async() => {
+    let validatorCallback;
+
     const hot = handsontable({
       data: arrayOfObjects(),
       validator(value, callback) {
-        setTimeout(() => {
-          callback(true);
-        }, 300);
+        validatorCallback = callback;
       }
     });
 
-    expect(async() => {
-      hot.validateCells();
-      await sleep(100);
+    hot.validateCells();
+    await sleep(10);
+    hot.destroy();
 
-      hot.destroy();
-      await sleep(500);
-      spec().$container.remove();
-      done();
-    }).not.toThrow();
+    expect(() => { validatorCallback(false); }).not.toThrow();
+    expect(validatorCallback(false)).toBe(void 0);
   });
 
   it('should call beforeValidate', () => {


### PR DESCRIPTION
### Context
If instance was destroyed before validators finish theirs job, then Handsontable throws an exception.

### How has this been tested?
Use template from https://jsfiddle.net/7nrxo6pq/

### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)

### Related issue(s):
1. #5567