### PR TITLE
Update editorManager.js

### DIFF
--- a/src/editorManager.js
+++ b/src/editorManager.js
@@ -175,7 +175,7 @@ class EditorManager {
     if (readOnly) {
       // move the selection after opening the editor with ENTER key
       if (event && event.keyCode === KEY_CODES.ENTER) {
-        this.moveSelectionAfterEnter();
+        this.moveSelectionAfterEnter(event);
       }
     } else {
       this.activeEditor.beginEditing(newInitialValue, event);
@@ -220,12 +220,12 @@ class EditorManager {
    * Controls selection's behaviour after clicking `Enter`.
    *
    * @private
-   * @param {Boolean} isShiftPressed
+   * @param {Event} event
    */
-  moveSelectionAfterEnter(isShiftPressed) {
+  moveSelectionAfterEnter(event) {
     const enterMoves = typeof this.priv.settings.enterMoves === 'function' ? this.priv.settings.enterMoves(event) : this.priv.settings.enterMoves;
 
-    if (isShiftPressed) {
+    if (event.shiftKey) {
       // move selection up
       this.selection.transformStart(-enterMoves.row, -enterMoves.col);
     } else {
@@ -424,7 +424,7 @@ class EditorManager {
           if (this.activeEditor && this.activeEditor.state !== EditorState.WAITING) {
             this.closeEditorAndSaveChanges(isCtrlPressed);
           }
-          this.moveSelectionAfterEnter(isShiftPressed);
+          this.moveSelectionAfterEnter(event);
 
         } else if (this.instance.getSettings().enterBeginsEditing) {
           if (this.activeEditor) {
@@ -433,7 +433,7 @@ class EditorManager {
           this.openEditor(null, event);
 
         } else {
-          this.moveSelectionAfterEnter(isShiftPressed);
+          this.moveSelectionAfterEnter(event);
         }
         event.preventDefault(); // don't add newline to field
         stopImmediatePropagation(event); // required by HandsontableEditor


### PR DESCRIPTION
moveSelectionAfterEnter calls enterMoves() which expects an Event.  The call is made without passing in a key event, just event.shiftKey.  This makes sure calls to moveSelectionAfterEnter actually pass an event.

### Context
Bug in existing code.  Won't pass type checks.

### How has this been tested?
Verified type checks pass.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
