### PR TITLE
Remove unused z-index in handsontableInputHolder class 

### DIFF
--- a/src/css/handsontable.css
+++ b/src/css/handsontable.css
@@ -227,7 +227,6 @@
   position: absolute;
   top: 0;
   left: 0;
-  z-index: 104;
 }
 
 .htSelectEditor {

--- a/test/e2e/editors/handsontableEditor.spec.js
+++ b/test/e2e/editors/handsontableEditor.spec.js
@@ -131,6 +131,27 @@ describe('HandsontableEditor', () => {
     expect(container.clientHeight).toBeGreaterThan(2);
   });
 
+  it('should change container z-index after open editor to 200', () => {
+    handsontable({
+      columns: [
+        {
+          type: 'handsontable',
+          handsontable: {
+            colHeaders: ['Marque', 'Country', 'Parent company'],
+            data: getManufacturerData()
+          }
+        }
+      ]
+    });
+
+    selectCell(0, 0);
+    keyDownUp('enter');
+
+    const container = spec().$container.find('.handsontableInputHolder');
+
+    expect(container.css('zIndex')).toBe('200');
+  });
+
   it('should destroy the editor when Esc is pressed', () => {
     handsontable({
       columns: [

--- a/test/e2e/editors/textEditor.spec.js
+++ b/test/e2e/editors/textEditor.spec.js
@@ -114,6 +114,54 @@ describe('TextEditor', () => {
     expect(overflow).not.toBe('hidden');
   });
 
+  it('should change editor\'s z-index properties during switching to overlay where editor was open', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(10, 10),
+      editor: 'text',
+      fixedRowsBottom: 2,
+      fixedRowsTop: 2,
+      fixedColumnsLeft: 2,
+    });
+
+    // .ht_clone_top_left_corner
+    selectCell(0, 0);
+    keyDownUp('enter');
+
+    const handsontableInputHolder = spec().$container.find('.handsontableInputHolder');
+
+    expect(handsontableInputHolder.css('zIndex')).toBe('180');
+
+    // .ht_clone_left
+    selectCell(5, 0);
+    keyDownUp('enter');
+
+    expect(handsontableInputHolder.css('zIndex')).toBe('120');
+
+    // .ht_clone_bottom_left_corner
+    selectCell(9, 0);
+    keyDownUp('enter');
+
+    expect(handsontableInputHolder.css('zIndex')).toBe('150');
+
+    // .ht_clone_top
+    selectCell(0, 5);
+    keyDownUp('enter');
+
+    expect(handsontableInputHolder.css('zIndex')).toBe('160');
+
+    // .ht_clone_master
+    selectCell(2, 2);
+    keyDownUp('enter');
+
+    expect(handsontableInputHolder.css('zIndex')).toBe('100');
+
+    // .ht_clone_bottom
+    selectCell(9, 5);
+    keyDownUp('enter');
+
+    expect(handsontableInputHolder.css('zIndex')).toBe('130');
+  });
+
   it('should render string in textarea', () => {
     handsontable();
     setDataAtCell(2, 2, 'string');


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
After moving some styles from `handsontable.css` to `walkontable.css` in `handsontable.full.css` overlay classes (e.g `.ht_clone_bottom`) are higher in the file than `.handsontableInputHolder`. According to cascading rules `.handsontableInputHolder` overwrite earlier style. 
But most importantly, this class (`.handsontableInputHolder`) shouldn't have any more own `z-index` style.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #6443

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
