### PR TITLE
cell editing Undo Redo doesn't work for column with data as function

### DIFF
--- a/src/plugins/undoRedo/undoRedo.js
+++ b/src/plugins/undoRedo/undoRedo.js
@@ -171,8 +171,13 @@ UndoRedo.prototype.undo = function() {
   if (this.isUndoAvailable()) {
     const action = this.doneActions.pop();
     const actionClone = deepClone(action);
+    
+    // deepClone doesn't clone a function, e.g: column data bag can be a string or a function.
+    if (typeof action.changes[0][1] === 'function')
+      actionClone.changes[0][1] = action.changes[0][1];
+    //
+    
     const instance = this.instance;
-
     const continueAction = instance.runHooks('beforeUndo', actionClone);
 
     if (continueAction === false) {
@@ -202,8 +207,13 @@ UndoRedo.prototype.redo = function() {
   if (this.isRedoAvailable()) {
     const action = this.undoneActions.pop();
     const actionClone = deepClone(action);
-    const instance = this.instance;
 
+    // deepClone doesn't clone a function, e.g: column data bag can be a string or a function.
+    if (typeof action.changes[0][1] === 'function')
+      actionClone.changes[0][1] = action.changes[0][1];
+    //
+
+    const instance = this.instance;
     const continueAction = instance.runHooks('beforeRedo', actionClone);
 
     if (continueAction === false) {
@@ -272,6 +282,12 @@ inherit(UndoRedo.ChangeAction, UndoRedo.Action);
 
 UndoRedo.ChangeAction.prototype.undo = function(instance, undoneCallback) {
   const data = deepClone(this.changes);
+
+  // deepClone doesn't clone a function, e.g: column data bag can be a string or a function.
+  if (typeof this.changes[0][1] === "function")
+    data[0][1] = this.changes[0][1];
+  //
+
   const emptyRowsAtTheEnd = instance.countEmptyRows(true);
   const emptyColsAtTheEnd = instance.countEmptyCols(true);
 
@@ -305,6 +321,11 @@ UndoRedo.ChangeAction.prototype.undo = function(instance, undoneCallback) {
 };
 UndoRedo.ChangeAction.prototype.redo = function(instance, onFinishCallback) {
   const data = deepClone(this.changes);
+
+  // deepClone doesn't clone a function, e.g: column data bag can be a string or a function.
+  if (typeof this.changes[0][1] === "function")
+    data[0][1] = this.changes[0][1];
+  //
 
   for (let i = 0, len = data.length; i < len; i++) {
     data[i].splice(2, 1);


### PR DESCRIPTION
### Context

When undo or redo a cell value change nothing happens when the column data is a function.

Cell Column Data is defined as such:

> interface ColumnSettings {
>       data: ColumnDataAccessor;


ColumnDataAccessor is defined as such:
 `type ColumnDataAccessor = string | ((row:any, val?:any) => string | void) | number;`
   
Undo redo functions deep clones the action ([row, ColumnDataAccessor, prev value, new value]), deepClone is essentially a simple JSON parsing of the action and will fail to convert the second item of the action (ColumnDataAccessor) if it is of type function, the result will be null. This prevent the undo redo machinery to find the cell to set.

One fix I would like to propose is to simply re-assign the ColumnDataAccessor function from the source action.

> const data = deepClone(this.changes);
> if (typeof this.changes[0][1] === "function")
>   data[0][1] = this.changes[0][1];

### How has this been tested?

Tested in our code for:

- column of data type string

- column of data type function

- autocomplete and dropdown with data type function

