### PR TITLE
&<> characters should not be parsed into HTML entities

### DIFF
--- a/src/utils/parseTable.js
+++ b/src/utils/parseTable.js
@@ -1,12 +1,13 @@
 import { matchesCSSRules } from './../helpers/dom/element';
 import { isEmpty } from './../helpers/mixed';
 
-const regSpace = /&nbsp;/gi;
 const ESCAPED_HTML_CHARS = {
+  '&nbsp;': '\x20',
   '&amp;': '&',
   '&lt;': '<',
   '&gt;': '>',
 };
+const regEscapedChars = new RegExp(Object.keys(ESCAPED_HTML_CHARS).map(key => `(${key})`).join('|'), 'gi');
 
 /**
  * Verifies if node is an HTMLTable element.
@@ -307,21 +308,16 @@ export function htmlToGridSettings(element, rootDocument = document) {
         let cellValue = '';
 
         if (cellStyle.whiteSpace === 'nowrap') {
-          cellValue = innerHTML.replace(/[\r\n][\x20]{0,2}/gim, '\x20')
-            .replace(/<br(\s*|\/)>/gim, '\r\n')
-            .replace(regSpace, '\x20');
+          cellValue = innerHTML.replace(/[\r\n][\x20]{0,2}/gim, '\x20').replace(/<br(\s*|\/)>/gim, '\r\n');
 
         } else if (generator && /excel/gi.test(generator.content)) {
-          cellValue = innerHTML.replace(/[\r\n][\x20]{0,2}/g, '\x20')
-            .replace(/<br(\s*|\/)>[\r\n]?[\x20]{0,3}/gim, '\r\n')
-            .replace(regSpace, '\x20');
+          cellValue = innerHTML.replace(/[\r\n][\x20]{0,2}/g, '\x20').replace(/<br(\s*|\/)>[\r\n]?[\x20]{0,3}/gim, '\r\n');
 
         } else {
-          cellValue = innerHTML.replace(/<br(\s*|\/)>[\r\n]?/gim, '\r\n')
-            .replace(regSpace, '\x20');
+          cellValue = innerHTML.replace(/<br(\s*|\/)>[\r\n]?/gim, '\r\n');
         }
 
-        dataArr[row][col] = cellValue.replace(/(&lt;)|(&gt;)|(&amp;)/gi, match => ESCAPED_HTML_CHARS[match]);
+        dataArr[row][col] = cellValue.replace(regEscapedChars, match => ESCAPED_HTML_CHARS[match]);
 
       } else {
         rowHeaders.push(innerHTML);

--- a/src/utils/parseTable.js
+++ b/src/utils/parseTable.js
@@ -1,6 +1,13 @@
 import { matchesCSSRules } from './../helpers/dom/element';
 import { isEmpty } from './../helpers/mixed';
 
+const regSpace = /&nbsp;/gi;
+const ESCAPED_HTML_CHARS = {
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+};
+
 /**
  * Verifies if node is an HTMLTable element.
  *
@@ -297,21 +304,24 @@ export function htmlToGridSettings(element, rootDocument = document) {
 
           return settings;
         }, {});
+        let cellValue = '';
 
         if (cellStyle.whiteSpace === 'nowrap') {
-          dataArr[row][col] = innerHTML.replace(/[\r\n][\x20]{0,2}/gim, '\x20')
+          cellValue = innerHTML.replace(/[\r\n][\x20]{0,2}/gim, '\x20')
             .replace(/<br(\s*|\/)>/gim, '\r\n')
-            .replace(/(<([^>]+)>)/gi, '')
-            .replace(/&nbsp;/gi, '\x20');
+            .replace(regSpace, '\x20');
 
         } else if (generator && /excel/gi.test(generator.content)) {
-          dataArr[row][col] = innerHTML.replace(/[\r\n][\x20]{0,2}/g, '\x20')
+          cellValue = innerHTML.replace(/[\r\n][\x20]{0,2}/g, '\x20')
             .replace(/<br(\s*|\/)>[\r\n]?[\x20]{0,3}/gim, '\r\n')
-            .replace(/(<([^>]+)>)/gi, '')
-            .replace(/&nbsp;/gi, '\x20');
+            .replace(regSpace, '\x20');
+
         } else {
-          dataArr[row][col] = innerHTML.replace(/<br(\s*|\/)>[\r\n]?/gim, '\r\n').replace(/(<([^>]+)>)/gi, '').replace(/&nbsp;/gi, '\x20');
+          cellValue = innerHTML.replace(/<br(\s*|\/)>[\r\n]?/gim, '\r\n')
+            .replace(regSpace, '\x20');
         }
+
+        dataArr[row][col] = cellValue.replace(/(&lt;)|(&gt;)|(&amp;)/gi, match => ESCAPED_HTML_CHARS[match]);
 
       } else {
         rowHeaders.push(innerHTML);

--- a/test/unit/utils/parseTable.spec.js
+++ b/test/unit/utils/parseTable.spec.js
@@ -95,6 +95,38 @@ describe('htmlToGridSettings', () => {
     expect(config.data.toString()).toBe('A3,B3,C3,A4,B4,C4,A5,B5,C5,A6,B6,C6');
   });
 
+  it('should parse data with special characters', () => {
+    const tableInnerHTML = [
+      '<table><tbody>',
+      '<tr><td>£§!@#$%^&*()-_=+[{]};:\'\\"|,<.>/?©</td></tr>',
+      '</tbody></table>',
+    ].join('');
+    const config = htmlToGridSettings(tableInnerHTML);
+
+    expect(config.data.toString()).toBe('£§!@#$%^&*()-_=+[{]};:\'\\"|,<.>/?©');
+  });
+
+  it('should parse data with HTML-like content', () => {
+    const tableInnerHTML = [
+      '<table><tbody>',
+      '<tr><td><div class="test">A</div></td><td><script>var b = 1 && 2 << 1</script></td></tr>',
+      '</tbody></table>',
+    ].join('');
+    const config = htmlToGridSettings(tableInnerHTML);
+
+    expect(config.data.toString()).toBe('<div class="test">A</div>,<script>var b = 1 && 2 << 1</script>');
+  });
+
+  it('should parse data with Unicode characters (emoji)', () => {
+    const tableInnerHTML = [
+      '<table><tbody>',
+      '<tr><td>☺️</td><td>✍️</td><td>☀️</td><td>❤️</td><td>✌️</td></tr>',
+      '</tbody></table>',
+    ].join('');
+    const config = htmlToGridSettings(tableInnerHTML);
+
+    expect(config.data.toString()).toBe('☺️,✍️,☀️,❤️,✌️');
+  });
   it('should parse headers from HTML table', () => {
     const tableInnerHTML = [
       '<table><thead>',


### PR DESCRIPTION
### Context
CopyPaste uses `parseTable` utils to convert `text/html` into an 2D array. Due performance reason we have to keep parsing in `documentFragment`.
Unfortunately, `<br>`  elements will be not replaced with `\n` in `innerText`, so we have to read `innerHTML` and replace them manually. Additionally, 

### How has this been tested?
1. Select `A1`
2. Open an editor and put: `£§!@#$%^&*()-_=+[{]};:'\"|,<.>/?©` as a value
3. Save changes
4. Select `A1` again and copy this cell
5. Select `A2` and paste clipboard's content

### Types of changes
- [x] Bugfix (a non-breaking change which fixes an issue)

### Related issue(s):
1. #1535