### PR TITLE
Additional test in autofill plugin

### DIFF
--- a/src/plugins/autofill/autofill.js
+++ b/src/plugins/autofill/autofill.js
@@ -194,6 +194,7 @@ class Autofill extends BasePlugin {
    * Try to apply fill values to the area in fill border, omitting the selection border.
    *
    * @private
+   * @returns {boolean} Reports if fill was applied.
    *
    * @fires Hooks#modifyAutofillRange
    * @fires Hooks#beforeAutofill
@@ -201,7 +202,7 @@ class Autofill extends BasePlugin {
    */
   fillIn() {
     if (this.hot.selection.highlight.getFill().isEmpty()) {
-      return;
+      return false;
     }
 
     let cornersOfSelectionAndDragAreas = this.hot.selection.highlight.getFill().getCorners();
@@ -220,7 +221,8 @@ class Autofill extends BasePlugin {
       if (beforeAutofillHook === false) {
         this.hot.selection.highlight.getFill().clear();
         this.hot.render();
-        return;
+
+        return false;
       }
 
       const deltas = getDeltas(startOfDragCoords, endOfDragCoords, selectionData, directionOfDrag);
@@ -272,6 +274,8 @@ class Autofill extends BasePlugin {
       // reset to avoid some range bug
       this.hot._refreshBorders();
     }
+
+    return true;
   }
 
   /**

--- a/src/plugins/autofill/test/autofill.e2e.js
+++ b/src/plugins/autofill/test/autofill.e2e.js
@@ -935,7 +935,7 @@ describe('AutoFill', () => {
   });
 
   it('should run afterAutofill once after each set of autofill changes have been applied', () => {
-    let count = 0;
+    const afterAutofill = jasmine.createSpy('afterAutofill');
 
     handsontable({
       data: [
@@ -944,16 +944,14 @@ describe('AutoFill', () => {
         [4, 5, 6, 7, 8, 9],
         [1, 2, 3, 4, 5, 6]
       ],
-      afterAutofill: () => {
-        count += 1;
-      }
+      afterAutofill
     });
 
     selectCell(0, 0);
     spec().$container.find('.wtBorder.current.corner').simulate('mousedown');
     spec().$container.find('tbody tr:eq(0) td:eq(1)').simulate('mouseover').simulate('mouseup');
 
-    expect(getDataAtCell(0, 1)).toEqual(1);
+    expect(afterAutofill).toHaveBeenCalledTimes(1);
 
     selectCell(0, 0);
     spec().$container.find('.wtBorder.current.corner').simulate('mousedown');
@@ -961,10 +959,10 @@ describe('AutoFill', () => {
 
     expect(getDataAtCell(1, 0)).toEqual(1);
 
-    expect(count).toEqual(2);
+    expect(afterAutofill).toHaveBeenCalledTimes(2);
   });
 
-  it('should does not call afterAutofill if beforeAutofill returns false', () => {
+  it('should not call afterAutofill if beforeAutofill returns false', () => {
     const afterAutofill = jasmine.createSpy('afterAutofill');
 
     handsontable({

--- a/src/plugins/autofill/test/autofill.e2e.js
+++ b/src/plugins/autofill/test/autofill.e2e.js
@@ -936,6 +936,7 @@ describe('AutoFill', () => {
 
   it('should run afterAutofill once after each set of autofill changes have been applied', () => {
     let count = 0;
+
     handsontable({
       data: [
         [1, 2, 3, 4, 5, 6],
@@ -961,5 +962,36 @@ describe('AutoFill', () => {
     expect(getDataAtCell(1, 0)).toEqual(1);
 
     expect(count).toEqual(2);
+  });
+
+  it('should does not call afterAutofill if beforeAutofill returns false', () => {
+    let count = 0;
+
+    handsontable({
+      data: [
+        [1, 2, 3, 4, 5, 6],
+        [1, 2, 3, 4, 5, 6],
+        [1, 2, 3, 4, 5, 6],
+        [1, 2, 3, 4, 5, 6]
+      ],
+      beforeAutofill() {
+        return false;
+      },
+      afterAutofill: () => {
+        count += 1;
+      }
+    });
+
+    selectCell(0, 0);
+    spec().$container.find('.wtBorder.current.corner').simulate('mousedown');
+    spec().$container.find('tbody tr:eq(0) td:eq(1)').simulate('mouseover').simulate('mouseup');
+
+    expect(count).toEqual(0);
+
+    selectCell(0, 0);
+    spec().$container.find('.wtBorder.current.corner').simulate('mousedown');
+    spec().$container.find('tbody tr:eq(1) td:eq(0)').simulate('mouseover').simulate('mouseup');
+
+    expect(count).toEqual(0);
   });
 });

--- a/src/plugins/autofill/test/autofill.e2e.js
+++ b/src/plugins/autofill/test/autofill.e2e.js
@@ -965,7 +965,7 @@ describe('AutoFill', () => {
   });
 
   it('should does not call afterAutofill if beforeAutofill returns false', () => {
-    let count = 0;
+    const afterAutofill = jasmine.createSpy('afterAutofill');
 
     handsontable({
       data: [
@@ -977,21 +977,19 @@ describe('AutoFill', () => {
       beforeAutofill() {
         return false;
       },
-      afterAutofill: () => {
-        count += 1;
-      }
+      afterAutofill,
     });
 
     selectCell(0, 0);
     spec().$container.find('.wtBorder.current.corner').simulate('mousedown');
     spec().$container.find('tbody tr:eq(0) td:eq(1)').simulate('mouseover').simulate('mouseup');
 
-    expect(count).toEqual(0);
+    expect(afterAutofill).toHaveBeenCalledTimes(0);
 
     selectCell(0, 0);
     spec().$container.find('.wtBorder.current.corner').simulate('mousedown');
     spec().$container.find('tbody tr:eq(1) td:eq(0)').simulate('mouseover').simulate('mouseup');
 
-    expect(count).toEqual(0);
+    expect(afterAutofill).toHaveBeenCalledTimes(0);
   });
 });


### PR DESCRIPTION
### Context
I added a test scenario which I check that if `beforeAutofill` return false `afterAutofill` hook doesn't call.

Additionally, I restore returned boolean value from `fillIn` method. It was removed in PR https://github.com/handsontable/handsontable/pull/5791 but I change my mind. I suppose that all of this information about returned value is valuable.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue:
1. #6756

### Related PRs:
1. https://github.com/handsontable/handsontable/pull/5791
2. https://github.com/handsontable/handsontable/pull/6704

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
