### PR TITLE
Fix focus losing of the filter component's input element

### DIFF
--- a/src/plugins/contextMenu/menu.js
+++ b/src/plugins/contextMenu/menu.js
@@ -213,7 +213,7 @@ class Menu {
         // Restore menu focus, fix for `this.instance.unlisten();` call in the tableView.js@260 file.
         // This prevents losing table responsiveness for keyboard events when filter select menu is closed (#6497).
         if (!this.hasSelectedItem() && this.isOpened()) {
-          this.hotMenu.listen();
+          this.hotMenu.listen(false);
         }
       },
     };

--- a/src/plugins/filters/test/filtersUI.e2e.js
+++ b/src/plugins/filters/test/filtersUI.e2e.js
@@ -477,6 +477,31 @@ describe('Filters UI', () => {
       expect(getPlugin('dropdownMenu').menu.hotMenu.isListening()).toBe(true);
     });
 
+    it('should not blur filter component\'s input element when it is clicked', async() => {
+      handsontable({
+        data: getDataForFilters(),
+        columns: getColumnsForFilters(),
+        dropdownMenu: true,
+        filters: true,
+        width: 500,
+        height: 300
+      });
+
+      dropdownMenu(1);
+      $(dropdownMenuRootElement().querySelector('.htUISelect')).simulate('mousedown').simulate('mouseup').simulate('click');
+      // "Is equal to"
+      $(conditionMenuRootElements().first.querySelector('tbody :nth-child(6) td')).simulate('mousedown').simulate('mouseup').simulate('click');
+
+      // The input element is focused asynchronously from the filter plugin code.
+      await sleep(50);
+
+      const inputElement = dropdownMenuRootElement().querySelector('.htUIInput input');
+
+      $(inputElement).simulate('mousedown').simulate('mouseup').simulate('click');
+
+      expect(document.activeElement).toBe(inputElement);
+    });
+
     it('shouldn\'t disappear dropdown menu after conditional options menu click', () => {
       handsontable({
         data: getDataForFilters(),


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
This PR fixes a bug that was introduced while fixing another bug (https://github.com/handsontable/handsontable/pull/6521). The filter component's input loses its focus after clicking them.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Added a new test that covers that behavior.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #6530
2. #6506

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
