### PR TITLE
Pre-code freeze fix for IE11

### DIFF
--- a/src/tableView.js
+++ b/src/tableView.js
@@ -315,7 +315,7 @@ class TableView {
       const eventY = event.y || event.clientY;
       let next = event.target;
 
-      if (priv.mouseDown || !rootElement) {
+      if (priv.mouseDown || !rootElement || !this.instance.view) {
         return; // it must have been started in a cell
       }
 


### PR DESCRIPTION
### Context
After rewrite `tableView` from ES5 to ES6 in IE was bug - `Unable to get property 'wt' of undefined or null reference`, to reproduce take this steps  - click in the `cell`, next open `contextMenu` and click besides table or inside table.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
