### PR TITLE
Fix an error being thrown, when dragging the autofill selection

### DIFF
--- a/src/plugins/autofill/autofill.js
+++ b/src/plugins/autofill/autofill.js
@@ -18,7 +18,8 @@ const INTERVAL_FOR_ADDING_ROW = 200;
  * This plugin provides "drag-down" and "copy-down" functionalities, both operated using the small square in the right
  * bottom of the cell selection.
  *
- * "Drag-down" expands the value of the selected cells to the neighbouring cells when you drag the small square in the corner.
+ * "Drag-down" expands the value of the selected cells to the neighbouring cells when you drag the small
+ * square in the corner.
  *
  * "Copy-down" copies the value of the selection to all empty cells below when you double click the small square.
  *
@@ -184,8 +185,9 @@ class Autofill extends BasePlugin {
       return false;
     }
 
-    // Fill area may starts or ends with invisible cell. There won't be any information about it as highlighted selection
-    // store just renderable indexes (It's part of Walkontable). I extrapolate where the start or/and the end is.
+    // Fill area may starts or ends with invisible cell. There won't be any information about it as highlighted
+    // selection store just renderable indexes (It's part of Walkontable). I extrapolate where the start or/and
+    // the end is.
     const [fillStartRow, fillStartColumn, fillEndRow, fillEndColumn] =
       this.hot.selection.highlight.getFill().getVisualCorners();
     const [selectionStartRow, selectionStartColumn, selectionEndRow, selectionEndColumn] = this.hot.getSelectedLast();
