### PR TITLE
fixed error in dist/handsontable.css file. If this is not fixed, the user has to delete it every time they npm i.

### DIFF
--- a/dist/handsontable.css
+++ b/dist/handsontable.css
@@ -429,7 +429,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  bottom: -100%\9; /* Fix for IE9 to spread the ":before" pseudo element to 100% height of the parent element */
+  bottom: -100%; /* Fix for IE9 to spread the ":before" pseudo element to 100% height of the parent element */
   background: #005eff;
 }
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
deleted \9 in the dist/handsontable.css file.  If not fixed, whenever you npm i, you have to manually go delete it.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

I have to do this manually every time I npm i.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
