### PR TITLE
Fix submenu selection

### DIFF
--- a/src/plugins/contextMenu/menu.js
+++ b/src/plugins/contextMenu/menu.js
@@ -177,6 +177,7 @@ class Menu {
       }],
       renderAllRows: true,
       fragmentSelection: false,
+      outsideClickDeselects: false,
       disableVisualSelection: 'area',
       beforeKeyDown: event => this.onBeforeKeyDown(event),
       afterOnCellMouseOver: (event, coords) => {

--- a/src/plugins/contextMenu/test/contextMenu.e2e.js
+++ b/src/plugins/contextMenu/test/contextMenu.e2e.js
@@ -1834,6 +1834,40 @@ describe('ContextMenu', () => {
       expect($('.htContextMenu').is(':visible')).toBe(true);
     });
 
+    it('should not deselect submenu while selecting child items', async() => {
+      handsontable({
+        data: createSpreadsheetData(4, 4),
+        contextMenu: ['row_above', 'remove_row', '---------', 'alignment'],
+        height: 400
+      });
+
+      selectCell(1, 0, 3, 0);
+      contextMenu();
+
+      $('.htContextMenu .ht_master .htCore tbody td')
+        .not('.htSeparator')
+        .eq(2) // "Alignment"
+        .simulate('mousemove')
+        .simulate('mouseover')
+        .simulate('mousedown')
+        .simulate('mouseup')
+        .simulate('click')
+        .simulate('mouseout');
+
+      // wait for a debounced delay in the appearing sub-menu
+      await sleep(500);
+
+      $('.htContextMenuSub_Alignment .ht_master .htCore tbody td')
+        .not('.htSeparator')
+        .eq(0) // "Left"
+        .simulate('mousemove')
+        .simulate('mouseover')
+        .simulate('mousedown'); // Without finishing LMB
+
+      // The selection of the ContextMenu should be active and pointed to "alignment" item
+      expect(getPlugin('contextMenu').menu.getSelectedItem().key).toBe('alignment');
+    });
+
     it('should make a group of selected cells read-only, if all of them are writable (reverse selection)', () => {
       const hot = handsontable({
         data: createSpreadsheetData(4, 4),

--- a/src/plugins/filters/test/filtersUI.e2e.js
+++ b/src/plugins/filters/test/filtersUI.e2e.js
@@ -251,8 +251,10 @@ describe('Filters UI', () => {
 
       keyDownUp('arrow_up');
       keyDownUp('arrow_up');
+      keyDownUp('arrow_up');
 
-      expect(getPlugin('dropdownMenu').menu.hasSelectedItem()).toBe(false);
+      // The menu item is frozen on the lastly selected item
+      expect(getPlugin('dropdownMenu').menu.getSelectedItem().key).toBe('filter_by_condition');
     });
 
     it('should appear specified conditional options menu depends on cell types when table has all filtered rows', () => {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
While moving the mouse through a submenu, the parent menu item loses its highlight. It turned out that the Handsontable internally deselect cell on `mouseup` event. I've applied for the menu `outsideClickDeselects` option to `false` which disables deselecting menu items.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Test manually and added a new test that covers this change.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #6508 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
