### PR TITLE
Replaced concat() with push() to improve performance

### DIFF
--- a/src/plugins/nestedRows/ui/collapsing.js
+++ b/src/plugins/nestedRows/ui/collapsing.js
@@ -105,10 +105,10 @@ class CollapsingUI extends BaseUI {
    * @param {Boolean} [doTrimming = true] `true` if the table should trim the provided rows.
    */
   collapseMultipleChildren(rows, forceRender = true, doTrimming = true) {
-    let rowsToTrim = [];
+    const rowsToTrim = [];
 
     arrayEach(rows, (elem) => {
-      rowsToTrim = rowsToTrim.concat(this.collapseChildren(elem, false, false));
+      rowsToTrim.push(...this.collapseChildren(elem, false, false));
     });
 
     if (doTrimming) {
@@ -292,10 +292,10 @@ class CollapsingUI extends BaseUI {
    * @param {Boolean} [doTrimming = true] `true` if the rows should be untrimmed after finishing the function.
    */
   expandMultipleChildren(rows, forceRender = true, doTrimming = true) {
-    let rowsToUntrim = [];
+    const rowsToUntrim = [];
 
     arrayEach(rows, (elem) => {
-      rowsToUntrim = rowsToUntrim.concat(this.expandChildren(elem, false, false));
+      rowsToUntrim.push(...this.expandChildren(elem, false, false));
     });
 
     if (doTrimming) {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Performance improvements for nested rows `collapseAll()` and `expandAll()` per https://github.com/handsontable/handsontable/issues/5711

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
`npm run test:e2e` and measuring performance with a 1k row table

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/5711
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
