### PR TITLE
Remove browsers native highlighting

### DIFF
--- a/src/css/handsontable.css
+++ b/src/css/handsontable.css
@@ -223,6 +223,10 @@
   /*overwrite styles potentionally made by a framework*/
 }
 
+.handsontableInput:focus {
+  outline: none;
+}
+
 .handsontableInputHolder {
   position: absolute;
   top: 0;
@@ -233,6 +237,10 @@
   -webkit-appearance: menulist-button !important;
   position: absolute;
   width: auto;
+}
+
+.htSelectEditor:focus {
+  outline: none;
 }
 
 /*

--- a/test/e2e/editors/autocompleteEditor.spec.js
+++ b/test/e2e/editors/autocompleteEditor.spec.js
@@ -280,6 +280,20 @@ describe('AutocompleteEditor', () => {
     expect(editorOffset()).toEqual($(getCell(0, 4, true)).offset());
   });
 
+  it('should not highlight the input element by browsers native selection', () => {
+    handsontable({
+      editor: 'autocomplete',
+      source: choices,
+    });
+
+    selectCell(0, 0);
+    keyDown('enter');
+
+    const editor = getActiveEditor().TEXTAREA;
+
+    expect(window.getComputedStyle(editor, 'focus').getPropertyValue('outline-style')).toBe('none');
+  });
+
   describe('open editor', () => {
     it('should display editor (after hitting ENTER)', () => {
       handsontable({

--- a/test/e2e/editors/dateEditor.spec.js
+++ b/test/e2e/editors/dateEditor.spec.js
@@ -280,6 +280,19 @@ describe('DateEditor', () => {
     expect(editorOffset()).toEqual($(getCell(0, 4, true)).offset());
   });
 
+  it('should not highlight the input element by browsers native selection', () => {
+    handsontable({
+      type: 'date',
+    });
+
+    selectCell(0, 0);
+    keyDown('enter');
+
+    const editor = getActiveEditor().TEXTAREA;
+
+    expect(window.getComputedStyle(editor, 'focus').getPropertyValue('outline-style')).toBe('none');
+  });
+
   it('should display Pikday calendar', () => {
     handsontable({
       data: getDates(),

--- a/test/e2e/editors/dropdownEditor.spec.js
+++ b/test/e2e/editors/dropdownEditor.spec.js
@@ -280,6 +280,20 @@ describe('DropdownEditor', () => {
     expect(editorOffset()).toEqual($(getCell(0, 4, true)).offset());
   });
 
+  it('should not highlight the input element by browsers native selection', () => {
+    handsontable({
+      editor: 'dropdown',
+      source: choices,
+    });
+
+    selectCell(0, 0);
+    keyDown('enter');
+
+    const editor = getActiveEditor().TEXTAREA;
+
+    expect(window.getComputedStyle(editor, 'focus').getPropertyValue('outline-style')).toBe('none');
+  });
+
   describe('open editor', () => {
     // see https://github.com/handsontable/handsontable/issues/3380
     it('should not throw error while selecting the next cell by hitting enter key', () => {

--- a/test/e2e/editors/handsontableEditor.spec.js
+++ b/test/e2e/editors/handsontableEditor.spec.js
@@ -305,6 +305,23 @@ describe('HandsontableEditor', () => {
     expect(editorOffset()).toEqual($(getCell(0, 4, true)).offset());
   });
 
+  it('should not highlight the input element by browsers native selection', () => {
+    handsontable({
+      type: 'handsontable',
+      handsontable: {
+        colHeaders: ['Marque', 'Country', 'Parent company'],
+        data: getManufacturerData()
+      }
+    });
+
+    selectCell(0, 0);
+    keyDown('enter');
+
+    const editor = getActiveEditor().TEXTAREA;
+
+    expect(window.getComputedStyle(editor, 'focus').getPropertyValue('outline-style')).toBe('none');
+  });
+
   it('should create an editor that is a Handsontable instance', () => {
     handsontable({
       columns: [

--- a/test/e2e/editors/numericEditor.spec.js
+++ b/test/e2e/editors/numericEditor.spec.js
@@ -304,6 +304,19 @@ describe('NumericEditor', () => {
     expect(editorOffset()).toEqual($(getCell(0, 4, true)).offset());
   });
 
+  it('should not highlight the input element by browsers native selection', () => {
+    handsontable({
+      type: 'numeric',
+    });
+
+    selectCell(0, 0);
+    keyDown('enter');
+
+    const editor = getActiveEditor().TEXTAREA;
+
+    expect(window.getComputedStyle(editor, 'focus').getPropertyValue('outline-style')).toBe('none');
+  });
+
   it('should convert "integer like" input value to number (object data source)', async() => {
     handsontable({
       data: arrayOfObjects(),

--- a/test/e2e/editors/passwordEditor.spec.js
+++ b/test/e2e/editors/passwordEditor.spec.js
@@ -270,6 +270,19 @@ describe('PasswordEditor', () => {
     expect(editorOffset()).toEqual($(getCell(0, 4, true)).offset());
   });
 
+  it('should not highlight the input element by browsers native selection', () => {
+    handsontable({
+      type: 'password',
+    });
+
+    selectCell(0, 0);
+    keyDown('enter');
+
+    const editor = getActiveEditor().TEXTAREA;
+
+    expect(window.getComputedStyle(editor, 'focus').getPropertyValue('outline-style')).toBe('none');
+  });
+
   it('should display editor as password field', () => {
     handsontable({
       data: [

--- a/test/e2e/editors/selectEditor.spec.js
+++ b/test/e2e/editors/selectEditor.spec.js
@@ -290,6 +290,19 @@ describe('SelectEditor', () => {
     }, 200);
   });
 
+  it('should not highlight the input element by browsers native selection', () => {
+    handsontable({
+      editor: 'select',
+    });
+
+    selectCell(0, 0);
+    keyDown('enter');
+
+    const editor = $('.htSelectEditor')[0];
+
+    expect(window.getComputedStyle(editor, 'focus').getPropertyValue('outline-style')).toBe('none');
+  });
+
   it('should populate select with given options (array)', () => {
     const options = [
       'Misubishi', 'Chevrolet', 'Lamborgini'

--- a/test/e2e/editors/textEditor.spec.js
+++ b/test/e2e/editors/textEditor.spec.js
@@ -271,6 +271,19 @@ describe('TextEditor', () => {
     expect(editorOffset()).toEqual($(getCell(0, 4, true)).offset());
   });
 
+  it('should not highlight the input element by browsers native selection', () => {
+    handsontable({
+      editor: 'text'
+    });
+
+    selectCell(0, 0);
+    keyDown('enter');
+
+    const editor = getActiveEditor().TEXTAREA;
+
+    expect(window.getComputedStyle(editor, 'focus').getPropertyValue('outline-style')).toBe('none');
+  });
+
   it('should begin editing when enterBeginsEditing equals true', () => {
     handsontable({
       enterBeginsEditing: true,


### PR DESCRIPTION
# Context
<!--- Why is this change required? What problem does it solve? -->
This PR removes browsers' native highlighting from the editors' focusable elements.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Add E2E tests and tested manually.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7103
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
