### PR TITLE
Fix the editor misalign

### DIFF
--- a/src/editors/selectEditor.js
+++ b/src/editors/selectEditor.js
@@ -213,13 +213,12 @@ class SelectEditor extends BaseEditor {
         break;
     }
 
-    const colHeadersCount = this.hot.hasColHeaders();
     const renderableRow = this.hot.rowIndexMapper.getRenderableFromVisualIndex(this.row);
     const renderableColumn = this.hot.columnIndexMapper.getRenderableFromVisualIndex(this.col);
     const nrOfRenderableRowIndexes = this.hot.rowIndexMapper.getRenderableIndexesLength();
     const firstRowIndexOfTheBottomOverlay = nrOfRenderableRowIndexes - this.hot.view.wt.getSetting('fixedRowsBottom');
 
-    if (colHeadersCount && renderableRow <= 0 || renderableRow === firstRowIndexOfTheBottomOverlay) {
+    if (renderableRow <= 0 || renderableRow === firstRowIndexOfTheBottomOverlay) {
       editTop += 1;
     }
 

--- a/src/editors/selectEditor.js
+++ b/src/editors/selectEditor.js
@@ -181,6 +181,7 @@ class SelectEditor extends BaseEditor {
 
       return;
     }
+
     const { wtOverlays } = this.hot.view.wt;
     const currentOffset = offset(this.TD);
     const containerOffset = offset(this.hot.rootElement);
@@ -212,10 +213,17 @@ class SelectEditor extends BaseEditor {
         break;
     }
 
-    if (this.hot.getSelectedLast()[0] <= 0) {
+    const colHeadersCount = this.hot.hasColHeaders();
+    const renderableRow = this.hot.rowIndexMapper.getRenderableFromVisualIndex(this.row);
+    const renderableColumn = this.hot.columnIndexMapper.getRenderableFromVisualIndex(this.col);
+    const nrOfRenderableRowIndexes = this.hot.rowIndexMapper.getRenderableIndexesLength();
+    const firstRowIndexOfTheBottomOverlay = nrOfRenderableRowIndexes - this.hot.view.wt.getSetting('fixedRowsBottom');
+
+    if (colHeadersCount && renderableRow <= 0 || renderableRow === firstRowIndexOfTheBottomOverlay) {
       editTop += 1;
     }
-    if (this.hot.getSelectedLast()[1] <= 0) {
+
+    if (renderableColumn <= 0) {
       editLeft += 1;
     }
 

--- a/src/editors/textEditor.js
+++ b/src/editors/textEditor.js
@@ -339,7 +339,6 @@ class TextEditor extends BaseEditor {
     const containerOffset = offset(this.hot.rootElement);
     const scrollableContainerTop = wtOverlays.topOverlay.holder;
     const scrollableContainerLeft = wtOverlays.leftOverlay.holder;
-    const totalRowsCount = this.hot.countRows();
     const containerScrollTop = scrollableContainerTop !== this.hot.rootWindow ?
       scrollableContainerTop.scrollTop : 0;
     const containerScrollLeft = scrollableContainerLeft !== this.hot.rootWindow ?
@@ -351,9 +350,6 @@ class TextEditor extends BaseEditor {
 
     // If colHeaders is disabled, cells in the first row have border-top
     const editTopModifier = currentOffset.top === containerOffset.top ? 0 : 1;
-
-    const settings = this.hot.getSettings();
-    const colHeadersCount = this.hot.hasColHeaders();
     const backgroundColor = this.TD.style.backgroundColor;
 
     let editTop = currentOffset.top - containerOffset.top - editTopModifier - scrollTop;
@@ -381,11 +377,13 @@ class TextEditor extends BaseEditor {
         break;
     }
 
+    const colHeadersCount = this.hot.hasColHeaders();
     const renderableRow = this.hot.rowIndexMapper.getRenderableFromVisualIndex(this.row);
     const renderableColumn = this.hot.columnIndexMapper.getRenderableFromVisualIndex(this.col);
+    const nrOfRenderableRowIndexes = this.hot.rowIndexMapper.getRenderableIndexesLength();
+    const firstRowIndexOfTheBottomOverlay = nrOfRenderableRowIndexes - this.hot.view.wt.getSetting('fixedRowsBottom');
 
-    if (colHeadersCount && renderableRow <= 0 ||
-        (settings.fixedRowsBottom && renderableRow < totalRowsCount - settings.fixedRowsBottom)) {
+    if (colHeadersCount && renderableRow <= 0 || renderableRow === firstRowIndexOfTheBottomOverlay) {
       editTop += 1;
     }
 

--- a/src/editors/textEditor.js
+++ b/src/editors/textEditor.js
@@ -381,12 +381,15 @@ class TextEditor extends BaseEditor {
         break;
     }
 
-    if (colHeadersCount && this.hot.getSelectedLast()[0] <= 0 ||
-        (settings.fixedRowsBottom && this.hot.getSelectedLast()[0] <= totalRowsCount - settings.fixedRowsBottom)) {
+    const renderableRow = this.hot.rowIndexMapper.getRenderableFromVisualIndex(this.row);
+    const renderableColumn = this.hot.columnIndexMapper.getRenderableFromVisualIndex(this.col);
+
+    if (colHeadersCount && renderableRow <= 0 ||
+        (settings.fixedRowsBottom && renderableRow < totalRowsCount - settings.fixedRowsBottom)) {
       editTop += 1;
     }
 
-    if (this.hot.getSelectedLast()[1] <= 0) {
+    if (renderableColumn <= 0) {
       editLeft += 1;
     }
 

--- a/src/editors/textEditor.js
+++ b/src/editors/textEditor.js
@@ -377,13 +377,13 @@ class TextEditor extends BaseEditor {
         break;
     }
 
-    const colHeadersCount = this.hot.hasColHeaders();
+    const hasColumnHeaders = this.hot.hasColHeaders();
     const renderableRow = this.hot.rowIndexMapper.getRenderableFromVisualIndex(this.row);
     const renderableColumn = this.hot.columnIndexMapper.getRenderableFromVisualIndex(this.col);
     const nrOfRenderableRowIndexes = this.hot.rowIndexMapper.getRenderableIndexesLength();
     const firstRowIndexOfTheBottomOverlay = nrOfRenderableRowIndexes - this.hot.view.wt.getSetting('fixedRowsBottom');
 
-    if (colHeadersCount && renderableRow <= 0 || renderableRow === firstRowIndexOfTheBottomOverlay) {
+    if (hasColumnHeaders && renderableRow <= 0 || renderableRow === firstRowIndexOfTheBottomOverlay) {
       editTop += 1;
     }
 

--- a/test/e2e/editors/autocompleteEditor.spec.js
+++ b/test/e2e/editors/autocompleteEditor.spec.js
@@ -14,6 +14,272 @@ describe('AutocompleteEditor', () => {
     }
   });
 
+  it('should render an editor in specified position at cell 0, 0', () => {
+    handsontable({
+      columns: [
+        {
+          editor: 'autocomplete',
+          source: choices,
+        }
+      ],
+    });
+
+    selectCell(0, 0);
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    keyDown('enter');
+
+    expect(editor.offset()).toEqual($(getCell(0, 0)).offset());
+  });
+
+  it('should render an editor in specified position at cell 0, 0 when all headers are selected', () => {
+    handsontable({
+      rowHeaders: true,
+      colHeaders: true,
+      columns: [
+        {
+          editor: 'autocomplete',
+          source: choices,
+        }
+      ],
+    });
+
+    selectAll();
+    listen();
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    keyDown('enter');
+
+    expect(editor.offset()).toEqual($(getCell(0, 0)).offset());
+  });
+
+  it('should render an editor in specified position while opening an editor from top to bottom when ' +
+     'top and bottom overlays are enabled', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(8, 2),
+      rowHeaders: true,
+      colHeaders: true,
+      fixedRowsTop: 3,
+      fixedRowsBottom: 3,
+      columns: [
+        {
+          editor: 'autocomplete',
+          source: choices,
+        },
+        {},
+      ],
+    });
+
+    selectCell(0, 0);
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    keyDown('enter');
+
+    expect(editor.offset()).toEqual($(getCell(0, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    // Cells that do not touch the edges of the table have an additional top border.
+    const editorOffset = () => ({
+      top: editor.offset().top + 1,
+      left: editor.offset().left,
+    });
+
+    expect(editorOffset()).toEqual($(getCell(1, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(3, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(4, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
+    expect(editor.offset()).toEqual($(getCell(5, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(6, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(7, 0, true)).offset());
+  });
+
+  it('should render an editor in specified position while opening an editor from left to right when ' +
+     'left overlay is enabled', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(2, 5),
+      rowHeaders: true,
+      colHeaders: true,
+      fixedColumnsLeft: 3,
+      editor: 'autocomplete',
+      source: choices,
+    });
+
+    selectCell(0, 0);
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    keyDown('enter');
+
+    expect(editor.offset()).toEqual($(getCell(0, 0, true)).offset());
+
+    selectCell(0, 1);
+    keyDown('enter');
+
+    // Cells that do not touch the edges of the table have an additional left border.
+    const editorOffset = () => ({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    });
+
+    expect(editorOffset()).toEqual($(getCell(0, 1, true)).offset());
+
+    selectCell(0, 2);
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(0, 2, true)).offset());
+
+    selectCell(0, 3);
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(0, 3, true)).offset());
+
+    selectCell(0, 4);
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(0, 4, true)).offset());
+  });
+
+  it('should render an editor in specified position while opening an editor from top to bottom when ' +
+       'top and bottom overlays are enabled and the first row of the both overlays are hidden', () => {
+    spec().$container.css('overflow', '').css('width', '').css('height', '');
+
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(8, 2),
+      rowHeaders: true,
+      colHeaders: true,
+      fixedRowsTop: 3,
+      fixedRowsBottom: 3,
+      hiddenRows: {
+        indicators: true,
+        rows: [0, 5],
+      },
+      columns: [
+        {
+          editor: 'autocomplete',
+          source: choices,
+        },
+        {},
+      ],
+    });
+
+    selectCell(1, 0);
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    keyDown('enter');
+
+    // First renderable row index.
+    expect(editor.offset()).toEqual($(getCell(1, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    // Cells that do not touch the edges of the table have an additional top border.
+    const editorOffset = () => ({
+      top: editor.offset().top + 1,
+      left: editor.offset().left,
+    });
+
+    expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(3, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(4, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
+    expect(editor.offset()).toEqual($(getCell(6, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(7, 0, true)).offset());
+  });
+
+  it('should render an editor in specified position while opening an editor from left to right when ' +
+     'left overlay is enabled and the first column of the overlay is hidden', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(2, 5),
+      rowHeaders: true,
+      colHeaders: true,
+      fixedColumnsLeft: 3,
+      hiddenColumns: {
+        indicators: true,
+        columns: [0],
+      },
+      editor: 'autocomplete',
+      source: choices,
+    });
+
+    selectCell(0, 1);
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    keyDown('enter');
+
+    // First renderable column index.
+    expect(editor.offset()).toEqual($(getCell(0, 1, true)).offset());
+
+    selectCell(0, 2);
+    keyDown('enter');
+
+    // Cells that do not touch the edges of the table have an additional left border.
+    const editorOffset = () => ({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    });
+
+    expect(editorOffset()).toEqual($(getCell(0, 2, true)).offset());
+
+    selectCell(0, 3);
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(0, 3, true)).offset());
+
+    selectCell(0, 4);
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(0, 4, true)).offset());
+  });
+
   describe('open editor', () => {
     it('should display editor (after hitting ENTER)', () => {
       handsontable({

--- a/test/e2e/editors/dateEditor.spec.js
+++ b/test/e2e/editors/dateEditor.spec.js
@@ -22,6 +22,264 @@ describe('DateEditor', () => {
     ];
   }
 
+  it('should render an editor in specified position at cell 0, 0', () => {
+    handsontable({
+      columns: [{ type: 'date' }],
+    });
+
+    selectCell(0, 0);
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    keyDown('enter');
+
+    expect(editor.offset()).toEqual($(getCell(0, 0)).offset());
+  });
+
+  it('should render an editor in specified position at cell 0, 0 when all headers are selected', () => {
+    handsontable({
+      rowHeaders: true,
+      colHeaders: true,
+      columns: [{ type: 'date' }],
+    });
+
+    selectAll();
+    listen();
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    keyDown('enter');
+
+    expect(editor.offset()).toEqual($(getCell(0, 0)).offset());
+  });
+
+  it('should render an editor in specified position while opening an editor from top to bottom when ' +
+     'top and bottom overlays are enabled', async() => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(8, 2),
+      rowHeaders: true,
+      colHeaders: true,
+      fixedRowsTop: 3,
+      fixedRowsBottom: 3,
+      columns: [{ type: 'date' }, {}],
+    });
+
+    selectCell(0, 0);
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    keyDown('enter');
+
+    expect(editor.offset()).toEqual($(getCell(0, 0, true)).offset());
+
+    keyDown('enter');
+    await sleep(50); // Caused by async DateEditor close.
+    keyDown('enter');
+
+    // Cells that do not touch the edges of the table have an additional top border.
+    const editorOffset = () => ({
+      top: editor.offset().top + 1,
+      left: editor.offset().left,
+    });
+
+    expect(editorOffset()).toEqual($(getCell(1, 0, true)).offset());
+
+    keyDown('enter');
+    await sleep(50); // Caused by async DateEditor close.
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
+
+    keyDown('enter');
+    await sleep(50); // Caused by async DateEditor close.
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(3, 0, true)).offset());
+
+    keyDown('enter');
+    await sleep(50); // Caused by async DateEditor close.
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(4, 0, true)).offset());
+
+    keyDown('enter');
+    await sleep(50); // Caused by async DateEditor close.
+    keyDown('enter');
+
+    // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
+    expect(editor.offset()).toEqual($(getCell(5, 0, true)).offset());
+
+    keyDown('enter');
+    await sleep(50); // Caused by async DateEditor close.
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(6, 0, true)).offset());
+
+    keyDown('enter');
+    await sleep(50); // Caused by async DateEditor close.
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(7, 0, true)).offset());
+  });
+
+  it('should render an editor in specified position while opening an editor from left to right when ' +
+     'left overlay is enabled', async() => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(2, 5),
+      rowHeaders: true,
+      colHeaders: true,
+      fixedColumnsLeft: 3,
+      type: 'date',
+    });
+
+    selectCell(0, 0);
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    keyDown('enter');
+
+    expect(editor.offset()).toEqual($(getCell(0, 0, true)).offset());
+
+    selectCell(0, 1);
+    await sleep(50); // Caused by async DateEditor close.
+    keyDown('enter');
+
+    // Cells that do not touch the edges of the table have an additional left border.
+    const editorOffset = () => ({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    });
+
+    expect(editorOffset()).toEqual($(getCell(0, 1, true)).offset());
+
+    selectCell(0, 2);
+    await sleep(50); // Caused by async DateEditor close.
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(0, 2, true)).offset());
+
+    selectCell(0, 3);
+    await sleep(50); // Caused by async DateEditor close.
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(0, 3, true)).offset());
+
+    selectCell(0, 4);
+    await sleep(50); // Caused by async DateEditor close.
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(0, 4, true)).offset());
+  });
+
+  it('should render an editor in specified position while opening an editor from top to bottom when ' +
+     'top and bottom overlays are enabled and the first row of the both overlays are hidden', async() => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(8, 2),
+      rowHeaders: true,
+      colHeaders: true,
+      fixedRowsTop: 3,
+      fixedRowsBottom: 3,
+      hiddenRows: {
+        indicators: true,
+        rows: [0, 5],
+      },
+      columns: [{ type: 'date' }, {}],
+    });
+
+    selectCell(1, 0);
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    keyDown('enter');
+
+    // First renderable row index.
+    expect(editor.offset()).toEqual($(getCell(1, 0, true)).offset());
+
+    keyDown('enter');
+    await sleep(50); // Caused by async DateEditor close.
+    keyDown('enter');
+
+    // Cells that do not touch the edges of the table have an additional top border.
+    const editorOffset = () => ({
+      top: editor.offset().top + 1,
+      left: editor.offset().left,
+    });
+
+    expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
+
+    keyDown('enter');
+    await sleep(50); // Caused by async DateEditor close.
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(3, 0, true)).offset());
+
+    keyDown('enter');
+    await sleep(50); // Caused by async DateEditor close.
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(4, 0, true)).offset());
+
+    keyDown('enter');
+    await sleep(50); // Caused by async DateEditor close.
+    keyDown('enter');
+
+    // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
+    expect(editor.offset()).toEqual($(getCell(6, 0, true)).offset());
+
+    keyDown('enter');
+    await sleep(50); // Caused by async DateEditor close.
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(7, 0, true)).offset());
+  });
+
+  it('should render an editor in specified position while opening an editor from left to right when ' +
+     'left overlay is enabled and the first column of the overlay is hidden', async() => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(2, 5),
+      rowHeaders: true,
+      colHeaders: true,
+      fixedColumnsLeft: 3,
+      hiddenColumns: {
+        indicators: true,
+        columns: [0],
+      },
+      type: 'date',
+    });
+
+    selectCell(0, 1);
+    keyDown('enter');
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    // First renderable column index.
+    expect(editor.offset()).toEqual($(getCell(0, 1, true)).offset());
+
+    selectCell(0, 2);
+    await sleep(50); // Caused by async DateEditor close.
+    keyDown('enter');
+
+    // Cells that do not touch the edges of the table have an additional left border.
+    const editorOffset = () => ({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    });
+
+    expect(editorOffset()).toEqual($(getCell(0, 2, true)).offset());
+
+    selectCell(0, 3);
+    await sleep(50); // Caused by async DateEditor close.
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(0, 3, true)).offset());
+
+    selectCell(0, 4);
+    await sleep(50); // Caused by async DateEditor close.
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(0, 4, true)).offset());
+  });
+
   it('should display Pikday calendar', () => {
     handsontable({
       data: getDates(),

--- a/test/e2e/editors/dropdownEditor.spec.js
+++ b/test/e2e/editors/dropdownEditor.spec.js
@@ -14,6 +14,272 @@ describe('DropdownEditor', () => {
     }
   });
 
+  it('should render an editor in specified position at cell 0, 0', () => {
+    handsontable({
+      columns: [
+        {
+          editor: 'dropdown',
+          source: choices,
+        }
+      ],
+    });
+
+    selectCell(0, 0);
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    keyDown('enter');
+
+    expect(editor.offset()).toEqual($(getCell(0, 0)).offset());
+  });
+
+  it('should render an editor in specified position at cell 0, 0 when all headers are selected', () => {
+    handsontable({
+      rowHeaders: true,
+      colHeaders: true,
+      columns: [
+        {
+          editor: 'dropdown',
+          source: choices,
+        }
+      ],
+    });
+
+    selectAll();
+    listen();
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    keyDown('enter');
+
+    expect(editor.offset()).toEqual($(getCell(0, 0)).offset());
+  });
+
+  it('should render an editor in specified position while opening an editor from top to bottom when ' +
+     'top and bottom overlays are enabled', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(8, 2),
+      rowHeaders: true,
+      colHeaders: true,
+      fixedRowsTop: 3,
+      fixedRowsBottom: 3,
+      columns: [
+        {
+          editor: 'dropdown',
+          source: choices,
+        },
+        {},
+      ],
+    });
+
+    selectCell(0, 0);
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    keyDown('enter');
+
+    expect(editor.offset()).toEqual($(getCell(0, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    // Cells that do not touch the edges of the table have an additional top border.
+    const editorOffset = () => ({
+      top: editor.offset().top + 1,
+      left: editor.offset().left,
+    });
+
+    expect(editorOffset()).toEqual($(getCell(1, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(3, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(4, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
+    expect(editor.offset()).toEqual($(getCell(5, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(6, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(7, 0, true)).offset());
+  });
+
+  it('should render an editor in specified position while opening an editor from left to right when ' +
+     'left overlay is enabled', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(2, 5),
+      rowHeaders: true,
+      colHeaders: true,
+      fixedColumnsLeft: 3,
+      editor: 'dropdown',
+      source: choices,
+    });
+
+    selectCell(0, 0);
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    keyDown('enter');
+
+    expect(editor.offset()).toEqual($(getCell(0, 0, true)).offset());
+
+    selectCell(0, 1);
+    keyDown('enter');
+
+    // Cells that do not touch the edges of the table have an additional left border.
+    const editorOffset = () => ({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    });
+
+    expect(editorOffset()).toEqual($(getCell(0, 1, true)).offset());
+
+    selectCell(0, 2);
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(0, 2, true)).offset());
+
+    selectCell(0, 3);
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(0, 3, true)).offset());
+
+    selectCell(0, 4);
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(0, 4, true)).offset());
+  });
+
+  it('should render an editor in specified position while opening an editor from top to bottom when ' +
+       'top and bottom overlays are enabled and the first row of the both overlays are hidden', () => {
+    spec().$container.css('overflow', '').css('width', '').css('height', '');
+
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(8, 2),
+      rowHeaders: true,
+      colHeaders: true,
+      fixedRowsTop: 3,
+      fixedRowsBottom: 3,
+      hiddenRows: {
+        indicators: true,
+        rows: [0, 5],
+      },
+      columns: [
+        {
+          editor: 'dropdown',
+          source: choices,
+        },
+        {},
+      ],
+    });
+
+    selectCell(1, 0);
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    keyDown('enter');
+
+    // First renderable row index.
+    expect(editor.offset()).toEqual($(getCell(1, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    // Cells that do not touch the edges of the table have an additional top border.
+    const editorOffset = () => ({
+      top: editor.offset().top + 1,
+      left: editor.offset().left,
+    });
+
+    expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(3, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(4, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
+    expect(editor.offset()).toEqual($(getCell(6, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(7, 0, true)).offset());
+  });
+
+  it('should render an editor in specified position while opening an editor from left to right when ' +
+     'left overlay is enabled and the first column of the overlay is hidden', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(2, 5),
+      rowHeaders: true,
+      colHeaders: true,
+      fixedColumnsLeft: 3,
+      hiddenColumns: {
+        indicators: true,
+        columns: [0],
+      },
+      editor: 'dropdown',
+      source: choices,
+    });
+
+    selectCell(0, 1);
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    keyDown('enter');
+
+    // First renderable column index.
+    expect(editor.offset()).toEqual($(getCell(0, 1, true)).offset());
+
+    selectCell(0, 2);
+    keyDown('enter');
+
+    // Cells that do not touch the edges of the table have an additional left border.
+    const editorOffset = () => ({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    });
+
+    expect(editorOffset()).toEqual($(getCell(0, 2, true)).offset());
+
+    selectCell(0, 3);
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(0, 3, true)).offset());
+
+    selectCell(0, 4);
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(0, 4, true)).offset());
+  });
+
   describe('open editor', () => {
     // see https://github.com/handsontable/handsontable/issues/3380
     it('should not throw error while selecting the next cell by hitting enter key', () => {

--- a/test/e2e/editors/handsontableEditor.spec.js
+++ b/test/e2e/editors/handsontableEditor.spec.js
@@ -23,6 +23,288 @@ describe('HandsontableEditor', () => {
     ];
   }
 
+  it('should render an editor in specified position at cell 0, 0', () => {
+    handsontable({
+      columns: [
+        {
+          type: 'handsontable',
+          handsontable: {
+            colHeaders: ['Marque', 'Country', 'Parent company'],
+            data: getManufacturerData()
+          }
+        }
+      ],
+    });
+
+    selectCell(0, 0);
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    keyDown('enter');
+
+    expect(editor.offset()).toEqual($(getCell(0, 0)).offset());
+  });
+
+  it('should render an editor in specified position at cell 0, 0 when all headers are selected', () => {
+    handsontable({
+      rowHeaders: true,
+      colHeaders: true,
+      columns: [
+        {
+          type: 'handsontable',
+          handsontable: {
+            colHeaders: ['Marque', 'Country', 'Parent company'],
+            data: getManufacturerData()
+          }
+        }
+      ],
+    });
+
+    selectAll();
+    listen();
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    keyDown('enter');
+
+    expect(editor.offset()).toEqual($(getCell(0, 0)).offset());
+  });
+
+  it('should render an editor in specified position while opening an editor from top to bottom when ' +
+     'top and bottom overlays are enabled', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(8, 2),
+      rowHeaders: true,
+      colHeaders: true,
+      fixedRowsTop: 3,
+      fixedRowsBottom: 3,
+      columns: [
+        {
+          type: 'handsontable',
+          handsontable: {
+            colHeaders: ['Marque', 'Country', 'Parent company'],
+            data: getManufacturerData()
+          }
+        },
+        {},
+      ],
+    });
+
+    selectCell(0, 0);
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    keyDown('enter');
+
+    expect(editor.offset()).toEqual($(getCell(0, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    // Cells that do not touch the edges of the table have an additional top border.
+    const editorOffset = () => ({
+      top: editor.offset().top + 1,
+      left: editor.offset().left,
+    });
+
+    expect(editorOffset()).toEqual($(getCell(1, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(3, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(4, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
+    expect(editor.offset()).toEqual($(getCell(5, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(6, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(7, 0, true)).offset());
+  });
+
+  it('should render an editor in specified position while opening an editor from left to right when ' +
+     'left overlay is enabled', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(2, 5),
+      rowHeaders: true,
+      colHeaders: true,
+      fixedColumnsLeft: 3,
+      type: 'handsontable',
+      handsontable: {
+        colHeaders: ['Marque', 'Country', 'Parent company'],
+        data: getManufacturerData()
+      }
+    });
+
+    selectCell(0, 0);
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    keyDown('enter');
+
+    expect(editor.offset()).toEqual($(getCell(0, 0, true)).offset());
+
+    selectCell(0, 1);
+    keyDown('enter');
+
+    // Cells that do not touch the edges of the table have an additional left border.
+    const editorOffset = () => ({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    });
+
+    expect(editorOffset()).toEqual($(getCell(0, 1, true)).offset());
+
+    selectCell(0, 2);
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(0, 2, true)).offset());
+
+    selectCell(0, 3);
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(0, 3, true)).offset());
+
+    selectCell(0, 4);
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(0, 4, true)).offset());
+  });
+
+  it('should render an editor in specified position while opening an editor from top to bottom when ' +
+       'top and bottom overlays are enabled and the first row of the both overlays are hidden', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(8, 2),
+      rowHeaders: true,
+      colHeaders: true,
+      fixedRowsTop: 3,
+      fixedRowsBottom: 3,
+      hiddenRows: {
+        indicators: true,
+        rows: [0, 5],
+      },
+      columns: [
+        {
+          type: 'handsontable',
+          handsontable: {
+            colHeaders: ['Marque', 'Country', 'Parent company'],
+            data: getManufacturerData()
+          }
+        },
+        {},
+      ],
+    });
+
+    selectCell(1, 0);
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    keyDown('enter');
+
+    // First renderable row index.
+    expect(editor.offset()).toEqual($(getCell(1, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    // Cells that do not touch the edges of the table have an additional top border.
+    const editorOffset = () => ({
+      top: editor.offset().top + 1,
+      left: editor.offset().left,
+    });
+
+    expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(3, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(4, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
+    expect(editor.offset()).toEqual($(getCell(6, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(7, 0, true)).offset());
+  });
+
+  it('should render an editor in specified position while opening an editor from left to right when ' +
+     'left overlay is enabled and the first column of the overlay is hidden', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(2, 5),
+      rowHeaders: true,
+      colHeaders: true,
+      fixedColumnsLeft: 3,
+      hiddenColumns: {
+        indicators: true,
+        columns: [0],
+      },
+      type: 'handsontable',
+      handsontable: {
+        colHeaders: ['Marque', 'Country', 'Parent company'],
+        data: getManufacturerData()
+      }
+    });
+
+    selectCell(0, 1);
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    keyDown('enter');
+
+    // First renderable column index.
+    expect(editor.offset()).toEqual($(getCell(0, 1, true)).offset());
+
+    selectCell(0, 2);
+    keyDown('enter');
+
+    // Cells that do not touch the edges of the table have an additional left border.
+    const editorOffset = () => ({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    });
+
+    expect(editorOffset()).toEqual($(getCell(0, 2, true)).offset());
+
+    selectCell(0, 3);
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(0, 3, true)).offset());
+
+    selectCell(0, 4);
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(0, 4, true)).offset());
+  });
+
   it('should create an editor that is a Handsontable instance', () => {
     handsontable({
       columns: [

--- a/test/e2e/editors/numericEditor.spec.js
+++ b/test/e2e/editors/numericEditor.spec.js
@@ -27,6 +27,283 @@ describe('NumericEditor', () => {
     ];
   };
 
+  it('should render an editor in specified position at cell 0, 0', () => {
+    handsontable({
+      columns: [
+        {
+          type: 'numeric'
+        }
+      ],
+    });
+
+    selectCell(0, 0);
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    keyDown('enter');
+
+    expect(editor.offset()).toEqual($(getCell(0, 0)).offset());
+  });
+
+  it('should render an editor in specified position at cell 0, 0 when all headers are selected', () => {
+    handsontable({
+      rowHeaders: true,
+      colHeaders: true,
+      columns: [
+        {
+          type: 'numeric'
+        }
+      ],
+    });
+
+    selectAll();
+    listen();
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    keyDown('enter');
+
+    expect(editor.offset()).toEqual($(getCell(0, 0)).offset());
+  });
+
+  it('should render an editor in specified position while opening an editor from top to bottom when ' +
+     'top and bottom overlays are enabled', async() => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(8, 2),
+      rowHeaders: true,
+      colHeaders: true,
+      fixedRowsTop: 3,
+      fixedRowsBottom: 3,
+      columns: [
+        {
+          type: 'numeric'
+        },
+        {},
+      ],
+    });
+
+    selectCell(0, 0);
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    keyDown('enter');
+
+    expect(editor.offset()).toEqual($(getCell(0, 0, true)).offset());
+
+    keyDown('enter');
+    await sleep(10); // Caused by async NumericEditor validation.
+    keyDown('enter');
+
+    // Cells that do not touch the edges of the table have an additional top border.
+    const editorOffset = () => ({
+      top: editor.offset().top + 1,
+      left: editor.offset().left,
+    });
+
+    expect(editorOffset()).toEqual($(getCell(1, 0, true)).offset());
+
+    keyDown('enter');
+    await sleep(10); // Caused by async NumericEditor validation.
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
+
+    keyDown('enter');
+    await sleep(10); // Caused by async NumericEditor validation.
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(3, 0, true)).offset());
+
+    keyDown('enter');
+    await sleep(10); // Caused by async NumericEditor validation.
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(4, 0, true)).offset());
+
+    keyDown('enter');
+    await sleep(10); // Caused by async NumericEditor validation.
+    keyDown('enter');
+
+    // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
+    expect(editor.offset()).toEqual($(getCell(5, 0, true)).offset());
+
+    keyDown('enter');
+    await sleep(10); // Caused by async NumericEditor validation.
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(6, 0, true)).offset());
+
+    keyDown('enter');
+    await sleep(10); // Caused by async NumericEditor validation.
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(7, 0, true)).offset());
+  });
+
+  it('should render an editor in specified position while opening an editor from left to right when ' +
+     'left overlay is enabled', async() => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(2, 5),
+      rowHeaders: true,
+      colHeaders: true,
+      fixedColumnsLeft: 3,
+      type: 'numeric'
+    });
+
+    selectCell(0, 0);
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    keyDown('enter');
+
+    expect(editor.offset()).toEqual($(getCell(0, 0, true)).offset());
+
+    selectCell(0, 1);
+    await sleep(10); // Caused by async NumericEditor validation.
+    keyDown('enter');
+
+    // Cells that do not touch the edges of the table have an additional left border.
+    const editorOffset = () => ({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    });
+
+    expect(editorOffset()).toEqual($(getCell(0, 1, true)).offset());
+
+    selectCell(0, 2);
+    await sleep(10); // Caused by async NumericEditor validation.
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(0, 2, true)).offset());
+
+    selectCell(0, 3);
+    await sleep(10); // Caused by async NumericEditor validation.
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(0, 3, true)).offset());
+
+    selectCell(0, 4);
+    await sleep(10); // Caused by async NumericEditor validation.
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(0, 4, true)).offset());
+  });
+
+  it('should render an editor in specified position while opening an editor from top to bottom when ' +
+       'top and bottom overlays are enabled and the first row of the both overlays are hidden', async() => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(8, 2),
+      rowHeaders: true,
+      colHeaders: true,
+      fixedRowsTop: 3,
+      fixedRowsBottom: 3,
+      hiddenRows: {
+        indicators: true,
+        rows: [0, 5],
+      },
+      columns: [
+        {
+          type: 'numeric'
+        },
+        {},
+      ],
+    });
+
+    selectCell(1, 0);
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    keyDown('enter');
+
+    // First renderable row index.
+    expect(editor.offset()).toEqual($(getCell(1, 0, true)).offset());
+
+    keyDown('enter');
+    await sleep(10); // Caused by async NumericEditor validation.
+    keyDown('enter');
+
+    // Cells that do not touch the edges of the table have an additional top border.
+    const editorOffset = () => ({
+      top: editor.offset().top + 1,
+      left: editor.offset().left,
+    });
+
+    expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
+
+    keyDown('enter');
+    await sleep(10); // Caused by async NumericEditor validation.
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(3, 0, true)).offset());
+
+    keyDown('enter');
+    await sleep(10); // Caused by async NumericEditor validation.
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(4, 0, true)).offset());
+
+    keyDown('enter');
+    await sleep(10); // Caused by async NumericEditor validation.
+    keyDown('enter');
+
+    // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
+    expect(editor.offset()).toEqual($(getCell(6, 0, true)).offset());
+
+    keyDown('enter');
+    await sleep(10); // Caused by async NumericEditor validation.
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(7, 0, true)).offset());
+  });
+
+  it('should render an editor in specified position while opening an editor from left to right when ' +
+     'left overlay is enabled and the first column of the overlay is hidden', async() => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(2, 5),
+      rowHeaders: true,
+      colHeaders: true,
+      fixedColumnsLeft: 3,
+      hiddenColumns: {
+        indicators: true,
+        columns: [0],
+      },
+      type: 'numeric',
+    });
+
+    selectCell(0, 1);
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    keyDown('enter');
+
+    // First renderable column index.
+    expect(editor.offset()).toEqual($(getCell(0, 1, true)).offset());
+
+    selectCell(0, 2);
+    await sleep(10); // Caused by async NumericEditor validation.
+    keyDown('enter');
+
+    // Cells that do not touch the edges of the table have an additional left border.
+    const editorOffset = () => ({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    });
+
+    expect(editorOffset()).toEqual($(getCell(0, 2, true)).offset());
+
+    selectCell(0, 3);
+    await sleep(10); // Caused by async NumericEditor validation.
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(0, 3, true)).offset());
+
+    selectCell(0, 4);
+    await sleep(10); // Caused by async NumericEditor validation.
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(0, 4, true)).offset());
+  });
+
   it('should convert "integer like" input value to number (object data source)', async() => {
     handsontable({
       data: arrayOfObjects(),

--- a/test/e2e/editors/passwordEditor.spec.js
+++ b/test/e2e/editors/passwordEditor.spec.js
@@ -12,6 +12,264 @@ describe('PasswordEditor', () => {
     }
   });
 
+  it('should render an editor in specified position at cell 0, 0', () => {
+    handsontable({
+      columns: [
+        {
+          type: 'password',
+        }
+      ],
+    });
+
+    selectCell(0, 0);
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    keyDown('enter');
+
+    expect(editor.offset()).toEqual($(getCell(0, 0)).offset());
+  });
+
+  it('should render an editor in specified position at cell 0, 0 when all headers are selected', () => {
+    handsontable({
+      rowHeaders: true,
+      colHeaders: true,
+      columns: [
+        {
+          type: 'password',
+        }
+      ],
+    });
+
+    selectAll();
+    listen();
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    keyDown('enter');
+
+    expect(editor.offset()).toEqual($(getCell(0, 0)).offset());
+  });
+
+  it('should render an editor in specified position while opening an editor from top to bottom when ' +
+     'top and bottom overlays are enabled', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(8, 2),
+      rowHeaders: true,
+      colHeaders: true,
+      fixedRowsTop: 3,
+      fixedRowsBottom: 3,
+      columns: [
+        {
+          type: 'password',
+        },
+        {},
+      ],
+    });
+
+    selectCell(0, 0);
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    keyDown('enter');
+
+    expect(editor.offset()).toEqual($(getCell(0, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    // Cells that do not touch the edges of the table have an additional top border.
+    const editorOffset = () => ({
+      top: editor.offset().top + 1,
+      left: editor.offset().left,
+    });
+
+    expect(editorOffset()).toEqual($(getCell(1, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(3, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(4, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
+    expect(editor.offset()).toEqual($(getCell(5, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(6, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(7, 0, true)).offset());
+  });
+
+  it('should render an editor in specified position while opening an editor from left to right when ' +
+     'left overlay is enabled', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(2, 5),
+      rowHeaders: true,
+      colHeaders: true,
+      fixedColumnsLeft: 3,
+      type: 'password',
+    });
+
+    selectCell(0, 0);
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    keyDown('enter');
+
+    expect(editor.offset()).toEqual($(getCell(0, 0, true)).offset());
+
+    selectCell(0, 1);
+    keyDown('enter');
+
+    // Cells that do not touch the edges of the table have an additional left border.
+    const editorOffset = () => ({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    });
+
+    expect(editorOffset()).toEqual($(getCell(0, 1, true)).offset());
+
+    selectCell(0, 2);
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(0, 2, true)).offset());
+
+    selectCell(0, 3);
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(0, 3, true)).offset());
+
+    selectCell(0, 4);
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(0, 4, true)).offset());
+  });
+
+  it('should render an editor in specified position while opening an editor from top to bottom when ' +
+       'top and bottom overlays are enabled and the first row of the both overlays are hidden', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(8, 2),
+      rowHeaders: true,
+      colHeaders: true,
+      fixedRowsTop: 3,
+      fixedRowsBottom: 3,
+      hiddenRows: {
+        indicators: true,
+        rows: [0, 5],
+      },
+      columns: [
+        {
+          type: 'password',
+        },
+        {},
+      ],
+    });
+
+    selectCell(1, 0);
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    keyDown('enter');
+
+    // First renderable row index.
+    expect(editor.offset()).toEqual($(getCell(1, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    // Cells that do not touch the edges of the table have an additional top border.
+    const editorOffset = () => ({
+      top: editor.offset().top + 1,
+      left: editor.offset().left,
+    });
+
+    expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(3, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(4, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
+    expect(editor.offset()).toEqual($(getCell(6, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(7, 0, true)).offset());
+  });
+
+  it('should render an editor in specified position while opening an editor from left to right when ' +
+     'left overlay is enabled and the first column of the overlay is hidden', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(2, 5),
+      rowHeaders: true,
+      colHeaders: true,
+      fixedColumnsLeft: 3,
+      hiddenColumns: {
+        indicators: true,
+        columns: [0],
+      },
+      type: 'password',
+    });
+
+    selectCell(0, 1);
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    keyDown('enter');
+
+    // First renderable column index.
+    expect(editor.offset()).toEqual($(getCell(0, 1, true)).offset());
+
+    selectCell(0, 2);
+    keyDown('enter');
+
+    // Cells that do not touch the edges of the table have an additional left border.
+    const editorOffset = () => ({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    });
+
+    expect(editorOffset()).toEqual($(getCell(0, 2, true)).offset());
+
+    selectCell(0, 3);
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(0, 3, true)).offset());
+
+    selectCell(0, 4);
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(0, 4, true)).offset());
+  });
+
   it('should display editor as password field', () => {
     handsontable({
       data: [

--- a/test/e2e/editors/selectEditor.spec.js
+++ b/test/e2e/editors/selectEditor.spec.js
@@ -13,7 +13,7 @@ describe('SelectEditor', () => {
     }
   });
 
-  it('should render select editor in specified position at cell 0, 0', () => {
+  it('should render an editor in specified position at cell 0, 0', () => {
     handsontable({
       columns: [{ editor: 'select' }],
     });
@@ -32,15 +32,15 @@ describe('SelectEditor', () => {
     expect(editor.offset()).toEqual($(getCell(0, 0)).offset());
   });
 
-  it('should render select editor in specified position at cell 0, 0 when all headers are selected', () => {
-    const hot = handsontable({
+  it('should render an editor in specified position at cell 0, 0 when all headers are selected', () => {
+    handsontable({
       rowHeaders: true,
       colHeaders: true,
       columns: [{ editor: 'select' }, {}],
     });
 
     selectAll();
-    hot.listen();
+    listen();
 
     const editor = $('.htSelectEditor');
 
@@ -52,6 +52,215 @@ describe('SelectEditor', () => {
 
     expect(editor.is(':visible')).toBe(true);
     expect(editor.offset()).toEqual($(getCell(0, 0)).offset());
+  });
+
+  it('should render an editor in specified position while opening an editor from top to bottom when ' +
+     'top and bottom overlays are enabled', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(8, 2),
+      rowHeaders: true,
+      colHeaders: true,
+      fixedRowsTop: 3,
+      fixedRowsBottom: 3,
+      columns: [{ editor: 'select' }, {}],
+    });
+
+    selectCell(0, 0);
+
+    const editor = $('.htSelectEditor');
+
+    keyDown('enter');
+
+    expect(editor.offset()).toEqual($(getCell(0, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    // Cells that do not touch the edges of the table have an additional top border.
+    const editorOffset = () => ({
+      top: editor.offset().top + 1,
+      left: editor.offset().left,
+    });
+
+    expect(editorOffset()).toEqual($(getCell(1, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(3, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(4, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
+    expect(editor.offset()).toEqual($(getCell(5, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(6, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(7, 0, true)).offset());
+  });
+
+  it('should render an editor in specified position while opening an editor from left to right when ' +
+     'left overlay is enabled', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(2, 5),
+      rowHeaders: true,
+      colHeaders: true,
+      fixedColumnsLeft: 3,
+      editor: 'select',
+    });
+
+    selectCell(0, 0);
+
+    const editor = $('.htSelectEditor');
+
+    keyDown('enter');
+
+    expect(editor.offset()).toEqual($(getCell(0, 0, true)).offset());
+
+    selectCell(0, 1);
+    keyDown('enter');
+
+    // Cells that do not touch the edges of the table have an additional left border.
+    const editorOffset = () => ({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    });
+
+    expect(editorOffset()).toEqual($(getCell(0, 1, true)).offset());
+
+    selectCell(0, 2);
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(0, 2, true)).offset());
+
+    selectCell(0, 3);
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(0, 3, true)).offset());
+
+    selectCell(0, 4);
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(0, 4, true)).offset());
+  });
+
+  it('should render an editor in specified position while opening an editor from top to bottom when ' +
+     'top and bottom overlays are enabled and the first row of the both overlays are hidden', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(8, 2),
+      rowHeaders: true,
+      colHeaders: true,
+      fixedRowsTop: 3,
+      fixedRowsBottom: 3,
+      hiddenRows: {
+        indicators: true,
+        rows: [0, 5],
+      },
+      columns: [{ editor: 'select' }, {}],
+    });
+
+    selectCell(1, 0);
+
+    const editor = $('.htSelectEditor');
+
+    keyDown('enter');
+
+    // First renderable row index.
+    expect(editor.offset()).toEqual($(getCell(1, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    // Cells that do not touch the edges of the table have an additional top border.
+    const editorOffset = () => ({
+      top: editor.offset().top + 1,
+      left: editor.offset().left,
+    });
+
+    expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(3, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(4, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
+    expect(editor.offset()).toEqual($(getCell(6, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(7, 0, true)).offset());
+  });
+
+  it('should render an editor in specified position while opening an editor from left to right when ' +
+     'left overlay is enabled and the first column of the overlay is hidden', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(2, 5),
+      rowHeaders: true,
+      colHeaders: true,
+      fixedColumnsLeft: 3,
+      hiddenColumns: {
+        indicators: true,
+        columns: [0],
+      },
+      editor: 'select',
+    });
+
+    selectCell(0, 1);
+
+    const editor = $('.htSelectEditor');
+
+    keyDown('enter');
+
+    // First renderable column index.
+    expect(editor.offset()).toEqual($(getCell(0, 1, true)).offset());
+
+    selectCell(0, 2);
+    keyDown('enter');
+
+    // Cells that do not touch the edges of the table have an additional left border.
+    const editorOffset = () => ({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    });
+
+    expect(editorOffset()).toEqual($(getCell(0, 2, true)).offset());
+
+    selectCell(0, 3);
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(0, 3, true)).offset());
+
+    selectCell(0, 4);
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(0, 4, true)).offset());
   });
 
   it('should display and correctly reposition select editor while scrolling', (done) => {

--- a/test/e2e/editors/textEditor.spec.js
+++ b/test/e2e/editors/textEditor.spec.js
@@ -13,6 +13,264 @@ describe('TextEditor', () => {
     }
   });
 
+  it('should render an editor in specified position at cell 0, 0', () => {
+    handsontable({
+      columns: [
+        {
+          type: 'text',
+        }
+      ],
+    });
+
+    selectCell(0, 0);
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    keyDown('enter');
+
+    expect(editor.offset()).toEqual($(getCell(0, 0)).offset());
+  });
+
+  it('should render an editor in specified position at cell 0, 0 when all headers are selected', () => {
+    handsontable({
+      rowHeaders: true,
+      colHeaders: true,
+      columns: [
+        {
+          type: 'text',
+        }
+      ],
+    });
+
+    selectAll();
+    listen();
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    keyDown('enter');
+
+    expect(editor.offset()).toEqual($(getCell(0, 0)).offset());
+  });
+
+  it('should render an editor in specified position while opening an editor from top to bottom when ' +
+     'top and bottom overlays are enabled', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(8, 2),
+      rowHeaders: true,
+      colHeaders: true,
+      fixedRowsTop: 3,
+      fixedRowsBottom: 3,
+      columns: [
+        {
+          type: 'text',
+        },
+        {},
+      ],
+    });
+
+    selectCell(0, 0);
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    keyDown('enter');
+
+    expect(editor.offset()).toEqual($(getCell(0, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    // Cells that do not touch the edges of the table have an additional top border.
+    const editorOffset = () => ({
+      top: editor.offset().top + 1,
+      left: editor.offset().left,
+    });
+
+    expect(editorOffset()).toEqual($(getCell(1, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(3, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(4, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
+    expect(editor.offset()).toEqual($(getCell(5, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(6, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(7, 0, true)).offset());
+  });
+
+  it('should render an editor in specified position while opening an editor from left to right when ' +
+     'left overlay is enabled', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(2, 5),
+      rowHeaders: true,
+      colHeaders: true,
+      fixedColumnsLeft: 3,
+      type: 'text',
+    });
+
+    selectCell(0, 0);
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    keyDown('enter');
+
+    expect(editor.offset()).toEqual($(getCell(0, 0, true)).offset());
+
+    selectCell(0, 1);
+    keyDown('enter');
+
+    // Cells that do not touch the edges of the table have an additional left border.
+    const editorOffset = () => ({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    });
+
+    expect(editorOffset()).toEqual($(getCell(0, 1, true)).offset());
+
+    selectCell(0, 2);
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(0, 2, true)).offset());
+
+    selectCell(0, 3);
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(0, 3, true)).offset());
+
+    selectCell(0, 4);
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(0, 4, true)).offset());
+  });
+
+  it('should render an editor in specified position while opening an editor from top to bottom when ' +
+       'top and bottom overlays are enabled and the first row of the both overlays are hidden', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(8, 2),
+      rowHeaders: true,
+      colHeaders: true,
+      fixedRowsTop: 3,
+      fixedRowsBottom: 3,
+      hiddenRows: {
+        indicators: true,
+        rows: [0, 5],
+      },
+      columns: [
+        {
+          type: 'text',
+        },
+        {},
+      ],
+    });
+
+    selectCell(1, 0);
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    keyDown('enter');
+
+    // First renderable row index.
+    expect(editor.offset()).toEqual($(getCell(1, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    // Cells that do not touch the edges of the table have an additional top border.
+    const editorOffset = () => ({
+      top: editor.offset().top + 1,
+      left: editor.offset().left,
+    });
+
+    expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(3, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(4, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
+    expect(editor.offset()).toEqual($(getCell(6, 0, true)).offset());
+
+    keyDown('enter');
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(7, 0, true)).offset());
+  });
+
+  it('should render an editor in specified position while opening an editor from left to right when ' +
+     'left overlay is enabled and the first column of the overlay is hidden', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(2, 5),
+      rowHeaders: true,
+      colHeaders: true,
+      fixedColumnsLeft: 3,
+      hiddenColumns: {
+        indicators: true,
+        columns: [0],
+      },
+      type: 'text',
+    });
+
+    selectCell(0, 1);
+
+    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+    keyDown('enter');
+
+    // First renderable column index.
+    expect(editor.offset()).toEqual($(getCell(0, 1, true)).offset());
+
+    selectCell(0, 2);
+    keyDown('enter');
+
+    // Cells that do not touch the edges of the table have an additional left border.
+    const editorOffset = () => ({
+      top: editor.offset().top,
+      left: editor.offset().left + 1,
+    });
+
+    expect(editorOffset()).toEqual($(getCell(0, 2, true)).offset());
+
+    selectCell(0, 3);
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(0, 3, true)).offset());
+
+    selectCell(0, 4);
+    keyDown('enter');
+
+    expect(editorOffset()).toEqual($(getCell(0, 4, true)).offset());
+  });
+
   it('should begin editing when enterBeginsEditing equals true', () => {
     handsontable({
       enterBeginsEditing: true,
@@ -223,7 +481,7 @@ describe('TextEditor', () => {
   });
 
   it('should render textarea editor in specified size at cell 0, 0 with headers', async() => {
-    const hot = handsontable({
+    handsontable({
       rowHeaders: true,
       colHeaders: true
     });
@@ -233,26 +491,24 @@ describe('TextEditor', () => {
 
     await sleep(200);
 
-    expect(hot.getActiveEditor().TEXTAREA.style.height).toBe('23px');
-    expect(hot.getActiveEditor().TEXTAREA.style.width).toBe('40px');
-    expect($(hot.getActiveEditor().TEXTAREA_PARENT).offset()).toEqual($(getCell(0, 0)).offset());
+    expect(getActiveEditor().TEXTAREA.style.height).toBe('23px');
+    expect(getActiveEditor().TEXTAREA.style.width).toBe('40px');
   });
 
   it('should render textarea editor in specified size at cell 0, 0 when headers are selected', async() => {
-    const hot = handsontable({
+    handsontable({
       rowHeaders: true,
       colHeaders: true
     });
 
     selectAll();
-    hot.listen();
+    listen();
     keyDown('enter');
 
     await sleep(200);
 
-    expect(hot.getActiveEditor().TEXTAREA.style.height).toBe('23px');
-    expect(hot.getActiveEditor().TEXTAREA.style.width).toBe('40px');
-    expect($(hot.getActiveEditor().TEXTAREA_PARENT).offset()).toEqual($(getCell(0, 0)).offset());
+    expect(getActiveEditor().TEXTAREA.style.height).toBe('23px');
+    expect(getActiveEditor().TEXTAREA.style.width).toBe('40px');
   });
 
   it('should render textarea editor in specified size at cell 0, 0 with headers defined in columns', async() => {

--- a/test/helpers/common.js
+++ b/test/helpers/common.js
@@ -96,6 +96,7 @@ export const getSourceDataAtCell = handsontableMethodFactory('getSourceDataAtCel
 export const getSourceDataAtCol = handsontableMethodFactory('getSourceDataAtCol');
 export const getSourceDataAtRow = handsontableMethodFactory('getSourceDataAtRow');
 export const getValue = handsontableMethodFactory('getValue');
+export const listen = handsontableMethodFactory('listen');
 export const loadData = handsontableMethodFactory('loadData');
 export const populateFromArray = handsontableMethodFactory('populateFromArray');
 export const propToCol = handsontableMethodFactory('propToCol');


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the editor position misalign when it's open. This happened when the first row or column was hidden or when there is a bottom overlay enabled. I fixed this by translating visual coordinates into renderable, which are then used in the condition which adjusts the editor position.

was (8.0.0 beta2 rev19):
![Kapture 2020-07-08 at 13 45 26](https://user-images.githubusercontent.com/571316/86914954-7b018480-c121-11ea-9fa2-9a2d6da315cb.gif)

Now:
![Kapture 2020-07-08 at 13 46 04](https://user-images.githubusercontent.com/571316/86914987-86ed4680-c121-11ea-9863-543157de211a.gif)

Tested using this settings:
```js
{
  data: Handsontable.helper.createSpreadsheetData(6, 5),
  rowHeaders: true,
  colHeaders: true,
  hiddenColumns: {
    columns: [0],
    indicators: true
  },
  hiddenRows: {
    rows: [0],
    indicators: true
  },
  fixedRowsBottom: 2,
  fixedRowsTop: 2,
  fixedColumnsLeft: 2,
}
```

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I added tons of new tests that check an editor position for each editor type. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #6982
2. #7087
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
