### PR TITLE
Fix overlay desync when indexes are trimmed

### DIFF
--- a/src/plugins/trimRows/test/settings/fixedColumnsLeft.e2e.js
+++ b/src/plugins/trimRows/test/settings/fixedColumnsLeft.e2e.js
@@ -1,0 +1,126 @@
+describe('TrimRows', () => {
+  const id = 'testContainer';
+
+  function extractDOMStructure(overlay) {
+    const overlayHead = overlay.find('thead')[0].cloneNode(true);
+    const overlayBody = overlay.find('tbody')[0].cloneNode(true);
+
+    Array.from(overlayHead.querySelectorAll('th')).forEach((TH) => {
+      // Simplify header content
+      TH.innerText = TH.querySelector('.colHeader').innerText;
+      TH.removeAttribute('style');
+    });
+
+    return `${overlayHead.outerHTML}${overlayBody.outerHTML}`;
+  }
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  // TODO: Tests should be moved to Core.fixedColumnsLeft E2E tests as soon as the TrimmingMap can be
+  // available for UMD (browsers).
+  describe('fixedColumnsLeft', () => {
+    it('should render left overlay with the same amount of columns than a master overlay', async() => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(2, 5),
+        colHeaders: true,
+        fixedColumnsLeft: 2,
+        columns: [{}, {}],
+      });
+
+      expect(extractDOMStructure(getLeftClone())).toMatchHTML(`
+        <thead>
+          <tr>
+            <th class="">A</th>
+            <th class="">B</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="">A1</td>
+            <td class="">B1</td>
+          </tr>
+          <tr>
+            <td class="">A2</td>
+            <td class="">B2</td>
+          </tr>
+        </tbody>
+        `);
+      expect(extractDOMStructure(getTopLeftClone())).toMatchHTML(`
+        <thead>
+          <tr>
+            <th class="">A</th>
+            <th class="">B</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+        `);
+    });
+
+    it('should shrink left overlay to a master overlay when defined overlay size is higher than total amount of columns', async() => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(2, 5),
+        colHeaders: true,
+        fixedColumnsLeft: 2,
+        columns: [{}],
+      });
+
+      expect(extractDOMStructure(getLeftClone())).toMatchHTML(`
+        <thead>
+          <tr>
+            <th class="">A</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="">A1</td>
+          </tr>
+          <tr>
+            <td class="">A2</td>
+          </tr>
+        </tbody>
+        `);
+      expect(extractDOMStructure(getTopLeftClone())).toMatchHTML(`
+        <thead>
+          <tr>
+            <th class="">A</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+        `);
+    });
+
+    it('should shrink top overlay to a master overlay when all rows are trimmed', async() => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(2, 5),
+        colHeaders: true,
+        fixedColumnsLeft: 2,
+        columns: [],
+      });
+
+      expect(extractDOMStructure(getLeftClone())).toMatchHTML(`
+        <thead>
+          <tr></tr>
+        </thead>
+        <tbody>
+          <tr></tr>
+          <tr></tr>
+        </tbody>
+        `);
+      expect(extractDOMStructure(getTopLeftClone())).toMatchHTML(`
+        <thead>
+          <tr></tr>
+        </thead>
+        <tbody></tbody>
+        `);
+    });
+  });
+});

