### PR TITLE
overflowY in textEditor changed to hidden

### DIFF
--- a/src/editors/textEditor.js
+++ b/src/editors/textEditor.js
@@ -315,7 +315,7 @@ class TextEditor extends BaseEditor {
     this.textareaParentStyle.opacity = '1';
 
     this.textareaStyle.textIndent = '';
-    this.textareaStyle.overflowY = 'auto';
+    this.textareaStyle.overflowY = 'hidden';
   }
 
   /**

--- a/test/e2e/editors/textEditor.spec.js
+++ b/test/e2e/editors/textEditor.spec.js
@@ -1208,6 +1208,32 @@ describe('TextEditor', () => {
     expect(hot.getActiveEditor().TEXTAREA.value).toEqual('Ma\nserati');
   });
 
+  it('should exceed the editor height only for one line when pressing ALT + ENTER', () => {
+    const data = [
+      ['Maserati', 'Mazda'],
+      ['Honda', 'Mini']
+    ];
+
+    const hot = handsontable({
+      data
+    });
+
+    selectCell(0, 0);
+    keyDownUp(Handsontable.helper.KEY_CODES.ENTER);
+
+    const $editorInput = $('.handsontableInput');
+
+    $editorInput.simulate('keydown', {
+      altKey: true,
+      keyCode: Handsontable.helper.KEY_CODES.ENTER
+    });
+
+    const height = hot.getActiveEditor().TEXTAREA.offsetHeight;
+    hot.getActiveEditor().TEXTAREA.style.height = '';
+
+    expect(hot.getActiveEditor().TEXTAREA.offsetHeight).toBe(height);
+  });
+
   it('should be displayed and resized properly, so it doesn\'t exceed the viewport dimensions', () => {
     const data = [
       ['', '', '', '', ''],


### PR DESCRIPTION
### Context
Change `overflowY` `textEditor` to `hidden` in `showEditableElement` method. Without this change in `textarea` reserve additional space for scrollbar.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #5969

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
