### PR TITLE
Remove post-install warning from package.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,8 +52,7 @@
     "build:walkontable": "cross-env-shell BABEL_ENV=commonjs NODE_ENV=walkontable env-cmd -f ./hot.config.js webpack --hide-modules ./src/3rdparty/walkontable/src/index.js",
     "build:languages": "cross-env-shell BABEL_ENV=commonjs NODE_ENV=languages-development env-cmd -f ./hot.config.js webpack",
     "build:languages.min": "cross-env-shell BABEL_ENV=commonjs NODE_ENV=languages-production env-cmd -f ./hot.config.js webpack",
-    "release": "npm run clean && npm run build && npm publish",
-    "postinstall": "node -p \"'Handsontable is no longer released under the MIT license. Read more about this change on our blog at https://handsontable.com/blog.'\""
+    "release": "npm run clean && npm run build && npm publish"
   },
   "keywords": [
     "data",


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Remove post-install warning from the package.json file. This PR resolves task for the upcoming 8.0.0 release (https://github.com/handsontable/handsontable/issues/6465).

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #6465

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
