### PR TITLE
Columns sizes will be calculated properly by GhostTable

### DIFF
--- a/src/plugins/autoColumnSize/autoColumnSize.js
+++ b/src/plugins/autoColumnSize/autoColumnSize.js
@@ -456,6 +456,10 @@ class AutoColumnSize extends BasePlugin {
    * @returns {Boolean}
    */
   isNeedRecalculate() {
+    // console.log(this.columnWidthsMap.getValues().slice());
+    // console.log(this.columnWidthsMap.getValues().slice(0, this.measuredColumns));
+    console.log(this.measuredColumns);
+
     return !!arrayFilter(this.columnWidthsMap.getValues().slice(0, this.measuredColumns), item => (item === null)).length;
   }
 
@@ -511,9 +515,9 @@ class AutoColumnSize extends BasePlugin {
    * @param {Array} changes
    */
   onBeforeChange(changes) {
-    const changedColumns = arrayMap(changes, ([, column]) => this.hot.propToCol(column));
+    const changedColumns = arrayMap(changes, ([, columnProperty]) => this.hot.toPhysicalColumn(this.hot.propToCol(columnProperty)));
 
-    this.clearCache(changedColumns);
+    this.clearCache(Array.from(new Set(changedColumns)));
   }
 
   /**

--- a/src/plugins/autoColumnSize/autoColumnSize.js
+++ b/src/plugins/autoColumnSize/autoColumnSize.js
@@ -205,15 +205,15 @@ class AutoColumnSize extends BasePlugin {
     const columnsRange = typeof colRange === 'number' ? { from: colRange, to: colRange } : colRange;
     const rowsRange = typeof rowRange === 'number' ? { from: rowRange, to: rowRange } : rowRange;
 
-    rangeEach(columnsRange.from, columnsRange.to, (col) => {
-      let physicalColumn = this.hot.toPhysicalColumn(col);
+    rangeEach(columnsRange.from, columnsRange.to, (visualColumn) => {
+      let physicalColumn = this.hot.toPhysicalColumn(visualColumn);
 
       if (physicalColumn === null) {
-        physicalColumn = col;
+        physicalColumn = visualColumn;
       }
 
       if (force || (this.columnWidthsMap.getValueAtIndex(physicalColumn) === null && !this.hot._getColWidthFromSettings(physicalColumn))) {
-        const samples = this.samplesGenerator.generateColumnSamples(physicalColumn, rowsRange);
+        const samples = this.samplesGenerator.generateColumnSamples(visualColumn, rowsRange);
 
         arrayEach(samples, ([column, sample]) => this.ghostTable.addColumn(column, sample));
       }
@@ -221,14 +221,14 @@ class AutoColumnSize extends BasePlugin {
 
     if (this.ghostTable.columns.length) {
       this.hot.executeBatchOperations(() => {
-        this.ghostTable.getWidths((col, width) => {
-          const physicalColumn = this.hot.toPhysicalColumn(col);
+        this.ghostTable.getWidths((visualColumn, width) => {
+          const physicalColumn = this.hot.toPhysicalColumn(visualColumn);
 
           this.columnWidthsMap.setValueAtIndex(physicalColumn, width);
         });
       });
 
-      this.measuredColumns = this.ghostTable.columns.length;
+      this.measuredColumns = columnsRange.to + 1;
 
       this.ghostTable.clean();
     }
@@ -456,10 +456,6 @@ class AutoColumnSize extends BasePlugin {
    * @returns {Boolean}
    */
   isNeedRecalculate() {
-    // console.log(this.columnWidthsMap.getValues().slice());
-    // console.log(this.columnWidthsMap.getValues().slice(0, this.measuredColumns));
-    console.log(this.measuredColumns);
-
     return !!arrayFilter(this.columnWidthsMap.getValues().slice(0, this.measuredColumns), item => (item === null)).length;
   }
 

--- a/src/plugins/autoColumnSize/test/autoColumnSize.e2e.js
+++ b/src/plugins/autoColumnSize/test/autoColumnSize.e2e.js
@@ -576,6 +576,25 @@ describe('AutoColumnSize', () => {
     expect(colWidth(spec().$container, 2)).toBe(147);
   });
 
+  it('should keep appropriate column size when columns order is changed and some column is cleared', () => {
+    const hot = handsontable({
+      data: Handsontable.helper.createSpreadsheetData(5, 3),
+      autoColumnSize: true,
+      colHeaders: ['Short', 'Longer', 'The longest header']
+    });
+
+    hot.columnIndexMapper.moveIndexes(2, 1);
+    render();
+
+    expect(colWidth(spec().$container, 1)).toBe(147);
+    expect(colWidth(spec().$container, 2)).toBe(59);
+
+    hot.populateFromArray(0, 1, [[null], [null], [null], [null], [null]]); // Empty values on the second visual column.
+
+    expect(colWidth(spec().$container, 1)).toBe(147);
+    expect(colWidth(spec().$container, 2)).toBe(59);
+  });
+
   describe('should cooperate with the `UndoRedo` plugin properly ', () => {
     it('when removing single column', () => {
       const hot = handsontable({

--- a/src/plugins/autoRowSize/autoRowSize.js
+++ b/src/plugins/autoRowSize/autoRowSize.js
@@ -203,6 +203,7 @@ class AutoRowSize extends BasePlugin {
         arrayEach(samples, ([rowIndex, sample]) => this.ghostTable.addRow(rowIndex, sample));
       }
     });
+
     if (this.ghostTable.rows.length) {
       this.hot.executeBatchOperations(() => {
         this.ghostTable.getHeights((row, height) => {
@@ -214,7 +215,7 @@ class AutoRowSize extends BasePlugin {
         });
       });
 
-      this.measuredRows = this.ghostTable.rows.length;
+      this.measuredRows = rowsRange.to + 1;
 
       this.ghostTable.clean();
     }


### PR DESCRIPTION
### Context
Some index translations were wrong, so `GhostTable` hasn't calculated column widths properly.
