### PR TITLE
Clicking in a contextmenu's border should not open the native context menu

### DIFF
--- a/src/plugins/contextMenu/contextMenu.css
+++ b/src/plugins/contextMenu/contextMenu.css
@@ -14,12 +14,6 @@
   display: none;
 }
 
-/* .htContextMenu .ht_master table.htCore {
-  border: 1px solid #ccc;
-  border-bottom-width: 2px;
-  border-right-width: 2px;
-} */
-
 .htContextMenu .wtBorder {
   visibility: hidden;
 }

--- a/src/plugins/contextMenu/contextMenu.css
+++ b/src/plugins/contextMenu/contextMenu.css
@@ -14,11 +14,11 @@
   display: none;
 }
 
-.htContextMenu .ht_master table.htCore {
+/* .htContextMenu .ht_master table.htCore {
   border: 1px solid #ccc;
   border-bottom-width: 2px;
   border-right-width: 2px;
-}
+} */
 
 .htContextMenu .wtBorder {
   visibility: hidden;
@@ -32,10 +32,16 @@
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+  border-left: 1px solid #ccc;
+  border-right: 2px solid #ccc;
 }
 
-.htContextMenu table tbody tr td:first-child {
-  border: 0;
+.htContextMenu table tbody tr:first-child td {
+  border-top: 1px solid #ccc;
+}
+
+.htContextMenu table tbody tr:last-child td {
+  border-bottom: 2px solid #ccc;
 }
 
 .htContextMenu table tbody tr td.htDimmed {

--- a/src/plugins/contextMenu/menu.js
+++ b/src/plugins/contextMenu/menu.js
@@ -7,7 +7,7 @@ import {
   isChildOf,
   removeClass,
 } from './../../helpers/dom/element';
-import { arrayEach, arrayFilter, arrayReduce } from './../../helpers/array';
+import { arrayEach, arrayFilter } from './../../helpers/array';
 import Cursor from './cursor';
 import EventManager from './../../eventManager';
 import { mixin, hasOwnProperty } from './../../helpers/object';
@@ -238,7 +238,6 @@ class Menu {
     });
     subMenu.setMenuItems(dataItem.submenu.items);
     subMenu.open();
-    // debugger;
     subMenu.setPosition(cell.getBoundingClientRect());
     this.hotSubMenus[dataItem.key] = subMenu;
 
@@ -701,11 +700,9 @@ class Menu {
    */
   onAfterInit() {
     const { wtTable } = this.hotMenu.view.wt;
-    const data = this.hotMenu.getSettings().data;
     const hiderStyle = wtTable.hider.style;
     const holderStyle = wtTable.holder.style;
-
-    const realHeight = arrayReduce(data, (accumulator, value) => accumulator + (value.name === SEPARATOR ? 1 : 26), 0);
+    const realHeight = wtTable.spreader.offsetHeight;
 
     holderStyle.width = hiderStyle.width;
     holderStyle.height = `${realHeight}px`;

--- a/src/plugins/contextMenu/menu.js
+++ b/src/plugins/contextMenu/menu.js
@@ -238,6 +238,7 @@ class Menu {
     });
     subMenu.setMenuItems(dataItem.submenu.items);
     subMenu.open();
+    // debugger;
     subMenu.setPosition(cell.getBoundingClientRect());
     this.hotSubMenus[dataItem.key] = subMenu;
 
@@ -376,7 +377,7 @@ class Menu {
     let top = this.offset.above + cursor.top - this.container.offsetHeight;
 
     if (this.isSubMenu()) {
-      top = cursor.top + cursor.cellHeight - this.container.offsetHeight + 3;
+      top = cursor.top + cursor.cellHeight - this.container.offsetHeight;
     }
     this.container.style.top = `${top}px`;
   }
@@ -404,9 +405,9 @@ class Menu {
     let left;
 
     if (this.isSubMenu()) {
-      left = 1 + cursor.left + cursor.cellWidth;
+      left = cursor.left + cursor.cellWidth;
     } else {
-      left = this.offset.right + 1 + cursor.left;
+      left = this.offset.right + cursor.left;
     }
 
     this.container.style.left = `${left}px`;
@@ -418,7 +419,7 @@ class Menu {
    * @param {Cursor} cursor `Cursor` object.
    */
   setPositionOnLeftOfCursor(cursor) {
-    const left = this.offset.left + cursor.left - this.container.offsetWidth + getScrollbarWidth(this.hot.rootDocument) + 4;
+    const left = this.offset.left + cursor.left - this.container.offsetWidth + getScrollbarWidth(this.hot.rootDocument);
 
     this.container.style.left = `${left}px`;
   }
@@ -703,13 +704,11 @@ class Menu {
     const data = this.hotMenu.getSettings().data;
     const hiderStyle = wtTable.hider.style;
     const holderStyle = wtTable.holder.style;
-    const currentHiderWidth = parseInt(hiderStyle.width, 10);
 
     const realHeight = arrayReduce(data, (accumulator, value) => accumulator + (value.name === SEPARATOR ? 1 : 26), 0);
 
-    // Additional 3px to menu's size because of additional border around its `table.htCore`.
-    holderStyle.width = `${currentHiderWidth + 3}px`;
-    holderStyle.height = `${realHeight + 3}px`;
+    holderStyle.width = hiderStyle.width;
+    holderStyle.height = `${realHeight}px`;
     hiderStyle.height = holderStyle.height;
   }
 

--- a/src/plugins/contextMenu/test/contextMenu.e2e.js
+++ b/src/plugins/contextMenu/test/contextMenu.e2e.js
@@ -101,7 +101,7 @@ describe('ContextMenu', () => {
       await sleep(300);
 
       expect($menu.find('.wtHider').width()).toEqual(215);
-      expect($menu.width()).toEqual(218);
+      expect($menu.width()).toEqual(215);
     });
 
     it('should expand menu when one of items is wider then default width of the menu', async() => {
@@ -935,7 +935,7 @@ describe('ContextMenu', () => {
 
       const contextSubMenu = $(`.htContextMenuSub_${item.text()}`);
 
-      expect(contextSubMenu.offset().top + contextSubMenu.height() - 28).toBeAroundValue(item.offset().top);
+      expect(contextSubMenu.offset().top + contextSubMenu.height() - 26).toBeAroundValue(item.offset().top); // 26 - row height
       expect(contextSubMenu.offset().left).toBeLessThan(contextMenuRoot.offset().left - contextSubMenu.width() + 30); // 30 - scroll
     });
 
@@ -961,7 +961,7 @@ describe('ContextMenu', () => {
 
       const contextSubMenu = $(`.htContextMenuSub_${item.text()}`);
 
-      expect(contextSubMenu.offset().top + contextSubMenu.height() - 28).toBeAroundValue(item.offset().top);
+      expect(contextSubMenu.offset().top + contextSubMenu.height() - 26).toBeAroundValue(item.offset().top); // 26 - row height
       expect(contextSubMenu.offset().left).toBeGreaterThan(contextMenuRoot.offset().left + contextMenuRoot.width() - 30); // 30 - scroll
     });
   });

--- a/src/plugins/dropdownMenu/dropdownMenu.css
+++ b/src/plugins/dropdownMenu/dropdownMenu.css
@@ -34,11 +34,6 @@
   display: none;
 }
 
-.htDropdownMenu table.htCore {
-  border: 1px solid #bbb;
-  border-bottom-width: 2px;
-  border-right-width: 2px;
-}
 
 .htDropdownMenu .wtBorder {
   visibility: hidden;
@@ -52,10 +47,16 @@
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+  border-left: 1px solid #ccc;
+  border-right: 2px solid #ccc;
 }
 
-.htDropdownMenu table tbody tr td:first-child {
-  border: 0;
+.htDropdownMenu table tbody tr:first-child td {
+  border-top: 1px solid #ccc;
+}
+
+.htDropdownMenu table tbody tr:last-child td {
+  border-bottom: 2px solid #ccc;
 }
 
 .htDropdownMenu table tbody tr td.htDimmed {

--- a/src/plugins/filters/test/filtersUI.e2e.js
+++ b/src/plugins/filters/test/filtersUI.e2e.js
@@ -3434,7 +3434,8 @@ describe('Filters UI', () => {
       const bothInputPaddings = 8;
       const bothWrapperMargins = 20;
       const bothCustomRendererPaddings = 12;
-      const parentsPaddings = bothInputBorders + bothInputPaddings + bothWrapperMargins + bothCustomRendererPaddings;
+      const parentBorders = 3; // 1px on left and 2px on right side
+      const parentsPaddings = bothInputBorders + bothInputPaddings + bothWrapperMargins + bothCustomRendererPaddings + parentBorders;
 
       expect(widthOfInput).toEqual(widthOfMenu - parentsPaddings);
     });
@@ -3464,7 +3465,8 @@ describe('Filters UI', () => {
       const widthOfSelect = $(conditionSelectRootElements().first).width();
       const bothWrapperMargins = 20;
       const bothCustomRendererPaddings = 12;
-      const parentsPaddings = bothWrapperMargins + bothCustomRendererPaddings;
+      const parentBorders = 3; // 1px on left and 2px on right side
+      const parentsPaddings = bothWrapperMargins + bothCustomRendererPaddings + parentBorders;
 
       expect(widthOfSelect).toEqual(widthOfMenu - parentsPaddings);
     });
@@ -3496,7 +3498,8 @@ describe('Filters UI', () => {
       const bothInputPaddings = 8;
       const bothWrapperMargins = 20;
       const bothCustomRendererPaddings = 12;
-      const parentsPaddings = bothInputBorders + bothInputPaddings + bothWrapperMargins + bothCustomRendererPaddings;
+      const parentBorders = 3; // 1px on left and 2px on right side
+      const parentsPaddings = bothInputBorders + bothInputPaddings + bothWrapperMargins + bothCustomRendererPaddings + parentBorders;
 
       expect(widthOfInput).toEqual(widthOfMenu - parentsPaddings);
     });
@@ -3529,8 +3532,9 @@ describe('Filters UI', () => {
       const widthOfValueBox = $(byValueBoxRootElement()).width();
       const bothWrapperMargins = 20;
       const bothCustomRendererPaddings = 12;
+      const parentBorders = 3; // 1px on left and 2px on right side
 
-      const parentsPaddings = bothWrapperMargins + bothCustomRendererPaddings;
+      const parentsPaddings = bothWrapperMargins + bothCustomRendererPaddings + parentBorders;
 
       expect(widthOfValueBox).toEqual(widthOfMenu - parentsPaddings);
     });


### PR DESCRIPTION
### Context
We're listening `contextmenu` event only on cells, so clicking <kbd>RMB</kbd> on top/right/bottom/left border open the native context menu.

### How has this been tested?
1. Initialize Handsontable with enabled `contextMenu` plugin.
2. Open context menu on `A1`.
3. Click <kbd>RMB</kbd> on top/right/bottom/left border.
Expected behaviour: nothing should happen.

### Types of changes
- [x] Bugfix (a non-breaking change which fixes an issue).

### Related issue(s):
1. #6218