### PR TITLE
Rename `executeBatchOperations` to `batch` for the core API.

### DIFF
--- a/handsontable.d.ts
+++ b/handsontable.d.ts
@@ -34,7 +34,7 @@ declare namespace _Handsontable {
     destroy(): void;
     destroyEditor(revertOriginal?: boolean, prepareEditorIfNeeded?: boolean): void;
     emptySelectedCells(): void;
-    executeBatchOperations(wrappedOperations: () => void): void;
+    batch(wrappedOperations: () => void): void;
     forceFullRender: boolean;
     getActiveEditor<T extends Handsontable._editors.Base>(): T | undefined;
     getCell(row: number, col: number, topmost?: boolean): HTMLTableCellElement | null;

--- a/src/core.js
+++ b/src/core.js
@@ -967,7 +967,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
    *
    * @param {Function} wrappedOperations Batched operations wrapped in a function.
    */
-  this.executeBatchOperations = function(wrappedOperations) {
+  this.batch = function(wrappedOperations) {
     this.columnIndexMapper.executeBatchOperations(() => {
       this.rowIndexMapper.executeBatchOperations(() => {
         wrappedOperations();
@@ -3646,7 +3646,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
       editorManager.destroy();
     }
 
-    instance.executeBatchOperations(() => {
+    instance.batch(() => {
       // The plugin's `destroy` method is called as a consequence and it should handle unregistration of plugin's maps. Some unregistered maps reset the cache.
       instance.runHooks('afterDestroy');
     });

--- a/src/plugins/autoColumnSize/autoColumnSize.js
+++ b/src/plugins/autoColumnSize/autoColumnSize.js
@@ -236,7 +236,7 @@ class AutoColumnSize extends BasePlugin {
     });
 
     if (this.ghostTable.columns.length) {
-      this.hot.executeBatchOperations(() => {
+      this.hot.batch(() => {
         this.ghostTable.getWidths((visualColumn, width) => {
           const physicalColumn = this.hot.toPhysicalColumn(visualColumn);
 
@@ -480,7 +480,7 @@ class AutoColumnSize extends BasePlugin {
    */
   clearCache(columns = []) {
     if (columns.length) {
-      this.hot.executeBatchOperations(() => {
+      this.hot.batch(() => {
         arrayEach(columns, (physicalIndex) => {
           this.columnWidthsMap.setValueAtIndex(physicalIndex, null);
         });

--- a/src/plugins/autoRowSize/autoRowSize.js
+++ b/src/plugins/autoRowSize/autoRowSize.js
@@ -215,7 +215,7 @@ class AutoRowSize extends BasePlugin {
     });
 
     if (this.ghostTable.rows.length) {
-      this.hot.executeBatchOperations(() => {
+      this.hot.batch(() => {
         this.ghostTable.getHeights((row, height) => {
           if (row < 0) {
             this.headerHeight = height;
@@ -425,7 +425,7 @@ class AutoRowSize extends BasePlugin {
   clearCacheByRange(range) {
     const { from, to } = typeof range === 'number' ? { from: range, to: range } : range;
 
-    this.hot.executeBatchOperations(() => {
+    this.hot.batch(() => {
       rangeEach(Math.min(from, to), Math.max(from, to), (row) => {
         this.rowHeightsMap.setValueAtIndex(row, null);
       });

--- a/src/plugins/collapsibleColumns/collapsibleColumns.js
+++ b/src/plugins/collapsibleColumns/collapsibleColumns.js
@@ -347,7 +347,7 @@ class CollapsibleColumns extends BasePlugin {
       return;
     }
 
-    this.hot.executeBatchOperations(() => {
+    this.hot.batch(() => {
       arrayEach(affectedColumnsIndexes, (visualColumn) => {
         this.#collapsedColumnsMap
           .setValueAtIndex(this.hot.toPhysicalColumn(visualColumn), actionTranslator.hideColumn);

--- a/src/plugins/columnSorting/columnSorting.js
+++ b/src/plugins/columnSorting/columnSorting.js
@@ -177,7 +177,7 @@ class ColumnSorting extends BasePlugin {
       this.hot.removeHook('afterGetColHeader', clearColHeader);
     });
 
-    this.hot.executeBatchOperations(() => {
+    this.hot.batch(() => {
       if (this.indexesSequenceCache !== null) {
         this.hot.rowIndexMapper.setIndexesSequence(this.indexesSequenceCache.getValues());
         this.hot.rowIndexMapper.unregisterMap(this.pluginKey);

--- a/src/plugins/filters/filters.js
+++ b/src/plugins/filters/filters.js
@@ -375,7 +375,7 @@ class Filters extends BasePlugin {
       if (needToFilter) {
         const trimmedRows = [];
 
-        this.hot.executeBatchOperations(() => {
+        this.hot.batch(() => {
           this.filtersRowsMap.clear();
 
           visibleVisualRows = arrayMap(dataFilter.filter(), rowData => rowData.meta.visualRow);

--- a/src/plugins/hiddenColumns/hiddenColumns.js
+++ b/src/plugins/hiddenColumns/hiddenColumns.js
@@ -168,7 +168,7 @@ class HiddenColumns extends BasePlugin {
     }
 
     if (isConfigValid) {
-      this.hot.executeBatchOperations(() => {
+      this.hot.batch(() => {
         arrayEach(columns, (visualColumn) => {
           this.#hiddenColumnsMap.setValueAtIndex(this.hot.toPhysicalColumn(visualColumn), false);
         });
@@ -210,7 +210,7 @@ class HiddenColumns extends BasePlugin {
     }
 
     if (isConfigValid) {
-      this.hot.executeBatchOperations(() => {
+      this.hot.batch(() => {
         arrayEach(columns, (visualColumn) => {
           this.#hiddenColumnsMap.setValueAtIndex(this.hot.toPhysicalColumn(visualColumn), true);
         });

--- a/src/plugins/hiddenRows/hiddenRows.js
+++ b/src/plugins/hiddenRows/hiddenRows.js
@@ -169,7 +169,7 @@ class HiddenRows extends BasePlugin {
     }
 
     if (isConfigValid) {
-      this.hot.executeBatchOperations(() => {
+      this.hot.batch(() => {
         arrayEach(rows, (visualRow) => {
           this.#hiddenRowsMap.setValueAtIndex(this.hot.toPhysicalRow(visualRow), false);
         });
@@ -210,7 +210,7 @@ class HiddenRows extends BasePlugin {
     }
 
     if (isConfigValid) {
-      this.hot.executeBatchOperations(() => {
+      this.hot.batch(() => {
         arrayEach(rows, (visualRow) => {
           this.#hiddenRowsMap.setValueAtIndex(this.hot.toPhysicalRow(visualRow), true);
         });

--- a/src/plugins/manualColumnResize/manualColumnResize.js
+++ b/src/plugins/manualColumnResize/manualColumnResize.js
@@ -176,14 +176,14 @@ class ManualColumnResize extends BasePlugin {
     const loadedManualColumnWidths = this.loadManualColumnWidths();
 
     if (typeof loadedManualColumnWidths !== 'undefined') {
-      this.hot.executeBatchOperations(() => {
+      this.hot.batch(() => {
         loadedManualColumnWidths.forEach((width, physicalIndex) => {
           this.columnWidthsMap.setValueAtIndex(physicalIndex, width);
         });
       });
 
     } else if (Array.isArray(initialSetting)) {
-      this.hot.executeBatchOperations(() => {
+      this.hot.batch(() => {
         initialSetting.forEach((width, physicalIndex) => {
           this.columnWidthsMap.setValueAtIndex(physicalIndex, width);
         });
@@ -192,7 +192,7 @@ class ManualColumnResize extends BasePlugin {
       priv.config = initialSetting;
 
     } else if (initialSetting === true && Array.isArray(priv.config)) {
-      this.hot.executeBatchOperations(() => {
+      this.hot.batch(() => {
         priv.config.forEach((width, physicalIndex) => {
           this.columnWidthsMap.setValueAtIndex(physicalIndex, width);
         });

--- a/src/plugins/manualRowResize/manualRowResize.js
+++ b/src/plugins/manualRowResize/manualRowResize.js
@@ -525,7 +525,7 @@ class ManualRowResize extends BasePlugin {
     const initialSetting = this.hot.getSettings().manualRowResize;
     const loadedManualRowHeights = this.loadManualRowHeights();
 
-    this.hot.executeBatchOperations(() => {
+    this.hot.batch(() => {
       if (typeof loadedManualRowHeights !== 'undefined') {
         loadedManualRowHeights.forEach((height, index) => {
           this.rowHeightsMap.setValueAtIndex(index, height);

--- a/src/plugins/nestedRows/ui/collapsing.js
+++ b/src/plugins/nestedRows/ui/collapsing.js
@@ -349,7 +349,7 @@ class CollapsingUI extends BaseUI {
    * @param {Array} rows Physical row indexes.
    */
   trimRows(rows) {
-    this.hot.executeBatchOperations(() => {
+    this.hot.batch(() => {
       arrayEach(rows, (physicalRow) => {
         this.plugin.collapsedRowsMap.setValueAtIndex(physicalRow, true);
       });
@@ -362,7 +362,7 @@ class CollapsingUI extends BaseUI {
    * @param {Array} rows Physical row indexes.
    */
   untrimRows(rows) {
-    this.hot.executeBatchOperations(() => {
+    this.hot.batch(() => {
       arrayEach(rows, (physicalRow) => {
         this.plugin.collapsedRowsMap.setValueAtIndex(physicalRow, false);
       });

--- a/src/plugins/trimRows/trimRows.js
+++ b/src/plugins/trimRows/trimRows.js
@@ -87,7 +87,7 @@ class TrimRows extends BasePlugin {
     const trimmedRows = this.hot.getSettings().trimRows;
 
     if (Array.isArray(trimmedRows)) {
-      this.hot.executeBatchOperations(() => {
+      this.hot.batch(() => {
         this.trimmedRowsMap.clear();
 
         arrayEach(trimmedRows, (physicalRow) => {
@@ -141,7 +141,7 @@ class TrimRows extends BasePlugin {
     }
 
     if (isValidConfig) {
-      this.hot.executeBatchOperations(() => {
+      this.hot.batch(() => {
         arrayEach(rows, (physicalRow) => {
           this.trimmedRowsMap.setValueAtIndex(physicalRow, true);
         });
@@ -185,7 +185,7 @@ class TrimRows extends BasePlugin {
     }
 
     if (isValidConfig) {
-      this.hot.executeBatchOperations(() => {
+      this.hot.batch(() => {
         arrayEach(rows, (physicalRow) => {
           this.trimmedRowsMap.setValueAtIndex(physicalRow, false);
         });
@@ -244,7 +244,7 @@ class TrimRows extends BasePlugin {
     const trimmedRows = this.hot.getSettings().trimRows;
 
     if (Array.isArray(trimmedRows)) {
-      this.hot.executeBatchOperations(() => {
+      this.hot.batch(() => {
         arrayEach(trimmedRows, (physicalRow) => {
           this.trimmedRowsMap.setValueAtIndex(physicalRow, true);
         });

--- a/src/plugins/undoRedo/undoRedo.js
+++ b/src/plugins/undoRedo/undoRedo.js
@@ -477,7 +477,7 @@ UndoRedo.RemoveColumnAction.prototype.undo = function(instance, undoneCallback) 
     });
   }
 
-  instance.executeBatchOperations(() => {
+  instance.batch(() => {
     // Restore row sequence in a case when all columns are removed. the original
     // row sequence is lost in that case.
     instance.rowIndexMapper.setIndexesSequence(this.rowPositions);

--- a/test/types/methods.types.ts
+++ b/test/types/methods.types.ts
@@ -27,7 +27,7 @@ hot.deselectCell();
 hot.destroy();
 hot.destroyEditor(true, true);
 hot.emptySelectedCells();
-hot.executeBatchOperations(() => {});
+hot.batch(() => {});
 hot.getActiveEditor();
 hot.getCell(123, 123, true)!.focus();
 hot.getCellEditor(123, 123);


### PR DESCRIPTION
### Context
Rename the `executeBatchOperations` method to `batch` for the core API.

### How has this been tested?
Run the tests to see if everything works as it did before.

### Related issue(s):
1. #7068