### PR TITLE
Enable subclasses to override the sortByRelevance method.

### DIFF
--- a/src/editors/autocompleteEditor.js
+++ b/src/editors/autocompleteEditor.js
@@ -169,7 +169,7 @@ AutocompleteEditor.prototype.updateChoicesList = function(choicesList) {
   let choices = choicesList;
 
   if (sortByRelevanceSetting) {
-    orderByRelevance = AutocompleteEditor.sortByRelevance(
+    orderByRelevance = this.sortByRelevance(
       this.stripValueIfNeeded(this.getValue()),
       choices,
       this.cellProperties.filteringCaseSensitive


### PR DESCRIPTION
### Context
Enable subclasses to override the `sortByRelevance` method.

### How has this been tested?
Manually.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
No related issue.

### Checklist:
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
