### PR TITLE
Corrected typo in the viewportColumnCalculatorOverride function

### DIFF
--- a/src/tableView.js
+++ b/src/tableView.js
@@ -559,7 +559,7 @@ class TableView {
             const center = calc.startColumn + calc.endColumn - calc.startColumn;
             const offset = Math.ceil(center / cols * 12);
 
-            calc.startRow = Math.max(calc.startColumn - offset, 0);
+            calc.startColumn = Math.max(calc.startColumn - offset, 0);
             calc.endColumn = Math.min(calc.endColumn + offset, cols - 1);
           }
         }


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Fixed typo from @budnix #6115 issue where `startColumn` was changed with `startRow`.

Quoting @budnix 

>While refactoring Walkontable renderer I've spotted that in the viewportColumnCalculatorOverride function is a typo. In this line, https://github.com/handsontable/handsontable/blob/master/src/tableView.js#L585 startRow should be changed to startColumn. This bug causes the wrong virtual DOM calculation for columns.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/6115

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
