### PR TITLE
Cooperation of the HiddenColumns plugin with the CustomBorders plugin

### DIFF
--- a/src/plugins/customBorders/customBorders.js
+++ b/src/plugins/customBorders/customBorders.js
@@ -1,11 +1,8 @@
 import BasePlugin from './../_base';
 import { registerPlugin } from './../../plugins';
-import {
-  hasOwnProperty,
-  objectEach, isObject } from './../../helpers/object';
+import { hasOwnProperty, objectEach } from './../../helpers/object';
 import { rangeEach } from './../../helpers/number';
 import { arrayEach, arrayReduce, arrayMap } from './../../helpers/array';
-import { isDefined } from '../../helpers/mixed';
 import { CellRange, CellCoords } from './../../3rdparty/walkontable/src';
 import * as C from './../../i18n/constants';
 import { bottom, left, noBorders, right, top } from './contextMenuItem';

--- a/src/plugins/customBorders/customBorders.js
+++ b/src/plugins/customBorders/customBorders.js
@@ -270,8 +270,6 @@ class CustomBorders extends BasePlugin {
    * @param {string} place Coordinate where add/remove border - `top`, `bottom`, `left`, `right`.
    */
   insertBorderIntoSettings(border, place) {
-    console.log(border);
-    
     const hasSavedBorders = this.checkSavedBorders(border);
 
     if (!hasSavedBorders) {
@@ -296,9 +294,7 @@ class CustomBorders extends BasePlugin {
    * @param {string} place Coordinate where add/remove border - `top`, `bottom`, `left`, `right`.
    */
   prepareBorderFromCustomAdded(row, column, borderDescriptor, place) {
-    const renderableRowIndex = this.hot.rowIndexMapper.getRenderableFromVisualIndex(row);
-    const renderableColumnIndex = this.hot.columnIndexMapper.getRenderableFromVisualIndex(column);
-    let border = createEmptyBorders(renderableRowIndex, renderableColumnIndex);
+    let border = createEmptyBorders.call(this, row, column);
 
     if (borderDescriptor) {
       border = extendDefaultBorder(border, borderDescriptor);
@@ -334,9 +330,7 @@ class CustomBorders extends BasePlugin {
 
     rangeEach(range.from.row, range.to.row, (rowIndex) => {
       rangeEach(range.from.col, range.to.col, (colIndex) => {
-        const renderableRowIndex = this.hot.rowIndexMapper.getRenderableFromVisualIndex(rowIndex);
-        const renderableColumnIndex = this.hot.columnIndexMapper.getRenderableFromVisualIndex(colIndex);
-        const border = createEmptyBorders(renderableRowIndex, renderableColumnIndex);
+        const border = createEmptyBorders.call(this, rowIndex, colIndex);
         let add = 0;
 
         if (rowIndex === range.from.row) {
@@ -408,10 +402,7 @@ class CustomBorders extends BasePlugin {
     let bordersMeta = this.hot.getCellMeta(row, column).borders;
 
     if (!bordersMeta || bordersMeta.border === void 0) {
-      const renderableRowIndex = this.hot.rowIndexMapper.getRenderableFromVisualIndex(row);
-      const renderableColumnIndex = this.hot.columnIndexMapper.getRenderableFromVisualIndex(column);
-
-      bordersMeta = createEmptyBorders(renderableRowIndex, renderableColumnIndex);
+      bordersMeta = createEmptyBorders.call(this, row, column);
     }
 
     if (remove) {

--- a/src/plugins/customBorders/customBorders.js
+++ b/src/plugins/customBorders/customBorders.js
@@ -270,6 +270,8 @@ class CustomBorders extends BasePlugin {
    * @param {string} place Coordinate where add/remove border - `top`, `bottom`, `left`, `right`.
    */
   insertBorderIntoSettings(border, place) {
+    console.log(border);
+    
     const hasSavedBorders = this.checkSavedBorders(border);
 
     if (!hasSavedBorders) {
@@ -294,7 +296,9 @@ class CustomBorders extends BasePlugin {
    * @param {string} place Coordinate where add/remove border - `top`, `bottom`, `left`, `right`.
    */
   prepareBorderFromCustomAdded(row, column, borderDescriptor, place) {
-    let border = createEmptyBorders(row, column);
+    const renderableRowIndex = this.hot.rowIndexMapper.getRenderableFromVisualIndex(row);
+    const renderableColumnIndex = this.hot.columnIndexMapper.getRenderableFromVisualIndex(column);
+    let border = createEmptyBorders(renderableRowIndex, renderableColumnIndex);
 
     if (borderDescriptor) {
       border = extendDefaultBorder(border, borderDescriptor);
@@ -330,7 +334,9 @@ class CustomBorders extends BasePlugin {
 
     rangeEach(range.from.row, range.to.row, (rowIndex) => {
       rangeEach(range.from.col, range.to.col, (colIndex) => {
-        const border = createEmptyBorders(rowIndex, colIndex);
+        const renderableRowIndex = this.hot.rowIndexMapper.getRenderableFromVisualIndex(rowIndex);
+        const renderableColumnIndex = this.hot.columnIndexMapper.getRenderableFromVisualIndex(colIndex);
+        const border = createEmptyBorders(renderableRowIndex, renderableColumnIndex);
         let add = 0;
 
         if (rowIndex === range.from.row) {
@@ -402,7 +408,10 @@ class CustomBorders extends BasePlugin {
     let bordersMeta = this.hot.getCellMeta(row, column).borders;
 
     if (!bordersMeta || bordersMeta.border === void 0) {
-      bordersMeta = createEmptyBorders(row, column);
+      const renderableRowIndex = this.hot.rowIndexMapper.getRenderableFromVisualIndex(row);
+      const renderableColumnIndex = this.hot.columnIndexMapper.getRenderableFromVisualIndex(column);
+
+      bordersMeta = createEmptyBorders(renderableRowIndex, renderableColumnIndex);
     }
 
     if (remove) {

--- a/src/plugins/customBorders/customBorders.js
+++ b/src/plugins/customBorders/customBorders.js
@@ -294,6 +294,10 @@ class CustomBorders extends BasePlugin {
    * @param {string} place Coordinate where add/remove border - `top`, `bottom`, `left`, `right`.
    */
   prepareBorderFromCustomAdded(row, column, borderDescriptor, place) {
+    if (this.hot.rowIndexMapper.isHidden(row) || this.hot.columnIndexMapper.isHidden(column)) {
+      return;
+    }
+
     let border = createEmptyBorders.call(this, row, column);
 
     if (borderDescriptor) {

--- a/src/plugins/customBorders/customBorders.js
+++ b/src/plugins/customBorders/customBorders.js
@@ -290,10 +290,6 @@ class CustomBorders extends BasePlugin {
       return;
     }
 
-    if (this.hot.rowIndexMapper.isHidden(row) || this.hot.columnIndexMapper.isHidden(column)) {
-      return;
-    }
-
     let border = createEmptyBorders(row, column);
 
     if (borderDescriptor) {

--- a/src/plugins/customBorders/customBorders.js
+++ b/src/plugins/customBorders/customBorders.js
@@ -326,35 +326,54 @@ class CustomBorders extends BasePlugin {
    * @param {object} rowDecriptor Object with `range`, `left`, `right`, `top` and `bottom` properties.
    */
   prepareBorderFromCustomAddedRange(rowDecriptor) {
+    const rowMaper = this.hot.rowIndexMapper;
+    const columnMaper = this.hot.columnIndexMapper;
     const range = rowDecriptor.range;
+    const lastRowIndex = this.hot.countRows() - 1;
+    const lastColumnIndex = this.hot.countCols() - 1;
 
-    rangeEach(range.from.row, range.to.row, (rowIndex) => {
-      rangeEach(range.from.col, range.to.col, (colIndex) => {
-        const border = createEmptyBorders.call(this, rowIndex, colIndex);
+    rangeEach(range.from.row, Math.min(range.to.row, lastRowIndex), (rowIndex) => {
+      if (rowMaper.isHidden(rowIndex)) {
+        return;
+      }
+
+      rangeEach(range.from.col, Math.min(range.to.col, lastColumnIndex), (colIndex) => {
+        if (columnMaper.isHidden(colIndex)) {
+          return;
+        }
+
+        const isFirstRow = rowIndex === rowMaper.getFirstNotHiddenIndex(range.from.row, 1);
+        const isLastRow = rowIndex === rowMaper.getFirstNotHiddenIndex(range.to.row, -1);
+        const isFirstColumn = colIndex === columnMaper.getFirstNotHiddenIndex(range.from.col, 1);
+        const isLastColumn = colIndex === columnMaper.getFirstNotHiddenIndex(range.to.col, -1);
+        const rowIncrementBy = isLastRow ? -1 : 1;
+        const columnIncrementBy = isLastColumn ? -1 : 1;
+
+        const border = createEmptyBorders.call(this, rowIndex, colIndex, rowIncrementBy, columnIncrementBy);
         let add = 0;
 
-        if (rowIndex === range.from.row) {
+        if (isFirstRow) {
           if (hasOwnProperty(rowDecriptor, 'top')) {
             add += 1;
             border.top = rowDecriptor.top;
           }
         }
 
-        if (rowIndex === range.to.row) {
+        if (isLastRow) {
           if (hasOwnProperty(rowDecriptor, 'bottom')) {
             add += 1;
             border.bottom = rowDecriptor.bottom;
           }
         }
 
-        if (colIndex === range.from.col) {
+        if (isFirstColumn) {
           if (hasOwnProperty(rowDecriptor, 'left')) {
             add += 1;
             border.left = rowDecriptor.left;
           }
         }
 
-        if (colIndex === range.to.col) {
+        if (isLastColumn) {
           if (hasOwnProperty(rowDecriptor, 'right')) {
             add += 1;
             border.right = rowDecriptor.right;

--- a/src/plugins/customBorders/customBorders.js
+++ b/src/plugins/customBorders/customBorders.js
@@ -286,7 +286,7 @@ class CustomBorders extends BasePlugin {
     const nrOfRows = this.hot.countRows();
     const nrOfColumns = this.hot.countCols();
 
-    if (row > nrOfRows || column > nrOfColumns) {
+    if (row >= nrOfRows || column >= nrOfColumns) {
       return;
     }
 
@@ -669,7 +669,8 @@ class CustomBorders extends BasePlugin {
     } else {
       arrayEach(this.hot.selection.highlight.customSelections, (customSelection) => {
         if (border.id === customSelection.settings.id) {
-          customSelection.cellRange = cellRange;
+          customSelection.visualCellRange = cellRange;
+          customSelection.commit();
 
           if (place) {
             objectEach(customSelection.instanceBorders, (borderObject) => {

--- a/src/plugins/customBorders/customBorders.js
+++ b/src/plugins/customBorders/customBorders.js
@@ -294,6 +294,13 @@ class CustomBorders extends BasePlugin {
    * @param {string} place Coordinate where add/remove border - `top`, `bottom`, `left`, `right`.
    */
   prepareBorderFromCustomAdded(row, column, borderDescriptor, place) {
+    const nrOfRows = this.hot.countRows();
+    const nrOfColumns = this.hot.countCols();
+
+    if (row > nrOfRows || column > nrOfColumns) {
+      return;
+    }
+
     if (this.hot.rowIndexMapper.isHidden(row) || this.hot.columnIndexMapper.isHidden(column)) {
       return;
     }

--- a/src/plugins/customBorders/test/customBorders.e2e.js
+++ b/src/plugins/customBorders/test/customBorders.e2e.js
@@ -1106,8 +1106,8 @@ describe('CustomBorders', () => {
     });
   });
 
-  // TODO: Should it work in this way?
-  it('should draw borders properly when they end beyond the table boundaries', () => {
+  // TODO: Should it work in this way? Probably some warn would be helpful.
+  it('should draw borders properly when they end beyond the table boundaries (drawing range)', () => {
     handsontable({
       data: Handsontable.helper.createSpreadsheetData(5, 5),
       rowHeaders: true,
@@ -1150,6 +1150,41 @@ describe('CustomBorders', () => {
     expect(getCellMeta(4, 4).borders).toBeUndefined();
     // Cell in the middle of area without borders
     expect(getCellMeta(2, 3).borders).toBeUndefined();
+  });
+
+  // TODO: Should it work in this way? Probably some warn would be helpful.
+  it('should draw borders properly when some of them are beyond the table boundaries (drawing single borders)', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(5, 5),
+      rowHeaders: true,
+      colHeaders: true,
+      hiddenColumns: {
+        columns: [1],
+        indicators: true
+      },
+      customBorders: [{
+        row: 0,
+        col: 0,
+        top: BLUE_BORDER,
+        left: ORANGE_BORDER,
+        bottom: RED_BORDER,
+        right: MAGENTA_BORDER
+      }, {
+        row: 7,
+        col: 7,
+        top: BLUE_BORDER,
+        left: ORANGE_BORDER,
+        bottom: RED_BORDER,
+        right: MAGENTA_BORDER
+      }]
+    });
+
+    expect(countVisibleCustomBorders()).toEqual(4);
+    expect(getCellMeta(0, 0).borders.left).toEqual(ORANGE_BORDER);
+    expect(getCellMeta(0, 0).borders.top).toEqual(BLUE_BORDER);
+    expect(getCellMeta(0, 0).borders.bottom).toEqual(RED_BORDER);
+    expect(getCellMeta(0, 0).borders.right).toEqual(MAGENTA_BORDER);
+    expect(getCellMeta(2, 2).borders).toBeUndefined();
   });
 
   describe('should cooperate with the `HiddenColumns` plugin properly', () => {
@@ -1486,6 +1521,87 @@ describe('CustomBorders', () => {
       expect(getCellMeta(4, 4).borders.right).toEqual(MAGENTA_BORDER);
       // Cell in the middle of area without borders
       expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
+    it('should not display custom border for single cell when it is placed on the hidden column', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenColumns: {
+          columns: [1],
+          indicators: true
+        },
+        customBorders: [{
+          row: 1,
+          col: 1,
+          top: BLUE_BORDER,
+          left: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          right: MAGENTA_BORDER
+        }]
+      });
+
+      expect(countVisibleCustomBorders()).toEqual(0);
+      expect(getCellMeta(1, 1).borders).toBeUndefined();
+      expect(getCellMeta(1, 1).borders).toBeUndefined();
+      expect(getCellMeta(1, 1).borders).toBeUndefined();
+      expect(getCellMeta(1, 1).borders).toBeUndefined();
+    });
+
+    it('should not display custom border for single cell when column containing border is hidden', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenColumns: true,
+        customBorders: [{
+          row: 1,
+          col: 1,
+          top: BLUE_BORDER,
+          left: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          right: MAGENTA_BORDER
+        }]
+      });
+
+      getPlugin('hiddenColumns').hideColumn(1);
+      render();
+
+      expect(countVisibleCustomBorders()).toEqual(0);
+      expect(getCellMeta(1, 1).borders).toBeUndefined();
+      expect(getCellMeta(1, 1).borders).toBeUndefined();
+      expect(getCellMeta(1, 1).borders).toBeUndefined();
+      expect(getCellMeta(1, 1).borders).toBeUndefined();
+    });
+
+    it('should display custom border for single cell when hidden column containing border has been shown', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenColumns: {
+          columns: [1],
+          indicators: true
+        },
+        customBorders: [{
+          row: 1,
+          col: 1,
+          top: BLUE_BORDER,
+          left: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          right: MAGENTA_BORDER
+        }]
+      });
+
+      getPlugin('hiddenColumns').showColumn(1);
+      render();
+
+      expect(countVisibleCustomBorders()).toEqual(0);
+      expect(getCellMeta(1, 1).borders).toBeUndefined();
+      expect(getCellMeta(1, 1).borders).toBeUndefined();
+      expect(getCellMeta(1, 1).borders).toBeUndefined();
+      expect(getCellMeta(1, 1).borders).toBeUndefined();
     });
 
     it('should draw border from context menu options in proper place when there are some hidden columns before ' +

--- a/src/plugins/customBorders/test/customBorders.e2e.js
+++ b/src/plugins/customBorders/test/customBorders.e2e.js
@@ -1216,32 +1216,29 @@ describe('CustomBorders', () => {
         }]
       });
 
-      expect(countVisibleCustomBorders()).toEqual((3 * 2) + (4 * 2)); // 4 rows x 3 columns
-      // Hidden column, start of the border has been shifted.
-      expect(getCellMeta(1, 1).borders).toBeUndefined();
-      expect(getCellMeta(4, 1).borders).toBeUndefined();
+      expect(countVisibleCustomBorders()).toEqual((3 * 2) + 4); // 4 rows x 3 columns without left border
       // First cell from the top-left position
-      expect(getCellMeta(1, 2).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(1, 2).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 2).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(1, 2).borders.right).toEqual(EMPTY);
+      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
       // First cell from the top-right position
       expect(getCellMeta(1, 4).borders.left).toEqual(EMPTY);
       expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
       expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
       expect(getCellMeta(1, 4).borders.right).toEqual(MAGENTA_BORDER);
       // // First cell from the bottom-left position
-      expect(getCellMeta(4, 2).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(4, 2).borders.top).toEqual(EMPTY);
-      expect(getCellMeta(4, 2).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(4, 2).borders.right).toEqual(EMPTY);
+      expect(getCellMeta(4, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 1).borders.right).toEqual(EMPTY);
       // // First cell from the bottom-right position
       expect(getCellMeta(4, 4).borders.left).toEqual(EMPTY);
       expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
       expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
       expect(getCellMeta(4, 4).borders.right).toEqual(MAGENTA_BORDER);
       // Cell in the middle of area without borders
-      expect(getCellMeta(2, 3).borders).toBeUndefined();
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
     });
 
     it('should display custom borders (drawing range) properly when hiding columns that have been visible ' +
@@ -1272,32 +1269,29 @@ describe('CustomBorders', () => {
       getPlugin('hiddenColumns').hideColumn(1);
       render();
 
-      expect(countVisibleCustomBorders()).toEqual((3 * 2) + (4 * 2)); // 4 rows x 3 columns
-      // Hidden column, start of the border has been shifted.
-      expect(getCellMeta(1, 1).borders).toBeUndefined();
-      expect(getCellMeta(4, 1).borders).toBeUndefined();
+      expect(countVisibleCustomBorders()).toEqual((3 * 2) + 4); // 4 rows x 3 columns without left border
       // First cell from the top-left position
-      expect(getCellMeta(1, 2).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(1, 2).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 2).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(1, 2).borders.right).toEqual(EMPTY);
+      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
       // First cell from the top-right position
       expect(getCellMeta(1, 4).borders.left).toEqual(EMPTY);
       expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
       expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
       expect(getCellMeta(1, 4).borders.right).toEqual(MAGENTA_BORDER);
       // // First cell from the bottom-left position
-      expect(getCellMeta(4, 2).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(4, 2).borders.top).toEqual(EMPTY);
-      expect(getCellMeta(4, 2).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(4, 2).borders.right).toEqual(EMPTY);
+      expect(getCellMeta(4, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 1).borders.right).toEqual(EMPTY);
       // // First cell from the bottom-right position
       expect(getCellMeta(4, 4).borders.left).toEqual(EMPTY);
       expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
       expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
       expect(getCellMeta(4, 4).borders.right).toEqual(MAGENTA_BORDER);
       // Cell in the middle of area without borders
-      expect(getCellMeta(2, 3).borders).toBeUndefined();
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
     });
 
     it('should display custom borders (drawing range) properly when showing columns that have been hidden ' +
@@ -1331,9 +1325,7 @@ describe('CustomBorders', () => {
       getPlugin('hiddenColumns').showColumn(1);
       render();
 
-      expect(countVisibleCustomBorders()).toEqual((4 * 2) + (4 * 2)); // 4 rows x 4 columns
-      expect(getCellMeta(1, 0).borders).toBeUndefined();
-      expect(getCellMeta(4, 0).borders).toBeUndefined();
+      expect(countVisibleCustomBorders()).toEqual(4 * 4); // 4 rows x 4 columns
       // First cell from the top-left position
       expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
       expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
@@ -1355,7 +1347,7 @@ describe('CustomBorders', () => {
       expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
       expect(getCellMeta(4, 4).borders.right).toEqual(MAGENTA_BORDER);
       // Cell in the middle of area without borders
-      expect(getCellMeta(2, 3).borders).toBeUndefined();
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
     });
 
     it('should display custom borders (drawing range) properly when some columns are hidden ' +
@@ -1386,30 +1378,27 @@ describe('CustomBorders', () => {
         }]
       });
 
-      expect(countVisibleCustomBorders()).toEqual((3 * 2) + (4 * 2)); // 4 rows x 3 columns
-      // Hidden column, start of the border has been shifted.
-      expect(getCellMeta(1, 4).borders).toBeUndefined();
-      expect(getCellMeta(4, 4).borders).toBeUndefined();
+      expect(countVisibleCustomBorders()).toEqual((3 * 2) + 4); // 4 rows x 3 columns without right border
       // First cell from the top-left position
       expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
       expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
       expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
       expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
       // First cell from the top-right position
-      expect(getCellMeta(1, 3).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(1, 3).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 3).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(1, 3).borders.right).toEqual(MAGENTA_BORDER);
+      expect(getCellMeta(1, 4).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.right).toEqual(MAGENTA_BORDER);
       // // First cell from the bottom-left position
       expect(getCellMeta(4, 1).borders.left).toEqual(ORANGE_BORDER);
       expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
       expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
       expect(getCellMeta(4, 1).borders.right).toEqual(EMPTY);
       // // First cell from the bottom-right position
-      expect(getCellMeta(4, 3).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(4, 3).borders.top).toEqual(EMPTY);
-      expect(getCellMeta(4, 3).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(4, 3).borders.right).toEqual(MAGENTA_BORDER);
+      expect(getCellMeta(4, 4).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 4).borders.right).toEqual(MAGENTA_BORDER);
       // Cell in the middle of area without borders
       expect(getCellMeta(2, 2).borders).toBeUndefined();
     });
@@ -1442,30 +1431,27 @@ describe('CustomBorders', () => {
       getPlugin('hiddenColumns').hideColumn(4);
       render();
 
-      expect(countVisibleCustomBorders()).toEqual((3 * 2) + (4 * 2)); // 4 rows x 3 columns
-      // Hidden column, start of the border has been shifted.
-      expect(getCellMeta(1, 4).borders).toBeUndefined();
-      expect(getCellMeta(4, 4).borders).toBeUndefined();
+      expect(countVisibleCustomBorders()).toEqual((3 * 2) + 4); // 4 rows x 3 columns without right border
       // First cell from the top-left position
       expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
       expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
       expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
       expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
       // First cell from the top-right position
-      expect(getCellMeta(1, 3).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(1, 3).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 3).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(1, 3).borders.right).toEqual(MAGENTA_BORDER);
+      expect(getCellMeta(1, 4).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.right).toEqual(MAGENTA_BORDER);
       // // First cell from the bottom-left position
       expect(getCellMeta(4, 1).borders.left).toEqual(ORANGE_BORDER);
       expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
       expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
       expect(getCellMeta(4, 1).borders.right).toEqual(EMPTY);
       // // First cell from the bottom-right position
-      expect(getCellMeta(4, 3).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(4, 3).borders.top).toEqual(EMPTY);
-      expect(getCellMeta(4, 3).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(4, 3).borders.right).toEqual(MAGENTA_BORDER);
+      expect(getCellMeta(4, 4).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 4).borders.right).toEqual(MAGENTA_BORDER);
       // Cell in the middle of area without borders
       expect(getCellMeta(2, 2).borders).toBeUndefined();
     });
@@ -1498,7 +1484,10 @@ describe('CustomBorders', () => {
         }]
       });
 
-      expect(countVisibleCustomBorders()).toEqual((4 * 2) + (4 * 2)); // 4 rows x 4 columns
+      getPlugin('hiddenColumns').showColumn(4);
+      render();
+
+      expect(countVisibleCustomBorders()).toEqual(4 * 4); // 4 rows x 4 columns
       // First cell from the top-left position
       expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
       expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
@@ -1542,11 +1531,13 @@ describe('CustomBorders', () => {
         }]
       });
 
+      // Just the meta is defined.
       expect(countVisibleCustomBorders()).toEqual(0);
-      expect(getCellMeta(1, 1).borders).toBeUndefined();
-      expect(getCellMeta(1, 1).borders).toBeUndefined();
-      expect(getCellMeta(1, 1).borders).toBeUndefined();
-      expect(getCellMeta(1, 1).borders).toBeUndefined();
+      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(1, 1).borders.right).toEqual(MAGENTA_BORDER);
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
     });
 
     it('should display custom borders for single cells properly when one of them is placed on the hidden column', () => {
@@ -1568,11 +1559,11 @@ describe('CustomBorders', () => {
         right: MAGENTA_BORDER
       });
 
-      expect(countVisibleCustomBorders()).toEqual(3 * 4); // 3 cells, all of them with 4 borders
-      expect(getCellMeta(1, 1).borders).toBeUndefined();
-      expect(getCellMeta(1, 1).borders).toBeUndefined();
-      expect(getCellMeta(1, 1).borders).toBeUndefined();
-      expect(getCellMeta(1, 1).borders).toBeUndefined();
+      expect(countVisibleCustomBorders()).toEqual(3 * 4); // Just 3 cells (2 columns are hidden), all of them with 4 borders
+      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(1, 1).borders.right).toEqual(MAGENTA_BORDER);
 
       expect(getCellMeta(1, 2).borders.left).toEqual(ORANGE_BORDER);
       expect(getCellMeta(1, 2).borders.top).toEqual(BLUE_BORDER);
@@ -1609,11 +1600,12 @@ describe('CustomBorders', () => {
       getPlugin('hiddenColumns').hideColumn(1);
       render();
 
+      // Just the meta is defined.
       expect(countVisibleCustomBorders()).toEqual(0);
-      expect(getCellMeta(1, 1).borders).toBeUndefined();
-      expect(getCellMeta(1, 1).borders).toBeUndefined();
-      expect(getCellMeta(1, 1).borders).toBeUndefined();
-      expect(getCellMeta(1, 1).borders).toBeUndefined();
+      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(1, 1).borders.right).toEqual(MAGENTA_BORDER);
     });
 
     it('should display custom border for single cell when hidden column containing border has been shown by API call', () => {

--- a/src/plugins/customBorders/test/customBorders.e2e.js
+++ b/src/plugins/customBorders/test/customBorders.e2e.js
@@ -7,6 +7,7 @@ describe('CustomBorders', () => {
   const MAGENTA_BORDER = { color: 'magenta', width: 2 };
   const BLUE_BORDER = { color: 'blue', width: 2 };
   const ORANGE_BORDER = { color: 'orange', width: 2 };
+  const YELLOW_BORDER = { color: 'yellow', width: 2 };
   const EMPTY = { hide: true };
 
   const CUSTOM_BORDER_SELECTOR = '.wtBorder:not(.fill, .current, .area)';
@@ -1189,7 +1190,7 @@ describe('CustomBorders', () => {
 
   describe('should cooperate with the `HiddenColumns` plugin properly', () => {
     it('should display custom borders (drawing range) properly when some columns are hidden ' +
-      '(starting range from hidden column)', () => {
+      '(range starts from hidden column)', () => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(5, 5),
         rowHeaders: true,
@@ -1295,7 +1296,7 @@ describe('CustomBorders', () => {
     });
 
     it('should display custom borders (drawing range) properly when showing columns that have been hidden ' +
-      '(starting range from hidden column)', () => {
+      '(range starts from hidden column)', () => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(5, 5),
         rowHeaders: true,
@@ -1351,7 +1352,7 @@ describe('CustomBorders', () => {
     });
 
     it('should display custom borders (drawing range) properly when some columns are hidden ' +
-      '(end range at hidden column)', () => {
+      '(range ends at hidden column)', () => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(5, 5),
         rowHeaders: true,
@@ -1457,7 +1458,7 @@ describe('CustomBorders', () => {
     });
 
     it('should display custom borders (drawing range) properly when showing columns that have been hidden ' +
-      '(end range at hidden column)', () => {
+      '(range ends at hidden column)', () => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(5, 5),
         rowHeaders: true,
@@ -1510,6 +1511,271 @@ describe('CustomBorders', () => {
       expect(getCellMeta(4, 4).borders.right).toEqual(MAGENTA_BORDER);
       // Cell in the middle of area without borders
       expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
+    it('should display custom borders (drawing range) properly when some columns are hidden ' +
+      '(hidden column in the middle of the range)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenColumns: {
+          columns: [2],
+          indicators: true
+        },
+        customBorders: [{
+          range: {
+            from: {
+              row: 1,
+              col: 1
+            },
+            to: {
+              row: 4,
+              col: 4
+            }
+          },
+          top: BLUE_BORDER,
+          left: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          right: MAGENTA_BORDER
+        }]
+      });
+
+      expect(countVisibleCustomBorders()).toEqual((3 * 2) + (4 * 2)); // 4 rows x 3 columns
+      // First cell from the top-left position
+      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
+      // First cell from the top-right position
+      expect(getCellMeta(1, 4).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.right).toEqual(MAGENTA_BORDER);
+      // // First cell from the bottom-left position
+      expect(getCellMeta(4, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 1).borders.right).toEqual(EMPTY);
+      // // First cell from the bottom-right position
+      expect(getCellMeta(4, 4).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 4).borders.right).toEqual(MAGENTA_BORDER);
+      // Cell in the middle of area without borders
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
+    it('should display custom borders (drawing range) properly when hiding columns that have been visible ' +
+      '(hiding column in the middle of the range)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenColumns: true,
+        customBorders: [{
+          range: {
+            from: {
+              row: 1,
+              col: 1
+            },
+            to: {
+              row: 4,
+              col: 4
+            }
+          },
+          top: BLUE_BORDER,
+          left: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          right: MAGENTA_BORDER
+        }]
+      });
+
+      getPlugin('hiddenColumns').hideColumn(2);
+      render();
+
+      expect(countVisibleCustomBorders()).toEqual((3 * 2) + (4 * 2)); // 4 rows x 3 columns
+      // First cell from the top-left position
+      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
+      // First cell from the top-right position
+      expect(getCellMeta(1, 4).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.right).toEqual(MAGENTA_BORDER);
+      // // First cell from the bottom-left position
+      expect(getCellMeta(4, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 1).borders.right).toEqual(EMPTY);
+      // // First cell from the bottom-right position
+      expect(getCellMeta(4, 4).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 4).borders.right).toEqual(MAGENTA_BORDER);
+      // Cell in the middle of area without borders
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
+
+    it('should display custom borders (drawing range) properly when showing columns that have been hidden ' +
+      '(hidden column in the middle of the range)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenColumns: {
+          columns: [4],
+          indicators: true
+        },
+        customBorders: [{
+          range: {
+            from: {
+              row: 1,
+              col: 1
+            },
+            to: {
+              row: 4,
+              col: 4
+            }
+          },
+          top: BLUE_BORDER,
+          left: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          right: MAGENTA_BORDER
+        }]
+      });
+
+      getPlugin('hiddenColumns').showColumn(4);
+      render();
+
+      expect(countVisibleCustomBorders()).toEqual(4 * 4); // 4 rows x 4 columns
+      // First cell from the top-left position
+      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
+      // First cell from the top-right position
+      expect(getCellMeta(1, 4).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.right).toEqual(MAGENTA_BORDER);
+      // // First cell from the bottom-left position
+      expect(getCellMeta(4, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 1).borders.right).toEqual(EMPTY);
+      // // First cell from the bottom-right position
+      expect(getCellMeta(4, 4).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 4).borders.right).toEqual(MAGENTA_BORDER);
+      // Cell in the middle of area without borders
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
+    it('should display borders properly when hiding cells separating another cells with borders (they will stick together) #1', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenColumns: true,
+        customBorders: [{
+          row: 1,
+          col: 0,
+          top: GREEN_BORDER,
+          left: GREEN_BORDER,
+          bottom: GREEN_BORDER,
+          right: GREEN_BORDER
+        }, {
+          row: 1,
+          col: 2,
+          top: BLUE_BORDER,
+          left: BLUE_BORDER,
+          bottom: BLUE_BORDER,
+          right: BLUE_BORDER
+        }, {
+          row: 1,
+          col: 4,
+          top: YELLOW_BORDER,
+          left: YELLOW_BORDER,
+          bottom: YELLOW_BORDER,
+          right: YELLOW_BORDER
+        }]
+      });
+
+      getPlugin('hiddenColumns').hideColumns([1, 3]);
+      render();
+
+      expect(countVisibleCustomBorders()).toEqual(3 * 4); // It isn't ok probably. There is no specification.
+      // expect(countVisibleCustomBorders()).toEqual((4 * 2) + 2); // TODO: It should work.
+      expect(getCellMeta(1, 0).borders.left).toEqual(GREEN_BORDER);
+      expect(getCellMeta(1, 0).borders.top).toEqual(GREEN_BORDER);
+      expect(getCellMeta(1, 0).borders.bottom).toEqual(GREEN_BORDER);
+      expect(getCellMeta(1, 0).borders.right).toEqual(GREEN_BORDER); // Is it ok?
+
+      expect(getCellMeta(1, 2).borders.left).toEqual(BLUE_BORDER); // Is it ok?
+      expect(getCellMeta(1, 2).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 2).borders.bottom).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 2).borders.right).toEqual(BLUE_BORDER); // Is it ok?
+
+      expect(getCellMeta(1, 4).borders.left).toEqual(YELLOW_BORDER); // Is it ok?
+      expect(getCellMeta(1, 4).borders.top).toEqual(YELLOW_BORDER);
+      expect(getCellMeta(1, 4).borders.bottom).toEqual(YELLOW_BORDER);
+      expect(getCellMeta(1, 4).borders.right).toEqual(YELLOW_BORDER);
+    });
+
+    it('should display borders properly when hiding cells separating another cells with borders (they will stick together) #2', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenColumns: true,
+        customBorders: [{
+          row: 1,
+          col: 0,
+          top: GREEN_BORDER,
+          left: GREEN_BORDER,
+          bottom: GREEN_BORDER,
+          right: GREEN_BORDER
+        }, {
+          row: 1,
+          col: 2,
+          top: BLUE_BORDER,
+          left: BLUE_BORDER,
+          bottom: BLUE_BORDER,
+          right: BLUE_BORDER
+        }, {
+          row: 1,
+          col: 4,
+          top: YELLOW_BORDER,
+          left: YELLOW_BORDER,
+          bottom: YELLOW_BORDER,
+          right: YELLOW_BORDER
+        }]
+      });
+
+      getPlugin('hiddenColumns').hideColumns([1, 2, 3]);
+      render();
+
+      expect(countVisibleCustomBorders()).toEqual(2 * 4); // It isn't ok probably. There is no specification.
+      // expect(countVisibleCustomBorders()).toEqual((4 + 3)); // TODO: It should work.
+      expect(getCellMeta(1, 0).borders.left).toEqual(GREEN_BORDER);
+      expect(getCellMeta(1, 0).borders.top).toEqual(GREEN_BORDER);
+      expect(getCellMeta(1, 0).borders.bottom).toEqual(GREEN_BORDER);
+      expect(getCellMeta(1, 0).borders.right).toEqual(GREEN_BORDER); // Is it ok?
+
+      expect(getCellMeta(1, 2).borders.left).toEqual(BLUE_BORDER); // There should be `EMPTY`
+      expect(getCellMeta(1, 2).borders.top).toEqual(BLUE_BORDER); // There should be `EMPTY`
+      expect(getCellMeta(1, 2).borders.bottom).toEqual(BLUE_BORDER); // There should be `EMPTY`
+      expect(getCellMeta(1, 2).borders.right).toEqual(BLUE_BORDER); // There should be `EMPTY`
+
+      expect(getCellMeta(1, 4).borders.left).toEqual(YELLOW_BORDER); // Is it ok?
+      expect(getCellMeta(1, 4).borders.top).toEqual(YELLOW_BORDER);
+      expect(getCellMeta(1, 4).borders.bottom).toEqual(YELLOW_BORDER);
+      expect(getCellMeta(1, 4).borders.right).toEqual(YELLOW_BORDER);
     });
 
     it('should not display custom border for single cell when it is placed on the hidden column', () => {

--- a/src/plugins/customBorders/test/customBorders.e2e.js
+++ b/src/plugins/customBorders/test/customBorders.e2e.js
@@ -1549,6 +1549,47 @@ describe('CustomBorders', () => {
       expect(getCellMeta(1, 1).borders).toBeUndefined();
     });
 
+    it('should display custom borders for single cell properly when one of them is placed on the hidden column', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenColumns: {
+          columns: [1, 3],
+          indicators: true
+        },
+        customBorders: true
+      });
+
+      getPlugin('customBorders').setBorders([[1, 1, 3, 3]], {
+        top: BLUE_BORDER,
+        left: ORANGE_BORDER,
+        bottom: RED_BORDER,
+        right: MAGENTA_BORDER
+      });
+
+      expect(countVisibleCustomBorders()).toEqual(3 * 4); // 3 cells, all of them with 4 borders
+      expect(getCellMeta(1, 1).borders).toBeUndefined();
+      expect(getCellMeta(1, 1).borders).toBeUndefined();
+      expect(getCellMeta(1, 1).borders).toBeUndefined();
+      expect(getCellMeta(1, 1).borders).toBeUndefined();
+
+      expect(getCellMeta(1, 2).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 2).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 2).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(1, 2).borders.right).toEqual(MAGENTA_BORDER);
+
+      expect(getCellMeta(2, 2).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(2, 2).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(2, 2).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(2, 2).borders.right).toEqual(MAGENTA_BORDER);
+
+      expect(getCellMeta(3, 2).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(3, 2).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(3, 2).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(3, 2).borders.right).toEqual(MAGENTA_BORDER);
+    });
+
     it('should not display custom border for single cell when column containing border is hidden by API call', () => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(5, 5),

--- a/src/plugins/customBorders/test/customBorders.e2e.js
+++ b/src/plugins/customBorders/test/customBorders.e2e.js
@@ -1209,6 +1209,120 @@ describe('CustomBorders', () => {
       expect(getCellMeta(2, 3).borders).toBeUndefined();
     });
 
+    it('should display custom borders (drawing range) properly when hiding columns that have been visible ' +
+      '(hiding column at the start of the range)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenColumns: true,
+        customBorders: [{
+          range: {
+            from: {
+              row: 1,
+              col: 1
+            },
+            to: {
+              row: 4,
+              col: 4
+            }
+          },
+          top: BLUE_BORDER,
+          left: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          right: MAGENTA_BORDER
+        }]
+      });
+
+      getPlugin('hiddenColumns').hideColumn(1);
+      render();
+
+      expect(countVisibleCustomBorders()).toEqual((3 * 2) + (4 * 2)); // 4 rows x 3 columns
+      // Hidden column, start of the border has been shifted.
+      expect(getCellMeta(1, 1).borders).toBeUndefined();
+      expect(getCellMeta(4, 1).borders).toBeUndefined();
+      // First cell from the top-left position
+      expect(getCellMeta(1, 2).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 2).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 2).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 2).borders.right).toEqual(EMPTY);
+      // First cell from the top-right position
+      expect(getCellMeta(1, 4).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.right).toEqual(MAGENTA_BORDER);
+      // // First cell from the bottom-left position
+      expect(getCellMeta(4, 2).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(4, 2).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 2).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 2).borders.right).toEqual(EMPTY);
+      // // First cell from the bottom-right position
+      expect(getCellMeta(4, 4).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 4).borders.right).toEqual(MAGENTA_BORDER);
+      // Cell in the middle of area without borders
+      expect(getCellMeta(2, 3).borders).toBeUndefined();
+    });
+
+    it('should display custom borders (drawing range) properly when showing columns that have been hidden ' +
+      '(starting range from hidden column)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenColumns: {
+          columns: [1],
+          indicators: true
+        },
+        customBorders: [{
+          range: {
+            from: {
+              row: 1,
+              col: 1
+            },
+            to: {
+              row: 4,
+              col: 4
+            }
+          },
+          top: BLUE_BORDER,
+          left: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          right: MAGENTA_BORDER
+        }]
+      });
+
+      getPlugin('hiddenColumns').showColumn(1);
+      render();
+
+      expect(countVisibleCustomBorders()).toEqual((4 * 2) + (4 * 2)); // 4 rows x 4 columns
+      expect(getCellMeta(1, 0).borders).toBeUndefined();
+      expect(getCellMeta(4, 0).borders).toBeUndefined();
+      // First cell from the top-left position
+      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
+      // First cell from the top-right position
+      expect(getCellMeta(1, 4).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.right).toEqual(MAGENTA_BORDER);
+      // // First cell from the bottom-left position
+      expect(getCellMeta(4, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 1).borders.right).toEqual(EMPTY);
+      // // First cell from the bottom-right position
+      expect(getCellMeta(4, 4).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 4).borders.right).toEqual(MAGENTA_BORDER);
+      // Cell in the middle of area without borders
+      expect(getCellMeta(2, 3).borders).toBeUndefined();
+    });
+
     it('should display custom borders (drawing range) properly when some columns are hidden ' +
       '(end range at hidden column)', () => {
       handsontable({
@@ -1265,8 +1379,117 @@ describe('CustomBorders', () => {
       expect(getCellMeta(2, 2).borders).toBeUndefined();
     });
 
+    it('should display custom borders (drawing range) properly when hiding columns that have been visible ' +
+      '(hiding column at the end of the range)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenColumns: true,
+        customBorders: [{
+          range: {
+            from: {
+              row: 1,
+              col: 1
+            },
+            to: {
+              row: 4,
+              col: 4
+            }
+          },
+          top: BLUE_BORDER,
+          left: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          right: MAGENTA_BORDER
+        }]
+      });
+
+      getPlugin('hiddenColumns').hideColumn(4);
+      render();
+
+      expect(countVisibleCustomBorders()).toEqual((3 * 2) + (4 * 2)); // 4 rows x 3 columns
+      // Hidden column, start of the border has been shifted.
+      expect(getCellMeta(1, 4).borders).toBeUndefined();
+      expect(getCellMeta(4, 4).borders).toBeUndefined();
+      // First cell from the top-left position
+      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
+      // First cell from the top-right position
+      expect(getCellMeta(1, 3).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(1, 3).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 3).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 3).borders.right).toEqual(MAGENTA_BORDER);
+      // // First cell from the bottom-left position
+      expect(getCellMeta(4, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 1).borders.right).toEqual(EMPTY);
+      // // First cell from the bottom-right position
+      expect(getCellMeta(4, 3).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(4, 3).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 3).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 3).borders.right).toEqual(MAGENTA_BORDER);
+      // Cell in the middle of area without borders
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
+    it('should display custom borders (drawing range) properly when showing columns that have been hidden ' +
+      '(end range at hidden column)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenColumns: {
+          columns: [4],
+          indicators: true
+        },
+        customBorders: [{
+          range: {
+            from: {
+              row: 1,
+              col: 1
+            },
+            to: {
+              row: 4,
+              col: 4
+            }
+          },
+          top: BLUE_BORDER,
+          left: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          right: MAGENTA_BORDER
+        }]
+      });
+
+      expect(countVisibleCustomBorders()).toEqual((4 * 2) + (4 * 2)); // 4 rows x 4 columns
+      // First cell from the top-left position
+      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
+      // First cell from the top-right position
+      expect(getCellMeta(1, 4).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.right).toEqual(MAGENTA_BORDER);
+      // // First cell from the bottom-left position
+      expect(getCellMeta(4, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 1).borders.right).toEqual(EMPTY);
+      // // First cell from the bottom-right position
+      expect(getCellMeta(4, 4).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 4).borders.right).toEqual(MAGENTA_BORDER);
+      // Cell in the middle of area without borders
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
     it('should draw border from context menu options in proper place when there are some hidden columns before ' +
-      'the place', async() => {
+      'a place where the border is added', async() => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(5, 5),
         contextMenu: true,

--- a/src/plugins/customBorders/test/customBorders.e2e.js
+++ b/src/plugins/customBorders/test/customBorders.e2e.js
@@ -1619,7 +1619,6 @@ describe('CustomBorders', () => {
       expect(getCellMeta(2, 2).borders).toBeUndefined();
     });
 
-
     it('should display custom borders (drawing range) properly when showing columns that have been hidden ' +
       '(hidden column in the middle of the range)', () => {
       handsontable({
@@ -2358,7 +2357,6 @@ describe('CustomBorders', () => {
       // Cell in the middle of area without borders
       expect(getCellMeta(2, 2).borders).toBeUndefined();
     });
-
 
     it('should display custom borders (drawing range) properly when showing rows that have been hidden ' +
       '(hidden row in the middle of the range)', () => {

--- a/src/plugins/customBorders/test/customBorders.e2e.js
+++ b/src/plugins/customBorders/test/customBorders.e2e.js
@@ -1105,4 +1105,187 @@ describe('CustomBorders', () => {
       expect(countCustomBorders()).toEqual(0);
     });
   });
+
+  // TODO: Should it work in this way?
+  it('should draw borders properly when they end beyond the table boundaries', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(5, 5),
+      rowHeaders: true,
+      colHeaders: true,
+      customBorders: [{
+        range: {
+          from: {
+            row: 1,
+            col: 1
+          },
+          to: {
+            row: 10,
+            col: 10
+          }
+        },
+        top: BLUE_BORDER,
+        left: ORANGE_BORDER,
+        bottom: RED_BORDER,
+        right: MAGENTA_BORDER
+      }]
+    });
+
+    expect(countVisibleCustomBorders()).toEqual(4 + 4); // 4 rows x 4 columns from one side
+    // First cell from the top-left position
+    expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
+    expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+    expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
+    // First cell from the top-right position
+    expect(getCellMeta(1, 4).borders.left).toEqual(EMPTY);
+    expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
+    expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(1, 4).borders.right).toEqual(EMPTY);
+    // // First cell from the bottom-left position
+    expect(getCellMeta(4, 1).borders.left).toEqual(ORANGE_BORDER);
+    expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
+    expect(getCellMeta(4, 1).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(4, 1).borders.right).toEqual(EMPTY);
+    // // First cell from the bottom-right position
+    expect(getCellMeta(4, 4).borders).toBeUndefined();
+    // Cell in the middle of area without borders
+    expect(getCellMeta(2, 3).borders).toBeUndefined();
+  });
+
+  describe('should cooperate with the `HiddenColumns` plugin properly', () => {
+    it('should display custom borders (drawing range) properly when some columns are hidden ' +
+      '(starting range from hidden column)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenColumns: {
+          columns: [1],
+          indicators: true
+        },
+        customBorders: [{
+          range: {
+            from: {
+              row: 1,
+              col: 1
+            },
+            to: {
+              row: 4,
+              col: 4
+            }
+          },
+          top: BLUE_BORDER,
+          left: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          right: MAGENTA_BORDER
+        }]
+      });
+
+      expect(countVisibleCustomBorders()).toEqual((3 * 2) + (4 * 2)); // 4 rows x 3 columns
+      // Hidden column, start of the border has been shifted.
+      expect(getCellMeta(1, 1).borders).toBeUndefined();
+      expect(getCellMeta(4, 1).borders).toBeUndefined();
+      // First cell from the top-left position
+      expect(getCellMeta(1, 2).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 2).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 2).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 2).borders.right).toEqual(EMPTY);
+      // First cell from the top-right position
+      expect(getCellMeta(1, 4).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.right).toEqual(MAGENTA_BORDER);
+      // // First cell from the bottom-left position
+      expect(getCellMeta(4, 2).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(4, 2).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 2).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 2).borders.right).toEqual(EMPTY);
+      // // First cell from the bottom-right position
+      expect(getCellMeta(4, 4).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 4).borders.right).toEqual(MAGENTA_BORDER);
+      // Cell in the middle of area without borders
+      expect(getCellMeta(2, 3).borders).toBeUndefined();
+    });
+
+    it('should display custom borders (drawing range) properly when some columns are hidden ' +
+      '(end range at hidden column)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenColumns: {
+          columns: [4],
+          indicators: true
+        },
+        customBorders: [{
+          range: {
+            from: {
+              row: 1,
+              col: 1
+            },
+            to: {
+              row: 4,
+              col: 4
+            }
+          },
+          top: BLUE_BORDER,
+          left: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          right: MAGENTA_BORDER
+        }]
+      });
+
+      expect(countVisibleCustomBorders()).toEqual((3 * 2) + (4 * 2)); // 4 rows x 3 columns
+      // Hidden column, start of the border has been shifted.
+      expect(getCellMeta(1, 4).borders).toBeUndefined();
+      expect(getCellMeta(4, 4).borders).toBeUndefined();
+      // First cell from the top-left position
+      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
+      // First cell from the top-right position
+      expect(getCellMeta(1, 3).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(1, 3).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 3).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 3).borders.right).toEqual(MAGENTA_BORDER);
+      // // First cell from the bottom-left position
+      expect(getCellMeta(4, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 1).borders.right).toEqual(EMPTY);
+      // // First cell from the bottom-right position
+      expect(getCellMeta(4, 3).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(4, 3).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 3).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 3).borders.right).toEqual(MAGENTA_BORDER);
+      // Cell in the middle of area without borders
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
+    it('should draw border from context menu options in proper place when there are some hidden columns before ' +
+      'the place', async() => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        contextMenu: true,
+        customBorders: true,
+        hiddenColumns: {
+          columns: [0, 1]
+        }
+      });
+
+      await selectContextSubmenuOption('Borders', 'Top', getCell(0, 2));
+      deselectCell();
+
+      expect(getCellMeta(0, 2).borders.top).toEqual(DEFAULT_BORDER);
+      expect(getCellMeta(0, 2).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(0, 2).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(0, 2).borders.right).toEqual(EMPTY);
+
+      expect(countVisibleCustomBorders()).toBe(1);
+      expect(countCustomBorders()).toBe(5);
+    });
+  });
 });

--- a/src/plugins/customBorders/test/customBorders.e2e.js
+++ b/src/plugins/customBorders/test/customBorders.e2e.js
@@ -1549,7 +1549,7 @@ describe('CustomBorders', () => {
       expect(getCellMeta(1, 1).borders).toBeUndefined();
     });
 
-    it('should not display custom border for single cell when column containing border is hidden', () => {
+    it('should not display custom border for single cell when column containing border is hidden by API call', () => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(5, 5),
         rowHeaders: true,
@@ -1575,7 +1575,7 @@ describe('CustomBorders', () => {
       expect(getCellMeta(1, 1).borders).toBeUndefined();
     });
 
-    it('should display custom border for single cell when hidden column containing border has been shown', () => {
+    it('should display custom border for single cell when hidden column containing border has been shown by API call', () => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(5, 5),
         rowHeaders: true,
@@ -1597,11 +1597,12 @@ describe('CustomBorders', () => {
       getPlugin('hiddenColumns').showColumn(1);
       render();
 
-      expect(countVisibleCustomBorders()).toEqual(0);
-      expect(getCellMeta(1, 1).borders).toBeUndefined();
-      expect(getCellMeta(1, 1).borders).toBeUndefined();
-      expect(getCellMeta(1, 1).borders).toBeUndefined();
-      expect(getCellMeta(1, 1).borders).toBeUndefined();
+      expect(countVisibleCustomBorders()).toEqual(4);
+      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(1, 1).borders.right).toEqual(MAGENTA_BORDER);
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
     });
 
     it('should draw border from context menu options in proper place when there are some hidden columns before ' +

--- a/src/plugins/customBorders/test/customBorders.e2e.js
+++ b/src/plugins/customBorders/test/customBorders.e2e.js
@@ -1767,10 +1767,10 @@ describe('CustomBorders', () => {
       expect(getCellMeta(1, 0).borders.bottom).toEqual(GREEN_BORDER);
       expect(getCellMeta(1, 0).borders.right).toEqual(GREEN_BORDER); // Is it ok?
 
-      expect(getCellMeta(1, 2).borders.left).toEqual(BLUE_BORDER); // There should be `EMPTY`
-      expect(getCellMeta(1, 2).borders.top).toEqual(BLUE_BORDER); // There should be `EMPTY`
-      expect(getCellMeta(1, 2).borders.bottom).toEqual(BLUE_BORDER); // There should be `EMPTY`
-      expect(getCellMeta(1, 2).borders.right).toEqual(BLUE_BORDER); // There should be `EMPTY`
+      expect(getCellMeta(1, 2).borders.left).toEqual(BLUE_BORDER); // Is it ok?
+      expect(getCellMeta(1, 2).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 2).borders.bottom).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 2).borders.right).toEqual(BLUE_BORDER); // Is it ok?
 
       expect(getCellMeta(1, 4).borders.left).toEqual(YELLOW_BORDER); // Is it ok?
       expect(getCellMeta(1, 4).borders.top).toEqual(YELLOW_BORDER);
@@ -1922,6 +1922,746 @@ describe('CustomBorders', () => {
       expect(getCellMeta(0, 2).borders.left).toEqual(EMPTY);
       expect(getCellMeta(0, 2).borders.bottom).toEqual(EMPTY);
       expect(getCellMeta(0, 2).borders.right).toEqual(EMPTY);
+
+      expect(countVisibleCustomBorders()).toBe(1);
+      expect(countCustomBorders()).toBe(5);
+    });
+  });
+
+  describe('should cooperate with the `HiddenRows` plugin properly', () => {
+    it('should display custom borders (drawing range) properly when some rows are hidden ' +
+      '(range starts from hidden row)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenRows: {
+          rows: [1],
+          indicators: true
+        },
+        customBorders: [{
+          range: {
+            from: {
+              row: 1,
+              col: 1
+            },
+            to: {
+              row: 4,
+              col: 4
+            }
+          },
+          top: BLUE_BORDER,
+          left: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          right: MAGENTA_BORDER
+        }]
+      });
+
+      expect(countVisibleCustomBorders()).toEqual((3 * 2) + 4); // 3 rows x 4 columns without top border
+      // First cell from the top-left position
+      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
+      // First cell from the top-right position
+      expect(getCellMeta(1, 4).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.right).toEqual(MAGENTA_BORDER);
+      // // First cell from the bottom-left position
+      expect(getCellMeta(4, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 1).borders.right).toEqual(EMPTY);
+      // // First cell from the bottom-right position
+      expect(getCellMeta(4, 4).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 4).borders.right).toEqual(MAGENTA_BORDER);
+      // Cell in the middle of area without borders
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
+    it('should display custom borders (drawing range) properly when hiding rows that have been visible ' +
+      '(hiding row at the start of the range)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenRows: true,
+        customBorders: [{
+          range: {
+            from: {
+              row: 1,
+              col: 1
+            },
+            to: {
+              row: 4,
+              col: 4
+            }
+          },
+          top: BLUE_BORDER,
+          left: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          right: MAGENTA_BORDER
+        }]
+      });
+
+      getPlugin('hiddenRows').hideRow(1);
+      render();
+
+      expect(countVisibleCustomBorders()).toEqual((3 * 2) + 4); // 3 rows x 4 columns without top border
+      // First cell from the top-left position
+      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
+      // First cell from the top-right position
+      expect(getCellMeta(1, 4).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.right).toEqual(MAGENTA_BORDER);
+      // // First cell from the bottom-left position
+      expect(getCellMeta(4, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 1).borders.right).toEqual(EMPTY);
+      // // First cell from the bottom-right position
+      expect(getCellMeta(4, 4).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 4).borders.right).toEqual(MAGENTA_BORDER);
+      // Cell in the middle of area without borders
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
+    it('should display custom borders (drawing range) properly when showing rows that have been hidden ' +
+      '(range starts from hidden row)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenRows: {
+          rows: [1],
+          indicators: true
+        },
+        customBorders: [{
+          range: {
+            from: {
+              row: 1,
+              col: 1
+            },
+            to: {
+              row: 4,
+              col: 4
+            }
+          },
+          top: BLUE_BORDER,
+          left: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          right: MAGENTA_BORDER
+        }]
+      });
+
+      getPlugin('hiddenRows').showRow(1);
+      render();
+
+      expect(countVisibleCustomBorders()).toEqual(4 * 4); // 4 rows x 4 columns
+      // First cell from the top-left position
+      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
+      // First cell from the top-right position
+      expect(getCellMeta(1, 4).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.right).toEqual(MAGENTA_BORDER);
+      // // First cell from the bottom-left position
+      expect(getCellMeta(4, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 1).borders.right).toEqual(EMPTY);
+      // // First cell from the bottom-right position
+      expect(getCellMeta(4, 4).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 4).borders.right).toEqual(MAGENTA_BORDER);
+      // Cell in the middle of area without borders
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
+    it('should display custom borders (drawing range) properly when some rows are hidden ' +
+      '(range ends at hidden row)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenRows: {
+          rows: [4],
+          indicators: true
+        },
+        customBorders: [{
+          range: {
+            from: {
+              row: 1,
+              col: 1
+            },
+            to: {
+              row: 4,
+              col: 4
+            }
+          },
+          top: BLUE_BORDER,
+          left: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          right: MAGENTA_BORDER
+        }]
+      });
+
+      expect(countVisibleCustomBorders()).toEqual((3 * 2) + 4); // 3 rows x 4 columns without bottom border
+      // First cell from the top-left position
+      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
+      // First cell from the top-right position
+      expect(getCellMeta(1, 4).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.right).toEqual(MAGENTA_BORDER);
+      // // First cell from the bottom-left position
+      expect(getCellMeta(4, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 1).borders.right).toEqual(EMPTY);
+      // // First cell from the bottom-right position
+      expect(getCellMeta(4, 4).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 4).borders.right).toEqual(MAGENTA_BORDER);
+      // Cell in the middle of area without borders
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
+    it('should display custom borders (drawing range) properly when hiding rows that have been visible ' +
+      '(hiding row at the end of the range)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenRows: true,
+        customBorders: [{
+          range: {
+            from: {
+              row: 1,
+              col: 1
+            },
+            to: {
+              row: 4,
+              col: 4
+            }
+          },
+          top: BLUE_BORDER,
+          left: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          right: MAGENTA_BORDER
+        }]
+      });
+
+      getPlugin('hiddenRows').hideRow(4);
+      render();
+
+      expect(countVisibleCustomBorders()).toEqual((3 * 2) + 4); // 3 rows x 4 columns without right border
+      // First cell from the top-left position
+      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
+      // First cell from the top-right position
+      expect(getCellMeta(1, 4).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.right).toEqual(MAGENTA_BORDER);
+      // // First cell from the bottom-left position
+      expect(getCellMeta(4, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 1).borders.right).toEqual(EMPTY);
+      // // First cell from the bottom-right position
+      expect(getCellMeta(4, 4).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 4).borders.right).toEqual(MAGENTA_BORDER);
+      // Cell in the middle of area without borders
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
+    it('should display custom borders (drawing range) properly when showing rows that have been hidden ' +
+      '(range ends at hidden row)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenRows: {
+          rows: [4],
+          indicators: true
+        },
+        customBorders: [{
+          range: {
+            from: {
+              row: 1,
+              col: 1
+            },
+            to: {
+              row: 4,
+              col: 4
+            }
+          },
+          top: BLUE_BORDER,
+          left: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          right: MAGENTA_BORDER
+        }]
+      });
+
+      getPlugin('hiddenRows').showRow(4);
+      render();
+
+      expect(countVisibleCustomBorders()).toEqual(4 * 4); // 4 rows x 4 columns
+      // First cell from the top-left position
+      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
+      // First cell from the top-right position
+      expect(getCellMeta(1, 4).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.right).toEqual(MAGENTA_BORDER);
+      // // First cell from the bottom-left position
+      expect(getCellMeta(4, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 1).borders.right).toEqual(EMPTY);
+      // // First cell from the bottom-right position
+      expect(getCellMeta(4, 4).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 4).borders.right).toEqual(MAGENTA_BORDER);
+      // Cell in the middle of area without borders
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
+    it('should display custom borders (drawing range) properly when some rows are hidden ' +
+      '(hidden row in the middle of the range)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenRows: {
+          rows: [2],
+          indicators: true
+        },
+        customBorders: [{
+          range: {
+            from: {
+              row: 1,
+              col: 1
+            },
+            to: {
+              row: 4,
+              col: 4
+            }
+          },
+          top: BLUE_BORDER,
+          left: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          right: MAGENTA_BORDER
+        }]
+      });
+
+      expect(countVisibleCustomBorders()).toEqual((3 * 2) + (4 * 2)); // 3 rows x 4 columns
+      // First cell from the top-left position
+      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
+      // First cell from the top-right position
+      expect(getCellMeta(1, 4).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.right).toEqual(MAGENTA_BORDER);
+      // // First cell from the bottom-left position
+      expect(getCellMeta(4, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 1).borders.right).toEqual(EMPTY);
+      // // First cell from the bottom-right position
+      expect(getCellMeta(4, 4).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 4).borders.right).toEqual(MAGENTA_BORDER);
+      // Cell in the middle of area without borders
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
+    it('should display custom borders (drawing range) properly when hiding rows that have been visible ' +
+      '(hiding row in the middle of the range)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenRows: true,
+        customBorders: [{
+          range: {
+            from: {
+              row: 1,
+              col: 1
+            },
+            to: {
+              row: 4,
+              col: 4
+            }
+          },
+          top: BLUE_BORDER,
+          left: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          right: MAGENTA_BORDER
+        }]
+      });
+
+      getPlugin('hiddenRows').hideRow(2);
+      render();
+
+      expect(countVisibleCustomBorders()).toEqual((3 * 2) + (4 * 2)); // 3 rows x 4 columns
+      // First cell from the top-left position
+      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
+      // First cell from the top-right position
+      expect(getCellMeta(1, 4).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.right).toEqual(MAGENTA_BORDER);
+      // // First cell from the bottom-left position
+      expect(getCellMeta(4, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 1).borders.right).toEqual(EMPTY);
+      // // First cell from the bottom-right position
+      expect(getCellMeta(4, 4).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 4).borders.right).toEqual(MAGENTA_BORDER);
+      // Cell in the middle of area without borders
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
+
+    it('should display custom borders (drawing range) properly when showing rows that have been hidden ' +
+      '(hidden row in the middle of the range)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenRows: {
+          rows: [4],
+          indicators: true
+        },
+        customBorders: [{
+          range: {
+            from: {
+              row: 1,
+              col: 1
+            },
+            to: {
+              row: 4,
+              col: 4
+            }
+          },
+          top: BLUE_BORDER,
+          left: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          right: MAGENTA_BORDER
+        }]
+      });
+
+      getPlugin('hiddenRows').showRow(4);
+      render();
+
+      expect(countVisibleCustomBorders()).toEqual(4 * 4); // 4 rows x 4 columns
+      // First cell from the top-left position
+      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
+      // First cell from the top-right position
+      expect(getCellMeta(1, 4).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.right).toEqual(MAGENTA_BORDER);
+      // // First cell from the bottom-left position
+      expect(getCellMeta(4, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 1).borders.right).toEqual(EMPTY);
+      // // First cell from the bottom-right position
+      expect(getCellMeta(4, 4).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 4).borders.right).toEqual(MAGENTA_BORDER);
+      // Cell in the middle of area without borders
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
+    it('should display borders properly when hiding cells separating another cells with borders (they will stick together) #1', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenRows: true,
+        customBorders: [{
+          row: 0,
+          col: 1,
+          top: GREEN_BORDER,
+          left: GREEN_BORDER,
+          bottom: GREEN_BORDER,
+          right: GREEN_BORDER
+        }, {
+          row: 2,
+          col: 1,
+          top: BLUE_BORDER,
+          left: BLUE_BORDER,
+          bottom: BLUE_BORDER,
+          right: BLUE_BORDER
+        }, {
+          row: 4,
+          col: 1,
+          top: YELLOW_BORDER,
+          left: YELLOW_BORDER,
+          bottom: YELLOW_BORDER,
+          right: YELLOW_BORDER
+        }]
+      });
+
+      getPlugin('hiddenRows').hideRows([1, 3]);
+      render();
+
+      expect(countVisibleCustomBorders()).toEqual(3 * 4); // It isn't ok probably. There is no specification.
+      // expect(countVisibleCustomBorders()).toEqual((4 * 2) + 2); // TODO: It should work.
+      expect(getCellMeta(0, 1).borders.left).toEqual(GREEN_BORDER);
+      expect(getCellMeta(0, 1).borders.top).toEqual(GREEN_BORDER);
+      expect(getCellMeta(0, 1).borders.bottom).toEqual(GREEN_BORDER); // Is it ok?
+      expect(getCellMeta(0, 1).borders.right).toEqual(GREEN_BORDER);
+
+      expect(getCellMeta(2, 1).borders.left).toEqual(BLUE_BORDER);
+      expect(getCellMeta(2, 1).borders.top).toEqual(BLUE_BORDER); // Is it ok?
+      expect(getCellMeta(2, 1).borders.bottom).toEqual(BLUE_BORDER); // Is it ok?
+      expect(getCellMeta(2, 1).borders.right).toEqual(BLUE_BORDER);
+
+      expect(getCellMeta(4, 1).borders.left).toEqual(YELLOW_BORDER);
+      expect(getCellMeta(4, 1).borders.top).toEqual(YELLOW_BORDER); // Is it ok?
+      expect(getCellMeta(4, 1).borders.bottom).toEqual(YELLOW_BORDER);
+      expect(getCellMeta(4, 1).borders.right).toEqual(YELLOW_BORDER);
+    });
+
+    it('should display borders properly when hiding cells separating another cells with borders (they will stick together) #2', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenRows: true,
+        customBorders: [{
+          row: 0,
+          col: 1,
+          top: GREEN_BORDER,
+          left: GREEN_BORDER,
+          bottom: GREEN_BORDER,
+          right: GREEN_BORDER
+        }, {
+          row: 2,
+          col: 1,
+          top: BLUE_BORDER,
+          left: BLUE_BORDER,
+          bottom: BLUE_BORDER,
+          right: BLUE_BORDER
+        }, {
+          row: 4,
+          col: 1,
+          top: YELLOW_BORDER,
+          left: YELLOW_BORDER,
+          bottom: YELLOW_BORDER,
+          right: YELLOW_BORDER
+        }]
+      });
+
+      getPlugin('hiddenRows').hideRows([1, 2, 3]);
+      render();
+
+      expect(countVisibleCustomBorders()).toEqual(2 * 4); // It isn't ok probably. There is no specification.
+      // expect(countVisibleCustomBorders()).toEqual((4 + 3)); // TODO: It should work.
+      expect(getCellMeta(0, 1).borders.left).toEqual(GREEN_BORDER);
+      expect(getCellMeta(0, 1).borders.top).toEqual(GREEN_BORDER);
+      expect(getCellMeta(0, 1).borders.bottom).toEqual(GREEN_BORDER); // Is it ok?
+      expect(getCellMeta(0, 1).borders.right).toEqual(GREEN_BORDER);
+
+      expect(getCellMeta(2, 1).borders.left).toEqual(BLUE_BORDER);
+      expect(getCellMeta(2, 1).borders.top).toEqual(BLUE_BORDER); // Is it ok?
+      expect(getCellMeta(2, 1).borders.bottom).toEqual(BLUE_BORDER); // Is it ok?
+      expect(getCellMeta(2, 1).borders.right).toEqual(BLUE_BORDER);
+
+      expect(getCellMeta(4, 1).borders.left).toEqual(YELLOW_BORDER);
+      expect(getCellMeta(4, 1).borders.top).toEqual(YELLOW_BORDER); // Is it ok?
+      expect(getCellMeta(4, 1).borders.bottom).toEqual(YELLOW_BORDER);
+      expect(getCellMeta(4, 1).borders.right).toEqual(YELLOW_BORDER);
+    });
+
+    it('should not display custom border for single cell when it is placed on the hidden row', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenRows: {
+          rows: [1],
+          indicators: true
+        },
+        customBorders: [{
+          row: 1,
+          col: 1,
+          top: BLUE_BORDER,
+          left: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          right: MAGENTA_BORDER
+        }]
+      });
+
+      // Just the meta is defined.
+      expect(countVisibleCustomBorders()).toEqual(0);
+      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(1, 1).borders.right).toEqual(MAGENTA_BORDER);
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
+    it('should display custom borders for single cells properly when one of them is placed on the hidden row', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenRows: {
+          rows: [1, 3],
+          indicators: true
+        },
+        customBorders: true
+      });
+
+      getPlugin('customBorders').setBorders([[1, 1, 3, 3]], {
+        top: BLUE_BORDER,
+        left: ORANGE_BORDER,
+        bottom: RED_BORDER,
+        right: MAGENTA_BORDER
+      });
+
+      expect(countVisibleCustomBorders()).toEqual(3 * 4); // Just 3 cells (2 rows are hidden), all of them with 4 borders
+      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(1, 1).borders.right).toEqual(MAGENTA_BORDER);
+
+      expect(getCellMeta(1, 2).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 2).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 2).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(1, 2).borders.right).toEqual(MAGENTA_BORDER);
+
+      expect(getCellMeta(2, 2).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(2, 2).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(2, 2).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(2, 2).borders.right).toEqual(MAGENTA_BORDER);
+
+      expect(getCellMeta(3, 2).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(3, 2).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(3, 2).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(3, 2).borders.right).toEqual(MAGENTA_BORDER);
+    });
+
+    it('should not display custom border for single cell when row containing border is hidden by API call', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenRows: true,
+        customBorders: [{
+          row: 1,
+          col: 1,
+          top: BLUE_BORDER,
+          left: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          right: MAGENTA_BORDER
+        }]
+      });
+
+      getPlugin('hiddenRows').hideRow(1);
+      render();
+
+      // Just the meta is defined.
+      expect(countVisibleCustomBorders()).toEqual(0);
+      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(1, 1).borders.right).toEqual(MAGENTA_BORDER);
+    });
+
+    it('should display custom border for single cell when hidden row containing border has been shown by API call', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenRows: {
+          rows: [1],
+          indicators: true
+        },
+        customBorders: [{
+          row: 1,
+          col: 1,
+          top: BLUE_BORDER,
+          left: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          right: MAGENTA_BORDER
+        }]
+      });
+
+      getPlugin('hiddenRows').showRow(1);
+      render();
+
+      expect(countVisibleCustomBorders()).toEqual(4);
+      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(1, 1).borders.right).toEqual(MAGENTA_BORDER);
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
+    it('should draw border from context menu options in proper place when there are some hidden rows before ' +
+      'a place where the border is added', async() => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        contextMenu: true,
+        customBorders: true,
+        hiddenRows: {
+          rows: [0, 1]
+        }
+      });
+
+      await selectContextSubmenuOption('Borders', 'Top', getCell(2, 0));
+      deselectCell();
+
+      expect(getCellMeta(2, 0).borders.top).toEqual(DEFAULT_BORDER);
+      expect(getCellMeta(2, 0).borders.left).toEqual(EMPTY);
+      expect(getCellMeta(2, 0).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(2, 0).borders.right).toEqual(EMPTY);
 
       expect(countVisibleCustomBorders()).toBe(1);
       expect(countCustomBorders()).toBe(5);

