### PR TITLE
Fix missing bottom border

### DIFF
--- a/src/3rdparty/walkontable/css/walkontable.css
+++ b/src/3rdparty/walkontable/css/walkontable.css
@@ -113,19 +113,14 @@
   border-right-width: 0;
 }
 
-/* Property controlled by top overlay */
-.ht_master:not(.innerBorderTop) thead tr:last-child th,
-.ht_master:not(.innerBorderTop) ~ .handsontable thead tr:last-child th,
-.ht_master:not(.innerBorderTop) thead tr.lastChild th,
-.ht_master:not(.innerBorderTop) ~ .handsontable thead tr.lastChild th {
-  border-bottom-width: 0;
-}
-
-/* Property controlled by bottom overlay */
-.ht_master:not(.innerBorderBottom) thead tr:last-child th,
-.ht_master:not(.innerBorderBottom) ~ .handsontable thead tr:last-child th,
-.ht_master:not(.innerBorderBottom) thead tr.lastChild th,
-.ht_master:not(.innerBorderBottom) ~ .handsontable thead tr.lastChild th {
+/*
+innerBorderTop - Property controlled by top overlay
+innerBorderBottom - Property controlled by bottom overlay
+ */
+.ht_master:not(.innerBorderTop):not(.innerBorderBottom) thead tr:last-child th,
+.ht_master:not(.innerBorderTop):not(.innerBorderBottom) ~ .handsontable thead tr:last-child th,
+.ht_master:not(.innerBorderTop):not(.innerBorderBottom) thead tr.lastChild th,
+.ht_master:not(.innerBorderTop):not(.innerBorderBottom) ~ .handsontable thead tr.lastChild th {
   border-bottom-width: 0;
 }
 

--- a/src/3rdparty/walkontable/test/spec/overlay.spec.js
+++ b/src/3rdparty/walkontable/test/spec/overlay.spec.js
@@ -393,4 +393,24 @@ describe('WalkontableOverlay', () => {
       left: documentClientWidth - totalColumnsWidth,
     }));
   });
+
+  it('cloned overlays have to have all borders when an empty dataset is passed', () => {
+    createDataArray(0, 0);
+
+    const wt = walkontable({
+      data: getData,
+      totalRows: getTotalRows,
+      totalColumns: getTotalColumns,
+      rowHeaders: [function(row, TH) { // makes top overlay
+        TH.innerHTML = row + 1;
+      }],
+      columnHeaders: [function(column, TH) { // makes left overlay
+        TH.innerHTML = column + 1;
+      }],
+    });
+
+    wt.draw();
+
+    expect(getTableTopClone().find('thead tr th').css('border-bottom-width')).toBe('1px');
+  });
 });


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
This PR fixes missing overlay bottom border in a case when the table rows are trimmed or hidden. In terms of the Walkontable, it does not matter as in both cases total renderable rows are equal to 0. The source of the problem was the CSS rule controlled by separate overlays that overwrite the `border-bottom-width` alternately. After CSS rule unification, the issue is gone. 

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Added new E2E tests and tested manually.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7106
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
