### PR TITLE
Prevent the trimRows plugin from overriding the first argument of the…

### DIFF
--- a/src/plugins/trimRows/test/trimRows.e2e.js
+++ b/src/plugins/trimRows/test/trimRows.e2e.js
@@ -634,6 +634,20 @@ describe('TrimRows', () => {
         expect(plugin.isTrimmed(5)).toBeTruthy();
       });
     });
+
+    it('should not override the `index` parameter of the `beforeCreateRow` hook', () => {
+      const onBeforeCreateRowCallback = jasmine.createSpy('beforeCreateRow');
+
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(3, 3),
+        trimRows: true,
+        beforeCreateRow: onBeforeCreateRowCallback
+      });
+
+      alter('insert_row', 1);
+
+      expect(onBeforeCreateRowCallback).toHaveBeenCalledWith(1, 1, ...new Array(4));
+    });
   });
 
   describe('copy-paste functionality', () => {

--- a/src/plugins/trimRows/trimRows.js
+++ b/src/plugins/trimRows/trimRows.js
@@ -289,7 +289,9 @@ class TrimRows extends BasePlugin {
    * @param {String} source Source of the change.
    */
   onBeforeCreateRow(index, amount, source) {
-    return !(this.isEnabled() && this.trimmedRows.length > 0 && source === 'auto');
+    if (this.isEnabled() && this.trimmedRows.length > 0 && source === 'auto') {
+      return false;
+    }
   }
 
   /**


### PR DESCRIPTION
… 'beforeCreateRow' hook. #5585

### Context
The hook callback from the `trimRows` plugin modified the first argument (`index`) for all the consecutive callbacks to `true`.

### How has this been tested?
Added a test case.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #5585 
