### PR TITLE
Low performance when using updateSettings if settings contain the mergeCells

### DIFF
--- a/src/plugins/mergeCells/mergeCells.js
+++ b/src/plugins/mergeCells/mergeCells.js
@@ -124,7 +124,6 @@ class MergeCells extends BasePlugin {
    */
   disablePlugin() {
     this.clearCollections();
-    this.hot.render();
     super.disablePlugin();
   }
 


### PR DESCRIPTION
Remove the render in disablePlugin because we don't need it and it will cause the performance issue when using the updateSettings with handsontable instance.

### Context
<!--- Why is this change required? What problem does it solve? -->

When using the hotInstance.updateSettings, if the settings include the mergeCells setting, it will trigger the updatePlugin of mergeCells but updatePlugin will trigger the disablePlugin for render. I think it is useless code because the updateSettings will fire the render at the end. We don't need to render it again.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
1) npm install handsontable vue-handsontable
2) use hotInstance.updateSettings(...)
3) Watch the performance on console of Chrome.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. Low performance when using updateSettings if settings contain the mergeCells.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
