### PR TITLE
Fix double selection for alter operations

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -407,8 +407,12 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
                 currentFromColumn = -1;
               }
 
+              // Remove from the stack the last added selection as that selection below will be
+              // replaced by new transformed selection.
+              selection.getSelectedRange().pop();
+
               // I can't use transforms as they don't work in negative indexes.
-              selection.setRangeStartOnly(new CellCoords(currentFromRow + delta, currentFromColumn));
+              selection.setRangeStartOnly(new CellCoords(currentFromRow + delta, currentFromColumn), true);
               selection.setRangeEnd(new CellCoords(currentToRow + delta, currentToColumn)); // will call render() internally
             } else {
               instance._refreshBorders(); // it will call render and prepare methods
@@ -424,6 +428,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
 
             if (Array.isArray(tableMeta.colHeaders)) {
               const spliceArray = [index, 0];
+
               spliceArray.length += delta; // inserts empty (undefined) elements at the end of an array
               Array.prototype.splice.apply(tableMeta.colHeaders, spliceArray); // inserts empty (undefined) elements into the colHeader array
             }
@@ -443,8 +448,12 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
                 currentFromRow = -1;
               }
 
+              // Remove from the stack the last added selection as that selection below will be
+              // replaced by new transformed selection.
+              selection.getSelectedRange().pop();
+
               // I can't use transforms as they don't work in negative indexes.
-              selection.setRangeStartOnly(new CellCoords(currentFromRow, currentFromColumn + delta));
+              selection.setRangeStartOnly(new CellCoords(currentFromRow, currentFromColumn + delta), true);
               selection.setRangeEnd(new CellCoords(currentToRow, currentToColumn + delta)); // will call render() internally
             } else {
               instance._refreshBorders(); // it will call render and prepare methods

--- a/src/plugins/undoRedo/test/UndoRedo.e2e.js
+++ b/src/plugins/undoRedo/test/UndoRedo.e2e.js
@@ -2787,5 +2787,119 @@ describe('UndoRedo', () => {
       expect(getSelected()[0]).toEqual([0, 0, 1, 1]);
       expect(getSelected()[1]).toEqual([1, 2, 2, 3]);
     });
+
+    it('should transform the header selection down after undoing rows removal', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(10, 10),
+        rowHeaders: true,
+        colHeaders: true,
+      });
+
+      selectRows(4, 5)
+      alter('remove_row', 1, 3);
+      undo();
+
+      expect(getSelected()).toEqual([[7, 0, 8, 9]]);
+      expect(`
+        |   ║ - : - : - : - : - : - : - : - : - : - |
+        |===:===:===:===:===:===:===:===:===:===:===|
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        | * ║ A : 0 : 0 : 0 : 0 : 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 : 0 : 0 : 0 : 0 : 0 |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+      `).toBeMatchToSelectionPattern();
+    });
+
+    it('should transform cells selection down after undoing rows removal', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(10, 10),
+        rowHeaders: true,
+        colHeaders: true,
+      });
+
+      selectCells([[3, 3, 3, 3], [5, 2, 6, 2]])
+      alter('remove_row', 1, 3);
+      undo();
+
+      expect(getSelected()).toEqual([[3, 3, 3, 3], [8, 2, 9, 2]]);
+      // By design only last selection is interactive.
+      expect(`
+        |   ║   :   : - : - :   :   :   :   :   :   |
+        |===:===:===:===:===:===:===:===:===:===:===|
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        | - ║   :   :   : 0 :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        | - ║   :   : A :   :   :   :   :   :   :   |
+        | - ║   :   : 0 :   :   :   :   :   :   :   |
+      `).toBeMatchToSelectionPattern();
+    });
+
+    it('should transform the header selection right after undoing columns removal', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(10, 10),
+        rowHeaders: true,
+        colHeaders: true,
+      });
+
+      selectColumns(4, 5)
+      alter('remove_col', 1, 3);
+      undo();
+
+      expect(getSelected()).toEqual([[0, 7, 9, 8]]);
+      expect(`
+        |   ║   :   :   :   :   :   :   : * : * :   |
+        |===:===:===:===:===:===:===:===:===:===:===|
+        | - ║   :   :   :   :   :   :   : A : 0 :   |
+        | - ║   :   :   :   :   :   :   : 0 : 0 :   |
+        | - ║   :   :   :   :   :   :   : 0 : 0 :   |
+        | - ║   :   :   :   :   :   :   : 0 : 0 :   |
+        | - ║   :   :   :   :   :   :   : 0 : 0 :   |
+        | - ║   :   :   :   :   :   :   : 0 : 0 :   |
+        | - ║   :   :   :   :   :   :   : 0 : 0 :   |
+        | - ║   :   :   :   :   :   :   : 0 : 0 :   |
+        | - ║   :   :   :   :   :   :   : 0 : 0 :   |
+        | - ║   :   :   :   :   :   :   : 0 : 0 :   |
+      `).toBeMatchToSelectionPattern();
+    });
+
+    it('should transform cells selection right after undoing columns removal', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(10, 10),
+        rowHeaders: true,
+        colHeaders: true,
+      });
+
+      selectCells([[3, 3, 3, 3], [2, 5, 2, 6]])
+      alter('remove_col', 1, 3);
+      undo();
+
+      expect(getSelected()).toEqual([[3, 3, 3, 3], [2, 8, 2, 9]]);
+      // By design only last selection is interactive.
+      expect(`
+        |   ║   :   :   : - :   :   :   :   : - : - |
+        |===:===:===:===:===:===:===:===:===:===:===|
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        | - ║   :   :   :   :   :   :   :   : A : 0 |
+        | - ║   :   :   : 0 :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+      `).toBeMatchToSelectionPattern();
+    });
   });
 });

