### PR TITLE
Fix headers size update after dbl-click on resize handler

### DIFF
--- a/src/plugins/autoColumnSize/autoColumnSize.js
+++ b/src/plugins/autoColumnSize/autoColumnSize.js
@@ -143,11 +143,12 @@ class AutoColumnSize extends BasePlugin {
      * @type {PhysicalIndexToValueMap}
      */
     this.columnWidthsMap = new IndexToValueMap();
-
-    // moved to constructor to allow auto-sizing the columns when the plugin is disabled
-    this
-      .addHook('beforeColumnResize', (size, column, isDblClick) => this.onBeforeColumnResize(size, column, isDblClick));
     this.hot.columnIndexMapper.registerMap(COLUMN_SIZE_MAP_NAME, this.columnWidthsMap);
+
+    // Leave the listener active to allow auto-sizing the columns when the plugin is disabled.
+    // This is necesseary for width recalculation for resize handler doubleclick (ManualColumnResize).
+    this.addHook('beforeColumnResize',
+      (size, column, isDblClick) => this.onBeforeColumnResize(size, column, isDblClick));
   }
 
   /**
@@ -194,6 +195,18 @@ class AutoColumnSize extends BasePlugin {
       this.clearCache(changedColumns);
     }
     super.updatePlugin();
+  }
+
+  /**
+   * Disables the plugin functionality for this Handsontable instance.
+   */
+  disablePlugin() {
+    super.disablePlugin();
+
+    // Leave the listener active to allow auto-sizing the columns when the plugin is disabled.
+    // This is necesseary for width recalculation for resize handler doubleclick (ManualColumnResize).
+    this.addHook('beforeColumnResize',
+      (size, column, isDblClick) => this.onBeforeColumnResize(size, column, isDblClick));
   }
 
   /**
@@ -574,13 +587,6 @@ class AutoColumnSize extends BasePlugin {
    */
   onAfterInit() {
     privatePool.get(this).cachedColumnHeaders = this.hot.getColHeader();
-  }
-
-  /**
-   * Disables the plugin functionality for this Handsontable instance.
-   */
-  disablePlugin() {
-    super.disablePlugin();
   }
 
   /**

--- a/src/plugins/autoRowSize/autoRowSize.js
+++ b/src/plugins/autoRowSize/autoRowSize.js
@@ -130,12 +130,18 @@ class AutoRowSize extends BasePlugin {
      * @type {number}
      */
     this.measuredRows = 0;
-
-    // moved to constructor to allow auto-sizing the rows when the plugin is disabled
-    this.addHook('beforeRowResize', (size, row, isDblClick) => this.onBeforeRowResize(size, row, isDblClick));
-
+    /**
+     * PhysicalIndexToValueMap to keep and track heights for physical row indexes.
+     *
+     * @private
+     * @type {PhysicalIndexToValueMap}
+     */
     this.rowHeightsMap = new IndexToValueMap();
     this.hot.rowIndexMapper.registerMap(ROW_WIDTHS_MAP_NAME, this.rowHeightsMap);
