### PR TITLE
Fix navigation by arrow keys for the ContextMenu

### DIFF
--- a/src/plugins/contextMenu/menu.js
+++ b/src/plugins/contextMenu/menu.js
@@ -674,7 +674,7 @@ class Menu {
   onBeforeKeyDown(event) {
     // For input elements, prevent event propagation. It allows entering text into an input
     // element freely - without steeling the key events from the menu module (#6506).
-    if (isInput(event.target)) {
+    if (isInput(event.target) && this.container.contains(event.target)) {
       stopImmediatePropagation(event);
 
       return;

--- a/src/plugins/contextMenu/menu.js
+++ b/src/plugins/contextMenu/menu.js
@@ -673,7 +673,7 @@ class Menu {
    */
   onBeforeKeyDown(event) {
     // For input elements, prevent event propagation. It allows entering text into an input
-    // element freely - without steeling the key events from the menu module (#6506).
+    // element freely - without steeling the key events from the menu module (#6506, #6549).
     if (isInput(event.target) && this.container.contains(event.target)) {
       stopImmediatePropagation(event);
 

--- a/src/plugins/contextMenu/test/contextMenu.e2e.js
+++ b/src/plugins/contextMenu/test/contextMenu.e2e.js
@@ -2490,6 +2490,29 @@ describe('ContextMenu', () => {
         expect(menuHot.getSelected()).toEqual([[2, 0, 2, 0]]);
       });
 
+      it('should select the first item in the menu, even when external input is focused (#6550)', () => {
+        handsontable({
+          contextMenu: true,
+          height: 100
+        });
+
+        const input = document.createElement('input');
+
+        document.body.appendChild(input);
+        contextMenu();
+
+        const menuHot = getPlugin('contextMenu').menu.hotMenu;
+
+        expect(menuHot.getSelected()).toBeUndefined();
+
+        input.focus();
+        keyDownUp('arrow_down');
+
+        expect(menuHot.getSelected()).toEqual([[0, 0, 0, 0]]);
+
+        document.body.removeChild(input);
+      });
+
       it('should NOT select any items in menu, when user hits ARROW_DOWN and there is no items enabled', () => {
         handsontable({
           contextMenu: {


### PR DESCRIPTION
# Context
<!--- Why is this change required? What problem does it solve? -->
I've specified more precisely what input element blocks the key navigation on the ContextMenu menu instance. Only inputs which are mounted in the menu's parent element are considered.

Otherwise, there is a conflict with other input elements that are focused e.q by the CopyPaste plugin, which met that condition.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Tested manually and added a new E2E test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #6549

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
