### PR TITLE
Prevent null exception with columns using "object.inner.value" keys

### DIFF
--- a/src/dataMap.js
+++ b/src/dataMap.js
@@ -594,7 +594,7 @@ class DataMap {
       for (let i = 0, ilen = sliced.length; i < ilen; i++) {
         out = out[sliced[i]];
 
-        if (typeof out === 'undefined') {
+        if (out === undefined || out === null) {
           return null;
         }
       }

--- a/src/helpers/object.js
+++ b/src/helpers/object.js
@@ -252,7 +252,7 @@ export function getProperty(object, name) {
   objectEach(names, (nameItem) => {
     result = result[nameItem];
 
-    if (result === void 0) {
+    if (result === void 0 || result === null) {
       result = void 0;
 
       return false;


### PR DESCRIPTION
### Context
When reading a column description of the form "object.inner.value", with data of form e.g. 
[ { inner:{ value:2 } }, { inner: null } ]
getProperty and DataMap.get would return an exception 'Cannot read property 'value' of null' on the second row.

Expanded the existing "=== undefined" (void 0) check to also include "=== null", as this is similarly defensive and should not be trigger an exception.

### How has this been tested?
Tested with null and undefined values, and undefined members in column keys for multiple datasets.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Checklist:
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
