### PR TITLE
Add 'getCommentAtCell' method into typings

### DIFF
--- a/handsontable.d.ts
+++ b/handsontable.d.ts
@@ -840,7 +840,7 @@ declare namespace Handsontable {
 
       clearRange(): void;
       getComment(): string;
-      getCommentAtCell(row: number, column: number): string;
+      getCommentAtCell(row: number, column: number): string | undefined;
       getCommentMeta(row: number, column: number, property: string): any;
       hide(): void;
       refreshEditor(force?: boolean): void;

--- a/handsontable.d.ts
+++ b/handsontable.d.ts
@@ -840,6 +840,7 @@ declare namespace Handsontable {
 
       clearRange(): void;
       getComment(): string;
+      getCommentAtCell(row: number, column: number): string;
       getCommentMeta(row: number, column: number, property: string): any;
       hide(): void;
       refreshEditor(force?: boolean): void;


### PR DESCRIPTION
### Context
On my recent commercial Angular project, I use `getCommentAtCell` method and it is missing in typings. I have to use a workaround like `plugin['getCommentAtCell']()`.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I added `getCommentAtCell` method to typings file on my local machine and snippet`hot.getPlugin('comments').getCommentAtCell(1, 2);` has no TSLint errors.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

<!--- ### Related issue(s):
1.
2.
3. -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
