### PR TITLE
Prevent the 'emptySelectedCells' method from being called on tables with 0 rows/columns.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1578,9 +1578,10 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
    * @since 0.36.0
    */
   this.emptySelectedCells = function(source) {
-    if (!selection.isSelected()) {
+    if (!selection.isSelected() || this.countRows() === 0 || this.countCols() === 0) {
       return;
     }
+
     const changes = [];
 
     arrayEach(selection.getSelectedRange(), (cellRange) => {

--- a/test/e2e/core/emptySelectedCells.spec.js
+++ b/test/e2e/core/emptySelectedCells.spec.js
@@ -39,14 +39,14 @@ describe('Core.emptySelectedCells', () => {
     /* eslint-disable no-multi-spaces, comma-spacing */
     const snapshot = [
       ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1'],
-      ['A2',  null,   null,   null,   null,  'F2', 'G2', 'H2'],
-      ['A3',  null,   null,   null,   null,  'F3', 'G3', 'H3'],
-      ['A4',  null,   null,   null,   null,  'F4', 'G4', 'H4'],
-      ['A5',  null,   null,   null,   null,  'F5', 'G5', 'H5'],
-      ['A6',  null,   null,   null,   null,  'F6', 'G6', 'H6'],
-      ['A7', 'B7',  null,  'D7', 'E7', 'F7', 'G7', 'H7'],
-      ['A8', 'B8',  null,  'D8', 'E8', 'F8',  null,   null,],
-      ['A9', 'B9', 'C9', 'D9', 'E9', 'F9',  null,   null,],
+      ['A2', null, null, null, null, 'F2', 'G2', 'H2'],
+      ['A3', null, null, null, null, 'F3', 'G3', 'H3'],
+      ['A4', null, null, null, null, 'F4', 'G4', 'H4'],
+      ['A5', null, null, null, null, 'F5', 'G5', 'H5'],
+      ['A6', null, null, null, null, 'F6', 'G6', 'H6'],
+      ['A7', 'B7', null, 'D7', 'E7', 'F7', 'G7', 'H7'],
+      ['A8', 'B8', null, 'D8', 'E8', 'F8', null, null,],
+      ['A9', 'B9', 'C9', 'D9', 'E9', 'F9', null, null,],
     ];
     /* eslint-enable no-multi-spaces, comma-spacing */
 
@@ -65,5 +65,66 @@ describe('Core.emptySelectedCells', () => {
     expect(() => {
       emptySelectedCells();
     }).not.toThrowError();
+  });
+
+  it('should not be performed, when there are no rows (even when there are headers selected)', () => {
+    // We're using the `beforeChange` hook, as the `emptySelectedCells` method ends up doing a bunch of changes to
+    // clear the selected cells.
+    const onBeforeChange = jasmine.createSpy('beforeChange');
+
+    handsontable({
+      startRows: 0,
+      startCols: 1,
+      rowHeaders: true,
+      colHeaders: true,
+      beforeChange: onBeforeChange
+    });
+
+    simulateClick(spec().$container.find('.ht_clone_top tr:eq(0) th:eq(0)'));
+
+    emptySelectedCells();
+
+    expect(onBeforeChange).not.toHaveBeenCalled();
+  });
+
+  it('should not be performed, when there are no columns (even when there are headers selected)', () => {
+    // We're using the `beforeChange` hook, as the `emptySelectedCells` method ends up doing a bunch of changes to
+    // clear the selected cells.
+    const onBeforeChange = jasmine.createSpy('beforeChange');
+
+    handsontable({
+      startRows: 1,
+      startCols: 0,
+      rowHeaders: true,
+      colHeaders: true,
+      beforeChange: onBeforeChange
+    });
+
+    simulateClick(spec().$container.find('.ht_clone_left tr:eq(1) th:eq(0)'));
+
+    emptySelectedCells();
+
+    expect(onBeforeChange).not.toHaveBeenCalled();
+  });
+
+  it('should not be performed, when all rows are trimmed (even when there are headers selected)', () => {
+    // We're using the `beforeChange` hook, as the `emptySelectedCells` method ends up doing a bunch of changes to
+    // clear the selected cells.
+    const onBeforeChange = jasmine.createSpy('beforeChange');
+
+    handsontable({
+      startRows: 2,
+      startCols: 1,
+      trimRows: [0, 1], // TODO: The TrimmingMap should be used instead of the plugin.
+      rowHeaders: true,
+      colHeaders: true,
+      beforeChange: onBeforeChange
+    });
+
+    simulateClick(spec().$container.find('.ht_clone_top tr:eq(0) th:eq(0)'));
+
+    emptySelectedCells();
+
+    expect(onBeforeChange).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
### Context
This PR fixes a problem described in  #7108 by preventing the `emptySelectedCells` method from being performed on tables with 0 rows/column or with all rows trimmed.

### How has this been tested?
- Added some test cases.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7108 
