### PR TITLE
Fix all tests on Windows and add run-script for Walkontable watch (#5878)

### DIFF
--- a/.config/bin/trigger-on-stdout-change.js
+++ b/.config/bin/trigger-on-stdout-change.js
@@ -54,7 +54,8 @@ function run(commands, commandToTrigger, spawnOpts) {
   child.stderr.pipe(process.stderr);
 
   if (commandToTrigger) {
-    ['SIGINT', 'SIGTERM'].forEach(function(signal) {
+    ['SIGINT', 'SIGTERM', 'SIGQUIT'].forEach(function(signal) {
+   //   ['SIGKILL', 'SIGTERM', 'SIGINT', 'SIGQUIT', 'SIGSTP', 'SIGHUP'].forEach(function(signal) {
       process.on(signal, function() {
         treeKill(child.pid, signal);
       });

--- a/.config/bin/trigger-on-stdout-change.js
+++ b/.config/bin/trigger-on-stdout-change.js
@@ -55,7 +55,6 @@ function run(commands, commandToTrigger, spawnOpts) {
 
   if (commandToTrigger) {
     ['SIGINT', 'SIGTERM', 'SIGQUIT'].forEach(function(signal) {
-   //   ['SIGKILL', 'SIGTERM', 'SIGINT', 'SIGQUIT', 'SIGSTP', 'SIGHUP'].forEach(function(signal) {
       process.on(signal, function() {
         treeKill(child.pid, signal);
       });

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "convert-source-map": "^1.1.0",
         "fs-readdir-recursive": "^1.1.0",
         "glob": "^7.0.0",
-        "lodash": "^4.17.13",
+        "lodash": "^4.17.11",
         "mkdirp": "^0.5.1",
         "output-file-sync": "^2.0.0",
         "slash": "^2.0.0",
@@ -47,7 +47,7 @@
         "convert-source-map": "^1.1.0",
         "debug": "^4.1.0",
         "json5": "^2.1.0",
-        "lodash": "^4.17.13",
+        "lodash": "^4.17.11",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
@@ -78,7 +78,7 @@
       "requires": {
         "@babel/types": "^7.5.0",
         "jsesc": "^2.5.1",
-        "lodash": "^4.17.13",
+        "lodash": "^4.17.11",
         "source-map": "^0.5.0",
         "trim-right": "^1.0.1"
       }
@@ -873,8 +873,8 @@
         "@babel/plugin-transform-arrow-functions": "^7.2.0",
         "@babel/plugin-transform-async-to-generator": "^7.5.0",
         "@babel/plugin-transform-block-scoped-functions": "^7.2.0",
-        "@babel/plugin-transform-block-scoping": "^7.5.5",
-        "@babel/plugin-transform-classes": "^7.5.5",
+        "@babel/plugin-transform-block-scoping": "^7.4.4",
+        "@babel/plugin-transform-classes": "^7.4.4",
         "@babel/plugin-transform-computed-properties": "^7.2.0",
         "@babel/plugin-transform-destructuring": "^7.5.0",
         "@babel/plugin-transform-dotall-regex": "^7.4.4",
@@ -890,7 +890,7 @@
         "@babel/plugin-transform-modules-umd": "^7.2.0",
         "@babel/plugin-transform-named-capturing-groups-regex": "^7.4.5",
         "@babel/plugin-transform-new-target": "^7.4.4",
-        "@babel/plugin-transform-object-super": "^7.5.5",
+        "@babel/plugin-transform-object-super": "^7.2.0",
         "@babel/plugin-transform-parameters": "^7.4.4",
         "@babel/plugin-transform-property-literals": "^7.2.0",
         "@babel/plugin-transform-regenerator": "^7.4.5",
@@ -957,7 +957,7 @@
         "@babel/types": "^7.5.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
-        "lodash": "^4.17.13"
+        "lodash": "^4.17.11"
       },
       "dependencies": {
         "debug": {
@@ -984,7 +984,7 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2",
-        "lodash": "^4.17.13",
+        "lodash": "^4.17.11",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -2212,6 +2212,13 @@
       "integrity": "sha1-E8s5zSkjMhnsLacl4LoMZvtGtvI=",
       "requires": {
         "voc": "^1.1.0"
+      },
+      "dependencies": {
+        "voc": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/voc/-/voc-1.1.0.tgz",
+          "integrity": "sha512-fthgd8OJLqq8vPcLjElTk6Rcl2e3v5ekcXauImaqEnQqd5yUWKg1+ZOBgS2KTWuVKcuvZMQq4TDptiT1uYddUA=="
+        }
       }
     },
     "big.js": {
@@ -2943,41 +2950,148 @@
       }
     },
     "concurrently": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-3.6.1.tgz",
-      "integrity": "sha512-/+ugz+gwFSEfTGUxn0KHkY+19XPRTXR8+7oUK/HxgiN1n7FjeJmkrbSiXAJfyQ0zORgJYPaenmymwon51YXH9Q==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-4.1.1.tgz",
+      "integrity": "sha512-48+FE5RJ0qc8azwKv4keVQWlni1hZeSjcWr8shBelOBtBHcKj1aJFM9lHRiSc1x7lq416pkvsqfBMhSRja+Lhw==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.1",
-        "commander": "2.6.0",
         "date-fns": "^1.23.0",
-        "lodash": "^4.5.1",
-        "read-pkg": "^3.0.0",
-        "rx": "2.3.24",
+        "lodash": "^4.17.10",
+        "read-pkg": "^4.0.1",
+        "rxjs": "^6.3.3",
         "spawn-command": "^0.0.2-1",
-        "supports-color": "^3.2.3",
-        "tree-kill": "^1.1.0"
+        "supports-color": "^4.5.0",
+        "tree-kill": "^1.1.0",
+        "yargs": "^12.0.1"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
-          "integrity": "sha1-nfflL7Kgyw+4kFjugMMQQiXzfh0=",
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
           "dev": true
         },
-        "supports-color": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+        "cliui": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
+          }
+        },
+        "invert-kv": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+          "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+          "dev": true
+        },
+        "lcid": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+          "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+          "dev": true,
+          "requires": {
+            "invert-kv": "^2.0.0"
+          }
+        },
+        "mem": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+          "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+          "dev": true,
+          "requires": {
+            "map-age-cleaner": "^0.1.1",
+            "mimic-fn": "^2.0.0",
+            "p-is-promise": "^2.0.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+          "dev": true
+        },
+        "os-locale": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+          "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+          "dev": true,
+          "requires": {
+            "execa": "^1.0.0",
+            "lcid": "^2.0.0",
+            "mem": "^4.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-4.0.1.tgz",
+          "integrity": "sha1-ljYlN48+HE1IyFhytabsfV0JMjc=",
+          "dev": true,
+          "requires": {
+            "normalize-package-data": "^2.3.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0"
+          }
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "yargs": {
+          "version": "12.0.5",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+          "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^3.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1 || ^4.0.0",
+            "yargs-parser": "^11.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+          "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }
@@ -9961,12 +10075,6 @@
         "aproba": "^1.1.1"
       }
     },
-    "rx": {
-      "version": "2.3.24",
-      "resolved": "https://registry.npmjs.org/rx/-/rx-2.3.24.tgz",
-      "integrity": "sha1-FPlQpCF9fjXapxu8vljv9o6ksrc=",
-      "dev": true
-    },
     "rx-lite": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
@@ -9980,6 +10088,15 @@
       "dev": true,
       "requires": {
         "rx-lite": "*"
+      }
+    },
+    "rxjs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
+      "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
       }
     },
     "safe-buffer": {
@@ -11603,11 +11720,6 @@
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.0.tgz",
       "integrity": "sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw==",
       "dev": true
-    },
-    "voc": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/voc/-/voc-1.1.0.tgz",
-      "integrity": "sha512-fthgd8OJLqq8vPcLjElTk6Rcl2e3v5ekcXauImaqEnQqd5yUWKg1+ZOBgS2KTWuVKcuvZMQq4TDptiT1uYddUA=="
     },
     "void-elements": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test.random": "npm run lint && npm run test:unit && npm run test:types && npm run test:walkontable.random && npm run test:e2e.random && npm run test:production.random",
     "test:walkontable": "npm run build:walkontable && npm run test:walkontable.dump && npm run test:walkontable.puppeteer",
     "test:walkontable.random": "npm run build:walkontable && npm run test:walkontable.dump && npm run test:walkontable.puppeteer -- --random",
