### PR TITLE
NodeList in htmlToGridSettings has to be parsed into an array.

### DIFF
--- a/src/utils/parseTable.js
+++ b/src/utils/parseTable.js
@@ -256,7 +256,7 @@ export function htmlToGridSettings(element, rootDocument = document) {
   const dataRows = [
     ...fixedRowsTop,
     ...Array.from(checkElement.tBodies).reduce((sections, section) => {
-      sections.push(...section.rows); return sections;
+      sections.push(...Array.from(section.rows)); return sections;
     }, []),
     ...fixedRowsBottom];
 


### PR DESCRIPTION
### Context
As it was mentioned in #6350, in `htmlToGridSettings` is a bug with non-iterable NodeList what we try to put into an array using spread syntax. There was a missing conversion for `section.rows`.

### How has this been tested?
Use `Handsontable.helper.htmlToGridSettings` on IE9-11.
It should prepare grid settings without errors.

### Types of changes
- [x] Bugfix (a non-breaking change which fixes an issue)

### Related issue(s):
1. #6350