### PR TITLE
Remove background-clip CSS prop

### DIFF
--- a/src/3rdparty/walkontable/css/walkontable.css
+++ b/src/3rdparty/walkontable/css/walkontable.css
@@ -85,7 +85,6 @@
   outline-width: 0;
   white-space: pre-line;
   /* preserve new line character in cell */
-  background-clip: padding-box;
 }
 
 .handsontable th:last-child {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The CSS property was added within #2411 where the selection was not working correctly on IE. It seems that different means fix that issue, and the `background-clip` can be removed safely.

Currently `background-clip` creates problems with Chrome - unfilled cells
![Zrzut ekranu 2020-01-10 o 11 46 52](https://user-images.githubusercontent.com/571316/72147855-c2d86680-339f-11ea-8515-648419f315c0.png)

I didn't find any side effects after removing the property.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Tested manually in IE9, IE11 and using the latest Chrome, FF, and Safari.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #6459
2. https://github.com/handsontable/handsontable/issues/6465

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
