### PR TITLE
Fixed contextmenu test spec with scrolling window by arrow down

### DIFF
--- a/src/plugins/contextMenu/test/contextMenu.e2e.js
+++ b/src/plugins/contextMenu/test/contextMenu.e2e.js
@@ -2326,6 +2326,8 @@ describe('ContextMenu', () => {
       });
 
       it('should scroll down, when user hits ARROW_DOWN for item in menu below the viewport', () => {
+        spec().$container.css({ marginTop: '4000px' });
+
         handsontable({
           height: 100,
           contextMenu: {


### PR DESCRIPTION
Fixed contextmenu test spec with scrolling window by arrow down

### Context
On bigger screens, context menu in `ContextMenu > keyboard navigation > no item selected > should scroll down, when the user hits ARROW_DOWN for an item in the menu below the viewport` test spec will not increase the viewport. I added the top margin to be sure that the context menu will generate additional scrollable space.

### How has this been tested?
Run `ContextMenu > keyboard navigation > no item selected > should scroll down when the user hits ARROW_DOWN for an item in the menu below the viewport` test spec in a browser (Chrome, Firefox or Opera).

### Types of changes
- [x] Bugfix (a non-breaking change which fixes an issue)