### PR TITLE
Enable subclasses to override the sortByRelevance method.

### DIFF
--- a/src/editors/autocompleteEditor.js
+++ b/src/editors/autocompleteEditor.js
@@ -210,7 +210,7 @@ class AutocompleteEditor extends HandsontableEditor {
     let choices = choicesList;
 
     if (sortByRelevanceSetting) {
-      orderByRelevance = this.sortByRelevance(
+      orderByRelevance = this.constructor.sortByRelevance(
         this.stripValueIfNeeded(this.getValue()),
         choices,
         this.cellProperties.filteringCaseSensitive
@@ -492,83 +492,83 @@ class AutocompleteEditor extends HandsontableEditor {
 
     super.onBeforeKeyDown(event);
   }
-}
 
-/**
- * Filters and sorts by relevance.
- *
- * @param value
- * @param choices
- * @param caseSensitive
- * @returns {Number[]} array of indexes in original choices array
- */
-AutocompleteEditor.sortByRelevance = function(value, choices, caseSensitive) {
-  const choicesRelevance = [];
-  let currentItem;
-  const valueLength = value.length;
-  let valueIndex;
-  let charsLeft;
-  const result = [];
-  let i;
-  let choicesCount = choices.length;
+  /**
+   * Filters and sorts by relevance.
+   *
+   * @param value
+   * @param choices
+   * @param caseSensitive
+   * @returns {Number[]} array of indexes in original choices array
+   */
+  static sortByRelevance(value, choices, caseSensitive) {
+    const choicesRelevance = [];
+    let currentItem;
+    const valueLength = value.length;
+    let valueIndex;
+    let charsLeft;
+    const result = [];
+    let i;
+    let choicesCount = choices.length;
 
-  if (valueLength === 0) {
+    if (valueLength === 0) {
+      for (i = 0; i < choicesCount; i++) {
+        result.push(i);
+      }
+      return result;
+    }
+
     for (i = 0; i < choicesCount; i++) {
-      result.push(i);
-    }
-    return result;
-  }
+      currentItem = stripTags(stringify(choices[i]));
 
-  for (i = 0; i < choicesCount; i++) {
-    currentItem = stripTags(stringify(choices[i]));
+      if (caseSensitive) {
+        valueIndex = currentItem.indexOf(value);
+      } else {
+        valueIndex = currentItem.toLowerCase().indexOf(value.toLowerCase());
+      }
 
-    if (caseSensitive) {
-      valueIndex = currentItem.indexOf(value);
-    } else {
-      valueIndex = currentItem.toLowerCase().indexOf(value.toLowerCase());
-    }
+      if (valueIndex !== -1) {
+        charsLeft = currentItem.length - valueIndex - valueLength;
 
-    if (valueIndex !== -1) {
-      charsLeft = currentItem.length - valueIndex - valueLength;
-
-      choicesRelevance.push({
-        baseIndex: i,
-        index: valueIndex,
-        charsLeft,
-        value: currentItem
-      });
-    }
-  }
-
-  choicesRelevance.sort((a, b) => {
-
-    if (b.index === -1) {
-      return -1;
-    }
-    if (a.index === -1) {
-      return 1;
-    }
-
-    if (a.index < b.index) {
-      return -1;
-    } else if (b.index < a.index) {
-      return 1;
-    } else if (a.index === b.index) {
-      if (a.charsLeft < b.charsLeft) {
-        return -1;
-      } else if (a.charsLeft > b.charsLeft) {
-        return 1;
+        choicesRelevance.push({
+          baseIndex: i,
+          index: valueIndex,
+          charsLeft,
+          value: currentItem
+        });
       }
     }
 
-    return 0;
-  });
+    choicesRelevance.sort((a, b) => {
 
-  for (i = 0, choicesCount = choicesRelevance.length; i < choicesCount; i++) {
-    result.push(choicesRelevance[i].baseIndex);
+      if (b.index === -1) {
+        return -1;
+      }
+      if (a.index === -1) {
+        return 1;
+      }
+
+      if (a.index < b.index) {
+        return -1;
+      } else if (b.index < a.index) {
+        return 1;
+      } else if (a.index === b.index) {
+        if (a.charsLeft < b.charsLeft) {
+          return -1;
+        } else if (a.charsLeft > b.charsLeft) {
+          return 1;
+        }
+      }
+
+      return 0;
+    });
+
+    for (i = 0, choicesCount = choicesRelevance.length; i < choicesCount; i++) {
+      result.push(choicesRelevance[i].baseIndex);
+    }
+
+    return result;
   }
-
-  return result;
-};
+}
 
 export default AutocompleteEditor;

--- a/src/editors/autocompleteEditor.js
+++ b/src/editors/autocompleteEditor.js
@@ -210,7 +210,7 @@ class AutocompleteEditor extends HandsontableEditor {
     let choices = choicesList;
 
     if (sortByRelevanceSetting) {
-      orderByRelevance = AutocompleteEditor.sortByRelevance(
+      orderByRelevance = this.sortByRelevance(
         this.stripValueIfNeeded(this.getValue()),
         choices,
         this.cellProperties.filteringCaseSensitive


### PR DESCRIPTION
I don't know if this is intentional, but it prevents the subclasses to override the `sortByRelevance` method.

### Context
Enable subclasses to override the `sortByRelevance` method.

### How has this been tested?
Manually.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Checklist:
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
