### PR TITLE
Pre-code freeze fix for calculations of the overlays' dimensions

### DIFF
--- a/src/3rdparty/walkontable/src/overlay/bottom.js
+++ b/src/3rdparty/walkontable/src/overlay/bottom.js
@@ -162,7 +162,7 @@ class BottomOverlay extends Overlay {
   adjustRootElementSize() {
     const { wtTable, wtViewport, rootWindow } = this.wot;
     const masterHolder = wtTable.holder;
-    const scrollbarWidth = masterHolder.clientWidth === masterHolder.offsetWidth ? 0 : getScrollbarWidth(this.wot.rootDocument);
+     const scrollbarWidth = getScrollbarWidth(this.wot.rootDocument);
     const overlayRoot = this.clone.wtTable.holder.parentNode;
     const overlayRootStyle = overlayRoot.style;
     const preventOverflow = this.wot.getSetting('preventOverflow');

--- a/src/3rdparty/walkontable/src/overlay/bottom.js
+++ b/src/3rdparty/walkontable/src/overlay/bottom.js
@@ -165,12 +165,20 @@ class BottomOverlay extends Overlay {
     const scrollbarWidth = masterHolder.clientWidth === masterHolder.offsetWidth ? 0 : getScrollbarWidth(this.wot.rootDocument);
     const overlayRoot = this.clone.wtTable.holder.parentNode;
     const overlayRootStyle = overlayRoot.style;
+    const preventOverflow = this.wot.getSetting('preventOverflow');
 
-    if (this.trimmingContainer === rootWindow) {
-      overlayRootStyle.width = '';
+    if (this.trimmingContainer !== rootWindow || preventOverflow === 'horizontal') {
+      let width = wtViewport.getWorkspaceWidth();
+
+      if (this.wot.wtOverlays.hasScrollbarRight) {
+        width -= scrollbarWidth;
+      }
+
+      width = Math.min(width, wtTable.wtRootElement.scrollWidth);
+      overlayRootStyle.width = `${width}px`;
 
     } else {
-      overlayRootStyle.width = `${wtViewport.getWorkspaceWidth() - scrollbarWidth}px`;
+      overlayRootStyle.width = '';
     }
 
     this.clone.wtTable.holder.style.width = overlayRootStyle.width;

--- a/src/3rdparty/walkontable/src/overlay/bottom.js
+++ b/src/3rdparty/walkontable/src/overlay/bottom.js
@@ -161,8 +161,7 @@ class BottomOverlay extends Overlay {
    */
   adjustRootElementSize() {
     const { wtTable, wtViewport, rootWindow } = this.wot;
-    const masterHolder = wtTable.holder;
-     const scrollbarWidth = getScrollbarWidth(this.wot.rootDocument);
+    const scrollbarWidth = getScrollbarWidth(this.wot.rootDocument);
     const overlayRoot = this.clone.wtTable.holder.parentNode;
     const overlayRootStyle = overlayRoot.style;
     const preventOverflow = this.wot.getSetting('preventOverflow');

--- a/src/3rdparty/walkontable/src/overlay/left.js
+++ b/src/3rdparty/walkontable/src/overlay/left.js
@@ -153,38 +153,13 @@ class LeftOverlay extends Overlay {
     const preventOverflow = this.wot.getSetting('preventOverflow');
 
     if (this.trimmingContainer !== rootWindow || preventOverflow === 'vertical') {
-      const {
-        scrollHeight: rootElemScrollHeight,
-        scrollWidth: rootElemScrollWidth,
-      } = wtTable.wtRootElement;
-      const {
-        scrollHeight: holderScrollHeight,
-        scrollWidth: holderScrollWidth,
-      } = wtTable.holder;
-
-      let viewportHeight = rootElemScrollHeight;
-      let hasBottomScroll = scrollbarHeight > 0;
       let height = this.wot.wtViewport.getWorkspaceHeight();
 
-      if (hasBottomScroll) {
-        // it has scrollbar on the bottom
-        if (rootElemScrollWidth < holderScrollWidth) {
-          viewportHeight -= scrollbarHeight;
-
-        } else if (holderScrollHeight > rootElemScrollHeight) {
-          if (wtTable.hider.scrollWidth + scrollbarHeight < rootElemScrollWidth) {
-            hasBottomScroll = false;
-          }
-        } else {
-          hasBottomScroll = false;
-        }
-      }
-
-      if (hasBottomScroll) {
+      if (this.wot.wtOverlays.hasScrollbarBottom) {
         height -= scrollbarHeight;
       }
 
-      height = Math.min(height, viewportHeight);
+      height = Math.min(height, wtTable.wtRootElement.scrollHeight);
       overlayRootStyle.height = `${height}px`;
 
     } else {

--- a/src/3rdparty/walkontable/src/overlay/left.js
+++ b/src/3rdparty/walkontable/src/overlay/left.js
@@ -5,11 +5,9 @@ import {
   getWindowScrollTop,
   hasClass,
   outerWidth,
-  // innerWidth,
-  // innerHeight,
   removeClass,
   setOverlayPosition,
-  resetCssTransform
+  resetCssTransform,
 } from './../../../../helpers/dom/element';
 import Overlay from './_base';
 

--- a/src/3rdparty/walkontable/src/overlay/left.js
+++ b/src/3rdparty/walkontable/src/overlay/left.js
@@ -5,7 +5,8 @@ import {
   getWindowScrollTop,
   hasClass,
   outerWidth,
-  innerHeight,
+  // innerWidth,
+  // innerHeight,
   removeClass,
   setOverlayPosition,
   resetCssTransform
@@ -152,10 +153,38 @@ class LeftOverlay extends Overlay {
     const preventOverflow = this.wot.getSetting('preventOverflow');
 
     if (this.trimmingContainer !== rootWindow || preventOverflow === 'vertical') {
-      let height = this.wot.wtViewport.getWorkspaceHeight() - scrollbarHeight;
+      const {
+        scrollHeight: rootElemScrollHeight,
+        scrollWidth: rootElemScrollWidth,
+      } = wtTable.wtRootElement;
+      const {
+        scrollHeight: holderScrollHeight,
+        scrollWidth: holderScrollWidth,
+      } = wtTable.holder;
 
-      height = Math.min(height, innerHeight(wtTable.wtRootElement));
+      let viewportHeight = rootElemScrollHeight;
+      let hasBottomScroll = scrollbarHeight > 0;
+      let height = this.wot.wtViewport.getWorkspaceHeight();
 
+      if (hasBottomScroll) {
+        // it has scrollbar on the bottom
+        if (rootElemScrollWidth < holderScrollWidth) {
+          viewportHeight -= scrollbarHeight;
+
+        } else if (holderScrollHeight > rootElemScrollHeight) {
+          if (wtTable.hider.scrollWidth + scrollbarHeight < rootElemScrollWidth) {
+            hasBottomScroll = false;
+          }
+        } else {
+          hasBottomScroll = false;
+        }
+      }
+
+      if (hasBottomScroll) {
+        height -= scrollbarHeight;
+      }
+
+      height = Math.min(height, viewportHeight);
       overlayRootStyle.height = `${height}px`;
 
     } else {

--- a/src/3rdparty/walkontable/src/overlay/top.js
+++ b/src/3rdparty/walkontable/src/overlay/top.js
@@ -5,11 +5,9 @@ import {
   getWindowScrollLeft,
   hasClass,
   outerHeight,
-  // innerWidth,
-  // innerHeight,
   removeClass,
   setOverlayPosition,
-  resetCssTransform
+  resetCssTransform,
 } from './../../../../helpers/dom/element';
 import { arrayEach } from './../../../../helpers/array';
 import Overlay from './_base';

--- a/src/3rdparty/walkontable/src/overlay/top.js
+++ b/src/3rdparty/walkontable/src/overlay/top.js
@@ -156,38 +156,13 @@ class TopOverlay extends Overlay {
     const preventOverflow = this.wot.getSetting('preventOverflow');
 
     if (this.trimmingContainer !== rootWindow || preventOverflow === 'horizontal') {
-      const {
-        scrollHeight: rootElemScrollHeight,
-        scrollWidth: rootElemScrollWidth,
-      } = wtTable.wtRootElement;
-      const {
-        scrollHeight: holderScrollHeight,
-        scrollWidth: holderScrollWidth,
-      } = wtTable.holder;
-
-      let viewportWidth = rootElemScrollWidth;
-      let hasScroll = scrollbarWidth > 0;
       let width = this.wot.wtViewport.getWorkspaceWidth();
 
-      if (hasScroll) {
-        // it has scrollbar on the bottom
-        if (rootElemScrollHeight < holderScrollHeight) {
-          viewportWidth -= scrollbarWidth;
-
-        } else if (holderScrollWidth > rootElemScrollWidth) {
-          if (wtTable.hider.scrollHeight + scrollbarWidth < rootElemScrollHeight) {
-            hasScroll = false;
-          }
-        } else {
-          hasScroll = false;
-        }
-      }
-
-      if (hasScroll) {
+      if (this.wot.wtOverlays.hasScrollbarRight) {
         width -= scrollbarWidth;
       }
 
-      width = Math.min(width, viewportWidth);
+      width = Math.min(width, wtTable.wtRootElement.scrollWidth);
       overlayRootStyle.width = `${width}px`;
 
     } else {

--- a/src/3rdparty/walkontable/src/overlay/top.js
+++ b/src/3rdparty/walkontable/src/overlay/top.js
@@ -5,7 +5,8 @@ import {
   getWindowScrollLeft,
   hasClass,
   outerHeight,
-  innerWidth,
+  // innerWidth,
+  // innerHeight,
   removeClass,
   setOverlayPosition,
   resetCssTransform
@@ -148,16 +149,45 @@ class TopOverlay extends Overlay {
    * Adjust overlay root element size (width and height).
    */
   adjustRootElementSize() {
-    const scrollbarWidth = getScrollbarWidth(this.wot.rootDocument);
+    const { wtTable, rootDocument, rootWindow } = this.wot;
+    const scrollbarWidth = getScrollbarWidth(rootDocument);
     const overlayRoot = this.clone.wtTable.holder.parentNode;
     const overlayRootStyle = overlayRoot.style;
     const preventOverflow = this.wot.getSetting('preventOverflow');
 
-    if (this.trimmingContainer !== this.wot.rootWindow || preventOverflow === 'horizontal') {
-      let width = this.wot.wtViewport.getWorkspaceWidth() - scrollbarWidth;
+    if (this.trimmingContainer !== rootWindow || preventOverflow === 'horizontal') {
+      const {
+        scrollHeight: rootElemScrollHeight,
+        scrollWidth: rootElemScrollWidth,
+      } = wtTable.wtRootElement;
+      const {
+        scrollHeight: holderScrollHeight,
+        scrollWidth: holderScrollWidth,
+      } = wtTable.holder;
 
-      width = Math.min(width, innerWidth(this.wot.wtTable.wtRootElement));
+      let viewportWidth = rootElemScrollWidth;
+      let hasScroll = scrollbarWidth > 0;
+      let width = this.wot.wtViewport.getWorkspaceWidth();
 
+      if (hasScroll) {
+        // it has scrollbar on the bottom
+        if (rootElemScrollHeight < holderScrollHeight) {
+          viewportWidth -= scrollbarWidth;
+
+        } else if (holderScrollWidth > rootElemScrollWidth) {
+          if (wtTable.hider.scrollHeight + scrollbarWidth < rootElemScrollHeight) {
+            hasScroll = false;
+          }
+        } else {
+          hasScroll = false;
+        }
+      }
+
+      if (hasScroll) {
+        width -= scrollbarWidth;
+      }
+
+      width = Math.min(width, viewportWidth);
       overlayRootStyle.width = `${width}px`;
 
     } else {

--- a/src/3rdparty/walkontable/src/overlays.js
+++ b/src/3rdparty/walkontable/src/overlays.js
@@ -581,13 +581,6 @@ class Overlays {
       } else if (this.hasScrollbarBottom && wtTable.hider.scrollHeight + this.scrollBarSize > rootElemScrollHeight) {
         this.hasScrollbarRight = true;
       }
-      // else if (holderScrollWidth > rootElemScrollWidth) {
-      //   if (wtTable.hider.scrollHeight + scrollbarWidth < rootElemScrollHeight) {
-      //     hasScroll = false;
-      //   }
-      // } else {
-      //   hasScroll = false;
-      // }
     }
 
     this.topOverlay.adjustElementsSize(force);

--- a/src/3rdparty/walkontable/src/overlays.js
+++ b/src/3rdparty/walkontable/src/overlays.js
@@ -36,9 +36,9 @@ class Overlays {
     this.instance = this.wot;
     this.eventManager = new EventManager(this.wot);
 
-    this.scrollBarSize = getScrollbarWidth(rootDocument);
-    this.wot.update('scrollbarWidth', this.scrollBarSize);
-    this.wot.update('scrollbarHeight', this.scrollBarSize);
+    this.scrollbarSize = getScrollbarWidth(rootDocument);
+    this.wot.update('scrollbarWidth', this.scrollbarSize);
+    this.wot.update('scrollbarHeight', this.scrollbarSize);
 
     if (rootWindow.getComputedStyle(wtTable.wtRootElement.parentNode).getPropertyValue('overflow') === 'hidden') {
       this.scrollableElement = wtTable.holder;
@@ -563,7 +563,7 @@ class Overlays {
     hiderStyle.width = `${headerRowSize + this.leftOverlay.sumCellSizes(0, totalColumns)}px`;
     hiderStyle.height = `${headerColumnSize + this.topOverlay.sumCellSizes(0, totalRows) + 1}px`;
 
-    if (this.scrollBarSize > 0) {
+    if (this.scrollbarSize > 0) {
       const {
         scrollHeight: rootElemScrollHeight,
         scrollWidth: rootElemScrollWidth,
@@ -576,9 +576,9 @@ class Overlays {
       this.hasScrollbarRight = rootElemScrollHeight < holderScrollHeight;
       this.hasScrollbarBottom = rootElemScrollWidth < holderScrollWidth;
 
-      if (this.hasScrollbarRight && wtTable.hider.scrollWidth + this.scrollBarSize > rootElemScrollWidth) {
+      if (this.hasScrollbarRight && wtTable.hider.scrollWidth + this.scrollbarSize > rootElemScrollWidth) {
         this.hasScrollbarBottom = true;
-      } else if (this.hasScrollbarBottom && wtTable.hider.scrollHeight + this.scrollBarSize > rootElemScrollHeight) {
+      } else if (this.hasScrollbarBottom && wtTable.hider.scrollHeight + this.scrollbarSize > rootElemScrollHeight) {
         this.hasScrollbarRight = true;
       }
     }

--- a/src/3rdparty/walkontable/src/overlays.js
+++ b/src/3rdparty/walkontable/src/overlays.js
@@ -36,8 +36,9 @@ class Overlays {
     this.instance = this.wot;
     this.eventManager = new EventManager(this.wot);
 
-    this.wot.update('scrollbarWidth', getScrollbarWidth(rootDocument));
-    this.wot.update('scrollbarHeight', getScrollbarWidth(rootDocument));
+    this.scrollBarSize = getScrollbarWidth(rootDocument);
+    this.wot.update('scrollbarWidth', this.scrollBarSize);
+    this.wot.update('scrollbarHeight', this.scrollBarSize);
 
     if (rootWindow.getComputedStyle(wtTable.wtRootElement.parentNode).getPropertyValue('overflow') === 'hidden') {
       this.scrollableElement = wtTable.holder;
@@ -46,6 +47,9 @@ class Overlays {
     }
 
     this.prepareOverlays();
+
+    this.hasScrollbarBottom = false;
+    this.hasScrollbarRight = false;
 
     this.destroyed = false;
     this.keyPressed = false;
@@ -549,22 +553,46 @@ class Overlays {
    * @param {Boolean} [force=false]
    */
   adjustElementsSize(force = false) {
-    const { wot } = this;
-    const totalColumns = wot.getSetting('totalColumns');
-    const totalRows = wot.getSetting('totalRows');
-    const headerRowSize = wot.wtViewport.getRowHeaderWidth();
-    const headerColumnSize = wot.wtViewport.getColumnHeaderHeight();
-    const hiderStyle = wot.wtTable.hider.style;
+    const { wtViewport, wtTable } = this.wot;
+    const totalColumns = this.wot.getSetting('totalColumns');
+    const totalRows = this.wot.getSetting('totalRows');
+    const headerRowSize = wtViewport.getRowHeaderWidth();
+    const headerColumnSize = wtViewport.getColumnHeaderHeight();
+    const hiderStyle = wtTable.hider.style;
 
     hiderStyle.width = `${headerRowSize + this.leftOverlay.sumCellSizes(0, totalColumns)}px`;
     hiderStyle.height = `${headerColumnSize + this.topOverlay.sumCellSizes(0, totalRows) + 1}px`;
 
+    if (this.scrollBarSize > 0) {
+      const {
+        scrollHeight: rootElemScrollHeight,
+        scrollWidth: rootElemScrollWidth,
+      } = wtTable.wtRootElement;
+      const {
+        scrollHeight: holderScrollHeight,
+        scrollWidth: holderScrollWidth,
+      } = wtTable.holder;
+
+      this.hasScrollbarRight = rootElemScrollHeight < holderScrollHeight;
+      this.hasScrollbarBottom = rootElemScrollWidth < holderScrollWidth;
+
+      if (this.hasScrollbarRight && wtTable.hider.scrollWidth + this.scrollBarSize > rootElemScrollWidth) {
+        this.hasScrollbarBottom = true;
+      } else if (this.hasScrollbarBottom && wtTable.hider.scrollHeight + this.scrollBarSize > rootElemScrollHeight) {
+        this.hasScrollbarRight = true;
+      }
+      // else if (holderScrollWidth > rootElemScrollWidth) {
+      //   if (wtTable.hider.scrollHeight + scrollbarWidth < rootElemScrollHeight) {
+      //     hasScroll = false;
+      //   }
+      // } else {
+      //   hasScroll = false;
+      // }
+    }
+
     this.topOverlay.adjustElementsSize(force);
     this.leftOverlay.adjustElementsSize(force);
-
-    if (this.bottomOverlay.clone) {
-      this.bottomOverlay.adjustElementsSize(force);
-    }
+    this.bottomOverlay.adjustElementsSize(force);
   }
 
   /**

--- a/src/3rdparty/walkontable/src/table.js
+++ b/src/3rdparty/walkontable/src/table.js
@@ -179,7 +179,11 @@ class Table {
       } else {
         const trimmingHeight = getStyle(trimmingElement, 'height', rootWindow);
         const holderStyle = this.holder.style;
-        const { width, height } = trimmingElement.getBoundingClientRect();
+        const { scrollWidth, scrollHeight } = trimmingElement;
+        let { width, height } = trimmingElement.getBoundingClientRect();
+
+        width = Math.min(width, scrollWidth);
+        height = Math.min(height, scrollHeight);
 
         holderStyle.width = `${width}px`;
         holderStyle.height = trimmingHeight === 'auto' ? 'auto' : `${height}px`;

--- a/src/helpers/dom/element.js
+++ b/src/helpers/dom/element.js
@@ -616,11 +616,11 @@ export function getScrollLeft(element, rootWindow = window) {
  * @returns {HTMLElement} Element's scrollable parent
  */
 export function getScrollableElement(element) {
-  let rootDocument = element.document;
-  let rootWindow = element;
+  let rootDocument = element.ownerDocument;
+  let rootWindow = rootDocument ? rootDocument.defaultView : void 0;
 
   if (!rootDocument) {
-    rootDocument = element.ownerDocument ? element.ownerDocument : element;
+    rootDocument = element.document ? element.document : element;
     rootWindow = rootDocument.defaultView;
   }
 

--- a/test/e2e/ColHeader.spec.js
+++ b/test/e2e/ColHeader.spec.js
@@ -26,6 +26,26 @@ describe('ColHeader', () => {
     expect(spec().$container.find('thead th').length).toBeGreaterThan(0);
   });
 
+  it('should properly calculate colHeaders\' overlay width', () => {
+    handsontable({
+      colHeaders: true,
+      startCols: 5,
+      startRows: 1,
+      width: 250,
+      height: 100,
+      colWidths: 50,
+    });
+
+    const cloneTop = spec().$container.find('.ht_clone_top');
+    const masterHolder = spec().$container.find('.ht_master .wtHolder');
+
+    expect(cloneTop.width()).toBe(masterHolder.width());
+
+    alter('insert_row', void 0, 10);
+
+    expect(cloneTop.width()).toBeLessThan(masterHolder.width());
+  });
+
   it('should show default columns headers labelled A-(Z * n)', () => {
     const startCols = 5;
 

--- a/test/e2e/Core_view.spec.js
+++ b/test/e2e/Core_view.spec.js
@@ -75,6 +75,32 @@ describe('Core_view', () => {
     expect(spec().$container.find('.undefined').length).toBe(0);
   });
 
+  it('should properly calculate dimensions of the table if a container has border', () => {
+    spec().$container[0].style.width = '250px';
+    spec().$container[0].style.height = '200px';
+    spec().$container[0].style.overflow = 'hidden';
+    spec().$container[0].style.border = '10px solid #000';
+
+    const hot = handsontable({
+      startRows: 10,
+      startCols: 10,
+      colWidths: 50,
+      rowHeights: 50,
+      rowHeaders: true,
+      colHeaders: true,
+    });
+
+    const scrollbarSize = hot.view.wt.wtOverlays.scrollbarSize;
+    const { scrollWidth: masterScrollWidth, scrollHeight: masterScrollHeight } = spec().$container.find('.ht_master')[0];
+    const topScrollWidth = spec().$container.find('.ht_clone_top')[0].scrollWidth;
+    const leftScrollHeight = spec().$container.find('.ht_clone_left')[0].scrollHeight;
+
+    expect(masterScrollWidth).toBe(250);
+    expect(masterScrollHeight).toBe(200);
+    expect(masterScrollWidth - scrollbarSize).toBe(topScrollWidth);
+    expect(masterScrollHeight - scrollbarSize).toBe(leftScrollHeight);
+  });
+
   it('should scroll viewport when partially visible cell is clicked', () => {
     spec().$container[0].style.width = '400px';
     spec().$container[0].style.height = '60px';

--- a/test/e2e/RowHeader.spec.js
+++ b/test/e2e/RowHeader.spec.js
@@ -26,6 +26,26 @@ describe('RowHeader', () => {
     expect(spec().$container.find('tbody th').length).toBeGreaterThan(0);
   });
 
+  it('should properly calculate colHeaders\' overlay width', () => {
+    handsontable({
+      rowHeaders: true,
+      startCols: 1,
+      startRows: 5,
+      width: 150,
+      height: 126,
+      rowHeights: 25,
+    });
+
+    const cloneTop = spec().$container.find('.ht_clone_left');
+    const masterHolder = spec().$container.find('.ht_master .wtHolder');
+
+    expect(cloneTop.height()).toBe(masterHolder.height());
+
+    alter('insert_col', void 0, 10);
+
+    expect(cloneTop.height()).toBeLessThan(masterHolder.height());
+  });
+
   it('should show row headers numbered 1-10 by default', () => {
     const startRows = 5;
     handsontable({


### PR DESCRIPTION
### Context
In one of ready to release changes introduces a bug with dimensions calculations of the pinned overlays.

### How has this been tested?
Initialise Handsontable inside a container with a defined width and height. Add as many columns and rows as possible to not generate scrollbars on its container. Overlays should have proper dimensions. You can try to remove/insert rows and columns in many different configurations - overlays shouldn't cover scrollbars up and always should match its viewport.

### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)

## Update
- [x] #5812 - describes another problem, related to proper calculations of the table's dimensions.
Thank you @jansiegel :+1:!