### PR TITLE
Fix unstable selection for hidden rows/columns

### DIFF
--- a/src/plugins/hiddenColumns/contextMenuItem/showColumn.js
+++ b/src/plugins/hiddenColumns/contextMenuItem/showColumn.js
@@ -16,42 +16,35 @@ export default function showColumnItem(hiddenColumnsPlugin) {
       return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_SHOW_COLUMN, pluralForm);
     },
     callback() {
-      const [, startVisualColumn, , endVisualColumn] = this.getSelectedLast();
-      const noVisibleIndexesBefore =
-        this.columnIndexMapper.getFirstNotHiddenIndex(startVisualColumn - 1, -1) === null;
-      const onlyFirstVisibleColumnSelected = noVisibleIndexesBefore && startVisualColumn === endVisualColumn;
-      const noVisibleIndexesAfter =
-        this.columnIndexMapper.getFirstNotHiddenIndex(endVisualColumn + 1, 1) === null;
-      const onlyLastVisibleColumnSelected = noVisibleIndexesAfter && startVisualColumn === endVisualColumn;
-
-      let startPhysicalColumn = this.toPhysicalColumn(startVisualColumn);
-      let endPhysicalColumn = this.toPhysicalColumn(endVisualColumn);
-
-      if (onlyFirstVisibleColumnSelected) {
-        startPhysicalColumn = 0;
+      if (columns.length === 0) {
+        return;
       }
 
-      if (onlyLastVisibleColumnSelected) {
-        endPhysicalColumn = this.countSourceCols() - 1; // All columns after the selected column will be shown.
-      }
+      let startVisualColumn = columns[0];
+      let endVisualColumn = columns[columns.length - 1];
+
+      // Add to the selection one more visual column on the left.
+      startVisualColumn = this.columnIndexMapper.getFirstNotHiddenIndex(startVisualColumn - 1, -1);
+      // Add to the selection one more visual column on the right.
+      endVisualColumn = this.columnIndexMapper.getFirstNotHiddenIndex(endVisualColumn + 1, 1);
+
+      startVisualColumn = startVisualColumn === null ? 0 : startVisualColumn;
+      endVisualColumn = endVisualColumn === null ? this.countCols() - 1 : endVisualColumn;
 
       hiddenColumnsPlugin.showColumns(columns);
-
-      const startVisualColumnAfterAction = this.toVisualColumn(startPhysicalColumn);
-      const endVisualColumnAfterAction = this.toVisualColumn(endPhysicalColumn);
-
-      const allColumnsSelected = endVisualColumnAfterAction - startVisualColumnAfterAction + 1 === this.countCols();
-      // TODO: Workaround, because selection doesn't select headers properly in a case when we select all columns
-      // from `0` to `n`, where `n` is number of columns in the `DataMap`.
-      const selectionStart = allColumnsSelected ? -1 : startVisualColumnAfterAction;
 
       // We render columns at first. It was needed for getting fixed columns.
       // Please take a look at #6864 for broader description.
       this.render();
       this.view.wt.wtOverlays.adjustElementsSize(true);
 
-      // Selection start and selection end coordinates might be changed after showing some items.
-      this.selectColumns(selectionStart, endVisualColumnAfterAction);
+      const allColumnsSelected = endVisualColumn - startVisualColumn + 1 === this.countCols();
+
+      // When all headers needs to be selected then do nothing. The header selection is
+      // automatically handled by corner click.
+      if (!allColumnsSelected) {
+        this.selectColumns(startVisualColumn, endVisualColumn);
+      }
     },
     disabled: false,
     hidden() {

--- a/src/plugins/hiddenColumns/contextMenuItem/showColumn.js
+++ b/src/plugins/hiddenColumns/contextMenuItem/showColumn.js
@@ -28,8 +28,8 @@ export default function showColumnItem(hiddenColumnsPlugin) {
       // Add to the selection one more visual column on the right.
       endVisualColumn = this.columnIndexMapper.getFirstNotHiddenIndex(endVisualColumn + 1, 1);
 
-      startVisualColumn = startVisualColumn === null ? 0 : startVisualColumn;
-      endVisualColumn = endVisualColumn === null ? this.countCols() - 1 : endVisualColumn;
+      startVisualColumn = startVisualColumn ?? 0;
+      endVisualColumn = endVisualColumn ?? this.countCols() - 1;
 
       hiddenColumnsPlugin.showColumns(columns);
 

--- a/src/plugins/hiddenColumns/contextMenuItem/showColumn.js
+++ b/src/plugins/hiddenColumns/contextMenuItem/showColumn.js
@@ -24,12 +24,11 @@ export default function showColumnItem(hiddenColumnsPlugin) {
       let endVisualColumn = columns[columns.length - 1];
 
       // Add to the selection one more visual column on the left.
-      startVisualColumn = this.columnIndexMapper.getFirstNotHiddenIndex(startVisualColumn - 1, -1);
+      startVisualColumn = this.columnIndexMapper
+        .getFirstNotHiddenIndex(startVisualColumn - 1, -1) ?? 0;
       // Add to the selection one more visual column on the right.
-      endVisualColumn = this.columnIndexMapper.getFirstNotHiddenIndex(endVisualColumn + 1, 1);
-
-      startVisualColumn = startVisualColumn ?? 0;
-      endVisualColumn = endVisualColumn ?? this.countCols() - 1;
+      endVisualColumn = this.columnIndexMapper
+        .getFirstNotHiddenIndex(endVisualColumn + 1, 1) ?? this.countCols() - 1;
 
       hiddenColumnsPlugin.showColumns(columns);
 

--- a/src/plugins/hiddenColumns/test/plugins/manualColumnMove.e2e.js
+++ b/src/plugins/hiddenColumns/test/plugins/manualColumnMove.e2e.js
@@ -3,6 +3,7 @@ describe('HiddenColumns', () => {
 
   const CSS_CLASS_BEFORE_HIDDEN = 'beforeHiddenColumn';
   const CSS_CLASS_AFTER_HIDDEN = 'afterHiddenColumn';
+  const CONTEXTMENU_ITEM_SHOW = 'hidden_columns_show';
 
   beforeEach(function() {
     this.$container = $(`<div id="${id}"></div>`).appendTo('body');
@@ -193,6 +194,51 @@ describe('HiddenColumns', () => {
       expect(getCell(-1, 4)).toHaveClass(CSS_CLASS_AFTER_HIDDEN);
       expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('A1');
       expect(spec().$container.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('C1');
+    });
+
+    describe('selection', () => {
+      it('should correctly set the selection of the unhidden column when it\'s placed as a most-left' +
+         'table record (caused by moving first visible column on the right of the hidden one)', () => {
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(2, 5),
+          rowHeaders: true,
+          colHeaders: true,
+          contextMenu: [CONTEXTMENU_ITEM_SHOW],
+          hiddenColumns: {
+            columns: [1],
+          },
+          manualColumnMove: true,
+        });
+
+        getPlugin('manualColumnMove').moveColumn(0, 2);
+        render();
+
+        selectColumns(1);
+
+        contextMenu();
+        getPlugin('contextMenu').executeCommand(CONTEXTMENU_ITEM_SHOW);
+
+        expect(spec().$container.find('tr:eq(0) th').length).toBe(6);
+        expect(spec().$container.find('tr:eq(1) td').length).toBe(5);
+        expect(getCell(0, 0).innerText).toBe('B1');
+        expect(getCell(0, 1).innerText).toBe('C1');
+        expect(getCell(0, 2).innerText).toBe('A1');
+        expect(getCell(0, 3).innerText).toBe('D1');
+        expect(getCell(0, 4).innerText).toBe('E1');
+        expect(getSelected()).toEqual([[0, 0, 1, 1]]);
+        expect(getSelectedRangeLast().highlight.row).toBe(0);
+        expect(getSelectedRangeLast().highlight.col).toBe(0);
+        expect(getSelectedRangeLast().from.row).toBe(0);
+        expect(getSelectedRangeLast().from.col).toBe(0);
+        expect(getSelectedRangeLast().to.row).toBe(1);
+        expect(getSelectedRangeLast().to.col).toBe(1);
+        expect(`
+        |   ║ * : * :   :   :   |
+        |===:===:===:===:===:===|
+        | - ║ A : 0 :   :   :   |
+        | - ║ 0 : 0 :   :   :   |
+        `).toBeMatchToSelectionPattern();
+      });
     });
 
     describe('UI', () => {

--- a/src/plugins/hiddenRows/contextMenuItem/showRow.js
+++ b/src/plugins/hiddenRows/contextMenuItem/showRow.js
@@ -16,45 +16,35 @@ export default function showRowItem(hiddenRowsPlugin) {
       return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_SHOW_ROW, pluralForm);
     },
     callback() {
-      const selectedRangeLast = this.getSelectedRangeLast();
-      const visualStartRow = selectedRangeLast.getTopLeftCorner().row;
-      const visualEndRow = selectedRangeLast.getBottomRightCorner().row;
-      const rowIndexMapper = this.rowIndexMapper;
-      const noVisibleIndexesBefore =
-        rowIndexMapper.getFirstNotHiddenIndex(visualStartRow - 1, -1) === null;
-      const onlyFirstVisibleRowSelected = noVisibleIndexesBefore && visualStartRow === visualEndRow;
-      const noVisibleIndexesAfter =
-        rowIndexMapper.getFirstNotHiddenIndex(visualEndRow + 1, 1) === null;
-      const onlyLastVisibleRowSelected = noVisibleIndexesAfter && visualStartRow === visualEndRow;
-
-      let startPhysicalRow = this.toPhysicalRow(visualStartRow);
-      let endPhysicalRow = this.toPhysicalRow(visualEndRow);
-
-      if (onlyFirstVisibleRowSelected) {
-        startPhysicalRow = 0;
+      if (rows.length === 0) {
+        return;
       }
 
-      if (onlyLastVisibleRowSelected) {
-        endPhysicalRow = this.countSourceRows() - 1; // All rows after the selected row will be shown.
-      }
+      let startVisualRow = rows[0];
+      let endVisualRow = rows[rows.length - 1];
+
+      // Add to the selection one more visual row on the top.
+      startVisualRow = this.rowIndexMapper.getFirstNotHiddenIndex(startVisualRow - 1, -1);
+      // Add to the selection one more visual row on the bottom.
+      endVisualRow = this.rowIndexMapper.getFirstNotHiddenIndex(endVisualRow + 1, 1);
+
+      startVisualRow = startVisualRow === null ? 0 : startVisualRow;
+      endVisualRow = endVisualRow === null ? this.countRows() - 1 : endVisualRow;
 
       hiddenRowsPlugin.showRows(rows);
-
-      const startVisualRowAfterAction = this.toVisualRow(startPhysicalRow);
-      const endVisualRowAfterAction = this.toVisualRow(endPhysicalRow);
-
-      const allRowsSelected = endVisualRowAfterAction - startVisualRowAfterAction + 1 === this.countRows();
-      // TODO: Workaround, because selection doesn't select headers properly in a case when we select all rows
-      // from `0` to `n`, where `n` is number of rows in the `DataMap`.
-      const selectionStart = allRowsSelected ? -1 : startVisualRowAfterAction;
 
       // We render rows at first. It was needed for getting fixed rows.
       // Please take a look at #6864 for broader description.
       this.render();
       this.view.wt.wtOverlays.adjustElementsSize(true);
 
-      // Selection start and selection end coordinates might be changed after showing some items.
-      this.selectRows(selectionStart, endVisualRowAfterAction);
+      const allRowsSelected = endVisualRow - startVisualRow + 1 === this.countRows();
+
+      // When all headers needs to be selected then do nothing. The header selection is
+      // automatically handled by corner click.
+      if (!allRowsSelected) {
+        this.selectRows(startVisualRow, endVisualRow);
+      }
     },
     disabled: false,
     hidden() {

--- a/src/plugins/hiddenRows/contextMenuItem/showRow.js
+++ b/src/plugins/hiddenRows/contextMenuItem/showRow.js
@@ -24,12 +24,11 @@ export default function showRowItem(hiddenRowsPlugin) {
       let endVisualRow = rows[rows.length - 1];
 
       // Add to the selection one more visual row on the top.
-      startVisualRow = this.rowIndexMapper.getFirstNotHiddenIndex(startVisualRow - 1, -1);
+      startVisualRow = this.rowIndexMapper
+        .getFirstNotHiddenIndex(startVisualRow - 1, -1) ?? 0;
       // Add to the selection one more visual row on the bottom.
-      endVisualRow = this.rowIndexMapper.getFirstNotHiddenIndex(endVisualRow + 1, 1);
-
-      startVisualRow = startVisualRow ?? 0;
-      endVisualRow = endVisualRow ?? this.countRows() - 1;
+      endVisualRow = this.rowIndexMapper
+        .getFirstNotHiddenIndex(endVisualRow + 1, 1) ?? this.countRows() - 1;
 
       hiddenRowsPlugin.showRows(rows);
 

--- a/src/plugins/hiddenRows/contextMenuItem/showRow.js
+++ b/src/plugins/hiddenRows/contextMenuItem/showRow.js
@@ -28,8 +28,8 @@ export default function showRowItem(hiddenRowsPlugin) {
       // Add to the selection one more visual row on the bottom.
       endVisualRow = this.rowIndexMapper.getFirstNotHiddenIndex(endVisualRow + 1, 1);
 
-      startVisualRow = startVisualRow === null ? 0 : startVisualRow;
-      endVisualRow = endVisualRow === null ? this.countRows() - 1 : endVisualRow;
+      startVisualRow = startVisualRow ?? 0;
+      endVisualRow = endVisualRow ?? this.countRows() - 1;
 
       hiddenRowsPlugin.showRows(rows);
 

--- a/src/plugins/hiddenRows/test/plugins/manualRowMove.e2e.js
+++ b/src/plugins/hiddenRows/test/plugins/manualRowMove.e2e.js
@@ -1,6 +1,8 @@
 describe('HiddenRows', () => {
   const id = 'testContainer';
 
+  const CONTEXTMENU_ITEM_SHOW = 'hidden_rows_show';
+
   function extractDOMStructure(overlay) {
     const overlayBody = overlay.find('tbody')[0].cloneNode(true);
 
@@ -305,6 +307,53 @@ describe('HiddenRows', () => {
           </tr>
         </tbody>
         `);
+    });
+
+    describe('selection', () => {
+      it('should correctly set the selection of the unhidden row when it\'s placed as a most-top ' +
+         'table record (caused by moving first visible row under hidden one)', () => {
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(5, 2),
+          rowHeaders: true,
+          colHeaders: true,
+          contextMenu: [CONTEXTMENU_ITEM_SHOW],
+          hiddenRows: {
+            rows: [1],
+          },
+          manualRowMove: true,
+        });
+
+        getPlugin('manualRowMove').moveRow(0, 2);
+        render();
+
+        selectRows(1);
+
+        contextMenu();
+        getPlugin('contextMenu').executeCommand(CONTEXTMENU_ITEM_SHOW);
+
+        expect(spec().$container.find('.ht_master tbody th').length).toBe(5);
+        expect(getCell(0, 0).innerText).toBe('A2');
+        expect(getCell(1, 0).innerText).toBe('A3');
+        expect(getCell(2, 0).innerText).toBe('A1');
+        expect(getCell(3, 0).innerText).toBe('A4');
+        expect(getCell(4, 0).innerText).toBe('A5');
+        expect(getSelected()).toEqual([[0, 0, 1, 1]]);
+        expect(getSelectedRangeLast().highlight.row).toBe(0);
+        expect(getSelectedRangeLast().highlight.col).toBe(0);
+        expect(getSelectedRangeLast().from.row).toBe(0);
+        expect(getSelectedRangeLast().from.col).toBe(0);
+        expect(getSelectedRangeLast().to.row).toBe(1);
+        expect(getSelectedRangeLast().to.col).toBe(1);
+        expect(`
+          |   ║ - : - |
+          |===:===:===|
+          | * ║ A : 0 |
+          | * ║ 0 : 0 |
+          |   ║   :   |
+          |   ║   :   |
+          |   ║   :   |
+        `).toBeMatchToSelectionPattern();
+      });
     });
 
     describe('UI', () => {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Fix unstable selection (described here https://github.com/handsontable/handsontable/issues/6874) which occurs when some rows/columns are moved between hidden records. Additionally, I've found a solution for simplifying the code inside the context menu callbacks by reusing the collected indexes from the "hidden" function.

This's how the previous selection selects the first unhidden column (The B cells should be selected, column A):
![wrong](https://user-images.githubusercontent.com/571316/83407501-24fa3c80-a411-11ea-93d7-aeb000feab3a.gif)

Now, it selects the previously hidden column and adjacent column:
![good](https://user-images.githubusercontent.com/571316/83407528-37747600-a411-11ea-99ea-a101a6b6d9b4.gif)

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Added E2E tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #6874
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
