### PR TITLE
Fix: #6102 Wrong typings in CopyPaste plugin

### DIFF
--- a/handsontable.d.ts
+++ b/handsontable.d.ts
@@ -1,4 +1,4 @@
-import { PikadayOptions } from "pikaday";
+import { PikadayOptions } from 'pikaday';
 
 /**
  * @internal
@@ -62,7 +62,7 @@ declare namespace _Handsontable {
     getSchema(): Handsontable.RowObject;
     getSelected(): Array<[number, number, number, number]> | undefined;
     getSelectedLast(): number[] | undefined;
-    getSelectedRange():  Handsontable.wot.CellRange[] | undefined;
+    getSelectedRange(): Handsontable.wot.CellRange[] | undefined;
     getSelectedRangeLast(): Handsontable.wot.CellRange | undefined;
     getSettings(): Handsontable.GridSettings;
     getSourceData(row?: number, column?: number, row2?: number, column2?: number): Handsontable.CellValue[][] | Handsontable.RowObject[];
@@ -270,7 +270,7 @@ declare namespace Handsontable {
 
       beginEditing(initialValue?: any, event?: Event): void;
       cancelChanges(): void;
-      checkEditorSection(): 'top-left-corner' | 'top' | 'bottom-left-corner' | 'bottom' | 'left' | '' ;
+      checkEditorSection(): 'top-left-corner' | 'top' | 'bottom-left-corner' | 'bottom' | 'left' | '';
       abstract close(): void;
       discardEditor(validationResult?: boolean): void;
       enableFullEditMode(): void;
@@ -358,9 +358,9 @@ declare namespace Handsontable {
       assignHooks(): void;
     }
 
-    class Numeric extends Text {}
+    class Numeric extends Text { }
 
-    class Password extends Text {}
+    class Password extends Text { }
 
     class Autocomplete extends Handsontable {
       allowKeyEventPropagation(keyCode?: number): boolean;
@@ -377,7 +377,7 @@ declare namespace Handsontable {
       updateDropdownHeight(): void;
     }
 
-    class Dropdown extends Autocomplete {}
+    class Dropdown extends Autocomplete { }
   }
 
   namespace plugins {
@@ -470,7 +470,7 @@ declare namespace Handsontable {
         show(): void;
         update(): void;
       }
-      interface InputUI extends BaseUI {}
+      interface InputUI extends BaseUI { }
       interface MultipleSelectUI extends BaseUI {
         clearAllUI: BaseUI;
         items: any[];
@@ -913,9 +913,9 @@ declare namespace Handsontable {
       setCopyableText(): void;
       getRangedCopyableData(ranges: RangeType[]): string;
       getRangedData(ranges: RangeType[]): any[];
-      copy(triggeredByClick?: boolean): void;
-      cut(triggeredByClick?: boolean): void;
-      paste(triggeredByClick?: boolean): void;
+      copy(): void;
+      cut(): void;
+      paste(pastableText: string, pastableHtml?: string): void;
     }
 
     interface CustomBorders extends Base {
@@ -1041,7 +1041,7 @@ declare namespace Handsontable {
       toString(): string;
       translateTo(rowOffset: number, columnOffset: number): void;
     }
-    interface CellReference extends BaseCell {}
+    interface CellReference extends BaseCell { }
 
     interface CellValue extends BaseCell {
       error: string | void;
@@ -1290,8 +1290,8 @@ declare namespace Handsontable {
         setSize(width: number, height: number): void;
       }
 
-      interface BacklightUI extends BaseUI {}
-      interface GuidelineUI extends BaseUI {}
+      interface BacklightUI extends BaseUI { }
+      interface GuidelineUI extends BaseUI { }
     }
 
     interface MergeCells extends Base {
@@ -1586,17 +1586,17 @@ declare namespace Handsontable {
       (instance: _Handsontable.Core, TD: HTMLTableCellElement, row: number, col: number, prop: string | number, value: CellValue, cellProperties: CellProperties): HTMLTableCellElement | void;
     }
 
-    interface Autocomplete extends Base {}
+    interface Autocomplete extends Base { }
 
-    interface Checkbox extends Base {}
+    interface Checkbox extends Base { }
 
-    interface Html extends Base {}
+    interface Html extends Base { }
 
-    interface Numeric extends Base {}
+    interface Numeric extends Base { }
 
-    interface Password extends Base {}
+    interface Password extends Base { }
 
-    interface Text extends Base {}
+    interface Text extends Base { }
   }
 
   namespace validators {
@@ -1604,13 +1604,13 @@ declare namespace Handsontable {
       (this: CellProperties, value: CellValue, callback: (valid: boolean) => void): void;
     }
 
-    interface Autocomplete extends Base {}
+    interface Autocomplete extends Base { }
 
-    interface Date extends Base {}
+    interface Date extends Base { }
 
-    interface Numeric extends Base {}
+    interface Numeric extends Base { }
 
-    interface Time extends Base {}
+    interface Time extends Base { }
   }
 
   interface DefaultSettings {


### PR DESCRIPTION
change: copy and cut methods should not expect any arguments
change: paste should expect one or two arguments that are strings

### Context
Because it is impossibleto call paste with the expected arguments, which by the source code are strings, not boolean

### How has this been tested?
in beforePaste I verify if the copied columns are more than the size of the table if they are more, I show a confirmation dialog, when confirmed the following code is execute
```
const slicedData = copiedData.map((row) => {
     return row.slice(0, sliceNumber);
});
this.hotInstance.listen();
const parsed = SheetClip.stringify(slicedData);
console.log(copyableRanges, coords);
this.hotInstance.selectCells(coords);
this.hotInstance.getPlugin('copyPaste').paste(parsed);
```

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #6102 

### Checklist:
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