+    "test:walkontable.watch": "node ./.config/bin/trigger-on-stdout-change.js \"concurrently --raw --kill-others \\\"npm run build:walkontable -- --watch\\\" \\\"npm run test:walkontable.dump -- --watch\\\"\" \"npm run test:walkontable.puppeteer\"",
     "test:production": "npm run build:umd.min && npm run build:languages.min && npm run test:production.dump && npm run test:e2e.puppeteer",
     "test:production.random": "npm run build:umd.min && npm run build:languages.min && npm run test:production.dump && npm run test:e2e.puppeteer -- --random",
     "test:e2e": "npm run build:umd && npm run build:languages && npm run test:e2e.dump && npm run test:e2e.puppeteer",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "babel-plugin-transform-inline-environment-variables": "^0.4.3",
     "babel-plugin-transform-require-ignore": "^0.1.1",
     "check-es3-syntax-cli": "^0.2.0",
-    "concurrently": "^3.5.0",
+    "concurrently": "^4.1.1",
     "copy-webpack-plugin": "^4.6.0",
     "cpy-cli": "^2.0.0",
     "cross-env": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:production.random": "npm run build:umd.min && npm run build:languages.min && npm run test:production.dump && npm run test:e2e.puppeteer -- --random",
     "test:e2e": "npm run build:umd && npm run build:languages && npm run test:e2e.dump && npm run test:e2e.puppeteer",
     "test:e2e.random": "npm run build:umd && npm run build:languages && npm run test:e2e.dump && npm run test:e2e.puppeteer -- --random",
