### PR TITLE
Should be possible to block UndoRedo's keyboard shortcuts

### DIFF
--- a/src/plugins/undoRedo/test/UndoRedo.e2e.js
+++ b/src/plugins/undoRedo/test/UndoRedo.e2e.js
@@ -2438,7 +2438,7 @@ describe('UndoRedo', () => {
         selectCell(0, 0);
         setDataAtCell(0, 0, 'new value');
 
-        spec().$container.simulate('keydown', { ctrlKey: true, keyCode: 'Z'.charCodeAt(0) });
+        keyDown('ctrl+z');
         expect(getDataAtCell(0, 0)).toBe('A1');
       });
 
@@ -2456,7 +2456,7 @@ describe('UndoRedo', () => {
         HOT.undo();
         expect(getDataAtCell(0, 0)).toBe('A1');
 
-        spec().$container.simulate('keydown', { ctrlKey: true, keyCode: 'Y'.charCodeAt(0) });
+        keyDown('ctrl+y');
 
         expect(getDataAtCell(0, 0)).toBe('new value');
       });
@@ -2475,8 +2475,27 @@ describe('UndoRedo', () => {
         HOT.undo();
         expect(getDataAtCell(0, 0)).toBe('A1');
 
-        spec().$container.simulate('keydown', { ctrlKey: true, shiftKey: true, keyCode: 'Z'.charCodeAt(0) });
+        keyDown('ctrl+shift+z');
 
+        expect(getDataAtCell(0, 0)).toBe('new value');
+      });
+
+      it('should be possible to block keyboard shortcuts', () => {
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(2, 2),
+          beforeKeyDown: (e) => {
+            const ctrlDown = (e.ctrlKey || e.metaKey) && !e.altKey;
+
+            if (ctrlDown && (e.keyCode === 90 || (e.shiftKey && e.keyCode === 90))) {
+              Handsontable.dom.stopImmediatePropagation(e);
+            }
+          }
+        });
+
+        selectCell(0, 0);
+        setDataAtCell(0, 0, 'new value');
+
+        keyDown('ctrl+z');
         expect(getDataAtCell(0, 0)).toBe('new value');
       });
     });

--- a/src/plugins/undoRedo/test/UndoRedo.e2e.js
+++ b/src/plugins/undoRedo/test/UndoRedo.e2e.js
@@ -2442,27 +2442,24 @@ describe('UndoRedo', () => {
         expect(getDataAtCell(0, 0)).toBe('A1');
       });
 
