### PR TITLE
Fix overlays appearance while scrolling and fix bottom overlay positioning 

### DIFF
--- a/src/3rdparty/walkontable/css/walkontable.css
+++ b/src/3rdparty/walkontable/css/walkontable.css
@@ -113,10 +113,19 @@
   border-right-width: 0;
 }
 
+/* Property controlled by top overlay */
 .ht_master:not(.innerBorderTop) thead tr:last-child th,
 .ht_master:not(.innerBorderTop) ~ .handsontable thead tr:last-child th,
 .ht_master:not(.innerBorderTop) thead tr.lastChild th,
 .ht_master:not(.innerBorderTop) ~ .handsontable thead tr.lastChild th {
+  border-bottom-width: 0;
+}
+
+/* Property controlled by bottom overlay */
+.ht_master:not(.innerBorderBottom) thead tr:last-child th,
+.ht_master:not(.innerBorderBottom) ~ .handsontable thead tr:last-child th,
+.ht_master:not(.innerBorderBottom) thead tr.lastChild th,
+.ht_master:not(.innerBorderBottom) ~ .handsontable thead tr.lastChild th {
   border-bottom-width: 0;
 }
 

--- a/src/3rdparty/walkontable/src/overlay/bottom.js
+++ b/src/3rdparty/walkontable/src/overlay/bottom.js
@@ -6,7 +6,6 @@ import {
   hasClass,
   outerHeight,
   removeClass,
-  resetCssTransform
 } from './../../../../helpers/dom/element';
 import BottomOverlayTable from './../table/bottom';
 import Overlay from './_base';
@@ -43,22 +42,6 @@ class BottomOverlay extends Overlay {
   }
 
   /**
-   *
-   */
-  repositionOverlay() {
-    const { wtTable, rootDocument } = this.wot;
-    const cloneRoot = this.clone.wtTable.holder.parentNode;
-    let scrollbarWidth = getScrollbarWidth(rootDocument);
-
-    if (wtTable.holder.clientHeight === wtTable.holder.offsetHeight) {
-      scrollbarWidth = 0;
-    }
-
-    cloneRoot.style.top = '';
-    cloneRoot.style.bottom = `${scrollbarWidth}px`;
-  }
-
-  /**
    * Checks if overlay should be fully rendered.
    *
    * @returns {boolean}
@@ -79,16 +62,17 @@ class BottomOverlay extends Overlay {
     }
 
     const overlayRoot = this.clone.wtTable.holder.parentNode;
-    let headerPosition = 0;
 
     overlayRoot.style.top = '';
 
+    let headerPosition = 0;
     const preventOverflow = this.wot.getSetting('preventOverflow');
 
     if (this.trimmingContainer === this.wot.rootWindow && (!preventOverflow || preventOverflow !== 'vertical')) {
       const { rootDocument, wtTable } = this.wot;
-      const bottom = wtTable.hider.offsetTop + wtTable.hider.offsetHeight;
-      const bodyHeight = rootDocument.body.offsetHeight;
+      const hiderRect = wtTable.hider.getBoundingClientRect();
+      const bottom = Math.ceil(hiderRect.bottom);
+      const bodyHeight = rootDocument.documentElement.clientHeight;
       let finalLeft;
       let finalBottom;
 
@@ -104,13 +88,11 @@ class BottomOverlay extends Overlay {
       headerPosition = finalBottom;
       finalBottom += 'px';
 
-      overlayRoot.style.top = '';
       overlayRoot.style.left = finalLeft;
       overlayRoot.style.bottom = finalBottom;
 
     } else {
       headerPosition = this.getScrollPosition();
-      resetCssTransform(overlayRoot);
       this.repositionOverlay();
     }
 
@@ -119,6 +101,21 @@ class BottomOverlay extends Overlay {
     this.adjustElementsSize();
 
     return positionChanged;
+  }
+
+  /**
+   * Updates the bottom overlay position.
+   */
+  repositionOverlay() {
+    const { wtTable, rootDocument } = this.wot;
+    const cloneRoot = this.clone.wtTable.holder.parentNode;
+    let scrollbarWidth = getScrollbarWidth(rootDocument);
+
+    if (wtTable.holder.clientHeight === wtTable.holder.offsetHeight) {
+      scrollbarWidth = 0;
+    }
+
+    cloneRoot.style.bottom = `${scrollbarWidth}px`;
   }
 
   /**
@@ -342,15 +339,15 @@ class BottomOverlay extends Overlay {
 
     if ((areFixedRowsBottomChanged || fixedRowsBottom === 0) && columnHeaders.length > 0) {
       const masterParent = this.wot.wtTable.holder.parentNode;
-      const previousState = hasClass(masterParent, 'innerBorderTop');
+      const previousState = hasClass(masterParent, 'innerBorderBottom');
 
       this.cachedFixedRowsBottom = this.wot.getSetting('fixedRowsBottom');
 
       if (position || this.wot.getSetting('totalRows') === 0) {
-        addClass(masterParent, 'innerBorderTop');
+        addClass(masterParent, 'innerBorderBottom');
         positionChanged = !previousState;
       } else {
-        removeClass(masterParent, 'innerBorderTop');
+        removeClass(masterParent, 'innerBorderBottom');
         positionChanged = previousState;
       }
 

--- a/src/3rdparty/walkontable/src/overlay/bottomLeftCorner.js
+++ b/src/3rdparty/walkontable/src/overlay/bottomLeftCorner.js
@@ -42,22 +42,6 @@ class BottomLeftCornerOverlay extends Overlay {
   }
 
   /**
-   * Reposition the overlay.
-   */
-  repositionOverlay() {
-    const { wtTable, rootDocument } = this.wot;
-    const cloneRoot = this.clone.wtTable.holder.parentNode;
-    let scrollbarWidth = getScrollbarWidth(rootDocument);
-
-    if (wtTable.holder.clientHeight === wtTable.holder.offsetHeight) {
-      scrollbarWidth = 0;
-    }
-
-    cloneRoot.style.top = '';
-    cloneRoot.style.bottom = `${scrollbarWidth}px`;
-  }
-
-  /**
    * Updates the corner overlay position.
    *
    * @returns {boolean}
@@ -78,9 +62,10 @@ class BottomLeftCornerOverlay extends Overlay {
 
     if (this.trimmingContainer === wot.rootWindow) {
       const { rootDocument, wtTable } = this.wot;
-      const bottom = wtTable.hider.offsetTop + wtTable.hider.offsetHeight;
-      const left = wtTable.hider.offsetLeft;
-      const bodyHeight = rootDocument.body.offsetHeight;
+      const hiderRect = wtTable.hider.getBoundingClientRect();
+      const bottom = Math.ceil(hiderRect.bottom);
+      const left = Math.ceil(hiderRect.left);
+      const bodyHeight = rootDocument.documentElement.clientHeight;
       let finalLeft;
       let finalBottom;
 
@@ -99,7 +84,6 @@ class BottomLeftCornerOverlay extends Overlay {
       finalBottom += 'px';
       finalLeft += 'px';
 
-      overlayRoot.style.top = '';
       overlayRoot.style.left = finalLeft;
       overlayRoot.style.bottom = finalBottom;
 
@@ -119,6 +103,21 @@ class BottomLeftCornerOverlay extends Overlay {
     overlayRoot.style.width = `${tableWidth}px`;
 
     return false;
+  }
+
+  /**
+   * Reposition the overlay.
+   */
+  repositionOverlay() {
+    const { wtTable, rootDocument } = this.wot;
+    const cloneRoot = this.clone.wtTable.holder.parentNode;
+    let scrollbarWidth = getScrollbarWidth(rootDocument);
+
+    if (wtTable.holder.clientHeight === wtTable.holder.offsetHeight) {
+      scrollbarWidth = 0;
+    }
+
+    cloneRoot.style.bottom = `${scrollbarWidth}px`;
   }
 }
 

