### PR TITLE
docs: Fix simple typo, specyfied -> specified

### DIFF
--- a/src/3rdparty/walkontable/src/calculator/viewportColumns.js
+++ b/src/3rdparty/walkontable/src/calculator/viewportColumns.js
@@ -19,7 +19,7 @@ class ViewportColumnsCalculator {
   }
 
   /**
-   * @param {object} options Object with all options specyfied for column viewport calculation.
+   * @param {object} options Object with all options specified for column viewport calculation.
    * @param {number} options.viewportWidth Width of the viewport.
    * @param {number} options.scrollOffset Current horizontal scroll position of the viewport.
    * @param {number} options.totalColumns Total number of columns.

--- a/src/3rdparty/walkontable/src/calculator/viewportRows.js
+++ b/src/3rdparty/walkontable/src/calculator/viewportRows.js
@@ -19,7 +19,7 @@ class ViewportRowsCalculator {
   }
 
   /**
-   * @param {object} options Object with all options specyfied for row viewport calculation.
+   * @param {object} options Object with all options specified for row viewport calculation.
    * @param {number} options.viewportHeight Height of the viewport.
    * @param {number} options.scrollOffset Current vertical scroll position of the viewport.
    * @param {number} options.totalRows Total number of rows.

--- a/src/core.js
+++ b/src/core.js
@@ -2523,7 +2523,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
   };
 
   /**
-   * Returns an array of cell meta objects for specyfied physical row index.
+   * Returns an array of cell meta objects for specified physical row index.
    *
    * @memberof Core#
    * @function getCellMetaAtRow

--- a/src/plugins/autoColumnSize/autoColumnSize.js
+++ b/src/plugins/autoColumnSize/autoColumnSize.js
@@ -236,7 +236,7 @@ class AutoColumnSize extends BasePlugin {
 
   /**
    * Calculates all columns width. The calculated column will be cached in the {@link AutoColumnSize#widths} property.
-   * To retrieve width for specyfied column use {@link AutoColumnSize#getColumnWidth} method.
+   * To retrieve width for specified column use {@link AutoColumnSize#getColumnWidth} method.
    *
    * @param {object|number} rowRange Row index or an object with `from` and `to` properties which define row range.
    */

