### PR TITLE
Correct renderable/visual indexes in the comments plugin.

### DIFF
--- a/src/plugins/comments/comments.js
+++ b/src/plugins/comments/comments.js
@@ -558,7 +558,10 @@ class Comments extends BasePlugin {
     if (this.targetIsCellWithComment(event)) {
       const coordinates = this.hot.view.wt.wtTable.getCoords(event.target);
       const range = {
-        from: new CellCoords(coordinates.row, coordinates.col)
+        from: new CellCoords(
+          this.hot.rowIndexMapper.getVisualFromRenderableIndex(coordinates.row),
+          this.hot.columnIndexMapper.getVisualFromRenderableIndex(coordinates.col)
+        )
       };
 
       this.displaySwitch.show(range);

--- a/src/plugins/comments/test/comments.e2e.js
+++ b/src/plugins/comments/test/comments.e2e.js
@@ -723,5 +723,41 @@ describe('Comments', () => {
         left: $(getCell(7, 7)).offset().left + $(getCell(7, 7)).outerWidth()
       });
     });
+
+    it('should display the correct values in the comment editor, for cells placed past hidden rows/columns', () => {
+      const hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(6, 6),
+        comments: true,
+        hiddenColumns: {
+          columns: [0, 1, 4],
+          indicators: true
+        },
+        hiddenRows: {
+          rows: [0, 1, 4],
+          indicators: true
+        },
+        cell: [
+          { row: 2, col: 2, comment: { value: 'Foo' } },
+          { row: 5, col: 5, comment: { value: 'Bar' } },
+        ],
+      });
+
+      const plugin = hot.getPlugin('comments');
+      const editor = plugin.editor.getInputElement();
+
+      plugin.showAtCell(2, 2);
+      expect($(editor).val()).toEqual('Foo');
+      expect(plugin.getCommentMeta(2, 2, 'value')).toEqual('Foo');
+      expect(plugin.getCommentAtCell(2, 2)).toEqual('Foo');
+      selectCell(2, 2);
+      expect(plugin.getComment()).toEqual('Foo');
+
+      plugin.showAtCell(5, 5);
+      expect($(editor).val()).toEqual('Bar');
+      expect(plugin.getCommentMeta(5, 5, 'value')).toEqual('Bar');
+      expect(plugin.getCommentAtCell(5, 5)).toEqual('Bar');
+      selectCell(5, 5);
+      expect(plugin.getComment()).toEqual('Bar');
+    });
   });
 });

--- a/src/plugins/comments/test/comments.e2e.js
+++ b/src/plugins/comments/test/comments.e2e.js
@@ -91,7 +91,7 @@ describe('Comments', () => {
       expect(getCell(2, 2).className.indexOf('htCommentCell')).toBeGreaterThan(-1);
     });
 
