### PR TITLE
Fix inconsistency in how the context menu closes

### DIFF
--- a/src/helpers/browser.js
+++ b/src/helpers/browser.js
@@ -22,6 +22,12 @@ const browsers = {
   safari: tester((ua, vendor) => /Safari/.test(ua) && /Apple Computer/.test(vendor)),
 };
 
+const platforms = {
+  mac: tester(platform => /^Mac/.test(platform)),
+  win: tester(platform => /^Win/.test(platform)),
+  linux: tester(platform => /^Linux/.test(platform)),
+};
+
 /**
  * @param {object} [metaObject] The browser identity collection.
  * @param {object} [metaObject.userAgent] The user agent reported by browser.
@@ -31,7 +37,16 @@ export function setBrowserMeta({ userAgent = navigator.userAgent, vendor = navig
   objectEach(browsers, ({ test }) => void test(userAgent, vendor));
 }
 
+/**
+ * @param {object} [metaObject] The platform identity collection.
+ * @param {object} [metaObject.platform] The platform ID.
+ */
+export function setPlatformMeta({ platform = navigator.platform } = {}) {
+  objectEach(platforms, ({ test }) => void test(platform));
+}
+
 setBrowserMeta();
+setPlatformMeta();
 
 /**
  * @returns {boolean}
@@ -87,4 +102,25 @@ export function isSafari() {
  */
 export function isFirefox() {
   return browsers.firefox.value;
+}
+
+/**
+ * @returns {boolean}
+ */
+export function isWindowsOS() {
+  return platforms.win.value;
+}
+
+/**
+ * @returns {boolean}
+ */
+export function isMacOS() {
+  return platforms.mac.value;
+}
+
+/**
+ * @returns {boolean}
+ */
+export function isLinuxOS() {
+  return platforms.linux.value;
 }

--- a/src/plugins/contextMenu/menu.js
+++ b/src/plugins/contextMenu/menu.js
@@ -20,6 +20,7 @@ import { KEY_CODES } from './../../helpers/unicode';
 import localHooks from './../../mixins/localHooks';
 import { SEPARATOR, NO_ITEMS, predefinedItems } from './predefinedItems';
 import { stopImmediatePropagation } from './../../helpers/dom/event';
+import { isWindowsOS } from './../../helpers/browser';
 
 const MIN_WIDTH = 215;
 
