### PR TITLE
Normalize tests which runs on browsers

### DIFF
--- a/src/plugins/autoColumnSize/test/autoColumnSize.e2e.js
+++ b/src/plugins/autoColumnSize/test/autoColumnSize.e2e.js
@@ -42,18 +42,18 @@ describe('AutoColumnSize', () => {
       ]
     });
 
-    expect(colWidth(spec().$container, 0)).toBeAroundValue(50, 3);
-    expect([117, 120, 121, 129, 135]).toEqual(jasmine.arrayContaining([colWidth(spec().$container, 1)]));
-    expect([216, 229, 247, 260, 261]).toEqual(jasmine.arrayContaining([colWidth(spec().$container, 2)]));
+    expect(colWidth(spec().$container, 0)).toBe(50);
+    expect(colWidth(spec().$container, 1)).toBe(110);
+    expect(colWidth(spec().$container, 2)).toBeAroundValue(210, 1);
 
     setDataAtRowProp(0, 'id', 'foo bar foo bar foo bar');
     setDataAtRowProp(0, 'name', 'foo');
 
     await sleep(50);
 
-    expect([165, 168, 169, 189, 191]).toEqual(jasmine.arrayContaining([colWidth(spec().$container, 0)]));
-    expect(colWidth(spec().$container, 1)).toBeAroundValue(50, 3);
-    expect([216, 229, 247, 260, 261]).toEqual(jasmine.arrayContaining([colWidth(spec().$container, 2)]));
+    expect(colWidth(spec().$container, 0)).toBeAroundValue(155, 1);
+    expect(colWidth(spec().$container, 1)).toBe(50);
+    expect(colWidth(spec().$container, 2)).toBeAroundValue(210, 1);
   });
 
   it('should correctly detect column widths with colHeaders', () => {
@@ -67,7 +67,7 @@ describe('AutoColumnSize', () => {
       ]
     });
 
-    expect([149, 155, 174, 178]).toEqual(jasmine.arrayContaining([colWidth(spec().$container, 0)]));
+    expect(colWidth(spec().$container, 0)).toBeAroundValue(146, 1);
   });
 
   it('should correctly detect column widths after update colHeaders when headers were passed as an array', () => {
@@ -81,12 +81,12 @@ describe('AutoColumnSize', () => {
       ]
     });
 
-    expect([50, 51, 53]).toEqual(jasmine.arrayContaining([colWidth(spec().$container, 0)]));
+    expect(colWidth(spec().$container, 0)).toBe(50);
 
     updateSettings({ colHeaders: ['Identifier Longer text', 'Identifier Longer and longer text'] });
 
-    expect([149, 155, 174, 178]).toEqual(jasmine.arrayContaining([colWidth(spec().$container, 0)]));
-    expect([226, 235, 263, 270]).toEqual(jasmine.arrayContaining([colWidth(spec().$container, 1)]));
+    expect(colWidth(spec().$container, 0)).toBeAroundValue(146, 1);
+    expect(colWidth(spec().$container, 1)).toBeAroundValue(218, 1);
   });
 
   it('should correctly detect column widths after update colHeaders when headers were passed as a string', () => {
@@ -100,12 +100,12 @@ describe('AutoColumnSize', () => {
       ]
     });
 
-    expect([50, 51, 53]).toEqual(jasmine.arrayContaining([colWidth(spec().$container, 0)]));
+    expect(colWidth(spec().$container, 0)).toBe(50);
 
     updateSettings({ colHeaders: 'Identifier Longer text' });
 
-    expect([149, 155, 174, 178]).toEqual(jasmine.arrayContaining([colWidth(spec().$container, 0)]));
-    expect([149, 155, 174, 178]).toEqual(jasmine.arrayContaining([colWidth(spec().$container, 1)]));
+    expect(colWidth(spec().$container, 0)).toBeAroundValue(146, 1);
+    expect(colWidth(spec().$container, 1)).toBeAroundValue(146, 1);
   });
 
   it('should correctly detect column widths after update colHeaders when headers were passed as a function', () => {
@@ -119,7 +119,7 @@ describe('AutoColumnSize', () => {
       ]
     });
 
-    expect([50, 51, 53]).toEqual(jasmine.arrayContaining([colWidth(spec().$container, 0)]));
+    expect(colWidth(spec().$container, 0)).toBe(50);
 
     updateSettings({
       colHeaders(index) {
@@ -127,8 +127,8 @@ describe('AutoColumnSize', () => {
       },
     });
 
-    expect([149, 155, 174, 178]).toEqual(jasmine.arrayContaining([colWidth(spec().$container, 0)]));
-    expect([226, 235, 263, 270]).toEqual(jasmine.arrayContaining([colWidth(spec().$container, 1)]));
+    expect(colWidth(spec().$container, 0)).toBeAroundValue(146, 1);
+    expect(colWidth(spec().$container, 1)).toBeAroundValue(218, 1);
   });
 
   it('should correctly detect column width with colHeaders and the useHeaders option set to false (not taking the header widths into calculation)', () => {
@@ -157,7 +157,7 @@ describe('AutoColumnSize', () => {
       ]
     });
 
-    expect([68, 70, 71, 80, 82]).toEqual(jasmine.arrayContaining([colWidth(spec().$container, 0)]));
+    expect(colWidth(spec().$container, 0)).toBeAroundValue(68, 1);
   });
 
   it('should correctly detect column widths after update columns.title', () => {
@@ -175,7 +175,7 @@ describe('AutoColumnSize', () => {
       ],
     });
 
-    expect([174, 182, 183, 208, 213]).toEqual(jasmine.arrayContaining([colWidth(spec().$container, 0)]));
+    expect(colWidth(spec().$container, 0)).toBeAroundValue(173, 1);
   });
 
   // https://github.com/handsontable/handsontable/issues/2684