--- a/src/plugins/customBorders/test/customBorders.e2e.js
+++ b/src/plugins/customBorders/test/customBorders.e2e.js
@@ -1549,7 +1549,7 @@ describe('CustomBorders', () => {
       expect(getCellMeta(1, 1).borders).toBeUndefined();
     });
 
-    it('should display custom borders for single cell properly when one of them is placed on the hidden column', () => {
+    it('should display custom borders for single cells properly when one of them is placed on the hidden column', () => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(5, 5),
         rowHeaders: true,

--- a/src/plugins/customBorders/utils.js
+++ b/src/plugins/customBorders/utils.js
@@ -53,24 +53,15 @@ export function createDefaultHtBorder() {
  *
  * @param {number} row Visual row index.
  * @param {number} col Visual column index.
- * @param {number} [rowIncrementBy] Row indexes shift.
- * @param {number} [columnIncrementBy] Column indexes shift.
- * @returns {object} Returns border configuration containing renderable indexes. Example of an object defining it:
+ * @returns {object} Returns border configuration containing visual indexes. Example of an object defining it:
  * `{{id: *, border: *, row: *, col: *, top: {hide: boolean}, right: {hide: boolean}, bottom: {hide: boolean}, left: {hide: boolean}}}`.
  */
-export function createEmptyBorders(row, col, rowIncrementBy = 1, columnIncrementBy = 1) {
-  const renderableRowIndex = this.hot.rowIndexMapper.getRenderableFromVisualIndex(
-    this.hot.rowIndexMapper.getFirstNotHiddenIndex(row, rowIncrementBy)
-  );
-  const renderableColumnIndex = this.hot.columnIndexMapper.getRenderableFromVisualIndex(
-    this.hot.columnIndexMapper.getFirstNotHiddenIndex(col, columnIncrementBy)
-  );
-
+export function createEmptyBorders(row, col) {
   return {
     id: createId(row, col),
     border: createDefaultHtBorder(),
-    row: renderableRowIndex,
-    col: renderableColumnIndex,
+    row,
+    col,
     top: createSingleEmptyBorder(),
     right: createSingleEmptyBorder(),
     bottom: createSingleEmptyBorder(),

--- a/src/plugins/customBorders/utils.js
+++ b/src/plugins/customBorders/utils.js
@@ -51,17 +51,24 @@ export function createDefaultHtBorder() {
 /**
  * Prepare empty border for each cell with all custom borders hidden.
  *
- * @param {number} row Renderable row index.
- * @param {number} col Renderable column index.
- * @returns {object} Returns border configuration created using renderable indexes. Example of an object defining it:
+ * @param {number} row Visual row index.
+ * @param {number} col Visual column index.
+ * @returns {object} Returns border configuration containing renderable indexes. Example of an object defining it:
  * `{{id: *, border: *, row: *, col: *, top: {hide: boolean}, right: {hide: boolean}, bottom: {hide: boolean}, left: {hide: boolean}}}`.
  */
 export function createEmptyBorders(row, col) {
+  const renderableRowIndex = this.hot.rowIndexMapper.getRenderableFromVisualIndex(
+    this.hot.rowIndexMapper.getFirstNotHiddenIndex(row, 1)
+  );
+  const renderableColumnIndex = this.hot.columnIndexMapper.getRenderableFromVisualIndex(
+    this.hot.columnIndexMapper.getFirstNotHiddenIndex(col, 1)
+  );
+
   return {
     id: createId(row, col),
     border: createDefaultHtBorder(),
-    row,
-    col,
+    row: renderableRowIndex,
+    col: renderableColumnIndex,
     top: createSingleEmptyBorder(),
     right: createSingleEmptyBorder(),
     bottom: createSingleEmptyBorder(),

--- a/src/plugins/customBorders/utils.js
+++ b/src/plugins/customBorders/utils.js
@@ -53,15 +53,17 @@ export function createDefaultHtBorder() {
  *
  * @param {number} row Visual row index.
  * @param {number} col Visual column index.
+ * @param {number} [rowIncrementBy] Row indexes shift.
+ * @param {number} [columnIncrementBy] Column indexes shift.
  * @returns {object} Returns border configuration containing renderable indexes. Example of an object defining it:
  * `{{id: *, border: *, row: *, col: *, top: {hide: boolean}, right: {hide: boolean}, bottom: {hide: boolean}, left: {hide: boolean}}}`.
  */
-export function createEmptyBorders(row, col) {
+export function createEmptyBorders(row, col, rowIncrementBy = 1, columnIncrementBy = 1) {
   const renderableRowIndex = this.hot.rowIndexMapper.getRenderableFromVisualIndex(
-    this.hot.rowIndexMapper.getFirstNotHiddenIndex(row, 1)
+    this.hot.rowIndexMapper.getFirstNotHiddenIndex(row, rowIncrementBy)
   );
   const renderableColumnIndex = this.hot.columnIndexMapper.getRenderableFromVisualIndex(
-    this.hot.columnIndexMapper.getFirstNotHiddenIndex(col, 1)
+    this.hot.columnIndexMapper.getFirstNotHiddenIndex(col, columnIncrementBy)
   );
 
   return {

--- a/src/plugins/customBorders/utils.js
+++ b/src/plugins/customBorders/utils.js
@@ -51,9 +51,10 @@ export function createDefaultHtBorder() {
 /**
  * Prepare empty border for each cell with all custom borders hidden.
  *
- * @param {number} row Visual row index.
- * @param {number} col Visual column index.
- * @returns {object} `{{id: *, border: *, row: *, col: *, top: {hide: boolean}, right: {hide: boolean}, bottom: {hide: boolean}, left: {hide: boolean}}}`.
+ * @param {number} row Renderable row index.
+ * @param {number} col Renderable column index.
+ * @returns {object} Returns border configuration created using renderable indexes. Example of an object defining it:
+ * `{{id: *, border: *, row: *, col: *, top: {hide: boolean}, right: {hide: boolean}, bottom: {hide: boolean}, left: {hide: boolean}}}`.
  */
 export function createEmptyBorders(row, col) {
   return {

--- a/src/plugins/hiddenColumns/test/hiddenColumns.e2e.js
+++ b/src/plugins/hiddenColumns/test/hiddenColumns.e2e.js
@@ -6404,6 +6404,122 @@ describe('HiddenColumns', () => {
     });
   });
 
+  describe('should cooperate with the `fixedColumnsLeft` option properly', () => {
+    it('when there are hidden columns in the middle of fixed columns', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(1, 10),
+        colHeaders: true,
+        hiddenColumns: {
+          columns: [2, 3],
+          indicators: true
+        },
+        fixedColumnsLeft: 6
+      });
+
+      expect(getLeftClone().find('tbody tr:eq(0) td').length).toEqual(6 - 2);
+      expect(getLeftClone().width()).toBe((4 * 50) + (2 * 15)); // 4 fixed, visible columns, with space for indicators.
+      expect($(getCell(-1, 0).querySelector('span')).text()).toBe('A');
+      expect($(getCell(-1, 1).querySelector('span')).text()).toBe('B');
+      expect(getCell(-1, 2)).toBe(null);
+      expect(getCell(-1, 3)).toBe(null);
+      expect($(getCell(-1, 4).querySelector('span')).text()).toBe('E');
+      expect($(getCell(-1, 5).querySelector('span')).text()).toBe('F');
+    });
+
+    it('when there is hidden column by the fixed column', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(1, 10),
+        colHeaders: true,
+        hiddenColumns: {
+          columns: [1],
+          indicators: true
+        },
+        fixedColumnsLeft: 1
+      });
+
+      expect(getLeftClone().find('tbody tr:eq(0) td').length).toEqual(1);
+      expect(getLeftClone().width()).toBe(50 + 15); // 1 fixed, visible column, with space for indicator.
+      expect($(getCell(-1, 0).querySelector('span')).text()).toBe('A');
+      expect(getCell(-1, 1)).toBe(null);
+      expect($(getCell(-1, 2).querySelector('span')).text()).toBe('C');
+    });
+
+    it('when there are hidden columns at the start of fixed columns', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(1, 10),
+        colHeaders: true,
+        hiddenColumns: {
+          columns: [0, 1, 2],
+          indicators: true
+        },
+        fixedColumnsLeft: 6
+      });
+
+      expect(getLeftClone().find('tbody tr:eq(0) td').length).toEqual(6 - 3);
+      expect(getLeftClone().width()).toBe((3 * 50) + 15); // 3 fixed, visible columns, with space for indicator.
+      expect(getCell(-1, 0)).toBe(null);
+      expect(getCell(-1, 1)).toBe(null);
+      expect(getCell(-1, 2)).toBe(null);
+      expect($(getCell(-1, 3).querySelector('span')).text()).toBe('D');
+      expect($(getCell(-1, 4).querySelector('span')).text()).toBe('E');
+      expect($(getCell(-1, 5).querySelector('span')).text()).toBe('F');
+    });
+
+    it('when there are hidden columns at the end of fixed columns', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(1, 10),
+        colHeaders: true,
+        hiddenColumns: {
+          columns: [3, 4, 5],
+          indicators: true
+        },
+        fixedColumnsLeft: 6
+      });
+
+      expect(getLeftClone().find('tbody tr:eq(0) td').length).toEqual(6 - 3);
+      expect(getLeftClone().width()).toBe((3 * 50) + 15); // 3 fixed, visible columns, with space for indicator.
+      expect($(getCell(-1, 0).querySelector('span')).text()).toBe('A');
+      expect($(getCell(-1, 1).querySelector('span')).text()).toBe('B');
+      expect($(getCell(-1, 2).querySelector('span')).text()).toBe('C');
+      expect(getCell(-1, 3)).toBe(null);
+      expect(getCell(-1, 4)).toBe(null);
+      expect(getCell(-1, 5)).toBe(null);
+    });
+
+    it('when all fixed columns are hidden', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(1, 10),
+        colHeaders: true,
+        hiddenColumns: {
+          columns: [0, 1, 2, 3],
+          indicators: true
+        },
+        fixedColumnsLeft: 4
+      });
+
+      expect(getLeftClone().find('tbody tr:eq(0) td').length).toEqual(0);
+      expect(getLeftClone().width()).toBe(0);
+    });
+
+    it('should not display cells after API call hiding all columns', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(1, 10),
+        hiddenColumns: true,
+        fixedColumnsLeft: 3
+      });
+
+      getPlugin('hiddenColumns').hideColumns([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+      render();
+
+      expect(getLeftClone().find('tbody td').length).toBe(0);
+      expect(extractDOMStructure(getLeftClone())).toMatchHTML(`
+        <tbody>
+          <tr></tr>
+        </tbody>
+        `);
+    });
+  });
+
   describe('alter actions', () => {
     it('should update hidden column indexes after columns removal (removing not hidden columns)', () => {
       const hot = handsontable({
@@ -6567,122 +6683,6 @@ describe('HiddenColumns', () => {
       // Hidden H1
       expect(spec().$container.find('tbody tr:eq(0) td:eq(8)').text()).toEqual('J1');
       expect(getDataAtRow(0)).toEqual(['E1', 'A1', 'I1', 'F1', 'C1', 'G1', 'B1', null, null, 'H1', 'D1', 'J1']);
-    });
-  });
-
-  describe('should cooperate with the `fixedColumnsLeft` option properly', () => {
-    it('when there are hidden columns in the middle of fixed columns', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(1, 10),
-        colHeaders: true,
-        hiddenColumns: {
-          columns: [2, 3],
-          indicators: true
-        },
-        fixedColumnsLeft: 6
-      });
-
-      expect(getLeftClone().find('tbody tr:eq(0) td').length).toEqual(6 - 2);
-      expect(getLeftClone().width()).toBe((4 * 50) + (2 * 15)); // 4 fixed, visible columns, with space for indicators.
-      expect($(getCell(-1, 0).querySelector('span')).text()).toBe('A');
-      expect($(getCell(-1, 1).querySelector('span')).text()).toBe('B');
-      expect(getCell(-1, 2)).toBe(null);
-      expect(getCell(-1, 3)).toBe(null);
-      expect($(getCell(-1, 4).querySelector('span')).text()).toBe('E');
-      expect($(getCell(-1, 5).querySelector('span')).text()).toBe('F');
-    });
-
-    it('when there is hidden column by the fixed column', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(1, 10),
-        colHeaders: true,
-        hiddenColumns: {
-          columns: [1],
-          indicators: true
-        },
-        fixedColumnsLeft: 1
-      });
-
-      expect(getLeftClone().find('tbody tr:eq(0) td').length).toEqual(1);
-      expect(getLeftClone().width()).toBe(50 + 15); // 1 fixed, visible column, with space for indicator.
-      expect($(getCell(-1, 0).querySelector('span')).text()).toBe('A');
-      expect(getCell(-1, 1)).toBe(null);
-      expect($(getCell(-1, 2).querySelector('span')).text()).toBe('C');
-    });
-
-    it('when there are hidden columns at the start of fixed columns', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(1, 10),
-        colHeaders: true,
-        hiddenColumns: {
-          columns: [0, 1, 2],
-          indicators: true
-        },
-        fixedColumnsLeft: 6
-      });
-
-      expect(getLeftClone().find('tbody tr:eq(0) td').length).toEqual(6 - 3);
-      expect(getLeftClone().width()).toBe((3 * 50) + 15); // 3 fixed, visible columns, with space for indicator.
-      expect(getCell(-1, 0)).toBe(null);
-      expect(getCell(-1, 1)).toBe(null);
-      expect(getCell(-1, 2)).toBe(null);
-      expect($(getCell(-1, 3).querySelector('span')).text()).toBe('D');
-      expect($(getCell(-1, 4).querySelector('span')).text()).toBe('E');
-      expect($(getCell(-1, 5).querySelector('span')).text()).toBe('F');
-    });
-
-    it('when there are hidden columns at the end of fixed columns', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(1, 10),
-        colHeaders: true,
-        hiddenColumns: {
-          columns: [3, 4, 5],
-          indicators: true
-        },
-        fixedColumnsLeft: 6
-      });
-
-      expect(getLeftClone().find('tbody tr:eq(0) td').length).toEqual(6 - 3);
-      expect(getLeftClone().width()).toBe((3 * 50) + 15); // 3 fixed, visible columns, with space for indicator.
-      expect($(getCell(-1, 0).querySelector('span')).text()).toBe('A');
-      expect($(getCell(-1, 1).querySelector('span')).text()).toBe('B');
-      expect($(getCell(-1, 2).querySelector('span')).text()).toBe('C');
-      expect(getCell(-1, 3)).toBe(null);
-      expect(getCell(-1, 4)).toBe(null);
-      expect(getCell(-1, 5)).toBe(null);
-    });
-
-    it('when all fixed columns are hidden', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(1, 10),
-        colHeaders: true,
-        hiddenColumns: {
-          columns: [0, 1, 2, 3],
-          indicators: true
-        },
-        fixedColumnsLeft: 4
-      });
-
-      expect(getLeftClone().find('tbody tr:eq(0) td').length).toEqual(0);
-      expect(getLeftClone().width()).toBe(0);
-    });
-
-    it('should not display cells after API call hiding all columns', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(1, 10),
-        hiddenColumns: true,
-        fixedColumnsLeft: 3
-      });
-
-      getPlugin('hiddenColumns').hideColumns([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
-      render();
-
-      expect(getLeftClone().find('tbody td').length).toBe(0);
-      expect(extractDOMStructure(getLeftClone())).toMatchHTML(`
-        <tbody>
-          <tr></tr>
-        </tbody>
-        `);
     });
   });
 

