### PR TITLE
Improve hiddenRows performance by using a Set internally

### DIFF
--- a/src/plugins/filters/filters.js
+++ b/src/plugins/filters/filters.js
@@ -829,7 +829,7 @@ class Filters extends BasePlugin {
    * @param {number} rowIndex Physical row index.
    */
   saveHiddenRowsCache(rowIndex) {
-    this.hiddenRowsCache.set(rowIndex, this.dropdownMenuPlugin.menu.hotMenu.getPlugin('hiddenRows').hiddenRows);
+    this.hiddenRowsCache.set(rowIndex, Array.from(this.dropdownMenuPlugin.menu.hotMenu.getPlugin('hiddenRows').hiddenRows));
   }
 
   /**

--- a/src/plugins/hiddenRows/contextMenuItem/showRow.js
+++ b/src/plugins/hiddenRows/contextMenuItem/showRow.js
@@ -64,7 +64,7 @@ export default function showRowItem(hiddenRowsPlugin) {
     },
     disabled: false,
     hidden() {
-      if (!hiddenRowsPlugin.hiddenRows.length || !this.selection.isSelectedByRowHeader()) {
+      if (!hiddenRowsPlugin.hiddenRows.size || !this.selection.isSelectedByRowHeader()) {
         return true;
       }
 
@@ -83,7 +83,7 @@ export default function showRowItem(hiddenRowsPlugin) {
         rangeEach(0, totalRowsLength, (i) => {
           const partedHiddenLength = beforeHiddenRows.length + afterHiddenRows.length;
 
-          if (partedHiddenLength === hiddenRowsPlugin.hiddenRows.length) {
+          if (partedHiddenLength === hiddenRowsPlugin.hiddenRows.size) {
             return false;
           }
 

--- a/src/plugins/hiddenRows/test/hiddenRows.e2e.js
+++ b/src/plugins/hiddenRows/test/hiddenRows.e2e.js
@@ -272,7 +272,8 @@ describe('HiddenRows', () => {
       const plugin = hot.getPlugin('hiddenRows');
       hot.alter('insert_row', 0, 2);
 
-      expect(plugin.hiddenRows[0]).toEqual(5);
+      expect(plugin.isHidden(3)).toBeFalsy();
+      expect(plugin.isHidden(5)).toBeTruthy();
     });
 
     it('should recalculate index of the hidden rows after remove rows', () => {
@@ -288,7 +289,8 @@ describe('HiddenRows', () => {
       const plugin = hot.getPlugin('hiddenRows');
       hot.alter('remove_row', 0, 2);
 
-      expect(plugin.hiddenRows[0]).toEqual(1);
+      expect(plugin.isHidden(3)).toBeFalsy();
+      expect(plugin.isHidden(1)).toBeTruthy();
     });
   });
 
@@ -604,7 +606,8 @@ describe('HiddenRows', () => {
       manualRowMove.moveRows([0, 1], 3);
       hot.render();
 
-      expect(hiddenRows.hiddenRows[0]).toEqual(3);
+      expect(hiddenRows.isHidden(3)).toBeFalsy();
+      expect(hiddenRows.isHidden(1)).toBeTruthy();
       expect(hot.getRowHeight(1)).toEqual(0.1);
     });
   });


### PR DESCRIPTION
### Context
The current `hiddenRows` plugin gets slow with large tables. This is because internally the set of hidden rows is stored as a list, and `.includes()` takes linear time, causing `.isHidden()` to be linear and `.render()` and `.showRows()` quadratic.

With this change, we keep a `Set` instead of a list internally, making `.isHidden()` logarithmic and `.render()` and `.showRows()` *n* log(*n*).

### How has this been tested?
On a private project and using the test suite.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
- #4381

### Checklist:
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.

### Questions / notes:
1. If users rely on the type of the `hiddenRows` member things may break. This member is undocumented and private, though. However it may be a good idea to add a method `.getHiddenRows()` which returns an array. Then it is also easily possible to show all rows again, using `hr.showRows(hr.getHiddenRows())` (or perhaps I'm overlooking a way to do this?).
2. Could you suggest how to add a test for a performance thing like this?
3. If you're OK with this change, I can do the same for `hiddenColumns` (although it's probably less urgent there as tables tend to have more rows than columns), but I thought I'd check first.