-    it('should display the comment edditor in the correct place', () => {
+    it('should display the comment editor in the correct place', () => {
       const hot = handsontable({
         data: Handsontable.helper.createSpreadsheetData(4, 4),
         comments: true,
@@ -670,7 +670,7 @@ describe('Comments', () => {
   });
 
   describe('hidden row an column integration', () => {
-    it('should display the comment edditor in the correct place, when the active cell is past hidden rows/columns', () => {
+    it('should display the comment editor in the correct place, when the active cell is past hidden rows/columns', () => {
       const hot = handsontable({
         data: Handsontable.helper.createSpreadsheetData(10, 10),
         comments: true,
@@ -688,36 +688,45 @@ describe('Comments', () => {
       const editor = plugin.editor.getInputElement();
 
       plugin.showAtCell(0, 0);
+
       expect($(editor.parentNode).offset()).toEqual($(hot.rootElement).offset());
 
       plugin.showAtCell(1, 1);
+
       expect($(editor.parentNode).offset()).toEqual($(hot.rootElement).offset());
 
       plugin.showAtCell(2, 2);
+
       expect($(editor.parentNode).offset()).toEqual($(getCell(2, 3)).offset());
 
       plugin.showAtCell(3, 3);
+
       expect($(editor.parentNode).offset()).toEqual($(getCell(3, 5)).offset());
 
       plugin.showAtCell(4, 4);
+
       expect($(editor.parentNode).offset()).toEqual($(getCell(5, 5)).offset());
 
       plugin.showAtCell(5, 5);
+
       expect($(editor.parentNode).offset()).toEqual($(getCell(5, 6)).offset());
 
       plugin.showAtCell(7, 7);
+
       expect($(editor.parentNode).offset()).toEqual({
         top: $(getCell(7, 7)).offset().top,
         left: $(getCell(7, 7)).offset().left + $(getCell(7, 7)).outerWidth()
       });
 
       plugin.showAtCell(8, 8);
+
       expect($(editor.parentNode).offset()).toEqual({
         top: $(getCell(7, 7)).offset().top + $(getCell(7, 7)).outerHeight(),
         left: $(getCell(7, 7)).offset().left + $(getCell(7, 7)).outerWidth()
       });
 
       plugin.showAtCell(9, 9);
+
       expect($(editor.parentNode).offset()).toEqual({
         top: $(getCell(7, 7)).offset().top + $(getCell(7, 7)).outerHeight(),
         left: $(getCell(7, 7)).offset().left + $(getCell(7, 7)).outerWidth()

--- a/src/plugins/comments/test/comments.e2e.js
+++ b/src/plugins/comments/test/comments.e2e.js
@@ -90,6 +90,20 @@ describe('Comments', () => {
       expect(getCell(1, 1).className.indexOf('htCommentCell')).toBeGreaterThan(-1);
       expect(getCell(2, 2).className.indexOf('htCommentCell')).toBeGreaterThan(-1);
     });
+
+    it('should display the comment edditor in the correct place', () => {
+      const hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(4, 4),
+        comments: true,
+      });
+
+      const plugin = hot.getPlugin('comments');
+      const editor = plugin.editor.getInputElement();
+
+      plugin.showAtCell(0, 1);
+
+      expect($(editor.parentNode).offset()).toEqual($(getCell(0, 2)).offset());
+    });
   });
 
   describe('Displaying comment after `mouseover` event', () => {
@@ -652,6 +666,62 @@ describe('Comments', () => {
       await sleep(400);
 
       expect(getCellMeta(0, 0).comment.value).toEqual('test');
+    });
+  });
+
+  describe('hidden row an column integration', () => {
+    it('should display the comment edditor in the correct place, when the active cell is past hidden rows/columns', () => {
+      const hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(10, 10),
+        comments: true,
+        hiddenColumns: {
+          columns: [0, 1, 4, 8, 9],
+          indicators: true
+        },
+        hiddenRows: {
+          rows: [0, 1, 4, 8, 9],
+          indicators: true
+        },
+      });
+
+      const plugin = hot.getPlugin('comments');
+      const editor = plugin.editor.getInputElement();
+
+      plugin.showAtCell(0, 0);
+      expect($(editor.parentNode).offset()).toEqual($(hot.rootElement).offset());
+
+      plugin.showAtCell(1, 1);
+      expect($(editor.parentNode).offset()).toEqual($(hot.rootElement).offset());
+
+      plugin.showAtCell(2, 2);
+      expect($(editor.parentNode).offset()).toEqual($(getCell(2, 3)).offset());
+
+      plugin.showAtCell(3, 3);
+      expect($(editor.parentNode).offset()).toEqual($(getCell(3, 5)).offset());
+
+      plugin.showAtCell(4, 4);
+      expect($(editor.parentNode).offset()).toEqual($(getCell(5, 5)).offset());
+
+      plugin.showAtCell(5, 5);
+      expect($(editor.parentNode).offset()).toEqual($(getCell(5, 6)).offset());
+
+      plugin.showAtCell(7, 7);
+      expect($(editor.parentNode).offset()).toEqual({
+        top: $(getCell(7, 7)).offset().top,
+        left: $(getCell(7, 7)).offset().left + $(getCell(7, 7)).outerWidth()
+      });
+
+      plugin.showAtCell(8, 8);
+      expect($(editor.parentNode).offset()).toEqual({
+        top: $(getCell(7, 7)).offset().top + $(getCell(7, 7)).outerHeight(),
+        left: $(getCell(7, 7)).offset().left + $(getCell(7, 7)).outerWidth()
+      });
+
+      plugin.showAtCell(9, 9);
+      expect($(editor.parentNode).offset()).toEqual({
+        top: $(getCell(7, 7)).offset().top + $(getCell(7, 7)).outerHeight(),
+        left: $(getCell(7, 7)).offset().left + $(getCell(7, 7)).outerWidth()
+      });
     });
   });
 });


### PR DESCRIPTION
### Context
This PR should fix 2 issues (#6896, #6875) regarding the Comments plugin, caused by renderable/visual index mismatches.

### How has this been tested?
Added test cases for the fixed issues.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #6896
2. #6875
