### PR TITLE
Make the `selectAll` method select the headers.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -3533,11 +3533,15 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
    * @since 0.38.2
    * @memberof Core#
    * @function selectAll
-   * @param {boolean} [includeCorner=true] `true` If the selection should include the corner header, `false` otherwise.
+   * @param {boolean} [includeHeaders=true] `true` If the selection should include the row, column and corner headers,
+   * `false` otherwise.
    */
-  this.selectAll = function(includeCorner = true) {
+  this.selectAll = function(includeHeaders = true) {
+    const includeRowHeaders = includeHeaders && this.hasRowHeaders();
+    const includeColumnHeaders = includeHeaders && this.hasColHeaders();
+
     preventScrollingToCell = true;
-    selection.selectAll(includeCorner);
+    selection.selectAll(includeRowHeaders, includeColumnHeaders);
     preventScrollingToCell = false;
   };
 

--- a/src/plugins/contextMenu/test/predefinedItems/insertColumnRight.e2e.js
+++ b/src/plugins/contextMenu/test/predefinedItems/insertColumnRight.e2e.js
@@ -66,7 +66,8 @@ describe('ContextMenu', () => {
 
       simulateClick(item);
 
-      expect(getColHeader()).toEqual(['A', 1, 2, 3, 4, 5]);
+      // The new column will be placed at the very end, because clicking the corner header selects all cells.
+      expect(getColHeader()).toEqual([1, 2, 3, 4, 5, 'F']);
     });
 
     describe('UI', () => {

--- a/src/plugins/hiddenColumns/test/hiddenColumns.e2e.js
+++ b/src/plugins/hiddenColumns/test/hiddenColumns.e2e.js
@@ -771,6 +771,7 @@ describe('HiddenColumns', () => {
           expect(getSelectedLast()).toBeUndefined();
           expect(`
           |   |
+          |===|
           |   |
           |   |
           `).toBeMatchToSelectionPattern();
@@ -1120,6 +1121,7 @@ describe('HiddenColumns', () => {
             expect(getSelectedRangeLast().to.col).toBe(3);
             expect(`
             |   |
+            |===|
             |   |
             | * |
             |   |
@@ -1207,6 +1209,7 @@ describe('HiddenColumns', () => {
             expect(getSelectedRangeLast().to.col).toBe(3);
             expect(`
             |   |
+            |===|
             | * |
             |   |
             |   |
@@ -1341,6 +1344,7 @@ describe('HiddenColumns', () => {
       expect(getSelectedRangeLast().to.col).toBe(4);
       expect(`
       |   |
+      |===|
       | * |
       |   |
       |   |
@@ -1550,6 +1554,7 @@ describe('HiddenColumns', () => {
         expect(getSelectedRangeLast().to.col).toBe(4);
         expect(`
         |   |
+        |===|
         | * |
         | * |
         | * |
@@ -1634,6 +1639,7 @@ describe('HiddenColumns', () => {
       expect(getSelectedRangeLast().to.col).toBe(0);
       expect(`
         |   |
+        |===|
         | - |
         |   |
         |   |
@@ -1652,6 +1658,7 @@ describe('HiddenColumns', () => {
       expect(getSelectedRangeLast().to.col).toBe(1);
       expect(`
         |   |
+        |===|
         |   |
         |   |
         | - |
@@ -1681,6 +1688,7 @@ describe('HiddenColumns', () => {
       expect(getSelectedRangeLast().to.col).toBe(0);
       expect(`
         |   |
+        |===|
         | - |
         |   |
         |   |
@@ -1699,6 +1707,7 @@ describe('HiddenColumns', () => {
       expect(getSelectedRangeLast().to.col).toBe(1);
       expect(`
         |   |
+        |===|
         |   |
         |   |
         | - |
@@ -1729,6 +1738,7 @@ describe('HiddenColumns', () => {
       expect(getSelectedRangeLast().to.col).toBe(0);
       expect(`
         |   |
+        |===|
         | - |
         |   |
         |   |
@@ -1747,6 +1757,7 @@ describe('HiddenColumns', () => {
       expect(getSelectedRangeLast().to.col).toBe(1);
       expect(`
         |   |
+        |===|
         |   |
         |   |
         | - |
@@ -1806,6 +1817,7 @@ describe('HiddenColumns', () => {
       expect(getSelectedRangeLast().to.col).toBe(4);
       expect(`
       |   |
+      |===|
       | * |
       | * |
       | * |
@@ -2810,6 +2822,7 @@ describe('HiddenColumns', () => {
         expect(getSelectedRangeLast().to.col).toBe(4);
         expect(`
         |   |
+        |===|
         | * |
         | * |
         | * |

--- a/src/plugins/hiddenRows/test/plugins/contextMenu.e2e.js
+++ b/src/plugins/hiddenRows/test/plugins/contextMenu.e2e.js
@@ -650,7 +650,7 @@ describe('HiddenRows', () => {
 
           expect(getSelectedLast()).toBeUndefined();
           expect(`
-            |   |   :   |
+            |   ║   :   |
             |===:===:===|
           `).toBeMatchToSelectionPattern();
         });
@@ -1067,7 +1067,7 @@ describe('HiddenRows', () => {
             expect(getSelectedRangeLast().to.row).toBe(3);
             expect(getSelectedRangeLast().to.col).toBe(1);
             expect(`
-              |   |   : * :   :   :   |
+              |   ║   : * :   :   :   |
               |===:===:===:===:===:===|
             `).toBeMatchToSelectionPattern();
           });
@@ -1144,7 +1144,7 @@ describe('HiddenRows', () => {
             expect(getSelectedRangeLast().to.row).toBe(3);
             expect(getSelectedRangeLast().to.col).toBe(0);
             expect(`
-              |   | * :   :   :   :   |
+              |   ║ * :   :   :   :   |
               |===:===:===:===:===:===|
             `).toBeMatchToSelectionPattern();
           });

--- a/src/plugins/hiddenRows/test/selection.e2e.js
+++ b/src/plugins/hiddenRows/test/selection.e2e.js
@@ -126,7 +126,7 @@ describe('HiddenRows', () => {
       expect(getSelectedRangeLast().to.row).toBe(4);
       expect(getSelectedRangeLast().to.col).toBe(4);
       expect(`
-        |   | * : * : * : * : * |
+        |   ║ * : * : * : * : * |
         |===:===:===:===:===:===|
       `).toBeMatchToSelectionPattern();
     });
@@ -312,7 +312,7 @@ describe('HiddenRows', () => {
 
         expect(getSelected()).toEqual([[-1, -1, 4, 4]]);
         expect(`
-          |   | * : * : * : * : * |
+          |   ║ * : * : * : * : * |
           |===:===:===:===:===:===|
         `).toBeMatchToSelectionPattern();
       });
@@ -413,7 +413,7 @@ describe('HiddenRows', () => {
       expect(getSelectedRangeLast().to.row).toBe(0);
       expect(getSelectedRangeLast().to.col).toBe(0);
       expect(`
-        |   | - :   :   :   :   |
+        |   ║ - :   :   :   :   |
         |===:===:===:===:===:===|
       `).toBeMatchToSelectionPattern();
 
@@ -427,7 +427,7 @@ describe('HiddenRows', () => {
       expect(getSelectedRangeLast().to.row).toBe(1);
       expect(getSelectedRangeLast().to.col).toBe(2);
       expect(`
-        |   |   :   : - :   :   |
+        |   ║   :   : - :   :   |
         |===:===:===:===:===:===|
       `).toBeMatchToSelectionPattern();
     });
@@ -453,7 +453,7 @@ describe('HiddenRows', () => {
       expect(getSelectedRangeLast().to.row).toBe(0);
       expect(getSelectedRangeLast().to.col).toBe(0);
       expect(`
-        |   | - :   :   :   :   |
+        |   ║ - :   :   :   :   |
         |===:===:===:===:===:===|
       `).toBeMatchToSelectionPattern();
 
@@ -467,7 +467,7 @@ describe('HiddenRows', () => {
       expect(getSelectedRangeLast().to.row).toBe(1);
       expect(getSelectedRangeLast().to.col).toBe(2);
       expect(`
-        |   |   :   : - :   :   |
+        |   ║   :   : - :   :   |
         |===:===:===:===:===:===|
       `).toBeMatchToSelectionPattern();
     });
@@ -520,7 +520,7 @@ describe('HiddenRows', () => {
       expect(getSelectedRangeLast().to.row).toBe(4);
       expect(getSelectedRangeLast().to.col).toBe(4);
       expect(`
-        |   | * : * : * : * : * |
+        |   ║ * : * : * : * : * |
         |===:===:===:===:===:===|
       `).toBeMatchToSelectionPattern();
     });
@@ -1489,7 +1489,7 @@ describe('HiddenRows', () => {
         expect(getSelectedRangeLast().to.row).toBe(4);
         expect(getSelectedRangeLast().to.col).toBe(4);
         expect(`
-          |   | * : * : * : * : * |
+          |   ║ * : * : * : * : * |
           |===:===:===:===:===:===|
         `).toBeMatchToSelectionPattern();
       });

--- a/src/selection/mouseEventHandler.js
+++ b/src/selection/mouseEventHandler.js
@@ -69,7 +69,7 @@ export function mouseDown({ isShiftKey, isLeftClick, isRightClick, coords, selec
         selection.setRangeStart(coords);
       }
     } else if (coords.col < 0 && coords.row < 0) {
-      selection.selectAll(true);
+      selection.selectAll(true, true);
     }
   }
 }

--- a/src/selection/selection.js
+++ b/src/selection/selection.js
@@ -517,20 +517,21 @@ class Selection {
   /**
    * Select all cells.
    *
-   * @param {boolean} [includeCorner=false] `true` If the selection should include the corner header, `false` otherwise.
+   * @param {boolean} [includeRowHeaders=false] `true` If the selection should include the row headers, `false`
+   * otherwise.
+   * @param {boolean} [includeColumnHeaders=false] `true` If the selection should include the column headers, `false`
+   * otherwise.
    */
-  selectAll(includeCorner = false) {
+  selectAll(includeRowHeaders = false, includeColumnHeaders = false) {
     const nrOfRows = this.tableProps.countRows();
     const nrOfColumns = this.tableProps.countCols();
 
     // We can't select cells when there is no data.
-    if (nrOfRows === 0 || nrOfColumns === 0) {
+    if (!includeRowHeaders && !includeColumnHeaders && (nrOfRows === 0 || nrOfColumns === 0)) {
       return;
     }
 
-    const startCoords = includeCorner ?
-      new CellCoords(-1, -1) :
-      new CellCoords(0, 0);
+    const startCoords = new CellCoords(includeColumnHeaders ? -1 : 0, includeRowHeaders ? -1 : 0);
 
     this.clear();
     this.setRangeStartOnly(startCoords);
@@ -538,7 +539,6 @@ class Selection {
     this.selectedByColumnHeader.add(this.getLayerLevel());
     this.setRangeEnd(new CellCoords(nrOfRows - 1, nrOfColumns - 1));
     this.finish();
-
   }
 
   /**

--- a/test/e2e/Core_selection.spec.js
+++ b/test/e2e/Core_selection.spec.js
@@ -327,7 +327,24 @@ describe('Core_selection', () => {
 
     expect(getSelected()).toEqual([[-1, 1, -1, 1]]);
     expect(`
-      |   |   : - :   :   :   |
+      |   ║   : - :   :   :   |
+      |===:===:===:===:===:===|
+    `).toBeMatchToSelectionPattern();
+  });
+
+  it('should select the row and column headers after clicking the corner header, when all rows are trimmed', () => {
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+      rowHeaders: true,
+      colHeaders: true,
+      trimRows: [0, 1, 2, 3, 4], // The TrimmingMap should be used instead of the plugin.
+    });
+
+    simulateClick(spec().$container.find('.ht_clone_top tr:eq(0) th:eq(0)'));
+
+    expect(getSelected()).toEqual([[-1, -1, -1, 4]]);
+    expect(`
+      |   ║ - : - : - : - : - |
       |===:===:===:===:===:===|
     `).toBeMatchToSelectionPattern();
   });
@@ -345,6 +362,7 @@ describe('Core_selection', () => {
     expect(getSelected()).toEqual([[1, -1, 1, -1]]);
     expect(`
       |   |
+      |===|
       |   |
       | - |
       |   |

--- a/test/e2e/core/selectAll.spec.js
+++ b/test/e2e/core/selectAll.spec.js
@@ -52,4 +52,38 @@ describe('Core.selectAll', () => {
     expect(hot.view.wt.wtTable.holder.scrollTop).toBe(150);
     expect(hot.view.wt.wtTable.holder.scrollLeft).toBe(150);
   });
+
+  it('should select the row and column headers after calling the `selectAll` method, when all rows are trimmed', () => {
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+      rowHeaders: true,
+      colHeaders: true,
+      trimRows: [0, 1, 2, 3, 4], // TODO: The TrimmingMap should be used instead of the plugin.
+    });
+
+    selectAll();
+
+    expect(getSelected()).toEqual([[-1, -1, -1, 4]]);
+    expect(`
+      |   ║ - : - : - : - : - |
+      |===:===:===:===:===:===|
+    `).toBeMatchToSelectionPattern();
+  });
+
+  it('should NOT select the row and column headers after calling the `selectAll` method with the `inclueHeaders`' +
+    ' arguments set to `false`, when all rows are trimmed', () => {
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+      rowHeaders: true,
+      colHeaders: true,
+      trimRows: [0, 1, 2, 3, 4], // TODO: The TrimmingMap should be used instead of the plugin.
+    });
+
+    selectAll(false);
+
+    expect(`
+      |   ║   :   :   :   :   |
+      |===:===:===:===:===:===|
+    `).toBeMatchToSelectionPattern();
+  });
 });

--- a/test/helpers/asciiTable.js
+++ b/test/helpers/asciiTable.js
@@ -95,6 +95,16 @@ function isTopHeader(cell) {
 }
 
 /**
+ * Check if the provided cell element is a table header.
+ *
+ * @param {HTMLTableCellElement} cell The overlay element to process.
+ * @returns {boolean}
+ */
+function isHeader(cell) {
+  return cell.tagName === 'TH';
+}
+
+/**
  * @param {HTMLTableElement} overlay The overlay element to process.
  * @returns {Function}
  */
@@ -127,11 +137,18 @@ export function generateASCIITable(context) {
   const topOverlayCells = cellFactory(topOverlayTable);
   const masterCells = cellFactory(masterTable);
 
-  const hasLeftHeader = leftOverlayCells(1, 0) ? isLeftHeader(leftOverlayCells(1, 0)) : false;
-  const hasTopHeader = topOverlayCells(0, 1) ? isTopHeader(topOverlayCells(0, 1)) : false;
-  const hasCornerHeader = hasLeftHeader && hasTopHeader;
-  const hasFixedLeftCells = leftOverlayCells(1, 1) ? !isLeftHeader(leftOverlayCells(1, 1)) : false;
-  const hasFixedTopCells = topOverlayCells(1, 1) ? !isTopHeader(topOverlayCells(1, 1)) : false;
+  const hasTopHeader = topOverlayCells(0, 0) ? isTopHeader(topOverlayCells(0, 0)) : false;
+  const hasCornerHeader = cornerOverlayCells(0, 0) ? isHeader(cornerOverlayCells(0, 0)) : false;
+  const hasLeftHeader = (leftOverlayCells(0, 0) && isLeftHeader(leftOverlayCells(0, 0))) ||
+                        (hasTopHeader && hasCornerHeader);
+  const firstCellCoords = {
+    row: hasTopHeader ? 1 : 0,
+    column: hasLeftHeader ? 1 : 0
+  };
+  const leftOverlayFirstCell = leftOverlayCells(firstCellCoords.row, firstCellCoords.column);
+  const hasFixedLeftCells = leftOverlayFirstCell ? !isLeftHeader(leftOverlayFirstCell) : false;
+  const topOverlayFirstCell = topOverlayCells(firstCellCoords.row, firstCellCoords.column);
+  const hasFixedTopCells = topOverlayFirstCell ? !isTopHeader(topOverlayFirstCell) : false;
 
   const consumedFlags = new Map([
     ['hasLeftHeader', hasLeftHeader],


### PR DESCRIPTION
### Context
Details described in #7063.

This PR makes the `selectAll` method select the headers by default, same thing with clicking on the corner header.
Also, I fixed a couple of issues with the `toBeMatchToSelectionPattern` matcher.

### How has this been tested?
- Added a test case and testes manually

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7063 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
