### PR TITLE
Changed CSS reading in parseTable utility

### DIFF
--- a/src/utils/parseTable.js
+++ b/src/utils/parseTable.js
@@ -182,8 +182,8 @@ export function htmlToGridSettings(element, rootDocument = document) {
   if (styleElem) {
     rootDocument.body.appendChild(styleElem);
     styleElem.disabled = true;
-    styleSheet = rootDocument.styleSheets.item(styleElem);
-    styleSheetArr = Array.from(styleSheet.cssRules);
+    styleSheet = styleElem.sheet;
+    styleSheetArr = styleSheet ? Array.from(styleSheet.cssRules) : [];
     rootDocument.body.removeChild(styleElem);
   }
 

--- a/src/utils/parseTable.js
+++ b/src/utils/parseTable.js
@@ -135,7 +135,7 @@ export function _dataToHTML(input) {
  * Helper to verify and get CSSRules for the element.
  *
  * @param {Element} element Element to verify with selector text.
- * @param {*} selector Selector text from CSSRule.
+ * @param {String} selector Selector text from CSSRule.
  */
 function matchCSSRules(element, selector) {
   let result;

--- a/src/utils/parseTable.js
+++ b/src/utils/parseTable.js
@@ -131,13 +131,20 @@ export function _dataToHTML(input) {
   return result.join('');
 }
 
-function matchCSSRules(elem, selector) {
+/**
+ * Helper to verify and get CSSRules for the element.
+ *
+ * @param {Element} element Element to verify with selector text.
+ * @param {*} selector Selector text from CSSRule.
+ */
+function matchCSSRules(element, selector) {
   let result;
 
-  if (elem.msMatchesSelector) {
-    result = elem.msMatchesSelector(selector);
-  } else if (elem.matches) {
-    result = elem.matches(selector);
+  if (element.msMatchesSelector) {
+    result = element.msMatchesSelector(selector);
+
+  } else if (element.matches) {
+    result = element.matches(selector);
   }
 
   return result;


### PR DESCRIPTION
### Context
During QA, @wojciechczerniak found an issue with non-supported `new CSSStyleSheet()` in other browsers than Chrome.
This PR changes the way how CSSStyleSheet are resolving in `parseTable.htmlToGridSettings` .

### How has this been tested?
Run in browser dev console:
```
Handsontable.helper.htmlToGridSettings([
   '<table><tbody>',
   '<tr><td>A3</td><td>B3<br><br><br><br><br><br></td><td>C3</td></tr>',
   '<tr><td>A4</td><td>B4</td><td>C4</td></tr>',
  '<tr><td>A5</td><td>B5</td><td>C5</td></tr>',
   '<tr><td>A6</td><td>B6</td><td>C6</td></tr>',
  '</tbody></table>',
].join(''));
```
Should not cause errors in browser's dev console.

### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)