### PR TITLE
Fixed escaping HTML tags for pasting text/html data

### DIFF
--- a/src/plugins/copyPaste/test/copyPaste.e2e.js
+++ b/src/plugins/copyPaste/test/copyPaste.e2e.js
@@ -276,7 +276,7 @@ describe('CopyPaste', () => {
       expect(copyEvent.clipboardData.getData('text/html')).toEqual([
         '<meta name="generator" content="Handsontable"/><style type="text/css">td{white-space:normal}br{mso-data-placement:same-cell}</style>',
         '<table><tbody><tr><td>!@#$%^&*()_+-={[</td>',
-        '<td>]};:\'"\\|,<.>/?~</td></tr></tbody></table>'
+        '<td>]};:\'"\\|,&lt;.&gt;/?~</td></tr></tbody></table>'
       ].join(''));
     });
 

--- a/test/unit/utils/parseTable.spec.js
+++ b/test/unit/utils/parseTable.spec.js
@@ -78,6 +78,18 @@ describe('_dataToHTML', () => {
       '</tbody></table>',
     ].join(''));
   });
+
+  it('should escape HTML tags into entities', () => {
+    const data = [
+      ['<div class="test">A1</div>'],
+    ];
+
+    expect(_dataToHTML(data)).toBe([
+      '<table><tbody>',
+      '<tr><td>&lt;div&nbsp;class="test"&gt;A1&lt;/div&gt;</td></tr>',
+      '</tbody></table>',
+    ].join(''));
+  });
 });
 
 describe('htmlToGridSettings', () => {
@@ -98,7 +110,7 @@ describe('htmlToGridSettings', () => {
   it('should parse data with special characters', () => {
     const tableInnerHTML = [
       '<table><tbody>',
-      '<tr><td>£§!@#$%^&*()-_=+[{]};:\'\\"|,<.>/?©</td></tr>',
+      '<tr><td>£§!@#$%^&*()-_=+[{]};:\'\\"|,&lt;.&gt;/?©</td></tr>',
       '</tbody></table>',
     ].join('');
     const config = htmlToGridSettings(tableInnerHTML);
@@ -106,10 +118,21 @@ describe('htmlToGridSettings', () => {
     expect(config.data.toString()).toBe('£§!@#$%^&*()-_=+[{]};:\'\\"|,<.>/?©');
   });
 
+  it('should parse data without unescaped HTML tags', () => {
+    const tableInnerHTML = [
+      '<table><tbody>',
+      '<tr><td>1<span class="abc">   </span>2</td></tr>',
+      '</tbody></table>',
+    ].join('');
+    const config = htmlToGridSettings(tableInnerHTML);
+
+    expect(config.data.toString()).toBe('1   2');
+  });
+
   it('should parse data with HTML-like content', () => {
     const tableInnerHTML = [
       '<table><tbody>',
-      '<tr><td><div class="test">A</div></td><td><script>var b = 1 && 2 << 1</script></td></tr>',
+      '<tr><td>&lt;div class="test"&gt;A&lt;/div&gt;</td><td>&lt;script&gt;var b = 1 && 2 &lt;&lt; 1&lt;/script&gt;</td></tr>',
       '</tbody></table>',
     ].join('');
     const config = htmlToGridSettings(tableInnerHTML);


### PR DESCRIPTION
### Context
As a part of work for not escaping everything that we get from the clipboard, I broke this functionality by allowing all HTML tags to be pasted into cells. Although, Excel/Numbers/Google Spreadsheets adds many additional tags into a cell's value and we have to remove them before we parse them from `documentFragment` in `parseTable` utility.

### How has this been tested?
1. Paste `<div class="test">1    3</div>` into cell `A1` in Excel/Numbers/Google Spreadsheets
2. Copy `A1` cell's value
3. Paste this value into Handsontable

Expected behaviour: You should get the same result as in Excel/Numbers/Google Spreadsheets

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. #6489