### PR TITLE
Bump dev-dependency "tree-kill"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11581,9 +11581,9 @@
       }
     },
     "tree-kill": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.1.tgz",
-      "integrity": "sha512-4hjqbObwlh2dLyW4tcz0Ymw0ggoaVDMveUB9w8kFSQScdRLo0gxO9J7WFcUBo+W3C1TLdFIEwNOWebgZZ0RH9Q==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
       "dev": true
     },
     "trim": {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "style-loader": "^0.18.2",
     "stylelint": "^11.1.1",
     "supports-color": "^4.2.1",
-    "tree-kill": "^1.2.1",
+    "tree-kill": "^1.2.2",
     "typescript": "^3.3.3",
     "webpack": "^4.29.6",
     "webpack-cli": "^3.3.0"


### PR DESCRIPTION
### Context
An outdated dev-dependency `tree-kill` is causing builds to fail because of a high vulnerability reported by npm audit. This is fixable by running `npm audit fix`.

Link to the failing build: https://app.codeship.com/projects/26649/builds/45557707?pipeline=0912008e-8a1e-412d-b8e1-eb31a62e86ff

The npm audit report that shows the failure:

```
                       === npm audit security report ===                        
                                                                                
# Run  npm update tree-kill --depth 2  to resolve 2 vulnerabilities

 High           Command Injection                                            

 Package        tree-kill                                                    

 Dependency of  concurrently [dev]                                           

 Path           concurrently > tree-kill                                     

 More info      https://npmjs.com/advisories/1432                            




 High           Command Injection                                            

 Package        tree-kill                                                    

 Dependency of  tree-kill [dev]                                              

 Path           tree-kill                                                    

 More info      https://npmjs.com/advisories/1432                            



found 2 high severity vulnerabilities in 1773604 scanned packages
run `npm audit fix` to fix 2 of them.
```  

### How has this been tested?
All automated tests pass after this change.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
