### PR TITLE
Add a missing argument in the deepObjectSize function.

### DIFF
--- a/src/helpers/object.js
+++ b/src/helpers/object.js
@@ -315,7 +315,7 @@ export function deepObjectSize(object) {
           return;
         }
 
-        result += recursObjLen(key);
+        result += recursObjLen(value);
       });
     } else {
       result += 1;

--- a/src/helpers/object.js
+++ b/src/helpers/object.js
@@ -310,7 +310,7 @@ export function deepObjectSize(object) {
     let result = 0;
 
     if (isObject(obj)) {
-      objectEach(obj, (key) => {
+      objectEach(obj, (value, key) => {
         if (key === '__children') {
           return;
         }

--- a/test/unit/helpers/Object.spec.js
+++ b/test/unit/helpers/Object.spec.js
@@ -253,6 +253,35 @@ describe('Object helper', () => {
 
       expect(deepObjectSize(toCount)).toEqual(8);
     });
+
+    it('should ignore the `__children` key, when calculating the object size', () => {
+      const toCount = {
+        prop1: 1,
+        prop2: 2,
+        prop3: {
+          prop31: {
+            prop311: 311,
+            prop312: 312
+          },
+          prop32: 32,
+          prop33: 33
+        },
+        prop4: 4,
+        prop5: 5,
+        __children: [
+          {
+            prop1: 1,
+            prop2: 2,
+          },
+          {
+            prop1: 1,
+            prop2: 2,
+          }
+        ]
+      };
+
+      expect(deepObjectSize(toCount)).toEqual(8);
+    });
   });
 
   //


### PR DESCRIPTION
### Context
There was a missing argument in the `objectEach` function in the `deepObjectSize` helper.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

