### PR TITLE
Inherit font size in the dropdown menu.

### DIFF
--- a/src/css/handsontable.css
+++ b/src/css/handsontable.css
@@ -517,6 +517,7 @@ CheckboxRenderer
   opacity: 0.5;
 }
 .handsontable .htCheckboxRendererLabel {
+  font-size: inherit;
   cursor: pointer;
   display: inline-block;
   width: 100%;

--- a/src/css/handsontable.css
+++ b/src/css/handsontable.css
@@ -511,13 +511,13 @@ CheckboxRenderer
 */
 .handsontable .htCheckboxRendererInput {
   display: inline-block;
-  vertical-align: middle;
 }
 .handsontable .htCheckboxRendererInput.noValue {
   opacity: 0.5;
 }
 .handsontable .htCheckboxRendererLabel {
   font-size: inherit;
+  vertical-align: middle;
   cursor: pointer;
   display: inline-block;
   width: 100%;

--- a/src/plugins/filters/filters.css
+++ b/src/plugins/filters/filters.css
@@ -94,7 +94,7 @@
 
 /* Menu label */
 .handsontable .htFiltersMenuLabel {
-  font-size: 0.7em;
+  font-size: 0.75em;
 }
 
 /* Component action bar */
@@ -122,7 +122,7 @@
 .handsontable .htFiltersMenuCondition .htUIInput input,
 .handsontable .htFiltersMenuValue .htUIMultipleSelectSearch input {
   font-family: inherit;
-  font-size: 0.7em;
+  font-size: 0.75em;
   padding: 4px;
   box-sizing: border-box;
   width: 100%;
@@ -148,7 +148,7 @@
 
 .handsontable .htUIClearAll a, .handsontable .htUISelectAll a {
   color: #3283D8;
-  font-size: 0.7em;
+  font-size: 0.75em;
 }
 
 .handsontable .htUISelectionControls {

--- a/src/plugins/filters/filters.css
+++ b/src/plugins/filters/filters.css
@@ -94,7 +94,7 @@
 
 /* Menu label */
 .handsontable .htFiltersMenuLabel {
-  font-size: 12px;
+  font-size: 0.7em;
 }
 
 /* Component action bar */
@@ -121,6 +121,8 @@
 }
 .handsontable .htFiltersMenuCondition .htUIInput input,
 .handsontable .htFiltersMenuValue .htUIMultipleSelectSearch input {
+  font-family: inherit;
+  font-size: 0.7em;
   padding: 4px;
   box-sizing: border-box;
   width: 100%;
@@ -146,7 +148,7 @@
 
 .handsontable .htUIClearAll a, .handsontable .htUISelectAll a {
   color: #3283D8;
-  font-size: 12px;
+  font-size: 0.7em;
 }
 
 .handsontable .htUISelectionControls {
@@ -154,7 +156,7 @@
 }
 
 .handsontable .htCheckboxRendererInput {
-  margin: -3px 5px 0 0;
+  margin: 0 5px 0 0;
   vertical-align: middle;
   height: 1em;
 }
@@ -186,8 +188,8 @@
   background-color: #eee;
   color: #000;
   cursor: pointer;
-  font-family: arial, sans-serif;
-  font-size: 11px;
+  font-family: inherit;
+  font-size: 0.7em;
   font-weight: bold;
   height: 19px;
   min-width: 64px;
@@ -219,8 +221,8 @@
   background-color: #e8e8e8;
   border-radius: 2px;
   border: 1px solid #d2d1d1;
-  font-family: arial, sans-serif;
-  font-size: 11px;
+  font-family: inherit;
+  font-size: 0.7em;
   font-weight: bold;
   padding: 3px 20px 3px 10px;
   text-overflow: ellipsis;
@@ -272,6 +274,10 @@
 
 .handsontable .htUIRadio > input[type=radio] {
   margin-right: 0.5ex;
+}
+
+.handsontable .htUIRadio label {
+  vertical-align: middle;
 }
 
 .handsontable .htFiltersMenuOperators {

--- a/src/plugins/filters/filters.css
+++ b/src/plugins/filters/filters.css
@@ -154,7 +154,7 @@
 }
 
 .handsontable .htCheckboxRendererInput {
-  margin: 0 5px 0 0;
+  margin: -3px 5px 0 0;
   vertical-align: middle;
   height: 1em;
 }

--- a/src/plugins/filters/test/filtersUI.e2e.js
+++ b/src/plugins/filters/test/filtersUI.e2e.js
@@ -3277,6 +3277,45 @@ describe('Filters UI', () => {
     });
   });
 
+  it('should inherit font family and size from body', () => {
+    handsontable({
+      data: getDataForFilters(),
+      colHeaders: true,
+      filters: true,
+      dropdownMenu: true
+    });
+
+    const body = document.body;
+    const bodyStyle = body.style;
+    const fontFamily = bodyStyle.fontFamily;
+    const fontSize = bodyStyle.fontSize;
+
+    bodyStyle.fontFamily = 'Helvetica';
+    bodyStyle.fontSize = '24px';
+
+    dropdownMenu(0);
+    const htItemWrapper = document.querySelector('.htItemWrapper');
+    const compStyleHtItemWrapper = Handsontable.dom.getComputedStyle(htItemWrapper);
+
+    const htFiltersMenuLabel = document.querySelector('.htFiltersMenuLabel');
+    const compStyleHtFiltersMenuLabel = Handsontable.dom.getComputedStyle(htFiltersMenuLabel);
+
+    const htUISelectCaption = document.querySelector('.htUISelectCaption');
+    const compStyleHtUISelectCaption = Handsontable.dom.getComputedStyle(htUISelectCaption);
+
+    expect(compStyleHtItemWrapper.fontFamily).toBe('Helvetica');
+    expect(compStyleHtItemWrapper.fontSize).toBe('24px');
+
+    expect(compStyleHtFiltersMenuLabel.fontFamily).toBe('Helvetica');
+    expect(compStyleHtFiltersMenuLabel.fontSize).toBe('18px');
+
+    expect(compStyleHtUISelectCaption.fontFamily).toBe('Helvetica');
+    expect(compStyleHtUISelectCaption.fontSize).toBe('16.8px');
+
+    bodyStyle.fontFamily = fontFamily;
+    bodyStyle.fontSize = fontSize;
+  });
+
   describe('Dimensions of filter\'s elements inside drop-down menu', () => {
     it('should scale text input showed after condition selection (pixel perfect)', () => {
       handsontable({


### PR DESCRIPTION
### Context
To keep the consistency between the fonts in the dropdown menu.
I'm not sure change `htCheckboxRendererInput` `margin` to `-3px`, is a good idea.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #5948

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
