### PR TITLE
Fix a problem, where it was impossible to open the filter dropdown ...

### DIFF
--- a/src/plugins/contextMenu/menu.js
+++ b/src/plugins/contextMenu/menu.js
@@ -560,9 +560,6 @@ class Menu {
       className = `${this.options.className}Sub_${className}`;
 
       container = rootDocument.querySelector(`.${this.options.className}.${className}`);
-
-    } else {
-      container = rootDocument.querySelector(`.${this.options.className}`);
     }
 
     if (!container) {

--- a/src/plugins/filters/test/filtersUI.e2e.js
+++ b/src/plugins/filters/test/filtersUI.e2e.js
@@ -1335,6 +1335,48 @@ describe('Filters UI', () => {
     }, 100);
   });
 
+  it('should allow opening the filtering dropdown menu, when there are multiple Handsontable instances present', () => {
+    handsontable({
+      data: getDataForFilters(),
+      columns: getColumnsForFilters(),
+      filters: true,
+      dropdownMenu: true,
+      width: 500,
+      height: 300
+    });
+
+    const hot2Container = document.createElement('DIV');
+    document.body.appendChild(hot2Container);
+    const hot2 = new Handsontable(hot2Container, {
+      data: getDataForFilters(),
+      columns: getColumnsForFilters(),
+      filters: true,
+      dropdownMenu: true,
+      width: 500,
+      height: 300
+    });
+
+    expect(document.querySelectorAll('.htDropdownMenu').length).toBe(2);
+
+    dropdownMenu(1);
+    closeDropdownMenu();
+
+    expect(getPlugin('dropdownMenu').menu.container.style.display).toBe('block');
+    expect(getPlugin('dropdownMenu').menu.container.parentElement).not.toBe(null);
+
+    const th = hot2.view.wt.wtTable.getColumnHeader(1);
+    const button = th.querySelector('.changeType');
+    $(button).simulate('mousedown');
+    $(button).simulate('mouseup');
+    $(button).simulate('click');
+
+    expect(hot2.getPlugin('dropdownMenu').menu.container.style.display).toBe('block');
+    expect(hot2.getPlugin('dropdownMenu').menu.container.parentElement).not.toBe(null);
+
+    hot2.destroy();
+    hot2Container.parentElement.removeChild(hot2Container);
+  });
+
   describe('Simple filtering (one column)', () => {
     it('should filter empty values and revert back after removing filter', () => {
       handsontable({


### PR DESCRIPTION
... when multiple Handsontable instances were present on a page.

### Context
When two Handsontable instances are implemented on a page, the filtering dropdown was not working on the first one.

### How has this been tested?
Added a test case.