### PR TITLE
Properly check all options in getCoordsOfDragAndDropBorders in autofill

### DIFF
--- a/src/plugins/autofill/autofill.js
+++ b/src/plugins/autofill/autofill.js
@@ -308,8 +308,16 @@ class Autofill extends BasePlugin {
     const bottomRightCorner = this.hot.getSelectedRangeLast().getBottomRightCorner();
     let coords;
 
-    if (this.directions.includes(DIRECTIONS.vertical) &&
-      (bottomRightCorner.row < coordsOfSelection.row || topLeftCorner.row > coordsOfSelection.row)) {
+    if (this.directions.includes(DIRECTIONS.vertical) && this.directions.includes(DIRECTIONS.horizontal)) {
+      if (bottomRightCorner.col <= coordsOfSelection.col || topLeftCorner.col >= coordsOfSelection.col) {
+        coords = new CellCoords(bottomRightCorner.row, coordsOfSelection.col);
+      }
+
+      if (bottomRightCorner.row < coordsOfSelection.row || topLeftCorner.row > coordsOfSelection.row) {
+        coords = new CellCoords(coordsOfSelection.row, bottomRightCorner.col);
+      }
+
+    } else if (this.directions.includes(DIRECTIONS.vertical)) {
       coords = new CellCoords(coordsOfSelection.row, bottomRightCorner.col);
 
     } else if (this.directions.includes(DIRECTIONS.horizontal)) {

--- a/src/plugins/autofill/test/autofill.e2e.js
+++ b/src/plugins/autofill/test/autofill.e2e.js
@@ -990,4 +990,51 @@ describe('AutoFill', () => {
 
     expect(afterAutofill).toHaveBeenCalledTimes(0);
   });
+
+  it('should not call beforeAutofill and afterAutofill if we return to the cell from where we start', () => {
+    const beforeAutofill = jasmine.createSpy('beforeAutofill');
+    const afterAutofill = jasmine.createSpy('afterAutofill');
+
+    handsontable({
+      data: [
+        [1, 2, 3, 4, 5, 6],
+        [1, 2, 3, 4, 5, 6],
+        [1, 2, 3, 4, 5, 6],
+        [1, 2, 3, 4, 5, 6]
+      ],
+      beforeAutofill,
+      afterAutofill,
+      fillHandle: {
+        direction: 'vertical'
+      }
+    });
+
+    selectCell(0, 0);
+    spec().$container.find('.wtBorder.current.corner').simulate('mousedown');
+    spec().$container.find('tbody tr:eq(1) td:eq(0)').simulate('mouseover');
+    spec().$container.find('tbody tr:eq(0) td:eq(0)').simulate('mouseover').simulate('mouseup');
+
+    expect(beforeAutofill).toHaveBeenCalledTimes(0);
+    expect(afterAutofill).toHaveBeenCalledTimes(0);
+  });
+
+  it('should not change cell value if we return to the cell from where we start (when fillHandle option is set to `vertical`)', () => {
+    handsontable({
+      data: [
+        [1, 2, 3, 4, 5, 6],
+        [7, 8, 9, 1, 2, 3],
+        [4, 5, 6, 7, 8, 9],
+        [1, 2, 3, 4, 5, 6]
+      ],
+      fillHandle: 'vertical'
+    });
+
+    selectCell(0, 0);
+    spec().$container.find('.wtBorder.current.corner').simulate('mousedown');
+    spec().$container.find('tbody tr:eq(1) td:eq(0)').simulate('mouseover');
+    spec().$container.find('tbody tr:eq(0) td:eq(0)').simulate('mouseover').simulate('mouseup');
+
+    expect(getDataAtCell(0, 0)).toEqual(1);
+    expect(getDataAtCell(1, 0)).toEqual(7);
+  });
 });


### PR DESCRIPTION
### Context
So far we checked only two directions - either `vertical` or `horizontal`. But we use both of them when we don't specify any direction. 
With this detailed checking, we don't have a bug when we can't come back to the original cell from where we have been starting (and if `fillHandle` option is set to `vertical`).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #4233 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
