### PR TITLE
Fix selection corner cut when overlay was selected

### DIFF
--- a/src/3rdparty/walkontable/src/border.js
+++ b/src/3rdparty/walkontable/src/border.js
@@ -52,6 +52,8 @@ class Border {
       borderStyle: 'solid',
       borderColor: '#FFF'
     };
+    // Offset to moving the corner to be centered relative to the grid.
+    this.cornerCenterPointOffset = -(parseInt(this.cornerDefaultStyle.width, 10) / 2);
     this.corner = null;
     this.cornerStyle = null;
 
@@ -495,8 +497,8 @@ class Border {
       this.cornerStyle.display = 'none';
 
     } else {
-      this.cornerStyle.top = `${top + height - 4}px`;
-      this.cornerStyle.left = `${left + width - 4}px`;
+      this.cornerStyle.top = `${top + height + this.cornerCenterPointOffset - 1}px`;
+      this.cornerStyle.left = `${left + width + this.cornerCenterPointOffset - 1}px`;
       this.cornerStyle.borderRightWidth = this.cornerDefaultStyle.borderWidth;
       this.cornerStyle.width = this.cornerDefaultStyle.width;
 
@@ -516,7 +518,7 @@ class Border {
         const cornerOverlappingContainer = cornerRightEdge >= innerWidth(trimmingContainer);
 
         if (cornerOverlappingContainer) {
-          this.cornerStyle.left = `${Math.floor(left + width - 3 - (parseInt(this.cornerDefaultStyle.width, 10) / 2))}px`; // eslint-disable-line max-len
+          this.cornerStyle.left = `${Math.floor(left + width + this.cornerCenterPointOffset - (parseInt(this.cornerDefaultStyle.width, 10) / 2))}px`; // eslint-disable-line max-len
           this.cornerStyle.borderRightWidth = 0;
         }
       }
@@ -527,7 +529,7 @@ class Border {
         const cornerOverlappingContainer = cornerBottomEdge >= innerHeight(trimmingContainer);
 
         if (cornerOverlappingContainer) {
-          this.cornerStyle.top = `${Math.floor(top + height - 3 - (parseInt(this.cornerDefaultStyle.height, 10) / 2))}px`; // eslint-disable-line max-len
+          this.cornerStyle.top = `${Math.floor(top + height + this.cornerCenterPointOffset - (parseInt(this.cornerDefaultStyle.height, 10) / 2))}px`; // eslint-disable-line max-len
           this.cornerStyle.borderBottomWidth = 0;
         }
       }

--- a/src/3rdparty/walkontable/src/overlay/left.js
+++ b/src/3rdparty/walkontable/src/overlay/left.js
@@ -57,7 +57,8 @@ class LeftOverlay extends Overlay {
     let headerPosition = 0;
     const preventOverflow = this.wot.getSetting('preventOverflow');
 
-    if (this.trimmingContainer === this.wot.rootWindow && (!preventOverflow || preventOverflow !== 'horizontal')) {
+    if (this.trimmingContainer === this.wot.rootWindow &&
+        (!preventOverflow || preventOverflow !== 'horizontal')) {
       const box = wtTable.hider.getBoundingClientRect();
       const left = Math.ceil(box.left);
       const right = Math.ceil(box.right);
@@ -188,10 +189,14 @@ class LeftOverlay extends Overlay {
    */
   adjustRootChildrenSize() {
     const { holder } = this.clone.wtTable;
+    const { selections } = this.wot;
+    const selectionCornerOffset = Math.abs(selections?.getCell().getBorder(this.wot).cornerCenterPointOffset ?? 0);
 
     this.clone.wtTable.hider.style.height = this.hider.style.height;
     holder.style.height = holder.parentNode.style.height;
-    holder.style.width = holder.parentNode.style.width;
+    // Add corner protruding part to the holder total width to make sure that borders' corner
+    // won't be cut after horizontal scroll (#6937).
+    holder.style.width = `${parseInt(holder.parentNode.style.width, 10) + selectionCornerOffset}px`;
   }
 
   /**
@@ -235,7 +240,8 @@ class LeftOverlay extends Overlay {
    * Scrolls horizontally to a column at the left edge of the viewport.
    *
    * @param {number} sourceCol  Column index which you want to scroll to.
-   * @param {boolean} [beyondRendered]  If `true`, scrolls according to the bottom edge (top edge is by default).
+   * @param {boolean} [beyondRendered]  If `true`, scrolls according to the bottom
+   *                                    edge (top edge is by default).
    * @returns {boolean}
    */
   scrollTo(sourceCol, beyondRendered) {

--- a/src/3rdparty/walkontable/src/overlay/left.js
+++ b/src/3rdparty/walkontable/src/overlay/left.js
@@ -194,8 +194,8 @@ class LeftOverlay extends Overlay {
 
     this.clone.wtTable.hider.style.height = this.hider.style.height;
     holder.style.height = holder.parentNode.style.height;
-    // Add corner protruding part to the holder total width to make sure that borders' corner
-    // won't be cut after horizontal scroll (#6937).
+    // Add selection corner protruding part to the holder total width to make sure that
+    // borders' corner won't be cut after horizontal scroll (#6937).
     holder.style.width = `${parseInt(holder.parentNode.style.width, 10) + selectionCornerOffset}px`;
   }
 

--- a/src/3rdparty/walkontable/src/overlay/top.js
+++ b/src/3rdparty/walkontable/src/overlay/top.js
@@ -201,8 +201,8 @@ class TopOverlay extends Overlay {
 
     this.clone.wtTable.hider.style.width = this.hider.style.width;
     holder.style.width = holder.parentNode.style.width;
-    // Add corner protruding part to the holder total height to make sure that borders' corner
-    // won't be cut after vertical scroll (#6937).
+    // Add selection corner protruding part to the holder total height to make sure that
+    // borders' corner won't be cut after vertical scroll (#6937).
     holder.style.height = `${parseInt(holder.parentNode.style.height, 10) + selectionCornerOffset}px`;
   }
 

--- a/src/3rdparty/walkontable/src/overlay/top.js
+++ b/src/3rdparty/walkontable/src/overlay/top.js
@@ -196,10 +196,14 @@ class TopOverlay extends Overlay {
    */
   adjustRootChildrenSize() {
     const { holder } = this.clone.wtTable;
+    const { selections } = this.wot;
+    const selectionCornerOffset = Math.abs(selections?.getCell().getBorder(this.wot).cornerCenterPointOffset ?? 0);
 
     this.clone.wtTable.hider.style.width = this.hider.style.width;
     holder.style.width = holder.parentNode.style.width;
-    holder.style.height = holder.parentNode.style.height;
+    // Add corner protruding part to the holder total height to make sure that borders' corner
+    // won't be cut after vertical scroll (#6937).
+    holder.style.height = `${parseInt(holder.parentNode.style.height, 10) + selectionCornerOffset}px`;
   }
 
   /**

--- a/src/3rdparty/walkontable/test/spec/border.spec.js
+++ b/src/3rdparty/walkontable/test/spec/border.spec.js
@@ -211,6 +211,78 @@ describe('WalkontableBorder', () => {
     expect($corner.position().left).toBe(95);
   });
 
+  it('should properly render a selection corner on the edge of the left fixed column', () => {
+    const wt = walkontable({
+      data: getData,
+      totalRows: 5,
+      totalColumns: 5,
+      fixedColumnsLeft: 2,
+      selections: createSelectionController({
+        current: new Walkontable.Selection({
+          border: {
+            width: 2,
+            color: 'green',
+            cornerVisible() {
+              return true;
+            }
+          }
+        }),
+        area: new Walkontable.Selection({}),
+      }),
+      onCellMouseDown(event, coords) {
+        wt.selections.getCell().clear();
+        wt.selections.getCell().add(coords);
+        wt.draw();
+      }
+    });
+    wt.draw();
+
+    const $td1 = spec().$table.find('tbody tr:eq(2) td:eq(1)');
+    const $corner = $(wt.selections.getCell().getBorder(wt).corner);
+    const leftOverlay = $(wt.wtOverlays.leftOverlay.clone.wtTable.holder);
+
+    $td1.simulate('mousedown');
+
+    expect(leftOverlay.position().left + leftOverlay.outerWidth())
+      .toBe($corner.position().left + $corner.outerWidth());
+  });
+
+  it('should properly render a selection corner on the edge of the top fixed row', () => {
+    const wt = walkontable({
+      data: getData,
+      totalRows: 5,
+      totalColumns: 5,
+      fixedRowsTop: 2,
+      selections: createSelectionController({
+        current: new Walkontable.Selection({
+          border: {
+            width: 2,
+            color: 'green',
+            cornerVisible() {
+              return true;
+            }
+          }
+        }),
+        area: new Walkontable.Selection({}),
+      }),
+      onCellMouseDown(event, coords) {
+        wt.selections.getCell().clear();
+        wt.selections.getCell().add(coords);
+        wt.draw();
+      }
+    });
+    wt.draw();
+
+    const $td1 = spec().$table.find('tbody tr:eq(1) td:eq(1)');
+    const $corner = $(wt.selections.getCell().getBorder(wt).corner);
+    const topOverlay = $(wt.wtOverlays.topOverlay.clone.wtTable.holder);
+
+    $td1.simulate('mousedown');
+
+    expect(topOverlay.position().top + topOverlay.outerHeight())
+      .toBe($corner.position().top + $corner.outerHeight());
+  });
+
   it('should draw only one corner if selection is added between overlays', () => {
     const wt = walkontable({
       data: getData,
@@ -221,6 +293,7 @@ describe('WalkontableBorder', () => {
       selections: createSelectionController({
         current: new Walkontable.Selection({
           className: 'current',
+          border: {},
         }),
         area: new Walkontable.Selection({
           className: 'area',

--- a/src/3rdparty/walkontable/test/spec/selection.spec.js
+++ b/src/3rdparty/walkontable/test/spec/selection.spec.js
@@ -282,7 +282,8 @@ describe('Walkontable.Selection', () => {
       selections: createSelectionController({
         current: new Walkontable.Selection({
           highlightRowClassName: 'highlightRow',
-          highlightColumnClassName: 'highlightColumn'
+          highlightColumnClassName: 'highlightColumn',
+          border: {},
         }),
       }),
     });


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The selection corner is cut by the holder element of the left and top overlay. This PR fixes the problem by expanding the width and height of the overlays' holders by the length/size of the protruding corner element.

This is a kind of reversion of the behavior of how the latest stable HoT version works. However, now it is expanded not by scrollbar width/height but by the actual length needed to display the selection corner correctly.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Added E2E tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #6937
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
