### PR TITLE
Rewritten SheetClip.parse method

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,7 +1,8 @@
 node_modules
 src/3rdparty/walkontable/test/lib/*
 dist/*
-lib/*
+lib/jsonpatch/*
+lib/autoResize/*
 src/3rdparty/walkontable/test/dist/*
 src/3rdparty/walkontable/dist/*
 test/lib/*

--- a/lib/SheetClip/SheetClip.js
+++ b/lib/SheetClip/SheetClip.js
@@ -17,8 +17,9 @@
   }
 
   const regUniversalNewLine = /^(\r\n|\n\r|\r|\n)/;
-  const regNextCell = /^[^\t\r\n]+(?:\t)?/;
-  const regNextMultilineCell = /^\"+[\r\n\W\D\d]+\"+(?:\t|[\r\n])/;
+  const regNextCellNoQuotes = /^[^\t\r\n]+(\t)?/;
+  const regNextCellQuotes = /^(\")[^\t\r\n]+(\")?(\t|[\r\n])?/;
+  const regNextMultilineCell = /^(\")?[\r\n\W\D\d]+(\"\t|\"[\r\n])(?!\"[\t\n\r])/;
   const regNextEmptyCell = /^\t/;
 
   var SheetClip = {
@@ -50,8 +51,7 @@
           str = str.replace(regNextEmptyCell, '');
 
           if (!arr[row]) {
-            arr[row] = [];
-            arr[row][0] = '';
+            arr[row] = [''];
           }
 
           column += 1;
@@ -69,7 +69,18 @@
           continue;
         }
 
-        let fragment = str.startsWith('"') ? str.match(regNextMultilineCell) : str.match(regNextCell);
+        let fragment;
+
+        if (str.startsWith('"')) {
+          fragment = str.match(regNextMultilineCell) || str.match(/^\"[\d\D]*\"$/);
+          
+          if (!fragment) {
+            fragment = str.match(regNextCellQuotes);
+          }
+
+        } else {
+          fragment = str.match(regNextCellNoQuotes);
+        }
 
         if (!fragment) {
           if (lastLength) {
@@ -87,11 +98,24 @@
 
         str = nextCell.match(/[\r\n\t]$/) ? str.slice(nextCell.length - 1) : str.slice(nextCell.length);
 
-        nextCell = nextCell.replace(/\t$/, '').replace(/[\r\n]$/, '');
+        nextCell = nextCell.replace(/\t$/, '').replace(/[\r\n]$/, ''); //.replace(/\"$/, '');
 
-        if (nextCell.match(/^\"+[\r\n\W\D\d]+\"$/)) {
-          nextCell = nextCell.replace(/^\"/, '').replace(/\"$/, '');
+        if (nextCell.startsWith('"')) {
+          const endingQuotes = nextCell.match(/[\"]*$/);
+          nextCell = nextCell.replace(/^\"/, '');
+
+  
+          if (endingQuotes) {
+            let charsToDelete = endingQuotes[0].length;
+  
+            if (charsToDelete > 1) {
+              charsToDelete = charsToDelete % 2;
+            }
+  
+            nextCell = nextCell.replace(new RegExp(`.{${charsToDelete}}$`), '').replace(/\"\"/g, '"');
+          }
         }
+
 
         arr[row][column] = nextCell;
       }

--- a/lib/SheetClip/SheetClip.js
+++ b/lib/SheetClip/SheetClip.js
@@ -63,7 +63,7 @@
           continue;
         
         } else if (str.match(regNextRow)) {
-          str = str.replace(regNextRow, '');
+          str = str.replace(/^(\r\n|\n\r|\r|\n)/, '');
           column = 0;
           row += 1;
 

--- a/lib/SheetClip/SheetClip.js
+++ b/lib/SheetClip/SheetClip.js
@@ -40,12 +40,6 @@
 
       const regUniversalNewLine = /^(\r\n|\n\r|\r|\n)/;
 
-      // if (str.replace(regUniversalNewLine, '').length === 0) {
-      //   arr.push(['']);
-
-      //   return arr;
-      // }
-
       const regNextCell = /^[^\t\r\n]+(?:\t)?/;
       const regNextMultilineCell = /^\"+[\r\n\W\D\d]+\"+(?:\t|[\r\n])/;
       const regNextEmptyCell = /^\t/;

--- a/lib/SheetClip/SheetClip.js
+++ b/lib/SheetClip/SheetClip.js
@@ -9,27 +9,19 @@
  * Licensed under the MIT license.
  * http://github.com/warpech/sheetclip/
  */
