### PR TITLE
Fixes issue #6232: rimWhitespace=false and wordWrapping=true conflicting

### DIFF
--- a/src/css/handsontable.css
+++ b/src/css/handsontable.css
@@ -103,6 +103,11 @@
   white-space: nowrap;
 }
 
+/* see src/renderers/_cellDecorator.js */
+.handsontable td.htAllowWrap {
+  white-space: pre-line;
+}
+
 .handsontable th:last-child {
   /*Foundation framework fix*/
   border-right: 1px solid #CCC;

--- a/src/renderers/_cellDecorator.js
+++ b/src/renderers/_cellDecorator.js
@@ -30,6 +30,12 @@ function cellDecorator(instance, TD, row, col, prop, value, cellProperties) {
     classesToAdd.push(cellProperties.noWordWrapClassName);
   }
 
+  if (cellProperties.wordWrap && instance.getSettings().trimWhitespace === false) {
+    // default css class (.handsontable th, .handsontable td) sets 'white-space: pre-line;' which will not break lines,
+    // thus the ghost table will calculate the width wrong
+    classesToAdd.push('htAllowWrap');
+  }
+
   if (!value && cellProperties.placeholder) {
     classesToAdd.push(cellProperties.placeholderCellClassName);
   }

--- a/src/renderers/textRenderer.js
+++ b/src/renderers/textRenderer.js
@@ -25,7 +25,8 @@ function textRenderer(instance, TD, row, col, prop, value, cellProperties, ...ar
 
   escaped = stringify(escaped);
 
-  if (!instance.getSettings().trimWhitespace) {
+  if (!instance.getSettings().trimWhitespace && !instance.getSettings().wordWrap) {
+    // 160 is &nbsp; which won't wrap and preserves sequences of whitespace
     escaped = escaped.replace(/ /g, String.fromCharCode(160));
   }
 

--- a/test/e2e/renderers/textRenderer.spec.js
+++ b/test/e2e/renderers/textRenderer.spec.js
@@ -84,4 +84,25 @@ describe('TextRenderer', () => {
 
     expect($(getCell(1, 0)).height()).toBeGreaterThan($(getCell(0, 0)).height());
   });
+
+  it('should wrap text when trimWhitespace option is false', () => {
+    const HOT = handsontable({
+      trimWhitespace: false,
+      wordWrap: true,
+      data: [
+        ['text', 'long long long long long text']
+      ],
+      colWidths: [100, 500]
+    });
+
+    const oldRowHeight = $(getCell(0, 1)).height();
+
+    HOT.updateSettings({
+      colWidths: [100, 100]
+    });
+
+    const newRowHeight = $(getCell(0, 1)).height();
+
+    expect(newRowHeight).toBeGreaterThan(oldRowHeight);
+  });
 });


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->

There was a bug when setting `wordWrap: true` and `trimWhitespace: false` which prevented cells from wrapping (because `& nbsp;` was inserted)

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
see changes to `textRenderer.spec.js`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/6232

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.