### PR TITLE
Fix #6149: row height cannt reset if the new value is smaller than th…

### DIFF
--- a/src/plugins/manualRowResize/manualRowResize.js
+++ b/src/plugins/manualRowResize/manualRowResize.js
@@ -482,18 +482,18 @@ class ManualRowResize extends BasePlugin {
    * @fires Hooks#modifyRow
    */
   onModifyRowHeight(height, row) {
-    if (this.enabled) {
-      const autoRowSizePlugin = this.hot.getPlugin('autoRowSize');
-      const autoRowHeightResult = autoRowSizePlugin ? autoRowSizePlugin.heights[row] : null;
-      const physicalRow = this.hot.runHooks('modifyRow', row);
-      const manualRowHeight = this.manualRowHeights[physicalRow];
+    let newHeight = height;
 
-      if (manualRowHeight !== void 0 && (manualRowHeight === autoRowHeightResult || manualRowHeight > (height || 0))) {
-        return manualRowHeight;
+    if (this.enabled) {
+      const physicalRow = this.hot.runHooks('modifyRow', row);
+      const rowHeight = this.manualRowHeights[physicalRow];
+
+      if (this.hot.getSettings().manualRowResize && rowHeight) {
+        newHeight = rowHeight;
       }
     }
 
-    return height;
+    return newHeight
   }
 }
 


### PR DESCRIPTION
### Context
row height cannt reset if the new value is smaller than that defined in rowHeights

### How has this been tested?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. #6149 
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
