### PR TITLE
Fix double border for top/bottom overlays

### DIFF
--- a/src/3rdparty/walkontable/src/overlay/bottomLeftCorner.js
+++ b/src/3rdparty/walkontable/src/overlay/bottomLeftCorner.js
@@ -59,26 +59,30 @@ class BottomLeftCornerOverlay extends Overlay {
 
   /**
    * Updates the corner overlay position.
+   *
+   * @returns {boolean}
    */
   resetFixedPosition() {
     const { wot } = this;
+
     this.updateTrimmingContainer();
 
     if (!wot.wtTable.holder.parentNode) {
       // removed from DOM
       return;
     }
+
     const overlayRoot = this.clone.wtTable.holder.parentNode;
 
     overlayRoot.style.top = '';
 
     if (this.trimmingContainer === wot.rootWindow) {
-      const box = wot.wtTable.hider.getBoundingClientRect();
-      const bottom = Math.ceil(box.bottom);
-      const left = Math.ceil(box.left);
+      const { rootDocument, wtTable } = this.wot;
+      const bottom = wtTable.hider.offsetTop + wtTable.hider.offsetHeight;
+      const left = wtTable.hider.offsetLeft;
+      const bodyHeight = rootDocument.body.offsetHeight;
       let finalLeft;
       let finalBottom;
-      const bodyHeight = wot.rootDocument.body.offsetHeight;
 
       if (left < 0) {
         finalLeft = -left;
@@ -91,6 +95,7 @@ class BottomLeftCornerOverlay extends Overlay {
       } else {
         finalBottom = 0;
       }
+
       finalBottom += 'px';
       finalLeft += 'px';
 
@@ -112,6 +117,8 @@ class BottomLeftCornerOverlay extends Overlay {
 
     overlayRoot.style.height = `${tableHeight}px`;
     overlayRoot.style.width = `${tableWidth}px`;
+
+    return false;
   }
 }
 

--- a/src/3rdparty/walkontable/src/overlay/left.js
+++ b/src/3rdparty/walkontable/src/overlay/left.js
@@ -46,22 +46,24 @@ class LeftOverlay extends Overlay {
 
   /**
    * Updates the left overlay position.
+   *
+   * @returns {boolean}
    */
   resetFixedPosition() {
     const { wtTable } = this.wot;
+
     if (!this.needFullRender || !wtTable.holder.parentNode) {
       // removed from DOM
       return;
     }
+
     const overlayRoot = this.clone.wtTable.holder.parentNode;
     let headerPosition = 0;
     const preventOverflow = this.wot.getSetting('preventOverflow');
 
-    if (this.trimmingContainer === this.wot.rootWindow &&
-        (!preventOverflow || preventOverflow !== 'horizontal')) {
-      const box = wtTable.hider.getBoundingClientRect();
-      const left = Math.ceil(box.left);
-      const right = Math.ceil(box.right);
+    if (this.trimmingContainer === this.wot.rootWindow && (!preventOverflow || preventOverflow !== 'horizontal')) {
+      const left = wtTable.hider.offsetLeft;
+      const right = left + wtTable.hider.offsetWidth;
       let finalLeft;
       let finalTop;
 
@@ -73,6 +75,7 @@ class LeftOverlay extends Overlay {
       } else {
         finalLeft = 0;
       }
+
       headerPosition = finalLeft;
       finalLeft += 'px';
 
@@ -82,8 +85,12 @@ class LeftOverlay extends Overlay {
       headerPosition = this.getScrollPosition();
       resetCssTransform(overlayRoot);
     }
-    this.adjustHeaderBordersPosition(headerPosition);
+
+    const positionChanged = this.adjustHeaderBordersPosition(headerPosition);
+
     this.adjustElementsSize();
+
+    return positionChanged;
   }
 
   /**
@@ -295,6 +302,7 @@ class LeftOverlay extends Overlay {
    * Adds css classes to hide the header border's header (cell-selection border hiding issue).
    *
    * @param {number} position Header X position if trimming container is window or scroll top if not.
+   * @returns {boolean}
    */
   adjustHeaderBordersPosition(position) {
     const masterParent = this.wot.wtTable.holder.parentNode;
@@ -308,6 +316,8 @@ class LeftOverlay extends Overlay {
       addClass(masterParent, 'emptyRows');
     }
 
+    let positionChanged = false;
+
     if (fixedColumnsLeft && !rowHeaders.length) {
       addClass(masterParent, 'innerBorderLeft');
 
@@ -316,13 +326,18 @@ class LeftOverlay extends Overlay {
 
       if (position) {
         addClass(masterParent, 'innerBorderLeft');
+        positionChanged = !previousState;
       } else {
         removeClass(masterParent, 'innerBorderLeft');
+        positionChanged = previousState;
       }
+
       if (!previousState && position || previousState && !position) {
         this.wot.wtOverlays.adjustElementsSize();
       }
     }
+
+    return positionChanged;
   }
 }
 

--- a/src/3rdparty/walkontable/src/overlay/topLeftCorner.js
+++ b/src/3rdparty/walkontable/src/overlay/topLeftCorner.js
@@ -44,6 +44,8 @@ class TopLeftCornerOverlay extends Overlay {
 
   /**
    * Updates the corner overlay position.
+   *
+   * @returns {boolean}
    */
   resetFixedPosition() {
     this.updateTrimmingContainer();
@@ -52,15 +54,16 @@ class TopLeftCornerOverlay extends Overlay {
       // removed from DOM
       return;
     }
+
     const overlayRoot = this.clone.wtTable.holder.parentNode;
     const preventOverflow = this.wot.getSetting('preventOverflow');
 
     if (this.trimmingContainer === this.wot.rootWindow) {
-      const box = this.wot.wtTable.hider.getBoundingClientRect();
-      const top = Math.ceil(box.top);
-      const left = Math.ceil(box.left);
-      const bottom = Math.ceil(box.bottom);
-      const right = Math.ceil(box.right);
+      const { wtTable } = this.wot;
+      const top = wtTable.hider.offsetTop;
+      const left = wtTable.hider.offsetLeft;
+      const bottom = top + wtTable.hider.offsetHeight;
+      const right = left + wtTable.hider.offsetWidth;
       let finalLeft = '0';
       let finalTop = '0';
 
@@ -89,6 +92,8 @@ class TopLeftCornerOverlay extends Overlay {
 
     overlayRoot.style.height = `${tableHeight}px`;
     overlayRoot.style.width = `${tableWidth}px`;
+
+    return false;
   }
 }
 

--- a/src/3rdparty/walkontable/src/table.js
+++ b/src/3rdparty/walkontable/src/table.js
@@ -337,16 +337,15 @@ class Table {
         }
       }
     }
-    this.refreshSelections(runFastDraw);
 
     if (this.isMaster) {
-      wtOverlays.topOverlay.resetFixedPosition();
+      let positionChanged = wtOverlays.topOverlay.resetFixedPosition();
 
       if (wtOverlays.bottomOverlay.clone) {
-        wtOverlays.bottomOverlay.resetFixedPosition();
+        positionChanged = wtOverlays.bottomOverlay.resetFixedPosition() || positionChanged;
       }
 
-      wtOverlays.leftOverlay.resetFixedPosition();
+      positionChanged = wtOverlays.leftOverlay.resetFixedPosition() || positionChanged;
 
       if (wtOverlays.topLeftCornerOverlay) {
         wtOverlays.topLeftCornerOverlay.resetFixedPosition();
@@ -355,7 +354,17 @@ class Table {
       if (wtOverlays.bottomLeftCornerOverlay && wtOverlays.bottomLeftCornerOverlay.clone) {
         wtOverlays.bottomLeftCornerOverlay.resetFixedPosition();
       }
+
+      if (positionChanged) {
+        // It refreshes the cells borders caused by a 1px shift (introduced by overlays which add or
+        // remove `innerBorderTop` and `innerBorderLeft` CSS classes to the DOM element. This happens
+        // when there is a switch between rendering from 0 to N rows/columns and vice versa).
+        wtOverlays.refreshAll();
+      }
     }
+
+    this.refreshSelections(runFastDraw);
+
     if (syncScroll) {
       wtOverlays.syncScrollWithMaster();
     }

--- a/src/3rdparty/walkontable/test/spec/overlay.spec.js
+++ b/src/3rdparty/walkontable/test/spec/overlay.spec.js
@@ -1,5 +1,4 @@
 describe('WalkontableOverlay', () => {
-
   beforeEach(function() {
     this.$wrapper = $('<div></div>').addClass('handsontable').css({ overflow: 'hidden' });
     this.$wrapper.width(200).height(200);
@@ -8,6 +7,7 @@ describe('WalkontableOverlay', () => {
     this.$wrapper.append(this.$container);
     this.$container.append(this.$table);
     this.$wrapper.appendTo('body');
+
     createDataArray(50, 50);
   });
 
@@ -25,14 +25,85 @@ describe('WalkontableOverlay', () => {
       fixedRowsTop: 2,
       fixedRowsBottom: 2,
     });
+
     wt.draw();
 
+    expect($(wt.wtTable.holder).width()).toBe(200);
+    expect($(wt.wtTable.holder).height()).toBe(200);
+    expect($(wt.wtOverlays.topOverlay.clone.wtTable.holder).width()).toBe(185); // 200px - 15px scrollbar width
     expect($(wt.wtOverlays.topOverlay.clone.wtTable.holder).height()).toBe(47);
-    expect($(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable.holder).height()).toBe(47);
     expect($(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable.holder).width()).toBe(100);
+    expect($(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable.holder).height()).toBe(47);
     expect($(wt.wtOverlays.leftOverlay.clone.wtTable.holder).width()).toBe(100);
-    expect($(wt.wtOverlays.bottomOverlay.clone.wtTable.holder).height()).toBe(47);
+    expect($(wt.wtOverlays.leftOverlay.clone.wtTable.holder).height()).toBe(185);
     expect($(wt.wtOverlays.bottomLeftCornerOverlay.clone.wtTable.holder).width()).toBe(100);
     expect($(wt.wtOverlays.bottomLeftCornerOverlay.clone.wtTable.holder).height()).toBe(47);
+    expect($(wt.wtOverlays.bottomOverlay.clone.wtTable.holder).width()).toBe(185);
+    expect($(wt.wtOverlays.bottomOverlay.clone.wtTable.holder).height()).toBe(47);
+  });
+
+  it('cloned overlays have to have proper positions', () => {
+    createDataArray(5, 5);
+    spec().$wrapper
+      .css('overflow', '')
+      .css('width', '')
+      .css('height', '');
+
+    // When margin is applied, the bottom overlay had a tendency to misalign.
+    $(document.body).css('margin-top', 20);
+
+    const wt = walkontable({
+      data: getData,
+      totalRows: getTotalRows,
+      totalColumns: getTotalColumns,
+      fixedColumnsLeft: 2,
+      fixedRowsTop: 2,
+      fixedRowsBottom: 2,
+    });
+
+    wt.draw();
+
+    const getTableRect = (wtTable) => {
+      const rect = wtTable.holder.getBoundingClientRect();
+
+      return {
+        top: rect.top,
+        bottom: rect.bottom,
+        left: rect.left,
+      };
+    };
+
+    const baseRect = getTableRect(wt.wtTable);
+
+    expect(baseRect).toEqual(jasmine.objectContaining({
+      top: 100,
+      bottom: 216,
+      left: 8,
+    }));
+    expect(getTableRect(wt.wtOverlays.topOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
+      top: 100,
+      bottom: 147,
+      left: 8,
+    }));
+    expect(getTableRect(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
+      top: 100,
+      bottom: 147,
+      left: 8,
+    }));
+    expect(getTableRect(wt.wtOverlays.leftOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
+      top: 100,
+      bottom: 216,
+      left: 8,
+    }));
+    expect(getTableRect(wt.wtOverlays.bottomLeftCornerOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
+      top: 169,
+      bottom: 216,
+      left: 8,
+    }));
+    expect(getTableRect(wt.wtOverlays.bottomOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
+      top: 169,
+      bottom: 216,
+      left: 8,
+    }));
   });
 });

--- a/test/e2e/core/selectAll.spec.js
+++ b/test/e2e/core/selectAll.spec.js
@@ -42,12 +42,8 @@ describe('Core.selectAll', () => {
       | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
       | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
       | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
-      | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
-      | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
-      | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
-      | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
-      | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
       `).toBeMatchToSelectionPattern();
+
     // "Select all" shouldn't scroll te table.
     expect(hot.view.wt.wtTable.holder.scrollTop).toBe(150);
     expect(hot.view.wt.wtTable.holder.scrollLeft).toBe(150);

--- a/test/e2e/settings/fixedColumnsLeft.spec.js
+++ b/test/e2e/settings/fixedColumnsLeft.spec.js
@@ -130,5 +130,56 @@ describe('settings', () => {
         expect(getLeftClone().find('.wtHolder').scrollTop()).toBe(getMaster().find('.wtHolder').scrollTop());
       });
     });
+
+    it('should limit fixed columns to dataset columns length', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(3, 3),
+        fixedColumnsLeft: 3
+      });
+
+      expect(getLeftClone().find('tbody tr:eq(0) td').length).toBe(3);
+
+      updateSettings({
+        data: Handsontable.helper.createSpreadsheetData(3, 2),
+      });
+
+      expect(getLeftClone().find('tbody tr:eq(0) td').length).toBe(2);
+
+      updateSettings({
+        data: Handsontable.helper.createSpreadsheetData(3, 1),
+      });
+
+      expect(getLeftClone().find('tbody tr:eq(0) td').length).toBe(1);
+
+      updateSettings({
+        data: Handsontable.helper.createSpreadsheetData(3, 0),
+      });
+
+      expect(getLeftClone().find('tbody tr:eq(0) td').length).toBe(0);
+
+      updateSettings({
+        data: Handsontable.helper.createSpreadsheetData(3, 1),
+      });
+
+      expect(getLeftClone().find('tbody tr:eq(0) td').length).toBe(1);
+
+      updateSettings({
+        data: Handsontable.helper.createSpreadsheetData(3, 2),
+      });
+
+      expect(getLeftClone().find('tbody tr:eq(0) td').length).toBe(2);
+
+      updateSettings({
+        data: Handsontable.helper.createSpreadsheetData(3, 3),
+      });
+
+      expect(getLeftClone().find('tbody tr:eq(0) td').length).toBe(3);
+
+      updateSettings({
+        data: Handsontable.helper.createSpreadsheetData(3, 4),
+      });
+
+      expect(getLeftClone().find('tbody tr:eq(0) td').length).toBe(3);
+    });
   });
 });

--- a/test/e2e/settings/fixedRowsBottom.spec.js
+++ b/test/e2e/settings/fixedRowsBottom.spec.js
@@ -143,5 +143,83 @@ describe('settings', () => {
 
       expect(getBottomClone().find('tbody tr:eq(0) td:eq(0)').html()).toEqual('test');
     });
+
+    it('should limit fixed rows to dataset rows length', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(3, 3),
+        fixedRowsBottom: 3
+      });
+
+      expect(getBottomClone().find('tbody tr').length).toBe(3);
+
+      updateSettings({
+        data: Handsontable.helper.createSpreadsheetData(2, 3),
+      });
+
+      expect(getBottomClone().find('tbody tr').length).toBe(2);
+
+      updateSettings({
+        data: Handsontable.helper.createSpreadsheetData(1, 3),
+      });
+
+      expect(getBottomClone().find('tbody tr').length).toBe(1);
+
+      updateSettings({
+        data: Handsontable.helper.createSpreadsheetData(0, 3),
+      });
+
+      expect(getBottomClone().find('tbody tr').length).toBe(0);
+
+      updateSettings({
+        data: Handsontable.helper.createSpreadsheetData(1, 3),
+      });
+
+      expect(getBottomClone().find('tbody tr').length).toBe(1);
+
+      updateSettings({
+        data: Handsontable.helper.createSpreadsheetData(2, 3),
+      });
+
+      expect(getBottomClone().find('tbody tr').length).toBe(2);
+
+      updateSettings({
+        data: Handsontable.helper.createSpreadsheetData(3, 3),
+      });
+
+      expect(getBottomClone().find('tbody tr').length).toBe(3);
+
+      updateSettings({
+        data: Handsontable.helper.createSpreadsheetData(4, 3),
+      });
+
+      expect(getBottomClone().find('tbody tr').length).toBe(3);
+    });
+
+    it('should not render column header with doubled border after inserting a new row (#7065)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(0, 0),
+        colHeaders: true,
+        rowHeaders: true,
+        fixedRowsBottom: 3,
+      });
+
+      alter('insert_row', 0);
+
+      expect(getMaster().height()).toBe(50); // 25px corner + 25px added row
+      expect(getTopClone().height()).toBe(26); // 26px as rowHeaders is enabled
+      expect(getTopLeftClone().height()).toBe(26); // 26px as rowHeaders is enabled
+      expect(getLeftClone().height()).toBe(50);
+      expect(getBottomClone().height()).toBe(24);
+      expect(getBottomLeftClone().height()).toBe(24);
+
+      alter('insert_row', 0);
+
+      expect(getMaster().height()).toBe(73);
+      expect(getTopClone().height()).toBe(26);
+      expect(getTopLeftClone().height()).toBe(26);
+      expect(getLeftClone().height()).toBe(73);
+      expect(getBottomClone().height()).toBe(47);
+      expect(getBottomLeftClone().height()).toBe(47);
+    });
   });
 });

--- a/test/e2e/settings/fixedRowsTop.spec.js
+++ b/test/e2e/settings/fixedRowsTop.spec.js
@@ -130,5 +130,81 @@ describe('settings', () => {
         expect(getTopClone().find('.wtHolder').scrollLeft()).toBe(getMaster().find('.wtHolder').scrollLeft());
       });
     });
+
+    it('should limit fixed rows to dataset rows length', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(3, 3),
+        fixedRowsTop: 3
+      });
+
+      expect(getTopClone().find('tbody tr').length).toBe(3);
+
+      updateSettings({
+        data: Handsontable.helper.createSpreadsheetData(2, 3),
+      });
+
+      expect(getTopClone().find('tbody tr').length).toBe(2);
+
+      updateSettings({
+        data: Handsontable.helper.createSpreadsheetData(1, 3),
+      });
+
+      expect(getTopClone().find('tbody tr').length).toBe(1);
+
+      updateSettings({
+        data: Handsontable.helper.createSpreadsheetData(0, 3),
+      });
+
+      expect(getTopClone().find('tbody tr').length).toBe(0);
+
+      updateSettings({
+        data: Handsontable.helper.createSpreadsheetData(1, 3),
+      });
+
+      expect(getTopClone().find('tbody tr').length).toBe(1);
+
+      updateSettings({
+        data: Handsontable.helper.createSpreadsheetData(2, 3),
+      });
+
+      expect(getTopClone().find('tbody tr').length).toBe(2);
+
+      updateSettings({
+        data: Handsontable.helper.createSpreadsheetData(3, 3),
+      });
+
+      expect(getTopClone().find('tbody tr').length).toBe(3);
+
+      updateSettings({
+        data: Handsontable.helper.createSpreadsheetData(4, 3),
+      });
+
+      expect(getTopClone().find('tbody tr').length).toBe(3);
+    });
+
+    it('should not render column header with doubled border after inserting a new row (#7065)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(0, 0),
+        colHeaders: true,
+        rowHeaders: true,
+        fixedRowsTop: 3,
+      });
+
+      alter('insert_row', 0);
+
+      expect(getMaster().height()).toBe(50); // 25px corner + 25px added row
+      expect(getTopClone().height()).toBe(50);
+      expect(getTopLeftClone().height()).toBe(50);
+      expect(getLeftClone().height()).toBe(50);
+      expect(getBottomClone().height()).toBe(0);
+
+      alter('insert_row', 0);
+
+      expect(getMaster().height()).toBe(73);
+      expect(getTopClone().height()).toBe(73);
+      expect(getTopLeftClone().height()).toBe(73);
+      expect(getLeftClone().height()).toBe(73);
+      expect(getBottomClone().height()).toBe(0);
+    });
   });
 });


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
I adjusted when and how the `innerBorderTop` CSS class is added or removed. When the value of the `fixedRowsTop` and `fixedRowsBottom` option is changed, the overlay is now readjusted and selection refreshed.

I've changed how the `getBoundingClientRect` method is used ([diff-813dfa5a5cc245cd80f1c514f9d74f71L78](https://github.com/handsontable/handsontable/pull/7075/files#diff-813dfa5a5cc245cd80f1c514f9d74f71L78)).  The method calculates the body size including its margin and padding where in conjunction with `body.offsetHeight` (which doesn't includes margin) causes wrong calculations and overlays shifts.

Broken demo `8.0.0-beta.2-rev17` https://jsfiddle.net/budnix/dey1nLv5/. After this PR the bottom rows overlay (red border) is synced with the master table:
![Zrzut ekranu 2020-07-6 o 13 31 35](https://user-images.githubusercontent.com/571316/86589081-3fce4c80-bf8d-11ea-93ba-562a17b1db10.png)

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7065
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
