### PR TITLE
Adjust the context menu items the inability state

### DIFF
--- a/src/plugins/contextMenu/predefinedItems/columnLeft.js
+++ b/src/plugins/contextMenu/predefinedItems/columnLeft.js
@@ -16,10 +16,7 @@ export default function columnLeftItem() {
       const isSelectedByCorner = this.selection.isSelectedByCorner();
       let columnLeft = 0;
 
-      if (isSelectedByCorner) {
-        columnLeft = 0;
-
-      } else {
+      if (!isSelectedByCorner) {
         const latestSelection = normalizedSelection[Math.max(normalizedSelection.length - 1, 0)];
 
         columnLeft = latestSelection.start.col;

--- a/src/plugins/contextMenu/predefinedItems/columnLeft.js
+++ b/src/plugins/contextMenu/predefinedItems/columnLeft.js
@@ -13,9 +13,23 @@ export default function columnLeftItem() {
       return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_INSERT_LEFT);
     },
     callback(key, normalizedSelection) {
-      const latestSelection = normalizedSelection[Math.max(normalizedSelection.length - 1, 0)];
+      const isSelectedByCorner = this.selection.isSelectedByCorner();
+      let columnLeft = 0;
 
-      this.alter('insert_col', latestSelection.start.col, 1, 'ContextMenu.columnLeft');
+      if (isSelectedByCorner) {
+        columnLeft = 0;
+
+      } else {
+        const latestSelection = normalizedSelection[Math.max(normalizedSelection.length - 1, 0)];
+
+        columnLeft = latestSelection.start.col;
+      }
+
+      this.alter('insert_col', columnLeft, 1, 'ContextMenu.columnLeft');
+
+      if (isSelectedByCorner) {
+        this.selectAll();
+      }
     },
     disabled() {
       if (!this.isColumnModificationAllowed()) {
@@ -28,8 +42,14 @@ export default function columnLeftItem() {
         return true;
       }
 
+      if (this.selection.isSelectedByCorner()) {
+        const totalColumns = this.countCols();
+
+        // Enable "Insert column left" only when there is at least one column.
+        return totalColumns === 0;
+      }
+
       return this.selection.isSelectedByRowHeader() ||
-        this.selection.isSelectedByCorner() ||
         this.countCols() >= this.getSettings().maxCols;
     },
     hidden() {

--- a/src/plugins/contextMenu/predefinedItems/columnRight.js
+++ b/src/plugins/contextMenu/predefinedItems/columnRight.js
@@ -14,24 +14,26 @@ export default function columnRightItem() {
       return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_INSERT_RIGHT);
     },
     callback(key, normalizedSelection) {
-      const latestSelection = normalizedSelection[Math.max(normalizedSelection.length - 1, 0)];
-      const selectedColumn = latestSelection?.end?.col;
-      // If there is no selection we have clicked on the corner and there is no data.
-      const columnRight = isDefined(selectedColumn) ? selectedColumn + 1 : 0;
+      const isSelectedByCorner = this.selection.isSelectedByCorner();
+      let columnRight = 0;
+
+      if (!isSelectedByCorner) {
+        const latestSelection = normalizedSelection[Math.max(normalizedSelection.length - 1, 0)];
+        const selectedColumn = latestSelection?.end?.col;
+
+        // If there is no selection we have clicked on the corner and there is no data.
+        columnRight = isDefined(selectedColumn) ? selectedColumn + 1 : 0;
+      }
 
       this.alter('insert_col', columnRight, 1, 'ContextMenu.columnRight');
+
+      if (isSelectedByCorner) {
+        this.selectAll();
+      }
     },
     disabled() {
       if (!this.isColumnModificationAllowed()) {
         return true;
-      }
-
-      const anyCellVisible = this.countRows() > 0 && this.countCols() > 0;
-
-      // There is no selection, because we have clicked on the corner and there is no data
-      // (click on the corner by default selects all cells, but there are no cells).
-      if (!anyCellVisible) {
-        return false;
       }
 
       const selected = getValidSelection(this);
@@ -40,8 +42,11 @@ export default function columnRightItem() {
         return true;
       }
 
+      if (this.selection.isSelectedByCorner()) {
+        return false;
+      }
+
       return this.selection.isSelectedByRowHeader() ||
-        this.selection.isSelectedByCorner() ||
         this.countCols() >= this.getSettings().maxCols;
     },
     hidden() {

--- a/src/plugins/contextMenu/predefinedItems/columnRight.js
+++ b/src/plugins/contextMenu/predefinedItems/columnRight.js
@@ -17,7 +17,10 @@ export default function columnRightItem() {
       const isSelectedByCorner = this.selection.isSelectedByCorner();
       let columnRight = 0;
 
-      if (!isSelectedByCorner) {
+      if (isSelectedByCorner) {
+        columnRight = this.countCols();
+
+      } else {
         const latestSelection = normalizedSelection[Math.max(normalizedSelection.length - 1, 0)];
         const selectedColumn = latestSelection?.end?.col;
 
@@ -43,6 +46,7 @@ export default function columnRightItem() {
       }
 
       if (this.selection.isSelectedByCorner()) {
+        // Enable "Insert column right" always when the menu is triggered by corner click.
         return false;
       }
 

--- a/src/plugins/contextMenu/predefinedItems/removeColumn.js
+++ b/src/plugins/contextMenu/predefinedItems/removeColumn.js
@@ -34,14 +34,21 @@ export default function removeColumnItem() {
     },
     disabled() {
       const selected = getValidSelection(this);
-      const totalColumns = this.countCols();
 
       if (!selected) {
         return true;
       }
 
-      return this.selection.isSelectedByRowHeader() || this.selection.isSelectedByCorner() ||
-             !this.isColumnModificationAllowed() || !totalColumns;
+      const totalColumns = this.countCols();
+
+      if (this.selection.isSelectedByCorner()) {
+        // Enable "Remove column" only when there is at least one column.
+        return totalColumns === 0;
+      }
+
+      return this.selection.isSelectedByRowHeader() ||
+        !this.isColumnModificationAllowed() ||
+        totalColumns === 0;
     },
     hidden() {
       return !this.getSettings().allowRemoveColumn;

--- a/src/plugins/contextMenu/predefinedItems/removeRow.js
+++ b/src/plugins/contextMenu/predefinedItems/removeRow.js
@@ -35,13 +35,19 @@ export default function removeRowItem() {
     },
     disabled() {
       const selected = getValidSelection(this);
-      const totalRows = this.countRows();
 
       if (!selected) {
         return true;
       }
 
-      return this.selection.isSelectedByColumnHeader() || this.selection.isSelectedByCorner() || !totalRows;
+      const totalRows = this.countRows();
+
+      if (this.selection.isSelectedByCorner()) {
+        // Enable "Remove row" only when there is at least one row.
+        return totalRows === 0;
+      }
+
+      return this.selection.isSelectedByColumnHeader() || totalRows === 0;
     },
     hidden() {
       return !this.getSettings().allowRemoveRow;

--- a/src/plugins/contextMenu/predefinedItems/rowAbove.js
+++ b/src/plugins/contextMenu/predefinedItems/rowAbove.js
@@ -13,9 +13,23 @@ export default function rowAboveItem() {
       return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_ROW_ABOVE);
     },
     callback(key, normalizedSelection) {
-      const latestSelection = normalizedSelection[Math.max(normalizedSelection.length - 1, 0)];
+      const isSelectedByCorner = this.selection.isSelectedByCorner();
+      let rowAbove = 0;
 
-      this.alter('insert_row', latestSelection.start.row, 1, 'ContextMenu.rowAbove');
+      if (isSelectedByCorner) {
+        rowAbove = 0;
+
+      } else {
+        const latestSelection = normalizedSelection[Math.max(normalizedSelection.length - 1, 0)];
+
+        rowAbove = latestSelection.start.row;
+      }
+
+      this.alter('insert_row', rowAbove, 1, 'ContextMenu.rowAbove');
+
+      if (isSelectedByCorner) {
+        this.selectAll();
+      }
     },
     disabled() {
       const selected = getValidSelection(this);
@@ -24,8 +38,14 @@ export default function rowAboveItem() {
         return true;
       }
 
+      if (this.selection.isSelectedByCorner()) {
+        const totalRows = this.countRows();
+
+        // Enable "Insert row above" only when there is at least one row.
+        return totalRows === 0;
+      }
+
       return this.selection.isSelectedByColumnHeader() ||
-        this.selection.isSelectedByCorner() ||
         this.countRows() >= this.getSettings().maxRows;
     },
     hidden() {

--- a/src/plugins/contextMenu/predefinedItems/rowAbove.js
+++ b/src/plugins/contextMenu/predefinedItems/rowAbove.js
@@ -16,10 +16,7 @@ export default function rowAboveItem() {
       const isSelectedByCorner = this.selection.isSelectedByCorner();
       let rowAbove = 0;
 
-      if (isSelectedByCorner) {
-        rowAbove = 0;
-
-      } else {
+      if (!isSelectedByCorner) {
         const latestSelection = normalizedSelection[Math.max(normalizedSelection.length - 1, 0)];
 
         rowAbove = latestSelection.start.row;

--- a/src/plugins/contextMenu/predefinedItems/rowBelow.js
+++ b/src/plugins/contextMenu/predefinedItems/rowBelow.js
@@ -17,7 +17,10 @@ export default function rowBelowItem() {
       const isSelectedByCorner = this.selection.isSelectedByCorner();
       let rowBelow = 0;
 
-      if (!this.selection.isSelectedByCorner()) {
+      if (isSelectedByCorner) {
+        rowBelow = this.countRows();
+
+      } else {
         const latestSelection = normalizedSelection[Math.max(normalizedSelection.length - 1, 0)];
         const selectedRow = latestSelection?.end?.row;
 
@@ -39,6 +42,7 @@ export default function rowBelowItem() {
       }
 
       if (this.selection.isSelectedByCorner()) {
+        // Enable "Insert row below" always when the menu is triggered by corner click.
         return false;
       }
 

--- a/src/plugins/contextMenu/predefinedItems/rowBelow.js
+++ b/src/plugins/contextMenu/predefinedItems/rowBelow.js
@@ -14,29 +14,35 @@ export default function rowBelowItem() {
       return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_ROW_BELOW);
     },
     callback(key, normalizedSelection) {
-      const latestSelection = normalizedSelection[Math.max(normalizedSelection.length - 1, 0)];
-      const selectedRow = latestSelection?.end?.row;
-      // If there is no selection we have clicked on the corner and there is no data.
-      const rowBelow = isDefined(selectedRow) ? selectedRow + 1 : 0;
+      const isSelectedByCorner = this.selection.isSelectedByCorner();
+      let rowBelow = 0;
+
+      if (!this.selection.isSelectedByCorner()) {
+        const latestSelection = normalizedSelection[Math.max(normalizedSelection.length - 1, 0)];
+        const selectedRow = latestSelection?.end?.row;
+
+        // If there is no selection we have clicked on the corner and there is no data.
+        rowBelow = isDefined(selectedRow) ? selectedRow + 1 : 0;
+      }
 
       this.alter('insert_row', rowBelow, 1, 'ContextMenu.rowBelow');
+
+      if (isSelectedByCorner) {
+        this.selectAll();
+      }
     },
     disabled() {
       const selected = getValidSelection(this);
-      const anyCellVisible = this.countRows() > 0 && this.countCols() > 0;
-
-      // There is no selection, because we have clicked on the corner and there is no data (click on the corner by
-      // default select all cells, but there are no cells).
-      if (!anyCellVisible) {
-        return false;
-      }
 
       if (!selected) {
         return true;
       }
 
+      if (this.selection.isSelectedByCorner()) {
+        return false;
+      }
+
       return this.selection.isSelectedByColumnHeader() ||
-        this.selection.isSelectedByCorner() ||
         this.countRows() >= this.getSettings().maxRows;
     },
     hidden() {

--- a/src/plugins/contextMenu/test/contextMenu.e2e.js
+++ b/src/plugins/contextMenu/test/contextMenu.e2e.js
@@ -1199,10 +1199,6 @@ describe('ContextMenu', () => {
       contextMenu(corner);
 
       expect($('.htContextMenu tbody td.htDisabled').text()).toBe([
-        'Insert row above',
-        'Insert column left',
-        'Remove rows',
-        'Remove columns',
         'Undo',
         'Redo',
         'Read only',

--- a/src/plugins/contextMenu/test/contextMenu.e2e.js
+++ b/src/plugins/contextMenu/test/contextMenu.e2e.js
@@ -1200,9 +1200,7 @@ describe('ContextMenu', () => {
 
       expect($('.htContextMenu tbody td.htDisabled').text()).toBe([
         'Insert row above',
-        'Insert row below',
         'Insert column left',
-        'Insert column right',
         'Remove rows',
         'Remove columns',
         'Undo',

--- a/src/plugins/contextMenu/test/predefinedItems/insertColumnLeft.e2e.js
+++ b/src/plugins/contextMenu/test/predefinedItems/insertColumnLeft.e2e.js
@@ -13,49 +13,15 @@ describe('ContextMenu', () => {
   });
 
   describe('insert column left', () => {
-    it('should insert column on the left through column header when all rows are trimmed', () => {
-      handsontable({
-        data: createSpreadsheetData(5, 5),
-        colHeaders: [1, 2, 3, 4, 5],
-        contextMenu: true,
-        trimRows: [0, 1, 2, 3, 4], // The TrimmingMap should be used instead of the plugin.
-      });
-
-      contextMenu(getCell(-1, 1));
-
-      {
-        const item = $('.htContextMenu .ht_master .htCore tbody')
-          .find('td')
-          .not('.htSeparator')
-          .eq(2); // "Insert column left"
-
-        simulateClick(item);
-      }
-
-      expect(getColHeader()).toEqual([1, 'B', 2, 3, 4, 5]);
-
-      contextMenu(getCell(-1, 5));
-
-      {
-        const item = $('.htContextMenu .ht_master .htCore tbody')
-          .find('td')
-          .not('.htSeparator')
-          .eq(2); // "Insert column left"
-
-        simulateClick(item);
-      }
-
-      expect(getColHeader()).toEqual([1, 'B', 2, 3, 4, 'F', 5]);
-    });
-
     it('should insert column on the left of the clicked column header', () => {
       handsontable({
         data: createSpreadsheetData(5, 5),
         colHeaders: true,
+        rowHeaders: true,
         contextMenu: true,
       });
 
-      contextMenu(getCell(-1, 1));
+      contextMenu(getCell(-1, 1, true));
 
       const item = $('.htContextMenu .ht_master .htCore tbody')
         .find('td')
@@ -64,13 +30,216 @@ describe('ContextMenu', () => {
 
       simulateClick(item);
 
+      expect(item.hasClass('htDisabled')).toBe(false);
       expect(getDataAtRow(0)).toEqual(['A1', null, 'B1', 'C1', 'D1', 'E1']);
+      expect(`
+        |   ║   :   : * :   :   :   |
+        |===:===:===:===:===:===:===|
+        | - ║   :   : A :   :   :   |
+        | - ║   :   : 0 :   :   :   |
+        | - ║   :   : 0 :   :   :   |
+        | - ║   :   : 0 :   :   :   |
+        | - ║   :   : 0 :   :   :   |
+        `).toBeMatchToSelectionPattern();
+    });
+
+    it('should not insert column when the menu is triggered by row header for object-based dataset', () => {
+      handsontable({
+        data: createSpreadsheetObjectData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(-1, 1, true));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(2); // "Insert column left"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(true);
+      expect(getDataAtRow(0)).toEqual(['A1', 'B1', 'C1', 'D1', 'E1']);
+      expect(`
+        |   ║   : * :   :   :   |
+        |===:===:===:===:===:===|
+        | - ║   : A :   :   :   |
+        | - ║   : 0 :   :   :   |
+        | - ║   : 0 :   :   :   |
+        | - ║   : 0 :   :   :   |
+        | - ║   : 0 :   :   :   |
+        `).toBeMatchToSelectionPattern();
+    });
+
+    it('should not insert column when the menu is triggered by row header', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(1, -1, true));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(2); // "Insert column left"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(true);
+      expect(getDataAtRow(0)).toEqual(['A1', 'B1', 'C1', 'D1', 'E1']);
+    });
+
+    it('should insert column on the left when the menu is triggered by corner', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(-1, -1, true));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(2); // "Insert column left"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(false);
+      expect(getDataAtRow(0)).toEqual([null, 'A1', 'B1', 'C1', 'D1', 'E1']);
+      expect(`
+        |   ║ * : * : * : * : * : * |
+        |===:===:===:===:===:===:===|
+        | * ║ A : 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
+        `).toBeMatchToSelectionPattern();
+    });
+
+    it('should not insert column when the menu is triggered by corner for object-based dataset', () => {
+      handsontable({
+        data: createSpreadsheetObjectData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(-1, -1, true));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(2); // "Insert column left"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(true);
+      expect(getDataAtRow(0)).toEqual(['A1', 'B1', 'C1', 'D1', 'E1']);
+      expect(`
+        |   ║ * : * : * : * : * |
+        |===:===:===:===:===:===|
+        | * ║ A : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 |
+        `).toBeMatchToSelectionPattern();
+    });
+
+    it('should insert column on the left when the menu is triggered by corner and all rows are trimmed', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: [1, 2, 3, 4, 5],
+        rowHeaders: true,
+        contextMenu: true,
+        trimRows: [0, 1, 2, 3, 4],
+      });
+
+      contextMenu(getCell(-1, -1, true));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(2); // "Insert column left"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(false);
+      expect(getColHeader()).toEqual(['A', 1, 2, 3, 4, 5]);
+      expect(`
+        |   ║ - : - : - : - : - : - |
+        |===:===:===:===:===:===:===|
+        `).toBeMatchToSelectionPattern();
+    });
+
+    it('should not insert column on the left when the menu is triggered by corner and all columns are trimmed', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 0),
+        dataSchema: [], // Unlocks adding new rows through the context menu.
+        colHeaders: true,
+        rowHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(-1, -1, true));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(2); // "Insert column left"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(true);
+      expect(`
+        |   |
+        |===|
+        | - |
+        | - |
+        | - |
+        | - |
+        | - |
+        `).toBeMatchToSelectionPattern();
+    });
+
+    it('should not insert column on the left when the menu is triggered by corner and dataset is empty', () => {
+      handsontable({
+        data: createSpreadsheetData(0, 0),
+        dataSchema: [], // Unlocks adding new rows through the context menu.
+        colHeaders: true,
+        rowHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(-1, -1, true));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(2); // "Insert column left"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(true);
+      expect(`
+        |   |
+        |===|
+        `).toBeMatchToSelectionPattern();
     });
 
     it('should insert column on the left of the clicked cell', () => {
       handsontable({
         data: createSpreadsheetData(5, 5),
         colHeaders: true,
+        rowHeaders: true,
         contextMenu: true,
       });
 
@@ -83,13 +252,23 @@ describe('ContextMenu', () => {
 
       simulateClick(item);
 
+      expect(item.hasClass('htDisabled')).toBe(false);
       expect(getDataAtRow(0)).toEqual(['A1', null, 'B1', 'C1', 'D1', 'E1']);
+      expect(`
+        |   ║   :   : - :   :   :   |
+        |===:===:===:===:===:===:===|
+        |   ║   :   :   :   :   :   |
+        | - ║   :   : # :   :   :   |
+        |   ║   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   |
+        `).toBeMatchToSelectionPattern();
     });
 
     describe('UI', () => {
       it('should display a disabled entry, when there\'s nothing selected', () => {
         handsontable({
-          data: Handsontable.helper.createSpreadsheetData(4, 4),
+          data: createSpreadsheetData(4, 4),
           contextMenu: true,
           height: 100,
           beforeContextMenuShow() {
@@ -98,63 +277,6 @@ describe('ContextMenu', () => {
         });
 
         contextMenu();
-
-        const item = $('.htContextMenu .ht_master .htCore tbody')
-          .find('td')
-          .not('.htSeparator')
-          .eq(2); // "Insert column left"
-
-        expect(item.hasClass('htDisabled')).toBe(true);
-      });
-
-      it('should display a disabled entry, when clicking on a row header', () => {
-        handsontable({
-          data: Handsontable.helper.createSpreadsheetData(4, 4),
-          contextMenu: true,
-          height: 100,
-          colHeaders: true,
-          rowHeaders: true
-        });
-
-        contextMenu(spec().$container.find('.ht_clone_left tbody tr').eq(0).find('th').eq(0));
-
-        const item = $('.htContextMenu .ht_master .htCore tbody')
-          .find('td')
-          .not('.htSeparator')
-          .eq(2); // "Insert column left"
-
-        expect(item.hasClass('htDisabled')).toBe(true);
-      });
-
-      it('should display a disabled entry, when clicking on a corner header', () => {
-        handsontable({
-          data: Handsontable.helper.createSpreadsheetData(4, 4),
-          contextMenu: true,
-          height: 100,
-          colHeaders: true,
-          rowHeaders: true
-        });
-
-        contextMenu(spec().$container.find('.ht_clone_top_left_corner thead th').eq(0));
-
-        const item = $('.htContextMenu .ht_master .htCore tbody')
-          .find('td')
-          .not('.htSeparator')
-          .eq(2); // "Insert column left"
-
-        expect(item.hasClass('htDisabled')).toBe(true);
-      });
-
-      it('should display a disabled entry, when clicking on a corner header when there are no cells visible', () => {
-        handsontable({
-          data: Handsontable.helper.createSpreadsheetData(0, 0),
-          contextMenu: true,
-          height: 100,
-          colHeaders: true,
-          rowHeaders: true,
-        });
-
-        contextMenu(spec().$container.find('.ht_clone_top_left_corner thead th').eq(0));
 
         const item = $('.htContextMenu .ht_master .htCore tbody')
           .find('td')

--- a/src/plugins/contextMenu/test/predefinedItems/insertColumnLeft.e2e.js
+++ b/src/plugins/contextMenu/test/predefinedItems/insertColumnLeft.e2e.js
@@ -48,6 +48,44 @@ describe('ContextMenu', () => {
       expect(getColHeader()).toEqual([1, 'B', 2, 3, 4, 'F', 5]);
     });
 
+    it('should insert column on the left of the clicked column header', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(-1, 1));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(2); // "Insert column left"
+
+      simulateClick(item);
+
+      expect(getDataAtRow(0)).toEqual(['A1', null, 'B1', 'C1', 'D1', 'E1']);
+    });
+
+    it('should insert column on the left of the clicked cell', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(1, 1));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(2); // "Insert column left"
+
+      simulateClick(item);
+
+      expect(getDataAtRow(0)).toEqual(['A1', null, 'B1', 'C1', 'D1', 'E1']);
+    });
+
     describe('UI', () => {
       it('should display a disabled entry, when there\'s nothing selected', () => {
         handsontable({
@@ -65,8 +103,6 @@ describe('ContextMenu', () => {
           .find('td')
           .not('.htSeparator')
           .eq(2); // "Insert column left"
-
-        simulateClick(item);
 
         expect(item.hasClass('htDisabled')).toBe(true);
       });
@@ -87,8 +123,6 @@ describe('ContextMenu', () => {
           .not('.htSeparator')
           .eq(2); // "Insert column left"
 
-        simulateClick(item);
-
         expect(item.hasClass('htDisabled')).toBe(true);
       });
 
@@ -108,7 +142,24 @@ describe('ContextMenu', () => {
           .not('.htSeparator')
           .eq(2); // "Insert column left"
 
-        simulateClick(item);
+        expect(item.hasClass('htDisabled')).toBe(true);
+      });
+
+      it('should display a disabled entry, when clicking on a corner header when there are no cells visible', () => {
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(0, 0),
+          contextMenu: true,
+          height: 100,
+          colHeaders: true,
+          rowHeaders: true,
+        });
+
+        contextMenu(spec().$container.find('.ht_clone_top_left_corner thead th').eq(0));
+
+        const item = $('.htContextMenu .ht_master .htCore tbody')
+          .find('td')
+          .not('.htSeparator')
+          .eq(2); // "Insert column left"
 
         expect(item.hasClass('htDisabled')).toBe(true);
       });

--- a/src/plugins/contextMenu/test/predefinedItems/insertColumnRight.e2e.js
+++ b/src/plugins/contextMenu/test/predefinedItems/insertColumnRight.e2e.js
@@ -66,8 +66,74 @@ describe('ContextMenu', () => {
 
       simulateClick(item);
 
-      // The new column will be placed at the very end, because clicking the corner header selects all cells.
-      expect(getColHeader()).toEqual([1, 2, 3, 4, 5, 'F']);
+      expect(getColHeader()).toEqual(['A', 1, 2, 3, 4, 5]);
+    });
+
+    it('should insert column on the right of the clicked column header', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(-1, 1));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(3); // "Insert column right"
+
+      simulateClick(item);
+
+      expect(getDataAtRow(0)).toEqual(['A1', 'B1', null, 'C1', 'D1', 'E1']);
+    });
+
+    it('should insert column on the right of the clicked cell', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(1, 1));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(3); // "Insert column right"
+
+      simulateClick(item);
+
+      expect(getDataAtRow(0)).toEqual(['A1', 'B1', null, 'C1', 'D1', 'E1']);
+    });
+
+    it('should insert column on the right of the clicked corner', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(-1, -1));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(3); // "Insert column right"
+
+      simulateClick(item);
+
+      expect(getDataAtRow(0)).toEqual([null, 'A1', 'B1', 'C1', 'D1', 'E1']);
+      expect(`
+        |   ║ * : * : * : * : * : * |
+        |===:===:===:===:===:===:===|
+        | * ║ A : 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
+        `).toBeMatchToSelectionPattern();
     });
 
     describe('UI', () => {
@@ -88,8 +154,6 @@ describe('ContextMenu', () => {
           .not('.htSeparator')
           .eq(3); // "Insert column right"
 
-        simulateClick(item);
-
         expect(item.hasClass('htDisabled')).toBe(true);
       });
 
@@ -109,12 +173,10 @@ describe('ContextMenu', () => {
           .not('.htSeparator')
           .eq(3); // "Insert column right"
 
-        simulateClick(item);
-
         expect(item.hasClass('htDisabled')).toBe(true);
       });
 
-      it('should display a disabled entry, when clicking on a corner header', () => {
+      it('should display an enabled entry, when clicking on a corner header', () => {
         handsontable({
           data: Handsontable.helper.createSpreadsheetData(4, 4),
           contextMenu: true,
@@ -130,19 +192,17 @@ describe('ContextMenu', () => {
           .not('.htSeparator')
           .eq(3); // "Insert column right"
 
-        simulateClick(item);
-
-        expect(item.hasClass('htDisabled')).toBe(true);
+        expect(item.hasClass('htDisabled')).toBe(false);
       });
 
-      it('should display an entry, when clicking on a corner header when all rows are trimmed', () => {
+      it('should display an enabled entry, when clicking on a corner header when there are no cells visible', () => {
         handsontable({
-          data: Handsontable.helper.createSpreadsheetData(4, 4),
+          data: Handsontable.helper.createSpreadsheetData(0, 0),
           contextMenu: true,
           height: 100,
           colHeaders: true,
           rowHeaders: true,
-          trimRows: [0, 1, 2, 3], // The TrimmingMap should be used instead of the plugin.
+          dataSchema: [],
         });
 
         contextMenu(spec().$container.find('.ht_clone_top_left_corner thead th').eq(0));
@@ -151,8 +211,6 @@ describe('ContextMenu', () => {
           .find('td')
           .not('.htSeparator')
           .eq(3); // "Insert column right"
-
-        simulateClick(item);
 
         expect(item.hasClass('htDisabled')).toBe(false);
       });

--- a/src/plugins/contextMenu/test/predefinedItems/insertColumnRight.e2e.js
+++ b/src/plugins/contextMenu/test/predefinedItems/insertColumnRight.e2e.js
@@ -13,51 +13,148 @@ describe('ContextMenu', () => {
   });
 
   describe('insert column right', () => {
-    it('should insert column on the right through column header when all rows are trimmed', () => {
+    it('should insert column on the right of the clicked column header', () => {
       handsontable({
         data: createSpreadsheetData(5, 5),
-        colHeaders: [1, 2, 3, 4, 5],
+        colHeaders: true,
+        rowHeaders: true,
         contextMenu: true,
-        trimRows: [0, 1, 2, 3, 4], // The TrimmingMap should be used instead of the plugin.
       });
 
-      contextMenu(getCell(-1, 1));
+      contextMenu(getCell(-1, 1, true));
 
-      {
-        const item = $('.htContextMenu .ht_master .htCore tbody')
-          .find('td')
-          .not('.htSeparator')
-          .eq(3); // "Insert column right"
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(3); // "Insert column right"
 
-        simulateClick(item);
-      }
+      simulateClick(item);
 
-      expect(getColHeader()).toEqual([1, 2, 'C', 3, 4, 5]);
-
-      contextMenu(getCell(-1, 5));
-
-      {
-        const item = $('.htContextMenu .ht_master .htCore tbody')
-          .find('td')
-          .not('.htSeparator')
-          .eq(3); // "Insert column right"
-
-        simulateClick(item);
-      }
-
-      expect(getColHeader()).toEqual([1, 2, 'C', 3, 4, 5, 'G']);
+      expect(item.hasClass('htDisabled')).toBe(false);
+      expect(getDataAtRow(0)).toEqual(['A1', 'B1', null, 'C1', 'D1', 'E1']);
+      expect(`
+        |   ║   : * :   :   :   :   |
+        |===:===:===:===:===:===:===|
+        | - ║   : A :   :   :   :   |
+        | - ║   : 0 :   :   :   :   |
+        | - ║   : 0 :   :   :   :   |
+        | - ║   : 0 :   :   :   :   |
+        | - ║   : 0 :   :   :   :   |
+        `).toBeMatchToSelectionPattern();
     });
 
-    it('should insert column on the right through corner header when all rows are trimmed', () => {
+    it('should not insert column when the menu is triggered by row header', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(1, -1, true));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(3); // "Insert column right"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(true);
+      expect(getDataAtRow(0)).toEqual(['A1', 'B1', 'C1', 'D1', 'E1']);
+    });
+
+    it('should not insert column when the menu is triggered by row header for object-based dataset', () => {
+      handsontable({
+        data: createSpreadsheetObjectData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(1, -1, true));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(3); // "Insert column right"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(true);
+      expect(getDataAtRow(0)).toEqual(['A1', 'B1', 'C1', 'D1', 'E1']);
+    });
+
+    it('should insert column on the right when the menu is triggered by corner', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(-1, -1, true));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(3); // "Insert column right"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(false);
+      expect(getDataAtRow(0)).toEqual(['A1', 'B1', 'C1', 'D1', 'E1', null]);
+      expect(`
+        |   ║ * : * : * : * : * : * |
+        |===:===:===:===:===:===:===|
+        | * ║ A : 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
+        `).toBeMatchToSelectionPattern();
+    });
+
+    it('should not insert column when the menu is triggered by corner for object-based dataset', () => {
+      handsontable({
+        data: createSpreadsheetObjectData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(-1, -1, true));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(3); // "Insert column right"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(true);
+      expect(getDataAtRow(0)).toEqual(['A1', 'B1', 'C1', 'D1', 'E1']);
+      expect(`
+        |   ║ * : * : * : * : * |
+        |===:===:===:===:===:===|
+        | * ║ A : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 |
+        `).toBeMatchToSelectionPattern();
+    });
+
+    it('should insert column on the right when the menu is triggered by corner and all rows are trimmed', () => {
       handsontable({
         data: createSpreadsheetData(5, 5),
         colHeaders: [1, 2, 3, 4, 5],
         rowHeaders: true,
         contextMenu: true,
-        trimRows: [0, 1, 2, 3, 4], // The TrimmingMap should be used instead of the plugin.
+        trimRows: [0, 1, 2, 3, 4],
       });
 
-      contextMenu(getCell(-1, -1));
+      contextMenu(getCell(-1, -1, true));
 
       const item = $('.htContextMenu .ht_master .htCore tbody')
         .find('td')
@@ -66,17 +163,24 @@ describe('ContextMenu', () => {
 
       simulateClick(item);
 
-      expect(getColHeader()).toEqual(['A', 1, 2, 3, 4, 5]);
+      expect(item.hasClass('htDisabled')).toBe(false);
+      expect(getColHeader()).toEqual([1, 2, 3, 4, 5, 'F']);
+      expect(`
+        |   ║ - : - : - : - : - : - |
+        |===:===:===:===:===:===:===|
+        `).toBeMatchToSelectionPattern();
     });
 
-    it('should insert column on the right of the clicked column header', () => {
+    it('should insert column on the right when the menu is triggered by corner and all columns are trimmed', () => {
       handsontable({
-        data: createSpreadsheetData(5, 5),
+        data: createSpreadsheetData(5, 0),
+        dataSchema: [], // Unlocks adding new rows through the context menu.
         colHeaders: true,
+        rowHeaders: true,
         contextMenu: true,
       });
 
-      contextMenu(getCell(-1, 1));
+      contextMenu(getCell(-1, -1, true));
 
       const item = $('.htContextMenu .ht_master .htCore tbody')
         .find('td')
@@ -85,13 +189,48 @@ describe('ContextMenu', () => {
 
       simulateClick(item);
 
-      expect(getDataAtRow(0)).toEqual(['A1', 'B1', null, 'C1', 'D1', 'E1']);
+      expect(item.hasClass('htDisabled')).toBe(false);
+      expect(`
+        |   ║ * |
+        |===:===|
+        | * ║ A |
+        | * ║ 0 |
+        | * ║ 0 |
+        | * ║ 0 |
+        | * ║ 0 |
+        `).toBeMatchToSelectionPattern();
+    });
+
+    it('should insert column on the right when the menu is triggered by corner and dataset is empty', () => {
+      handsontable({
+        data: createSpreadsheetData(0, 0),
+        dataSchema: [], // Unlocks adding new rows through the context menu.
+        colHeaders: true,
+        rowHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(-1, -1, true));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(3); // "Insert column right"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(false);
+      expect(`
+        |   ║ - |
+        |===:===|
+        `).toBeMatchToSelectionPattern();
     });
 
     it('should insert column on the right of the clicked cell', () => {
       handsontable({
         data: createSpreadsheetData(5, 5),
         colHeaders: true,
+        rowHeaders: true,
         contextMenu: true,
       });
 
@@ -104,42 +243,23 @@ describe('ContextMenu', () => {
 
       simulateClick(item);
 
+      expect(item.hasClass('htDisabled')).toBe(false);
       expect(getDataAtRow(0)).toEqual(['A1', 'B1', null, 'C1', 'D1', 'E1']);
-    });
-
-    it('should insert column on the right of the clicked corner', () => {
-      handsontable({
-        data: createSpreadsheetData(5, 5),
-        rowHeaders: true,
-        colHeaders: true,
-        contextMenu: true,
-      });
-
-      contextMenu(getCell(-1, -1));
-
-      const item = $('.htContextMenu .ht_master .htCore tbody')
-        .find('td')
-        .not('.htSeparator')
-        .eq(3); // "Insert column right"
-
-      simulateClick(item);
-
-      expect(getDataAtRow(0)).toEqual([null, 'A1', 'B1', 'C1', 'D1', 'E1']);
       expect(`
-        |   ║ * : * : * : * : * : * |
+        |   ║   : - :   :   :   :   |
         |===:===:===:===:===:===:===|
-        | * ║ A : 0 : 0 : 0 : 0 : 0 |
-        | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
-        | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
-        | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
-        | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
+        |   ║   :   :   :   :   :   |
+        | - ║   : # :   :   :   :   |
+        |   ║   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   |
         `).toBeMatchToSelectionPattern();
     });
 
     describe('UI', () => {
       it('should display a disabled entry, when there\'s nothing selected', () => {
         handsontable({
-          data: Handsontable.helper.createSpreadsheetData(4, 4),
+          data: createSpreadsheetData(4, 4),
           contextMenu: true,
           height: 100,
           beforeContextMenuShow() {
@@ -155,64 +275,6 @@ describe('ContextMenu', () => {
           .eq(3); // "Insert column right"
 
         expect(item.hasClass('htDisabled')).toBe(true);
-      });
-
-      it('should display a disabled entry, when clicking on a row header', () => {
-        handsontable({
-          data: Handsontable.helper.createSpreadsheetData(4, 4),
-          contextMenu: true,
-          height: 100,
-          colHeaders: true,
-          rowHeaders: true
-        });
-
-        contextMenu(spec().$container.find('.ht_clone_left tbody tr').eq(0).find('th').eq(0));
-
-        const item = $('.htContextMenu .ht_master .htCore tbody')
-          .find('td')
-          .not('.htSeparator')
-          .eq(3); // "Insert column right"
-
-        expect(item.hasClass('htDisabled')).toBe(true);
-      });
-
-      it('should display an enabled entry, when clicking on a corner header', () => {
-        handsontable({
-          data: Handsontable.helper.createSpreadsheetData(4, 4),
-          contextMenu: true,
-          height: 100,
-          colHeaders: true,
-          rowHeaders: true
-        });
-
-        contextMenu(spec().$container.find('.ht_clone_top_left_corner thead th').eq(0));
-
-        const item = $('.htContextMenu .ht_master .htCore tbody')
-          .find('td')
-          .not('.htSeparator')
-          .eq(3); // "Insert column right"
-
-        expect(item.hasClass('htDisabled')).toBe(false);
-      });
-
-      it('should display an enabled entry, when clicking on a corner header when there are no cells visible', () => {
-        handsontable({
-          data: Handsontable.helper.createSpreadsheetData(0, 0),
-          contextMenu: true,
-          height: 100,
-          colHeaders: true,
-          rowHeaders: true,
-          dataSchema: [],
-        });
-
-        contextMenu(spec().$container.find('.ht_clone_top_left_corner thead th').eq(0));
-
-        const item = $('.htContextMenu .ht_master .htCore tbody')
-          .find('td')
-          .not('.htSeparator')
-          .eq(3); // "Insert column right"
-
-        expect(item.hasClass('htDisabled')).toBe(false);
       });
     });
   });

--- a/src/plugins/contextMenu/test/predefinedItems/insertRowAbove.e2e.js
+++ b/src/plugins/contextMenu/test/predefinedItems/insertRowAbove.e2e.js
@@ -52,6 +52,44 @@ describe('ContextMenu', () => {
       expect(getRowHeader()).toEqual(['A', 'B', 'C', 'D', 'E', 6, 7]);
     });
 
+    it('should insert row above the clicked row header', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(1, -1));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(0); // "Insert row above"
+
+      simulateClick(item);
+
+      expect(getDataAtCol(0)).toEqual(['A1', null, 'A2', 'A3', 'A4', 'A5']);
+    });
+
+    it('should insert row above the clicked cell', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(1, 1));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(0); // "Insert row above"
+
+      simulateClick(item);
+
+      expect(getDataAtCol(0)).toEqual(['A1', null, 'A2', 'A3', 'A4', 'A5']);
+    });
+
     describe('UI', () => {
       it('should display a disabled entry, when there\'s nothing selected', () => {
         handsontable({
@@ -69,8 +107,6 @@ describe('ContextMenu', () => {
           .find('td')
           .not('.htSeparator')
           .eq(0); // "Insert row above"
-
-        simulateClick(item);
 
         expect(item.hasClass('htDisabled')).toBe(true);
       });
@@ -91,8 +127,6 @@ describe('ContextMenu', () => {
           .not('.htSeparator')
           .eq(0); // "Insert row above"
 
-        simulateClick(item);
-
         expect(item.hasClass('htDisabled')).toBe(true);
       });
 
@@ -112,7 +146,24 @@ describe('ContextMenu', () => {
           .not('.htSeparator')
           .eq(0); // "Insert row above"
 
-        simulateClick(item);
+        expect(item.hasClass('htDisabled')).toBe(true);
+      });
+
+      it('should display a disabled entry, when clicking on a corner header when there are no cells visible', () => {
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(0, 0),
+          contextMenu: true,
+          height: 100,
+          colHeaders: true,
+          rowHeaders: true,
+        });
+
+        contextMenu(spec().$container.find('.ht_clone_top_left_corner thead th').eq(0));
+
+        const item = $('.htContextMenu .ht_master .htCore tbody')
+          .find('td')
+          .not('.htSeparator')
+          .eq(0); // "Insert row above"
 
         expect(item.hasClass('htDisabled')).toBe(true);
       });

--- a/src/plugins/contextMenu/test/predefinedItems/insertRowAbove.e2e.js
+++ b/src/plugins/contextMenu/test/predefinedItems/insertRowAbove.e2e.js
@@ -13,53 +13,15 @@ describe('ContextMenu', () => {
   });
 
   describe('insert row above', () => {
-    it('should insert row above through row header when all columns are trimmed (using columns option)', () => {
+    it('should not insert row above when the menu is triggered by column header', () => {
       handsontable({
         data: createSpreadsheetData(5, 5),
-        rowHeaders: ['A', 'B', 'C', 'D', 'E'],
-        contextMenu: true,
-        columns: [], // The TrimmingMap should be used instead of the `columns` option.
-      });
-
-      contextMenu(getCell(1, -1));
-
-      {
-        const item = $('.htContextMenu .ht_master .htCore tbody')
-          .find('td')
-          .not('.htSeparator')
-          .eq(0); // "Insert row above"
-
-        simulateClick(item);
-      }
-
-      // Currently HoT doesn't support row headers shift as it support columns.
-      // Should be `['A', 2, 'B', 'C', 'D', 'E']`.
-      expect(getRowHeader()).toEqual(['A', 'B', 'C', 'D', 'E', 6]);
-
-      contextMenu(getCell(5, -1));
-
-      {
-        const item = $('.htContextMenu .ht_master .htCore tbody')
-          .find('td')
-          .not('.htSeparator')
-          .eq(0); // "Insert row above"
-
-        simulateClick(item);
-      }
-
-      // Currently HoT doesn't support row headers shift as it support columns.
-      // Should be `['A', 2, 'B', 'C', 'D', 6, 'E']`.
-      expect(getRowHeader()).toEqual(['A', 'B', 'C', 'D', 'E', 6, 7]);
-    });
-
-    it('should insert row above the clicked row header', () => {
-      handsontable({
-        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
         rowHeaders: true,
         contextMenu: true,
       });
 
-      contextMenu(getCell(1, -1));
+      contextMenu(getCell(-1, 1, true));
 
       const item = $('.htContextMenu .ht_master .htCore tbody')
         .find('td')
@@ -68,12 +30,158 @@ describe('ContextMenu', () => {
 
       simulateClick(item);
 
-      expect(getDataAtCol(0)).toEqual(['A1', null, 'A2', 'A3', 'A4', 'A5']);
+      expect(item.hasClass('htDisabled')).toBe(true);
+      expect(getDataAtCol(0)).toEqual(['A1', 'A2', 'A3', 'A4', 'A5']);
     });
 
-    it('should insert row above the clicked cell', () => {
+    it('should insert row above of the clicked row header', () => {
       handsontable({
         data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(1, -1, true));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(0); // "Insert row above"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(false);
+      expect(getDataAtCol(0)).toEqual(['A1', null, 'A2', 'A3', 'A4', 'A5']);
+      expect(`
+        |   ║ - : - : - : - : - |
+        |===:===:===:===:===:===|
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        | * ║ A : 0 : 0 : 0 : 0 |
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        `).toBeMatchToSelectionPattern();
+    });
+
+    it('should insert row above when the menu is triggered by corner', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(-1, -1, true));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(0); // "Insert row above"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(false);
+      expect(getDataAtCol(0)).toEqual([null, 'A1', 'A2', 'A3', 'A4', 'A5']);
+      expect(`
+        |   ║ * : * : * : * : * |
+        |===:===:===:===:===:===|
+        | * ║ A : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 |
+        `).toBeMatchToSelectionPattern();
+    });
+
+    it('should not insert row above when the menu is triggered by corner and all rows are trimmed', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        contextMenu: true,
+        trimRows: [0, 1, 2, 3, 4],
+      });
+
+      contextMenu(getCell(-1, -1, true));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(0); // "Insert row above"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(true);
+      expect(`
+        |   ║ - : - : - : - : - |
+        |===:===:===:===:===:===|
+        `).toBeMatchToSelectionPattern();
+    });
+
+    it('should insert row above when the menu is triggered by corner and all columns are trimmed', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 0),
+        colHeaders: true,
+        rowHeaders: ['A', 'B', 'C', 'D', 'E'],
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(-1, -1, true));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(0); // "Insert row above"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(false);
+      // Currently HoT doesn't support row headers shift as it support columns.
+      // Should be `[1, 'A', 'B', 'C', 'D', 'E']`.
+      expect(getRowHeader()).toEqual(['A', 'B', 'C', 'D', 'E', 6]);
+      expect(`
+        |   |
+        |===|
+        | - |
+        | - |
+        | - |
+        | - |
+        | - |
+        | - |
+        `).toBeMatchToSelectionPattern();
+    });
+
+    it('should not insert row above when the menu is triggered by corner and dataset is empty', () => {
+      handsontable({
+        data: createSpreadsheetData(0, 0),
+        colHeaders: true,
+        rowHeaders: ['A', 'B', 'C', 'D', 'E'],
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(-1, -1, true));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(0); // "Insert row above"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(true);
+      expect(`
+        |   |
+        |===|
+        `).toBeMatchToSelectionPattern();
+    });
+
+    it('should insert row above of the clicked cell', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
         rowHeaders: true,
         contextMenu: true,
       });
@@ -87,13 +195,24 @@ describe('ContextMenu', () => {
 
       simulateClick(item);
 
+      expect(item.hasClass('htDisabled')).toBe(false);
       expect(getDataAtCol(0)).toEqual(['A1', null, 'A2', 'A3', 'A4', 'A5']);
+      expect(`
+        |   ║   : - :   :   :   |
+        |===:===:===:===:===:===|
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        | - ║   : # :   :   :   |
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        `).toBeMatchToSelectionPattern();
     });
 
     describe('UI', () => {
       it('should display a disabled entry, when there\'s nothing selected', () => {
         handsontable({
-          data: Handsontable.helper.createSpreadsheetData(4, 4),
+          data: createSpreadsheetData(4, 4),
           contextMenu: true,
           height: 100,
           beforeContextMenuShow() {
@@ -102,63 +221,6 @@ describe('ContextMenu', () => {
         });
 
         contextMenu();
-
-        const item = $('.htContextMenu .ht_master .htCore tbody')
-          .find('td')
-          .not('.htSeparator')
-          .eq(0); // "Insert row above"
-
-        expect(item.hasClass('htDisabled')).toBe(true);
-      });
-
-      it('should display a disabled entry, when clicking on a column header', () => {
-        handsontable({
-          data: Handsontable.helper.createSpreadsheetData(4, 4),
-          contextMenu: true,
-          height: 100,
-          colHeaders: true,
-          rowHeaders: true
-        });
-
-        contextMenu(spec().$container.find('.ht_clone_top thead th').eq(1));
-
-        const item = $('.htContextMenu .ht_master .htCore tbody')
-          .find('td')
-          .not('.htSeparator')
-          .eq(0); // "Insert row above"
-
-        expect(item.hasClass('htDisabled')).toBe(true);
-      });
-
-      it('should display a disabled entry, when clicking on a corner header', () => {
-        handsontable({
-          data: Handsontable.helper.createSpreadsheetData(4, 4),
-          contextMenu: true,
-          height: 100,
-          colHeaders: true,
-          rowHeaders: true
-        });
-
-        contextMenu(spec().$container.find('.ht_clone_top_left_corner thead th').eq(0));
-
-        const item = $('.htContextMenu .ht_master .htCore tbody')
-          .find('td')
-          .not('.htSeparator')
-          .eq(0); // "Insert row above"
-
-        expect(item.hasClass('htDisabled')).toBe(true);
-      });
-
-      it('should display a disabled entry, when clicking on a corner header when there are no cells visible', () => {
-        handsontable({
-          data: Handsontable.helper.createSpreadsheetData(0, 0),
-          contextMenu: true,
-          height: 100,
-          colHeaders: true,
-          rowHeaders: true,
-        });
-
-        contextMenu(spec().$container.find('.ht_clone_top_left_corner thead th').eq(0));
 
         const item = $('.htContextMenu .ht_master .htCore tbody')
           .find('td')

--- a/src/plugins/contextMenu/test/predefinedItems/insertRowBelow.e2e.js
+++ b/src/plugins/contextMenu/test/predefinedItems/insertRowBelow.e2e.js
@@ -13,6 +13,113 @@ describe('ContextMenu', () => {
   });
 
   describe('insert row below', () => {
+    it('should insert row below through row header when all columns are trimmed (using columns option)', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        rowHeaders: ['A', 'B', 'C', 'D', 'E'],
+        contextMenu: true,
+        columns: [], // The TrimmingMap should be used instead of the `columns` option.
+      });
+
+      contextMenu(getCell(1, -1));
+
+      {
+        const item = $('.htContextMenu .ht_master .htCore tbody')
+          .find('td')
+          .not('.htSeparator')
+          .eq(1); // "Insert row below"
+
+        simulateClick(item);
+      }
+
+      // Currently HoT doesn't support row headers shift as it support columns.
+      // Should be `['A', 'B', 2, 'C', 'D', 'E']`.
+      expect(getRowHeader()).toEqual(['A', 'B', 'C', 'D', 'E', 6]);
+
+      contextMenu(getCell(5, -1));
+
+      {
+        const item = $('.htContextMenu .ht_master .htCore tbody')
+          .find('td')
+          .not('.htSeparator')
+          .eq(1); // "Insert row below"
+
+        simulateClick(item);
+      }
+
+      // Currently HoT doesn't support row headers shift as it support columns.
+      // Should be `['A', 'B', 2, 'C', 'D', 'E', 6]`.
+      expect(getRowHeader()).toEqual(['A', 'B', 'C', 'D', 'E', 6, 7]);
+    });
+
+    it('should insert row below the clicked row header', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(1, -1));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(1); // "Insert row below"
+
+      simulateClick(item);
+
+      expect(getDataAtCol(0)).toEqual(['A1', 'A2', null, 'A3', 'A4', 'A5']);
+    });
+
+    it('should insert row below the clicked cell', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(1, 1));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(1); // "Insert row below"
+
+      simulateClick(item);
+
+      expect(getDataAtCol(0)).toEqual(['A1', 'A2', null, 'A3', 'A4', 'A5']);
+    });
+
+    it('should insert row below the clicked corner', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(-1, -1));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(1); // "Insert row below"
+
+      simulateClick(item);
+
+      expect(getDataAtCol(0)).toEqual([null, 'A1', 'A2', 'A3', 'A4', 'A5']);
+      expect(`
+        |   ║ * : * : * : * : * |
+        |===:===:===:===:===:===|
+        | * ║ A : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 |
+        `).toBeMatchToSelectionPattern();
+    });
+
     describe('UI', () => {
       it('should display a disabled entry, when there\'s nothing selected', () => {
         handsontable({
@@ -30,8 +137,6 @@ describe('ContextMenu', () => {
           .find('td')
           .not('.htSeparator')
           .eq(1); // "Insert row below"
-
-        simulateClick(item);
 
         expect(item.hasClass('htDisabled')).toBe(true);
       });
@@ -52,12 +157,10 @@ describe('ContextMenu', () => {
           .not('.htSeparator')
           .eq(1); // "Insert row below"
 
-        simulateClick(item);
-
         expect(item.hasClass('htDisabled')).toBe(true);
       });
 
-      it('should display a disabled entry, when clicking on a corner header', () => {
+      it('should display an enabled entry, when clicking on a corner header', () => {
         handsontable({
           data: Handsontable.helper.createSpreadsheetData(4, 4),
           contextMenu: true,
@@ -73,9 +176,26 @@ describe('ContextMenu', () => {
           .not('.htSeparator')
           .eq(1); // "Insert row below"
 
-        simulateClick(item);
+        expect(item.hasClass('htDisabled')).toBe(false);
+      });
 
-        expect(item.hasClass('htDisabled')).toBe(true);
+      it('should display an enabled entry, when clicking on a corner header when there are no cells visible', () => {
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(0, 0),
+          contextMenu: true,
+          height: 100,
+          colHeaders: true,
+          rowHeaders: true,
+        });
+
+        contextMenu(spec().$container.find('.ht_clone_top_left_corner thead th').eq(0));
+
+        const item = $('.htContextMenu .ht_master .htCore tbody')
+          .find('td')
+          .not('.htSeparator')
+          .eq(1); // "Insert row below"
+
+        expect(item.hasClass('htDisabled')).toBe(false);
       });
     });
   });

--- a/src/plugins/contextMenu/test/predefinedItems/insertRowBelow.e2e.js
+++ b/src/plugins/contextMenu/test/predefinedItems/insertRowBelow.e2e.js
@@ -13,101 +13,77 @@ describe('ContextMenu', () => {
   });
 
   describe('insert row below', () => {
-    it('should insert row below through row header when all columns are trimmed (using columns option)', () => {
+    it('should not insert row below when the menu is triggered by column header', () => {
       handsontable({
         data: createSpreadsheetData(5, 5),
-        rowHeaders: ['A', 'B', 'C', 'D', 'E'],
-        contextMenu: true,
-        columns: [], // The TrimmingMap should be used instead of the `columns` option.
-      });
-
-      contextMenu(getCell(1, -1));
-
-      {
-        const item = $('.htContextMenu .ht_master .htCore tbody')
-          .find('td')
-          .not('.htSeparator')
-          .eq(1); // "Insert row below"
-
-        simulateClick(item);
-      }
-
-      // Currently HoT doesn't support row headers shift as it support columns.
-      // Should be `['A', 'B', 2, 'C', 'D', 'E']`.
-      expect(getRowHeader()).toEqual(['A', 'B', 'C', 'D', 'E', 6]);
-
-      contextMenu(getCell(5, -1));
-
-      {
-        const item = $('.htContextMenu .ht_master .htCore tbody')
-          .find('td')
-          .not('.htSeparator')
-          .eq(1); // "Insert row below"
-
-        simulateClick(item);
-      }
-
-      // Currently HoT doesn't support row headers shift as it support columns.
-      // Should be `['A', 'B', 2, 'C', 'D', 'E', 6]`.
-      expect(getRowHeader()).toEqual(['A', 'B', 'C', 'D', 'E', 6, 7]);
-    });
-
-    it('should insert row below the clicked row header', () => {
-      handsontable({
-        data: createSpreadsheetData(5, 5),
-        rowHeaders: true,
-        contextMenu: true,
-      });
-
-      contextMenu(getCell(1, -1));
-
-      const item = $('.htContextMenu .ht_master .htCore tbody')
-        .find('td')
-        .not('.htSeparator')
-        .eq(1); // "Insert row below"
-
-      simulateClick(item);
-
-      expect(getDataAtCol(0)).toEqual(['A1', 'A2', null, 'A3', 'A4', 'A5']);
-    });
-
-    it('should insert row below the clicked cell', () => {
-      handsontable({
-        data: createSpreadsheetData(5, 5),
-        rowHeaders: true,
-        contextMenu: true,
-      });
-
-      contextMenu(getCell(1, 1));
-
-      const item = $('.htContextMenu .ht_master .htCore tbody')
-        .find('td')
-        .not('.htSeparator')
-        .eq(1); // "Insert row below"
-
-      simulateClick(item);
-
-      expect(getDataAtCol(0)).toEqual(['A1', 'A2', null, 'A3', 'A4', 'A5']);
-    });
-
-    it('should insert row below the clicked corner', () => {
-      handsontable({
-        data: createSpreadsheetData(5, 5),
-        rowHeaders: true,
         colHeaders: true,
+        rowHeaders: true,
         contextMenu: true,
       });
 
-      contextMenu(getCell(-1, -1));
+      contextMenu(getCell(-1, 1, true));
 
       const item = $('.htContextMenu .ht_master .htCore tbody')
         .find('td')
         .not('.htSeparator')
-        .eq(1); // "Insert row below"
+        .eq(1); // "insert row below"
 
       simulateClick(item);
 
-      expect(getDataAtCol(0)).toEqual([null, 'A1', 'A2', 'A3', 'A4', 'A5']);
+      expect(item.hasClass('htDisabled')).toBe(true);
+      expect(getDataAtCol(0)).toEqual(['A1', 'A2', 'A3', 'A4', 'A5']);
+    });
+
+    it('should insert row below of the clicked row header', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(1, -1, true));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(1); // "insert row below"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(false);
+      expect(getDataAtCol(0)).toEqual(['A1', 'A2', null, 'A3', 'A4', 'A5']);
+      expect(`
+        |   ║ - : - : - : - : - |
+        |===:===:===:===:===:===|
+        |   ║   :   :   :   :   |
+        | * ║ A : 0 : 0 : 0 : 0 |
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        `).toBeMatchToSelectionPattern();
+    });
+
+    it('should insert row below when the menu is triggered by corner', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(-1, -1, true));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(1); // "insert row below"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(false);
+      expect(getDataAtCol(0)).toEqual(['A1', 'A2', 'A3', 'A4', 'A5', null]);
       expect(`
         |   ║ * : * : * : * : * |
         |===:===:===:===:===:===|
@@ -120,10 +96,129 @@ describe('ContextMenu', () => {
         `).toBeMatchToSelectionPattern();
     });
 
+    it('should insert row below when the menu is triggered by corner and all rows are trimmed', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        contextMenu: true,
+        trimRows: [0, 1, 2, 3, 4],
+      });
+
+      contextMenu(getCell(-1, -1, true));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(1); // "insert row below"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(false);
+      expect(getDataAtCol(0)).toEqual([null]);
+      expect(`
+        |   ║ * : * : * : * : * |
+        |===:===:===:===:===:===|
+        | * ║ A : 0 : 0 : 0 : 0 |
+        `).toBeMatchToSelectionPattern();
+    });
+
+    it('should insert row below when the menu is triggered by corner and all columns are trimmed', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 0),
+        colHeaders: true,
+        rowHeaders: ['A', 'B', 'C', 'D', 'E'],
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(-1, -1, true));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(1); // "insert row below"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(false);
+      // Currently HoT doesn't support row headers shift as it support columns.
+      // Should be `[1, 'A', 'B', 'C', 'D', 'E']`.
+      expect(getRowHeader()).toEqual(['A', 'B', 'C', 'D', 'E', 6]);
+      expect(`
+        |   |
+        |===|
+        | - |
+        | - |
+        | - |
+        | - |
+        | - |
+        | - |
+        `).toBeMatchToSelectionPattern();
+    });
+
+    it('should insert row below when the menu is triggered by corner and dataset is empty', () => {
+      handsontable({
+        data: createSpreadsheetData(0, 0),
+        colHeaders: true,
+        rowHeaders: ['A', 'B', 'C', 'D', 'E'],
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(-1, -1, true));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(1); // "insert row below"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(false);
+      // Currently HoT doesn't support row headers shift as it support columns.
+      // Should be `[1]`.
+      expect(getRowHeader()).toEqual(['A']);
+      expect(`
+        |   |
+        |===|
+        | - |
+        `).toBeMatchToSelectionPattern();
+    });
+
+    it('should insert row below of the clicked cell', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(1, 1));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(1); // "insert row below"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(false);
+      expect(getDataAtCol(0)).toEqual(['A1', 'A2', null, 'A3', 'A4', 'A5']);
+      expect(`
+        |   ║   : - :   :   :   |
+        |===:===:===:===:===:===|
+        |   ║   :   :   :   :   |
+        | - ║   : # :   :   :   |
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        `).toBeMatchToSelectionPattern();
+    });
+
     describe('UI', () => {
       it('should display a disabled entry, when there\'s nothing selected', () => {
         handsontable({
-          data: Handsontable.helper.createSpreadsheetData(4, 4),
+          data: createSpreadsheetData(4, 4),
           contextMenu: true,
           height: 100,
           beforeContextMenuShow() {
@@ -139,63 +234,6 @@ describe('ContextMenu', () => {
           .eq(1); // "Insert row below"
 
         expect(item.hasClass('htDisabled')).toBe(true);
-      });
-
-      it('should display a disabled entry, when clicking on a column header', () => {
-        handsontable({
-          data: Handsontable.helper.createSpreadsheetData(4, 4),
-          contextMenu: true,
-          height: 100,
-          colHeaders: true,
-          rowHeaders: true
-        });
-
-        contextMenu(spec().$container.find('.ht_clone_top thead th').eq(1));
-
-        const item = $('.htContextMenu .ht_master .htCore tbody')
-          .find('td')
-          .not('.htSeparator')
-          .eq(1); // "Insert row below"
-
-        expect(item.hasClass('htDisabled')).toBe(true);
-      });
-
-      it('should display an enabled entry, when clicking on a corner header', () => {
-        handsontable({
-          data: Handsontable.helper.createSpreadsheetData(4, 4),
-          contextMenu: true,
-          height: 100,
-          colHeaders: true,
-          rowHeaders: true
-        });
-
-        contextMenu(spec().$container.find('.ht_clone_top_left_corner thead th').eq(0));
-
-        const item = $('.htContextMenu .ht_master .htCore tbody')
-          .find('td')
-          .not('.htSeparator')
-          .eq(1); // "Insert row below"
-
-        expect(item.hasClass('htDisabled')).toBe(false);
-      });
-
-      it('should display an enabled entry, when clicking on a corner header when there are no cells visible', () => {
-        handsontable({
-          data: Handsontable.helper.createSpreadsheetData(0, 0),
-          contextMenu: true,
-          height: 100,
-          colHeaders: true,
-          rowHeaders: true,
-        });
-
-        contextMenu(spec().$container.find('.ht_clone_top_left_corner thead th').eq(0));
-
-        const item = $('.htContextMenu .ht_master .htCore tbody')
-          .find('td')
-          .not('.htSeparator')
-          .eq(1); // "Insert row below"
-
-        expect(item.hasClass('htDisabled')).toBe(false);
       });
     });
   });

--- a/src/plugins/contextMenu/test/predefinedItems/removeColumn.e2e.js
+++ b/src/plugins/contextMenu/test/predefinedItems/removeColumn.e2e.js
@@ -13,49 +13,238 @@ describe('ContextMenu', () => {
   });
 
   describe('remove columns', () => {
-    it('should execute action when single cell is selected', () => {
+    it('should remove column of the clicked column header', () => {
       handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
         contextMenu: true,
       });
 
-      selectCell(2, 2);
-      contextMenu();
+      contextMenu(getCell(-1, 1, true));
 
-      // "Remove column" item
-      $('.htContextMenu .ht_master .htCore')
-        .find('tbody td')
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
         .not('.htSeparator')
-        .eq(5)
-        .simulate('mousedown')
-        .simulate('mouseup');
+        .eq(5); // "Remove column"
 
-      expect(getDataAtRow(0)).toEqual(['A1', 'B1', 'D1', 'E1']);
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(false);
+      expect(getDataAtRow(0)).toEqual(['A1', 'C1', 'D1', 'E1']);
+      expect(`
+        |   ║   : * :   :   |
+        |===:===:===:===:===|
+        | - ║   : A :   :   |
+        | - ║   : 0 :   :   |
+        | - ║   : 0 :   :   |
+        | - ║   : 0 :   :   |
+        | - ║   : 0 :   :   |
+        `).toBeMatchToSelectionPattern();
     });
 
-    it('should execute action when range of the cells are selected', () => {
+    it('should not remove column when the menu is triggered by row header', () => {
       handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(1, -1, true));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(5); // "Remove column"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(true);
+      expect(getDataAtRow(0)).toEqual(['A1', 'B1', 'C1', 'D1', 'E1']);
+      expect(`
+        |   ║ - : - : - : - : - |
+        |===:===:===:===:===:===|
+        |   ║   :   :   :   :   |
+        | * ║ A : 0 : 0 : 0 : 0 |
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        `).toBeMatchToSelectionPattern();
+    });
+
+    it('should remove all columns when the menu is triggered by corner', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(-1, -1, true));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(5); // "Remove column"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(false);
+      expect(getData()).toEqual([]);
+      expect(`
+        |   |
+        |===|
+        `).toBeMatchToSelectionPattern();
+    });
+
+    it('should remove all columns when the menu is triggered by corner and all rows are trimmed', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        contextMenu: true,
+        trimRows: [0, 1, 2, 3, 4],
+      });
+
+      contextMenu(getCell(-1, -1, true));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(5); // "Remove column"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(false);
+      expect(getData()).toEqual([]);
+      expect(`
+        |   |
+        |===|
+        `).toBeMatchToSelectionPattern();
+    });
+
+    it('should not remove columns when the menu is triggered by corner and all columns are trimmed', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 0),
+        dataSchema: [], // Unlocks adding new rows through the context menu.
+        colHeaders: true,
+        rowHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(-1, -1, true));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(5); // "Remove column"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(true);
+      expect(`
+        |   |
+        |===|
+        | - |
+        | - |
+        | - |
+        | - |
+        | - |
+        `).toBeMatchToSelectionPattern();
+    });
+
+    it('should not remove columns when the menu is triggered by corner and dataset is empty', () => {
+      handsontable({
+        data: createSpreadsheetData(0, 0),
+        dataSchema: [], // Unlocks adding new rows through the context menu.
+        colHeaders: true,
+        rowHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(-1, -1, true));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(5); // "Remove column"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(true);
+      expect(`
+        |   |
+        |===|
+        `).toBeMatchToSelectionPattern();
+    });
+
+    it('should remove column from the single cell', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(1, 1));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(5); // "Remove column"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(false);
+      expect(getDataAtRow(0)).toEqual(['A1', 'C1', 'D1', 'E1']);
+      expect(`
+        |   ║   : - :   :   |
+        |===:===:===:===:===|
+        |   ║   :   :   :   |
+        | - ║   : # :   :   |
+        |   ║   :   :   :   |
+        |   ║   :   :   :   |
+        |   ║   :   :   :   |
+        `).toBeMatchToSelectionPattern();
+    });
+
+    it('should remove rows from the multiple selection range', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
         contextMenu: true,
       });
 
       selectCell(2, 2, 4, 4);
-      contextMenu();
+      contextMenu(getCell(2, 2));
 
-      // "Remove column" item
-      $('.htContextMenu .ht_master .htCore')
-        .find('tbody td')
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
         .not('.htSeparator')
-        .eq(5)
-        .simulate('mousedown')
-        .simulate('mouseup');
+        .eq(5); // "Remove column"
 
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(false);
       expect(getDataAtRow(0)).toEqual(['A1', 'B1']);
+      expect(`
+        |   ║   : - |
+        |===:===:===|
+        |   ║   :   |
+        |   ║   :   |
+        | - ║   : A |
+        | - ║   : 0 |
+        | - ║   : 0 |
+        `).toBeMatchToSelectionPattern();
     });
 
-    it('should execute action when multiple cells are selected', () => {
+    it('should remove columns from the non-contiques selection range', () => {
       handsontable({
-        data: Handsontable.helper.createSpreadsheetData(8, 5),
+        data: createSpreadsheetData(8, 8),
+        colHeaders: true,
+        rowHeaders: true,
         contextMenu: true,
       });
 
@@ -73,70 +262,50 @@ describe('ContextMenu', () => {
       $(getCell(5, 3)).simulate('mouseover');
       $(getCell(5, 3)).simulate('mouseup');
 
+      $(getCell(5, 0)).simulate('mousedown');
+      $(getCell(5, 4)).simulate('mouseover');
+      $(getCell(5, 4)).simulate('mouseup');
+
       $(getCell(7, 4)).simulate('mousedown');
       $(getCell(7, 4)).simulate('mouseover');
       $(getCell(7, 4)).simulate('mouseup');
 
+      expect(`
+        |   ║ - : - : - : - : - :   :   :   |
+        |===:===:===:===:===:===:===:===:===|
+        | - ║ 0 :   :   : 0 :   :   :   :   |
+        | - ║ 0 :   :   : 0 :   :   :   :   |
+        | - ║   : 0 :   : 0 :   :   :   :   |
+        | - ║   :   :   : 0 :   :   :   :   |
+        | - ║   :   :   : 0 :   :   :   :   |
+        | - ║ 0 : 0 : 0 : 1 : 0 :   :   :   |
+        |   ║   :   :   :   :   :   :   :   |
+        | - ║   :   :   :   : A :   :   :   |
+        `).toBeMatchToSelectionPattern();
+
       contextMenu();
 
-      // "Remove column" item
-      $('.htContextMenu .ht_master .htCore')
-        .find('tbody td')
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
         .not('.htSeparator')
-        .eq(5)
-        .simulate('mousedown')
-        .simulate('mouseup');
+        .eq(5); // "Remove column"
 
-      expect(getDataAtRow(0)).toEqual(['C1']);
-    });
+      simulateClick(item);
 
-    it('should display a disabled entry for "Remove column", when there\'s nothing selected', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(4, 4),
-        contextMenu: true,
-        height: 100,
-        beforeContextMenuShow() {
-          this.deselectCell();
-        }
-      });
-
-      contextMenu();
-
-      const item = $('.htContextMenu .ht_master .htCore').find('tbody td').not('.htSeparator').eq(5);
-
-      expect(item.hasClass('htDisabled')).toBe(true);
-    });
-
-    it('should display a disabled entry for "Remove column", when clicking on a row header', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(4, 4),
-        contextMenu: true,
-        height: 100,
-        colHeaders: true,
-        rowHeaders: true
-      });
-
-      contextMenu(spec().$container.find('.ht_clone_left tbody tr').eq(0).find('th').eq(0));
-
-      const item = $('.htContextMenu .ht_master .htCore').find('tbody td').not('.htSeparator').eq(5);
-
-      expect(item.hasClass('htDisabled')).toBe(true);
-    });
-
-    it('should display a disabled entry for "Remove column", when clicking on a corner header', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(4, 4),
-        contextMenu: true,
-        height: 100,
-        colHeaders: true,
-        rowHeaders: true
-      });
-
-      contextMenu(spec().$container.find('.ht_clone_top_left_corner thead th').eq(0));
-
-      const item = $('.htContextMenu .ht_master .htCore').find('tbody td').not('.htSeparator').eq(5);
-
-      expect(item.hasClass('htDisabled')).toBe(true);
+      expect(item.hasClass('htDisabled')).toBe(false);
+      expect(getDataAtRow(0)).toEqual(['F1', 'G1', 'H1']);
+      expect(`
+        |   ║   :   : - |
+        |===:===:===:===|
+        |   ║   :   :   |
+        |   ║   :   :   |
+        |   ║   :   :   |
+        |   ║   :   :   |
+        |   ║   :   :   |
+        |   ║   :   :   |
+        |   ║   :   :   |
+        | - ║   :   : # |
+        `).toBeMatchToSelectionPattern();
     });
   });
 });

--- a/src/plugins/contextMenu/test/predefinedItems/removeRow.e2e.js
+++ b/src/plugins/contextMenu/test/predefinedItems/removeRow.e2e.js
@@ -13,49 +13,217 @@ describe('ContextMenu', () => {
   });
 
   describe('remove rows', () => {
-    it('should execute action when single cell is selected', () => {
+    it('should not remove row when the menu is triggered by column header', () => {
       handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
         contextMenu: true,
       });
 
-      selectCell(2, 2);
-      contextMenu();
+      contextMenu(getCell(-1, 1, true));
 
-      // "Remove row" item
-      $('.htContextMenu .ht_master .htCore')
-        .find('tbody td')
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
         .not('.htSeparator')
-        .eq(4)
-        .simulate('mousedown')
-        .simulate('mouseup');
+        .eq(4); // "Remove row"
 
-      expect(getDataAtCol(0)).toEqual(['A1', 'A2', 'A4', 'A5']);
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(true);
+      expect(getDataAtCol(0)).toEqual(['A1', 'A2', 'A3', 'A4', 'A5']);
     });
 
-    it('should execute action when range of the cells are selected', () => {
+    it('should remove row of the clicked row header', () => {
       handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(1, -1, true));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(4); // "Remove row"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(false);
+      expect(getDataAtCol(0)).toEqual(['A1', 'A3', 'A4', 'A5']);
+      expect(`
+        |   ║ - : - : - : - : - |
+        |===:===:===:===:===:===|
+        |   ║   :   :   :   :   |
+        | * ║ A : 0 : 0 : 0 : 0 |
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        `).toBeMatchToSelectionPattern();
+    });
+
+    it('should remove all rows when the menu is triggered by corner', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(-1, -1, true));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(4); // "Remove row"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(false);
+      expect(getData()).toEqual([]);
+      expect(`
+        |   |
+        |===|
+        `).toBeMatchToSelectionPattern();
+    });
+
+    it('should not remove rows when the menu is triggered by corner and all rows are trimmed', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        contextMenu: true,
+        trimRows: [0, 1, 2, 3, 4],
+      });
+
+      contextMenu(getCell(-1, -1, true));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(4); // "Remove row"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(true);
+      expect(`
+        |   ║ - : - : - : - : - |
+        |===:===:===:===:===:===|
+        `).toBeMatchToSelectionPattern();
+    });
+
+    it('should remove all rows when the menu is triggered by corner and all columns are trimmed', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 0),
+        colHeaders: true,
+        rowHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(-1, -1, true));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(4); // "Remove row"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(false);
+      expect(getData()).toEqual([]);
+      expect(`
+        |   |
+        |===|
+        `).toBeMatchToSelectionPattern();
+    });
+
+    it('should not remove rows when the menu is triggered by corner and dataset is empty', () => {
+      handsontable({
+        data: createSpreadsheetData(0, 0),
+        colHeaders: true,
+        rowHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(-1, -1, true));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(4); // "Remove row"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(true);
+      expect(`
+        |   |
+        |===|
+        `).toBeMatchToSelectionPattern();
+    });
+
+    it('should remove row from the single cell', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(1, 1));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(4); // "Remove row"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(false);
+      expect(getDataAtCol(0)).toEqual(['A1', 'A3', 'A4', 'A5']);
+      expect(`
+        |   ║   : - :   :   :   |
+        |===:===:===:===:===:===|
+        |   ║   :   :   :   :   |
+        | - ║   : # :   :   :   |
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        `).toBeMatchToSelectionPattern();
+    });
+
+    it('should remove rows from the multiple selection range', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
         contextMenu: true,
       });
 
       selectCell(2, 2, 4, 4);
-      contextMenu();
+      contextMenu(getCell(2, 2));
 
-      // "Remove row" item
-      $('.htContextMenu .ht_master .htCore')
-        .find('tbody td')
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
         .not('.htSeparator')
-        .eq(4)
-        .simulate('mousedown')
-        .simulate('mouseup');
+        .eq(4); // "Remove row"
 
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(false);
       expect(getDataAtCol(0)).toEqual(['A1', 'A2']);
+      expect(`
+        |   ║   :   : - : - : - |
+        |===:===:===:===:===:===|
+        |   ║   :   :   :   :   |
+        | - ║   :   : A : 0 : 0 |
+        `).toBeMatchToSelectionPattern();
     });
 
-    it('should execute action when multiple cells are selected', () => {
+    it('should remove rows from the non-contiques selection range', () => {
       handsontable({
-        data: Handsontable.helper.createSpreadsheetData(8, 5),
+        data: createSpreadsheetData(8, 8),
+        colHeaders: true,
+        rowHeaders: true,
         contextMenu: true,
       });
 
@@ -81,17 +249,35 @@ describe('ContextMenu', () => {
       $(getCell(7, 4)).simulate('mouseover');
       $(getCell(7, 4)).simulate('mouseup');
 
+      expect(`
+        |   ║ - : - : - : - : - :   :   :   |
+        |===:===:===:===:===:===:===:===:===|
+        | - ║ 0 :   :   : 0 :   :   :   :   |
+        | - ║ 0 :   :   : 0 :   :   :   :   |
+        | - ║   : 0 :   : 0 :   :   :   :   |
+        | - ║   :   :   : 0 :   :   :   :   |
+        | - ║   :   :   : 0 :   :   :   :   |
+        | - ║ 0 : 0 : 0 : 1 : 0 :   :   :   |
+        |   ║   :   :   :   :   :   :   :   |
+        | - ║   :   :   :   : A :   :   :   |
+        `).toBeMatchToSelectionPattern();
+
       contextMenu();
 
-      // "Remove row" item
-      $('.htContextMenu .ht_master .htCore')
-        .find('tbody td')
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
         .not('.htSeparator')
-        .eq(4)
-        .simulate('mousedown')
-        .simulate('mouseup');
+        .eq(4); // "Remove row"
 
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(false);
       expect(getDataAtCol(0)).toEqual(['A7']);
+      expect(`
+        |   ║   :   :   :   : - :   :   :   |
+        |===:===:===:===:===:===:===:===:===|
+        | - ║   :   :   :   : # :   :   :   |
+        `).toBeMatchToSelectionPattern();
     });
 
     it('should not shift invalid row when removing a single row', async() => {
@@ -123,64 +309,14 @@ describe('ContextMenu', () => {
       selectCell(1, 1);
       contextMenu();
 
-      // "Remove row" item
-      $('.htContextMenu .ht_master .htCore')
-        .find('tbody td')
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
         .not('.htSeparator')
-        .eq(4)
-        .simulate('mousedown')
-        .simulate('mouseup');
+        .eq(4); // "Remove row"
+
+      simulateClick(item);
 
       expect($(hot.getCell(2, 1)).hasClass('htInvalid')).toBeTruthy();
-    });
-
-    it('should display a disabled entry for "Remove row", when there\'s nothing selected', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(4, 4),
-        contextMenu: true,
-        height: 100,
-        beforeContextMenuShow() {
-          this.deselectCell();
-        }
-      });
-
-      contextMenu();
-
-      const item = $('.htContextMenu .ht_master .htCore').find('tbody td').not('.htSeparator').eq(4);
-
-      expect(item.hasClass('htDisabled')).toBe(true);
-    });
-
-    it('should display a disabled entry for "Remove row", when clicking on a column header', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(4, 4),
-        contextMenu: true,
-        height: 100,
-        colHeaders: true,
-        rowHeaders: true
-      });
-
-      contextMenu(spec().$container.find('.ht_clone_top thead th').eq(1));
-
-      const item = $('.htContextMenu .ht_master .htCore').find('tbody td').not('.htSeparator').eq(4);
-
-      expect(item.hasClass('htDisabled')).toBe(true);
-    });
-
-    it('should display a disabled entry for "Remove row", when clicking on a corner header', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(4, 4),
-        contextMenu: true,
-        height: 100,
-        colHeaders: true,
-        rowHeaders: true
-      });
-
-      contextMenu(spec().$container.find('.ht_clone_top_left_corner thead th').eq(0));
-
-      const item = $('.htContextMenu .ht_master .htCore').find('tbody td').not('.htSeparator').eq(4);
-
-      expect(item.hasClass('htDisabled')).toBe(true);
     });
   });
 });

--- a/src/plugins/customBorders/test/customBorders.e2e.js
+++ b/src/plugins/customBorders/test/customBorders.e2e.js
@@ -1031,7 +1031,6 @@ describe('CustomBorders', () => {
 
     expect($('.htContextMenu tbody td.htDisabled').text()).toBe([
       'Insert row above',
-      'Insert row below',
       'Insert column left',
       'Insert column right',
       'Remove rows',

--- a/src/plugins/customBorders/test/customBorders.e2e.js
+++ b/src/plugins/customBorders/test/customBorders.e2e.js
@@ -1030,11 +1030,8 @@ describe('CustomBorders', () => {
     contextMenu();
 
     expect($('.htContextMenu tbody td.htDisabled').text()).toBe([
-      'Insert row above',
       'Insert column left',
       'Insert column right',
-      'Remove rows',
-      'Remove columns',
       'Undo',
       'Redo',
       'Read only',

--- a/src/plugins/mergeCells/test/mergeCells.e2e.js
+++ b/src/plugins/mergeCells/test/mergeCells.e2e.js
@@ -1360,11 +1360,8 @@ describe('MergeCells', () => {
       contextMenu();
 
       expect($('.htContextMenu tbody td.htDisabled').text()).toBe([
-        'Insert row above',
         'Insert column left',
         'Insert column right',
-        'Remove rows',
-        'Remove columns',
         'Undo',
         'Redo',
         'Read only',

--- a/src/plugins/mergeCells/test/mergeCells.e2e.js
+++ b/src/plugins/mergeCells/test/mergeCells.e2e.js
@@ -1361,7 +1361,6 @@ describe('MergeCells', () => {
 
       expect($('.htContextMenu tbody td.htDisabled').text()).toBe([
         'Insert row above',
-        'Insert row below',
         'Insert column left',
         'Insert column right',
         'Remove rows',

--- a/test/helpers/common.js
+++ b/test/helpers/common.js
@@ -894,13 +894,25 @@ export function triggerTouchEvent(type, target, pageX, pageY) {
 }
 
 /**
- * Creates spreadsheet data as an array of arrays filled with spreadsheet-like label values (e.q "A1", "A2"...).
+ * Creates spreadsheet data as an array of arrays filled with spreadsheet-like label
+ * values (e.q "A1", "A2"...).
  *
  * @param {*} args The arguments passed directly to the Handsontable helper.
  * @returns {Array}
  */
 export function createSpreadsheetData(...args) {
   return Handsontable.helper.createSpreadsheetData(...args);
+}
+
+/**
+ * Creates spreadsheet data as an array of objects filled with spreadsheet-like label
+ * values (e.q "A1", "A2"...).
+ *
+ * @param {*} args The arguments passed directly to the Handsontable helper.
+ * @returns {Array}
+ */
+export function createSpreadsheetObjectData(...args) {
+  return Handsontable.helper.createSpreadsheetObjectData(...args);
 }
 
 /**


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
This PR adjusts the inactivity state of the context menu items responsible for inserting or removing row or columns. The behavior is based on the following spec: 

### Spec

Menu options activity state (checked checkbox means item is active):
1. Triggered by columns' headers. Both cases: all column headers are selected, some of the column headers are selected
    - [ ] `Insert row above`
    - [ ] `Insert row below`
    - [x] `Insert column on the right`
    - [x] `Insert column on the left`
    - [ ] `Remove row`
    - [x] `Remove column`
2. Triggered by rows' headers. Both cases: all row headers are selected, some of the row headers are selected
    - [x] `Insert row above`
    - [x] `Insert row below`
    - [ ] `Insert column on the right`
    - [ ] `Insert column on the left`
    - [x] `Remove row`
    - [ ] `Remove column`
3. Triggered by corner when there is at least one row and column
    - [x] `Insert row above`
    - [x] `Insert row below`
    - [x] `Insert column on the right`
    - [x] `Insert column on the left`
    - [x] `Remove row`
    - [x] `Remove column`
4. Triggered by corner when there are all rows trimmed but there is at least one column (the filter plugin case)
    - [ ] `Insert row above`
    - [x] `Insert row below`
    - [x] `Insert column on the right`
    - [x] `Insert column on the left`
    - [ ] `Remove row`
    - [x] `Remove column`
5. Triggered by corner when there are all columns trimmed but there is at least one row
    - [x] `Insert row above`
    - [x] `Insert row below`
    - [x] `Insert column on the right`
    - [ ] `Insert column on the left`
    - [x] `Remove row`
    - [ ] `Remove column`
6. Triggered by corner when there are all rows and columns trimmed or passed data is empty 
    - [ ] `Insert row above`
    - [x] `Insert row below`
    - [x] `Insert column on the right`
    - [ ] `Insert column on the left`
    - [ ] `Remove row`
    - [ ] `Remove column`
7. Triggered by cell click
    - [x] `Insert row above`
    - [x] `Insert row below`
    - [x] `Insert column on the right`
    - [x] `Insert column on the left`
    - [x] `Remove row`
    - [x] `Remove column`

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Updated E2E tests to the new behavior.

To emulate rows trimming the _TrimRows_ plugin is used:
```js
{
  data: Handsontable.helper.createSpreadsheetData(5, 5),
  colHeaders: true,
  rowHeaders: true,
  contextMenu: true,
  trimRows: [0, 1, 2, 3, 4],
}
```
For columns trimming emulation the `columns: []` option can be used but then the "Insert columns" option is disabled as the HoT disallow add a new column when it doesn't know about data schema. However, this can be emulated by passing data with 0 columns:
```js
{
  data: Handsontable.helper.createSpreadsheetData(5, 0),
  dataSchema: [], // Unlocks adding new rows through the context menu.
  colHeaders: true,
  rowHeaders: true,
  contextMenu: true,
}
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7060 
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