@@ -298,14 +300,16 @@ class Autofill extends BasePlugin {
    *
    * @private
    * @param {CellCoords} coordsOfSelection `CellCoords` coord object.
-   * @returns {Array}
+   * @returns {CellCoords}
    */
   getCoordsOfDragAndDropBorders(coordsOfSelection) {
-    const topLeftCorner = this.hot.getSelectedRangeLast().getTopLeftCorner();
-    const bottomRightCorner = this.hot.getSelectedRangeLast().getBottomRightCorner();
-    let coords;
+    const currentSelection = this.hot.getSelectedRangeLast();
+    const bottomRightCorner = currentSelection.getBottomRightCorner();
+    let coords = coordsOfSelection;
 
     if (this.directions.includes(DIRECTIONS.vertical) && this.directions.includes(DIRECTIONS.horizontal)) {
+      const topLeftCorner = currentSelection.getTopLeftCorner();
+
       if (bottomRightCorner.col <= coordsOfSelection.col || topLeftCorner.col >= coordsOfSelection.col) {
         coords = new CellCoords(bottomRightCorner.row, coordsOfSelection.col);
       }

--- a/src/plugins/autofill/test/autofill.e2e.js
+++ b/src/plugins/autofill/test/autofill.e2e.js
@@ -1192,4 +1192,123 @@ describe('AutoFill', () => {
     expect(getDataAtCell(0, 0)).toEqual(1);
     expect(getDataAtCell(1, 0)).toEqual(7);
   });
+
+  describe('fill border position', () => {
+    it('display the fill border in the correct position', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(10, 10),
+        fillHandle: true
+      });
+
+      selectCell(3, 3, 5, 5);
+
+      spec().$container.find('.wtBorder.current.corner').simulate('mousedown');
+
+      spec().$container.find('.ht_master tbody tr').eq(2).find('td').eq(3).simulate('mouseover');
+
+      expect(Handsontable.dom.hasClass(getCell(2, 3), 'fill')).toBe(true);
+      expect(Handsontable.dom.hasClass(getCell(2, 4), 'fill')).toBe(true);
+      expect(Handsontable.dom.hasClass(getCell(2, 5), 'fill')).toBe(true);
+
+      spec().$container.find('.ht_master tbody tr').eq(2).find('td').eq(4).simulate('mouseover');
+
+      expect(Handsontable.dom.hasClass(getCell(2, 3), 'fill')).toBe(true);
+      expect(Handsontable.dom.hasClass(getCell(2, 4), 'fill')).toBe(true);
+      expect(Handsontable.dom.hasClass(getCell(2, 5), 'fill')).toBe(true);
+
+      spec().$container.find('.ht_master tbody tr').eq(2).find('td').eq(5).simulate('mouseover');
+
+      expect(Handsontable.dom.hasClass(getCell(2, 3), 'fill')).toBe(true);
+      expect(Handsontable.dom.hasClass(getCell(2, 4), 'fill')).toBe(true);
+      expect(Handsontable.dom.hasClass(getCell(2, 5), 'fill')).toBe(true);
+
+      spec().$container.find('.ht_master tbody tr').eq(3).find('td').eq(2).simulate('mouseover');
+
+      expect(Handsontable.dom.hasClass(getCell(3, 2), 'fill')).toBe(true);
+      expect(Handsontable.dom.hasClass(getCell(4, 2), 'fill')).toBe(true);
+      expect(Handsontable.dom.hasClass(getCell(5, 2), 'fill')).toBe(true);
+
+      spec().$container.find('.ht_master tbody tr').eq(4).find('td').eq(2).simulate('mouseover');
+
+      expect(Handsontable.dom.hasClass(getCell(3, 2), 'fill')).toBe(true);
+      expect(Handsontable.dom.hasClass(getCell(4, 2), 'fill')).toBe(true);
+      expect(Handsontable.dom.hasClass(getCell(5, 2), 'fill')).toBe(true);
+
+      spec().$container.find('.ht_master tbody tr').eq(5).find('td').eq(2).simulate('mouseover');
+
+      expect(Handsontable.dom.hasClass(getCell(3, 2), 'fill')).toBe(true);
+      expect(Handsontable.dom.hasClass(getCell(4, 2), 'fill')).toBe(true);
+      expect(Handsontable.dom.hasClass(getCell(5, 2), 'fill')).toBe(true);
+
+      spec().$container.find('.ht_master tbody tr').eq(6).find('td').eq(3).simulate('mouseover');
+
+      expect(Handsontable.dom.hasClass(getCell(6, 3), 'fill')).toBe(true);
+      expect(Handsontable.dom.hasClass(getCell(6, 4), 'fill')).toBe(true);
+      expect(Handsontable.dom.hasClass(getCell(6, 5), 'fill')).toBe(true);
+
+      spec().$container.find('.ht_master tbody tr').eq(6).find('td').eq(4).simulate('mouseover');
+
+      expect(Handsontable.dom.hasClass(getCell(5, 3), 'fill')).toBe(true);
+      expect(Handsontable.dom.hasClass(getCell(5, 4), 'fill')).toBe(true);
+      expect(Handsontable.dom.hasClass(getCell(6, 5), 'fill')).toBe(true);
+
+      spec().$container.find('.ht_master tbody tr').eq(6).find('td').eq(5).simulate('mouseover');
+
+      expect(Handsontable.dom.hasClass(getCell(5, 3), 'fill')).toBe(true);
+      expect(Handsontable.dom.hasClass(getCell(5, 4), 'fill')).toBe(true);
+      expect(Handsontable.dom.hasClass(getCell(6, 5), 'fill')).toBe(true);
+
+      spec().$container.find('.ht_master tbody tr').eq(3).find('td').eq(6).simulate('mouseover');
+
+      expect(Handsontable.dom.hasClass(getCell(3, 6), 'fill')).toBe(true);
+      expect(Handsontable.dom.hasClass(getCell(4, 6), 'fill')).toBe(true);
+      expect(Handsontable.dom.hasClass(getCell(5, 6), 'fill')).toBe(true);
+
+      spec().$container.find('.ht_master tbody tr').eq(4).find('td').eq(6).simulate('mouseover');
+
+      expect(Handsontable.dom.hasClass(getCell(3, 6), 'fill')).toBe(true);
+      expect(Handsontable.dom.hasClass(getCell(4, 6), 'fill')).toBe(true);
+      expect(Handsontable.dom.hasClass(getCell(5, 6), 'fill')).toBe(true);
+
+      spec().$container.find('.ht_master tbody tr').eq(5).find('td').eq(6).simulate('mouseover');
+
+      expect(Handsontable.dom.hasClass(getCell(3, 6), 'fill')).toBe(true);
+      expect(Handsontable.dom.hasClass(getCell(4, 6), 'fill')).toBe(true);
+      expect(Handsontable.dom.hasClass(getCell(5, 6), 'fill')).toBe(true);
+
+      spec().$container.find('.ht_master tbody tr').eq(2).find('td').eq(2).simulate('mouseover');
+
+      expect(Handsontable.dom.hasClass(getCell(2, 3), 'fill')).toBe(true);
+      expect(Handsontable.dom.hasClass(getCell(2, 4), 'fill')).toBe(true);
+      expect(Handsontable.dom.hasClass(getCell(2, 5), 'fill')).toBe(true);
+
+      spec().$container.find('.ht_master tbody tr').eq(2).find('td').eq(6).simulate('mouseover');
+
+      expect(Handsontable.dom.hasClass(getCell(2, 3), 'fill')).toBe(true);
+      expect(Handsontable.dom.hasClass(getCell(2, 4), 'fill')).toBe(true);
+      expect(Handsontable.dom.hasClass(getCell(2, 5), 'fill')).toBe(true);
+
+      spec().$container.find('.ht_master tbody tr').eq(6).find('td').eq(2).simulate('mouseover');
+
+      expect(Handsontable.dom.hasClass(getCell(6, 3), 'fill')).toBe(true);
+      expect(Handsontable.dom.hasClass(getCell(6, 4), 'fill')).toBe(true);
+      expect(Handsontable.dom.hasClass(getCell(6, 5), 'fill')).toBe(true);
+
+      spec().$container.find('.ht_master tbody tr').eq(6).find('td').eq(6).simulate('mouseover');
+
+      expect(Handsontable.dom.hasClass(getCell(6, 3), 'fill')).toBe(true);
+      expect(Handsontable.dom.hasClass(getCell(6, 4), 'fill')).toBe(true);
+      expect(Handsontable.dom.hasClass(getCell(6, 5), 'fill')).toBe(true);
+
+      // Inside of the selection
+      spec().$container.find('.ht_master tbody tr').eq(5).find('td').eq(4).simulate('mouseover');
+
+      expect(Handsontable.dom.hasClass(getCell(3, 3), 'fill')).toBe(true);
+      expect(Handsontable.dom.hasClass(getCell(3, 4), 'fill')).toBe(true);
+      expect(Handsontable.dom.hasClass(getCell(4, 3), 'fill')).toBe(true);
+      expect(Handsontable.dom.hasClass(getCell(4, 4), 'fill')).toBe(true);
+      expect(Handsontable.dom.hasClass(getCell(5, 3), 'fill')).toBe(true);
+      expect(Handsontable.dom.hasClass(getCell(5, 4), 'fill')).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
### Context
Fixed a problem with an error being thrown, when dragging the autofill handle through a larger selection.

### How has this been tested?
- Added a test case to check the fill selection in various cases.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. #6995
