### PR TITLE
Fix contextMenu hidden: true option.

### DIFF
--- a/src/plugins/contextMenu/menu.js
+++ b/src/plugins/contextMenu/menu.js
@@ -13,7 +13,7 @@ import EventManager from './../../eventManager';
 import { mixin, hasOwnProperty } from './../../helpers/object';
 import { isUndefined, isDefined } from './../../helpers/mixed';
 import { debounce, isFunction } from './../../helpers/function';
-import { filterSeparators, hasSubMenu, isDisabled, isItemHidden, isSeparator, isSelectionDisabled, normalizeSelection } from './utils';
+import { filterSeparators, hasSubMenu, isDisabled, isItemNotHidden, isSeparator, isSelectionDisabled, normalizeSelection } from './utils';
 import { KEY_CODES } from './../../helpers/unicode';
 import localHooks from './../../mixins/localHooks';
 import { SEPARATOR } from './predefinedItems';
@@ -102,15 +102,17 @@ class Menu {
   open() {
     this.runLocalHooks('beforeOpen');
 
+    let filteredItems = arrayFilter(this.menuItems, item => isItemNotHidden(item, this.hot));
+
+    filteredItems = filterSeparators(filteredItems, SEPARATOR);
+
     this.container.removeAttribute('style');
-    this.container.style.display = 'block';
+    if (filteredItems.length) {
+      this.container.style.display = 'block';
+    }
 
     const delayedOpenSubMenu = debounce(row => this.openSubMenu(row), 300);
     const minWidthOfMenu = this.options.minWidth || MIN_WIDTH;
-
-    let filteredItems = arrayFilter(this.menuItems, item => isItemHidden(item, this.hot));
-
-    filteredItems = filterSeparators(filteredItems, SEPARATOR);
 
     const settings = {
       data: filteredItems,

--- a/src/plugins/contextMenu/test/contextMenu.e2e.js
+++ b/src/plugins/contextMenu/test/contextMenu.e2e.js
@@ -530,6 +530,26 @@ describe('ContextMenu', () => {
       expect(separators.length).toEqual(2);
     });
 
+    it('should hide option if hidden value equals to true', () => {
+      handsontable({
+        startCols: 5,
+        colHeaders: true,
+        contextMenu: [
+          {
+            key: '',
+            name: 'Custom option',
+            hidden: true
+          }
+        ]
+      });
+
+      contextMenu();
+      const items = $('.htContextMenu tbody td');
+      const actions = items.not('.htSeparator');
+
+      expect(actions.length).toEqual(0);
+    });
+
     it('should hide option if hidden function return true', () => {
       handsontable({
         startCols: 5,

--- a/src/plugins/contextMenu/utils.js
+++ b/src/plugins/contextMenu/utils.js
@@ -137,8 +137,8 @@ export function markLabelAsSelected(label) {
   return `<span class="selected">${String.fromCharCode(10003)}</span>${label}`;
 }
 
-export function isItemHidden(item, instance) {
-  return !item.hidden || !(typeof item.hidden === 'function' && item.hidden.call(instance));
+export function isItemNotHidden(item, instance) {
+  return !(item.hidden === true) && !(typeof item.hidden === 'function' && item.hidden.call(instance));
 }
 
 function shiftSeparators(items, separator) {


### PR DESCRIPTION
### Context
1. contextMenu items hidden option with boolean value, `hidden: true`, cannot be hidden while with function, `hidden: () => true`, works.
2. stop contextMenu to open when options all be hidden

### How has this been tested?
New test added to `contextMenu.e2e.js`

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #4262 

### Checklist:
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
