### PR TITLE
Fix SVG in cell causing manualColumnMove mouse handler TypeError

### DIFF
--- a/src/plugins/manualColumnMove/manualColumnMove.js
+++ b/src/plugins/manualColumnMove/manualColumnMove.js
@@ -1,7 +1,7 @@
 import BasePlugin from './../_base';
 import Hooks from './../../pluginHooks';
 import { arrayEach } from './../../helpers/array';
-import { addClass, removeClass, offset } from './../../helpers/dom/element';
+import { addClass, removeClass, offset, hasClass } from './../../helpers/dom/element';
 import { rangeEach } from './../../helpers/number';
 import EventManager from './../../eventManager';
 import { registerPlugin } from './../../plugins';
@@ -477,7 +477,7 @@ class ManualColumnMove extends BasePlugin {
     const selection = this.hot.getSelectedRangeLast();
     const priv = privatePool.get(this);
     // This block action shouldn't be handled below.
-    const isSortingElement = event.realTarget.className.indexOf('sortAction') > -1;
+    const isSortingElement = hasClass(event.realTarget, 'sortAction');
 
     if (!selection || !isHeaderSelection || priv.pressed || event.button !== 0 || isSortingElement) {
       priv.pressed = false;


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
This is the same bug as https://github.com/handsontable/handsontable/issues/4120 but in a different area.

With `manualColumnMove` enabled the call to `event.realTarget.className.indexOf()` breaks if the target is an SVG element, since SVG `className` is some other weird string-like thing that doesn't have `indexOf`. 

**Example**: https://jsfiddle.net/fvoqsxu5/
- Click one of the `[...]` buttons rendered in the ID column, result:

```
Uncaught TypeError: event.realTarget.className.indexOf is not a function
    at ManualColumnMove.onBeforeOnCellMouseDown (manualColumnMove.js:582)
    at Core.<anonymous> (manualColumnMove.js:184)
    at Hooks.run (pluginHooks.js:1956)
    at Core.runHooks (core.js:3815)
    at Object.onCellMouseDown (tableView.js:518)
    at Settings.getSetting (settings.js:163)
    at Walkontable.getSetting (core.js:270)
    at Event.onMouseDown (event.js:211)
    at HTMLDivElement.<anonymous> (event.js:115)
    at HTMLDivElement.callbackProxy (eventManager.js:65)
```

Fix was to use `hasClass()` helper.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Manually in my app which has cells with SVG buttons like the demo: https://jsfiddle.net/fvoqsxu5/

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/4120
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