-      // Chrome opens chrome://history on this shortcut. This hoykey works properly in others browser.
-      if (!Handsontable.helper.isChrome()) {
-        it('should redo single change after hitting CTRL+Y', () => {
-          handsontable({
-            data: Handsontable.helper.createSpreadsheetData(2, 2)
-          });
-          const HOT = getInstance();
-
-          selectCell(0, 0);
-          setDataAtCell(0, 0, 'new value');
-
-          expect(getDataAtCell(0, 0)).toBe('new value');
-
-          HOT.undo();
-          expect(getDataAtCell(0, 0)).toBe('A1');
-
-          keyDown('ctrl+y');
-
-          expect(getDataAtCell(0, 0)).toBe('new value');
+      it('should redo single change after hitting CTRL+Y', () => {
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(2, 2)
         });
-      }
+        const HOT = getInstance();
+
+        selectCell(0, 0);
+        setDataAtCell(0, 0, 'new value');
+
+        expect(getDataAtCell(0, 0)).toBe('new value');
+
+        HOT.undo();
+        expect(getDataAtCell(0, 0)).toBe('A1');
+
+        keyDown('ctrl+y');
+
+        expect(getDataAtCell(0, 0)).toBe('new value');
+      });
 
       it('should redo single change after hitting CTRL+SHIFT+Z', () => {
         handsontable({

--- a/src/plugins/undoRedo/test/UndoRedo.e2e.js
+++ b/src/plugins/undoRedo/test/UndoRedo.e2e.js
@@ -2442,24 +2442,27 @@ describe('UndoRedo', () => {
         expect(getDataAtCell(0, 0)).toBe('A1');
       });
 
-      it('should redo single change after hitting CTRL+Y', () => {
-        handsontable({
-          data: Handsontable.helper.createSpreadsheetData(2, 2)
+      // Chrome opens chrome://history on this shortcut. This hoykey works properly in others browser.
+      if (!Handsontable.helper.isChrome()) {
+        it('should redo single change after hitting CTRL+Y', () => {
+          handsontable({
+            data: Handsontable.helper.createSpreadsheetData(2, 2)
+          });
+          const HOT = getInstance();
+
+          selectCell(0, 0);
+          setDataAtCell(0, 0, 'new value');
+
+          expect(getDataAtCell(0, 0)).toBe('new value');
+
+          HOT.undo();
+          expect(getDataAtCell(0, 0)).toBe('A1');
+
+          keyDown('ctrl+y');
+
+          expect(getDataAtCell(0, 0)).toBe('new value');
         });
-        const HOT = getInstance();
-
-        selectCell(0, 0);
-        setDataAtCell(0, 0, 'new value');
-
-        expect(getDataAtCell(0, 0)).toBe('new value');
-
-        HOT.undo();
-        expect(getDataAtCell(0, 0)).toBe('A1');
-
-        keyDown('ctrl+y');
-
-        expect(getDataAtCell(0, 0)).toBe('new value');
-      });
+      }
 
       it('should redo single change after hitting CTRL+SHIFT+Z', () => {
         handsontable({

--- a/src/plugins/undoRedo/undoRedo.js
+++ b/src/plugins/undoRedo/undoRedo.js
@@ -5,8 +5,9 @@ import Hooks from './../../pluginHooks';
 import { arrayMap, arrayEach } from './../../helpers/array';
 import { rangeEach } from './../../helpers/number';
 import { inherit, deepClone } from './../../helpers/object';
-import { stopImmediatePropagation } from './../../helpers/dom/event';
+import { stopImmediatePropagation, isImmediatePropagationStopped } from './../../helpers/dom/event';
 import { align } from './../contextMenu/utils';
+import { isChrome } from './../../helpers/browser';
 
 /**
  * @description
@@ -629,18 +630,33 @@ function init() {
 }
 
 function onBeforeKeyDown(event) {
+  if (isImmediatePropagationStopped(event)) {
+    return;
+  }
+
   const instance = this;
+  const {
+    altKey,
+    ctrlKey,
+    keyCode,
+    metaKey,
+    shiftKey,
+  } = event;
+  const isCtrlDown = (ctrlKey || metaKey) && !altKey;
 
-  const ctrlDown = (event.ctrlKey || event.metaKey) && !event.altKey;
+  if (!isCtrlDown) {
+    return;
+  }
 
-  if (ctrlDown) {
-    if (event.keyCode === 89 || (event.shiftKey && event.keyCode === 90)) { // CTRL + Y or CTRL + SHIFT + Z
-      instance.undoRedo.redo();
-      stopImmediatePropagation(event);
-    } else if (event.keyCode === 90) { // CTRL + Z
-      instance.undoRedo.undo();
-      stopImmediatePropagation(event);
-    }
+  const isRedoHotkey = (!isChrome() && keyCode === 89) || (shiftKey && keyCode === 90);
+
+  if (isRedoHotkey) { // CTRL + Y or CTRL + SHIFT + Z
+    instance.undoRedo.redo();
+    stopImmediatePropagation(event);
+
+  } else if (keyCode === 90) { // CTRL + Z
+    instance.undoRedo.undo();
+    stopImmediatePropagation(event);
   }
 }
 

--- a/src/plugins/undoRedo/undoRedo.js
+++ b/src/plugins/undoRedo/undoRedo.js
@@ -7,7 +7,6 @@ import { rangeEach } from './../../helpers/number';
 import { inherit, deepClone } from './../../helpers/object';
 import { stopImmediatePropagation, isImmediatePropagationStopped } from './../../helpers/dom/event';
 import { align } from './../contextMenu/utils';
-import { isChrome } from './../../helpers/browser';
 
 /**
  * @description

--- a/src/plugins/undoRedo/undoRedo.js
+++ b/src/plugins/undoRedo/undoRedo.js
@@ -648,7 +648,7 @@ function onBeforeKeyDown(event) {
     return;
   }
 
-  const isRedoHotkey = (!isChrome() && keyCode === 89) || (shiftKey && keyCode === 90);
+  const isRedoHotkey = keyCode === 89 || (shiftKey && keyCode === 90);
 
   if (isRedoHotkey) { // CTRL + Y or CTRL + SHIFT + Z
     instance.undoRedo.redo();

--- a/test/helpers/common.js
+++ b/test/helpers/common.js
@@ -394,6 +394,14 @@ export function handsontableKeyTriggerFactory(type) {
           ev.keyCode = 65;
           break;
 
+        case 'y':
+          ev.keyCode = 89;
+          break;
+
+        case 'z':
+          ev.keyCode = 90;
+          break;
+
         default:
           throw new Error(`Unrecognised key name: ${keyToTrigger}`);
       }

--- a/test/helpers/common.js
+++ b/test/helpers/common.js
@@ -310,15 +310,15 @@ export function handsontableKeyTriggerFactory(type) {
     let keyToTrigger = key;
 
     if (typeof keyToTrigger === 'string') {
-      if (keyToTrigger.indexOf('shift+') > -1) {
-        keyToTrigger = keyToTrigger.substring(6);
-        ev.shiftKey = true;
-      }
-
       if (keyToTrigger.indexOf('ctrl+') > -1) {
         keyToTrigger = keyToTrigger.substring(5);
         ev.ctrlKey = true;
         ev.metaKey = true;
+      }
+
+      if (keyToTrigger.indexOf('shift+') > -1) {
+        keyToTrigger = keyToTrigger.substring(6);
+        ev.shiftKey = true;
       }
 
       switch (keyToTrigger) {


### PR DESCRIPTION
### Context
Without these changes, there is no way to block UndoRedo's keyboard shortcuts.

Moreover, <kbd>CTRL / CMD</kbd> + <kbd>Y</kbd> for redo command in Chrome on MacOS uses this combination to open `chrome://history`: https://bugs.chromium.org/p/chromium/issues/detail?id=97945 perhaps we should discuss what to do with this `won't fix' issue.

### How has this been tested?
Initialize Handsontable with following option:
```js
beforeKeyDown: (e) => {
   const ctrlDown = (e.ctrlKey || e.metaKey) && !e.altKey;

   if (ctrlDown && (e.keyCode === 90 || (e.shiftKey && e.keyCode === 90))) {
      Handsontable.dom.stopImmediatePropagation(e);
   }
}
```

### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)

### Related issue(s):
1. #6028
