### PR TITLE
Add deprecated warning messages mechanism for plugin hooks

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1775,7 +1775,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
         /* eslint-disable-next-line no-continue */
         continue;
 
-      } else if (Hooks.getSingleton().getRegistered().indexOf(i) > -1 || Hooks.getSingleton().getDeprecated().indexOf(i) > -1) {
+      } else if (Hooks.getSingleton().isRegistered(i) || Hooks.getSingleton().isDeprecated(i)) {
         if (isFunction(settings[i]) || Array.isArray(settings[i])) {
           settings[i].initialHook = true;
           instance.addHook(i, settings[i]);

--- a/src/core.js
+++ b/src/core.js
@@ -1775,7 +1775,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
         /* eslint-disable-next-line no-continue */
         continue;
 
-      } else if (Hooks.getSingleton().getRegistered().indexOf(i) > -1) {
+      } else if (Hooks.getSingleton().getRegistered().indexOf(i) > -1 || Hooks.getSingleton().getDeprecated().indexOf(i) > -1) {
         if (isFunction(settings[i]) || Array.isArray(settings[i])) {
           settings[i].initialHook = true;
           instance.addHook(i, settings[i]);

--- a/src/helpers/templateLiteralTag.js
+++ b/src/helpers/templateLiteralTag.js
@@ -11,7 +11,7 @@ import { arrayReduce } from '../helpers/array';
 export function toSingleLine(strings, ...expressions) {
   const result = arrayReduce(strings, (previousValue, currentValue, index) => {
 
-    const valueWithoutWhiteSpaces = currentValue.replace(/(?:\r?\n\s+)/g, '');
+    const valueWithoutWhiteSpaces = currentValue.replace(/\r?\n\s*/g, '');
     const expressionForIndex = expressions[index] ? expressions[index] : '';
 
     return previousValue + valueWithoutWhiteSpaces + expressionForIndex;

--- a/src/pluginHooks.js
+++ b/src/pluginHooks.js
@@ -1847,7 +1847,8 @@ const REGISTERED_HOOKS = [
  *
  * @type {String}
  */
-const REMOVED_MESSAGE = 'The plugin hook "[hookName]" was removed in Handsontable [hotVersion]. Please consult release notes https://github.com/handsontable/handsontable/releases/tag/[hotVersion] to learn about the migration path.';
+const REMOVED_MESSAGE = `The plugin hook "[hookName]" was removed in Handsontable [hotVersion].\x20
+Please consult release notes https://github.com/handsontable/handsontable/releases/tag/[hotVersion] to learn about the migration path.`;
 
 /**
  * The list of the hooks which are removed from the API. The warning message is printed out in

--- a/src/pluginHooks.js
+++ b/src/pluginHooks.js
@@ -1848,8 +1848,8 @@ const REGISTERED_HOOKS = [
  *
  * @type {String}
  */
-const REMOVED_MESSAGE = toSingleLine`The plugin hook "[hookName]" was removed in Handsontable [hotVersion].\x20
-  Please consult release notes https://github.com/handsontable/handsontable/releases/tag/[hotVersion] to learn about the migration path.`;
+const REMOVED_MESSAGE = toSingleLine`The plugin hook "[hookName]" was removed in Handsontable [removedInVersion].\x20
+  Please consult release notes https://github.com/handsontable/handsontable/releases/tag/[removedInVersion] to learn about the migration path.`;
 
 /**
  * The list of the hooks which are removed from the API. The warning message is printed out in
@@ -1981,7 +1981,7 @@ class Hooks {
     } else {
 
       if (REMOVED_HOOKS.has(key)) {
-        warn(substitute(REMOVED_MESSAGE, { hookName: key, hotVersion: REMOVED_HOOKS.get(key) }));
+        warn(substitute(REMOVED_MESSAGE, { hookName: key, removedInVersion: REMOVED_HOOKS.get(key) }));
       }
       if (DEPRECATED_HOOKS.has(key)) {
         warn(DEPRECATED_HOOKS.get(key));

--- a/src/pluginHooks.js
+++ b/src/pluginHooks.js
@@ -2218,9 +2218,28 @@ class Hooks {
   }
 
   /**
+   * Returns a boolean value depending on if a hook by such name has been removed or deprecated.
+   *
+   * @param key {String} The hook name to check.
+   * @returns {Boolean} Returns `true` if the provided hook name was marked as deprecated or
+   *                    removed from API, `false` otherwise.
+   *
+   * @example
+   * ```js
+   * Handsontable.hooks.isDeprecated('skipLengthCache');
+   *
+   * // Results:
+   * true
+   * ```
+   */
+  isDeprecated(hookName) {
+    return DEPRECATED_HOOKS.has(hookName) || REMOVED_HOOKS.has(hookName);
+  }
+
+  /**
    * Returns a boolean depending on if a hook by such name has been registered.
    *
-   * @param key {String} Hook name.
+   * @param key {String} The hook name to check.
    * @returns {Boolean} `true` for success, `false` otherwise.
    *
    * @example
@@ -2231,8 +2250,8 @@ class Hooks {
    * true
    * ```
    */
-  isRegistered(key) {
-    return REGISTERED_HOOKS.indexOf(key) >= 0;
+  isRegistered(hookName) {
+    return REGISTERED_HOOKS.indexOf(hookName) >= 0;
   }
 
   /**
@@ -2258,29 +2277,6 @@ class Hooks {
    */
   getRegistered() {
     return REGISTERED_HOOKS;
-  }
-
-  /**
-   * Returns an array of removed and deprecated hooks from the API. The list is used to detect if the removed
-   * or deprecated hook is used. If true, then migration path or deprecation message is printed out in the
-   * developer console as warning message.
-   *
-   * @returns {Array} An array of removed and deprecated hooks.
-   *
-   * @example
-   * ```js
-   * Handsontable.hooks.getDeprecated();
-   *
-   * // Results:
-   * [
-   * ...
-   *   'modifyRow',
-   * ...
-   * ]
-   * ```
-   */
-  getDeprecated() {
-    return [...Array.from(DEPRECATED_HOOKS.keys()), ...Array.from(REMOVED_HOOKS.keys())];
   }
 }
 

--- a/src/pluginHooks.js
+++ b/src/pluginHooks.js
@@ -2,6 +2,7 @@ import { arrayEach } from './helpers/array';
 import { objectEach } from './helpers/object';
 import { substitute } from './helpers/string';
 import { warn } from './helpers/console';
+import { toSingleLine } from './helpers/templateLiteralTag';
 
 /**
  * @description
@@ -1847,8 +1848,8 @@ const REGISTERED_HOOKS = [
  *
  * @type {String}
  */
-const REMOVED_MESSAGE = `The plugin hook "[hookName]" was removed in Handsontable [hotVersion].\x20
-Please consult release notes https://github.com/handsontable/handsontable/releases/tag/[hotVersion] to learn about the migration path.`;
+const REMOVED_MESSAGE = toSingleLine`The plugin hook "[hookName]" was removed in Handsontable [hotVersion].\x20
+  Please consult release notes https://github.com/handsontable/handsontable/releases/tag/[hotVersion] to learn about the migration path.`;
 
 /**
  * The list of the hooks which are removed from the API. The warning message is printed out in

--- a/test/unit/PluginHooks.spec.js
+++ b/test/unit/PluginHooks.spec.js
@@ -125,6 +125,21 @@ describe('PluginHooks', () => {
     expect(hooks.add.calls.argsFor(1)[2]).toBe(null);
   });
 
+  it('should print out a warning message if removed hook from API is used', () => {
+    const hooks = new Hooks();
+    const fn1 = function() {};
+    const context = {};
+
+    spyOn(console, 'warn');
+
+    hooks.add('skipLengthCache', fn1, context);
+
+    expect(console.warn.calls.mostRecent().args).toEqual(['The plugin hook "skipLengthCache" was removed in Handsontable' +
+      ' 8.0.0. Please consult release notes https://github.com/handsontable/handsontable/releases/tag/8.0.0 to learn ' +
+      'about the migration path.']);
+    expect(context.pluginHookBucket.skipLengthCache).toEqual([fn1]);
+  });
+
   it('should remove hook', () => {
     const hooks = new Hooks();
     const fn1 = function() {};
@@ -274,6 +289,13 @@ describe('PluginHooks', () => {
     const hooks = new Hooks();
 
     expect(hooks.getRegistered().length).toBeGreaterThan(0);
+  });
+
+  it('should returns `true` if hooks is deprecated', () => {
+    const hooks = new Hooks();
+
+    expect(hooks.isDeprecated('skipLengthCache')).toBe(true);
+    expect(hooks.isDeprecated('test2')).toBe(false);
   });
 
   it('should returns `true` if at least one listener was added to the hook', () => {

--- a/test/unit/helpers/TemplateLiteralTag.spec.js
+++ b/test/unit/helpers/TemplateLiteralTag.spec.js
@@ -2,16 +2,23 @@ import { toSingleLine } from 'handsontable/helpers/templateLiteralTag';
 
 describe('Helpers for template literals', () => {
   describe('toSingleLine', () => {
-    it('should strip two line string (string with whitespace at end of first line and indention at second one)', () => {
-      const text = toSingleLine`Hello world 
+    it('should strip two line string (string with whitespace in both lines)', () => {
+      const text = toSingleLine`Hello world\x20
         Hello world`;
 
       expect(text).toEqual('Hello world Hello world');
     });
 
-    it('should strip two line string (string without whitespace at end of first line and indention at second one)', () => {
+    it('should strip two line string (string with whitespace only in the second line)', () => {
       const text = toSingleLine`Hello world
         Hello world`;
+
+      expect(text).toEqual('Hello worldHello world');
+    });
+
+    it('should strip two line string (string without whitespace in both lines)', () => {
+      const text = toSingleLine`Hello world
+Hello world`;
 
       expect(text).toEqual('Hello worldHello world');
     });


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The implementation adds the ability to add warning messages for deprecated hooks (that hooks which are planned to remove) and for removed hooks from the API. All messages are printed in the console of the developer tool using `console.warn`.

The "removed" messages are the same for all hooks and it is defined here https://github.com/handsontable/handsontable/blob/feature/deprecate-warning-modify-hooks/src/pluginHooks.js#L1851. For deprecated hooks the message is always different, [here](https://github.com/handsontable/handsontable/blob/feature/deprecate-warning-modify-hooks/src/pluginHooks.js#L1882) is a prepared collection for that kind of hooks.

The messages work for `addHook` method as well for hooks added through object initialization or `updateSettings` method.

Additionally, while using `toSingleLine` I've found a bug that appeared when I tried to strip newlines from a string that didn't have any whitespace. The code doesn't work in that case. I fixed the issue and cover with the tests.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Add tests and check manually in the browser.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/6465

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
