### PR TITLE
Update moment to use loose version match

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@types/pikaday": "1.6.0",
     "core-js": "^3.0.0",
     "hot-formula-parser": "^3.0.1",
-    "moment": "2.20.1",
+    "moment": "^2.20.1",
     "numbro": "2.1.1",
     "pikaday": "1.5.1"
   },


### PR DESCRIPTION
### Context
This moment version is too strict, and doesn't match other package's moment version, so it increases the bundle size.

### How has this been tested?
moment is stable, can be trusted.