--- a/src/3rdparty/walkontable/src/overlay/left.js
+++ b/src/3rdparty/walkontable/src/overlay/left.js
@@ -62,8 +62,9 @@ class LeftOverlay extends Overlay {
     const preventOverflow = this.wot.getSetting('preventOverflow');
 
     if (this.trimmingContainer === this.wot.rootWindow && (!preventOverflow || preventOverflow !== 'horizontal')) {
-      const left = wtTable.hider.offsetLeft;
-      const right = left + wtTable.hider.offsetWidth;
+      const hiderRect = wtTable.hider.getBoundingClientRect();
+      const left = Math.ceil(hiderRect.left);
+      const right = Math.ceil(hiderRect.right);
       let finalLeft;
       let finalTop;
 

--- a/src/3rdparty/walkontable/src/overlay/top.js
+++ b/src/3rdparty/walkontable/src/overlay/top.js
@@ -69,8 +69,9 @@ class TopOverlay extends Overlay {
 
     if (this.trimmingContainer === this.wot.rootWindow && (!preventOverflow || preventOverflow !== 'vertical')) {
       const { wtTable } = this.wot;
-      const top = wtTable.hider.offsetTop;
-      const bottom = top + wtTable.hider.offsetHeight;
+      const hiderRect = wtTable.hider.getBoundingClientRect();
+      const top = Math.ceil(hiderRect.top);
+      const bottom = Math.ceil(hiderRect.bottom);
       let finalLeft;
       let finalTop;
 

--- a/src/3rdparty/walkontable/src/overlay/topLeftCorner.js
+++ b/src/3rdparty/walkontable/src/overlay/topLeftCorner.js
@@ -60,10 +60,11 @@ class TopLeftCornerOverlay extends Overlay {
 
     if (this.trimmingContainer === this.wot.rootWindow) {
       const { wtTable } = this.wot;
-      const top = wtTable.hider.offsetTop;
-      const left = wtTable.hider.offsetLeft;
-      const bottom = top + wtTable.hider.offsetHeight;
-      const right = left + wtTable.hider.offsetWidth;
+      const hiderRect = wtTable.hider.getBoundingClientRect();
+      const top = Math.ceil(hiderRect.top);
+      const left = Math.ceil(hiderRect.left);
+      const bottom = Math.ceil(hiderRect.bottom);
+      const right = Math.ceil(hiderRect.right);
       let finalLeft = '0';
       let finalTop = '0';
 

--- a/src/3rdparty/walkontable/test/spec/overlay.spec.js
+++ b/src/3rdparty/walkontable/test/spec/overlay.spec.js
@@ -8,15 +8,19 @@ describe('WalkontableOverlay', () => {
     this.$container.append(this.$table);
     this.$wrapper.appendTo('body');
 
-    createDataArray(50, 50);
+    createDataArray(200, 200);
+
+    $('.jasmine_html-reporter').hide(); // Workaround for making the test more predictable.
   });
 
   afterEach(function() {
+    $('.jasmine_html-reporter').show(); // Workaround for making the test more predictable.
+
     this.$wrapper.remove();
     this.wotInstance.destroy();
   });
 
-  it('cloned overlays have to have proper dimensions', () => {
+  it('cloned overlays have to have proper dimensions (overflow hidden)', () => {
     const wt = walkontable({
       data: getData,
       totalRows: getTotalRows,
@@ -42,16 +46,109 @@ describe('WalkontableOverlay', () => {
     expect($(wt.wtOverlays.bottomOverlay.clone.wtTable.holder).height()).toBe(47);
   });
 
-  it('cloned overlays have to have proper positions', () => {
-    createDataArray(5, 5);
+  it('cloned overlays have to have proper dimensions (window object as scrollable element)', () => {
     spec().$wrapper
       .css('overflow', '')
       .css('width', '')
       .css('height', '');
 
-    // When margin is applied, the bottom overlay had a tendency to misalign.
-    $(document.body).css('margin-top', 20);
+    const wt = walkontable({
+      data: getData,
+      totalRows: getTotalRows,
+      totalColumns: getTotalColumns,
+      fixedColumnsLeft: 2,
+      fixedRowsTop: 2,
+      fixedRowsBottom: 2,
+    });
 
+    wt.draw();
+
+    const clientWidth = document.body.clientWidth;
+    const clientHeight = document.body.clientHeight;
+    const totalColumnsWidth = getTotalColumns() * 50; // total columns * 50px (cell width)
+
+    expect($(wt.wtTable.holder).width()).toBe(clientWidth);
+    expect($(wt.wtTable.holder).height()).toBe(clientHeight);
+    expect($(wt.wtOverlays.topOverlay.clone.wtTable.holder).width()).toBe(totalColumnsWidth);
+    expect($(wt.wtOverlays.topOverlay.clone.wtTable.holder).height()).toBe(47);
+    expect($(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable.holder).width()).toBe(100);
+    expect($(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable.holder).height()).toBe(47);
+    expect($(wt.wtOverlays.leftOverlay.clone.wtTable.holder).width()).toBe(100);
+    expect($(wt.wtOverlays.leftOverlay.clone.wtTable.holder).height()).toBe(clientHeight);
+    expect($(wt.wtOverlays.bottomLeftCornerOverlay.clone.wtTable.holder).width()).toBe(100);
+    expect($(wt.wtOverlays.bottomLeftCornerOverlay.clone.wtTable.holder).height()).toBe(47);
+    expect($(wt.wtOverlays.bottomOverlay.clone.wtTable.holder).width()).toBe(totalColumnsWidth);
+    expect($(wt.wtOverlays.bottomOverlay.clone.wtTable.holder).height()).toBe(47);
+  });
+
+  it('cloned overlays have to have proper dimensions after table scroll (overflow hidden)', () => {
+    const wt = walkontable({
+      data: getData,
+      totalRows: getTotalRows,
+      totalColumns: getTotalColumns,
+      fixedColumnsLeft: 2,
+      fixedRowsTop: 2,
+      fixedRowsBottom: 2,
+    });
+
+    wt.draw();
+    wt.scrollViewportHorizontally(getTotalColumns() - 1);
+    wt.scrollViewportVertically(getTotalRows() - 3); // -1 - 2 (fixedRowsBottom)
+    wt.draw();
+
+    expect($(wt.wtTable.holder).width()).toBe(200);
+    expect($(wt.wtTable.holder).height()).toBe(200);
+    expect($(wt.wtOverlays.topOverlay.clone.wtTable.holder).width()).toBe(185); // 200px - 15px scrollbar width
+    expect($(wt.wtOverlays.topOverlay.clone.wtTable.holder).height()).toBe(47);
+    expect($(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable.holder).width()).toBe(100);
+    expect($(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable.holder).height()).toBe(47);
+    expect($(wt.wtOverlays.leftOverlay.clone.wtTable.holder).width()).toBe(100);
+    expect($(wt.wtOverlays.leftOverlay.clone.wtTable.holder).height()).toBe(185);
+    expect($(wt.wtOverlays.bottomLeftCornerOverlay.clone.wtTable.holder).width()).toBe(100);
+    expect($(wt.wtOverlays.bottomLeftCornerOverlay.clone.wtTable.holder).height()).toBe(47);
+    expect($(wt.wtOverlays.bottomOverlay.clone.wtTable.holder).width()).toBe(185);
+    expect($(wt.wtOverlays.bottomOverlay.clone.wtTable.holder).height()).toBe(47);
+  });
+
+  it('cloned overlays have to have proper dimensions after table scroll (window object as scrollable element)', () => {
+    spec().$wrapper
+      .css('overflow', '')
+      .css('width', '')
+      .css('height', '');
+
+    const wt = walkontable({
+      data: getData,
+      totalRows: getTotalRows,
+      totalColumns: getTotalColumns,
+      fixedColumnsLeft: 2,
+      fixedRowsTop: 2,
+      fixedRowsBottom: 2,
+    });
+
+    wt.draw();
+    wt.scrollViewportHorizontally(getTotalColumns() - 1);
+    wt.scrollViewportVertically(getTotalRows() - 3); // -1 - 2 (fixedRowsBottom)
+    wt.draw();
+
+    const clientWidth = document.body.clientWidth;
+    const clientHeight = document.body.clientHeight;
+    const totalColumnsWidth = getTotalColumns() * 50; // total columns * 50px (cell width)
+
+    expect($(wt.wtTable.holder).width()).toBe(clientWidth);
+    expect($(wt.wtTable.holder).height()).toBe(clientHeight);
+    expect($(wt.wtOverlays.topOverlay.clone.wtTable.holder).width()).toBe(totalColumnsWidth);
+    expect($(wt.wtOverlays.topOverlay.clone.wtTable.holder).height()).toBe(47);
+    expect($(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable.holder).width()).toBe(100);
+    expect($(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable.holder).height()).toBe(47);
+    expect($(wt.wtOverlays.leftOverlay.clone.wtTable.holder).width()).toBe(100);
+    expect($(wt.wtOverlays.leftOverlay.clone.wtTable.holder).height()).toBe(clientHeight);
+    expect($(wt.wtOverlays.bottomLeftCornerOverlay.clone.wtTable.holder).width()).toBe(100);
+    expect($(wt.wtOverlays.bottomLeftCornerOverlay.clone.wtTable.holder).height()).toBe(47);
+    expect($(wt.wtOverlays.bottomOverlay.clone.wtTable.holder).width()).toBe(totalColumnsWidth);
+    expect($(wt.wtOverlays.bottomOverlay.clone.wtTable.holder).height()).toBe(47);
+  });
+
+  it('cloned overlays have to have proper positions (overflow hidden)', () => {
     const wt = walkontable({
       data: getData,
       totalRows: getTotalRows,
@@ -76,34 +173,224 @@ describe('WalkontableOverlay', () => {
     const baseRect = getTableRect(wt.wtTable);
 
     expect(baseRect).toEqual(jasmine.objectContaining({
-      top: 100,
-      bottom: 216,
+      top: 8,
+      bottom: 208,
       left: 8,
     }));
     expect(getTableRect(wt.wtOverlays.topOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
-      top: 100,
-      bottom: 147,
+      top: 8,
+      bottom: 55,
       left: 8,
     }));
     expect(getTableRect(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
-      top: 100,
-      bottom: 147,
+      top: 8,
+      bottom: 55,
       left: 8,
     }));
     expect(getTableRect(wt.wtOverlays.leftOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
-      top: 100,
-      bottom: 216,
+      top: 8,
+      bottom: 193,
       left: 8,
     }));
     expect(getTableRect(wt.wtOverlays.bottomLeftCornerOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
-      top: 169,
-      bottom: 216,
+      top: 146,
+      bottom: 193,
       left: 8,
     }));
     expect(getTableRect(wt.wtOverlays.bottomOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
-      top: 169,
-      bottom: 216,
+      top: 146,
+      bottom: 193,
       left: 8,
+    }));
+  });
+
+  it('cloned overlays have to have proper positions (window object as scrollable element)', () => {
+    spec().$wrapper
+      .css('overflow', '')
+      .css('width', '')
+      .css('height', '');
+
+    const wt = walkontable({
+      data: getData,
+      totalRows: getTotalRows,
+      totalColumns: getTotalColumns,
+      fixedColumnsLeft: 2,
+      fixedRowsTop: 2,
+      fixedRowsBottom: 2,
+    });
+
+    wt.draw();
+
+    const getTableRect = (wtTable) => {
+      const rect = wtTable.holder.getBoundingClientRect();
+
+      return {
+        top: rect.top,
+        bottom: rect.bottom,
+        left: rect.left,
+      };
+    };
+
+    const documentClientHeight = document.documentElement.clientHeight;
+    const totalRowsHight = (getTotalRows() * 23) + 1; // total columns * 23px + 1px cell top border
+    const baseRect = getTableRect(wt.wtTable);
+
+    expect(baseRect).toEqual(jasmine.objectContaining({
+      top: 8,
+      bottom: totalRowsHight + 8, // 8 default browser margin
+      left: 8,
+    }));
+    expect(getTableRect(wt.wtOverlays.topOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
+      top: 8,
+      bottom: 47 + 8, // 2 fixed top rows * 23px + body margin
+      left: 8,
+    }));
+    expect(getTableRect(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
+      top: 8,
+      bottom: 47 + 8, // 2 fixed top rows * 23px + body margin
+      left: 8,
+    }));
+    expect(getTableRect(wt.wtOverlays.leftOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
+      top: 8,
+      bottom: totalRowsHight + 8, // 8 default browser margin
+      left: 8,
+    }));
+    expect(getTableRect(wt.wtOverlays.bottomLeftCornerOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
+      top: documentClientHeight - 47, // 2 fixed bottom rows * 23px + 1px cell top border
+      bottom: documentClientHeight,
+      left: 8,
+    }));
+    expect(getTableRect(wt.wtOverlays.bottomOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
+      top: documentClientHeight - 47, // 2 fixed bottom rows * 23px + 1px cell top border
+      bottom: documentClientHeight,
+      left: 8,
+    }));
+  });
+
+  it('cloned overlays have to have proper positions after table scroll (overflow hidden)', () => {
+    const wt = walkontable({
+      data: getData,
+      totalRows: getTotalRows,
+      totalColumns: getTotalColumns,
+      fixedColumnsLeft: 2,
+      fixedRowsTop: 2,
+      fixedRowsBottom: 2,
+    });
+
+    wt.draw();
+    wt.scrollViewportHorizontally(getTotalColumns() - 1);
+    wt.scrollViewportVertically(getTotalRows() - 3); // -1 - 2 (fixedRowsBottom)
+    wt.draw();
+
+    const getTableRect = (wtTable) => {
+      const rect = wtTable.holder.getBoundingClientRect();
+
+      return {
+        top: rect.top,
+        bottom: rect.bottom,
+        left: rect.left,
+      };
+    };
+
+    const baseRect = getTableRect(wt.wtTable);
+
+    expect(baseRect).toEqual(jasmine.objectContaining({
+      top: 8,
+      bottom: 208,
+      left: 8,
+    }));
+    expect(getTableRect(wt.wtOverlays.topOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
+      top: 8,
+      bottom: 55,
+      left: 8,
+    }));
+    expect(getTableRect(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
+      top: 8,
+      bottom: 55,
+      left: 8,
+    }));
+    expect(getTableRect(wt.wtOverlays.leftOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
+      top: 8,
+      bottom: 193,
+      left: 8,
+    }));
+    expect(getTableRect(wt.wtOverlays.bottomLeftCornerOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
+      top: 146,
+      bottom: 193,
+      left: 8,
+    }));
+    expect(getTableRect(wt.wtOverlays.bottomOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
+      top: 146,
+      bottom: 193,
+      left: 8,
+    }));
+  });
+
+  it('cloned overlays have to have proper positions after table scroll (window object as scrollable element)', () => {
+    spec().$wrapper
+      .css('overflow', '')
+      .css('width', '')
+      .css('height', '');
+
+    const wt = walkontable({
+      data: getData,
+      totalRows: getTotalRows,
+      totalColumns: getTotalColumns,
+      fixedColumnsLeft: 2,
+      fixedRowsTop: 2,
+      fixedRowsBottom: 2,
+    });
+
+    wt.draw();
+    wt.scrollViewportHorizontally(getTotalColumns() - 1);
+    wt.scrollViewportVertically(getTotalRows() - 3); // -1 - 2 (fixedRowsBottom)
+    wt.draw();
+
+    const getTableRect = (wtTable) => {
+      const rect = wtTable.holder.getBoundingClientRect();
+
+      return {
+        top: rect.top,
+        bottom: rect.bottom,
+        left: rect.left,
+      };
+    };
+
+    const documentClientHeight = document.documentElement.clientHeight;
+    const documentClientWidth = document.documentElement.clientWidth;
+    const totalRowsHeight = (getTotalRows() * 23) + 1; // total columns * 23px + 1px cell top border
+    const totalColumnsWidth = getTotalColumns() * 50; // total columns * 50px (cell width)
+    const baseRect = getTableRect(wt.wtTable);
+
+    expect(baseRect).toEqual(jasmine.objectContaining({
+      top: documentClientHeight - totalRowsHeight,
+      bottom: documentClientHeight,
+      left: documentClientWidth - totalColumnsWidth,
+    }));
+    expect(getTableRect(wt.wtOverlays.topOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
+      top: 0,
+      bottom: 47,
+      left: documentClientWidth - totalColumnsWidth,
+    }));
+    expect(getTableRect(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
+      top: 0,
+      bottom: 47,
+      left: 0,
+    }));
+    expect(getTableRect(wt.wtOverlays.leftOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
+      top: documentClientHeight - totalRowsHeight,
+      bottom: documentClientHeight,
+      left: 0,
+    }));
+    expect(getTableRect(wt.wtOverlays.bottomLeftCornerOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
+      top: documentClientHeight - 47, // 2 fixed bottom rows * 23px + 1px cell top border
+      bottom: documentClientHeight,
+      left: 0,
+    }));
+    expect(getTableRect(wt.wtOverlays.bottomOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
+      top: documentClientHeight - 47, // 2 fixed bottom rows * 23px + 1px cell top border
+      bottom: documentClientHeight,
+      left: documentClientWidth - totalColumnsWidth,
     }));
   });
 });

