### PR TITLE
Provide TD element that is relevant to the current overlay to the editor `prepare` method (#6043)

### DIFF
--- a/handsontable.d.ts
+++ b/handsontable.d.ts
@@ -277,6 +277,8 @@ declare namespace Handsontable {
       extend<T extends _editors.Base>(): T;
       finishEditing(restoreOriginalValue?: boolean, ctrlDown?: boolean, callback?: () => void): void;
       abstract focus(): void;
+      getEditedCell(): HTMLTableCellElement | undefined;
+      getEditedCellsZIndex(): string;
       abstract getValue(): any;
       init(): void;
       isInFullEditMode(): boolean;
@@ -319,7 +321,6 @@ declare namespace Handsontable {
       open(): void;
       setValue(newValue?: any): void;
 
-      getEditedCell(): HTMLTableCellElement | undefined;
       prepareOptions(optionsToPrepare?: RowObject | CellValue[]): void;
       refreshDimensions(): void;
       refreshValue(): void;
@@ -338,7 +339,6 @@ declare namespace Handsontable {
       destroy(): void;
       hideEditableElement(): void;
       showEditableElement(): void;
-      getEditedCell(): HTMLTableCellElement | undefined;
       refreshDimensions(force?: boolean): void;
       refreshValue(): void;
       TEXTAREA: HTMLInputElement;
@@ -1747,7 +1747,7 @@ declare namespace Handsontable {
     nestedHeaders?: (string | nestedHeaders.NestedHeader)[][];
     nestedRows?: boolean;
     noWordWrapClassName?: string;
-    numericFormat?: NumericFormatOptions;                                   
+    numericFormat?: NumericFormatOptions;
     observeChanges?: boolean;
     observeDOMVisibility?: boolean;
     outsideClickDeselects?: boolean | ((target: HTMLElement) => boolean);

--- a/src/editorManager.js
+++ b/src/editorManager.js
@@ -136,13 +136,13 @@ class EditorManager {
 
     const { row, col } = this.instance.selection.selectedRange.current().highlight;
     const prop = this.instance.colToProp(col);
-    const td = this.instance.getCell(row, col);
     const originalValue = this.instance.getSourceDataAtCell(this.instance.runHooks('modifyRow', row), col);
     const cellProperties = this.instance.getCellMeta(row, col);
     const editorClass = this.instance.getCellEditor(cellProperties);
 
     if (editorClass) {
       this.activeEditor = getEditorInstance(editorClass, this.instance);
+      const td = this.activeEditor.getEditedCell();
       this.activeEditor.prepare(row, col, prop, td, originalValue, cellProperties);
 
     } else {

--- a/src/editors/_baseEditor.js
+++ b/src/editors/_baseEditor.js
@@ -367,6 +367,66 @@ class BaseEditor {
   }
 
   /**
+   * Gets HTMLTableCellElement of the edited cell if exist.
+   *
+   * @public
+   * @returns {string}
+   */
+  getEditedCellsZIndex() {
+    const editorSection = this.checkEditorSection();
+
+    switch (editorSection) {
+      case 'top':
+        return '101';
+      case 'top-left-corner':
+      case 'bottom-left-corner':
+        return '103';
+      case 'left':
+      case 'bottom':
+        return '102';
+      default:
+        // return '-1'; // 'auto' would be preferable but -1 was introduced in c78dc0c for some reason
+        return 'auto'; // 'auto' would be preferable but -1 was introduced in c78dc0c for some reason
+    }
+  }
+
+  /**
+   * Gets HTMLTableCellElement of the edited cell if exist.
+   *
+   * @public
+   * @returns {HTMLTableCellElement|undefined}
+   */
+  getEditedCell() {
+    const { wtOverlays, wtTable } = this.hot.view.wt;
+    const editorSection = this.checkEditorSection();
+    const coords = new CellCoords(this.row, this.col);
+    let editedCell;
+
+    switch (editorSection) {
+      case 'top':
+        editedCell = wtOverlays.topOverlay.clone.wtTable.getCell(coords);
+        break;
+      case 'top-left-corner':
+        editedCell = wtOverlays.topLeftCornerOverlay.clone.wtTable.getCell(coords);
+        break;
+      case 'bottom-left-corner':
+        editedCell = wtOverlays.bottomLeftCornerOverlay.clone.wtTable.getCell(coords);
+        break;
+      case 'left':
+        editedCell = wtOverlays.leftOverlay.clone.wtTable.getCell(coords);
+        break;
+      case 'bottom':
+        editedCell = wtOverlays.bottomOverlay.clone.wtTable.getCell(coords);
+        break;
+      default:
+        editedCell = wtTable.getCell(coords);
+        break;
+    }
+
+    return editedCell < 0 ? void 0 : editedCell;
+  }
+
+  /**
    * Returns name of the overlay, where editor is placed.
    *
    * @private

--- a/src/editors/_baseEditor.js
+++ b/src/editors/_baseEditor.js
@@ -369,7 +369,6 @@ class BaseEditor {
   /**
    * Gets HTMLTableCellElement of the edited cell if exist.
    *
-   * @public
    * @returns {string}
    */
   getEditedCellsZIndex() {
@@ -385,15 +384,13 @@ class BaseEditor {
       case 'bottom':
         return '102';
       default:
-        // return '-1'; // 'auto' would be preferable but -1 was introduced in c78dc0c for some reason
-        return 'auto'; // 'auto' would be preferable but -1 was introduced in c78dc0c for some reason
+        return 'auto';
     }
   }
 
   /**
    * Gets HTMLTableCellElement of the edited cell if exist.
    *
-   * @public
    * @returns {HTMLTableCellElement|undefined}
    */
   getEditedCell() {

--- a/src/editors/selectEditor.js
+++ b/src/editors/selectEditor.js
@@ -234,48 +234,7 @@ class SelectEditor extends BaseEditor {
     selectStyle.top = `${editTop}px`;
     selectStyle.left = `${editLeft}px`;
     selectStyle.margin = '0px';
-  }
-
-  /**
-   * Gets HTMLTableCellElement of the edited cell if exist.
-   *
-   * @private
-   * @returns {HTMLTableCellElement|undefined}
-   */
-  getEditedCell() {
-    const { wtOverlays } = this.hot.view.wt;
-    const editorSection = this.checkEditorSection();
-    let editedCell;
-
-    switch (editorSection) {
-      case 'top':
-        editedCell = wtOverlays.topOverlay.clone.wtTable.getCell({
-          row: this.row,
-          col: this.col
-        });
-        this.select.style.zIndex = 101;
-        break;
-      case 'corner':
-        editedCell = wtOverlays.topLeftCornerOverlay.clone.wtTable.getCell({
-          row: this.row,
-          col: this.col
-        });
-        this.select.style.zIndex = 103;
-        break;
-      case 'left':
-        editedCell = wtOverlays.leftOverlay.clone.wtTable.getCell({
-          row: this.row,
-          col: this.col
-        });
-        this.select.style.zIndex = 102;
-        break;
-      default:
-        editedCell = this.hot.getCell(this.row, this.col);
-        this.select.style.zIndex = '';
-        break;
-    }
-
-    return editedCell < 0 ? void 0 : editedCell;
+    selectStyle.zIndex = this.getEditedCellsZIndex();
   }
 
   /**

--- a/src/editors/textEditor.js
+++ b/src/editors/textEditor.js
@@ -46,13 +46,6 @@ class TextEditor extends BaseEditor {
      */
     this.autoResize = autoResize();
     /**
-     * Contains  `z-index` of the editor. Helps display editor on overlays on correct elevation.
-     *
-     * @private
-     * @type {Number}
-     */
-    this.holderZIndex = -1;
-    /**
      * An TEXTAREA element.
      *
      * @private
@@ -231,61 +224,6 @@ class TextEditor extends BaseEditor {
   }
 
   /**
-   * Gets HTMLTableCellElement of the edited cell if exist.
-   *
-   * @private
-   * @returns {HTMLTableCellElement|undefined}
-   */
-  getEditedCell() {
-    const editorSection = this.checkEditorSection();
-    let editedCell;
-
-    switch (editorSection) {
-      case 'top':
-        editedCell = this.hot.view.wt.wtOverlays.topOverlay.clone.wtTable.getCell({
-          row: this.row,
-          col: this.col
-        });
-        this.holderZIndex = 101;
-        break;
-      case 'top-left-corner':
-        editedCell = this.hot.view.wt.wtOverlays.topLeftCornerOverlay.clone.wtTable.getCell({
-          row: this.row,
-          col: this.col
-        });
-        this.holderZIndex = 103;
-        break;
-      case 'bottom-left-corner':
-        editedCell = this.hot.view.wt.wtOverlays.bottomLeftCornerOverlay.clone.wtTable.getCell({
-          row: this.row,
-          col: this.col
-        });
-        this.holderZIndex = 103;
-        break;
-      case 'left':
-        editedCell = this.hot.view.wt.wtOverlays.leftOverlay.clone.wtTable.getCell({
-          row: this.row,
-          col: this.col
-        });
-        this.holderZIndex = 102;
-        break;
-      case 'bottom':
-        editedCell = this.hot.view.wt.wtOverlays.bottomOverlay.clone.wtTable.getCell({
-          row: this.row,
-          col: this.col
-        });
-        this.holderZIndex = 102;
-        break;
-      default:
-        editedCell = this.hot.getCell(this.row, this.col);
-        this.holderZIndex = -1;
-        break;
-    }
-
-    return editedCell < 0 ? void 0 : editedCell;
-  }
-
-  /**
    * Moves an editable element out of the viewport, but element must be able to hold focus for IME support.
    *
    * @private
@@ -311,7 +249,8 @@ class TextEditor extends BaseEditor {
     this.textareaParentStyle.overflow = '';
     this.textareaParentStyle.position = '';
     this.textareaParentStyle.right = 'auto';
-    this.textareaParentStyle.zIndex = this.holderZIndex >= 0 ? this.holderZIndex : '';
+    const zIndex = this.getEditedCellsZIndex();
+    this.textareaParentStyle.zIndex = zIndex !== 'auto' ? zIndex : '';
     this.textareaParentStyle.opacity = '1';
 
     this.textareaStyle.textIndent = '';

--- a/test/e2e/settings/editor.spec.js
+++ b/test/e2e/settings/editor.spec.js
@@ -59,9 +59,11 @@ describe('settings', () => {
 
       it('should use editor class passed directly', () => {
         const customEditor = jasmine.createSpy('customEditor');
+        const td = document.createElement('td');
 
         customEditor.and.callFake(function() {
           this.prepare = function() {};
+          this.getEditedCell = () => td;
           this.isOpened = function() {};
         });
 
@@ -79,9 +81,11 @@ describe('settings', () => {
 
       it('should use editor class passed directly when columns is a function', () => {
         const customEditor = jasmine.createSpy('customEditor');
+        const td = document.createElement('td');
 
         customEditor.and.callFake(function() {
           this.prepare = function() {};
+          this.getEditedCell = () => td;
           this.isOpened = function() {};
         });
 
@@ -97,8 +101,10 @@ describe('settings', () => {
 
       it('should use editor from custom string', () => {
         const customEditor = jasmine.createSpy('customEditor');
+        const td = document.createElement('td');
         customEditor.and.callFake(function() {
           this.prepare = function() {};
+          this.getEditedCell = () => td;
           this.isOpened = function() {};
         });
 
@@ -118,9 +124,11 @@ describe('settings', () => {
 
       it('should use editor from custom string when columns is a function', () => {
         const customEditor = jasmine.createSpy('customEditor');
+        const td = document.createElement('td');
 
         customEditor.and.callFake(function() {
           this.prepare = function() {};
+          this.getEditedCell = () => td;
           this.isOpened = function() {};
         });
 
@@ -134,6 +142,71 @@ describe('settings', () => {
         selectCell(0, 0);
 
         expect(customEditor).toHaveBeenCalled();
+      });
+
+      it('should provide correct set of arguments to the prepare callback', (done) => {
+        const customEditor = jasmine.createSpy('customEditor');
+        const myData = Handsontable.helper.createSpreadsheetData(1, 5);
+        const editedTd = document.createElement('td');
+
+        customEditor.and.callFake(function() {
+          this.prepare = function(row, col, prop, td, originalValue, cellProperties) {
+            expect(row).toEqual(0);
+            expect(col).toEqual(0);
+            expect(prop).toEqual(0);
+            expect(td).toEqual(editedTd);
+            expect(originalValue).toEqual(myData[0][0]);
+            expect(cellProperties.editor).toEqual(customEditor);
+            done();
+          };
+          this.getEditedCell = () => editedTd;
+          this.isOpened = function() {};
+        });
+
+        handsontable({
+          data: myData,
+          columns: [
+            {
+              editor: customEditor
+            }
+          ]
+        });
+        selectCell(0, 0);
+      });
+
+      it('should provide correct set of arguments to the prepare callback (fixed column, cell rendered overlay but not rendered on master)', (done) => {
+        // https://github.com/handsontable/handsontable/issues/6043
+        const customEditor = jasmine.createSpy('customEditor');
+        const myData = Handsontable.helper.createSpreadsheetData(1, 5);
+        const editedTd = document.createElement('td');
+
+        customEditor.and.callFake(function() {
+          this.prepare = function(row, col, prop, td, originalValue, cellProperties) {
+            expect(row).toEqual(0);
+            expect(col).toEqual(0);
+            expect(prop).toEqual(0);
+            expect(td).toEqual(editedTd);
+            expect(originalValue).toEqual(myData[0][0]);
+            expect(cellProperties.editor).toEqual(customEditor);
+            done();
+          };
+          this.getEditedCell = () => editedTd;
+          this.isOpened = function() {};
+        });
+
+        handsontable({
+          data: myData,
+          cells(row, col) {
+            if (col === 0) {
+              return { editor: customEditor };
+            }
+          },
+          colWidths: 100,
+          width: 400,
+          fixedColumnsLeft: 1,
+          viewportColumnRenderingOffset: 0,
+        });
+        selectCell(0, 0);
       });
     });
   });

--- a/test/types/editors.types.ts
+++ b/test/types/editors.types.ts
@@ -3,7 +3,7 @@ import Handsontable from 'handsontable';
 const elem = document.createElement('div');
 const hot = new Handsontable(elem, {});
 
-const cellProperties: Handsontable.CellProperties = { 
+const cellProperties: Handsontable.CellProperties = {
   row: 0,
   col: 0,
   instance: {} as Handsontable,
@@ -41,6 +41,8 @@ mobile.scrollToView();
 
 const numeric = new Handsontable.editors.NumericEditor(hot, 0, 0, 'prop', TD, cellProperties);
 numeric.checkEditorSection();
+numeric.getEditedCell();
+numeric.getEditedCellsZIndex();
 numeric.close();
 
 const password = new Handsontable.editors.PasswordEditor(hot, 0, 0, 'prop', TD, cellProperties);


### PR DESCRIPTION
### Context
This PR contains a solution for https://github.com/handsontable/handsontable/issues/6043

Context is funny, because I started working on it thinking that this issue is related to https://github.com/handsontable/handsontable/issues/6191

However, the problem turned out to be completely unrelated, but since it was alrady investigated by me, I decided to finish work on this fix.

### How has this been tested?
I added a test based on the snippet provided by the author of https://github.com/handsontable/handsontable/issues/6043

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/6043
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
