### PR TITLE
Fix an issue where the cursor was stuck in the filter component

### DIFF
--- a/src/plugins/contextMenu/menu.js
+++ b/src/plugins/contextMenu/menu.js
@@ -5,6 +5,7 @@ import {
   fastInnerHTML,
   getScrollbarWidth,
   isChildOf,
+  isInput,
   removeClass,
   getParentWindow,
 } from './../../helpers/dom/element';
@@ -670,6 +671,14 @@ class Menu {
    * @param {Event} event
    */
   onBeforeKeyDown(event) {
+    // For input elements, prevent event propagation. It allows entering text into an input
+    // element freely - without steeling the key events from the menu module (#6506).
+    if (isInput(event.target)) {
+      stopImmediatePropagation(event);
+
+      return;
+    }
+
     const selection = this.hotMenu.getSelectedLast();
     let stopEvent = false;
     this.keyEvent = true;

--- a/src/plugins/filters/test/filtersUI.e2e.js
+++ b/src/plugins/filters/test/filtersUI.e2e.js
@@ -230,6 +230,31 @@ describe('Filters UI', () => {
       ]);
     });
 
+    it('should not select dropdown menu item while pressing arrow up key when filter\'s input component is focused (#6506)', async() => {
+      handsontable({
+        data: getDataForFilters(),
+        columns: getColumnsForFilters(),
+        filters: true,
+        dropdownMenu: true,
+        width: 500,
+        height: 300,
+      });
+
+      dropdownMenu(2);
+      $(dropdownMenuRootElement().querySelector('.htUISelect')).simulate('mousedown').simulate('mouseup').simulate('click');
+      // "Is equal to"
+      $(conditionMenuRootElements().first.querySelector('tbody :nth-child(6) td')).simulate('mousedown').simulate('mouseup').simulate('click');
+
+      await sleep(100); // Wait for autofocus of the filter input element
+
+      document.activeElement.value = '123';
+
+      keyDownUp('arrow_up');
+      keyDownUp('arrow_up');
+
+      expect(getPlugin('dropdownMenu').menu.hasSelectedItem()).toBe(false);
+    });
+
     it('should appear specified conditional options menu depends on cell types when table has all filtered rows', () => {
       handsontable({
         data: getDataForFilters(),

--- a/src/plugins/filters/test/filtersUI.e2e.js
+++ b/src/plugins/filters/test/filtersUI.e2e.js
@@ -359,7 +359,7 @@ describe('Filters UI', () => {
     });
 
     it('should disappear dropdown menu after hitting ESC key in conditional component ' +
-      'which don\'t show other input and focus is loosen #86', (done) => {
+      'which don\'t show other input and focus is loosen #86', async() => {
       handsontable({
         data: getDataForFilters(),
         columns: getColumnsForFilters(),
@@ -369,20 +369,31 @@ describe('Filters UI', () => {
         height: 300
       });
 
-      dropdownMenu(1);
-      $(dropdownMenuRootElement().querySelector('.htUISelect')).simulate('click');
-      $(conditionMenuRootElements().first).find('tbody td:contains("Is empty")').simulate('mousedown').simulate('mouseup');
+      const button = hot().view.wt.wtTable.getColumnHeader(1).querySelector('.changeType');
 
-      setTimeout(() => {
-        keyDownUp('esc');
+      $(button).simulate('mousedown');
 
-        expect($(conditionMenuRootElements().first).is(':visible')).toBe(false);
-        expect($(dropdownMenuRootElement()).is(':visible')).toBe(false);
-        done();
-      }, 200);
+      // This sleep emulates more realistic user behavior. The `mouseup` event in all cases is not
+      // triggered directly after the `mousedown` event. First of all, a user is not able to
+      // click so fast. Secondly, there can be a device lag between `mousedown` and `mouseup`
+      // events. This fixes an issue related to failing test, which works on browser under
+      // user control but fails while automatic tests.
+      await sleep(0);
+
+      $(button).simulate('mouseup');
+      $(button).simulate('click');
+
+      $(dropdownMenuRootElement().querySelector('.htUISelect')).simulate('mousedown').simulate('mouseup').simulate('click');
+      $(conditionMenuRootElements().first).find('tbody td:contains("Is empty")').simulate('mousedown').simulate('mouseup').simulate('click');
+
+      await sleep(200);
+      keyDownUp('esc');
+
+      expect($(conditionMenuRootElements().first).is(':visible')).toBe(false);
+      expect($(dropdownMenuRootElement()).is(':visible')).toBe(false);
     });
 
-    it('should disappear dropdown menu after hitting ESC key, next to closing SelectUI #149', (done) => {
+    it('should disappear dropdown menu after hitting ESC key, next to closing SelectUI #149', async() => {
       handsontable({
         data: getDataForFilters(),
         columns: getColumnsForFilters(),
@@ -392,16 +403,29 @@ describe('Filters UI', () => {
         height: 300
       });
 
-      dropdownMenu(1);
-      $(dropdownMenuRootElement().querySelector('.htUISelect')).simulate('click');
+      const button = hot().view.wt.wtTable.getColumnHeader(1).querySelector('.changeType');
 
-      setTimeout(() => {
-        keyDownUp('esc');
-        keyDownUp('esc');
-        expect($(conditionMenuRootElements().first).is(':visible')).toBe(false);
-        expect($(dropdownMenuRootElement()).is(':visible')).toBe(false);
-        done();
-      }, 200);
+      $(button).simulate('mousedown');
+
+      // This sleep emulates more realistic user behavior. The `mouseup` event in all cases is not
+      // triggered directly after the `mousedown` event. First of all, a user is not able to
+      // click so fast. Secondly, there can be a device lag between `mousedown` and `mouseup`
+      // events. This fixes an issue related to failing test, which works on browser under
+      // user control but fails while automatic tests.
+      await sleep(0);
+
+      $(button).simulate('mouseup');
+      $(button).simulate('click');
+
+      $(dropdownMenuRootElement().querySelector('.htUISelect')).simulate('mousedown').simulate('mouseup').simulate('click');
+
+      await sleep(200);
+
+      keyDownUp('esc');
+      keyDownUp('esc');
+
+      expect($(conditionMenuRootElements().first).is(':visible')).toBe(false);
+      expect($(dropdownMenuRootElement()).is(':visible')).toBe(false);
     });
 
     it('should focus dropdown menu after closing select component', () => {

--- a/test/helpers/common.js
+++ b/test/helpers/common.js
@@ -418,7 +418,7 @@ export function handsontableKeyTriggerFactory(type) {
     } else if (typeof keyToTrigger === 'number') {
       ev.keyCode = keyToTrigger;
     }
-    //    ev.originalEvent = {}; //needed as long Handsontable searches for event.originalEvent
+
     $.extend(ev, extend);
     $(document.activeElement).simulate(type, ev);
   };

--- a/test/helpers/common.js
+++ b/test/helpers/common.js
@@ -242,7 +242,6 @@ export async function selectContextSubmenuOption(submenuName, optionName) {
 
 export function closeContextMenu() {
   $(document).simulate('mousedown');
-  // $(document).trigger('mousedown');
 }
 
 /**


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Cursor in the dropdown menu of the filter component sometimes stuck and doesn't want to move. This PR resolves that issue by adding additional checking of the key events. If the event is triggered by INPUT-ish element which belongs to the menu root element than stop propagation is executed. This allows users to interact with an input element without distraction.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #6506

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
