### PR TITLE
Fixed merged cells selection

### DIFF
--- a/src/plugins/mergeCells/mergeCells.js
+++ b/src/plugins/mergeCells/mergeCells.js
@@ -701,7 +701,7 @@ class MergeCells extends BasePlugin {
     selRange.to = coords;
     let rangeExpanded = false;
 
-    if ((selRange.from.row === 0 && selRange.to.row === this.hot.countRows() - 1) || (selRange.from.col === 0 && selRange.to.col === this.hot.countCols() - 1)) {
+    if (this.hot.selection.isSelectedByColumnHeader() || this.hot.selection.isSelectedByRowHeader()) {
       return;
     }
 

--- a/src/plugins/mergeCells/test/mergeCells.e2e.js
+++ b/src/plugins/mergeCells/test/mergeCells.e2e.js
@@ -1235,7 +1235,7 @@ describe('MergeCells', () => {
         ]
       });
 
-      hot.selectCell(0, 5, 9, 5);
+      hot.selectColumns(5);
       expect(JSON.stringify(hot.getSelectedLast())).toEqual('[0,5,9,5]');
 
       // it should work only for selecting the entire column
@@ -1251,7 +1251,7 @@ describe('MergeCells', () => {
         ]
       });
 
-      hot.selectCell(5, 0, 5, 9);
+      hot.selectRows(5);
       expect(JSON.stringify(hot.getSelectedLast())).toEqual('[5,0,5,9]');
 
       // it should work only for selecting the entire row


### PR DESCRIPTION
### Context
If a merged cell is placed next to the left or right edge, then selection to the last cell in row/column works incorrectly. 

### How has this been tested?
1. Use the following configuration:
```
{
  data: Handsontable.helper.createSpreadsheetData(6, 6),
  mergeCells: [
    { row: 0, col: 0, rowspan: 3, colspan: 3 }
  ]
}
```
2. Select range: `selectCell(0, 0, 1, 5)`
3. Verify current selection: `getSelectedLast()` should be `[0, 0, 2, 5]`

### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)

### Related issue(s):
1. #4912

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
