### PR TITLE
Fixed `closest` helper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3270,6 +3270,12 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/mime-types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.0.tgz",
+      "integrity": "sha1-nKUs2jY/aZxpRmwqbM2q2RPqenM=",
+      "dev": true
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -3575,13 +3581,10 @@
       "dev": true
     },
     "agent-base": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
-      "dev": true,
-      "requires": {
-        "es6-promisify": "^5.0.0"
-      }
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
+      "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
+      "dev": true
     },
     "ajv": {
       "version": "6.10.2",
@@ -5873,15 +5876,6 @@
       "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
       "dev": true
     },
-    "es6-promisify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "dev": true,
-      "requires": {
-        "es6-promise": "^4.0.3"
-      }
-    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -7956,19 +7950,19 @@
       "dev": true
     },
     "https-proxy-agent": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
-      "integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
+      "integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
       "dev": true,
       "requires": {
-        "agent-base": "^4.3.0",
-        "debug": "^3.1.0"
+        "agent-base": "5",
+        "debug": "4"
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
@@ -11525,15 +11519,17 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-2.0.0.tgz",
-      "integrity": "sha512-t3MmTWzQxPRP71teU6l0jX47PHXlc4Z52sQv4LJQSZLq1ttkKS2yGM3gaI57uQwZkNaoGd0+HPPMELZkcyhlqA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-2.1.1.tgz",
+      "integrity": "sha512-LWzaDVQkk1EPiuYeTOj+CZRIjda4k2s5w4MK4xoH2+kgWV/SDlkYHmxatDdtYrciHUKSXTsGgPgPP8ILVdBsxg==",
       "dev": true,
       "requires": {
+        "@types/mime-types": "^2.1.0",
         "debug": "^4.1.0",
         "extract-zip": "^1.6.6",
-        "https-proxy-agent": "^3.0.0",
+        "https-proxy-agent": "^4.0.0",
         "mime": "^2.0.3",
+        "mime-types": "^2.1.25",
         "progress": "^2.0.1",
         "proxy-from-env": "^1.0.0",
         "rimraf": "^2.6.1",
@@ -11547,6 +11543,21 @@
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
+          }
+        },
+        "mime-db": {
+          "version": "1.43.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+          "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==",
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.26",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+          "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+          "dev": true,
+          "requires": {
+            "mime-db": "1.43.0"
           }
         },
         "ms": {

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "on-build-webpack": "^0.1.0",
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "progress-bar-webpack-plugin": "^1.10.0",
-    "puppeteer": "^2.0.0",
+    "puppeteer": "^2.1.1",
     "rimraf": "^2.5.4",
     "spawn-command": "0.0.2",
     "string-replace-webpack-plugin": "^0.1.3",

--- a/src/helpers/dom/element.js
+++ b/src/helpers/dom/element.js
@@ -67,23 +67,50 @@ export function hasAccessToParentWindow(frame) {
 }
 
 /**
- * Goes up the DOM tree (including given element) until it finds an element that matches the nodes or nodes name.
+ * Goes up the DOM tree (including given element) until it finds an parent element that matches the nodes or nodes name.
  * This method goes up through web components.
  *
- * @param {HTMLElement} element Element from which traversing is started.
- * @param {Array} nodes Array of elements or Array of elements name.
- * @param {HTMLElement} [until] The element until the traversing ends.
- * @returns {HTMLElement|null}
+ * @param {Node} element Element from which traversing is started.
+ * @param {(string | Node)[]} nodes Array of elements or Array of elements name.
+ * @param {EventTarget} [until] The element until the traversing ends.
+ * @returns {EventTarget|null}
  */
 export function closest(element, nodes, until) {
+  if (!element) {
+    throw new Error('Element has to be defined');
+  }
+
+  // support for Window
+  if (element.frameElement !== void 0) {
+    return null;
+  }
+
+  if (!element.cloneNode) {
+    throw new Error('Element has to be valid "Node" element');
+  }
+
+  if (!nodes) {
+    throw new Error('Nodes list has to be defined');
+  }
+
+  if (nodes.length === 0) {
+    throw new Error('Nodes list has to has at least one element');
+  }
+
+  const { ELEMENT_NODE, DOCUMENT_FRAGMENT_NODE } = Node;
   let elementToCheck = element;
 
-  while (elementToCheck !== null && elementToCheck !== until) {
-    if (elementToCheck.nodeType === Node.ELEMENT_NODE && (nodes.indexOf(elementToCheck.nodeName) > -1 || nodes.indexOf(elementToCheck) > -1)) {
+  while (elementToCheck && elementToCheck !== until) {
+    const { nodeType, nodeName } = elementToCheck;
+
+    if (nodeType === ELEMENT_NODE && (nodes.includes(nodeName) || nodes.includes(elementToCheck))) {
       return elementToCheck;
     }
-    if (elementToCheck.host && elementToCheck.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
-      elementToCheck = elementToCheck.host;
+
+    const { host } = elementToCheck;
+
+    if (host && nodeType === DOCUMENT_FRAGMENT_NODE) {
+      elementToCheck = host;
 
     } else {
       elementToCheck = elementToCheck.parentNode;

--- a/test/e2e/Core_resize.spec.js
+++ b/test/e2e/Core_resize.spec.js
@@ -82,4 +82,16 @@ describe('Core resize', () => {
     expect(getLeftClone().height()).toBe(200);
     expect(getBottomLeftClone().height()).toBe(24);
   });
+
+  // Unfortunately, it doesn't test as expected in headless chromium :(
+  it('should not throw an error if `hot-table` element is the container', () => {
+    spec().$container.html('<hot-table></hot-table>');
+
+    expect(() => {
+      const hot = new Handsontable(document.querySelector('hot-table'), {});
+      window.dispatchEvent(new Event('resize'));
+      hot.destroy();
+
+    }).not.toThrow();
+  });
 });

--- a/test/unit/helpers/dom/Element.spec.js
+++ b/test/unit/helpers/dom/Element.spec.js
@@ -1,5 +1,6 @@
 import {
   addClass,
+  closest,
   closestDown,
   getParent,
   hasClass,
@@ -25,6 +26,114 @@ describe('DomElement helper', () => {
       div.contentEditable = 'true';
 
       expect(isInput(div)).toBe(true);
+    });
+  });
+
+  //
+  // Handsontable.helper.closest
+  //
+  describe('closest', () => {
+    describe('catching errors', () => {
+      it('should throw an error if element is falsy (null, undefined)', () => {
+        expect(() => {
+          closest();
+        }).toThrow('Element has to be defined');
+      });
+
+      it('shoult throw an error if element is not an valid Node element', () => {
+        const element = 123;
+
+        expect(() => {
+          closest(element);
+        }).toThrow('Element has to be valid "Node" element');
+      });
+
+      it('should throw an error if nodes is not defined', () => {
+        const element = document.createElement('div');
+
+        expect(() => {
+          closest(element);
+        }).toThrow('Nodes list has to be defined');
+      });
+
+      it('should throw an error if nodes is an empty array', () => {
+        const element = document.createElement('div');
+
+        expect(() => {
+          closest(element, []);
+        }).toThrow('Nodes list has to has at least one element');
+      });
+    });
+
+    describe('lookup for the closest element', () => {
+      let wrapper = null;
+
+      beforeEach(() => {
+        wrapper = document.createElement('div');
+      });
+
+      afterEach(() => {
+        wrapper = null;
+      });
+
+      it('should return element itself if the searched elment is the same one', () => {
+        wrapper.innerHTML = '<a><b><c></c></b></a>';
+
+        const element = wrapper.querySelector('c');
+        const nodes = [element];
+
+        expect(closest(element, nodes)).toBe(element);
+      });
+
+      it('should return null if the searched element is also an until element', () => {
+        wrapper.innerHTML = '<a><b><c></c></b></a>';
+
+        const element = wrapper.querySelector('c');
+        const nodes = ['a', 'b'];
+        const until = element;
+
+        expect(closest(element, nodes, until)).toBe(null);
+      });
+
+      it('should return null if doesn\'t find any element fitting to the nodes\' list', () => {
+        wrapper.innerHTML = '<a><b><c></c></b></a>';
+
+        const element = wrapper.querySelector('c');
+        const nodes = ['x', 'y', 'z'];
+
+        expect(closest(element, nodes)).toBe(null);
+      });
+
+      it('should return null if the searched element lies over until element', () => {
+        wrapper.innerHTML = '<a><b><c></c></b></a>';
+
+        const element = wrapper.querySelector('c');
+        const nodes = ['a'];
+        const until = wrapper.querySelector('b');
+
+        expect(closest(element, nodes, until)).toBe(null);
+      });
+
+      it('should return the closest parent from the starting element', () => {
+        wrapper.innerHTML = '<a><b><c></c></b></a>';
+
+        const parentA = wrapper.querySelector('a');
+        const parentB = wrapper.querySelector('b');
+        const element = wrapper.querySelector('c');
+        const nodes = [parentA, parentB];
+
+        expect(closest(element, nodes)).toBe(parentB);
+      });
+
+      it('should not throw an error if window is starting element', () => {
+        wrapper.innerHTML = '<a><b><c></c></b></a>';
+
+        const element = window;
+        const nodes = ['a'];
+        const until = wrapper.querySelector('b');
+
+        expect(closest(element, nodes, until)).toBe(null);
+      });
     });
   });
 


### PR DESCRIPTION
### Context
Chromium v80 drops out support for ShadowDOMv0 - and accidentally due to legacy solution in `eventExtend` (part of EventManager) browser goes through `closest` helper.
During `ESLINT` fewer, I adjusted this helper under `no-param-reassing` rule, but unfortunately, I didn't notice I changed `while`'s condition 😞(perhaps I counted on tests?).

This time I added tests and rewrote helper a little bit (with errors reporting).

BTW. This helper should be named: `closestParent` to be clear what it's doing actually 😉

### How has this been tested?
In unit and E2E tests.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality) - Error reporting is an improvement?

### Related issue(s):
1. #6710 

### Checklist:
- [x] My code follows the code style of this project
