### PR TITLE
Improve performance for undo and for gathering cell metas

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -2394,7 +2394,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
    * @param {boolean} [silentMode=false] If `true`, the effects of the data source changing
    *                                     will not be visible right after the method call.
    *                                     But, right after the first table render cycle. Otherwise,
-   *                                     the changes are visibel right after the method call.
+   *                                     the changes are visible right after the method call.
    */
   this.setSourceDataAtCell = function(row, column, value, source, silentMode = false) {
     const input = setDataInputToArray(row, column, value);

--- a/src/dataMap/metaManager/utils.js
+++ b/src/dataMap/metaManager/utils.js
@@ -1,4 +1,4 @@
-import { hasOwnProperty, isObject, objectEach } from '../../helpers/object';
+import { hasOwnProperty, isObject, objectEach, inherit } from '../../helpers/object';
 import { getCellType } from '../../cellTypes';
 
 /**
@@ -40,7 +40,15 @@ export function expandMetaType(type, metaObject) {
  * @returns {ColumnMeta} Returns constructor ready to initialize with `new` operator.
  */
 export function columnFactory(TableMeta, conflictList = []) {
-  class ColumnMeta extends TableMeta {}
+  // Do not use ES6 "class extends" syntax here. It seems that the babel produces code
+  // which drastically decreases the performance of the ColumnMeta class creation.
+
+  /**
+   * Base "class" for column meta.
+   */
+  function ColumnMeta() {}
+
+  inherit(ColumnMeta, TableMeta);
 
   // Clear conflict settings
   for (let i = 0; i < conflictList.length; i++) {

--- a/src/plugins/undoRedo/undoRedo.js
+++ b/src/plugins/undoRedo/undoRedo.js
@@ -453,17 +453,17 @@ UndoRedo.RemoveColumnAction.prototype.undo = function(instance, undoneCallback) 
 
   // TODO Temporary hook for undo/redo mess
   if (isFormulaPluginEnabled) {
-    const changes = [];
+    const setDataAtCellChanges = [];
 
     arrayEach(instance.getSourceDataArray(), (rowData, rowIndex) => {
       arrayEach(ascendingIndexes, (changedIndex, contiquesIndex) => {
         rowData[changedIndex] = sortedData[rowIndex][contiquesIndex];
 
-        changes.push([rowIndex, changedIndex, null, rowData[changedIndex]]);
+        setDataAtCellChanges.push([rowIndex, changedIndex, null, rowData[changedIndex]]);
       });
     });
 
-    instance.getPlugin('formulas').onAfterSetDataAtCell(changes);
+    instance.getPlugin('formulas').onAfterSetDataAtCell(setDataAtCellChanges);
   }
 
   if (typeof this.headers !== 'undefined') {

--- a/src/plugins/undoRedo/undoRedo.js
+++ b/src/plugins/undoRedo/undoRedo.js
@@ -448,7 +448,7 @@ UndoRedo.RemoveColumnAction.prototype.undo = function(instance, undoneCallback) 
       changes.push([i, ascendingIndexes[j], null, sortedData[i][j]]);
     });
 
-    instance.setSourceDataAtCell(dataRowToChangesArray(row, i));
+    instance.setSourceDataAtCell(dataRowToChangesArray(row, i), void 0, void 0, void 0, true);
   });
 
   instance.columnIndexMapper.insertIndexes(ascendingIndexes[0], ascendingIndexes.length);

--- a/src/plugins/undoRedo/undoRedo.js
+++ b/src/plugins/undoRedo/undoRedo.js
@@ -1,6 +1,5 @@
 import Hooks from './../../pluginHooks';
 import { arrayMap, arrayEach } from './../../helpers/array';
-import { dataRowToChangesArray } from '../../helpers/data';
 import { rangeEach } from './../../helpers/number';
 import { inherit, deepClone } from './../../helpers/object';
 import { stopImmediatePropagation, isImmediatePropagationStopped } from './../../helpers/dom/event';
@@ -428,39 +427,48 @@ UndoRedo.RemoveColumnAction.prototype.undo = function(instance, undoneCallback) 
   const ascendingIndexes = this.indexes.slice(0).sort();
   const sortByIndexes = (elem, j, arr) => arr[this.indexes.indexOf(ascendingIndexes[j])];
 
+  const removedDataLength = this.data.length;
   const sortedData = [];
-  rangeEach(this.data.length - 1, (i) => {
-    sortedData[i] = arrayMap(this.data[i], sortByIndexes);
-  });
 