@@ -190,6 +191,11 @@ class Menu {
       rowHeights: row => (filteredItems[row].name === SEPARATOR ? 1 : 23),
       afterOnCellContextMenu: (event) => {
         event.preventDefault();
+        // On the Windows platform, the "contextmenu" is triggered after the "mouseup" so that's
+        // why the closing menu is here. (#6507#issuecomment-582392301).
+        if (isWindowsOS() && shouldAutoCloseMenu && this.hasSelectedItem()) {
+          this.close(true);
+        }
       },
       beforeOnCellMouseUp: (event) => {
         if (this.hasSelectedItem()) {
@@ -198,7 +204,9 @@ class Menu {
         }
       },
       afterOnCellMouseUp: () => {
-        if (shouldAutoCloseMenu && this.hasSelectedItem()) {
+        // If the code runs on the other platform than Windows, the "contextmenu" is triggered
+        // before the "mouseup". So then "mouseup" closes the menu (#6507#issuecomment-582392301).
+        if (!isWindowsOS() && shouldAutoCloseMenu && this.hasSelectedItem()) {
           this.close(true);
         }
       },

--- a/src/plugins/contextMenu/menu.js
+++ b/src/plugins/contextMenu/menu.js
@@ -19,7 +19,7 @@ import { filterSeparators, hasSubMenu, isDisabled, isItemHidden, isSeparator, is
 import { KEY_CODES } from './../../helpers/unicode';
 import localHooks from './../../mixins/localHooks';
 import { SEPARATOR, NO_ITEMS, predefinedItems } from './predefinedItems';
-import { stopImmediatePropagation } from './../../helpers/dom/event';
+import { stopImmediatePropagation, isRightClick } from './../../helpers/dom/event';
 import { isWindowsOS } from './../../helpers/browser';
 
 const MIN_WIDTH = 215;
@@ -203,10 +203,11 @@ class Menu {
           this.executeCommand(event);
         }
       },
-      afterOnCellMouseUp: () => {
-        // If the code runs on the other platform than Windows, the "contextmenu" is triggered
-        // before the "mouseup". So then "mouseup" closes the menu (#6507#issuecomment-582392301).
-        if (!isWindowsOS() && shouldAutoCloseMenu && this.hasSelectedItem()) {
+      afterOnCellMouseUp: (event) => {
+        // If the code runs on the other platform than Windows, the "mouseup" is triggered
+        // after the "contextmenu". So then "mouseup" closes the menu. Otherwise, the closing
+        // menu responsibility is forwarded to "afterOnCellContextMenu" callback (#6507#issuecomment-582392301).
+        if ((!isWindowsOS() || !isRightClick(event)) && shouldAutoCloseMenu && this.hasSelectedItem()) {
           this.close(true);
         }
       },

--- a/src/plugins/contextMenu/test/contextMenu.e2e.js
+++ b/src/plugins/contextMenu/test/contextMenu.e2e.js
@@ -456,7 +456,7 @@ describe('ContextMenu', () => {
         .not('.htSeparator')
         .eq(0)
         .simulate('mousedown')
-        .simulate('mouseup')
+        .simulate('mouseup');
 
       expect($('.htContextMenu').is(':visible')).toBe(false);
 
@@ -479,7 +479,7 @@ describe('ContextMenu', () => {
         .not('.htSeparator')
         .eq(0)
         .simulate('mousedown')
-        .simulate('mouseup')
+        .simulate('mouseup');
 
       expect($('.htContextMenu').is(':visible')).toBe(false);
 

--- a/src/plugins/contextMenu/test/contextMenu.e2e.js
+++ b/src/plugins/contextMenu/test/contextMenu.e2e.js
@@ -440,26 +440,53 @@ describe('ContextMenu', () => {
       expect($('.htContextMenu').is(':visible')).toBe(false);
     });
 
-    it('should close menu after click under the menu', () => {
+    it('should close menu after left click on menu item (Windows OS simulation)', () => {
+      Handsontable.helper.setPlatformMeta({ platform: 'Win' }); // Let HoT think that it runs on Windows OS
       handsontable({
-        data: createSpreadsheetData(500, 10),
-        contextMenu: true,
-        height: 500
+        data: createSpreadsheetData(4, 4),
+        contextMenu: ['row_above', 'remove_row', '---------', 'alignment'],
+        height: 400,
       });
 
+      selectCell(0, 0);
       contextMenu();
 
-      expect($('.htContextMenu').is(':visible')).toBe(true);
-
-      const rect = $('.htContextMenu')[0].getBoundingClientRect();
-      const x = parseInt(rect.left + (rect.width / 2), 10);
-      const y = parseInt(rect.top + rect.height, 10);
-      mouseDown(document.elementFromPoint(x, y));
+      $('.htContextMenu .ht_master .htCore')
+        .find('tbody td')
+        .not('.htSeparator')
+        .eq(0)
+        .simulate('mousedown')
+        .simulate('mouseup')
 
       expect($('.htContextMenu').is(':visible')).toBe(false);
+
+      Handsontable.helper.setPlatformMeta(); // Reset platform
     });
 
-    it('should close menu after right click on menu item (#6507#issuecomment-582392301)', () => {
+    it('should close menu after left click on menu item (macOS and others OS simulation)', () => {
+      Handsontable.helper.setPlatformMeta({ platform: 'MacIntel' }); // Let HoT think that it runs on macOS
+      handsontable({
+        data: createSpreadsheetData(4, 4),
+        contextMenu: ['row_above', 'remove_row', '---------', 'alignment'],
+        height: 400,
+      });
+
+      selectCell(0, 0);
+      contextMenu();
+
+      $('.htContextMenu .ht_master .htCore')
+        .find('tbody td')
+        .not('.htSeparator')
+        .eq(0)
+        .simulate('mousedown')
+        .simulate('mouseup')
+
+      expect($('.htContextMenu').is(':visible')).toBe(false);
+
+      Handsontable.helper.setPlatformMeta(); // Reset platform
+    });
+
+    it('should close menu after right click on menu item (Windows OS simulation, #6507#issuecomment-582392301)', () => {
       Handsontable.helper.setPlatformMeta({ platform: 'Win' }); // Let HoT think that it runs on Windows OS
       handsontable({
         data: createSpreadsheetData(4, 4),
@@ -480,13 +507,57 @@ describe('ContextMenu', () => {
         .find('tbody td')
         .not('.htSeparator')
         .eq(0)
-        .simulate('mousedown')
-        .simulate('mouseup')
+        .simulate('mousedown', { button: 2 })
+        .simulate('mouseup', { button: 2 })
         .simulate('contextmenu');
 
       expect($('.htContextMenu').is(':visible')).toBe(false);
 
       Handsontable.helper.setPlatformMeta(); // Reset platform
+    });
+
+    it('should close menu after right click on menu item (mac OS and others OS simulation, #6507#issuecomment-582392301)', () => {
+      Handsontable.helper.setPlatformMeta({ platform: 'MacIntel' }); // Let HoT think that it runs on macOS
+      handsontable({
+        data: createSpreadsheetData(4, 4),
+        contextMenu: ['row_above', 'remove_row', '---------', 'alignment'],
+        height: 400,
+      });
+
+      selectCell(0, 0);
+      contextMenu();
+
+      // Order of events occurrence on macOS machines is "mousedown" -> "contextmenu" -> "mouseup"
+      $('.htContextMenu .ht_master .htCore')
+        .find('tbody td')
+        .not('.htSeparator')
+        .eq(0)
+        .simulate('mousedown', { button: 2 })
+        .simulate('contextmenu')
+        .simulate('mouseup', { button: 2 });
+
+      expect($('.htContextMenu').is(':visible')).toBe(false);
+
+      Handsontable.helper.setPlatformMeta(); // Reset platform
+    });
+
+    it('should close menu after click under the menu', () => {
+      handsontable({
+        data: createSpreadsheetData(500, 10),
+        contextMenu: true,
+        height: 500
+      });
+
+      contextMenu();
+
+      expect($('.htContextMenu').is(':visible')).toBe(true);
+
+      const rect = $('.htContextMenu')[0].getBoundingClientRect();
+      const x = parseInt(rect.left + (rect.width / 2), 10);
+      const y = parseInt(rect.top + rect.height, 10);
+      mouseDown(document.elementFromPoint(x, y));
+
+      expect($('.htContextMenu').is(':visible')).toBe(false);
     });
   });
 
@@ -3256,7 +3327,8 @@ describe('ContextMenu', () => {
       expect(callback.calls.count()).toBe(0);
     });
 
-    it('should not open another instance of ContextMenu after fireing command by the RMB', () => {
+    it('should not open another instance of ContextMenu after fireing command by the RMB (Windows OS simulation)', () => {
+      Handsontable.helper.setPlatformMeta({ platform: 'Win' }); // Let HoT think that it runs on Windows OS
       handsontable({
         contextMenu: {
           items: {
@@ -3271,12 +3343,44 @@ describe('ContextMenu', () => {
 
       contextMenu();
 
+      // Order of events occurrence on Windows machines is "mousedown" -> "mouseup" -> "contextmenu"
       $('.htContextMenu .ht_master .htCore').find('tbody td:eq(0)')
         .simulate('mousedown', { button: 2 })
+        .simulate('mouseup', { button: 2 })
+        .simulate('contextmenu')
+      ;
+
+      expect($('.htContextMenu').is(':visible')).toBe(false);
+
+      Handsontable.helper.setPlatformMeta(); // Reset platform
+    });
+
+    it('should not open another instance of ContextMenu after fireing command by the RMB (macOS and others simulation)', () => {
+      Handsontable.helper.setPlatformMeta({ platform: 'MacIntel' }); // Let HoT think that it runs on macOS
+      handsontable({
+        contextMenu: {
+          items: {
+            item1: {
+              name: 'Item',
+              callback: () => {},
+            },
+          },
+        },
+        height: 100
+      });
+
+      contextMenu();
+
+      // Order of events occurrence on macOS machines is "mousedown" -> "contextmenu" -> "mouseup"
+      $('.htContextMenu .ht_master .htCore').find('tbody td:eq(0)')
+        .simulate('mousedown', { button: 2 })
+        .simulate('contextmenu')
         .simulate('mouseup', { button: 2 })
       ;
 
       expect($('.htContextMenu').is(':visible')).toBe(false);
+
+      Handsontable.helper.setPlatformMeta(); // Reset platform
     });
   });
 

--- a/src/plugins/contextMenu/test/contextMenu.e2e.js
+++ b/src/plugins/contextMenu/test/contextMenu.e2e.js
@@ -458,6 +458,36 @@ describe('ContextMenu', () => {
 
       expect($('.htContextMenu').is(':visible')).toBe(false);
     });
+
+    it('should close menu after right click on menu item (#6507#issuecomment-582392301)', () => {
+      Handsontable.helper.setPlatformMeta({ platform: 'Win' }); // Let HoT think that it runs on Windows OS
+      handsontable({
+        data: createSpreadsheetData(4, 4),
+        contextMenu: ['row_above', 'remove_row', '---------', 'alignment'],
+        height: 400,
+        beforeOnCellContextMenu(event) {
+          // Block event priopagation to test if the "contextmenu" handler closes the menu.
+          Handsontable.dom.stopImmediatePropagation(event);
+        }
+      });
+
+      selectCell(0, 0);
+      contextMenu();
+
+      // Order of events occurrence on Windows machines is "mousedown" -> "mouseup" -> "contextmenu" (other OS'
+      // have "mousedown" -> "contextmenu" -> "mouseup").
+      $('.htContextMenu .ht_master .htCore')
+        .find('tbody td')
+        .not('.htSeparator')
+        .eq(0)
+        .simulate('mousedown')
+        .simulate('mouseup')
+        .simulate('contextmenu');
+
+      expect($('.htContextMenu').is(':visible')).toBe(false);
+
+      Handsontable.helper.setPlatformMeta(); // Reset platform
+    });
   });
 
   describe('menu disabled', () => {

--- a/test/unit/helpers/Browser.spec.js
+++ b/test/unit/helpers/Browser.spec.js
@@ -6,7 +6,11 @@ import {
   isMobileBrowser,
   isMSBrowser,
   isSafari,
+  isWindowsOS,
+  isMacOS,
+  isLinuxOS,
   setBrowserMeta,
+  setPlatformMeta,
 } from 'handsontable/helpers/browser';
 
 describe('Browser helper', () => {
@@ -436,6 +440,144 @@ describe('Browser helper', () => {
       });
 
       expect(isFirefox()).toBeFalsy();
+    });
+  });
+
+  describe('isWindowsOS', () => {
+    it('should recognize platform correctly', () => {
+      setPlatformMeta({
+        platform: 'MacIntel'
+      });
+
+      expect(isWindowsOS()).toBeFalsy();
+
+      setPlatformMeta({
+        platform: 'Linux armv7l'
+      });
+
+      expect(isWindowsOS()).toBeFalsy();
+
+      setPlatformMeta({
+        platform: 'Linux i686'
+      });
+
+      expect(isWindowsOS()).toBeFalsy();
+
+      setPlatformMeta({
+        platform: 'Linux x86_64'
+      });
+
+      expect(isWindowsOS()).toBeFalsy();
+
+      setPlatformMeta({
+        platform: 'HP-UX'
+      });
+
+      expect(isWindowsOS()).toBeFalsy();
+
+      setPlatformMeta({
+        platform: 'Win'
+      });
+
+      expect(isWindowsOS()).toBeTruthy();
+
+      setPlatformMeta({
+        platform: 'Win32'
+      });
+
+      expect(isWindowsOS()).toBeTruthy();
+    });
+  });
+
+  describe('isMacOS', () => {
+    it('should recognize platform correctly', () => {
+      setPlatformMeta({
+        platform: 'Win'
+      });
+
+      expect(isMacOS()).toBeFalsy();
+
+      setPlatformMeta({
+        platform: 'Win32'
+      });
+
+      expect(isMacOS()).toBeFalsy();
+
+      setPlatformMeta({
+        platform: 'Linux i686'
+      });
+
+      expect(isMacOS()).toBeFalsy();
+
+      setPlatformMeta({
+        platform: 'Linux x86_64'
+      });
+
+      expect(isMacOS()).toBeFalsy();
+
+      setPlatformMeta({
+        platform: 'HP-UX'
+      });
+
+      expect(isMacOS()).toBeFalsy();
+
+      setPlatformMeta({
+        platform: 'Mac'
+      });
+
+      expect(isMacOS()).toBeTruthy();
+
+      setPlatformMeta({
+        platform: 'MacIntel'
+      });
+
+      expect(isMacOS()).toBeTruthy();
+    });
+  });
+
+  describe('isLinuxOS', () => {
+    it('should recognize platform correctly', () => {
+      setPlatformMeta({
+        platform: 'Win'
+      });
+
+      expect(isLinuxOS()).toBeFalsy();
+
+      setPlatformMeta({
+        platform: 'Win32'
+      });
+
+      expect(isLinuxOS()).toBeFalsy();
+
+      setPlatformMeta({
+        platform: 'Mac'
+      });
+
+      expect(isLinuxOS()).toBeFalsy();
+
+      setPlatformMeta({
+        platform: 'MacIntel'
+      });
+
+      expect(isLinuxOS()).toBeFalsy();
+
+      setPlatformMeta({
+        platform: 'HP-UX'
+      });
+
+      expect(isLinuxOS()).toBeFalsy();
+
+      setPlatformMeta({
+        platform: 'Linux i686'
+      });
+
+      expect(isLinuxOS()).toBeTruthy();
+
+      setPlatformMeta({
+        platform: 'Linux x86_64'
+      });
+
+      expect(isLinuxOS()).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
On Windows machine, the "contextmenu" event is fired after the "mouseup"
event. This causes a bug where the context menu was not closed after
clicking the menu item by RMB. I've added a new helper which detects on
what OS the code runs and add proper conditional to support the
differences between Windows vs Linux and macOS.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Tested manually in Windows, Linux, and macOS.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #6507
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
