### PR TITLE
Should be able to disable colHeaders using updateSettings.

### DIFF
--- a/src/3rdparty/walkontable/src/viewport.js
+++ b/src/3rdparty/walkontable/src/viewport.js
@@ -189,7 +189,11 @@ class Viewport {
    * @returns {Number}
    */
   getColumnHeaderHeight() {
-    if (isNaN(this.columnHeaderHeight)) {
+    const columnHeaders = this.instance.getSetting('columnHeaders');
+
+    if (!columnHeaders.length) {
+      this.columnHeaderHeight = 0;
+    } else if (isNaN(this.columnHeaderHeight)) {
       this.columnHeaderHeight = outerHeight(this.wot.wtTable.THEAD);
     }
 

--- a/src/plugins/autoColumnSize/autoColumnSize.js
+++ b/src/plugins/autoColumnSize/autoColumnSize.js
@@ -254,11 +254,11 @@ class AutoColumnSize extends BasePlugin {
         this.inProgress = false;
 
         // @TODO Should call once per render cycle, currently fired separately in different plugins
-        this.hot.view.wt.wtOverlays.adjustElementsSize(true);
-        // tmp
-        if (this.hot.view.wt.wtOverlays.leftOverlay.needFullRender) {
-          this.hot.view.wt.wtOverlays.leftOverlay.clone.draw();
-        }
+        // this.hot.view.wt.wtOverlays.adjustElementsSize(true);
+        // // tmp
+        // if (this.hot.view.wt.wtOverlays.leftOverlay.needFullRender) {
+        //   this.hot.view.wt.wtOverlays.leftOverlay.clone.draw();
+        // }
       }
     };
 

--- a/test/e2e/ColHeader.spec.js
+++ b/test/e2e/ColHeader.spec.js
@@ -107,18 +107,24 @@ describe('ColHeader', () => {
 
   it('should hide columns headers after updateSettings', () => {
     const hot = handsontable({
-      startCols: 5,
+      startCols: 100,
+      startRows: 100,
+      width: 250,
+      height: 200,
       colHeaders: true
     });
+    let headers = getHtCore().find('thead th').length;
 
-    expect(getHtCore().find('thead th').length).toEqual(5);
-    expect(getTopClone().find('thead th').length).toEqual(5);
+    expect(headers).toBeGreaterThan(0);
+    expect(getTopClone().find('thead th').length).toEqual(headers);
 
     hot.updateSettings({
       colHeaders: false
     });
 
-    expect(getHtCore().find('thead th').length).toEqual(0);
+    headers = getHtCore().find('thead th').length;
+
+    expect(headers).toEqual(0);
     expect(getTopClone().width()).toEqual(0);
   });
 

--- a/test/e2e/RowHeader.spec.js
+++ b/test/e2e/RowHeader.spec.js
@@ -68,18 +68,25 @@ describe('RowHeader', () => {
 
   it('should hide rows headers after updateSetting', () => {
     const hot = handsontable({
-      startRows: 5,
+      startCols: 100,
+      startRows: 100,
+      width: 250,
+      height: 200,
       rowHeaders: true
     });
+    let headers = getHtCore().find('tbody th').length;
 
-    expect(getHtCore().find('tbody th').length).toEqual(5);
-    expect(getLeftClone().find('tbody th').length).toEqual(5);
+    expect(headers).toBeGreaterThan(0);
+    expect(getLeftClone().find('tbody th').length).toEqual(headers);
 
     hot.updateSettings({
       rowHeaders: false
     });
 
-    expect(getHtCore().find('tbody th').length).toEqual(0);
+    headers = getHtCore().find('tbody th').length;
+
+    expect(headers).toEqual(0);
+    expect(getLeftClone().width()).toEqual(0);
   });
 
   it('should show rows headers after updateSettings', () => {


### PR DESCRIPTION
### Context
A bug occurs only in a specific configuration. Handsontable's container has to have defined size. Dataset has to be big enough to run a virtual rendering.

### How has this been tested?
1. Initialize Handsontable using the following settings:
```
{
  data: Handsontable.helper.createSpreadsheetData(40, 40),
  width: 600,
  height: 400,
  colHeaders: true
}
```
2. Disable `colHeaders` using `updateSettings`.
```
updateSettings({ colHeaders: false });
```

### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)

### Related issue(s):
1. #4136