--- a/src/plugins/autoRowSize/autoRowSize.js
+++ b/src/plugins/autoRowSize/autoRowSize.js
@@ -223,7 +223,7 @@ class AutoRowSize extends BasePlugin {
 
   /**
    * Calculate all rows heights. The calculated row will be cached in the {@link AutoRowSize#heights} property.
-   * To retrieve height for specyfied row use {@link AutoRowSize#getRowHeight} method.
+   * To retrieve height for specified row use {@link AutoRowSize#getRowHeight} method.
    *
    * @param {object|number} colRange Row index or an object with `from` and `to` properties which define row range.
    */

--- a/src/plugins/columnSorting/test/columnSorting.e2e.js
+++ b/src/plugins/columnSorting/test/columnSorting.e2e.js
@@ -1555,7 +1555,7 @@ describe('ColumnSorting', () => {
     spec().$container2.remove();
   });
 
-  it('should return updated data at specyfied row after sorted', () => {
+  it('should return updated data at specified row after sorted', () => {
     handsontable({
       data: [
         [1, 'Ted', 'Right'],
@@ -1585,7 +1585,7 @@ describe('ColumnSorting', () => {
     expect(getDataAtRow(4)).toEqual([5, 'Jane', 'Neat']);
   });
 
-  it('should return updated data at specyfied col after sorted', () => {
+  it('should return updated data at specified col after sorted', () => {
     handsontable({
       data: [
         [1, 'Ted', 'Right'],

--- a/src/plugins/customBorders/utils.js
+++ b/src/plugins/customBorders/utils.js
@@ -141,7 +141,7 @@ export function extendDefaultBorder(defaultBorder, customBorder) {
  * Check if selection has border.
  *
  * @param {Core} hot The Handsontable instance.
- * @param {string} [direction] If set ('left' or 'top') then only the specyfied border side will be checked.
+ * @param {string} [direction] If set ('left' or 'top') then only the specified border side will be checked.
  * @returns {boolean}
  */
 export function checkSelectionBorders(hot, direction) {

--- a/src/plugins/multiColumnSorting/test/multiColumnSorting.e2e.js
+++ b/src/plugins/multiColumnSorting/test/multiColumnSorting.e2e.js
@@ -1537,7 +1537,7 @@ describe('MultiColumnSorting', () => {
     spec().$container2.remove();
   });
 
-  it('should return updated data at specyfied row after sorted', () => {
+  it('should return updated data at specified row after sorted', () => {
     handsontable({
       data: [
         [1, 'Ted', 'Right'],
@@ -1567,7 +1567,7 @@ describe('MultiColumnSorting', () => {
     expect(getDataAtRow(4)).toEqual([5, 'Jane', 'Neat']);
   });
 
-  it('should return updated data at specyfied col after sorted', () => {
+  it('should return updated data at specified col after sorted', () => {
     handsontable({
       data: [
         [1, 'Ted', 'Right'],

--- a/src/selection/highlight/highlight.js
+++ b/src/selection/highlight/highlight.js
@@ -87,7 +87,7 @@ class Highlight {
   }
 
   /**
-   * Check if highlight cell rendering is disabled for specyfied highlight type.
+   * Check if highlight cell rendering is disabled for specified highlight type.
    *
    * @param {string} highlightType Highlight type. Possible values are: `cell`, `area`, `fill` or `header`.
    * @returns {boolean}

--- a/src/utils/staticRegister.js
+++ b/src/utils/staticRegister.js
@@ -31,7 +31,7 @@ export default function staticRegister(namespace = 'common') {
   }
 
   /**
-   * Check if item under specyfied name is exists.
+   * Check if item under specified name is exists.
    *
    * @param {string} name Identification of the item.
    * @returns {boolean} Returns `true` or `false` depends on if element exists in the collection.

--- a/test/e2e/Core_getDataType.spec.js
+++ b/test/e2e/Core_getDataType.spec.js
@@ -21,7 +21,7 @@ describe('Core_getDataType', () => {
     ];
   };
 
-  it('should return data type at specyfied range (default type)', () => {
+  it('should return data type at specified range (default type)', () => {
     handsontable({
       data: arrayOfArrays()
     });
@@ -43,7 +43,7 @@ describe('Core_getDataType', () => {
     expect(hot.getCellMeta.calls.mostRecent().args).toEqual([2, 2]);
   });
 
-  it('should return data type at specyfied range (type defined in columns)', () => {
+  it('should return data type at specified range (type defined in columns)', () => {
     handsontable({
       data: arrayOfArrays(),
       columns: [
@@ -63,7 +63,7 @@ describe('Core_getDataType', () => {
     expect(getDataType(3, 4, 3, 4)).toEqual('dropdown');
   });
 
-  it('should return data type at specyfied range (type defined in columns) when columns is a function', () => {
+  it('should return data type at specified range (type defined in columns) when columns is a function', () => {
     handsontable({
       data: arrayOfArrays(),
       columns(column) {
@@ -100,7 +100,7 @@ describe('Core_getDataType', () => {
     expect(getDataType(3, 4, 3, 4)).toEqual('dropdown');
   });
 
-  it('should return data type at specyfied range (type defined in cells)', () => {
+  it('should return data type at specified range (type defined in cells)', () => {
     handsontable({
       data: arrayOfArrays(),
       cells(row, column) {


### PR DESCRIPTION
There is a small typo in src/core.js, src/plugins/autoColumnSize/autoColumnSize.js, src/plugins/autoRowSize/autoRowSize.js, src/selection/highlight/highlight.js, src/utils/staticRegister.js.

Should read specified rather than specyfied.

Moved to target the develop branch from #6815