### PR TITLE
Fixed tests for browsers other than Chrome

### DIFF
--- a/src/plugins/autoColumnSize/test/autoColumnSize.e2e.js
+++ b/src/plugins/autoColumnSize/test/autoColumnSize.e2e.js
@@ -587,33 +587,33 @@ describe('AutoColumnSize', () => {
 
       hot.undo();
 
-      expect(colWidth(spec().$container, 0)).toBe(50);
-      expect(colWidth(spec().$container, 1)).toBe(121);
-      expect(colWidth(spec().$container, 2)).toBe(229);
+      expect(colWidth(spec().$container, 0)).toBeAroundValue(50);
+      expect(colWidth(spec().$container, 1)).toBeAroundValue(121);
+      expect(colWidth(spec().$container, 2)).toBeAroundValue(229);
 
       hot.redo();
 
-      expect(colWidth(spec().$container, 0)).toBe(121);
-      expect(colWidth(spec().$container, 1)).toBe(229);
+      expect(colWidth(spec().$container, 0)).toBeAroundValue(121);
+      expect(colWidth(spec().$container, 1)).toBeAroundValue(229);
 
       hot.undo();
 
-      expect(colWidth(spec().$container, 0)).toBe(50);
-      expect(colWidth(spec().$container, 1)).toBe(121);
-      expect(colWidth(spec().$container, 2)).toBe(229);
+      expect(colWidth(spec().$container, 0)).toBeAroundValue(50);
+      expect(colWidth(spec().$container, 1)).toBeAroundValue(121);
+      expect(colWidth(spec().$container, 2)).toBeAroundValue(229);
 
       alter('remove_col', 1);
 
       hot.undo();
 
-      expect(colWidth(spec().$container, 0)).toBe(50);
-      expect(colWidth(spec().$container, 1)).toBe(121);
-      expect(colWidth(spec().$container, 2)).toBe(229);
+      expect(colWidth(spec().$container, 0)).toBeAroundValue(50);
+      expect(colWidth(spec().$container, 1)).toBeAroundValue(121);
+      expect(colWidth(spec().$container, 2)).toBeAroundValue(229);
 
       hot.redo();
 
-      expect(colWidth(spec().$container, 0)).toBe(50);
-      expect(colWidth(spec().$container, 1)).toBe(229);
+      expect(colWidth(spec().$container, 0)).toBeAroundValue(50);
+      expect(colWidth(spec().$container, 1)).toBeAroundValue(229);
 
       hot.undo();
 
@@ -621,14 +621,14 @@ describe('AutoColumnSize', () => {
 
       hot.undo();
 
-      expect(colWidth(spec().$container, 0)).toBe(50);
-      expect(colWidth(spec().$container, 1)).toBe(121);
-      expect(colWidth(spec().$container, 2)).toBe(229);
+      expect(colWidth(spec().$container, 0)).toBeAroundValue(50);
+      expect(colWidth(spec().$container, 1)).toBeAroundValue(121);
+      expect(colWidth(spec().$container, 2)).toBeAroundValue(229);
 
       hot.redo();
 
-      expect(colWidth(spec().$container, 0)).toBe(50);
-      expect(colWidth(spec().$container, 1)).toBe(121);
+      expect(colWidth(spec().$container, 0)).toBeAroundValue(50);
+      expect(colWidth(spec().$container, 1)).toBeAroundValue(121);
     });
 
     it('when inserting single column', () => {
@@ -641,79 +641,79 @@ describe('AutoColumnSize', () => {
 
       hot.undo();
 
-      expect(colWidth(spec().$container, 0)).toBe(50);
-      expect(colWidth(spec().$container, 1)).toBe(121);
-      expect(colWidth(spec().$container, 2)).toBe(229);
+      expect(colWidth(spec().$container, 0)).toBeAroundValue(50);
+      expect(colWidth(spec().$container, 1)).toBeAroundValue(121);
+      expect(colWidth(spec().$container, 2)).toBeAroundValue(229);
 
       hot.redo();
 
-      expect(colWidth(spec().$container, 0)).toBe(50);
-      expect(colWidth(spec().$container, 1)).toBe(50);
-      expect(colWidth(spec().$container, 2)).toBe(121);
-      expect(colWidth(spec().$container, 3)).toBe(229);
+      expect(colWidth(spec().$container, 0)).toBeAroundValue(50);
+      expect(colWidth(spec().$container, 1)).toBeAroundValue(50);
+      expect(colWidth(spec().$container, 2)).toBeAroundValue(121);
+      expect(colWidth(spec().$container, 3)).toBeAroundValue(229);
 
       hot.undo();
 
-      expect(colWidth(spec().$container, 0)).toBe(50);
-      expect(colWidth(spec().$container, 1)).toBe(121);
-      expect(colWidth(spec().$container, 2)).toBe(229);
+      expect(colWidth(spec().$container, 0)).toBeAroundValue(50);
+      expect(colWidth(spec().$container, 1)).toBeAroundValue(121);
+      expect(colWidth(spec().$container, 2)).toBeAroundValue(229);
 
       alter('insert_col', 1);
 
       hot.undo();
 
-      expect(colWidth(spec().$container, 0)).toBe(50);
-      expect(colWidth(spec().$container, 1)).toBe(121);
-      expect(colWidth(spec().$container, 2)).toBe(229);
+      expect(colWidth(spec().$container, 0)).toBeAroundValue(50);
+      expect(colWidth(spec().$container, 1)).toBeAroundValue(121);
+      expect(colWidth(spec().$container, 2)).toBeAroundValue(229);
 
       hot.redo();
 
-      expect(colWidth(spec().$container, 0)).toBe(50);
-      expect(colWidth(spec().$container, 1)).toBe(50);
-      expect(colWidth(spec().$container, 2)).toBe(121);
-      expect(colWidth(spec().$container, 3)).toBe(229);
+      expect(colWidth(spec().$container, 0)).toBeAroundValue(50);
+      expect(colWidth(spec().$container, 1)).toBeAroundValue(50);
+      expect(colWidth(spec().$container, 2)).toBeAroundValue(121);
+      expect(colWidth(spec().$container, 3)).toBeAroundValue(229);
 
       hot.undo();
 
-      expect(colWidth(spec().$container, 0)).toBe(50);
-      expect(colWidth(spec().$container, 1)).toBe(121);
-      expect(colWidth(spec().$container, 2)).toBe(229);
+      expect(colWidth(spec().$container, 0)).toBeAroundValue(50);
+      expect(colWidth(spec().$container, 1)).toBeAroundValue(121);
+      expect(colWidth(spec().$container, 2)).toBeAroundValue(229);
 
       alter('insert_col', 2);
 
       hot.undo();
 
-      expect(colWidth(spec().$container, 0)).toBe(50);
-      expect(colWidth(spec().$container, 1)).toBe(121);
-      expect(colWidth(spec().$container, 2)).toBe(229);
+      expect(colWidth(spec().$container, 0)).toBeAroundValue(50);
+      expect(colWidth(spec().$container, 1)).toBeAroundValue(121);
+      expect(colWidth(spec().$container, 2)).toBeAroundValue(229);
 
       hot.redo();
 
-      expect(colWidth(spec().$container, 0)).toBe(50);
-      expect(colWidth(spec().$container, 1)).toBe(121);
-      expect(colWidth(spec().$container, 2)).toBe(50);
-      expect(colWidth(spec().$container, 3)).toBe(229);
+      expect(colWidth(spec().$container, 0)).toBeAroundValue(50);
+      expect(colWidth(spec().$container, 1)).toBeAroundValue(121);
+      expect(colWidth(spec().$container, 2)).toBeAroundValue(50);
+      expect(colWidth(spec().$container, 3)).toBeAroundValue(229);
 
       hot.undo();
 
-      expect(colWidth(spec().$container, 0)).toBe(50);
-      expect(colWidth(spec().$container, 1)).toBe(121);
-      expect(colWidth(spec().$container, 2)).toBe(229);
+      expect(colWidth(spec().$container, 0)).toBeAroundValue(50);
+      expect(colWidth(spec().$container, 1)).toBeAroundValue(121);
+      expect(colWidth(spec().$container, 2)).toBeAroundValue(229);
 
       alter('insert_col', 3);
 
       hot.undo();
 
-      expect(colWidth(spec().$container, 0)).toBe(50);
-      expect(colWidth(spec().$container, 1)).toBe(121);
-      expect(colWidth(spec().$container, 2)).toBe(229);
+      expect(colWidth(spec().$container, 0)).toBeAroundValue(50);
+      expect(colWidth(spec().$container, 1)).toBeAroundValue(121);
+      expect(colWidth(spec().$container, 2)).toBeAroundValue(229);
 
       hot.redo();
 
-      expect(colWidth(spec().$container, 0)).toBe(50);
-      expect(colWidth(spec().$container, 1)).toBe(121);
-      expect(colWidth(spec().$container, 2)).toBe(229);
-      expect(colWidth(spec().$container, 3)).toBe(50);
+      expect(colWidth(spec().$container, 0)).toBeAroundValue(50);
+      expect(colWidth(spec().$container, 1)).toBeAroundValue(121);
+      expect(colWidth(spec().$container, 2)).toBeAroundValue(229);
+      expect(colWidth(spec().$container, 3)).toBeAroundValue(50);
     });
 
     it('when removing all rows', async() => {


### PR DESCRIPTION
Some elements are displayed in browsers as wider/thinner. I changed test checks from the `toBe` to the `toBeAroundValue` to have `1px` offset for the test.

Tested in Edge 42, FF 38, Safari 12.1.