### PR TITLE
getRenderableIndexes and cacheFromPhysicalToVisualIndexes optimization

### DIFF
--- a/src/translations/indexMapper.js
+++ b/src/translations/indexMapper.js
@@ -623,14 +623,15 @@ class IndexMapper {
   cacheFromVisualToRenderabIendexes() {
     const notTrimmedIndexes = this.notTrimmedIndexesCache;
     const nrOfNotTrimmedIndexes = notTrimmedIndexes.length;
-    const isHiddenForVisualIndexes = notTrimmedIndexes.map(physicalIndexForVisualIndex => this.isHidden(physicalIndexForVisualIndex));
 
     this.fromVisualToRenderableIndexesCache.clear();
 
     let nrOfHiddenIndexesBefore = 0;
 
     for (let visualIndex = 0; visualIndex < nrOfNotTrimmedIndexes; visualIndex += 1) {
-      if (isHiddenForVisualIndexes[visualIndex]) {
+      const physicalIndex = notTrimmedIndexes[visualIndex];
+
+      if (this.isHidden(physicalIndex)) {
         nrOfHiddenIndexesBefore += 1;
 
       } else {

--- a/src/translations/indexMapper.js
+++ b/src/translations/indexMapper.js
@@ -606,11 +606,11 @@ class IndexMapper {
    */
   cacheFromPhysicalToVisualIndexes() {
     const notTrimmedIndexes = this.getNotTrimmedIndexes();
-    const nrOfIndexes = this.getNotTrimmedIndexesLength();
+    const nrOfNotTrimmedIndexes = this.getNotTrimmedIndexesLength();
 
     this.fromPhysicalToVisualIndexesCache.clear();
 
-    for (let visualIndex = 0; visualIndex < nrOfIndexes; visualIndex += 1) {
+    for (let visualIndex = 0; visualIndex < nrOfNotTrimmedIndexes; visualIndex += 1) {
       const physicalIndex = notTrimmedIndexes[visualIndex];
 
       // Every visual index have corresponding physical index, but some physical indexes may don't have
@@ -625,8 +625,8 @@ class IndexMapper {
    * @private
    */
   cacheFromVisualToRenderabIendexes() {
-    const notTrimmedIndexes = this.notTrimmedIndexesCache;
-    const nrOfNotTrimmedIndexes = notTrimmedIndexes.length;
+    const notTrimmedIndexes = this.getNotTrimmedIndexes();
+    const nrOfNotTrimmedIndexes = this.getNotTrimmedIndexesLength();
 
     this.fromVisualToRenderableIndexesCache.clear();
 

--- a/src/translations/indexMapper.js
+++ b/src/translations/indexMapper.js
@@ -1,4 +1,4 @@
-import { arrayFilter, arrayMap } from '../helpers/array';
+import { arrayMap } from '../helpers/array';
 import { getListWithRemovedItems, getListWithInsertedItems } from './maps/utils/indexesSequence';
 import IndexesSequence from './maps/indexesSequence';
 import TrimmingMap from './maps/trimmingMap';
@@ -605,13 +605,12 @@ class IndexMapper {
    * @private
    */
   cacheFromPhysicalToVisualIndexes() {
-    const notTrimmedIndexes = this.getNotTrimmedIndexes();
     const nrOfNotTrimmedIndexes = this.getNotTrimmedIndexesLength();
 
     this.fromPhysicalToVisualIndexesCache.clear();
 
     for (let visualIndex = 0; visualIndex < nrOfNotTrimmedIndexes; visualIndex += 1) {
-      const physicalIndex = notTrimmedIndexes[visualIndex];
+      const physicalIndex = this.getPhysicalFromVisualIndex(visualIndex);
 
       // Every visual index have corresponding physical index, but some physical indexes may don't have
       // corresponding visual indexes (physical indexes may represent trimmed indexes, beyond the table boundaries)
@@ -625,24 +624,16 @@ class IndexMapper {
    * @private
    */
   cacheFromVisualToRenderabIendexes() {
-    const notTrimmedIndexes = this.getNotTrimmedIndexes();
-    const nrOfNotTrimmedIndexes = this.getNotTrimmedIndexesLength();
+    const nrOfRenderableIndexes = this.getRenderableIndexesLength();
 
     this.fromVisualToRenderableIndexesCache.clear();
 
-    let nrOfHiddenIndexesBefore = 0;
+    for (let renderableIndex = 0; renderableIndex < nrOfRenderableIndexes; renderableIndex += 1) {
+      // Can't use getRenderableFromVisualIndex here because we're building the cache here
+      const physicalIndex = this.getPhysicalFromRenderableIndex(renderableIndex);
+      const visualIndex = this.getVisualFromPhysicalIndex(physicalIndex);
 
-    for (let visualIndex = 0; visualIndex < nrOfNotTrimmedIndexes; visualIndex += 1) {
-      const physicalIndex = notTrimmedIndexes[visualIndex];
-
-      if (this.isHidden(physicalIndex)) {
-        nrOfHiddenIndexesBefore += 1;
-
-      } else {
-        const renderableIndex = visualIndex - nrOfHiddenIndexesBefore;
-
-        this.fromVisualToRenderableIndexesCache.set(visualIndex, renderableIndex);
-      }
+      this.fromVisualToRenderableIndexesCache.set(visualIndex, renderableIndex);
     }
   }
 }

--- a/src/translations/indexMapper.js
+++ b/src/translations/indexMapper.js
@@ -402,7 +402,9 @@ class IndexMapper {
       return this.notTrimmedIndexesCache;
     }
 
-    return arrayFilter(this.getIndexesSequence(), physicalIndex => this.isTrimmed(physicalIndex) === false);
+    const indexesSequence = this.getIndexesSequence();
+
+    return indexesSequence.filter(physicalIndex => this.isTrimmed(physicalIndex) === false);
   }
 
   /**
@@ -429,7 +431,9 @@ class IndexMapper {
       return this.notHiddenIndexesCache;
     }
 
-    return arrayFilter(this.getIndexesSequence(), index => this.isHidden(index) === false);
+    const indexesSequence = this.getIndexesSequence();
+
+    return indexesSequence.filter(physicalIndex => this.isHidden(physicalIndex) === false);
   }
 
   /**

--- a/src/translations/indexMapper.js
+++ b/src/translations/indexMapper.js
@@ -456,9 +456,8 @@ class IndexMapper {
     }
 
     const notTrimmedIndexes = this.getNotTrimmedIndexes();
-    const notHiddenIndexes = this.getNotHiddenIndexes();
 
-    return notTrimmedIndexes.filter(physicalIndex => notHiddenIndexes.includes(physicalIndex));
+    return notTrimmedIndexes.filter(physicalIndex => !this.isHidden(physicalIndex));
   }
 
   /**

--- a/src/translations/indexMapper.js
+++ b/src/translations/indexMapper.js
@@ -457,7 +457,7 @@ class IndexMapper {
 
     const notTrimmedIndexes = this.getNotTrimmedIndexes();
 
-    return notTrimmedIndexes.filter(physicalIndex => !this.isHidden(physicalIndex));
+    return notTrimmedIndexes.filter(physicalIndex => this.isHidden(physicalIndex) === false);
   }
 
   /**
@@ -602,7 +602,7 @@ class IndexMapper {
    */
   cacheFromPhysicalToVisualIndexes() {
     const notTrimmedIndexes = this.getNotTrimmedIndexes();
-    const nrOfIndexes = this.getNotHiddenIndexesLength();
+    const nrOfIndexes = this.getNotTrimmedIndexesLength();
 
     this.fromPhysicalToVisualIndexesCache.clear();
 

--- a/src/translations/indexMapper.js
+++ b/src/translations/indexMapper.js
@@ -601,21 +601,17 @@ class IndexMapper {
    * @private
    */
   cacheFromPhysicalToVisualIndexes() {
-    const notTrimmedIndexes = this.notTrimmedIndexesCache;
-    const sequenceOfPhysicalIndexes = this.getIndexesSequence(); // From visual to physical indexes.
-    const nrOfIndexes = sequenceOfPhysicalIndexes.length;
+    const notTrimmedIndexes = this.getNotTrimmedIndexes();
+    const nrOfIndexes = this.getNotHiddenIndexesLength();
 
     this.fromPhysicalToVisualIndexesCache.clear();
 
-    for (let index = 0; index < nrOfIndexes; index += 1) {
-      const physicalIndex = sequenceOfPhysicalIndexes[index];
-      const visualIndex = notTrimmedIndexes.indexOf(physicalIndex);
+    for (let visualIndex = 0; visualIndex < nrOfIndexes; visualIndex += 1) {
+      const physicalIndex = notTrimmedIndexes[visualIndex];
 
       // Every visual index have corresponding physical index, but some physical indexes may don't have
       // corresponding visual indexes (physical indexes may represent trimmed indexes, beyond the table boundaries)
-      if (visualIndex !== -1) {
-        this.fromPhysicalToVisualIndexesCache.set(physicalIndex, visualIndex);
-      }
+      this.fromPhysicalToVisualIndexesCache.set(physicalIndex, visualIndex);
     }
   }
 


### PR DESCRIPTION
### Context
Initialization and `updateSettings` are slow when we have 50k indexes. Investigating 🕵️ 
An example from #3770: https://jsfiddle.net/AMBudnik/6y50qmh9/

* https://github.com/handsontable/handsontable/commit/272a22fde48062ca64fbf67828f7f8df8d0ca019 `getRenderableIndexes` iterations loop grows with the number of indexes, because `includes` has more and more indexes to iterate over. Up to `N = length` operations for each row, `N * N` operations in the worst-case scenario. We can switch to O(1) op here and have a stable `N` number of operations
* https://github.com/handsontable/handsontable/pull/6936/commits/90abc5263aac68b99ac2b9feab969806c0925d1c `cacheFromPhysicalToVisualIndexes` iteration loop grows with the number of indexes, because `indexOf` has more and more indexes to scan over. In the worst-case scenario it's `N*N` as above. `notTrimmedIndexes` are already in the right order (build with `indexesSequence` and cached) so we can use that to just rewrite indexes to cache with `N` interactions only. 
* Same commit ☝️ Use trimmed indexes instead of the whole collection. `N` iterations becomes even smaller, reduced to the trimmed indexes which we previously filtered out. It should be faster when we have multiple indexes trimmed.
* https://github.com/handsontable/handsontable/pull/6936/commits/db00123e043cc4239e3faeeaa8e723e0754232ad Do not recreate filtered renderable collection, we already have it cached
* https://github.com/handsontable/handsontable/pull/6936/commits/2580c2e50bb27442771d07342be75a062b9b9584 iterate only over renderable indexes, this should be quicker when we have multiple indexes hidden
* https://github.com/handsontable/handsontable/pull/6936/commits/f6ac09ed694dee5dac669439b0da26cd5025d3de might be controversial, I know there were some discussions helpers vs native. We were using both in this file


### How has this been tested?
I'm running tests assuming refactor changes just op time. 
Performance compared in Chrome perf tools.

#### Results
https://github.com/handsontable/handsontable/commit/272a22fde48062ca64fbf67828f7f8df8d0ca019 reduced the time for `getRenderableIndexes` in the given example from 2s to 2.5ms
https://github.com/handsontable/handsontable/pull/6936/commits/90abc5263aac68b99ac2b9feab969806c0925d1c reduced the time for `cacheFromPhysicalToVisualIndexes` in the given example from 2.1s to 5.4ms

Other commits are not that impressive but should be noticeable when we have multiple indexes trimmed or hidden or both.

Total `initToLength` from 4.22s to 29ms.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #3770
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