--- a/src/plugins/mergeCells/calculations/selection.js
+++ b/src/plugins/mergeCells/calculations/selection.js
@@ -137,8 +137,8 @@ class SelectionCalculations {
       return;
     }
 
-    const mergeRowEnd = mergedCell.row + mergedCell.rowspan - 1;
-    const mergeColumnEnd = mergedCell.col + mergedCell.colspan - 1;
+    const mergeRowEnd = mergedCell.getLastRow();
+    const mergeColumnEnd = mergedCell.getLastColumn;
     const fullMergeAreaWithinSelection =
       startRow <= mergedCell.row && startColumn <= mergedCell.col &&
       endRow >= mergeRowEnd && endColumn >= mergeColumnEnd;

--- a/src/plugins/mergeCells/calculations/selection.js
+++ b/src/plugins/mergeCells/calculations/selection.js
@@ -138,7 +138,7 @@ class SelectionCalculations {
     }
 
     const mergeRowEnd = mergedCell.getLastRow();
-    const mergeColumnEnd = mergedCell.getLastColumn;
+    const mergeColumnEnd = mergedCell.getLastColumn();
     const fullMergeAreaWithinSelection =
       startRow <= mergedCell.row && startColumn <= mergedCell.col &&
       endRow >= mergeRowEnd && endColumn >= mergeColumnEnd;