-    "test:e2e.watch": "node ./.config/bin/trigger-on-stdout-change.js \"concurrently --raw --kill-others 'npm run build:umd -- --watch' 'npm run test:e2e.dump -- --watch'\" \"npm run test:e2e.puppeteer\"",
+    "test:e2e.watch": "node ./.config/bin/trigger-on-stdout-change.js \"concurrently --raw --kill-others \\\"npm run build:umd -- --watch\\\" \\\"npm run test:e2e.dump -- --watch\\\"\" \"npm run test:e2e.puppeteer\"",
     "test:e2e.puppeteer": "node test/scripts/run-puppeteer.js test/E2ERunner.html",
     "test:unit": "cross-env-shell npm_config_testPathPattern=. BABEL_ENV=commonjs env-cmd -f ./hot.config.js jest --testPathPattern=$npm_config_testPathPattern",
     "test:unit.watch": "cross-env-shell BABEL_ENV=commonjs env-cmd -f ./hot.config.js jest --testPathPattern=$npm_config_testPathPattern --watch",

--- a/src/3rdparty/walkontable/test/spec/selection.spec.js
+++ b/src/3rdparty/walkontable/test/spec/selection.spec.js
@@ -155,11 +155,19 @@ describe('Walkontable.Selection', () => {
 
     wt.scrollViewportVertically(17);
     wt.draw();
-    expect(wt.wtTable.getFirstVisibleRow()).toEqual(10);
+
+    let expectedFirstVisibleRow = 10;
+    if(wt.wtSettings.getSetting("scrollbarHeight") >= 17) {
+      // on Windows scrollbar is 17px, on macOS it is 15px
+      // taller scrollbar means less space for rows
+      expectedFirstVisibleRow = 11;
+    }
+
+    expect(wt.wtTable.getFirstVisibleRow()).toEqual(expectedFirstVisibleRow);
     expect(wt.wtTable.getLastVisibleRow()).toBeAroundValue(17);
 
     wt.selections.getCell().clear();
-    expect(wt.wtTable.getFirstVisibleRow()).toEqual(10);
+    expect(wt.wtTable.getFirstVisibleRow()).toEqual(expectedFirstVisibleRow);
     expect(wt.wtTable.getLastVisibleRow()).toBeAroundValue(17);
   });
 

