### PR TITLE
Add missing hide prop and remove style in CustomBorders typings 

### DIFF
--- a/handsontable.d.ts
+++ b/handsontable.d.ts
@@ -2516,7 +2516,7 @@ declare namespace Handsontable {
     type BorderOptions = {
       width?: number;
       color?: string;
-      style?: string;
+      hide?: boolean;
     }
     type BorderRange = {
       range: {


### PR DESCRIPTION
### Context
We could use `hide` property which has a boolean value - e.g. `customBordersPlugin.setBorders(hot.getSelectedRange(), {left: {hide: false, width: 2, color: 'blue'}});`. 
On the other hand, I remove a `style` in `BorderOptions`. It was launch in PR https://github.com/handsontable/handsontable/pull/5767 though we never had this property. Admittedly at the same time, we worked on `customBorders` and introduced `style` in PR https://github.com/handsontable/handsontable/pull/5692 but we closed it and eventually didn't release these changes.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue:
1. ##6788

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