--- a/src/selection/highlight/highlight.js
+++ b/src/selection/highlight/highlight.js
@@ -237,14 +237,9 @@ class Highlight {
    * Add selection to the custom selection instance. The new selection are added to the end of the selection collection.
    *
    * @param {object} selectionInstance The selection instance.
-   * @returns {Selection}
    */
   addCustomSelection(selectionInstance) {
-    const customSelection = createHighlight(CUSTOM_SELECTION, { ...this.options, ...selectionInstance });
-
-    this.customSelections.push(customSelection);
-
-    return customSelection;
+    this.customSelections.push(createHighlight(CUSTOM_SELECTION, { ...this.options, ...selectionInstance }));
   }
 
   /**

--- a/src/selection/highlight/highlight.js
+++ b/src/selection/highlight/highlight.js
@@ -237,9 +237,14 @@ class Highlight {
    * Add selection to the custom selection instance. The new selection are added to the end of the selection collection.
    *
    * @param {object} selectionInstance The selection instance.
+   * @returns {Selection}
    */
   addCustomSelection(selectionInstance) {
-    this.customSelections.push(createHighlight(CUSTOM_SELECTION, { ...this.options, ...selectionInstance }));
+    const customSelection = createHighlight(CUSTOM_SELECTION, { ...this.options, ...selectionInstance });
+
+    this.customSelections.push(customSelection);
+
+    return customSelection;
   }
 
   /**

--- a/src/selection/highlight/types/customSelection.js
+++ b/src/selection/highlight/types/customSelection.js
@@ -6,11 +6,11 @@ import VisualSelection from '../visualSelection';
  *
  * @returns {Selection}
  */
-function createHighlight({ border, cellRange, ...restOptions }) {
+function createHighlight({ border, visualCellRange, ...restOptions }) {
   const s = new VisualSelection({
     ...border,
     ...restOptions,
-  }, cellRange);
+  }, visualCellRange);
 
   return s;
 }

