### PR TITLE
Normalize the selection coordinates when switching the selection axis using the SHIFT key.

### DIFF
--- a/src/selection/mouseEventHandler.js
+++ b/src/selection/mouseEventHandler.js
@@ -33,12 +33,13 @@ export function mouseDown({ isShiftKey, isLeftClick, isRightClick, coords, selec
 
     } else if (((!selectedCorner && !selectedRow && coords.col < 0) ||
                (selectedCorner && coords.col < 0)) && !controller.row) {
-      selection.selectRows(currentSelection.from.row, coords.row);
+      selection.selectRows(Math.max(currentSelection.from.row, 0), coords.row);
 
     } else if (((!selectedCorner && !selectedRow && coords.row < 0) ||
                (selectedRow && coords.row < 0)) && !controller.column) {
-      selection.selectColumns(currentSelection.from.col, coords.col);
+      selection.selectColumns(Math.max(currentSelection.from.col, 0), coords.col);
     }
+
   } else {
     const newCoord = new CellCoords(coords.row, coords.col);
 

--- a/test/e2e/Core_selection.spec.js
+++ b/test/e2e/Core_selection.spec.js
@@ -533,6 +533,60 @@ describe('Core_selection', () => {
     `).toBeMatchToSelectionPattern();
   });
 
+  it('should allow switching between row/column selection, when clicking on the headers ' +
+    'while holding the SHIFT key', () => {
+    handsontable({
+      rowHeaders: true,
+      colHeaders: true,
+      startRows: 5,
+      startCols: 5,
+    });
+
+    selectCell(0, 0, 0, 0);
+
+    spec().$container.find('.ht_clone_left tr:eq(5) th:eq(0)').simulate('mousedown', { shiftKey: true });
+    spec().$container.find('.ht_clone_left tr:eq(5) th:eq(0)').simulate('mouseup');
+
+    expect(getSelected()).toEqual([[0, -1, 4, 4]]);
+    expect(`
+    |   ║ - : - : - : - : - |
+    |===:===:===:===:===:===|
+    | * ║ A : 0 : 0 : 0 : 0 |
+    | * ║ 0 : 0 : 0 : 0 : 0 |
+    | * ║ 0 : 0 : 0 : 0 : 0 |
+    | * ║ 0 : 0 : 0 : 0 : 0 |
+    | * ║ 0 : 0 : 0 : 0 : 0 |
+    `).toBeMatchToSelectionPattern();
+
+    spec().$container.find('.ht_clone_top tr:eq(0) th:eq(5)').simulate('mousedown', { shiftKey: true });
+    spec().$container.find('.ht_clone_top tr:eq(0) th:eq(5)').simulate('mouseup');
+
+    expect(getSelected()).toEqual([[-1, 0, 4, 4]]);
+    expect(`
+    |   ║ * : * : * : * : * |
+    |===:===:===:===:===:===|
+    | - ║ A : 0 : 0 : 0 : 0 |
+    | - ║ 0 : 0 : 0 : 0 : 0 |
+    | - ║ 0 : 0 : 0 : 0 : 0 |
+    | - ║ 0 : 0 : 0 : 0 : 0 |
+    | - ║ 0 : 0 : 0 : 0 : 0 |
+    `).toBeMatchToSelectionPattern();
+
+    spec().$container.find('.ht_clone_left tr:eq(3) th:eq(0)').simulate('mousedown', { shiftKey: true });
+    spec().$container.find('.ht_clone_left tr:eq(3) th:eq(0)').simulate('mouseup');
+
+    expect(getSelected()).toEqual([[0, -1, 2, 4]]);
+    expect(`
+    |   ║ - : - : - : - : - |
+    |===:===:===:===:===:===|
+    | * ║ A : 0 : 0 : 0 : 0 |
+    | * ║ 0 : 0 : 0 : 0 : 0 |
+    | * ║ 0 : 0 : 0 : 0 : 0 |
+    |   ║   :   :   :   :   |
+    |   ║   :   :   :   :   |
+    `).toBeMatchToSelectionPattern();
+  });
+
   it('should call onSelection while user selects cells with mouse; onSelectionEnd when user finishes selection', () => {
     let tick = 0;
     let tickEnd = 0;


### PR DESCRIPTION
### Context
This PR normalizes (prevents using negative indexes, to be precise) the selection coordinates when switching the entire row selection to entire column selection (or the other way round) using the <kbd>SHIFT</kbd> key.

### How has this been tested?
Added a test case.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7089
