### PR TITLE
Fix focus movement between focusable elements

### DIFF
--- a/src/editorManager.js
+++ b/src/editorManager.js
@@ -161,7 +161,9 @@ class EditorManager {
     const { activeElement } = this.instance.rootDocument;
 
     if (activeElement) {
-      // Bluring prepares an editor to focus its input element to interact with the user.
+      // Bluring the activeElement removes unwanted border around the focusable element
+      // (and resets activeElement prop). Without blurring the activeElement points to the
+      // previously focusable element after clicking onto the cell (#6877).
       activeElement.blur();
     }
 

--- a/src/editorManager.js
+++ b/src/editorManager.js
@@ -158,6 +158,13 @@ class EditorManager {
 
     this.cellProperties = this.instance.getCellMeta(row, col);
 
+    const { activeElement } = this.instance.rootDocument;
+
+    if (activeElement) {
+      // Bluring prepares an editor to focus its input element to interact with the user.
+      activeElement.blur();
+    }
+
     if (this.cellProperties.readOnly) {
       this.clearActiveEditor();
 

--- a/src/editors/textEditor.js
+++ b/src/editors/textEditor.js
@@ -10,7 +10,6 @@ import {
   setCaretPosition,
   hasVerticalScrollbar,
   hasHorizontalScrollbar,
-  selectElementIfAllowed,
   hasClass,
   removeClass
 } from './../helpers/dom/element';
@@ -157,19 +156,21 @@ class TextEditor extends BaseEditor {
       } = cellProperties;
 
       if (allowInvalid) {
-        this.TEXTAREA.value = ''; // Remove an empty space from texarea (added by copyPaste plugin to make copy/paste functionality work with IME)
+        // Remove an empty space from texarea (added by copyPaste plugin to make copy/paste
+        // functionality work with IME)
+        this.TEXTAREA.value = '';
       }
 
       if (previousState !== EditorState.FINISHED) {
         this.hideEditableElement();
       }
 
-      // @TODO: The fragmentSelection functionality is conflicted with IME. For this feature refocus has to
-      // be disabled (to make IME working).
+      // @TODO: The fragmentSelection functionality is conflicted with IME. For this feature
+      // refocus has to be disabled (to make IME working).
       const restoreFocus = !fragmentSelection;
 
       if (restoreFocus && !isMobileBrowser()) {
-        this.focus(true);
+        this.focus();
       }
     }
   }
@@ -191,20 +192,13 @@ class TextEditor extends BaseEditor {
 
   /**
    * Sets focus state on the select element.
-   *
-   * @param {boolean} [safeFocus=false] If `true` select element only when is handsontableInput. Otherwise sets focus on this element.
-   * If focus is calling without param textarea need be select and set caret position.
    */
-  focus(safeFocus = false) {
-    // For IME editor textarea element must be focused using ".select" method. Using ".focus" browser automatically scroll into
-    // the focused element which is undesire effect.
-    if (safeFocus) {
-      selectElementIfAllowed(this.TEXTAREA);
-
-    } else {
-      this.TEXTAREA.select();
-      setCaretPosition(this.TEXTAREA, this.TEXTAREA.value.length);
-    }
+  focus() {
+    // For IME editor textarea element must be focused using ".select" method.
+    // Using ".focus" browser automatically scroll into the focused element which
+    // is undesire effect.
+    this.TEXTAREA.select();
+    setCaretPosition(this.TEXTAREA, this.TEXTAREA.value.length);
   }
 
   /**

--- a/test/e2e/editors/baseEditor.spec.js
+++ b/test/e2e/editors/baseEditor.spec.js
@@ -12,6 +12,51 @@ describe('BaseEditor', () => {
     }
   });
 
+  it('should exported all editors into Handsontable.editors object', () => {
+    expect(Handsontable.editors.AutocompleteEditor).toBeDefined();
+    expect(Handsontable.editors.BaseEditor).toBeDefined();
+    expect(Handsontable.editors.CheckboxEditor).toBeDefined();
+    expect(Handsontable.editors.DateEditor).toBeDefined();
+    expect(Handsontable.editors.DropdownEditor).toBeDefined();
+    expect(Handsontable.editors.HandsontableEditor).toBeDefined();
+    expect(Handsontable.editors.NumericEditor).toBeDefined();
+    expect(Handsontable.editors.PasswordEditor).toBeDefined();
+    expect(Handsontable.editors.SelectEditor).toBeDefined();
+    expect(Handsontable.editors.TextEditor).toBeDefined();
+  });
+
+  it('should blur activeElement while preparing the editor to open', () => {
+    const externalInputElement = document.createElement('input');
+
+    document.body.appendChild(externalInputElement);
+
+    handsontable();
+
+    externalInputElement.select();
+    selectCell(2, 2);
+
+    expect(document.activeElement).not.toBe(externalInputElement);
+
+    document.body.removeChild(externalInputElement);
+  });
+
+  it('should blur activeElement while preparing the editor to open even when readOnly is enabled', () => {
+    const externalInputElement = document.createElement('input');
+
+    document.body.appendChild(externalInputElement);
+
+    handsontable({
+      readOnly: true,
+    });
+
+    externalInputElement.select();
+    selectCell(2, 2);
+
+    expect(document.activeElement).not.toBe(externalInputElement);
+
+    document.body.removeChild(externalInputElement);
+  });
+
   describe('ctrl + enter when editor is active', () => {
     it('should populate value from the currently active cell to every cell in the selected range', () => {
       handsontable({
@@ -70,19 +115,6 @@ describe('BaseEditor', () => {
       expect(getDataAtCell(2, 1)).toEqual('B3');
       expect(getDataAtCell(2, 2)).toEqual('B3');
     });
-  });
-
-  it('should exported all editors into Handsontable.editors object', () => {
-    expect(Handsontable.editors.AutocompleteEditor).toBeDefined();
-    expect(Handsontable.editors.BaseEditor).toBeDefined();
-    expect(Handsontable.editors.CheckboxEditor).toBeDefined();
-    expect(Handsontable.editors.DateEditor).toBeDefined();
-    expect(Handsontable.editors.DropdownEditor).toBeDefined();
-    expect(Handsontable.editors.HandsontableEditor).toBeDefined();
-    expect(Handsontable.editors.NumericEditor).toBeDefined();
-    expect(Handsontable.editors.PasswordEditor).toBeDefined();
-    expect(Handsontable.editors.SelectEditor).toBeDefined();
-    expect(Handsontable.editors.TextEditor).toBeDefined();
   });
 
   describe('IME support', () => {

--- a/test/e2e/editors/noEditor.spec.js
+++ b/test/e2e/editors/noEditor.spec.js
@@ -155,6 +155,23 @@ describe('noEditor', () => {
     expect(isEditorVisible()).toBe(false);
   });
 
+  it('should blur activeElement while preparing the editor to open', () => {
+    const externalInputElement = document.createElement('input');
+
+    document.body.appendChild(externalInputElement);
+
+    handsontable({
+      editor: false,
+    });
+
+    externalInputElement.select();
+    selectCell(2, 2);
+
+    expect(document.activeElement).not.toBe(externalInputElement);
+
+    document.body.removeChild(externalInputElement);
+  });
+
   describe('IME support', () => {
     it('should focus editable element (from copyPaste plugin) after selecting the cell', async() => {
       handsontable({

--- a/test/e2e/editors/textEditor.spec.js
+++ b/test/e2e/editors/textEditor.spec.js
@@ -198,34 +198,32 @@ describe('TextEditor', () => {
     expect(hot.getActiveEditor().TEXTAREA.getAttribute('tabindex')).toBe('-1');
   });
 
-  it('should render textarea editor in specified size at cell 0, 0 without headers', (done) => {
+  it('should render textarea editor in specified size at cell 0, 0 without headers', async() => {
     const hot = handsontable();
 
     selectCell(0, 0);
 
     keyDown('enter');
 
-    setTimeout(() => {
-      expect(hot.getActiveEditor().TEXTAREA.style.height).toBe('23px');
-      expect(hot.getActiveEditor().TEXTAREA.style.width).toBe('40px');
-      done();
-    }, 200);
+    await sleep(200);
+
+    expect(hot.getActiveEditor().TEXTAREA.style.height).toBe('23px');
+    expect(hot.getActiveEditor().TEXTAREA.style.width).toBe('40px');
   });
 
-  it('should render textarea editor in specified size at cell 1, 0 without headers', (done) => {
+  it('should render textarea editor in specified size at cell 1, 0 without headers', async() => {
     const hot = handsontable();
 
     selectCell(1, 1);
 
     keyDown('enter');
 
-    setTimeout(() => {
-      expect(hot.getActiveEditor().TEXTAREA.style.height).toBe('23px');
-      done();
-    }, 200);
+    await sleep(200);
+
+    expect(hot.getActiveEditor().TEXTAREA.style.height).toBe('23px');
   });
 
-  it('should render textarea editor in specified size at cell 0, 0 with headers', (done) => {
+  it('should render textarea editor in specified size at cell 0, 0 with headers', async() => {
     const hot = handsontable({
       rowHeaders: true,
       colHeaders: true
@@ -235,15 +233,14 @@ describe('TextEditor', () => {
 
     keyDown('enter');
 
-    setTimeout(() => {
-      expect(hot.getActiveEditor().TEXTAREA.style.height).toBe('23px');
-      expect(hot.getActiveEditor().TEXTAREA.style.width).toBe('40px');
-      expect(hot.getActiveEditor().textareaParentStyle.top).toBe('26px');
-      done();
-    }, 200);
+    await sleep(200);
+
+    expect(hot.getActiveEditor().TEXTAREA.style.height).toBe('23px');
+    expect(hot.getActiveEditor().TEXTAREA.style.width).toBe('40px');
+    expect(hot.getActiveEditor().textareaParentStyle.top).toBe('26px');
   });
 
-  it('should render textarea editor in specified size at cell 0, 0 with headers defined in columns', (done) => {
+  it('should render textarea editor in specified size at cell 0, 0 with headers defined in columns', async() => {
     const hot = handsontable({
       data: Handsontable.helper.createSpreadsheetObjectData(10, 10),
       columns: [{
@@ -265,12 +262,11 @@ describe('TextEditor', () => {
 
     keyDown('enter');
 
-    setTimeout(() => {
-      expect(hot.getActiveEditor().TEXTAREA.style.height).toBe('23px');
-      expect(parseInt(hot.getActiveEditor().TEXTAREA.style.width, 10)).toBeAroundValue(50, 4);
-      expect(hot.getActiveEditor().textareaParentStyle.top).toBe('26px');
-      done();
-    }, 200);
+    await sleep(200);
+
+    expect(hot.getActiveEditor().TEXTAREA.style.height).toBe('23px');
+    expect(parseInt(hot.getActiveEditor().TEXTAREA.style.width, 10)).toBeAroundValue(50, 4);
+    expect(hot.getActiveEditor().textareaParentStyle.top).toBe('26px');
   });
 
   it('should hide whole editor when it is higher then header and TD is not rendered anymore', async() => {
@@ -772,6 +768,7 @@ describe('TextEditor', () => {
 
   it('should call editor focus() method after opening an editor', () => {
     const hot = handsontable();
+
     selectCell(2, 2);
 
     const editor = hot.getActiveEditor();


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
This is a PoC for fixing focus-related issues. It seems that the
activeElement has to be blurred while editor preparation. Otherwise the
active element stays focused while interacting with an editor.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Tested in the FF, Safari, and Chrome. I tested copy/paste functionality with and without plugin _CopyPaste_. Additionally, I added some new tests related to the state of the `activeElement` prop.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #6877
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