--- a/src/selection/highlight/visualSelection.js
+++ b/src/selection/highlight/visualSelection.js
@@ -1,14 +1,16 @@
 import { Selection, CellCoords, CellRange } from './../../3rdparty/walkontable/src';
 
 class VisualSelection extends Selection {
-  constructor(...args) {
-    super(...args);
+  constructor(settings, visualCellRange) {
+    super(settings, null);
     /**
      * Range of selection visually. Visual representation may have representation in a rendered selection.
      *
      * @type {null|CellRange}
      */
-    this.visualCellRange = null;
+    this.visualCellRange = visualCellRange || null;
+
+    this.commit();
   }
   /**
    * Adds a cell coords to the selection.

--- a/src/selection/selection.js
+++ b/src/selection/selection.js
@@ -645,6 +645,12 @@ class Selection {
    * Rewrite the rendered state of the selection as visual selection may have a new representation in the DOM.
    */
   refresh() {
+    const customSelections = this.highlight.getCustomSelections();
+
+    customSelections.forEach((customSelection) => {
+      customSelection.commit();
+    });
+
     if (!this.isSelected()) {
       return;
     }


### PR DESCRIPTION
### Context
This fix may be threatened as a breaking change. After some changes, the product will work similarly to Excel.

Assumptions:

- Cell meta for hidden cells will stay on its position
- 🔴 Hiding cells at the start or at the end of a range will also hide the border (it won't be shifted as on the current `master` branch). It may be a breaking change. For example, for a config:

```js
data: Handsontable.helper.createSpreadsheetData(5, 5),
rowHeaders: true,
colHeaders: true,
hiddenColumns: {
  columns: [4],
  indicators: true
},
customBorders: [{
  range: {
    from: {
      row: 1,
      col: 1
    },
    to: {
      row: 4,
      col: 4
    }
  },
  top: BLUE_BORDER,
  left: ORANGE_BORDER,
  bottom: RED_BORDER,
  right: MAGENTA_BORDER
}]
```

Was `7.4.2`:

![Screenshot 2020-07-07 at 13 54 27](https://user-images.githubusercontent.com/141330/86777493-825d5b00-c059-11ea-9b69-1906cc9acbc5.png)

Will be:

![Screenshot 2020-07-07 at 13 55 14](https://user-images.githubusercontent.com/141330/86777491-81c4c480-c059-11ea-9323-42c21cc2ee93.png)

- 🔴 Hiding a single cell with borders will hide all its borders. It may be a breaking change. For example, for a config:

```js
data: Handsontable.helper.createSpreadsheetData(5, 5),
rowHeaders: true,
colHeaders: true,
  hiddenColumns: {
    columns: [2],
    indicators: true
  },
customBorders: [{
  row: 2,
  col: 2,
  top: BLUE_BORDER,
  left: ORANGE_BORDER,
  bottom: RED_BORDER,
  right: MAGENTA_BORDER
}]
```

Was `7.4.2`:

![Screenshot 2020-07-07 at 14 03 32](https://user-images.githubusercontent.com/141330/86778462-b08f6a80-c05a-11ea-8da4-d5d32cef7c27.png)

Will be:

![Screenshot 2020-07-07 at 14 01 33](https://user-images.githubusercontent.com/141330/86778470-b38a5b00-c05a-11ea-843d-bcd211c96516.png)


### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Manual tests with the `HiddenColumns` and `HiddenRows` plugins.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7057 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