+
+    // Leave the listener active to allow auto-sizing the rows when the plugin is disabled.
+    // This is necesseary for height recalculation for resize handler doubleclick (ManualRowResize).
+    this.addHook('beforeRowResize', (size, row, isDblClick) => this.onBeforeRowResize(size, row, isDblClick));
   }
 
   /**
@@ -175,6 +181,10 @@ class AutoRowSize extends BasePlugin {
     this.headerHeight = null;
 
     super.disablePlugin();
+
+    // Leave the listener active to allow auto-sizing the rows when the plugin is disabled.
+    // This is necesseary for height recalculation for resize handler doubleclick (ManualRowResize).
+    this.addHook('beforeRowResize', (size, row, isDblClick) => this.onBeforeRowResize(size, row, isDblClick));
   }
 
   /**

--- a/src/plugins/manualColumnResize/manualColumnResize.js
+++ b/src/plugins/manualColumnResize/manualColumnResize.js
@@ -459,7 +459,7 @@ class ManualColumnResize extends BasePlugin {
   onMouseDown(event) {
     if (hasClass(event.target, 'manualColumnResizer')) {
       this.setupGuidePosition();
-      this.pressed = this.hot;
+      this.pressed = true;
 
       if (this.autoresizeTimeout === null) {
         this.autoresizeTimeout = setTimeout(() => this.afterMouseDownTimeout(), 500);

--- a/src/plugins/manualColumnResize/test/manualColumnResize.e2e.js
+++ b/src/plugins/manualColumnResize/test/manualColumnResize.e2e.js
@@ -298,11 +298,7 @@ describe('manualColumnResize', () => {
     const $resizer = spec().$container.find('.manualColumnResizer');
     const resizerPosition = $resizer.position();
 
-    $resizer.simulate('mousedown', { clientX: resizerPosition.left });
-    $resizer.simulate('mouseup');
-
-    $resizer.simulate('mousedown', { clientX: resizerPosition.left });
-    $resizer.simulate('mouseup');
+    mouseDoubleClick($resizer, { clientX: resizerPosition.left });
 
     await sleep(1000);
 
@@ -338,11 +334,7 @@ describe('manualColumnResize', () => {
     const $resizer = spec().$container.find('.manualColumnResizer');
     const resizerPosition = $resizer.position();
 
-    $resizer.simulate('mousedown', { clientX: resizerPosition.left });
-    $resizer.simulate('mouseup');
-
-    $resizer.simulate('mousedown', { clientX: resizerPosition.left });
-    $resizer.simulate('mouseup');
+    mouseDoubleClick($resizer, { clientX: resizerPosition.left });
 
     await sleep(1000);
 
@@ -379,14 +371,7 @@ describe('manualColumnResize', () => {
       const $resizer = spec().$container.find('.manualColumnResizer');
       const resizerPosition = $resizer.position();
 
-      $resizer
-        .simulate('mousedown', { clientX: resizerPosition.left })
-        .simulate('mouseup')
-        .simulate('click')
-        .simulate('mousedown', { clientX: resizerPosition.left })
-        .simulate('mouseup')
-        .simulate('click')
-      ;
+      mouseDoubleClick($resizer, { clientX: resizerPosition.left });
 
       await sleep(1000);
 
@@ -404,14 +389,7 @@ describe('manualColumnResize', () => {
       const $resizer = spec().$container.find('.manualColumnResizer');
       const resizerPosition = $resizer.position();
 
-      $resizer
-        .simulate('mousedown', { clientX: resizerPosition.left })
-        .simulate('mouseup')
-        .simulate('click')
-        .simulate('mousedown', { clientX: resizerPosition.left })
-        .simulate('mouseup')
-        .simulate('click')
-      ;
+      mouseDoubleClick($resizer, { clientX: resizerPosition.left });
 
       await sleep(1000);
 
@@ -489,11 +467,7 @@ describe('manualColumnResize', () => {
     const $resizer = spec().$container.find('.manualColumnResizer');
     const resizerPosition = $resizer.position();
 
-    $resizer.simulate('mousedown', { clientX: resizerPosition.left });
-    $resizer.simulate('mouseup');
-
-    $resizer.simulate('mousedown', { clientX: resizerPosition.left });
-    $resizer.simulate('mouseup');
+    mouseDoubleClick($resizer, { clientX: resizerPosition.left });
 
     await sleep(700);
 
@@ -554,8 +528,7 @@ describe('manualColumnResize', () => {
     const $resizer = spec().$container.find('.manualColumnResizer');
     const resizerPosition = $resizer.position();
 
-    $resizer.simulate('mousedown', { clientX: resizerPosition.left });
-    $resizer.simulate('mouseup');
+    simulateClick($resizer, { clientX: resizerPosition.left });
 
     expect(afterColumnResizeCallback).not.toHaveBeenCalled();
     expect(colWidth(spec().$container, 0)).toEqual(50);
@@ -580,11 +553,7 @@ describe('manualColumnResize', () => {
     const $resizer = spec().$container.find('.manualColumnResizer');
     const resizerPosition = $resizer.position();
 
-    $resizer.simulate('mousedown', { clientX: resizerPosition.left });
-    $resizer.simulate('mouseup');
-
-    $resizer.simulate('mousedown', { clientX: resizerPosition.left });
-    $resizer.simulate('mouseup');
+    mouseDoubleClick($resizer, { clientX: resizerPosition.left });
 
     await sleep(1000);
 
@@ -612,11 +581,7 @@ describe('manualColumnResize', () => {
     const $resizer = spec().$container.find('.manualColumnResizer');
     const resizerPosition = $resizer.position();
 
-    $resizer.simulate('mousedown', { clientX: resizerPosition.left });
-    $resizer.simulate('mouseup');
-
-    $resizer.simulate('mousedown', { clientX: resizerPosition.left });
-    $resizer.simulate('mouseup');
+    mouseDoubleClick($resizer, { clientX: resizerPosition.left });
 
     await sleep(1000);
 
@@ -640,11 +605,7 @@ describe('manualColumnResize', () => {
     const $resizer = spec().$container.find('.manualColumnResizer');
     const resizerPosition = $resizer.position();
 
-    $resizer.simulate('mousedown', { clientX: resizerPosition.left });
-    $resizer.simulate('mouseup');
-
-    $resizer.simulate('mousedown', { clientX: resizerPosition.left });
-    $resizer.simulate('mouseup');
+    mouseDoubleClick($resizer, { clientX: resizerPosition.left });
 
     await sleep(1000);
 
@@ -671,10 +632,7 @@ describe('manualColumnResize', () => {
 
     await sleep(600);
 
-    $resizer.simulate('mousedown', { clientX: resizerPosition.left });
-    $resizer.simulate('mouseup');
-    $resizer.simulate('mousedown', { clientX: resizerPosition.left });
-    $resizer.simulate('mouseup');
+    mouseDoubleClick($resizer, { clientX: resizerPosition.left });
 
     await sleep(600);
 

--- a/src/plugins/manualColumnResize/test/manualColumnResize.e2e.js
+++ b/src/plugins/manualColumnResize/test/manualColumnResize.e2e.js
@@ -353,6 +353,76 @@ describe('manualColumnResize', () => {
     expect($columnHeaders.eq(4).width()).toBeAroundValue(738);
   });
 
+  it('should resize appropriate columns to calculated autoColumnSize width after double click on column handler after ' +
+     'updateSettings usage with new `colWidths` values', async() => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(5, 5),
+      colHeaders: true,
+      manualColumnResize: true,
+    });
+
+    setDataAtCell(0, 1, 'Longer text');
+
+    await sleep(50);
+
+    updateSettings({
+      colWidths: [45, 120, 160, 60, 80],
+    });
+
+    const $columnHeaders = spec().$container.find('thead tr:eq(0) th');
+
+    {
+      const $th = $columnHeaders.eq(0); // resize the first column.
+
+      $th.simulate('mouseover');
+
+      const $resizer = spec().$container.find('.manualColumnResizer');
+      const resizerPosition = $resizer.position();
+
+      $resizer
+        .simulate('mousedown', { clientX: resizerPosition.left })
+        .simulate('mouseup')
+        .simulate('click')
+        .simulate('mousedown', { clientX: resizerPosition.left })
+        .simulate('mouseup')
+        .simulate('click')
+      ;
+
+      await sleep(1000);
+
+      expect($columnHeaders.eq(0).width()).toBe(28);
+      expect($columnHeaders.eq(1).width()).toBe(118);
+      expect($columnHeaders.eq(2).width()).toBe(159);
+      expect($columnHeaders.eq(3).width()).toBe(59);
+      expect($columnHeaders.eq(4).width()).toBe(79);
+    }
+    {
+      const $th = $columnHeaders.eq(1); // resize the second column.
+
+      $th.simulate('mouseover');
+
+      const $resizer = spec().$container.find('.manualColumnResizer');
+      const resizerPosition = $resizer.position();
+
+      $resizer
+        .simulate('mousedown', { clientX: resizerPosition.left })
+        .simulate('mouseup')
+        .simulate('click')
+        .simulate('mousedown', { clientX: resizerPosition.left })
+        .simulate('mouseup')
+        .simulate('click')
+      ;
+
+      await sleep(1000);
+
+      expect($columnHeaders.eq(0).width()).toBe(28);
+      expect($columnHeaders.eq(1).width()).toBe(89);
+      expect($columnHeaders.eq(2).width()).toBe(159);
+      expect($columnHeaders.eq(3).width()).toBe(59);
+      expect($columnHeaders.eq(4).width()).toBe(79);
+    }
+  });
+
   it('should resize appropriate columns, even if the column order was changed with manualColumnMove plugin', function() {
     handsontable({
       colHeaders: ['First', 'Second', 'Third'],

--- a/src/plugins/manualRowResize/manualRowResize.js
+++ b/src/plugins/manualRowResize/manualRowResize.js
@@ -398,7 +398,7 @@ class ManualRowResize extends BasePlugin {
   onMouseDown(event) {
     if (hasClass(event.target, 'manualRowResizer')) {
       this.setupGuidePosition();
-      this.pressed = this.hot;
+      this.pressed = true;
 
       if (this.autoresizeTimeout === null) {
         this.autoresizeTimeout = setTimeout(() => this.afterMouseDownTimeout(), 500);

--- a/src/plugins/manualRowResize/test/manualRowResize.e2e.js
+++ b/src/plugins/manualRowResize/test/manualRowResize.e2e.js
@@ -320,6 +320,77 @@ describe('manualRowResize', () => {
     expect(afterRowResizeCallback.calls.argsFor(0)[0]).toEqual(defaultRowHeight + 1);
     expect(rowHeight(spec().$container, 2)).toEqual(defaultRowHeight + 1);
   });
+
+  it('should resize appropriate rows to calculated autoRowSize height after double click on row handler after ' +
+     'updateSettings usage with new `rowHeights` values', async() => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(5, 5),
+      rowHeaders: true,
+      manualRowResize: true,
+    });
+
+    setDataAtCell(1, 0, 'Longer\ntext');
+
+    await sleep(50);
+
+    updateSettings({
+      rowHeights: [45, 120, 160, 60, 80],
+    });
+
+    const $rowHeaders = spec().$container.find('tbody tr th');
+
+    {
+      const $th = $rowHeaders.eq(0); // resize the first row.
+
+      $th.simulate('mouseover');
+
+      const $resizer = spec().$container.find('.manualRowResizer');
+      const resizerPosition = $resizer.position();
+
+      $resizer
+        .simulate('mousedown', { clientY: resizerPosition.top })
+        .simulate('mouseup')
+        .simulate('click')
+        .simulate('mousedown', { clientY: resizerPosition.top })
+        .simulate('mouseup')
+        .simulate('click')
+      ;
+
+      await sleep(1000);
+
+      expect($rowHeaders.eq(0).height()).toBe(22);
+      expect($rowHeaders.eq(1).height()).toBe(119);
+      expect($rowHeaders.eq(2).height()).toBe(159);
+      expect($rowHeaders.eq(3).height()).toBe(59);
+      expect($rowHeaders.eq(4).height()).toBe(79);
+    }
+    {
+      const $th = $rowHeaders.eq(1); // resize the second column.
+
+      $th.simulate('mouseover');
+
+      const $resizer = spec().$container.find('.manualRowResizer');
+      const resizerPosition = $resizer.position();
+
+      $resizer
+        .simulate('mousedown', { clientY: resizerPosition.top })
+        .simulate('mouseup')
+        .simulate('click')
+        .simulate('mousedown', { clientY: resizerPosition.top })
+        .simulate('mouseup')
+        .simulate('click')
+      ;
+
+      await sleep(1000);
+
+      expect($rowHeaders.eq(0).height()).toBe(22);
+      expect($rowHeaders.eq(1).height()).toBe(42);
+      expect($rowHeaders.eq(2).height()).toBe(159);
+      expect($rowHeaders.eq(3).height()).toBe(59);
+      expect($rowHeaders.eq(4).height()).toBe(79);
+    }
+  });
+
   it('should not trigger afterRowResize event after if row height does not change (no dblclick event)', () => {
     const afterRowResizeCallback = jasmine.createSpy('afterRowResizeCallback');
 

--- a/src/plugins/manualRowResize/test/manualRowResize.e2e.js
+++ b/src/plugins/manualRowResize/test/manualRowResize.e2e.js
@@ -196,9 +196,7 @@ describe('manualRowResize', () => {
     expect(rowHeight(spec().$container, 0)).toEqual(24);
 
     hot.addHook('beforeRowResize', () => 100);
-
     hot.addHook('beforeRowResize', () => 200);
-
     hot.addHook('beforeRowResize', () => void 0);
 
     const $th = spec().$container.find('tbody tr:eq(0) th:eq(0)');
@@ -207,15 +205,7 @@ describe('manualRowResize', () => {
     const $resizer = spec().$container.find('.manualRowResizer');
     const resizerPosition = $resizer.position();
 
-    $resizer.simulate('mousedown', {
-      clientY: resizerPosition.top
-    });
-    $resizer.simulate('mouseup');
-
-    $resizer.simulate('mousedown', {
-      clientY: resizerPosition.top
-    });
-    $resizer.simulate('mouseup');
+    mouseDoubleClick($resizer, { clientY: resizerPosition.top });
 
     await sleep(700);
 
@@ -274,11 +264,7 @@ describe('manualRowResize', () => {
     const $resizer = spec().$container.find('.manualRowResizer');
     const resizerPosition = $resizer.position();
 
-    $resizer.simulate('mousedown', {
-      clientY: resizerPosition.top
-    });
-
-    $resizer.simulate('mouseup');
+    simulateClick($resizer, { clientY: resizerPosition.top });
 
     expect(afterRowResizeCallback).not.toHaveBeenCalled();
     expect(rowHeight(spec().$container, 0)).toEqual(defaultRowHeight + 2);
@@ -303,15 +289,7 @@ describe('manualRowResize', () => {
     const $resizer = spec().$container.find('.manualRowResizer');
     const resizerPosition = $resizer.position();
 
-    $resizer.simulate('mousedown', {
-      clientY: resizerPosition.top
-    });
-    $resizer.simulate('mouseup');
-
-    $resizer.simulate('mousedown', {
-      clientY: resizerPosition.top
-    });
-    $resizer.simulate('mouseup');
+    mouseDoubleClick($resizer, { clientY: resizerPosition.top });
 
     await sleep(1000);
 
@@ -347,14 +325,7 @@ describe('manualRowResize', () => {
       const $resizer = spec().$container.find('.manualRowResizer');
       const resizerPosition = $resizer.position();
 
-      $resizer
-        .simulate('mousedown', { clientY: resizerPosition.top })
-        .simulate('mouseup')
-        .simulate('click')
-        .simulate('mousedown', { clientY: resizerPosition.top })
-        .simulate('mouseup')
-        .simulate('click')
-      ;
+      mouseDoubleClick($resizer, { clientY: resizerPosition.top });
 
       await sleep(1000);
 
@@ -372,14 +343,7 @@ describe('manualRowResize', () => {
       const $resizer = spec().$container.find('.manualRowResizer');
       const resizerPosition = $resizer.position();
 
-      $resizer
-        .simulate('mousedown', { clientY: resizerPosition.top })
-        .simulate('mouseup')
-        .simulate('click')
-        .simulate('mousedown', { clientY: resizerPosition.top })
-        .simulate('mouseup')
-        .simulate('click')
-      ;
+      mouseDoubleClick($resizer, { clientY: resizerPosition.top });
 
       await sleep(1000);
 
@@ -409,10 +373,7 @@ describe('manualRowResize', () => {
     const $resizer = spec().$container.find('.manualRowResizer');
     const resizerPosition = $resizer.position();
 
-    $resizer.simulate('mousedown', {
-      clientY: resizerPosition.top
-    });
-    $resizer.simulate('mouseup');
+    simulateClick($resizer, { clientY: resizerPosition.top });
 
     expect(afterRowResizeCallback).not.toHaveBeenCalled();
     expect(rowHeight(spec().$container, 0)).toEqual(defaultRowHeight + 2);
@@ -461,11 +422,7 @@ describe('manualRowResize', () => {
     const $resizer = spec().$container.find('.manualRowResizer');
     const resizerPosition = $resizer.position();
 
-    $resizer.simulate('mousedown', { clientY: resizerPosition.top });
-    $resizer.simulate('mouseup');
-
-    $resizer.simulate('mousedown', { clientY: resizerPosition.top });
-    $resizer.simulate('mouseup');
+    mouseDoubleClick($resizer, { clientY: resizerPosition.top });
 
     await sleep(1000);
 
@@ -489,11 +446,7 @@ describe('manualRowResize', () => {
     const $resizer = spec().$container.find('.manualRowResizer');
     const resizerPosition = $resizer.position();
 
-    $resizer.simulate('mousedown', { clientY: resizerPosition.top });
-    $resizer.simulate('mouseup');
-
-    $resizer.simulate('mousedown', { clientY: resizerPosition.top });
-    $resizer.simulate('mouseup');
+    mouseDoubleClick($resizer, { clientY: resizerPosition.top });
 
     await sleep(1000);
 
@@ -520,10 +473,7 @@ describe('manualRowResize', () => {
 
     await sleep(600);
 
-    $resizer.simulate('mousedown', { clientY: resizerPosition.top });
-    $resizer.simulate('mouseup');
-    $resizer.simulate('mousedown', { clientY: resizerPosition.top });
-    $resizer.simulate('mouseup');
+    mouseDoubleClick($resizer, { clientY: resizerPosition.top });
 
     await sleep(1000);
 
@@ -602,6 +552,7 @@ describe('manualRowResize', () => {
 
       $rowHeader = spec().$container.find('.ht_clone_left tr:eq(13) th:eq(0)');
       $rowHeader.simulate('mouseover');
+
       expect($rowHeader.offset().top + $rowHeader.height() - 5).toBeCloseTo($handle.offset().top, 0);
       expect($rowHeader.offset().left).toBeCloseTo($handle.offset().left, 0);
     });
@@ -631,6 +582,7 @@ describe('manualRowResize', () => {
 
       $rowHeader = spec().$container.find('.ht_clone_left tr:eq(13) th:eq(0)');
       $rowHeader.simulate('mouseover');
+
       expect($rowHeader.offset().top + $rowHeader.height() - 5).toBeCloseTo($handle.offset().top, 0);
       expect($rowHeader.offset().left).toBeCloseTo($handle.offset().left, 0);
 

--- a/test/helpers/mouseEvents.js
+++ b/test/helpers/mouseEvents.js
@@ -9,7 +9,7 @@ MOUSE_BUTTONS.set('RMB', 3);
  * Get number describing specific mouse click.
  *
  * @param {number} buttonKey Number representing mouse button key.
- * @returns {V}
+ * @returns {number}
  */
 function getMouseButton(buttonKey) {
   return MOUSE_BUTTONS.get(buttonKey);
@@ -19,10 +19,11 @@ function getMouseButton(buttonKey) {
  * Returns a function that triggers a mouse event.
  *
  * @param {string} type Event type.
- * @param {number} buttonKey Number representing mouse button key.
+ * @param {number} [buttonKey] Number representing mouse button key.
+ * @param {object} [eventProps] Addional object with props to merge with the event.
  * @returns {Function}
  */
-export function handsontableMouseTriggerFactory(type, buttonKey) {
+export function handsontableMouseTriggerFactory(type, buttonKey = getMouseButton('LMB'), eventProps = {}) {
   return function(element) {
     let handsontableElement = element;
 
@@ -30,7 +31,12 @@ export function handsontableMouseTriggerFactory(type, buttonKey) {
       handsontableElement = $(handsontableElement);
     }
     const ev = $.Event(type);
-    ev.which = buttonKey || getMouseButton('LMB'); // left click by default
+
+    ev.which = buttonKey;
+
+    Object.keys(eventProps).forEach((key) => {
+      ev[key] = eventProps[key];
+    });
 
     handsontableElement.simulate(type, ev);
   };
@@ -46,26 +52,28 @@ export const mouseClick = handsontableMouseTriggerFactory('click');
  * Simulate click (all mouse events).
  *
  * @param {Element} element An element on which there will be performed mouse events.
- * @param {number} buttonKey Number representing mouse button key.
+ * @param {number} [buttonKey] Number representing mouse button key.
+ * @param {object} [eventProps] Addional object with props to merge with the event.
  */
-export function simulateClick(element, buttonKey) {
+export function simulateClick(element, buttonKey, eventProps) {
   const mouseButton = getMouseButton(buttonKey);
 
-  mouseDown(element, mouseButton);
-  mouseUp(element, mouseButton);
-  mouseClick(element, mouseButton);
+  mouseDown(element, mouseButton, eventProps);
+  mouseUp(element, mouseButton, eventProps);
+  mouseClick(element, mouseButton, eventProps);
 }
 
 /**
  * Simulate double click (all mouse events).
  *
  * @param {Element} element An element on which there will be performed mouse events.
+ * @param {object} [eventProps] Addional object with props to merge with the event.
  */
-export function mouseDoubleClick(element) {
-  mouseDown(element);
-  mouseUp(element);
-  mouseDown(element);
-  mouseUp(element);
+export function mouseDoubleClick(element, eventProps) {
+  mouseDown(element, eventProps);
+  mouseUp(element, eventProps);
+  mouseDown(element, eventProps);
+  mouseUp(element, eventProps);
 }
 
 export const mouseRightDown = handsontableMouseTriggerFactory('mousedown', getMouseButton('RMB'));


### PR DESCRIPTION
# Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the issue by leaving the `beforeColumnResize` and `beforeRowResize` listeners active no matter if the plugin is disabled or so. This allows the resize handler of the _ManualColumnResize_ and _ManualRowResize_ to calculate the new size after the header double-click. 

If the _AutoColumnSize_ or _AutoRowSize_ plugin will be no available (by removing the code from the final build for example) the headers will stay unchanged after a double-click - which seems to be reasonable behavior as the size depends on that plugins.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Tested manually and added new E2E tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #6755
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
