### PR TITLE
CSSPageRule should not cause an exception in parsing HTML into grid settings

### DIFF
--- a/handsontable.d.ts
+++ b/handsontable.d.ts
@@ -2295,6 +2295,7 @@ declare namespace Handsontable {
     isOutsideInput: (element: HTMLElement) => boolean;
     isRightClick: (event: Event) => boolean;
     isVisible: (elem: HTMLElement) => boolean;
+    matchesCSSRules: (elem: HTMLElement, rule: CSSRule) => boolean;
     offset: (elem: HTMLElement) => object;
     outerHeight: (elem: HTMLElement) => number;
     outerWidth: (element: HTMLElement) => number;

--- a/src/helpers/dom/element.js
+++ b/src/helpers/dom/element.js
@@ -728,6 +728,32 @@ export function getStyle(element, prop, rootWindow = window) {
 }
 
 /**
+ * Verifies if element fit to provided CSSRule.
+ *
+ * @param {Element} element Element to verify with selector text.
+ * @param {CSSRule} rule Selector text from CSSRule.
+ * @returns {Boolean}
+ */
+export function matchesCSSRules(element, rule) {
+  const { selectorText } = rule;
+
+  if (rule.type !== CSSRule.STYLE_RULE && !selectorText) {
+    return false;
+  }
+
+  let result;
+
+  if (element.msMatchesSelector) {
+    result = element.msMatchesSelector(selectorText);
+
+  } else if (element.matches) {
+    result = element.matches(selectorText);
+  }
+
+  return result;
+}
+
+/**
  * Returns a computed style object for the provided element. (Needed if style is declared in external stylesheet).
  *
  * @param element

--- a/src/helpers/dom/element.js
+++ b/src/helpers/dom/element.js
@@ -736,18 +736,15 @@ export function getStyle(element, prop, rootWindow = window) {
  */
 export function matchesCSSRules(element, rule) {
   const { selectorText } = rule;
+  let result = false;
 
-  if (rule.type !== CSSRule.STYLE_RULE && !selectorText) {
-    return false;
-  }
+  if (rule.type === CSSRule.STYLE_RULE && selectorText) {
+    if (element.msMatchesSelector) {
+      result = element.msMatchesSelector(selectorText);
 
-  let result;
-
-  if (element.msMatchesSelector) {
-    result = element.msMatchesSelector(selectorText);
-
-  } else if (element.matches) {
-    result = element.matches(selectorText);
+    } else if (element.matches) {
+      result = element.matches(selectorText);
+    }
   }
 
   return result;

--- a/src/utils/parseTable.js
+++ b/src/utils/parseTable.js
@@ -132,32 +132,6 @@ export function _dataToHTML(input) {
   return result.join('');
 }
 
-// /**
-//  * Verifies if element fit to provided CSSRule.
-//  *
-//  * @param {Element} element Element to verify with selector text.
-//  * @param {CSSRule} rule Selector text from CSSRule.
-//  * @returns {Boolean}
-//  */
-// function matchCSSRules(element, rule) {
-//   const { selectorText } = rule;
-
-//   if (rule.type !== CSSRule.STYLE_RULE && !selectorText) {
-//     return false;
-//   }
-
-//   let result;
-
-//   if (element.msMatchesSelector) {
-//     result = element.msMatchesSelector(selectorText);
-
-//   } else if (element.matches) {
-//     result = element.matches(selectorText);
-//   }
-
-//   return result;
-// }
-
 /**
  * Converts HTMLTable or string into Handsontable configuration object.
  *

--- a/src/utils/parseTable.js
+++ b/src/utils/parseTable.js
@@ -1,3 +1,4 @@
+import { matchesCSSRules } from './../helpers/dom/element';
 import { isEmpty } from './../helpers/mixed';
 
 /**
@@ -131,24 +132,31 @@ export function _dataToHTML(input) {
   return result.join('');
 }
 
-/**
- * Helper to verify and get CSSRules for the element.
- *
- * @param {Element} element Element to verify with selector text.
- * @param {String} selector Selector text from CSSRule.
- */
-function matchCSSRules(element, selector) {
-  let result;
+// /**
+//  * Verifies if element fit to provided CSSRule.
+//  *
+//  * @param {Element} element Element to verify with selector text.
+//  * @param {CSSRule} rule Selector text from CSSRule.
+//  * @returns {Boolean}
+//  */
+// function matchCSSRules(element, rule) {
+//   const { selectorText } = rule;
 
-  if (element.msMatchesSelector) {
-    result = element.msMatchesSelector(selector);
+//   if (rule.type !== CSSRule.STYLE_RULE && !selectorText) {
+//     return false;
+//   }
 
-  } else if (element.matches) {
-    result = element.matches(selector);
-  }
+//   let result;
 
-  return result;
-}
+//   if (element.msMatchesSelector) {
+//     result = element.msMatchesSelector(selectorText);
+
+//   } else if (element.matches) {
+//     result = element.matches(selectorText);
+//   }
+
+//   return result;
+// }
 
 /**
  * Converts HTMLTable or string into Handsontable configuration object.
@@ -305,7 +313,7 @@ export function htmlToGridSettings(element, rootDocument = document) {
         }
 
         const cellStyle = styleSheetArr.reduce((settings, cssRule) => {
-          if (cssRule.selectorText && matchCSSRules(cell, cssRule.selectorText)) {
+          if (matchesCSSRules(cell, cssRule)) {
             const { whiteSpace } = cssRule.style;
 
             if (whiteSpace) {

--- a/test/e2e/utils/parseTable.spec.js
+++ b/test/e2e/utils/parseTable.spec.js
@@ -1,0 +1,44 @@
+describe('parseTable', () => {
+  function getMatchesMethod(elem) {
+    let result = 'matches';
+
+    if (elem.msMatchesSelector) {
+      result = 'msMatchesSelector';
+    }
+
+    return result;
+  }
+
+  beforeEach(function() {
+    this.$container = $('<div id="testContainer"></div>').appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      this.$container.remove();
+    }
+  });
+
+  /**
+   * Unfortunately, jsDOM in unit tests doesn't support properly creating StyleSheet's CSSRules.
+   * We have to verify it's working as expected in a browser environment.
+   */
+  describe('matchesCSSRules', () => {
+    it('should verify only STYLE_RULE type rules', () => {
+      const styleElem = $('<style/>').html('@page div {} div {} * {} .test {}').appendTo(spec().$container);
+      const testElem = $('<div/>').addClass('test').appendTo(spec().$container)[0];
+      const { cssRules } = styleElem[0].sheet;
+      const matchesMethod = getMatchesMethod(testElem);
+
+      expect(cssRules.length).toBe(4);
+      spyOn(testElem, matchesMethod);
+
+      Handsontable.dom.matchesCSSRules(testElem, cssRules[0]);
+      Handsontable.dom.matchesCSSRules(testElem, cssRules[1]);
+      Handsontable.dom.matchesCSSRules(testElem, cssRules[2]);
+      Handsontable.dom.matchesCSSRules(testElem, cssRules[3]);
+
+      expect(testElem[matchesMethod]).toHaveBeenCalledTimes(3);
+    });
+  });
+});

--- a/test/types/helpers/dom.types.ts
+++ b/test/types/helpers/dom.types.ts
@@ -2,6 +2,7 @@ import Handsontable from 'handsontable';
 
 const domElement = new HTMLElement();
 const domEvent = new Event('foo');
+const cssRule = new CSSRule();
 
 const htmlCharacters = Handsontable.dom.HTML_CHARACTERS;
 
@@ -52,6 +53,7 @@ Handsontable.dom.isLeftClick(domEvent);
 Handsontable.dom.isOutsideInput(domElement);
 Handsontable.dom.isRightClick(domEvent);
 Handsontable.dom.isVisible(domElement);
+Handsontable.dom.matchesCSSRules(domElement, cssRule);
 Handsontable.dom.offset(domElement);
 Handsontable.dom.outerHeight(domElement);
 Handsontable.dom.outerWidth(domElement);


### PR DESCRIPTION
### Context
Our helper - `htmlToGridSettings` - uses another helper - `matchesCSSRules`. It helps us in properly parsing clipboard data from Excel into Handsontable configuration.
In some older browsers (it's difficult to say it was a bug or by design), CSSPageRules (`@page`) got fulfilled `selectorText` with `@page`. `HTMLElement.matches` returns the error message that this kind of selectors is invalid.
To prevent regression I moved `matchesCSSRules` to `DOM`'s helpers. Unfortunately, unit tests don't work as expected because of a leak of correct behaviour of CSS* interfaces in jsDOM (Jest uses it to creating virtual DOM)

### How has this been tested?
1. Create `<style></style>` element an fill it with CSS rules. eg.:
```
* {}
@page div {}
div {}
.test {}
```
2. Create `<div.test></div>` element
3. Append both elements to `document.body`
4. Verify cssRules against your test element from second step using `Handsontable.dom.matchesCSSRules(testElem, styleElement.sheet.cssRules[xyz]);`
where `x` is a number of rule index.

The helper should return `false` for `@page div {}` and don't throw an exception.

### Types of changes
- [x] Bugfix (a non-breaking change which fixes an issue)

### Related issue(s):
1. #6217