### PR TITLE
UndoRedo should track cell selection after data changes

### DIFF
--- a/src/plugins/nestedRows/ui/collapsing.js
+++ b/src/plugins/nestedRows/ui/collapsing.js
@@ -105,10 +105,10 @@ class CollapsingUI extends BaseUI {
    * @param {Boolean} [doTrimming = true] `true` if the table should trim the provided rows.
    */
   collapseMultipleChildren(rows, forceRender = true, doTrimming = true) {
-    let rowsToTrim = [];
+    const rowsToTrim = [];
 
     arrayEach(rows, (elem) => {
-      rowsToTrim = rowsToTrim.concat(this.collapseChildren(elem, false, false));
+      rowsToTrim.push(...this.collapseChildren(elem, false, false));
     });
 
     if (doTrimming) {
@@ -292,10 +292,10 @@ class CollapsingUI extends BaseUI {
    * @param {Boolean} [doTrimming = true] `true` if the rows should be untrimmed after finishing the function.
    */
   expandMultipleChildren(rows, forceRender = true, doTrimming = true) {
-    let rowsToUntrim = [];
+    const rowsToUntrim = [];
 
     arrayEach(rows, (elem) => {
-      rowsToUntrim = rowsToUntrim.concat(this.expandChildren(elem, false, false));
+      rowsToUntrim.push(...this.expandChildren(elem, false, false));
     });
 
     if (doTrimming) {

--- a/src/plugins/undoRedo/test/UndoRedo.e2e.js
+++ b/src/plugins/undoRedo/test/UndoRedo.e2e.js
@@ -2566,4 +2566,40 @@ describe('UndoRedo', () => {
       }, 100);
     });
   });
+
+  describe('selection', () => {
+    it('should keep saved selection state ater undo and redo data change', () => {
+      handsontable();
+
+      selectCell(0, 0);
+      setDataAtCell(0, 0, 'test');
+      selectCell(0, 1);
+      setDataAtCell(0, 1, 'test2');
+
+      selectCell(0, 2);
+      undo();
+      undo();
+
+      expect(getSelectedLast()).toEqual([0, 0, 0, 0]);
+
+      redo();
+      redo();
+
+      expect(getSelectedLast()).toEqual([0, 1, 0, 1]);
+    });
+
+    it('should keep saved selection state ater undoing non-contignous selected cells', () => {
+      handsontable();
+
+      selectCells([[0, 0, 1, 1], [1, 2, 2, 3]]);
+      emptySelectedCells();
+
+      selectCell(4, 0);
+      undo();
+
+      expect(getSelected().length).toBe(2);
+      expect(getSelected()[0]).toEqual([0, 0, 1, 1]);
+      expect(getSelected()[1]).toEqual([1, 2, 2, 3]);
+    });
+  });
 });

--- a/src/plugins/undoRedo/test/UndoRedo.e2e.js
+++ b/src/plugins/undoRedo/test/UndoRedo.e2e.js
@@ -2498,6 +2498,20 @@ describe('UndoRedo', () => {
         keyDown('ctrl+z');
         expect(getDataAtCell(0, 0)).toBe('new value');
       });
+
+      it('should not undo changes in the other cells if editor is open', () => {
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(2, 2),
+        });
+
+        selectCell(0, 0);
+        setDataAtCell(0, 0, 'new value');
+
+        selectCell(1, 0);
+        keyDownUp('enter');
+        keyDown('ctrl+z');
+        expect(getDataAtCell(0, 0)).toBe('new value');
+      });
     });
   });
 

