### PR TITLE
perf: avoid reflow when sets preventOverflow

### DIFF
--- a/src/3rdparty/walkontable/src/viewport.js
+++ b/src/3rdparty/walkontable/src/viewport.js
@@ -64,16 +64,16 @@ class Viewport {
   getWorkspaceWidth() {
     const { wot } = this;
     const { rootDocument, rootWindow } = wot;
+
+    if (wot.getSetting('preventOverflow')) {
+      return outerWidth(this.instance.wtTable.wtRootElement);
+    }
+
     const trimmingContainer = this.instance.wtOverlays.leftOverlay.trimmingContainer;
     const docOffsetWidth = rootDocument.documentElement.offsetWidth;
     const totalColumns = wot.getSetting('totalColumns');
-    const preventOverflow = wot.getSetting('preventOverflow');
     let width;
     let overflow;
-
-    if (preventOverflow) {
-      return outerWidth(this.instance.wtTable.wtRootElement);
-    }
 
     if (wot.getSetting('freezeOverlays')) {
       width = Math.min(docOffsetWidth - this.getWorkspaceOffset().left, docOffsetWidth);


### PR DESCRIPTION
### Context
set preventOverflow to true, needn't to calc documentElement.offsetWidth, which will cause a reflow 
 redundantly

### How has this been tested?

### Types of changes

### Related issue(s):

### Checklist:
- [done ] My code follows the code style of this project,
