### PR TITLE
Fix row and column resize handler

### DIFF
--- a/src/3rdparty/walkontable/src/overlay/_base.js
+++ b/src/3rdparty/walkontable/src/overlay/_base.js
@@ -214,6 +214,7 @@ class Overlay {
     const fixedColumn = columnIndex < this.wot.getSetting('fixedColumnsLeft');
     const fixedRowTop = rowIndex < this.wot.getSetting('fixedRowsTop');
     const fixedRowBottom = rowIndex >= this.wot.getSetting('totalRows') - this.wot.getSetting('fixedRowsBottom');
+
     const spreaderOffset = {
       left: this.clone.wtTable.spreader.offsetLeft,
       top: this.clone.wtTable.spreader.offsetTop

--- a/src/plugins/hiddenColumns/test/plugins/manualColumnResize.e2e.js
+++ b/src/plugins/hiddenColumns/test/plugins/manualColumnResize.e2e.js
@@ -77,6 +77,36 @@ describe('HiddenColumns', () => {
       expect($handle.height()).toBe($headerTH.outerHeight());
     });
 
+    it('should display the resize handler in the proper position when the table contains hidden fixed left column', () => {
+      handsontable({
+        data: [
+          { id: 1, name: 'Ted', lastName: 'Right', addr: 'NYC' },
+          { id: 2, name: 'Frank', lastName: 'Honest', addr: 'NYC' },
+          { id: 3, name: 'Joan', lastName: 'Well', addr: 'NYC' },
+          { id: 4, name: 'Sid', lastName: 'Strong', addr: 'NYC' },
+          { id: 5, name: 'Jane', lastName: 'Neat', addr: 'NYC' }
+        ],
+        colHeaders: true,
+        hiddenColumns: {
+          columns: [1],
+          indicators: true,
+        },
+        fixedColumnsLeft: 3,
+        manualColumnResize: true
+      });
+
+      // Show resize handler using the third renderable column. This column belongs to master as
+      // the "fixedColumnsLeft" is decreased to 2.
+      const $headerTH = spec().$container.find('thead tr:eq(0) th:eq(2)'); // Header "D"
+
+      $headerTH.simulate('mouseover');
+
+      const $handle = $('.manualColumnResizer');
+
+      expect($handle.offset().left).toBe($headerTH.offset().left + $headerTH.outerWidth() - $handle.outerWidth() - 1);
+      expect($handle.height()).toBe($headerTH.outerHeight());
+    });
+
     it('should resize a proper column using the resize handler when the table contains hidden column', () => {
       handsontable({
         data: [

--- a/src/plugins/hiddenRows/test/plugins/manualRowResize.e2e.js
+++ b/src/plugins/hiddenRows/test/plugins/manualRowResize.e2e.js
@@ -78,6 +78,66 @@ describe('HiddenRows', () => {
       expect($handle.width()).toBeCloseTo($headerTH.outerWidth(), 0);
     });
 
+    it('should display the resize handler in the proper position when the table contains hidden fixed top row', () => {
+      handsontable({
+        data: [
+          { id: 1, name: 'Ted', lastName: 'Right' },
+          { id: 2, name: 'Frank', lastName: 'Honest' },
+          { id: 3, name: 'Joan', lastName: 'Well' },
+          { id: 4, name: 'Sid', lastName: 'Strong' },
+          { id: 5, name: 'Jane', lastName: 'Neat' }
+        ],
+        rowHeaders: true,
+        hiddenRows: {
+          rows: [1],
+          indicators: true,
+        },
+        fixedRowsTop: 3,
+        manualRowResize: true
+      });
+
+      // Show resize handler using the third renderable row. This row belongs to master as
+      // the "fixedRowsTop" is decreased to 2.
+      const $headerTH = spec().$container.find('tbody tr:eq(2) th:eq(0)');
+
+      $headerTH.simulate('mouseover');
+
+      const $handle = $('.manualRowResizer');
+
+      expect($handle.offset().top).toBeCloseTo($headerTH.offset().top + $headerTH.outerHeight() - $handle.outerHeight() - 1, 0);
+      expect($handle.width()).toBeCloseTo($headerTH.outerWidth(), 0);
+    });
+
+    it('should display the resize handler in the proper position when the table contains hidden fixed bottom row', () => {
+      handsontable({
+        data: [
+          { id: 1, name: 'Ted', lastName: 'Right' },
+          { id: 2, name: 'Frank', lastName: 'Honest' },
+          { id: 3, name: 'Joan', lastName: 'Well' },
+          { id: 4, name: 'Sid', lastName: 'Strong' },
+          { id: 5, name: 'Jane', lastName: 'Neat' }
+        ],
+        rowHeaders: true,
+        hiddenRows: {
+          rows: [3],
+          indicators: true,
+        },
+        fixedRowsBottom: 3,
+        manualRowResize: true
+      });
+
+      // Show resize handler using the second renderable row. This row belongs to master as
+      // the "fixedRowsBottom" is decreased to 2.
+      const $headerTH = spec().$container.find('tbody tr:eq(1) th:eq(0)');
+
+      $headerTH.simulate('mouseover');
+
+      const $handle = $('.manualRowResizer');
+
+      expect($handle.offset().top).toBeCloseTo($headerTH.offset().top + $headerTH.outerHeight() - $handle.outerHeight() - 1, 0);
+      expect($handle.width()).toBeCloseTo($headerTH.outerWidth(), 0);
+    });
+
     it('should resize a proper row using the resize handler when the table contains hidden row', () => {
       handsontable({
         data: [

--- a/src/plugins/manualColumnResize/manualColumnResize.js
+++ b/src/plugins/manualColumnResize/manualColumnResize.js
@@ -234,7 +234,8 @@ class ManualColumnResize extends BasePlugin {
       // the top overlay - as this overlay contains the rest of the headers.
       if (!relativeHeaderPosition) {
         const fallbackOverlay = wt.wtOverlays.topOverlay;
-        const currentTH = fallbackOverlay.clone.wtTable.THEAD.lastChild[col];
+        const rowHeadersCount = this.hot.getSettings().rowHeaders ? 1 : 0;
+        const currentTH = fallbackOverlay.clone.wtTable.THEAD.lastChild.children[col + rowHeadersCount];
 
         relativeHeaderPosition = fallbackOverlay.getRelativeCellPosition(currentTH, cellCoords.row, cellCoords.col);
       }

--- a/src/plugins/manualColumnResize/manualColumnResize.js
+++ b/src/plugins/manualColumnResize/manualColumnResize.js
@@ -214,65 +214,74 @@ class ManualColumnResize extends BasePlugin {
     const { view: { wt } } = this.hot;
     const cellCoords = wt.wtTable.getCoords(this.currentTH);
     const col = cellCoords.col;
+
+    // Ignore column headers.
+    if (col < 0) {
+      return;
+    }
+
     const headerHeight = outerHeight(this.currentTH);
+    const box = this.currentTH.getBoundingClientRect();
+    // Read "fixedColumnsLeft" through the Walkontable as in that context, the fixed columns
+    // are modified (reduced by the number of hidden columns) by TableView module.
+    const fixedColumn = col < wt.getSetting('fixedColumnsLeft');
+    let relativeHeaderPosition;
 
-    if (col >= 0) { // if col header
-      const box = this.currentTH.getBoundingClientRect();
-      // Read "fixedColumnsLeft" through the Walkontable as in that context, the fixed columns
-      // are modified (reduced by the number of hidden columns) by TableView module.
-      const fixedColumn = col < wt.getSetting('fixedColumnsLeft');
-      let relativeHeaderPosition;
+    if (fixedColumn) {
+      relativeHeaderPosition = wt
+        .wtOverlays
+        .topLeftCornerOverlay
+        .getRelativeCellPosition(this.currentTH, cellCoords.row, cellCoords.col);
 
-      if (fixedColumn) {
-        relativeHeaderPosition = wt
-          .wtOverlays
-          .topLeftCornerOverlay
-          .getRelativeCellPosition(this.currentTH, cellCoords.row, cellCoords.col);
+    } else {
+      relativeHeaderPosition = wt
+        .wtOverlays
+        .topOverlay
+        .getRelativeCellPosition(this.currentTH, cellCoords.row, cellCoords.col);
+    }
+
+    // If the TH is not a child of the top-left or top overlay, recalculate using
+    // the master overlay - as this overlay contains the rest of the headers.
+    if (!relativeHeaderPosition) {
+      const fallbackOverlay = wt.wtOverlays.topOverlay;
+      const rowHeadersCount = this.hot.getSettings().rowHeaders ? 1 : 0;
+      const currentTH = fallbackOverlay.clone.wtTable.THEAD.lastChild.children[col + rowHeadersCount];
+
+      relativeHeaderPosition = fallbackOverlay.getRelativeCellPosition(currentTH, cellCoords.row, cellCoords.col);
+    }
+
+    this.currentCol = this.hot.columnIndexMapper.getVisualFromRenderableIndex(col);
+    this.selectedCols = [];
+
+    if (this.hot.selection.isSelected() && this.hot.selection.isSelectedByColumnHeader()) {
+      const { from, to } = this.hot.getSelectedRangeLast();
+      let start = from.col;
+      let end = to.col;
+
+      if (start >= end) {
+        start = to.col;
+        end = from.col;
       }
 
-      // If the TH is not a child of the top-left overlay, recalculate using
-      // the top overlay - as this overlay contains the rest of the headers.
-      if (!relativeHeaderPosition) {
-        const fallbackOverlay = wt.wtOverlays.topOverlay;
-        const rowHeadersCount = this.hot.getSettings().rowHeaders ? 1 : 0;
-        const currentTH = fallbackOverlay.clone.wtTable.THEAD.lastChild.children[col + rowHeadersCount];
-
-        relativeHeaderPosition = fallbackOverlay.getRelativeCellPosition(currentTH, cellCoords.row, cellCoords.col);
-      }
-
-      this.currentCol = this.hot.columnIndexMapper.getVisualFromRenderableIndex(col);
-      this.selectedCols = [];
-
-      if (this.hot.selection.isSelected() && this.hot.selection.isSelectedByColumnHeader()) {
-        const { from, to } = this.hot.getSelectedRangeLast();
-        let start = from.col;
-        let end = to.col;
-
-        if (start >= end) {
-          start = to.col;
-          end = from.col;
-        }
-
-        if (this.currentCol >= start && this.currentCol <= end) {
-          rangeEach(start, end, i => this.selectedCols.push(i));
-
-        } else {
-          this.selectedCols.push(this.currentCol);
-        }
+      if (this.currentCol >= start && this.currentCol <= end) {
+        rangeEach(start, end, i => this.selectedCols.push(i));
 
       } else {
         this.selectedCols.push(this.currentCol);
       }
 
-      this.startOffset = relativeHeaderPosition.left - 6;
-      this.startWidth = parseInt(box.width, 10);
-
-      this.handle.style.top = `${relativeHeaderPosition.top}px`;
-      this.handle.style.left = `${this.startOffset + this.startWidth}px`;
-
-      this.handle.style.height = `${headerHeight}px`;
-      this.hot.rootElement.appendChild(this.handle);
+    } else {
+      this.selectedCols.push(this.currentCol);
     }
+
+    this.startOffset = relativeHeaderPosition.left - 6;
+    this.startWidth = parseInt(box.width, 10);
+
+    this.handle.style.top = `${relativeHeaderPosition.top}px`;
+    this.handle.style.left = `${this.startOffset + this.startWidth}px`;
+
+    this.handle.style.height = `${headerHeight}px`;
+    this.hot.rootElement.appendChild(this.handle);
   }
 
   /**

--- a/src/plugins/manualColumnResize/manualColumnResize.js
+++ b/src/plugins/manualColumnResize/manualColumnResize.js
@@ -219,7 +219,7 @@ class ManualColumnResize extends BasePlugin {
     if (col >= 0) { // if col header
       const box = this.currentTH.getBoundingClientRect();
       // Read "fixedColumnsLeft" through the Walkontable as in that context, the fixed columns
-      // are modified (decreased if there are no renderable columns) by TableView module.
+      // are modified (reduced by the number of hidden columns) by TableView module.
       const fixedColumn = col < wt.getSetting('fixedColumnsLeft');
       let relativeHeaderPosition;
 

--- a/src/plugins/manualColumnResize/test/manualColumnResize.e2e.js
+++ b/src/plugins/manualColumnResize/test/manualColumnResize.e2e.js
@@ -641,6 +641,7 @@ describe('manualColumnResize', () => {
 
     handleBox = handle[0].getBoundingClientRect();
     thBox = th0[0].getBoundingClientRect();
+
     expect(handleBox.left + handleBox.width).toEqual(thBox.left + thBox.width - 1);
   });
 
@@ -654,7 +655,7 @@ describe('manualColumnResize', () => {
     });
 
     const mainHolder = hot.view.wt.wtTable.holder;
-    let $colHeader = spec().$container.find('.ht_clone_top thead tr:eq(0) th:eq(2)');
+    let $colHeader = spec().$container.find('.ht_clone_top thead tr:eq(0) th:eq(2)'); // Header "C"
 
     $colHeader.simulate('mouseover');
 
@@ -670,6 +671,7 @@ describe('manualColumnResize', () => {
 
     $colHeader = spec().$container.find('.ht_clone_top thead tr:eq(0) th:eq(2)');
     $colHeader.simulate('mouseover');
+
     expect($colHeader.offset().left + $colHeader.width() - 5).toBeCloseTo($handle.offset().left, 0);
     expect($colHeader.offset().top).toBeCloseTo($handle.offset().top, 0);
   });
@@ -703,6 +705,7 @@ describe('manualColumnResize', () => {
 
       $colHeader = spec().$container.find('.ht_clone_top thead tr:eq(0) th:eq(7)');
       $colHeader.simulate('mouseover');
+
       expect($colHeader.offset().left + $colHeader.width() - 5).toBeCloseTo($handle.offset().left, 0);
       expect($colHeader.offset().top).toBeCloseTo($handle.offset().top, 0);
     });
@@ -732,6 +735,7 @@ describe('manualColumnResize', () => {
 
       $colHeader = spec().$container.find('.ht_clone_top thead tr:eq(0) th:eq(7)');
       $colHeader.simulate('mouseover');
+
       expect($colHeader.offset().left + $colHeader.width() - 5).toBeCloseTo($handle.offset().left, 0);
       expect($colHeader.offset().top).toBeCloseTo($handle.offset().top, 0);
 

--- a/src/plugins/manualRowResize/manualRowResize.js
+++ b/src/plugins/manualRowResize/manualRowResize.js
@@ -171,8 +171,8 @@ class ManualRowResize extends BasePlugin {
 
     if (row >= 0) { // if not col header
       const box = this.currentTH.getBoundingClientRect();
-      // Read "fixedRowsTop" through the Walkontable as in that context, the fixed rows
-      // are modified (decreased if there are no renderable columns) by TableView module.
+      // Read "fixedRowsTop" and "fixedRowsBottom" through the Walkontable as in that context, the fixed
+      // rows are modified (reduced by the number of hidden rows) by TableView module.
       const fixedRowTop = row < wt.getSetting('fixedRowsTop');
       const fixedRowBottom = row >= view.countNotHiddenRowIndexes(0, 1) - wt.getSetting('fixedRowsBottom');
       let relativeHeaderPosition;


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
When some fixed rows or columns are hidden the handler from the manual row/column resize throws exceptions while hovering adjacent columns/rows.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Added E2E tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #6885
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