--- a/src/plugins/trimRows/test/settings/fixedRowsBottom.e2e.js
+++ b/src/plugins/trimRows/test/settings/fixedRowsBottom.e2e.js
@@ -1,0 +1,106 @@
+describe('TrimRows', () => {
+  const id = 'testContainer';
+
+  function extractDOMStructure(overlay) {
+    const overlayBody = overlay.find('tbody')[0].cloneNode(true);
+
+    Array.from(overlayBody.querySelectorAll('th')).forEach((TH) => {
+      // Simplify header content
+      TH.innerText = TH.querySelector('.rowHeader').innerText;
+      TH.removeAttribute('style');
+    });
+
+    return `${overlayBody.outerHTML}`;
+  }
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  // TODO: Tests should be moved to Core.fixedRowsBottom E2E tests as soon as the TrimmingMap can be
+  // available for UMD (browsers).
+  describe('fixedRowsBottom', () => {
+    it('should render bottom overlay with the same amount of rows than a master overlay', async() => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 2),
+        rowHeaders: true,
+        fixedRowsBottom: 2,
+        trimRows: [0, 1, 2],
+      });
+
+      expect(extractDOMStructure(getBottomClone())).toMatchHTML(`
+        <tbody>
+          <tr>
+            <th class="">1</th>
+            <td class="">A4</td>
+            <td class="">B4</td>
+          </tr>
+          <tr>
+            <th class="">2</th>
+            <td class="">A5</td>
+            <td class="">B5</td>
+          </tr>
+        </tbody>
+        `);
+      expect(extractDOMStructure(getBottomLeftClone())).toMatchHTML(`
+        <tbody>
+          <tr>
+            <th class="">1</th>
+          </tr>
+          <tr>
+            <th class="">2</th>
+          </tr>
+        </tbody>
+        `);
+    });
+
+    it('should shrink bottom overlay to a master overlay when defined overlay size is higher than total amount of rows', async() => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 2),
+        rowHeaders: true,
+        fixedRowsBottom: 2,
+        trimRows: [0, 1, 2, 3],
+      });
+
+      expect(extractDOMStructure(getBottomClone())).toMatchHTML(`
+        <tbody>
+          <tr>
+            <th class="">1</th>
+            <td class="">A5</td>
+            <td class="">B5</td>
+          </tr>
+        </tbody>
+        `);
+      expect(extractDOMStructure(getBottomLeftClone())).toMatchHTML(`
+        <tbody>
+          <tr>
+            <th class="">1</th>
+          </tr>
+        </tbody>
+        `);
+    });
+
+    it('should shrink bottom overlay to a master overlay when all rows are trimmed', async() => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 2),
+        rowHeaders: true,
+        fixedRowsBottom: 2,
+        trimRows: [0, 1, 2, 3, 4],
+      });
+
+      expect(extractDOMStructure(getBottomClone())).toMatchHTML(`
+        <tbody></tbody>
+        `);
+      expect(extractDOMStructure(getBottomLeftClone())).toMatchHTML(`
+        <tbody></tbody>
+        `);
+    });
+  });
+});

--- a/src/plugins/trimRows/test/settings/fixedRowsTop.e2e.js
+++ b/src/plugins/trimRows/test/settings/fixedRowsTop.e2e.js
@@ -1,0 +1,106 @@
+describe('TrimRows', () => {
+  const id = 'testContainer';
+
+  function extractDOMStructure(overlay) {
+    const overlayBody = overlay.find('tbody')[0].cloneNode(true);
+
+    Array.from(overlayBody.querySelectorAll('th')).forEach((TH) => {
+      // Simplify header content
+      TH.innerText = TH.querySelector('.rowHeader').innerText;
+      TH.removeAttribute('style');
+    });
+
+    return `${overlayBody.outerHTML}`;
+  }
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  // TODO: Tests should be moved to Core.fixedRowsTop E2E tests as soon as the TrimmingMap can be
+  // available for UMD (browsers).
+  describe('fixedRowsTop', () => {
+    it('should render top overlay with the same amount of rows than a master overlay', async() => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 2),
+        rowHeaders: true,
+        fixedRowsTop: 2,
+        trimRows: [0, 1, 2],
+      });
+
+      expect(extractDOMStructure(getTopClone())).toMatchHTML(`
+        <tbody>
+          <tr>
+            <th class="">1</th>
+            <td class="">A4</td>
+            <td class="">B4</td>
+          </tr>
+          <tr>
+            <th class="">2</th>
+            <td class="">A5</td>
+            <td class="">B5</td>
+          </tr>
+        </tbody>
+        `);
+      expect(extractDOMStructure(getTopLeftClone())).toMatchHTML(`
+        <tbody>
+          <tr>
+            <th class="">1</th>
+          </tr>
+          <tr>
+            <th class="">2</th>
+          </tr>
+        </tbody>
+        `);
+    });
+
+    it('should shrink top overlay to a master overlay when defined overlay size is higher than total amount of rows', async() => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 2),
+        rowHeaders: true,
+        fixedRowsTop: 2,
+        trimRows: [0, 1, 2, 3],
+      });
+
+      expect(extractDOMStructure(getTopClone())).toMatchHTML(`
+        <tbody>
+          <tr>
+            <th class="">1</th>
+            <td class="">A5</td>
+            <td class="">B5</td>
+          </tr>
+        </tbody>
+        `);
+      expect(extractDOMStructure(getTopLeftClone())).toMatchHTML(`
+        <tbody>
+          <tr>
+            <th class="">1</th>
+          </tr>
+        </tbody>
+        `);
+    });
+
+    it('should shrink top overlay to a master overlay when all rows are trimmed', async() => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 2),
+        rowHeaders: true,
+        fixedRowsTop: 2,
+        trimRows: [0, 1, 2, 3, 4],
+      });
+
+      expect(extractDOMStructure(getTopClone())).toMatchHTML(`
+        <tbody></tbody>
+        `);
+      expect(extractDOMStructure(getTopLeftClone())).toMatchHTML(`
+        <tbody></tbody>
+        `);
+    });
+  });
+});

