### PR TITLE
The trimRows plugin will update trimmed row indexes after rows insertion

### DIFF
--- a/src/plugins/columnSorting/columnSorting.js
+++ b/src/plugins/columnSorting/columnSorting.js
@@ -775,11 +775,11 @@ class ColumnSorting extends BasePlugin {
    * Callback for the `afterRemoveRow` hook.
    *
    * @private
-   * @param {Number} removedRows Visual indexes of the removed row.
-   * @param {Number} amount  Amount of removed rows.
+   * @param {Number} index Visual index of the removed row.
+   * @param {Number} amount Amount of removed rows.
    */
-  onAfterRemoveRow(removedRows, amount) {
-    this.rowsMapper.unshiftItems(removedRows, amount);
+  onAfterRemoveRow(index, amount) {
+    this.rowsMapper.unshiftItems(index, amount);
   }
 
   // TODO: Workaround. Inheriting of non-primitive cell meta values doesn't work. We clear the cache after action which reorganize sequence of columns.

--- a/src/plugins/trimRows/test/trimRows.e2e.js
+++ b/src/plugins/trimRows/test/trimRows.e2e.js
@@ -204,12 +204,32 @@ describe('TrimRows', () => {
     plugin.trimRows([1, 7, 3]); // physical row indexes after move
     alter('remove_row', 2, 3); // visual row indexes
 
+    expect(plugin.isTrimmed(1)).toBeTruthy();
+    expect(plugin.isTrimmed(5)).toBeTruthy(); // 7 -> 5
+    expect(plugin.isTrimmed(2)).toBeTruthy(); // 3 -> 2
+
     expect(plugin.isTrimmed(7)).toBeFalsy();
     expect(plugin.isTrimmed(3)).toBeFalsy();
+  });
+
+  it('should update trimmed row indexes after insertion', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(10, 1),
+      trimRows: true,
+      manualRowMove: [4, 0, 8, 5, 2, 6, 1, 7, 3, 9]
+    });
+
+    const plugin = getPlugin('trimRows');
+
+    plugin.trimRows([1, 7, 3]); // physical row indexes after move
+    alter('insert_row', 2, 3); // visual row indexes
 
     expect(plugin.isTrimmed(1)).toBeTruthy();
-    expect(plugin.isTrimmed(5)).toBeTruthy();
-    expect(plugin.isTrimmed(2)).toBeTruthy();
+    expect(plugin.isTrimmed(10)).toBeTruthy(); // 7 -> 10
+    expect(plugin.isTrimmed(6)).toBeTruthy(); // 3 -> 6
+
+    expect(plugin.isTrimmed(7)).toBeFalsy();
+    expect(plugin.isTrimmed(3)).toBeFalsy();
   });
 
   it('should clear cache after loading new data by `loadData` function, when plugin `trimRows` is enabled #92', function(done) {

--- a/src/plugins/trimRows/trimRows.js
+++ b/src/plugins/trimRows/trimRows.js
@@ -301,6 +301,14 @@ class TrimRows extends BasePlugin {
    */
   onAfterCreateRow(index, amount) {
     this.rowsMapper.shiftItems(index, amount);
+
+    this.trimmedRows = arrayMap(this.trimmedRows, (trimmedRow) => {
+      if (trimmedRow >= this.rowsMapper.getValueByIndex(index)) {
+        return trimmedRow + amount;
+      }
+
+      return trimmedRow;
+    });
   }
 
   /**


### PR DESCRIPTION
### Context
As the title says.
### How has this been tested?
Manual tests of the plugin, also with enabled `bindWithHeaders` plugin. Known problem: https://github.com/handsontable/handsontable/issues/5208#issuecomment-460960340.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)
### Related issue(s):
1. #5761
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
