### PR TITLE
Fix addClass if some classes in an array are the empty string

### DIFF
--- a/src/helpers/dom/element.js
+++ b/src/helpers/dom/element.js
@@ -208,20 +208,11 @@ let _removeClass;
  * @returns {string[]}
  */
 function filterEmptyClassNames(classNames) {
-  const result = [];
-
   if (!classNames || !classNames.length) {
-    return result;
+    return [];
   }
 
-  let len = 0;
-
-  while (classNames[len]) {
-    result.push(classNames[len]);
-    len += 1;
-  }
-
-  return result;
+  return classNames.filter(x => !!x);
 }
 
 if (isClassListSupported()) {

--- a/src/helpers/dom/element.js
+++ b/src/helpers/dom/element.js
@@ -292,7 +292,6 @@ if (isClassListSupported()) {
   };
 
   _addClass = function(element, classes) {
-    let len = 0;
     let _className = element.className;
     let className = classes;
 
@@ -303,11 +302,10 @@ if (isClassListSupported()) {
       _className = className.join(' ');
 
     } else {
-      while (className && className[len]) {
-        if (!createClassNameRegExp(className[len]).test(_className)) {
+      for (let len = 0; len < className.length; len++) {
+        if (className[len] && !createClassNameRegExp(className[len]).test(_className)) {
           _className += ` ${className[len]}`;
         }
-        len += 1;
       }
     }
     element.className = _className;

--- a/src/renderers/_cellDecorator.js
+++ b/src/renderers/_cellDecorator.js
@@ -17,11 +17,7 @@ function cellDecorator(instance, TD, row, col, prop, value, cellProperties) {
   const classesToRemove = [];
 
   if (cellProperties.className) {
-    if (TD.className) {
-      TD.className = `${TD.className} ${cellProperties.className}`;
-    } else {
-      TD.className = cellProperties.className;
-    }
+    addClass(TD, cellProperties.className);
   }
 
   if (cellProperties.readOnly) {

--- a/test/e2e/renderers/cellDecorator.spec.js
+++ b/test/e2e/renderers/cellDecorator.spec.js
@@ -117,4 +117,15 @@ describe('CellDecorator', () => {
       done();
     }, 200);
   });
+
+  // When PR#6425 has been approved I will move this test to className.spec.js
+  it('should add all CSS classes to each cell without removing old one (passed as an array)', () => {
+    handsontable({
+      data: [[1, true]],
+      className: ['First', 'Second', '', 'Third'],
+    });
+
+    expect(getCell(0, 0).className).toBe('First Second Third');
+    expect(getCell(0, 1).className).toBe('First Second Third');
+  });
 });

--- a/test/unit/helpers/dom/Element.spec.js
+++ b/test/unit/helpers/dom/Element.spec.js
@@ -282,6 +282,12 @@ describe('DomElement helper', () => {
       expect(element.className).toBe('test1 test2 test4 test3');
     });
 
+    it('should add all CSS classes without removing old one (passed as an array)', () => {
+      addClass(element, ['test2', 'test4', '', 'test3']);
+
+      expect(element.className).toBe('test1 test2 test4 test3');
+    });
+
     it('should not touch the DOM element when the passed argument is empty', () => {
       const elementMock = {
         classList: {

--- a/test/unit/helpers/dom/Element.spec.js
+++ b/test/unit/helpers/dom/Element.spec.js
@@ -307,6 +307,12 @@ describe('DomElement helper', () => {
 
       expect(elementMock.classList.add).not.toHaveBeenCalled();
     });
+
+    it('should filter empty and falsy classNames', () => {
+      addClass(element, [undefined, null, '', false, 'false']); // only the last one is not filtered
+
+      expect(element.className).toBe('false');
+    });
   });
 
   /**

--- a/test/unit/helpers/dom/Element.spec.js
+++ b/test/unit/helpers/dom/Element.spec.js
@@ -317,7 +317,7 @@ describe('DomElement helper', () => {
     it('should filter empty and falsy classNames', () => {
       addClass(element, [undefined, null, '', false, 'false']); // only the last one is not filtered
 
-      expect(element.className).toBe('false');
+      expect(element.className).toBe('test1 false');
     });
   });
 


### PR DESCRIPTION
### Context
@zachary822 in PR #6369 started fixing this error. 
After a deeper analysis, we decided to merge his approach with @warpech which improve `filterEmptyClassNames` function. 

And based on these improvements we can complete the bug fix.

`className` setting add a class name not only for the Handsontable container element but for every cell. If we use this settings `className: ['First', 'Second', '', 'Third']` after involved improvements we get `First Second Third` class name on the container, but in the cell `First,Second,,Third`. 
So I suppose we need correcting in the cells too.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #6371 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
