### PR TITLE
Make context menu "Remove column" option inactive

### DIFF
--- a/src/plugins/contextMenu/predefinedItems/removeColumn.js
+++ b/src/plugins/contextMenu/predefinedItems/removeColumn.js
@@ -33,6 +33,10 @@ export default function removeColumnItem() {
         transformSelectionToColumnDistance(this.getSelected()), null, 'ContextMenu.removeColumn');
     },
     disabled() {
+      if (!this.isColumnModificationAllowed()) {
+        return true;
+      }
+
       const selected = getValidSelection(this);
 
       if (!selected) {
@@ -46,9 +50,7 @@ export default function removeColumnItem() {
         return totalColumns === 0;
       }
 
-      return this.selection.isSelectedByRowHeader() ||
-        !this.isColumnModificationAllowed() ||
-        totalColumns === 0;
+      return this.selection.isSelectedByRowHeader() || totalColumns === 0;
     },
     hidden() {
       return !this.getSettings().allowRemoveColumn;

--- a/src/plugins/contextMenu/test/predefinedItems/removeColumn.e2e.js
+++ b/src/plugins/contextMenu/test/predefinedItems/removeColumn.e2e.js
@@ -73,7 +73,7 @@ describe('ContextMenu', () => {
         `).toBeMatchToSelectionPattern();
     });
 
-    it('should remove all columns when the menu is triggered by corner', () => {
+    it('should remove all columns when the menu is triggered by corner (dataset as an array of arrays)', () => {
       handsontable({
         data: createSpreadsheetData(5, 5),
         colHeaders: true,
@@ -95,6 +95,35 @@ describe('ContextMenu', () => {
       expect(`
         |   |
         |===|
+        `).toBeMatchToSelectionPattern();
+    });
+
+    it('should not remove all columns when the menu is triggered by corner (dataset as an array of objects)', () => {
+      handsontable({
+        data: createSpreadsheetObjectData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(-1, -1, true));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(5); // "Remove column"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(true);
+      expect(`
+        |   ║ * : * : * : * : * |
+        |===:===:===:===:===:===|
+        | * ║ A : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 |
         `).toBeMatchToSelectionPattern();
     });
 

--- a/src/plugins/customBorders/test/customBorders.e2e.js
+++ b/src/plugins/customBorders/test/customBorders.e2e.js
@@ -1033,6 +1033,7 @@ describe('CustomBorders', () => {
     expect($('.htContextMenu tbody td.htDisabled').text()).toBe([
       'Insert column left',
       'Insert column right',
+      'Remove columns',
       'Undo',
       'Redo',
       'Read only',

--- a/src/plugins/mergeCells/test/mergeCells.e2e.js
+++ b/src/plugins/mergeCells/test/mergeCells.e2e.js
@@ -1362,6 +1362,7 @@ describe('MergeCells', () => {
       expect($('.htContextMenu tbody td.htDisabled').text()).toBe([
         'Insert column left',
         'Insert column right',
+        'Remove columns',
         'Undo',
         'Redo',
         'Read only',


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
When the context menu is triggered by corner RMB click then the option "Remove column" should be inactive when the dataset is passed as an array of objects. The commit fixes the logic by shifting condition with `isColumnModificationAllowed()` checking to the top of the `disabled` method body.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7116
2. #7117
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
