### PR TITLE
Bump moment, pikaday and numbro to the latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2236,9 +2236,9 @@
       "dev": true
     },
     "bignumber.js": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz",
-      "integrity": "sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA=="
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.1.1.tgz",
+      "integrity": "sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ=="
     },
     "binary-extensions": {
       "version": "1.13.1",
@@ -8223,11 +8223,11 @@
       "dev": true
     },
     "numbro": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/numbro/-/numbro-2.1.1.tgz",
-      "integrity": "sha512-H3VamlHyqYYomNngAbrl/CT92DnOSC2rJxx6hfZrgj0NVnqxAtOvGbwgpOYjv4ASgxodDWBSYHJ1ZxaEq2lfTg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/numbro/-/numbro-2.1.2.tgz",
+      "integrity": "sha512-7w833BxZmKGLE9HI0aREtNVRVH6WTYUUlWf4qgA5gKNhPQ4F/MRZ14sc0v8eoLORprk9ZTVwYaLwj8N3Zgxwiw==",
       "requires": {
-        "bignumber.js": "^4.0.4"
+        "bignumber.js": "^8.0.1"
       }
     },
     "nwsapi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7986,9 +7986,9 @@
       }
     },
     "moment": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
-      "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg=="
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "move-concurrently": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1236,9 +1236,9 @@
       "dev": true
     },
     "@types/pikaday": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@types/pikaday/-/pikaday-1.6.0.tgz",
-      "integrity": "sha512-cnKjF7i6oA1ADxQdSWHcEStLZeiH8qbf6l7B9O88PhLgnmbUMM62ali0/PaDtINm6ezpNcqtERWL6Y+pAgHKQQ==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@types/pikaday/-/pikaday-1.7.4.tgz",
+      "integrity": "sha512-0KsHVyw5pTG829nqG4IRu7m+BFQlFEBdbE/1i3S5182HeKUKv1uEW0gyEmkJVp5i4IV+9pyh23O83+KpRkSQbw==",
       "requires": {
         "moment": ">=2.14.0"
       }
@@ -8741,12 +8741,9 @@
       "dev": true
     },
     "pikaday": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/pikaday/-/pikaday-1.5.1.tgz",
-      "integrity": "sha1-CkhUm8GhTqHQjEQHTXYbwvK/z9M=",
-      "requires": {
-        "moment": "2.x"
-      }
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/pikaday/-/pikaday-1.8.0.tgz",
+      "integrity": "sha512-SgGxMYX0NHj9oQnMaSyAipr2gOrbB4Lfs/TJTb6H6hRHs39/5c5VZi73Q8hr53+vWjdn6HzkWcj8Vtl3c9ziaA=="
     },
     "pinkie": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -70,12 +70,12 @@
     "data-spreadsheet"
   ],
   "dependencies": {
-    "@types/pikaday": "1.6.0",
+    "@types/pikaday": "1.7.4",
     "core-js": "^3.0.0",
     "hot-formula-parser": "^3.0.1",
     "moment": "2.24.0",
     "numbro": "2.1.2",
-    "pikaday": "1.5.1"
+    "pikaday": "1.8.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "core-js": "^3.0.0",
     "hot-formula-parser": "^3.0.1",
     "moment": "2.24.0",
-    "numbro": "2.1.1",
+    "numbro": "2.1.2",
     "pikaday": "1.5.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@types/pikaday": "1.6.0",
     "core-js": "^3.0.0",
     "hot-formula-parser": "^3.0.1",
-    "moment": "2.20.1",
+    "moment": "2.24.0",
     "numbro": "2.1.1",
     "pikaday": "1.5.1"
   },


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Bump dependencies:
 * `moment` to fixed v2.24.0;
 * `numbro` to fixed v2.1.2;
 * `pikaday` to fixed v1.8.0;

comparing dist files it seems that after upgrading the `handsontable.full.js` file is lighter ~20kB.

### How has this been tested?

- [x]  Build a version
- [x] Check the size of the version
- [ ] Build a version and install with wrappers, check their size
- [ ] Browser e2e tests on Chrome, Firefox, Safari, Opera, Edge
    `$ npm run test: e2e.dump`
    file is on `test/E2ERunner.html`  
- [ ] Tests walkontable on Chrome, Firefox, Safari, Opera, Edge
      `$ test: walkontable.dump`
    file is on `src/3rdparty/walkontable/test/SpecRunner.html`
- [ ] Check the numeric type editor
     - [ ] non-integer numbers, currency, commas, number format, formulas
     - [ ] repeat above after changing the keyboard language to American
     - [ ] and after changing the keyboard language to German
     - [ ] IME after changing the language to Chinese or Japanese
- [ ] Click through key functions on a minified version (crud, move, formulas)
- [ ] Click through key functions (crud, move, fixing, formulas) on wrappers
- [ ] Validation check:
    - [ ] Has the number of licenses changed?
    - [ ] check key with incorrect date - when the license expires yesterday, today and tomorrow

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #5159
2. https://github.com/handsontable/handsontable/issues/6465
1. [#5159 Support newer versions of momentjs etc](https://github.com/handsontable/handsontable/issues/5159)
2. [#6110 License suggestion for R community: rhandsontable ](https://github.com/handsontable/handsontable/issues/6110)
3. [#5790 RangeError: toFixed() digits arguments must be between 0 and 100 ](https://github.com/handsontable/handsontable/issues/5790#issuecomment-471581724)
4. [#6582 We're not able to undo changes while using summary calculations and `numeric` cell data.](https://github.com/handsontable/handsontable/issues/6582)
5. [#6423 The column type: data is not protected against pasting data using autoFill / fillHandle ](https://github.com/handsontable/handsontable/issues/6423)
6. [#5863 We get `Maximum call stack size exceeded` when enabling summaryCalculations and minSpareRows](https://github.com/handsontable/handsontable/issues/5863)
7. [#5569 Numeric Type Does Not Work with Expected to Decimal ](https://github.com/handsontable/handsontable/issues/5569)
8. [#5344 [0.35.1+] Numeric cell type percentage format not calculated ](https://github.com/handsontable/handsontable/issues/5344)
9.  [#5251 [3.0.0+] cell invalid after copy paste from excel in version PRO 4.0.0 ](https://github.com/handsontable/handsontable/issues/5251)
10. [#4884 Searching uses values hidden by numericFormat ](https://github.com/handsontable/handsontable/issues/4884)
11. [#4396 Numbers parsed incorrectly if "." is thousands separator, "," decimal separator and decimal part not specified](https://github.com/handsontable/handsontable/issues/4396)
12. [#4360 When changing cell type, cell editor does not dynamically change ](https://github.com/handsontable/handsontable/issues/4360)
13. [#4353 When the cell type is numeric, the formula does not work properly.](https://github.com/handsontable/handsontable/issues/4353)
14. [#4119 `Uncaught TypeError` in date cell type with numeric value.](https://github.com/handsontable/handsontable/issues/4119)
15. [#3402 Alter value before validation ](https://github.com/handsontable/handsontable/issues/3402)
16. [#2966 Cells function gets the property function in the col argument during validation ](https://github.com/handsontable/handsontable/issues/2966)
17. [#5848 Numeric cell type fails to validate -.n ](https://github.com/handsontable/handsontable/issues/5848)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
