### PR TITLE
Correct CSSPageRule notation in tests.

### DIFF
--- a/test/e2e/utils/parseTable.spec.js
+++ b/test/e2e/utils/parseTable.spec.js
@@ -25,7 +25,7 @@ describe('parseTable', () => {
    */
   describe('matchesCSSRules', () => {
     it('should verify only STYLE_RULE type rules', () => {
-      const styleElem = $('<style/>').html('@page div {} div {} * {} .test {}').appendTo(spec().$container);
+      const styleElem = $('<style/>').html('@page {} div {} * {} .test {}').appendTo(spec().$container);
       const testElem = $('<div/>').addClass('test').appendTo(spec().$container)[0];
       const { cssRules } = styleElem[0].sheet;
       const matchesMethod = getMatchesMethod(testElem);


### PR DESCRIPTION
### Context
In `matchCSSRules` helper I used improper `CSSPageRule`. Now it's adjusted to being compatible with its definition.
Short definition you can find on MDN website: https://developer.mozilla.org/en-US/docs/Web/API/CSSPageRule

### How has this been tested?
Run `parseTable > matchesCSSRules > should verify only STYLE_RULE type rules` test spec in Firefox.

### Types of changes
- [x] Bugfix (a non-breaking change which fixes an issue)