### PR TITLE
Refactor ManualColumnResize to be compatible with upcoming IndexMappers

### DIFF
--- a/src/plugins/manualColumnResize/manualColumnResize.js
+++ b/src/plugins/manualColumnResize/manualColumnResize.js
@@ -145,10 +145,6 @@ class ManualColumnResize extends BasePlugin {
    */
   setManualSize(column, width) {
     const newWidth = Math.max(width, 20);
-    /**
-     *  We need to run col through modifyCol hook, in case the order of displayed columns is different than the order
-     *  in data source. For instance, this order can be modified by manualColumnMove plugin.
-     */
     const physicalColumn = this.hot.toPhysicalColumn(column);
 
     this.columnWidthsMap.setValueAtIndex(physicalColumn, newWidth);

--- a/src/plugins/manualColumnResize/manualColumnResize.js
+++ b/src/plugins/manualColumnResize/manualColumnResize.js
@@ -9,7 +9,7 @@ import { ValueMap } from './../../translations';
 
 // Developer note! Whenever you make a change in this file, make an analogous change in manualRowResize.js
 
-const COLUMN_WIDTHS_MAP_NAME = 'columnWidths';
+const COLUMN_WIDTHS_MAP_NAME = 'ManualColumnResize';
 const PERSISTENT_STATE_KEY = 'manualColumnWidths';
 const privatePool = new WeakMap();
 /**

--- a/src/plugins/manualColumnResize/manualColumnResize.js
+++ b/src/plugins/manualColumnResize/manualColumnResize.js
@@ -5,9 +5,13 @@ import { pageX } from './../../helpers/dom/event';
 import { arrayEach } from './../../helpers/array';
 import { rangeEach } from './../../helpers/number';
 import { registerPlugin } from './../../plugins';
+import { ValueMap } from './../../translations';
 
 // Developer note! Whenever you make a change in this file, make an analogous change in manualRowResize.js
 
+const COLUMN_WIDTHS_MAP_NAME = 'columnWidths';
+const PERSISTENT_STATE_KEY = 'manualColumnWidths';
+const privatePool = new WeakMap();
 /**
  * @description
  * This plugin allows to change columns width. To make columns width persistent the {@link Options#persistentState}
@@ -39,7 +43,19 @@ class ManualColumnResize extends BasePlugin {
     this.pressed = null;
     this.dblclick = 0;
     this.autoresizeTimeout = null;
-    this.manualColumnWidths = [];
+
+    /**
+     * ValueMap to keep and track widths for physical column indexes.
+     *
+     * @type {ValueMap}
+     */
+    this.columnWidthsMap = void 0;
+    /**
+     * Private pool to save configuration from updateSettings.
+     */
+    privatePool.set(this, {
+      config: void 0,
+    });
 
     addClass(this.handle, 'manualColumnResizer');
     addClass(this.guide, 'manualColumnResizerGuide');
@@ -63,24 +79,13 @@ class ManualColumnResize extends BasePlugin {
       return;
     }
 
-    this.manualColumnWidths = [];
-    const initialColumnWidth = this.hot.getSettings().manualColumnResize;
-    const loadedManualColumnWidths = this.loadManualColumnWidths();
+    this.columnWidthsMap = new ValueMap(() => void 0);
+    this.columnWidthsMap.addLocalHook('init', () => this.onMapInit());
+    this.columnIndexMapper.registerMap(COLUMN_WIDTHS_MAP_NAME, this.columnWidthsMap);
 
     this.addHook('modifyColWidth', (width, col) => this.onModifyColWidth(width, col));
     this.addHook('beforeStretchingColumnWidth', (stretchedWidth, column) => this.onBeforeStretchingColumnWidth(stretchedWidth, column));
     this.addHook('beforeColumnResize', (currentColumn, newSize, isDoubleClick) => this.onBeforeColumnResize(currentColumn, newSize, isDoubleClick));
-
-    if (typeof loadedManualColumnWidths !== 'undefined') {
-      this.manualColumnWidths = loadedManualColumnWidths;
-    } else if (Array.isArray(initialColumnWidth)) {
-      this.manualColumnWidths = initialColumnWidth;
-    } else {
-      this.manualColumnWidths = [];
-    }
-
-    // Handsontable.hooks.register('beforeColumnResize');
-    // Handsontable.hooks.register('afterColumnResize');
 
     this.bindEvents();
 
@@ -91,44 +96,104 @@ class ManualColumnResize extends BasePlugin {
    * Updates the plugin state. This method is executed when {@link Core#updateSettings} is invoked.
    */
   updatePlugin() {
-    const initialColumnWidth = this.hot.getSettings().manualColumnResize;
+    this.disablePlugin();
+    this.enablePlugin();
 
-    if (Array.isArray(initialColumnWidth)) {
-      this.manualColumnWidths = initialColumnWidth;
-
-    } else if (!initialColumnWidth) {
-      this.manualColumnWidths = [];
-    }
+    super.updatePlugin();
   }
 
   /**
    * Disables the plugin functionality for this Handsontable instance.
    */
   disablePlugin() {
+    const priv = privatePool.get(this);
+    priv.config = this.columnWidthsMap.getValues();
+
+    this.columnIndexMapper.unregisterMap(COLUMN_WIDTHS_MAP_NAME);
     super.disablePlugin();
   }
 
   /**
    * Saves the current sizes using the persistentState plugin (the {@link Options#persistentState} option has to be enabled).
+   *
+   * @fires Hooks#persistentStateSave
    */
   saveManualColumnWidths() {
-    this.hot.runHooks('persistentStateSave', 'manualColumnWidths', this.manualColumnWidths);
+    this.hot.runHooks('persistentStateSave', PERSISTENT_STATE_KEY, this.columnWidthsMap.getValues());
   }
 
   /**
    * Loads the previously saved sizes using the persistentState plugin (the {@link Options#persistentState} option has to be enabled).
    *
    * @returns {Array}
-   *
    * @fires Hooks#persistentStateLoad
-   * @fires Hooks#manualColumnWidths
    */
   loadManualColumnWidths() {
     const storedState = {};
 
-    this.hot.runHooks('persistentStateLoad', 'manualColumnWidths', storedState);
+    this.hot.runHooks('persistentStateLoad', PERSISTENT_STATE_KEY, storedState);
 
     return storedState.value;
+  }
+
+  /**
+   * Sets the new width for specified column index.
+   *
+   * @param {Number} column Visual column index.
+   * @param {Number} width Column width (no less than 20px).
+   * @returns {Number} Returns new width.
+   */
+  setManualSize(column, width) {
+    const newWidth = Math.max(width, 20);
+    /**
+     *  We need to run col through modifyCol hook, in case the order of displayed columns is different than the order
+     *  in data source. For instance, this order can be modified by manualColumnMove plugin.
+     */
+    const physicalColumn = this.hot.toPhysicalColumn(column);
+
+    this.columnWidthsMap.setValueAtIndex(physicalColumn, newWidth);
+
+    return newWidth;
+  }
+
+  /**
+   * Clears the cache for the specified column index.
+   *
+   * @param {Number} column Visual column index.
+   */
+  clearManualSize(column) {
+    const physicalColumn = this.hot.toPhysicalColumn(column);
+
+    this.columnWidthsMap.setValueAtIndex(physicalColumn, void 0);
+  }
+
+  /**
+   * Callback to call on map's `init` local hook.
+   *
+   * @private
+   */
+  onMapInit() {
+    const priv = privatePool.get(this);
+
+    const initialSetting = this.hot.getSettings().manualColumnResize;
+    const loadedManualColumnWidths = this.loadManualColumnWidths();
+
+    if (typeof loadedManualColumnWidths !== 'undefined') {
+      loadedManualColumnWidths.forEach((width, index) => {
+        this.columnWidthsMap.setValueAtIndex(index, width);
+      });
+
+    } else if (Array.isArray(initialSetting)) {
+      initialSetting.forEach((width, index) => {
+        this.columnWidthsMap.setValueAtIndex(index, width);
+      });
+      priv.config = initialSetting;
+
+    } else if (initialSetting === true && Array.isArray(priv.config)) {
+      priv.config.forEach((width, index) => {
+        this.columnWidthsMap.setValueAtIndex(index, width);
+      });
+    }
   }
 
   /**
@@ -310,7 +375,6 @@ class ManualColumnResize extends BasePlugin {
    * Auto-size row after doubleclick - callback.
    *
    * @private
-   *
    * @fires Hooks#beforeColumnResize
    * @fires Hooks#afterColumnResize
    */
@@ -466,38 +530,6 @@ class ManualColumnResize extends BasePlugin {
   }
 
   /**
-   * Sets the new width for specified column index.
-   *
-   * @param {Number} column Visual column index.
-   * @param {Number} width Column width (no less than 20px).
-   * @returns {Number} Returns new width.
-   */
-  setManualSize(column, width) {
-    const newWidth = Math.max(width, 20);
-
-    /**
-     *  We need to run col through modifyCol hook, in case the order of displayed columns is different than the order
-     *  in data source. For instance, this order can be modified by manualColumnMove plugin.
-     */
-    const physicalColumn = this.hot.toPhysicalColumn(column);
-
-    this.manualColumnWidths[physicalColumn] = newWidth;
-
-    return newWidth;
-  }
-
-  /**
-   * Clears the cache for the specified column index.
-   *
-   * @param {Number} column Visual column index.
-   */
-  clearManualSize(column) {
-    const physicalColumn = this.hot.toPhysicalColumn(column);
-
-    this.manualColumnWidths[physicalColumn] = void 0;
-  }
-
-  /**
    * Modifies the provided column width, based on the plugin settings
    *
    * @private
@@ -510,7 +542,7 @@ class ManualColumnResize extends BasePlugin {
 
     if (this.enabled) {
       const physicalColumn = this.hot.toPhysicalColumn(column);
-      const columnWidth = this.manualColumnWidths[physicalColumn];
+      const columnWidth = this.columnWidthsMap.getValueAtIndex(physicalColumn);
 
       if (this.hot.getSettings().manualColumnResize && columnWidth) {
         newWidth = columnWidth;
@@ -529,7 +561,7 @@ class ManualColumnResize extends BasePlugin {
    * @returns {Number}
    */
   onBeforeStretchingColumnWidth(stretchedWidth, column) {
-    let width = this.manualColumnWidths[column];
+    let width = this.columnWidthsMap.getValueAtIndex(column);
 
     if (width === void 0) {
       width = stretchedWidth;

--- a/src/plugins/manualColumnResize/manualColumnResize.js
+++ b/src/plugins/manualColumnResize/manualColumnResize.js
@@ -9,7 +9,7 @@ import { ValueMap } from './../../translations';
 
 // Developer note! Whenever you make a change in this file, make an analogous change in manualRowResize.js
 
-const COLUMN_WIDTHS_MAP_NAME = 'ManualColumnResize';
+const COLUMN_WIDTHS_MAP_NAME = 'manualColumnResize';
 const PERSISTENT_STATE_KEY = 'manualColumnWidths';
 const privatePool = new WeakMap();
 /**

--- a/src/plugins/manualColumnResize/test/manualColumnResize.e2e.js
+++ b/src/plugins/manualColumnResize/test/manualColumnResize.e2e.js
@@ -113,6 +113,42 @@ describe('manualColumnResize', () => {
     expect(colWidth(spec().$container, 2)).toBe(180);
   });
 
+  it('should keep proper column widths after inserting column', () => {
+    handsontable({
+      manualColumnResize: [void 0, void 0, 120]
+    });
+
+    expect(colWidth(spec().$container, 0)).toBe(50);
+    expect(colWidth(spec().$container, 1)).toBe(50);
+    expect(colWidth(spec().$container, 2)).toBe(120);
+    expect(colWidth(spec().$container, 3)).toBe(50);
+
+    alter('insert_col', 0);
+
+    expect(colWidth(spec().$container, 0)).toBe(50);
+    expect(colWidth(spec().$container, 1)).toBe(50);
+    expect(colWidth(spec().$container, 2)).toBe(50);
+    expect(colWidth(spec().$container, 3)).toBe(120);
+  });
+
+  it('should keep proper column widths after removing column', () => {
+    handsontable({
+      manualColumnResize: [void 0, void 0, 120]
+    });
+
+    expect(colWidth(spec().$container, 0)).toBe(50);
+    expect(colWidth(spec().$container, 1)).toBe(50);
+    expect(colWidth(spec().$container, 2)).toBe(120);
+    expect(colWidth(spec().$container, 3)).toBe(50);
+
+    alter('remove_col', 0);
+
+    expect(colWidth(spec().$container, 0)).toBe(50);
+    expect(colWidth(spec().$container, 1)).toBe(120);
+    expect(colWidth(spec().$container, 2)).toBe(50);
+    expect(colWidth(spec().$container, 3)).toBe(50);
+  });
+
   it('should resize (narrowing) appropriate columns, even when stretchH `all` is enabled', () => {
     spec().$container.css('width', '910px');
     handsontable({


### PR DESCRIPTION
### Context
As in title and in description of #6163. Here are necessary changes to adjust plugin to upcoming IndexMappers.

### How has this been tested?
- Change column widths using ManualColumnResize handler
- Insert or remove column/columns on the left side of resized columns.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. #6163