@@ -192,7 +192,7 @@ describe('AutoColumnSize', () => {
     spec().$container.css('display', 'block');
     hot.render();
 
-    expect([68, 70, 71, 80, 82]).toEqual(jasmine.arrayContaining([colWidth(spec().$container, 0)]));
+    expect(colWidth(spec().$container, 0)).toBeAroundValue(68, 1);
   });
 
   it('should not wrap the cell values when the whole column has values with the same length', () => {
@@ -222,7 +222,7 @@ describe('AutoColumnSize', () => {
       ]
     });
 
-    expect([93]).toEqual(jasmine.arrayContaining([colWidth(spec().$container, 0)]));
+    expect(colWidth(spec().$container, 0)).toBe(92);
     expect(rowHeight(spec().$container, 0)).toBe(24);
     expect(rowHeight(spec().$container, 1)).toBe(23);
     expect(rowHeight(spec().$container, 2)).toBe(23);
@@ -478,13 +478,13 @@ describe('AutoColumnSize', () => {
 
     const cloneTopHider = spec().$container.find('.ht_clone_top .wtHider');
 
-    expect(cloneTopHider.width()).toBeAroundValue(140);
+    expect(cloneTopHider.width()).toBeAroundValue(131, 1);
 
     selectCell(0, 0);
 
     await sleep(300);
 
-    expect(cloneTopHider.width()).toBeAroundValue(140);
+    expect(cloneTopHider.width()).toBeAroundValue(131, 1);
   });
 
   it('should not calculate any column widths, if there are no columns in the dataset', () => {
@@ -508,33 +508,33 @@ describe('AutoColumnSize', () => {
     });
 
     expect(colWidth(spec().$container, 0)).toBe(50);
-    expect(colWidth(spec().$container, 1)).toBe(59);
-    expect(colWidth(spec().$container, 2)).toBe(147);
+    expect(colWidth(spec().$container, 1)).toBeAroundValue(55, 1);
+    expect(colWidth(spec().$container, 2)).toBe(131);
 
     alter('insert_col', 0);
 
     expect(colWidth(spec().$container, 0)).toBe(50); // Added new row here.
     expect(colWidth(spec().$container, 1)).toBe(50);
-    expect(colWidth(spec().$container, 2)).toBe(59);
-    expect(colWidth(spec().$container, 3)).toBe(147);
+    expect(colWidth(spec().$container, 2)).toBeAroundValue(55, 1);
+    expect(colWidth(spec().$container, 3)).toBe(131);
     expect(colWidth(spec().$container, 4)).toBe(50);
 
     alter('insert_col', 3);
 
     expect(colWidth(spec().$container, 0)).toBe(50);
     expect(colWidth(spec().$container, 1)).toBe(50);
-    expect(colWidth(spec().$container, 2)).toBe(59);
+    expect(colWidth(spec().$container, 2)).toBeAroundValue(55, 1);
     expect(colWidth(spec().$container, 3)).toBe(50); // Added new row here.
-    expect(colWidth(spec().$container, 4)).toBe(147);
+    expect(colWidth(spec().$container, 4)).toBe(131);
     expect(colWidth(spec().$container, 5)).toBe(50);
 
     alter('insert_col', 5);
 
     expect(colWidth(spec().$container, 0)).toBe(50);
     expect(colWidth(spec().$container, 1)).toBe(50);
-    expect(colWidth(spec().$container, 2)).toBe(59);
+    expect(colWidth(spec().$container, 2)).toBeAroundValue(55, 1);
     expect(colWidth(spec().$container, 3)).toBe(50);
-    expect(colWidth(spec().$container, 4)).toBe(147);
+    expect(colWidth(spec().$container, 4)).toBe(131);
     expect(colWidth(spec().$container, 5)).toBe(50); // Added new row here.
     expect(colWidth(spec().$container, 6)).toBe(50);
   });
@@ -546,14 +546,14 @@ describe('AutoColumnSize', () => {
     });
 
     expect(colWidth(spec().$container, 0)).toBe(50);
-    expect(colWidth(spec().$container, 1)).toBe(59);
-    expect(colWidth(spec().$container, 2)).toBe(147);
+    expect(colWidth(spec().$container, 1)).toBeAroundValue(55, 1);
+    expect(colWidth(spec().$container, 2)).toBe(131);
     expect(colWidth(spec().$container, 3)).toBe(50);
 
     alter('remove_col', 0);
 
-    expect(colWidth(spec().$container, 0)).toBe(59);
-    expect(colWidth(spec().$container, 1)).toBe(147);
+    expect(colWidth(spec().$container, 0)).toBeAroundValue(55, 1);
+    expect(colWidth(spec().$container, 1)).toBe(131);
     expect(colWidth(spec().$container, 2)).toBe(50);
   });
 
