### PR TITLE
Fix addClass

### DIFF
--- a/src/helpers/dom/element.js
+++ b/src/helpers/dom/element.js
@@ -225,11 +225,10 @@ function filterEmptyClassNames(classNames) {
     return result;
   }
 
-  let len = 0;
-
-  while (classNames[len]) {
-    result.push(classNames[len]);
-    len += 1;
+  for (let len = 0; len < classNames.length; len++) {
+    if (classNames[len]) {
+      result.push(classNames[len]);
+    }
   }
 
   return result;
@@ -312,7 +311,6 @@ if (isClassListSupported()) {
   };
 
   _addClass = function(element, classes) {
-    let len = 0;
     let _className = element.className;
     let className = classes;
 
@@ -323,11 +321,10 @@ if (isClassListSupported()) {
       _className = className.join(' ');
 
     } else {
-      while (className && className[len]) {
-        if (!createClassNameRegExp(className[len]).test(_className)) {
+      for (let len = 0; len < className.length; len++) {
+        if (className[len] && !createClassNameRegExp(className[len]).test(_className)) {
           _className += ` ${className[len]}`;
         }
-        len += 1;
       }
     }
     element.className = _className;

--- a/test/unit/helpers/dom/Element.spec.js
+++ b/test/unit/helpers/dom/Element.spec.js
@@ -175,6 +175,12 @@ describe('DomElement helper', () => {
       expect(element.className).toBe('test1 test2 test4 test3');
     });
 
+    it('should add all CSS classes without removing old one (passed as an array)', () => {
+      addClass(element, ['test2', 'test4', '', 'test3']);
+
+      expect(element.className).toBe('test1 test2 test4 test3');
+    });
+
     it('should not touch the DOM element when the passed argument is empty', () => {
       const elementMock = {
         classList: {


### PR DESCRIPTION
Fix bug where if an empty string class name is introduced into an array of
classes, all classes after the empty string will be ignored.

### Context
The addClass function if there is an empty element in the className array, all successive classes will be ignored. `addClass(ele, ['a', '', 'b', 'c'])` will not add classes `'b'` and `'c'`.

### How has this been tested?

Calling `addClass` with an array containing an empty string, and making sure all classes after the empty string are added as well.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
