### PR TITLE
Fix a problem with custom borders + merge cells initialization.

### DIFF
--- a/src/plugins/mergeCells/mergeCells.js
+++ b/src/plugins/mergeCells/mergeCells.js
@@ -1179,6 +1179,11 @@ class MergeCells extends BasePlugin {
    * @returns {string|undefined} A `String`, which will act as an additional `className` to be added to the currently processed cell.
    */
   onAfterDrawSelection(currentRow, currentColumn, cornersOfSelection, layerLevel) {
+    // Nothing's selected (hook might be triggered by the custom borders)
+    if (!cornersOfSelection) {
+      return;
+    }
+
     return this.selectionCalculations
       .getSelectedMergedCellClassName(currentRow, currentColumn, cornersOfSelection, layerLevel);
   }

--- a/src/plugins/mergeCells/test/pluginCompatibility.e2e.js
+++ b/src/plugins/mergeCells/test/pluginCompatibility.e2e.js
@@ -1,0 +1,48 @@
+describe('MergeCells compatibility with other plugins', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  describe('Custom Borders', () => {
+    it('should be possible to add custom borders to a merged cell at initialization', () => {
+      const hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(10, 10),
+        mergeCells: [{ row: 1, col: 1, rowspan: 2, colspan: 2 }],
+        customBorders: [
+          {
+            range: {
+              from: {
+                row: 1,
+                col: 1
+              },
+              to: {
+                row: 2,
+                col: 2
+              }
+            },
+            top: {
+              width: 2,
+              color: 'blue'
+            }
+          }
+        ]
+      });
+
+      const border = hot.getPlugin('customBorders').getBorders([[1, 1, 2, 2]])[0];
+
+      expect(border.row).toEqual(1);
+      expect(border.col).toEqual(1);
+      expect(border.top.width).toEqual(2);
+      expect(border.top.color).toEqual('blue');
+    });
+  });
+});


### PR DESCRIPTION
### Context
Because of the fact, that custom borders act like a selection, the MergeCells plugin threw an error on one of the selection-related hooks.

### How has this been tested?
Added a test case/

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7088 