### PR TITLE
Add z-index to fixedRowsBottom

### DIFF
--- a/src/css/handsontable.css
+++ b/src/css/handsontable.css
@@ -585,11 +585,11 @@ CheckboxRenderer
   background: #eee;
 }
 
-.ht_editor_hide {
+.ht_editor_hidden {
   z-index: -1;
 }
 
-.ht_editor_show {
+.ht_editor_visible {
   z-index: 200;
 }
 

--- a/src/css/handsontable.css
+++ b/src/css/handsontable.css
@@ -585,18 +585,18 @@ CheckboxRenderer
   background: #eee;
 }
 
-.ht_clone_left,
 .ht_clone_bottom {
-  z-index: 102;
+  z-index: 101;
 }
 
+.ht_clone_left,
 .ht_clone_bottom_left_corner {
-  z-index: 103;
+  z-index: 102;
 }
 
 .ht_clone_top_left_corner,
 .ht_clone_top {
-  z-index: 104;
+  z-index: 103;
 }
 
 .handsontable td.htSearchResult {

--- a/src/css/handsontable.css
+++ b/src/css/handsontable.css
@@ -589,7 +589,8 @@ CheckboxRenderer
   z-index: 101;
 }
 
-.ht_clone_left {
+.ht_clone_left,
+.ht_clone_bottom {
   z-index: 102;
 }
 

--- a/src/css/handsontable.css
+++ b/src/css/handsontable.css
@@ -585,18 +585,48 @@ CheckboxRenderer
   background: #eee;
 }
 
+.ht_editor_hide {
+  z-index: -1;
+}
+
+.ht_editor_show {
+  z-index: 200;
+}
+
+.ht_clone_master {
+  z-index: 100;
+}
+
+.ht_clone_right {
+  z-index: 110;
+}
+
+.ht_clone_left {
+  z-index: 120;
+}
+
 .ht_clone_bottom {
-  z-index: 101;
+  z-index: 130;
 }
 
-.ht_clone_left,
+.ht_clone_bottom_right_corner {
+  z-index: 140;
+}
+
 .ht_clone_bottom_left_corner {
-  z-index: 102;
+  z-index: 150;
 }
 
-.ht_clone_top_left_corner,
 .ht_clone_top {
-  z-index: 103;
+  z-index: 160;
+}
+
+.ht_clone_top_right_corner {
+  z-index: 170;
+}
+
+.ht_clone_top_left_corner {
+  z-index: 180;
 }
 
 .handsontable td.htSearchResult {

--- a/src/css/handsontable.css
+++ b/src/css/handsontable.css
@@ -585,22 +585,18 @@ CheckboxRenderer
   background: #eee;
 }
 
-.ht_clone_top {
-  z-index: 101;
-}
-
 .ht_clone_left,
 .ht_clone_bottom {
   z-index: 102;
 }
 
-.ht_clone_top_left_corner,
 .ht_clone_bottom_left_corner {
   z-index: 103;
 }
 
-.ht_clone_debug {
-  z-index: 103;
+.ht_clone_top_left_corner,
+.ht_clone_top {
+  z-index: 104;
 }
 
 .handsontable td.htSearchResult {

--- a/src/editors/_baseEditor.js
+++ b/src/editors/_baseEditor.js
@@ -375,14 +375,14 @@ class BaseEditor {
     const editorSection = this.checkEditorSection();
 
     switch (editorSection) {
-      case 'top':
-        return '101';
-      case 'top-left-corner':
-      case 'bottom-left-corner':
-        return '103';
-      case 'left':
       case 'bottom':
+        return '101';
+      case 'left':
+      case 'bottom-left-corner':
         return '102';
+      case 'top':
+      case 'top-left-corner':
+        return '103';
       default:
         return 'auto';
     }

--- a/src/editors/_baseEditor.js
+++ b/src/editors/_baseEditor.js
@@ -371,20 +371,28 @@ class BaseEditor {
    *
    * @returns {string}
    */
-  getEditedCellsZIndex() {
+  getEditedCellsZIndexClass() {
     const editorSection = this.checkEditorSection();
 
     switch (editorSection) {
-      case 'bottom':
-        return '101';
+      case 'right':
+        return 'ht_clone_right';
       case 'left':
+        return 'ht_clone_left';
+      case 'bottom':
+        return 'ht_clone_bottom';
+      case 'bottom-right-corner':
+        return 'ht_clone_bottom_right_corner';
       case 'bottom-left-corner':
-        return '102';
+        return 'ht_clone_bottom_left_corner';
       case 'top':
+        return 'ht_clone_top';
+      case 'top-right-corner':
+        return 'ht_clone_top_right_corner';
       case 'top-left-corner':
-        return '103';
+        return 'ht_clone_top_left_corner';
       default:
-        return 'auto';
+        return 'ht_clone_master';
     }
   }
 

--- a/src/editors/_baseEditor.js
+++ b/src/editors/_baseEditor.js
@@ -371,7 +371,7 @@ class BaseEditor {
    *
    * @returns {string}
    */
-  getEditedCellsZIndexClass() {
+  getEditedCellsLayerClass() {
     const editorSection = this.checkEditorSection();
 
     switch (editorSection) {

--- a/src/editors/_baseEditor.js
+++ b/src/editors/_baseEditor.js
@@ -367,7 +367,7 @@ class BaseEditor {
   }
 
   /**
-   * Gets HTMLTableCellElement of the edited cell if exist.
+   * Gets className of the edited cell if exist.
    *
    * @returns {string}
    */

--- a/src/editors/selectEditor.js
+++ b/src/editors/selectEditor.js
@@ -16,6 +16,8 @@ import { KEY_CODES } from './../helpers/unicode';
 import BaseEditor, { EditorState } from './_baseEditor';
 import { objectEach } from '../helpers/object';
 
+const EDITOR_VISIBLE_CLASS_NAME = 'ht_editor_visible';
+
 /**
  * @private
  * @editor SelectEditor
@@ -69,8 +71,8 @@ class SelectEditor extends BaseEditor {
     this._opened = false;
     this.select.style.display = 'none';
 
-    if (hasClass(this.select, 'ht_editor_show')) {
-      removeClass(this.select, 'ht_editor_show');
+    if (hasClass(this.select, EDITOR_VISIBLE_CLASS_NAME)) {
+      removeClass(this.select, EDITOR_VISIBLE_CLASS_NAME);
     }
     this.clearHooks();
   }
@@ -241,7 +243,7 @@ class SelectEditor extends BaseEditor {
     selectStyle.left = `${editLeft}px`;
     selectStyle.margin = '0px';
 
-    addClass(this.select, 'ht_editor_show');
+    addClass(this.select, EDITOR_VISIBLE_CLASS_NAME);
   }
 
   /**

--- a/src/editors/selectEditor.js
+++ b/src/editors/selectEditor.js
@@ -4,9 +4,11 @@ import {
   fastInnerHTML,
   getComputedStyle,
   getCssTransform,
+  hasClass,
   offset,
   outerHeight,
   outerWidth,
+  removeClass,
   resetCssTransform,
 } from './../helpers/dom/element';
 import { stopImmediatePropagation } from './../helpers/dom/event';
@@ -66,6 +68,10 @@ class SelectEditor extends BaseEditor {
   close() {
     this._opened = false;
     this.select.style.display = 'none';
+
+    if (hasClass(this.select, 'ht_editor_show')) {
+      removeClass(this.select, 'ht_editor_show');
+    }
     this.clearHooks();
   }
 
@@ -234,7 +240,8 @@ class SelectEditor extends BaseEditor {
     selectStyle.top = `${editTop}px`;
     selectStyle.left = `${editLeft}px`;
     selectStyle.margin = '0px';
-    selectStyle.zIndex = this.getEditedCellsZIndex();
+
+    addClass(this.select, 'ht_editor_show');
   }
 
   /**

--- a/src/editors/textEditor.js
+++ b/src/editors/textEditor.js
@@ -14,6 +14,7 @@ import {
   hasClass,
   removeClass
 } from './../helpers/dom/element';
+import { arrayFilter } from './../helpers/array';
 import autoResize from './../../lib/autoResize/autoResize';
 import { isMobileBrowser, isIE, isEdge } from './../helpers/browser';
 import BaseEditor, { EditorState } from './_baseEditor';
@@ -75,6 +76,13 @@ class TextEditor extends BaseEditor {
      * @type {CSSStyleDeclaration}
      */
     this.textareaParentStyle = void 0;
+    /**
+     * Style declaration object of the TEXTAREA_PARENT element.
+     *
+     * @private
+     * @type {string}
+     */
+    this.zIndexClass = void 0;
 
     this.createElements();
     this.bindEvents();
@@ -217,8 +225,8 @@ class TextEditor extends BaseEditor {
     this.TEXTAREA_PARENT = rootDocument.createElement('DIV');
     addClass(this.TEXTAREA_PARENT, 'handsontableInputHolder');
 
-    if (hasClass(this.TEXTAREA_PARENT, 'ht_editor_show')) {
-      removeClass(this.TEXTAREA_PARENT, 'ht_editor_show');
+    if (hasClass(this.TEXTAREA_PARENT, this.zIndexClass)) {
+      removeClass(this.TEXTAREA_PARENT, this.zIndexClass);
     }
 
     addClass(this.TEXTAREA_PARENT, 'ht_editor_hide');
@@ -244,8 +252,8 @@ class TextEditor extends BaseEditor {
     this.textareaParentStyle.opacity = '0';
     this.textareaParentStyle.height = '1px';
 
-    if (hasClass(this.TEXTAREA_PARENT, 'ht_editor_show')) {
-      removeClass(this.TEXTAREA_PARENT, 'ht_editor_show');
+    if (hasClass(this.TEXTAREA_PARENT, this.zIndexClass)) {
+      removeClass(this.TEXTAREA_PARENT, this.zIndexClass);
     }
 
     addClass(this.TEXTAREA_PARENT, 'ht_editor_hide');
@@ -266,11 +274,29 @@ class TextEditor extends BaseEditor {
     this.textareaStyle.textIndent = '';
     this.textareaStyle.overflowY = 'hidden';
 
+    const childNodes = this.TEXTAREA_PARENT.childNodes;
+    let hasClassHandsontableEditor = false;
+
+    arrayFilter(childNodes, (childNode) => {
+      if (hasClass(childNode, 'handsontableEditor')) {
+        hasClassHandsontableEditor = true;
+      }
+    });
+
     if (hasClass(this.TEXTAREA_PARENT, 'ht_editor_hide')) {
       removeClass(this.TEXTAREA_PARENT, 'ht_editor_hide');
     }
 
-    addClass(this.TEXTAREA_PARENT, 'ht_editor_show');
+    if (hasClassHandsontableEditor) {
+      this.zIndexClass = 'ht_editor_show';
+
+      addClass(this.TEXTAREA_PARENT, this.zIndexClass);
+
+    } else {
+      this.zIndexClass = this.getEditedCellsZIndexClass();
+
+      addClass(this.TEXTAREA_PARENT, this.zIndexClass);
+    }
   }
 
   /**

--- a/src/editors/textEditor.js
+++ b/src/editors/textEditor.js
@@ -77,7 +77,7 @@ class TextEditor extends BaseEditor {
      */
     this.textareaParentStyle = void 0;
     /**
-     * Style declaration object of the TEXTAREA_PARENT element.
+     * z-index class style for the editor.
      *
      * @private
      * @type {string}

--- a/src/editors/textEditor.js
+++ b/src/editors/textEditor.js
@@ -14,13 +14,16 @@ import {
   hasClass,
   removeClass
 } from './../helpers/dom/element';
-import { arrayFilter } from './../helpers/array';
+import { rangeEach } from './../helpers/number';
 import autoResize from './../../lib/autoResize/autoResize';
 import { isMobileBrowser, isIE, isEdge } from './../helpers/browser';
 import BaseEditor, { EditorState } from './_baseEditor';
 import EventManager from './../eventManager';
 import { KEY_CODES } from './../helpers/unicode';
 import { stopPropagation, stopImmediatePropagation, isImmediatePropagationStopped } from './../helpers/dom/event';
+
+const EDITOR_VISIBLE_CLASS_NAME = 'ht_editor_visible';
+const EDITOR_HIDDEN_CLASS_NAME = 'ht_editor_hidden';
 
 /**
  * @private
@@ -82,7 +85,7 @@ class TextEditor extends BaseEditor {
      * @private
      * @type {string}
      */
-    this.zIndexClass = void 0;
+    this.layerClass = void 0;
 
     this.createElements();
     this.bindEvents();
@@ -225,11 +228,11 @@ class TextEditor extends BaseEditor {
     this.TEXTAREA_PARENT = rootDocument.createElement('DIV');
     addClass(this.TEXTAREA_PARENT, 'handsontableInputHolder');
 
-    if (hasClass(this.TEXTAREA_PARENT, this.zIndexClass)) {
-      removeClass(this.TEXTAREA_PARENT, this.zIndexClass);
+    if (hasClass(this.TEXTAREA_PARENT, this.layerClass)) {
+      removeClass(this.TEXTAREA_PARENT, this.layerClass);
     }
 
-    addClass(this.TEXTAREA_PARENT, 'ht_editor_hide');
+    addClass(this.TEXTAREA_PARENT, EDITOR_HIDDEN_CLASS_NAME);
 
     this.textareaParentStyle = this.TEXTAREA_PARENT.style;
 
@@ -252,11 +255,11 @@ class TextEditor extends BaseEditor {
     this.textareaParentStyle.opacity = '0';
     this.textareaParentStyle.height = '1px';
 
-    if (hasClass(this.TEXTAREA_PARENT, this.zIndexClass)) {
-      removeClass(this.TEXTAREA_PARENT, this.zIndexClass);
+    if (hasClass(this.TEXTAREA_PARENT, this.layerClass)) {
+      removeClass(this.TEXTAREA_PARENT, this.layerClass);
     }
 
-    addClass(this.TEXTAREA_PARENT, 'ht_editor_hide');
+    addClass(this.TEXTAREA_PARENT, EDITOR_HIDDEN_CLASS_NAME);
   }
 
   /**
@@ -277,25 +280,29 @@ class TextEditor extends BaseEditor {
     const childNodes = this.TEXTAREA_PARENT.childNodes;
     let hasClassHandsontableEditor = false;
 
-    arrayFilter(childNodes, (childNode) => {
+    rangeEach(childNodes.length - 1, (index) => {
+      const childNode = childNodes[index];
+
       if (hasClass(childNode, 'handsontableEditor')) {
         hasClassHandsontableEditor = true;
+
+        return false;
       }
     });
 
-    if (hasClass(this.TEXTAREA_PARENT, 'ht_editor_hide')) {
-      removeClass(this.TEXTAREA_PARENT, 'ht_editor_hide');
+    if (hasClass(this.TEXTAREA_PARENT, EDITOR_HIDDEN_CLASS_NAME)) {
+      removeClass(this.TEXTAREA_PARENT, EDITOR_HIDDEN_CLASS_NAME);
     }
 
     if (hasClassHandsontableEditor) {
-      this.zIndexClass = 'ht_editor_show';
+      this.layerClass = EDITOR_VISIBLE_CLASS_NAME;
 
-      addClass(this.TEXTAREA_PARENT, this.zIndexClass);
+      addClass(this.TEXTAREA_PARENT, this.layerClass);
 
     } else {
-      this.zIndexClass = this.getEditedCellsZIndexClass();
+      this.layerClass = this.getEditedCellsLayerClass();
 
-      addClass(this.TEXTAREA_PARENT, this.zIndexClass);
+      addClass(this.TEXTAREA_PARENT, this.layerClass);
     }
   }
 

--- a/src/editors/textEditor.js
+++ b/src/editors/textEditor.js
@@ -10,7 +10,9 @@ import {
   setCaretPosition,
   hasVerticalScrollbar,
   hasHorizontalScrollbar,
-  selectElementIfAllowed
+  selectElementIfAllowed,
+  hasClass,
+  removeClass
 } from './../helpers/dom/element';
 import autoResize from './../../lib/autoResize/autoResize';
 import { isMobileBrowser, isIE, isEdge } from './../helpers/browser';
@@ -215,8 +217,13 @@ class TextEditor extends BaseEditor {
     this.TEXTAREA_PARENT = rootDocument.createElement('DIV');
     addClass(this.TEXTAREA_PARENT, 'handsontableInputHolder');
 
+    if (hasClass(this.TEXTAREA_PARENT, 'ht_editor_show')) {
+      removeClass(this.TEXTAREA_PARENT, 'ht_editor_show');
+    }
+
+    addClass(this.TEXTAREA_PARENT, 'ht_editor_hide');
+
     this.textareaParentStyle = this.TEXTAREA_PARENT.style;
-    this.textareaParentStyle.zIndex = '-1';
 
     this.TEXTAREA_PARENT.appendChild(this.TEXTAREA);
 
@@ -236,7 +243,12 @@ class TextEditor extends BaseEditor {
 
     this.textareaParentStyle.opacity = '0';
     this.textareaParentStyle.height = '1px';
-    this.textareaParentStyle.zIndex = '-1';
+
+    if (hasClass(this.TEXTAREA_PARENT, 'ht_editor_show')) {
+      removeClass(this.TEXTAREA_PARENT, 'ht_editor_show');
+    }
+
+    addClass(this.TEXTAREA_PARENT, 'ht_editor_hide');
   }
 
   /**
@@ -249,12 +261,17 @@ class TextEditor extends BaseEditor {
     this.textareaParentStyle.overflow = '';
     this.textareaParentStyle.position = '';
     this.textareaParentStyle.right = 'auto';
-    const zIndex = this.getEditedCellsZIndex();
-    this.textareaParentStyle.zIndex = zIndex !== 'auto' ? zIndex : '';
     this.textareaParentStyle.opacity = '1';
+    this.textareaParentStyle.zIndex = '';
 
     this.textareaStyle.textIndent = '';
     this.textareaStyle.overflowY = 'hidden';
+
+    if (hasClass(this.TEXTAREA_PARENT, 'ht_editor_hide')) {
+      removeClass(this.TEXTAREA_PARENT, 'ht_editor_hide');
+    }
+
+    addClass(this.TEXTAREA_PARENT, 'ht_editor_show');
   }
 
   /**

--- a/src/editors/textEditor.js
+++ b/src/editors/textEditor.js
@@ -262,7 +262,6 @@ class TextEditor extends BaseEditor {
     this.textareaParentStyle.position = '';
     this.textareaParentStyle.right = 'auto';
     this.textareaParentStyle.opacity = '1';
-    this.textareaParentStyle.zIndex = '';
 
     this.textareaStyle.textIndent = '';
     this.textareaStyle.overflowY = 'hidden';

--- a/src/plugins/contextMenu/contextMenu.css
+++ b/src/plugins/contextMenu/contextMenu.css
@@ -10,8 +10,7 @@
 
 .htContextMenu .ht_clone_top,
 .htContextMenu .ht_clone_left,
-.htContextMenu .ht_clone_corner,
-.htContextMenu .ht_clone_debug {
+.htContextMenu .ht_clone_corner {
   display: none;
 }
 

--- a/src/plugins/dropdownMenu/dropdownMenu.css
+++ b/src/plugins/dropdownMenu/dropdownMenu.css
@@ -30,8 +30,7 @@
 
 .htDropdownMenu .ht_clone_top,
 .htDropdownMenu .ht_clone_left,
-.htDropdownMenu .ht_clone_corner,
-.htDropdownMenu .ht_clone_debug {
+.htDropdownMenu .ht_clone_corner {
   display: none;
 }
 

--- a/src/plugins/filters/filters.css
+++ b/src/plugins/filters/filters.css
@@ -11,8 +11,7 @@
 
 .htFiltersConditionsMenu .ht_clone_top,
 .htFiltersConditionsMenu .ht_clone_left,
-.htFiltersConditionsMenu .ht_clone_corner,
-.htFiltersConditionsMenu .ht_clone_debug {
+.htFiltersConditionsMenu .ht_clone_corner {
   display: none;
 }
 


### PR DESCRIPTION
### Context
After added z-indexes to selection borders (class `.current`, `.area` and `.fill`), and after scroll over `fixedRowsBottom` selection borders overlap to fixed area. 
<del>Honestly, `z-index: 12` is enough to `.ht_clone_bottom` class. But I decided to use the existing place (`clones` class) and values to keep it easier to manage.<del>

### How has this been tested?
I tested with different cell types.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #5947
2. #5105

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