--- a/src/tableView.js
+++ b/src/tableView.js
@@ -473,23 +473,26 @@ class TableView {
       },
       totalRows: () => this.countRenderableRows(),
       totalColumns: () => this.countRenderableColumns(),
-      // Rendered fixed rows on the left
+      // Number of renderable columns for the left overlay.
       fixedColumnsLeft: () => {
-        const fixedColumnsLeft = parseInt(this.settings.fixedColumnsLeft, 10);
+        const countCols = this.instance.countCols();
+        const visualFixedColumnsLeft = Math.min(parseInt(this.settings.fixedColumnsLeft, 10), countCols) - 1;
 
-        return this.countNotHiddenColumnIndexes(fixedColumnsLeft - 1, -1);
+        return this.countNotHiddenColumnIndexes(visualFixedColumnsLeft, -1);
       },
-      // Rendered fixed rows at the top
+      // Number of renderable rows for the top overlay.
       fixedRowsTop: () => {
-        const fixedRowsTop = parseInt(this.settings.fixedRowsTop, 10);
+        const countRows = this.instance.countRows();
+        const visualFixedRowsTop = Math.min(parseInt(this.settings.fixedRowsTop, 10), countRows) - 1;
 
-        return this.countNotHiddenRowIndexes(fixedRowsTop - 1, -1);
+        return this.countNotHiddenRowIndexes(visualFixedRowsTop, -1);
       },
-      // Rendered fixed rows at the bottom
+      // Number of renderable rows for the bottom overlay.
       fixedRowsBottom: () => {
-        const fixedRowsBottom = parseInt(this.settings.fixedRowsBottom, 10);
+        const countRows = this.instance.countRows();
+        const visualFixedRowsBottom = Math.max(countRows - parseInt(this.settings.fixedRowsBottom, 10), 0);
 
-        return this.countNotHiddenRowIndexes(this.instance.countRows() - fixedRowsBottom, 1);
+        return this.countNotHiddenRowIndexes(visualFixedRowsBottom, 1);
       },
       // Enable the left overlay when conditions are met.
       shouldRenderLeftOverlay: () => {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
This PR fixes an overlay desynchronization. The overlays (top, left and bottom) acted strangely when they are enabled in a case when the dataset is less or equal to the number of indexes defined in the `fixed*` (e.q `fixedRowsTop`) options while trim indexes are applied.

I fixed the issue by clamping the number of indexes provided by `fixed*` options to the range of the actual dataset range.

### case 1 
Previously on the develop branch, the bottom overlay was not visible after trimming 4 out of 5 rows:
![Zrzut ekranu 2020-06-16 o 09 26 12](https://user-images.githubusercontent.com/571316/84744567-be9a2000-afb3-11ea-9766-9cea66c4e478.png)

Now:
![Zrzut ekranu 2020-06-16 o 09 26 40](https://user-images.githubusercontent.com/571316/84744584-c22da700-afb3-11ea-9b89-efaa7ea4658b.png)

### case 2
Previously on the develop branch, the top overlay was shrunk to 0 when it has the same number of rows as dataset and one (or more) row is trimmed:
![Zrzut ekranu 2020-06-16 o 09 30 22](https://user-images.githubusercontent.com/571316/84745421-d32ae800-afb4-11ea-9ba5-892c0ebb523a.png)

Now:
![Zrzut ekranu 2020-06-16 o 09 32 17](https://user-images.githubusercontent.com/571316/84745043-4bdd7480-afb4-11ea-8d8f-a26199ed1da2.png)

The same thing happened for fixed left column overlay.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Added new E2E tests, and tested manually.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7011
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
