### PR TITLE
The trimRows plugin will update trimmed row indexes after rows removal 

### DIFF
--- a/src/plugins/trimRows/test/trimRows.e2e.js
+++ b/src/plugins/trimRows/test/trimRows.e2e.js
@@ -201,8 +201,8 @@ describe('TrimRows', () => {
 
     const plugin = getPlugin('trimRows');
 
-    plugin.trimRows([1, 7, 3]);
-    alter('remove_row', 2, 3);
+    plugin.trimRows([1, 7, 3]); // physical row indexes after move
+    alter('remove_row', 2, 3); // visual row indexes
 
     expect(plugin.isTrimmed(7)).toBeFalsy();
     expect(plugin.isTrimmed(3)).toBeFalsy();

--- a/src/plugins/trimRows/test/trimRows.e2e.js
+++ b/src/plugins/trimRows/test/trimRows.e2e.js
@@ -192,6 +192,26 @@ describe('TrimRows', () => {
     expect(getDataAtCell(3, 0)).toBe(null);
   });
 
+  it('should update trimmed row indexes after rows removal', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(10, 1),
+      trimRows: true,
+      manualRowMove: [4, 0, 8, 5, 2, 6, 1, 7, 3, 9]
+    });
+
+    const plugin = getPlugin('trimRows');
+
+    plugin.trimRows([1, 7, 3]);
+    alter('remove_row', 2, 3);
+
+    expect(plugin.isTrimmed(7)).toBeFalsy();
+    expect(plugin.isTrimmed(3)).toBeFalsy();
+
+    expect(plugin.isTrimmed(1)).toBeTruthy();
+    expect(plugin.isTrimmed(5)).toBeTruthy();
+    expect(plugin.isTrimmed(2)).toBeTruthy();
+  });
+
   it('should clear cache after loading new data by `loadData` function, when plugin `trimRows` is enabled #92', function(done) {
     const hot = handsontable({
       data: Handsontable.helper.createSpreadsheetData(5, 5),

--- a/src/plugins/trimRows/trimRows.js
+++ b/src/plugins/trimRows/trimRows.js
@@ -2,7 +2,7 @@ import BasePlugin from '../_base';
 import { rangeEach } from '../../helpers/number';
 import { registerPlugin } from '../../plugins';
 import RowsMapper from './rowsMapper';
-import {arrayMap} from '../../helpers/array';
+import { arrayMap } from '../../helpers/array';
 
 /**
  * @plugin TrimRows

--- a/src/plugins/trimRows/trimRows.js
+++ b/src/plugins/trimRows/trimRows.js
@@ -2,6 +2,7 @@ import BasePlugin from '../_base';
 import { rangeEach } from '../../helpers/number';
 import { registerPlugin } from '../../plugins';
 import RowsMapper from './rowsMapper';
+import {arrayMap} from '../../helpers/array';
 
 /**
  * @plugin TrimRows
@@ -223,7 +224,7 @@ class TrimRows extends BasePlugin {
    * @returns {Boolean}
    */
   isTrimmed(row) {
-    return this.trimmedRows.indexOf(row) > -1;
+    return this.trimmedRows.includes(row);
   }
 
   /**
@@ -329,6 +330,9 @@ class TrimRows extends BasePlugin {
    */
   onAfterRemoveRow() {
     this.rowsMapper.unshiftItems(this.removedRows);
+    // TODO: Maybe it can be optimized? N x M checks, where N is number of already trimmed rows and M is number of removed rows.
+    // Decreasing physical indexes (some of them should be updated, because few indexes are missing in new list of indexes after removal).
+    this.trimmedRows = arrayMap(this.trimmedRows, trimmedRow => trimmedRow - this.removedRows.filter(removedRow => removedRow < trimmedRow).length);
   }
 
   /**


### PR DESCRIPTION
### Context
Indexes will be updated from now with `N x M` checks, where `N` is a number of already trimmed rows and `M` is a number of removed rows.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
