### PR TITLE
priv.activeWt in TableView has to be public

### DIFF
--- a/src/tableView.js
+++ b/src/tableView.js
@@ -65,6 +65,13 @@ class TableView {
      * @type {Walkontable}
      */
     this.wt = void 0;
+    /**
+     * Main Walkontable instance.
+     *
+     * @private
+     * @type {Walkontable}
+     */
+    this.activeWt = void 0;
 
     privatePool.set(this, {
       /**
@@ -86,13 +93,6 @@ class TableView {
        * @type {HTMLTableElement}
        */
       table: void 0,
-      /**
-       * Main Walkontable instance.
-       *
-       * @private
-       * @type {Walkontable}
-       */
-      activeWt: void 0,
       /**
        * Cached width of the rootElement.
        *
@@ -446,7 +446,7 @@ class TableView {
 
         this.instance.listen();
 
-        priv.activeWt = wt;
+        this.activeWt = wt;
         priv.mouseDown = true;
 
         this.instance.runHooks('beforeOnCellMouseDown', event, coords, TD, blockCalculations);
@@ -462,10 +462,10 @@ class TableView {
         });
 
         this.instance.runHooks('afterOnCellMouseDown', event, coords, TD);
-        priv.activeWt = this.wt;
+        this.activeWt = this.wt;
       },
       onCellContextMenu: (event, coords, TD, wt) => {
-        priv.activeWt = wt;
+        this.activeWt = wt;
         priv.mouseDown = false;
 
         if (this.instance.selection.isInProgress()) {
@@ -480,10 +480,10 @@ class TableView {
 
         this.instance.runHooks('afterOnCellContextMenu', event, coords, TD);
 
-        priv.activeWt = this.wt;
+        this.activeWt = this.wt;
       },
       onCellMouseOut: (event, coords, TD, wt) => {
-        priv.activeWt = wt;
+        this.activeWt = wt;
         this.instance.runHooks('beforeOnCellMouseOut', event, coords, TD);
 
         if (isImmediatePropagationStopped(event)) {
@@ -491,7 +491,7 @@ class TableView {
         }
 
         this.instance.runHooks('afterOnCellMouseOut', event, coords, TD);
-        priv.activeWt = this.wt;
+        this.activeWt = this.wt;
       },
       onCellMouseOver: (event, coords, TD, wt) => {
         const blockCalculations = {
@@ -500,7 +500,7 @@ class TableView {
           cell: false
         };
 
-        priv.activeWt = wt;
+        this.activeWt = wt;
 
         this.instance.runHooks('beforeOnCellMouseOver', event, coords, TD, blockCalculations);
 
@@ -517,14 +517,14 @@ class TableView {
         }
 
         this.instance.runHooks('afterOnCellMouseOver', event, coords, TD);
-        priv.activeWt = this.wt;
+        this.activeWt = this.wt;
       },
       onCellMouseUp: (event, coords, TD, wt) => {
-        priv.activeWt = wt;
+        this.activeWt = wt;
         this.instance.runHooks('beforeOnCellMouseUp', event, coords, TD);
 
         this.instance.runHooks('afterOnCellMouseUp', event, coords, TD);
-        priv.activeWt = this.wt;
+        this.activeWt = this.wt;
       },
       onCellCornerMouseDown: (event) => {
         event.preventDefault();
@@ -597,7 +597,7 @@ class TableView {
     this.instance.runHooks('beforeInitWalkontable', walkontableConfig);
 
     this.wt = new Walkontable(walkontableConfig);
-    priv.activeWt = this.wt;
+    this.activeWt = this.wt;
 
     const spreader = this.wt.wtTable.spreader;
     // We have to cache width and height after Walkontable initialization.
@@ -840,9 +840,7 @@ class TableView {
    * @returns {Boolean}
    */
   mainViewIsActive() {
-    const priv = privatePool.get(this);
-
-    return this.wt === priv.activeWt;
+    return this.wt === this.activeWt;
   }
 
   /**

--- a/test/e2e/Core_init.spec.js
+++ b/test/e2e/Core_init.spec.js
@@ -73,11 +73,16 @@ describe('Core_init', () => {
   });
 
   it('should create table even if is launched inside custom element', () => {
+    const onErrorSpy = spyOn(window, 'onerror');
     spec().$container = $(`<hot-table><div id="${id}"></div></hot-table>`).appendTo('body');
+
     handsontable();
 
-    expect(() => {
-      mouseOver(spec().$container.find('tr:eq(0) td:eq(1)'));
-    }).not.toThrow();
+    const cell = spec().$container.find('tr:eq(0) td:eq(1)');
+
+    mouseOver(cell);
+    mouseDown(cell);
+
+    expect(onErrorSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
`priv.activeWt` in TableView hast to be public. Otherwise, it throws an error on Firefox.

### Context
If element is embedded in a custom element (`<hot-table></hot-table>`), then `EventManager` throws an error.

### How has this been tested?
1. Initialise Handsontable in a custom element:
```
<hot-table>
  <div id="hot"></div>
</hot-table>
```
2. Open console in dev tools.
3. Try to interact with the Handsontable's instance.

### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)