### PR TITLE
Make the row resize hooks not use `null` as a row height.

### DIFF
--- a/src/plugins/hiddenRows/test/plugins/manualRowResize.e2e.js
+++ b/src/plugins/hiddenRows/test/plugins/manualRowResize.e2e.js
@@ -29,7 +29,7 @@ describe('HiddenRows', () => {
       // Resize renderable row index `1` (within visual index term the index at 1 is hidden).
       resizeRow(1, 100);
 
-      expect(rowHeight(spec().$container, 1)).toEqual(99);
+      expect(rowHeight(spec().$container, 1)).toEqual(100);
     });
 
     it('should resize a proper row when the table contains hidden row using public API', () => {

--- a/src/plugins/manualRowResize/manualRowResize.js
+++ b/src/plugins/manualRowResize/manualRowResize.js
@@ -113,7 +113,8 @@ class ManualRowResize extends BasePlugin {
   }
 
   /**
-   * Saves the current sizes using the persistentState plugin (the {@link Options#persistentState} option has to be enabled).
+   * Saves the current sizes using the persistentState plugin (the {@link Options#persistentState} option has to be
+   * enabled).
    *
    * @fires Hooks#persistentStateSave
    */
@@ -122,7 +123,8 @@ class ManualRowResize extends BasePlugin {
   }
 
   /**
-   * Loads the previously saved sizes using the persistentState plugin (the {@link Options#persistentState} option has to be enabled).
+   * Loads the previously saved sizes using the persistentState plugin (the {@link Options#persistentState} option
+   * has be enabled).
    *
    * @returns {Array}
    * @fires Hooks#persistentStateLoad
@@ -334,10 +336,9 @@ class ManualRowResize extends BasePlugin {
 
     if (walkontableHeight !== void 0 && this.newSize < walkontableHeight) {
       return walkontableHeight;
-
-    } else {
-      return this.newSize;
     }
+
+    return this.newSize;
   }
 
   /**

--- a/src/plugins/manualRowResize/manualRowResize.js
+++ b/src/plugins/manualRowResize/manualRowResize.js
@@ -327,6 +327,7 @@ class ManualRowResize extends BasePlugin {
   /**
    * Returns the actual height for the provided row index.
    *
+   * @private
    * @param {number} row Visual row index.
    * @returns {number} Actual row height.
    */

--- a/src/plugins/manualRowResize/test/manualRowResize.e2e.js
+++ b/src/plugins/manualRowResize/test/manualRowResize.e2e.js
@@ -241,7 +241,7 @@ describe('manualRowResize', () => {
 
     expect(rowHeight(spec().$container, 0)).toEqual(defaultRowHeight + 2);
 
-    resizeRow(0, defaultRowHeight);
+    resizeRow(0, defaultRowHeight + 2);
     expect(afterRowResizeCallback).not.toHaveBeenCalled();
     expect(rowHeight(spec().$container, 0)).toEqual(defaultRowHeight + 2);
   });
@@ -698,6 +698,42 @@ describe('manualRowResize', () => {
       const $handle = $('.manualRowResizer');
 
       expect($handle.css('z-index')).toBeGreaterThan(getLeftClone().css('z-index'));
+    });
+  });
+
+  describe('hooks', () => {
+    it('should run the `beforeRowResize` and `afterRowResize` hooks with numeric values for both the row height and' +
+      ' row index', () => {
+      const beforeRowResizeCallback = jasmine.createSpy('beforeRowResizeCallback');
+      const afterRowResizeCallback = jasmine.createSpy('afterRowResizeCallback');
+
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 1),
+        rowHeaders: true,
+        manualRowResize: true,
+        beforeRowResize: beforeRowResizeCallback,
+        afterRowResize: afterRowResizeCallback
+      });
+
+      resizeRow(2, 300);
+
+      expect(beforeRowResizeCallback.calls.mostRecent().args).toEqual([300, 2, false, void 0, void 0, void 0]);
+      expect(afterRowResizeCallback.calls.mostRecent().args).toEqual([300, 2, false, void 0, void 0, void 0]);
+
+      resizeRow(2, -10);
+
+      expect(beforeRowResizeCallback.calls.mostRecent().args).toEqual([23, 2, false, void 0, void 0, void 0]);
+      expect(afterRowResizeCallback.calls.mostRecent().args).toEqual([23, 2, false, void 0, void 0, void 0]);
+
+      resizeRow(2, 100);
+
+      expect(beforeRowResizeCallback.calls.mostRecent().args).toEqual([100, 2, false, void 0, void 0, void 0]);
+      expect(afterRowResizeCallback.calls.mostRecent().args).toEqual([100, 2, false, void 0, void 0, void 0]);
+
+      resizeRow(2, 5);
+
+      expect(beforeRowResizeCallback.calls.mostRecent().args).toEqual([23, 2, false, void 0, void 0, void 0]);
+      expect(afterRowResizeCallback.calls.mostRecent().args).toEqual([23, 2, false, void 0, void 0, void 0]);
     });
   });
 });

--- a/test/helpers/common.js
+++ b/test/helpers/common.js
@@ -763,7 +763,7 @@ export function resizeRow(renderableRowIndex, height) {
     clientY: resizerPosition.top
   });
 
-  let delta = newHeight - $th.height() - 2;
+  const delta = newHeight - $th.height() - 2;
 
   $resizer.simulate('mousemove', {
     clientY: resizerPosition.top + delta

--- a/test/helpers/common.js
+++ b/test/helpers/common.js
@@ -752,6 +752,7 @@ export function resizeColumn(renderableColumnIndex, width) {
 export function resizeRow(renderableRowIndex, height) {
   const $container = spec().$container;
   const $th = getLeftClone().find(`tbody tr:eq(${renderableRowIndex}) th:eq(0)`);
+  const newHeight = renderableRowIndex !== 0 ? height + 1 : height; // compensate border
 
   $th.simulate('mouseover');
 
@@ -762,11 +763,7 @@ export function resizeRow(renderableRowIndex, height) {
     clientY: resizerPosition.top
   });
 
-  let delta = height - $th.height() - 2;
-
-  if (delta < 0) {
-    delta = 0;
-  }
+  let delta = newHeight - $th.height() - 2;
 
   $resizer.simulate('mousemove', {
     clientY: resizerPosition.top + delta


### PR DESCRIPTION
### Context
Described in #7074.

This PR makes the `beforeRowResize` and `afterRowResize` hooks not pass `null` as a row height.

Additionally, we're introducing a change in a way these hooks are triggered. Previously, every change of height (even when it didn't have any effect on the actual row height) triggered both of them. After this change resizing rows will work more like resizing columns: if the row size after the resizing action does not change - no hooks will be triggered.
I consider it as a bugfix, not a breaking change.

### How has this been tested?
Tested manually and added a test case.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7074
