### PR TITLE
Feature/issue 6911

### DIFF
--- a/src/3rdparty/walkontable/src/table.js
+++ b/src/3rdparty/walkontable/src/table.js
@@ -763,6 +763,7 @@ class Table {
     return Math.abs(row) <= columnHeadersCount;
   }
 
+  /* eslint-disable jsdoc/require-description-complete-sentence */
   /**
    * Check if the given row index is smaller than the index of the first row that
    * is currently rendered and return TRUE in that case, or FALSE otherwise.
@@ -789,6 +790,7 @@ class Table {
    * @param {number} row The visual row index.
    * @returns {boolean}
    */
+  /* eslint-enable jsdoc/require-description-complete-sentence */
   isRowBeforeRenderedRows(row) {
     const first = this.getFirstRenderedRow();
 
@@ -801,6 +803,7 @@ class Table {
     return row < first;
   }
 
+  /* eslint-disable jsdoc/require-description-complete-sentence */
   /**
    * Check if the given column index is larger than the index of the last column that
    * is currently rendered and return TRUE in that case, or FALSE otherwise.
@@ -830,10 +833,12 @@ class Table {
    * @param {nunber} row The visual row index.
    * @returns {boolean}
    */
+  /* eslint-enable jsdoc/require-description-complete-sentence */
   isRowAfterRenderedRows(row) {
     return row > this.getLastRenderedRow();
   }
 
+  /* eslint-disable jsdoc/require-description-complete-sentence */
   /**
    * Check if the given column index is smaller than the index of the first column that
    * is currently rendered and return TRUE in that case, or FALSE otherwise.
@@ -859,6 +864,7 @@ class Table {
    * @param {number} column The visual column index.
    * @returns {boolean}
    */
+  /* eslint-enable jsdoc/require-description-complete-sentence */
   isColumnBeforeRenderedColumns(column) {
     const first = this.getFirstRenderedColumn();
 
@@ -871,6 +877,7 @@ class Table {
     return column < first;
   }
 
+  /* eslint-disable jsdoc/require-description-complete-sentence */
   /**
    * Check if the given column index is larger than the index of the last column that
    * is currently rendered and return TRUE in that case, or FALSE otherwise.
@@ -899,6 +906,7 @@ class Table {
    * @param {number} column The visual column index.
    * @returns {boolean}
    */
+  /* eslint-enable jsdoc/require-description-complete-sentence */
   isColumnAfterRenderedColumns(column) {
     return this.columnFilter && (column > this.getLastRenderedColumn());
   }

--- a/src/3rdparty/walkontable/src/table.js
+++ b/src/3rdparty/walkontable/src/table.js
@@ -765,7 +765,7 @@ class Table {
 
   /* eslint-disable jsdoc/require-description-complete-sentence */
   /**
-   * Check if the given row index is smaller than the index of the first row that
+   * Check if the given row index is lower than the index of the first row that
    * is currently rendered and return TRUE in that case, or FALSE otherwise.
    *
    * Negative row index is used to check the columns' headers.
@@ -805,7 +805,7 @@ class Table {
 
   /* eslint-disable jsdoc/require-description-complete-sentence */
   /**
-   * Check if the given column index is larger than the index of the last column that
+   * Check if the given column index is greater than the index of the last column that
    * is currently rendered and return TRUE in that case, or FALSE otherwise.
    *
    * The negative row index is used to check the columns' headers. However,
@@ -830,7 +830,7 @@ class Table {
    *                                                                │
    *                                                                │ TRUE
    *
-   * @param {nunber} row The visual row index.
+   * @param {number} row The visual row index.
    * @returns {boolean}
    */
   /* eslint-enable jsdoc/require-description-complete-sentence */
@@ -840,7 +840,7 @@ class Table {
 
   /* eslint-disable jsdoc/require-description-complete-sentence */
   /**
-   * Check if the given column index is smaller than the index of the first column that
+   * Check if the given column index is lower than the index of the first column that
    * is currently rendered and return TRUE in that case, or FALSE otherwise.
    *
    * Negative column index is used to check the rows' headers.
@@ -879,7 +879,7 @@ class Table {
 
   /* eslint-disable jsdoc/require-description-complete-sentence */
   /**
-   * Check if the given column index is larger than the index of the last column that
+   * Check if the given column index is greater than the index of the last column that
    * is currently rendered and return TRUE in that case, or FALSE otherwise.
    *
    * The negative column index is used to check the rows' headers. However,

--- a/src/3rdparty/walkontable/src/table.js
+++ b/src/3rdparty/walkontable/src/table.js
@@ -730,38 +730,61 @@ class Table {
   }
 
   /**
-   * 0-based index of column header.
+   * Checks if the column index (negative value from -1 to N) is rendered.
    *
-   * @param {number} level The header level to check.
+   * @param {number} column The column index (negative value from -1 to N).
    * @returns {boolean}
    */
-  isColumnHeaderLevelRendered(level) {
+  isColumnHeaderRendered(column) {
+    if (column >= 0) {
+      return false;
+    }
+
+    const rowHeaders = this.wot.getSetting('rowHeaders');
+    const rowHeadersCount = rowHeaders.length;
+
+    return Math.abs(column) <= rowHeadersCount;
+  }
+
+  /**
+   * Checks if the row index (negative value from -1 to N) is rendered.
+   *
+   * @param {number} row The row index (negative value from -1 to N).
+   * @returns {boolean}
+   */
+  isRowHeaderRendered(row) {
+    if (row >= 0) {
+      return false;
+    }
+
     const columnHeaders = this.wot.getSetting('columnHeaders');
     const columnHeadersCount = columnHeaders.length;
 
-    return level > (columnHeadersCount - 1);
+    return Math.abs(row) <= columnHeadersCount;
   }
 
   /**
-   * 0-based index of row header.
+   * Check if the given row index is smaller than the index of the first row that
+   * is currently rendered and return TRUE in that case, or FALSE otherwise.
    *
-   * @param {number} level The header level to check.
-   * @returns {boolean}
-   */
-  isRowHeaderLevelRendered(level) {
-    const columnHeaders = this.wot.getSetting('rowHeaders');
-    const columnHeadersCount = columnHeaders.length;
-
-    return level > (columnHeadersCount - 1);
-  }
-
-  /**
-   * Check if the given row index is smaller than the index of the first row that is currently redered
-   * and return TRUE in that case, or FALSE otherwise.
+   * Negative row index is used to check the columns' headers.
    *
-   * Negative row index is used to check the header cells. As a simplification, it checks negative row index
-   * the same way as a regular row 0. You can interpret this as follows: If the row 0 is rendered, all header
-   * cells are also rendered.
+   *  Headers
+   *           +--------------+                                     │
+   *       -3  │    │    │    │                                     │
+   *           +--------------+                                     │
+   *       -2  │    │    │    │                                     │ TRUE
+   *           +--------------+                                     │
+   *       -1  │    │    │    │                                     │
+   *  Cells  +==================+                                   │
+   *        0  ┇    ┇    ┇    ┇ <--- For fixedRowsTop: 1            │
+   *           +--------------+      the master overlay do       ---+ first rendered row (index 1)
+   *        1  │ A2 │ B2 │ C2 │      not render the first row.      │
+   *           +--------------+                                     │ FALSE
+   *        2  │ A3 │ B3 │ C3 │                                     │
+   *           +--------------+                                  ---+ last rendered row
+   *                                                                │
+   *                                                                │ FALSE
    *
    * @param {number} row The visual row index.
    * @returns {boolean}
@@ -769,50 +792,69 @@ class Table {
   isRowBeforeRenderedRows(row) {
     const first = this.getFirstRenderedRow();
 
-    if (row < 0) {
-      row = 0;
+    // Check the headers only in case when the first rendered row is -1 or 0.
+    // This is an indication that the overlay is placed on the most top-left position.
+    if (row < 0 && first <= 0) {
+      return !this.isRowHeaderRendered(row);
     }
 
-    if (first === -1) {
-      return true;
-    }
     return row < first;
   }
 
-  isRowAfterViewport(row) {
-    return this.rowFilter && (row > this.getLastVisibleRow());
-  }
-
   /**
-   * Check if the given column index is larger than the index of the last column that is currently redered
-   * and return TRUE in that case, or FALSE otherwise.
+   * Check if the given column index is larger than the index of the last column that
+   * is currently rendered and return TRUE in that case, or FALSE otherwise.
    *
-   * Negative column index is used to check the header cells.
+   * The negative row index is used to check the columns' headers. However,
+   * keep in mind that for negative indexes, the method always returns FALSE as
+   * it is not possible to render headers partially. The "after" index can not be
+   * lower than -1.
+   *
+   *  Headers
+   *           +--------------+                                     │
+   *       -3  │    │    │    │                                     │
+   *           +--------------+                                     │
+   *       -2  │    │    │    │                                     │ FALSE
+   *           +--------------+                                     │
+   *       -1  │    │    │    │                                     │
+   *  Cells  +==================+                                   │
+   *        0  ┇    ┇    ┇    ┇ <--- For fixedRowsTop: 1            │
+   *           +--------------+      the master overlay do       ---+ first rendered row (index 1)
+   *        1  │ A2 │ B2 │ C2 │      not render the first rows      │
+   *           +--------------+                                     │ FALSE
+   *        2  │ A3 │ B3 │ C3 │                                     │
+   *           +--------------+                                  ---+ last rendered row
+   *                                                                │
+   *                                                                │ TRUE
    *
    * @param {nunber} row The visual row index.
    * @returns {boolean}
    */
   isRowAfterRenderedRows(row) {
-    if (row < 0) {
-      const columnHeaders = this.wot.getSetting('columnHeaders');
-      const columnHeadersCount = columnHeaders.length;
-      const zeroBasedHeaderLevel = columnHeadersCount + row;
-      return this.isColumnHeaderLevelRendered(zeroBasedHeaderLevel);
-    }
     return row > this.getLastRenderedRow();
   }
 
-  isColumnBeforeViewport(column) {
-    return this.columnFilter && (this.columnFilter.sourceToRendered(column) < 0 && column >= 0);
-  }
-
   /**
-   * Check if the given column index is smaller than the index of the first column that is currently redered
-   * and return TRUE in that case, or FALSE otherwise.
+   * Check if the given column index is smaller than the index of the first column that
+   * is currently rendered and return TRUE in that case, or FALSE otherwise.
    *
-   * Negative column index is used to check the header cells. As a simplification, it checks negative column index
-   * the same way as a regular column 0. You can interpret this as follows: If the column 0 is rendered, all header
-   * cells are also rendered.
+   * Negative column index is used to check the rows' headers.
+   *
+   *                            For fixedColumnsLeft: 1 the master overlay
+   *                            do not render this first columns.
+   *  Headers    -3   -2   -1    |
+   *           +----+----+----║┄ ┄ +------+------+
+   *           │    │    │    ║    │  B1  │  C1  │
+   *           +--------------║┄ ┄ --------------│
+   *           │    │    │    ║    │  B2  │  C2  │
+   *           +--------------║┄ ┄ --------------│
+   *           │    │    │    ║    │  B3  │  C3  │
+   *           +----+----+----║┄ ┄ +------+------+
+   *                               ╷             ╷
+   *      -------------------------+-------------+---------------->
+   *          TRUE             first    FALSE   last         FALSE
+   *                           rendered         rendered
+   *                           column           column
    *
    * @param {number} column The visual column index.
    * @returns {boolean}
@@ -820,37 +862,57 @@ class Table {
   isColumnBeforeRenderedColumns(column) {
     const first = this.getFirstRenderedColumn();
 
-    if (column < 0) {
-      column = 0;
+    // Check the headers only in case when the first rendered column is -1 or 0.
+    // This is an indication that the overlay is placed on the most top-left position.
+    if (column < 0 && first <= 0) {
+      return !this.isColumnHeaderRendered(column);
     }
 
-    if (first === -1) {
-      return true;
-    }
     return column < first;
+  }
+
+  /**
+   * Check if the given column index is larger than the index of the last column that
+   * is currently rendered and return TRUE in that case, or FALSE otherwise.
+   *
+   * The negative column index is used to check the rows' headers. However,
+   * keep in mind that for negative indexes, the method always returns FALSE as
+   * it is not possible to render headers partially. The "after" index can not be
+   * lower than -1.
+   *
+   *                            For fixedColumnsLeft: 1 the master overlay
+   *                            do not render this first columns.
+   *  Headers    -3   -2   -1    |
+   *           +----+----+----║┄ ┄ +------+------+
+   *           │    │    │    ║    │  B1  │  C1  │
+   *           +--------------║┄ ┄ --------------│
+   *           │    │    │    ║    │  B2  │  C2  │
+   *           +--------------║┄ ┄ --------------│
+   *           │    │    │    ║    │  B3  │  C3  │
+   *           +----+----+----║┄ ┄ +------+------+
+   *                               ╷             ╷
+   *      -------------------------+-------------+---------------->
+   *          FALSE             first    FALSE   last         TRUE
+   *                           rendered         rendered
+   *                           column           column
+   *
+   * @param {number} column The visual column index.
+   * @returns {boolean}
+   */
+  isColumnAfterRenderedColumns(column) {
+    return this.columnFilter && (column > this.getLastRenderedColumn());
   }
 
   isColumnAfterViewport(column) {
     return this.columnFilter && (column > this.getLastVisibleColumn());
   }
 
-  /**
-   * Check if the given column index is larger than the index of the last column that is currently redered
-   * and return TRUE in that case, or FALSE otherwise.
-   *
-   * Negative column index is used to check the header cells.
-   *
-   * @param {number} column The visual column index.
-   * @returns {boolean}
-   */
-  isColumnAfterRenderedColumns(column) {
-    if (column < 0) {
-      const rowHeaders = this.wot.getSetting('rowHeaders');
-      const rowHeadersCount = rowHeaders.length;
-      const zeroBasedHeaderLevel = rowHeadersCount + column;
-      return this.isRowHeaderLevelRendered(zeroBasedHeaderLevel);
-    }
-    return this.columnFilter && (column > this.getLastRenderedColumn());
+  isRowAfterViewport(row) {
+    return this.rowFilter && (row > this.getLastVisibleRow());
+  }
+
+  isColumnBeforeViewport(column) {
+    return this.columnFilter && (this.columnFilter.sourceToRendered(column) < 0 && column >= 0);
   }
 
   isLastRowFullyVisible() {

--- a/src/3rdparty/walkontable/src/table.js
+++ b/src/3rdparty/walkontable/src/table.js
@@ -795,7 +795,7 @@ class Table {
     const first = this.getFirstRenderedRow();
 
     // Check the headers only in case when the first rendered row is -1 or 0.
-    // This is an indication that the overlay is placed on the most top-left position.
+    // This is an indication that the overlay is placed on the most top position.
     if (row < 0 && first <= 0) {
       return !this.isRowHeaderRendered(row);
     }
@@ -869,7 +869,7 @@ class Table {
     const first = this.getFirstRenderedColumn();
 
     // Check the headers only in case when the first rendered column is -1 or 0.
-    // This is an indication that the overlay is placed on the most top-left position.
+    // This is an indication that the overlay is placed on the most left position.
     if (column < 0 && first <= 0) {
       return !this.isColumnHeaderRendered(column);
     }

--- a/src/3rdparty/walkontable/test/helpers/common.js
+++ b/src/3rdparty/walkontable/test/helpers/common.js
@@ -411,6 +411,7 @@ export function getScrollbarWidth() {
  */
 export function expectWtTable(wt, callb, name) {
   const callbAsString = callb.toString().replace(/\s\s+/g, ' ');
+
   if (name === 'master') {
     return expect(callb(wt.wtTable)).withContext(`${name}: ${callbAsString}`);
   }

--- a/test/e2e/core/getCell.spec.js
+++ b/test/e2e/core/getCell.spec.js
@@ -1,0 +1,91 @@
+describe('Core.getCell', () => {
+  beforeEach(function() {
+    this.$container = $('<div id="testContainer"></div>').appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should return corner TH element from the correct overlay when all rows are hidden', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetObjectData(5, 5),
+      rowHeaders: true,
+      colHeaders: true,
+      hiddenRows: {
+        rows: [0, 1, 2, 3, 4],
+        indicators: true,
+      },
+    });
+
+    expect(getCell(-1, -1)).toBe(getMaster().find('thead tr:eq(0) th:eq(0)')[0]);
+    expect(getCell(-1, -1, true)).toBe(getTopLeftClone().find('thead tr:eq(0) th:eq(0)')[0]);
+  });
+
+  it('should return corner TH element from the correct overlay when all columns are hidden', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetObjectData(5, 5),
+      rowHeaders: true,
+      colHeaders: true,
+      hiddenColumns: {
+        columns: [0, 1, 2, 3, 4],
+        indicators: true,
+      },
+    });
+
+    expect(getCell(-1, -1)).toBe(getMaster().find('thead tr:eq(0) th:eq(0)')[0]);
+    expect(getCell(-1, -1, true)).toBe(getTopLeftClone().find('thead tr:eq(0) th:eq(0)')[0]);
+  });
+
+  it('should return corner TH element from the correct overlay when all indexes are hidden', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetObjectData(5, 5),
+      rowHeaders: true,
+      colHeaders: true,
+      hiddenColumns: {
+        columns: [0, 1, 2, 3, 4],
+        indicators: true,
+      },
+      hiddenRows: {
+        rows: [0, 1, 2, 3, 4],
+        indicators: true,
+      },
+    });
+
+    expect(getCell(-1, -1)).toBe(getMaster().find('thead tr:eq(0) th:eq(0)')[0]);
+    expect(getCell(-1, -1, true)).toBe(getTopLeftClone().find('thead tr:eq(0) th:eq(0)')[0]);
+  });
+
+  it('should return row header TH element when all columns are hidden', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetObjectData(5, 5),
+      rowHeaders: true,
+      colHeaders: true,
+      hiddenColumns: {
+        columns: [0, 1, 2, 3, 4],
+        indicators: true,
+      },
+    });
+
+    expect(getCell(2, -1)).toBe(getMaster().find('tbody tr:eq(2) th:eq(0)')[0]);
+    expect(getCell(2, -1, true)).toBe(getLeftClone().find('tbody tr:eq(2) th:eq(0)')[0]);
+  });
+
+  it('should return row header TH element when all rows are hidden', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetObjectData(5, 5),
+      rowHeaders: true,
+      colHeaders: true,
+      hiddenRows: {
+        rows: [0, 1, 2, 3, 4],
+        indicators: true,
+      },
+    });
+
+    expect(getCell(-1, 2)).toBe(getMaster().find('thead tr:eq(0) th:eq(3)')[0]);
+    expect(getCell(-1, 2, true)).toBe(getTopClone().find('thead tr:eq(0) th:eq(3)')[0]);
+  });
+});


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
It seems that the Walkontable Table class has a logical bug in the `isRowBeforeRenderedRows`, `isRowAfterRenderedRows`, `isColumnBeforeRenderedColumns` and `isColumnAfterRenderedColumns` method in conjunction with hidden indexes. The methods among other things, are responsible for logic behind `getCell` method. 

I adjusted those methods to support header coordinates and updated documentation for them. Generally, the fix is about adding an additional condition for checking negative values (header coordinates). The presence of the header existence can be checked only in a case when the overlay is rendered from an index 0 (first renderable index) or if there are no rows or columns (first renderable index is then equal to -1). When the overlay is enabled by `fixedRowsTop` and counterparts options then the master overlay is shifted inwards so its first renderable index starts from 2 (depends on `fixedRowsTop` etc. settings). Hence, the master overlay doesn't have headers - in reality, they are hidden and offset from the top-left position (side effect).

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Added E2E tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #6911
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