@@ -566,14 +566,14 @@ describe('AutoColumnSize', () => {
     hot.columnIndexMapper.moveIndexes(2, 1);
     render();
 
-    expect(colWidth(spec().$container, 1)).toBe(147);
-    expect(colWidth(spec().$container, 2)).toBe(59);
+    expect(colWidth(spec().$container, 1)).toBe(131);
+    expect(colWidth(spec().$container, 2)).toBeAroundValue(55, 1);
 
     hot.columnIndexMapper.moveIndexes(1, 2);
     render();
 
-    expect(colWidth(spec().$container, 1)).toBe(59);
-    expect(colWidth(spec().$container, 2)).toBe(147);
+    expect(colWidth(spec().$container, 1)).toBeAroundValue(55, 1);
+    expect(colWidth(spec().$container, 2)).toBe(131);
   });
 
   it('should keep appropriate column size when columns order is changed and some column is cleared', () => {
@@ -586,16 +586,16 @@ describe('AutoColumnSize', () => {
     hot.columnIndexMapper.moveIndexes(2, 1);
     render();
 
-    expect(colWidth(spec().$container, 1)).toBe(147);
-    expect(colWidth(spec().$container, 2)).toBe(59);
+    expect(colWidth(spec().$container, 1)).toBe(131);
+    expect(colWidth(spec().$container, 2)).toBeAroundValue(55, 1);
 
     hot.populateFromArray(0, 1, [[null], [null], [null], [null], [null]]); // Empty values on the second visual column.
 
-    expect(colWidth(spec().$container, 1)).toBe(147);
-    expect(colWidth(spec().$container, 2)).toBe(59);
+    expect(colWidth(spec().$container, 1)).toBe(131);
+    expect(colWidth(spec().$container, 2)).toBeAroundValue(55, 1);
   });
 
-  describe('should cooperate with the `UndoRedo` plugin properly ', () => {
+  describe('should cooperate with the `UndoRedo` plugin properly', () => {
     it('when removing single column', () => {
       const hot = handsontable({
         data: [['Short', 'Somewhat long', 'The very very very longest one']],
@@ -607,32 +607,32 @@ describe('AutoColumnSize', () => {
       hot.undo();
 
       expect(colWidth(spec().$container, 0)).toBeAroundValue(50);
-      expect(colWidth(spec().$container, 1)).toBeAroundValue(121);
-      expect(colWidth(spec().$container, 2)).toBeAroundValue(229);
+      expect(colWidth(spec().$container, 1)).toBeAroundValue(110);
+      expect(colWidth(spec().$container, 2)).toBeAroundValue(210);
 
       hot.redo();
 
-      expect(colWidth(spec().$container, 0)).toBeAroundValue(121);
-      expect(colWidth(spec().$container, 1)).toBeAroundValue(229);
+      expect(colWidth(spec().$container, 0)).toBeAroundValue(110);
+      expect(colWidth(spec().$container, 1)).toBeAroundValue(210);
 
       hot.undo();
 
       expect(colWidth(spec().$container, 0)).toBeAroundValue(50);
-      expect(colWidth(spec().$container, 1)).toBeAroundValue(121);
-      expect(colWidth(spec().$container, 2)).toBeAroundValue(229);
+      expect(colWidth(spec().$container, 1)).toBeAroundValue(110);
+      expect(colWidth(spec().$container, 2)).toBeAroundValue(210);
 
       alter('remove_col', 1);
 
       hot.undo();
 
       expect(colWidth(spec().$container, 0)).toBeAroundValue(50);
-      expect(colWidth(spec().$container, 1)).toBeAroundValue(121);
-      expect(colWidth(spec().$container, 2)).toBeAroundValue(229);
+      expect(colWidth(spec().$container, 1)).toBeAroundValue(110);
+      expect(colWidth(spec().$container, 2)).toBeAroundValue(210);
 
       hot.redo();
 
       expect(colWidth(spec().$container, 0)).toBeAroundValue(50);
-      expect(colWidth(spec().$container, 1)).toBeAroundValue(229);
+      expect(colWidth(spec().$container, 1)).toBeAroundValue(210);
 
       hot.undo();
 
@@ -641,13 +641,13 @@ describe('AutoColumnSize', () => {
       hot.undo();
 
       expect(colWidth(spec().$container, 0)).toBeAroundValue(50);
-      expect(colWidth(spec().$container, 1)).toBeAroundValue(121);
-      expect(colWidth(spec().$container, 2)).toBeAroundValue(229);
+      expect(colWidth(spec().$container, 1)).toBeAroundValue(110);
+      expect(colWidth(spec().$container, 2)).toBeAroundValue(210);
 
       hot.redo();
 
       expect(colWidth(spec().$container, 0)).toBeAroundValue(50);
-      expect(colWidth(spec().$container, 1)).toBeAroundValue(121);
+      expect(colWidth(spec().$container, 1)).toBeAroundValue(110);
     });
 
     it('when inserting single column', () => {
@@ -661,77 +661,77 @@ describe('AutoColumnSize', () => {
       hot.undo();
 
       expect(colWidth(spec().$container, 0)).toBeAroundValue(50);
-      expect(colWidth(spec().$container, 1)).toBeAroundValue(121);
-      expect(colWidth(spec().$container, 2)).toBeAroundValue(229);
+      expect(colWidth(spec().$container, 1)).toBeAroundValue(110);
+      expect(colWidth(spec().$container, 2)).toBeAroundValue(210);
 
       hot.redo();
 
       expect(colWidth(spec().$container, 0)).toBeAroundValue(50);
       expect(colWidth(spec().$container, 1)).toBeAroundValue(50);
-      expect(colWidth(spec().$container, 2)).toBeAroundValue(121);
-      expect(colWidth(spec().$container, 3)).toBeAroundValue(229);
+      expect(colWidth(spec().$container, 2)).toBeAroundValue(110);
+      expect(colWidth(spec().$container, 3)).toBeAroundValue(210);
 
       hot.undo();
 
       expect(colWidth(spec().$container, 0)).toBeAroundValue(50);
-      expect(colWidth(spec().$container, 1)).toBeAroundValue(121);
-      expect(colWidth(spec().$container, 2)).toBeAroundValue(229);
+      expect(colWidth(spec().$container, 1)).toBeAroundValue(110);
+      expect(colWidth(spec().$container, 2)).toBeAroundValue(210);
 
       alter('insert_col', 1);
 
       hot.undo();
 
       expect(colWidth(spec().$container, 0)).toBeAroundValue(50);
-      expect(colWidth(spec().$container, 1)).toBeAroundValue(121);
-      expect(colWidth(spec().$container, 2)).toBeAroundValue(229);
+      expect(colWidth(spec().$container, 1)).toBeAroundValue(110);
+      expect(colWidth(spec().$container, 2)).toBeAroundValue(210);
 
       hot.redo();
 
       expect(colWidth(spec().$container, 0)).toBeAroundValue(50);
       expect(colWidth(spec().$container, 1)).toBeAroundValue(50);
-      expect(colWidth(spec().$container, 2)).toBeAroundValue(121);
-      expect(colWidth(spec().$container, 3)).toBeAroundValue(229);
+      expect(colWidth(spec().$container, 2)).toBeAroundValue(110);
+      expect(colWidth(spec().$container, 3)).toBeAroundValue(210);
 
       hot.undo();
 
       expect(colWidth(spec().$container, 0)).toBeAroundValue(50);
-      expect(colWidth(spec().$container, 1)).toBeAroundValue(121);
-      expect(colWidth(spec().$container, 2)).toBeAroundValue(229);
+      expect(colWidth(spec().$container, 1)).toBeAroundValue(110);
+      expect(colWidth(spec().$container, 2)).toBeAroundValue(210);
 
       alter('insert_col', 2);
 
       hot.undo();
 
       expect(colWidth(spec().$container, 0)).toBeAroundValue(50);
-      expect(colWidth(spec().$container, 1)).toBeAroundValue(121);
-      expect(colWidth(spec().$container, 2)).toBeAroundValue(229);
+      expect(colWidth(spec().$container, 1)).toBeAroundValue(110);
+      expect(colWidth(spec().$container, 2)).toBeAroundValue(210);
 
       hot.redo();
 
       expect(colWidth(spec().$container, 0)).toBeAroundValue(50);
-      expect(colWidth(spec().$container, 1)).toBeAroundValue(121);
+      expect(colWidth(spec().$container, 1)).toBeAroundValue(110);
       expect(colWidth(spec().$container, 2)).toBeAroundValue(50);
-      expect(colWidth(spec().$container, 3)).toBeAroundValue(229);
+      expect(colWidth(spec().$container, 3)).toBeAroundValue(210);
 
       hot.undo();
 
       expect(colWidth(spec().$container, 0)).toBeAroundValue(50);
-      expect(colWidth(spec().$container, 1)).toBeAroundValue(121);
-      expect(colWidth(spec().$container, 2)).toBeAroundValue(229);
+      expect(colWidth(spec().$container, 1)).toBeAroundValue(110);
+      expect(colWidth(spec().$container, 2)).toBeAroundValue(210);
 
       alter('insert_col', 3);
 
       hot.undo();
 
       expect(colWidth(spec().$container, 0)).toBeAroundValue(50);
-      expect(colWidth(spec().$container, 1)).toBeAroundValue(121);
-      expect(colWidth(spec().$container, 2)).toBeAroundValue(229);
+      expect(colWidth(spec().$container, 1)).toBeAroundValue(110);
+      expect(colWidth(spec().$container, 2)).toBeAroundValue(210);
 
       hot.redo();
 
       expect(colWidth(spec().$container, 0)).toBeAroundValue(50);
-      expect(colWidth(spec().$container, 1)).toBeAroundValue(121);
-      expect(colWidth(spec().$container, 2)).toBeAroundValue(229);
+      expect(colWidth(spec().$container, 1)).toBeAroundValue(110);
+      expect(colWidth(spec().$container, 2)).toBeAroundValue(210);
       expect(colWidth(spec().$container, 3)).toBeAroundValue(50);
     });
 
@@ -746,17 +746,17 @@ describe('AutoColumnSize', () => {
         ]
       });
 
-      expect([68, 70, 71, 80, 82]).toEqual(jasmine.arrayContaining([colWidth(spec().$container, 0)]));
-      expect([117, 120, 121, 129, 135]).toEqual(jasmine.arrayContaining([colWidth(spec().$container, 1)]));
-      expect([216, 229, 247, 260, 261]).toEqual(jasmine.arrayContaining([colWidth(spec().$container, 2)]));
+      expect(colWidth(spec().$container, 0)).toBeAroundValue(68, 1);
+      expect(colWidth(spec().$container, 1)).toBe(110);
+      expect(colWidth(spec().$container, 2)).toBeAroundValue(210, 1);
 
       hot.alter('remove_row', 0);
 
       hot.undo();
 
-      expect([68, 70, 71, 80, 82]).toEqual(jasmine.arrayContaining([colWidth(spec().$container, 0)]));
-      expect([117, 120, 121, 129, 135]).toEqual(jasmine.arrayContaining([colWidth(spec().$container, 1)]));
-      expect([216, 229, 247, 260, 261]).toEqual(jasmine.arrayContaining([colWidth(spec().$container, 2)]));
+      expect(colWidth(spec().$container, 0)).toBeAroundValue(68, 1);
+      expect(colWidth(spec().$container, 1)).toBe(110);
+      expect(colWidth(spec().$container, 2)).toBeAroundValue(210, 1);
     });
   });
 
@@ -777,9 +777,8 @@ describe('AutoColumnSize', () => {
         }
       });
 
-      expect(colWidth(spec().$container, 0)).toBeAroundValue(50 + 15, 3);
-      expect([216 + 15, 229 + 15, 247 + 15, 260 + 15, 261 + 15])
-        .toEqual(jasmine.arrayContaining([colWidth(spec().$container, 1)])); // Renderable index 1 for helper.
+      expect(colWidth(spec().$container, 0)).toBe(65);
+      expect(colWidth(spec().$container, 1)).toBeAroundValue(225, 1);
     });
   });
 });

--- a/src/plugins/comments/test/comments.e2e.js
+++ b/src/plugins/comments/test/comments.e2e.js
@@ -70,7 +70,7 @@ describe('Comments', () => {
         clientY: Handsontable.dom.offset(getCell(1, 1)).top + 5,
       });
 
-      await sleep(300);
+      await sleep(400);
 
       expect(editor.parentNode.style.display).toEqual('block');
     });
