### PR TITLE
Fix onCellMouseUp and onCellDblClick Walkontable hooks

### DIFF
--- a/src/3rdparty/walkontable/src/event.js
+++ b/src/3rdparty/walkontable/src/event.js
@@ -174,7 +174,8 @@ class Event {
       this.instance.getSetting('onCellMouseDown', event, cell.coords, cell.TD, this.instance);
     }
 
-    if (event.button !== 2 && cell.TD) { // if not right mouse button
+    // doubleclick reacts only for left mouse button
+    if (event.button === 0 && cell.TD) {
       priv.dblClickOrigin[0] = cell.TD;
 
       clearTimeout(priv.dblClickTimeout[0]);
@@ -250,16 +251,16 @@ class Event {
    * @param {MouseEvent} event
    */
   onMouseUp(event) {
-    if (event.button === 2) {
-      return;
-    }
-
-    // if not right mouse button
     const priv = privatePool.get(this);
     const cell = this.parentCell(event.realTarget);
 
     if (cell.TD && this.instance.hasSetting('onCellMouseUp')) {
       this.instance.getSetting('onCellMouseUp', event, cell.coords, cell.TD, this.instance);
+    }
+
+    // if not left mouse button, then ignore
+    if (event.button !== 0) {
+      return;
     }
 
     if (cell.TD === priv.dblClickOrigin[0] && cell.TD === priv.dblClickOrigin[1]) {

--- a/src/3rdparty/walkontable/test/spec/event.spec.js
+++ b/src/3rdparty/walkontable/test/spec/event.spec.js
@@ -22,39 +22,136 @@ describe('WalkontableEvent', () => {
   });
 
   it('should call `onCellMouseDown` callback', () => {
-    let myCoords = null;
-    let myTD = null;
+    const onCellMouseDown = jasmine.createSpy('onCellMouseDown');
     const wt = walkontable({
       data: getData,
       totalRows: getTotalRows,
       totalColumns: getTotalColumns,
-      onCellMouseDown(event, coords, TD) {
-        myCoords = coords;
-        myTD = TD;
-      }
+      onCellMouseDown,
     });
 
     wt.draw();
 
-    const $td = spec().$table.find('tbody tr:eq(1) td:eq(1)');
+    {
+      const $td = spec().$table.find('tbody tr:eq(1) td:eq(1)');
+      const button = 0;
 
-    $td.simulate('mousedown');
+      $td
+        .simulate('mouseover', { button })
+        .simulate('mousemove', { button })
+        .simulate('mousedown', { button })
+        .simulate('mouseup', { button })
+        .simulate('click', { button })
+      ;
 
-    expect(myCoords).toEqual(new Walkontable.CellCoords(1, 1));
-    expect(myTD).toEqual($td[0]);
+      expect(onCellMouseDown).toHaveBeenCalledWith(jasmine.any(MouseEvent), new Walkontable.CellCoords(1, 1), $td[0], jasmine.any(wt.constructor));
+      expect(onCellMouseDown).toHaveBeenCalledTimes(1);
+    }
+
+    {
+      const $td = spec().$table.find('tbody tr:eq(2) td:eq(2)');
+      const button = 1;
+
+      onCellMouseDown.calls.reset();
+      $td
+        .simulate('mouseover', { button })
+        .simulate('mousemove', { button })
+        .simulate('mousedown', { button })
+        .simulate('mouseup', { button })
+        .simulate('click', { button })
+      ;
+
+      expect(onCellMouseDown).toHaveBeenCalledWith(jasmine.any(MouseEvent), new Walkontable.CellCoords(2, 2), $td[0], jasmine.any(wt.constructor));
+      expect(onCellMouseDown).toHaveBeenCalledTimes(1);
+    }
+
+    {
+      const $td = spec().$table.find('tbody tr:eq(3) td:eq(3)');
+      const button = 2;
+
+      onCellMouseDown.calls.reset();
+      $td
+        .simulate('mouseover', { button })
+        .simulate('mousemove', { button })
+        .simulate('mousedown', { button })
+        .simulate('mouseup', { button })
+        .simulate('click', { button })
+      ;
+
+      expect(onCellMouseDown).toHaveBeenCalledWith(jasmine.any(MouseEvent), new Walkontable.CellCoords(3, 3), $td[0], jasmine.any(wt.constructor));
+      expect(onCellMouseDown).toHaveBeenCalledTimes(1);
+    }
   });
 
-  it('should call `onCellContextMenu` callback', () => {
-    let myCoords = null;
-    let myTD = null;
+  it('should call `onCellMouseUp` callback', () => {
+    const onCellMouseUp = jasmine.createSpy('onCellMouseUp');
     const wt = walkontable({
       data: getData,
       totalRows: getTotalRows,
       totalColumns: getTotalColumns,
-      onCellContextMenu(event, coords, TD) {
-        myCoords = coords;
-        myTD = TD;
-      }
+      onCellMouseUp,
+    });
+
+    wt.draw();
+
+    {
+      const $td = spec().$table.find('tbody tr:eq(1) td:eq(1)');
+      const button = 0;
+
+      $td
+        .simulate('mouseover', { button })
+        .simulate('mousemove', { button })
+        .simulate('mousedown', { button })
+        .simulate('mouseup', { button })
+        .simulate('click', { button })
+      ;
+
+      expect(onCellMouseUp).toHaveBeenCalledWith(jasmine.any(MouseEvent), new Walkontable.CellCoords(1, 1), $td[0], jasmine.any(wt.constructor));
+      expect(onCellMouseUp).toHaveBeenCalledTimes(1);
+    }
+
+    {
+      const $td = spec().$table.find('tbody tr:eq(2) td:eq(2)');
+      const button = 1;
+
+      onCellMouseUp.calls.reset();
+      $td
+        .simulate('mouseover', { button })
+        .simulate('mousemove', { button })
+        .simulate('mousedown', { button })
+        .simulate('mouseup', { button })
+        .simulate('click', { button })
+      ;
+
+      expect(onCellMouseUp).toHaveBeenCalledWith(jasmine.any(MouseEvent), new Walkontable.CellCoords(2, 2), $td[0], jasmine.any(wt.constructor));
+      expect(onCellMouseUp).toHaveBeenCalledTimes(1);
+    }
+
+    {
+      const $td = spec().$table.find('tbody tr:eq(3) td:eq(3)');
+      const button = 2;
+
+      onCellMouseUp.calls.reset();
+      $td
+        .simulate('mouseover', { button })
+        .simulate('mousemove', { button })
+        .simulate('mousedown', { button })
+        .simulate('mouseup', { button })
+        .simulate('click', { button })
+      ;
+
+      expect(onCellMouseUp).toHaveBeenCalledWith(jasmine.any(MouseEvent), new Walkontable.CellCoords(3, 3), $td[0], jasmine.any(wt.constructor));
+      expect(onCellMouseUp).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it('should call `onCellContextMenu` callback', () => {
+    const onCellContextMenu = jasmine.createSpy('onCellContextMenu');
+    const wt = walkontable({
+      data: getData,
+      totalRows: getTotalRows,
+      totalColumns: getTotalColumns,
+      onCellContextMenu,
     });
 
     wt.draw();
@@ -63,40 +160,79 @@ describe('WalkontableEvent', () => {
 
     $td.simulate('contextmenu');
 
-    expect(myCoords).toEqual(new Walkontable.CellCoords(1, 1));
-    expect(myTD).toEqual($td[0]);
+    expect(onCellContextMenu).toHaveBeenCalledWith(jasmine.any(MouseEvent), new Walkontable.CellCoords(1, 1), $td[0], jasmine.any(wt.constructor));
+    expect(onCellContextMenu).toHaveBeenCalledTimes(1);
   });
 
   it('should call `onCellMouseOver` callback', () => {
-    let myCoords = null;
-    let myTD = null;
+    const onCellMouseOver = jasmine.createSpy('onCellMouseOver');
     const wt = walkontable({
       data: getData,
       totalRows: getTotalRows,
       totalColumns: getTotalColumns,
-      onCellMouseOver(event, coords, TD) {
-        myCoords = coords;
-        myTD = TD;
-      }
+      onCellMouseOver,
     });
 
     wt.draw();
 
-    const $td = spec().$table.find('tbody tr:eq(1) td:eq(1)');
+    {
+      const $td = spec().$table.find('tbody tr:eq(1) td:eq(1)');
+      const button = 0;
 
-    $td.simulate('mouseover');
+      $td
+        .simulate('mouseover', { button })
+        .simulate('mousemove', { button })
+        .simulate('mousedown', { button })
+        .simulate('mouseup', { button })
+        .simulate('click', { button })
+      ;
 
-    expect(myCoords).toEqual(new Walkontable.CellCoords(1, 1));
-    expect(myTD).toEqual($td[0]);
+      expect(onCellMouseOver).toHaveBeenCalledWith(jasmine.any(MouseEvent), new Walkontable.CellCoords(1, 1), $td[0], jasmine.any(wt.constructor));
+      expect(onCellMouseOver).toHaveBeenCalledTimes(1);
+    }
+
+    {
+      const $td = spec().$table.find('tbody tr:eq(2) td:eq(2)');
+      const button = 1;
+
+      onCellMouseOver.calls.reset();
+      $td
+        .simulate('mouseover', { button })
+        .simulate('mousemove', { button })
+        .simulate('mousedown', { button })
+        .simulate('mouseup', { button })
+        .simulate('click', { button })
+      ;
+
+      expect(onCellMouseOver).toHaveBeenCalledWith(jasmine.any(MouseEvent), new Walkontable.CellCoords(2, 2), $td[0], jasmine.any(wt.constructor));
+      expect(onCellMouseOver).toHaveBeenCalledTimes(1);
+    }
+
+    {
+      const $td = spec().$table.find('tbody tr:eq(3) td:eq(3)');
+      const button = 2;
+
+      onCellMouseOver.calls.reset();
+      $td
+        .simulate('mouseover', { button })
+        .simulate('mousemove', { button })
+        .simulate('mousedown', { button })
+        .simulate('mouseup', { button })
+        .simulate('click', { button })
+      ;
+
+      expect(onCellMouseOver).toHaveBeenCalledWith(jasmine.any(MouseEvent), new Walkontable.CellCoords(3, 3), $td[0], jasmine.any(wt.constructor));
+      expect(onCellMouseOver).toHaveBeenCalledTimes(1);
+    }
   });
 
   it('should call `onCellMouseOver` callback with correctly passed TD element when cell contains another table', () => {
-    const fn = jasmine.createSpy();
+    const onCellMouseOver = jasmine.createSpy('onCellMouseOver');
     const wt = walkontable({
       data: [['<table style="width: 50px;"><tr><td class="test">TEST</td></tr></table>']],
       totalRows: 1,
       totalColumns: 1,
-      onCellMouseOver: fn,
+      onCellMouseOver,
       cellRenderer(row, column, TD) {
         TD.innerHTML = wt.wtSettings.getSetting('data', row, column);
       },
@@ -109,40 +245,72 @@ describe('WalkontableEvent', () => {
 
     innerTD.simulate('mouseover');
 
-    expect(fn.calls.argsFor(0)[2]).toBe(outerTD[0]);
+    expect(onCellMouseOver.calls.argsFor(0)[2]).toBe(outerTD[0]);
   });
 
   it('should call `onCellMouseOut` callback', () => {
-    let myCoords = null;
-    let myTD = null;
+    const onCellMouseOut = jasmine.createSpy('onCellMouseOut');
     const wt = walkontable({
       data: getData,
       totalRows: getTotalRows,
       totalColumns: getTotalColumns,
-      onCellMouseOut(event, coords, TD) {
-        myCoords = coords;
-        myTD = TD;
-      }
+      onCellMouseOut,
     });
 
     wt.draw();
 
-    const $td = spec().$table.find('tbody tr:eq(1) td:eq(1)');
+    {
+      const $td = spec().$table.find('tbody tr:eq(1) td:eq(1)');
+      const button = 0;
 
-    $td.simulate('mouseover')
-      .simulate('mouseout');
+      $td
+        .simulate('mouseover', { button })
+        .simulate('mousemove', { button })
+        .simulate('mouseout', { button })
+      ;
 
-    expect(myCoords).toEqual(new Walkontable.CellCoords(1, 1));
-    expect(myTD).toEqual($td[0]);
+      expect(onCellMouseOut).toHaveBeenCalledWith(jasmine.any(MouseEvent), new Walkontable.CellCoords(1, 1), $td[0], jasmine.any(wt.constructor));
+      expect(onCellMouseOut).toHaveBeenCalledTimes(1);
+    }
+
+    {
+      const $td = spec().$table.find('tbody tr:eq(2) td:eq(2)');
+      const button = 1;
+
+      onCellMouseOut.calls.reset();
+      $td
+        .simulate('mouseover', { button })
+        .simulate('mousemove', { button })
+        .simulate('mouseout', { button })
+      ;
+
+      expect(onCellMouseOut).toHaveBeenCalledWith(jasmine.any(MouseEvent), new Walkontable.CellCoords(2, 2), $td[0], jasmine.any(wt.constructor));
+      expect(onCellMouseOut).toHaveBeenCalledTimes(1);
+    }
+
+    {
+      const $td = spec().$table.find('tbody tr:eq(3) td:eq(3)');
+      const button = 2;
+
+      onCellMouseOut.calls.reset();
+      $td
+        .simulate('mouseover', { button })
+        .simulate('mousemove', { button })
+        .simulate('mouseout', { button })
+      ;
+
+      expect(onCellMouseOut).toHaveBeenCalledWith(jasmine.any(MouseEvent), new Walkontable.CellCoords(3, 3), $td[0], jasmine.any(wt.constructor));
+      expect(onCellMouseOut).toHaveBeenCalledTimes(1);
+    }
   });
 
   it('should call `onCellMouseOut` callback with correctly passed TD element when cell contains another table', () => {
-    const fn = jasmine.createSpy();
+    const onCellMouseOut = jasmine.createSpy('onCellMouseOut');
     const wt = walkontable({
       data: [['<table style="width: 50px;"><tr><td class="test">TEST</td></tr></table>']],
       totalRows: 1,
       totalColumns: 1,
-      onCellMouseOut: fn,
+      onCellMouseOut,
       cellRenderer(row, column, TD) {
         TD.innerHTML = wt.wtSettings.getSetting('data', row, column);
       },
@@ -154,40 +322,86 @@ describe('WalkontableEvent', () => {
 
     spec().$table.find('tbody td.test')
       .simulate('mouseover')
-      .simulate('mouseout');
+      .simulate('mousemove')
+      .simulate('mouseout')
+    ;
 
-    expect(fn.calls.argsFor(0)[2]).toBe(outerTD[0]);
+    expect(onCellMouseOut.calls.argsFor(0)[2]).toBe(outerTD[0]);
   });
 
-  it('should call `onCellDblClick` callback', () => {
-    let myCoords = null;
-    let myTD = null;
+  it('should call `onCellDblClick` callback but only for LMB', () => {
+    const onCellDblClick = jasmine.createSpy('onCellDblClick');
     const wt = walkontable({
       data: getData,
       totalRows: getTotalRows,
       totalColumns: getTotalColumns,
-      onCellDblClick(event, coords, TD) {
-        myCoords = coords;
-        myTD = TD;
-      }
+      onCellDblClick,
     });
 
     wt.draw();
 
-    const $td = spec().$table.find('tbody tr:eq(1) td:eq(1)');
+    {
+      const $td = spec().$table.find('tbody tr:eq(1) td:eq(1)');
+      const button = 0;
 
-    $td.simulate('mousedown')
-      .simulate('mouseup')
-      .simulate('mousedown')
-      .simulate('mouseup');
+      $td
+        .simulate('mousemove', { button })
+        .simulate('mousedown', { button })
+        .simulate('mouseup', { button })
+        .simulate('click', { button })
+        .simulate('mousedown', { button })
+        .simulate('mouseup', { button })
+        .simulate('click', { button })
+        .simulate('dblclick', { button })
+      ;
 
-    expect(myCoords).toEqual(new Walkontable.CellCoords(1, 1));
-    expect(myTD).toEqual($td[0]);
+      expect(onCellDblClick).toHaveBeenCalledWith(jasmine.any(MouseEvent), new Walkontable.CellCoords(1, 1), $td[0], jasmine.any(wt.constructor));
+      expect(onCellDblClick).toHaveBeenCalledTimes(1);
+    }
+
+    {
+      // Middle button click
+      const $td = spec().$table.find('tbody tr:eq(2) td:eq(2)');
+      const button = 1;
+
+      onCellDblClick.calls.reset();
+      $td
+        .simulate('mousemove', { button })
+        .simulate('mousedown', { button })
+        .simulate('mouseup', { button })
+        .simulate('click', { button })
+        .simulate('mousedown', { button })
+        .simulate('mouseup', { button })
+        .simulate('click', { button })
+        .simulate('dblclick', { button })
+      ;
+
+      expect(onCellDblClick).toHaveBeenCalledTimes(0);
+    }
+
+    {
+      // Right button click
+      const $td = spec().$table.find('tbody tr:eq(3) td:eq(3)');
+      const button = 2;
+
+      onCellDblClick.calls.reset();
+      $td
+        .simulate('mousemove', { button })
+        .simulate('mousedown', { button })
+        .simulate('mouseup', { button })
+        .simulate('click', { button })
+        .simulate('mousedown', { button })
+        .simulate('mouseup', { button })
+        .simulate('click', { button })
+        .simulate('dblclick', { button })
+      ;
+
+      expect(onCellDblClick).toHaveBeenCalledTimes(0);
+    }
   });
 
   it('should call `onCellDblClick` callback, even when it is set only after first click', () => {
-    let myCoords = null;
-    let myTD = null;
+    const onCellDblClick = jasmine.createSpy('onCellDblClick');
     const wt = walkontable({
       data: getData,
       totalRows: getTotalRows,
@@ -198,21 +412,27 @@ describe('WalkontableEvent', () => {
 
     const $td = spec().$table.find('tbody tr:eq(1) td:eq(1)');
 
-    $td.simulate('mousedown')
+    $td
+      .simulate('mousemove')
+      .simulate('mousedown')
       .simulate('mouseup')
-      .simulate('mousedown');
-    wt.update('onCellDblClick', (event, coords, TD) => {
-      myCoords = coords;
-      myTD = TD;
-    });
-    $td.simulate('mouseup');
+      .simulate('click')
+    ;
 
-    expect(myCoords).toEqual(new Walkontable.CellCoords(1, 1));
-    expect(myTD).toEqual($td[0]);
+    wt.update('onCellDblClick', onCellDblClick);
+
+    $td
+      .simulate('mousemove')
+      .simulate('mousedown')
+      .simulate('mouseup')
+      .simulate('click')
+    ;
+
+    expect(onCellDblClick).toHaveBeenCalledWith(jasmine.any(MouseEvent), new Walkontable.CellCoords(1, 1), $td[0], jasmine.any(wt.constructor));
   });
 
   it('should call `onCellMouseDown` callback when clicked on TH', () => {
-    let called = false;
+    const onCellMouseDown = jasmine.createSpy('onCellMouseDown');
     const wt = walkontable({
       data: getData,
       totalRows: getTotalRows,
@@ -220,100 +440,7 @@ describe('WalkontableEvent', () => {
       columnHeaders: [function(col, TH) {
         TH.innerHTML = col + 1;
       }],
-      onCellMouseDown() {
-        called = true;
-      }
-    });
-
-    wt.draw();
-
-    spec().$table.find('th:first').simulate('mousedown');
-
-    expect(called).toEqual(true);
-  });
-
-  it('should not call `onCellMouseDown` callback when clicked on the focusable element (column headers)', () => {
-    const opt = ['Maserati', 'Mazda', 'Mercedes', 'Mini', 'Mitsubishi'].map(value => `<option value="${value}">${value}</option>`).join('');
-    let called = false;
-    const wt = walkontable({
-      data: getData,
-      totalRows: getTotalRows,
-      totalColumns: getTotalColumns,
-      columnHeaders: [function(col, TH) {
-        TH.innerHTML = `#${col}<select>${opt}</select>`;
-      }],
-      onCellMouseDown() {
-        called = true;
-      }
-    });
-
-    wt.draw();
-
-    spec().$table.find('.ht_clone_top th:first select')
-      .focus()
-      .simulate('mousedown');
-
-    expect(called).toBe(false);
-  });
-
-  it('should not call `onCellMouseDown` callback when clicked on the focusable element (cell renderer)', () => {
-    const opt = ['Maserati', 'Mazda', 'Mercedes', 'Mini', 'Mitsubishi'].map(value => `<option value="${value}">${value}</option>`).join('');
-    let called = false;
-    const wt = walkontable({
-      data: getData,
-      totalRows: getTotalRows,
-      totalColumns: getTotalColumns,
-      cellRenderer(row, column, TD) {
-        TD.innerHTML = `<select>${opt}</select>`;
-      },
-      onCellMouseDown() {
-        called = true;
-      }
-    });
-
-    wt.draw();
-
-    spec().$table.find('td:first select')
-      .focus()
-      .simulate('mousedown');
-
-    expect(called).toBe(false);
-  });
-
-  it('should call `onCellMouseOver` callback when clicked on TH', () => {
-    let called = false;
-    const wt = walkontable({
-      data: getData,
-      totalRows: getTotalRows,
-      totalColumns: getTotalColumns,
-      columnHeaders: [function(col, TH) {
-        TH.innerHTML = col + 1;
-      }],
-      onCellMouseOver(event, coords) {
-        called = coords;
-      }
-    });
-
-    wt.draw();
-
-    spec().$table.find('th:first').simulate('mouseover');
-
-    expect(called.row).toEqual(-1);
-    expect(called.col).toEqual(0);
-  });
-
-  it('should call `onCellDblClick` callback when clicked on TH', () => {
-    let called = false;
-    const wt = walkontable({
-      data: getData,
-      totalRows: getTotalRows,
-      totalColumns: getTotalColumns,
-      columnHeaders: [function(col, TH) {
-        TH.innerHTML = col + 1;
-      }],
-      onCellDblClick() {
-        called = true;
-      }
+      onCellMouseDown,
     });
 
     wt.draw();
@@ -321,99 +448,139 @@ describe('WalkontableEvent', () => {
     spec().$table.find('th:first')
       .simulate('mousedown')
       .simulate('mouseup')
-      .simulate('mousedown')
-      .simulate('mouseup');
+      .simulate('click')
+    ;
 
-    expect(called).toEqual(true);
+    expect(onCellMouseDown).toHaveBeenCalledTimes(1);
   });
 
-  it('should not call `onCellDblClick` callback when right-clicked', () => {
-    let called = false;
+  it('should not call `onCellMouseDown` callback when clicked on the focusable element (column headers)', () => {
+    const opt = ['Maserati', 'Mazda', 'Mercedes', 'Mini', 'Mitsubishi'].map(value => `<option value="${value}">${value}</option>`).join('');
+    const onCellMouseDown = jasmine.createSpy('onCellMouseDown');
     const wt = walkontable({
       data: getData,
       totalRows: getTotalRows,
       totalColumns: getTotalColumns,
-      onCellDblClick() {
-        called = true;
-      }
+      columnHeaders: [function(col, TH) {
+        TH.innerHTML = `#${col}<select>${opt}</select>`;
+      }],
+      onCellMouseDown,
     });
 
     wt.draw();
 
-    const options = {
-      button: 2
-    };
+    spec().$table.find('.ht_clone_top th:first select')
+      .focus()
+      .simulate('mousedown')
+      .simulate('mouseup')
+      .simulate('click')
+    ;
 
-    spec().$table.find('tbody tr:first td:first')
-      .simulate('mousedown', options)
-      .simulate('mouseup', options)
-      .simulate('mousedown', options)
-      .simulate('mouseup', options);
+    expect(onCellMouseDown).toHaveBeenCalledTimes(0);
+  });
 
-    expect(called).toEqual(false);
+  it('should not call `onCellMouseDown` callback when clicked on the focusable element (cell renderer)', () => {
+    const opt = ['Maserati', 'Mazda', 'Mercedes', 'Mini', 'Mitsubishi'].map(value => `<option value="${value}">${value}</option>`).join('');
+    const onCellMouseDown = jasmine.createSpy('onCellMouseDown');
+    const wt = walkontable({
+      data: getData,
+      totalRows: getTotalRows,
+      totalColumns: getTotalColumns,
+      cellRenderer(row, column, TD) {
+        TD.innerHTML = `<select>${opt}</select>`;
+      },
+      onCellMouseDown,
+    });
+
+    wt.draw();
+
+    spec().$table.find('td:first select')
+      .focus()
+      .simulate('mousedown')
+      .simulate('mouseup')
+      .simulate('click')
+    ;
+
+    expect(onCellMouseDown).toHaveBeenCalledTimes(0);
+  });
+
+  it('should call `onCellMouseOver` callback when clicked on TH', () => {
+    const onCellMouseOver = jasmine.createSpy('onCellMouseOver');
+    const wt = walkontable({
+      data: getData,
+      totalRows: getTotalRows,
+      totalColumns: getTotalColumns,
+      columnHeaders: [function(col, TH) {
+        TH.innerHTML = col + 1;
+      }],
+      onCellMouseOver,
+    });
+
+    wt.draw();
+
+    spec().$table.find('th:first')
+      .simulate('mouseover')
+      .simulate('mousemove')
+    ;
+
+    expect(onCellMouseOver).toHaveBeenCalledWith(jasmine.any(MouseEvent), new Walkontable.CellCoords(-1, 0), jasmine.anything(), jasmine.any(wt.constructor));
+  });
+
+  it('should call `onCellDblClick` callback when clicked on TH', () => {
+    const onCellDblClick = jasmine.createSpy('onCellDblClick');
+    const wt = walkontable({
+      data: getData,
+      totalRows: getTotalRows,
+      totalColumns: getTotalColumns,
+      columnHeaders: [function(col, TH) {
+        TH.innerHTML = col + 1;
+      }],
+      onCellDblClick,
+    });
+
+    wt.draw();
+
+    spec().$table.find('th:first')
+      .simulate('mousemove')
+      .simulate('mousedown')
+      .simulate('mouseup')
+      .simulate('click')
+      .simulate('mousedown')
+      .simulate('mouseup')
+      .simulate('click')
+      .simulate('dblclick')
+    ;
+
+    expect(onCellDblClick).toHaveBeenCalledTimes(1);
   });
 
   it('should not call `onCellDblClick` when first mouse up came from mouse drag', () => {
-    let called = false;
+    const onCellDblClick = jasmine.createSpy('onCellDblClick');
     const wt = walkontable({
       data: getData,
       totalRows: getTotalRows,
       totalColumns: getTotalColumns,
-      onCellDblClick() {
-        called = true;
-      }
+      onCellDblClick,
     });
 
     wt.draw();
 
-    spec().$table.find('tbody tr:first td:eq(1)').simulate('mousedown');
+    spec().$table.find('tbody tr:first td:eq(1)')
+      .simulate('mousedown')
+    ;
     spec().$table.find('tbody tr:first td:first')
       .simulate('mouseup')
       .simulate('mousedown')
-      .simulate('mouseup');
+      .simulate('mouseup')
+      .simulate('click')
+      .simulate('dblclick')
+    ;
 
-    expect(called).toEqual(false);
-  });
-
-  it('border click should call `onCellMouseDown` callback', () => {
-    let myCoords = null;
-    let myTD = null;
-    const wt = walkontable({
-      data: getData,
-      totalRows: getTotalRows,
-      totalColumns: getTotalColumns,
-      selections: createSelectionController({
-        current: new Walkontable.Selection({
-          className: 'current',
-          border: {
-            width: 1,
-            color: 'red',
-            style: 'solid'
-          }
-        })
-      }),
-      onCellMouseDown(event, coords, TD) {
-        myCoords = coords;
-        myTD = TD;
-      }
-    });
-
-    wt.selections.getCell().add(new Walkontable.CellCoords(1, 1));
-    wt.draw();
-
-    const $td = spec().$table.find('tbody tr:eq(1) td:eq(1)');
-
-    spec().$table.parents('.wtHolder')
-      .find('.current:first')
-      .simulate('mousedown');
-
-    expect(myCoords).toEqual(new Walkontable.CellCoords(1, 1));
-    expect(myTD).toEqual($td[0]);
+    expect(onCellDblClick).toHaveBeenCalledTimes(0);
   });
 
   it('border click should call `onCellDblClick` callback', () => {
-    let myCoords = null;
-    let myTD = null;
+    const onCellDblClick = jasmine.createSpy('onCellDblClick');
     const wt = walkontable({
       data: getData,
       totalRows: getTotalRows,
@@ -428,10 +595,7 @@ describe('WalkontableEvent', () => {
           }
         })
       }),
-      onCellDblClick(event, coords, TD) {
-        myCoords = coords;
-        myTD = TD;
-      }
+      onCellDblClick,
     });
 
     wt.selections.getCell().add(new Walkontable.CellCoords(1, 1));
@@ -441,18 +605,23 @@ describe('WalkontableEvent', () => {
 
     spec().$table.parents('.wtHolder')
       .find('.current:first')
+      .simulate('mouseover')
+      .simulate('mousemove')
       .simulate('mousedown')
       .simulate('mouseup')
+      .simulate('click')
       .simulate('mousedown')
-      .simulate('mouseup');
+      .simulate('mouseup')
+      .simulate('click')
+      .simulate('dblclick')
+    ;
 
-    expect(myCoords).toEqual(new Walkontable.CellCoords(1, 1));
-    expect(myTD).toEqual($td[0]);
+    expect(onCellDblClick).toHaveBeenCalledWith(jasmine.any(MouseEvent), new Walkontable.CellCoords(1, 1), $td[0], jasmine.any(wt.constructor));
+    expect(onCellDblClick).toHaveBeenCalledTimes(1);
   });
 
-  // corner
-  it('should call `onCellCornerMouseDown` callback', () => {
-    let clicked = false;
+  it('border click should call `onCellMouseDown` callback', () => {
+    const onCellMouseDown = jasmine.createSpy('onCellMouseDown');
     const wt = walkontable({
       data: getData,
       totalRows: getTotalRows,
@@ -467,23 +636,103 @@ describe('WalkontableEvent', () => {
           }
         })
       }),
-      onCellCornerMouseDown() {
-        clicked = true;
-      }
+      onCellMouseDown,
+    });
+
+    wt.selections.getCell().add(new Walkontable.CellCoords(1, 1));
+    wt.draw();
+
+    const $td = spec().$table.find('tbody tr:eq(1) td:eq(1)');
+
+    spec().$table.parents('.wtHolder')
+      .find('.current:first')
+      .simulate('mouseover')
+      .simulate('mousemove')
+      .simulate('mousedown')
+      .simulate('mouseup')
+      .simulate('click')
+    ;
+
+    expect(onCellMouseDown).toHaveBeenCalledWith(jasmine.any(MouseEvent), new Walkontable.CellCoords(1, 1), $td[0], jasmine.any(wt.constructor));
+    expect(onCellMouseDown).toHaveBeenCalledTimes(1);
+  });
+
+  it('border click should call `onCellMouseUp` callback', () => {
+    const onCellMouseUp = jasmine.createSpy('onCellMouseUp');
+    const wt = walkontable({
+      data: getData,
+      totalRows: getTotalRows,
+      totalColumns: getTotalColumns,
+      selections: createSelectionController({
+        current: new Walkontable.Selection({
+          className: 'current',
+          border: {
+            width: 1,
+            color: 'red',
+            style: 'solid'
+          }
+        })
+      }),
+      onCellMouseUp,
+    });
+
+    wt.selections.getCell().add(new Walkontable.CellCoords(1, 1));
+    wt.draw();
+
+    const $td = spec().$table.find('tbody tr:eq(1) td:eq(1)');
+
+    spec().$table.parents('.wtHolder')
+      .find('.current:first')
+      .simulate('mouseover')
+      .simulate('mousemove')
+      .simulate('mousedown')
+      .simulate('mouseup')
+      .simulate('click')
+    ;
+
+    expect(onCellMouseUp).toHaveBeenCalledWith(jasmine.any(MouseEvent), new Walkontable.CellCoords(1, 1), $td[0], jasmine.any(wt.constructor));
+    expect(onCellMouseUp).toHaveBeenCalledTimes(1);
+  });
+
+  // corner
+  it('border click should call `onCellCornerMouseDown` callback', () => {
+    const onCellCornerMouseDown = jasmine.createSpy('onCellCornerMouseDown');
+    const wt = walkontable({
+      data: getData,
+      totalRows: getTotalRows,
+      totalColumns: getTotalColumns,
+      selections: createSelectionController({
+        current: new Walkontable.Selection({
+          className: 'current',
+          border: {
+            width: 1,
+            color: 'red',
+            style: 'solid'
+          }
+        })
+      }),
+      onCellCornerMouseDown,
     });
 
     wt.selections.getCell().add(new Walkontable.CellCoords(10, 2));
     wt.draw();
 
-    spec().$table.parents('.wtHolder')
-      .find('.current.corner')
-      .simulate('mousedown');
+    const $el = spec().$table.parents('.wtHolder').find('.current.corner');
 
-    expect(clicked).toEqual(true);
+    $el
+      .simulate('mouseover')
+      .simulate('mousemove')
+      .simulate('mousedown')
+      .simulate('mouseup')
+      .simulate('click')
+    ;
+
+    expect(onCellCornerMouseDown).toHaveBeenCalledWith(jasmine.any(MouseEvent), $el[0], void 0, void 0);
+    expect(onCellCornerMouseDown).toHaveBeenCalledTimes(1);
   });
 
-  it('should call `onCellCornerDblClick` callback, even when it is set only after first click', () => {
-    let clicked = false;
+  it('border click should call `onCellCornerDblClick` callback, even when it is set only after first click', () => {
+    const onCellCornerDblClick = jasmine.createSpy('onCellCornerDblClick');
     const wt = walkontable({
       data: getData,
       totalRows: getTotalRows,
@@ -505,30 +754,35 @@ describe('WalkontableEvent', () => {
 
     const $td = spec().$table.parents('.wtHolder').find('.current.corner');
 
-    $td.simulate('mousedown')
+    $td
+      .simulate('mousemove')
+      .simulate('mousedown')
       .simulate('mouseup')
-      .simulate('mousedown');
-    wt.update('onCellCornerDblClick', () => {
-      clicked = true;
-    });
-    $td.simulate('mouseup');
+      .simulate('click')
+    ;
 
-    expect(clicked).toEqual(true);
+    wt.update('onCellCornerDblClick', onCellCornerDblClick);
+
+    $td
+      .simulate('mousedown')
+      .simulate('mouseup')
+      .simulate('click')
+    ;
+
+    expect(onCellCornerDblClick).toHaveBeenCalledWith(jasmine.any(MouseEvent), new Walkontable.CellCoords(10, 2), -2, jasmine.any(wt.constructor));
   });
 
   it('should call `onDraw` callback after render', () => {
-    let count = 0;
+    const onDraw = jasmine.createSpy('onDraw');
     const wt = walkontable({
       data: getData,
       totalRows: getTotalRows,
       totalColumns: getTotalColumns,
-      onDraw() {
-        count += 1;
-      }
+      onDraw,
     });
 
     wt.draw();
 
-    expect(count).toEqual(1);
+    expect(onDraw).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/pluginHooks.js
+++ b/src/pluginHooks.js
@@ -784,8 +784,6 @@ const REGISTERED_HOOKS = [
    * @param {Event} event The `mouseup` event object.
    * @param {CellCoords} coords Cell coords object containing the visual coordinates of the clicked cell.
    * @param {HTMLTableCellElement} TD TD element.
-   * @param {Object} controller An object with keys `row`, `column` and `cells` which contains boolean values. This
-   *                            object allows or disallows changing the selection for the particular axies.
    */
   'beforeOnCellMouseUp',
 

--- a/src/plugins/contextMenu/menu.js
+++ b/src/plugins/contextMenu/menu.js
@@ -190,14 +190,6 @@ class Menu {
       rowHeights: row => (filteredItems[row].name === SEPARATOR ? 1 : 23),
       afterOnCellContextMenu: (event) => {
         event.preventDefault();
-
-        if (this.hasSelectedItem()) {
-          this.executeCommand(event);
-
-          if (!this.isCommandPassive(this.getSelectedItem())) {
-            this.close(true);
-          }
-        }
       },
       beforeOnCellMouseUp: (event) => {
         if (this.hasSelectedItem()) {

--- a/src/plugins/contextMenu/test/contextMenu.e2e.js
+++ b/src/plugins/contextMenu/test/contextMenu.e2e.js
@@ -3091,7 +3091,7 @@ describe('ContextMenu', () => {
       expect(scrollHeight).toBe(0);
     });
 
-    it('should fire commend after the \'mouseup\' event', () => {
+    it('should fire commend after the \'mouseup\' event triggered by the left mouse button', () => {
       const callback = jasmine.createSpy('callback');
 
       handsontable({
@@ -3109,15 +3109,17 @@ describe('ContextMenu', () => {
       contextMenu();
 
       const item = $('.htContextMenu .ht_master .htCore').find('tbody td:eq(0)');
+
       item.simulate('mousedown');
 
-      expect(callback.calls.count()).toEqual(0);
+      expect(callback.calls.count()).toBe(0);
 
       item.simulate('mouseup');
-      expect(callback.calls.count()).toEqual(1);
+
+      expect(callback.calls.count()).toBe(1);
     });
 
-    it('should fire commend after the \'contextmenu\' event', () => {
+    it('should fire commend after the \'mouseup\' event triggered by the middle mouse button', () => {
       const callback = jasmine.createSpy('callback');
 
       handsontable({
@@ -3135,16 +3137,73 @@ describe('ContextMenu', () => {
       contextMenu();
 
       const item = $('.htContextMenu .ht_master .htCore').find('tbody td:eq(0)');
+
       item.simulate('mousedown');
 
-      expect(callback.calls.count()).toEqual(0);
+      expect(callback.calls.count()).toBe(0);
+
+      item.simulate('mouseup', { button: 1 });
+
+      expect(callback.calls.count()).toBe(1);
+    });
+
+    it('should fire commend after the \'mouseup\' event triggered by the right mouse button', () => {
+      const callback = jasmine.createSpy('callback');
+
+      handsontable({
+        contextMenu: {
+          items: {
+            item1: {
+              name: 'Item',
+              callback,
+            },
+          },
+        },
+        height: 100
+      });
+
+      contextMenu();
+
+      const item = $('.htContextMenu .ht_master .htCore').find('tbody td:eq(0)');
+
+      item.simulate('mousedown');
+
+      expect(callback.calls.count()).toBe(0);
+
+      item.simulate('mouseup', { button: 2 });
+
+      expect(callback.calls.count()).toBe(1);
+    });
+
+    it('should not fire commend after the \'contextmenu\' event', () => {
+      const callback = jasmine.createSpy('callback');
+
+      handsontable({
+        contextMenu: {
+          items: {
+            item1: {
+              name: 'Item',
+              callback,
+            },
+          },
+        },
+        height: 100
+      });
+
+      contextMenu();
+
+      const item = $('.htContextMenu .ht_master .htCore').find('tbody td:eq(0)');
+
+      item.simulate('mousedown');
+
+      expect(callback.calls.count()).toBe(0);
 
       item.simulate('contextmenu');
 
-      expect(callback.calls.count()).toEqual(1);
+      expect(callback.calls.count()).toBe(0);
     });
 
-    it('should not open another instance of ContextMenu after fireing command by the \'contextmenu\' event', () => {
+    it('should not open another instance of ContextMenu after fireing command by the RMB', () => {
       handsontable({
         contextMenu: {
           items: {
@@ -3159,7 +3218,10 @@ describe('ContextMenu', () => {
 
       contextMenu();
 
-      $('.htContextMenu .ht_master .htCore').find('tbody td:eq(0)').simulate('mousedown').simulate('contextmenu');
+      $('.htContextMenu .ht_master .htCore').find('tbody td:eq(0)')
+        .simulate('mousedown', { button: 2 })
+        .simulate('mouseup', { button: 2 })
+      ;
 
       expect($('.htContextMenu').is(':visible')).toBe(false);
     });

--- a/test/e2e/editors/textEditor.spec.js
+++ b/test/e2e/editors/textEditor.spec.js
@@ -669,35 +669,105 @@ describe('TextEditor', () => {
     expect(isEditorVisible()).toEqual(true);
   });
 
-  it('should open editor after double clicking on a cell', (done) => {
-    const hot = handsontable({
+  it('should open editor after double clicking on a cell', async() => {
+    handsontable({
       data: Handsontable.helper.createSpreadsheetData(5, 2)
     });
     const cell = $(getCell(0, 0));
-    let clicks = 0;
 
+    selectCell(0, 0);
     window.scrollTo(0, cell.offset().top);
 
-    setTimeout(() => {
-      mouseDown(cell);
-      mouseUp(cell);
-      clicks += 1;
-    }, 0);
+    await sleep(0);
 
-    setTimeout(() => {
-      mouseDown(cell);
-      mouseUp(cell);
-      clicks += 1;
-    }, 100);
+    cell
+      .simulate('mousedown')
+      .simulate('mouseup')
+      .simulate('click')
+    ;
 
-    setTimeout(() => {
-      const editor = hot.getActiveEditor();
+    await sleep(100);
 
-      expect(clicks).toBe(2);
-      expect(editor.isOpened()).toBe(true);
-      expect(editor.isInFullEditMode()).toBe(true);
-      done();
-    }, 200);
+    cell
+      .simulate('mousedown')
+      .simulate('mouseup')
+      .simulate('click')
+    ;
+
+    await sleep(100);
+
+    const editor = getActiveEditor();
+
+    expect(editor.isOpened()).toBe(true);
+    expect(editor.isInFullEditMode()).toBe(true);
+  });
+
+  it('should not open editor after double clicking on a cell using the middle mouse button', async() => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(5, 2)
+    });
+    const cell = $(getCell(0, 0));
+    const button = 1;
+
+    selectCell(0, 0);
+    window.scrollTo(0, cell.offset().top);
+
+    await sleep(0);
+
+    cell
+      .simulate('mousedown', { button })
+      .simulate('mouseup', { button })
+      .simulate('click', { button })
+    ;
+
+    await sleep(100);
+
+    cell
+      .simulate('mousedown', { button })
+      .simulate('mouseup', { button })
+      .simulate('click', { button })
+    ;
+
+    await sleep(100);
+
+    const editor = getActiveEditor();
+
+    expect(editor.isOpened()).toBe(false);
+    expect(editor.isInFullEditMode()).toBe(false);
+  });
+
+  it('should not open editor after double clicking on a cell using the right mouse button', async() => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(5, 2)
+    });
+    const cell = $(getCell(0, 0));
+    const button = 2;
+
+    selectCell(0, 0);
+    window.scrollTo(0, cell.offset().top);
+
+    await sleep(0);
+
+    cell
+      .simulate('mousedown', { button })
+      .simulate('mouseup', { button })
+      .simulate('click', { button })
+    ;
+
+    await sleep(100);
+
+    cell
+      .simulate('mousedown', { button })
+      .simulate('mouseup', { button })
+      .simulate('click', { button })
+    ;
+
+    await sleep(100);
+
+    const editor = getActiveEditor();
+
+    expect(editor.isOpened()).toBe(false);
+    expect(editor.isInFullEditMode()).toBe(false);
   });
 
   it('should call editor focus() method after opening an editor', () => {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The Walkontable has a bug where `onCellMouseUp` hook is fired for all mouse buttons except RMB. It is not consistent with `onCellMouseDown` hook, which fires for all mouse buttons.

To make the changes more consistent with the native `dblclick` event where it is triggered only for the LMB button. The `onCellDblClick` and `onCellCornerDblClick` hooks are changed. They now are triggered on LMB only (previously on any mouse button except RMB).

Armed with those changes I fixed #6507 issue.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Tested manually and add new E2E tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #6507

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