--- a/src/plugins/undoRedo/test/UndoRedo.e2e.js
+++ b/src/plugins/undoRedo/test/UndoRedo.e2e.js
@@ -2795,7 +2795,7 @@ describe('UndoRedo', () => {
         colHeaders: true,
       });
 
-      selectRows(4, 5)
+      selectRows(4, 5);
       alter('remove_row', 1, 3);
       undo();
 
@@ -2823,7 +2823,7 @@ describe('UndoRedo', () => {
         colHeaders: true,
       });
 
-      selectCells([[3, 3, 3, 3], [5, 2, 6, 2]])
+      selectCells([[3, 3, 3, 3], [5, 2, 6, 2]]);
       alter('remove_row', 1, 3);
       undo();
 
@@ -2852,7 +2852,7 @@ describe('UndoRedo', () => {
         colHeaders: true,
       });
 
-      selectColumns(4, 5)
+      selectColumns(4, 5);
       alter('remove_col', 1, 3);
       undo();
 
@@ -2880,7 +2880,7 @@ describe('UndoRedo', () => {
         colHeaders: true,
       });
 
-      selectCells([[3, 3, 3, 3], [2, 5, 2, 6]])
+      selectCells([[3, 3, 3, 3], [2, 5, 2, 6]]);
       alter('remove_col', 1, 3);
       undo();
 

