### PR TITLE
Fix afterRowMove .d.ts args

### DIFF
--- a/handsontable.d.ts
+++ b/handsontable.d.ts
@@ -1823,7 +1823,7 @@ declare namespace Handsontable {
       afterRemoveRow?: (index: number, amount: number, physicalColumns: number[], source?: ChangeSource) => void;
       afterRender?: (isForced: boolean) => void;
       afterRenderer?: (TD: HTMLTableCellElement, row: number, col: number, prop: string | number, value: string, cellProperties: CellProperties) => void;
-      afterRowMove?: (startRow: number, endRow: number) => void;
+      afterRowMove?: (rows: number[], target: number) => void;
       afterRowResize?: (newSize: number, row: number, isDoubleClick: boolean) => void;
       afterScrollHorizontally?: () => void;
       afterScrollVertically?: () => void;

--- a/test/types/settings.types.ts
+++ b/test/types/settings.types.ts
@@ -408,7 +408,7 @@ const allSettings: Required<Handsontable.GridSettings> = {
   afterRemoveRow: (index, amount, physicalRows = [1, 2, 3], source) => {},
   afterRender: (isForced) => {},
   afterRenderer: (TD, row, col, prop, value, cellProperties) => {},
-  afterRowMove: (startRow, endRow) => {},
+  afterRowMove: (rows, target) => rows.forEach(row => row.toFixed(1) === target.toFixed(1)),
   afterRowResize: (newSize, row, isDoubleClick) => {},
   afterScrollHorizontally: () => {},
   afterScrollVertically: () => {},


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
`afterRowMove` args have wrong types [per docs](https://handsontable.com/docs/7.2.2/Hooks.html#event:afterRowMove)

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
`npm run test:types` and inspecting args at runtime

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
