### PR TITLE
Added missing rootInstanceSymbol to Handsontable.Core

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ function Handsontable(rootElement, userSettings) {
 
 jQueryWrapper(Handsontable);
 
-Handsontable.Core = Core;
+Handsontable.Core = (rootElement, userSettings = {}) => new Core(rootElement, userSettings, rootInstanceSymbol);
 Handsontable.DefaultSettings = DefaultSettings;
 Handsontable.EventManager = EventManager;
 Handsontable._getListenersCounter = getListenersCounter; // For MemoryLeak tests

--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,9 @@ function Handsontable(rootElement, userSettings) {
 
 jQueryWrapper(Handsontable);
 
-Handsontable.Core = (rootElement, userSettings = {}) => new Core(rootElement, userSettings, rootInstanceSymbol);
+Handsontable.Core = function(rootElement, userSettings = {}) {
+  return new Core(rootElement, userSettings, rootInstanceSymbol);
+};
 Handsontable.DefaultSettings = DefaultSettings;
 Handsontable.EventManager = EventManager;
 Handsontable._getListenersCounter = getListenersCounter; // For MemoryLeak tests

--- a/test/e2e/settings/licenseKey.spec.js
+++ b/test/e2e/settings/licenseKey.spec.js
@@ -1,0 +1,47 @@
+describe('settings', () => {
+  describe('licenseKey', () => {
+    const id = 'testContainer';
+
+    beforeEach(function() {
+      this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+    });
+
+    afterEach(function() {
+      if (this.$container) {
+        destroy();
+        this.$container.remove();
+      }
+    });
+
+    it('should add info under table about missing license key', () => {
+      handsontable({});
+
+      const info = spec().$container[0].nextSibling;
+      expect(info.innerText).toBe([
+        'The license key for Handsontable is missing. Use your purchased key to activate the product. ',
+        'Alternatively, you can activate Handsontable to use for non-commercial purposes by passing the key: \'non-commercial-and-evaluation\'. ',
+        'Read more about it in the documentation or contact us at support@handsontable.com.',
+      ].join(''));
+    });
+
+    it('should add info under table about invalid license key', () => {
+      handsontable({
+        licenseKey: 'invalidKey'
+      });
+
+      const info = spec().$container[0].nextSibling;
+      expect(info.innerText).toBe([
+        'The license key for Handsontable is invalid. ',
+        'Read more on how to install it properly or contact us at support@handsontable.com.',
+      ].join(''));
+    });
+
+    it('should not add info under table if non-commercial key is used', () => {
+      handsontable({
+        licenseKey: 'non-commercial-and-evaluation'
+      });
+
+      expect(spec().$container[0].nextSibling).toBe(null);
+    });
+  });
+});


### PR DESCRIPTION
### Context
Whole context is described in #6040.

### How has this been tested?
Use configuration from: https://stackblitz.com/edit/js-q7ldvr
`new Handsontable.Core(...)` should be the valid instance.

### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)

### Related issue(s):
1. #6040
