### PR TITLE
afterColumnMove hook is enable only when beforeColumnMove not returns false

### DIFF
--- a/src/plugins/manualColumnMove/manualColumnMove.js
+++ b/src/plugins/manualColumnMove/manualColumnMove.js
@@ -210,9 +210,9 @@ class ManualColumnMove extends BasePlugin {
 
       // after moving we have to clear columnsMapper from null entries
       this.columnsMapper.clearNull();
-    }
 
-    this.hot.runHooks('afterColumnMove', visualColumns, target);
+      this.hot.runHooks('afterColumnMove', visualColumns, target);
+    }
   }
 
   /**

--- a/src/plugins/manualColumnMove/test/manualColumnMove.e2e.js
+++ b/src/plugins/manualColumnMove/test/manualColumnMove.e2e.js
@@ -285,6 +285,33 @@ describe('manualColumnMove', () => {
       expect(afterMoveColumnCallback).toHaveBeenCalledWith([8, 9, 7], 0, void 0, void 0, void 0, void 0);
     });
 
+    it('should not trigger an afterColumnMove event after column move when beforeColumnMove returns false', () => {
+      const afterMoveColumnCallback = jasmine.createSpy('afterMoveColumnCallback');
+
+      spec().$container.height(150);
+
+      const hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(10, 10),
+        colHeaders: true,
+        manualColumnMove: true,
+        beforeColumnMove: () => false,
+        afterColumnMove: afterMoveColumnCallback
+      });
+
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('A1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('B1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('C1');
+
+      hot.getPlugin('manualColumnMove').moveColumns([8, 9, 7], 0);
+      hot.render();
+
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('A1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('B1');
+      expect(spec().$container.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('C1');
+
+      expect(afterMoveColumnCallback).not.toHaveBeenCalled();
+    });
+
     it('should move the second column to the first column', () => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(10, 10),


### PR DESCRIPTION
### Context
If we abort a move by returning false from `beforeColumnMove` shouldn't an `afterColumnMove` event hook fired.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #5958

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
