### PR TITLE
Configurable secondary focusable element's container (CopyPaste) 

### DIFF
--- a/handsontable.d.ts
+++ b/handsontable.d.ts
@@ -927,6 +927,7 @@ declare namespace Handsontable {
       focusableElement: FocusableWrapper;
       pasteMode: PasteModeType;
       rowsLimit: number;
+      uiContainer: HTMLElement;
 
       copy(): void;
       cut(): void;

--- a/src/helpers/dom/element.js
+++ b/src/helpers/dom/element.js
@@ -1081,7 +1081,7 @@ export function isInput(element) {
  * @returns {Boolean}
  */
 export function isOutsideInput(element) {
-  return isInput(element) && element.className.indexOf('handsontableInput') === -1 && element.className.indexOf('copyPaste') === -1;
+  return isInput(element) && element.className.indexOf('handsontableInput') === -1 && element.className.indexOf('HandsontableCopyPaste') === -1;
 }
 
 /**

--- a/src/plugins/copyPaste/copyPaste.css
+++ b/src/plugins/copyPaste/copyPaste.css
@@ -1,4 +1,4 @@
-textarea#HandsontableCopyPaste {
+textarea.HandsontableCopyPaste {
   position: fixed !important;
   top: 0 !important;
   right: 100% !important;

--- a/src/plugins/copyPaste/copyPaste.js
+++ b/src/plugins/copyPaste/copyPaste.js
@@ -100,6 +100,11 @@ class CopyPaste extends BasePlugin {
      */
     this.rowsLimit = ROWS_LIMIT;
 
+    /**
+     * UI container for the secondary focusable element.
+     *
+     * @type {HTMLElement}
+     */
     this.uiContainer = this.hot.rootDocument.body;
 
     privatePool.set(this, {

--- a/src/plugins/copyPaste/copyPaste.js
+++ b/src/plugins/copyPaste/copyPaste.js
@@ -100,6 +100,8 @@ class CopyPaste extends BasePlugin {
      */
     this.rowsLimit = ROWS_LIMIT;
 
+    this.uiContainer = this.hot.rootDocument.body;
+
     privatePool.set(this, {
       isTriggeredByCopy: false,
       isTriggeredByCut: false,
@@ -125,15 +127,16 @@ class CopyPaste extends BasePlugin {
     if (this.enabled) {
       return;
     }
-    const settings = this.hot.getSettings();
+    const { copyPaste: settings, fragmentSelection } = this.hot.getSettings();
     const priv = privatePool.get(this);
 
-    priv.isFragmentSelectionEnabled = settings.fragmentSelection;
+    priv.isFragmentSelectionEnabled = !!fragmentSelection;
 
-    if (typeof settings.copyPaste === 'object') {
-      this.pasteMode = settings.copyPaste.pasteMode || this.pasteMode;
-      this.rowsLimit = settings.copyPaste.rowsLimit || this.rowsLimit;
-      this.columnsLimit = settings.copyPaste.columnsLimit || this.columnsLimit;
+    if (typeof settings === 'object') {
+      this.pasteMode = settings.pasteMode || this.pasteMode;
+      this.rowsLimit = isNaN(settings.rowsLimit) ? this.rowsLimit : settings.rowsLimit;
+      this.columnsLimit = isNaN(settings.columnsLimit) ? this.columnsLimit : settings.columnsLimit;
+      this.uiContainer = settings.uiContainer || this.uiContainer;
     }
 
     this.addHook('afterContextMenuDefaultOptions', options => this.onAfterContextMenuDefaultOptions(options));
@@ -141,15 +144,20 @@ class CopyPaste extends BasePlugin {
     this.addHook('afterSelectionEnd', () => this.onAfterSelectionEnd());
     this.addHook('beforeKeyDown', () => this.onBeforeKeyDown());
 
-    this.focusableElement = createElement(this.hot.rootDocument);
+    this.focusableElement = createElement(this.uiContainer);
     this.focusableElement
       .addLocalHook('copy', event => this.onCopy(event))
       .addLocalHook('cut', event => this.onCut(event))
-      .addLocalHook('paste', event => this.onPaste(event));
+      .addLocalHook('paste', event => this.onPaste(event))
+      .addLocalHook('keydown', event => this.onKeyDown(event));
 
     super.enablePlugin();
   }
 
+  onKeyDown() {
+    // console.log(event);
+    // this.hot.rootElement.dispatchEvent(event);
+  }
   /**
    * Updates the plugin state. This method is executed when {@link Core#updateSettings} is invoked.
    */

--- a/src/plugins/copyPaste/copyPaste.js
+++ b/src/plugins/copyPaste/copyPaste.js
@@ -42,6 +42,7 @@ const META_HEAD = [
  * * `'columnsLimit'` (see {@link CopyPaste#columnsLimit})
  * * `'rowsLimit'` (see {@link CopyPaste#rowsLimit})
  * * `'pasteMode'` (see {@link CopyPaste#pasteMode})
+ * * `'uiContainer'` (see {@link CopyPaste#uiContainer})
  *
  * See [the copy/paste demo](https://handsontable.com/docs/demo-copy-paste.html) for examples.
  *
@@ -54,6 +55,7 @@ const META_HEAD = [
  *   columnsLimit: 25,
  *   rowsLimit: 50,
  *   pasteMode: 'shift_down',
+ *   pasteMode: document.body,
  * },
  * ```
  * @class CopyPaste

--- a/src/plugins/copyPaste/copyPaste.js
+++ b/src/plugins/copyPaste/copyPaste.js
@@ -148,16 +148,11 @@ class CopyPaste extends BasePlugin {
     this.focusableElement
       .addLocalHook('copy', event => this.onCopy(event))
       .addLocalHook('cut', event => this.onCut(event))
-      .addLocalHook('paste', event => this.onPaste(event))
-      .addLocalHook('keydown', event => this.onKeyDown(event));
+      .addLocalHook('paste', event => this.onPaste(event));
 
     super.enablePlugin();
   }
 
-  onKeyDown() {
-    // console.log(event);
-    // this.hot.rootElement.dispatchEvent(event);
-  }
   /**
    * Updates the plugin state. This method is executed when {@link Core#updateSettings} is invoked.
    */

--- a/src/plugins/copyPaste/copyPaste.js
+++ b/src/plugins/copyPaste/copyPaste.js
@@ -55,7 +55,7 @@ const META_HEAD = [
  *   columnsLimit: 25,
  *   rowsLimit: 50,
  *   pasteMode: 'shift_down',
- *   pasteMode: document.body,
+ *   uiContainer: document.body,
  * },
  * ```
  * @class CopyPaste

--- a/src/plugins/copyPaste/focusableElement.js
+++ b/src/plugins/copyPaste/focusableElement.js
@@ -126,7 +126,6 @@ function forwardEventsToLocalHooks(eventManager, element, subject) {
   eventManager.addEventListener(element, 'copy', runLocalHooks('copy', subject));
   eventManager.addEventListener(element, 'cut', runLocalHooks('cut', subject));
   eventManager.addEventListener(element, 'paste', runLocalHooks('paste', subject));
-  eventManager.addEventListener(element, 'keydown', runLocalHooks('keydown', subject));
 }
 
 const secondaryElements = new WeakMap();

--- a/src/plugins/copyPaste/focusableElement.js
+++ b/src/plugins/copyPaste/focusableElement.js
@@ -151,7 +151,7 @@ function createOrGetSecondaryElement(container) {
   const element = doc.createElement('textarea');
 
   secondaryElements.set(container, element);
-  element.className = 'copyPaste HandsontableCopyPaste';
+  element.className = 'HandsontableCopyPaste';
   element.tabIndex = -1;
   element.autocomplete = 'off';
   element.wrap = 'hard';

--- a/src/plugins/copyPaste/focusableElement.js
+++ b/src/plugins/copyPaste/focusableElement.js
@@ -30,7 +30,11 @@ class FocusableWrapper {
      * @type {WeakSet}
      */
     this.listenersCount = new WeakSet();
-
+    /**
+     * Parent for an focusable element.
+     *
+     * @type {HTMLElement}
+     */
     this.container = container;
   }
 

--- a/src/plugins/copyPaste/test/copyPaste.e2e.js
+++ b/src/plugins/copyPaste/test/copyPaste.e2e.js
@@ -34,7 +34,7 @@ describe('CopyPaste', () => {
         copyPaste: false
       });
 
-      expect($('#HandsontableCopyPaste').length).toEqual(0);
+      expect($('.HandsontableCopyPaste').length).toEqual(0);
     });
   });
 
@@ -46,7 +46,7 @@ describe('CopyPaste', () => {
       await sleep(150);
 
       expect(document.activeElement).toBe(getActiveEditor().TEXTAREA);
-      expect($('#HandsontableCopyPaste').length).toBe(0);
+      expect($('.HandsontableCopyPaste').length).toBe(0);
     });
 
     it('should create focusable element when cell editor doesn\'t exist', () => {
@@ -55,7 +55,7 @@ describe('CopyPaste', () => {
       });
       selectCell(0, 0);
 
-      expect($('#HandsontableCopyPaste').length).toEqual(1);
+      expect($('.HandsontableCopyPaste').length).toEqual(1);
     });
 
     it('should keep focusable element if updateSettings occurred after the end of the selection', () => {
@@ -91,7 +91,7 @@ describe('CopyPaste', () => {
       handsontable();
       spec().$container2.handsontable();
 
-      expect($('#HandsontableCopyPaste').length).toBe(0);
+      expect($('.HandsontableCopyPaste').length).toBe(0);
     });
 
     it('should use focusable element from cell editor of the lastly selected table', async() => {
@@ -103,7 +103,7 @@ describe('CopyPaste', () => {
 
       await sleep(100);
 
-      expect($('#HandsontableCopyPaste').length).toBe(0);
+      expect($('.HandsontableCopyPaste').length).toBe(0);
       expect(document.activeElement).toBe(hot2.getActiveEditor().TEXTAREA);
     });
 
@@ -114,15 +114,15 @@ describe('CopyPaste', () => {
       hot1.selectCell(0, 0);
       hot2.selectCell(0, 0);
 
-      expect($('#HandsontableCopyPaste').length).toBe(1);
+      expect($('.HandsontableCopyPaste').length).toBe(1);
 
       hot1.updateSettings({ copyPaste: false });
 
-      expect($('#HandsontableCopyPaste').length).toBe(1);
+      expect($('.HandsontableCopyPaste').length).toBe(1);
 
       hot2.updateSettings({ copyPaste: false });
 
-      expect($('#HandsontableCopyPaste').length).toBe(0);
+      expect($('.HandsontableCopyPaste').length).toBe(0);
     });
 
     it('should not touch focusable element borrowed from cell editors', () => {

--- a/src/plugins/copyPaste/test/focusableElement.unit.js
+++ b/src/plugins/copyPaste/test/focusableElement.unit.js
@@ -128,6 +128,9 @@ describe('CopyPaste', () => {
 
       fw1.useSecondaryElement();
       fw2.useSecondaryElement();
+
+      expect(document.querySelectorAll('.HandsontableCopyPaste').length).toBe(2);
+
       destroyElement(fw2);
 
       expect(document.querySelectorAll('.HandsontableCopyPaste').length).toBe(1);

--- a/src/plugins/copyPaste/test/focusableElement.unit.js
+++ b/src/plugins/copyPaste/test/focusableElement.unit.js
@@ -17,14 +17,14 @@ describe('CopyPaste', () => {
     });
 
     it('should create and return instance of FocusableWrapper class', () => {
-      fw1 = createElement(document);
+      fw1 = createElement(document.body);
 
       expect(fw1.constructor.name).toBe('FocusableWrapper');
     });
 
     it('should create new instance of FocusableWrapper class on every createElement call', () => {
-      fw1 = createElement(document);
-      fw2 = createElement(document);
+      fw1 = createElement(document.body);
+      fw2 = createElement(document.body);
 
       fw1.useSecondaryElement();
       fw2.useSecondaryElement();
@@ -34,23 +34,23 @@ describe('CopyPaste', () => {
     });
 
     it('should create focusable element only once when useSecondaryElement method is called multiple times', () => {
-      fw1 = createElement(document);
+      fw1 = createElement(document.body);
       fw1.useSecondaryElement();
 
-      expect(fw1.mainElement).toBe(document.querySelector('#HandsontableCopyPaste'));
-
-      fw1.useSecondaryElement();
-
-      expect(fw1.mainElement).toBe(document.querySelector('#HandsontableCopyPaste'));
+      expect(fw1.mainElement).toBe(document.querySelector('.HandsontableCopyPaste'));
 
       fw1.useSecondaryElement();
 
-      expect(fw1.mainElement).toBe(document.querySelector('#HandsontableCopyPaste'));
-      expect(document.querySelectorAll('#HandsontableCopyPaste').length).toBe(1);
+      expect(fw1.mainElement).toBe(document.querySelector('.HandsontableCopyPaste'));
+
+      fw1.useSecondaryElement();
+
+      expect(fw1.mainElement).toBe(document.querySelector('.HandsontableCopyPaste'));
+      expect(document.querySelectorAll('.HandsontableCopyPaste').length).toBe(1);
     });
 
     it('should fire internal events only once when useSecondaryElement method is called multiple times', () => {
-      fw1 = createElement(document);
+      fw1 = createElement(document.body);
 
       fw1.useSecondaryElement();
       fw1.useSecondaryElement();
@@ -65,7 +65,7 @@ describe('CopyPaste', () => {
     });
 
     it('should fire internal events only once when external focusable element is passed multiple times', () => {
-      fw1 = createElement(document);
+      fw1 = createElement(document.body);
       const element = document.createElement('textarea');
 
       fw1.setFocusableElement(element);
@@ -82,7 +82,7 @@ describe('CopyPaste', () => {
     });
 
     it('should return focusable element through mainElement property', () => {
-      fw1 = createElement(document);
+      fw1 = createElement(document.body);
       const element = document.createElement('textarea');
 
       expect(fw1.getFocusableElement()).toBe(null);
@@ -93,7 +93,7 @@ describe('CopyPaste', () => {
     });
 
     it('should select focusable element and set value as an empty string when focus method is called', () => {
-      fw1 = createElement(document);
+      fw1 = createElement(document.body);
       const element = document.createElement('textarea');
 
       spyOn(element, 'select');
@@ -105,18 +105,37 @@ describe('CopyPaste', () => {
     });
 
     it('should destroy FocusableWrapper object instance and detach secondary focusable element from DOM', () => {
-      fw1 = createElement(document);
-      fw2 = createElement(document);
+      fw1 = createElement(document.body);
+      fw2 = createElement(document.body);
 
       fw1.useSecondaryElement();
       fw2.useSecondaryElement();
       destroyElement(fw2);
 
-      expect(document.querySelectorAll('#HandsontableCopyPaste').length).toBe(1);
+      expect(document.querySelectorAll('.HandsontableCopyPaste').length).toBe(1);
 
       destroyElement(fw1);
 
-      expect(document.querySelectorAll('#HandsontableCopyPaste').length).toBe(0);
+      expect(document.querySelectorAll('.HandsontableCopyPaste').length).toBe(0);
+    });
+
+    it('should destroy FocusableWrapper object instance and detach secondary focusable element from DOM if they have different container', () => {
+      const testContainer = document.createElement('div');
+      document.body.appendChild(testContainer);
+
+      fw1 = createElement(document.body);
+      fw2 = createElement(testContainer);
+
+      fw1.useSecondaryElement();
+      fw2.useSecondaryElement();
+      destroyElement(fw2);
+
+      expect(document.querySelectorAll('.HandsontableCopyPaste').length).toBe(1);
+
+      destroyElement(fw1);
+
+      expect(document.querySelectorAll('.HandsontableCopyPaste').length).toBe(0);
+      testContainer.parentNode.removeChild(testContainer);
     });
   });
 });

--- a/test/e2e/editors/noEditor.spec.js
+++ b/test/e2e/editors/noEditor.spec.js
@@ -164,7 +164,7 @@ describe('noEditor', () => {
 
       await sleep(10);
 
-      expect(document.activeElement).toBe(document.querySelector('#HandsontableCopyPaste'));
+      expect(document.activeElement).toBe(document.querySelector('.HandsontableCopyPaste'));
     });
   });
 });

--- a/test/e2e/editors/selectEditor.spec.js
+++ b/test/e2e/editors/selectEditor.spec.js
@@ -283,7 +283,7 @@ describe('SelectEditor', () => {
 
       await sleep(10);
 
-      expect(document.activeElement).toBe(document.querySelector('#HandsontableCopyPaste'));
+      expect(document.activeElement).toBe(document.querySelector('.HandsontableCopyPaste'));
     });
   });
 });

--- a/test/types/settings.types.ts
+++ b/test/types/settings.types.ts
@@ -132,6 +132,7 @@ const allSettings: Required<Handsontable.GridSettings> = {
     pasteMode: oneOf('overwrite', 'shift_down', 'shift_right'),
     rowsLimit: 10,
     columnsLimit: 20,
+    uiContainer: document.body,
   }),
   correctFormat: true,
   currentColClassName: 'foo',


### PR DESCRIPTION
### Context
Currently, we have hard-coded `rootDocument.body` as a container for CopyPaste's focusable element. Thanks to these changes, it's possible to define the custom container.
Changes are backward compatible. If `copyPaste.uiContainer` is not defined, there `rootDocument.body` is used.

### How has this been tested?
Use the following options to initialize Handsontable:
```
editor: false,
copyPaste: {
  uiContainer: ... // reference to an element
}
```

### Types of changes
- [x] New feature or improvement (a non-breaking change which adds functionality)

### Related issue(s):
1. #6343