### PR TITLE
Refactor ManualRowResize to be compatible with upcoming IndexMappers

### DIFF
--- a/src/plugins/manualRowResize/manualRowResize.js
+++ b/src/plugins/manualRowResize/manualRowResize.js
@@ -9,7 +9,7 @@ import { ValueMap } from './../../translations';
 
 // Developer note! Whenever you make a change in this file, make an analogous change in manualRowResize.js
 
-const ROW_HEIGHTS_MAP_NAME = 'rowHeights';
+const ROW_HEIGHTS_MAP_NAME = 'manualRowResize';
 const PERSISTENT_STATE_KEY = 'manualRowHeights';
 const privatePool = new WeakMap();
 

--- a/src/plugins/manualRowResize/manualRowResize.js
+++ b/src/plugins/manualRowResize/manualRowResize.js
@@ -5,8 +5,13 @@ import { pageY } from './../../helpers/dom/event';
 import { arrayEach } from './../../helpers/array';
 import { rangeEach } from './../../helpers/number';
 import { registerPlugin } from './../../plugins';
+import { ValueMap } from './../../translations';
 
 // Developer note! Whenever you make a change in this file, make an analogous change in manualRowResize.js
+
+const ROW_HEIGHTS_MAP_NAME = 'rowHeights';
+const PERSISTENT_STATE_KEY = 'manualRowHeights';
+const privatePool = new WeakMap();
 
 /**
  * @description
@@ -41,6 +46,19 @@ class ManualRowResize extends BasePlugin {
     this.autoresizeTimeout = null;
     this.manualRowHeights = [];
 
+    /**
+     * ValueMap to keep and track widths for physical column indexes.
+     *
+     * @type {ValueMap}
+     */
+    this.columnWidthsMap = void 0;
+    /**
+     * Private pool to save configuration from updateSettings.
+     */
+    privatePool.set(this, {
+      config: void 0,
+    });
+
     addClass(this.handle, 'manualRowResizer');
     addClass(this.guide, 'manualRowResizerGuide');
   }
@@ -63,23 +81,11 @@ class ManualRowResize extends BasePlugin {
       return;
     }
 
-    this.manualRowHeights = [];
-
-    const initialRowHeights = this.hot.getSettings().manualRowResize;
-    const loadedManualRowHeights = this.loadManualRowHeights();
-
-    if (typeof loadedManualRowHeights !== 'undefined') {
-      this.manualRowHeights = loadedManualRowHeights;
-    } else if (Array.isArray(initialRowHeights)) {
-      this.manualRowHeights = initialRowHeights;
-    } else {
-      this.manualRowHeights = [];
-    }
+    this.rowHeightsMap = new ValueMap(() => void 0);
+    this.rowHeightsMap.addLocalHook('init', () => this.onMapInit());
+    this.rowIndexMapper.registerMap(ROW_HEIGHTS_MAP_NAME, this.rowHeightsMap);
 
     this.addHook('modifyRowHeight', (height, row) => this.onModifyRowHeight(height, row));
-
-    // Handsontable.hooks.register('beforeRowResize');
-    // Handsontable.hooks.register('afterRowResize');
 
     this.bindEvents();
 
