### PR TITLE
Add (pseudo)static properties to contextMenu type

### DIFF
--- a/handsontable.d.ts
+++ b/handsontable.d.ts
@@ -910,6 +910,8 @@ declare namespace Handsontable {
     }
 
     interface ContextMenu extends Base {
+      DEFAULT_ITEMS: contextMenu.PredefinedMenuItemKey[];
+      SEPARATOR: SeparatorObject;
       eventManager: EventManager;
       commandExecutor: CommandExecutor;
       itemsFactory: ItemsFactory | void;


### PR DESCRIPTION
### Context
In the definition type, we have missed two `static` properties (`DEFAULT_ITEMS` and `SEPARATOR`) on the `contextMenu` type. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #6347

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
