### PR TITLE
Fix rows and columns resizing

### DIFF
--- a/src/plugins/hiddenColumns/test/plugins/manualColumnResize.e2e.js
+++ b/src/plugins/hiddenColumns/test/plugins/manualColumnResize.e2e.js
@@ -29,7 +29,7 @@ describe('HiddenColumns', () => {
       // Resize renderable column index `1` (within visual index term the index at 1 is hidden).
       resizeColumn(1, 100);
 
-      expect(colWidth(spec().$container, 1)).toBe(115); // 100 + 15 (indicator)
+      expect(colWidth(spec().$container, 1)).toBe(114); // 100 + 15 (indicator) - 1 (margin from overlay)
     });
 
     it('should resize a proper column when the table contains hidden column using public API', () => {
@@ -67,7 +67,7 @@ describe('HiddenColumns', () => {
         manualColumnResize: true
       });
 
-      const $headerTH = spec().$container.find('thead tr:eq(0) th:eq(1)'); // Header "C"
+      const $headerTH = getTopClone().find('thead tr:eq(0) th:eq(1)'); // Header "C"
 
       $headerTH.simulate('mouseover');
 
@@ -97,7 +97,7 @@ describe('HiddenColumns', () => {
 
       // Show resize handler using the third renderable column. This column belongs to master as
       // the "fixedColumnsLeft" is decreased to 2.
-      const $headerTH = spec().$container.find('thead tr:eq(0) th:eq(2)'); // Header "D"
+      const $headerTH = getTopClone().find('thead tr:eq(0) th:eq(2)'); // Header "D"
 
       $headerTH.simulate('mouseover');
 
@@ -124,7 +124,7 @@ describe('HiddenColumns', () => {
         manualColumnResize: true
       });
 
-      const $headerTH = spec().$container.find('thead tr:eq(0) th:eq(1)'); // Header "C"
+      const $headerTH = getTopClone().find('thead tr:eq(0) th:eq(1)'); // Header "C"
 
       $headerTH.simulate('mouseover');
 

--- a/src/plugins/hiddenRows/test/plugins/manualRowResize.e2e.js
+++ b/src/plugins/hiddenRows/test/plugins/manualRowResize.e2e.js
@@ -68,7 +68,7 @@ describe('HiddenRows', () => {
         manualRowResize: true
       });
 
-      const $headerTH = spec().$container.find('tbody tr:eq(1) th:eq(0)');
+      const $headerTH = getLeftClone().find('tbody tr:eq(1) th:eq(0)');
 
       $headerTH.simulate('mouseover');
 
@@ -99,7 +99,7 @@ describe('HiddenRows', () => {
 
       // Show resize handler using the third renderable row. This row belongs to master as
       // the "fixedRowsTop" is decreased to 2.
-      const $headerTH = spec().$container.find('tbody tr:eq(2) th:eq(0)');
+      const $headerTH = getLeftClone().find('tbody tr:eq(2) th:eq(0)');
 
       $headerTH.simulate('mouseover');
 
@@ -130,7 +130,7 @@ describe('HiddenRows', () => {
 
       // Show resize handler using the second renderable row. This row belongs to master as
       // the "fixedRowsBottom" is decreased to 2.
-      const $headerTH = spec().$container.find('tbody tr:eq(1) th:eq(0)');
+      const $headerTH = getLeftClone().find('tbody tr:eq(1) th:eq(0)');
 
       $headerTH.simulate('mouseover');
 
@@ -158,7 +158,7 @@ describe('HiddenRows', () => {
         manualRowResize: true
       });
 
-      const $headerTH = spec().$container.find('tbody tr:eq(1) th:eq(0)');
+      const $headerTH = getLeftClone().find('tbody tr:eq(1) th:eq(0)');
 
       $headerTH.simulate('mouseover');
 

--- a/src/plugins/manualColumnResize/manualColumnResize.js
+++ b/src/plugins/manualColumnResize/manualColumnResize.js
@@ -234,22 +234,15 @@ class ManualColumnResize extends BasePlugin {
         .wtOverlays
         .topLeftCornerOverlay
         .getRelativeCellPosition(this.currentTH, cellCoords.row, cellCoords.col);
+    }
 
-    } else {
+    // If the TH is not a child of the top-left overlay, recalculate using
+    // the top overlay - as this overlay contains the rest of the headers.
+    if (!relativeHeaderPosition) {
       relativeHeaderPosition = wt
         .wtOverlays
         .topOverlay
         .getRelativeCellPosition(this.currentTH, cellCoords.row, cellCoords.col);
-    }
-
-    // If the TH is not a child of the top-left or top overlay, recalculate using
-    // the master overlay - as this overlay contains the rest of the headers.
-    if (!relativeHeaderPosition) {
-      const fallbackOverlay = wt.wtOverlays.topOverlay;
-      const rowHeadersCount = this.hot.getSettings().rowHeaders ? 1 : 0;
-      const currentTH = fallbackOverlay.clone.wtTable.THEAD.lastChild.children[col + rowHeadersCount];
-
-      relativeHeaderPosition = fallbackOverlay.getRelativeCellPosition(currentTH, cellCoords.row, cellCoords.col);
     }
 
     this.currentCol = this.hot.columnIndexMapper.getVisualFromRenderableIndex(col);

--- a/src/plugins/manualColumnResize/test/manualColumnResize.e2e.js
+++ b/src/plugins/manualColumnResize/test/manualColumnResize.e2e.js
@@ -688,7 +688,7 @@ describe('manualColumnResize', () => {
     });
 
     const mainHolder = hot.view.wt.wtTable.holder;
-    let $colHeader = spec().$container.find('.ht_clone_top thead tr:eq(0) th:eq(2)'); // Header "C"
+    const $colHeader = getTopClone().find('thead tr:eq(0) th:eq(2)'); // Header "C"
 
     $colHeader.simulate('mouseover');
 
@@ -702,7 +702,6 @@ describe('manualColumnResize', () => {
 
     await sleep(400);
 
-    $colHeader = spec().$container.find('.ht_clone_top thead tr:eq(0) th:eq(2)');
     $colHeader.simulate('mouseover');
 
     expect($colHeader.offset().left + $colHeader.width() - 5).toBeCloseTo($handle.offset().left, 0);
@@ -723,7 +722,7 @@ describe('manualColumnResize', () => {
       });
 
       const mainHolder = hot.view.wt.wtTable.holder;
-      let $colHeader = spec().$container.find('.ht_clone_top thead tr:eq(0) th:eq(2)');
+      let $colHeader = getTopClone().find('thead tr:eq(0) th:eq(2)');
 
       $colHeader.simulate('mouseover');
 
@@ -736,7 +735,7 @@ describe('manualColumnResize', () => {
 
       await sleep(400);
 
-      $colHeader = spec().$container.find('.ht_clone_top thead tr:eq(0) th:eq(7)');
+      $colHeader = getTopClone().find('thead tr:eq(0) th:eq(7)');
       $colHeader.simulate('mouseover');
 
       expect($colHeader.offset().left + $colHeader.width() - 5).toBeCloseTo($handle.offset().left, 0);
@@ -753,7 +752,7 @@ describe('manualColumnResize', () => {
         manualColumnResize: true
       });
 
-      let $colHeader = spec().$container.find('.ht_clone_top thead tr:eq(0) th:eq(2)');
+      let $colHeader = getTopClone().find('thead tr:eq(0) th:eq(2)');
 
       $colHeader.simulate('mouseover');
 
@@ -766,7 +765,7 @@ describe('manualColumnResize', () => {
 
       await sleep(400);
 
-      $colHeader = spec().$container.find('.ht_clone_top thead tr:eq(0) th:eq(7)');
+      $colHeader = getTopClone().find('thead tr:eq(0) th:eq(7)');
       $colHeader.simulate('mouseover');
 
       expect($colHeader.offset().left + $colHeader.width() - 5).toBeCloseTo($handle.offset().left, 0);

--- a/src/plugins/manualColumnResize/test/manualColumnResize.e2e.js
+++ b/src/plugins/manualColumnResize/test/manualColumnResize.e2e.js
@@ -36,7 +36,7 @@ describe('manualColumnResize', () => {
 
     updateSettings({ manualColumnResize: true });
 
-    spec().$container.find('thead tr:eq(0) th:eq(0)').simulate('mouseover');
+    getTopClone().find('thead tr:eq(0) th:eq(0)').simulate('mouseover');
 
     expect($('.manualColumnResizer').size()).toBeGreaterThan(0);
   });
@@ -185,11 +185,11 @@ describe('manualColumnResize', () => {
 
     const $columnHeaders = spec().$container.find('thead tr:eq(1) th');
 
-    expect($columnHeaders.eq(0).width()).toBe(209);
-    expect($columnHeaders.eq(1).width()).toBe(64);
-    expect($columnHeaders.eq(2).width()).toBe(210);
-    expect($columnHeaders.eq(3).width()).toBe(210);
-    expect($columnHeaders.eq(4).width()).toBe(211);
+    expect($columnHeaders.eq(0).width()).toBe(210);
+    expect($columnHeaders.eq(1).width()).toBe(63);
+    expect($columnHeaders.eq(2).width()).toBe(211);
+    expect($columnHeaders.eq(3).width()).toBe(211);
+    expect($columnHeaders.eq(4).width()).toBe(209);
   });
 
   it('should resize (extending) appropriate columns, even when stretchH `all` is enabled', () => {
@@ -204,11 +204,11 @@ describe('manualColumnResize', () => {
 
     const $columnHeaders = spec().$container.find('thead tr:eq(1) th');
 
-    expect($columnHeaders.eq(0).width()).toBe(125);
-    expect($columnHeaders.eq(1).width()).toBe(399);
-    expect($columnHeaders.eq(2).width()).toBe(126);
-    expect($columnHeaders.eq(3).width()).toBe(126);
-    expect($columnHeaders.eq(4).width()).toBe(128);
+    expect($columnHeaders.eq(0).width()).toBe(126);
+    expect($columnHeaders.eq(1).width()).toBe(398);
+    expect($columnHeaders.eq(2).width()).toBe(127);
+    expect($columnHeaders.eq(3).width()).toBe(127);
+    expect($columnHeaders.eq(4).width()).toBe(126);
   });
 
   it('should resize (narrowing) selected columns', async() => {
@@ -218,24 +218,26 @@ describe('manualColumnResize', () => {
       manualColumnResize: true
     });
 
-    const $columnHeaders = spec().$container.find('thead tr:eq(0) th');
-    const $colHeader = spec().$container.find('thead tr:eq(0) th:eq(1)');
+    const $colHeader = getTopClone().find('thead tr:eq(0) th:eq(1)');
+
     $colHeader.simulate('mouseover');
 
     const $resizer = spec().$container.find('.manualColumnResizer');
     const resizerPosition = $resizer.position();
 
-    spec().$container.find('tr:eq(0) th:eq(1)').simulate('mousedown');
-    spec().$container.find('tr:eq(0) th:eq(2)').simulate('mouseover');
-    spec().$container.find('tr:eq(0) th:eq(3)').simulate('mouseover');
-    spec().$container.find('tr:eq(0) th:eq(3)').simulate('mousemove');
-    spec().$container.find('tr:eq(0) th:eq(3)').simulate('mouseup');
+    getTopClone().find('tr:eq(0) th:eq(1)').simulate('mousedown');
+    getTopClone().find('tr:eq(0) th:eq(2)').simulate('mouseover');
+    getTopClone().find('tr:eq(0) th:eq(3)').simulate('mouseover');
+    getTopClone().find('tr:eq(0) th:eq(3)').simulate('mousemove');
+    getTopClone().find('tr:eq(0) th:eq(3)').simulate('mouseup');
 
     $resizer.simulate('mousedown', { clientX: resizerPosition.left });
     $resizer.simulate('mousemove', { clientX: spec().$container.find('tr:eq(0) th:eq(1)').position().left + 29 });
     $resizer.simulate('mouseup');
 
     await sleep(1000);
+
+    const $columnHeaders = spec().$container.find('thead tr:eq(0) th');
 
     expect($columnHeaders.eq(1).width()).toBe(33);
     expect($columnHeaders.eq(2).width()).toBe(34);
@@ -249,24 +251,26 @@ describe('manualColumnResize', () => {
       manualColumnResize: true
     });
 
-    const $columnHeaders = spec().$container.find('thead tr:eq(0) th');
-    const $colHeader = spec().$container.find('thead tr:eq(0) th:eq(1)');
+    const $colHeader = getTopClone().find('thead tr:eq(0) th:eq(1)');
+
     $colHeader.simulate('mouseover');
 
     const $resizer = spec().$container.find('.manualColumnResizer');
     const resizerPosition = $resizer.position();
 
-    spec().$container.find('tr:eq(0) th:eq(1)').simulate('mousedown');
-    spec().$container.find('tr:eq(0) th:eq(2)').simulate('mouseover');
-    spec().$container.find('tr:eq(0) th:eq(3)').simulate('mouseover');
-    spec().$container.find('tr:eq(0) th:eq(3)').simulate('mousemove');
-    spec().$container.find('tr:eq(0) th:eq(3)').simulate('mouseup');
+    getTopClone().find('tr:eq(0) th:eq(1)').simulate('mousedown');
+    getTopClone().find('tr:eq(0) th:eq(2)').simulate('mouseover');
+    getTopClone().find('tr:eq(0) th:eq(3)').simulate('mouseover');
+    getTopClone().find('tr:eq(0) th:eq(3)').simulate('mousemove');
+    getTopClone().find('tr:eq(0) th:eq(3)').simulate('mouseup');
 
     $resizer.simulate('mousedown', { clientX: resizerPosition.left });
     $resizer.simulate('mousemove', { clientX: spec().$container.find('tr:eq(0) th:eq(1)').position().left + 150 });
     $resizer.simulate('mouseup');
 
     await sleep(1000);
+
+    const $columnHeaders = spec().$container.find('thead tr:eq(0) th');
 
     expect($columnHeaders.eq(1).width()).toBe(154);
     expect($columnHeaders.eq(2).width()).toBe(155);
@@ -285,13 +289,13 @@ describe('manualColumnResize', () => {
 
     const $columnHeaders = spec().$container.find('thead tr:eq(1) th');
 
-    expect($columnHeaders.eq(0).width()).toBe(209);
-    expect($columnHeaders.eq(1).width()).toBe(64);
-    expect($columnHeaders.eq(2).width()).toBe(210);
-    expect($columnHeaders.eq(3).width()).toBe(210);
-    expect($columnHeaders.eq(4).width()).toBe(211);
+    expect($columnHeaders.eq(0).width()).toBe(210);
+    expect($columnHeaders.eq(1).width()).toBe(63);
+    expect($columnHeaders.eq(2).width()).toBe(211);
+    expect($columnHeaders.eq(3).width()).toBe(211);
+    expect($columnHeaders.eq(4).width()).toBe(209);
 
-    const $th = $columnHeaders.eq(1);
+    const $th = getTopClone().find('thead tr:eq(1) th:eq(1)');
 
     $th.simulate('mouseover');
 
@@ -327,7 +331,7 @@ describe('manualColumnResize', () => {
     expect($columnHeaders.eq(3).width()).toBe(49);
     expect($columnHeaders.eq(4).width()).toBe(694);
 
-    const $th = $columnHeaders.eq(0);
+    const $th = getTopClone().find('thead tr:eq(1) th:eq(0)');
 
     $th.simulate('mouseover');
 
@@ -364,7 +368,7 @@ describe('manualColumnResize', () => {
     const $columnHeaders = spec().$container.find('thead tr:eq(0) th');
 
     {
-      const $th = $columnHeaders.eq(0); // resize the first column.
+      const $th = getTopClone().find('thead tr:eq(0) th:eq(0)'); // resize the first column.
 
       $th.simulate('mouseover');
 
@@ -382,7 +386,7 @@ describe('manualColumnResize', () => {
       expect($columnHeaders.eq(4).width()).toBe(79);
     }
     {
-      const $th = $columnHeaders.eq(1); // resize the second column.
+      const $th = getTopClone().find('thead tr:eq(0) th:eq(1)'); // resize the second column.
 
       $th.simulate('mouseover');
 
@@ -417,7 +421,7 @@ describe('manualColumnResize', () => {
 
     resizeColumn.call(this, 0, 100);
 
-    const $resizedTh = $columnHeaders.eq(0);
+    const $resizedTh = getTopClone().find('thead tr:eq(0) th:eq(0)');
 
     expect($resizedTh.text()).toEqual('Third');
     expect($resizedTh.outerWidth()).toEqual(100);
@@ -460,7 +464,7 @@ describe('manualColumnResize', () => {
 
     hot.addHook('beforeColumnResize', () => void 0);
 
-    const $th = spec().$container.find('thead tr:eq(0) th:eq(0)');
+    const $th = getTopClone().find('thead tr:eq(0) th:eq(0)');
 
     $th.simulate('mouseover');
 
@@ -522,7 +526,8 @@ describe('manualColumnResize', () => {
 
     expect(colWidth(spec().$container, 0)).toEqual(50);
 
-    const $th = spec().$container.find('thead tr:eq(0) th:eq(0)');
+    const $th = getTopClone().find('thead tr:eq(0) th:eq(0)');
+
     $th.simulate('mouseover');
 
     const $resizer = spec().$container.find('.manualColumnResizer');
@@ -546,7 +551,7 @@ describe('manualColumnResize', () => {
 
     expect(colWidth(spec().$container, 0)).toEqual(50);
 
-    const $th = spec().$container.find('thead tr:eq(0) th:eq(0)');
+    const $th = getTopClone().find('thead tr:eq(0) th:eq(0)');
 
     $th.simulate('mouseover');
 
@@ -621,11 +626,11 @@ describe('manualColumnResize', () => {
 
     resizeColumn(2, 300);
 
-    spec().$container.find('thead tr:eq(0) th:eq(1)').simulate('mousedown');
-    spec().$container.find('thead tr:eq(0) th:eq(2)').simulate('mouseover');
-    spec().$container.find('thead tr:eq(0) th:eq(3)').simulate('mouseover');
-    spec().$container.find('thead tr:eq(0) th:eq(3)').simulate('mousemove');
-    spec().$container.find('thead tr:eq(0) th:eq(3)').simulate('mouseup');
+    getTopClone().find('thead tr:eq(0) th:eq(1)').simulate('mousedown');
+    getTopClone().find('thead tr:eq(0) th:eq(2)').simulate('mouseover');
+    getTopClone().find('thead tr:eq(0) th:eq(3)').simulate('mouseover');
+    getTopClone().find('thead tr:eq(0) th:eq(3)').simulate('mousemove');
+    getTopClone().find('thead tr:eq(0) th:eq(3)').simulate('mouseup');
 
     const $resizer = spec().$container.find('.manualColumnResizer');
     const resizerPosition = $resizer.position();
@@ -653,10 +658,10 @@ describe('manualColumnResize', () => {
       }
     });
 
-    spec().$container.find('thead th:eq(0)').simulate('mouseover');
+    getTopClone().find('thead th:eq(0)').simulate('mouseover');
 
     const handle = spec().$container.find('.manualColumnResizer');
-    const th0 = spec().$container.find('thead th:eq(0)');
+    const th0 = getTopClone().find('thead th:eq(0)');
     let handleBox = handle[0].getBoundingClientRect();
     let thBox = th0[0].getBoundingClientRect();
 
@@ -665,7 +670,7 @@ describe('manualColumnResize', () => {
     maxed = true;
 
     render();
-    spec().$container.find('thead th:eq(0)').simulate('mouseover');
+    getTopClone().find('thead th:eq(0)').simulate('mouseover');
 
     handleBox = handle[0].getBoundingClientRect();
     thBox = th0[0].getBoundingClientRect();
@@ -789,10 +794,10 @@ describe('manualColumnResize', () => {
 
       await sleep(400);
 
-      spec().$container.find('thead tr:eq(0) th:eq(5)').simulate('mousedown');
-      spec().$container.find('thead tr:eq(0) th:eq(6)').simulate('mouseover');
-      spec().$container.find('thead tr:eq(0) th:eq(7)').simulate('mouseover');
-      spec().$container.find('thead tr:eq(0) th:eq(7)').simulate('mouseup');
+      getTopClone().find('thead tr:eq(0) th:eq(5)').simulate('mousedown');
+      getTopClone().find('thead tr:eq(0) th:eq(6)').simulate('mouseover');
+      getTopClone().find('thead tr:eq(0) th:eq(7)').simulate('mouseover');
+      getTopClone().find('thead tr:eq(0) th:eq(7)').simulate('mouseup');
 
       const $resizer = spec().$container.find('.manualColumnResizer');
       const resizerPosition = $resizer.position();
@@ -800,9 +805,9 @@ describe('manualColumnResize', () => {
       $resizer.simulate('mousemove', { clientX: resizerPosition.left + 30 });
       $resizer.simulate('mouseup');
 
-      expect(spec().$container.find('thead tr:eq(0) th:eq(5)').width()).toBe(79);
-      expect(spec().$container.find('thead tr:eq(0) th:eq(6)').width()).toBe(79);
-      expect(spec().$container.find('thead tr:eq(0) th:eq(7)').width()).toBe(79);
+      expect(getTopClone().find('thead tr:eq(0) th:eq(5)').width()).toBe(79);
+      expect(getTopClone().find('thead tr:eq(0) th:eq(6)').width()).toBe(79);
+      expect(getTopClone().find('thead tr:eq(0) th:eq(7)').width()).toBe(79);
     });
 
     it('should resize (expanding) selected columns, with window as a scroll parent', () => {
@@ -817,10 +822,10 @@ describe('manualColumnResize', () => {
 
       $(window).scrollLeft(400);
 
-      spec().$container.find('thead tr:eq(0) th:eq(9)').simulate('mousedown');
-      spec().$container.find('thead tr:eq(0) th:eq(10)').simulate('mouseover');
-      spec().$container.find('thead tr:eq(0) th:eq(11)').simulate('mouseover');
-      spec().$container.find('thead tr:eq(0) th:eq(11)').simulate('mouseup');
+      getTopClone().find('thead tr:eq(0) th:eq(9)').simulate('mousedown');
+      getTopClone().find('thead tr:eq(0) th:eq(10)').simulate('mouseover');
+      getTopClone().find('thead tr:eq(0) th:eq(11)').simulate('mouseover');
+      getTopClone().find('thead tr:eq(0) th:eq(11)').simulate('mouseup');
 
       const $resizer = spec().$container.find('.manualColumnResizer');
       const resizerPosition = $resizer.position();
@@ -828,9 +833,9 @@ describe('manualColumnResize', () => {
       $resizer.simulate('mousemove', { clientX: resizerPosition.left + 30 });
       $resizer.simulate('mouseup');
 
-      expect(spec().$container.find('thead tr:eq(0) th:eq(9)').width()).toBe(79);
-      expect(spec().$container.find('thead tr:eq(0) th:eq(10)').width()).toBe(79);
-      expect(spec().$container.find('thead tr:eq(0) th:eq(11)').width()).toBe(79);
+      expect(getTopClone().find('thead tr:eq(0) th:eq(9)').width()).toBe(79);
+      expect(getTopClone().find('thead tr:eq(0) th:eq(10)').width()).toBe(79);
+      expect(getTopClone().find('thead tr:eq(0) th:eq(11)').width()).toBe(79);
 
       $(window).scrollLeft(0);
     });
@@ -850,7 +855,7 @@ describe('manualColumnResize', () => {
         manualColumnResize: true
       });
 
-      const $headerTH = spec().$container.find('thead tr:eq(0) th:eq(1)');
+      const $headerTH = getTopClone().find('thead tr:eq(0) th:eq(1)');
       $headerTH.simulate('mouseover');
 
       const $handle = $('.manualColumnResizer');
@@ -873,7 +878,7 @@ describe('manualColumnResize', () => {
         manualColumnResize: true
       });
 
-      const $headerTH = spec().$container.find('thead tr:eq(0) th:eq(1)');
+      const $headerTH = getTopClone().find('thead tr:eq(0) th:eq(1)');
       $headerTH.simulate('mouseover');
 
       const $handle = $('.manualColumnResizer');

--- a/src/plugins/manualRowResize/manualRowResize.js
+++ b/src/plugins/manualRowResize/manualRowResize.js
@@ -194,12 +194,12 @@ class ManualRowResize extends BasePlugin {
     }
 
     // If the TH is not a child of the top-left/bottom-left overlay, recalculate using
-    // the master overlay - as this overlay contains the rest of the headers.
+    // the left overlay - as this overlay contains the rest of the headers.
     if (!relativeHeaderPosition) {
-      const fallbackOverlay = wt.wtOverlays.leftOverlay;
-      const currentTH = fallbackOverlay.clone.wtTable.TBODY.children[row].firstChild;
-
-      relativeHeaderPosition = fallbackOverlay.getRelativeCellPosition(currentTH, cellCoords.row, cellCoords.col);
+      relativeHeaderPosition = wt
+        .wtOverlays
+        .leftOverlay
+        .getRelativeCellPosition(this.currentTH, cellCoords.row, cellCoords.col);
     }
 
     const rowIndexMapper = this.hot.rowIndexMapper;

--- a/src/plugins/manualRowResize/test/manualRowResize.e2e.js
+++ b/src/plugins/manualRowResize/test/manualRowResize.e2e.js
@@ -389,11 +389,12 @@ describe('manualRowResize', () => {
     });
 
     const mainHolder = hot.view.wt.wtTable.holder;
-    let $rowHeader = spec().$container.find('.ht_clone_left tbody tr:eq(2) th:eq(0)');
+    let $rowHeader = getLeftClone().find('tbody tr:eq(2) th:eq(0)');
 
     $rowHeader.simulate('mouseover');
 
     const $handle = spec().$container.find('.manualRowResizer');
+
     $handle[0].style.background = 'red';
 
     expect($rowHeader.offset().left).toBeCloseTo($handle.offset().left, 0);
@@ -404,8 +405,9 @@ describe('manualRowResize', () => {
 
     await sleep(400);
 
-    $rowHeader = spec().$container.find('.ht_clone_left tbody tr:eq(10) th:eq(0)');
+    $rowHeader = getLeftClone().find('tbody tr:eq(10) th:eq(0)');
     $rowHeader.simulate('mouseover');
+
     expect($rowHeader.offset().left).toBeCloseTo($handle.offset().left, 0);
     expect($rowHeader.offset().top + $rowHeader.height() - 5).toBeCloseTo($handle.offset().top, 0);
   });
@@ -465,11 +467,11 @@ describe('manualRowResize', () => {
     const $resizer = spec().$container.find('.manualRowResizer');
     const resizerPosition = $resizer.position();
 
-    spec().$container.find('.ht_clone_left tbody tr:eq(1) th:eq(0)').simulate('mousedown');
-    spec().$container.find('.ht_clone_left tbody tr:eq(2) th:eq(0)').simulate('mouseover');
-    spec().$container.find('.ht_clone_left tbody tr:eq(3) th:eq(0)').simulate('mouseover');
-    spec().$container.find('.ht_clone_left tbody tr:eq(3) th:eq(0)').simulate('mousemove');
-    spec().$container.find('.ht_clone_left tbody tr:eq(3) th:eq(0)').simulate('mouseup');
+    getLeftClone().find('tbody tr:eq(1) th:eq(0)').simulate('mousedown');
+    getLeftClone().find('tbody tr:eq(2) th:eq(0)').simulate('mouseover');
+    getLeftClone().find('tbody tr:eq(3) th:eq(0)').simulate('mouseover');
+    getLeftClone().find('tbody tr:eq(3) th:eq(0)').simulate('mousemove');
+    getLeftClone().find('tbody tr:eq(3) th:eq(0)').simulate('mouseup');
 
     await sleep(600);
 
@@ -490,9 +492,9 @@ describe('manualRowResize', () => {
     });
 
     resizeRow(2, 60);
+    getLeftClone().find('tbody tr:eq(1) th:eq(0)').simulate('mouseover');
 
-    const $rowsHeaders = spec().$container.find('.ht_clone_left tr th');
-    spec().$container.find('.ht_clone_left tbody tr:eq(1) th:eq(0)').simulate('mouseover');
+    const $rowsHeaders = getLeftClone().find('tr th');
 
     $rowsHeaders.eq(1).simulate('mousedown');
     $rowsHeaders.eq(2).simulate('mouseover');
@@ -537,7 +539,7 @@ describe('manualRowResize', () => {
       });
 
       const mainHolder = hot.view.wt.wtTable.holder;
-      let $rowHeader = spec().$container.find('.ht_clone_left tr:eq(2) th:eq(0)');
+      let $rowHeader = getLeftClone().find('tr:eq(2) th:eq(0)');
 
       $rowHeader.simulate('mouseover');
 
@@ -550,7 +552,7 @@ describe('manualRowResize', () => {
 
       await sleep(400);
 
-      $rowHeader = spec().$container.find('.ht_clone_left tr:eq(13) th:eq(0)');
+      $rowHeader = getLeftClone().find('tr:eq(13) th:eq(0)');
       $rowHeader.simulate('mouseover');
 
       expect($rowHeader.offset().top + $rowHeader.height() - 5).toBeCloseTo($handle.offset().top, 0);
@@ -567,7 +569,7 @@ describe('manualRowResize', () => {
         manualRowResize: true,
       });
 
-      let $rowHeader = spec().$container.find('.ht_clone_left tr:eq(2) th:eq(0)');
+      let $rowHeader = getLeftClone().find('tr:eq(2) th:eq(0)');
 
       $rowHeader.simulate('mouseover');
 
@@ -580,7 +582,7 @@ describe('manualRowResize', () => {
 
       await sleep(400);
 
-      $rowHeader = spec().$container.find('.ht_clone_left tr:eq(13) th:eq(0)');
+      $rowHeader = getLeftClone().find('tr:eq(13) th:eq(0)');
       $rowHeader.simulate('mouseover');
 
       expect($rowHeader.offset().top + $rowHeader.height() - 5).toBeCloseTo($handle.offset().top, 0);

--- a/src/plugins/manualRowResize/test/manualRowResize.e2e.js
+++ b/src/plugins/manualRowResize/test/manualRowResize.e2e.js
@@ -38,7 +38,7 @@ describe('manualRowResize', () => {
 
     updateSettings({ manualRowResize: true });
 
-    spec().$container.find('tbody tr:eq(0) th:eq(0)').simulate('mouseover');
+    getLeftClone().find('tbody tr:eq(0) th:eq(0)').simulate('mouseover');
 
     expect($('.manualRowResizer').size()).toBeGreaterThan(0);
   });
@@ -199,7 +199,7 @@ describe('manualRowResize', () => {
     hot.addHook('beforeRowResize', () => 200);
     hot.addHook('beforeRowResize', () => void 0);
 
-    const $th = spec().$container.find('tbody tr:eq(0) th:eq(0)');
+    const $th = getLeftClone().find('tbody tr:eq(0) th:eq(0)');
     $th.simulate('mouseover');
 
     const $resizer = spec().$container.find('.manualRowResizer');
@@ -258,7 +258,7 @@ describe('manualRowResize', () => {
 
     expect(rowHeight(spec().$container, 0)).toEqual(defaultRowHeight + 2);
 
-    const $th = spec().$container.find('tbody tr:eq(0) th:eq(0)');
+    const $th = getLeftClone().find('tbody tr:eq(0) th:eq(0)');
     $th.simulate('mouseover');
 
     const $resizer = spec().$container.find('.manualRowResizer');
@@ -283,7 +283,7 @@ describe('manualRowResize', () => {
 
     expect(rowHeight(spec().$container, 0)).toEqual(defaultRowHeight + 2);
 
-    const $th = spec().$container.find('tbody tr:eq(2) th:eq(0)');
+    const $th = getLeftClone().find('tbody tr:eq(2) th:eq(0)');
     $th.simulate('mouseover');
 
     const $resizer = spec().$container.find('.manualRowResizer');
@@ -315,7 +315,7 @@ describe('manualRowResize', () => {
       rowHeights: [45, 120, 160, 60, 80],
     });
 
-    const $rowHeaders = spec().$container.find('tbody tr th');
+    const $rowHeaders = getLeftClone().find('tbody tr th');
 
     {
       const $th = $rowHeaders.eq(0); // resize the first row.
@@ -367,7 +367,7 @@ describe('manualRowResize', () => {
 
     expect(rowHeight(spec().$container, 0)).toEqual(defaultRowHeight + 2);
 
-    const $th = spec().$container.find('tbody tr:eq(2) th:eq(0)');
+    const $th = getLeftClone().find('tbody tr:eq(2) th:eq(0)');
     $th.simulate('mouseover');
 
     const $resizer = spec().$container.find('.manualRowResizer');
@@ -607,10 +607,10 @@ describe('manualRowResize', () => {
 
       await sleep(400);
 
-      spec().$container.find('tbody tr:eq(12) th:eq(0)').simulate('mousedown');
-      spec().$container.find('tbody tr:eq(13) th:eq(0)').simulate('mouseover');
-      spec().$container.find('tbody tr:eq(14) th:eq(0)').simulate('mouseover');
-      spec().$container.find('tbody tr:eq(14) th:eq(0)').simulate('mouseup');
+      getLeftClone().find('tbody tr:eq(12) th:eq(0)').simulate('mousedown');
+      getLeftClone().find('tbody tr:eq(13) th:eq(0)').simulate('mouseover');
+      getLeftClone().find('tbody tr:eq(14) th:eq(0)').simulate('mouseover');
+      getLeftClone().find('tbody tr:eq(14) th:eq(0)').simulate('mouseup');
 
       const $resizer = spec().$container.find('.manualRowResizer');
       const resizerPosition = $resizer.position();
@@ -618,9 +618,9 @@ describe('manualRowResize', () => {
       $resizer.simulate('mousemove', { clientY: resizerPosition.top + 30 });
       $resizer.simulate('mouseup');
 
-      expect(spec().$container.find('tbody tr:eq(12) th:eq(0)').height()).toBe(52);
-      expect(spec().$container.find('tbody tr:eq(13) th:eq(0)').height()).toBe(52);
-      expect(spec().$container.find('tbody tr:eq(14) th:eq(0)').height()).toBe(52);
+      expect(getLeftClone().find('tbody tr:eq(12) th:eq(0)').height()).toBe(52);
+      expect(getLeftClone().find('tbody tr:eq(13) th:eq(0)').height()).toBe(52);
+      expect(getLeftClone().find('tbody tr:eq(14) th:eq(0)').height()).toBe(52);
     });
 
     it('should resize (expanding) selected columns, with window as a scroll parent', () => {
@@ -634,10 +634,10 @@ describe('manualRowResize', () => {
 
       $(window).scrollTop(200);
 
-      spec().$container.find('tbody tr:eq(12) th:eq(0)').simulate('mousedown');
-      spec().$container.find('tbody tr:eq(13) th:eq(0)').simulate('mouseover');
-      spec().$container.find('tbody tr:eq(14) th:eq(0)').simulate('mouseover');
-      spec().$container.find('tbody tr:eq(14) th:eq(0)').simulate('mouseup');
+      getLeftClone().find('tbody tr:eq(12) th:eq(0)').simulate('mousedown');
+      getLeftClone().find('tbody tr:eq(13) th:eq(0)').simulate('mouseover');
+      getLeftClone().find('tbody tr:eq(14) th:eq(0)').simulate('mouseover');
+      getLeftClone().find('tbody tr:eq(14) th:eq(0)').simulate('mouseup');
 
       const $resizer = spec().$container.find('.manualRowResizer');
       const resizerPosition = $resizer.position();
@@ -645,9 +645,9 @@ describe('manualRowResize', () => {
       $resizer.simulate('mousemove', { clientY: resizerPosition.top + 30 });
       $resizer.simulate('mouseup');
 
-      expect(spec().$container.find('tbody tr:eq(12) th:eq(0)').height()).toBe(52);
-      expect(spec().$container.find('tbody tr:eq(13) th:eq(0)').height()).toBe(52);
-      expect(spec().$container.find('tbody tr:eq(14) th:eq(0)').height()).toBe(52);
+      expect(getLeftClone().find('tbody tr:eq(12) th:eq(0)').height()).toBe(52);
+      expect(getLeftClone().find('tbody tr:eq(13) th:eq(0)').height()).toBe(52);
+      expect(getLeftClone().find('tbody tr:eq(14) th:eq(0)').height()).toBe(52);
 
       $(window).scrollTop(0);
     });
@@ -667,7 +667,7 @@ describe('manualRowResize', () => {
         manualRowResize: true
       });
 
-      const $headerTH = spec().$container.find('tbody tr:eq(1) th:eq(0)');
+      const $headerTH = getLeftClone().find('tbody tr:eq(1) th:eq(0)');
       $headerTH.simulate('mouseover');
 
       const $handle = $('.manualRowResizer');
@@ -690,7 +690,7 @@ describe('manualRowResize', () => {
         manualRowResize: true
       });
 
-      const $headerTH = spec().$container.find('tbody tr:eq(1) th:eq(0)');
+      const $headerTH = getLeftClone().find('tbody tr:eq(1) th:eq(0)');
       $headerTH.simulate('mouseover');
 
       const $handle = $('.manualRowResizer');

--- a/test/helpers/common.js
+++ b/test/helpers/common.js
@@ -719,7 +719,7 @@ export function createAccessorForProperty(name) {
  */
 export function resizeColumn(renderableColumnIndex, width) {
   const $container = spec().$container;
-  const $th = $container.find(`thead tr:eq(0) th:eq(${renderableColumnIndex})`);
+  const $th = getTopClone().find(`thead tr:eq(0) th:eq(${renderableColumnIndex})`);
 
   $th.simulate('mouseover');
 
@@ -745,7 +745,7 @@ export function resizeColumn(renderableColumnIndex, width) {
  */
 export function resizeRow(renderableRowIndex, height) {
   const $container = spec().$container;
-  const $th = $container.find(`tbody tr:eq(${renderableRowIndex}) th:eq(0)`);
+  const $th = getLeftClone().find(`tbody tr:eq(${renderableRowIndex}) th:eq(0)`);
 
   $th.simulate('mouseover');
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
There was a problem with getting a relative cell position for the TH elements. I've simplified the fallback logic by retrieving the coordinates from top (or left for rows) overlay when no other overlay exists. The previous logic assumes that the header element (passed within mouseover event) can be part of the master overlay but it's wrong. Indeed the master overlay has rendered those elements but they are hidden by CSS (visibility: hidden). So it's not possible from UI to resize headers through the master overlay. 

I've fixed tests that wrongly resize the headers by resizing the top or left overlay.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Tested manually. No new tests added as after fixing the old ones (https://github.com/handsontable/handsontable/pull/7044/commits/7f6825c216129c91e8618e783aac572ba8d29704, https://github.com/handsontable/handsontable/pull/7044/commits/9921e520233a680f427e02696f3be85c8ad3ed08) they correctly fail in a scenario described in this issue #7038.

https://jsfiddle.net/aninde/b3dfok96/1/

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7038
2. #7049
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
