### PR TITLE
Update definition file to specify string values for preventOverflow option

### DIFF
--- a/handsontable.d.ts
+++ b/handsontable.d.ts
@@ -1754,7 +1754,7 @@ declare namespace Handsontable {
     persistentState?: boolean;
     placeholder?: string;
     placeholderCellClassName?: string;
-    preventOverflow?: string | boolean;
+    preventOverflow?: boolean | 'vertical' | 'horizontal';
     readOnly?: boolean;
     readOnlyCellClassName?: string;
     renderAllRows?: boolean;


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Added accepted string values for `preventOverflow` option in the definition file. Previously the definition mentioned `string`. It got replaced with `vertical` and `horizontal`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/6152

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