--- a/test/e2e/editors/dateEditor.spec.js
+++ b/test/e2e/editors/dateEditor.spec.js
@@ -73,7 +73,7 @@ describe('DateEditor', () => {
     expect(editor.offset()).toEqual($(getCell(0, 0, true)).offset());
 
     keyDown('enter');
-    await sleep(50); // Caused by async DateEditor close.
+    await sleep(100); // Caused by async DateEditor close.
     keyDown('enter');
 
     // Cells that do not touch the edges of the table have an additional top border.
@@ -85,38 +85,38 @@ describe('DateEditor', () => {
     expect(editorOffset()).toEqual($(getCell(1, 0, true)).offset());
 
     keyDown('enter');
-    await sleep(50); // Caused by async DateEditor close.
+    await sleep(100); // Caused by async DateEditor close.
     keyDown('enter');
 
     expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
 
     keyDown('enter');
-    await sleep(50); // Caused by async DateEditor close.
+    await sleep(100); // Caused by async DateEditor close.
     keyDown('enter');
 
     expect(editorOffset()).toEqual($(getCell(3, 0, true)).offset());
 
     keyDown('enter');
-    await sleep(50); // Caused by async DateEditor close.
+    await sleep(100); // Caused by async DateEditor close.
     keyDown('enter');
 
     expect(editorOffset()).toEqual($(getCell(4, 0, true)).offset());
 
     keyDown('enter');
-    await sleep(50); // Caused by async DateEditor close.
+    await sleep(100); // Caused by async DateEditor close.
     keyDown('enter');
 
     // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
     expect(editor.offset()).toEqual($(getCell(5, 0, true)).offset());
 
     keyDown('enter');
-    await sleep(50); // Caused by async DateEditor close.
+    await sleep(100); // Caused by async DateEditor close.
     keyDown('enter');
 
     expect(editorOffset()).toEqual($(getCell(6, 0, true)).offset());
 
     keyDown('enter');
-    await sleep(50); // Caused by async DateEditor close.
+    await sleep(100); // Caused by async DateEditor close.
     keyDown('enter');
 
     expect(editorOffset()).toEqual($(getCell(7, 0, true)).offset());
@@ -141,7 +141,7 @@ describe('DateEditor', () => {
     expect(editor.offset()).toEqual($(getCell(0, 0, true)).offset());
 
     selectCell(0, 1);
-    await sleep(50); // Caused by async DateEditor close.
+    await sleep(100); // Caused by async DateEditor close.
     keyDown('enter');
 
     // Cells that do not touch the edges of the table have an additional left border.
@@ -153,19 +153,19 @@ describe('DateEditor', () => {
     expect(editorOffset()).toEqual($(getCell(0, 1, true)).offset());
 
     selectCell(0, 2);
-    await sleep(50); // Caused by async DateEditor close.
+    await sleep(100); // Caused by async DateEditor close.
     keyDown('enter');
 
     expect(editorOffset()).toEqual($(getCell(0, 2, true)).offset());
 
     selectCell(0, 3);
-    await sleep(50); // Caused by async DateEditor close.
+    await sleep(100); // Caused by async DateEditor close.
     keyDown('enter');
 
     expect(editorOffset()).toEqual($(getCell(0, 3, true)).offset());
 
     selectCell(0, 4);
-    await sleep(50); // Caused by async DateEditor close.
+    await sleep(100); // Caused by async DateEditor close.
     keyDown('enter');
 
     expect(editorOffset()).toEqual($(getCell(0, 4, true)).offset());
@@ -196,7 +196,7 @@ describe('DateEditor', () => {
     expect(editor.offset()).toEqual($(getCell(1, 0, true)).offset());
 
     keyDown('enter');
-    await sleep(50); // Caused by async DateEditor close.
+    await sleep(100); // Caused by async DateEditor close.
     keyDown('enter');
 
     // Cells that do not touch the edges of the table have an additional top border.
@@ -208,26 +208,26 @@ describe('DateEditor', () => {
     expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
 
     keyDown('enter');
-    await sleep(50); // Caused by async DateEditor close.
+    await sleep(100); // Caused by async DateEditor close.
     keyDown('enter');
 
     expect(editorOffset()).toEqual($(getCell(3, 0, true)).offset());
 
     keyDown('enter');
-    await sleep(50); // Caused by async DateEditor close.
+    await sleep(100); // Caused by async DateEditor close.
     keyDown('enter');
 
     expect(editorOffset()).toEqual($(getCell(4, 0, true)).offset());
 
     keyDown('enter');
-    await sleep(50); // Caused by async DateEditor close.
+    await sleep(100); // Caused by async DateEditor close.
     keyDown('enter');
 
     // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
     expect(editor.offset()).toEqual($(getCell(6, 0, true)).offset());
 
     keyDown('enter');
-    await sleep(50); // Caused by async DateEditor close.
+    await sleep(100); // Caused by async DateEditor close.
     keyDown('enter');
 
     expect(editorOffset()).toEqual($(getCell(7, 0, true)).offset());
@@ -256,7 +256,7 @@ describe('DateEditor', () => {
     expect(editor.offset()).toEqual($(getCell(0, 1, true)).offset());
 
     selectCell(0, 2);
-    await sleep(50); // Caused by async DateEditor close.
+    await sleep(100); // Caused by async DateEditor close.
     keyDown('enter');
 
     // Cells that do not touch the edges of the table have an additional left border.
@@ -268,13 +268,13 @@ describe('DateEditor', () => {
     expect(editorOffset()).toEqual($(getCell(0, 2, true)).offset());
 
     selectCell(0, 3);
-    await sleep(50); // Caused by async DateEditor close.
+    await sleep(100); // Caused by async DateEditor close.
     keyDown('enter');
 
     expect(editorOffset()).toEqual($(getCell(0, 3, true)).offset());
 
     selectCell(0, 4);
-    await sleep(50); // Caused by async DateEditor close.
+    await sleep(100); // Caused by async DateEditor close.
     keyDown('enter');
 
     expect(editorOffset()).toEqual($(getCell(0, 4, true)).offset());

--- a/test/e2e/editors/numericEditor.spec.js
+++ b/test/e2e/editors/numericEditor.spec.js
@@ -91,7 +91,7 @@ describe('NumericEditor', () => {
     expect(editor.offset()).toEqual($(getCell(0, 0, true)).offset());
 
     keyDown('enter');
-    await sleep(10); // Caused by async NumericEditor validation.
+    await sleep(100); // Caused by async DateEditor close.
     keyDown('enter');
 
     // Cells that do not touch the edges of the table have an additional top border.
@@ -103,38 +103,38 @@ describe('NumericEditor', () => {
     expect(editorOffset()).toEqual($(getCell(1, 0, true)).offset());
 
     keyDown('enter');
-    await sleep(10); // Caused by async NumericEditor validation.
+    await sleep(100); // Caused by async DateEditor close.
     keyDown('enter');
 
     expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
 
     keyDown('enter');
-    await sleep(10); // Caused by async NumericEditor validation.
+    await sleep(100); // Caused by async DateEditor close.
     keyDown('enter');
 
     expect(editorOffset()).toEqual($(getCell(3, 0, true)).offset());
 
     keyDown('enter');
-    await sleep(10); // Caused by async NumericEditor validation.
+    await sleep(100); // Caused by async DateEditor close.
     keyDown('enter');
 
     expect(editorOffset()).toEqual($(getCell(4, 0, true)).offset());
 
     keyDown('enter');
-    await sleep(10); // Caused by async NumericEditor validation.
+    await sleep(100); // Caused by async DateEditor close.
     keyDown('enter');
 
     // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
     expect(editor.offset()).toEqual($(getCell(5, 0, true)).offset());
 
     keyDown('enter');
-    await sleep(10); // Caused by async NumericEditor validation.
+    await sleep(100); // Caused by async DateEditor close.
     keyDown('enter');
 
     expect(editorOffset()).toEqual($(getCell(6, 0, true)).offset());
 
     keyDown('enter');
-    await sleep(10); // Caused by async NumericEditor validation.
+    await sleep(100); // Caused by async DateEditor close.
     keyDown('enter');
 
     expect(editorOffset()).toEqual($(getCell(7, 0, true)).offset());
@@ -159,7 +159,7 @@ describe('NumericEditor', () => {
     expect(editor.offset()).toEqual($(getCell(0, 0, true)).offset());
 
     selectCell(0, 1);
-    await sleep(10); // Caused by async NumericEditor validation.
+    await sleep(100); // Caused by async DateEditor close.
     keyDown('enter');
 
     // Cells that do not touch the edges of the table have an additional left border.
@@ -171,19 +171,19 @@ describe('NumericEditor', () => {
     expect(editorOffset()).toEqual($(getCell(0, 1, true)).offset());
 
     selectCell(0, 2);
-    await sleep(10); // Caused by async NumericEditor validation.
+    await sleep(100); // Caused by async DateEditor close.
     keyDown('enter');
 
     expect(editorOffset()).toEqual($(getCell(0, 2, true)).offset());
 
     selectCell(0, 3);
-    await sleep(10); // Caused by async NumericEditor validation.
+    await sleep(100); // Caused by async DateEditor close.
     keyDown('enter');
 
     expect(editorOffset()).toEqual($(getCell(0, 3, true)).offset());
 
     selectCell(0, 4);
-    await sleep(10); // Caused by async NumericEditor validation.
+    await sleep(100); // Caused by async DateEditor close.
     keyDown('enter');
 
     expect(editorOffset()).toEqual($(getCell(0, 4, true)).offset());
@@ -219,7 +219,7 @@ describe('NumericEditor', () => {
     expect(editor.offset()).toEqual($(getCell(1, 0, true)).offset());
 
     keyDown('enter');
-    await sleep(10); // Caused by async NumericEditor validation.
+    await sleep(100); // Caused by async DateEditor close.
     keyDown('enter');
 
     // Cells that do not touch the edges of the table have an additional top border.
@@ -231,26 +231,26 @@ describe('NumericEditor', () => {
     expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
 
     keyDown('enter');
-    await sleep(10); // Caused by async NumericEditor validation.
+    await sleep(100); // Caused by async DateEditor close.
     keyDown('enter');
 
     expect(editorOffset()).toEqual($(getCell(3, 0, true)).offset());
 
     keyDown('enter');
-    await sleep(10); // Caused by async NumericEditor validation.
+    await sleep(100); // Caused by async DateEditor close.
     keyDown('enter');
 
     expect(editorOffset()).toEqual($(getCell(4, 0, true)).offset());
 
     keyDown('enter');
-    await sleep(10); // Caused by async NumericEditor validation.
+    await sleep(100); // Caused by async DateEditor close.
     keyDown('enter');
 
     // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
     expect(editor.offset()).toEqual($(getCell(6, 0, true)).offset());
 
     keyDown('enter');
-    await sleep(10); // Caused by async NumericEditor validation.
+    await sleep(100); // Caused by async DateEditor close.
     keyDown('enter');
 
     expect(editorOffset()).toEqual($(getCell(7, 0, true)).offset());
@@ -280,7 +280,7 @@ describe('NumericEditor', () => {
     expect(editor.offset()).toEqual($(getCell(0, 1, true)).offset());
 
     selectCell(0, 2);
-    await sleep(10); // Caused by async NumericEditor validation.
+    await sleep(100); // Caused by async DateEditor close.
     keyDown('enter');
 
     // Cells that do not touch the edges of the table have an additional left border.
@@ -292,13 +292,13 @@ describe('NumericEditor', () => {
     expect(editorOffset()).toEqual($(getCell(0, 2, true)).offset());
 
     selectCell(0, 3);
-    await sleep(10); // Caused by async NumericEditor validation.
+    await sleep(100); // Caused by async DateEditor close.
     keyDown('enter');
 
     expect(editorOffset()).toEqual($(getCell(0, 3, true)).offset());
 
     selectCell(0, 4);
-    await sleep(10); // Caused by async NumericEditor validation.
+    await sleep(100); // Caused by async DateEditor close.
     keyDown('enter');
 
     expect(editorOffset()).toEqual($(getCell(0, 4, true)).offset());


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR #7075 while fixing double border issues introduced a new bug which causes missing overlays when the table is scrolled. This happened only when the window object was set as a scrollable element. I reverted usage of the `getBoundingClientRect` method as this is used to calculate negative values to detect if the overlay has to be stuck to the client window edge.

Additionally, this PR fixes the bottom overlay which in the case when the window is set as a scrollable element the overlay wasn't stuck to the bottom of the client window. Now it behaves as the top and left overlay.

Was:
![Kapture 2020-07-10 at 14 14 14](https://user-images.githubusercontent.com/571316/87153394-b0d87180-c2b7-11ea-977f-959843c9177b.gif)

After fixes:
![Kapture 2020-07-10 at 14 13 40](https://user-images.githubusercontent.com/571316/87153410-b6ce5280-c2b7-11ea-9fd5-91ac18b99659.gif)


### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Added new E2E tests and tested manually on FF, Chrome, and Safari.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7086
2. #6338
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
