### PR TITLE
Fix 'getFirstRenderedRows' method for the rows fixed on the bottom.

### DIFF
--- a/src/3rdparty/walkontable/src/table/mixin/stickyRowsBottom.js
+++ b/src/3rdparty/walkontable/src/table/mixin/stickyRowsBottom.js
@@ -21,9 +21,14 @@ const stickyRowsBottom = {
     const fixedRowsBottom = this.wot.getSetting('fixedRowsBottom');
     const index = totalRows - fixedRowsBottom;
 
-    if (index < 0) {
+    if (totalRows === 0 || fixedRowsBottom === 0) {
       return -1;
     }
+
+    if (index < 0) {
+      return 0;
+    }
+
     return index;
   },
 

--- a/src/3rdparty/walkontable/test/spec/table.spec.js
+++ b/src/3rdparty/walkontable/test/spec/table.spec.js
@@ -1428,6 +1428,22 @@ describe('WalkontableTable', () => {
       expectWtTable(wt, wtTable => wtTable.getFirstRenderedRow(), 'topLeftCorner').toBe(0);
       expectWtTable(wt, wtTable => wtTable.getFirstRenderedRow(), 'top').toBe(0);
     });
+
+    it('should return 0 as the first rendered row, when there\'s more fixed bottom rows than rows in total', () => {
+      createDataArray(18, 18);
+      spec().$wrapper.width(250).height(170);
+
+      const wt = walkontable({
+        data: [[1], [1]],
+        totalRows: 2,
+        totalColumns: 1,
+        fixedRowsBottom: 3,
+      });
+      wt.draw();
+
+      expectWtTable(wt, wtTable => wtTable.getFirstRenderedRow(), 'master').toBe(0);
+      expectWtTable(wt, wtTable => wtTable.getFirstRenderedRow(), 'bottom').toBe(0);
+    });
   });
 
   describe('isRowBeforeRenderedRows', () => {


### PR DESCRIPTION
### Context
Change the way `getFirstRenderedRow` method works - for bottom fixed rows it should return `0` as the first rendered row, when there's more rows on the bottom overlay than overall in the table. 

### How has this been tested?
Added a test case.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #6718 