--- a/src/selection/range.js
+++ b/src/selection/range.js
@@ -53,6 +53,17 @@ class SelectionRange {
   }
 
   /**
+   * Removes from the stack the last added coordinates.
+   *
+   * @returns {SelectionRange}
+   */
+  pop() {
+    this.ranges.pop();
+
+    return this;
+  }
+
+  /**
    * Get last added coordinates from ranges, it returns a CellRange instance.
    *
    * @returns {CellRange|undefined}

--- a/test/e2e/Core_selection.spec.js
+++ b/test/e2e/Core_selection.spec.js
@@ -2051,4 +2051,244 @@ describe('Core_selection', () => {
       expect(hooks.afterSelectionEnd.calls.argsFor(0)).toEqual([10, 'prop10', 10, 'prop25', 10, void 0]);
     });
   });
+
+  describe('alter the table', () => {
+    it('should transform the selection down by amount of added rows when they added before the last selection', () => {
+      handsontable({
+        rowHeaders: true,
+        colHeaders: true,
+        startRows: 10,
+        startCols: 10
+      });
+
+      selectCells([[2, 2, 5, 5], [6, 1], [3, 3, 6, 6], [8, 0]]);
+      alter('insert_row', 1, 3);
+
+      expect(getSelected()).toEqual([[2, 2, 5, 5], [6, 1, 6, 1], [3, 3, 6, 6], [11, 0, 11, 0]]);
+      // By design only last selection is interactive.
+      expect(`
+        |   ║ - : - : - : - : - : - : - :   :   :   |
+        |===:===:===:===:===:===:===:===:===:===:===|
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        | - ║   :   : 0 : 0 : 0 : 0 :   :   :   :   |
+        | - ║   :   : 0 : 1 : 1 : 1 : 0 :   :   :   |
+        | - ║   :   : 0 : 1 : 1 : 1 : 0 :   :   :   |
+        | - ║   :   : 0 : 1 : 1 : 1 : 0 :   :   :   |
+        | - ║   : 0 :   : 0 : 0 : 0 : 0 :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        | - ║ A :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+      `).toBeMatchToSelectionPattern();
+    });
+
+    it('should transform the header selection down by amount of added rows when they added before the selection', () => {
+      handsontable({
+        rowHeaders: true,
+        colHeaders: true,
+        startRows: 10,
+        startCols: 10
+      });
+
+      selectRows(3, 5);
+      alter('insert_row', 1, 3);
+
+      expect(getSelected()).toEqual([[6, 0, 8, 9]]);
+      expect(`
+        |   ║ - : - : - : - : - : - : - : - : - : - |
+        |===:===:===:===:===:===:===:===:===:===:===|
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        | * ║ A : 0 : 0 : 0 : 0 : 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 : 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 : 0 : 0 : 0 : 0 : 0 |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+      `).toBeMatchToSelectionPattern();
+    });
+
+    it('should not transform the selection down by amount of added rows when they added after the last selection', () => {
+      handsontable({
+        rowHeaders: true,
+        colHeaders: true,
+        startRows: 10,
+        startCols: 10
+      });
+
+      selectCells([[2, 2, 5, 5], [6, 1], [3, 3, 6, 6], [8, 0]]);
+      alter('insert_row', 9, 3);
+
+      expect(getSelected()).toEqual([[2, 2, 5, 5], [6, 1, 6, 1], [3, 3, 6, 6], [8, 0, 8, 0]]);
+      expect(`
+        |   ║ - : - : - : - : - : - : - :   :   :   |
+        |===:===:===:===:===:===:===:===:===:===:===|
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        | - ║   :   : 0 : 0 : 0 : 0 :   :   :   :   |
+        | - ║   :   : 0 : 1 : 1 : 1 : 0 :   :   :   |
+        | - ║   :   : 0 : 1 : 1 : 1 : 0 :   :   :   |
+        | - ║   :   : 0 : 1 : 1 : 1 : 0 :   :   :   |
+        | - ║   : 0 :   : 0 : 0 : 0 : 0 :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        | - ║ A :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+      `).toBeMatchToSelectionPattern();
+    });
+
+    it('should not transform the header selection down by amount of added rows when they added after the selection', () => {
+      handsontable({
+        rowHeaders: true,
+        colHeaders: true,
+        startRows: 10,
+        startCols: 10
+      });
+
+      selectRows(3, 5);
+      alter('insert_row', 5, 3);
+
+      expect(getSelected()).toEqual([[3, 0, 5, 9]]);
+      expect(`
+        |   ║ - : - : - : - : - : - : - : - : - : - |
+        |===:===:===:===:===:===:===:===:===:===:===|
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        | * ║ A : 0 : 0 : 0 : 0 : 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 : 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 : 0 : 0 : 0 : 0 : 0 |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   |
+      `).toBeMatchToSelectionPattern();
+    });
+
+    it('should transform the selection right by amount of added columns when they added before the last selection', () => {
+      handsontable({
+        rowHeaders: true,
+        colHeaders: true,
+        startRows: 10,
+        startCols: 10
+      });
+
+      selectCells([[2, 2, 5, 5], [6, 1], [3, 3, 6, 6], [8, 5]]);
+      alter('insert_col', 1, 3);
+
+      expect(getSelected()).toEqual([[2, 2, 5, 5], [6, 1, 6, 1], [3, 3, 6, 6], [8, 8, 8, 8]]);
+      // By design only last selection is interactive.
+      expect(`
+        |   ║   : - : - : - : - : - : - :   : - :   :   :   :   |
+        |===:===:===:===:===:===:===:===:===:===:===:===:===:===|
+        |   ║   :   :   :   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   :   :   :   |
+        | - ║   :   : 0 : 0 : 0 : 0 :   :   :   :   :   :   :   |
+        | - ║   :   : 0 : 1 : 1 : 1 : 0 :   :   :   :   :   :   |
+        | - ║   :   : 0 : 1 : 1 : 1 : 0 :   :   :   :   :   :   |
+        | - ║   :   : 0 : 1 : 1 : 1 : 0 :   :   :   :   :   :   |
+        | - ║   : 0 :   : 0 : 0 : 0 : 0 :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   :   :   :   |
+        | - ║   :   :   :   :   :   :   :   : A :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   :   :   :   |
+      `).toBeMatchToSelectionPattern();
+    });
+
+    it('should transform the header selection right by amount of added columns when they added before the selection', () => {
+      handsontable({
+        rowHeaders: true,
+        colHeaders: true,
+        startRows: 10,
+        startCols: 10
+      });
+
+      selectColumns(3, 5);
+      alter('insert_col', 1, 3);
+
+      expect(getSelected()).toEqual([[0, 6, 9, 8]]);
+      expect(`
+        |   ║   :   :   :   :   :   : * : * : * :   :   :   :   |
+        |===:===:===:===:===:===:===:===:===:===:===:===:===:===|
+        | - ║   :   :   :   :   :   : A : 0 : 0 :   :   :   :   |
+        | - ║   :   :   :   :   :   : 0 : 0 : 0 :   :   :   :   |
+        | - ║   :   :   :   :   :   : 0 : 0 : 0 :   :   :   :   |
+        | - ║   :   :   :   :   :   : 0 : 0 : 0 :   :   :   :   |
+        | - ║   :   :   :   :   :   : 0 : 0 : 0 :   :   :   :   |
+        | - ║   :   :   :   :   :   : 0 : 0 : 0 :   :   :   :   |
+        | - ║   :   :   :   :   :   : 0 : 0 : 0 :   :   :   :   |
+        | - ║   :   :   :   :   :   : 0 : 0 : 0 :   :   :   :   |
+        | - ║   :   :   :   :   :   : 0 : 0 : 0 :   :   :   :   |
+        | - ║   :   :   :   :   :   : 0 : 0 : 0 :   :   :   :   |
+      `).toBeMatchToSelectionPattern();
+    });
+
+    it('should not transform the selection right by amount of added columns when they added after the last selection', () => {
+      handsontable({
+        rowHeaders: true,
+        colHeaders: true,
+        startRows: 10,
+        startCols: 10
+      });
+
+      selectCells([[2, 2, 5, 5], [6, 1], [3, 3, 6, 6], [8, 5]]);
+      alter('insert_col', 6, 3);
+
+      expect(getSelected()).toEqual([[2, 2, 5, 5], [6, 1, 6, 1], [3, 3, 6, 6], [8, 5, 8, 5]]);
+      expect(`
+        |   ║   : - : - : - : - : - : - :   :   :   :   :   :   |
+        |===:===:===:===:===:===:===:===:===:===:===:===:===:===|
+        |   ║   :   :   :   :   :   :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   :   :   :   |
+        | - ║   :   : 0 : 0 : 0 : 0 :   :   :   :   :   :   :   |
+        | - ║   :   : 0 : 1 : 1 : 1 : 0 :   :   :   :   :   :   |
+        | - ║   :   : 0 : 1 : 1 : 1 : 0 :   :   :   :   :   :   |
+        | - ║   :   : 0 : 1 : 1 : 1 : 0 :   :   :   :   :   :   |
+        | - ║   : 0 :   : 0 : 0 : 0 : 0 :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   :   :   :   |
+        | - ║   :   :   :   :   : A :   :   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   :   :   :   :   :   :   :   |
+      `).toBeMatchToSelectionPattern();
+    });
+
+    it('should not transform the header selection right by amount of added columns when they added after the selection', () => {
+      handsontable({
+        rowHeaders: true,
+        colHeaders: true,
+        startRows: 10,
+        startCols: 10
+      });
+
+      selectColumns(3, 5);
+      alter('insert_col', 5, 3);
+
+      expect(getSelected()).toEqual([[0, 3, 9, 5]]);
+      expect(`
+        |   ║   :   :   : * : * : * :   :   :   :   :   :   :   |
+        |===:===:===:===:===:===:===:===:===:===:===:===:===:===|
+        | - ║   :   :   : A : 0 : 0 :   :   :   :   :   :   :   |
+        | - ║   :   :   : 0 : 0 : 0 :   :   :   :   :   :   :   |
+        | - ║   :   :   : 0 : 0 : 0 :   :   :   :   :   :   :   |
+        | - ║   :   :   : 0 : 0 : 0 :   :   :   :   :   :   :   |
+        | - ║   :   :   : 0 : 0 : 0 :   :   :   :   :   :   :   |
+        | - ║   :   :   : 0 : 0 : 0 :   :   :   :   :   :   :   |
+        | - ║   :   :   : 0 : 0 : 0 :   :   :   :   :   :   :   |
+        | - ║   :   :   : 0 : 0 : 0 :   :   :   :   :   :   :   |
+        | - ║   :   :   : 0 : 0 : 0 :   :   :   :   :   :   :   |
+        | - ║   :   :   : 0 : 0 : 0 :   :   :   :   :   :   :   |
+      `).toBeMatchToSelectionPattern();
+    });
+  });
 });

--- a/test/unit/selection/range.spec.js
+++ b/test/unit/selection/range.spec.js
@@ -71,6 +71,44 @@ describe('SelectionRange', () => {
     });
   });
 
+  describe('.pop', () => {
+    it('should remove the last element from the ranges array', () => {
+      selectionRange.ranges.push(
+        new CellRange(new CellCoords(4, 4)),
+        new CellRange(new CellCoords(0, 0)),
+        new CellRange(new CellCoords(1, 2))
+      );
+
+      selectionRange.pop();
+
+      expect(selectionRange.ranges.length).toBe(2);
+      expect(selectionRange.ranges[0].toObject()).toEqual({
+        from: { col: 4, row: 4 },
+        to: { col: 4, row: 4 },
+      });
+      expect(selectionRange.ranges[1].toObject()).toEqual({
+        from: { col: 0, row: 0 },
+        to: { col: 0, row: 0 },
+      });
+
+      selectionRange.pop();
+
+      expect(selectionRange.ranges.length).toBe(1);
+      expect(selectionRange.ranges[0].toObject()).toEqual({
+        from: { col: 4, row: 4 },
+        to: { col: 4, row: 4 },
+      });
+
+      selectionRange.pop();
+
+      expect(selectionRange.ranges.length).toBe(0);
+
+      selectionRange.pop();
+
+      expect(selectionRange.ranges.length).toBe(0);
+    });
+  });
+
   describe('.current', () => {
     it('should return `undefined` when an array of ranges is empty', () => {
       expect(selectionRange.current()).not.toBeDefined();


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Fix double selection for altering operations after undo by popping out the last added selection from the selection stack.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #6963
2. #6964
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