--- a/src/plugins/undoRedo/undoRedo.js
+++ b/src/plugins/undoRedo/undoRedo.js
@@ -29,19 +29,13 @@ function UndoRedo(instance) {
   this.ignoreNewActions = false;
 
   instance.addHook('afterChange', function(changes, source) {
-    if (!changes || ['UndoRedo.undo', 'UndoRedo.redo', 'MergeCells'].includes(source)) {
+    const changesLen = changes && changes.length;
+
+    if (!changesLen || ['UndoRedo.undo', 'UndoRedo.redo', 'MergeCells'].includes(source)) {
       return;
     }
 
-    const changesLen = changes.length;
-    let selected = [];
-
-    if (changesLen > 1) {
-      selected = this.getSelected();
-
-    } else {
-      selected = [[changes[0][0], changes[0][1]]];
-    }
+    const selected = changesLen > 1 ? this.getSelected() : [[changes[0][0], changes[0][1]]];
 
     plugin.done(new UndoRedo.ChangeAction(changes, selected));
   });

--- a/src/plugins/undoRedo/undoRedo.js
+++ b/src/plugins/undoRedo/undoRedo.js
@@ -32,16 +32,14 @@ function UndoRedo(instance) {
     if (!changes || ['UndoRedo.undo', 'UndoRedo.redo', 'MergeCells'].includes(source)) {
       return;
     }
-    const changesLen = changes && changes.length;
+
+    const changesLen = changes.length;
     let selected = [];
 
-    if (source === 'CopyPaste.paste') {
-      instance.addHookOnce('afterPaste', (...args) => selected.push(...args[1].map(range => [range.startRow, range.startCol, range.endRow, range.endCol])));
-
-    } else if (changesLen > 1) {
+    if (changesLen > 1) {
       selected = this.getSelected();
 
-    } else if (changesLen) {
+    } else {
       selected = [[changes[0][0], changes[0][1]]];
     }
 
@@ -311,7 +309,10 @@ UndoRedo.ChangeAction.prototype.redo = function(instance, onFinishCallback) {
 
   instance.addHookOnce('afterChange', onFinishCallback);
   instance.setDataAtRowProp(data, null, null, 'UndoRedo.redo');
-  instance.selectCells(this.selected, false, false);
+
+  if (this.selected) {
+    instance.selectCells(this.selected, false, false);
+  }
 };
 
 /**

--- a/src/plugins/undoRedo/undoRedo.js
+++ b/src/plugins/undoRedo/undoRedo.js
@@ -647,6 +647,12 @@ function onBeforeKeyDown(event) {
   }
 
   const instance = this;
+  const editor = instance.getActiveEditor();
+
+  if (editor && editor.isOpened()) {
+    return;
+  }
+
   const {
     altKey,
     ctrlKey,

--- a/src/plugins/undoRedo/undoRedo.js
+++ b/src/plugins/undoRedo/undoRedo.js
@@ -32,14 +32,17 @@ function UndoRedo(instance) {
     if (!changes || ['UndoRedo.undo', 'UndoRedo.redo', 'MergeCells'].includes(source)) {
       return;
     }
-
+    const changesLen = changes && changes.length;
     let selected = [];
 
     if (source === 'CopyPaste.paste') {
       instance.addHookOnce('afterPaste', (...args) => selected.push(...args[1].map(range => [range.startRow, range.startCol, range.endRow, range.endCol])));
 
-    } else {
-      selected = changes.length > 1 ? this.getSelected() : [[changes[0][0], changes[0][1]]];
+    } else if (changesLen > 1) {
+      selected = this.getSelected();
+
+    } else if (changesLen) {
+      selected = [[changes[0][0], changes[0][1]]];
     }
 
     plugin.done(new UndoRedo.ChangeAction(changes, selected));

--- a/test/helpers/common.js
+++ b/test/helpers/common.js
@@ -88,6 +88,7 @@ export const getValue = handsontableMethodFactory('getValue');
 export const loadData = handsontableMethodFactory('loadData');
 export const populateFromArray = handsontableMethodFactory('populateFromArray');
 export const propToCol = handsontableMethodFactory('propToCol');
+export const redo = handsontableMethodFactory('redo');
 export const refreshDimensions = handsontableMethodFactory('refreshDimensions');
 export const removeCellMeta = handsontableMethodFactory('removeCellMeta');
 export const render = handsontableMethodFactory('render');


### PR DESCRIPTION
### Context
Currently, there is no built-in solution to track cell selection during data editing. This PR adds this functionality for a few simple scenarios like:
1. Editing cells one-by-one.
2. Cut/Paste (if there is no inserting/removing rows or columns).
3. Emptying selected ranges.

### How has this been tested?
1. Edit `A1`,
2. Edit `B2`,
3. Select `C3`,
4. Use keyboard shortcuts to undo previous changes,
5. Use keyboard shortcuts to redo changes.

Selection should follow data changes.
 
### Types of changes
- [x] New feature or improvement (a non-breaking change which adds functionality)

### Related issue(s):
1. #6017