### PR TITLE
Fix a problem with traversing through partially hidden merged cells

### DIFF
--- a/src/plugins/mergeCells/cellsCollection.js
+++ b/src/plugins/mergeCells/cellsCollection.js
@@ -273,6 +273,27 @@ class MergedCellsCollection {
   }
 
   /**
+   * Get the first renderable coords of the merged cell at the provided coordinates.
+   *
+   * @param {number} row Visual row index.
+   * @param {number} column Visual column index.
+   * @returns {CellCoords} A `CellCoords` object with the coordinates to the first renderable cell within the
+   *                        merged cell.
+   */
+  getFirstRenderableCoords(row, column) {
+    const mergeParent = this.get(row, column);
+
+    if (!mergeParent || this.isFirstRenderableMergedCell(row, column)) {
+      return new CellCoords(row, column);
+    }
+
+    const firstRenderableRow = this.hot.rowIndexMapper.getFirstNotHiddenIndex(mergeParent.row, 1);
+    const firstRenderableColumn = this.hot.columnIndexMapper.getFirstNotHiddenIndex(mergeParent.col, 1);
+
+    return new CellCoords(firstRenderableRow, firstRenderableColumn);
+  }
+
+  /**
    * Shift the merged cell in the direction and by an offset defined in the arguments.
    *
    * @param {string} direction `right`, `left`, `up` or `down`.

--- a/src/plugins/mergeCells/mergeCells.js
+++ b/src/plugins/mergeCells/mergeCells.js
@@ -606,13 +606,19 @@ class MergeCells extends BasePlugin {
       currentlySelectedRange.highlight.col + newDelta.col
     );
 
-    const nextParentIsMerged = this.mergedCellsCollection.get(nextPosition.row, nextPosition.col);
+    const nextPositionMergedCell = this.mergedCellsCollection.get(nextPosition.row, nextPosition.col);
 
-    if (nextParentIsMerged) { // skipping the invisible cells in the merge range
+    if (nextPositionMergedCell) { // skipping the invisible cells in the merge range
+      const firstRenderableCoords = this.mergedCellsCollection.getFirstRenderableCoords(
+        nextPositionMergedCell.row,
+        nextPositionMergedCell.col
+      );
+
       priv.lastDesiredCoords = nextPosition;
+
       newDelta = {
-        row: nextParentIsMerged.row - currentPosition.row,
-        col: nextParentIsMerged.col - currentPosition.col
+        row: firstRenderableCoords.row - currentPosition.row,
+        col: firstRenderableCoords.col - currentPosition.col
       };
     }
 

--- a/src/plugins/mergeCells/test/mergeCells.e2e.js
+++ b/src/plugins/mergeCells/test/mergeCells.e2e.js
@@ -434,7 +434,180 @@ describe('MergeCells', () => {
       keyDownUp('shift+enter');
 
       expect(spec().$container.find('.handsontableInputHolder textarea').val()).toEqual('I1');
-      keyDownUp('shift+enter');
+    });
+
+    describe('compatibility with other plugins', () => {
+      it('should be possible to traverse through columns using the DOWN ARROW or ENTER, when there\'s a' +
+        ' partially-hidden merged cell in the way', () => {
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(4, 4),
+          hiddenColumns: {
+            columns: [1],
+            indicators: true
+          },
+          mergeCells: [
+            { row: 1, col: 1, rowspan: 2, colspan: 2 }
+          ]
+        });
+
+        selectCell(0, 2);
+
+        keyDownUp('enter');
+        keyDownUp('enter');
+
+        let lastSelectedRange = getSelectedRangeLast();
+
+        expect(getCell(lastSelectedRange.highlight.row, lastSelectedRange.highlight.col)).toEqual(getCell(2, 2));
+
+        keyDownUp('enter');
+        keyDownUp('enter');
+
+        lastSelectedRange = getSelectedRangeLast();
+
+        expect(getCell(lastSelectedRange.highlight.row, lastSelectedRange.highlight.col)).toEqual(getCell(3, 2));
+
+        selectCell(0, 2);
+
+        keyDownUp('arrow_down');
+
+        lastSelectedRange = getSelectedRangeLast();
+
+        expect(getCell(lastSelectedRange.highlight.row, lastSelectedRange.highlight.col)).toEqual(getCell(2, 2));
+
+        keyDownUp('arrow_down');
+
+        lastSelectedRange = getSelectedRangeLast();
+
+        expect(getCell(lastSelectedRange.highlight.row, lastSelectedRange.highlight.col)).toEqual(getCell(3, 2));
+      });
+
+      it('should be possible to traverse through columns using the UP ARROW or SHIFT+ENTER, when there\'s a' +
+        ' partially-hidden merged cell in the way', () => {
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(4, 4),
+          hiddenColumns: {
+            columns: [1],
+            indicators: true
+          },
+          mergeCells: [
+            { row: 1, col: 1, rowspan: 2, colspan: 2 }
+          ]
+        });
+
+        selectCell(3, 2);
+
+        keyDownUp('shift+enter');
+        keyDownUp('shift+enter');
+
+        let lastSelectedRange = getSelectedRangeLast();
+
+        expect(getCell(lastSelectedRange.highlight.row, lastSelectedRange.highlight.col)).toEqual(getCell(2, 2));
+
+        keyDownUp('shift+enter');
+        keyDownUp('shift+enter');
+
+        lastSelectedRange = getSelectedRangeLast();
+
+        expect(getCell(lastSelectedRange.highlight.row, lastSelectedRange.highlight.col)).toEqual(getCell(0, 2));
+
+        selectCell(3, 2);
+
+        keyDownUp('arrow_up');
+
+        lastSelectedRange = getSelectedRangeLast();
+
+        expect(getCell(lastSelectedRange.highlight.row, lastSelectedRange.highlight.col)).toEqual(getCell(2, 2));
+
+        keyDownUp('arrow_up');
+
+        lastSelectedRange = getSelectedRangeLast();
+
+        expect(getCell(lastSelectedRange.highlight.row, lastSelectedRange.highlight.col)).toEqual(getCell(0, 2));
+      });
+
+      it('should be possible to traverse through columns using the RIGHT ARROW or TAB, when there\'s a' +
+        ' partially-hidden merged cell in the way', () => {
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(4, 4),
+          hiddenRows: {
+            rows: [1],
+            indicators: true
+          },
+          mergeCells: [
+            { row: 1, col: 1, rowspan: 2, colspan: 2 }
+          ]
+        });
+
+        selectCell(2, 0);
+
+        keyDownUp('tab');
+
+        let lastSelectedRange = getSelectedRangeLast();
+
+        expect(getCell(lastSelectedRange.highlight.row, lastSelectedRange.highlight.col)).toEqual(getCell(2, 2));
+
+        keyDownUp('tab');
+
+        lastSelectedRange = getSelectedRangeLast();
+
+        expect(getCell(lastSelectedRange.highlight.row, lastSelectedRange.highlight.col)).toEqual(getCell(2, 3));
+
+        selectCell(2, 0);
+
+        keyDownUp('arrow_right');
+
+        lastSelectedRange = getSelectedRangeLast();
+
+        expect(getCell(lastSelectedRange.highlight.row, lastSelectedRange.highlight.col)).toEqual(getCell(2, 2));
+
+        keyDownUp('arrow_right');
+
+        lastSelectedRange = getSelectedRangeLast();
+
+        expect(getCell(lastSelectedRange.highlight.row, lastSelectedRange.highlight.col)).toEqual(getCell(2, 3));
+      });
+
+      it('should be possible to traverse through columns using the LEFT ARROW or SHIFT+TAB, when there\'s a' +
+        ' partially-hidden merged cell in the way', () => {
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(4, 4),
+          hiddenRows: {
+            rows: [1],
+            indicators: true
+          },
+          mergeCells: [
+            { row: 1, col: 1, rowspan: 2, colspan: 2 }
+          ]
+        });
+
+        selectCell(2, 3);
+
+        keyDownUp('shift+tab');
+
+        let lastSelectedRange = getSelectedRangeLast();
+
+        expect(getCell(lastSelectedRange.highlight.row, lastSelectedRange.highlight.col)).toEqual(getCell(2, 2));
+
+        keyDownUp('shift+tab');
+
+        lastSelectedRange = getSelectedRangeLast();
+
+        expect(getCell(lastSelectedRange.highlight.row, lastSelectedRange.highlight.col)).toEqual(getCell(2, 0));
+
+        selectCell(2, 3);
+
+        keyDownUp('arrow_left');
+
+        lastSelectedRange = getSelectedRangeLast();
+
+        expect(getCell(lastSelectedRange.highlight.row, lastSelectedRange.highlight.col)).toEqual(getCell(2, 2));
+
+        keyDownUp('arrow_left');
+
+        lastSelectedRange = getSelectedRangeLast();
+
+        expect(getCell(lastSelectedRange.highlight.row, lastSelectedRange.highlight.col)).toEqual(getCell(2, 0));
+      });
     });
   });
 


### PR DESCRIPTION
### Context
This should fix a problem with going through partially hidden merged cells using <kbd>ENTER</kbd>/<kbd>↓</kbd> and <kbd>TAB</kbd>/<kbd>→</kbd>.

### How has this been tested?
- Added the test cases for the issue.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #6981 
