### PR TITLE
Layers for fixed rows/columns will be rendered also when all elements are trimmed/hidden

### DIFF
--- a/src/3rdparty/walkontable/src/overlay/bottom.js
+++ b/src/3rdparty/walkontable/src/overlay/bottom.js
@@ -56,7 +56,7 @@ class BottomOverlay extends Overlay {
    * @returns {boolean}
    */
   shouldBeRendered() {
-    return this.wot.getSetting('hasFixedRowsBottom');
+    return this.wot.getSetting('shouldRenderBottomOverlay');
   }
 
   /**

--- a/src/3rdparty/walkontable/src/overlay/bottom.js
+++ b/src/3rdparty/walkontable/src/overlay/bottom.js
@@ -56,8 +56,7 @@ class BottomOverlay extends Overlay {
    * @returns {boolean}
    */
   shouldBeRendered() {
-    /* eslint-disable no-unneeded-ternary */
-    return this.wot.getSetting('fixedRowsBottom') ? true : false;
+    return this.wot.getSetting('hasFixedRowsBottom');
   }
 
   /**

--- a/src/3rdparty/walkontable/src/overlay/bottomLeftCorner.js
+++ b/src/3rdparty/walkontable/src/overlay/bottomLeftCorner.js
@@ -37,9 +37,9 @@ class BottomLeftCornerOverlay extends Overlay {
    */
   shouldBeRendered() {
     const { wot } = this;
-    /* eslint-disable no-unneeded-ternary */
-    return wot.getSetting('fixedRowsBottom') &&
-      (wot.getSetting('fixedColumnsLeft') || wot.getSetting('rowHeaders').length) ? true : false;
+
+    return wot.getSetting('hasFixedRowsBottom') &&
+      (wot.getSetting('hasFixedColumnsLeft') || wot.getSetting('rowHeaders').length > 0);
   }
 
   /**

--- a/src/3rdparty/walkontable/src/overlay/bottomLeftCorner.js
+++ b/src/3rdparty/walkontable/src/overlay/bottomLeftCorner.js
@@ -38,8 +38,7 @@ class BottomLeftCornerOverlay extends Overlay {
   shouldBeRendered() {
     const { wot } = this;
 
-    return wot.getSetting('hasFixedRowsBottom') &&
-      (wot.getSetting('hasFixedColumnsLeft') || wot.getSetting('rowHeaders').length > 0);
+    return wot.getSetting('shouldRenderBottomOverlay') && wot.getSetting('shouldRenderLeftOverlay');
   }
 
   /**

--- a/src/3rdparty/walkontable/src/overlay/left.js
+++ b/src/3rdparty/walkontable/src/overlay/left.js
@@ -41,7 +41,7 @@ class LeftOverlay extends Overlay {
    * @returns {boolean}
    */
   shouldBeRendered() {
-    return !!(this.wot.getSetting('fixedColumnsLeft') || this.wot.getSetting('rowHeaders').length);
+    return this.wot.getSetting('hasFixedColumnsLeft') || this.wot.getSetting('rowHeaders').length > 0;
   }
 
   /**

--- a/src/3rdparty/walkontable/src/overlay/left.js
+++ b/src/3rdparty/walkontable/src/overlay/left.js
@@ -41,7 +41,7 @@ class LeftOverlay extends Overlay {
    * @returns {boolean}
    */
   shouldBeRendered() {
-    return this.wot.getSetting('hasFixedColumnsLeft') || this.wot.getSetting('rowHeaders').length > 0;
+    return this.wot.getSetting('shouldRenderLeftOverlay');
   }
 
   /**

--- a/src/3rdparty/walkontable/src/overlay/top.js
+++ b/src/3rdparty/walkontable/src/overlay/top.js
@@ -42,7 +42,7 @@ class TopOverlay extends Overlay {
    * @returns {boolean}
    */
   shouldBeRendered() {
-    return this.wot.getSetting('hasFixedRowsTop') || this.wot.getSetting('columnHeaders').length > 0;
+    return this.wot.getSetting('shouldRenderTopOverlay');
   }
 
   /**

--- a/src/3rdparty/walkontable/src/overlay/top.js
+++ b/src/3rdparty/walkontable/src/overlay/top.js
@@ -42,7 +42,7 @@ class TopOverlay extends Overlay {
    * @returns {boolean}
    */
   shouldBeRendered() {
-    return !!(this.wot.getSetting('fixedRowsTop') || this.wot.getSetting('columnHeaders').length);
+    return this.wot.getSetting('hasFixedRowsTop') || this.wot.getSetting('columnHeaders').length > 0;
   }
 
   /**

--- a/src/3rdparty/walkontable/src/overlay/topLeftCorner.js
+++ b/src/3rdparty/walkontable/src/overlay/topLeftCorner.js
@@ -38,8 +38,9 @@ class TopLeftCornerOverlay extends Overlay {
    */
   shouldBeRendered() {
     const { wot } = this;
-    return !!((wot.getSetting('fixedRowsTop') || wot.getSetting('columnHeaders').length) &&
-        (wot.getSetting('fixedColumnsLeft') || wot.getSetting('rowHeaders').length));
+
+    return (wot.getSetting('hasFixedRowsTop') || wot.getSetting('columnHeaders').length > 0) &&
+        (wot.getSetting('hasFixedColumnsLeft') || wot.getSetting('rowHeaders').length > 0);
   }
 
   /**

--- a/src/3rdparty/walkontable/src/overlay/topLeftCorner.js
+++ b/src/3rdparty/walkontable/src/overlay/topLeftCorner.js
@@ -39,8 +39,7 @@ class TopLeftCornerOverlay extends Overlay {
   shouldBeRendered() {
     const { wot } = this;
 
-    return (wot.getSetting('hasFixedRowsTop') || wot.getSetting('columnHeaders').length > 0) &&
-        (wot.getSetting('hasFixedColumnsLeft') || wot.getSetting('rowHeaders').length > 0);
+    return wot.getSetting('shouldRenderTopOverlay') && wot.getSetting('shouldRenderLeftOverlay');
   }
 
   /**

--- a/src/3rdparty/walkontable/src/settings.js
+++ b/src/3rdparty/walkontable/src/settings.js
@@ -36,13 +36,13 @@ class Settings {
       fixedRowsTop: 0,
       fixedRowsBottom: 0,
       hasFixedColumnsLeft() {
-        return false;
+        return this.fixedColumnsLeft > 0;
       },
       hasFixedRowsTop() {
-        return false;
+        return this.fixedRowsTop > 0;
       },
       hasFixedRowsBottom() {
-        return false;
+        return this.fixedRowsBottom > 0;
       },
       minSpareRows: 0,
 

--- a/src/3rdparty/walkontable/src/settings.js
+++ b/src/3rdparty/walkontable/src/settings.js
@@ -35,6 +35,15 @@ class Settings {
       fixedColumnsLeft: 0,
       fixedRowsTop: 0,
       fixedRowsBottom: 0,
+      hasFixedColumnsLeft() {
+        return false;
+      },
+      hasFixedRowsTop() {
+        return false;
+      },
+      hasFixedRowsBottom() {
+        return false;
+      },
       minSpareRows: 0,
 
       // this must be array of functions: [function (row, TH) {}]

--- a/src/3rdparty/walkontable/src/settings.js
+++ b/src/3rdparty/walkontable/src/settings.js
@@ -32,23 +32,23 @@ class Settings {
       // data source
       data: void 0,
       freezeOverlays: false,
+      // Number of renderable columns for the left overlay.
       fixedColumnsLeft: 0,
+      // Number of renderable rows for the top overlay.
       fixedRowsTop: 0,
+      // Number of renderable rows for the bottom overlay.
       fixedRowsBottom: 0,
-      // By default, every function related to the fixed cells get information from the `fixedColumnsLeft` config.
-      // However, Walkontable may get both independent function for purpose of rendering fixed columns.
-      hasFixedColumnsLeft() {
-        return this.fixedColumnsLeft > 0;
+      // Enable the left overlay when conditions are met.
+      shouldRenderLeftOverlay: () => {
+        return this.getSetting('fixedColumnsLeft') > 0 || this.getSetting('rowHeaders').length > 0;
       },
-      // By default, every function related to the fixed cells get information from the `fixedRowsTop` config.
-      // However, Walkontable may get both independent function for purpose of rendering fixed rows.
-      hasFixedRowsTop() {
-        return this.fixedRowsTop > 0;
+      // Enable the top overlay when conditions are met.
+      shouldRenderTopOverlay: () => {
+        return this.getSetting('fixedRowsTop') > 0 || this.getSetting('columnHeaders').length > 0;
       },
-      // By default, every function related to the fixed cells get information from the `fixedRowsBottom` config.
-      // However, Walkontable may get both independent function for purpose of rendering fixed rows.
-      hasFixedRowsBottom() {
-        return this.fixedRowsBottom > 0;
+      // Enable the bottom overlay when conditions are met.
+      shouldRenderBottomOverlay: () => {
+        return this.getSetting('fixedRowsBottom') > 0;
       },
       minSpareRows: 0,
 

--- a/src/3rdparty/walkontable/src/settings.js
+++ b/src/3rdparty/walkontable/src/settings.js
@@ -35,12 +35,18 @@ class Settings {
       fixedColumnsLeft: 0,
       fixedRowsTop: 0,
       fixedRowsBottom: 0,
+      // By default, every function related to the fixed cells get information from the `fixedColumnsLeft` config.
+      // However, Walkontable may get both independent function for purpose of rendering fixed columns.
       hasFixedColumnsLeft() {
         return this.fixedColumnsLeft > 0;
       },
+      // By default, every function related to the fixed cells get information from the `fixedRowsTop` config.
+      // However, Walkontable may get both independent function for purpose of rendering fixed rows.
       hasFixedRowsTop() {
         return this.fixedRowsTop > 0;
       },
+      // By default, every function related to the fixed cells get information from the `fixedRowsBottom` config.
+      // However, Walkontable may get both independent function for purpose of rendering fixed rows.
       hasFixedRowsBottom() {
         return this.fixedRowsBottom > 0;
       },

--- a/src/plugins/hiddenColumns/test/hiddenColumns.e2e.js
+++ b/src/plugins/hiddenColumns/test/hiddenColumns.e2e.js
@@ -6708,6 +6708,7 @@ describe('HiddenColumns', () => {
       expect(getLeftClone().find('tbody td').length).toBe(0);
       expect(extractDOMStructure(getLeftClone())).toMatchHTML(`
         <tbody>
+          <tr></tr>
         </tbody>
         `);
     });

--- a/src/plugins/hiddenColumns/test/hiddenColumns.e2e.js
+++ b/src/plugins/hiddenColumns/test/hiddenColumns.e2e.js
@@ -6699,7 +6699,7 @@ describe('HiddenColumns', () => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(1, 10),
         hiddenColumns: true,
-        fixedRowsLeft: 3
+        fixedColumnsLeft: 3
       });
 
       getPlugin('hiddenColumns').hideColumns([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);

--- a/src/plugins/hiddenColumns/test/hiddenColumns.e2e.js
+++ b/src/plugins/hiddenColumns/test/hiddenColumns.e2e.js
@@ -1,6 +1,18 @@
 describe('HiddenColumns', () => {
   const id = 'testContainer';
 
+  function extractDOMStructure(overlay) {
+    const overlayBody = overlay.find('tbody')[0].cloneNode(true);
+
+    Array.from(overlayBody.querySelectorAll('th')).forEach((TH) => {
+      // Simplify header content
+      TH.innerText = TH.querySelector('.rowHeader').innerText;
+      TH.removeAttribute('style');
+    });
+
+    return `${overlayBody.outerHTML}`;
+  }
+
   const {
     CONTEXTMENU_ITEMS_SHOW_COLUMN,
     CONTEXTMENU_ITEMS_HIDE_COLUMN,
@@ -6681,6 +6693,23 @@ describe('HiddenColumns', () => {
 
       expect(getLeftClone().find('tbody tr:eq(0) td').length).toEqual(0);
       expect(getLeftClone().width()).toBe(0);
+    });
+
+    it('should not display cells after API call hiding all columns', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(1, 10),
+        hiddenColumns: true,
+        fixedRowsLeft: 3
+      });
+
+      getPlugin('hiddenColumns').hideColumns([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+      render();
+
+      expect(getLeftClone().find('tbody td').length).toBe(0);
+      expect(extractDOMStructure(getLeftClone())).toMatchHTML(`
+        <tbody>
+        </tbody>
+        `);
     });
   });
 

--- a/src/plugins/hiddenRows/test/settings/fixedRowsBottom.e2e.js
+++ b/src/plugins/hiddenRows/test/settings/fixedRowsBottom.e2e.js
@@ -139,5 +139,39 @@ describe('HiddenRows', () => {
         </tbody>
         `);
     });
+
+    it('should not display cells after API call hiding all rows', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(10, 1),
+        hiddenRows: true,
+        fixedRowsBottom: 3
+      });
+
+      getPlugin('hiddenRows').hideRows([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+      render();
+
+      expect(getBottomClone().find('tbody tr').length).toBe(0);
+      expect(extractDOMStructure(getBottomClone())).toMatchHTML(`
+        <tbody>
+        </tbody>
+        `);
+    });
+
+    it('should not display cells after API call trimming all rows', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(10, 1),
+        trimRows: true,
+        fixedRowsBottom: 3
+      });
+
+      getPlugin('trimRows').trimRows([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+      render();
+
+      expect(getBottomClone().find('tbody tr').length).toBe(0);
+      expect(extractDOMStructure(getBottomClone())).toMatchHTML(`
+        <tbody>
+        </tbody>
+        `);
+    });
   });
 });

--- a/src/plugins/hiddenRows/test/settings/fixedRowsBottom.e2e.js
+++ b/src/plugins/hiddenRows/test/settings/fixedRowsBottom.e2e.js
@@ -140,7 +140,7 @@ describe('HiddenRows', () => {
         `);
     });
 
-    it('should not display cells after API call hiding all rows', () => {
+    it('should not display cells after API call hiding all rows (headers disabled)', () => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(10, 1),
         hiddenRows: true,
@@ -154,10 +154,34 @@ describe('HiddenRows', () => {
       expect(extractDOMStructure(getBottomClone())).toMatchHTML(`
         <tbody>
         </tbody>
-        `);
+      `);
     });
 
-    it('should not display cells after API call trimming all rows', () => {
+    it('should not display cells after API call hiding all rows (headers enabled)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(10, 1),
+        hiddenRows: true,
+        fixedRowsBottom: 3,
+        rowHeaders: true,
+        colHeaders: true,
+      });
+
+      getPlugin('hiddenRows').hideRows([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+      render();
+
+      expect(getBottomClone().find('tbody tr').length).toBe(0);
+      expect(extractDOMStructure(getBottomClone())).toMatchHTML(`
+        <tbody>
+        </tbody>
+      `);
+      expect(getBottomLeftClone().find('tbody tr').length).toBe(0);
+      expect(extractDOMStructure(getBottomLeftClone())).toMatchHTML(`
+        <tbody>
+        </tbody>
+      `);
+    });
+
+    it('should not display cells after API call trimming all rows (headers disabled)', () => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(10, 1),
         trimRows: true,
@@ -171,7 +195,31 @@ describe('HiddenRows', () => {
       expect(extractDOMStructure(getBottomClone())).toMatchHTML(`
         <tbody>
         </tbody>
-        `);
+      `);
+    });
+
+    it('should not display cells after API call trimming all rows (headers enabled)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(10, 1),
+        trimRows: true,
+        fixedRowsBottom: 3,
+        rowHeaders: true,
+        colHeaders: true,
+      });
+
+      getPlugin('trimRows').trimRows([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+      render();
+
+      expect(getBottomClone().find('tbody tr').length).toBe(0);
+      expect(extractDOMStructure(getBottomClone())).toMatchHTML(`
+        <tbody>
+        </tbody>
+      `);
+      expect(getBottomLeftClone().find('tbody tr').length).toBe(0);
+      expect(extractDOMStructure(getBottomLeftClone())).toMatchHTML(`
+        <tbody>
+        </tbody>
+      `);
     });
   });
 });

--- a/src/plugins/hiddenRows/test/settings/fixedRowsTop.e2e.js
+++ b/src/plugins/hiddenRows/test/settings/fixedRowsTop.e2e.js
@@ -150,8 +150,8 @@ describe('HiddenRows', () => {
       getPlugin('hiddenRows').hideRows([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
       render();
 
-      expect(getBottomClone().find('tbody tr').length).toBe(0);
-      expect(extractDOMStructure(getBottomClone())).toMatchHTML(`
+      expect(getTopClone().find('tbody tr').length).toBe(0);
+      expect(extractDOMStructure(getTopClone())).toMatchHTML(`
         <tbody>
         </tbody>
         `);
@@ -167,8 +167,8 @@ describe('HiddenRows', () => {
       getPlugin('trimRows').trimRows([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
       render();
 
-      expect(getBottomClone().find('tbody tr').length).toBe(0);
-      expect(extractDOMStructure(getBottomClone())).toMatchHTML(`
+      expect(getTopClone().find('tbody tr').length).toBe(0);
+      expect(extractDOMStructure(getTopClone())).toMatchHTML(`
         <tbody>
         </tbody>
         `);

--- a/src/plugins/hiddenRows/test/settings/fixedRowsTop.e2e.js
+++ b/src/plugins/hiddenRows/test/settings/fixedRowsTop.e2e.js
@@ -139,5 +139,39 @@ describe('HiddenRows', () => {
         </tbody>
         `);
     });
+
+    it('should not display cells after API call hiding all rows', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(10, 1),
+        hiddenRows: true,
+        fixedRowsTop: 3
+      });
+
+      getPlugin('hiddenRows').hideRows([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+      render();
+
+      expect(getBottomClone().find('tbody tr').length).toBe(0);
+      expect(extractDOMStructure(getBottomClone())).toMatchHTML(`
+        <tbody>
+        </tbody>
+        `);
+    });
+
+    it('should not display cells after API call trimming all rows', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(10, 1),
+        trimRows: true,
+        fixedRowsTop: 3
+      });
+
+      getPlugin('trimRows').trimRows([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+      render();
+
+      expect(getBottomClone().find('tbody tr').length).toBe(0);
+      expect(extractDOMStructure(getBottomClone())).toMatchHTML(`
+        <tbody>
+        </tbody>
+        `);
+    });
   });
 });

--- a/src/tableView.js
+++ b/src/tableView.js
@@ -491,15 +491,21 @@ class TableView {
 
         return this.countNotHiddenRowIndexes(this.instance.countRows() - fixedRowsBottom, 1);
       },
-      // Just simple information whether fixed columns on the left are defined within configuration.
+      // Just simple information whether fixed rows at the top are defined within configuration. It overrides default
+      // behaviour (reading from the `fixedColumnsLeft` method). We have two independent functions for purpose of
+      // rendering fixed cells.
       hasFixedColumnsLeft: () => {
         return this.settings.fixedColumnsLeft > 0;
       },
-      // Just simple information whether fixed rows at the top are defined within configuration.
+      // Just simple information whether fixed rows at the top are defined within configuration. It overrides default
+      // behaviour (reading from the `fixedRowsTop` method). We have two independent functions for purpose of
+      // rendering fixed cells.
       hasFixedRowsTop: () => {
         return this.settings.fixedRowsTop > 0;
       },
-      // Just simple information whether fixed rows at the bottom are defined within configuration.
+      // Just simple information whether fixed rows at the top are defined within configuration. It overrides default
+      // behaviour (reading from the `fixedRowsBottom` method). We have two independent functions for purpose of
+      // rendering fixed cells.
       hasFixedRowsBottom: () => {
         return this.settings.fixedRowsBottom > 0;
       },

--- a/src/tableView.js
+++ b/src/tableView.js
@@ -491,22 +491,16 @@ class TableView {
 
         return this.countNotHiddenRowIndexes(this.instance.countRows() - fixedRowsBottom, 1);
       },
-      // Just simple information whether fixed rows at the top are defined within configuration. It overrides default
-      // behaviour (reading from the `fixedColumnsLeft` method). We have two independent functions for purpose of
-      // rendering fixed cells.
-      hasFixedColumnsLeft: () => {
-        return this.settings.fixedColumnsLeft > 0;
+      // Enable the left overlay when conditions are met.
+      shouldRenderLeftOverlay: () => {
+        return this.settings.fixedColumnsLeft > 0 || walkontableConfig.rowHeaders().length > 0;
       },
-      // Just simple information whether fixed rows at the top are defined within configuration. It overrides default
-      // behaviour (reading from the `fixedRowsTop` method). We have two independent functions for purpose of
-      // rendering fixed cells.
-      hasFixedRowsTop: () => {
-        return this.settings.fixedRowsTop > 0;
+      // Enable the top overlay when conditions are met.
+      shouldRenderTopOverlay: () => {
+        return this.settings.fixedRowsTop > 0 || walkontableConfig.columnHeaders().length > 0;
       },
-      // Just simple information whether fixed rows at the top are defined within configuration. It overrides default
-      // behaviour (reading from the `fixedRowsBottom` method). We have two independent functions for purpose of
-      // rendering fixed cells.
-      hasFixedRowsBottom: () => {
+      // Enable the bottom overlay when conditions are met.
+      shouldRenderBottomOverlay: () => {
         return this.settings.fixedRowsBottom > 0;
       },
       minSpareRows: () => this.settings.minSpareRows,

--- a/src/tableView.js
+++ b/src/tableView.js
@@ -473,20 +473,35 @@ class TableView {
       },
       totalRows: () => this.countRenderableRows(),
       totalColumns: () => this.countRenderableColumns(),
+      // Rendered fixed rows on the left
       fixedColumnsLeft: () => {
         const fixedColumnsLeft = parseInt(this.settings.fixedColumnsLeft, 10);
 
         return this.countNotHiddenColumnIndexes(fixedColumnsLeft - 1, -1);
       },
+      // Rendered fixed rows at the top
       fixedRowsTop: () => {
         const fixedRowsTop = parseInt(this.settings.fixedRowsTop, 10);
 
         return this.countNotHiddenRowIndexes(fixedRowsTop - 1, -1);
       },
+      // Rendered fixed rows at the bottom
       fixedRowsBottom: () => {
         const fixedRowsBottom = parseInt(this.settings.fixedRowsBottom, 10);
 
         return this.countNotHiddenRowIndexes(this.instance.countRows() - fixedRowsBottom, 1);
+      },
+      // Just simple information whether fixed columns on the left are defined within configuration.
+      hasFixedColumnsLeft: () => {
+        return this.settings.fixedColumnsLeft > 0;
+      },
+      // Just simple information whether fixed rows at the top are defined within configuration.
+      hasFixedRowsTop: () => {
+        return this.settings.fixedRowsTop > 0;
+      },
+      // Just simple information whether fixed rows at the bottom are defined within configuration.
+      hasFixedRowsBottom: () => {
+        return this.settings.fixedRowsBottom > 0;
       },
       minSpareRows: () => this.settings.minSpareRows,
       renderAllRows: this.settings.renderAllRows,


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
On the current `master` branch, layers responsible for rendering fixed cells **are rendered also when all cells are trimmed**. 

Layers checked just if the option defining fixed cells was set.

https://github.com/handsontable/handsontable/blob/88d78a5be5e37ad703c11914c86690d2436d3024/src/3rdparty/walkontable/src/overlay/bottom.js#L53-L61

Thus, in a situation when we trimmed elements just after showing a table with fixed cells, an **extra cycle of rendering happens**. In consequence, not needed cells are removed from the layer. Maybe that isn't perfect, but I wouldn't change the behavior, as it's not the part of the project.

However, there was a change in the way how the `fixedRowsBottom` method of Walkontable works.

Was:

https://github.com/handsontable/handsontable/blob/88d78a5be5e37ad703c11914c86690d2436d3024/src/tableView.js#L359

Is:

https://github.com/handsontable/handsontable/blob/7fbf9c8c19ecd96fbb7fc5721b2fb26419126e64/src/tableView.js#L486-L490

Since the change has been applied the `Walkontable` method may return also `0`. Thus, the next rendering cycle won't happen (The `shouldBeRendered ` method will return `false`). It's needed for removing unnecessary cells. 

That's why new methods have been introduced. They inform just whether settings for `fixedRowsBottom` or `fixedRowsTop` or `fixedColumnsLeft` was set.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Checked how it works while using `updateSetting` method, `TrimRows` and `HiddenRows` plugins and also `fixedColumnsLeft`, `fixedRowsTop`, `fixedRowsBottom` settings.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7004 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
