### PR TITLE
In beforeCreateCol hook add support for return false 

### DIFF
--- a/handsontable.d.ts
+++ b/handsontable.d.ts
@@ -1878,7 +1878,7 @@ declare namespace Handsontable {
       beforeContextMenuSetItems?: (menuItems: contextMenu.MenuItemConfig[]) => void;
       beforeContextMenuShow?: (context: plugins.ContextMenu) => void;
       beforeCopy?: (data: CellValue[][], coords: plugins.RangeType[]) => void | boolean;
-      beforeCreateCol?: (index: number, amount: number, source?: ChangeSource) => void;
+      beforeCreateCol?: (index: number, amount: number, source?: ChangeSource) => void | boolean;
       beforeCreateRow?: (index: number, amount: number, source?: ChangeSource) => void;
       beforeCut?: (data: CellValue[][], coords: plugins.RangeType[]) => void | boolean;
       beforeDetachChild?: (parent: RowObject, element: RowObject) => void;

--- a/src/core.js
+++ b/src/core.js
@@ -1022,15 +1022,20 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
         }
       }
 
+      if (instance.dataType === 'array' && (!priv.settings.columns || priv.settings.columns.length === 0) && priv.settings.allowInsertColumn) {
+        while (datamap.propToCol(changes[i][1]) > instance.countCols() - 1) {
+          const numberOfCreatedColumns = datamap.createCol(void 0, void 0, source);
+
+          if (numberOfCreatedColumns === 0) {
+            skipThisChange = true;
+            break;
+          }
+        }
+      }
+
       if (skipThisChange) {
         /* eslint-disable no-continue */
         continue;
-      }
-
-      if (instance.dataType === 'array' && (!priv.settings.columns || priv.settings.columns.length === 0) && priv.settings.allowInsertColumn) {
-        while (datamap.propToCol(changes[i][1]) > instance.countCols() - 1) {
-          datamap.createCol(void 0, void 0, source);
-        }
       }
 
       datamap.set(changes[i][0], changes[i][1], changes[i][3]);

