### PR TITLE
[FIX] Issue #4882 Change the state of non-contiguous checkbox-type cells using SPACE|ENTER

### DIFF
--- a/src/renderers/checkboxRenderer.js
+++ b/src/renderers/checkboxRenderer.js
@@ -125,54 +125,56 @@ function checkboxRenderer(instance, TD, row, col, prop, value, cellProperties, .
    * @param {Boolean} [uncheckCheckbox=false]
    */
   function changeSelectedCheckboxesState(uncheckCheckbox = false) {
-    const selRange = instance.getSelectedRangeLast();
+    const selRange = instance.getSelectedRange();
 
     if (!selRange) {
       return;
     }
 
-    const { row: startRow, col: startColumn } = selRange.getTopLeftCorner();
-    const { row: endRow, col: endColumn } = selRange.getBottomRightCorner();
-    const changes = [];
+    for (let key = 0; key < selRange.length; key++) {
+      const { row: startRow, col: startColumn } = selRange[key].getTopLeftCorner();
+      const { row: endRow, col: endColumn } = selRange[key].getBottomRightCorner();
+      const changes = [];
 
-    for (let visualRow = startRow; visualRow <= endRow; visualRow += 1) {
-      for (let visualColumn = startColumn; visualColumn <= endColumn; visualColumn += 1) {
-        const cachedCellProperties = instance.getCellMeta(visualRow, visualColumn);
+      for (let visualRow = startRow; visualRow <= endRow; visualRow += 1) {
+        for (let visualColumn = startColumn; visualColumn <= endColumn; visualColumn += 1) {
+          const cachedCellProperties = instance.getCellMeta(visualRow, visualColumn);
 
-        if (cachedCellProperties.type !== 'checkbox') {
-          return;
-        }
-
-        /* eslint-disable no-continue */
-        if (cachedCellProperties.readOnly === true) {
-          continue;
-        }
-
-        if (typeof cachedCellProperties.checkedTemplate === 'undefined') {
-          cachedCellProperties.checkedTemplate = true;
-        }
-        if (typeof cachedCellProperties.uncheckedTemplate === 'undefined') {
-          cachedCellProperties.uncheckedTemplate = false;
-        }
-
-        const dataAtCell = instance.getDataAtCell(visualRow, visualColumn);
-
-        if (uncheckCheckbox === false) {
-          if ([cachedCellProperties.checkedTemplate, cachedCellProperties.checkedTemplate.toString()].includes(dataAtCell)) {
-            changes.push([visualRow, visualColumn, cachedCellProperties.uncheckedTemplate]);
-
-          } else if ([cachedCellProperties.uncheckedTemplate, cachedCellProperties.uncheckedTemplate.toString(), null, void 0].includes(dataAtCell)) {
-            changes.push([visualRow, visualColumn, cachedCellProperties.checkedTemplate]);
+          if (cachedCellProperties.type !== 'checkbox') {
+            return;
           }
 
-        } else {
-          changes.push([visualRow, visualColumn, cachedCellProperties.uncheckedTemplate]);
+          /* eslint-disable no-continue */
+          if (cachedCellProperties.readOnly === true) {
+            continue;
+          }
+
+          if (typeof cachedCellProperties.checkedTemplate === 'undefined') {
+            cachedCellProperties.checkedTemplate = true;
+          }
+          if (typeof cachedCellProperties.uncheckedTemplate === 'undefined') {
+            cachedCellProperties.uncheckedTemplate = false;
+          }
+
+          const dataAtCell = instance.getDataAtCell(visualRow, visualColumn);
+
+          if (uncheckCheckbox === false) {
+            if ([cachedCellProperties.checkedTemplate, cachedCellProperties.checkedTemplate.toString()].includes(dataAtCell)) {
+              changes.push([visualRow, visualColumn, cachedCellProperties.uncheckedTemplate]);
+
+            } else if ([cachedCellProperties.uncheckedTemplate, cachedCellProperties.uncheckedTemplate.toString(), null, void 0].includes(dataAtCell)) {
+              changes.push([visualRow, visualColumn, cachedCellProperties.checkedTemplate]);
+            }
+
+          } else {
+            changes.push([visualRow, visualColumn, cachedCellProperties.uncheckedTemplate]);
+          }
         }
       }
-    }
 
-    if (changes.length > 0) {
-      instance.setDataAtCell(changes);
+      if (changes.length > 0) {
+        instance.setDataAtCell(changes);
+      }
     }
   }
 
@@ -183,32 +185,35 @@ function checkboxRenderer(instance, TD, row, col, prop, value, cellProperties, .
    * @param {Function} callback
    */
   function eachSelectedCheckboxCell(callback) {
-    const selRange = instance.getSelectedRangeLast();
+    const selRange = instance.getSelectedRange();
 
     if (!selRange) {
       return;
     }
-    const topLeft = selRange.getTopLeftCorner();
-    const bottomRight = selRange.getBottomRightCorner();
 
-    for (let visualRow = topLeft.row; visualRow <= bottomRight.row; visualRow++) {
-      for (let visualColumn = topLeft.col; visualColumn <= bottomRight.col; visualColumn++) {
-        const cachedCellProperties = instance.getCellMeta(visualRow, visualColumn);
+    for (let key = 0; key < selRange.length; key++) {
+      const topLeft = selRange[key].getTopLeftCorner();
+      const bottomRight = selRange[key].getBottomRightCorner();
 
-        if (cachedCellProperties.type !== 'checkbox') {
-          return;
-        }
+      for (let visualRow = topLeft.row; visualRow <= bottomRight.row; visualRow++) {
+        for (let visualColumn = topLeft.col; visualColumn <= bottomRight.col; visualColumn++) {
+          const cachedCellProperties = instance.getCellMeta(visualRow, visualColumn);
 
-        const cell = instance.getCell(visualRow, visualColumn);
+          if (cachedCellProperties.type !== 'checkbox') {
+            return;
+          }
 
-        if (cell === null || cell === void 0) {
-          callback(visualRow, visualColumn, cachedCellProperties);
+          const cell = instance.getCell(visualRow, visualColumn);
 
-        } else {
-          const checkboxes = cell.querySelectorAll('input[type=checkbox]');
+          if (cell === null || cell === void 0) {
+            callback(visualRow, visualColumn, cachedCellProperties);
 
-          if (checkboxes.length > 0 && !cachedCellProperties.readOnly) {
-            callback(checkboxes);
+          } else {
+            const checkboxes = cell.querySelectorAll('input[type=checkbox]');
+
+            if (checkboxes.length > 0 && !cachedCellProperties.readOnly) {
+              callback(checkboxes);
+            }
           }
         }
       }

--- a/test/e2e/renderers/checkboxRenderer.spec.js
+++ b/test/e2e/renderers/checkboxRenderer.spec.js
@@ -294,6 +294,68 @@ describe('CheckboxRenderer', () => {
     expect(afterChangeCallback).toHaveBeenCalledWith([[0, 0, true, false], [1, 0, false, true], [2, 0, true, false]], 'edit', undefined, undefined, undefined, undefined);
   });
 
+  it('should reverse checkboxes state after hitting space, when multiple non-contiguous cells are selected', () => {
+    handsontable({
+      data: [[true], [false], [true]],
+      columns: [
+        { type: 'checkbox' }
+      ]
+    });
+
+    const afterChangeCallback = jasmine.createSpy('afterChangeCallback');
+    addHook('afterChange', afterChangeCallback);
+
+    let checkboxes = spec().$container.find(':checkbox');
+
+    expect(checkboxes.eq(0).prop('checked')).toBe(true);
+    expect(checkboxes.eq(1).prop('checked')).toBe(false);
+    expect(checkboxes.eq(2).prop('checked')).toBe(true);
+    expect(getData()).toEqual([[true], [false], [true]]);
+
+    selectCells([[0, 0], [2, 0]]);
+
+    keyDown('space');
+
+    checkboxes = spec().$container.find(':checkbox');
+
+    expect(checkboxes.eq(0).prop('checked')).toBe(false);
+    expect(checkboxes.eq(1).prop('checked')).toBe(false);
+    expect(checkboxes.eq(2).prop('checked')).toBe(false);
+    expect(getData()).toEqual([[false], [false], [false]]);
+    expect(afterChangeCallback.calls.count()).toEqual(2);
+  });
+
+  it('should reverse checkboxes state after hitting enter, when multiple non-contiguous cells are selected', () => {
+    handsontable({
+      data: [[false], [true], [true]],
+      columns: [
+        { type: 'checkbox' }
+      ]
+    });
+
+    const afterChangeCallback = jasmine.createSpy('afterChangeCallback');
+    addHook('afterChange', afterChangeCallback);
+
+    let checkboxes = spec().$container.find(':checkbox');
+
+    expect(checkboxes.eq(0).prop('checked')).toBe(false);
+    expect(checkboxes.eq(1).prop('checked')).toBe(true);
+    expect(checkboxes.eq(2).prop('checked')).toBe(true);
+    expect(getData()).toEqual([[false], [true], [true]]);
+
+    selectCells([[0, 0], [2, 0]]);
+
+    keyDown('enter');
+
+    checkboxes = spec().$container.find(':checkbox');
+
+    expect(checkboxes.eq(0).prop('checked')).toBe(true);
+    expect(checkboxes.eq(1).prop('checked')).toBe(true);
+    expect(checkboxes.eq(2).prop('checked')).toBe(false);
+    expect(getData()).toEqual([[true], [true], [false]]);
+    expect(afterChangeCallback.calls.count()).toEqual(2);
+  });
+
   it('should reverse checkboxes state after hitting space, when multiple cells are selected and selStart > selEnd', () => {
     handsontable({
       data: [[true], [false], [true]],


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Change the state of non-contiguous checkbox-type cells using SPACE|ENTER
Issue - https://github.com/handsontable/handsontable/issues/4882

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Tested it on some of the demos to ensure that it working proper without affecting others.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/4882

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