-(function (global) {
-  "use strict";
-
-  function countQuotes(str) {
-    return str.split('"').length - 1;
-  }
-
+(((global) => {
   const regUniversalNewLine = /^(\r\n|\n\r|\r|\n)/;
-  const regNextCellNoQuotes = /^[^\t\r\n]+(\t)?/;
-  const regNextCellQuotes = /^(\")[^\t\r\n]+(\")?(\t|[\r\n])?/;
-  const regNextMultilineCell = /^(\")?[\r\n\W\D\d]+(\"\t|\"[\r\n])(?!\"[\t\n\r])/;
+  const regNextCellNoQuotes = /^[^\t\r\n]+/;
   const regNextEmptyCell = /^\t/;
 
-  var SheetClip = {
+  const SheetClip = {
     /**
      * Decode spreadsheet string into array
      *
      * @param {String} str
      * @returns {Array}
      */
-    parse: function (str) {
+    parse(str) {
       const arr = [['']];
 
       if (str.length === 0) {
@@ -42,23 +34,18 @@
 
       while (str.length > 0) {
         if (lastLength === str.length) {
+          // In the case If in last cycle we didn't match anything, we have to leave the infinite loop
           break;
         }
 
         lastLength = str.length;
 
-        if (str.startsWith('\t')) {
+        if (str.match(regNextEmptyCell)) {
           str = str.replace(regNextEmptyCell, '');
-
-          if (!arr[row]) {
-            arr[row] = [''];
-          }
 
           column += 1;
           arr[row][column] = '';
 
-          continue;
-        
         } else if (str.match(regUniversalNewLine)) {
           str = str.replace(regUniversalNewLine, '');
           column = 0;
@@ -66,58 +53,41 @@
 
           arr[row] = [''];
 
-          continue;
-        }
-
-        let fragment;
-
-        if (str.startsWith('"')) {
-          fragment = str.match(regNextMultilineCell) || str.match(/^\"[\d\D]*\"$/);
-          
-          if (!fragment) {
-            fragment = str.match(regNextCellQuotes);
-          }
-
         } else {
-          fragment = str.match(regNextCellNoQuotes);
-        }
+          let nextCell = '';
 
-        if (!fragment) {
-          if (lastLength) {
-            fragment = [str];
-          } else {
-            break;
-          }
-        }
+          if (str.startsWith('"')) {
+            let quoteNo = 0;
+            let isStillCell = true;
 
-        if (!arr[row]) {
-          arr[row] = [];
-        }
+            while (isStillCell) {
+              const nextChar = str.slice(0, 1);
 
-        let nextCell = fragment[0];
+              if (nextChar === '"') {
+                quoteNo += 1;
+              }
 
-        str = nextCell.match(/[\r\n\t]$/) ? str.slice(nextCell.length - 1) : str.slice(nextCell.length);
+              nextCell += nextChar;
 
-        nextCell = nextCell.replace(/\t$/, '').replace(/[\r\n]$/, ''); //.replace(/\"$/, '');
+              str = str.slice(1);
 
-        if (nextCell.startsWith('"')) {
-          const endingQuotes = nextCell.match(/[\"]*$/);
-          nextCell = nextCell.replace(/^\"/, '');
-
-  
-          if (endingQuotes) {
-            let charsToDelete = endingQuotes[0].length;
-  
-            if (charsToDelete > 1) {
-              charsToDelete = charsToDelete % 2;
+              if (str.length === 0 || (str.match(/^[\t\r\n]/) && quoteNo % 2 === 0)) {
+                isStillCell = false;
+              }
             }
-  
-            nextCell = nextCell.replace(new RegExp(`.{${charsToDelete}}$`), '').replace(/\"\"/g, '"');
+
+            nextCell = nextCell.replace(/^"/, '').replace(/"$/, '')
+              .replace(/["]*/g, match => (new Array(Math.floor(match.length / 2))).fill('"').join(''));
+
+          } else {
+            const matchedText = str.match(regNextCellNoQuotes);
+            nextCell = matchedText ? matchedText[0] : '';
+            str = str.slice(nextCell.length);
           }
+
+          arr[row][column] = nextCell;
         }
 
-
-        arr[row][column] = nextCell;
       }
 
       return arr;
@@ -129,8 +99,13 @@
      * @param arr
      * @returns {String}
      */
-    stringify: function (arr) {
-      var r, rLen, c, cLen, str = '', val;
+    stringify(arr) {
+      let r;
+      let rLen;
+      let c;
+      let cLen;
+      let str = '';
+      let val;
 
       for (r = 0, rLen = arr.length; r < rLen; r += 1) {
         cLen = arr[r].length;
@@ -143,16 +118,15 @@
 
           if (typeof val === 'string') {
             if (val.indexOf('\n') > -1) {
-              str += '"' + val.replace(/"/g, '""') + '"';
-            }
-            else {
+              str += `"${val.replace(/"/g, '""')}"`;
+            } else {
               str += val;
             }
-          }
-          else if (val === null || val === void 0) { // void 0 resolves to undefined
+
+          } else if (val === null || val === void 0) { // void 0 resolves to undefined
             str += '';
-          }
-          else {
+
+          } else {
             str += val;
           }
         }
@@ -172,4 +146,5 @@
   } else {
     global.SheetClip = SheetClip;
   }
-}(window));
+// eslint-disable-next-line no-restricted-globals
+})(window));

--- a/lib/SheetClip/SheetClip.js
+++ b/lib/SheetClip/SheetClip.js
@@ -17,6 +17,13 @@
     return str.split('"').length - 1;
   }
 
+  const regNextCell = /^[^\t\r\n]+(\t)?/;
+  const regNextMultilineCell = /^\"+[\r\n\W\D\d]+\"+(\t)?/
+  // https://regexr.com/4o4v2
+  // while (str.length > 0) { ... }
+  // /^\"+[\r\n\W\D\d]+\"+(\t|\r\n)/ next multiline cell
+  // /^[^\t]+(\t|\r\n)/ next cell if `first character !== "`
+
   var SheetClip = {
     /**
      * Decode spreadsheet string into array
@@ -25,43 +32,71 @@
      * @returns {Array}
      */
     parse: function (str) {
-      var r, rLen, rows, arr = [], a = 0, c, cLen, multiline, last;
+      const regNextCell = /^[^\t\r\n]+(?:\t)?/;
+      const regNextMultilineCell = /^\"+[\r\n\W\D\d]+\"+(?:\t|[\r\n])/;
+      const regLastMultilineCell = /^\"+[\r\n\W\D\d]+\"+(?:\t|[\r\n])?/;
+      const regNextEmptyCell = /^\t/;
+      const regNextRow = /^[\r\n]/;
 
-      rows = str.replace(/\r\n|\r/g, '\n').split('\n');
+      const arr = [];
+      let column = 0;
+      let row = 0;
+      let lastLength;
 
-      if (rows.length > 1 && rows[rows.length - 1] === '') {
-        rows.pop();
-      }
-      for (r = 0, rLen = rows.length; r < rLen; r += 1) {
-        rows[r] = rows[r].split('\t');
+      while (str.length > 0) {
+        if (lastLength === str.length) {
+          break;
+        }
 
-        for (c = 0, cLen = rows[r].length; c < cLen; c += 1) {
-          if (!arr[a]) {
-            arr[a] = [];
+        lastLength = str.length;
+
+        if (str.startsWith('\t')) {
+          str = str.replace(regNextEmptyCell, '');
+
+          if (!arr[row]) {
+            arr[row] = [];
           }
-          if (multiline && c === 0) {
-            last = arr[a].length - 1;
-            arr[a][last] = arr[a][last] + '\n' + rows[r][0];
 
-            if (multiline && (countQuotes(rows[r][0]) & 1)) { //& 1 is a bitwise way of performing mod 2
-              multiline = false;
-              arr[a][last] = arr[a][last].substring(0, arr[a][last].length - 1).replace(/""/g, '"');
-            }
-          }
-          else {
-            if (c === cLen - 1 && rows[r][c].indexOf('"') === 0 && (countQuotes(rows[r][c]) & 1)) {
-              arr[a].push(rows[r][c].substring(1).replace(/""/g, '"'));
-              multiline = true;
-            }
-            else {
-              arr[a].push(rows[r][c].replace(/""/g, '"'));
-              multiline = false;
-            }
+          arr[row][column] = '';
+          column += 1;
+
+          continue;
+        
+        } else if (str.match(regNextRow)) {
+          str = str.replace(regNextRow, '');
+          column = 0;
+          row += 1;
+
+          continue;
+        }
+
+        let fragment = str.startsWith('"') ? str.match(regNextMultilineCell) : str.match(regNextCell);
+
+        if (!fragment) {
+          if (lastLength) {
+            fragment = [str];
+          } else {
+            break;
           }
         }
-        if (!multiline) {
-          a += 1;
+
+        if (!arr[row]) {
+          arr[row] = [];
         }
+
+        let nextCell = fragment[0];
+
+        str = nextCell.match(/[\r\n]$/) ? str.slice(nextCell.length - 1) : str.slice(nextCell.length);
+
+        nextCell = nextCell.replace(/\t$/, '').replace(/[\r\n]$/, '');
+
+        if (nextCell.match(/^\"+[\r\n\W\D\d]+\"$/)) {
+          nextCell = nextCell.replace(/^\"/, '').replace(/\"$/, '');
+        }
+
+        arr[row][column] = nextCell;
+
+        column += 1;
       }
 
       return arr;

--- a/lib/SheetClip/SheetClip.js
+++ b/lib/SheetClip/SheetClip.js
@@ -32,13 +32,24 @@
      * @returns {Array}
      */
     parse: function (str) {
+      const arr = [['']];
+
+      if (str.length === 0) {
+        return arr;
+      }
+
+      const regUniversalNewLine = /^(\r\n|\n\r|\r|\n)/;
+
+      // if (str.replace(regUniversalNewLine, '').length === 0) {
+      //   arr.push(['']);
+
+      //   return arr;
+      // }
+
       const regNextCell = /^[^\t\r\n]+(?:\t)?/;
       const regNextMultilineCell = /^\"+[\r\n\W\D\d]+\"+(?:\t|[\r\n])/;
-      const regLastMultilineCell = /^\"+[\r\n\W\D\d]+\"+(?:\t|[\r\n])?/;
       const regNextEmptyCell = /^\t/;
-      const regNextRow = /^[\r\n]/;
 
-      const arr = [];
       let column = 0;
       let row = 0;
       let lastLength;
@@ -55,17 +66,20 @@
 
           if (!arr[row]) {
             arr[row] = [];
+            arr[row][0] = '';
           }
 
-          arr[row][column] = '';
           column += 1;
+          arr[row][column] = '';
 
           continue;
         
-        } else if (str.match(regNextRow)) {
-          str = str.replace(/^(\r\n|\n\r|\r|\n)/, '');
+        } else if (str.match(regUniversalNewLine)) {
+          str = str.replace(regUniversalNewLine, '');
           column = 0;
           row += 1;
+
+          arr[row] = [''];
 
           continue;
         }
@@ -86,7 +100,7 @@
 
         let nextCell = fragment[0];
 
-        str = nextCell.match(/[\r\n]$/) ? str.slice(nextCell.length - 1) : str.slice(nextCell.length);
+        str = nextCell.match(/[\r\n\t]$/) ? str.slice(nextCell.length - 1) : str.slice(nextCell.length);
 
         nextCell = nextCell.replace(/\t$/, '').replace(/[\r\n]$/, '');
 
@@ -95,8 +109,6 @@
         }
 
         arr[row][column] = nextCell;
-
-        column += 1;
       }
 
       return arr;

--- a/lib/SheetClip/SheetClip.js
+++ b/lib/SheetClip/SheetClip.js
@@ -9,7 +9,6 @@
  * Licensed under the MIT license.
  * http://github.com/warpech/sheetclip/
  */
-/*jslint white: true*/
 (function (global) {
   "use strict";
 
@@ -17,12 +16,10 @@
     return str.split('"').length - 1;
   }
 
-  const regNextCell = /^[^\t\r\n]+(\t)?/;
-  const regNextMultilineCell = /^\"+[\r\n\W\D\d]+\"+(\t)?/
-  // https://regexr.com/4o4v2
-  // while (str.length > 0) { ... }
-  // /^\"+[\r\n\W\D\d]+\"+(\t|\r\n)/ next multiline cell
-  // /^[^\t]+(\t|\r\n)/ next cell if `first character !== "`
+  const regUniversalNewLine = /^(\r\n|\n\r|\r|\n)/;
+  const regNextCell = /^[^\t\r\n]+(?:\t)?/;
+  const regNextMultilineCell = /^\"+[\r\n\W\D\d]+\"+(?:\t|[\r\n])/;
+  const regNextEmptyCell = /^\t/;
 
   var SheetClip = {
     /**
@@ -37,12 +34,6 @@
       if (str.length === 0) {
         return arr;
       }
-
-      const regUniversalNewLine = /^(\r\n|\n\r|\r|\n)/;
-
-      const regNextCell = /^[^\t\r\n]+(?:\t)?/;
-      const regNextMultilineCell = /^\"+[\r\n\W\D\d]+\"+(?:\t|[\r\n])/;
-      const regNextEmptyCell = /^\t/;
 
       let column = 0;
       let row = 0;

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint:fix": "npm run eslint:fix && npm run stylelint:fix",
     "stylelint": "stylelint \"src/**/*.css\" \"test/**/*.css\"",
     "stylelint:fix": "stylelint --fix \"src/**/*.css\" \"test/**/*.css\"",
-    "eslint": "eslint src/ test/",
+    "eslint": "eslint src/ test/ lib/",
     "eslint:fix": "eslint --fix src/ test/",
     "test": "npm run lint && npm run test:unit && npm run test:types && npm run test:walkontable && npm run test:e2e && npm run test:production",
     "test.random": "npm run lint && npm run test:unit && npm run test:types && npm run test:walkontable.random && npm run test:e2e.random && npm run test:production.random",

--- a/test/unit/lib/SheetClip.spec.js
+++ b/test/unit/lib/SheetClip.spec.js
@@ -175,32 +175,32 @@ describe('SheetClip', () => {
       expect(result).toEqual(expected);
     });
 
-    it('should parse inproperly escaped quotes in cell value separated by tab into two cells in one row with', () => {
+    it('should ignore inproperly escaped quotes in cell value separated by tab into two cells in one row with', () => {
       const entry = '""A""\t""B""';
       const result = SheetClip.parse(entry);
       const expected = [
-        ['A""', 'B""'],
+        ['A', 'B'],
       ];
 
       expect(result).toEqual(expected);
     });
 
-    it('should parse inproperly escaped quotes in cell value separated by new line into two rows with one column each', () => {
+    it('should ignore inproperly escaped quotes in cell value separated by new line into two rows with one column each', () => {
       const entry = '""A""\n""B""';
       const result = SheetClip.parse(entry);
       const expected = [
-        ['A""'],
-        ['B""'],
+        ['A'],
+        ['B'],
       ];
 
       expect(result).toEqual(expected);
     });
 
     it('should parse properly escaped quotes in cell value separated by tab into two cells in one row with', () => {
-      const entry = '""A""\t""B""';
+      const entry = '"""A"""\t"""B"""';
       const result = SheetClip.parse(entry);
       const expected = [
-        ['"A', '"B"'],
+        ['"A"', '"B"'],
       ];
 
       expect(result).toEqual(expected);

--- a/test/unit/lib/SheetClip.spec.js
+++ b/test/unit/lib/SheetClip.spec.js
@@ -153,5 +153,47 @@ describe('SheetClip', () => {
 
       expect(result).toEqual(expected);
     });
+
+    it('should parse text in quotes separated by tab into two cells in one row', () => {
+      const entry = '"A"\t"B"';
+      const result = SheetClip.parse(entry);
+      const expected = [
+        ['A', 'B'],
+      ];
+
+      expect(result).toEqual(expected);
+    });
+
+    it('should parse text in quotes separated by new line into two rows with one column each', () => {
+      const entry = '"A"\n"B"';
+      const result = SheetClip.parse(entry);
+      const expected = [
+        ['A'],
+        ['B'],
+      ];
+
+      expect(result).toEqual(expected);
+    });
+
+    it('should parse empty quotes separated by tab into two empty cells in one row', () => {
+      const entry = '""\t""';
+      const result = SheetClip.parse(entry);
+      const expected = [
+        ['', ''],
+      ];
+
+      expect(result).toEqual(expected);
+    });
+
+    it('should parse text in quotes separated by new line into two rows with one empty cell each', () => {
+      const entry = '""\n""';
+      const result = SheetClip.parse(entry);
+      const expected = [
+        [''],
+        [''],
+      ];
+
+      expect(result).toEqual(expected);
+    });
   });
 });

--- a/test/unit/lib/SheetClip.spec.js
+++ b/test/unit/lib/SheetClip.spec.js
@@ -175,6 +175,48 @@ describe('SheetClip', () => {
       expect(result).toEqual(expected);
     });
 
+    it('should parse inproperly escaped quotes in cell value separated by tab into two cells in one row with', () => {
+      const entry = '""A""\t""B""';
+      const result = SheetClip.parse(entry);
+      const expected = [
+        ['A""', 'B""'],
+      ];
+
+      expect(result).toEqual(expected);
+    });
+
+    it('should parse inproperly escaped quotes in cell value separated by new line into two rows with one column each', () => {
+      const entry = '""A""\n""B""';
+      const result = SheetClip.parse(entry);
+      const expected = [
+        ['A""'],
+        ['B""'],
+      ];
+
+      expect(result).toEqual(expected);
+    });
+
+    it('should parse properly escaped quotes in cell value separated by tab into two cells in one row with', () => {
+      const entry = '""A""\t""B""';
+      const result = SheetClip.parse(entry);
+      const expected = [
+        ['"A', '"B"'],
+      ];
+
+      expect(result).toEqual(expected);
+    });
+
+    it('should parse properly escaped quotes in cell value separated by new line into two rows with one column each', () => {
+      const entry = '"""A"""\n"""B"""';
+      const result = SheetClip.parse(entry);
+      const expected = [
+        ['"A"'],
+        ['"B"'],
+      ];
+
+      expect(result).toEqual(expected);
+    });
+
     it('should parse empty quotes separated by tab into two empty cells in one row', () => {
       const entry = '""\t""';
       const result = SheetClip.parse(entry);

--- a/test/unit/lib/SheetClip.spec.js
+++ b/test/unit/lib/SheetClip.spec.js
@@ -1,0 +1,157 @@
+import SheetClip from 'handsontable/../lib/SheetClip/SheetClip';
+
+describe('SheetClip', () => {
+  describe('parse', () => {
+    it('should parse letter into one cell', () => {
+      const entry = 'A';
+      const result = SheetClip.parse(entry);
+      const expected = [
+        ['A'],
+      ];
+
+      expect(result).toEqual(expected);
+    });
+
+    it('should parse letters into one cell', () => {
+      const entry = 'A B C';
+      const result = SheetClip.parse(entry);
+      const expected = [
+        ['A B C'],
+      ];
+
+      expect(result).toEqual(expected);
+    });
+
+    it('should parse tab separated values into separated cells in one row', () => {
+      const entry = 'A\tB';
+      const result = SheetClip.parse(entry);
+      const expected = [
+        ['A', 'B'],
+      ];
+
+      expect(result).toEqual(expected);
+    });
+
+    it('should parse non-alphanumeric data into separated cells', () => {
+      const entry = '£§!@#$%^&*()\t_-+=~`{[}]:;"\t\'\\|<,>.?/';
+      const result = SheetClip.parse(entry);
+      const expected = [
+        ['£§!@#$%^&*()', '_-+=~`{[}]:;"', '\'\\|<,>.?/'],
+      ];
+
+      expect(result).toEqual(expected);
+    });
+
+    it('should parse quotes chars into cell if there is no tab char', () => {
+      const entry = '{"json": "like", "value": ""}';
+      const result = SheetClip.parse(entry);
+      const expected = [
+        ['{"json": "like", "value": ""}'],
+      ];
+
+      expect(result).toEqual(expected);
+    });
+
+    it('should parse multiline text into one cell', () => {
+      const entry = '"A\r\nB"';
+      const result = SheetClip.parse(entry);
+      const expected = [
+        ['A\r\nB'],
+      ];
+
+      expect(result).toEqual(expected);
+    });
+
+    it('should parse multiline text with new lines at the end into many rows', () => {
+      const entry = '"A\r\nB"\r\n\r\n';
+      const result = SheetClip.parse(entry);
+      const expected = [
+        ['A\r\nB'],
+        [''],
+        [''],
+      ];
+
+      expect(result).toEqual(expected);
+    });
+
+    it('should parse text into cells in separated rows', () => {
+      const entry = 'A\r\nB\r\nC';
+      const result = SheetClip.parse(entry);
+      const expected = [
+        ['A'],
+        ['B'],
+        ['C'],
+      ];
+
+      expect(result).toEqual(expected);
+    });
+
+    it('should ignore tab char separator in a multiline text', () => {
+      const entry = 'A\r\n"B\tC\r\nD"\r\nE';
+      const result = SheetClip.parse(entry);
+      const expected = [
+        ['A'],
+        ['B\tC\r\nD'],
+        ['E'],
+      ];
+
+      expect(result).toEqual(expected);
+    });
+
+    it('should parse multiline phrase into separated cells with multiline text at the end of middle row', () => {
+      const entry = 'A\tB\tC\r\nD\tE\t"F\r\nG\r\n\r\nH"\r\nI\tJ\tK';
+      const result = SheetClip.parse(entry);
+      const expected = [
+        ['A', 'B', 'C'],
+        ['D', 'E', 'F\r\nG\r\n\r\nH'],
+        ['I', 'J', 'K'],
+      ];
+
+      expect(result).toEqual(expected);
+    });
+
+    it('should parse empty cells 2x2 into array with two rows with two column each', () => {
+      const entry = '\t\r\n\t';
+      const result = SheetClip.parse(entry);
+      const expected = [
+        ['', ''],
+        ['', ''],
+      ];
+
+      expect(result).toEqual(expected);
+    });
+
+    it('should parse empty cells 2x1 into array with two rows with one column each', () => {
+      const entry = '\r\n';
+      const result = SheetClip.parse(entry);
+      const expected = [
+        [''],
+        [''],
+      ];
+
+      expect(result).toEqual(expected);
+    });
+
+    it('should parse following empty lines into rows with empty strings', () => {
+      const entry = '\r\n\r\n';
+      const result = SheetClip.parse(entry);
+      const expected = [
+        [''],
+        [''],
+        [''],
+      ];
+
+      expect(result).toEqual(expected);
+    });
+
+    it('should parse empty cell into array with one column in one row', () => {
+      const entry = '';
+      const result = SheetClip.parse(entry);
+      const expected = [
+        [''],
+      ];
+
+      expect(result).toEqual(expected);
+    });
+  });
+});


### PR DESCRIPTION
### Context
We use `SheetClip.parse` mostly to parse ClipboardEvent's  `text/plain` data into an two dimensional array. 
Nowadays, we ignore `text/plain` if `text/html` has proper data.
However, if the user copied only `text/plain`, we have a few problems to parse some edge-cases.
I decided to rewrite this method completely. Currently, text parsing might be a little bit slower than previously. Although, now we can parse `text/plain` data with better compatibility to an expected result.

### How has this been tested?
Prepare data in 3x3 cells with JSON-style value and multiline text ( you can use Excel/Google Spreadsheets/Numbers/Open Office/Libre Office).
Copy these cells and paste the value into a text editor (IDE/textarea element in the browser)
Copy pasted text into Handsontable

You should see the same cells with the same values.

### Types of changes
- [x] Bugfix (a non-breaking change which fixes an issue)

### Related issue(s):
1. #6167