### PR TITLE
improving the check in getCell 

### DIFF
--- a/src/3rdparty/walkontable/src/core.js
+++ b/src/3rdparty/walkontable/src/core.js
@@ -119,7 +119,7 @@ class Walkontable {
     } else if (coords.col < fixedColumns) {
       return this.wtOverlays.leftOverlay.clone.wtTable.getCell(coords);
 
-    } else if (coords.row < totalRows && coords.row > totalRows - fixedRowsBottom) {
+    } else if (coords.row < totalRows && coords.row >= totalRows - fixedRowsBottom) {
       if (this.wtOverlays.bottomOverlay && this.wtOverlays.bottomOverlay.clone) {
         return this.wtOverlays.bottomOverlay.clone.wtTable.getCell(coords);
       }

--- a/test/e2e/settings/fixedRowsBottom.spec.js
+++ b/test/e2e/settings/fixedRowsBottom.spec.js
@@ -129,5 +129,19 @@ describe('settings', () => {
 
       expect(getBottomClone().find('.wtHolder').scrollLeft()).toBe(getMaster().find('.wtHolder').scrollLeft());
     });
+
+    it('should overwrite td value in fixed bottom rows when fixedRowsBottom is equal to one', () => {
+      const hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(20, 10),
+        fixedRowsBottom: 1
+      });
+
+      expect(getBottomClone().find('tbody tr:eq(0) td:eq(0)').html()).toEqual('A20');
+
+      const td = hot.getCell(19, 0, true);
+      td.innerHTML = 'test';
+
+      expect(getBottomClone().find('tbody tr:eq(0) td:eq(0)').html()).toEqual('test');
+    });
   });
 });


### PR DESCRIPTION
### Context
`getCell` with `topmost = true` doesn’t work for `fixedRowsBottom = 1`, because there was an incorrect check.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #5896

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
