### PR TITLE
Fixed onCloneWheel in overlays

### DIFF
--- a/src/3rdparty/walkontable/src/overlays.js
+++ b/src/3rdparty/walkontable/src/overlays.js
@@ -213,29 +213,30 @@ class Overlays {
     }
 
     const isHighPixelRatio = rootWindow.devicePixelRatio && rootWindow.devicePixelRatio > 1;
+    const isScrollOnWindow = this.scrollableElement === rootWindow;
 
     if (isHighPixelRatio || !isChrome()) {
-      listenersToRegister.push([this.wot.wtTable.wtRootElement.parentNode, 'wheel', event => this.onCloneWheel(event), { passive: true }]);
+      listenersToRegister.push([this.wot.wtTable.wtRootElement.parentNode, 'wheel', event => this.onCloneWheel(event), { passive: isScrollOnWindow }]);
 
     } else {
       if (this.topOverlay.needFullRender) {
-        listenersToRegister.push([this.topOverlay.clone.wtTable.holder, 'wheel', event => this.onCloneWheel(event), { passive: true }]);
+        listenersToRegister.push([this.topOverlay.clone.wtTable.holder, 'wheel', event => this.onCloneWheel(event), { passive: isScrollOnWindow }]);
       }
 
       if (this.bottomOverlay.needFullRender) {
-        listenersToRegister.push([this.bottomOverlay.clone.wtTable.holder, 'wheel', event => this.onCloneWheel(event), { passive: true }]);
+        listenersToRegister.push([this.bottomOverlay.clone.wtTable.holder, 'wheel', event => this.onCloneWheel(event), { passive: isScrollOnWindow }]);
       }
 
       if (this.leftOverlay.needFullRender) {
-        listenersToRegister.push([this.leftOverlay.clone.wtTable.holder, 'wheel', event => this.onCloneWheel(event), { passive: true }]);
+        listenersToRegister.push([this.leftOverlay.clone.wtTable.holder, 'wheel', event => this.onCloneWheel(event), { passive: isScrollOnWindow }]);
       }
 
       if (this.topLeftCornerOverlay && this.topLeftCornerOverlay.needFullRender) {
-        listenersToRegister.push([this.topLeftCornerOverlay.clone.wtTable.holder, 'wheel', event => this.onCloneWheel(event), { passive: true }]);
+        listenersToRegister.push([this.topLeftCornerOverlay.clone.wtTable.holder, 'wheel', event => this.onCloneWheel(event), { passive: isScrollOnWindow }]);
       }
 
       if (this.bottomLeftCornerOverlay && this.bottomLeftCornerOverlay.needFullRender) {
-        listenersToRegister.push([this.bottomLeftCornerOverlay.clone.wtTable.holder, 'wheel', event => this.onCloneWheel(event), { passive: true }]);
+        listenersToRegister.push([this.bottomLeftCornerOverlay.clone.wtTable.holder, 'wheel', event => this.onCloneWheel(event), { passive: isScrollOnWindow }]);
       }
     }
 
@@ -300,6 +301,10 @@ class Overlays {
   onCloneWheel(event) {
     const { rootWindow } = this.wot;
 
+    if (this.scrollableElement !== rootWindow) {
+      event.preventDefault();
+    }
+
     // There was if statement which controlled flow of this function. It avoided the execution of the next lines
     // on mobile devices. It was changed. Broader description of this case is included within issue #4856.
 
@@ -309,8 +314,8 @@ class Overlays {
 
     // For key press, sync only master -> overlay position because while pressing Walkontable.render is triggered
     // by hot.refreshBorder
-    const shouldNotWheelVertically = masterVertical !== rootWindow && target !== rootWindow && !event.target.contains(masterVertical);
-    const shouldNotWheelHorizontally = masterHorizontal !== rootWindow && target !== rootWindow && !event.target.contains(masterHorizontal);
+    const shouldNotWheelVertically = masterVertical !== rootWindow && target !== rootWindow && !target.contains(masterVertical);
+    const shouldNotWheelHorizontally = masterHorizontal !== rootWindow && target !== rootWindow && !target.contains(masterHorizontal);
 
     if (this.keyPressed && (shouldNotWheelVertically || shouldNotWheelHorizontally)) {
       return;

--- a/test/e2e/Core_view.spec.js
+++ b/test/e2e/Core_view.spec.js
@@ -498,6 +498,80 @@ describe('Core_view', () => {
     expect(hot.view.wt.wtTable.holder.style.width).toBe('220px');
   });
 
+  describe('scroll', () => {
+    it('should call preventDefault in a wheel event on fixed overlay\'s element', async() => {
+      spec().$container.css({
+        width: '200px',
+        height: '200px',
+        overflow: 'hidden',
+      });
+
+      window.scrollTo(0, 0);
+
+      const hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(50, 50),
+        colHeaders: true,
+        rowHeaders: true,
+      });
+
+      const eventManager = new Handsontable.EventManager(hot);
+      const spy = jasmine.createSpy();
+      eventManager.addEventListener(window, 'wheel', spy);
+
+      const wheelEvt = new WheelEvent('wheel', {
+        bubbles: true,
+        cancelable: true,
+        view: window,
+        deltaMode: 0,
+        deltaX: 800,
+        deltaY: 400,
+      });
+
+      spec().$container.find('.ht_clone_top_left_corner .wtHolder')[0].dispatchEvent(wheelEvt);
+
+      await sleep(100);
+
+      expect(spy.calls.argsFor(0)[0].defaultPrevented).toBe(true);
+      eventManager.destroy();
+    });
+
+    it('should not scroll window when a wheel event occurs on fixed overlay', async() => {
+      spec().$container.css({
+        width: '200px',
+        height: '200px',
+        overflow: 'hidden',
+        margin: '2000px',
+      });
+
+      window.scrollTo(0, 0);
+
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(50, 50),
+        colHeaders: true,
+        rowHeaders: true,
+      });
+
+      const wheelEvt = new WheelEvent('wheel', {
+        bubbles: true,
+        cancelable: true,
+        view: window,
+        deltaMode: 0,
+        deltaX: 800,
+        deltaY: 400,
+      });
+
+      spec().$container.find('.ht_clone_top_left_corner .wtHolder')[0].dispatchEvent(wheelEvt);
+
+      await sleep(100);
+      const masterHolder = spec().$container.find('.ht_master .wtHolder')[0];
+
+      expect(masterHolder.scrollLeft).toBe(800);
+      expect(masterHolder.scrollTop).toBe(400);
+      expect(window.scrollX).toBe(0);
+      expect(window.scrollY).toBe(0);
+    });
+  });
+
   describe('resize', () => {
     beforeEach(() => {
       spec().$iframe = $('<iframe style="width:"/>').appendTo(spec().$container);


### PR DESCRIPTION
### Context
#5919 introduced support for passive listeners. Unfortunately, `preventDefault()` in `onCloneWheel` is necessary if the main scrollable element is different than window.

### How has this been tested?
Use the following demo: https://jsfiddle.net/k4jx803n/
Try to scroll the table by the mouse wheel on row/column headers or the corner.

### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
