### PR TITLE
Release mouse event from bubbling

### DIFF
--- a/src/plugins/contextMenu/contextMenu.js
+++ b/src/plugins/contextMenu/contextMenu.js
@@ -157,7 +157,6 @@ class ContextMenu extends BasePlugin {
     this.menu.addLocalHook('executeCommand', (...params) => this.executeCommand.call(this, ...params));
 
     this.addHook('afterOnCellContextMenu', event => this.onAfterOnCellContextMenu(event));
-    this.addHook('afterSelection', (...params) => this.onAfterSelection(...params));
 
     super.enablePlugin();
   }
@@ -201,7 +200,6 @@ class ContextMenu extends BasePlugin {
     }
 
     this.prepareMenuItems();
-
     this.menu.open();
 
     if (!this.menu.isOpened()) {
@@ -304,17 +302,6 @@ class ContextMenu extends BasePlugin {
 
     // Register all commands. Predefined and added by user or by plugins
     arrayEach(menuItems, command => this.commandExecutor.registerCommand(command.key, command));
-  }
-
-  /**
-   * Callback for the `afterSelection` hook.
-   *
-   * @private
-   */
-  onAfterSelection() {
-    if (this.menu.isOpened()) {
-      this.menu.close();
-    }
   }
 
   /**

--- a/src/plugins/contextMenu/menu.js
+++ b/src/plugins/contextMenu/menu.js
@@ -175,7 +175,7 @@ class Menu {
         renderer: (hot, TD, row, col, prop, value) => this.menuItemRenderer(hot, TD, row, col, prop, value)
       }],
       renderAllRows: true,
-      fragmentSelection: 'cell',
+      fragmentSelection: false,
       disableVisualSelection: 'area',
       beforeKeyDown: event => this.onBeforeKeyDown(event),
       afterOnCellMouseOver: (event, coords) => {

--- a/src/plugins/contextMenu/menu.js
+++ b/src/plugins/contextMenu/menu.js
@@ -83,6 +83,24 @@ class Menu {
   }
 
   /**
+   * Returns currently selected menu item. Returns `null` if no item was selected.
+   *
+   * @returns {Object|null}
+   */
+  getSelectedItem() {
+    return this.hasSelectedItem() ? this.hotMenu.getSourceDataAtRow(this.hotMenu.getSelectedLast()[0]) : null;
+  }
+
+  /**
+   * Checks if the menu has selected (highlighted) any item from the menu list.
+   *
+   * @returns {Boolean}
+   */
+  hasSelectedItem() {
+    return Array.isArray(this.hotMenu.getSelectedLast());
+  }
+
+  /**
    * Set offset menu position for specified area (`above`, `below`, `left` or `right`).
    *
    * @param {String} area Specified area name (`above`, `below`, `left` or `right`).
@@ -134,6 +152,8 @@ class Menu {
 
     filteredItems = filterSeparators(filteredItems, SEPARATOR);
 
+    let shouldAutoCloseMenu = false;
+
     const settings = {
       data: filteredItems,
       colHeaders: false,
@@ -168,12 +188,32 @@ class Menu {
       rowHeights: row => (filteredItems[row].name === SEPARATOR ? 1 : 23),
       afterOnCellContextMenu: (event) => {
         event.preventDefault();
-        stopImmediatePropagation(event);
-        this.executeCommand(event);
+
+        if (this.hasSelectedItem()) {
+          this.executeCommand(event);
+
+          if (!this.isCommandPassive(this.getSelectedItem())) {
+            this.close(true);
+          }
+        }
       },
       beforeOnCellMouseUp: (event) => {
-        stopImmediatePropagation(event);
-        this.executeCommand(event);
+        if (this.hasSelectedItem()) {
+          shouldAutoCloseMenu = !this.isCommandPassive(this.getSelectedItem());
+          this.executeCommand(event);
+        }
+      },
+      afterOnCellMouseUp: () => {
+        if (shouldAutoCloseMenu && this.hasSelectedItem()) {
+          this.close(true);
+        }
+      },
+      afterUnlisten: () => {
+        // Restore menu focus, fix for `this.instance.unlisten();` call in the tableView.js@260 file.
+        // This prevents losing table responsiveness for keyboard events when filter select menu is closed (#6497).
+        if (!this.hasSelectedItem() && this.isOpened()) {
+          this.hotMenu.listen();
+        }
       },
     };
     this.origOutsideClickDeselects = this.hot.getSettings().outsideClickDeselects;
@@ -196,6 +236,7 @@ class Menu {
     if (!this.isOpened()) {
       return;
     }
+
     if (closeParent && this.parentMenu) {
       this.parentMenu.close();
     } else {
@@ -308,36 +349,42 @@ class Menu {
    * @param {Event} [event]
    */
   executeCommand(event) {
-    if (!this.isOpened() || !this.hotMenu.getSelectedLast()) {
+    if (!this.isOpened() || !this.hasSelectedItem()) {
       return;
     }
-    const selectedItem = this.hotMenu.getSourceDataAtRow(this.hotMenu.getSelectedLast()[0]);
+    const selectedItem = this.getSelectedItem();
 
     this.runLocalHooks('select', selectedItem, event);
 
-    if (selectedItem.isCommand === false || selectedItem.name === SEPARATOR) {
+    if (this.isCommandPassive(selectedItem)) {
       return;
     }
+
     const selRanges = this.hot.getSelectedRange();
     const normalizedSelection = selRanges ? normalizeSelection(selRanges) : [];
-    let autoClose = true;
-
-    // Don't close context menu if item is disabled or it has submenu
-    if (selectedItem.disabled === true ||
-        (typeof selectedItem.disabled === 'function' && selectedItem.disabled.call(this.hot) === true) ||
-        selectedItem.submenu) {
-      autoClose = false;
-    }
 
     this.runLocalHooks('executeCommand', selectedItem.key, normalizedSelection, event);
 
     if (this.isSubMenu()) {
       this.parentMenu.runLocalHooks('executeCommand', selectedItem.key, normalizedSelection, event);
     }
+  }
 
-    if (autoClose) {
-      this.close(true);
-    }
+  /**
+   * Checks if the passed command is passive or not. The command is passive when it's marked as
+   * disabled, the descriptor object contains `isCommand` property set to `false`, command
+   * is a separator, or the item is recognized as submenu. For passive items the menu is not
+   * closed automatically after the user trigger the command through the UI.
+   *
+   * @param {Object} commandDescriptor Selected menu item from the menu data source.
+   * @returns {Boolean}
+   */
+  isCommandPassive(commandDescriptor) {
+    const { isCommand, name: commandName, disabled, submenu } = commandDescriptor;
+
+    const isDisable = disabled === true || (typeof disabled === 'function' && disabled.call(this.hot) === true);
+
+    return isCommand === false || commandName === SEPARATOR || isDisable === true || submenu;
   }
 
   /**

--- a/src/plugins/contextMenu/menu.js
+++ b/src/plugins/contextMenu/menu.js
@@ -382,9 +382,9 @@ class Menu {
   isCommandPassive(commandDescriptor) {
     const { isCommand, name: commandName, disabled, submenu } = commandDescriptor;
 
-    const isDisable = disabled === true || (typeof disabled === 'function' && disabled.call(this.hot) === true);
+    const isDisabled = disabled === true || (typeof disabled === 'function' && disabled.call(this.hot) === true);
 
-    return isCommand === false || commandName === SEPARATOR || isDisable === true || submenu;
+    return isCommand === false || commandName === SEPARATOR || isDisabled === true || submenu;
   }
 
   /**

--- a/src/plugins/contextMenu/menu.js
+++ b/src/plugins/contextMenu/menu.js
@@ -175,7 +175,7 @@ class Menu {
         renderer: (hot, TD, row, col, prop, value) => this.menuItemRenderer(hot, TD, row, col, prop, value)
       }],
       renderAllRows: true,
-      fragmentSelection: false,
+      fragmentSelection: 'cell',
       disableVisualSelection: 'area',
       beforeKeyDown: event => this.onBeforeKeyDown(event),
       afterOnCellMouseOver: (event, coords) => {

--- a/src/plugins/contextMenu/menu.js
+++ b/src/plugins/contextMenu/menu.js
@@ -382,9 +382,9 @@ class Menu {
   isCommandPassive(commandDescriptor) {
     const { isCommand, name: commandName, disabled, submenu } = commandDescriptor;
 
-    const isDisabled = disabled === true || (typeof disabled === 'function' && disabled.call(this.hot) === true);
+    const isItemDisabled = disabled === true || (typeof disabled === 'function' && disabled.call(this.hot) === true);
 
-    return isCommand === false || commandName === SEPARATOR || isDisabled === true || submenu;
+    return isCommand === false || commandName === SEPARATOR || isItemDisabled === true || submenu;
   }
 
   /**

--- a/src/plugins/contextMenu/test/contextMenu.e2e.js
+++ b/src/plugins/contextMenu/test/contextMenu.e2e.js
@@ -3106,6 +3106,7 @@ describe('ContextMenu', () => {
       expect(callback.calls.count()).toEqual(0);
 
       item.simulate('contextmenu');
+
       expect(callback.calls.count()).toEqual(1);
     });
 
@@ -3125,6 +3126,7 @@ describe('ContextMenu', () => {
       contextMenu();
 
       $('.htContextMenu .ht_master .htCore').find('tbody td:eq(0)').simulate('mousedown').simulate('contextmenu');
+
       expect($('.htContextMenu').is(':visible')).toBe(false);
     });
   });

--- a/src/plugins/filters/filters.js
+++ b/src/plugins/filters/filters.js
@@ -708,8 +708,8 @@ class Filters extends BasePlugin {
     const operationType = this.conditionCollection.columnTypes[column];
 
     if (conditionsByValue.length === 2 || conditionsWithoutByValue.length === 3) {
-      warn(toSingleLine`The filter conditions have been applied properly, but couldn’t be displayed visually. 
-        The overall amount of conditions exceed the capability of the dropdown menu. 
+      warn(toSingleLine`The filter conditions have been applied properly, but couldn’t be displayed visually.\x20
+        The overall amount of conditions exceed the capability of the dropdown menu.\x20
         For more details see the documentation.`);
 
     } else {

--- a/src/plugins/filters/test/filtersUI.e2e.js
+++ b/src/plugins/filters/test/filtersUI.e2e.js
@@ -404,6 +404,30 @@ describe('Filters UI', () => {
       }, 200);
     });
 
+    it('should focus dropdown menu after closing select component', () => {
+      handsontable({
+        data: getDataForFilters(),
+        columns: getColumnsForFilters(),
+        dropdownMenu: true,
+        filters: true,
+        width: 500,
+        height: 300
+      });
+
+      dropdownMenu(1);
+      $(dropdownMenuRootElement().querySelector('.htUISelect')).simulate('click');
+      // is empty (test for condition which doesn't have input elements to provide filtered values)
+      $(conditionMenuRootElements().first.querySelector('tbody :nth-child(3) td')).simulate('mousedown').simulate('mouseup');
+
+      expect(getPlugin('dropdownMenu').menu.hotMenu.isListening()).toBe(true);
+
+      // is equal to (test for condition which has input elements to provide filtered values, that focusable elements
+      // can cause the menu focus)
+      $(conditionMenuRootElements().first.querySelector('tbody :nth-child(6) td')).simulate('mousedown').simulate('mouseup');
+
+      expect(getPlugin('dropdownMenu').menu.hotMenu.isListening()).toBe(true);
+    });
+
     it('shouldn\'t disappear dropdown menu after conditional options menu click', () => {
       handsontable({
         data: getDataForFilters(),
@@ -710,6 +734,33 @@ describe('Filters UI', () => {
       // does not steal the components' element while recalculating column width (PR #5555).
       expect(dropdownMenuRootElement().querySelector('.htFiltersMenuValue .htFiltersMenuLabel').textContent).toBe('Filter by value:');
       expect(dropdownMenuRootElement().querySelector('.htFiltersMenuValue .htUIMultipleSelect')).not.toBeNull();
+    });
+
+    it('should not scroll the view after selecting the item (test for checking if the event bubbling is not blocked, #6497)', async() => {
+      handsontable({
+        data: getDataForFilters().slice(0, 15),
+        columns: getColumnsForFilters(),
+        dropdownMenu: true,
+        filters: true,
+        width: 500,
+        height: 300
+      });
+
+      dropdownMenu(2);
+
+      await sleep(200);
+
+      $(byValueBoxRootElement()).find('tr:nth-child(1) :checkbox').simulate('mousedown').simulate('mouseup').simulate('click');
+
+      expect($(byValueBoxRootElement()).find('.ht_master .wtHolder').scrollTop()).toBe(0);
+
+      $(byValueBoxRootElement()).find('tr:nth-child(5) :checkbox').simulate('mouseover');
+      $(byValueBoxRootElement()).find('tr:nth-child(6) :checkbox').simulate('mouseover');
+      $(byValueBoxRootElement()).find('tr:nth-child(7) :checkbox').simulate('mouseover');
+
+      await sleep(200);
+
+      expect($(byValueBoxRootElement()).find('.ht_master .wtHolder').scrollTop()).toBe(0);
     });
 
     it('should display empty values as "(Blank cells)"', () => {

--- a/src/plugins/filters/ui/select.js
+++ b/src/plugins/filters/ui/select.js
@@ -161,7 +161,6 @@ class SelectUI extends BaseUI {
   onMenuSelect(command) {
     if (command.name !== SEPARATOR) {
       this.options.value = command;
-      this.closeOptions();
       this.update();
       this.runLocalHooks('select', this.options.value);
     }


### PR DESCRIPTION
# Context
<!--- Why is this change required? What problem does it solve? -->
Canceling event bubbling causes a bug that prevents child components such as "Filter by condition" to interact appropriately on mouse events. These changes remove that limit.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #6497
2. #6304

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
