### PR TITLE
SVG borders: refactor Overlay classes, fix fast scrolling

### DIFF
--- a/src/3rdparty/walkontable/src/borderRenderer/svg/pathsRenderer.js
+++ b/src/3rdparty/walkontable/src/borderRenderer/svg/pathsRenderer.js
@@ -122,10 +122,7 @@ function getStateForStyle(states, style, parent) {
 
     elem.setAttribute('stroke', color);
     elem.setAttribute('stroke-width', width);
-    // elem.setAttribute('stroke-linecap', 'square'); // default: butt
-    // elem.setAttribute('shape-rendering', 'optimizeSpeed');
-    elem.setAttribute('shape-rendering', 'geometricPrecision'); // TODO why the border renders wrong when this is on
-    // elem.setAttribute('shape-rendering', 'crispEdges');
+    elem.setAttribute('shape-rendering', 'geometricPrecision');
     elem.setAttribute('data-stroke-style', style);
 
     state = {

--- a/src/3rdparty/walkontable/src/core/clone.js
+++ b/src/3rdparty/walkontable/src/core/clone.js
@@ -12,14 +12,14 @@ class Clone extends Core {
   constructor(settings) {
     super(settings);
 
-    this.cloneSource = settings.masterInstance;
-    this.overlayName = settings.type;
-    this.wtSettings = this.cloneSource.wtSettings;
+    this.overlay = settings.overlay;
+    this.overlayName = settings.overlay.type;
+    this.wtSettings = this.overlay.master.wtSettings;
     this.wtTable = settings.createTableFn(this, settings.table);
     this.wtScroll = new Scroll(this);
-    this.wtViewport = this.cloneSource.wtViewport;
+    this.wtViewport = this.overlay.master.wtViewport;
     this.wtEvent = new Event(this);
-    this.selections = this.cloneSource.selections;
+    this.selections = this.overlay.master.selections;
   }
 
   /**

--- a/src/3rdparty/walkontable/src/core/master.js
+++ b/src/3rdparty/walkontable/src/core/master.js
@@ -7,6 +7,8 @@ import Scroll from '../scroll';
 import Settings from '../settings';
 import MasterTable from '../table/master';
 import Viewport from '../viewport';
+import ColumnUtils from '../utils/column';
+import RowUtils from '../utils/row';
 
 /**
  * @class Master
@@ -20,6 +22,8 @@ class Master extends Core {
 
     // bootstrap from settings
     this.wtSettings = new Settings(this, settings);
+    this.rowUtils = new RowUtils(this);
+    this.columnUtils = new ColumnUtils(this);
     this.wtTable = new MasterTable(this, settings.table);
     this.wtScroll = new Scroll(this);
     this.wtViewport = new Viewport(this);

--- a/src/3rdparty/walkontable/src/event.js
+++ b/src/3rdparty/walkontable/src/event.js
@@ -214,7 +214,7 @@ class Event {
 
     const table = this.instance.wtTable.TABLE;
     const td = closestDown(event.realTarget, ['TD', 'TH'], table);
-    const mainWOT = this.instance.cloneSource || this.instance;
+    const mainWOT = this.instance.overlay ? this.instance.overlay.master : this.instance;
 
     if (td && td !== mainWOT.lastMouseOver && isChildOf(td, table)) {
       mainWOT.lastMouseOver = td;

--- a/src/3rdparty/walkontable/src/event.js
+++ b/src/3rdparty/walkontable/src/event.js
@@ -214,10 +214,10 @@ class Event {
 
     const table = this.instance.wtTable.TABLE;
     const td = closestDown(event.realTarget, ['TD', 'TH'], table);
-    const mainWOT = this.instance.overlay ? this.instance.overlay.master : this.instance;
+    const master = this.instance.overlay ? this.instance.overlay.master : this.instance;
 
-    if (td && td !== mainWOT.lastMouseOver && isChildOf(td, table)) {
-      mainWOT.lastMouseOver = td;
+    if (td && td !== master.lastMouseOver && isChildOf(td, table)) {
+      master.lastMouseOver = td;
 
       this.instance.getSetting('onCellMouseOver', event, this.instance.wtTable.getCoords(td), td, this.instance);
     }

--- a/src/3rdparty/walkontable/src/overlay/_base.js
+++ b/src/3rdparty/walkontable/src/overlay/_base.js
@@ -272,8 +272,8 @@ class Overlay {
    */
   getRelativeCellPositionWithinHolder(onFixedRowTop, onFixedRowBottom, onFixedColumn, elementOffset, spreaderOffset) {
     const tableScrollPosition = {
-      horizontal: this.clone.cloneSource.wtOverlays.leftOverlay.getScrollPosition(),
-      vertical: this.clone.cloneSource.wtOverlays.topOverlay.getScrollPosition()
+      horizontal: this.clone.overlay.master.wtOverlays.leftOverlay.getScrollPosition(),
+      vertical: this.clone.overlay.master.wtOverlays.topOverlay.getScrollPosition()
     };
     let horizontalOffset = 0;
     let verticalOffset = 0;
@@ -338,8 +338,7 @@ class Overlay {
     }
 
     return new Clone({
-      masterInstance: this.master,
-      type: this.type,
+      overlay: this,
       createTableFn: this.createTable,
       table: clonedTable,
     });

--- a/src/3rdparty/walkontable/src/overlay/_base.js
+++ b/src/3rdparty/walkontable/src/overlay/_base.js
@@ -112,23 +112,9 @@ class Overlay {
    */
   constructor(wotInstance) {
     this.master = wotInstance;
-
-    const {
-      TABLE,
-      hider,
-      spreader,
-      holder,
-      wtRootElement,
-    } = this.master.wtTable;
-
     this.type = '';
     this.mainTableScrollableElement = null;
-    this.TABLE = TABLE;
-    this.hider = hider;
-    this.spreader = spreader;
-    this.holder = holder;
-    this.wtRootElement = wtRootElement;
-    this.trimmingContainer = getTrimmingContainer(this.hider.parentNode.parentNode);
+    this.trimmingContainer = getTrimmingContainer(this.master.wtTable.hider.parentNode.parentNode);
     this.areElementSizesAdjusted = false;
   }
 
@@ -160,7 +146,7 @@ class Overlay {
    * Set the DOM element responsible for trimming the overlay's root element. It will be some parent element or the window.
    */
   updateTrimmingContainer() {
-    this.trimmingContainer = getTrimmingContainer(this.hider.parentNode.parentNode);
+    this.trimmingContainer = getTrimmingContainer(this.master.wtTable.hider.parentNode.parentNode);
   }
 
   /**

--- a/src/3rdparty/walkontable/src/overlay/_base.js
+++ b/src/3rdparty/walkontable/src/overlay/_base.js
@@ -362,11 +362,10 @@ class Overlay {
     if (!this.clone) {
       return;
     }
-    const holder = this.clone.wtTable.holder;
-    const hider = this.clone.wtTable.hider;
+    const { holder, hider, wtRootElement } = this.clone.wtTable;
     const holderStyle = holder.style;
     const hidderStyle = hider.style;
-    const rootStyle = holder.parentNode.style;
+    const rootStyle = wtRootElement.style;
 
     arrayEach([holderStyle, hidderStyle, rootStyle], (style) => {
       style.width = '';

--- a/src/3rdparty/walkontable/src/overlay/_base.js
+++ b/src/3rdparty/walkontable/src/overlay/_base.js
@@ -130,7 +130,6 @@ class Overlay {
     this.wtRootElement = wtRootElement;
     this.trimmingContainer = getTrimmingContainer(this.hider.parentNode.parentNode);
     this.areElementSizesAdjusted = false;
-    this.updateStateOfRendering();
   }
 
   /**
@@ -349,7 +348,7 @@ class Overlay {
     // When hot settings are changed we allow to refresh overlay once before blocking
     const nextCycleRenderFlag = this.shouldBeRendered();
 
-    if (this.clone && (this.needFullRender || nextCycleRenderFlag)) {
+    if (this.needFullRender || nextCycleRenderFlag) {
       this.clone.drawClone(fastDraw);
     }
     this.needFullRender = nextCycleRenderFlag;
@@ -359,9 +358,6 @@ class Overlay {
    * Reset overlay styles to initial values.
    */
   reset() {
-    if (!this.clone) {
-      return;
-    }
     const { holder, hider, wtRootElement } = this.clone.wtTable;
     const holderStyle = holder.style;
     const hidderStyle = hider.style;

--- a/src/3rdparty/walkontable/src/overlay/_base.js
+++ b/src/3rdparty/walkontable/src/overlay/_base.js
@@ -113,7 +113,7 @@ class Overlay {
     this.master = wotInstance;
     this.type = '';
     this.mainTableScrollableElement = null;
-    this.trimmingContainer = getTrimmingContainer(this.master.wtTable.hider.parentNode.parentNode);
+    this.updateTrimmingContainer();
     this.areElementSizesAdjusted = false;
   }
 
@@ -143,7 +143,7 @@ class Overlay {
    * Set the DOM element responsible for trimming the overlay's root element. It will be some parent element or the window.
    */
   updateTrimmingContainer() {
-    this.trimmingContainer = getTrimmingContainer(this.master.wtTable.hider.parentNode.parentNode);
+    this.trimmingContainer = getTrimmingContainer(this.master.wtTable.wtRootElement);
   }
 
   /**

--- a/src/3rdparty/walkontable/src/overlay/_base.js
+++ b/src/3rdparty/walkontable/src/overlay/_base.js
@@ -2,7 +2,6 @@ import {
   getScrollableElement,
   getTrimmingContainer
 } from './../../../../helpers/dom/element';
-import { arrayEach } from './../../../../helpers/array';
 import { warn } from './../../../../helpers/console';
 import EventManager from './../../../../eventManager';
 import Clone from '../core/clone';
@@ -151,12 +150,12 @@ class Overlay {
    * Update the main scrollable element.
    */
   updateMainScrollableElement() {
-    const { wtTable, rootWindow } = this.master;
+    const { master } = this;
 
-    if (rootWindow.getComputedStyle(wtTable.wtRootElement.parentNode).getPropertyValue('overflow') === 'hidden') {
-      this.mainTableScrollableElement = this.master.wtTable.holder;
+    if (master.rootWindow.getComputedStyle(master.wtTable.wtRootElement.parentNode).getPropertyValue('overflow') === 'hidden') {
+      this.mainTableScrollableElement = master.wtTable.holder;
     } else {
-      this.mainTableScrollableElement = getScrollableElement(wtTable.TABLE);
+      this.mainTableScrollableElement = getScrollableElement(master.wtTable.TABLE);
     }
   }
 
@@ -287,33 +286,33 @@ class Overlay {
     if (Overlay.CLONE_TYPES.indexOf(direction) === -1) {
       throw new Error(`Clone type "${direction}" is not supported.`);
     }
-    const { wtTable, rootDocument, rootWindow } = this.master;
-    const clone = rootDocument.createElement('DIV');
-    const clonedTable = rootDocument.createElement('TABLE');
+    const { master } = this;
+    const overlayRootElement = master.rootDocument.createElement('DIV');
+    const clonedTable = master.rootDocument.createElement('TABLE');
 
-    clone.className = `ht_clone_${direction} handsontable`;
-    clone.style.position = 'absolute';
-    clone.style.top = 0;
-    clone.style.left = 0;
-    clone.style.overflow = 'visible';
+    overlayRootElement.className = `ht_clone_${direction} handsontable`;
+    overlayRootElement.style.position = 'absolute';
+    overlayRootElement.style.top = 0;
+    overlayRootElement.style.left = 0;
+    overlayRootElement.style.overflow = 'visible';
 
-    clonedTable.className = wtTable.TABLE.className;
-    clone.appendChild(clonedTable);
+    clonedTable.className = master.wtTable.TABLE.className;
+    overlayRootElement.appendChild(clonedTable);
 
     this.type = direction;
-    wtTable.wtRootElement.parentNode.appendChild(clone);
+    master.wtTable.wtRootElement.parentNode.appendChild(overlayRootElement);
 
-    const preventOverflow = this.master.getSetting('preventOverflow');
+    const preventOverflow = master.getSetting('preventOverflow');
 
     if (preventOverflow === true ||
       preventOverflow === 'horizontal' && this.type === Overlay.CLONE_TOP ||
       preventOverflow === 'vertical' && this.type === Overlay.CLONE_LEFT) {
-      this.mainTableScrollableElement = rootWindow;
+      this.mainTableScrollableElement = master.rootWindow;
 
-    } else if (rootWindow.getComputedStyle(wtTable.wtRootElement.parentNode).getPropertyValue('overflow') === 'hidden') {
-      this.mainTableScrollableElement = wtTable.holder;
+    } else if (master.rootWindow.getComputedStyle(master.wtTable.wtRootElement.parentNode).getPropertyValue('overflow') === 'hidden') {
+      this.mainTableScrollableElement = master.wtTable.holder;
     } else {
-      this.mainTableScrollableElement = getScrollableElement(wtTable.TABLE);
+      this.mainTableScrollableElement = getScrollableElement(master.wtTable.TABLE);
     }
 
     return new Clone({
@@ -339,15 +338,14 @@ class Overlay {
    * Reset overlay root element's width and height to initial values.
    */
   resetElementsSize() {
-    const { holder, hider, wtRootElement } = this.clone.wtTable;
-    const holderStyle = holder.style;
-    const hidderStyle = hider.style;
-    const rootStyle = wtRootElement.style;
+    const { clone } = this;
 
-    arrayEach([holderStyle, hidderStyle, rootStyle], (style) => {
-      style.width = '';
-      style.height = '';
-    });
+    clone.wtTable.holder.style.width = '';
+    clone.wtTable.holder.style.height = '';
+    clone.wtTable.hider.style.width = '';
+    clone.wtTable.hider.style.height = '';
+    clone.wtTable.wtRootElement.style.width = '';
+    clone.wtTable.wtRootElement.style.height = '';
   }
 
   /**

--- a/src/3rdparty/walkontable/src/overlay/_base.js
+++ b/src/3rdparty/walkontable/src/overlay/_base.js
@@ -330,13 +330,9 @@ class Overlay {
    * @param {Boolean} [fastDraw=false]
    */
   redrawClone(fastDraw = false) {
-    // When hot settings are changed we allow to refresh overlay once before blocking
-    const nextCycleRenderFlag = this.shouldBeRendered();
-
-    if (this.needFullRender || nextCycleRenderFlag) {
+    if (this.needFullRender) {
       this.clone.drawClone(fastDraw);
     }
-    this.needFullRender = nextCycleRenderFlag;
   }
 
   /**

--- a/src/3rdparty/walkontable/src/overlay/_base.js
+++ b/src/3rdparty/walkontable/src/overlay/_base.js
@@ -50,13 +50,6 @@ class Overlay {
   }
 
   /**
-   * @type {String}
-   */
-  static get CLONE_DEBUG() {
-    return 'debug';
-  }
-
-  /**
    * List of all availables clone types
    *
    * @type {Array}
@@ -68,7 +61,6 @@ class Overlay {
       Overlay.CLONE_LEFT,
       Overlay.CLONE_TOP_LEFT_CORNER,
       Overlay.CLONE_BOTTOM_LEFT_CORNER,
-      Overlay.CLONE_DEBUG,
     ];
   }
 
@@ -270,7 +262,7 @@ class Overlay {
    * Make a clone of table for overlay
    *
    * @param {String} direction Can be `Overlay.CLONE_TOP`, `Overlay.CLONE_LEFT`,
-   *                           `Overlay.CLONE_TOP_LEFT_CORNER`, `Overlay.CLONE_DEBUG`
+   *                           `Overlay.CLONE_TOP_LEFT_CORNER`
    * @returns {Walkontable}
    */
   makeClone(direction) {

--- a/src/3rdparty/walkontable/src/overlay/_base.js
+++ b/src/3rdparty/walkontable/src/overlay/_base.js
@@ -112,7 +112,6 @@ class Overlay {
     this.master = wotInstance;
     this.type = '';
     this.mainTableScrollableElement = null;
-    this.trimmingContainer = null;
     this.areElementSizesAdjusted = false;
   }
 
@@ -136,13 +135,6 @@ class Overlay {
    */
   shouldBeRendered() {
     return true;
-  }
-
-  /**
-   * Set the DOM element responsible for trimming the overlay's root element. It will be some parent element or the window.
-   */
-  updateTrimmingContainer(trimmingContainer) {
-    this.trimmingContainer = trimmingContainer;
   }
 
   /**

--- a/src/3rdparty/walkontable/src/overlay/_base.js
+++ b/src/3rdparty/walkontable/src/overlay/_base.js
@@ -122,13 +122,11 @@ class Overlay {
    * Update internal state of object with an information about the need of full rendering of the overlay.
    */
   updateStateOfRendering() {
-    const previousState = this.needFullRender;
+    const oldNeedFullRender = this.needFullRender;
 
     this.needFullRender = this.shouldBeRendered();
 
-    const changed = previousState !== this.needFullRender;
-
-    if (changed && !this.needFullRender) {
+    if (oldNeedFullRender && !this.needFullRender) {
       this.resetElementsSize();
     }
   }

--- a/src/3rdparty/walkontable/src/overlay/_base.js
+++ b/src/3rdparty/walkontable/src/overlay/_base.js
@@ -124,9 +124,6 @@ class Overlay {
       wtRootElement,
     } = this.wot.wtTable;
 
-    // legacy support, deprecated in the future
-    this.instance = this.wot;
-
     this.type = '';
     this.mainTableScrollableElement = null;
     this.TABLE = TABLE;

--- a/src/3rdparty/walkontable/src/overlay/_base.js
+++ b/src/3rdparty/walkontable/src/overlay/_base.js
@@ -312,6 +312,7 @@ class Overlay {
    * @param {Boolean} [fastDraw=false]
    */
   redrawClone(fastDraw = false) {
+    this.adjustElementsPosition();
     if (this.needFullRender) {
       this.clone.drawClone(fastDraw);
     }

--- a/src/3rdparty/walkontable/src/overlay/_base.js
+++ b/src/3rdparty/walkontable/src/overlay/_base.js
@@ -1,6 +1,5 @@
 import {
   getScrollableElement,
-  getTrimmingContainer
 } from './../../../../helpers/dom/element';
 import { warn } from './../../../../helpers/console';
 import EventManager from './../../../../eventManager';
@@ -113,7 +112,7 @@ class Overlay {
     this.master = wotInstance;
     this.type = '';
     this.mainTableScrollableElement = null;
-    this.updateTrimmingContainer();
+    this.trimmingContainer = null;
     this.areElementSizesAdjusted = false;
   }
 
@@ -142,8 +141,8 @@ class Overlay {
   /**
    * Set the DOM element responsible for trimming the overlay's root element. It will be some parent element or the window.
    */
-  updateTrimmingContainer() {
-    this.trimmingContainer = getTrimmingContainer(this.master.wtTable.wtRootElement);
+  updateTrimmingContainer(trimmingContainer) {
+    this.trimmingContainer = trimmingContainer;
   }
 
   /**

--- a/src/3rdparty/walkontable/src/overlay/_base.js
+++ b/src/3rdparty/walkontable/src/overlay/_base.js
@@ -143,7 +143,7 @@ class Overlay {
     const changed = previousState !== this.needFullRender;
 
     if (changed && !this.needFullRender) {
-      this.reset();
+      this.resetElementsSize();
     }
   }
 
@@ -340,11 +340,12 @@ class Overlay {
   }
 
   /**
-   * Refresh/Redraw overlay
+   * Redraws the content of the overlay's clone instance of Walkontable, including the cells, selections and borders.
+   * Does not change the size nor the position of the overlay root element.
    *
    * @param {Boolean} [fastDraw=false]
    */
-  refresh(fastDraw = false) {
+  redrawClone(fastDraw = false) {
     // When hot settings are changed we allow to refresh overlay once before blocking
     const nextCycleRenderFlag = this.shouldBeRendered();
 
@@ -355,9 +356,9 @@ class Overlay {
   }
 
   /**
-   * Reset overlay styles to initial values.
+   * Reset overlay root element's width and height to initial values.
    */
-  reset() {
+  resetElementsSize() {
     const { holder, hider, wtRootElement } = this.clone.wtTable;
     const holderStyle = holder.style;
     const hidderStyle = hider.style;

--- a/src/3rdparty/walkontable/src/overlay/_base.js
+++ b/src/3rdparty/walkontable/src/overlay/_base.js
@@ -135,8 +135,6 @@ class Overlay {
 
   /**
    * Update internal state of object with an information about the need of full rendering of the overlay.
-   *
-   * @returns {Boolean} Returns `true` if the state has changed since the last check.
    */
   updateStateOfRendering() {
     const previousState = this.needFullRender;
@@ -148,8 +146,6 @@ class Overlay {
     if (changed && !this.needFullRender) {
       this.reset();
     }
-
-    return changed;
   }
 
   /**

--- a/src/3rdparty/walkontable/src/overlay/bottom.js
+++ b/src/3rdparty/walkontable/src/overlay/bottom.js
@@ -259,7 +259,7 @@ class BottomOverlay extends Overlay {
    */
   scrollTo(sourceRow, bottomEdge) {
     let newY = this.getTableParentOffset();
-    const sourceInstance = this.master.cloneSource ? this.master.cloneSource : this.master;
+    const sourceInstance = this.master.overlay ? this.master.overlay.master : this.master; // TODO what?
     const mainHolder = sourceInstance.wtTable.holder;
     let scrollbarCompensation = 0;
 

--- a/src/3rdparty/walkontable/src/overlay/bottom.js
+++ b/src/3rdparty/walkontable/src/overlay/bottom.js
@@ -39,7 +39,7 @@ class BottomOverlay extends Overlay {
    */
   repositionOverlay() {
     const { wtTable, rootDocument } = this.master;
-    const overlayRoot = this.clone.wtTable.holder.parentNode;
+    const overlayRoot = this.clone.wtTable.wtRootElement;
     let scrollbarWidth = getScrollbarWidth(rootDocument);
 
     if (wtTable.holder.clientHeight === wtTable.holder.offsetHeight) {
@@ -69,7 +69,7 @@ class BottomOverlay extends Overlay {
       return;
     }
 
-    const overlayRoot = this.clone.wtTable.holder.parentNode;
+    const overlayRoot = this.clone.wtTable.wtRootElement;
     let headerPosition = 0;
     overlayRoot.style.top = '';
     const preventOverflow = this.master.getSetting('preventOverflow');
@@ -180,7 +180,7 @@ class BottomOverlay extends Overlay {
   adjustRootElementSize() {
     const { wtTable, wtViewport, rootWindow } = this.master;
     const scrollbarWidth = getScrollbarWidth(this.master.rootDocument);
-    const overlayRoot = this.clone.wtTable.holder.parentNode;
+    const overlayRoot = this.clone.wtTable.wtRootElement;
     const overlayRootStyle = overlayRoot.style;
     const preventOverflow = this.master.getSetting('preventOverflow');
 
@@ -206,11 +206,11 @@ class BottomOverlay extends Overlay {
 
     overlayRootStyle.height = `${tableHeight}px`;
 
-    const { holder, hider } = this.clone.wtTable;
+    const { holder, hider, wtRootElement } = this.clone.wtTable;
 
     hider.style.width = this.hider.style.width;
-    holder.style.width = holder.parentNode.style.width;
-    holder.style.height = holder.parentNode.style.height;
+    holder.style.width = wtRootElement.style.width;
+    holder.style.height = wtRootElement.style.height;
   }
 
   /**
@@ -309,7 +309,7 @@ class BottomOverlay extends Overlay {
    */
   adjustHeaderBordersPosition(position) {
     if (this.master.getSetting('fixedRowsBottom') === 0 && this.master.getSetting('columnHeaders').length > 0) {
-      const masterParent = this.master.wtTable.holder.parentNode;
+      const masterParent = this.master.wtTable.wtRootElement;
       const previousState = hasClass(masterParent, 'innerBorderTop');
 
       if (position) {

--- a/src/3rdparty/walkontable/src/overlay/bottom.js
+++ b/src/3rdparty/walkontable/src/overlay/bottom.js
@@ -167,19 +167,10 @@ class BottomOverlay extends Overlay {
   adjustElementsSize(force = false) {
     this.updateTrimmingContainer();
 
-    if (this.needFullRender || force) {
-      this._adjustElementsSize();
-
-      if (!force) {
-        this.areElementSizesAdjusted = true;
-      }
+    if (!this.needFullRender && !force) {
+      return;
     }
-  }
 
-  /**
-   * Adjust the sizes of the clone and the master elements to the dimensions of the trimming container.
-   */
-  _adjustElementsSize() {
     const { clone, master } = this;
     const scrollbarWidth = getScrollbarWidth(master.rootDocument);
     const overlayRootElement = clone.wtTable.wtRootElement;
@@ -211,6 +202,10 @@ class BottomOverlay extends Overlay {
     clone.wtTable.hider.style.width = this.master.wtTable.hider.style.width;
     clone.wtTable.holder.style.width = clone.wtTable.wtRootElement.style.width;
     clone.wtTable.holder.style.height = clone.wtTable.wtRootElement.style.height;
+
+    if (!force) {
+      this.areElementSizesAdjusted = true;
+    }
   }
 
   /**

--- a/src/3rdparty/walkontable/src/overlay/bottom.js
+++ b/src/3rdparty/walkontable/src/overlay/bottom.js
@@ -142,13 +142,13 @@ class BottomOverlay extends Overlay {
    * @returns {Number} Height sum
    */
   sumCellSizes(from, to) {
-    const { wtTable, wtSettings } = this.wot;
+    const { wtSettings } = this.wot;
     const defaultRowHeight = wtSettings.settings.defaultRowHeight;
     let row = from;
     let sum = 0;
 
     while (row < to) {
-      const height = wtTable.getRowHeight(row);
+      const height = this.wot.rowUtils.getHeight(row);
 
       sum += height === void 0 ? defaultRowHeight : height;
       row += 1;

--- a/src/3rdparty/walkontable/src/overlay/bottom.js
+++ b/src/3rdparty/walkontable/src/overlay/bottom.js
@@ -35,22 +35,6 @@ class BottomOverlay extends Overlay {
   }
 
   /**
-   *
-   */
-  repositionOverlay() {
-    const { master } = this;
-    const overlayRootElement = this.clone.wtTable.wtRootElement;
-    let scrollbarWidth = getScrollbarWidth(master.rootDocument);
-
-    if (master.wtTable.holder.clientHeight === master.wtTable.holder.offsetHeight) {
-      scrollbarWidth = 0;
-    }
-
-    overlayRootElement.style.top = '';
-    overlayRootElement.style.bottom = `${scrollbarWidth}px`;
-  }
-
-  /**
    * Checks if overlay should be fully rendered
    *
    * @returns {Boolean}
@@ -65,6 +49,28 @@ class BottomOverlay extends Overlay {
    */
   adjustElementsPosition() {
     const { master } = this;
+    const total = master.getSetting('totalRows');
+
+    if (typeof master.wtViewport.rowsRenderCalculator.startPosition === 'number') {
+      master.wtTable.spreader.style.top = `${master.wtViewport.rowsRenderCalculator.startPosition}px`;
+
+    } else if (total === 0) {
+      // can happen if there are 0 rows
+      master.wtTable.spreader.style.top = '0';
+
+    } else {
+      throw new Error('Incorrect value of the rowsRenderCalculator');
+    }
+    master.wtTable.spreader.style.bottom = '';
+
+    if (this.needFullRender) {
+      if (typeof master.wtViewport.columnsRenderCalculator.startPosition === 'number') {
+        this.clone.wtTable.spreader.style.left = `${master.wtViewport.columnsRenderCalculator.startPosition}px`;
+
+      } else {
+        this.clone.wtTable.spreader.style.left = '';
+      }
+    }
 
     if (!this.needFullRender || !master.wtTable.holder.parentNode) {
       // removed from DOM
@@ -102,7 +108,15 @@ class BottomOverlay extends Overlay {
     } else {
       headerPosition = this.getScrollPosition();
       resetCssTransform(overlayRootElement);
-      this.repositionOverlay();
+
+      let scrollbarWidth = getScrollbarWidth(master.rootDocument);
+
+      if (master.wtTable.holder.clientHeight === master.wtTable.holder.offsetHeight) {
+        scrollbarWidth = 0;
+      }
+
+      overlayRootElement.style.top = '';
+      overlayRootElement.style.bottom = `${scrollbarWidth}px`;
     }
     this.adjustHeaderBordersPosition(headerPosition);
   }
@@ -204,35 +218,6 @@ class BottomOverlay extends Overlay {
 
     if (!force) {
       this.areElementSizesAdjusted = true;
-    }
-  }
-
-  /**
-   * Adjust the overlay position
-   */
-  workaroundsForPosition() {
-    const { master } = this;
-    const total = master.getSetting('totalRows');
-
-    if (typeof master.wtViewport.rowsRenderCalculator.startPosition === 'number') {
-      master.wtTable.spreader.style.top = `${master.wtViewport.rowsRenderCalculator.startPosition}px`;
-
-    } else if (total === 0) {
-      // can happen if there are 0 rows
-      master.wtTable.spreader.style.top = '0';
-
-    } else {
-      throw new Error('Incorrect value of the rowsRenderCalculator');
-    }
-    master.wtTable.spreader.style.bottom = '';
-
-    if (this.needFullRender) {
-      if (typeof master.wtViewport.columnsRenderCalculator.startPosition === 'number') {
-        this.clone.wtTable.spreader.style.left = `${master.wtViewport.columnsRenderCalculator.startPosition}px`;
-
-      } else {
-        this.clone.wtTable.spreader.style.left = '';
-      }
     }
   }
 

--- a/src/3rdparty/walkontable/src/overlay/bottom.js
+++ b/src/3rdparty/walkontable/src/overlay/bottom.js
@@ -83,7 +83,7 @@ class BottomOverlay extends Overlay {
 
     overlayRootElement.style.top = '';
 
-    if (this.trimmingContainer === master.rootWindow && (!preventOverflow || preventOverflow !== 'vertical')) {
+    if (master.wtTable.trimmingContainer === master.rootWindow && (!preventOverflow || preventOverflow !== 'vertical')) {
       const box = master.wtTable.hider.getBoundingClientRect();
       const bottom = Math.ceil(box.bottom);
       let finalLeft;
@@ -187,7 +187,7 @@ class BottomOverlay extends Overlay {
     const overlayRootElementStyle = overlayRootElement.style;
     const preventOverflow = master.getSetting('preventOverflow');
 
-    if (this.trimmingContainer !== master.rootWindow || preventOverflow === 'horizontal') {
+    if (master.wtTable.trimmingContainer !== master.rootWindow || preventOverflow === 'horizontal') {
       let width = master.wtViewport.getWorkspaceWidth();
 
       if (master.wtOverlays.hasScrollbarRight) {

--- a/src/3rdparty/walkontable/src/overlay/bottom.js
+++ b/src/3rdparty/walkontable/src/overlay/bottom.js
@@ -271,6 +271,27 @@ class BottomOverlay extends Overlay {
   }
 
   /**
+   * Redraws the content of the overlay's clone instance of Walkontable, including the cells, selections and borders.
+   * Does not change the size nor the position of the overlay root element.
+   *
+   * @param {Boolean} [fastDraw=false]
+   */
+  redrawClone(fastDraw = false) {
+    Overlay.prototype.redrawClone.call(this, fastDraw); // equals: super(fastDraw)
+
+    if (!fastDraw) {
+      // nasty workaround for double border in the header, TODO: find a pure-css solution
+      if (this.master.getSetting('rowHeaders').length === 0) {
+        const secondHeaderCell = this.clone.wtTable.THEAD.querySelector('th:nth-of-type(2)');
+
+        if (secondHeaderCell) {
+          secondHeaderCell.style['border-left-width'] = 0;
+        }
+      }
+    }
+  }
+
+  /**
    * Adds css classes to hide the header border's header (cell-selection border hiding issue)
    *
    * @param {Number} position Header Y position if trimming container is window or scroll top if not
@@ -285,14 +306,6 @@ class BottomOverlay extends Overlay {
         addClass(masterRootElement, 'innerBorderTop');
       } else {
         removeClass(masterRootElement, 'innerBorderTop');
-      }
-    }
-    // nasty workaround for double border in the header, TODO: find a pure-css solution
-    if (master.getSetting('rowHeaders').length === 0) {
-      const secondHeaderCell = this.clone.wtTable.THEAD.querySelector('th:nth-of-type(2)');
-
-      if (secondHeaderCell) {
-        secondHeaderCell.style['border-left-width'] = 0;
       }
     }
   }

--- a/src/3rdparty/walkontable/src/overlay/bottom.js
+++ b/src/3rdparty/walkontable/src/overlay/bottom.js
@@ -219,9 +219,6 @@ class BottomOverlay extends Overlay {
   workaroundsForPositionAndSize() {
     const total = this.master.getSetting('totalRows');
 
-    if (!this.areElementSizesAdjusted) {
-      this.adjustElementsSize();
-    }
     if (typeof this.master.wtViewport.rowsRenderCalculator.startPosition === 'number') {
       this.master.wtTable.spreader.style.top = `${this.master.wtViewport.rowsRenderCalculator.startPosition}px`;
 

--- a/src/3rdparty/walkontable/src/overlay/bottom.js
+++ b/src/3rdparty/walkontable/src/overlay/bottom.js
@@ -178,8 +178,6 @@ class BottomOverlay extends Overlay {
    * @param {Boolean} [force=false]
    */
   adjustElementsSize(force = false) {
-    this.updateTrimmingContainer();
-
     if (!this.needFullRender && !force) {
       return;
     }

--- a/src/3rdparty/walkontable/src/overlay/bottom.js
+++ b/src/3rdparty/walkontable/src/overlay/bottom.js
@@ -38,7 +38,7 @@ class BottomOverlay extends Overlay {
    *
    */
   repositionOverlay() {
-    const { wtTable, rootDocument } = this.wot;
+    const { wtTable, rootDocument } = this.master;
     const overlayRoot = this.clone.wtTable.holder.parentNode;
     let scrollbarWidth = getScrollbarWidth(rootDocument);
 
@@ -57,14 +57,14 @@ class BottomOverlay extends Overlay {
    */
   shouldBeRendered() {
     /* eslint-disable no-unneeded-ternary */
-    return this.wot.getSetting('fixedRowsBottom') ? true : false;
+    return this.master.getSetting('fixedRowsBottom') ? true : false;
   }
 
   /**
    * Updates the top overlay position
    */
   resetFixedPosition() {
-    if (!this.needFullRender || !this.wot.wtTable.holder.parentNode) {
+    if (!this.needFullRender || !this.master.wtTable.holder.parentNode) {
       // removed from DOM
       return;
     }
@@ -72,10 +72,10 @@ class BottomOverlay extends Overlay {
     const overlayRoot = this.clone.wtTable.holder.parentNode;
     let headerPosition = 0;
     overlayRoot.style.top = '';
-    const preventOverflow = this.wot.getSetting('preventOverflow');
+    const preventOverflow = this.master.getSetting('preventOverflow');
 
-    if (this.trimmingContainer === this.wot.rootWindow && (!preventOverflow || preventOverflow !== 'vertical')) {
-      const { rootDocument, wtTable } = this.wot;
+    if (this.trimmingContainer === this.master.rootWindow && (!preventOverflow || preventOverflow !== 'vertical')) {
+      const { rootDocument, wtTable } = this.master;
       const box = wtTable.hider.getBoundingClientRect();
       const bottom = Math.ceil(box.bottom);
       let finalLeft;
@@ -112,7 +112,7 @@ class BottomOverlay extends Overlay {
    * @param {Number} pos
    */
   setScrollPosition(pos) {
-    const { rootWindow } = this.wot;
+    const { rootWindow } = this.master;
     let result = false;
 
     if (this.mainTableScrollableElement === rootWindow) {
@@ -131,7 +131,7 @@ class BottomOverlay extends Overlay {
    * Triggers onScroll hook callback
    */
   onScroll() {
-    this.wot.getSetting('onScrollHorizontally');
+    this.master.getSetting('onScrollHorizontally');
   }
 
   /**
@@ -142,13 +142,13 @@ class BottomOverlay extends Overlay {
    * @returns {Number} Height sum
    */
   sumCellSizes(from, to) {
-    const { wtSettings } = this.wot;
+    const { wtSettings } = this.master;
     const defaultRowHeight = wtSettings.settings.defaultRowHeight;
     let row = from;
     let sum = 0;
 
     while (row < to) {
-      const height = this.wot.rowUtils.getHeight(row);
+      const height = this.master.rowUtils.getHeight(row);
 
       sum += height === void 0 ? defaultRowHeight : height;
       row += 1;
@@ -178,16 +178,16 @@ class BottomOverlay extends Overlay {
    * Adjust the width and height of the overlay root element and its children (hider, holder) to the dimensions of the trimming container.
    */
   adjustRootElementSize() {
-    const { wtTable, wtViewport, rootWindow } = this.wot;
-    const scrollbarWidth = getScrollbarWidth(this.wot.rootDocument);
+    const { wtTable, wtViewport, rootWindow } = this.master;
+    const scrollbarWidth = getScrollbarWidth(this.master.rootDocument);
     const overlayRoot = this.clone.wtTable.holder.parentNode;
     const overlayRootStyle = overlayRoot.style;
-    const preventOverflow = this.wot.getSetting('preventOverflow');
+    const preventOverflow = this.master.getSetting('preventOverflow');
 
     if (this.trimmingContainer !== rootWindow || preventOverflow === 'horizontal') {
       let width = wtViewport.getWorkspaceWidth();
 
-      if (this.wot.wtOverlays.hasScrollbarRight) {
+      if (this.master.wtOverlays.hasScrollbarRight) {
         width -= scrollbarWidth;
       }
 
@@ -200,7 +200,7 @@ class BottomOverlay extends Overlay {
 
     let tableHeight = outerHeight(this.clone.wtTable.TABLE);
 
-    if (!this.wot.wtTable.hasDefinedSize()) {
+    if (!this.master.wtTable.hasDefinedSize()) {
       tableHeight = 0;
     }
 
@@ -217,13 +217,13 @@ class BottomOverlay extends Overlay {
    * Adjust the overlay dimensions and position
    */
   applyToDOM() {
-    const total = this.wot.getSetting('totalRows');
+    const total = this.master.getSetting('totalRows');
 
     if (!this.areElementSizesAdjusted) {
       this.adjustElementsSize();
     }
-    if (typeof this.wot.wtViewport.rowsRenderCalculator.startPosition === 'number') {
-      this.spreader.style.top = `${this.wot.wtViewport.rowsRenderCalculator.startPosition}px`;
+    if (typeof this.master.wtViewport.rowsRenderCalculator.startPosition === 'number') {
+      this.spreader.style.top = `${this.master.wtViewport.rowsRenderCalculator.startPosition}px`;
 
     } else if (total === 0) {
       // can happen if there are 0 rows
@@ -243,8 +243,8 @@ class BottomOverlay extends Overlay {
    * Synchronize calculated left position to an element
    */
   syncOverlayOffset() {
-    if (typeof this.wot.wtViewport.columnsRenderCalculator.startPosition === 'number') {
-      this.clone.wtTable.spreader.style.left = `${this.wot.wtViewport.columnsRenderCalculator.startPosition}px`;
+    if (typeof this.master.wtViewport.columnsRenderCalculator.startPosition === 'number') {
+      this.clone.wtTable.spreader.style.left = `${this.master.wtViewport.columnsRenderCalculator.startPosition}px`;
 
     } else {
       this.clone.wtTable.spreader.style.left = '';
@@ -259,22 +259,22 @@ class BottomOverlay extends Overlay {
    */
   scrollTo(sourceRow, bottomEdge) {
     let newY = this.getTableParentOffset();
-    const sourceInstance = this.wot.cloneSource ? this.wot.cloneSource : this.wot;
+    const sourceInstance = this.master.cloneSource ? this.master.cloneSource : this.master;
     const mainHolder = sourceInstance.wtTable.holder;
     let scrollbarCompensation = 0;
 
     if (bottomEdge && mainHolder.offsetHeight !== mainHolder.clientHeight) {
-      scrollbarCompensation = getScrollbarWidth(this.wot.rootDocument);
+      scrollbarCompensation = getScrollbarWidth(this.master.rootDocument);
     }
 
     if (bottomEdge) {
       newY += this.sumCellSizes(0, sourceRow + 1);
-      newY -= this.wot.wtViewport.getViewportHeight();
+      newY -= this.master.wtViewport.getViewportHeight();
       // Fix 1 pixel offset when cell is selected
       newY += 1;
 
     } else {
-      newY += this.sumCellSizes(this.wot.getSetting('fixedRowsBottom'), sourceRow);
+      newY += this.sumCellSizes(this.master.getSetting('fixedRowsBottom'), sourceRow);
     }
     newY += scrollbarCompensation;
 
@@ -287,8 +287,8 @@ class BottomOverlay extends Overlay {
    * @returns {Number}
    */
   getTableParentOffset() {
-    if (this.mainTableScrollableElement === this.wot.rootWindow) {
-      return this.wot.wtTable.holderOffset.top;
+    if (this.mainTableScrollableElement === this.master.rootWindow) {
+      return this.master.wtTable.holderOffset.top;
     }
 
     return 0;
@@ -300,7 +300,7 @@ class BottomOverlay extends Overlay {
    * @returns {Number} Main table's vertical scroll position
    */
   getScrollPosition() {
-    return getScrollTop(this.mainTableScrollableElement, this.wot.rootWindow);
+    return getScrollTop(this.mainTableScrollableElement, this.master.rootWindow);
   }
 
   /**
@@ -309,8 +309,8 @@ class BottomOverlay extends Overlay {
    * @param {Number} position Header Y position if trimming container is window or scroll top if not
    */
   adjustHeaderBordersPosition(position) {
-    if (this.wot.getSetting('fixedRowsBottom') === 0 && this.wot.getSetting('columnHeaders').length > 0) {
-      const masterParent = this.wot.wtTable.holder.parentNode;
+    if (this.master.getSetting('fixedRowsBottom') === 0 && this.master.getSetting('columnHeaders').length > 0) {
+      const masterParent = this.master.wtTable.holder.parentNode;
       const previousState = hasClass(masterParent, 'innerBorderTop');
 
       if (position) {
@@ -319,11 +319,11 @@ class BottomOverlay extends Overlay {
         removeClass(masterParent, 'innerBorderTop');
       }
       if (!previousState && position || previousState && !position) {
-        this.wot.wtOverlays.adjustElementsSize();
+        this.master.wtOverlays.adjustElementsSize();
       }
     }
     // nasty workaround for double border in the header, TODO: find a pure-css solution
-    if (this.wot.getSetting('rowHeaders').length === 0) {
+    if (this.master.getSetting('rowHeaders').length === 0) {
       const secondHeaderCell = this.clone.wtTable.THEAD.querySelector('th:nth-of-type(2)');
 
       if (secondHeaderCell) {

--- a/src/3rdparty/walkontable/src/overlay/bottom.js
+++ b/src/3rdparty/walkontable/src/overlay/bottom.js
@@ -208,9 +208,9 @@ class BottomOverlay extends Overlay {
   }
 
   /**
-   * Adjust the overlay dimensions and position
+   * Adjust the overlay position
    */
-  workaroundsForPositionAndSize() {
+  workaroundsForPosition() {
     const { master } = this;
     const total = master.getSetting('totalRows');
 

--- a/src/3rdparty/walkontable/src/overlay/bottom.js
+++ b/src/3rdparty/walkontable/src/overlay/bottom.js
@@ -179,20 +179,19 @@ class BottomOverlay extends Overlay {
    * Adjust the sizes of the clone and the master elements to the dimensions of the trimming container.
    */
   _adjustElementsSize() {
-    const { wtTable, wtViewport, rootWindow } = this.master;
     const scrollbarWidth = getScrollbarWidth(this.master.rootDocument);
     const overlayRoot = this.clone.wtTable.wtRootElement;
     const overlayRootStyle = overlayRoot.style;
     const preventOverflow = this.master.getSetting('preventOverflow');
 
-    if (this.trimmingContainer !== rootWindow || preventOverflow === 'horizontal') {
-      let width = wtViewport.getWorkspaceWidth();
+    if (this.trimmingContainer !== this.master.rootWindow || preventOverflow === 'horizontal') {
+      let width = this.master.wtViewport.getWorkspaceWidth();
 
       if (this.master.wtOverlays.hasScrollbarRight) {
         width -= scrollbarWidth;
       }
 
-      width = Math.min(width, wtTable.wtRootElement.scrollWidth);
+      width = Math.min(width, this.master.wtTable.wtRootElement.scrollWidth);
       overlayRootStyle.width = `${width}px`;
 
     } else {

--- a/src/3rdparty/walkontable/src/overlay/bottom.js
+++ b/src/3rdparty/walkontable/src/overlay/bottom.js
@@ -62,9 +62,9 @@ class BottomOverlay extends Overlay {
   }
 
   /**
-   * Updates the top overlay position
+   * Updates the position of the overlay root element relatively to the position of the master instance
    */
-  resetFixedPosition() {
+  adjustElementsPosition() {
     if (!this.needFullRender || !this.master.wtTable.holder.parentNode) {
       // removed from DOM
       return;
@@ -159,7 +159,7 @@ class BottomOverlay extends Overlay {
   }
 
   /**
-   * Adjust overlay root element, childs and master table element sizes (width, height).
+   * If needed, adjust the sizes of the clone and the master elements to the dimensions of the trimming container.
    *
    * @param {Boolean} [force=false]
    */
@@ -167,7 +167,7 @@ class BottomOverlay extends Overlay {
     this.updateTrimmingContainer();
 
     if (this.needFullRender || force) {
-      this.adjustRootElementSize();
+      this._adjustElementsSize();
 
       if (!force) {
         this.areElementSizesAdjusted = true;
@@ -176,9 +176,9 @@ class BottomOverlay extends Overlay {
   }
 
   /**
-   * Adjust the width and height of the overlay root element and its children (hider, holder) to the dimensions of the trimming container.
+   * Adjust the sizes of the clone and the master elements to the dimensions of the trimming container.
    */
-  adjustRootElementSize() {
+  _adjustElementsSize() {
     const { wtTable, wtViewport, rootWindow } = this.master;
     const scrollbarWidth = getScrollbarWidth(this.master.rootDocument);
     const overlayRoot = this.clone.wtTable.wtRootElement;
@@ -217,7 +217,7 @@ class BottomOverlay extends Overlay {
   /**
    * Adjust the overlay dimensions and position
    */
-  applyToDOM() {
+  workaroundsForPositionAndSize() {
     const total = this.master.getSetting('totalRows');
 
     if (!this.areElementSizesAdjusted) {
@@ -319,7 +319,7 @@ class BottomOverlay extends Overlay {
         removeClass(masterParent, 'innerBorderTop');
       }
       if (!previousState && position || previousState && !position) {
-        this.master.wtOverlays.adjustElementsSize();
+        this.master.wtOverlays.adjustElementsSizes();
       }
     }
     // nasty workaround for double border in the header, TODO: find a pure-css solution

--- a/src/3rdparty/walkontable/src/overlay/bottom.js
+++ b/src/3rdparty/walkontable/src/overlay/bottom.js
@@ -236,19 +236,12 @@ class BottomOverlay extends Overlay {
     this.spreader.style.bottom = '';
 
     if (this.needFullRender) {
-      this.syncOverlayOffset();
-    }
-  }
+      if (typeof this.master.wtViewport.columnsRenderCalculator.startPosition === 'number') {
+        this.clone.wtTable.spreader.style.left = `${this.master.wtViewport.columnsRenderCalculator.startPosition}px`;
 
-  /**
-   * Synchronize calculated left position to an element
-   */
-  syncOverlayOffset() {
-    if (typeof this.master.wtViewport.columnsRenderCalculator.startPosition === 'number') {
-      this.clone.wtTable.spreader.style.left = `${this.master.wtViewport.columnsRenderCalculator.startPosition}px`;
-
-    } else {
-      this.clone.wtTable.spreader.style.left = '';
+      } else {
+        this.clone.wtTable.spreader.style.left = '';
+      }
     }
   }
 

--- a/src/3rdparty/walkontable/src/overlay/bottom.js
+++ b/src/3rdparty/walkontable/src/overlay/bottom.js
@@ -185,7 +185,6 @@ class BottomOverlay extends Overlay {
     }
 
     const { clone, master } = this;
-    const scrollbarWidth = getScrollbarWidth(master.rootDocument);
     const overlayRootElement = clone.wtTable.wtRootElement;
     const overlayRootElementStyle = overlayRootElement.style;
     const preventOverflow = master.getSetting('preventOverflow');
@@ -194,7 +193,7 @@ class BottomOverlay extends Overlay {
       let width = master.wtViewport.getWorkspaceWidth();
 
       if (master.wtOverlays.hasScrollbarRight) {
-        width -= scrollbarWidth;
+        width -= getScrollbarWidth(master.rootDocument);
       }
 
       width = Math.min(width, master.wtTable.wtRootElement.scrollWidth);

--- a/src/3rdparty/walkontable/src/overlay/bottom.js
+++ b/src/3rdparty/walkontable/src/overlay/bottom.js
@@ -212,8 +212,8 @@ class BottomOverlay extends Overlay {
     overlayRootElementStyle.height = `${tableHeight}px`;
 
     clone.wtTable.hider.style.width = this.master.wtTable.hider.style.width;
-    clone.wtTable.holder.style.width = clone.wtTable.wtRootElement.style.width;
-    clone.wtTable.holder.style.height = clone.wtTable.wtRootElement.style.height;
+    clone.wtTable.holder.style.width = overlayRootElementStyle.width;
+    clone.wtTable.holder.style.height = overlayRootElementStyle.height;
 
     if (!force) {
       this.areElementSizesAdjusted = true;

--- a/src/3rdparty/walkontable/src/overlay/bottom.js
+++ b/src/3rdparty/walkontable/src/overlay/bottom.js
@@ -106,7 +106,6 @@ class BottomOverlay extends Overlay {
       this.repositionOverlay();
     }
     this.adjustHeaderBordersPosition(headerPosition);
-    this.adjustElementsSize();
   }
 
   /**

--- a/src/3rdparty/walkontable/src/overlay/bottom.js
+++ b/src/3rdparty/walkontable/src/overlay/bottom.js
@@ -209,7 +209,7 @@ class BottomOverlay extends Overlay {
 
     const { holder, hider, wtRootElement } = this.clone.wtTable;
 
-    hider.style.width = this.hider.style.width;
+    hider.style.width = this.master.wtTable.hider.style.width;
     holder.style.width = wtRootElement.style.width;
     holder.style.height = wtRootElement.style.height;
   }
@@ -224,16 +224,16 @@ class BottomOverlay extends Overlay {
       this.adjustElementsSize();
     }
     if (typeof this.master.wtViewport.rowsRenderCalculator.startPosition === 'number') {
-      this.spreader.style.top = `${this.master.wtViewport.rowsRenderCalculator.startPosition}px`;
+      this.master.wtTable.spreader.style.top = `${this.master.wtViewport.rowsRenderCalculator.startPosition}px`;
 
     } else if (total === 0) {
       // can happen if there are 0 rows
-      this.spreader.style.top = '0';
+      this.master.wtTable.spreader.style.top = '0';
 
     } else {
       throw new Error('Incorrect value of the rowsRenderCalculator');
     }
-    this.spreader.style.bottom = '';
+    this.master.wtTable.spreader.style.bottom = '';
 
     if (this.needFullRender) {
       if (typeof this.master.wtViewport.columnsRenderCalculator.startPosition === 'number') {

--- a/src/3rdparty/walkontable/src/overlay/bottom.js
+++ b/src/3rdparty/walkontable/src/overlay/bottom.js
@@ -39,16 +39,16 @@ class BottomOverlay extends Overlay {
    *
    */
   repositionOverlay() {
-    const { wtTable, rootDocument } = this.master;
-    const overlayRoot = this.clone.wtTable.wtRootElement;
-    let scrollbarWidth = getScrollbarWidth(rootDocument);
+    const { master } = this;
+    const overlayRootElement = this.clone.wtTable.wtRootElement;
+    let scrollbarWidth = getScrollbarWidth(master.rootDocument);
 
-    if (wtTable.holder.clientHeight === wtTable.holder.offsetHeight) {
+    if (master.wtTable.holder.clientHeight === master.wtTable.holder.offsetHeight) {
       scrollbarWidth = 0;
     }
 
-    overlayRoot.style.top = '';
-    overlayRoot.style.bottom = `${scrollbarWidth}px`;
+    overlayRootElement.style.top = '';
+    overlayRootElement.style.bottom = `${scrollbarWidth}px`;
   }
 
   /**
@@ -65,25 +65,27 @@ class BottomOverlay extends Overlay {
    * Updates the position of the overlay root element relatively to the position of the master instance
    */
   adjustElementsPosition() {
-    if (!this.needFullRender || !this.master.wtTable.holder.parentNode) {
+    const { master } = this;
+
+    if (!this.needFullRender || !master.wtTable.holder.parentNode) {
       // removed from DOM
       return;
     }
 
-    const overlayRoot = this.clone.wtTable.wtRootElement;
+    const overlayRootElement = this.clone.wtTable.wtRootElement;
     let headerPosition = 0;
-    overlayRoot.style.top = '';
-    const preventOverflow = this.master.getSetting('preventOverflow');
+    const preventOverflow = master.getSetting('preventOverflow');
 
-    if (this.trimmingContainer === this.master.rootWindow && (!preventOverflow || preventOverflow !== 'vertical')) {
-      const { rootDocument, wtTable } = this.master;
-      const box = wtTable.hider.getBoundingClientRect();
+    overlayRootElement.style.top = '';
+
+    if (this.trimmingContainer === master.rootWindow && (!preventOverflow || preventOverflow !== 'vertical')) {
+      const box = master.wtTable.hider.getBoundingClientRect();
       const bottom = Math.ceil(box.bottom);
       let finalLeft;
       let finalBottom;
-      const bodyHeight = rootDocument.body.offsetHeight;
+      const bodyHeight = master.rootDocument.body.offsetHeight;
 
-      finalLeft = wtTable.hider.style.left;
+      finalLeft = master.wtTable.hider.style.left;
       finalLeft = finalLeft === '' ? 0 : finalLeft;
 
       if (bottom > bodyHeight) {
@@ -94,13 +96,13 @@ class BottomOverlay extends Overlay {
       headerPosition = finalBottom;
       finalBottom += 'px';
 
-      overlayRoot.style.top = '';
-      overlayRoot.style.left = finalLeft;
-      overlayRoot.style.bottom = finalBottom;
+      overlayRootElement.style.top = '';
+      overlayRootElement.style.left = finalLeft;
+      overlayRootElement.style.bottom = finalBottom;
 
     } else {
       headerPosition = this.getScrollPosition();
-      resetCssTransform(overlayRoot);
+      resetCssTransform(overlayRootElement);
       this.repositionOverlay();
     }
     this.adjustHeaderBordersPosition(headerPosition);
@@ -113,11 +115,11 @@ class BottomOverlay extends Overlay {
    * @param {Number} pos
    */
   setScrollPosition(pos) {
-    const { rootWindow } = this.master;
+    const { master } = this;
     let result = false;
 
-    if (this.mainTableScrollableElement === rootWindow) {
-      rootWindow.scrollTo(getWindowScrollLeft(rootWindow), pos);
+    if (this.mainTableScrollableElement === master.rootWindow) {
+      master.rootWindow.scrollTo(getWindowScrollLeft(master.rootWindow), pos);
       result = true;
 
     } else if (this.mainTableScrollableElement.scrollTop !== pos) {
@@ -143,13 +145,13 @@ class BottomOverlay extends Overlay {
    * @returns {Number} Height sum
    */
   sumCellSizes(from, to) {
-    const { wtSettings } = this.master;
-    const defaultRowHeight = wtSettings.settings.defaultRowHeight;
+    const { master } = this;
+    const defaultRowHeight = master.wtSettings.settings.defaultRowHeight;
     let row = from;
     let sum = 0;
 
     while (row < to) {
-      const height = this.master.rowUtils.getHeight(row);
+      const height = master.rowUtils.getHeight(row);
 
       sum += height === void 0 ? defaultRowHeight : height;
       row += 1;
@@ -179,61 +181,61 @@ class BottomOverlay extends Overlay {
    * Adjust the sizes of the clone and the master elements to the dimensions of the trimming container.
    */
   _adjustElementsSize() {
-    const scrollbarWidth = getScrollbarWidth(this.master.rootDocument);
-    const overlayRoot = this.clone.wtTable.wtRootElement;
-    const overlayRootStyle = overlayRoot.style;
-    const preventOverflow = this.master.getSetting('preventOverflow');
+    const { clone, master } = this;
+    const scrollbarWidth = getScrollbarWidth(master.rootDocument);
+    const overlayRootElement = clone.wtTable.wtRootElement;
+    const overlayRootElementStyle = overlayRootElement.style;
+    const preventOverflow = master.getSetting('preventOverflow');
 
-    if (this.trimmingContainer !== this.master.rootWindow || preventOverflow === 'horizontal') {
-      let width = this.master.wtViewport.getWorkspaceWidth();
+    if (this.trimmingContainer !== master.rootWindow || preventOverflow === 'horizontal') {
+      let width = master.wtViewport.getWorkspaceWidth();
 
-      if (this.master.wtOverlays.hasScrollbarRight) {
+      if (master.wtOverlays.hasScrollbarRight) {
         width -= scrollbarWidth;
       }
 
-      width = Math.min(width, this.master.wtTable.wtRootElement.scrollWidth);
-      overlayRootStyle.width = `${width}px`;
+      width = Math.min(width, master.wtTable.wtRootElement.scrollWidth);
+      overlayRootElementStyle.width = `${width}px`;
 
     } else {
-      overlayRootStyle.width = '';
+      overlayRootElementStyle.width = '';
     }
 
-    let tableHeight = outerHeight(this.clone.wtTable.TABLE);
+    let tableHeight = outerHeight(clone.wtTable.TABLE);
 
-    if (!this.master.wtTable.hasDefinedSize()) {
+    if (!master.wtTable.hasDefinedSize()) {
       tableHeight = 0;
     }
 
-    overlayRootStyle.height = `${tableHeight}px`;
+    overlayRootElementStyle.height = `${tableHeight}px`;
 
-    const { holder, hider, wtRootElement } = this.clone.wtTable;
-
-    hider.style.width = this.master.wtTable.hider.style.width;
-    holder.style.width = wtRootElement.style.width;
-    holder.style.height = wtRootElement.style.height;
+    clone.wtTable.hider.style.width = this.master.wtTable.hider.style.width;
+    clone.wtTable.holder.style.width = clone.wtTable.wtRootElement.style.width;
+    clone.wtTable.holder.style.height = clone.wtTable.wtRootElement.style.height;
   }
 
   /**
    * Adjust the overlay dimensions and position
    */
   workaroundsForPositionAndSize() {
-    const total = this.master.getSetting('totalRows');
+    const { master } = this;
+    const total = master.getSetting('totalRows');
 
-    if (typeof this.master.wtViewport.rowsRenderCalculator.startPosition === 'number') {
-      this.master.wtTable.spreader.style.top = `${this.master.wtViewport.rowsRenderCalculator.startPosition}px`;
+    if (typeof master.wtViewport.rowsRenderCalculator.startPosition === 'number') {
+      master.wtTable.spreader.style.top = `${master.wtViewport.rowsRenderCalculator.startPosition}px`;
 
     } else if (total === 0) {
       // can happen if there are 0 rows
-      this.master.wtTable.spreader.style.top = '0';
+      master.wtTable.spreader.style.top = '0';
 
     } else {
       throw new Error('Incorrect value of the rowsRenderCalculator');
     }
-    this.master.wtTable.spreader.style.bottom = '';
+    master.wtTable.spreader.style.bottom = '';
 
     if (this.needFullRender) {
-      if (typeof this.master.wtViewport.columnsRenderCalculator.startPosition === 'number') {
-        this.clone.wtTable.spreader.style.left = `${this.master.wtViewport.columnsRenderCalculator.startPosition}px`;
+      if (typeof master.wtViewport.columnsRenderCalculator.startPosition === 'number') {
+        this.clone.wtTable.spreader.style.left = `${master.wtViewport.columnsRenderCalculator.startPosition}px`;
 
       } else {
         this.clone.wtTable.spreader.style.left = '';
@@ -248,22 +250,23 @@ class BottomOverlay extends Overlay {
    * @param [bottomEdge=false] {Boolean} if `true`, scrolls according to the bottom edge (top edge is by default)
    */
   scrollTo(sourceRow, bottomEdge) {
+    const { master } = this;
     let newY = this.getTableParentOffset();
-    const mainHolder = this.master.wtTable.holder;
+    const mainHolder = master.wtTable.holder;
     let scrollbarCompensation = 0;
 
     if (bottomEdge && mainHolder.offsetHeight !== mainHolder.clientHeight) {
-      scrollbarCompensation = getScrollbarWidth(this.master.rootDocument);
+      scrollbarCompensation = getScrollbarWidth(master.rootDocument);
     }
 
     if (bottomEdge) {
       newY += this.sumCellSizes(0, sourceRow + 1);
-      newY -= this.master.wtViewport.getViewportHeight();
+      newY -= master.wtViewport.getViewportHeight();
       // Fix 1 pixel offset when cell is selected
       newY += 1;
 
     } else {
-      newY += this.sumCellSizes(this.master.getSetting('fixedRowsBottom'), sourceRow);
+      newY += this.sumCellSizes(master.getSetting('fixedRowsBottom'), sourceRow);
     }
     newY += scrollbarCompensation;
 
@@ -298,21 +301,23 @@ class BottomOverlay extends Overlay {
    * @param {Number} position Header Y position if trimming container is window or scroll top if not
    */
   adjustHeaderBordersPosition(position) {
-    if (this.master.getSetting('fixedRowsBottom') === 0 && this.master.getSetting('columnHeaders').length > 0) {
-      const masterParent = this.master.wtTable.wtRootElement;
-      const previousState = hasClass(masterParent, 'innerBorderTop');
+    const { master } = this;
+
+    if (master.getSetting('fixedRowsBottom') === 0 && master.getSetting('columnHeaders').length > 0) {
+      const masterRootElement = master.wtTable.wtRootElement;
+      const previousState = hasClass(masterRootElement, 'innerBorderTop');
 
       if (position) {
-        addClass(masterParent, 'innerBorderTop');
+        addClass(masterRootElement, 'innerBorderTop');
       } else {
-        removeClass(masterParent, 'innerBorderTop');
+        removeClass(masterRootElement, 'innerBorderTop');
       }
       if (!previousState && position || previousState && !position) {
-        this.master.wtOverlays.adjustElementsSizes();
+        master.wtOverlays.adjustElementsSizes();
       }
     }
     // nasty workaround for double border in the header, TODO: find a pure-css solution
-    if (this.master.getSetting('rowHeaders').length === 0) {
+    if (master.getSetting('rowHeaders').length === 0) {
       const secondHeaderCell = this.clone.wtTable.THEAD.querySelector('th:nth-of-type(2)');
 
       if (secondHeaderCell) {

--- a/src/3rdparty/walkontable/src/overlay/bottom.js
+++ b/src/3rdparty/walkontable/src/overlay/bottom.js
@@ -259,8 +259,7 @@ class BottomOverlay extends Overlay {
    */
   scrollTo(sourceRow, bottomEdge) {
     let newY = this.getTableParentOffset();
-    const sourceInstance = this.master.overlay ? this.master.overlay.master : this.master; // TODO what?
-    const mainHolder = sourceInstance.wtTable.holder;
+    const mainHolder = this.master.wtTable.holder;
     let scrollbarCompensation = 0;
 
     if (bottomEdge && mainHolder.offsetHeight !== mainHolder.clientHeight) {

--- a/src/3rdparty/walkontable/src/overlay/bottom.js
+++ b/src/3rdparty/walkontable/src/overlay/bottom.js
@@ -3,7 +3,6 @@ import {
   getScrollbarWidth,
   getScrollTop,
   getWindowScrollLeft,
-  hasClass,
   outerHeight,
   removeClass,
   resetCssTransform
@@ -299,15 +298,11 @@ class BottomOverlay extends Overlay {
 
     if (master.getSetting('fixedRowsBottom') === 0 && master.getSetting('columnHeaders').length > 0) {
       const masterRootElement = master.wtTable.wtRootElement;
-      const previousState = hasClass(masterRootElement, 'innerBorderTop');
 
       if (position) {
         addClass(masterRootElement, 'innerBorderTop');
       } else {
         removeClass(masterRootElement, 'innerBorderTop');
-      }
-      if (!previousState && position || previousState && !position) {
-        master.wtOverlays.adjustElementsSizes();
       }
     }
     // nasty workaround for double border in the header, TODO: find a pure-css solution

--- a/src/3rdparty/walkontable/src/overlay/bottom.js
+++ b/src/3rdparty/walkontable/src/overlay/bottom.js
@@ -21,6 +21,7 @@ class BottomOverlay extends Overlay {
   constructor(wotInstance) {
     super(wotInstance);
     this.clone = this.makeClone(Overlay.CLONE_BOTTOM);
+    this.updateStateOfRendering();
   }
 
   /**

--- a/src/3rdparty/walkontable/src/overlay/bottomLeftCorner.js
+++ b/src/3rdparty/walkontable/src/overlay/bottomLeftCorner.js
@@ -95,9 +95,22 @@ class BottomLeftCornerOverlay extends Overlay {
       overlayRootElement.style.top = '';
       overlayRootElement.style.bottom = `${scrollbarWidth}px`;
     }
+  }
 
+  /**
+   * If needed, adjust the sizes of the clone and the master elements to the dimensions of the trimming container.
+   *
+   * @param {Boolean} [force=false]
+   */
+  adjustElementsSize(force = false) {
+    if (!this.needFullRender && !force) {
+      return;
+    }
+
+    const { clone, master } = this;
     let tableHeight = outerHeight(clone.wtTable.TABLE);
     const tableWidth = outerWidth(clone.wtTable.TABLE);
+    const overlayRootElement = clone.wtTable.wtRootElement;
 
     if (!master.wtTable.hasDefinedSize()) {
       tableHeight = 0;

--- a/src/3rdparty/walkontable/src/overlay/bottomLeftCorner.js
+++ b/src/3rdparty/walkontable/src/overlay/bottomLeftCorner.js
@@ -17,6 +17,7 @@ class BottomLeftCornerOverlay extends Overlay {
   constructor(wotInstance) {
     super(wotInstance);
     this.clone = this.makeClone(Overlay.CLONE_BOTTOM_LEFT_CORNER);
+    this.updateStateOfRendering();
   }
 
   /**

--- a/src/3rdparty/walkontable/src/overlay/bottomLeftCorner.js
+++ b/src/3rdparty/walkontable/src/overlay/bottomLeftCorner.js
@@ -60,9 +60,9 @@ class BottomLeftCornerOverlay extends Overlay {
   }
 
   /**
-   * Updates the corner overlay position
+   * Updates the position of the overlay root element relatively to the position of the master instance
    */
-  resetFixedPosition() {
+  adjustElementsPosition() {
     const { master } = this;
     this.updateTrimmingContainer();
 

--- a/src/3rdparty/walkontable/src/overlay/bottomLeftCorner.js
+++ b/src/3rdparty/walkontable/src/overlay/bottomLeftCorner.js
@@ -36,17 +36,17 @@ class BottomLeftCornerOverlay extends Overlay {
    * @returns {Boolean}
    */
   shouldBeRendered() {
-    const { wot } = this;
+    const { master } = this;
     /* eslint-disable no-unneeded-ternary */
-    return wot.getSetting('fixedRowsBottom') &&
-      (wot.getSetting('fixedColumnsLeft') || wot.getSetting('rowHeaders').length) ? true : false;
+    return master.getSetting('fixedRowsBottom') &&
+      (master.getSetting('fixedColumnsLeft') || master.getSetting('rowHeaders').length) ? true : false;
   }
 
   /**
    * Reposition the overlay.
    */
   repositionOverlay() {
-    const { wtTable, rootDocument } = this.wot;
+    const { wtTable, rootDocument } = this.master;
     const overlayRoot = this.clone.wtTable.holder.parentNode;
     let scrollbarWidth = getScrollbarWidth(rootDocument);
 
@@ -62,10 +62,10 @@ class BottomLeftCornerOverlay extends Overlay {
    * Updates the corner overlay position
    */
   resetFixedPosition() {
-    const { wot } = this;
+    const { master } = this;
     this.updateTrimmingContainer();
 
-    if (!wot.wtTable.holder.parentNode) {
+    if (!master.wtTable.holder.parentNode) {
       // removed from DOM
       return;
     }
@@ -73,13 +73,13 @@ class BottomLeftCornerOverlay extends Overlay {
 
     overlayRoot.style.top = '';
 
-    if (this.trimmingContainer === wot.rootWindow) {
-      const box = wot.wtTable.hider.getBoundingClientRect();
+    if (this.trimmingContainer === master.rootWindow) {
+      const box = master.wtTable.hider.getBoundingClientRect();
       const bottom = Math.ceil(box.bottom);
       const left = Math.ceil(box.left);
       let finalLeft;
       let finalBottom;
-      const bodyHeight = wot.rootDocument.body.offsetHeight;
+      const bodyHeight = master.rootDocument.body.offsetHeight;
 
       if (left < 0) {
         finalLeft = -left;
@@ -107,7 +107,7 @@ class BottomLeftCornerOverlay extends Overlay {
     let tableHeight = outerHeight(this.clone.wtTable.TABLE);
     const tableWidth = outerWidth(this.clone.wtTable.TABLE);
 
-    if (!this.wot.wtTable.hasDefinedSize()) {
+    if (!this.master.wtTable.hasDefinedSize()) {
       tableHeight = 0;
     }
 

--- a/src/3rdparty/walkontable/src/overlay/bottomLeftCorner.js
+++ b/src/3rdparty/walkontable/src/overlay/bottomLeftCorner.js
@@ -48,7 +48,6 @@ class BottomLeftCornerOverlay extends Overlay {
    */
   adjustElementsPosition() {
     const { clone, master } = this;
-    this.updateTrimmingContainer();
 
     if (!master.wtTable.holder.parentNode) {
       // removed from DOM

--- a/src/3rdparty/walkontable/src/overlay/bottomLeftCorner.js
+++ b/src/3rdparty/walkontable/src/overlay/bottomLeftCorner.js
@@ -57,7 +57,7 @@ class BottomLeftCornerOverlay extends Overlay {
 
     overlayRootElement.style.top = '';
 
-    if (this.trimmingContainer === master.rootWindow) {
+    if (master.wtTable.trimmingContainer === master.rootWindow) {
       const box = master.wtTable.hider.getBoundingClientRect();
       const bottom = Math.ceil(box.bottom);
       const left = Math.ceil(box.left);

--- a/src/3rdparty/walkontable/src/overlay/bottomLeftCorner.js
+++ b/src/3rdparty/walkontable/src/overlay/bottomLeftCorner.js
@@ -47,7 +47,7 @@ class BottomLeftCornerOverlay extends Overlay {
    */
   repositionOverlay() {
     const { wtTable, rootDocument } = this.master;
-    const overlayRoot = this.clone.wtTable.holder.parentNode;
+    const overlayRoot = this.clone.wtTable.wtRootElement;
     let scrollbarWidth = getScrollbarWidth(rootDocument);
 
     if (wtTable.holder.clientHeight === wtTable.holder.offsetHeight) {
@@ -69,7 +69,7 @@ class BottomLeftCornerOverlay extends Overlay {
       // removed from DOM
       return;
     }
-    const overlayRoot = this.clone.wtTable.holder.parentNode;
+    const overlayRoot = this.clone.wtTable.wtRootElement;
 
     overlayRoot.style.top = '';
 

--- a/src/3rdparty/walkontable/src/overlay/bottomLeftCorner.js
+++ b/src/3rdparty/walkontable/src/overlay/bottomLeftCorner.js
@@ -47,32 +47,32 @@ class BottomLeftCornerOverlay extends Overlay {
    * Reposition the overlay.
    */
   repositionOverlay() {
-    const { wtTable, rootDocument } = this.master;
-    const overlayRoot = this.clone.wtTable.wtRootElement;
-    let scrollbarWidth = getScrollbarWidth(rootDocument);
+    const { master } = this;
+    const overlayRootElement = this.clone.wtTable.wtRootElement;
+    let scrollbarWidth = getScrollbarWidth(master.rootDocument);
 
-    if (wtTable.holder.clientHeight === wtTable.holder.offsetHeight) {
+    if (master.wtTable.holder.clientHeight === master.wtTable.holder.offsetHeight) {
       scrollbarWidth = 0;
     }
 
-    overlayRoot.style.top = '';
-    overlayRoot.style.bottom = `${scrollbarWidth}px`;
+    overlayRootElement.style.top = '';
+    overlayRootElement.style.bottom = `${scrollbarWidth}px`;
   }
 
   /**
    * Updates the position of the overlay root element relatively to the position of the master instance
    */
   adjustElementsPosition() {
-    const { master } = this;
+    const { clone, master } = this;
     this.updateTrimmingContainer();
 
     if (!master.wtTable.holder.parentNode) {
       // removed from DOM
       return;
     }
-    const overlayRoot = this.clone.wtTable.wtRootElement;
+    const overlayRootElement = clone.wtTable.wtRootElement;
 
-    overlayRoot.style.top = '';
+    overlayRootElement.style.top = '';
 
     if (this.trimmingContainer === master.rootWindow) {
       const box = master.wtTable.hider.getBoundingClientRect();
@@ -96,24 +96,24 @@ class BottomLeftCornerOverlay extends Overlay {
       finalBottom += 'px';
       finalLeft += 'px';
 
-      overlayRoot.style.top = '';
-      overlayRoot.style.left = finalLeft;
-      overlayRoot.style.bottom = finalBottom;
+      overlayRootElement.style.top = '';
+      overlayRootElement.style.left = finalLeft;
+      overlayRootElement.style.bottom = finalBottom;
 
     } else {
-      resetCssTransform(overlayRoot);
+      resetCssTransform(overlayRootElement);
       this.repositionOverlay();
     }
 
-    let tableHeight = outerHeight(this.clone.wtTable.TABLE);
-    const tableWidth = outerWidth(this.clone.wtTable.TABLE);
+    let tableHeight = outerHeight(clone.wtTable.TABLE);
+    const tableWidth = outerWidth(clone.wtTable.TABLE);
 
-    if (!this.master.wtTable.hasDefinedSize()) {
+    if (!master.wtTable.hasDefinedSize()) {
       tableHeight = 0;
     }
 
-    overlayRoot.style.height = `${tableHeight}px`;
-    overlayRoot.style.width = `${tableWidth}px`;
+    overlayRootElement.style.height = `${tableHeight}px`;
+    overlayRootElement.style.width = `${tableWidth}px`;
   }
 }
 

--- a/src/3rdparty/walkontable/src/overlay/bottomLeftCorner.js
+++ b/src/3rdparty/walkontable/src/overlay/bottomLeftCorner.js
@@ -44,22 +44,6 @@ class BottomLeftCornerOverlay extends Overlay {
   }
 
   /**
-   * Reposition the overlay.
-   */
-  repositionOverlay() {
-    const { master } = this;
-    const overlayRootElement = this.clone.wtTable.wtRootElement;
-    let scrollbarWidth = getScrollbarWidth(master.rootDocument);
-
-    if (master.wtTable.holder.clientHeight === master.wtTable.holder.offsetHeight) {
-      scrollbarWidth = 0;
-    }
-
-    overlayRootElement.style.top = '';
-    overlayRootElement.style.bottom = `${scrollbarWidth}px`;
-  }
-
-  /**
    * Updates the position of the overlay root element relatively to the position of the master instance
    */
   adjustElementsPosition() {
@@ -102,7 +86,15 @@ class BottomLeftCornerOverlay extends Overlay {
 
     } else {
       resetCssTransform(overlayRootElement);
-      this.repositionOverlay();
+
+      let scrollbarWidth = getScrollbarWidth(master.rootDocument);
+
+      if (master.wtTable.holder.clientHeight === master.wtTable.holder.offsetHeight) {
+        scrollbarWidth = 0;
+      }
+
+      overlayRootElement.style.top = '';
+      overlayRootElement.style.bottom = `${scrollbarWidth}px`;
     }
 
     let tableHeight = outerHeight(clone.wtTable.TABLE);

--- a/src/3rdparty/walkontable/src/overlay/left.js
+++ b/src/3rdparty/walkontable/src/overlay/left.js
@@ -46,9 +46,9 @@ class LeftOverlay extends Overlay {
   }
 
   /**
-   * Updates the left overlay position.
+   * Updates the position of the overlay root element relatively to the position of the master instance
    */
-  resetFixedPosition() {
+  adjustElementsPosition() {
     const { wtTable } = this.master;
     if (!this.needFullRender || !wtTable.holder.parentNode) {
       // removed from DOM
@@ -136,7 +136,7 @@ class LeftOverlay extends Overlay {
   }
 
   /**
-   * Adjust overlay root element, childs and master table element sizes (width, height).
+   * If needed, adjust the sizes of the clone and the master elements to the dimensions of the trimming container.
    *
    * @param {Boolean} [force=false]
    */
@@ -144,7 +144,7 @@ class LeftOverlay extends Overlay {
     this.updateTrimmingContainer();
 
     if (this.needFullRender || force) {
-      this.adjustRootElementSize();
+      this._adjustElementsSize();
 
       if (!force) {
         this.areElementSizesAdjusted = true;
@@ -153,9 +153,9 @@ class LeftOverlay extends Overlay {
   }
 
   /**
-   * Adjust the width and height of the overlay root element and its children (hider, holder) to the dimensions of the trimming container.
+   * Adjust the sizes of the clone and the master elements to the dimensions of the trimming container.
    */
-  adjustRootElementSize() {
+  _adjustElementsSize() {
     const { wtTable, rootDocument, rootWindow } = this.master;
     const scrollbarHeight = getScrollbarWidth(rootDocument);
     const overlayRoot = this.clone.wtTable.wtRootElement;
@@ -190,7 +190,7 @@ class LeftOverlay extends Overlay {
   /**
    * Adjust the overlay dimensions and position.
    */
-  applyToDOM() {
+  workaroundsForPositionAndSize() {
     const total = this.master.getSetting('totalColumns');
 
     if (!this.areElementSizesAdjusted) {
@@ -306,7 +306,7 @@ class LeftOverlay extends Overlay {
         removeClass(masterParent, 'innerBorderLeft');
       }
       if (!previousState && position || previousState && !position) {
-        this.master.wtOverlays.adjustElementsSize();
+        this.master.wtOverlays.adjustElementsSizes();
       }
     }
   }

--- a/src/3rdparty/walkontable/src/overlay/left.js
+++ b/src/3rdparty/walkontable/src/overlay/left.js
@@ -232,8 +232,7 @@ class LeftOverlay extends Overlay {
    */
   scrollTo(sourceCol, beyondRendered) {
     let newX = this.getTableParentOffset();
-    const sourceInstance = this.master.overlay ? this.master.overlay.master : this.master; // TODO what?
-    const mainHolder = sourceInstance.wtTable.holder;
+    const mainHolder = this.master.wtTable.holder;
     let scrollbarCompensation = 0;
 
     if (beyondRendered && mainHolder.offsetWidth !== mainHolder.clientWidth) {

--- a/src/3rdparty/walkontable/src/overlay/left.js
+++ b/src/3rdparty/walkontable/src/overlay/left.js
@@ -143,19 +143,10 @@ class LeftOverlay extends Overlay {
   adjustElementsSize(force = false) {
     this.updateTrimmingContainer();
 
-    if (this.needFullRender || force) {
-      this._adjustElementsSize();
-
-      if (!force) {
-        this.areElementSizesAdjusted = true;
-      }
+    if (!this.needFullRender && !force) {
+      return;
     }
-  }
 
-  /**
-   * Adjust the sizes of the clone and the master elements to the dimensions of the trimming container.
-   */
-  _adjustElementsSize() {
     const { clone, master } = this;
     const scrollbarHeight = getScrollbarWidth(master.rootDocument);
     const overlayRootElement = clone.wtTable.wtRootElement;
@@ -183,6 +174,10 @@ class LeftOverlay extends Overlay {
     clone.wtTable.hider.style.height = master.wtTable.hider.style.height;
     clone.wtTable.holder.style.height = clone.wtTable.wtRootElement.style.height;
     clone.wtTable.holder.style.width = clone.wtTable.wtRootElement.style.width;
+
+    if (!force) {
+      this.areElementSizesAdjusted = true;
+    }
   }
 
   /**

--- a/src/3rdparty/walkontable/src/overlay/left.js
+++ b/src/3rdparty/walkontable/src/overlay/left.js
@@ -53,7 +53,7 @@ class LeftOverlay extends Overlay {
       // removed from DOM
       return;
     }
-    const overlayRoot = this.clone.wtTable.holder.parentNode;
+    const overlayRoot = this.clone.wtTable.wtRootElement;
     let headerPosition = 0;
     const preventOverflow = this.master.getSetting('preventOverflow');
 
@@ -157,7 +157,7 @@ class LeftOverlay extends Overlay {
   adjustRootElementSize() {
     const { wtTable, rootDocument, rootWindow } = this.master;
     const scrollbarHeight = getScrollbarWidth(rootDocument);
-    const overlayRoot = this.clone.wtTable.holder.parentNode;
+    const overlayRoot = this.clone.wtTable.wtRootElement;
     const overlayRootStyle = overlayRoot.style;
     const preventOverflow = this.master.getSetting('preventOverflow');
 
@@ -179,11 +179,11 @@ class LeftOverlay extends Overlay {
 
     overlayRootStyle.width = `${tableWidth}px`;
 
-    const { holder, hider } = this.clone.wtTable;
+    const { holder, hider, wtRootElement } = this.clone.wtTable;
 
     hider.style.height = this.hider.style.height;
-    holder.style.height = holder.parentNode.style.height;
-    holder.style.width = holder.parentNode.style.width;
+    holder.style.height = wtRootElement.style.height;
+    holder.style.width = wtRootElement.style.width;
   }
 
   /**
@@ -282,7 +282,7 @@ class LeftOverlay extends Overlay {
    * @param {Number} position Header X position if trimming container is window or scroll top if not.
    */
   adjustHeaderBordersPosition(position) {
-    const masterParent = this.master.wtTable.holder.parentNode;
+    const masterParent = this.master.wtTable.wtRootElement;
     const rowHeaders = this.master.getSetting('rowHeaders');
     const fixedColumnsLeft = this.master.getSetting('fixedColumnsLeft');
     const totalRows = this.master.getSetting('totalRows');

--- a/src/3rdparty/walkontable/src/overlay/left.js
+++ b/src/3rdparty/walkontable/src/overlay/left.js
@@ -80,7 +80,7 @@ class LeftOverlay extends Overlay {
     let headerPosition = 0;
     const preventOverflow = master.getSetting('preventOverflow');
 
-    if (this.trimmingContainer === master.rootWindow && (!preventOverflow || preventOverflow !== 'horizontal')) {
+    if (master.wtTable.trimmingContainer === master.rootWindow && (!preventOverflow || preventOverflow !== 'horizontal')) {
       const box = master.wtTable.hider.getBoundingClientRect();
       const left = Math.ceil(box.left);
       const right = Math.ceil(box.right);
@@ -171,7 +171,7 @@ class LeftOverlay extends Overlay {
     const overlayRootElementStyle = overlayRootElement.style;
     const preventOverflow = master.getSetting('preventOverflow');
 
-    if (this.trimmingContainer !== master.rootWindow || preventOverflow === 'vertical') {
+    if (master.wtTable.trimmingContainer !== master.rootWindow || preventOverflow === 'vertical') {
       let height = master.wtViewport.getWorkspaceHeight();
 
       if (master.wtOverlays.hasScrollbarBottom) {
@@ -236,7 +236,7 @@ class LeftOverlay extends Overlay {
     const preventOverflow = this.master.getSetting('preventOverflow');
     let offset = 0;
 
-    if (!preventOverflow && this.trimmingContainer === this.master.rootWindow) {
+    if (!preventOverflow && this.master.wtTable.trimmingContainer === this.master.rootWindow) {
       offset = this.master.wtTable.holderOffset.left;
     }
 

--- a/src/3rdparty/walkontable/src/overlay/left.js
+++ b/src/3rdparty/walkontable/src/overlay/left.js
@@ -127,7 +127,7 @@ class LeftOverlay extends Overlay {
     let sum = 0;
 
     while (column < to) {
-      sum += this.wot.wtTable.getStretchedColumnWidth(column) || defaultColumnWidth;
+      sum += this.wot.columnUtils.getStretchedColumnWidth(column) || defaultColumnWidth;
       column += 1;
     }
 

--- a/src/3rdparty/walkontable/src/overlay/left.js
+++ b/src/3rdparty/walkontable/src/overlay/left.js
@@ -162,8 +162,6 @@ class LeftOverlay extends Overlay {
    * @param {Boolean} [force=false]
    */
   adjustElementsSize(force = false) {
-    this.updateTrimmingContainer();
-
     if (!this.needFullRender && !force) {
       return;
     }

--- a/src/3rdparty/walkontable/src/overlay/left.js
+++ b/src/3rdparty/walkontable/src/overlay/left.js
@@ -49,26 +49,27 @@ class LeftOverlay extends Overlay {
    * Updates the position of the overlay root element relatively to the position of the master instance
    */
   adjustElementsPosition() {
-    const { wtTable } = this.master;
-    if (!this.needFullRender || !wtTable.holder.parentNode) {
+    const { master } = this;
+
+    if (!this.needFullRender || !master.wtTable.holder.parentNode) {
       // removed from DOM
       return;
     }
-    const overlayRoot = this.clone.wtTable.wtRootElement;
+    const overlayRootElement = this.clone.wtTable.wtRootElement;
     let headerPosition = 0;
-    const preventOverflow = this.master.getSetting('preventOverflow');
+    const preventOverflow = master.getSetting('preventOverflow');
 
-    if (this.trimmingContainer === this.master.rootWindow && (!preventOverflow || preventOverflow !== 'horizontal')) {
-      const box = wtTable.hider.getBoundingClientRect();
+    if (this.trimmingContainer === master.rootWindow && (!preventOverflow || preventOverflow !== 'horizontal')) {
+      const box = master.wtTable.hider.getBoundingClientRect();
       const left = Math.ceil(box.left);
       const right = Math.ceil(box.right);
       let finalLeft;
       let finalTop;
 
-      finalTop = wtTable.hider.style.top;
+      finalTop = master.wtTable.hider.style.top;
       finalTop = finalTop === '' ? 0 : finalTop;
 
-      if (left < 0 && (right - overlayRoot.offsetWidth) > 0) {
+      if (left < 0 && (right - overlayRootElement.offsetWidth) > 0) {
         finalLeft = -left;
       } else {
         finalLeft = 0;
@@ -76,11 +77,11 @@ class LeftOverlay extends Overlay {
       headerPosition = finalLeft;
       finalLeft += 'px';
 
-      setOverlayPosition(overlayRoot, finalLeft, finalTop);
+      setOverlayPosition(overlayRootElement, finalLeft, finalTop);
 
     } else {
       headerPosition = this.getScrollPosition();
-      resetCssTransform(overlayRoot);
+      resetCssTransform(overlayRootElement);
     }
     this.adjustHeaderBordersPosition(headerPosition);
     this.adjustElementsSize();
@@ -156,56 +157,56 @@ class LeftOverlay extends Overlay {
    * Adjust the sizes of the clone and the master elements to the dimensions of the trimming container.
    */
   _adjustElementsSize() {
-    const scrollbarHeight = getScrollbarWidth(this.master.rootDocument);
-    const overlayRoot = this.clone.wtTable.wtRootElement;
-    const overlayRootStyle = overlayRoot.style;
-    const preventOverflow = this.master.getSetting('preventOverflow');
+    const { clone, master } = this;
+    const scrollbarHeight = getScrollbarWidth(master.rootDocument);
+    const overlayRootElement = clone.wtTable.wtRootElement;
+    const overlayRootElementStyle = overlayRootElement.style;
+    const preventOverflow = master.getSetting('preventOverflow');
 
-    if (this.trimmingContainer !== this.master.rootWindow || preventOverflow === 'vertical') {
-      let height = this.master.wtViewport.getWorkspaceHeight();
+    if (this.trimmingContainer !== master.rootWindow || preventOverflow === 'vertical') {
+      let height = master.wtViewport.getWorkspaceHeight();
 
-      if (this.master.wtOverlays.hasScrollbarBottom) {
+      if (master.wtOverlays.hasScrollbarBottom) {
         height -= scrollbarHeight;
       }
 
-      height = Math.min(height, this.master.wtTable.wtRootElement.scrollHeight);
-      overlayRootStyle.height = `${height}px`;
+      height = Math.min(height, master.wtTable.wtRootElement.scrollHeight);
+      overlayRootElementStyle.height = `${height}px`;
 
     } else {
-      overlayRootStyle.height = '';
+      overlayRootElementStyle.height = '';
     }
 
-    const tableWidth = outerWidth(this.clone.wtTable.TABLE);
+    const tableWidth = outerWidth(clone.wtTable.TABLE);
 
-    overlayRootStyle.width = `${tableWidth}px`;
+    overlayRootElementStyle.width = `${tableWidth}px`;
 
-    const { holder, hider, wtRootElement } = this.clone.wtTable;
-
-    hider.style.height = this.master.wtTable.hider.style.height;
-    holder.style.height = wtRootElement.style.height;
-    holder.style.width = wtRootElement.style.width;
+    clone.wtTable.hider.style.height = master.wtTable.hider.style.height;
+    clone.wtTable.holder.style.height = clone.wtTable.wtRootElement.style.height;
+    clone.wtTable.holder.style.width = clone.wtTable.wtRootElement.style.width;
   }
 
   /**
    * Adjust the overlay dimensions and position.
    */
   workaroundsForPositionAndSize() {
-    const total = this.master.getSetting('totalColumns');
+    const { master } = this;
+    const total = master.getSetting('totalColumns');
 
-    if (typeof this.master.wtViewport.columnsRenderCalculator.startPosition === 'number') {
-      this.master.wtTable.spreader.style.left = `${this.master.wtViewport.columnsRenderCalculator.startPosition}px`;
+    if (typeof master.wtViewport.columnsRenderCalculator.startPosition === 'number') {
+      master.wtTable.spreader.style.left = `${master.wtViewport.columnsRenderCalculator.startPosition}px`;
 
     } else if (total === 0) {
-      this.master.wtTable.spreader.style.left = '0';
+      master.wtTable.spreader.style.left = '0';
 
     } else {
       throw new Error('Incorrect value of the columnsRenderCalculator');
     }
-    this.master.wtTable.spreader.style.right = '';
+    master.wtTable.spreader.style.right = '';
 
     if (this.needFullRender) {
-      if (typeof this.master.wtViewport.rowsRenderCalculator.startPosition === 'number') {
-        this.clone.wtTable.spreader.style.top = `${this.master.wtViewport.rowsRenderCalculator.startPosition}px`;
+      if (typeof master.wtViewport.rowsRenderCalculator.startPosition === 'number') {
+        this.clone.wtTable.spreader.style.top = `${master.wtViewport.rowsRenderCalculator.startPosition}px`;
 
       } else {
         this.clone.wtTable.spreader.style.top = '';
@@ -221,19 +222,20 @@ class LeftOverlay extends Overlay {
    * @returns {Boolean}
    */
   scrollTo(sourceCol, beyondRendered) {
+    const { master } = this;
     let newX = this.getTableParentOffset();
-    const mainHolder = this.master.wtTable.holder;
+    const mainHolder = master.wtTable.holder;
     let scrollbarCompensation = 0;
 
     if (beyondRendered && mainHolder.offsetWidth !== mainHolder.clientWidth) {
-      scrollbarCompensation = getScrollbarWidth(this.master.rootDocument);
+      scrollbarCompensation = getScrollbarWidth(master.rootDocument);
     }
     if (beyondRendered) {
       newX += this.sumCellSizes(0, sourceCol + 1);
-      newX -= this.master.wtViewport.getViewportWidth();
+      newX -= master.wtViewport.getViewportWidth();
 
     } else {
-      newX += this.sumCellSizes(this.master.getSetting('fixedColumnsLeft'), sourceCol);
+      newX += this.sumCellSizes(master.getSetting('fixedColumnsLeft'), sourceCol);
     }
 
     newX += scrollbarCompensation;
@@ -272,30 +274,31 @@ class LeftOverlay extends Overlay {
    * @param {Number} position Header X position if trimming container is window or scroll top if not.
    */
   adjustHeaderBordersPosition(position) {
-    const masterParent = this.master.wtTable.wtRootElement;
-    const rowHeaders = this.master.getSetting('rowHeaders');
-    const fixedColumnsLeft = this.master.getSetting('fixedColumnsLeft');
-    const totalRows = this.master.getSetting('totalRows');
+    const { master } = this;
+    const masterRootElement = master.wtTable.wtRootElement;
+    const rowHeaders = master.getSetting('rowHeaders');
+    const fixedColumnsLeft = master.getSetting('fixedColumnsLeft');
+    const totalRows = master.getSetting('totalRows');
 
     if (totalRows) {
-      removeClass(masterParent, 'emptyRows');
+      removeClass(masterRootElement, 'emptyRows');
     } else {
-      addClass(masterParent, 'emptyRows');
+      addClass(masterRootElement, 'emptyRows');
     }
 
     if (fixedColumnsLeft && !rowHeaders.length) {
-      addClass(masterParent, 'innerBorderLeft');
+      addClass(masterRootElement, 'innerBorderLeft');
 
     } else if (!fixedColumnsLeft && rowHeaders.length) {
-      const previousState = hasClass(masterParent, 'innerBorderLeft');
+      const previousState = hasClass(masterRootElement, 'innerBorderLeft');
 
       if (position) {
-        addClass(masterParent, 'innerBorderLeft');
+        addClass(masterRootElement, 'innerBorderLeft');
       } else {
-        removeClass(masterParent, 'innerBorderLeft');
+        removeClass(masterRootElement, 'innerBorderLeft');
       }
       if (!previousState && position || previousState && !position) {
-        this.master.wtOverlays.adjustElementsSizes();
+        master.wtOverlays.adjustElementsSizes();
       }
     }
   }

--- a/src/3rdparty/walkontable/src/overlay/left.js
+++ b/src/3rdparty/walkontable/src/overlay/left.js
@@ -49,11 +49,33 @@ class LeftOverlay extends Overlay {
    */
   adjustElementsPosition() {
     const { master } = this;
+    const total = master.getSetting('totalColumns');
+
+    if (typeof master.wtViewport.columnsRenderCalculator.startPosition === 'number') {
+      master.wtTable.spreader.style.left = `${master.wtViewport.columnsRenderCalculator.startPosition}px`;
+
+    } else if (total === 0) {
+      master.wtTable.spreader.style.left = '0';
+
+    } else {
+      throw new Error('Incorrect value of the columnsRenderCalculator');
+    }
+    master.wtTable.spreader.style.right = '';
+
+    if (this.needFullRender) {
+      if (typeof master.wtViewport.rowsRenderCalculator.startPosition === 'number') {
+        this.clone.wtTable.spreader.style.top = `${master.wtViewport.rowsRenderCalculator.startPosition}px`;
+
+      } else {
+        this.clone.wtTable.spreader.style.top = '';
+      }
+    }
 
     if (!this.needFullRender || !master.wtTable.holder.parentNode) {
       // removed from DOM
       return;
     }
+
     const overlayRootElement = this.clone.wtTable.wtRootElement;
     let headerPosition = 0;
     const preventOverflow = master.getSetting('preventOverflow');
@@ -176,34 +198,6 @@ class LeftOverlay extends Overlay {
 
     if (!force) {
       this.areElementSizesAdjusted = true;
-    }
-  }
-
-  /**
-   * Adjust the overlay position
-   */
-  workaroundsForPosition() {
-    const { master } = this;
-    const total = master.getSetting('totalColumns');
-
-    if (typeof master.wtViewport.columnsRenderCalculator.startPosition === 'number') {
-      master.wtTable.spreader.style.left = `${master.wtViewport.columnsRenderCalculator.startPosition}px`;
-
-    } else if (total === 0) {
-      master.wtTable.spreader.style.left = '0';
-
-    } else {
-      throw new Error('Incorrect value of the columnsRenderCalculator');
-    }
-    master.wtTable.spreader.style.right = '';
-
-    if (this.needFullRender) {
-      if (typeof master.wtViewport.rowsRenderCalculator.startPosition === 'number') {
-        this.clone.wtTable.spreader.style.top = `${master.wtViewport.rowsRenderCalculator.startPosition}px`;
-
-      } else {
-        this.clone.wtTable.spreader.style.top = '';
-      }
     }
   }
 

--- a/src/3rdparty/walkontable/src/overlay/left.js
+++ b/src/3rdparty/walkontable/src/overlay/left.js
@@ -208,19 +208,12 @@ class LeftOverlay extends Overlay {
     this.spreader.style.right = '';
 
     if (this.needFullRender) {
-      this.syncOverlayOffset();
-    }
-  }
+      if (typeof this.master.wtViewport.rowsRenderCalculator.startPosition === 'number') {
+        this.clone.wtTable.spreader.style.top = `${this.master.wtViewport.rowsRenderCalculator.startPosition}px`;
 
-  /**
-   * Synchronize calculated top position to an element.
-   */
-  syncOverlayOffset() {
-    if (typeof this.master.wtViewport.rowsRenderCalculator.startPosition === 'number') {
-      this.clone.wtTable.spreader.style.top = `${this.master.wtViewport.rowsRenderCalculator.startPosition}px`;
-
-    } else {
-      this.clone.wtTable.spreader.style.top = '';
+      } else {
+        this.clone.wtTable.spreader.style.top = '';
+      }
     }
   }
 

--- a/src/3rdparty/walkontable/src/overlay/left.js
+++ b/src/3rdparty/walkontable/src/overlay/left.js
@@ -232,7 +232,7 @@ class LeftOverlay extends Overlay {
    */
   scrollTo(sourceCol, beyondRendered) {
     let newX = this.getTableParentOffset();
-    const sourceInstance = this.master.cloneSource ? this.master.cloneSource : this.master;
+    const sourceInstance = this.master.overlay ? this.master.overlay.master : this.master; // TODO what?
     const mainHolder = sourceInstance.wtTable.holder;
     let scrollbarCompensation = 0;
 

--- a/src/3rdparty/walkontable/src/overlay/left.js
+++ b/src/3rdparty/walkontable/src/overlay/left.js
@@ -3,7 +3,6 @@ import {
   getScrollbarWidth,
   getScrollLeft,
   getWindowScrollTop,
-  hasClass,
   outerWidth,
   removeClass,
   setOverlayPosition,
@@ -284,15 +283,10 @@ class LeftOverlay extends Overlay {
       addClass(masterRootElement, 'innerBorderLeft');
 
     } else if (!fixedColumnsLeft && rowHeaders.length) {
-      const previousState = hasClass(masterRootElement, 'innerBorderLeft');
-
       if (position) {
         addClass(masterRootElement, 'innerBorderLeft');
       } else {
         removeClass(masterRootElement, 'innerBorderLeft');
-      }
-      if (!previousState && position || previousState && !position) {
-        master.wtOverlays.adjustElementsSizes();
       }
     }
   }

--- a/src/3rdparty/walkontable/src/overlay/left.js
+++ b/src/3rdparty/walkontable/src/overlay/left.js
@@ -192,8 +192,8 @@ class LeftOverlay extends Overlay {
     overlayRootElementStyle.width = `${tableWidth}px`;
 
     clone.wtTable.hider.style.height = master.wtTable.hider.style.height;
-    clone.wtTable.holder.style.height = clone.wtTable.wtRootElement.style.height;
-    clone.wtTable.holder.style.width = clone.wtTable.wtRootElement.style.width;
+    clone.wtTable.holder.style.height = overlayRootElementStyle.height;
+    clone.wtTable.holder.style.width = overlayRootElementStyle.width;
 
     if (!force) {
       this.areElementSizesAdjusted = true;

--- a/src/3rdparty/walkontable/src/overlay/left.js
+++ b/src/3rdparty/walkontable/src/overlay/left.js
@@ -169,7 +169,6 @@ class LeftOverlay extends Overlay {
     }
 
     const { clone, master } = this;
-    const scrollbarHeight = getScrollbarWidth(master.rootDocument);
     const overlayRootElement = clone.wtTable.wtRootElement;
     const overlayRootElementStyle = overlayRootElement.style;
     const preventOverflow = master.getSetting('preventOverflow');
@@ -178,7 +177,7 @@ class LeftOverlay extends Overlay {
       let height = master.wtViewport.getWorkspaceHeight();
 
       if (master.wtOverlays.hasScrollbarBottom) {
-        height -= scrollbarHeight;
+        height -= getScrollbarWidth(master.rootDocument);
       }
 
       height = Math.min(height, master.wtTable.wtRootElement.scrollHeight);

--- a/src/3rdparty/walkontable/src/overlay/left.js
+++ b/src/3rdparty/walkontable/src/overlay/left.js
@@ -22,6 +22,7 @@ class LeftOverlay extends Overlay {
   constructor(wotInstance) {
     super(wotInstance);
     this.clone = this.makeClone(Overlay.CLONE_LEFT);
+    this.updateStateOfRendering();
   }
 
   /**

--- a/src/3rdparty/walkontable/src/overlay/left.js
+++ b/src/3rdparty/walkontable/src/overlay/left.js
@@ -156,20 +156,19 @@ class LeftOverlay extends Overlay {
    * Adjust the sizes of the clone and the master elements to the dimensions of the trimming container.
    */
   _adjustElementsSize() {
-    const { wtTable, rootDocument, rootWindow } = this.master;
-    const scrollbarHeight = getScrollbarWidth(rootDocument);
+    const scrollbarHeight = getScrollbarWidth(this.master.rootDocument);
     const overlayRoot = this.clone.wtTable.wtRootElement;
     const overlayRootStyle = overlayRoot.style;
     const preventOverflow = this.master.getSetting('preventOverflow');
 
-    if (this.trimmingContainer !== rootWindow || preventOverflow === 'vertical') {
+    if (this.trimmingContainer !== this.master.rootWindow || preventOverflow === 'vertical') {
       let height = this.master.wtViewport.getWorkspaceHeight();
 
       if (this.master.wtOverlays.hasScrollbarBottom) {
         height -= scrollbarHeight;
       }
 
-      height = Math.min(height, wtTable.wtRootElement.scrollHeight);
+      height = Math.min(height, this.master.wtTable.wtRootElement.scrollHeight);
       overlayRootStyle.height = `${height}px`;
 
     } else {

--- a/src/3rdparty/walkontable/src/overlay/left.js
+++ b/src/3rdparty/walkontable/src/overlay/left.js
@@ -41,23 +41,23 @@ class LeftOverlay extends Overlay {
    * @returns {Boolean}
    */
   shouldBeRendered() {
-    return !!(this.wot.getSetting('fixedColumnsLeft') || this.wot.getSetting('rowHeaders').length);
+    return !!(this.master.getSetting('fixedColumnsLeft') || this.master.getSetting('rowHeaders').length);
   }
 
   /**
    * Updates the left overlay position.
    */
   resetFixedPosition() {
-    const { wtTable } = this.wot;
+    const { wtTable } = this.master;
     if (!this.needFullRender || !wtTable.holder.parentNode) {
       // removed from DOM
       return;
     }
     const overlayRoot = this.clone.wtTable.holder.parentNode;
     let headerPosition = 0;
-    const preventOverflow = this.wot.getSetting('preventOverflow');
+    const preventOverflow = this.master.getSetting('preventOverflow');
 
-    if (this.trimmingContainer === this.wot.rootWindow && (!preventOverflow || preventOverflow !== 'horizontal')) {
+    if (this.trimmingContainer === this.master.rootWindow && (!preventOverflow || preventOverflow !== 'horizontal')) {
       const box = wtTable.hider.getBoundingClientRect();
       const left = Math.ceil(box.left);
       const right = Math.ceil(box.right);
@@ -92,7 +92,7 @@ class LeftOverlay extends Overlay {
    * @returns {Boolean}
    */
   setScrollPosition(pos) {
-    const { rootWindow } = this.wot;
+    const { rootWindow } = this.master;
     let result = false;
 
     if (this.mainTableScrollableElement === rootWindow && rootWindow.scrollX !== pos) {
@@ -111,7 +111,7 @@ class LeftOverlay extends Overlay {
    * Triggers onScroll hook callback.
    */
   onScroll() {
-    this.wot.getSetting('onScrollVertically');
+    this.master.getSetting('onScrollVertically');
   }
 
   /**
@@ -122,12 +122,12 @@ class LeftOverlay extends Overlay {
    * @returns {Number} Width sum.
    */
   sumCellSizes(from, to) {
-    const defaultColumnWidth = this.wot.wtSettings.defaultColumnWidth;
+    const defaultColumnWidth = this.master.wtSettings.defaultColumnWidth;
     let column = from;
     let sum = 0;
 
     while (column < to) {
-      sum += this.wot.columnUtils.getStretchedColumnWidth(column) || defaultColumnWidth;
+      sum += this.master.columnUtils.getStretchedColumnWidth(column) || defaultColumnWidth;
       column += 1;
     }
 
@@ -155,16 +155,16 @@ class LeftOverlay extends Overlay {
    * Adjust the width and height of the overlay root element and its children (hider, holder) to the dimensions of the trimming container.
    */
   adjustRootElementSize() {
-    const { wtTable, rootDocument, rootWindow } = this.wot;
+    const { wtTable, rootDocument, rootWindow } = this.master;
     const scrollbarHeight = getScrollbarWidth(rootDocument);
     const overlayRoot = this.clone.wtTable.holder.parentNode;
     const overlayRootStyle = overlayRoot.style;
-    const preventOverflow = this.wot.getSetting('preventOverflow');
+    const preventOverflow = this.master.getSetting('preventOverflow');
 
     if (this.trimmingContainer !== rootWindow || preventOverflow === 'vertical') {
-      let height = this.wot.wtViewport.getWorkspaceHeight();
+      let height = this.master.wtViewport.getWorkspaceHeight();
 
-      if (this.wot.wtOverlays.hasScrollbarBottom) {
+      if (this.master.wtOverlays.hasScrollbarBottom) {
         height -= scrollbarHeight;
       }
 
@@ -190,13 +190,13 @@ class LeftOverlay extends Overlay {
    * Adjust the overlay dimensions and position.
    */
   applyToDOM() {
-    const total = this.wot.getSetting('totalColumns');
+    const total = this.master.getSetting('totalColumns');
 
     if (!this.areElementSizesAdjusted) {
       this.adjustElementsSize();
     }
-    if (typeof this.wot.wtViewport.columnsRenderCalculator.startPosition === 'number') {
-      this.spreader.style.left = `${this.wot.wtViewport.columnsRenderCalculator.startPosition}px`;
+    if (typeof this.master.wtViewport.columnsRenderCalculator.startPosition === 'number') {
+      this.spreader.style.left = `${this.master.wtViewport.columnsRenderCalculator.startPosition}px`;
 
     } else if (total === 0) {
       this.spreader.style.left = '0';
@@ -215,8 +215,8 @@ class LeftOverlay extends Overlay {
    * Synchronize calculated top position to an element.
    */
   syncOverlayOffset() {
-    if (typeof this.wot.wtViewport.rowsRenderCalculator.startPosition === 'number') {
-      this.clone.wtTable.spreader.style.top = `${this.wot.wtViewport.rowsRenderCalculator.startPosition}px`;
+    if (typeof this.master.wtViewport.rowsRenderCalculator.startPosition === 'number') {
+      this.clone.wtTable.spreader.style.top = `${this.master.wtViewport.rowsRenderCalculator.startPosition}px`;
 
     } else {
       this.clone.wtTable.spreader.style.top = '';
@@ -232,19 +232,19 @@ class LeftOverlay extends Overlay {
    */
   scrollTo(sourceCol, beyondRendered) {
     let newX = this.getTableParentOffset();
-    const sourceInstance = this.wot.cloneSource ? this.wot.cloneSource : this.wot;
+    const sourceInstance = this.master.cloneSource ? this.master.cloneSource : this.master;
     const mainHolder = sourceInstance.wtTable.holder;
     let scrollbarCompensation = 0;
 
     if (beyondRendered && mainHolder.offsetWidth !== mainHolder.clientWidth) {
-      scrollbarCompensation = getScrollbarWidth(this.wot.rootDocument);
+      scrollbarCompensation = getScrollbarWidth(this.master.rootDocument);
     }
     if (beyondRendered) {
       newX += this.sumCellSizes(0, sourceCol + 1);
-      newX -= this.wot.wtViewport.getViewportWidth();
+      newX -= this.master.wtViewport.getViewportWidth();
 
     } else {
-      newX += this.sumCellSizes(this.wot.getSetting('fixedColumnsLeft'), sourceCol);
+      newX += this.sumCellSizes(this.master.getSetting('fixedColumnsLeft'), sourceCol);
     }
 
     newX += scrollbarCompensation;
@@ -258,11 +258,11 @@ class LeftOverlay extends Overlay {
    * @returns {Number}
    */
   getTableParentOffset() {
-    const preventOverflow = this.wot.getSetting('preventOverflow');
+    const preventOverflow = this.master.getSetting('preventOverflow');
     let offset = 0;
 
-    if (!preventOverflow && this.trimmingContainer === this.wot.rootWindow) {
-      offset = this.wot.wtTable.holderOffset.left;
+    if (!preventOverflow && this.trimmingContainer === this.master.rootWindow) {
+      offset = this.master.wtTable.holderOffset.left;
     }
 
     return offset;
@@ -274,7 +274,7 @@ class LeftOverlay extends Overlay {
    * @returns {Number} Main table's vertical scroll position.
    */
   getScrollPosition() {
-    return getScrollLeft(this.mainTableScrollableElement, this.wot.rootWindow);
+    return getScrollLeft(this.mainTableScrollableElement, this.master.rootWindow);
   }
 
   /**
@@ -283,10 +283,10 @@ class LeftOverlay extends Overlay {
    * @param {Number} position Header X position if trimming container is window or scroll top if not.
    */
   adjustHeaderBordersPosition(position) {
-    const masterParent = this.wot.wtTable.holder.parentNode;
-    const rowHeaders = this.wot.getSetting('rowHeaders');
-    const fixedColumnsLeft = this.wot.getSetting('fixedColumnsLeft');
-    const totalRows = this.wot.getSetting('totalRows');
+    const masterParent = this.master.wtTable.holder.parentNode;
+    const rowHeaders = this.master.getSetting('rowHeaders');
+    const fixedColumnsLeft = this.master.getSetting('fixedColumnsLeft');
+    const totalRows = this.master.getSetting('totalRows');
 
     if (totalRows) {
       removeClass(masterParent, 'emptyRows');
@@ -306,7 +306,7 @@ class LeftOverlay extends Overlay {
         removeClass(masterParent, 'innerBorderLeft');
       }
       if (!previousState && position || previousState && !position) {
-        this.wot.wtOverlays.adjustElementsSize();
+        this.master.wtOverlays.adjustElementsSize();
       }
     }
   }

--- a/src/3rdparty/walkontable/src/overlay/left.js
+++ b/src/3rdparty/walkontable/src/overlay/left.js
@@ -192,9 +192,6 @@ class LeftOverlay extends Overlay {
   workaroundsForPositionAndSize() {
     const total = this.master.getSetting('totalColumns');
 
-    if (!this.areElementSizesAdjusted) {
-      this.adjustElementsSize();
-    }
     if (typeof this.master.wtViewport.columnsRenderCalculator.startPosition === 'number') {
       this.master.wtTable.spreader.style.left = `${this.master.wtViewport.columnsRenderCalculator.startPosition}px`;
 

--- a/src/3rdparty/walkontable/src/overlay/left.js
+++ b/src/3rdparty/walkontable/src/overlay/left.js
@@ -180,9 +180,9 @@ class LeftOverlay extends Overlay {
   }
 
   /**
-   * Adjust the overlay dimensions and position.
+   * Adjust the overlay position
    */
-  workaroundsForPositionAndSize() {
+  workaroundsForPosition() {
     const { master } = this;
     const total = master.getSetting('totalColumns');
 

--- a/src/3rdparty/walkontable/src/overlay/left.js
+++ b/src/3rdparty/walkontable/src/overlay/left.js
@@ -84,7 +84,6 @@ class LeftOverlay extends Overlay {
       resetCssTransform(overlayRootElement);
     }
     this.adjustHeaderBordersPosition(headerPosition);
-    this.adjustElementsSize();
   }
 
   /**

--- a/src/3rdparty/walkontable/src/overlay/left.js
+++ b/src/3rdparty/walkontable/src/overlay/left.js
@@ -182,7 +182,7 @@ class LeftOverlay extends Overlay {
 
     const { holder, hider, wtRootElement } = this.clone.wtTable;
 
-    hider.style.height = this.hider.style.height;
+    hider.style.height = this.master.wtTable.hider.style.height;
     holder.style.height = wtRootElement.style.height;
     holder.style.width = wtRootElement.style.width;
   }
@@ -197,15 +197,15 @@ class LeftOverlay extends Overlay {
       this.adjustElementsSize();
     }
     if (typeof this.master.wtViewport.columnsRenderCalculator.startPosition === 'number') {
-      this.spreader.style.left = `${this.master.wtViewport.columnsRenderCalculator.startPosition}px`;
+      this.master.wtTable.spreader.style.left = `${this.master.wtViewport.columnsRenderCalculator.startPosition}px`;
 
     } else if (total === 0) {
-      this.spreader.style.left = '0';
+      this.master.wtTable.spreader.style.left = '0';
 
     } else {
       throw new Error('Incorrect value of the columnsRenderCalculator');
     }
-    this.spreader.style.right = '';
+    this.master.wtTable.spreader.style.right = '';
 
     if (this.needFullRender) {
       if (typeof this.master.wtViewport.rowsRenderCalculator.startPosition === 'number') {

--- a/src/3rdparty/walkontable/src/overlay/top.js
+++ b/src/3rdparty/walkontable/src/overlay/top.js
@@ -42,23 +42,23 @@ class TopOverlay extends Overlay {
    * @returns {Boolean}
    */
   shouldBeRendered() {
-    return !!(this.wot.getSetting('fixedRowsTop') || this.wot.getSetting('columnHeaders').length);
+    return !!(this.master.getSetting('fixedRowsTop') || this.master.getSetting('columnHeaders').length);
   }
 
   /**
    * Updates the top overlay position.
    */
   resetFixedPosition() {
-    if (!this.needFullRender || !this.wot.wtTable.holder.parentNode) {
+    if (!this.needFullRender || !this.master.wtTable.holder.parentNode) {
       // removed from DOM
       return;
     }
     const overlayRoot = this.clone.wtTable.holder.parentNode;
     let headerPosition = 0;
-    const preventOverflow = this.wot.getSetting('preventOverflow');
+    const preventOverflow = this.master.getSetting('preventOverflow');
 
-    if (this.trimmingContainer === this.wot.rootWindow && (!preventOverflow || preventOverflow !== 'vertical')) {
-      const { wtTable } = this.wot;
+    if (this.trimmingContainer === this.master.rootWindow && (!preventOverflow || preventOverflow !== 'vertical')) {
+      const { wtTable } = this.master;
       const box = wtTable.hider.getBoundingClientRect();
       const top = Math.ceil(box.top);
       const bottom = Math.ceil(box.bottom);
@@ -94,7 +94,7 @@ class TopOverlay extends Overlay {
    * @returns {Boolean}
    */
   setScrollPosition(pos) {
-    const rootWindow = this.wot.rootWindow;
+    const rootWindow = this.master.rootWindow;
     let result = false;
 
     if (this.mainTableScrollableElement === rootWindow && rootWindow.scrollY !== pos) {
@@ -113,7 +113,7 @@ class TopOverlay extends Overlay {
    * Triggers onScroll hook callback.
    */
   onScroll() {
-    this.wot.getSetting('onScrollHorizontally');
+    this.master.getSetting('onScrollHorizontally');
   }
 
   /**
@@ -124,12 +124,12 @@ class TopOverlay extends Overlay {
    * @returns {Number} Height sum.
    */
   sumCellSizes(from, to) {
-    const defaultRowHeight = this.wot.wtSettings.settings.defaultRowHeight;
+    const defaultRowHeight = this.master.wtSettings.settings.defaultRowHeight;
     let row = from;
     let sum = 0;
 
     while (row < to) {
-      const height = this.wot.rowUtils.getHeight(row);
+      const height = this.master.rowUtils.getHeight(row);
 
       sum += height === void 0 ? defaultRowHeight : height;
       row += 1;
@@ -159,16 +159,16 @@ class TopOverlay extends Overlay {
    * Adjust the width and height of the overlay root element and its children (hider, holder) to the dimensions of the trimming container.
    */
   adjustRootElementSize() {
-    const { wtTable, rootDocument, rootWindow } = this.wot;
+    const { wtTable, rootDocument, rootWindow } = this.master;
     const scrollbarWidth = getScrollbarWidth(rootDocument);
     const overlayRoot = this.clone.wtTable.holder.parentNode;
     const overlayRootStyle = overlayRoot.style;
-    const preventOverflow = this.wot.getSetting('preventOverflow');
+    const preventOverflow = this.master.getSetting('preventOverflow');
 
     if (this.trimmingContainer !== rootWindow || preventOverflow === 'horizontal') {
-      let width = this.wot.wtViewport.getWorkspaceWidth();
+      let width = this.master.wtViewport.getWorkspaceWidth();
 
-      if (this.wot.wtOverlays.hasScrollbarRight) {
+      if (this.master.wtOverlays.hasScrollbarRight) {
         width -= scrollbarWidth;
       }
 
@@ -181,7 +181,7 @@ class TopOverlay extends Overlay {
 
     let tableHeight = outerHeight(this.clone.wtTable.TABLE);
 
-    if (!this.wot.wtTable.hasDefinedSize()) {
+    if (!this.master.wtTable.hasDefinedSize()) {
       tableHeight = 0;
     }
 
@@ -198,13 +198,13 @@ class TopOverlay extends Overlay {
    * Adjust the overlay dimensions and position.
    */
   applyToDOM() {
-    const total = this.wot.getSetting('totalRows');
+    const total = this.master.getSetting('totalRows');
 
     if (!this.areElementSizesAdjusted) {
       this.adjustElementsSize();
     }
-    if (typeof this.wot.wtViewport.rowsRenderCalculator.startPosition === 'number') {
-      this.spreader.style.top = `${this.wot.wtViewport.rowsRenderCalculator.startPosition}px`;
+    if (typeof this.master.wtViewport.rowsRenderCalculator.startPosition === 'number') {
+      this.spreader.style.top = `${this.master.wtViewport.rowsRenderCalculator.startPosition}px`;
 
     } else if (total === 0) {
       // can happen if there are 0 rows
@@ -224,8 +224,8 @@ class TopOverlay extends Overlay {
    * Synchronize calculated left position to an element.
    */
   syncOverlayOffset() {
-    if (typeof this.wot.wtViewport.columnsRenderCalculator.startPosition === 'number') {
-      this.clone.wtTable.spreader.style.left = `${this.wot.wtViewport.columnsRenderCalculator.startPosition}px`;
+    if (typeof this.master.wtViewport.columnsRenderCalculator.startPosition === 'number') {
+      this.clone.wtTable.spreader.style.left = `${this.master.wtViewport.columnsRenderCalculator.startPosition}px`;
 
     } else {
       this.clone.wtTable.spreader.style.left = '';
@@ -240,27 +240,27 @@ class TopOverlay extends Overlay {
    * @returns {Boolean}
    */
   scrollTo(sourceRow, bottomEdge) {
-    const { wot } = this;
-    const sourceInstance = wot.cloneSource ? wot.cloneSource : wot;
+    const { master } = this;
+    const sourceInstance = master.cloneSource ? master.cloneSource : master;
     const mainHolder = sourceInstance.wtTable.holder;
     let newY = this.getTableParentOffset();
     let scrollbarCompensation = 0;
 
     if (bottomEdge && mainHolder.offsetHeight !== mainHolder.clientHeight) {
-      scrollbarCompensation = getScrollbarWidth(wot.rootDocument);
+      scrollbarCompensation = getScrollbarWidth(master.rootDocument);
     }
 
     if (bottomEdge) {
-      const fixedRowsBottom = wot.getSetting('fixedRowsBottom');
-      const totalRows = wot.getSetting('totalRows');
+      const fixedRowsBottom = master.getSetting('fixedRowsBottom');
+      const totalRows = master.getSetting('totalRows');
 
       newY += this.sumCellSizes(0, sourceRow + 1);
-      newY -= wot.wtViewport.getViewportHeight() - this.sumCellSizes(totalRows - fixedRowsBottom, totalRows);
+      newY -= master.wtViewport.getViewportHeight() - this.sumCellSizes(totalRows - fixedRowsBottom, totalRows);
       // Fix 1 pixel offset when cell is selected
       newY += 1;
 
     } else {
-      newY += this.sumCellSizes(wot.getSetting('fixedRowsTop'), sourceRow);
+      newY += this.sumCellSizes(master.getSetting('fixedRowsTop'), sourceRow);
     }
     newY += scrollbarCompensation;
 
@@ -273,8 +273,8 @@ class TopOverlay extends Overlay {
    * @returns {Number}
    */
   getTableParentOffset() {
-    if (this.mainTableScrollableElement === this.wot.rootWindow) {
-      return this.wot.wtTable.holderOffset.top;
+    if (this.mainTableScrollableElement === this.master.rootWindow) {
+      return this.master.wtTable.holderOffset.top;
 
     }
     return 0;
@@ -287,7 +287,7 @@ class TopOverlay extends Overlay {
    * @returns {Number} Main table's vertical scroll position.
    */
   getScrollPosition() {
-    return getScrollTop(this.mainTableScrollableElement, this.wot.rootWindow);
+    return getScrollTop(this.mainTableScrollableElement, this.master.rootWindow);
   }
 
   /**
@@ -297,7 +297,7 @@ class TopOverlay extends Overlay {
    */
   redrawSelectionBorders(selection) {
     if (selection && selection.cellRange && selection.hasSelectionHandle()) {
-      const selectionHandle = selection.getSelectionHandle(this.wot);
+      const selectionHandle = selection.getSelectionHandle(this.master);
       const corners = selection.getCorners();
 
       selectionHandle.disappear();
@@ -309,7 +309,7 @@ class TopOverlay extends Overlay {
    * Redrawing borders of all selections.
    */
   redrawAllSelectionsBorders() {
-    const selections = this.wot.selections;
+    const selections = this.master.selections;
 
     this.redrawSelectionBorders(selections.getCell());
 
@@ -318,7 +318,7 @@ class TopOverlay extends Overlay {
     });
     this.redrawSelectionBorders(selections.getFill());
 
-    this.wot.wtOverlays.leftOverlay.refresh();
+    this.master.wtOverlays.leftOverlay.refresh();
   }
 
   /**
@@ -327,8 +327,8 @@ class TopOverlay extends Overlay {
    * @param {Number} position Header Y position if trimming container is window or scroll top if not.
    */
   adjustHeaderBordersPosition(position) {
-    const masterParent = this.wot.wtTable.holder.parentNode;
-    const totalColumns = this.wot.getSetting('totalColumns');
+    const masterParent = this.master.wtTable.holder.parentNode;
+    const totalColumns = this.master.getSetting('totalColumns');
 
     if (totalColumns) {
       removeClass(masterParent, 'emptyColumns');
@@ -336,17 +336,17 @@ class TopOverlay extends Overlay {
       addClass(masterParent, 'emptyColumns');
     }
 
-    if (this.wot.getSetting('fixedRowsTop') === 0 && this.wot.getSetting('columnHeaders').length > 0) {
+    if (this.master.getSetting('fixedRowsTop') === 0 && this.master.getSetting('columnHeaders').length > 0) {
       const previousState = hasClass(masterParent, 'innerBorderTop');
 
-      if (position || this.wot.getSetting('totalRows') === 0) {
+      if (position || this.master.getSetting('totalRows') === 0) {
         addClass(masterParent, 'innerBorderTop');
       } else {
         removeClass(masterParent, 'innerBorderTop');
       }
 
       if (!previousState && position || previousState && !position) {
-        this.wot.wtOverlays.adjustElementsSize();
+        this.master.wtOverlays.adjustElementsSize();
 
         // cell borders should be positioned once again,
         // because we added / removed 1px border from table header
@@ -355,7 +355,7 @@ class TopOverlay extends Overlay {
     }
 
     // nasty workaround for double border in the header, TODO: find a pure-css solution
-    if (this.wot.getSetting('rowHeaders').length === 0) {
+    if (this.master.getSetting('rowHeaders').length === 0) {
       const secondHeaderCell = this.clone.wtTable.THEAD.querySelectorAll('th:nth-of-type(2)');
 
       if (secondHeaderCell) {

--- a/src/3rdparty/walkontable/src/overlay/top.js
+++ b/src/3rdparty/walkontable/src/overlay/top.js
@@ -200,9 +200,6 @@ class TopOverlay extends Overlay {
   workaroundsForPositionAndSize() {
     const total = this.master.getSetting('totalRows');
 
-    if (!this.areElementSizesAdjusted) {
-      this.adjustElementsSize();
-    }
     if (typeof this.master.wtViewport.rowsRenderCalculator.startPosition === 'number') {
       this.master.wtTable.spreader.style.top = `${this.master.wtViewport.rowsRenderCalculator.startPosition}px`;
 

--- a/src/3rdparty/walkontable/src/overlay/top.js
+++ b/src/3rdparty/walkontable/src/overlay/top.js
@@ -241,8 +241,7 @@ class TopOverlay extends Overlay {
    */
   scrollTo(sourceRow, bottomEdge) {
     const { master } = this;
-    const sourceInstance = master.overlay ? master.overlay.master : master;
-    const mainHolder = sourceInstance.wtTable.holder;
+    const mainHolder = this.master.wtTable.holder;
     let newY = this.getTableParentOffset();
     let scrollbarCompensation = 0;
 

--- a/src/3rdparty/walkontable/src/overlay/top.js
+++ b/src/3rdparty/walkontable/src/overlay/top.js
@@ -188,9 +188,9 @@ class TopOverlay extends Overlay {
   }
 
   /**
-   * Adjust the overlay dimensions and position.
+   * Adjust the overlay position
    */
-  workaroundsForPositionAndSize() {
+  workaroundsForPosition() {
     const { master } = this;
     const total = master.getSetting('totalRows');
 

--- a/src/3rdparty/walkontable/src/overlay/top.js
+++ b/src/3rdparty/walkontable/src/overlay/top.js
@@ -23,6 +23,7 @@ class TopOverlay extends Overlay {
   constructor(wotInstance) {
     super(wotInstance);
     this.clone = this.makeClone(Overlay.CLONE_TOP);
+    this.updateStateOfRendering();
   }
 
   /**

--- a/src/3rdparty/walkontable/src/overlay/top.js
+++ b/src/3rdparty/walkontable/src/overlay/top.js
@@ -190,7 +190,7 @@ class TopOverlay extends Overlay {
 
     const { holder, hider, wtRootElement } = this.clone.wtTable;
 
-    hider.style.width = this.hider.style.width;
+    hider.style.width = this.master.wtTable.hider.style.width;
     holder.style.width = wtRootElement.style.width;
     holder.style.height = wtRootElement.style.height;
   }
@@ -205,16 +205,16 @@ class TopOverlay extends Overlay {
       this.adjustElementsSize();
     }
     if (typeof this.master.wtViewport.rowsRenderCalculator.startPosition === 'number') {
-      this.spreader.style.top = `${this.master.wtViewport.rowsRenderCalculator.startPosition}px`;
+      this.master.wtTable.spreader.style.top = `${this.master.wtViewport.rowsRenderCalculator.startPosition}px`;
 
     } else if (total === 0) {
       // can happen if there are 0 rows
-      this.spreader.style.top = '0';
+      this.master.wtTable.spreader.style.top = '0';
 
     } else {
       throw new Error('Incorrect value of the rowsRenderCalculator');
     }
-    this.spreader.style.bottom = '';
+    this.master.wtTable.spreader.style.bottom = '';
 
     if (this.needFullRender) {
       if (typeof this.master.wtViewport.columnsRenderCalculator.startPosition === 'number') {

--- a/src/3rdparty/walkontable/src/overlay/top.js
+++ b/src/3rdparty/walkontable/src/overlay/top.js
@@ -201,8 +201,8 @@ class TopOverlay extends Overlay {
     overlayRootElementStyle.height = `${tableHeight}px`;
 
     clone.wtTable.hider.style.width = master.wtTable.hider.style.width;
-    clone.wtTable.holder.style.width = clone.wtTable.wtRootElement.style.width;
-    clone.wtTable.holder.style.height = clone.wtTable.wtRootElement.style.height;
+    clone.wtTable.holder.style.width = overlayRootElementStyle.width;
+    clone.wtTable.holder.style.height = overlayRootElementStyle.height;
 
     if (!force) {
       this.areElementSizesAdjusted = true;

--- a/src/3rdparty/walkontable/src/overlay/top.js
+++ b/src/3rdparty/walkontable/src/overlay/top.js
@@ -241,7 +241,7 @@ class TopOverlay extends Overlay {
    */
   scrollTo(sourceRow, bottomEdge) {
     const { master } = this;
-    const sourceInstance = master.cloneSource ? master.cloneSource : master;
+    const sourceInstance = master.overlay ? master.overlay.master : master;
     const mainHolder = sourceInstance.wtTable.holder;
     let newY = this.getTableParentOffset();
     let scrollbarCompensation = 0;

--- a/src/3rdparty/walkontable/src/overlay/top.js
+++ b/src/3rdparty/walkontable/src/overlay/top.js
@@ -147,19 +147,10 @@ class TopOverlay extends Overlay {
   adjustElementsSize(force = false) {
     this.updateTrimmingContainer();
 
-    if (this.needFullRender || force) {
-      this._adjustElementsSize();
-
-      if (!force) {
-        this.areElementSizesAdjusted = true;
-      }
+    if (!this.needFullRender && !force) {
+      return;
     }
-  }
 
-  /**
-   * Adjust the sizes of the clone and the master elements to the dimensions of the trimming container.
-   */
-  _adjustElementsSize() {
     const { clone, master } = this;
     const scrollbarWidth = getScrollbarWidth(master.rootDocument);
     const overlayRootElement = clone.wtTable.wtRootElement;
@@ -191,6 +182,10 @@ class TopOverlay extends Overlay {
     clone.wtTable.hider.style.width = master.wtTable.hider.style.width;
     clone.wtTable.holder.style.width = clone.wtTable.wtRootElement.style.width;
     clone.wtTable.holder.style.height = clone.wtTable.wtRootElement.style.height;
+
+    if (!force) {
+      this.areElementSizesAdjusted = true;
+    }
   }
 
   /**

--- a/src/3rdparty/walkontable/src/overlay/top.js
+++ b/src/3rdparty/walkontable/src/overlay/top.js
@@ -174,7 +174,6 @@ class TopOverlay extends Overlay {
     }
 
     const { clone, master } = this;
-    const scrollbarWidth = getScrollbarWidth(master.rootDocument);
     const overlayRootElement = clone.wtTable.wtRootElement;
     const overlayRootElementStyle = overlayRootElement.style;
     const preventOverflow = master.getSetting('preventOverflow');
@@ -183,7 +182,7 @@ class TopOverlay extends Overlay {
       let width = master.wtViewport.getWorkspaceWidth();
 
       if (master.wtOverlays.hasScrollbarRight) {
-        width -= scrollbarWidth;
+        width -= getScrollbarWidth(master.rootDocument);
       }
 
       width = Math.min(width, master.wtTable.wtRootElement.scrollWidth);

--- a/src/3rdparty/walkontable/src/overlay/top.js
+++ b/src/3rdparty/walkontable/src/overlay/top.js
@@ -217,19 +217,12 @@ class TopOverlay extends Overlay {
     this.spreader.style.bottom = '';
 
     if (this.needFullRender) {
-      this.syncOverlayOffset();
-    }
-  }
+      if (typeof this.master.wtViewport.columnsRenderCalculator.startPosition === 'number') {
+        this.clone.wtTable.spreader.style.left = `${this.master.wtViewport.columnsRenderCalculator.startPosition}px`;
 
-  /**
-   * Synchronize calculated left position to an element.
-   */
-  syncOverlayOffset() {
-    if (typeof this.master.wtViewport.columnsRenderCalculator.startPosition === 'number') {
-      this.clone.wtTable.spreader.style.left = `${this.master.wtViewport.columnsRenderCalculator.startPosition}px`;
-
-    } else {
-      this.clone.wtTable.spreader.style.left = '';
+      } else {
+        this.clone.wtTable.spreader.style.left = '';
+      }
     }
   }
 

--- a/src/3rdparty/walkontable/src/overlay/top.js
+++ b/src/3rdparty/walkontable/src/overlay/top.js
@@ -53,7 +53,7 @@ class TopOverlay extends Overlay {
       // removed from DOM
       return;
     }
-    const overlayRoot = this.clone.wtTable.holder.parentNode;
+    const overlayRoot = this.clone.wtTable.wtRootElement;
     let headerPosition = 0;
     const preventOverflow = this.master.getSetting('preventOverflow');
 
@@ -161,7 +161,7 @@ class TopOverlay extends Overlay {
   adjustRootElementSize() {
     const { wtTable, rootDocument, rootWindow } = this.master;
     const scrollbarWidth = getScrollbarWidth(rootDocument);
-    const overlayRoot = this.clone.wtTable.holder.parentNode;
+    const overlayRoot = this.clone.wtTable.wtRootElement;
     const overlayRootStyle = overlayRoot.style;
     const preventOverflow = this.master.getSetting('preventOverflow');
 
@@ -187,11 +187,11 @@ class TopOverlay extends Overlay {
 
     overlayRootStyle.height = `${tableHeight}px`;
 
-    const { holder, hider } = this.clone.wtTable;
+    const { holder, hider, wtRootElement } = this.clone.wtTable;
 
     hider.style.width = this.hider.style.width;
-    holder.style.width = holder.parentNode.style.width;
-    holder.style.height = holder.parentNode.style.height;
+    holder.style.width = wtRootElement.style.width;
+    holder.style.height = wtRootElement.style.height;
   }
 
   /**
@@ -326,7 +326,7 @@ class TopOverlay extends Overlay {
    * @param {Number} position Header Y position if trimming container is window or scroll top if not.
    */
   adjustHeaderBordersPosition(position) {
-    const masterParent = this.master.wtTable.holder.parentNode;
+    const masterParent = this.master.wtTable.wtRootElement;
     const totalColumns = this.master.getSetting('totalColumns');
 
     if (totalColumns) {

--- a/src/3rdparty/walkontable/src/overlay/top.js
+++ b/src/3rdparty/walkontable/src/overlay/top.js
@@ -296,6 +296,29 @@ class TopOverlay extends Overlay {
   }
 
   /**
+   * Redraws the content of the overlay's clone instance of Walkontable, including the cells, selections and borders.
+   * Does not change the size nor the position of the overlay root element.
+   *
+   * @param {Boolean} [fastDraw=false]
+   */
+  redrawClone(fastDraw = false) {
+    Overlay.prototype.redrawClone.call(this, fastDraw); // equals: super(fastDraw)
+
+    if (!fastDraw) {
+      // nasty workaround for double border in the header, TODO: find a pure-css solution
+      if (this.master.getSetting('rowHeaders').length === 0) {
+        const secondHeaderCell = this.clone.wtTable.THEAD.querySelectorAll('th:nth-of-type(2)');
+
+        if (secondHeaderCell) {
+          for (let i = 0; i < secondHeaderCell.length; i++) {
+            secondHeaderCell[i].style['border-left-width'] = 0;
+          }
+        }
+      }
+    }
+  }
+
+  /**
    * Adds css classes to hide the header border's header (cell-selection border hiding issue).
    *
    * @param {Number} position Header Y position if trimming container is window or scroll top if not.
@@ -316,17 +339,6 @@ class TopOverlay extends Overlay {
         addClass(masterRootElement, 'innerBorderTop');
       } else {
         removeClass(masterRootElement, 'innerBorderTop');
-      }
-    }
-
-    // nasty workaround for double border in the header, TODO: find a pure-css solution
-    if (master.getSetting('rowHeaders').length === 0) {
-      const secondHeaderCell = this.clone.wtTable.THEAD.querySelectorAll('th:nth-of-type(2)');
-
-      if (secondHeaderCell) {
-        for (let i = 0; i < secondHeaderCell.length; i++) {
-          secondHeaderCell[i].style['border-left-width'] = 0;
-        }
       }
     }
   }

--- a/src/3rdparty/walkontable/src/overlay/top.js
+++ b/src/3rdparty/walkontable/src/overlay/top.js
@@ -86,7 +86,6 @@ class TopOverlay extends Overlay {
     }
 
     this.adjustHeaderBordersPosition(headerPosition);
-    this.adjustElementsSize();
   }
 
   /**

--- a/src/3rdparty/walkontable/src/overlay/top.js
+++ b/src/3rdparty/walkontable/src/overlay/top.js
@@ -167,8 +167,6 @@ class TopOverlay extends Overlay {
    * @param {Boolean} [force=false]
    */
   adjustElementsSize(force = false) {
-    this.updateTrimmingContainer();
-
     if (!this.needFullRender && !force) {
       return;
     }

--- a/src/3rdparty/walkontable/src/overlay/top.js
+++ b/src/3rdparty/walkontable/src/overlay/top.js
@@ -3,7 +3,6 @@ import {
   getScrollbarWidth,
   getScrollTop,
   getWindowScrollLeft,
-  hasClass,
   outerHeight,
   removeClass,
   setOverlayPosition,
@@ -322,20 +321,10 @@ class TopOverlay extends Overlay {
     }
 
     if (master.getSetting('fixedRowsTop') === 0 && master.getSetting('columnHeaders').length > 0) {
-      const previousState = hasClass(masterRootElement, 'innerBorderTop');
-
       if (position || master.getSetting('totalRows') === 0) {
         addClass(masterRootElement, 'innerBorderTop');
       } else {
         removeClass(masterRootElement, 'innerBorderTop');
-      }
-
-      if (!previousState && position || previousState && !position) {
-        master.wtOverlays.adjustElementsSizes();
-
-        // cell borders should be positioned once again,
-        // because we added / removed 1px border from table header
-        this.redrawAllSelectionsBorders();
       }
     }
 

--- a/src/3rdparty/walkontable/src/overlay/top.js
+++ b/src/3rdparty/walkontable/src/overlay/top.js
@@ -129,7 +129,7 @@ class TopOverlay extends Overlay {
     let sum = 0;
 
     while (row < to) {
-      const height = this.wot.wtTable.getRowHeight(row);
+      const height = this.wot.rowUtils.getHeight(row);
 
       sum += height === void 0 ? defaultRowHeight : height;
       row += 1;
@@ -318,7 +318,7 @@ class TopOverlay extends Overlay {
     });
     this.redrawSelectionBorders(selections.getFill());
 
-    this.wot.wtTable.wot.wtOverlays.leftOverlay.refresh();
+    this.wot.wtOverlays.leftOverlay.refresh();
   }
 
   /**

--- a/src/3rdparty/walkontable/src/overlay/top.js
+++ b/src/3rdparty/walkontable/src/overlay/top.js
@@ -82,7 +82,7 @@ class TopOverlay extends Overlay {
     let headerPosition = 0;
     const preventOverflow = master.getSetting('preventOverflow');
 
-    if (this.trimmingContainer === master.rootWindow && (!preventOverflow || preventOverflow !== 'vertical')) {
+    if (master.wtTable.trimmingContainer === master.rootWindow && (!preventOverflow || preventOverflow !== 'vertical')) {
       const box = master.wtTable.hider.getBoundingClientRect();
       const top = Math.ceil(box.top);
       const bottom = Math.ceil(box.bottom);
@@ -176,7 +176,7 @@ class TopOverlay extends Overlay {
     const overlayRootElementStyle = overlayRootElement.style;
     const preventOverflow = master.getSetting('preventOverflow');
 
-    if (this.trimmingContainer !== master.rootWindow || preventOverflow === 'horizontal') {
+    if (master.wtTable.trimmingContainer !== master.rootWindow || preventOverflow === 'horizontal') {
       let width = master.wtViewport.getWorkspaceWidth();
 
       if (master.wtOverlays.hasScrollbarRight) {

--- a/src/3rdparty/walkontable/src/overlay/top.js
+++ b/src/3rdparty/walkontable/src/overlay/top.js
@@ -50,11 +50,34 @@ class TopOverlay extends Overlay {
    */
   adjustElementsPosition() {
     const { master } = this;
+    const total = master.getSetting('totalRows');
+
+    if (typeof master.wtViewport.rowsRenderCalculator.startPosition === 'number') {
+      master.wtTable.spreader.style.top = `${master.wtViewport.rowsRenderCalculator.startPosition}px`;
+
+    } else if (total === 0) {
+      // can happen if there are 0 rows
+      master.wtTable.spreader.style.top = '0';
+
+    } else {
+      throw new Error('Incorrect value of the rowsRenderCalculator');
+    }
+    master.wtTable.spreader.style.bottom = '';
+
+    if (this.needFullRender) {
+      if (typeof master.wtViewport.columnsRenderCalculator.startPosition === 'number') {
+        this.clone.wtTable.spreader.style.left = `${master.wtViewport.columnsRenderCalculator.startPosition}px`;
+
+      } else {
+        this.clone.wtTable.spreader.style.left = '';
+      }
+    }
 
     if (!this.needFullRender || !master.wtTable.holder.parentNode) {
       // removed from DOM
       return;
     }
+
     const overlayRootElement = this.clone.wtTable.wtRootElement;
     let headerPosition = 0;
     const preventOverflow = master.getSetting('preventOverflow');
@@ -184,35 +207,6 @@ class TopOverlay extends Overlay {
 
     if (!force) {
       this.areElementSizesAdjusted = true;
-    }
-  }
-
-  /**
-   * Adjust the overlay position
-   */
-  workaroundsForPosition() {
-    const { master } = this;
-    const total = master.getSetting('totalRows');
-
-    if (typeof master.wtViewport.rowsRenderCalculator.startPosition === 'number') {
-      master.wtTable.spreader.style.top = `${master.wtViewport.rowsRenderCalculator.startPosition}px`;
-
-    } else if (total === 0) {
-      // can happen if there are 0 rows
-      master.wtTable.spreader.style.top = '0';
-
-    } else {
-      throw new Error('Incorrect value of the rowsRenderCalculator');
-    }
-    master.wtTable.spreader.style.bottom = '';
-
-    if (this.needFullRender) {
-      if (typeof master.wtViewport.columnsRenderCalculator.startPosition === 'number') {
-        this.clone.wtTable.spreader.style.left = `${master.wtViewport.columnsRenderCalculator.startPosition}px`;
-
-      } else {
-        this.clone.wtTable.spreader.style.left = '';
-      }
     }
   }
 

--- a/src/3rdparty/walkontable/src/overlay/top.js
+++ b/src/3rdparty/walkontable/src/overlay/top.js
@@ -50,26 +50,27 @@ class TopOverlay extends Overlay {
    * Updates the position of the overlay root element relatively to the position of the master instance
    */
   adjustElementsPosition() {
-    if (!this.needFullRender || !this.master.wtTable.holder.parentNode) {
+    const { master } = this;
+
+    if (!this.needFullRender || !master.wtTable.holder.parentNode) {
       // removed from DOM
       return;
     }
-    const overlayRoot = this.clone.wtTable.wtRootElement;
+    const overlayRootElement = this.clone.wtTable.wtRootElement;
     let headerPosition = 0;
-    const preventOverflow = this.master.getSetting('preventOverflow');
+    const preventOverflow = master.getSetting('preventOverflow');
 
-    if (this.trimmingContainer === this.master.rootWindow && (!preventOverflow || preventOverflow !== 'vertical')) {
-      const { wtTable } = this.master;
-      const box = wtTable.hider.getBoundingClientRect();
+    if (this.trimmingContainer === master.rootWindow && (!preventOverflow || preventOverflow !== 'vertical')) {
+      const box = master.wtTable.hider.getBoundingClientRect();
       const top = Math.ceil(box.top);
       const bottom = Math.ceil(box.bottom);
       let finalLeft;
       let finalTop;
 
-      finalLeft = wtTable.hider.style.left;
+      finalLeft = master.wtTable.hider.style.left;
       finalLeft = finalLeft === '' ? 0 : finalLeft;
 
-      if (top < 0 && (bottom - overlayRoot.offsetHeight) > 0) {
+      if (top < 0 && (bottom - overlayRootElement.offsetHeight) > 0) {
         finalTop = -top;
       } else {
         finalTop = 0;
@@ -77,11 +78,11 @@ class TopOverlay extends Overlay {
       headerPosition = finalTop;
       finalTop += 'px';
 
-      setOverlayPosition(overlayRoot, finalLeft, finalTop);
+      setOverlayPosition(overlayRootElement, finalLeft, finalTop);
 
     } else {
       headerPosition = this.getScrollPosition();
-      resetCssTransform(overlayRoot);
+      resetCssTransform(overlayRootElement);
     }
 
     this.adjustHeaderBordersPosition(headerPosition);
@@ -160,61 +161,61 @@ class TopOverlay extends Overlay {
    * Adjust the sizes of the clone and the master elements to the dimensions of the trimming container.
    */
   _adjustElementsSize() {
-    const scrollbarWidth = getScrollbarWidth(this.master.rootDocument);
-    const overlayRoot = this.clone.wtTable.wtRootElement;
-    const overlayRootStyle = overlayRoot.style;
-    const preventOverflow = this.master.getSetting('preventOverflow');
+    const { clone, master } = this;
+    const scrollbarWidth = getScrollbarWidth(master.rootDocument);
+    const overlayRootElement = clone.wtTable.wtRootElement;
+    const overlayRootElementStyle = overlayRootElement.style;
+    const preventOverflow = master.getSetting('preventOverflow');
 
-    if (this.trimmingContainer !== this.master.rootWindow || preventOverflow === 'horizontal') {
-      let width = this.master.wtViewport.getWorkspaceWidth();
+    if (this.trimmingContainer !== master.rootWindow || preventOverflow === 'horizontal') {
+      let width = master.wtViewport.getWorkspaceWidth();
 
-      if (this.master.wtOverlays.hasScrollbarRight) {
+      if (master.wtOverlays.hasScrollbarRight) {
         width -= scrollbarWidth;
       }
 
-      width = Math.min(width, this.master.wtTable.wtRootElement.scrollWidth);
-      overlayRootStyle.width = `${width}px`;
+      width = Math.min(width, master.wtTable.wtRootElement.scrollWidth);
+      overlayRootElementStyle.width = `${width}px`;
 
     } else {
-      overlayRootStyle.width = '';
+      overlayRootElementStyle.width = '';
     }
 
-    let tableHeight = outerHeight(this.clone.wtTable.TABLE);
+    let tableHeight = outerHeight(clone.wtTable.TABLE);
 
-    if (!this.master.wtTable.hasDefinedSize()) {
+    if (!master.wtTable.hasDefinedSize()) {
       tableHeight = 0;
     }
 
-    overlayRootStyle.height = `${tableHeight}px`;
+    overlayRootElementStyle.height = `${tableHeight}px`;
 
-    const { holder, hider, wtRootElement } = this.clone.wtTable;
-
-    hider.style.width = this.master.wtTable.hider.style.width;
-    holder.style.width = wtRootElement.style.width;
-    holder.style.height = wtRootElement.style.height;
+    clone.wtTable.hider.style.width = master.wtTable.hider.style.width;
+    clone.wtTable.holder.style.width = clone.wtTable.wtRootElement.style.width;
+    clone.wtTable.holder.style.height = clone.wtTable.wtRootElement.style.height;
   }
 
   /**
    * Adjust the overlay dimensions and position.
    */
   workaroundsForPositionAndSize() {
-    const total = this.master.getSetting('totalRows');
+    const { master } = this;
+    const total = master.getSetting('totalRows');
 
-    if (typeof this.master.wtViewport.rowsRenderCalculator.startPosition === 'number') {
-      this.master.wtTable.spreader.style.top = `${this.master.wtViewport.rowsRenderCalculator.startPosition}px`;
+    if (typeof master.wtViewport.rowsRenderCalculator.startPosition === 'number') {
+      master.wtTable.spreader.style.top = `${master.wtViewport.rowsRenderCalculator.startPosition}px`;
 
     } else if (total === 0) {
       // can happen if there are 0 rows
-      this.master.wtTable.spreader.style.top = '0';
+      master.wtTable.spreader.style.top = '0';
 
     } else {
       throw new Error('Incorrect value of the rowsRenderCalculator');
     }
-    this.master.wtTable.spreader.style.bottom = '';
+    master.wtTable.spreader.style.bottom = '';
 
     if (this.needFullRender) {
-      if (typeof this.master.wtViewport.columnsRenderCalculator.startPosition === 'number') {
-        this.clone.wtTable.spreader.style.left = `${this.master.wtViewport.columnsRenderCalculator.startPosition}px`;
+      if (typeof master.wtViewport.columnsRenderCalculator.startPosition === 'number') {
+        this.clone.wtTable.spreader.style.left = `${master.wtViewport.columnsRenderCalculator.startPosition}px`;
 
       } else {
         this.clone.wtTable.spreader.style.left = '';
@@ -231,7 +232,7 @@ class TopOverlay extends Overlay {
    */
   scrollTo(sourceRow, bottomEdge) {
     const { master } = this;
-    const mainHolder = this.master.wtTable.holder;
+    const mainHolder = master.wtTable.holder;
     let newY = this.getTableParentOffset();
     let scrollbarCompensation = 0;
 
@@ -316,26 +317,27 @@ class TopOverlay extends Overlay {
    * @param {Number} position Header Y position if trimming container is window or scroll top if not.
    */
   adjustHeaderBordersPosition(position) {
-    const masterParent = this.master.wtTable.wtRootElement;
-    const totalColumns = this.master.getSetting('totalColumns');
+    const { master } = this;
+    const masterRootElement = master.wtTable.wtRootElement;
+    const totalColumns = master.getSetting('totalColumns');
 
     if (totalColumns) {
-      removeClass(masterParent, 'emptyColumns');
+      removeClass(masterRootElement, 'emptyColumns');
     } else {
-      addClass(masterParent, 'emptyColumns');
+      addClass(masterRootElement, 'emptyColumns');
     }
 
-    if (this.master.getSetting('fixedRowsTop') === 0 && this.master.getSetting('columnHeaders').length > 0) {
-      const previousState = hasClass(masterParent, 'innerBorderTop');
+    if (master.getSetting('fixedRowsTop') === 0 && master.getSetting('columnHeaders').length > 0) {
+      const previousState = hasClass(masterRootElement, 'innerBorderTop');
 
-      if (position || this.master.getSetting('totalRows') === 0) {
-        addClass(masterParent, 'innerBorderTop');
+      if (position || master.getSetting('totalRows') === 0) {
+        addClass(masterRootElement, 'innerBorderTop');
       } else {
-        removeClass(masterParent, 'innerBorderTop');
+        removeClass(masterRootElement, 'innerBorderTop');
       }
 
       if (!previousState && position || previousState && !position) {
-        this.master.wtOverlays.adjustElementsSizes();
+        master.wtOverlays.adjustElementsSizes();
 
         // cell borders should be positioned once again,
         // because we added / removed 1px border from table header
@@ -344,7 +346,7 @@ class TopOverlay extends Overlay {
     }
 
     // nasty workaround for double border in the header, TODO: find a pure-css solution
-    if (this.master.getSetting('rowHeaders').length === 0) {
+    if (master.getSetting('rowHeaders').length === 0) {
       const secondHeaderCell = this.clone.wtTable.THEAD.querySelectorAll('th:nth-of-type(2)');
 
       if (secondHeaderCell) {

--- a/src/3rdparty/walkontable/src/overlay/top.js
+++ b/src/3rdparty/walkontable/src/overlay/top.js
@@ -47,9 +47,9 @@ class TopOverlay extends Overlay {
   }
 
   /**
-   * Updates the top overlay position.
+   * Updates the position of the overlay root element relatively to the position of the master instance
    */
-  resetFixedPosition() {
+  adjustElementsPosition() {
     if (!this.needFullRender || !this.master.wtTable.holder.parentNode) {
       // removed from DOM
       return;
@@ -140,7 +140,7 @@ class TopOverlay extends Overlay {
   }
 
   /**
-   * Adjust overlay root element, childs and master table element sizes (width, height).
+   * If needed, adjust the sizes of the clone and the master elements to the dimensions of the trimming container.
    *
    * @param {Boolean} [force=false]
    */
@@ -148,7 +148,7 @@ class TopOverlay extends Overlay {
     this.updateTrimmingContainer();
 
     if (this.needFullRender || force) {
-      this.adjustRootElementSize();
+      this._adjustElementsSize();
 
       if (!force) {
         this.areElementSizesAdjusted = true;
@@ -157,9 +157,9 @@ class TopOverlay extends Overlay {
   }
 
   /**
-   * Adjust the width and height of the overlay root element and its children (hider, holder) to the dimensions of the trimming container.
+   * Adjust the sizes of the clone and the master elements to the dimensions of the trimming container.
    */
-  adjustRootElementSize() {
+  _adjustElementsSize() {
     const { wtTable, rootDocument, rootWindow } = this.master;
     const scrollbarWidth = getScrollbarWidth(rootDocument);
     const overlayRoot = this.clone.wtTable.wtRootElement;
@@ -198,7 +198,7 @@ class TopOverlay extends Overlay {
   /**
    * Adjust the overlay dimensions and position.
    */
-  applyToDOM() {
+  workaroundsForPositionAndSize() {
     const total = this.master.getSetting('totalRows');
 
     if (!this.areElementSizesAdjusted) {
@@ -318,7 +318,7 @@ class TopOverlay extends Overlay {
     });
     this.redrawSelectionBorders(selections.getFill());
 
-    this.master.wtOverlays.leftOverlay.refresh();
+    this.master.wtOverlays.leftOverlay.redrawClone();
   }
 
   /**
@@ -346,7 +346,7 @@ class TopOverlay extends Overlay {
       }
 
       if (!previousState && position || previousState && !position) {
-        this.master.wtOverlays.adjustElementsSize();
+        this.master.wtOverlays.adjustElementsSizes();
 
         // cell borders should be positioned once again,
         // because we added / removed 1px border from table header

--- a/src/3rdparty/walkontable/src/overlay/top.js
+++ b/src/3rdparty/walkontable/src/overlay/top.js
@@ -160,20 +160,19 @@ class TopOverlay extends Overlay {
    * Adjust the sizes of the clone and the master elements to the dimensions of the trimming container.
    */
   _adjustElementsSize() {
-    const { wtTable, rootDocument, rootWindow } = this.master;
-    const scrollbarWidth = getScrollbarWidth(rootDocument);
+    const scrollbarWidth = getScrollbarWidth(this.master.rootDocument);
     const overlayRoot = this.clone.wtTable.wtRootElement;
     const overlayRootStyle = overlayRoot.style;
     const preventOverflow = this.master.getSetting('preventOverflow');
 
-    if (this.trimmingContainer !== rootWindow || preventOverflow === 'horizontal') {
+    if (this.trimmingContainer !== this.master.rootWindow || preventOverflow === 'horizontal') {
       let width = this.master.wtViewport.getWorkspaceWidth();
 
       if (this.master.wtOverlays.hasScrollbarRight) {
         width -= scrollbarWidth;
       }
 
-      width = Math.min(width, wtTable.wtRootElement.scrollWidth);
+      width = Math.min(width, this.master.wtTable.wtRootElement.scrollWidth);
       overlayRootStyle.width = `${width}px`;
 
     } else {

--- a/src/3rdparty/walkontable/src/overlay/topLeftCorner.js
+++ b/src/3rdparty/walkontable/src/overlay/topLeftCorner.js
@@ -37,9 +37,9 @@ class TopLeftCornerOverlay extends Overlay {
    * @returns {Boolean}
    */
   shouldBeRendered() {
-    const { wot } = this;
-    return !!((wot.getSetting('fixedRowsTop') || wot.getSetting('columnHeaders').length) &&
-        (wot.getSetting('fixedColumnsLeft') || wot.getSetting('rowHeaders').length));
+    const { master } = this;
+    return !!((master.getSetting('fixedRowsTop') || master.getSetting('columnHeaders').length) &&
+        (master.getSetting('fixedColumnsLeft') || master.getSetting('rowHeaders').length));
   }
 
   /**
@@ -48,15 +48,15 @@ class TopLeftCornerOverlay extends Overlay {
   resetFixedPosition() {
     this.updateTrimmingContainer();
 
-    if (!this.wot.wtTable.holder.parentNode) {
+    if (!this.master.wtTable.holder.parentNode) {
       // removed from DOM
       return;
     }
     const overlayRoot = this.clone.wtTable.holder.parentNode;
-    const preventOverflow = this.wot.getSetting('preventOverflow');
+    const preventOverflow = this.master.getSetting('preventOverflow');
 
-    if (this.trimmingContainer === this.wot.rootWindow) {
-      const box = this.wot.wtTable.hider.getBoundingClientRect();
+    if (this.trimmingContainer === this.master.rootWindow) {
+      const box = this.master.wtTable.hider.getBoundingClientRect();
       const top = Math.ceil(box.top);
       const left = Math.ceil(box.left);
       const bottom = Math.ceil(box.bottom);
@@ -83,7 +83,7 @@ class TopLeftCornerOverlay extends Overlay {
     let tableHeight = outerHeight(this.clone.wtTable.TABLE);
     const tableWidth = outerWidth(this.clone.wtTable.TABLE);
 
-    if (!this.wot.wtTable.hasDefinedSize()) {
+    if (!this.master.wtTable.hasDefinedSize()) {
       tableHeight = 0;
     }
 

--- a/src/3rdparty/walkontable/src/overlay/topLeftCorner.js
+++ b/src/3rdparty/walkontable/src/overlay/topLeftCorner.js
@@ -18,6 +18,7 @@ class TopLeftCornerOverlay extends Overlay {
   constructor(wotInstance) {
     super(wotInstance);
     this.clone = this.makeClone(Overlay.CLONE_TOP_LEFT_CORNER);
+    this.updateStateOfRendering();
   }
 
   /**

--- a/src/3rdparty/walkontable/src/overlay/topLeftCorner.js
+++ b/src/3rdparty/walkontable/src/overlay/topLeftCorner.js
@@ -56,7 +56,7 @@ class TopLeftCornerOverlay extends Overlay {
     const overlayRootElement = clone.wtTable.wtRootElement;
     const preventOverflow = master.getSetting('preventOverflow');
 
-    if (this.trimmingContainer === master.rootWindow) {
+    if (master.wtTable.trimmingContainer === master.rootWindow) {
       const box = master.wtTable.hider.getBoundingClientRect();
       const top = Math.ceil(box.top);
       const left = Math.ceil(box.left);

--- a/src/3rdparty/walkontable/src/overlay/topLeftCorner.js
+++ b/src/3rdparty/walkontable/src/overlay/topLeftCorner.js
@@ -80,9 +80,22 @@ class TopLeftCornerOverlay extends Overlay {
     } else {
       resetCssTransform(overlayRootElement);
     }
+  }
 
+  /**
+   * If needed, adjust the sizes of the clone and the master elements to the dimensions of the trimming container.
+   *
+   * @param {Boolean} [force=false]
+   */
+  adjustElementsSize(force = false) {
+    if (!this.needFullRender && !force) {
+      return;
+    }
+
+    const { clone, master } = this;
     let tableHeight = outerHeight(clone.wtTable.TABLE);
     const tableWidth = outerWidth(clone.wtTable.TABLE);
+    const overlayRootElement = clone.wtTable.wtRootElement;
 
     if (!master.wtTable.hasDefinedSize()) {
       tableHeight = 0;

--- a/src/3rdparty/walkontable/src/overlay/topLeftCorner.js
+++ b/src/3rdparty/walkontable/src/overlay/topLeftCorner.js
@@ -49,8 +49,6 @@ class TopLeftCornerOverlay extends Overlay {
   adjustElementsPosition() {
     const { clone, master } = this;
 
-    this.updateTrimmingContainer();
-
     if (!master.wtTable.holder.parentNode) {
       // removed from DOM
       return;

--- a/src/3rdparty/walkontable/src/overlay/topLeftCorner.js
+++ b/src/3rdparty/walkontable/src/overlay/topLeftCorner.js
@@ -47,17 +47,19 @@ class TopLeftCornerOverlay extends Overlay {
    * Updates the position of the overlay root element relatively to the position of the master instance
    */
   adjustElementsPosition() {
+    const { clone, master } = this;
+
     this.updateTrimmingContainer();
 
-    if (!this.master.wtTable.holder.parentNode) {
+    if (!master.wtTable.holder.parentNode) {
       // removed from DOM
       return;
     }
-    const overlayRoot = this.clone.wtTable.wtRootElement;
-    const preventOverflow = this.master.getSetting('preventOverflow');
+    const overlayRootElement = clone.wtTable.wtRootElement;
+    const preventOverflow = master.getSetting('preventOverflow');
 
-    if (this.trimmingContainer === this.master.rootWindow) {
-      const box = this.master.wtTable.hider.getBoundingClientRect();
+    if (this.trimmingContainer === master.rootWindow) {
+      const box = master.wtTable.hider.getBoundingClientRect();
       const top = Math.ceil(box.top);
       const left = Math.ceil(box.left);
       const bottom = Math.ceil(box.bottom);
@@ -66,30 +68,30 @@ class TopLeftCornerOverlay extends Overlay {
       let finalTop = '0';
 
       if (!preventOverflow || preventOverflow === 'vertical') {
-        if (left < 0 && (right - overlayRoot.offsetWidth) > 0) {
+        if (left < 0 && (right - overlayRootElement.offsetWidth) > 0) {
           finalLeft = `${-left}px`;
         }
       }
 
       if (!preventOverflow || preventOverflow === 'horizontal') {
-        if (top < 0 && (bottom - overlayRoot.offsetHeight) > 0) {
+        if (top < 0 && (bottom - overlayRootElement.offsetHeight) > 0) {
           finalTop = `${-top}px`;
         }
       }
-      setOverlayPosition(overlayRoot, finalLeft, finalTop);
+      setOverlayPosition(overlayRootElement, finalLeft, finalTop);
     } else {
-      resetCssTransform(overlayRoot);
+      resetCssTransform(overlayRootElement);
     }
 
-    let tableHeight = outerHeight(this.clone.wtTable.TABLE);
-    const tableWidth = outerWidth(this.clone.wtTable.TABLE);
+    let tableHeight = outerHeight(clone.wtTable.TABLE);
+    const tableWidth = outerWidth(clone.wtTable.TABLE);
 
-    if (!this.master.wtTable.hasDefinedSize()) {
+    if (!master.wtTable.hasDefinedSize()) {
       tableHeight = 0;
     }
 
-    overlayRoot.style.height = `${tableHeight}px`;
-    overlayRoot.style.width = `${tableWidth}px`;
+    overlayRootElement.style.height = `${tableHeight}px`;
+    overlayRootElement.style.width = `${tableWidth}px`;
   }
 }
 

--- a/src/3rdparty/walkontable/src/overlay/topLeftCorner.js
+++ b/src/3rdparty/walkontable/src/overlay/topLeftCorner.js
@@ -44,9 +44,9 @@ class TopLeftCornerOverlay extends Overlay {
   }
 
   /**
-   * Updates the corner overlay position
+   * Updates the position of the overlay root element relatively to the position of the master instance
    */
-  resetFixedPosition() {
+  adjustElementsPosition() {
     this.updateTrimmingContainer();
 
     if (!this.master.wtTable.holder.parentNode) {

--- a/src/3rdparty/walkontable/src/overlay/topLeftCorner.js
+++ b/src/3rdparty/walkontable/src/overlay/topLeftCorner.js
@@ -52,7 +52,7 @@ class TopLeftCornerOverlay extends Overlay {
       // removed from DOM
       return;
     }
-    const overlayRoot = this.clone.wtTable.holder.parentNode;
+    const overlayRoot = this.clone.wtTable.wtRootElement;
     const preventOverflow = this.master.getSetting('preventOverflow');
 
     if (this.trimmingContainer === this.master.rootWindow) {

--- a/src/3rdparty/walkontable/src/overlays.js
+++ b/src/3rdparty/walkontable/src/overlays.js
@@ -72,14 +72,10 @@ class Overlays {
 
   /**
    * Prepare overlays based on user settings.
-   *
-   * @returns {Boolean} Returns `true` if changes applied to overlay needs scroll synchronization.
    */
   prepareOverlays() {
-    let syncScroll = false;
-
     if (this.topOverlay) {
-      syncScroll = this.topOverlay.updateStateOfRendering() || syncScroll;
+      this.topOverlay.updateStateOfRendering();
     } else {
       this.topOverlay = Overlay.createOverlay(Overlay.CLONE_TOP, this.wot);
     }
@@ -87,31 +83,31 @@ class Overlays {
     if (!Overlay.hasOverlay(Overlay.CLONE_BOTTOM)) {
       this.bottomOverlay = {
         needFullRender: false,
-        updateStateOfRendering: () => false,
+        updateStateOfRendering: () => {},
       };
     }
     if (!Overlay.hasOverlay(Overlay.CLONE_BOTTOM_LEFT_CORNER)) {
       this.bottomLeftCornerOverlay = {
         needFullRender: false,
-        updateStateOfRendering: () => false,
+        updateStateOfRendering: () => {},
       };
     }
 
     if (this.bottomOverlay) {
-      syncScroll = this.bottomOverlay.updateStateOfRendering() || syncScroll;
+      this.bottomOverlay.updateStateOfRendering();
     } else {
       this.bottomOverlay = Overlay.createOverlay(Overlay.CLONE_BOTTOM, this.wot);
     }
 
     if (this.leftOverlay) {
-      syncScroll = this.leftOverlay.updateStateOfRendering() || syncScroll;
+      this.leftOverlay.updateStateOfRendering();
     } else {
       this.leftOverlay = Overlay.createOverlay(Overlay.CLONE_LEFT, this.wot);
     }
 
     if (this.topOverlay.needFullRender && this.leftOverlay.needFullRender) {
       if (this.topLeftCornerOverlay) {
-        syncScroll = this.topLeftCornerOverlay.updateStateOfRendering() || syncScroll;
+        this.topLeftCornerOverlay.updateStateOfRendering();
       } else {
         this.topLeftCornerOverlay = Overlay.createOverlay(Overlay.CLONE_TOP_LEFT_CORNER, this.wot);
       }
@@ -119,7 +115,7 @@ class Overlays {
 
     if (this.bottomOverlay.needFullRender && this.leftOverlay.needFullRender) {
       if (this.bottomLeftCornerOverlay) {
-        syncScroll = this.bottomLeftCornerOverlay.updateStateOfRendering() || syncScroll;
+        this.bottomLeftCornerOverlay.updateStateOfRendering();
       } else {
         this.bottomLeftCornerOverlay = Overlay.createOverlay(Overlay.CLONE_BOTTOM_LEFT_CORNER, this.wot);
       }
@@ -128,8 +124,6 @@ class Overlays {
     if (this.wot.getSetting('debug') && !this.debug) {
       this.debug = Overlay.createOverlay(Overlay.CLONE_DEBUG, this.wot);
     }
-
-    return syncScroll;
   }
 
   /**

--- a/src/3rdparty/walkontable/src/overlays.js
+++ b/src/3rdparty/walkontable/src/overlays.js
@@ -463,7 +463,7 @@ class Overlays {
     }
 
     if (!fastDraw) {
-      this.workaroundsForPositionsAndSizes();
+      this.workaroundsForPositions();
     }
 
     this.adjustElementsPositions(); // to fix the problem with double draw, this should be at the top
@@ -534,14 +534,14 @@ class Overlays {
   /**
    *
    */
-  workaroundsForPositionsAndSizes() {
-    this.topOverlay.workaroundsForPositionAndSize();
+  workaroundsForPositions() {
+    this.topOverlay.workaroundsForPosition();
 
     if (this.bottomOverlay.clone) {
-      this.bottomOverlay.workaroundsForPositionAndSize();
+      this.bottomOverlay.workaroundsForPosition();
     }
 
-    this.leftOverlay.workaroundsForPositionAndSize();
+    this.leftOverlay.workaroundsForPosition();
   }
 
   /**

--- a/src/3rdparty/walkontable/src/overlays.js
+++ b/src/3rdparty/walkontable/src/overlays.js
@@ -471,15 +471,12 @@ class Overlays {
    * For every overlay in the instance, update the overlay's position
    */
   adjustElementsPositions() {
-    this.topOverlay.workaroundsForPosition();
     this.topOverlay.adjustElementsPosition();
 
     if (this.bottomOverlay.clone) {
-      this.bottomOverlay.workaroundsForPosition();
       this.bottomOverlay.adjustElementsPosition();
     }
 
-    this.leftOverlay.workaroundsForPosition();
     this.leftOverlay.adjustElementsPosition();
 
     if (this.topLeftCornerOverlay) {

--- a/src/3rdparty/walkontable/src/overlays.js
+++ b/src/3rdparty/walkontable/src/overlays.js
@@ -429,18 +429,6 @@ class Overlays {
       this.prepareOverlays();
     }
 
-    if (this.topOverlay.areElementSizesAdjusted && this.leftOverlay.areElementSizesAdjusted) {
-      const container = this.wot.wtTable.wtRootElement.parentNode || this.wot.wtTable.wtRootElement;
-      const width = container.clientWidth;
-      const height = container.clientHeight;
-
-      if (width !== this.spreaderLastSize.width || height !== this.spreaderLastSize.height) {
-        this.spreaderLastSize.width = width;
-        this.spreaderLastSize.height = height;
-        this.adjustElementsSizes();
-      }
-    }
-
     if (this.bottomOverlay.clone) {
       this.bottomOverlay.redrawClone(fastDraw);
     }
@@ -458,6 +446,24 @@ class Overlays {
 
     if (this.debug) {
       this.debug.redrawClone(fastDraw);
+    }
+
+    if (this.topOverlay.areElementSizesAdjusted && this.leftOverlay.areElementSizesAdjusted) {
+      const container = this.wot.wtTable.wtRootElement.parentNode || this.wot.wtTable.wtRootElement;
+      const width = container.clientWidth;
+      const height = container.clientHeight;
+
+      if (width !== this.spreaderLastSize.width || height !== this.spreaderLastSize.height) {
+        this.spreaderLastSize.width = width;
+        this.spreaderLastSize.height = height;
+        this.adjustElementsSizes();
+      }
+    }
+
+    if (!fastDraw) {
+      if (!this.topOverlay.areElementSizesAdjusted || !this.leftOverlay.areElementSizesAdjusted) {
+        this.adjustElementsSizes();
+      }
     }
 
     if (!fastDraw) {
@@ -533,10 +539,6 @@ class Overlays {
    *
    */
   workaroundsForPositionsAndSizes() {
-    if (!this.topOverlay.areElementSizesAdjusted || !this.leftOverlay.areElementSizesAdjusted) {
-      this.adjustElementsSizes();
-    }
-
     this.topOverlay.workaroundsForPositionAndSize();
 
     if (this.bottomOverlay.clone) {

--- a/src/3rdparty/walkontable/src/overlays.js
+++ b/src/3rdparty/walkontable/src/overlays.js
@@ -518,6 +518,12 @@ class Overlays {
     this.topOverlay.adjustElementsSize(force);
     this.leftOverlay.adjustElementsSize(force);
     this.bottomOverlay.adjustElementsSize(force);
+    if (this.topLeftCornerOverlay) {
+      this.topLeftCornerOverlay.adjustElementsSize(force);
+    }
+    if (this.bottomLeftCornerOverlay) {
+      this.bottomLeftCornerOverlay.adjustElementsSize(force);
+    }
   }
 
   /**

--- a/src/3rdparty/walkontable/src/overlays.js
+++ b/src/3rdparty/walkontable/src/overlays.js
@@ -1,6 +1,7 @@
 import {
   getScrollableElement,
   getScrollbarWidth,
+  getTrimmingContainer,
 } from './../../../helpers/dom/element';
 import { arrayEach } from './../../../helpers/array';
 import { isKey } from './../../../helpers/unicode';
@@ -74,22 +75,27 @@ class Overlays {
    * Prepare overlays based on user settings.
    */
   prepareOverlays() {
+    const trimmingContainer = getTrimmingContainer(this.wot.wtTable.wtRootElement);
+
     if (this.topOverlay) {
       this.topOverlay.updateStateOfRendering();
     } else {
       this.topOverlay = Overlay.createOverlay(Overlay.CLONE_TOP, this.wot);
     }
+    this.topOverlay.updateTrimmingContainer(trimmingContainer);
 
     if (!Overlay.hasOverlay(Overlay.CLONE_BOTTOM)) {
       this.bottomOverlay = {
         needFullRender: false,
         updateStateOfRendering: () => {},
+        updateTrimmingContainer: () => {},
       };
     }
     if (!Overlay.hasOverlay(Overlay.CLONE_BOTTOM_LEFT_CORNER)) {
       this.bottomLeftCornerOverlay = {
         needFullRender: false,
         updateStateOfRendering: () => {},
+        updateTrimmingContainer: () => {},
       };
     }
 
@@ -98,12 +104,14 @@ class Overlays {
     } else {
       this.bottomOverlay = Overlay.createOverlay(Overlay.CLONE_BOTTOM, this.wot);
     }
+    this.bottomOverlay.updateTrimmingContainer(trimmingContainer);
 
     if (this.leftOverlay) {
       this.leftOverlay.updateStateOfRendering();
     } else {
       this.leftOverlay = Overlay.createOverlay(Overlay.CLONE_LEFT, this.wot);
     }
+    this.leftOverlay.updateTrimmingContainer(trimmingContainer);
 
     if (this.topOverlay.needFullRender && this.leftOverlay.needFullRender) {
       if (this.topLeftCornerOverlay) {
@@ -111,6 +119,7 @@ class Overlays {
       } else {
         this.topLeftCornerOverlay = Overlay.createOverlay(Overlay.CLONE_TOP_LEFT_CORNER, this.wot);
       }
+      this.topLeftCornerOverlay.updateTrimmingContainer(trimmingContainer);
     }
 
     if (this.bottomOverlay.needFullRender && this.leftOverlay.needFullRender) {
@@ -119,6 +128,7 @@ class Overlays {
       } else {
         this.bottomLeftCornerOverlay = Overlay.createOverlay(Overlay.CLONE_BOTTOM_LEFT_CORNER, this.wot);
       }
+      this.bottomLeftCornerOverlay.updateTrimmingContainer(trimmingContainer);
     }
 
     if (this.wot.getSetting('debug') && !this.debug) {

--- a/src/3rdparty/walkontable/src/overlays.js
+++ b/src/3rdparty/walkontable/src/overlays.js
@@ -74,27 +74,22 @@ class Overlays {
    * Prepare overlays based on user settings.
    */
   prepareOverlays() {
-    const trimmingContainer = this.wot.wtTable.trimmingContainer;
-
     if (this.topOverlay) {
       this.topOverlay.updateStateOfRendering();
     } else {
       this.topOverlay = Overlay.createOverlay(Overlay.CLONE_TOP, this.wot);
     }
-    this.topOverlay.updateTrimmingContainer(trimmingContainer);
 
     if (!Overlay.hasOverlay(Overlay.CLONE_BOTTOM)) {
       this.bottomOverlay = {
         needFullRender: false,
         updateStateOfRendering: () => {},
-        updateTrimmingContainer: () => {},
       };
     }
     if (!Overlay.hasOverlay(Overlay.CLONE_BOTTOM_LEFT_CORNER)) {
       this.bottomLeftCornerOverlay = {
         needFullRender: false,
         updateStateOfRendering: () => {},
-        updateTrimmingContainer: () => {},
       };
     }
 
@@ -103,14 +98,12 @@ class Overlays {
     } else {
       this.bottomOverlay = Overlay.createOverlay(Overlay.CLONE_BOTTOM, this.wot);
     }
-    this.bottomOverlay.updateTrimmingContainer(trimmingContainer);
 
     if (this.leftOverlay) {
       this.leftOverlay.updateStateOfRendering();
     } else {
       this.leftOverlay = Overlay.createOverlay(Overlay.CLONE_LEFT, this.wot);
     }
-    this.leftOverlay.updateTrimmingContainer(trimmingContainer);
 
     if (this.topOverlay.needFullRender && this.leftOverlay.needFullRender) {
       if (this.topLeftCornerOverlay) {
@@ -118,7 +111,6 @@ class Overlays {
       } else {
         this.topLeftCornerOverlay = Overlay.createOverlay(Overlay.CLONE_TOP_LEFT_CORNER, this.wot);
       }
-      this.topLeftCornerOverlay.updateTrimmingContainer(trimmingContainer);
     }
 
     if (this.bottomOverlay.needFullRender && this.leftOverlay.needFullRender) {
@@ -127,7 +119,6 @@ class Overlays {
       } else {
         this.bottomLeftCornerOverlay = Overlay.createOverlay(Overlay.CLONE_BOTTOM_LEFT_CORNER, this.wot);
       }
-      this.bottomLeftCornerOverlay.updateTrimmingContainer(trimmingContainer);
     }
 
     if (this.wot.getSetting('debug') && !this.debug) {

--- a/src/3rdparty/walkontable/src/overlays.js
+++ b/src/3rdparty/walkontable/src/overlays.js
@@ -458,12 +458,8 @@ class Overlays {
         this.spreaderLastSize.height = height;
         this.adjustElementsSizes();
       }
-    }
-
-    if (!fastDraw) {
-      if (!this.topOverlay.areElementSizesAdjusted || !this.leftOverlay.areElementSizesAdjusted) {
-        this.adjustElementsSizes();
-      }
+    } else if (!fastDraw) {
+      this.adjustElementsSizes();
     }
 
     if (!fastDraw) {

--- a/src/3rdparty/walkontable/src/overlays.js
+++ b/src/3rdparty/walkontable/src/overlays.js
@@ -127,9 +127,9 @@ class Overlays {
   }
 
   /**
-   * Refresh and redraw table
+   * Refresh and redraw the master table, which will include refreshing of the clones
    */
-  refreshAll() {
+  refreshMasterAndClones() {
     if (!this.wot.drawn) {
       return;
     }
@@ -366,7 +366,7 @@ class Overlays {
       leftHolder.scrollTop = scrollTop;
     }
 
-    this.refreshAll();
+    this.refreshMasterAndClones();
   }
 
   /**
@@ -437,9 +437,10 @@ class Overlays {
   }
 
   /**
+   * Refresh (update the sizes and positions) and redraw the clones
    * @param {Boolean} [fastDraw=false]
    */
-  refresh(fastDraw = false) {
+  refreshClones(fastDraw = false) {
     if (!fastDraw) {
       this.prepareOverlays();
     }
@@ -452,54 +453,54 @@ class Overlays {
       if (width !== this.spreaderLastSize.width || height !== this.spreaderLastSize.height) {
         this.spreaderLastSize.width = width;
         this.spreaderLastSize.height = height;
-        this.adjustElementsSize();
+        this.adjustElementsSizes();
       }
     }
 
     if (this.bottomOverlay.clone) {
-      this.bottomOverlay.refresh(fastDraw);
+      this.bottomOverlay.redrawClone(fastDraw);
     }
 
-    this.leftOverlay.refresh(fastDraw);
-    this.topOverlay.refresh(fastDraw);
+    this.leftOverlay.redrawClone(fastDraw);
+    this.topOverlay.redrawClone(fastDraw);
 
     if (this.topLeftCornerOverlay) {
-      this.topLeftCornerOverlay.refresh(fastDraw);
+      this.topLeftCornerOverlay.redrawClone(fastDraw);
     }
 
     if (this.bottomLeftCornerOverlay && this.bottomLeftCornerOverlay.clone) {
-      this.bottomLeftCornerOverlay.refresh(fastDraw);
+      this.bottomLeftCornerOverlay.redrawClone(fastDraw);
     }
 
     if (this.debug) {
-      this.debug.refresh(fastDraw);
+      this.debug.redrawClone(fastDraw);
     }
 
     if (!fastDraw) {
-      this.applyToDOM();
+      this.workaroundsForPositionsAndSizes();
     }
 
-    this.resetFixedPositions(); // to fix the problem with double draw, this should be at the top
+    this.adjustElementsPositions(); // to fix the problem with double draw, this should be at the top
   }
 
   /**
    * For every overlay in the instance, update the overlay's position
    */
-  resetFixedPositions() {
-    this.topOverlay.resetFixedPosition();
+  adjustElementsPositions() {
+    this.topOverlay.adjustElementsPosition();
 
     if (this.bottomOverlay.clone) {
-      this.bottomOverlay.resetFixedPosition();
+      this.bottomOverlay.adjustElementsPosition();
     }
 
-    this.leftOverlay.resetFixedPosition();
+    this.leftOverlay.adjustElementsPosition();
 
     if (this.topLeftCornerOverlay) {
-      this.topLeftCornerOverlay.resetFixedPosition();
+      this.topLeftCornerOverlay.adjustElementsPosition();
     }
 
     if (this.bottomLeftCornerOverlay && this.bottomLeftCornerOverlay.clone) {
-      this.bottomLeftCornerOverlay.resetFixedPosition();
+      this.bottomLeftCornerOverlay.adjustElementsPosition();
     }
   }
 
@@ -508,7 +509,7 @@ class Overlays {
    *
    * @param {Boolean} [force=false]
    */
-  adjustElementsSize(force = false) {
+  adjustElementsSizes(force = false) {
     const { wtViewport, wtTable } = this.wot;
     const totalColumns = this.wot.getSetting('totalColumns');
     const totalRows = this.wot.getSetting('totalRows');
@@ -547,7 +548,7 @@ class Overlays {
   /**
    *
    */
-  applyToDOM() {
+  workaroundsForPositionsAndSizes() {
     const { wtTable } = this.wot;
 
     if (!wtTable.isVisible()) {
@@ -555,16 +556,16 @@ class Overlays {
     }
 
     if (!this.topOverlay.areElementSizesAdjusted || !this.leftOverlay.areElementSizesAdjusted) {
-      this.adjustElementsSize();
+      this.adjustElementsSizes();
     }
 
-    this.topOverlay.applyToDOM();
+    this.topOverlay.workaroundsForPositionAndSize();
 
     if (this.bottomOverlay.clone) {
-      this.bottomOverlay.applyToDOM();
+      this.bottomOverlay.workaroundsForPositionAndSize();
     }
 
-    this.leftOverlay.applyToDOM();
+    this.leftOverlay.workaroundsForPositionAndSize();
   }
 
   /**

--- a/src/3rdparty/walkontable/src/overlays.js
+++ b/src/3rdparty/walkontable/src/overlays.js
@@ -32,8 +32,6 @@ class Overlays {
     const BODY_LINE_HEIGHT = parseInt(rootWindow.getComputedStyle(rootDocument.body).lineHeight, 10);
     const FALLBACK_BODY_LINE_HEIGHT = parseInt(rootWindow.getComputedStyle(rootDocument.body).fontSize, 10) * 1.2;
 
-    // legacy support
-    this.instance = this.wot;
     this.eventManager = new EventManager(this.wot);
 
     this.scrollbarSize = getScrollbarWidth(rootDocument);

--- a/src/3rdparty/walkontable/src/overlays.js
+++ b/src/3rdparty/walkontable/src/overlays.js
@@ -120,10 +120,6 @@ class Overlays {
         this.bottomLeftCornerOverlay = Overlay.createOverlay(Overlay.CLONE_BOTTOM_LEFT_CORNER, this.wot);
       }
     }
-
-    if (this.wot.getSetting('debug') && !this.debug) {
-      this.debug = Overlay.createOverlay(Overlay.CLONE_DEBUG, this.wot);
-    }
   }
 
   /**
@@ -414,9 +410,6 @@ class Overlays {
       this.bottomLeftCornerOverlay.destroy();
     }
 
-    if (this.debug) {
-      this.debug.destroy();
-    }
     this.destroyed = true;
   }
 
@@ -458,10 +451,6 @@ class Overlays {
         this.bottomLeftCornerOverlay.adjustElementsPosition(); // to fix the problem with double draw, this should be at the top
       }
       this.bottomLeftCornerOverlay.redrawClone(fastDraw);
-    }
-
-    if (this.debug) {
-      this.debug.redrawClone(fastDraw);
     }
 
     if (this.topOverlay.areElementSizesAdjusted && this.leftOverlay.areElementSizesAdjusted) {

--- a/src/3rdparty/walkontable/src/overlays.js
+++ b/src/3rdparty/walkontable/src/overlays.js
@@ -430,34 +430,34 @@ class Overlays {
     }
 
     if (this.bottomOverlay.clone) {
-      this.bottomOverlay.redrawClone(fastDraw);
       if (!fastDraw) {
         this.bottomOverlay.adjustElementsPosition(); // to fix the problem with double draw, this should be at the top
       }
+      this.bottomOverlay.redrawClone(fastDraw);
     }
 
-    this.leftOverlay.redrawClone(fastDraw);
     if (!fastDraw) {
       this.leftOverlay.adjustElementsPosition(); // to fix the problem with double draw, this should be at the top
     }
+    this.leftOverlay.redrawClone(fastDraw);
 
-    this.topOverlay.redrawClone(fastDraw);
     if (!fastDraw) {
       this.topOverlay.adjustElementsPosition(); // to fix the problem with double draw, this should be at the top
     }
+    this.topOverlay.redrawClone(fastDraw);
 
     if (this.topLeftCornerOverlay) {
-      this.topLeftCornerOverlay.redrawClone(fastDraw);
       if (!fastDraw) {
         this.topLeftCornerOverlay.adjustElementsPosition(); // to fix the problem with double draw, this should be at the top
       }
+      this.topLeftCornerOverlay.redrawClone(fastDraw);
     }
 
     if (this.bottomLeftCornerOverlay && this.bottomLeftCornerOverlay.clone) {
-      this.bottomLeftCornerOverlay.redrawClone(fastDraw);
       if (!fastDraw) {
         this.bottomLeftCornerOverlay.adjustElementsPosition(); // to fix the problem with double draw, this should be at the top
       }
+      this.bottomLeftCornerOverlay.redrawClone(fastDraw);
     }
 
     if (this.debug) {

--- a/src/3rdparty/walkontable/src/overlays.js
+++ b/src/3rdparty/walkontable/src/overlays.js
@@ -440,6 +440,10 @@ class Overlays {
    * @param {Boolean} [fastDraw=false]
    */
   refresh(fastDraw = false) {
+    if (!fastDraw) {
+      this.prepareOverlays();
+    }
+
     if (this.topOverlay.areElementSizesAdjusted && this.leftOverlay.areElementSizesAdjusted) {
       const container = this.wot.wtTable.wtRootElement.parentNode || this.wot.wtTable.wtRootElement;
       const width = container.clientWidth;
@@ -470,6 +474,12 @@ class Overlays {
     if (this.debug) {
       this.debug.refresh(fastDraw);
     }
+
+    if (!fastDraw) {
+      this.applyToDOM();
+    }
+
+    this.resetFixedPositions(); // to fix the problem with double draw, this should be at the top
   }
 
   /**

--- a/src/3rdparty/walkontable/src/overlays.js
+++ b/src/3rdparty/walkontable/src/overlays.js
@@ -464,9 +464,8 @@ class Overlays {
 
     if (!fastDraw) {
       this.workaroundsForPositions();
+      this.adjustElementsPositions(); // to fix the problem with double draw, this should be at the top
     }
-
-    this.adjustElementsPositions(); // to fix the problem with double draw, this should be at the top
   }
 
   /**

--- a/src/3rdparty/walkontable/src/overlays.js
+++ b/src/3rdparty/walkontable/src/overlays.js
@@ -533,12 +533,6 @@ class Overlays {
    *
    */
   workaroundsForPositionsAndSizes() {
-    const { wtTable } = this.wot;
-
-    if (!wtTable.isVisible()) {
-      return;
-    }
-
     if (!this.topOverlay.areElementSizesAdjusted || !this.leftOverlay.areElementSizesAdjusted) {
       this.adjustElementsSizes();
     }

--- a/src/3rdparty/walkontable/src/overlays.js
+++ b/src/3rdparty/walkontable/src/overlays.js
@@ -234,7 +234,8 @@ class Overlays {
       }
     }
 
-    this.syncScrollPositions(event);
+    this.propagateMasterScrollPositionsToClones();
+    this.refreshMasterAndClones();
   }
 
   /**
@@ -336,7 +337,7 @@ class Overlays {
    *
    * @private
    */
-  syncScrollPositions() {
+  propagateMasterScrollPositionsToClones() {
     if (this.destroyed) {
       return;
     }
@@ -344,6 +345,7 @@ class Overlays {
     const { rootWindow } = this.wot;
     const topHolder = this.topOverlay.clone.wtTable.holder;
     const leftHolder = this.leftOverlay.clone.wtTable.holder;
+    const bottomHolder = this.bottomOverlay.clone.wtTable.holder;
 
     const [scrollLeft, scrollTop] = [this.scrollableElement.scrollLeft, this.scrollableElement.scrollTop];
 
@@ -353,37 +355,19 @@ class Overlays {
     this.lastScrollY = rootWindow.scrollY;
 
     if (this.horizontalScrolling) {
-      topHolder.scrollLeft = scrollLeft;
+      if (this.topOverlay.needFullRender) {
+        topHolder.scrollLeft = scrollLeft;
+      }
 
-      const bottomHolder = this.bottomOverlay.needFullRender ? this.bottomOverlay.clone.wtTable.holder : null;
-
-      if (bottomHolder) {
+      if (this.bottomOverlay.needFullRender) {
         bottomHolder.scrollLeft = scrollLeft;
       }
     }
 
     if (this.verticalScrolling) {
-      leftHolder.scrollTop = scrollTop;
-    }
-
-    this.refreshMasterAndClones();
-  }
-
-  /**
-   * Synchronize overlay scrollbars with the master scrollbar
-   */
-  syncScrollWithMaster() {
-    const master = this.topOverlay.mainTableScrollableElement;
-    const { scrollLeft, scrollTop } = master;
-
-    if (this.topOverlay.needFullRender) {
-      this.topOverlay.clone.wtTable.holder.scrollLeft = scrollLeft;
-    }
-    if (this.bottomOverlay.needFullRender) {
-      this.bottomOverlay.clone.wtTable.holder.scrollLeft = scrollLeft;
-    }
-    if (this.leftOverlay.needFullRender) {
-      this.leftOverlay.clone.wtTable.holder.scrollTop = scrollTop;
+      if (this.leftOverlay.needFullRender) {
+        leftHolder.scrollTop = scrollTop;
+      }
     }
   }
 

--- a/src/3rdparty/walkontable/src/overlays.js
+++ b/src/3rdparty/walkontable/src/overlays.js
@@ -431,17 +431,33 @@ class Overlays {
 
     if (this.bottomOverlay.clone) {
       this.bottomOverlay.redrawClone(fastDraw);
+      if (!fastDraw) {
+        this.bottomOverlay.adjustElementsPosition(); // to fix the problem with double draw, this should be at the top
+      }
     }
 
     this.leftOverlay.redrawClone(fastDraw);
+    if (!fastDraw) {
+      this.leftOverlay.adjustElementsPosition(); // to fix the problem with double draw, this should be at the top
+    }
+
     this.topOverlay.redrawClone(fastDraw);
+    if (!fastDraw) {
+      this.topOverlay.adjustElementsPosition(); // to fix the problem with double draw, this should be at the top
+    }
 
     if (this.topLeftCornerOverlay) {
       this.topLeftCornerOverlay.redrawClone(fastDraw);
+      if (!fastDraw) {
+        this.topLeftCornerOverlay.adjustElementsPosition(); // to fix the problem with double draw, this should be at the top
+      }
     }
 
     if (this.bottomLeftCornerOverlay && this.bottomLeftCornerOverlay.clone) {
       this.bottomLeftCornerOverlay.redrawClone(fastDraw);
+      if (!fastDraw) {
+        this.bottomLeftCornerOverlay.adjustElementsPosition(); // to fix the problem with double draw, this should be at the top
+      }
     }
 
     if (this.debug) {
@@ -460,31 +476,6 @@ class Overlays {
       }
     } else if (!fastDraw) {
       this.adjustElementsSizes();
-    }
-
-    if (!fastDraw) {
-      this.adjustElementsPositions(); // to fix the problem with double draw, this should be at the top
-    }
-  }
-
-  /**
-   * For every overlay in the instance, update the overlay's position
-   */
-  adjustElementsPositions() {
-    this.topOverlay.adjustElementsPosition();
-
-    if (this.bottomOverlay.clone) {
-      this.bottomOverlay.adjustElementsPosition();
-    }
-
-    this.leftOverlay.adjustElementsPosition();
-
-    if (this.topLeftCornerOverlay) {
-      this.topLeftCornerOverlay.adjustElementsPosition();
-    }
-
-    if (this.bottomLeftCornerOverlay && this.bottomLeftCornerOverlay.clone) {
-      this.bottomLeftCornerOverlay.adjustElementsPosition();
     }
   }
 

--- a/src/3rdparty/walkontable/src/overlays.js
+++ b/src/3rdparty/walkontable/src/overlays.js
@@ -463,7 +463,6 @@ class Overlays {
     }
 
     if (!fastDraw) {
-      this.workaroundsForPositions();
       this.adjustElementsPositions(); // to fix the problem with double draw, this should be at the top
     }
   }
@@ -472,12 +471,15 @@ class Overlays {
    * For every overlay in the instance, update the overlay's position
    */
   adjustElementsPositions() {
+    this.topOverlay.workaroundsForPosition();
     this.topOverlay.adjustElementsPosition();
 
     if (this.bottomOverlay.clone) {
+      this.bottomOverlay.workaroundsForPosition();
       this.bottomOverlay.adjustElementsPosition();
     }
 
+    this.leftOverlay.workaroundsForPosition();
     this.leftOverlay.adjustElementsPosition();
 
     if (this.topLeftCornerOverlay) {
@@ -528,19 +530,6 @@ class Overlays {
     this.topOverlay.adjustElementsSize(force);
     this.leftOverlay.adjustElementsSize(force);
     this.bottomOverlay.adjustElementsSize(force);
-  }
-
-  /**
-   *
-   */
-  workaroundsForPositions() {
-    this.topOverlay.workaroundsForPosition();
-
-    if (this.bottomOverlay.clone) {
-      this.bottomOverlay.workaroundsForPosition();
-    }
-
-    this.leftOverlay.workaroundsForPosition();
   }
 
   /**

--- a/src/3rdparty/walkontable/src/overlays.js
+++ b/src/3rdparty/walkontable/src/overlays.js
@@ -1,7 +1,6 @@
 import {
   getScrollableElement,
   getScrollbarWidth,
-  getTrimmingContainer,
 } from './../../../helpers/dom/element';
 import { arrayEach } from './../../../helpers/array';
 import { isKey } from './../../../helpers/unicode';
@@ -75,7 +74,7 @@ class Overlays {
    * Prepare overlays based on user settings.
    */
   prepareOverlays() {
-    const trimmingContainer = getTrimmingContainer(this.wot.wtTable.wtRootElement);
+    const trimmingContainer = this.wot.wtTable.trimmingContainer;
 
     if (this.topOverlay) {
       this.topOverlay.updateStateOfRendering();

--- a/src/3rdparty/walkontable/src/overlays.js
+++ b/src/3rdparty/walkontable/src/overlays.js
@@ -423,33 +423,17 @@ class Overlays {
     }
 
     if (this.bottomOverlay.clone) {
-      if (!fastDraw) {
-        this.bottomOverlay.adjustElementsPosition(); // to fix the problem with double draw, this should be at the top
-      }
       this.bottomOverlay.redrawClone(fastDraw);
     }
 
-    if (!fastDraw) {
-      this.leftOverlay.adjustElementsPosition(); // to fix the problem with double draw, this should be at the top
-    }
     this.leftOverlay.redrawClone(fastDraw);
-
-    if (!fastDraw) {
-      this.topOverlay.adjustElementsPosition(); // to fix the problem with double draw, this should be at the top
-    }
     this.topOverlay.redrawClone(fastDraw);
 
     if (this.topLeftCornerOverlay) {
-      if (!fastDraw) {
-        this.topLeftCornerOverlay.adjustElementsPosition(); // to fix the problem with double draw, this should be at the top
-      }
       this.topLeftCornerOverlay.redrawClone(fastDraw);
     }
 
     if (this.bottomLeftCornerOverlay && this.bottomLeftCornerOverlay.clone) {
-      if (!fastDraw) {
-        this.bottomLeftCornerOverlay.adjustElementsPosition(); // to fix the problem with double draw, this should be at the top
-      }
       this.bottomLeftCornerOverlay.redrawClone(fastDraw);
     }
 

--- a/src/3rdparty/walkontable/src/selectionHandle.js
+++ b/src/3rdparty/walkontable/src/selectionHandle.js
@@ -1,6 +1,5 @@
 import {
   getComputedStyle,
-  getTrimmingContainer,
   innerWidth,
   innerHeight,
   offset,
@@ -430,7 +429,7 @@ class SelectionHandle {
       // Hide the fill handle, so the possible further adjustments won't force unneeded scrollbars.
       this.cornerStyle.display = 'none';
 
-      let trimmingContainer = getTrimmingContainer(wtTable.TABLE);
+      let trimmingContainer = this.wot.overlay ? this.wot.overlay.master.wtTable.trimmingContainer : wtTable.trimmingContainer;
       const trimToWindow = trimmingContainer === rootWindow;
 
       if (trimToWindow) {

--- a/src/3rdparty/walkontable/src/selectionHandle.js
+++ b/src/3rdparty/walkontable/src/selectionHandle.js
@@ -26,7 +26,6 @@ class SelectionHandle {
       return;
     }
     this.eventManager = new EventManager(wotInstance);
-    this.instance = wotInstance;
     this.wot = wotInstance;
     this.settings = settings;
     this.mouseDown = false;

--- a/src/3rdparty/walkontable/src/settings.js
+++ b/src/3rdparty/walkontable/src/settings.js
@@ -12,9 +12,6 @@ class Settings {
   constructor(wotInstance, settings) {
     this.wot = wotInstance;
 
-    // legacy support
-    this.instance = wotInstance;
-
     // default settings. void 0 means it is required, null means it can be empty
     this.defaults = {
       table: void 0,

--- a/src/3rdparty/walkontable/src/settings.js
+++ b/src/3rdparty/walkontable/src/settings.js
@@ -15,7 +15,6 @@ class Settings {
     // default settings. void 0 means it is required, null means it can be empty
     this.defaults = {
       table: void 0,
-      debug: false, // shows WalkontableDebugOverlay
 
       // presentation mode
       externalRowCalculator: false,

--- a/src/3rdparty/walkontable/src/table.js
+++ b/src/3rdparty/walkontable/src/table.js
@@ -376,30 +376,33 @@ class Table {
 
     const tableRowsCount = this.getRenderedRowsCount();
     const tableColumnsCount = this.getRenderedColumnsCount();
-    const tableStartRow = this.getFirstRenderedRow();
+    let tableStartRow = this.getFirstRenderedRow();
     const tableStartColumn = this.getFirstRenderedColumn();
-    const tableEndRow = this.getLastRenderedRow();
-    const tableEndColumn = this.getLastRenderedColumn();
+    let tableEndRow = this.getLastRenderedRow();
+    let tableEndColumn = this.getLastRenderedColumn();
     const borderEdgesDescriptors = [];
-    let neighborOverlapRight = 0;
-    let neighborOverlapBottom = 0;
-    let neighborOverlapTop = 0;
 
-    if (this.getTableNeighborEast && this.getTableNeighborEast().getFirstVisibleColumn() === this.getLastVisibleColumn() + 1) {
-      neighborOverlapRight = 1;
+    /*
+    On the edge of overlays, render borders from the outside of the overlay so that they do not become obscured
+    by the overlay's gridline.
+    The below adjustments are used to render side effects of borders from other overlays,
+    e.g. when fixedRowsTop === 1, this method will render the top border of the cell A2 (from the master table)
+    as the bottom border of the cell A1 (on the top overlay table).
+    */
+    if (this.is(Overlay.CLONE_LEFT) || this.is(Overlay.CLONE_TOP_LEFT_CORNER) || this.is(Overlay.CLONE_BOTTOM_LEFT_CORNER)) {
+      tableEndColumn += 1;
     }
-    if (this.getTableNeighborSouth && this.getTableNeighborSouth().getFirstVisibleRow() === this.getLastVisibleRow() + 1) {
-      neighborOverlapBottom = 1;
+    if (this.is(Overlay.CLONE_TOP) || this.is(Overlay.CLONE_TOP_LEFT_CORNER)) {
+      tableEndRow += 1;
     }
-    if (this.getTableNeighborNorth && this.getTableNeighborNorth().getLastVisibleRow() === this.getFirstVisibleRow() - 1) {
-      neighborOverlapTop = -1;
+    if (this.is(Overlay.CLONE_BOTTOM) || this.is(Overlay.CLONE_BOTTOM_LEFT_CORNER)) {
+      tableStartRow -= 1;
     }
 
     for (let i = 0; i < len; i++) {
       const borderEdgesDescriptor = selections[i].draw(wot,
         tableRowsCount, tableColumnsCount,
-        tableStartRow, tableStartColumn, tableEndRow, tableEndColumn,
-        neighborOverlapRight, neighborOverlapBottom, neighborOverlapTop);
+        tableStartRow, tableStartColumn, tableEndRow, tableEndColumn);
 
       if (borderEdgesDescriptor) {
         borderEdgesDescriptors.push(borderEdgesDescriptor);

--- a/src/3rdparty/walkontable/src/table.js
+++ b/src/3rdparty/walkontable/src/table.js
@@ -73,7 +73,7 @@ class Table {
     this.wtRootElement = this.holder.parentNode;
 
     if (this.isMaster) {
-      this.alignOverlaysWithTrimmingContainer();
+      this.alignOverlaysWithTrimmingContainer(); // TODO this better be removed
     }
     this.fixTableDomTree();
 
@@ -230,6 +230,7 @@ class Table {
     const columnHeadersCount = columnHeaders.length;
     let syncScroll = false;
     let runFastDraw = fastDraw;
+    let wtOverlaysNeedFullRefresh = false;
 
     if (this.isMaster) {
       this.holderOffset = offset(this.holder);
@@ -314,8 +315,7 @@ class Table {
 
         if (this.isMaster) {
           wtViewport.createVisibleCalculators();
-          wtOverlays.refresh(false);
-          wtOverlays.applyToDOM();
+          wtOverlaysNeedFullRefresh = true;
 
           const hiderWidth = outerWidth(this.hider);
           const tableWidth = outerWidth(this.TABLE);
@@ -342,7 +342,15 @@ class Table {
     }
 
     if (this.isMaster) {
+      if (wtOverlaysNeedFullRefresh) {
+        wtOverlays.refresh(false);
+        wtOverlays.applyToDOM();
+      }
       wtOverlays.resetFixedPositions();
+
+      // here be better for double draw
+      // wtOverlays.refresh(false);
+      // wtOverlays.applyToDOM();
     }
 
     this.refreshSelections(runFastDraw);

--- a/src/3rdparty/walkontable/src/table.js
+++ b/src/3rdparty/walkontable/src/table.js
@@ -240,7 +240,7 @@ class Table {
 
       if (this.is(Overlay.CLONE_BOTTOM)) {
         this.markOversizedRows();
-        this.wot.overlay.master.wtOverlays.adjustElementsSize();
+        this.wot.overlay.master.wtOverlays.adjustElementsSizes();
       }
     }
 

--- a/src/3rdparty/walkontable/src/table.js
+++ b/src/3rdparty/walkontable/src/table.js
@@ -38,7 +38,6 @@ class Table {
     this.TBODY = null;
     this.THEAD = null;
     this.COLGROUP = null;
-    this.holderOffset = 0;
     /**
      * Indicates if the table has height bigger than 0px.
      *

--- a/src/3rdparty/walkontable/src/table.js
+++ b/src/3rdparty/walkontable/src/table.js
@@ -50,13 +50,6 @@ class Table {
      * @type {Boolean}
      */
     this.hasTableWidth = true;
-    /**
-     * Indicates if the table is visible. By visible, it means that the holder
-     * element has CSS 'display' property different than 'none'.
-     *
-     * @type {Boolean}
-     */
-    this.isTableVisible = false;
 
     removeTextNodes(this.TABLE);
 

--- a/src/3rdparty/walkontable/src/table.js
+++ b/src/3rdparty/walkontable/src/table.js
@@ -38,7 +38,6 @@ class Table {
     this.TBODY = null;
     this.THEAD = null;
     this.COLGROUP = null;
-    this.tableOffset = 0;
     this.holderOffset = 0;
     /**
      * Indicates if the table has height bigger than 0px.
@@ -226,8 +225,6 @@ class Table {
     const columnHeadersCount = columnHeaders.length;
 
     if (!fastDraw) {
-      this.tableOffset = this.wot.overlay.master.wtTable.tableOffset;
-
       const startRow = totalRows > 0 ? this.getFirstRenderedRow() : 0;
       const startColumn = totalColumns > 0 ? this.getFirstRenderedColumn() : 0;
 

--- a/src/3rdparty/walkontable/src/table.js
+++ b/src/3rdparty/walkontable/src/table.js
@@ -59,16 +59,6 @@ class Table {
 
     this.wtRootElement = this.holder.parentNode;
 
-    /**
-     * Set the DOM element responsible for trimming the overlay's root element. It will be some parent element or the window. Only applicable to the master overlay.
-     *
-     * @type {HTMLElement|Window}
-     */
-    // this.trimmingContainer = null;
-
-    if (this.isMaster) {
-      this.alignOverlaysWithTrimmingContainer(); // TODO this better be removed
-    }
     this.fixTableDomTree();
 
     this.rowFilter = null;

--- a/src/3rdparty/walkontable/src/table.js
+++ b/src/3rdparty/walkontable/src/table.js
@@ -301,8 +301,8 @@ class Table {
         let workspaceWidth;
 
         if (this.isMaster) {
-          workspaceWidth = this.wot.wtViewport.getWorkspaceWidth();
-          this.wot.wtViewport.containerWidth = null;
+          workspaceWidth = wtViewport.getWorkspaceWidth();
+          wtViewport.containerWidth = null;
           this.markOversizedColumnHeaders();
         }
 
@@ -313,9 +313,9 @@ class Table {
         }
 
         if (this.isMaster) {
-          this.wot.wtViewport.createVisibleCalculators();
-          this.wot.wtOverlays.refresh(false);
-          this.wot.wtOverlays.applyToDOM();
+          wtViewport.createVisibleCalculators();
+          wtOverlays.refresh(false);
+          wtOverlays.applyToDOM();
 
           const hiderWidth = outerWidth(this.hider);
           const tableWidth = outerWidth(this.TABLE);
@@ -326,9 +326,9 @@ class Table {
             this.tableRenderer.renderer.colGroup.render();
           }
 
-          if (workspaceWidth !== this.wot.wtViewport.getWorkspaceWidth()) {
+          if (workspaceWidth !== wtViewport.getWorkspaceWidth()) {
             // workspace width changed though to shown/hidden vertical scrollbar. Let's reapply stretching
-            this.wot.wtViewport.containerWidth = null;
+            wtViewport.containerWidth = null;
             this.wot.columnUtils.calculateWidths();
             this.tableRenderer.renderer.colGroup.render();
           }

--- a/src/3rdparty/walkontable/src/table.js
+++ b/src/3rdparty/walkontable/src/table.js
@@ -59,6 +59,13 @@ class Table {
 
     this.wtRootElement = this.holder.parentNode;
 
+    /**
+     * Set the DOM element responsible for trimming the overlay's root element. It will be some parent element or the window. Only applicable to the master overlay.
+     *
+     * @type {HTMLElement|Window}
+     */
+    // this.trimmingContainer = null;
+
     if (this.isMaster) {
       this.alignOverlaysWithTrimmingContainer(); // TODO this better be removed
     }

--- a/src/3rdparty/walkontable/src/table.js
+++ b/src/3rdparty/walkontable/src/table.js
@@ -351,13 +351,13 @@ class Table {
       // here be better for double draw
       // wtOverlays.refresh(false);
       // wtOverlays.applyToDOM();
+
+      if (syncScroll) {
+        wtOverlays.syncScrollWithMaster();
+      }
     }
 
     this.refreshSelections(runFastDraw);
-
-    if (this.isMaster && syncScroll) {
-      wtOverlays.syncScrollWithMaster();
-    }
 
     return this;
   }

--- a/src/3rdparty/walkontable/src/table.js
+++ b/src/3rdparty/walkontable/src/table.js
@@ -353,7 +353,7 @@ class Table {
       // wtOverlays.applyToDOM();
 
       if (syncScroll) {
-        wtOverlays.syncScrollWithMaster();
+        // wtOverlays.syncScrollWithMaster();
       }
     }
 

--- a/src/3rdparty/walkontable/src/table.js
+++ b/src/3rdparty/walkontable/src/table.js
@@ -240,7 +240,6 @@ class Table {
 
       if (this.is(Overlay.CLONE_BOTTOM)) {
         this.markOversizedRows();
-        this.wot.overlay.master.wtOverlays.adjustElementsSizes();
       }
     }
 

--- a/src/3rdparty/walkontable/src/table.js
+++ b/src/3rdparty/walkontable/src/table.js
@@ -355,7 +355,7 @@ class Table {
   }
 
   markIfOversizedColumnHeader(col) {
-    const sourceColIndex = this.wot.wtTable.columnFilter.renderedToSource(col);
+    const sourceColIndex = this.columnFilter.renderedToSource(col);
     let level = this.wot.getSetting('columnHeaders').length;
     const defaultRowHeight = this.wot.wtSettings.settings.defaultRowHeight;
     let previousColHeaderHeight;
@@ -367,7 +367,7 @@ class Table {
       level -= 1;
 
       previousColHeaderHeight = this.wot.columnUtils.getHeaderHeight(level);
-      currentHeader = this.wot.wtTable.getColumnHeader(sourceColIndex, level);
+      currentHeader = this.getColumnHeader(sourceColIndex, level);
 
       if (!currentHeader) {
         /* eslint-disable no-continue */
@@ -396,7 +396,7 @@ class Table {
 
   adjustColumnHeaderHeights() {
     const { wot } = this;
-    const children = wot.wtTable.THEAD.childNodes;
+    const children = this.THEAD.childNodes;
     const oversizedColumnHeaders = wot.wtViewport.oversizedColumnHeaders;
     const columnHeaders = wot.getSetting('columnHeaders');
 

--- a/src/3rdparty/walkontable/src/table.js
+++ b/src/3rdparty/walkontable/src/table.js
@@ -190,9 +190,6 @@ class Table {
         // if TABLE is detached (e.g. in Jasmine test), it has no parentNode so we cannot attach holder to it
         parent.insertBefore(holder, hider);
       }
-      if (this.isMaster) {
-        holder.parentNode.className += 'ht_master handsontable';
-      }
       holder.appendChild(hider);
     }
 

--- a/src/3rdparty/walkontable/src/table.js
+++ b/src/3rdparty/walkontable/src/table.js
@@ -89,8 +89,8 @@ class Table {
       THEAD: this.THEAD,
       COLGROUP: this.COLGROUP,
       TBODY: this.TBODY,
-      rowUtils: this.isMaster ? this.wot.rowUtils : this.wot.cloneSource.rowUtils,
-      columnUtils: this.isMaster ? this.wot.columnUtils : this.wot.cloneSource.columnUtils,
+      rowUtils: this.isMaster ? this.wot.rowUtils : this.wot.overlay.master.rowUtils,
+      columnUtils: this.isMaster ? this.wot.columnUtils : this.wot.overlay.master.columnUtils,
       cellRenderer: this.wot.wtSettings.settings.cellRenderer,
     });
 
@@ -258,7 +258,7 @@ class Table {
       if (this.isMaster) {
         this.tableOffset = offset(this.TABLE);
       } else {
-        this.tableOffset = this.wot.cloneSource.wtTable.tableOffset;
+        this.tableOffset = this.wot.overlay.master.wtTable.tableOffset;
       }
 
       const startRow = totalRows > 0 ? this.getFirstRenderedRow() : 0;
@@ -334,7 +334,7 @@ class Table {
           this.wot.getSetting('onDraw', true);
 
         } else if (this.is(Overlay.CLONE_BOTTOM)) {
-          this.wot.cloneSource.wtOverlays.adjustElementsSize();
+          this.wot.overlay.master.wtOverlays.adjustElementsSize();
         }
       }
     }
@@ -693,7 +693,7 @@ class Table {
     let rowCount = this.TBODY.childNodes.length;
     const expectedTableHeight = rowCount * this.wot.wtSettings.settings.defaultRowHeight;
     const actualTableHeight = innerHeight(this.TBODY) - 1;
-    const rowUtils = this.isMaster ? this.wot.rowUtils : this.wot.cloneSource.rowUtils; // TODO this is not needed if we don't call markOversizedRows in the bottom overlay
+    const rowUtils = this.isMaster ? this.wot.rowUtils : this.wot.overlay.master.rowUtils; // TODO this is not needed if we don't call markOversizedRows in the bottom overlay
     let previousRowHeight;
     let rowInnerHeight;
     let sourceRowIndex;

--- a/src/3rdparty/walkontable/src/table.js
+++ b/src/3rdparty/walkontable/src/table.js
@@ -231,12 +231,12 @@ class Table {
       this.rowFilter = new RowFilter(startRow, totalRows, columnHeadersCount);
       this.columnFilter = new ColumnFilter(startColumn, totalColumns, rowHeadersCount);
 
-      this.tableRenderer.setHeaderContentRenderers(rowHeaders, columnHeaders);
-
       if (this.is(Overlay.CLONE_BOTTOM) ||
         this.is(Overlay.CLONE_BOTTOM_LEFT_CORNER)) {
         // do NOT render headers on the bottom or bottom-left corner overlay
         this.tableRenderer.setHeaderContentRenderers(rowHeaders, []);
+      } else {
+        this.tableRenderer.setHeaderContentRenderers(rowHeaders, columnHeaders);
       }
 
       if (this.is(Overlay.CLONE_BOTTOM)) {

--- a/src/3rdparty/walkontable/src/table.js
+++ b/src/3rdparty/walkontable/src/table.js
@@ -213,7 +213,6 @@ class Table {
    *
    * @param {Boolean} [fastDraw=false] If TRUE, will try to avoid full redraw and only update the border positions.
    *                                   If FALSE or UNDEFINED, will perform a full redraw.
-   * @returns {Table}
    */
   draw(fastDraw = false) {
     const { wot } = this;
@@ -257,8 +256,6 @@ class Table {
     }
 
     this.refreshSelections(fastDraw);
-
-    return this;
   }
 
   markIfOversizedColumnHeader(col) {

--- a/src/3rdparty/walkontable/src/table.js
+++ b/src/3rdparty/walkontable/src/table.js
@@ -245,9 +245,7 @@ class Table {
           runFastDraw = false;
         }
       }
-    }
 
-    if (this.isMaster) {
       syncScroll = wtOverlays.prepareOverlays();
     }
 
@@ -255,8 +253,6 @@ class Table {
       if (this.isMaster) {
         // in case we only scrolled without redraw, update visible rows information in oldRowsCalculator
         wtViewport.createVisibleCalculators();
-      }
-      if (wtOverlays) {
         wtOverlays.refresh(true);
       }
     } else {
@@ -293,7 +289,9 @@ class Table {
           this.tableRenderer.setHeaderContentRenderers(rowHeaders, []);
         }
 
-        this.resetOversizedRows();
+        if (this.isMaster || this.is(Overlay.CLONE_BOTTOM)) {
+          this.resetOversizedRows();
+        }
 
         this.tableRenderer
           .setViewportSize(this.getRenderedRowsCount(), this.getRenderedColumnsCount())
@@ -349,7 +347,7 @@ class Table {
 
     this.refreshSelections(runFastDraw);
 
-    if (syncScroll) {
+    if (this.isMaster && syncScroll) {
       wtOverlays.syncScrollWithMaster();
     }
 
@@ -418,10 +416,6 @@ class Table {
    */
   resetOversizedRows() {
     const { wot } = this;
-
-    if (!this.isMaster && !this.is(Overlay.CLONE_BOTTOM)) {
-      return;
-    }
 
     if (!wot.getSetting('externalRowCalculator')) {
       const rowsToRender = this.getRenderedRowsCount();

--- a/src/3rdparty/walkontable/src/table.js
+++ b/src/3rdparty/walkontable/src/table.js
@@ -36,8 +36,6 @@ class Table {
     this.isMaster = wotInstance instanceof Master;
     this.wot = wotInstance;
 
-    // legacy support
-    this.instance = this.wot;
     this.TABLE = table;
     this.TBODY = null;
     this.THEAD = null;

--- a/src/3rdparty/walkontable/src/table/bottom.js
+++ b/src/3rdparty/walkontable/src/table/bottom.js
@@ -7,15 +7,7 @@ import { mixin } from './../../../../helpers/object';
  * Subclass of `Table` that provides the helper methods relevant to BottomOverlay, implemented through mixins.
  */
 class BottomOverlayTable extends Table {
-  /**
-   * Returns an instance of `Table` that renders the rows before the first row
-   * in the current instance of `Table`.
-   *
-   * @returns {Table}
-   */
-  getTableNeighborNorth() {
-    return this.wot.overlay.master.wtTable;
-  }
+
 }
 
 mixin(BottomOverlayTable, stickyRowsBottom);

--- a/src/3rdparty/walkontable/src/table/bottom.js
+++ b/src/3rdparty/walkontable/src/table/bottom.js
@@ -14,7 +14,7 @@ class BottomOverlayTable extends Table {
    * @returns {Table}
    */
   getTableNeighborNorth() {
-    return this.wot.cloneSource.wtTable;
+    return this.wot.overlay.master.wtTable;
   }
 }
 

--- a/src/3rdparty/walkontable/src/table/bottomLeftCorner.js
+++ b/src/3rdparty/walkontable/src/table/bottomLeftCorner.js
@@ -14,7 +14,7 @@ class BottomLeftCornerOverlayTable extends Table {
    * @returns {Table}
    */
   getTableNeighborEast() {
-    return this.wot.cloneSource.wtOverlays.bottomOverlay.clone.wtTable;
+    return this.wot.overlay.master.wtOverlays.bottomOverlay.clone.wtTable;
   }
 
   /**
@@ -24,7 +24,7 @@ class BottomLeftCornerOverlayTable extends Table {
    * @returns {Table}
    */
   getTableNeighborNorth() {
-    return this.wot.cloneSource.wtOverlays.leftOverlay.clone.wtTable;
+    return this.wot.overlay.master.wtOverlays.leftOverlay.clone.wtTable;
   }
 
   /**
@@ -34,7 +34,7 @@ class BottomLeftCornerOverlayTable extends Table {
    * @returns {Table}
    */
   getTableNeighborDiagonal() {
-    return this.wot.cloneSource.wtTable;
+    return this.wot.overlay.master.wtTable;
   }
 }
 

--- a/src/3rdparty/walkontable/src/table/bottomLeftCorner.js
+++ b/src/3rdparty/walkontable/src/table/bottomLeftCorner.js
@@ -7,35 +7,7 @@ import { mixin } from './../../../../helpers/object';
  * Subclass of `Table` that provides the helper methods relevant to BottomLeftCornerOverlay, implemented through mixins.
  */
 class BottomLeftCornerOverlayTable extends Table {
-  /**
-   * Returns an instance of `Table` that renders the columns after the last column
-   * in the current instance of `Table`.
-   *
-   * @returns {Table}
-   */
-  getTableNeighborEast() {
-    return this.wot.overlay.master.wtOverlays.bottomOverlay.clone.wtTable;
-  }
 
-  /**
-   * Returns an instance of `Table` that renders the rows before the first row
-   * in the current instance of `Table`.
-   *
-   * @returns {Table}
-   */
-  getTableNeighborNorth() {
-    return this.wot.overlay.master.wtOverlays.leftOverlay.clone.wtTable;
-  }
-
-  /**
-   * Returns an instance of `Table` that renders the rows before the first rows, and the columns after the last column
-   * in the current instance of `Table`.
-   *
-   * @returns {Table}
-   */
-  getTableNeighborDiagonal() {
-    return this.wot.overlay.master.wtTable;
-  }
 }
 
 mixin(BottomLeftCornerOverlayTable, stickyRowsBottom);

--- a/src/3rdparty/walkontable/src/table/left.js
+++ b/src/3rdparty/walkontable/src/table/left.js
@@ -7,15 +7,7 @@ import { mixin } from './../../../../helpers/object';
  * Subclass of `Table` that provides the helper methods relevant to LeftOverlay, implemented through mixins.
  */
 class LeftOverlayTable extends Table {
-  /**
-   * Returns an instance of `Table` that renders the columns after the last column
-   * in the current instance of `Table`.
-   *
-   * @returns {Table}
-   */
-  getTableNeighborEast() {
-    return this.wot.overlay.master.wtTable;
-  }
+
 }
 
 mixin(LeftOverlayTable, calculatedRows);

--- a/src/3rdparty/walkontable/src/table/left.js
+++ b/src/3rdparty/walkontable/src/table/left.js
@@ -14,7 +14,7 @@ class LeftOverlayTable extends Table {
    * @returns {Table}
    */
   getTableNeighborEast() {
-    return this.wot.cloneSource.wtTable;
+    return this.wot.overlay.master.wtTable;
   }
 }
 

--- a/src/3rdparty/walkontable/src/table/master.js
+++ b/src/3rdparty/walkontable/src/table/master.js
@@ -135,6 +135,7 @@ class MasterTable extends Table {
       // in case we only scrolled without redraw, update visible rows information in oldRowsCalculator
       wtViewport.createVisibleCalculators();
       wtOverlays.refresh(true);
+      this.refreshSelections(true);
 
     } else {
 
@@ -192,9 +193,9 @@ class MasterTable extends Table {
         this.wot.getSetting('onDraw', true);
 
         wtOverlays.refresh(false);
+        this.refreshSelections(false);
       }
     }
-    this.refreshSelections(runFastDraw);
   }
 }
 

--- a/src/3rdparty/walkontable/src/table/master.js
+++ b/src/3rdparty/walkontable/src/table/master.js
@@ -131,14 +131,16 @@ class MasterTable extends Table {
       }
     }
 
-    wtOverlays.prepareOverlays();
-
     if (runFastDraw) {
+      wtOverlays.prepareOverlays();
       // in case we only scrolled without redraw, update visible rows information in oldRowsCalculator
       wtViewport.createVisibleCalculators();
       wtOverlays.refresh(true);
+      wtOverlays.resetFixedPositions();
 
     } else {
+      wtOverlays.prepareOverlays();
+
       const startRow = totalRows > 0 ? this.getFirstRenderedRow() : 0;
       const startColumn = totalColumns > 0 ? this.getFirstRenderedColumn() : 0;
 
@@ -194,15 +196,13 @@ class MasterTable extends Table {
 
         wtOverlays.refresh(false);
         wtOverlays.applyToDOM();
+        wtOverlays.resetFixedPositions();
+
+        // here be better for double draw
+        // wtOverlays.refresh(false);
+        // wtOverlays.applyToDOM();
       }
     }
-
-    wtOverlays.resetFixedPositions();
-
-    // here be better for double draw
-    // wtOverlays.refresh(false);
-    // wtOverlays.applyToDOM();
-
     this.refreshSelections(runFastDraw);
   }
 }

--- a/src/3rdparty/walkontable/src/table/master.js
+++ b/src/3rdparty/walkontable/src/table/master.js
@@ -27,7 +27,9 @@ class MasterTable extends Table {
   }
 
   alignOverlaysWithTrimmingContainer() {
-    const trimmingElement = getTrimmingContainer(this.wtRootElement);
+    this.trimmingContainer = getTrimmingContainer(this.wtRootElement);
+
+    const trimmingElement = this.trimmingContainer;
     const { rootWindow } = this.wot;
 
     if (trimmingElement === rootWindow) {

--- a/src/3rdparty/walkontable/src/table/master.js
+++ b/src/3rdparty/walkontable/src/table/master.js
@@ -24,6 +24,13 @@ class MasterTable extends Table {
     super(wotInstance, table);
     this.holderOffset = 0;
     this.wtRootElement.className += 'ht_master handsontable';
+    /**
+     * Set the DOM element responsible for trimming the overlay's root element. It will be some parent element or the window. Only applicable to the master overlay.
+     *
+     * @type {HTMLElement|Window}
+     */
+    this.trimmingContainer = null;
+    this.alignOverlaysWithTrimmingContainer(); // TODO this better be removed
   }
 
   alignOverlaysWithTrimmingContainer() {

--- a/src/3rdparty/walkontable/src/table/master.js
+++ b/src/3rdparty/walkontable/src/table/master.js
@@ -17,6 +17,15 @@ import RowFilter from './../filter/row';
  * Subclass of `Table` that provides the helper methods relevant to the master table (not overlays), implemented through mixins.
  */
 class MasterTable extends Table {
+  /**
+  * @param {Walkontable} wotInstance
+  * @param {HTMLTableElement} table
+  */
+  constructor(wotInstance, table) {
+    super(wotInstance, table);
+    this.holderOffset = 0;
+  }
+
   alignOverlaysWithTrimmingContainer() {
     const trimmingElement = getTrimmingContainer(this.wtRootElement);
     const { rootWindow } = this.wot;

--- a/src/3rdparty/walkontable/src/table/master.js
+++ b/src/3rdparty/walkontable/src/table/master.js
@@ -135,7 +135,6 @@ class MasterTable extends Table {
       // in case we only scrolled without redraw, update visible rows information in oldRowsCalculator
       wtViewport.createVisibleCalculators();
       wtOverlays.refresh(true);
-      wtOverlays.resetFixedPositions();
 
     } else {
 
@@ -192,14 +191,7 @@ class MasterTable extends Table {
 
         this.wot.getSetting('onDraw', true);
 
-        wtOverlays.prepareOverlays();
         wtOverlays.refresh(false);
-        wtOverlays.applyToDOM();
-        wtOverlays.resetFixedPositions();
-
-        // here be better for double draw
-        // wtOverlays.refresh(false);
-        // wtOverlays.applyToDOM();
       }
     }
     this.refreshSelections(runFastDraw);

--- a/src/3rdparty/walkontable/src/table/master.js
+++ b/src/3rdparty/walkontable/src/table/master.js
@@ -98,7 +98,6 @@ class MasterTable extends Table {
    *
    * @param {Boolean} [fastDraw=false] If TRUE, will try to avoid full redraw and only update the border positions.
    *                                   If FALSE or UNDEFINED, will perform a full redraw.
-   * @returns {Table}
    */
   draw(fastDraw = false) {
     const { wot } = this;
@@ -202,8 +201,6 @@ class MasterTable extends Table {
     // wtOverlays.applyToDOM();
 
     this.refreshSelections(runFastDraw);
-
-    return this;
   }
 }
 

--- a/src/3rdparty/walkontable/src/table/master.js
+++ b/src/3rdparty/walkontable/src/table/master.js
@@ -139,7 +139,6 @@ class MasterTable extends Table {
       wtOverlays.resetFixedPositions();
 
     } else {
-      wtOverlays.prepareOverlays();
 
       const startRow = totalRows > 0 ? this.getFirstRenderedRow() : 0;
       const startColumn = totalColumns > 0 ? this.getFirstRenderedColumn() : 0;
@@ -194,6 +193,7 @@ class MasterTable extends Table {
 
         this.wot.getSetting('onDraw', true);
 
+        wtOverlays.prepareOverlays();
         wtOverlays.refresh(false);
         wtOverlays.applyToDOM();
         wtOverlays.resetFixedPositions();

--- a/src/3rdparty/walkontable/src/table/master.js
+++ b/src/3rdparty/walkontable/src/table/master.js
@@ -23,6 +23,7 @@ class MasterTable extends Table {
   constructor(wotInstance, table) {
     super(wotInstance, table);
     this.holderOffset = 0;
+    this.wtRootElement.className += 'ht_master handsontable';
   }
 
   alignOverlaysWithTrimmingContainer() {

--- a/src/3rdparty/walkontable/src/table/master.js
+++ b/src/3rdparty/walkontable/src/table/master.js
@@ -134,8 +134,6 @@ class MasterTable extends Table {
       wtOverlays.refresh(true);
 
     } else {
-      this.tableOffset = offset(this.TABLE);
-
       const startRow = totalRows > 0 ? this.getFirstRenderedRow() : 0;
       const startColumn = totalColumns > 0 ? this.getFirstRenderedColumn() : 0;
 

--- a/src/3rdparty/walkontable/src/table/master.js
+++ b/src/3rdparty/walkontable/src/table/master.js
@@ -132,7 +132,6 @@ class MasterTable extends Table {
     }
 
     if (runFastDraw) {
-      wtOverlays.prepareOverlays();
       // in case we only scrolled without redraw, update visible rows information in oldRowsCalculator
       wtViewport.createVisibleCalculators();
       wtOverlays.refresh(true);

--- a/src/3rdparty/walkontable/src/table/master.js
+++ b/src/3rdparty/walkontable/src/table/master.js
@@ -118,7 +118,6 @@ class MasterTable extends Table {
     const columnHeaders = wot.getSetting('columnHeaders');
     const columnHeadersCount = columnHeaders.length;
     let runFastDraw = fastDraw;
-    let wtOverlaysNeedFullRefresh = false;
 
     this.holderOffset = offset(this.holder);
     runFastDraw = wtViewport.createRenderCalculators(runFastDraw);
@@ -148,15 +147,14 @@ class MasterTable extends Table {
       this.rowFilter = new RowFilter(startRow, totalRows, columnHeadersCount);
       this.columnFilter = new ColumnFilter(startColumn, totalColumns, rowHeadersCount);
 
-      let performRedraw = true;
-
       // Only master table rendering can be skipped
       this.alignOverlaysWithTrimmingContainer();
 
       const skipRender = {};
 
       this.wot.getSetting('beforeDraw', true, skipRender);
-      performRedraw = skipRender.skipRender !== true;
+
+      const performRedraw = skipRender.skipRender !== true;
 
       if (performRedraw) {
         this.tableRenderer.setHeaderContentRenderers(rowHeaders, columnHeaders);
@@ -177,7 +175,6 @@ class MasterTable extends Table {
         this.markOversizedRows();
 
         wtViewport.createVisibleCalculators();
-        wtOverlaysNeedFullRefresh = true;
 
         const hiderWidth = outerWidth(this.hider);
         const tableWidth = outerWidth(this.TABLE);
@@ -196,13 +193,12 @@ class MasterTable extends Table {
         }
 
         this.wot.getSetting('onDraw', true);
+
+        wtOverlays.refresh(false);
+        wtOverlays.applyToDOM();
       }
     }
 
-    if (wtOverlaysNeedFullRefresh) {
-      wtOverlays.refresh(false);
-      wtOverlays.applyToDOM();
-    }
     wtOverlays.resetFixedPositions();
 
     // here be better for double draw

--- a/src/3rdparty/walkontable/src/table/master.js
+++ b/src/3rdparty/walkontable/src/table/master.js
@@ -134,7 +134,7 @@ class MasterTable extends Table {
     if (runFastDraw) {
       // in case we only scrolled without redraw, update visible rows information in oldRowsCalculator
       wtViewport.createVisibleCalculators();
-      wtOverlays.refresh(true);
+      wtOverlays.refreshClones(true);
       this.refreshSelections(true);
 
     } else {
@@ -192,7 +192,7 @@ class MasterTable extends Table {
 
         this.wot.getSetting('onDraw', true);
 
-        wtOverlays.refresh(false);
+        wtOverlays.refreshClones(false);
         this.refreshSelections(false);
       }
     }

--- a/src/3rdparty/walkontable/src/table/master.js
+++ b/src/3rdparty/walkontable/src/table/master.js
@@ -2,7 +2,6 @@ import {
   getStyle,
   getComputedStyle,
   getTrimmingContainer,
-  isVisible,
   offset,
   outerWidth,
 } from './../../../../helpers/dom/element';
@@ -79,8 +78,6 @@ class MasterTable extends Table {
       this.hasTableHeight = holderStyle.height === 'auto' ? true : height > 0;
       this.hasTableWidth = width > 0;
     }
-
-    this.isTableVisible = isVisible(this.TABLE);
   }
 
   markOversizedColumnHeaders() {

--- a/src/3rdparty/walkontable/src/table/top.js
+++ b/src/3rdparty/walkontable/src/table/top.js
@@ -14,7 +14,7 @@ class TopOverlayTable extends Table {
    * @returns {Table}
    */
   getTableNeighborSouth() {
-    return this.wot.cloneSource.wtTable;
+    return this.wot.overlay.master.wtTable;
   }
 }
 

--- a/src/3rdparty/walkontable/src/table/top.js
+++ b/src/3rdparty/walkontable/src/table/top.js
@@ -7,15 +7,7 @@ import { mixin } from './../../../../helpers/object';
  * Subclass of `Table` that provides the helper methods relevant to TopOverlay, implemented through mixins.
  */
 class TopOverlayTable extends Table {
-  /**
-   * Returns an instance of `Table` that renders the rows after the last row
-   * in the current instance of `Table`.
-   *
-   * @returns {Table}
-   */
-  getTableNeighborSouth() {
-    return this.wot.overlay.master.wtTable;
-  }
+
 }
 
 mixin(TopOverlayTable, stickyRowsTop);

--- a/src/3rdparty/walkontable/src/table/topLeftCorner.js
+++ b/src/3rdparty/walkontable/src/table/topLeftCorner.js
@@ -7,35 +7,7 @@ import { mixin } from './../../../../helpers/object';
  * Subclass of `Table` that provides the helper methods relevant to TopLeftCornerOverlay, implemented through mixins.
  */
 class TopLeftCornerOverlayTable extends Table {
-  /**
-   * Returns an instance of `Table` that renders the columns after the last column
-   * in the current instance of `Table`.
-   *
-   * @returns {Table}
-   */
-  getTableNeighborEast() {
-    return this.wot.overlay.master.wtOverlays.topOverlay.clone.wtTable;
-  }
 
-  /**
-   * Returns an instance of `Table` that renders the rows after the last row
-   * in the current instance of `Table`.
-   *
-   * @returns {Table}
-   */
-  getTableNeighborSouth() {
-    return this.wot.overlay.master.wtOverlays.leftOverlay.clone.wtTable;
-  }
-
-  /**
-   * Returns an instance of `Table` that renders the rows after the last rows, and the columns after the last column
-   * in the current instance of `Table`.
-   *
-   * @returns {Table}
-   */
-  getTableNeighborDiagonal() {
-    return this.wot.overlay.master.wtTable;
-  }
 }
 
 mixin(TopLeftCornerOverlayTable, stickyRowsTop);

--- a/src/3rdparty/walkontable/src/table/topLeftCorner.js
+++ b/src/3rdparty/walkontable/src/table/topLeftCorner.js
@@ -14,7 +14,7 @@ class TopLeftCornerOverlayTable extends Table {
    * @returns {Table}
    */
   getTableNeighborEast() {
-    return this.wot.cloneSource.wtOverlays.topOverlay.clone.wtTable;
+    return this.wot.overlay.master.wtOverlays.topOverlay.clone.wtTable;
   }
 
   /**
@@ -24,7 +24,7 @@ class TopLeftCornerOverlayTable extends Table {
    * @returns {Table}
    */
   getTableNeighborSouth() {
-    return this.wot.cloneSource.wtOverlays.leftOverlay.clone.wtTable;
+    return this.wot.overlay.master.wtOverlays.leftOverlay.clone.wtTable;
   }
 
   /**
@@ -34,7 +34,7 @@ class TopLeftCornerOverlayTable extends Table {
    * @returns {Table}
    */
   getTableNeighborDiagonal() {
-    return this.wot.cloneSource.wtTable;
+    return this.wot.overlay.master.wtTable;
   }
 }
 

--- a/src/3rdparty/walkontable/src/utils/column.js
+++ b/src/3rdparty/walkontable/src/utils/column.js
@@ -86,8 +86,8 @@ export default class ColumnUtils {
    */
   calculateWidths() {
     const { wot } = this;
-    const { wtTable, wtViewport, cloneSource } = wot;
-    const mainHolder = cloneSource ? cloneSource.wtTable.holder : wtTable.holder;
+    const { wtTable, wtViewport, overlay } = wot;
+    const mainHolder = overlay ? overlay.master.wtTable.holder : wtTable.holder;
     const scrollbarCompensation = mainHolder.offsetHeight < mainHolder.scrollHeight ? getScrollbarWidth() : 0;
     let rowHeaderWidthSetting = wot.getSetting('rowHeaderWidth');
 

--- a/src/3rdparty/walkontable/src/viewport.js
+++ b/src/3rdparty/walkontable/src/viewport.js
@@ -43,7 +43,7 @@ class Viewport {
    */
   getWorkspaceHeight() {
     const currentDocument = this.wot.rootDocument;
-    const trimmingContainer = this.wot.wtOverlays.topOverlay.trimmingContainer;
+    const trimmingContainer = this.wot.wtTable.trimmingContainer;
     let height = 0;
 
     if (trimmingContainer === this.wot.rootWindow) {
@@ -61,7 +61,7 @@ class Viewport {
   getWorkspaceWidth() {
     const { wot } = this;
     const { rootDocument, rootWindow } = wot;
-    const trimmingContainer = this.wot.wtOverlays.leftOverlay.trimmingContainer;
+    const trimmingContainer = this.wot.wtTable.trimmingContainer;
     const docOffsetWidth = rootDocument.documentElement.offsetWidth;
     const totalColumns = wot.getSetting('totalColumns');
     const preventOverflow = wot.getSetting('preventOverflow');
@@ -87,7 +87,7 @@ class Viewport {
     }
 
     if (trimmingContainer !== rootWindow) {
-      overflow = getStyle(this.wot.wtOverlays.leftOverlay.trimmingContainer, 'overflow', rootWindow);
+      overflow = getStyle(trimmingContainer, 'overflow', rootWindow);
 
       if (overflow === 'scroll' || overflow === 'hidden' || overflow === 'auto') {
         // this is used in `scroll.html`

--- a/src/3rdparty/walkontable/src/viewport.js
+++ b/src/3rdparty/walkontable/src/viewport.js
@@ -22,8 +22,6 @@ class Viewport {
    */
   constructor(wotInstance) {
     this.wot = wotInstance;
-    // legacy support
-    this.instance = this.wot;
 
     this.oversizedRows = [];
     this.oversizedColumnHeaders = [];
@@ -45,7 +43,7 @@ class Viewport {
    */
   getWorkspaceHeight() {
     const currentDocument = this.wot.rootDocument;
-    const trimmingContainer = this.instance.wtOverlays.topOverlay.trimmingContainer;
+    const trimmingContainer = this.wot.wtOverlays.topOverlay.trimmingContainer;
     let height = 0;
 
     if (trimmingContainer === this.wot.rootWindow) {
@@ -63,7 +61,7 @@ class Viewport {
   getWorkspaceWidth() {
     const { wot } = this;
     const { rootDocument, rootWindow } = wot;
-    const trimmingContainer = this.instance.wtOverlays.leftOverlay.trimmingContainer;
+    const trimmingContainer = this.wot.wtOverlays.leftOverlay.trimmingContainer;
     const docOffsetWidth = rootDocument.documentElement.offsetWidth;
     const totalColumns = wot.getSetting('totalColumns');
     const preventOverflow = wot.getSetting('preventOverflow');
@@ -71,7 +69,7 @@ class Viewport {
     let overflow;
 
     if (preventOverflow) {
-      return outerWidth(this.instance.wtTable.wtRootElement);
+      return outerWidth(this.wot.wtTable.wtRootElement);
     }
 
     if (wot.getSetting('freezeOverlays')) {
@@ -89,7 +87,7 @@ class Viewport {
     }
 
     if (trimmingContainer !== rootWindow) {
-      overflow = getStyle(this.instance.wtOverlays.leftOverlay.trimmingContainer, 'overflow', rootWindow);
+      overflow = getStyle(this.wot.wtOverlays.leftOverlay.trimmingContainer, 'overflow', rootWindow);
 
       if (overflow === 'scroll' || overflow === 'hidden' || overflow === 'auto') {
         // this is used in `scroll.html`
@@ -102,7 +100,7 @@ class Viewport {
 
     if (stretchSetting === 'none' || !stretchSetting) {
       // if no stretching is used, return the maximum used workspace width
-      return Math.max(width, outerWidth(this.instance.wtTable.TABLE));
+      return Math.max(width, outerWidth(this.wot.wtTable.TABLE));
     }
 
     // if stretching is used, return the actual container width, so the columns can fit inside it
@@ -152,7 +150,7 @@ class Viewport {
       return this.containerWidth;
     }
 
-    const mainContainer = this.instance.wtTable.holder;
+    const mainContainer = this.wot.wtTable.holder;
     const dummyElement = this.wot.rootDocument.createElement('div');
 
     dummyElement.style.width = '100%';
@@ -195,7 +193,7 @@ class Viewport {
    * @returns {Number}
    */
   getColumnHeaderHeight() {
-    const columnHeaders = this.instance.getSetting('columnHeaders');
+    const columnHeaders = this.wot.getSetting('columnHeaders');
 
     if (!columnHeaders.length) {
       this.columnHeaderHeight = 0;
@@ -229,8 +227,8 @@ class Viewport {
    * @returns {Number}
    */
   getRowHeaderWidth() {
-    const rowHeadersWidthSetting = this.instance.getSetting('rowHeaderWidth');
-    const rowHeaders = this.instance.getSetting('rowHeaders');
+    const rowHeadersWidthSetting = this.wot.getSetting('rowHeaderWidth');
+    const rowHeaders = this.wot.getSetting('rowHeaders');
 
     if (rowHeadersWidthSetting) {
       this.rowHeaderWidth = 0;
@@ -247,7 +245,7 @@ class Viewport {
     if (isNaN(this.rowHeaderWidth)) {
 
       if (rowHeaders.length) {
-        let TH = this.instance.wtTable.TABLE.querySelector('TH');
+        let TH = this.wot.wtTable.TABLE.querySelector('TH');
         this.rowHeaderWidth = 0;
 
         for (let i = 0, len = rowHeaders.length; i < len; i++) {
@@ -266,7 +264,7 @@ class Viewport {
       }
     }
 
-    this.rowHeaderWidth = this.instance.getSetting('onModifyRowHeaderWidth', this.rowHeaderWidth) || this.rowHeaderWidth;
+    this.rowHeaderWidth = this.wot.getSetting('onModifyRowHeaderWidth', this.rowHeaderWidth) || this.rowHeaderWidth;
 
     return this.rowHeaderWidth;
   }

--- a/src/3rdparty/walkontable/src/viewport.js
+++ b/src/3rdparty/walkontable/src/viewport.js
@@ -238,8 +238,8 @@ class Viewport {
       }
     }
 
-    if (this.wot.cloneSource) {
-      return this.wot.cloneSource.wtViewport.getRowHeaderWidth();
+    if (this.wot.overlay) {
+      return this.wot.overlay.master.wtViewport.getRowHeaderWidth();
     }
 
     if (isNaN(this.rowHeaderWidth)) {

--- a/src/3rdparty/walkontable/src/viewport.js
+++ b/src/3rdparty/walkontable/src/viewport.js
@@ -133,12 +133,11 @@ class Viewport {
    * @returns {Number}
    */
   sumColumnWidths(from, length) {
-    const { wtTable } = this.wot;
     let sum = 0;
     let column = from;
 
     while (column < length) {
-      sum += wtTable.getColumnWidth(column);
+      sum += this.wot.columnUtils.getWidth(column);
       column += 1;
     }
 
@@ -345,7 +344,7 @@ class Viewport {
       viewportSize: height,
       scrollOffset: pos,
       totalItems: wot.getSetting('totalRows'),
-      itemSizeFn: sourceRow => wtTable.getRowHeight(sourceRow),
+      itemSizeFn: sourceRow => wot.rowUtils.getHeight(sourceRow),
       overrideFn: wtSettings.settings.viewportRowCalculatorOverride,
       calculationType,
       scrollbarHeight,
@@ -386,7 +385,7 @@ class Viewport {
       viewportSize: width,
       scrollOffset: pos,
       totalItems: wot.getSetting('totalColumns'),
-      itemSizeFn: sourceCol => wot.wtTable.getColumnWidth(sourceCol),
+      itemSizeFn: sourceCol => wot.columnUtils.getWidth(sourceCol),
       overrideFn: wtSettings.settings.viewportColumnCalculatorOverride,
       calculationType,
       stretchMode: wot.getSetting('stretchH'),

--- a/src/3rdparty/walkontable/test/spec/border.spec.js
+++ b/src/3rdparty/walkontable/test/spec/border.spec.js
@@ -40,7 +40,7 @@ describe('Walkontable Border Renderer', () => {
   }
 
   beforeEach(function() {
-    this.$wrapper = $('<div></div>').addClass('handsontable');
+    this.$wrapper = $('<div></div>').addClass('handsontable').css({ overflow: 'hidden' });
     this.$container = $('<div></div>');
     this.$wrapper.width(100).height(100);
     this.$table = $('<table></table>').addClass('htCore');
@@ -531,6 +531,99 @@ describe('Walkontable Border Renderer', () => {
       const elem = document.querySelector(`svg path[data-stroke-style='${expectedStrokeStyle}']`);
 
       expect(elem.getAttribute('stroke')).toEqual('rgb(0%,   100%,   0%)');
+    });
+  });
+
+  describe('should render the overlapping fragment of the master column with the overlay', () => {
+    it('should render overlapping fragment on left overlay after scroll, with container scrollbars', () => {
+      createDataArray(100, 100);
+      spec().$wrapper.width(300).height(100); // set grid sizing to large container
+
+      const wt = walkontable({
+        data: getData,
+        totalRows: getTotalRows,
+        totalColumns: getTotalColumns,
+        fixedColumnsLeft: 2,
+        selections: [
+          generateSelection({
+            left: THIN_GREEN_BORDER,
+            right: MEDIUM_GREEN_BORDER,
+            top: THICK_GREEN_BORDER,
+            bottom: HUGE_GREEN_BORDER
+          }).add(new Walkontable.CellCoords(0, 2))
+        ]
+      });
+
+      wt.draw();
+      wt.draw(); // TODO as it turns out, the desired rendering is only visible after the second draw. A problem that does not appear in HOT but appears in raw WOT. Why?
+
+      const topBorderSelector = 'svg path[data-stroke-style=\'3px solid green\']';
+      const topBorderExpectedPathInMaster = 'M 0 0.5 50 0.5'; // Master starts rendering from column 2
+      const topBorderExpectedPathInLeft = 'M 101 0.5 150 0.5'; // Left Overlay starts rendering from column 0
+      const pathInMaster = document.querySelector(`.ht_master ${topBorderSelector}`);
+      const pathInLeftOverlay = document.querySelector(`.ht_clone_left ${topBorderSelector}`);
+
+      expect(pathInMaster.getAttribute('d')).withContext('Master overlay top border of selection before scroll').toEqual(topBorderExpectedPathInMaster);
+      expect(pathInLeftOverlay.getAttribute('d')).withContext('Left overlay top border of selection before scroll').toEqual(topBorderExpectedPathInLeft);
+
+      wt.wtTable.holder.scrollLeft = 30;
+      wt.draw();
+
+      expect(pathInMaster.getAttribute('d')).withContext('Master overlay top border of selection after scroll').toEqual(topBorderExpectedPathInMaster);
+      expect(pathInLeftOverlay.getAttribute('d')).withContext('Left overlay top border of selection after scroll').toEqual(''); // the common border should not be rendered if the table is scrolled
+
+      wt.wtTable.holder.scrollLeft = 0;
+      wt.draw();
+      wt.draw(); // TODO as it turns out, the desired rendering is only visible after the second draw. A problem that does not appear in HOT but appears in raw WOT. Why?
+
+      expect(pathInMaster.getAttribute('d')).withContext('Master overlay top border of selection after scroll back').toEqual(topBorderExpectedPathInMaster);
+      expect(pathInLeftOverlay.getAttribute('d')).withContext('Left overlay top border of selection after scroll back').toEqual(topBorderExpectedPathInLeft);
+    });
+
+    it('should render overlapping fragment on left overlay after scroll, with window scrollbars', () => {
+      createDataArray(100, 100);
+      spec().$wrapper[0].setAttribute('style', ''); // set grid sizing to window
+
+      const wt = walkontable({
+        data: getData,
+        totalRows: getTotalRows,
+        totalColumns: getTotalColumns,
+        fixedColumnsLeft: 2,
+        selections: [
+          generateSelection({
+            left: THIN_GREEN_BORDER,
+            right: MEDIUM_GREEN_BORDER,
+            top: THICK_GREEN_BORDER,
+            bottom: HUGE_GREEN_BORDER
+          }).add(new Walkontable.CellCoords(0, 2))
+        ]
+      });
+
+      wt.draw();
+      wt.draw(); // TODO as it turns out, the desired rendering is only visible after the second draw. A problem that does not appear in HOT but appears in raw WOT. Why?
+
+      const topBorderSelector = 'svg path[data-stroke-style=\'3px solid green\']';
+      const topBorderExpectedPathInMaster = 'M 0 0.5 50 0.5'; // Master starts rendering from column 2
+      const topBorderExpectedPathInLeft = 'M 101 0.5 150 0.5'; // Left Overlay starts rendering from column 0
+      const pathInMaster = document.querySelector(`.ht_master ${topBorderSelector}`);
+      const pathInLeftOverlay = document.querySelector(`.ht_clone_left ${topBorderSelector}`);
+
+      expect(pathInMaster.getAttribute('d')).withContext('Master overlay top border of selection before scroll').toEqual(topBorderExpectedPathInMaster);
+      expect(pathInLeftOverlay.getAttribute('d')).withContext('Left overlay top border of selection before scroll').toEqual(topBorderExpectedPathInLeft);
+
+      window.scroll(30, 0);
+      wt.draw();
+
+      expect(pathInMaster.getAttribute('d')).withContext('Master overlay top border of selection after scroll').toEqual(topBorderExpectedPathInMaster);
+      expect(pathInLeftOverlay.getAttribute('d')).withContext('Left overlay top border of selection after scroll').toEqual(''); // the common border should not be rendered if the table is scrolled
+
+      window.scroll(0, 0);
+      wt.draw();
+      wt.draw(); // TODO as it turns out, the desired rendering is only visible after the second draw. A problem that does not appear in HOT but appears in raw WOT. Why?
+
+      expect(pathInMaster.getAttribute('d')).withContext('Master overlay top border of selection after scroll back').toEqual(topBorderExpectedPathInMaster);
+
+      expect(pathInLeftOverlay.getAttribute('d')).withContext('Left overlay top border of selection after scroll back').toEqual(topBorderExpectedPathInLeft);
     });
   });
 });

--- a/src/3rdparty/walkontable/test/spec/border.spec.js
+++ b/src/3rdparty/walkontable/test/spec/border.spec.js
@@ -569,7 +569,7 @@ describe('Walkontable Border Renderer', () => {
       wt.draw();
 
       expect(pathInMaster.getAttribute('d')).withContext('Master overlay top border of selection after scroll').toEqual(topBorderExpectedPathInMaster);
-      expect(pathInLeftOverlay.getAttribute('d')).withContext('Left overlay top border of selection after scroll').toEqual(topBorderExpectedPathInLeft); // the common border should not be rendered if the table is scrolled
+      expect(pathInLeftOverlay.getAttribute('d')).withContext('Left overlay top border of selection after scroll').toEqual(topBorderExpectedPathInLeft);
 
       wt.wtTable.holder.scrollLeft = 0;
       wt.draw();
@@ -612,7 +612,7 @@ describe('Walkontable Border Renderer', () => {
       wt.draw();
 
       expect(pathInMaster.getAttribute('d')).withContext('Master overlay top border of selection after scroll').toEqual(topBorderExpectedPathInMaster);
-      expect(pathInLeftOverlay.getAttribute('d')).withContext('Left overlay top border of selection after scroll').toEqual(topBorderExpectedPathInLeft); // the common border should not be rendered if the table is scrolled
+      expect(pathInLeftOverlay.getAttribute('d')).withContext('Left overlay top border of selection after scroll').toEqual(topBorderExpectedPathInLeft);
 
       window.scroll(0, 0);
       wt.draw();

--- a/src/3rdparty/walkontable/test/spec/border.spec.js
+++ b/src/3rdparty/walkontable/test/spec/border.spec.js
@@ -558,7 +558,7 @@ describe('Walkontable Border Renderer', () => {
 
       const topBorderSelector = 'svg path[data-stroke-style=\'3px solid green\']';
       const topBorderExpectedPathInMaster = 'M 0 0.5 50 0.5'; // Master starts rendering from column 2
-      const topBorderExpectedPathInLeft = 'M 101 0.5 150 0.5'; // Left Overlay starts rendering from column 0
+      const topBorderExpectedPathInLeft = 'M 99 0.5 150 0.5'; // Left Overlay starts rendering from column 0
       const pathInMaster = document.querySelector(`.ht_master ${topBorderSelector}`);
       const pathInLeftOverlay = document.querySelector(`.ht_clone_left ${topBorderSelector}`);
 
@@ -569,7 +569,7 @@ describe('Walkontable Border Renderer', () => {
       wt.draw();
 
       expect(pathInMaster.getAttribute('d')).withContext('Master overlay top border of selection after scroll').toEqual(topBorderExpectedPathInMaster);
-      expect(pathInLeftOverlay.getAttribute('d')).withContext('Left overlay top border of selection after scroll').toEqual(''); // the common border should not be rendered if the table is scrolled
+      expect(pathInLeftOverlay.getAttribute('d')).withContext('Left overlay top border of selection after scroll').toEqual(topBorderExpectedPathInLeft); // the common border should not be rendered if the table is scrolled
 
       wt.wtTable.holder.scrollLeft = 0;
       wt.draw();
@@ -601,7 +601,7 @@ describe('Walkontable Border Renderer', () => {
 
       const topBorderSelector = 'svg path[data-stroke-style=\'3px solid green\']';
       const topBorderExpectedPathInMaster = 'M 0 0.5 50 0.5'; // Master starts rendering from column 2
-      const topBorderExpectedPathInLeft = 'M 101 0.5 150 0.5'; // Left Overlay starts rendering from column 0
+      const topBorderExpectedPathInLeft = 'M 99 0.5 150 0.5'; // Left Overlay starts rendering from column 0
       const pathInMaster = document.querySelector(`.ht_master ${topBorderSelector}`);
       const pathInLeftOverlay = document.querySelector(`.ht_clone_left ${topBorderSelector}`);
 
@@ -612,7 +612,7 @@ describe('Walkontable Border Renderer', () => {
       wt.draw();
 
       expect(pathInMaster.getAttribute('d')).withContext('Master overlay top border of selection after scroll').toEqual(topBorderExpectedPathInMaster);
-      expect(pathInLeftOverlay.getAttribute('d')).withContext('Left overlay top border of selection after scroll').toEqual(''); // the common border should not be rendered if the table is scrolled
+      expect(pathInLeftOverlay.getAttribute('d')).withContext('Left overlay top border of selection after scroll').toEqual(topBorderExpectedPathInLeft); // the common border should not be rendered if the table is scrolled
 
       window.scroll(0, 0);
       wt.draw();

--- a/src/3rdparty/walkontable/test/spec/border.spec.js
+++ b/src/3rdparty/walkontable/test/spec/border.spec.js
@@ -555,7 +555,6 @@ describe('Walkontable Border Renderer', () => {
       });
 
       wt.draw();
-      wt.draw(); // TODO as it turns out, the desired rendering is only visible after the second draw. A problem that does not appear in HOT but appears in raw WOT. Why?
 
       const topBorderSelector = 'svg path[data-stroke-style=\'3px solid green\']';
       const topBorderExpectedPathInMaster = 'M 0 0.5 50 0.5'; // Master starts rendering from column 2
@@ -574,7 +573,6 @@ describe('Walkontable Border Renderer', () => {
 
       wt.wtTable.holder.scrollLeft = 0;
       wt.draw();
-      wt.draw(); // TODO as it turns out, the desired rendering is only visible after the second draw. A problem that does not appear in HOT but appears in raw WOT. Why?
 
       expect(pathInMaster.getAttribute('d')).withContext('Master overlay top border of selection after scroll back').toEqual(topBorderExpectedPathInMaster);
       expect(pathInLeftOverlay.getAttribute('d')).withContext('Left overlay top border of selection after scroll back').toEqual(topBorderExpectedPathInLeft);
@@ -600,7 +598,6 @@ describe('Walkontable Border Renderer', () => {
       });
 
       wt.draw();
-      wt.draw(); // TODO as it turns out, the desired rendering is only visible after the second draw. A problem that does not appear in HOT but appears in raw WOT. Why?
 
       const topBorderSelector = 'svg path[data-stroke-style=\'3px solid green\']';
       const topBorderExpectedPathInMaster = 'M 0 0.5 50 0.5'; // Master starts rendering from column 2
@@ -619,7 +616,6 @@ describe('Walkontable Border Renderer', () => {
 
       window.scroll(0, 0);
       wt.draw();
-      wt.draw(); // TODO as it turns out, the desired rendering is only visible after the second draw. A problem that does not appear in HOT but appears in raw WOT. Why?
 
       expect(pathInMaster.getAttribute('d')).withContext('Master overlay top border of selection after scroll back').toEqual(topBorderExpectedPathInMaster);
 

--- a/src/3rdparty/walkontable/test/spec/selection.spec.js
+++ b/src/3rdparty/walkontable/test/spec/selection.spec.js
@@ -147,14 +147,20 @@ describe('Walkontable.Selection', () => {
       .toEqual(['M 0 253.5 50 253.5 M 49.5 253 49.5 300 M 0 299.5 50 299.5']);
     expect(getRenderedBorderPaths(spec().$wrapper.find('.ht_clone_top')[0])).withContext('ht_clone_top')
       .toEqual([]);
+
+    const scrollbarWidth = getScrollbarWidth(); // 17 on Windows
+    let expectedY = 321 + scrollbarWidth;
+
     expect(getRenderedBorderPaths(spec().$wrapper.find('.ht_clone_left')[0])).withContext('ht_clone_left')
-      .toEqual(['M 0 253.5 100 253.5 M 99.5 253 99.5 -336 M 0 -336.5 100 -336.5 M 0.5 253 0.5 -336']);
+      .toEqual([`M 0 253.5 100 253.5 M 99.5 253 99.5 -${expectedY} M 0 -${expectedY}.5 100 -${expectedY}.5 M 0.5 253 0.5 -${expectedY}`]);
     expect(getRenderedBorderPaths(spec().$wrapper.find('.ht_clone_top_left_corner')[0])).withContext('ht_clone_top_left_corner')
       .toEqual(null);
     expect(getRenderedBorderPaths(spec().$wrapper.find('.ht_clone_bottom')[0])).withContext('ht_clone_bottom')
       .toEqual(['M 0 -22.5 50 -22.5 M 49.5 -23 49.5 24 M 0 23.5 50 23.5']);
+
+    expectedY = 598 + scrollbarWidth;
     expect(getRenderedBorderPaths(spec().$wrapper.find('.ht_clone_bottom_left_corner')[0])).withContext('ht_clone_bottom_left_corner')
-      .toEqual(['M 0 613.5 100 613.5 M 99.5 613 99.5 24 M 0 23.5 100 23.5 M 0.5 613 0.5 24']);
+      .toEqual([`M 0 ${expectedY}.5 100 ${expectedY}.5 M 99.5 ${expectedY} 99.5 24 M 0 23.5 100 23.5 M 0.5 ${expectedY} 0.5 24`]);
   });
 
   it('should not add class to selection until it is rerendered', () => {

--- a/src/3rdparty/walkontable/test/spec/selection.spec.js
+++ b/src/3rdparty/walkontable/test/spec/selection.spec.js
@@ -145,20 +145,14 @@ describe('Walkontable.Selection', () => {
       .toEqual(['M 0 253.5 50 253.5 M 49.5 253 49.5 300 M 0 299.5 50 299.5']);
     expect(getRenderedBorderPaths(spec().$wrapper.find('.ht_clone_top')[0])).withContext('ht_clone_top')
       .toEqual([]);
-
-    const scrollbarWidth = getScrollbarWidth(); // 17 on Windows
-    let expectedY = 285 + scrollbarWidth;
-
     expect(getRenderedBorderPaths(spec().$wrapper.find('.ht_clone_left')[0])).withContext('ht_clone_left')
-      .toEqual([`M 0 253.5 100 253.5 M 99.5 253 99.5 ${expectedY} M 0 ${expectedY - 1}.5 100 ${expectedY - 1}.5 M 0.5 253 0.5 ${expectedY}`]);
+      .toEqual(['M 0 253.5 100 253.5 M 99.5 253 99.5 300 M 0 299.5 100 299.5 M 0.5 253 0.5 300']);
     expect(getRenderedBorderPaths(spec().$wrapper.find('.ht_clone_top_left_corner')[0])).withContext('ht_clone_top_left_corner')
       .toEqual(null);
     expect(getRenderedBorderPaths(spec().$wrapper.find('.ht_clone_bottom')[0])).withContext('ht_clone_bottom')
       .toEqual(['M 0 -23.5 50 -23.5 M 49.5 -24 49.5 24 M 0 23.5 50 23.5']);
-
-    expectedY = -39 + scrollbarWidth;
     expect(getRenderedBorderPaths(spec().$wrapper.find('.ht_clone_bottom_left_corner')[0])).withContext('ht_clone_bottom_left_corner')
-      .toEqual([`M 0 ${expectedY + 1}.5 100 ${expectedY + 1}.5 M 99.5 ${expectedY} 99.5 24 M 0 23.5 100 23.5 M 0.5 ${expectedY} 0.5 24`]);
+      .toEqual(['M 0 -23.5 100 -23.5 M 99.5 -24 99.5 24 M 0 23.5 100 23.5 M 0.5 -24 0.5 24']);
   });
 
   it('should not add class to selection until it is rerendered', () => {

--- a/src/3rdparty/walkontable/test/spec/selection.spec.js
+++ b/src/3rdparty/walkontable/test/spec/selection.spec.js
@@ -105,7 +105,7 @@ describe('Walkontable.Selection', () => {
     expect(getRenderedBorderPaths(spec().$wrapper.find('.ht_master')[0])).withContext('ht_master')
       .toEqual(['M 49.5 0 49.5 24 M 0 23.5 50 23.5']);
     expect(getRenderedBorderPaths(spec().$wrapper.find('.ht_clone_top')[0])).withContext('ht_clone_top')
-      .toEqual(['M 0 0.5 50 0.5 M 49.5 0 49.5 47 M 0 46.5 50 46.5']);
+      .toEqual(['M 0 0.5 50 0.5 M 49.5 0 49.5 48 M 0 47.5 50 47.5']);
     expect(getRenderedBorderPaths(spec().$wrapper.find('.ht_clone_left')[0])).withContext('ht_clone_left')
       .toEqual(['M 99.5 0 99.5 24 M 0 23.5 100 23.5 M 0.5 0 0.5 24']);
     expect(spec().$wrapper.find('.ht_clone_bottom_left_corner').length).withContext('ht_clone_top_left_corner')
@@ -147,18 +147,21 @@ describe('Walkontable.Selection', () => {
       .toEqual([]);
 
     const scrollbarWidth = getScrollbarWidth(); // 17 on Windows
-    let expectedY = 321 + scrollbarWidth;
+    let expectedY = 285 + scrollbarWidth;
+
+    // M 0 253.5 100 253.5 M 99.5 253 99.5 300 M 0 299.5 100 299.5 M 0.5 253 0.5 300
+    // M 0 253.5 100 253.5 M 99.5 253 99.5 300 M 0 300.5 100 300.5 M 0.5 253 0.5 300
 
     expect(getRenderedBorderPaths(spec().$wrapper.find('.ht_clone_left')[0])).withContext('ht_clone_left')
-      .toEqual([`M 0 253.5 100 253.5 M 99.5 253 99.5 -${expectedY} M 0 -${expectedY}.5 100 -${expectedY}.5 M 0.5 253 0.5 -${expectedY}`]);
+      .toEqual([`M 0 253.5 100 253.5 M 99.5 253 99.5 ${expectedY} M 0 ${expectedY - 1}.5 100 ${expectedY - 1}.5 M 0.5 253 0.5 ${expectedY}`]);
     expect(getRenderedBorderPaths(spec().$wrapper.find('.ht_clone_top_left_corner')[0])).withContext('ht_clone_top_left_corner')
       .toEqual(null);
     expect(getRenderedBorderPaths(spec().$wrapper.find('.ht_clone_bottom')[0])).withContext('ht_clone_bottom')
-      .toEqual(['M 0 -22.5 50 -22.5 M 49.5 -23 49.5 24 M 0 23.5 50 23.5']);
+      .toEqual(['M 0 -23.5 50 -23.5 M 49.5 -24 49.5 24 M 0 23.5 50 23.5']);
 
-    expectedY = 598 + scrollbarWidth;
+    expectedY = -39 + scrollbarWidth;
     expect(getRenderedBorderPaths(spec().$wrapper.find('.ht_clone_bottom_left_corner')[0])).withContext('ht_clone_bottom_left_corner')
-      .toEqual([`M 0 ${expectedY}.5 100 ${expectedY}.5 M 99.5 ${expectedY} 99.5 24 M 0 23.5 100 23.5 M 0.5 ${expectedY} 0.5 24`]);
+      .toEqual([`M 0 ${expectedY + 1}.5 100 ${expectedY + 1}.5 M 99.5 ${expectedY} 99.5 24 M 0 23.5 100 23.5 M 0.5 ${expectedY} 0.5 24`]);
   });
 
   it('should not add class to selection until it is rerendered', () => {

--- a/src/3rdparty/walkontable/test/spec/selection.spec.js
+++ b/src/3rdparty/walkontable/test/spec/selection.spec.js
@@ -149,9 +149,6 @@ describe('Walkontable.Selection', () => {
     const scrollbarWidth = getScrollbarWidth(); // 17 on Windows
     let expectedY = 285 + scrollbarWidth;
 
-    // M 0 253.5 100 253.5 M 99.5 253 99.5 300 M 0 299.5 100 299.5 M 0.5 253 0.5 300
-    // M 0 253.5 100 253.5 M 99.5 253 99.5 300 M 0 300.5 100 300.5 M 0.5 253 0.5 300
-
     expect(getRenderedBorderPaths(spec().$wrapper.find('.ht_clone_left')[0])).withContext('ht_clone_left')
       .toEqual([`M 0 253.5 100 253.5 M 99.5 253 99.5 ${expectedY} M 0 ${expectedY - 1}.5 100 ${expectedY - 1}.5 M 0.5 253 0.5 ${expectedY}`]);
     expect(getRenderedBorderPaths(spec().$wrapper.find('.ht_clone_top_left_corner')[0])).withContext('ht_clone_top_left_corner')

--- a/src/3rdparty/walkontable/test/spec/selection.spec.js
+++ b/src/3rdparty/walkontable/test/spec/selection.spec.js
@@ -98,7 +98,6 @@ describe('Walkontable.Selection', () => {
     wt.selections.createOrGetArea().add(new Walkontable.CellCoords(1, 1));
 
     wt.draw();
-    wt.draw(); // TODO as it turns out, the desired rendering is only visible after the second draw. A problem that does not appear in HOT but appears in raw WOT
 
     const paths = spec().$wrapper.find('svg path');
     expect(paths.length).toBe(4);
@@ -138,7 +137,6 @@ describe('Walkontable.Selection', () => {
     wt.draw();
     wt.scrollViewport(new Walkontable.CellCoords(38, 0));
     wt.draw();
-    wt.draw(); // TODO as it turns out, the desired rendering is only visible after the second draw. A problem that does not appear in HOT but appears in raw WOT. Why?
 
     const paths = spec().$wrapper.find('svg path');
     expect(paths.length).toBe(4);

--- a/src/3rdparty/walkontable/test/spec/table.spec.js
+++ b/src/3rdparty/walkontable/test/spec/table.spec.js
@@ -726,7 +726,7 @@ describe('WalkontableTable', () => {
     expect(wt.wtTable.getCoords($td2[0])).toEqual(new Walkontable.CellCoords(1, 1));
   });
 
-  it('getStretchedColumnWidth should return valid column width when stretchH is set as \'all\'', () => {
+  it('wot.columnUtils.getStretchedColumnWidth should return valid column width when stretchH is set as \'all\'', () => {
     const wt = walkontable({
       data: getData,
       totalRows: getTotalRows,
@@ -739,13 +739,13 @@ describe('WalkontableTable', () => {
     wt.draw();
     wt.wtViewport.columnsRenderCalculator.refreshStretching(502);
 
-    expect(wt.wtTable.getStretchedColumnWidth(0, 50)).toBe(125);
-    expect(wt.wtTable.getStretchedColumnWidth(1, 50)).toBe(125);
-    expect(wt.wtTable.getStretchedColumnWidth(2, 50)).toBe(125);
-    expect(wt.wtTable.getStretchedColumnWidth(3, 50)).toBe(127);
+    expect(wt.columnUtils.getStretchedColumnWidth(0, 50)).toBe(125);
+    expect(wt.columnUtils.getStretchedColumnWidth(1, 50)).toBe(125);
+    expect(wt.columnUtils.getStretchedColumnWidth(2, 50)).toBe(125);
+    expect(wt.columnUtils.getStretchedColumnWidth(3, 50)).toBe(127);
   });
 
-  it('getStretchedColumnWidth should return valid column width when stretchH is set as \'last\'', () => {
+  it('wot.columnUtils.getStretchedColumnWidth should return valid column width when stretchH is set as \'last\'', () => {
     const wt = walkontable({
       data: getData,
       totalRows: getTotalRows,
@@ -758,10 +758,10 @@ describe('WalkontableTable', () => {
     wt.draw();
     wt.wtViewport.columnsRenderCalculator.refreshStretching(502);
 
-    expect(wt.wtTable.getStretchedColumnWidth(0, 50)).toBe(50);
-    expect(wt.wtTable.getStretchedColumnWidth(1, 50)).toBe(50);
-    expect(wt.wtTable.getStretchedColumnWidth(2, 50)).toBe(50);
-    expect(wt.wtTable.getStretchedColumnWidth(3, 50)).toBe(352);
+    expect(wt.columnUtils.getStretchedColumnWidth(0, 50)).toBe(50);
+    expect(wt.columnUtils.getStretchedColumnWidth(1, 50)).toBe(50);
+    expect(wt.columnUtils.getStretchedColumnWidth(2, 50)).toBe(50);
+    expect(wt.columnUtils.getStretchedColumnWidth(3, 50)).toBe(352);
   });
 
   it('should use custom cell renderer if provided', () => {

--- a/src/core.js
+++ b/src/core.js
@@ -636,7 +636,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
         });
       }
       if (instance.view) {
-        instance.view.wt.wtOverlays.adjustElementsSize();
+        instance.view.wt.wtOverlays.adjustElementsSizes();
       }
     },
 
@@ -1093,7 +1093,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
     editorManager.lockEditor();
     instance._refreshBorders(null);
     editorManager.unlockEditor();
-    instance.view.wt.wtOverlays.adjustElementsSize();
+    instance.view.wt.wtOverlays.adjustElementsSizes();
     instance.runHooks('afterChange', changes, source || 'edit');
 
     const activeEditor = instance.getActiveEditor();

--- a/src/editors/selectEditor.js
+++ b/src/editors/selectEditor.js
@@ -195,19 +195,19 @@ class SelectEditor extends BaseEditor {
 
     switch (editorSection) {
       case 'top':
-        cssTransformOffset = getCssTransform(wtOverlays.topOverlay.clone.wtTable.holder.parentNode);
+        cssTransformOffset = getCssTransform(wtOverlays.topOverlay.clone.wtTable.wtRootElement);
         break;
       case 'left':
-        cssTransformOffset = getCssTransform(wtOverlays.leftOverlay.clone.wtTable.holder.parentNode);
+        cssTransformOffset = getCssTransform(wtOverlays.leftOverlay.clone.wtTable.wtRootElement);
         break;
       case 'top-left-corner':
-        cssTransformOffset = getCssTransform(wtOverlays.topLeftCornerOverlay.clone.wtTable.holder.parentNode);
+        cssTransformOffset = getCssTransform(wtOverlays.topLeftCornerOverlay.clone.wtTable.wtRootElement);
         break;
       case 'bottom-left-corner':
-        cssTransformOffset = getCssTransform(wtOverlays.bottomLeftCornerOverlay.clone.wtTable.holder.parentNode);
+        cssTransformOffset = getCssTransform(wtOverlays.bottomLeftCornerOverlay.clone.wtTable.wtRootElement);
         break;
       case 'bottom':
-        cssTransformOffset = getCssTransform(wtOverlays.bottomOverlay.clone.wtTable.holder.parentNode);
+        cssTransformOffset = getCssTransform(wtOverlays.bottomOverlay.clone.wtTable.wtRootElement);
         break;
       default:
         break;

--- a/src/editors/textEditor.js
+++ b/src/editors/textEditor.js
@@ -344,8 +344,8 @@ class TextEditor extends BaseEditor {
     const { wtOverlays, wtViewport } = this.hot.view.wt;
     const currentOffset = offset(this.TD);
     const containerOffset = offset(this.hot.rootElement);
-    const scrollableContainerTop = wtOverlays.topOverlay.holder;
-    const scrollableContainerLeft = wtOverlays.leftOverlay.holder;
+    const scrollableContainerTop = wtOverlays.topOverlay.master.wtTable.holder;
+    const scrollableContainerLeft = wtOverlays.leftOverlay.master.wtTable.holder;
     const totalRowsCount = this.hot.countRows();
     const containerScrollTop = scrollableContainerTop !== this.hot.rootWindow ? scrollableContainerTop.scrollTop : 0;
     const containerScrollLeft = scrollableContainerLeft !== this.hot.rootWindow ? scrollableContainerLeft.scrollLeft : 0;

--- a/src/editors/textEditor.js
+++ b/src/editors/textEditor.js
@@ -368,19 +368,19 @@ class TextEditor extends BaseEditor {
     // TODO: Refactor this to the new instance.getCell method (from #ply-59), after 0.12.1 is released
     switch (editorSection) {
       case 'top':
-        cssTransformOffset = getCssTransform(wtOverlays.topOverlay.clone.wtTable.holder.parentNode);
+        cssTransformOffset = getCssTransform(wtOverlays.topOverlay.clone.wtTable.wtRootElement);
         break;
       case 'left':
-        cssTransformOffset = getCssTransform(wtOverlays.leftOverlay.clone.wtTable.holder.parentNode);
+        cssTransformOffset = getCssTransform(wtOverlays.leftOverlay.clone.wtTable.wtRootElement);
         break;
       case 'top-left-corner':
-        cssTransformOffset = getCssTransform(wtOverlays.topLeftCornerOverlay.clone.wtTable.holder.parentNode);
+        cssTransformOffset = getCssTransform(wtOverlays.topLeftCornerOverlay.clone.wtTable.wtRootElement);
         break;
       case 'bottom-left-corner':
-        cssTransformOffset = getCssTransform(wtOverlays.bottomLeftCornerOverlay.clone.wtTable.holder.parentNode);
+        cssTransformOffset = getCssTransform(wtOverlays.bottomLeftCornerOverlay.clone.wtTable.wtRootElement);
         break;
       case 'bottom':
-        cssTransformOffset = getCssTransform(wtOverlays.bottomOverlay.clone.wtTable.holder.parentNode);
+        cssTransformOffset = getCssTransform(wtOverlays.bottomOverlay.clone.wtTable.wtRootElement);
         break;
       default:
         break;

--- a/src/plugins/autoColumnSize/autoColumnSize.js
+++ b/src/plugins/autoColumnSize/autoColumnSize.js
@@ -271,7 +271,7 @@ class AutoColumnSize extends BasePlugin {
         this.inProgress = false;
 
         // @TODO Should call once per render cycle, currently fired separately in different plugins
-        this.hot.view.wt.wtOverlays.adjustElementsSize();
+        this.hot.view.wt.wtOverlays.adjustElementsSizes();
       }
     };
 

--- a/src/plugins/autoRowSize/autoRowSize.js
+++ b/src/plugins/autoRowSize/autoRowSize.js
@@ -252,7 +252,7 @@ class AutoRowSize extends BasePlugin {
         this.inProgress = false;
 
         // @TODO Should call once per render cycle, currently fired separately in different plugins
-        this.hot.view.wt.wtOverlays.adjustElementsSize(true);
+        this.hot.view.wt.wtOverlays.adjustElementsSizes(true);
         // tmp
         if (this.hot.view.wt.wtOverlays.leftOverlay.needFullRender) {
           this.hot.view.wt.wtOverlays.leftOverlay.clone.drawClone();
@@ -273,7 +273,7 @@ class AutoRowSize extends BasePlugin {
       loop();
     } else {
       this.inProgress = false;
-      this.hot.view.wt.wtOverlays.adjustElementsSize(false);
+      this.hot.view.wt.wtOverlays.adjustElementsSizes(false);
     }
   }
 

--- a/src/plugins/collapsibleColumns/collapsibleColumns.js
+++ b/src/plugins/collapsibleColumns/collapsibleColumns.js
@@ -550,7 +550,7 @@ class CollapsibleColumns extends BasePlugin {
     }
 
     this.hot.render();
-    this.hot.view.wt.wtOverlays.adjustElementsSize(true);
+    this.hot.view.wt.wtOverlays.adjustElementsSizes(true);
   }
 
   /**

--- a/src/plugins/comments/comments.js
+++ b/src/plugins/comments/comments.js
@@ -400,7 +400,7 @@ class Comments extends BasePlugin {
     const row = this.range.from.row;
     const column = this.range.from.col;
     const cellOffset = offset(TD);
-    const lastColWidth = wtTable.getStretchedColumnWidth(column);
+    const lastColWidth = this.hot.view.wt.columnUtils.getStretchedColumnWidth(column);
     let cellTopOffset = cellOffset.top < 0 ? 0 : cellOffset.top;
     let cellLeftOffset = cellOffset.left;
 

--- a/src/plugins/filters/filters.js
+++ b/src/plugins/filters/filters.js
@@ -373,7 +373,7 @@ class Filters extends BasePlugin {
 
     this.hot.runHooks('afterFilter', conditions);
 
-    this.hot.view.wt.wtOverlays.adjustElementsSize(true);
+    this.hot.view.wt.wtOverlays.adjustElementsSizes(true);
     this.hot.render();
     this.clearColumnSelection();
   }

--- a/src/plugins/hiddenColumns/contextMenuItem/hideColumn.js
+++ b/src/plugins/hiddenColumns/contextMenuItem/hideColumn.js
@@ -26,7 +26,7 @@ export default function hideColumnItem(hiddenColumnsPlugin) {
       rangeEach(start, end, column => hiddenColumnsPlugin.hideColumn(column));
 
       this.render();
-      this.view.wt.wtOverlays.adjustElementsSize(true);
+      this.view.wt.wtOverlays.adjustElementsSizes(true);
 
     },
     disabled: false,

--- a/src/plugins/hiddenColumns/contextMenuItem/showColumn.js
+++ b/src/plugins/hiddenColumns/contextMenuItem/showColumn.js
@@ -56,7 +56,7 @@ export default function showColumnItem(hiddenColumnsPlugin) {
       }
 
       this.render();
-      this.view.wt.wtOverlays.adjustElementsSize(true);
+      this.view.wt.wtOverlays.adjustElementsSizes(true);
     },
     disabled: false,
     hidden() {

--- a/src/plugins/hiddenRows/contextMenuItem/hideRow.js
+++ b/src/plugins/hiddenRows/contextMenuItem/hideRow.js
@@ -26,7 +26,7 @@ export default function hideRowItem(hiddenRowsPlugin) {
       rangeEach(start, end, row => hiddenRowsPlugin.hideRow(row));
 
       this.render();
-      this.view.wt.wtOverlays.adjustElementsSize(true);
+      this.view.wt.wtOverlays.adjustElementsSizes(true);
 
     },
     disabled: false,

--- a/src/plugins/hiddenRows/contextMenuItem/showRow.js
+++ b/src/plugins/hiddenRows/contextMenuItem/showRow.js
@@ -56,7 +56,7 @@ export default function showRowItem(hiddenRowsPlugin) {
       }
 
       this.render();
-      this.view.wt.wtOverlays.adjustElementsSize(true);
+      this.view.wt.wtOverlays.adjustElementsSizes(true);
     },
     disabled: false,
     hidden() {

--- a/src/plugins/manualColumnFreeze/contextMenuItem/freezeColumn.js
+++ b/src/plugins/manualColumnFreeze/contextMenuItem/freezeColumn.js
@@ -12,7 +12,7 @@ export default function freezeColumnItem(manualColumnFreezePlugin) {
       manualColumnFreezePlugin.freezeColumn(selectedColumn);
 
       this.render();
-      this.view.wt.wtOverlays.adjustElementsSize(true);
+      this.view.wt.wtOverlays.adjustElementsSizes(true);
     },
     hidden() {
       const selection = this.getSelectedRange();

--- a/src/plugins/manualColumnFreeze/contextMenuItem/unfreezeColumn.js
+++ b/src/plugins/manualColumnFreeze/contextMenuItem/unfreezeColumn.js
@@ -12,7 +12,7 @@ export default function unfreezeColumnItem(manualColumnFreezePlugin) {
       manualColumnFreezePlugin.unfreezeColumn(selectedColumn);
 
       this.render();
-      this.view.wt.wtOverlays.adjustElementsSize(true);
+      this.view.wt.wtOverlays.adjustElementsSizes(true);
     },
     hidden() {
       const selection = this.getSelectedRange();

--- a/src/plugins/manualColumnMove/manualColumnMove.js
+++ b/src/plugins/manualColumnMove/manualColumnMove.js
@@ -310,7 +310,7 @@ class ManualColumnMove extends BasePlugin {
       if (i < 0) {
         columnWidth = this.hot.view.wt.wtViewport.getRowHeaderWidth() || 0;
       } else {
-        columnWidth = this.hot.view.wt.wtTable.getStretchedColumnWidth(i) || 0;
+        columnWidth = this.hot.view.wt.columnUtils.getStretchedColumnWidth(i) || 0;
       }
 
       width += columnWidth;
@@ -556,7 +556,7 @@ class ManualColumnMove extends BasePlugin {
       priv.rootElementOffset = offset(this.hot.rootElement).left;
 
       const countColumnsFrom = priv.hasRowHeaders ? -1 : 0;
-      const topPos = wtTable.holder.scrollTop + wtTable.getColumnHeaderHeight(0) + 1;
+      const topPos = wtTable.holder.scrollTop + this.hot.view.wt.columnUtils.getHeaderHeight(0) + 1;
       const fixedColumns = coords.col < priv.fixedColumns;
       const scrollableElement = this.hot.view.wt.wtOverlays.scrollableElement;
       const wrapperIsWindow = scrollableElement.scrollX ? scrollableElement.scrollX - priv.rootElementOffset : 0;
@@ -684,7 +684,7 @@ class ManualColumnMove extends BasePlugin {
    */
   onAfterScrollVertically() {
     const wtTable = this.hot.view.wt.wtTable;
-    const headerHeight = wtTable.getColumnHeaderHeight(0) + 1;
+    const headerHeight = this.hot.view.wt.columnUtils.getHeaderHeight(0) + 1;
     const scrollTop = wtTable.holder.scrollTop;
     const posTop = headerHeight + scrollTop;
 

--- a/src/plugins/manualColumnMove/manualColumnMove.js
+++ b/src/plugins/manualColumnMove/manualColumnMove.js
@@ -668,7 +668,7 @@ class ManualColumnMove extends BasePlugin {
     if (movePerformed === true) {
       this.persistentStateSave();
       this.hot.render();
-      this.hot.view.wt.wtOverlays.adjustElementsSize(true);
+      this.hot.view.wt.wtOverlays.adjustElementsSizes(true);
 
       const selectionStart = this.hot.toVisualColumn(firstMovedPhysicalColumn);
       const selectionEnd = selectionStart + columnsLen - 1;

--- a/src/plugins/manualColumnResize/manualColumnResize.js
+++ b/src/plugins/manualColumnResize/manualColumnResize.js
@@ -386,7 +386,7 @@ class ManualColumnResize extends BasePlugin {
     const render = () => {
       this.hot.forceFullRender = true;
       this.hot.view.render(); // updates all
-      this.hot.view.wt.wtOverlays.adjustElementsSize(true);
+      this.hot.view.wt.wtOverlays.adjustElementsSizes(true);
     };
     const resize = (column, forceRender) => {
       const hookNewSize = this.hot.runHooks('beforeColumnResize', this.newSize, column, true);
@@ -482,7 +482,7 @@ class ManualColumnResize extends BasePlugin {
     const render = () => {
       this.hot.forceFullRender = true;
       this.hot.view.render(); // updates all
-      this.hot.view.wt.wtOverlays.adjustElementsSize(true);
+      this.hot.view.wt.wtOverlays.adjustElementsSizes(true);
     };
     const resize = (column, forceRender) => {
       this.hot.runHooks('beforeColumnResize', this.newSize, column, false);

--- a/src/plugins/manualRowMove/manualRowMove.js
+++ b/src/plugins/manualRowMove/manualRowMove.js
@@ -291,7 +291,7 @@ class ManualRowMove extends BasePlugin {
     let height = 0;
 
     for (let i = from; i < to; i++) {
-      const rowHeight = this.hot.view.wt.wtTable.getRowHeight(i) || 23;
+      const rowHeight = this.hot.view.wt.rowUtils.getHeight(i) || 23;
 
       height += rowHeight;
     }

--- a/src/plugins/manualRowMove/manualRowMove.js
+++ b/src/plugins/manualRowMove/manualRowMove.js
@@ -644,7 +644,7 @@ class ManualRowMove extends BasePlugin {
     if (movePerformed === true) {
       this.persistentStateSave();
       this.hot.render();
-      this.hot.view.wt.wtOverlays.adjustElementsSize(true);
+      this.hot.view.wt.wtOverlays.adjustElementsSizes(true);
 
       const selectionStart = this.hot.toVisualRow(firstMovedPhysicalRow);
       const selectionEnd = selectionStart + rowsLen - 1;

--- a/src/plugins/manualRowResize/manualRowResize.js
+++ b/src/plugins/manualRowResize/manualRowResize.js
@@ -339,7 +339,7 @@ class ManualRowResize extends BasePlugin {
     const render = () => {
       this.hot.forceFullRender = true;
       this.hot.view.render(); // updates all
-      this.hot.view.wt.wtOverlays.adjustElementsSize(true);
+      this.hot.view.wt.wtOverlays.adjustElementsSizes(true);
     };
     const resize = (row, forceRender) => {
       const hookNewSize = this.hot.runHooks('beforeRowResize', this.newSize, row, true);
@@ -429,7 +429,7 @@ class ManualRowResize extends BasePlugin {
     const render = () => {
       this.hot.forceFullRender = true;
       this.hot.view.render(); // updates all
-      this.hot.view.wt.wtOverlays.adjustElementsSize(true);
+      this.hot.view.wt.wtOverlays.adjustElementsSizes(true);
     };
     const runHooks = (row, forceRender) => {
       this.hot.runHooks('beforeRowResize', this.newSize, row, false);

--- a/src/plugins/nestedRows/ui/collapsing.js
+++ b/src/plugins/nestedRows/ui/collapsing.js
@@ -463,7 +463,7 @@ class CollapsingUI extends BaseUI {
     this.hot.render();
 
     // Dirty workaround to prevent scroll height not adjusting to the table height. Needs refactoring in the future.
-    this.hot.view.wt.wtOverlays.adjustElementsSize();
+    this.hot.view.wt.wtOverlays.adjustElementsSizes();
   }
 }
 

--- a/src/plugins/touchScroll/touchScroll.js
+++ b/src/plugins/touchScroll/touchScroll.js
@@ -121,19 +121,19 @@ class TouchScroll extends BasePlugin {
     this.clones.length = 0;
 
     if (topOverlay.needFullRender) {
-      this.clones.push(topOverlay.clone.wtTable.holder.parentNode);
+      this.clones.push(topOverlay.clone.wtTable.wtRootElement);
     }
     if (bottomOverlay.needFullRender) {
-      this.clones.push(bottomOverlay.clone.wtTable.holder.parentNode);
+      this.clones.push(bottomOverlay.clone.wtTable.wtRootElement);
     }
     if (leftOverlay.needFullRender) {
-      this.clones.push(leftOverlay.clone.wtTable.holder.parentNode);
+      this.clones.push(leftOverlay.clone.wtTable.wtRootElement);
     }
     if (topLeftCornerOverlay) {
-      this.clones.push(topLeftCornerOverlay.clone.wtTable.holder.parentNode);
+      this.clones.push(topLeftCornerOverlay.clone.wtTable.wtRootElement);
     }
     if (bottomLeftCornerOverlay && bottomLeftCornerOverlay.clone) {
-      this.clones.push(bottomLeftCornerOverlay.clone.wtTable.holder.parentNode);
+      this.clones.push(bottomLeftCornerOverlay.clone.wtTable.wtRootElement);
     }
   }
 

--- a/src/plugins/touchScroll/touchScroll.js
+++ b/src/plugins/touchScroll/touchScroll.js
@@ -170,8 +170,8 @@ class TouchScroll extends BasePlugin {
     }, 400);
 
     arrayEach(this.scrollbars, (scrollbar) => {
-      scrollbar.refresh();
-      scrollbar.resetFixedPosition();
+      scrollbar.redrawClone();
+      scrollbar.adjustElementsPosition();
     });
 
     this.hot.view.wt.wtOverlays.syncScrollWithMaster();

--- a/src/plugins/touchScroll/touchScroll.js
+++ b/src/plugins/touchScroll/touchScroll.js
@@ -174,7 +174,7 @@ class TouchScroll extends BasePlugin {
       scrollbar.adjustElementsPosition();
     });
 
-    this.hot.view.wt.wtOverlays.syncScrollWithMaster();
+    this.hot.view.wt.wtOverlays.propagateMasterScrollPositionsToClones();
   }
 }
 

--- a/src/utils/ghostTable.js
+++ b/src/utils/ghostTable.js
@@ -371,7 +371,7 @@ class GhostTable {
   createColElement(column) {
     const col = this.hot.rootDocument.createElement('col');
 
-    col.style.width = `${this.hot.view.wt.wtTable.getStretchedColumnWidth(column)}px`;
+    col.style.width = `${this.hot.view.wt.columnUtils.getStretchedColumnWidth(column)}px`;
 
     return col;
   }

--- a/test/e2e/core/selectAll.spec.js
+++ b/test/e2e/core/selectAll.spec.js
@@ -42,11 +42,6 @@ describe('Core.selectAll', () => {
       | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
       | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
       | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
-      | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
-      | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
-      | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
-      | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
-      | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
       `).toBeMatchToSelectionPattern();
     // "Select all" shouldn't scroll te table.
     expect(hot.view.wt.wtTable.holder.scrollTop).toBe(150);


### PR DESCRIPTION
### Context

This change was initiated as a response to "Case 1", "Case 3" and "Case 4" explained in https://github.com/handsontable/handsontable/issues/6467#issuecomment-559440649. 

The root of the problem was that my code, when rendering an overlay A, was sometimes reading the cell position from an overlay B, if the cell was was not rendered in the overlay A but its border was overlapping that overlay.

I had a big problem to investigate the overlay position synchronization, and the only way I could move forward was to cleanup and refactor the code until I started to understand it.

Now, the shameful part: After I refactored the code and fixed the problem, I realized that my concept explained in the second paragraph is flawed, because it will not work if the end user scrolls far enough. At that time I made another (simpler) solution to the problem: f8c226b. However, I kept the refactored code, because I think it is more maintainable.


### How has this been tested?
All tests are passing, I also did a few manual tests. I run the SV test suite against this branch, it passes OK.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/6467
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
