### PR TITLE
Fix header selection using RMB 

### DIFF
--- a/src/selection/mouseEventHandler.js
+++ b/src/selection/mouseEventHandler.js
@@ -39,17 +39,9 @@ export function mouseDown({ isShiftKey, isLeftClick, isRightClick, coords, selec
                (selectedRow && coords.row < 0)) && !controller.column) {
       selection.selectColumns(currentSelection.from.col, coords.col);
     }
+
   } else {
-    const newCoord = new CellCoords(coords.row, coords.col);
-
-    if (newCoord.row < 0) {
-      newCoord.row = 0;
-    }
-    if (newCoord.col < 0) {
-      newCoord.col = 0;
-    }
-
-    const allowRightClickSelection = !selection.inInSelection(newCoord);
+    const allowRightClickSelection = !selection.inInSelection(coords);
     const performSelection = isLeftClick || (isRightClick && allowRightClickSelection);
 
     // clicked row header and when some column was selected

--- a/test/e2e/Core_selection.spec.js
+++ b/test/e2e/Core_selection.spec.js
@@ -315,6 +315,92 @@ describe('Core_selection', () => {
     expect(tickEnd).toEqual(2);
   });
 
+  it('should select entire column by right click on column header', () => {
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+      rowHeaders: true,
+      colHeaders: true,
+    });
+
+    simulateClick(spec().$container.find('.ht_clone_top tr:eq(0) th:eq(1)'), 'RMB'); // Header "A"
+
+    expect(getSelected()).toEqual([[-1, 0, 4, 0]]);
+    expect(`
+      |   ║ * :   :   :   :   |
+      |===:===:===:===:===:===|
+      | - ║ A :   :   :   :   |
+      | - ║ 0 :   :   :   :   |
+      | - ║ 0 :   :   :   :   |
+      | - ║ 0 :   :   :   :   |
+      | - ║ 0 :   :   :   :   |
+    `).toBeMatchToSelectionPattern();
+  });
+
+  it('should select entire row by right click on row header', () => {
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+      rowHeaders: true,
+      colHeaders: true,
+    });
+
+    simulateClick(spec().$container.find('.ht_clone_left tbody tr:eq(0) th'), 'RMB'); // Header "1"
+
+    expect(getSelected()).toEqual([[0, -1, 0, 4]]);
+    expect(`
+      |   ║ - : - : - : - : - |
+      |===:===:===:===:===:===|
+      | * ║ A : 0 : 0 : 0 : 0 |
+      |   ║   :   :   :   :   |
+      |   ║   :   :   :   :   |
+      |   ║   :   :   :   :   |
+      |   ║   :   :   :   :   |
+    `).toBeMatchToSelectionPattern();
+  });
+
+  it('should select entire column by right click on column header and overwrite the previous cell selection (#7051)', () => {
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+      rowHeaders: true,
+      colHeaders: true,
+    });
+
+    selectCell(0, 0);
+    simulateClick(spec().$container.find('.ht_clone_top tr:eq(0) th:eq(1)'), 'RMB'); // Header "A"
+
+    expect(getSelected()).toEqual([[-1, 0, 4, 0]]);
+    expect(`
+      |   ║ * :   :   :   :   |
+      |===:===:===:===:===:===|
+      | - ║ A :   :   :   :   |
+      | - ║ 0 :   :   :   :   |
+      | - ║ 0 :   :   :   :   |
+      | - ║ 0 :   :   :   :   |
+      | - ║ 0 :   :   :   :   |
+    `).toBeMatchToSelectionPattern();
+  });
+
+  it('should select entire row by right click on row header and overwrite the previous cell selection (#7051)', () => {
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+      rowHeaders: true,
+      colHeaders: true,
+    });
+
+    selectCell(0, 0);
+    simulateClick(spec().$container.find('.ht_clone_left tbody tr:eq(0) th'), 'RMB'); // Header "1"
+
+    expect(getSelected()).toEqual([[0, -1, 0, 4]]);
+    expect(`
+      |   ║ - : - : - : - : - |
+      |===:===:===:===:===:===|
+      | * ║ A : 0 : 0 : 0 : 0 |
+      |   ║   :   :   :   :   |
+      |   ║   :   :   :   :   |
+      |   ║   :   :   :   :   |
+      |   ║   :   :   :   :   |
+    `).toBeMatchToSelectionPattern();
+  });
+
   it('should select columns by click on header when all rows are trimmed', () => {
     handsontable({
       data: createSpreadsheetData(5, 5),

--- a/test/helpers/mouseEvents.js
+++ b/test/helpers/mouseEvents.js
@@ -1,9 +1,10 @@
 
 const MOUSE_BUTTONS = new Map();
 
-MOUSE_BUTTONS.set('LMB', 1);
-MOUSE_BUTTONS.set('MMB', 2);
-MOUSE_BUTTONS.set('RMB', 3);
+// https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button#Return_value
+MOUSE_BUTTONS.set('LMB', 0);
+MOUSE_BUTTONS.set('MMB', 1);
+MOUSE_BUTTONS.set('RMB', 2);
 
 /**
  * Get number describing specific mouse click.
@@ -23,8 +24,8 @@ function getMouseButton(buttonKey) {
  * @param {object} [eventProps] Addional object with props to merge with the event.
  * @returns {Function}
  */
-export function handsontableMouseTriggerFactory(type, buttonKey = getMouseButton('LMB'), eventProps = {}) {
-  return function(element) {
+export function handsontableMouseTriggerFactory(type, defaultButtonKey = getMouseButton('LMB')) {
+  return function(element, buttonKey = defaultButtonKey, eventProps = {}) {
     let handsontableElement = element;
 
     if (!(handsontableElement instanceof jQuery)) {
@@ -32,7 +33,7 @@ export function handsontableMouseTriggerFactory(type, buttonKey = getMouseButton
     }
     const ev = $.Event(type);
 
-    ev.which = buttonKey;
+    ev.button = buttonKey;
 
     Object.keys(eventProps).forEach((key) => {
       ev[key] = eventProps[key];
@@ -47,6 +48,7 @@ export const mouseDown = handsontableMouseTriggerFactory('mousedown');
 export const mouseOver = handsontableMouseTriggerFactory('mouseover');
 export const mouseUp = handsontableMouseTriggerFactory('mouseup');
 export const mouseClick = handsontableMouseTriggerFactory('click');
+export const contextMenuEvent = handsontableMouseTriggerFactory('contextmenu');
 
 /**
  * Simulate click (all mouse events).
@@ -60,7 +62,16 @@ export function simulateClick(element, buttonKey, eventProps) {
 
   mouseDown(element, mouseButton, eventProps);
   mouseUp(element, mouseButton, eventProps);
-  mouseClick(element, mouseButton, eventProps);
+
+  // Only left click generates "click" events.
+  if (mouseButton === getMouseButton('LMB')) {
+    mouseClick(element, mouseButton, eventProps);
+  }
+
+  // Only right click generates "contextmenu" events.
+  if (mouseButton === getMouseButton('RMB')) {
+    contextMenuEvent(element, mouseButton, eventProps);
+  }
 }
 
 /**

--- a/test/helpers/mouseEvents.js
+++ b/test/helpers/mouseEvents.js
@@ -20,8 +20,7 @@ function getMouseButton(buttonKey) {
  * Returns a function that triggers a mouse event.
  *
  * @param {string} type Event type.
- * @param {number} [buttonKey] Number representing mouse button key.
- * @param {object} [eventProps] Addional object with props to merge with the event.
+ * @param {number} [defaultButtonKey] Number representing default mouse button key for this factory product.
  * @returns {Function}
  */
 export function handsontableMouseTriggerFactory(type, defaultButtonKey = getMouseButton('LMB')) {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
This PR fixes a bug that made it impossible to select a row or column header using RMB. This happens when under the clicked row or column header there was selected cell.

The PR fixes the bug by removing unnecessary code that was needed before the negative coordinates feature (#7027).

Additionally, I found that our test helper which emulates mouse events contains the wrong logic. The helper supports "which" property which is deprecated. I've replaced to "button" prop.

Was (rev19)
![Kapture 2020-07-09 at 15 52 44](https://user-images.githubusercontent.com/571316/87048696-58906980-c1fc-11ea-9c2d-2bfadef61db4.gif)

After fixes:
![Kapture 2020-07-09 at 15 50 56](https://user-images.githubusercontent.com/571316/87048684-5201f200-c1fc-11ea-9790-ba9bb1d2fd95.gif)


### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7051
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
