### PR TITLE
fix: #6102 Typings for copyPaste plugin methods

### DIFF
--- a/handsontable.d.ts
+++ b/handsontable.d.ts
@@ -914,9 +914,9 @@ declare namespace Handsontable {
       setCopyableText(): void;
       getRangedCopyableData(ranges: RangeType[]): string;
       getRangedData(ranges: RangeType[]): any[];
-      copy(triggeredByClick?: boolean): void;
-      cut(triggeredByClick?: boolean): void;
-      paste(triggeredByClick?: boolean): void;
+      copy(): void;
+      cut(): void;
+      paste(pastableText: string, pastableHtml?: string): void;
     }
 
     interface CustomBorders extends Base {


### PR DESCRIPTION
### Context
Solving issue with typings, which prevented methods of copyPaste plugin to be called programmatically from angular

change: copy and cut methods should not expect any arguments
change: paste should expect one or two arguments that are strings

### How has this been tested?
in beforePaste we get the copied data
then we slice because we don't want to overflow the size of the table
```
const slicedData = copiedData.map((row) => {
   return row.slice(0, sliceNumber);
});
// then if i want hot to react on the paste call I listen
this.hotInstance.listen();
// I parse the data with the internal library from hot
const parsed = SheetClip.stringify(slicedData);
// I force select cells
this.hotInstance.selectCells(coords);
// and call paste method
this.hotInstance.getPlugin('copyPaste').paste(parsed);
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #6102


### Checklist:
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
