### PR TITLE
Typedef added getCellsMeta

### DIFF
--- a/handsontable.d.ts
+++ b/handsontable.d.ts
@@ -39,9 +39,9 @@ declare namespace _Handsontable {
     getCellMetaAtRow(row: number): Handsontable.CellProperties[];
     getCellRenderer(row: number, col: number): Handsontable.renderers.Base;
     getCellRenderer(cellMeta: Handsontable.CellMeta): Handsontable.renderers.Base;
+    getCellsMeta(): Handsontable.CellProperties[];
     getCellValidator(row: number, col: number): Handsontable.validators.Base | RegExp | undefined;
     getCellValidator(cellMeta: Handsontable.CellMeta): Handsontable.validators.Base | RegExp | undefined;
-    getCellsMeta(): Handsontable.CellProperties[];
     getColHeader(): (number | string)[];
     getColHeader(col: number): number | string;
     getColWidth(col: number): number;

--- a/handsontable.d.ts
+++ b/handsontable.d.ts
@@ -41,6 +41,7 @@ declare namespace _Handsontable {
     getCellRenderer(cellMeta: Handsontable.CellMeta): Handsontable.renderers.Base;
     getCellValidator(row: number, col: number): Handsontable.validators.Base | RegExp | undefined;
     getCellValidator(cellMeta: Handsontable.CellMeta): Handsontable.validators.Base | RegExp | undefined;
+    getCellsMeta(): Handsontable.CellProperties[];
     getColHeader(): (number | string)[];
     getColHeader(col: number): number | string;
     getColWidth(col: number): number;

--- a/test/types/methods.types.ts
+++ b/test/types/methods.types.ts
@@ -32,8 +32,8 @@ hot.getCellEditor(123, 123);
 hot.getCellMeta(123, 123).type === "text";
 hot.getCellMetaAtRow(123).forEach(meta => meta.type === "text");
 hot.getCellRenderer(123, 123)(hot, {} as any as HTMLTableCellElement, 1, 2, 'prop', '', {} as any as Handsontable.CellProperties);
-hot.getCellValidator(123, 123);
 hot.getCellsMeta()[0].visualRow
+hot.getCellValidator(123, 123);
 hot.getColHeader().forEach((header: number | string) => {});
 hot.getColHeader(123).toString();
 hot.getColWidth(123) === 123;

--- a/test/types/methods.types.ts
+++ b/test/types/methods.types.ts
@@ -33,6 +33,7 @@ hot.getCellMeta(123, 123).type === "text";
 hot.getCellMetaAtRow(123).forEach(meta => meta.type === "text");
 hot.getCellRenderer(123, 123)(hot, {} as any as HTMLTableCellElement, 1, 2, 'prop', '', {} as any as Handsontable.CellProperties);
 hot.getCellValidator(123, 123);
+hot.getCellsMeta()[0].visualRow
 hot.getColHeader().forEach((header: number | string) => {});
 hot.getColHeader(123).toString();
 hot.getColWidth(123) === 123;


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
`getCellsMeta()` was missing from type defs: https://handsontable.com/docs/7.1.1/Core.html#getCellsMeta

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Added a test under `test:types`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
