### PR TITLE
Pre-release change of mismatched Core's methods after parseTable utility is added.

### DIFF
--- a/handsontable.d.ts
+++ b/handsontable.d.ts
@@ -108,11 +108,11 @@ declare namespace _Handsontable {
     setDataAtRowProp(changes: Array<[number, string | number, Handsontable.CellValue]>, source?: string): void;
     spliceCol(col: number, index: number, amount: number, ...elements: Handsontable.CellValue[]): void;
     spliceRow(row: number, index: number, amount: number, ...elements: Handsontable.CellValue[]): void;
+    toHTML(): string;
     toPhysicalColumn(column: number): number;
     toPhysicalRow(row: number): number;
     toVisualColumn(column: number): number;
     toVisualRow(row: number): number;
-    toHTML(): string;
     toTableElement(): HTMLTableElement;
     unlisten(): void;
     updateSettings(settings: Handsontable.GridSettings, init?: boolean): void;

--- a/src/core.js
+++ b/src/core.js
@@ -3565,21 +3565,21 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
    * Converts instance into outerHTML of HTMLTableElement.
    *
    * @memberof Core#
-   * @function toString
+   * @function toHTML
    * @since 7.1.0
    * @returns {String}
    */
-  this.toString = () => instanceToHTML(this);
+  this.toHTML = () => instanceToHTML(this);
 
   /**
-   * Converts instance into outerHTML of HTMLTableElement.
+   * Converts instance into HTMLTableElement.
    *
    * @memberof Core#
-   * @function toHTML
+   * @function toTableElement
    * @since 7.1.0
    * @returns {HTMLTableElement}
    */
-  this.toHTML = () => {
+  this.toTableElement = () => {
     const tempElement = this.rootDocument.createElement('div');
     tempElement.insertAdjacentHTML('afterbegin', instanceToHTML(this));
 

--- a/test/e2e/core/toHTML.spec.js
+++ b/test/e2e/core/toHTML.spec.js
@@ -1,0 +1,34 @@
+describe('Core.toHTML', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should convert instance into outerHTML of HTMLTableElement', () => {
+    const hot = handsontable({
+      data: Handsontable.helper.createSpreadsheetData(2, 2),
+      colHeaders: true,
+      rowHeaders: true,
+    });
+
+    expect(hot.toHTML()).toBe([
+      '<table>',
+      '<thead>',
+      '<tr><th></th><th>A</th><th>B</th></tr>',
+      '</thead>',
+      '<tbody>',
+      '<tr><th>1</th><td >A1</td><td >B1</td></tr>',
+      '<tr><th>2</th><td >A2</td><td >B2</td></tr>',
+      '</tbody>',
+      '</table>'
+    ].join(''));
+  });
+});

--- a/test/e2e/core/toTableElement.spec.js
+++ b/test/e2e/core/toTableElement.spec.js
@@ -1,0 +1,30 @@
+describe('Core.toTableElement', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should convert instance into HTMLTableElement', () => {
+    const hot = handsontable({
+      data: Handsontable.helper.createSpreadsheetData(2, 2),
+      colHeaders: true,
+      rowHeaders: true,
+    });
+
+    const newTable = hot.toTableElement();
+
+    expect(newTable.nodeName).toBe('TABLE');
+    expect(newTable.tBodies.length).toBe(1);
+    expect(newTable.tHead).not.toBe(null);
+    expect(newTable.rows.length).toBe(3);
+    expect(newTable.rows[2].cells[2].innerText).toBe('B2');
+  });
+});


### PR DESCRIPTION
### Context
During QA @wojciechczerniak noticed that I left previous methods names in `core.js`.

Additionally, I added test specs for new methods.