### PR TITLE
Fixed issue https://github.com/handsontable/handsontable/issues/5985

### DIFF
--- a/src/helpers/dom/element.js
+++ b/src/helpers/dom/element.js
@@ -209,8 +209,14 @@ export function index(element) {
  * @returns {boolean}
  */
 export function overlayContainsElement(overlayType, element) {
-  const overlayElement = element.ownerDocument.querySelector(`.ht_clone_${overlayType}`);
-  return overlayElement ? overlayElement.contains(element) : null;
+  const overlayElements = element.ownerDocument.querySelectorAll(`.ht_clone_${overlayType}`);
+  for (let overlayElementIndex = 0; overlayElementIndex < overlayElements.length; overlayElementIndex++) {
+    const overlayElement = overlayElements[overlayElementIndex];
+    if (overlayElement.contains(element)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 let _hasClass;


### PR DESCRIPTION
### Context
Issue described in 5985

### How has this been tested?
The issue we had previously is gone with this change. When multiple handsontables in the same page co-exist at the same time, mouse can be safely hovered over the column headers.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/5985

### Checklist:
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
