### PR TITLE
Remove deprecated selectCellByProp method

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -3204,28 +3204,6 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
   };
 
   /**
-   * Select the cell specified by the `row` and `prop` arguments, or a range finishing at `endRow`, `endProp`.
-   * By default, viewport will be scrolled to selection.
-   *
-   * @deprecated
-   * @memberof Core#
-   * @function selectCellByProp
-   * @param {Number} row Visual row index.
-   * @param {String} prop Property name.
-   * @param {Number} [endRow] visual end row index (if selecting a range).
-   * @param {String} [endProp] End property name (if selecting a range).
-   * @param {Boolean} [scrollToCell=true] If `true`, viewport will be scrolled to the selection.
-   * @param {Boolean} [changeListener=true] If `false`, Handsontable will not change keyboard events listener to himself.
-   * @returns {Boolean} `true` if selection was successful, `false` otherwise.
-   */
-  this.selectCellByProp = function(row, prop, endRow, endProp, scrollToCell = true, changeListener = true) {
-    warn(toSingleLine`Deprecation warning: This method is going to be removed in the next release.
-      If you want to select a cell using props, please use the \`selectCell\` method.`);
-
-    return this.selectCells([[row, prop, endRow, endProp]], scrollToCell, changeListener);
-  };
-
-  /**
    * Select column specified by `startColumn` visual index, column property or a range of columns finishing at `endColumn`.
    *
    * @example

--- a/src/core.js
+++ b/src/core.js
@@ -18,7 +18,6 @@ import {
   objectEach
 } from './helpers/object';
 import { arrayFlatten, arrayMap, arrayEach, arrayReduce } from './helpers/array';
-import { toSingleLine } from './helpers/templateLiteralTag';
 import { getPlugin } from './plugins';
 import { getRenderer } from './renderers';
 import { getValidator } from './validators';


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Remove deprecated `selectCellByProp` method.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
