### PR TITLE
Force focus on focusable element

### DIFF
--- a/src/helpers/dom/element.js
+++ b/src/helpers/dom/element.js
@@ -1150,5 +1150,6 @@ export function selectElementIfAllowed(element) {
 
   if (!isOutsideInput(activeElement)) {
     element.select();
+    element.focus();
   }
 }


### PR DESCRIPTION
### Context
`element.select()` doesn't focus element if is called from a different frame. More details you can find in the original issue and my [comment](https://github.com/handsontable/handsontable/issues/6492#issuecomment-557554703).

### How has this been tested?
1. Initialize Handsontable in an iframe element.
2. Disable editors eg.: `editor: false`
3. Add configuration for `copyPaste` with `uiContainer` in different frame, eg. in parent document.
4. Try to copy/paste cells values.

### Types of changes
- [x] Bugfix (a non-breaking change which fixes an issue)

### Related issue(s):
1. #6492

### Checklist:
- [x] My change requires a change to the documentation.