-  let sortedHeaders = [];
-  sortedHeaders = arrayMap(this.headers, sortByIndexes);
+  for (let rowIndex = 0; rowIndex < removedDataLength; rowIndex++) {
+    sortedData.push(arrayMap(this.data[rowIndex], sortByIndexes));
+  }
 
+  const sortedHeaders = arrayMap(this.headers, sortByIndexes);
+  const isFormulaPluginEnabled = instance.getPlugin('formulas') ? instance.getPlugin('formulas').enabled : false;
   const changes = [];
 
   instance.alter('insert_col', this.indexes[0], this.indexes.length, 'UndoRedo.undo');
 
-  rangeEach(this.data.length - 1, (i) => {
-    const row = instance.getSourceDataAtRow(i);
+  arrayEach(instance.getSourceDataArray(), (rowData, rowIndex) => {
+    arrayEach(ascendingIndexes, (changedIndex, contiquesIndex) => {
+      rowData[changedIndex] = sortedData[rowIndex][contiquesIndex];
 
-    rangeEach(ascendingIndexes.length - 1, (j) => {
-      row[ascendingIndexes[j]] = sortedData[i][j];
-      changes.push([i, ascendingIndexes[j], null, sortedData[i][j]]);
+      changes.push([rowIndex, changedIndex, rowData[changedIndex]]);
     });
-
-    instance.setSourceDataAtCell(dataRowToChangesArray(row, i), void 0, void 0, void 0, true);
   });
 
+  instance.setSourceDataAtCell(changes);
   instance.columnIndexMapper.insertIndexes(ascendingIndexes[0], ascendingIndexes.length);
 
   // TODO Temporary hook for undo/redo mess
-  if (instance.getPlugin('formulas')) {
+  if (isFormulaPluginEnabled) {
+    const changes = [];
+
+    arrayEach(instance.getSourceDataArray(), (rowData, rowIndex) => {
+      arrayEach(ascendingIndexes, (changedIndex, contiquesIndex) => {
+        rowData[changedIndex] = sortedData[rowIndex][contiquesIndex];
+
+        changes.push([rowIndex, changedIndex, null, rowData[changedIndex]]);
+      });
+    });
+
     instance.getPlugin('formulas').onAfterSetDataAtCell(changes);
   }
 
   if (typeof this.headers !== 'undefined') {
-    rangeEach(sortedHeaders.length - 1, (j) => {
-      instance.getSettings().colHeaders[ascendingIndexes[j]] = sortedHeaders[j];
+    arrayEach(sortedHeaders, (headerData, columnIndex) => {
+      instance.getSettings().colHeaders[ascendingIndexes[columnIndex]] = headerData;
     });
   }
 
@@ -471,7 +479,7 @@ UndoRedo.RemoveColumnAction.prototype.undo = function(instance, undoneCallback) 
   // TODO Temporary hook for undo/redo mess
   instance.runHooks('afterCreateCol', this.indexes[0], this.indexes.length, 'UndoRedo.undo');
 
-  if (instance.getPlugin('formulas')) {
+  if (isFormulaPluginEnabled) {
     instance.getPlugin('formulas').recalculateFull();
   }
 

--- a/src/plugins/undoRedo/undoRedo.js
+++ b/src/plugins/undoRedo/undoRedo.js
@@ -435,7 +435,7 @@ UndoRedo.RemoveColumnAction.prototype.undo = function(instance, undoneCallback) 
   }
 
   const sortedHeaders = arrayMap(this.headers, sortByIndexes);
-  const isFormulaPluginEnabled = instance.getPlugin('formulas') ? instance.getPlugin('formulas').enabled : false;
+  const isFormulaPluginEnabled = instance.getPlugin('formulas')?.enabled ?? false;
   const changes = [];
 
   instance.alter('insert_col', this.indexes[0], this.indexes.length, 'UndoRedo.undo');

--- a/test/e2e/core/setSourceDataAtCell.spec.js
+++ b/test/e2e/core/setSourceDataAtCell.spec.js
@@ -19,15 +19,15 @@ describe('Core.setSourceDataAtCell', () => {
 
     setSourceDataAtCell(0, 0, 'foo');
 
-    expect(getSourceData()[0][0]).toEqual('foo');
+    expect(getSourceData()[0][0]).toBe('foo');
 
     loadData([{ foo: 'bar' }]);
 
-    expect(getSourceData()[0].foo).toEqual('bar');
+    expect(getSourceData()[0].foo).toBe('bar');
 
     setSourceDataAtCell(0, 'foo', 'foo');
 
-    expect(getSourceData()[0].foo).toEqual('foo');
+    expect(getSourceData()[0].foo).toBe('foo');
   });
 
   it('should set the provided value in the source data set, using the physical coordinates', () => {
@@ -44,9 +44,36 @@ describe('Core.setSourceDataAtCell', () => {
 
     setSourceDataAtCell(0, 'lorem', 'foo');
 
-    expect(getSourceData()[0].lorem).toEqual('foo');
-    expect(getSourceData()[1].lorem).toEqual('sit');
-    expect(getSourceData()[2].lorem).toEqual('amet');
+    expect(getSourceData()[0].lorem).toBe('foo');
+    expect(getSourceData()[1].lorem).toBe('sit');
+    expect(getSourceData()[2].lorem).toBe('amet');
+  });
+
+  it('should not trigger table render cycle when method is called with "silentMode" set as `true`', () => {
+    const hot = handsontable({
+      data: [[1, 2, 3], ['a', 'b', 'c']],
+    });
+
+    spyOn(hot, 'render').and.callThrough();
+
+    setSourceDataAtCell(0, 1, 'foo', void 0, true);
+
+    expect(hot.render).not.toHaveBeenCalled();
+  });
+
+  it('should call "refreshValue" method of the active editor when new data is set', () => {
+    const hot = handsontable({
+      data: [[1, 2, 3], ['a', 'b', 'c']],
+    });
+
+    selectCell(0, 1);
+    keyDown('enter');
+
+    spyOn(hot.getActiveEditor(), 'refreshValue').and.callThrough();
+
+    setSourceDataAtCell(0, 1, 'foo');
+
+    expect(hot.getActiveEditor().refreshValue).toHaveBeenCalled();
   });
 
   it('should throw the `modifySourceData` hook (with the `set` argument) when calling the `setSourceDataAtCell` method', () => {
@@ -102,10 +129,11 @@ describe('Core.setSourceDataAtCell', () => {
       afterSetSourceDataAtCell: afterSetSourceDataAtCellSpy
     });
 
-    setSourceDataAtCell(0, 'foo', 'foo2');
+    setSourceDataAtCell(0, 'foo', 'foo2', 'caller-custom-source');
 
     let hookArguments = new Array(6).fill(void 0);
     hookArguments[0] = [[0, 'foo', 'bar', 'foo2']];
+    hookArguments[1] = 'caller-custom-source';
 
     expect(afterSetSourceDataAtCellSpy).toHaveBeenCalledWith(...hookArguments);
 

--- a/test/e2e/core/setSourceDataAtCell.spec.js
+++ b/test/e2e/core/setSourceDataAtCell.spec.js
@@ -49,16 +49,16 @@ describe('Core.setSourceDataAtCell', () => {
     expect(getSourceData()[2].lorem).toBe('amet');
   });
 
-  it('should not trigger table render cycle when method is called with "silentMode" set as `true`', () => {
+  it('should trigger table render cycle after changing the data', () => {
     const hot = handsontable({
       data: [[1, 2, 3], ['a', 'b', 'c']],
     });
 
     spyOn(hot, 'render').and.callThrough();
 
-    setSourceDataAtCell(0, 1, 'foo', void 0, true);
+    setSourceDataAtCell(0, 1, 'foo');
 
-    expect(hot.render).not.toHaveBeenCalled();
+    expect(hot.render).toHaveBeenCalled();
   });
 
   it('should call "refreshValue" method of the active editor when new data is set', () => {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
~The added argument determines if the table renders cycle should be performed after setting new source data. This fixes the performance issues that occur in multiple method calls.~

It turned out that the above-mentioned argument is not necessary. It is enough to collect all changes and call the `setSourceDataAtCell` only once.

While developing I spotted that context menu for a bigger dataset (10000x10) is about 5 times slower in opening than in the 7.4.2. It was caused by slow cell meta gathering. It turned out that extending class using ES6+ syntax (babel transformation) causes performance degradation (https://github.com/handsontable/handsontable/blob/feature/issue-6868/src/dataMap/metaManager/utils.js#L49). So, I changed the syntax to use old function style with changing its prototype.

After some local tests, I can confirm that the context menu shows 1.25 times faster than 7.4.2, and `undo` operation (after removing columns) is ~1.2 faster than 7.4.2. 

Additionally I've added a code that refreshes the editor value when the data source was changed. The bug was fixed for the `setDataAtCell` method so the same applied for the source data.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Added tests for editor value refreshing and test for `render` call.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #6868
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