@@ -90,30 +96,30 @@ class ManualRowResize extends BasePlugin {
    * Updates the plugin state. This method is executed when {@link Core#updateSettings} is invoked.
    */
   updatePlugin() {
-    const initialRowHeights = this.hot.getSettings().manualRowResize;
+    this.disablePlugin();
+    this.enablePlugin();
 
-    if (Array.isArray(initialRowHeights)) {
-      this.manualRowHeights = initialRowHeights;
-
-    } else if (!initialRowHeights) {
-      this.manualRowHeights = [];
-    }
+    super.updatePlugin();
   }
 
   /**
    * Disables the plugin functionality for this Handsontable instance.
    */
   disablePlugin() {
+    const priv = privatePool.get(this);
+    priv.config = this.rowHeightsMap.getValues();
+
+    this.rowIndexMapper.unregisterMap(ROW_HEIGHTS_MAP_NAME);
     super.disablePlugin();
   }
 
   /**
    * Saves the current sizes using the persistentState plugin (the {@link Options#persistentState} option has to be enabled).
+   *
    * @fires Hooks#persistentStateSave
-   * @fires Hooks#manualRowHeights
    */
   saveManualRowHeights() {
-    this.hot.runHooks('persistentStateSave', 'manualRowHeights', this.manualRowHeights);
+    this.hot.runHooks('persistentStateSave', PERSISTENT_STATE_KEY, this.rowHeightsMap.getValues());
   }
 
   /**
@@ -121,14 +127,30 @@ class ManualRowResize extends BasePlugin {
    *
    * @returns {Array}
    * @fires Hooks#persistentStateLoad
-   * @fires Hooks#manualRowHeights
    */
   loadManualRowHeights() {
     const storedState = {};
 
-    this.hot.runHooks('persistentStateLoad', 'manualRowHeights', storedState);
+    this.hot.runHooks('persistentStateLoad', PERSISTENT_STATE_KEY, storedState);
 
     return storedState.value;
+  }
+
+  /**
+   * Sets the new height for specified row index.
+   *
+   * @param {Number} row Visual row index.
+   * @param {Number} height Row height.
+   * @returns {Number} Returns new height.
+   *
+   * @fires Hooks#modifyRow
+   */
+  setManualSize(row, height) {
+    const physicalRow = this.hot.toPhysicalRow(row);
+
+    this.rowHeightsMap.setValueAtIndex(physicalRow, height);
+
+    return height;
   }
 
   /**
@@ -455,23 +477,6 @@ class ManualRowResize extends BasePlugin {
   }
 
   /**
-   * Sets the new height for specified row index.
-   *
-   * @param {Number} row Visual row index.
-   * @param {Number} height Row height.
-   * @returns {Number} Returns new height.
-   *
-   * @fires Hooks#modifyRow
-   */
-  setManualSize(row, height) {
-    const physicalRow = this.hot.toPhysicalRow(row);
-
-    this.manualRowHeights[physicalRow] = height;
-
-    return height;
-  }
-
-  /**
    * Modifies the provided row height, based on the plugin settings.
    *
    * @private
@@ -486,7 +491,7 @@ class ManualRowResize extends BasePlugin {
       const autoRowSizePlugin = this.hot.getPlugin('autoRowSize');
       const autoRowHeightResult = autoRowSizePlugin ? autoRowSizePlugin.heights[row] : null;
       const physicalRow = this.hot.toPhysicalRow(row);
-      const manualRowHeight = this.manualRowHeights[physicalRow];
+      const manualRowHeight = this.rowHeightsMap.getValueAtIndex(physicalRow);
 
       if (manualRowHeight !== void 0 && (manualRowHeight === autoRowHeightResult || manualRowHeight > (height || 0))) {
         return manualRowHeight;
@@ -494,6 +499,34 @@ class ManualRowResize extends BasePlugin {
     }
 
     return height;
+  }
+
+  /**
+   * Callback to call on map's `init` local hook.
+   *
+   * @private
+   */
+  onMapInit() {
+    const priv = privatePool.get(this);
+    const initialSetting = this.hot.getSettings().manualRowResize;
+    const loadedManualRowHeights = this.loadManualRowHeights();
+
+    if (typeof loadedManualColumnWidths !== 'undefined') {
+      loadedManualRowHeights.forEach((height, index) => {
+        this.rowHeightsMap.setValueAtIndex(index, height);
+      });
+
+    } else if (Array.isArray(initialSetting)) {
+      initialSetting.forEach((height, index) => {
+        this.rowHeightsMap.setValueAtIndex(index, height);
+      });
+      priv.config = initialSetting;
+
+    } else if (initialSetting === true && Array.isArray(priv.config)) {
+      priv.config.forEach((height, index) => {
+        this.rowHeightsMap.setValueAtIndex(index, height);
+      });
+    }
   }
 }
 

--- a/src/plugins/manualRowResize/manualRowResize.js
+++ b/src/plugins/manualRowResize/manualRowResize.js
@@ -47,11 +47,11 @@ class ManualRowResize extends BasePlugin {
     this.manualRowHeights = [];
 
     /**
-     * ValueMap to keep and track widths for physical column indexes.
+     * ValueMap to keep and track widths for physical row indexes.
      *
      * @type {ValueMap}
      */
-    this.columnWidthsMap = void 0;
+    this.rowHeightsMap = void 0;
     /**
      * Private pool to save configuration from updateSettings.
      */
@@ -142,8 +142,6 @@ class ManualRowResize extends BasePlugin {
    * @param {Number} row Visual row index.
    * @param {Number} height Row height.
    * @returns {Number} Returns new height.
-   *
-   * @fires Hooks#modifyRow
    */
   setManualSize(row, height) {
     const physicalRow = this.hot.toPhysicalRow(row);

--- a/src/plugins/manualRowResize/test/manualRowResize.e2e.js
+++ b/src/plugins/manualRowResize/test/manualRowResize.e2e.js
@@ -133,6 +133,42 @@ describe('manualRowResize', () => {
     expect(rowHeight(spec().$container, 2)).toEqual(defaultRowHeight + 1);
   });
 
+  it('should keep proper row heights after inserting row', () => {
+    handsontable({
+      manualRowResize: [void 0, void 0, 120]
+    });
+
+    expect(rowHeight(spec().$container, 0)).toBe(defaultRowHeight + 2);
+    expect(rowHeight(spec().$container, 1)).toBe(defaultRowHeight + 1);
+    expect(rowHeight(spec().$container, 2)).toBe(120);
+    expect(rowHeight(spec().$container, 3)).toBe(defaultRowHeight + 1);
+
+    alter('insert_row', 0);
+
+    expect(rowHeight(spec().$container, 0)).toBe(defaultRowHeight + 2);
+    expect(rowHeight(spec().$container, 1)).toBe(defaultRowHeight + 1);
+    expect(rowHeight(spec().$container, 2)).toBe(defaultRowHeight + 1);
+    expect(rowHeight(spec().$container, 3)).toBe(120);
+  });
+
+  it('should keep proper row heights after removing row', () => {
+    handsontable({
+      manualRowResize: [void 0, void 0, 120]
+    });
+
+    expect(rowHeight(spec().$container, 0)).toBe(defaultRowHeight + 2);
+    expect(rowHeight(spec().$container, 1)).toBe(defaultRowHeight + 1);
+    expect(rowHeight(spec().$container, 2)).toBe(120);
+    expect(rowHeight(spec().$container, 3)).toBe(defaultRowHeight + 1);
+
+    alter('remove_row', 0);
+
+    expect(rowHeight(spec().$container, 0)).toBe(defaultRowHeight + 2);
+    expect(rowHeight(spec().$container, 1)).toBe(120);
+    expect(rowHeight(spec().$container, 2)).toBe(defaultRowHeight + 1);
+    expect(rowHeight(spec().$container, 3)).toBe(defaultRowHeight + 1);
+  });
+
   it('should trigger afterRowResize event after row height changes', () => {
     const afterRowResizeCallback = jasmine.createSpy('afterRowResizeCallback');
 


### PR DESCRIPTION
### Context
As in title and in description of #6164. Here are necessary changes to adjust plugin to upcoming IndexMappers.

### How has this been tested?
- Change row heights using ManualRowResize handler
- Insert or remove row/rows above resized rows.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. #6164