@@ -102,7 +102,8 @@ describe('Comments', () => {
 
       plugin.showAtCell(0, 1);
 
-      expect($(editor.parentNode).offset()).toEqual($(getCell(0, 2)).offset());
+      expect($(editor.parentNode).offset().top).toBeCloseTo($(getCell(0, 2)).offset().top, 0);
+      expect($(editor.parentNode).offset().left).toBeCloseTo($(getCell(0, 2)).offset().left, 0);
     });
   });
 
@@ -703,13 +704,13 @@ describe('Comments', () => {
       textarea.focus();
       textarea.value = 'Edited comment';
 
-      await sleep(100);
+      await sleep(150);
 
       $('body').simulate('mousedown');
       $('body').simulate('mouseup');
       textarea.blur();
 
-      await sleep(400);
+      await sleep(500);
 
       expect(afterSetCellMetaCallback)
         .toHaveBeenCalledWith(0, 0, 'comment', { value: 'Edited comment' }, undefined, undefined);
@@ -778,48 +779,53 @@ describe('Comments', () => {
 
       plugin.showAtCell(0, 0);
 
-      expect($(editor.parentNode).offset()).toEqual($(hot.rootElement).offset());
+      expect($(editor.parentNode).offset().top).toBeCloseTo($(hot.rootElement).offset().top, 0);
+      expect($(editor.parentNode).offset().left).toBeCloseTo($(hot.rootElement).offset().left, 0);
 
       plugin.showAtCell(1, 1);
 
-      expect($(editor.parentNode).offset()).toEqual($(hot.rootElement).offset());
+      expect($(editor.parentNode).offset().top).toBeCloseTo($(hot.rootElement).offset().top, 0);
+      expect($(editor.parentNode).offset().left).toBeCloseTo($(hot.rootElement).offset().left, 0);
 
       plugin.showAtCell(2, 2);
 
-      expect($(editor.parentNode).offset()).toEqual($(getCell(2, 3)).offset());
+      expect($(editor.parentNode).offset().top).toBeCloseTo($(getCell(2, 3)).offset().top, 0);
+      expect($(editor.parentNode).offset().left).toBeCloseTo($(getCell(2, 3)).offset().left, 0);
 
       plugin.showAtCell(3, 3);
 
-      expect($(editor.parentNode).offset()).toEqual($(getCell(3, 5)).offset());
+      expect($(editor.parentNode).offset().top).toBeCloseTo($(getCell(3, 5)).offset().top, 0);
+      expect($(editor.parentNode).offset().left).toBeCloseTo($(getCell(3, 5)).offset().left, 0);
 
       plugin.showAtCell(4, 4);
 
-      expect($(editor.parentNode).offset()).toEqual($(getCell(5, 5)).offset());
+      expect($(editor.parentNode).offset().top).toBeCloseTo($(getCell(5, 5)).offset().top, 0);
+      expect($(editor.parentNode).offset().left).toBeCloseTo($(getCell(5, 5)).offset().left, 0);
 
       plugin.showAtCell(5, 5);
 
-      expect($(editor.parentNode).offset()).toEqual($(getCell(5, 6)).offset());
+      expect($(editor.parentNode).offset().top).toBeCloseTo($(getCell(5, 6)).offset().top, 0);
+      expect($(editor.parentNode).offset().left).toBeCloseTo($(getCell(5, 6)).offset().left, 0);
 
       plugin.showAtCell(7, 7);
 
-      expect($(editor.parentNode).offset()).toEqual({
-        top: $(getCell(7, 7)).offset().top,
-        left: $(getCell(7, 7)).offset().left + $(getCell(7, 7)).outerWidth()
-      });
+      expect($(editor.parentNode).offset().top).toBeCloseTo($(getCell(7, 7)).offset().top, 0);
+      expect($(editor.parentNode).offset().left)
+        .toBeCloseTo($(getCell(7, 7)).offset().left + $(getCell(7, 7)).outerWidth(), 0);
 
       plugin.showAtCell(8, 8);
 
-      expect($(editor.parentNode).offset()).toEqual({
-        top: $(getCell(7, 7)).offset().top + $(getCell(7, 7)).outerHeight(),
-        left: $(getCell(7, 7)).offset().left + $(getCell(7, 7)).outerWidth()
-      });
+      expect($(editor.parentNode).offset().top)
+        .toBeCloseTo($(getCell(7, 7)).offset().top + $(getCell(7, 7)).outerHeight(), 0);
+      expect($(editor.parentNode).offset().left)
+        .toBeCloseTo($(getCell(7, 7)).offset().left + $(getCell(7, 7)).outerWidth(), 0);
 
       plugin.showAtCell(9, 9);
 
-      expect($(editor.parentNode).offset()).toEqual({
-        top: $(getCell(7, 7)).offset().top + $(getCell(7, 7)).outerHeight(),
-        left: $(getCell(7, 7)).offset().left + $(getCell(7, 7)).outerWidth()
-      });
+      expect($(editor.parentNode).offset().top)
+        .toBeCloseTo($(getCell(7, 7)).offset().top + $(getCell(7, 7)).outerHeight(), 0);
+      expect($(editor.parentNode).offset().left)
+        .toBeCloseTo($(getCell(7, 7)).offset().left + $(getCell(7, 7)).outerWidth(), 0);
     });
 
     it('should display the correct values in the comment editor, for cells placed past hidden rows/columns', () => {

--- a/src/plugins/contextMenu/test/contextMenu.e2e.js
+++ b/src/plugins/contextMenu/test/contextMenu.e2e.js
@@ -254,7 +254,7 @@ describe('ContextMenu', () => {
       docInside.documentElement.scrollTop = 500;
       docInside.documentElement.scrollLeft = 500;
 
-      await sleep(300);
+      await sleep(400);
 
       const cell = hot.getCell(2, 2);
       contextMenu(cell, hot);

--- a/src/plugins/filters/test/filtersUI.e2e.js
+++ b/src/plugins/filters/test/filtersUI.e2e.js
@@ -3731,7 +3731,7 @@ describe('Filters UI', () => {
     expect(compStyleHtFiltersMenuLabel.fontSize).toBe('18px');
 
     expect(compStyleHtUISelectCaption.fontFamily).toBe('Helvetica');
-    expect(compStyleHtUISelectCaption.fontSize).toBe('16.8px');
+    expect(parseFloat(compStyleHtUISelectCaption.fontSize)).toBeCloseTo(16.8, 2);
 
     bodyStyle.fontFamily = fontFamily;
     bodyStyle.fontSize = fontSize;

--- a/src/plugins/hiddenColumns/test/hiddenColumns.e2e.js
+++ b/src/plugins/hiddenColumns/test/hiddenColumns.e2e.js
@@ -4489,7 +4489,7 @@ describe('HiddenColumns', () => {
 
       expect(hot.getColWidth(0)).toBe(0);
       expect(hot.getColWidth(1)).toBe(0);
-      expect([216 + 15, 229 + 15, 247 + 15, 260 + 15, 261 + 15]).toEqual(jasmine.arrayContaining([hot.getColWidth(2)]));
+      expect(hot.getColWidth(2)).toBeAroundValue(225, 1);
     });
 
     it('should return proper values from the `getColWidth` function (when indicator is disabled)', () => {
@@ -4510,7 +4510,7 @@ describe('HiddenColumns', () => {
 
       expect(hot.getColWidth(0)).toBe(0);
       expect(hot.getColWidth(1)).toBe(0);
-      expect([216, 229, 247, 260, 261]).toEqual(jasmine.arrayContaining([hot.getColWidth(2)]));
+      expect(hot.getColWidth(2)).toBeAroundValue(210, 1);
     });
 
     it('should return proper values from the `getColWidth` function when the `ManualColumnResize` plugin define sizes for some columns', () => {

--- a/src/plugins/hiddenColumns/test/plugins/manualColumnResize.e2e.js
+++ b/src/plugins/hiddenColumns/test/plugins/manualColumnResize.e2e.js
@@ -137,7 +137,7 @@ describe('HiddenColumns', () => {
         .simulate('mouseup')
       ;
 
-      expect(colWidth(spec().$container, 1)).toBe(91); // 61 (initial column width) + 30
+      expect(colWidth(spec().$container, 1)).toBeAroundValue(85, 1); // 55 (initial column width) + 30
     });
   });
 });

--- a/src/plugins/manualColumnMove/manualColumnMove.js
+++ b/src/plugins/manualColumnMove/manualColumnMove.js
@@ -556,7 +556,7 @@ class ManualColumnMove extends BasePlugin {
       const scrollableElement = this.hot.view.wt.wtOverlays.scrollableElement;
       const wrapperIsWindow = scrollableElement.scrollX ? scrollableElement.scrollX - priv.rootElementOffset : 0;
 
-      const mouseOffset = event.layerX - (fixedColumns ? wrapperIsWindow : 0);
+      const mouseOffset = event.offsetX - (fixedColumns ? wrapperIsWindow : 0);
       const leftOffset = Math.abs(this.getColumnsWidth(start, coords.col - 1) + mouseOffset);
 
       this.backlight.setPosition(topPos, this.getColumnsWidth(countColumnsFrom, start - 1) + leftOffset);

--- a/src/plugins/manualColumnResize/test/manualColumnResize.e2e.js
+++ b/src/plugins/manualColumnResize/test/manualColumnResize.e2e.js
@@ -398,7 +398,7 @@ describe('manualColumnResize', () => {
       await sleep(1000);
 
       expect($columnHeaders.eq(0).width()).toBe(28);
-      expect($columnHeaders.eq(1).width()).toBe(89);
+      expect($columnHeaders.eq(1).width()).toBeAroundValue(82, 1);
       expect($columnHeaders.eq(2).width()).toBe(159);
       expect($columnHeaders.eq(3).width()).toBe(59);
       expect($columnHeaders.eq(4).width()).toBe(79);
@@ -641,9 +641,9 @@ describe('manualColumnResize', () => {
 
     await sleep(600);
 
-    expect(colWidth(spec().$container, 1)).toBeAroundValue(32, 2);
-    expect(colWidth(spec().$container, 2)).toBeAroundValue(32, 2);
-    expect(colWidth(spec().$container, 3)).toBeAroundValue(32, 2);
+    expect(colWidth(spec().$container, 1)).toBe(29);
+    expect(colWidth(spec().$container, 2)).toBe(29);
+    expect(colWidth(spec().$container, 3)).toBe(30);
   });
 
   it('should adjust resize handles position after table size changed', () => {

--- a/src/plugins/manualRowMove/manualRowMove.js
+++ b/src/plugins/manualRowMove/manualRowMove.js
@@ -547,7 +547,7 @@ class ManualRowMove extends BasePlugin {
 
       this.backlight.setPosition(null, leftPos);
       this.backlight.setSize(wtTable.hider.offsetWidth - leftPos, this.getRowsHeight(start, end));
-      this.backlight.setOffset((this.getRowsHeight(start, coords.row - 1) + event.layerY) * -1, null);
+      this.backlight.setOffset((this.getRowsHeight(start, coords.row - 1) + event.offsetY) * -1, null);
 
       addClass(this.hot.rootElement, CSS_ON_MOVING);
 

--- a/src/plugins/multiColumnSorting/test/multiColumnSorting.e2e.js
+++ b/src/plugins/multiColumnSorting/test/multiColumnSorting.e2e.js
@@ -2465,7 +2465,7 @@ describe('MultiColumnSorting', () => {
         .getPropertyValue('content')).toEqual('"+"');
     });
 
-    it('should be properly hided when just one column is sorted', () => {
+    it('should be properly hided when just one column is sorted', async() => {
       handsontable({
         data: createSpreadsheetData(10, 10),
         colHeaders: true,
@@ -2489,9 +2489,9 @@ describe('MultiColumnSorting', () => {
       getPlugin('multiColumnSorting').sort({ column: 0, sortOrder: 'asc' });
 
       expect(window.getComputedStyle(spec().$container.find('th span.columnSorting')[0], ':after')
-        .getPropertyValue('content')).toEqual('none');
+        .getPropertyValue('content')).toMatch(/^(none|)$/);
       expect(window.getComputedStyle(spec().$container.find('th span.columnSorting')[1], ':after')
-        .getPropertyValue('content')).toEqual('none');
+        .getPropertyValue('content')).toMatch(/^(none|)$/);
     });
   });
 

--- a/test/e2e/Core_validate.spec.js
+++ b/test/e2e/Core_validate.spec.js
@@ -38,7 +38,9 @@ describe('Core_validate', () => {
     });
 
     hot.validateCells();
-    await sleep(10);
+
+    await sleep(100);
+
     hot.destroy();
     spec().$container.remove();
 

--- a/test/e2e/core/selectAll.spec.js
+++ b/test/e2e/core/selectAll.spec.js
@@ -12,7 +12,6 @@ describe('Core.selectAll', () => {
 
   it('should select all cells and clear previous selection', () => {
     const scrollbarWidth = Handsontable.dom.getScrollbarWidth(); // normalize viewport size disregarding of the scrollbar size on any OS
-
     const hot = handsontable({
       data: Handsontable.helper.createSpreadsheetObjectData(15, 20),
       width: 185 + scrollbarWidth,

--- a/test/e2e/editors/dateEditor.spec.js
+++ b/test/e2e/editors/dateEditor.spec.js
@@ -73,7 +73,7 @@ describe('DateEditor', () => {
     expect(editor.offset()).toEqual($(getCell(0, 0, true)).offset());
 
     keyDown('enter');
-    await sleep(100); // Caused by async DateEditor close.
+    await sleep(200); // Caused by async DateEditor close.
     keyDown('enter');
 
     // Cells that do not touch the edges of the table have an additional top border.
@@ -85,38 +85,38 @@ describe('DateEditor', () => {
     expect(editorOffset()).toEqual($(getCell(1, 0, true)).offset());
 
     keyDown('enter');
-    await sleep(100); // Caused by async DateEditor close.
+    await sleep(200); // Caused by async DateEditor close.
     keyDown('enter');
 
     expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
 
     keyDown('enter');
-    await sleep(100); // Caused by async DateEditor close.
+    await sleep(200); // Caused by async DateEditor close.
     keyDown('enter');
 
     expect(editorOffset()).toEqual($(getCell(3, 0, true)).offset());
 
     keyDown('enter');
-    await sleep(100); // Caused by async DateEditor close.
+    await sleep(200); // Caused by async DateEditor close.
     keyDown('enter');
 
     expect(editorOffset()).toEqual($(getCell(4, 0, true)).offset());
 
     keyDown('enter');
-    await sleep(100); // Caused by async DateEditor close.
+    await sleep(200); // Caused by async DateEditor close.
     keyDown('enter');
 
     // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
     expect(editor.offset()).toEqual($(getCell(5, 0, true)).offset());
 
     keyDown('enter');
-    await sleep(100); // Caused by async DateEditor close.
+    await sleep(200); // Caused by async DateEditor close.
     keyDown('enter');
 
     expect(editorOffset()).toEqual($(getCell(6, 0, true)).offset());
 
     keyDown('enter');
-    await sleep(100); // Caused by async DateEditor close.
+    await sleep(200); // Caused by async DateEditor close.
     keyDown('enter');
 
     expect(editorOffset()).toEqual($(getCell(7, 0, true)).offset());
@@ -141,7 +141,7 @@ describe('DateEditor', () => {
     expect(editor.offset()).toEqual($(getCell(0, 0, true)).offset());
 
     selectCell(0, 1);
-    await sleep(100); // Caused by async DateEditor close.
+    await sleep(200); // Caused by async DateEditor close.
     keyDown('enter');
 
     // Cells that do not touch the edges of the table have an additional left border.
@@ -153,19 +153,19 @@ describe('DateEditor', () => {
     expect(editorOffset()).toEqual($(getCell(0, 1, true)).offset());
 
     selectCell(0, 2);
-    await sleep(100); // Caused by async DateEditor close.
+    await sleep(200); // Caused by async DateEditor close.
     keyDown('enter');
 
     expect(editorOffset()).toEqual($(getCell(0, 2, true)).offset());
 
     selectCell(0, 3);
-    await sleep(100); // Caused by async DateEditor close.
+    await sleep(200); // Caused by async DateEditor close.
     keyDown('enter');
 
     expect(editorOffset()).toEqual($(getCell(0, 3, true)).offset());
 
     selectCell(0, 4);
-    await sleep(100); // Caused by async DateEditor close.
+    await sleep(200); // Caused by async DateEditor close.
     keyDown('enter');
 
     expect(editorOffset()).toEqual($(getCell(0, 4, true)).offset());
@@ -196,7 +196,7 @@ describe('DateEditor', () => {
     expect(editor.offset()).toEqual($(getCell(1, 0, true)).offset());
 
     keyDown('enter');
-    await sleep(100); // Caused by async DateEditor close.
+    await sleep(200); // Caused by async DateEditor close.
     keyDown('enter');
 
     // Cells that do not touch the edges of the table have an additional top border.
@@ -208,26 +208,26 @@ describe('DateEditor', () => {
     expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
 
     keyDown('enter');
-    await sleep(100); // Caused by async DateEditor close.
+    await sleep(200); // Caused by async DateEditor close.
     keyDown('enter');
 
     expect(editorOffset()).toEqual($(getCell(3, 0, true)).offset());
 
     keyDown('enter');
-    await sleep(100); // Caused by async DateEditor close.
+    await sleep(200); // Caused by async DateEditor close.
     keyDown('enter');
 
     expect(editorOffset()).toEqual($(getCell(4, 0, true)).offset());
 
     keyDown('enter');
-    await sleep(100); // Caused by async DateEditor close.
+    await sleep(200); // Caused by async DateEditor close.
     keyDown('enter');
 
     // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
     expect(editor.offset()).toEqual($(getCell(6, 0, true)).offset());
 
     keyDown('enter');
-    await sleep(100); // Caused by async DateEditor close.
+    await sleep(200); // Caused by async DateEditor close.
     keyDown('enter');
 
     expect(editorOffset()).toEqual($(getCell(7, 0, true)).offset());
@@ -256,7 +256,7 @@ describe('DateEditor', () => {
     expect(editor.offset()).toEqual($(getCell(0, 1, true)).offset());
 
     selectCell(0, 2);
-    await sleep(100); // Caused by async DateEditor close.
+    await sleep(200); // Caused by async DateEditor close.
     keyDown('enter');
 
     // Cells that do not touch the edges of the table have an additional left border.
@@ -268,13 +268,13 @@ describe('DateEditor', () => {
     expect(editorOffset()).toEqual($(getCell(0, 2, true)).offset());
 
     selectCell(0, 3);
-    await sleep(100); // Caused by async DateEditor close.
+    await sleep(200); // Caused by async DateEditor close.
     keyDown('enter');
 
     expect(editorOffset()).toEqual($(getCell(0, 3, true)).offset());
 
     selectCell(0, 4);
-    await sleep(100); // Caused by async DateEditor close.
+    await sleep(200); // Caused by async DateEditor close.
     keyDown('enter');
 
     expect(editorOffset()).toEqual($(getCell(0, 4, true)).offset());

--- a/test/e2e/editors/textEditor.spec.js
+++ b/test/e2e/editors/textEditor.spec.js
@@ -534,8 +534,8 @@ describe('TextEditor', () => {
 
     await sleep(200);
 
+    expect(parseInt(hot.getActiveEditor().TEXTAREA.style.width, 10)).toBeAroundValue(41, 1);
     expect(hot.getActiveEditor().TEXTAREA.style.height).toBe('23px');
-    expect(parseInt(hot.getActiveEditor().TEXTAREA.style.width, 10)).toBeAroundValue(50, 4);
     expect(hot.getActiveEditor().textareaParentStyle.top).toBe('26px');
   });
 
@@ -1855,7 +1855,7 @@ describe('TextEditor', () => {
 
       await sleep(100);
 
-      expect($(textarea).width()).toBe(201);
+      expect($(textarea).width()).toBe(175);
       expect($(textarea).height()).toBe(23);
     });
   });

--- a/test/e2e/utils/ghostTable.spec.js
+++ b/test/e2e/utils/ghostTable.spec.js
@@ -212,11 +212,11 @@ describe('GhostTable', () => {
 
       expect(widthSpy.calls.count()).toBe(3);
       expect(widthSpy.calls.argsFor(0)[0]).toBe(0);
-      expect(widthSpy.calls.argsFor(0)[1]).toBeAroundValue(87, 4);
+      expect(widthSpy.calls.argsFor(0)[1]).toBe(78);
       expect(widthSpy.calls.argsFor(1)[0]).toBe(1);
-      expect(widthSpy.calls.argsFor(1)[1]).toBeAroundValue(41, 4);
+      expect(widthSpy.calls.argsFor(1)[1]).toBe(36);
       expect(widthSpy.calls.argsFor(2)[0]).toBe(2);
-      expect(widthSpy.calls.argsFor(2)[1]).toBeAroundValue(68, 4);
+      expect(widthSpy.calls.argsFor(2)[1]).toBe(62);
     });
   });
 

--- a/test/lib/normalize.css
+++ b/test/lib/normalize.css
@@ -1,32 +1,25 @@
-
-/*! normalize.css v5.0.0 | MIT License | github.com/necolas/normalize.css */
-
-/**
- * 1. Change the default font family in all browsers (opinionated).
- * 2. Correct the line height in all browsers.
- * 3. Prevent adjustments of font size after orientation changes in
- *    IE on Windows Phone and in iOS.
- */
+/*! normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */
 
 /* Document
    ========================================================================== */
 
+/**
+ * 1. Correct the line height in all browsers.
+ * 2. Prevent adjustments of font size after orientation changes in iOS.
+ */
+
 html {
-    font-family: sans-serif;
- /* 1 */
     line-height: 1.15;
- /* 2 */
-    -ms-text-size-adjust: 100%;
- /* 3 */
+ /* 1 */
     -webkit-text-size-adjust: 100%;
- /* 3 */
+ /* 2 */
 }
 
 /* Sections
    ========================================================================== */
 
 /**
- * Remove the margin in all browsers (opinionated).
+ * Remove the margin in all browsers.
  */
 
 body {
@@ -34,15 +27,10 @@ body {
 }
 
 /**
- * Add the correct display in IE 9-.
+ * Render the `main` element consistently in IE.
  */
 
-article,
-aside,
-footer,
-header,
-nav,
-section {
+main {
     display: block;
 }
 
@@ -58,26 +46,6 @@ h1 {
 
 /* Grouping content
    ========================================================================== */
-
-/**
- * Add the correct display in IE 9-.
- * 1. Add the correct display in IE.
- */
-
-figcaption,
-figure,
-main {
- /* 1 */
-    display: block;
-}
-
-/**
- * Add the correct margin in IE 8.
- */
-
-figure {
-    margin: 1em 40px;
-}
 
 /**
  * 1. Add the correct box sizing in Firefox.
@@ -109,29 +77,15 @@ pre {
    ========================================================================== */
 
 /**
- * 1. Remove the gray background on active links in IE 10.
- * 2. Remove gaps in links underline in iOS 8+ and Safari 8+.
+ * Remove the gray background on active links in IE 10.
  */
 
 a {
     background-color: transparent;
- /* 1 */
-    -webkit-text-decoration-skip: objects;
- /* 2 */
 }
 
 /**
- * Remove the outline on focused links when they are also active or hovered
- * in all browsers (opinionated).
- */
-
-a:active,
-a:hover {
-    outline-width: 0;
-}
-
-/**
- * 1. Remove the bottom border in Firefox 39-.
+ * 1. Remove the bottom border in Chrome 57-
  * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
  */
 
@@ -142,15 +96,6 @@ abbr[title] {
  /* 2 */
     text-decoration: underline dotted;
  /* 2 */
-}
-
-/**
- * Prevent the duplicate application of `bolder` by the next rule in Safari 6.
- */
-
-b,
-strong {
-    font-weight: inherit;
 }
 
 /**
@@ -174,23 +119,6 @@ samp {
  /* 1 */
     font-size: 1em;
  /* 2 */
-}
-
-/**
- * Add the correct font style in Android 4.3-.
- */
-
-dfn {
-    font-style: italic;
-}
-
-/**
- * Add the correct background and color in IE 9-.
- */
-
-mark {
-    background-color: #ff0;
-    color: #000;
 }
 
 /**
@@ -226,44 +154,18 @@ sup {
    ========================================================================== */
 
 /**
- * Add the correct display in IE 9-.
- */
-
-audio,
-video {
-    display: inline-block;
-}
-
-/**
- * Add the correct display in iOS 4-7.
- */
-
-audio:not([controls]) {
-    display: none;
-    height: 0;
-}
-
-/**
- * Remove the border on images inside links in IE 10-.
+ * Remove the border on images inside links in IE 10.
  */
 
 img {
     border-style: none;
 }
 
-/**
- * Hide the overflow in IE.
- */
-
-svg:not(:root) {
-    overflow: hidden;
-}
-
 /* Forms
    ========================================================================== */
 
 /**
- * 1. Change the font styles in all browsers (opinionated).
+ * 1. Change the font styles in all browsers.
  * 2. Remove the margin in Firefox and Safari.
  */
 
@@ -272,7 +174,7 @@ input,
 optgroup,
 select,
 textarea {
-    font-family: sans-serif;
+    font-family: inherit;
  /* 1 */
     font-size: 100%;
  /* 1 */
@@ -305,17 +207,14 @@ select {
 }
 
 /**
- * 1. Prevent a WebKit bug where (2) destroys native `audio` and `video`
- *    controls in Android 4.
- * 2. Correct the inability to style clickable types in iOS and Safari.
+ * Correct the inability to style clickable types in iOS and Safari.
  */
 
 button,
-html [type="button"], /* 1 */
+[type="button"],
 [type="reset"],
 [type="submit"] {
     -webkit-appearance: button;
- /* 2 */
 }
 
 /**
@@ -342,13 +241,11 @@ button:-moz-focusring,
 }
 
 /**
- * Change the border, margin, and padding in all browsers (opinionated).
+ * Correct the padding in Firefox.
  */
 
 fieldset {
-    border: 1px solid #c0c0c0;
-    margin: 0 2px;
-    padding: 0.35em 0.625em 0.75em;
+    padding: 0.35em 0.75em 0.625em;
 }
 
 /**
@@ -374,19 +271,15 @@ legend {
 }
 
 /**
- * 1. Add the correct display in IE 9-.
- * 2. Add the correct vertical alignment in Chrome, Firefox, and Opera.
+ * Add the correct vertical alignment in Chrome, Firefox, and Opera.
  */
 
 progress {
-    display: inline-block;
- /* 1 */
     vertical-align: baseline;
- /* 2 */
 }
 
 /**
- * Remove the default vertical scrollbar in IE.
+ * Remove the default vertical scrollbar in IE 10+.
  */
 
 textarea {
@@ -394,8 +287,8 @@ textarea {
 }
 
 /**
- * 1. Add the correct box sizing in IE 10-.
- * 2. Remove the padding in IE 10-.
+ * 1. Add the correct box sizing in IE 10.
+ * 2. Remove the padding in IE 10.
  */
 
 [type="checkbox"],
@@ -428,10 +321,9 @@ textarea {
 }
 
 /**
- * Remove the inner padding and cancel buttons in Chrome and Safari on macOS.
+ * Remove the inner padding in Chrome and Safari on macOS.
  */
 
-[type="search"]::-webkit-search-cancel-button,
 [type="search"]::-webkit-search-decoration {
     -webkit-appearance: none;
 }
@@ -452,12 +344,10 @@ textarea {
    ========================================================================== */
 
 /*
- * Add the correct display in IE 9-.
- * 1. Add the correct display in Edge, IE, and Firefox.
+ * Add the correct display in Edge, IE 10+, and Firefox.
  */
 
-details, /* 1 */
-menu {
+details {
     display: block;
 }
 
@@ -469,30 +359,19 @@ summary {
     display: list-item;
 }
 
-/* Scripting
+/* Misc
    ========================================================================== */
 
 /**
- * Add the correct display in IE 9-.
- */
-
-canvas {
-    display: inline-block;
-}
-
-/**
- * Add the correct display in IE.
+ * Add the correct display in IE 10+.
  */
 
 template {
     display: none;
 }
 
-/* Hidden
-   ========================================================================== */
-
 /**
- * Add the correct display in IE 10-.
+ * Add the correct display in IE 10.
  */
 
 [hidden] {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
This PR adjusts E2E tests, which wasn't passed on browsers other than Chrome.  I've bumped the `normalize.css` to the latest version, which caused some tests failing. Additionally, I've spotted that `layerX` and `layerY` event props were used within the _ManualRowMove_ and _ManualColumnMove_ plugins. According to the MDN, those props are Non-standard. I've replaced them to `offsetX` and `offsetY` accordingly.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I've tested on macOS Catalina using Chrome (v83), Firefox (v78), Safari (v13.1.1), and Win10 (browserstack) using Chrome (v83) and Firefox (v78).

Some tests are still failing:
 * On Safari test `manualRowResize > should resize appropriate rows to calculated autoRowSize height after double click on row handler after updateSettings usage with new "rowHeights" values` generates a more abnormal result than other browsers and it needs further investigation to fix. 
 * On Chrome and FF under Win10 one test `Core.selectAll ->should select all cells and clear previous selection` fails. Failure is caused by virtual rendering somehow.

IMO above exceptions should be fixed as the next phase of the test normalization as the task is very time-consuming.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7110
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
