### PR TITLE
Fix typo on `skipRowOnPaste ` and fix bug on autofill

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -746,7 +746,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
             current.col = start.col;
             cellMeta = instance.getCellMeta(current.row, current.col);
 
-            if ((source === 'CopyPaste.paste' || source === 'Autofill.autofill') && cellMeta.skipRowOnPaste) {
+            if ((source === 'CopyPaste.paste' || source === 'Autofill.fill') && cellMeta.skipRowOnPaste) {
               skippedRow += 1;
               current.row += 1;
               rlen += 1;

--- a/src/defaultSettings.js
+++ b/src/defaultSettings.js
@@ -1338,7 +1338,7 @@ DefaultSettings.prototype = {
    *
    *  // don't paste data to the second row
    *  if (row === 1) {
-   *  cellProperties.skipRowOnPaste = true;
+   *    cellProperties.skipRowOnPaste = true;
    *  }
    *
    *  return cellProperties;

--- a/src/defaultSettings.js
+++ b/src/defaultSettings.js
@@ -1326,6 +1326,29 @@ DefaultSettings.prototype = {
 
   /**
    * @description
+   * When added to a cell property, it skips the row on paste and pastes the data on the following row.
+   *
+   * @type {Boolean}
+   * @default false
+   *
+   * @example
+   * ```js
+   * cells: function(row, column) {
+   *  const cellProperties = {};
+   *
+   *  // don't paste data to the second row
+   *  if (row === 1) {
+   *  cellProperties.skipRowOnPaste = true;
+   *  }
+   *
+   *  return cellProperties;
+   * }
+   * ```
+   */
+  skipRowOnPaste: false,
+
+  /**
+   * @description
    * Setting to `true` enables the {@link Search} plugin (see [demo](https://docs.handsontable.com/demo-search-for-values.html)).
    *
    * @type {Boolean}

--- a/src/plugins/autofill/test/autofill.e2e.js
+++ b/src/plugins/autofill/test/autofill.e2e.js
@@ -823,6 +823,37 @@ describe('AutoFill', () => {
     expect(JSON.stringify(getData(1, 1, 2, 4))).toEqual(JSON.stringify([[2, 0, 1, 2], [5, 3, 4, 5]]));
   });
 
+  it('should omitting data from hidden cells', () => {
+    handsontable({
+      data: [
+        [1, 2, 3, 4, 5, 6],
+        [1, 2, 3, 4, 5, 6],
+        [1, 2, null, null, null, null],
+        [1, 2, null, null, null, null]
+      ],
+      hiddenColumns: {
+        copyPasteEnabled: false,
+        indicators: true,
+        columns: [1]
+      },
+      hiddenRows: {
+        copyPasteEnabled: false,
+        rows: [1],
+        indicators: true
+      },
+    });
+
+    selectCell(0, 0, 0, 2);
+
+    spec().$container.find('.wtBorder.area.corner').simulate('mousedown');
+    $(getCell(2, 2, true)).simulate('mouseover').simulate('mouseup');
+
+    expect(getDataAtCell(0, 0)).toEqual(1);
+    expect(getDataAtCell(0, 2)).toEqual(3);
+    expect(getDataAtCell(2, 0)).toEqual(1);
+    expect(getDataAtCell(2, 2)).toEqual(3);
+  });
+
   describe('should works properly when two or more instances of Handsontable was initialized with other settings (#3257)', () => {
     let getData;
     let $container1;

--- a/src/plugins/autofill/utils.js
+++ b/src/plugins/autofill/utils.js
@@ -26,7 +26,7 @@ export function getDeltas(start, end, data, direction) {
   if (['down', 'up'].indexOf(direction) !== -1) {
     const arr = [];
 
-    for (let col = 0; col <= diffCol; col++) {
+    for (let col = 0; col < diffCol; col++) {
       const startValue = parseInt(data[0][col], 10);
       const endValue = parseInt(data[rowsLength - 1][col], 10);
       const delta = (direction === 'down' ? (endValue - startValue) : (startValue - endValue)) / (rowsLength - 1) || 0;
@@ -38,7 +38,7 @@ export function getDeltas(start, end, data, direction) {
   }
 
   if (['right', 'left'].indexOf(direction) !== -1) {
-    for (let row = 0; row <= diffRow; row++) {
+    for (let row = 0; row < diffRow; row++) {
       const startValue = parseInt(data[row][0], 10);
       const endValue = parseInt(data[row][columnsLength - 1], 10);
       const delta = (direction === 'right' ? (endValue - startValue) : (startValue - endValue)) / (columnsLength - 1) || 0;


### PR DESCRIPTION
### Context
Autofill don't ignore data from `hiddenRows` or `hiddenColumns`, so with this options we get different data compared to what we see.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #5845

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
