### PR TITLE
Fix #3914: nestedRows plugin not reloading data

### DIFF
--- a/src/plugins/nestedRows/nestedRows.js
+++ b/src/plugins/nestedRows/nestedRows.js
@@ -116,6 +116,7 @@ class NestedRows extends BasePlugin {
     this.addHook('afterCreateRow', (...args) => this.onAfterCreateRow(...args));
     this.addHook('beforeRowMove', (...args) => this.onBeforeRowMove(...args));
     this.addHook('afterRowMove', (...args) => this.onAfterRowMove(...args));
+    this.addHook('afterLoadData', (...args) => this.onAfterLoadData(...args));
 
     if (!this.trimRowsPlugin.isEnabled()) {
       // Workaround to prevent calling updateSetttings in the enablePlugin method, which causes many problems.
@@ -570,6 +571,16 @@ class NestedRows extends BasePlugin {
     if (priv.skipRender) {
       skipRender.skipRender = true;
     }
+  }
+
+  /**
+   * `afterLoadData` hook callback.
+   *
+   * @private
+   */
+  onAfterLoadData() {
+    this.dataManager.data = this.hot.getSourceData();
+    this.dataManager.rewriteCache();
   }
 }
 

--- a/src/plugins/nestedRows/test/nestedRows.e2e.js
+++ b/src/plugins/nestedRows/test/nestedRows.e2e.js
@@ -1,4 +1,4 @@
-fdescribe('NestedRows', () => {
+describe('NestedRows', () => {
   const id = 'testContainer';
 
   beforeEach(function() {

--- a/src/plugins/nestedRows/test/nestedRows.e2e.js
+++ b/src/plugins/nestedRows/test/nestedRows.e2e.js
@@ -1,4 +1,4 @@
-describe('NestedRows', () => {
+fdescribe('NestedRows', () => {
   const id = 'testContainer';
 
   beforeEach(function() {
@@ -56,5 +56,32 @@ describe('NestedRows', () => {
       expect(hot.getData().length).toEqual(12);
 
     });
+
+    it('should display the right amount of entries when calling loadData after being initialized with empty data', (done) => {
+      const hot = handsontable({
+        data: [],
+        nestedRows: true
+      });
+
+      setTimeout(() => {
+        hot.loadData(getDataForNestedRows());
+        expect(hot.countRows()).toEqual(12);
+        done();
+      }, 100);
+    });
+
+    it('should display the right amount of entries when calling loadData with another set of data', (done) => {
+      const hot = handsontable({
+        data: getDataForNestedRows(),
+        nestedRows: true
+      });
+
+      setTimeout(() => {
+        hot.loadData(getDataForNestedRows().slice(0, 1));
+        expect(hot.countRows()).toEqual(6);
+        done();
+      }, 100);
+    });
+
   });
 });


### PR DESCRIPTION
### Context
When using `nestedRows` plugin, loading a new set of data won't refresh the table.

It turns out the nested rows `DataManager` never gets the new data, it always keeps a copy of the original set.

As we see [here](https://github.com/handsontable/handsontable/blob/90752fda8be5ac6b2708e0f2de8809d51dc1be4f/src/plugins/nestedRows/data/dataManager.js#L25), it is initialized with the source data, but never get reassigned after.

### How has this been tested?
Added two E2E tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

Solution I found was to listen to `afterLoadData` hook in order to update the `DataManager` data and rebuild its internal cache. Not sure if it's the best way to go, but it sounds quite reasonable to me.

### Related issue(s):
1. #3914 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.

ESLint passes. Added a minimal JSDoc to the hook callback, following the style of the others.