### PR TITLE
Increased width of div.forceScrollbar element in Handsontable.Dom tests.

### DIFF
--- a/test/e2e/Dom.spec.js
+++ b/test/e2e/Dom.spec.js
@@ -4,8 +4,8 @@ describe('Handsontable.Dom', () => {
     const $window = $(window);
     const $forceScrollbar = $('<div id="forceScrollbar"></div>').css({
       position: 'absolute',
-      height: '4000px',
-      width: '4000px',
+      height: '10000px',
+      width: '10000px',
       top: 0,
       left: 0
     });


### PR DESCRIPTION
### Context
An `div.forceScrollbar` element in `Handsontable.Dom` tests had only `4000px` of its width. On wider screens it's not enough to generate scrollbar which is crucial to check correctness of: `Handsontable.Dom > offset > left > should return offset left with position fixed & scrolled window`

I decided to not use calculations (sum of real `window.scrollLeft` and left position) and increase default width and height of `.forceScrollbar` because In my opinion, it might help to catch potential regression / breaking changes in the future.

### How has this been tested?
Run `Handsontable.Dom > offset > left > should return offset left with position fixed & scrolled window` spec on wider screen than 4000 (you can use Chrome DevTools to simulate wider viewport).

### Types of changes
- [x] Bugfix (a non-breaking change which fixes an issue)