### PR TITLE
Radio buttons labels in filters dropdown have determine the font size

### DIFF
--- a/src/plugins/filters/filters.css
+++ b/src/plugins/filters/filters.css
@@ -278,6 +278,7 @@
 
 .handsontable .htUIRadio label {
   vertical-align: middle;
+  font-size: 0.75em;
 }
 
 .handsontable .htFiltersMenuOperators {

--- a/src/plugins/filters/test/filtersUI.e2e.js
+++ b/src/plugins/filters/test/filtersUI.e2e.js
@@ -3342,11 +3342,17 @@ describe('Filters UI', () => {
     const htUISelectCaption = document.querySelector('.htUISelectCaption');
     const compStyleHtUISelectCaption = Handsontable.dom.getComputedStyle(htUISelectCaption);
 
+    const htUIRadioLabel = document.querySelector('.htUIRadio label');
+    const compStyleHtUIRadioLabel = Handsontable.dom.getComputedStyle(htUIRadioLabel);
+
     expect(compStyleHtItemWrapper.fontFamily).toBe('Helvetica');
     expect(compStyleHtItemWrapper.fontSize).toBe('24px');
 
     expect(compStyleHtFiltersMenuLabel.fontFamily).toBe('Helvetica');
     expect(compStyleHtFiltersMenuLabel.fontSize).toBe('18px');
+
+    expect(compStyleHtUIRadioLabel.fontFamily).toBe('Helvetica');
+    expect(compStyleHtUIRadioLabel.fontSize).toBe('18px');
 
     expect(compStyleHtUISelectCaption.fontFamily).toBe('Helvetica');
     expect(compStyleHtUISelectCaption.fontSize).toBe('16.8px');


### PR DESCRIPTION
#5809 # Context
<!--- Why is this change required? What problem does it solve? -->
To keep the consistency between the fonts in the dropdown menu. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #6172

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
