### PR TITLE
Search query method args

### DIFF
--- a/handsontable.d.ts
+++ b/handsontable.d.ts
@@ -1563,18 +1563,20 @@ declare namespace Handsontable {
     }
 
     interface Search extends Base {
-      callback: () => void;
-      queryMethod: () => void;
+      callback: search.SearchCallback;
+      queryMethod: search.SearchQueryMethod;
       searchResultClass: string;
 
-      query(queryStr: string, callback: () => void, queryMethod: () => void): any[];
-      getCallback(): () => void;
-      setCallback(newCallback: () => void): void;
-      getQueryMethod(): () => void;
-      setQueryMethod(newQueryMethod: () => void): void;
+      query(queryStr: string, callback?: search.SearchCallback, queryMethod?: search.SearchQueryMethod): SearchResult[];
+      getCallback(): search.SearchCallback;
+      setCallback(newCallback: search.SearchCallback): void;
+      getQueryMethod(): search.SearchQueryMethod;
+      setQueryMethod(newQueryMethod: search.SearchQueryMethod): void;
       getSearchResultClass(): string;
       setSearchResultClass(newElementClass: string): void;
     }
+
+    type SearchResult = { row: number; col: number; data: CellValue };
   }
 
   namespace renderers {
@@ -1757,7 +1759,7 @@ declare namespace Handsontable {
     rowHeaders?: boolean | string[] | ((index: number) => string);
     rowHeaderWidth?: number | number[];
     rowHeights?: number | number[] | string | string[] | ((index: number) => string | number);
-    search?: boolean;
+    search?: boolean | search.Settings;
     selectionMode?: 'single' | 'range' | 'multiple';
     selectOptions?: string[];
     skipColumnOnPaste?: boolean;
@@ -2436,6 +2438,18 @@ declare namespace Handsontable {
       compareFunctionFactory?: ((sortOrder: columnSorting.SortOrderType, columnMeta: GridSettings) =>
         (value: any, nextValue: any) => -1 | 0 | 1);
     }
+  }
+
+  namespace search {
+    interface Settings {
+      callback?: SearchCallback;
+      queryMethod?: SearchQueryMethod;
+      searchResultClass?: string;
+    }
+
+    type SearchCallback = (instance: Handsontable, row: number, column: number, value: CellValue, result: boolean) => void;
+
+    type SearchQueryMethod = (queryStr: string, value: CellValue) => boolean;
   }
 
   namespace autoColumnSize {

--- a/handsontable.d.ts
+++ b/handsontable.d.ts
@@ -2449,7 +2449,7 @@ declare namespace Handsontable {
 
     type SearchCallback = (instance: Handsontable, row: number, column: number, value: CellValue, result: boolean) => void;
 
-    type SearchQueryMethod = (queryStr: string, value: CellValue) => boolean;
+    type SearchQueryMethod = (queryStr: string, value: CellValue, cellProperties: CellProperties) => boolean;
   }
 
   namespace autoColumnSize {

--- a/src/plugins/search/search.js
+++ b/src/plugins/search/search.js
@@ -147,7 +147,7 @@ class Search extends BasePlugin {
         const cellProperties = this.hot.getCellMeta(rowIndex, colIndex);
         const cellCallback = cellProperties.search.callback || callback;
         const cellQueryMethod = cellProperties.search.queryMethod || queryMethod;
-        const testResult = cellQueryMethod(queryStr, cellData);
+        const testResult = cellQueryMethod(queryStr, cellData, cellProperties);
 
         if (testResult) {
           const singleResult = {

--- a/src/plugins/search/test/search.e2e.js
+++ b/src/plugins/search/test/search.e2e.js
@@ -182,6 +182,53 @@ describe('Search plugin', () => {
 
       expect(customQueryMethod.calls.count()).toEqual(25);
     });
+
+    it('should pass search string and cell params to the query method', () => {
+      const customQueryMethod = jasmine.createSpy('customQueryMethod');
+
+      const hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        search: true
+      });
+
+      hot.getPlugin('search').query('A', null, customQueryMethod);
+
+      // Replace `cellProperties.instance` with fake to avoid unreadable test reports
+      const replaceInstanceWithFake = arg => (
+        arg && typeof arg === 'object' && 'instance' in arg
+          ? { ...arg, instance: {} }
+          : arg
+      );
+
+      expect(customQueryMethod.calls.count()).toEqual(25);
+      expect(customQueryMethod.calls.argsFor(0).map(replaceInstanceWithFake)).toEqual(['A', 'A1', {
+        row: 0,
+        col: 0,
+        visualRow: 0,
+        visualCol: 0,
+        prop: 0,
+        instance: {},
+        className: ''
+      }]);
+      expect(customQueryMethod.calls.argsFor(7).map(replaceInstanceWithFake)).toEqual(['A', 'C2', {
+        row: 1,
+        col: 2,
+        visualRow: 1,
+        visualCol: 2,
+        prop: 2,
+        instance: {},
+        className: ''
+      }]);
+      expect(customQueryMethod.calls.argsFor(24).map(replaceInstanceWithFake)).toEqual(['A', 'E5', {
+        row: 4,
+        col: 4,
+        visualRow: 4,
+        visualCol: 4,
+        prop: 4,
+        instance: {},
+        className: ''
+      }]);
+    });
   });
 
   describe('default query method', () => {

--- a/test/types/settings.types.ts
+++ b/test/types/settings.types.ts
@@ -305,7 +305,15 @@ const allSettings: Required<Handsontable.GridSettings> = {
   rowHeaders: oneOf(true, ['1', '2', '3'], (index: number) => `Row ${index}`),
   rowHeaderWidth: oneOf(25, [25, 30, 55]),
   rowHeights: oneOf(100, '100px', [100, 120, 90], (index: number) => index * 10),
-  search: true,
+  search: oneOf(true, {
+    searchResultClass: 'customClass',
+    queryMethod(queryStr: string, value: any) {
+      return true;
+    },
+    callback(instance: Handsontable, row: number, column: number, value: any, result: boolean) {
+      // ...
+    }
+  }),
   selectionMode: oneOf('single', 'range', 'multiple'),
   selectOptions: ['A', 'B', 'C'],
   skipColumnOnPaste: true,


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Related to the issue here: https://forum.handsontable.com/t/search-for-displayed-value/3185

Added `cellProperties` to the args of `queryMethod` so that it's possible to tell what kind of data is being queried (formatted number, etc).

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Tried it in my app.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. Includes the changes from https://github.com/handsontable/handsontable/pull/5971 because I added the `SearchQueryCallback` type there, but I need to add an arg in this PR.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [x] My change requires a change to the documentation. 
https://handsontable.com/docs/7.0.2/Options.html#search 
https://handsontable.com/docs/7.0.2/demo-searching.html
