### PR TITLE
Helpers for addClass and removeClass will work the same for different browsers

### DIFF
--- a/src/helpers/dom/element.js
+++ b/src/helpers/dom/element.js
@@ -292,12 +292,17 @@ if (isClassListSupported()) {
   };
 
   _addClass = function(element, classes) {
+    if (!classes) {
+      return;
+    }
+
     let _className = element.className;
     let className = classes;
 
     if (typeof className === 'string') {
       className = className.split(' ');
     }
+
     if (_className === '') {
       _className = className.join(' ');
 
@@ -308,10 +313,15 @@ if (isClassListSupported()) {
         }
       }
     }
+
     element.className = _className;
   };
 
   _removeClass = function(element, classes) {
+    if (!classes) {
+      return;
+    }
+
     let len = 0;
     let _className = element.className;
     let className = classes;

--- a/src/helpers/dom/element.js
+++ b/src/helpers/dom/element.js
@@ -292,16 +292,14 @@ if (isClassListSupported()) {
   };
 
   _addClass = function(element, classes) {
-    if (!classes) {
-      return;
-    }
-
     let _className = element.className;
     let className = classes;
 
     if (typeof className === 'string') {
       className = className.split(' ');
     }
+
+    className = filterEmptyClassNames(className);
 
     if (_className === '') {
       _className = className.join(' ');
@@ -318,10 +316,6 @@ if (isClassListSupported()) {
   };
 
   _removeClass = function(element, classes) {
-    if (!classes) {
-      return;
-    }
-
     let len = 0;
     let _className = element.className;
     let className = classes;
@@ -329,6 +323,9 @@ if (isClassListSupported()) {
     if (typeof className === 'string') {
       className = className.split(' ');
     }
+
+    className = filterEmptyClassNames(className);
+
     while (className && className[len]) {
       // String.prototype.trim is defined in polyfill.js
       _className = _className.replace(createClassNameRegExp(className[len]), ' ').trim();


### PR DESCRIPTION
### Context
There was a problem with the fact that `addClass` and `removeClass` haven't worked the same for browser supporting and not supporting the [classList](https://developer.mozilla.org/pl/docs/Web/API/Element/classList) feature. Thus, we had an error on `IE9` which is still supported by us.

Issue https://github.com/handsontable/handsontable/pull/6425 introduced some extra DOM manipulations. The below line of code sometimes tries to add `undefined` class (when options `className` and/or `tableClassName` aren't defined for the table). 

https://github.com/handsontable/handsontable/blob/e5201d989c6005958c175cb0a8875e595ee7c69f/src/core.js#L1918-L1922

It's handled by the `setClassName` method on table initialization (first `updateSettings` call).

https://github.com/handsontable/handsontable/blob/e5201d989c6005958c175cb0a8875e595ee7c69f/src/core.js#L929-L933

I'm not sure if there should be some conditional, but I'm sure that `addClass` and `removeClass` should work similarly for all browsers. That's why I've changed those helpers.

The `addClass` for newer web browsers filter `undefined` classes.

https://github.com/handsontable/handsontable/blob/f78bfbcc6b8818cec392b33a836dfdb5f5836477/src/helpers/dom/element.js#L243

https://github.com/handsontable/handsontable/blob/f78bfbcc6b8818cec392b33a836dfdb5f5836477/src/helpers/dom/element.js#L210-L213

### How has this been tested?
Tested on a virtual machine using Windows 7.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7054 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
