### PR TITLE
The hidden editor should not scroll window on Firefox.

### DIFF
--- a/src/editors/textEditor.js
+++ b/src/editors/textEditor.js
@@ -349,6 +349,7 @@ class TextEditor extends BaseEditor {
     this.textareaParentStyle.width = '';
     this.textareaParentStyle.height = '';
     this.textareaParentStyle.overflow = '';
+    this.textareaParentStyle.opacity = '';
 
     const { wtOverlays, wtViewport } = this.hot.view.wt;
     const currentOffset = offset(this.TD);

--- a/src/editors/textEditor.js
+++ b/src/editors/textEditor.js
@@ -165,10 +165,7 @@ class TextEditor extends BaseEditor {
       const restoreFocus = !fragmentSelection;
 
       if (restoreFocus && !isMobileBrowser()) {
-
-        this.hot._registerImmediate(() => {
-          this.focus(true);
-        });
+        this.hot._registerImmediate(() => this.focus(true));
       }
     }
   }
@@ -292,13 +289,11 @@ class TextEditor extends BaseEditor {
    */
   hideEditableElement() {
     this.textareaParentStyle.top = '0px';
-    this.textareaParentStyle.right = '0px';
+    this.textareaParentStyle.right = '100%';
+    this.textareaParentStyle.left = 'auto';
     this.textareaParentStyle.zIndex = '-1';
     this.textareaParentStyle.position = 'fixed';
-    this.textareaParentStyle.width = '1px';
-    this.textareaParentStyle.height = '1px';
     this.textareaParentStyle.overflow = 'hidden';
-    this.textareaParentStyle.opacity = '0';
   }
 
   /**
@@ -346,10 +341,8 @@ class TextEditor extends BaseEditor {
       return;
     }
 
-    this.textareaParentStyle.width = '';
-    this.textareaParentStyle.height = '';
     this.textareaParentStyle.overflow = '';
-    this.textareaParentStyle.opacity = '';
+    this.textareaParentStyle.right = 'auto';
 
     const { wtOverlays, wtViewport } = this.hot.view.wt;
     const currentOffset = offset(this.TD);

--- a/src/editors/textEditor.js
+++ b/src/editors/textEditor.js
@@ -165,7 +165,10 @@ class TextEditor extends BaseEditor {
       const restoreFocus = !fragmentSelection;
 
       if (restoreFocus && !isMobileBrowser()) {
-        this.hot._registerImmediate(() => this.focus(true));
+
+        this.hot._registerImmediate(() => {
+          this.focus(true);
+        });
       }
     }
   }
@@ -288,10 +291,14 @@ class TextEditor extends BaseEditor {
    * @private
    */
   hideEditableElement() {
-    this.textareaParentStyle.top = '-9999px';
-    this.textareaParentStyle.left = '-9999px';
+    this.textareaParentStyle.top = '0px';
+    this.textareaParentStyle.right = '0px';
     this.textareaParentStyle.zIndex = '-1';
     this.textareaParentStyle.position = 'fixed';
+    this.textareaParentStyle.width = '1px';
+    this.textareaParentStyle.height = '1px';
+    this.textareaParentStyle.overflow = 'hidden';
+    this.textareaParentStyle.opacity = '0';
   }
 
   /**
@@ -338,6 +345,10 @@ class TextEditor extends BaseEditor {
 
       return;
     }
+
+    this.textareaParentStyle.width = '';
+    this.textareaParentStyle.height = '';
+    this.textareaParentStyle.overflow = '';
 
     const { wtOverlays, wtViewport } = this.hot.view.wt;
     const currentOffset = offset(this.TD);

--- a/src/editors/textEditor.js
+++ b/src/editors/textEditor.js
@@ -288,12 +288,12 @@ class TextEditor extends BaseEditor {
    * @private
    */
   hideEditableElement() {
-    this.textareaParentStyle.top = '0px';
-    this.textareaParentStyle.right = '100%';
     this.textareaParentStyle.left = 'auto';
-    this.textareaParentStyle.zIndex = '-1';
-    this.textareaParentStyle.position = 'fixed';
     this.textareaParentStyle.overflow = 'hidden';
+    this.textareaParentStyle.position = 'fixed';
+    this.textareaParentStyle.right = '100%';
+    this.textareaParentStyle.top = '0px';
+    this.textareaParentStyle.zIndex = '-1';
   }
 
   /**
@@ -302,8 +302,10 @@ class TextEditor extends BaseEditor {
    * @private
    */
   showEditableElement() {
-    this.textareaParentStyle.zIndex = this.holderZIndex >= 0 ? this.holderZIndex : '';
+    this.textareaParentStyle.overflow = '';
     this.textareaParentStyle.position = '';
+    this.textareaParentStyle.right = 'auto';
+    this.textareaParentStyle.zIndex = this.holderZIndex >= 0 ? this.holderZIndex : '';
   }
 
   /**
@@ -340,9 +342,6 @@ class TextEditor extends BaseEditor {
 
       return;
     }
-
-    this.textareaParentStyle.overflow = '';
-    this.textareaParentStyle.right = 'auto';
 
     const { wtOverlays, wtViewport } = this.hot.view.wt;
     const currentOffset = offset(this.TD);

--- a/test/e2e/editors/textEditor.spec.js
+++ b/test/e2e/editors/textEditor.spec.js
@@ -74,12 +74,13 @@ describe('TextEditor', () => {
 
     selectCell(0, 0);
 
-    const { left, position, top, zIndex, overflow, height, width } = spec().$container.find('.handsontableInputHolder').css([
+    const { left, position, top, zIndex, overflow, opacity, height, width } = spec().$container.find('.handsontableInputHolder').css([
       'left',
       'position',
       'top',
       'zIndex',
       'overflow',
+      'opacity',
       'height',
       'width',
     ]);
@@ -89,8 +90,9 @@ describe('TextEditor', () => {
     expect(parseInt(top, 10)).toBe(0);
     expect(zIndex).toBe('-1');
     expect(overflow).toBe('hidden');
-    expect(parseInt(height, 10)).toBe(0);
-    expect(parseInt(width, 10)).toBe(0);
+    expect(parseInt(opacity, 10)).toBe(0);
+    expect(parseInt(height, 10)).toBe(1);
+    expect(parseInt(width, 10)).toBe(1);
   });
 
   it('should change editor\'s CSS properties during switching to being visible', () => {
@@ -103,12 +105,13 @@ describe('TextEditor', () => {
 
     const cell = getCell(0, 0);
     const [cellOffsetTop, cellOffsetLeft] = [cell.offsetTop, cell.offsetLeft];
-    const { left, position, top, zIndex, overflow, height, width } = spec().$container.find('.handsontableInputHolder').css([
+    const { left, position, top, zIndex, overflow, opacity, height, width } = spec().$container.find('.handsontableInputHolder').css([
       'left',
       'position',
       'top',
       'zIndex',
       'overflow',
+      'opacity',
       'height',
       'width',
     ]);
@@ -118,8 +121,9 @@ describe('TextEditor', () => {
     expect(parseInt(top, 10)).toBeAroundValue(cellOffsetTop);
     expect(zIndex).not.toBe('-1');
     expect(overflow).not.toBe('hidden');
-    expect(parseInt(height, 10)).not.toBe(0);
-    expect(parseInt(width, 10)).not.toBe(0);
+    expect(parseInt(opacity, 10)).not.toBe(0);
+    expect(parseInt(height, 10)).toBeGreaterThan(1);
+    expect(parseInt(width, 10)).toBeGreaterThan(1);
   });
 
   it('should render string in textarea', () => {

--- a/test/e2e/editors/textEditor.spec.js
+++ b/test/e2e/editors/textEditor.spec.js
@@ -74,25 +74,21 @@ describe('TextEditor', () => {
 
     selectCell(0, 0);
 
-    const { left, position, top, zIndex, overflow, opacity, height, width } = spec().$container.find('.handsontableInputHolder').css([
+    const { left, right, position, top, zIndex, overflow } = spec().$container.find('.handsontableInputHolder').css([
       'left',
+      'right',
       'position',
       'top',
       'zIndex',
       'overflow',
-      'opacity',
-      'height',
-      'width',
     ]);
 
-    expect(parseInt(left, 10)).toBe(0);
+    expect(parseInt(left, 10)).toBe(spec().$container.find('.handsontableInputHolder')[0].offsetWidth * -1);
+    expect(parseInt(right, 10)).toBe(document.body.offsetWidth);
     expect(position).toBe('fixed');
     expect(parseInt(top, 10)).toBe(0);
     expect(zIndex).toBe('-1');
     expect(overflow).toBe('hidden');
-    expect(parseInt(opacity, 10)).toBe(0);
-    expect(parseInt(height, 10)).toBe(1);
-    expect(parseInt(width, 10)).toBe(1);
   });
 
   it('should change editor\'s CSS properties during switching to being visible', () => {
@@ -105,25 +101,21 @@ describe('TextEditor', () => {
 
     const cell = getCell(0, 0);
     const [cellOffsetTop, cellOffsetLeft] = [cell.offsetTop, cell.offsetLeft];
-    const { left, position, top, zIndex, overflow, opacity, height, width } = spec().$container.find('.handsontableInputHolder').css([
+    const { left, right, position, top, zIndex, overflow } = spec().$container.find('.handsontableInputHolder').css([
       'left',
+      'right',
       'position',
       'top',
       'zIndex',
       'overflow',
-      'opacity',
-      'height',
-      'width',
     ]);
 
     expect(parseInt(left, 10)).toBeAroundValue(cellOffsetLeft);
+    expect(parseInt(right, 10)).not.toBe(document.body.offsetWidth);
     expect(position).toBe('absolute');
     expect(parseInt(top, 10)).toBeAroundValue(cellOffsetTop);
     expect(zIndex).not.toBe('-1');
     expect(overflow).not.toBe('hidden');
-    expect(parseInt(opacity, 10)).not.toBe(0);
-    expect(parseInt(height, 10)).toBeGreaterThan(1);
-    expect(parseInt(width, 10)).toBeGreaterThan(1);
   });
 
   it('should render string in textarea', () => {

--- a/test/e2e/editors/textEditor.spec.js
+++ b/test/e2e/editors/textEditor.spec.js
@@ -74,12 +74,23 @@ describe('TextEditor', () => {
 
     selectCell(0, 0);
 
-    const { left, position, top, zIndex } = spec().$container.find('.handsontableInputHolder').css(['left', 'position', 'top', 'zIndex']);
+    const { left, position, top, zIndex, overflow, height, width } = spec().$container.find('.handsontableInputHolder').css([
+      'left',
+      'position',
+      'top',
+      'zIndex',
+      'overflow',
+      'height',
+      'width',
+    ]);
 
-    expect(left).toBe('-9999px');
+    expect(parseInt(left, 10)).toBe(0);
     expect(position).toBe('fixed');
-    expect(top).toBe('-9999px');
+    expect(parseInt(top, 10)).toBe(0);
     expect(zIndex).toBe('-1');
+    expect(overflow).toBe('hidden');
+    expect(parseInt(height, 10)).toBe(0);
+    expect(parseInt(width, 10)).toBe(0);
   });
 
   it('should change editor\'s CSS properties during switching to being visible', () => {
@@ -92,12 +103,23 @@ describe('TextEditor', () => {
 
     const cell = getCell(0, 0);
     const [cellOffsetTop, cellOffsetLeft] = [cell.offsetTop, cell.offsetLeft];
-    const { left, position, top, zIndex } = spec().$container.find('.handsontableInputHolder').css(['left', 'position', 'top', 'zIndex']);
+    const { left, position, top, zIndex, overflow, height, width } = spec().$container.find('.handsontableInputHolder').css([
+      'left',
+      'position',
+      'top',
+      'zIndex',
+      'overflow',
+      'height',
+      'width',
+    ]);
 
     expect(parseInt(left, 10)).toBeAroundValue(cellOffsetLeft);
     expect(position).toBe('absolute');
     expect(parseInt(top, 10)).toBeAroundValue(cellOffsetTop);
     expect(zIndex).not.toBe('-1');
+    expect(overflow).not.toBe('hidden');
+    expect(parseInt(height, 10)).not.toBe(0);
+    expect(parseInt(width, 10)).not.toBe(0);
   });
 
   it('should render string in textarea', () => {

--- a/test/e2e/settings/fragmentSelection.spec.js
+++ b/test/e2e/settings/fragmentSelection.spec.js
@@ -18,23 +18,14 @@ describe('settings', () => {
      * @returns {*}
      */
     function getSelected() {
-      /* eslint-disable no-else-return */
-      let text = '';
+      const { activeElement } = document;
+      const selection = window.getSelection();
 
-      // IE8
-      if (window.getSelection && window.getSelection().toString() && $(window.getSelection()).attr('type') !== 'Caret') {
-        text = window.getSelection();
+      if (activeElement.value) {
+        return activeElement.value.substring(activeElement.selectionStart, activeElement.selectionEnd);
 
-        return text.toString();
-
-      } else { // standards
-        const selection = document.selection && document.selection.createRange();
-
-        if (!(typeof selection === 'undefined') && selection.text && selection.text.toString()) {
-          text = selection.text;
-
-          return text.toString();
-        }
+      } else if (selection.type !== 'Caret') {
+        return selection.toString();
       }
 
       return false;

--- a/test/e2e/settings/fragmentSelection.spec.js
+++ b/test/e2e/settings/fragmentSelection.spec.js
@@ -21,11 +21,10 @@ describe('settings', () => {
       const { activeElement } = document;
       const selection = window.getSelection();
 
-      if (activeElement.value) {
-        return activeElement.value.substring(activeElement.selectionStart, activeElement.selectionEnd);
-
-      } else if (selection.type !== 'Caret') {
+      if (selection.type === 'Range') {
         return selection.toString();
+      } else if (activeElement.value && activeElement.value.selectionStart) {
+        return activeElement.value.substring(activeElement.selectionStart, activeElement.selectionEnd);
       }
 
       return false;
@@ -81,16 +80,16 @@ describe('settings', () => {
         expect(sel).toEqual(' '); // copyPaste has selected space in textarea
       });
 
-      xit('should allow fragmentSelection when set to true', () => {
+      it('should allow fragmentSelection when set to true', () => {
         // We have to try another way to simulate text selection.
         handsontable({
           data: Handsontable.helper.createSpreadsheetData(4, 4),
           fragmentSelection: true
         });
-        selectElementText(spec().$container.find('td')[1], 3);
 
-        mouseDown(spec().$container.find('tr:eq(0) td:eq(3)'));
+        mouseDown(spec().$container.find('tr:eq(0) td:eq(1)'));
         mouseUp(spec().$container.find('tr:eq(0) td:eq(3)'));
+        selectElementText(spec().$container.find('td')[1], 3);
 
         let sel = getSelected();
         sel = sel.replace(/\s/g, ''); // tabs and spaces between <td>s are inconsistent in browsers, so let's ignore them
@@ -98,16 +97,17 @@ describe('settings', () => {
         expect(sel).toEqual('B1C1D1');
       });
 
-      xit('should allow fragmentSelection from one cell when set to `cell`', () => {
-        // We have to try another way to simulate text selection.
+      it('should allow fragmentSelection from one cell when set to `cell`', () => {
         handsontable({
           data: Handsontable.helper.createSpreadsheetData(4, 4),
           fragmentSelection: 'cell'
         });
-        selectElementText(spec().$container.find('td')[1], 1);
 
-        mouseDown(spec().$container.find('tr:eq(0) td:eq(1)'));
-        mouseUp(spec().$container.find('tr:eq(0) td:eq(1)'));
+        const $TD = spec().$container.find('tr:eq(0) td:eq(1)');
+
+        mouseDown($TD);
+        mouseUp($TD);
+        selectElementText($TD[0], 1);
 
         expect(getSelected().replace(/\s/g, '')).toEqual('B1');
       });


### PR DESCRIPTION
### Context
@vincent-cm described the whole context in #5605

### How has this been tested?
1. Run Handsontable in `iframe`.
2. Try to select a cell.

### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)

### Related issue(s):
1. #5605