--- a/src/dataMap.js
+++ b/src/dataMap.js
@@ -344,40 +344,42 @@ class DataMap {
     let numberOfCreatedCols = 0;
     let currentIndex;
 
-    const beforeCreateColHook = this.instance.runHooks('beforeCreateCol', columnIndex, amount, source);
+    const continueProcess = this.instance.runHooks('beforeCreateCol', columnIndex, amount, source);
+
+    if (continueProcess === false) {
+      return 0;
+    }
 
     currentIndex = columnIndex;
 
-    if (beforeCreateColHook !== false) {
-      const maxCols = this.instance.getSettings().maxCols;
-      while (numberOfCreatedCols < amount && this.instance.countCols() < maxCols) {
-        const constructor = columnFactory(this.GridSettings, this.priv.columnsSettingConflicts);
+    const maxCols = this.instance.getSettings().maxCols;
+    while (numberOfCreatedCols < amount && this.instance.countCols() < maxCols) {
+      const constructor = columnFactory(this.GridSettings, this.priv.columnsSettingConflicts);
 
-        if (typeof columnIndex !== 'number' || columnIndex >= this.instance.countCols()) {
-          if (rlen > 0) {
-            for (let r = 0; r < rlen; r++) {
-              if (typeof data[r] === 'undefined') {
-                data[r] = [];
-              }
-              data[r].push(null);
+      if (typeof columnIndex !== 'number' || columnIndex >= this.instance.countCols()) {
+        if (rlen > 0) {
+          for (let r = 0; r < rlen; r++) {
+            if (typeof data[r] === 'undefined') {
+              data[r] = [];
             }
-          } else {
-            data.push([null]);
+            data[r].push(null);
           }
-          // Add new column constructor
-          this.priv.columnSettings.push(constructor);
-
         } else {
-          for (let row = 0; row < rlen; row++) {
-            data[row].splice(currentIndex, 0, null);
-          }
-          // Add new column constructor at given index
-          this.priv.columnSettings.splice(currentIndex, 0, constructor);
+          data.push([null]);
         }
+        // Add new column constructor
+        this.priv.columnSettings.push(constructor);
 
-        numberOfCreatedCols += 1;
-        currentIndex += 1;
+      } else {
+        for (let row = 0; row < rlen; row++) {
+          data[row].splice(currentIndex, 0, null);
+        }
+        // Add new column constructor at given index
+        this.priv.columnSettings.splice(currentIndex, 0, constructor);
       }
+
+      numberOfCreatedCols += 1;
+      currentIndex += 1;
     }
 
     this.instance.runHooks('afterCreateCol', columnIndex, numberOfCreatedCols, source);

--- a/src/dataMap.js
+++ b/src/dataMap.js
@@ -344,38 +344,40 @@ class DataMap {
     let numberOfCreatedCols = 0;
     let currentIndex;
 
-    this.instance.runHooks('beforeCreateCol', columnIndex, amount, source);
+    const beforeCreateColHook = this.instance.runHooks('beforeCreateCol', columnIndex, amount, source);
 
     currentIndex = columnIndex;
 
-    const maxCols = this.instance.getSettings().maxCols;
-    while (numberOfCreatedCols < amount && this.instance.countCols() < maxCols) {
-      const constructor = columnFactory(this.GridSettings, this.priv.columnsSettingConflicts);
+    if (beforeCreateColHook !== false) {
+      const maxCols = this.instance.getSettings().maxCols;
+      while (numberOfCreatedCols < amount && this.instance.countCols() < maxCols) {
+        const constructor = columnFactory(this.GridSettings, this.priv.columnsSettingConflicts);
 
-      if (typeof columnIndex !== 'number' || columnIndex >= this.instance.countCols()) {
-        if (rlen > 0) {
-          for (let r = 0; r < rlen; r++) {
-            if (typeof data[r] === 'undefined') {
-              data[r] = [];
+        if (typeof columnIndex !== 'number' || columnIndex >= this.instance.countCols()) {
+          if (rlen > 0) {
+            for (let r = 0; r < rlen; r++) {
+              if (typeof data[r] === 'undefined') {
+                data[r] = [];
+              }
+              data[r].push(null);
             }
-            data[r].push(null);
+          } else {
+            data.push([null]);
           }
+          // Add new column constructor
+          this.priv.columnSettings.push(constructor);
+
         } else {
-          data.push([null]);
+          for (let row = 0; row < rlen; row++) {
+            data[row].splice(currentIndex, 0, null);
+          }
+          // Add new column constructor at given index
+          this.priv.columnSettings.splice(currentIndex, 0, constructor);
         }
-        // Add new column constructor
-        this.priv.columnSettings.push(constructor);
 
-      } else {
-        for (let row = 0; row < rlen; row++) {
-          data[row].splice(currentIndex, 0, null);
-        }
-        // Add new column constructor at given index
-        this.priv.columnSettings.splice(currentIndex, 0, constructor);
+        numberOfCreatedCols += 1;
+        currentIndex += 1;
       }
-
-      numberOfCreatedCols += 1;
-      currentIndex += 1;
     }
 
     this.instance.runHooks('afterCreateCol', columnIndex, numberOfCreatedCols, source);

--- a/src/pluginHooks.js
+++ b/src/pluginHooks.js
@@ -173,10 +173,10 @@ const REGISTERED_HOOKS = [
    * @param {Number} amount Number of newly created columns in the data source array.
    * @param {String} [source] String that identifies source of hook call
    *                          ([list of all available sources]{@link http://docs.handsontable.com/tutorial-using-callbacks.html#page-source-definition}).
-   * @returns {*} If returns `false` then operation of the creating the columns is canceled.
+   * @returns {*} If `false` then creating columns is cancelled.
    * @example
    * ```js
-   * // To cancel a create column action, just return `false`.
+   * // Return `false` to cancel column inserting.
    * new Handsontable(element, {
    *   beforeCreateCol: function(data, coords) {
    *     return false;

--- a/src/pluginHooks.js
+++ b/src/pluginHooks.js
@@ -173,6 +173,16 @@ const REGISTERED_HOOKS = [
    * @param {Number} amount Number of newly created columns in the data source array.
    * @param {String} [source] String that identifies source of hook call
    *                          ([list of all available sources]{@link http://docs.handsontable.com/tutorial-using-callbacks.html#page-source-definition}).
+   * @returns {*} If returns `false` then operation of the creating the columns is canceled.
+   * @example
+   * ```js
+   * // To cancel a create column action, just return `false`.
+   * new Handsontable(element, {
+   *   beforeCreateCol: function(data, coords) {
+   *     return false;
+   *   }
+   * });
+   * ```
    */
   'beforeCreateCol',
 

--- a/test/e2e/Core_alter.spec.js
+++ b/test/e2e/Core_alter.spec.js
@@ -1130,7 +1130,7 @@ describe('Core_alter', () => {
       expect(outputAfter).toEqual([2, 1, 'customSource']);
     });
 
-    it('should not create columns when beforeCreateCol return false', () => {
+    it('should not create columns when beforeCreateCol returns false', () => {
       handsontable({
         data: arrayOfArrays(),
         beforeCreateCol() {

--- a/test/e2e/Core_alter.spec.js
+++ b/test/e2e/Core_alter.spec.js
@@ -1130,6 +1130,21 @@ describe('Core_alter', () => {
       expect(outputAfter).toEqual([2, 1, 'customSource']);
     });
 
+    it('should not create columns when beforeCreateCol return false', () => {
+      handsontable({
+        data: arrayOfArrays(),
+        beforeCreateCol() {
+          return false;
+        },
+      });
+
+      const countedColumns = countCols();
+
+      alter('insert_col', 2, 1, 'customSource');
+
+      expect(countCols()).toBe(countedColumns);
+    });
+
     it('should not create column header together with the column, if headers were NOT specified explicitly', () => {
 
       handsontable({

--- a/test/e2e/Core_setDataAtCell.spec.js
+++ b/test/e2e/Core_setDataAtCell.spec.js
@@ -299,31 +299,51 @@ describe('Core_setDataAtCell', () => {
     expect(getData()).toEqual([['bar', 1], ['b', 33], ['c', 3]]);
   });
 
-  it('shouldn\'t add new column when `beforeCreateCol` false', () => {
-    handsontable({
-      data: Handsontable.helper.createSpreadsheetData(1, 1),
-      beforeCreateCol() {
-        return false;
-      }
+  describe('Coordinates out of dataset', () => {
+    it('should insert new column', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(1, 1)
+      });
+
+      setDataAtCell([[0, 1, 'new column']], 'customSource');
+      expect(countCols()).toBe(2);
     });
 
-    const countedColumns = countCols();
+    it('should insert new row', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(1, 1)
+      });
 
-    setDataAtCell([[0, 1, 'new column']], 'customSource');
-    expect(countCols()).toBe(countedColumns);
-  });
-
-  it('shouldn\'t add new row when `beforeCreateRow` false', () => {
-    handsontable({
-      data: Handsontable.helper.createSpreadsheetData(1, 1),
-      beforeCreateRow() {
-        return false;
-      }
+      setDataAtCell([[1, 0, 'new row']], 'customSource');
+      expect(countRows()).toBe(2);
     });
 
-    const countedRows = countRows();
+    it('should not insert new column if `beforeCreateCol` returns false', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(1, 1),
+        beforeCreateCol() {
+          return false;
+        }
+      });
 
-    setDataAtCell([[1, 0, 'new row']], 'customSource');
-    expect(countRows()).toBe(countedRows);
+      const countedColumns = countCols();
+
+      setDataAtCell([[0, 1, 'new column']], 'customSource');
+      expect(countCols()).toBe(countedColumns);
+    });
+
+    it('should not insert new row if `beforeCreateRow` returns false', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(1, 1),
+        beforeCreateRow() {
+          return false;
+        }
+      });
+
+      const countedRows = countRows();
+
+      setDataAtCell([[1, 0, 'new row']], 'customSource');
+      expect(countRows()).toBe(countedRows);
+    });
   });
 });

--- a/test/e2e/Core_setDataAtCell.spec.js
+++ b/test/e2e/Core_setDataAtCell.spec.js
@@ -298,4 +298,32 @@ describe('Core_setDataAtCell', () => {
     expect(getDataAtRowProp(1, 'id')).toBe(33);
     expect(getData()).toEqual([['bar', 1], ['b', 33], ['c', 3]]);
   });
+
+  it('shouldn\'t add new column when `beforeCreateCol` false', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(1, 1),
+      beforeCreateCol() {
+        return false;
+      }
+    });
+
+    const countedColumns = countCols();
+
+    setDataAtCell([[0, 1, 'new column']], 'customSource');
+    expect(countCols()).toBe(countedColumns);
+  });
+
+  it('shouldn\'t add new row when `beforeCreateRow` false', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(1, 1),
+      beforeCreateRow() {
+        return false;
+      }
+    });
+
+    const countedRows = countRows();
+
+    setDataAtCell([[1, 0, 'new row']], 'customSource');
+    expect(countRows()).toBe(countedRows);
+  });
 });


### PR DESCRIPTION
### Context
To be consistent, we need likewise  abort the operation when returning false from `beforeCreateCol`, just like we do when returning false from `beforeCreateRow`, `beforeRemoveCol`, `beforeRemoveRow`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #5691

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
