### PR TITLE
Multiline text from Excel has to be parsed in a different way

### DIFF
--- a/src/plugins/copyPaste/test/copyPaste.e2e.js
+++ b/src/plugins/copyPaste/test/copyPaste.e2e.js
@@ -726,6 +726,32 @@ describe('CopyPaste', () => {
       expect(getDataAtCell(0, 0)).toEqual('very\r\nlong\r\n\r\ntext');
     });
 
+    it('should properly paste data with excel-style multiline text', async() => {
+      handsontable();
+
+      const clipboardEvent = getClipboardEvent();
+      const plugin = getPlugin('CopyPaste');
+
+      clipboardEvent.clipboardData.setData('text/html', [
+        '<meta name=Generator content="Excel">',
+        '<table><tbody><tr><td>Line\r\n',
+        '  1<br>\r\n',
+        '    Line 2<br>\r\n',
+        '    <br>\r\n',
+        '    Line 3<br>\r\n',
+        '    Line 4<br>\r\n',
+        '    <br>\r\n',
+        '    <br>\r\n',
+        '    Line 5</td></tr></tbody></table>',
+      ].join(''));
+
+      selectCell(0, 0);
+
+      plugin.onPaste(clipboardEvent);
+
+      expect(getDataAtCell(0, 0)).toEqual('Line 1\r\nLine 2\r\n\r\nLine 3\r\nLine 4\r\n\r\n\r\nLine 5');
+    });
+
     it('should properly paste data with merged cells', async() => {
       handsontable();
 

--- a/src/utils/parseTable.js
+++ b/src/utils/parseTable.js
@@ -323,7 +323,10 @@ export function htmlToGridSettings(element, rootDocument = document) {
             .replace(/&nbsp;/gi, '\x20');
 
         } else if (generator && /excel/gi.test(generator.content)) {
-          dataArr[row][col] = innerHTML.replace(/<br(\s*|\/)>[\r\n]?[\x20]{0,2}/gim, '\r\n').replace(/(<([^>]+)>)/gi, '').replace(/&nbsp;/gi, '\x20');
+          dataArr[row][col] = innerHTML.replace(/[\r\n][\x20]{0,2}/g, '\x20')
+            .replace(/<br(\s*|\/)>[\r\n]?[\x20]{0,3}/gim, '\r\n')
+            .replace(/(<([^>]+)>)/gi, '')
+            .replace(/&nbsp;/gi, '\x20');
         } else {
           dataArr[row][col] = innerHTML.replace(/<br(\s*|\/)>[\r\n]?/gim, '\r\n').replace(/(<([^>]+)>)/gi, '').replace(/&nbsp;/gi, '\x20');
         }


### PR DESCRIPTION
### Context
Multiline text copied from Excel into Handsontable had a problem with an unexpected new line in a first row.

### How has this been tested?
1. Paste the following text into a cell in Excel (into an editor):
```
Line 1
Line 2

Line 3
Line 4


Line 5
```
2. Select this cell and copy its value using <kbd>CTRL/CMD</kbd> + <kbd>C</kbd>
3. Go to Handsontable and paste copied value into selected cell (not into its editor)

The expected result is to have the same rendered value in a cell as is in Excel.

### Types of changes
- [x] Bugfix (a non-breaking change which fixes an issue)

### Related issue(s):
1. #6258