--- a/src/3rdparty/walkontable/test/spec/selection.spec.js
+++ b/src/3rdparty/walkontable/test/spec/selection.spec.js
@@ -157,7 +157,7 @@ describe('Walkontable.Selection', () => {
     wt.draw();
 
     let expectedFirstVisibleRow = 10;
-    if(wt.wtSettings.getSetting("scrollbarHeight") >= 17) {
+    if (wt.wtSettings.getSetting('scrollbarHeight') >= 17) {
       // on Windows scrollbar is 17px, on macOS it is 15px
       // taller scrollbar means less space for rows
       expectedFirstVisibleRow = 11;

--- a/src/3rdparty/walkontable/test/spec/selection.spec.js
+++ b/src/3rdparty/walkontable/test/spec/selection.spec.js
@@ -140,6 +140,9 @@ describe('Walkontable.Selection', () => {
   });
 
   it('should not scroll the viewport after selection is cleared', () => {
+    const scrollbarWidth = getScrollbarWidth(); // normalize viewport size disregarding of the scrollbar size on any OS
+    spec().$wrapper.width(100 + scrollbarWidth).height(200 + scrollbarWidth);
+
     const wt = walkontable({
       data: getData,
       totalRows: getTotalRows,
@@ -156,12 +159,7 @@ describe('Walkontable.Selection', () => {
     wt.scrollViewportVertically(17);
     wt.draw();
 
-    let expectedFirstVisibleRow = 10;
-    if (wt.wtSettings.getSetting('scrollbarHeight') >= 17) {
-      // on Windows scrollbar is 17px, on macOS it is 15px
-      // taller scrollbar means less space for rows
-      expectedFirstVisibleRow = 11;
-    }
+    const expectedFirstVisibleRow = 10;
 
     expect(wt.wtTable.getFirstVisibleRow()).toEqual(expectedFirstVisibleRow);
     expect(wt.wtTable.getLastVisibleRow()).toBeAroundValue(17);

--- a/src/3rdparty/walkontable/test/spec/table.spec.js
+++ b/src/3rdparty/walkontable/test/spec/table.spec.js
@@ -119,7 +119,7 @@ describe('WalkontableTable', () => {
 
     let expectedGetCellOutputForRowsInFirstColumn = [-1, -1, HTMLElement, HTMLElement, HTMLElement, HTMLElement, HTMLElement, HTMLElement, HTMLElement, HTMLElement,
       HTMLElement, HTMLElement, -2, -2, -2, -2, -2, -2, -2, -2];
-    if(wt.wtSettings.getSetting("scrollbarHeight") >= 17) {
+    if (wt.wtSettings.getSetting('scrollbarHeight') >= 17) {
       // on Windows scrollbar is 17px, on macOS it is 15px
       // taller scrollbar means less space for rows
       expectedGetCellOutputForRowsInFirstColumn = [-1, -1, -1, HTMLElement, HTMLElement, HTMLElement, HTMLElement, HTMLElement, HTMLElement, HTMLElement,

--- a/src/3rdparty/walkontable/test/spec/table.spec.js
+++ b/src/3rdparty/walkontable/test/spec/table.spec.js
@@ -116,8 +116,18 @@ describe('WalkontableTable', () => {
       const result = wt.wtTable.getCell(new Walkontable.CellCoords(i, 6));
       results.push(result instanceof HTMLElement ? HTMLElement : result);
     }
-    expect(results).toEqual([-1, -1, HTMLElement, HTMLElement, HTMLElement, HTMLElement, HTMLElement, HTMLElement, HTMLElement, HTMLElement,
-      HTMLElement, HTMLElement, -2, -2, -2, -2, -2, -2, -2, -2]);
+
+    let expectedGetCellOutputForRowsInFirstColumn = [-1, -1, HTMLElement, HTMLElement, HTMLElement, HTMLElement, HTMLElement, HTMLElement, HTMLElement, HTMLElement,
+      HTMLElement, HTMLElement, -2, -2, -2, -2, -2, -2, -2, -2];
+    if(wt.wtSettings.getSetting("scrollbarHeight") >= 17) {
+      // on Windows scrollbar is 17px, on macOS it is 15px
+      // taller scrollbar means less space for rows
+      expectedGetCellOutputForRowsInFirstColumn = [-1, -1, -1, HTMLElement, HTMLElement, HTMLElement, HTMLElement, HTMLElement, HTMLElement, HTMLElement,
+        HTMLElement, HTMLElement, -2, -2, -2, -2, -2, -2, -2, -2];
+    }
+
+    expect(results).toEqual(expectedGetCellOutputForRowsInFirstColumn);
+
   });
 
   it('getCell should only return cells from rendered rows and columns (with fixedRowsBottom)', () => {

--- a/src/3rdparty/walkontable/test/spec/table.spec.js
+++ b/src/3rdparty/walkontable/test/spec/table.spec.js
@@ -84,6 +84,9 @@ describe('WalkontableTable', () => {
   });
 
   it('getCell should only return cells from rendered rows and columns', function() {
+    const scrollbarWidth = getScrollbarWidth(); // normalize viewport size disregarding of the scrollbar size on any OS
+    spec().$wrapper.width(100 + scrollbarWidth).height(201 + scrollbarWidth);
+
     createDataArray(20, 20);
     const wt = walkontable({
       data: getData,
@@ -117,14 +120,8 @@ describe('WalkontableTable', () => {
       results.push(result instanceof HTMLElement ? HTMLElement : result);
     }
 
-    let expectedGetCellOutputForRowsInFirstColumn = [-1, -1, HTMLElement, HTMLElement, HTMLElement, HTMLElement, HTMLElement, HTMLElement, HTMLElement, HTMLElement,
+    const expectedGetCellOutputForRowsInFirstColumn = [-1, -1, HTMLElement, HTMLElement, HTMLElement, HTMLElement, HTMLElement, HTMLElement, HTMLElement, HTMLElement,
       HTMLElement, HTMLElement, -2, -2, -2, -2, -2, -2, -2, -2];
-    if (wt.wtSettings.getSetting('scrollbarHeight') >= 17) {
-      // on Windows scrollbar is 17px, on macOS it is 15px
-      // taller scrollbar means less space for rows
-      expectedGetCellOutputForRowsInFirstColumn = [-1, -1, -1, HTMLElement, HTMLElement, HTMLElement, HTMLElement, HTMLElement, HTMLElement, HTMLElement,
-        HTMLElement, HTMLElement, -2, -2, -2, -2, -2, -2, -2, -2];
-    }
 
     expect(results).toEqual(expectedGetCellOutputForRowsInFirstColumn);
 

--- a/test/e2e/core/selectAll.spec.js
+++ b/test/e2e/core/selectAll.spec.js
@@ -22,8 +22,8 @@ describe('Core.selectAll', () => {
 
     selectCells([[1, 1, 2, 2], [2, 2, 4, 4]]);
 
-    hot.view.wt.wtTable.holder.scrollTop = 150;
-    hot.view.wt.wtTable.holder.scrollLeft = 150;
+    hot.view.wt.wtTable.holder.scrollTop = 155;
+    hot.view.wt.wtTable.holder.scrollLeft = 155;
 
     selectAll();
 
@@ -47,7 +47,7 @@ describe('Core.selectAll', () => {
       | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
       `).toBeMatchToSelectionPattern();
     // "Select all" shouldn't scroll te table.
-    expect(hot.view.wt.wtTable.holder.scrollTop).toBe(150);
-    expect(hot.view.wt.wtTable.holder.scrollLeft).toBe(150);
+    expect(hot.view.wt.wtTable.holder.scrollTop).toBe(155);
+    expect(hot.view.wt.wtTable.holder.scrollLeft).toBe(155);
   });
 });

--- a/test/e2e/core/selectAll.spec.js
+++ b/test/e2e/core/selectAll.spec.js
@@ -11,10 +11,12 @@ describe('Core.selectAll', () => {
   });
 
   it('should select all cells and clear previous selection', () => {
+    const scrollbarWidth = Handsontable.dom.getScrollbarWidth(); // normalize viewport size disregarding of the scrollbar size on any OS
+
     const hot = handsontable({
       data: Handsontable.helper.createSpreadsheetObjectData(15, 20),
-      width: 200,
-      height: 100,
+      width: 185 + scrollbarWidth,
+      height: 85 + scrollbarWidth,
       selectionMode: 'multiple',
       colHeaders: true,
       rowHeaders: true,
@@ -22,8 +24,8 @@ describe('Core.selectAll', () => {
 
     selectCells([[1, 1, 2, 2], [2, 2, 4, 4]]);
 
-    hot.view.wt.wtTable.holder.scrollTop = 155;
-    hot.view.wt.wtTable.holder.scrollLeft = 155;
+    hot.view.wt.wtTable.holder.scrollTop = 150;
+    hot.view.wt.wtTable.holder.scrollLeft = 150;
 
     selectAll();
 
@@ -47,7 +49,7 @@ describe('Core.selectAll', () => {
       | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
       `).toBeMatchToSelectionPattern();
     // "Select all" shouldn't scroll te table.
-    expect(hot.view.wt.wtTable.holder.scrollTop).toBe(155);
-    expect(hot.view.wt.wtTable.holder.scrollLeft).toBe(155);
+    expect(hot.view.wt.wtTable.holder.scrollTop).toBe(150);
+    expect(hot.view.wt.wtTable.holder.scrollLeft).toBe(150);
   });
 });


### PR DESCRIPTION
### Context
Continuation of https://github.com/handsontable/handsontable/pull/6128. This fixes https://github.com/handsontable/handsontable/issues/5878

I need this change, because I am using a Windows desktop PC for development. That's because `time npm run build` takes 53s on Windows and 1m21s on macOS.

### How has this been tested?
Run the following scripts on Windows with success:

```
npm run test
npm run test:walkontable
npm run test:walkontable.watch
npm run test:e2e
npm run test:e2e.watch
npm run test:unit
npm run test:unit.watch
```

As well as manually running spec runners in Chrome:

- http://localhost:5000/test/E2ERunner.html
- http://localhost:5000/src/3rdparty/walkontable/test/SpecRunner.html

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/5878
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
