### PR TITLE
Add a unified way to identify HOT "input" elements

### DIFF
--- a/src/editors/passwordEditor.js
+++ b/src/editors/passwordEditor.js
@@ -11,6 +11,7 @@ class PasswordEditor extends TextEditor {
 
     this.TEXTAREA = this.hot.rootDocument.createElement('input');
     this.TEXTAREA.setAttribute('type', 'password');
+    this.TEXTAREA.setAttribute('data-hot-input', ''); // Makes the element recognizable by Hot as its own component's element.
     this.TEXTAREA.className = 'handsontableInput';
     this.textareaStyle = this.TEXTAREA.style;
     this.textareaStyle.width = 0;

--- a/src/editors/textEditor.js
+++ b/src/editors/textEditor.js
@@ -214,6 +214,7 @@ class TextEditor extends BaseEditor {
     const { rootDocument } = this.hot;
 
     this.TEXTAREA = rootDocument.createElement('TEXTAREA');
+    this.TEXTAREA.setAttribute('data-hot-input', ''); // Makes the element recognizable by Hot as its own component's element.
     this.TEXTAREA.tabIndex = -1;
 
     addClass(this.TEXTAREA, 'handsontableInput');

--- a/src/helpers/dom/element.js
+++ b/src/helpers/dom/element.js
@@ -1086,13 +1086,13 @@ export function isInput(element) {
 
 /**
  * Determines if the given DOM element is an input field placed OUTSIDE of HOT.
- * Notice: By 'input' we mean input, textarea and select nodes.
+ * Notice: By 'input' we mean input, textarea and select nodes which have defined 'data-hot-input' attribute.
  *
  * @param {HTMLElement} element - DOM element.
  * @returns {boolean}
  */
 export function isOutsideInput(element) {
-  return isInput(element) && element.className.indexOf('handsontableInput') === -1 && element.className.indexOf('HandsontableCopyPaste') === -1;
+  return isInput(element) && element.hasAttribute('data-hot-input') === false;
 }
 
 /**

--- a/src/plugins/copyPaste/focusableElement.js
+++ b/src/plugins/copyPaste/focusableElement.js
@@ -156,6 +156,7 @@ function createOrGetSecondaryElement(container) {
   const element = doc.createElement('textarea');
 
   secondaryElements.set(container, element);
+  element.setAttribute('data-hot-input', ''); // Makes the element recognizable by Hot as its own component's element.
   element.className = 'HandsontableCopyPaste';
   element.tabIndex = -1;
   element.autocomplete = 'off';

--- a/test/types/editors/password.types.ts
+++ b/test/types/editors/password.types.ts
@@ -8,6 +8,7 @@ class PasswordEditor extends Handsontable.editors.TextEditor {
     // Create password input and update relevant properties
     this.TEXTAREA = document.createElement('input');
     this.TEXTAREA.setAttribute('type', 'password');
+    this.TEXTAREA.setAttribute('data-hot-input', '');
     this.TEXTAREA.className = 'handsontableInput';
     this.textareaStyle = this.TEXTAREA.style;
     this.textareaStyle.width = '0';

--- a/test/unit/helpers/dom/Element.spec.js
+++ b/test/unit/helpers/dom/Element.spec.js
@@ -266,9 +266,11 @@ describe('DomElement helper', () => {
   // Handsontable.helper.selectElementIfAllowed
   //
   describe('selectElementIfAllowed', () => {
-    it('should select hot editor', () => {
+    it('should focus known textarea element', () => {
       const textarea = document.createElement('textarea');
-      textarea.className = 'handsontableInput';
+
+      textarea.setAttribute('data-hot-input', '');
+      textarea.focus();
 
       const spy = spyOn(textarea, 'select');
 
@@ -277,8 +279,23 @@ describe('DomElement helper', () => {
       expect(spy).toHaveBeenCalled();
     });
 
-    it('shouldn\'t focus input', () => {
+    it('should not focus unknown textarea element with the same class name as HOT editor input', () => {
+      const textarea = document.createElement('textarea');
+
+      textarea.className = 'handsontableInput';
+      textarea.focus();
+
+      const spy = spyOn(textarea, 'select');
+
+      selectElementIfAllowed(textarea);
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('should not focus unknown input (bare input)', () => {
       const input = document.createElement('input');
+
+      input.focus();
 
       const spy = spyOn(input, 'focus');
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
All input elements owned by HOT got an attribute "data-hot-input" which are identified by that key. Previously it was done by searching a proper class name which was a lot less extendable.

The documentation has to be updated (https://github.com/handsontable/docs/pull/92). The "input" element which is created in the `createElements` method must have an `"data-hot-input"` attribute (https://handsontable.com/docs/7.3.0/tutorial-cell-editor.html#-passwordeditor-extending-an-existing-editor).

Currently, I've removed className checking and replaced it with attribute checking. This can be treated as a breaking change. When a developer has implemented a custom editor with class name set as "handsontableInput" (this was a workaround previously) then this stops working - the input element will lose focus. 

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
E2E tests.

It can be tested using this demo https://codesandbox.io/s/dazzling-butterfly-t85dt. With the previous version <kbd>ESC</kbd>-aping an editor didn't work https://jsfiddle.net/6po2scjb/.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #6383

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [x] My change requires a change to the documentation.
