### PR TITLE
Fix transform selection to indexes distance

### DIFF
--- a/src/selection/utils.js
+++ b/src/selection/utils.js
@@ -143,9 +143,10 @@ export function transformSelectionToColumnDistance(selectionRanges) {
   // Iterate through all ranges and collect all column indexes which are not saved yet.
   arrayEach(selectionRanges, (selection) => {
     const [, columnStart,, columnEnd] = selectionSchemaNormalizer(selection);
-    const amount = columnEnd - columnStart + 1;
+    const columnNonHeaderStart = Math.max(columnStart, 0);
+    const amount = columnEnd - columnNonHeaderStart + 1;
 
-    arrayEach(Array.from(new Array(amount), (_, i) => columnStart + i), (index) => {
+    arrayEach(Array.from(new Array(amount), (_, i) => columnNonHeaderStart + i), (index) => {
       if (!unorderedIndexes.has(index)) {
         unorderedIndexes.add(index);
       }
@@ -193,9 +194,10 @@ export function transformSelectionToRowDistance(selectionRanges) {
   // Iterate through all ranges and collect all column indexes which are not saved yet.
   arrayEach(selectionRanges, (selection) => {
     const [rowStart,, rowEnd] = selectionSchemaNormalizer(selection);
-    const amount = rowEnd - rowStart + 1;
+    const rowNonHeaderStart = Math.max(rowStart, 0);
+    const amount = rowEnd - rowNonHeaderStart + 1;
 
-    arrayEach(Array.from(new Array(amount), (_, i) => rowStart + i), (index) => {
+    arrayEach(Array.from(new Array(amount), (_, i) => rowNonHeaderStart + i), (index) => {
       if (!unorderedIndexes.has(index)) {
         unorderedIndexes.add(index);
       }

--- a/test/unit/selection/utils.spec.js
+++ b/test/unit/selection/utils.spec.js
@@ -3,8 +3,7 @@ import {
   isValidCoord,
   normalizeSelectionFactory,
   transformSelectionToColumnDistance,
-  // TODO: add tests for transformSelectionToRowDistance
-  // transformSelectionToRowDistance,
+  transformSelectionToRowDistance,
   SELECTION_TYPE_ARRAY,
   SELECTION_TYPE_EMPTY,
   SELECTION_TYPE_OBJECT,
@@ -171,6 +170,7 @@ describe('selection utils', () => {
     it('should translate selection ranges passed as an array of arrays to column distances', () => {
       expect(transformSelectionToColumnDistance([[1, 1, 2, 2]])).toEqual([[1, 2]]);
       expect(transformSelectionToColumnDistance([[1, 1], [3, 3, 3, 5]])).toEqual([[1, 1], [3, 3]]);
+      expect(transformSelectionToColumnDistance([[-1, 1], [-3, -3, 3, 5]])).toEqual([[0, 6]]);
       expect(transformSelectionToColumnDistance([[1, 1], [3, 3, 3, 5], [5, 1, 6, 3]])).toEqual([[1, 5]]);
       expect(transformSelectionToColumnDistance([[1, 1], [3, 3, 3, 5], [5, 1, 6, 3], [5, 7, 5, 7]]))
         .toEqual([[1, 5], [7, 1]]);
@@ -178,7 +178,35 @@ describe('selection utils', () => {
 
     it('should translate selection ranges passed as an array of CellRange objects to column distances', () => {
       expect(transformSelectionToColumnDistance([range(1, 1, 1, 1, 2, 2)])).toEqual([[1, 2]]);
+      expect(transformSelectionToColumnDistance([range(0, 0, 1, 1, -2, -2)])).toEqual([[0, 2]]);
       expect(transformSelectionToColumnDistance([range(1, 1, 1, 1, 2, 2), range(3, 3, 3, 3, 3, 5)]))
+        .toEqual([[1, 5]]);
+    });
+  });
+
+  describe('transformSelectionToRowDistance', () => {
+    it('should return an empty array when selection schema is unrecoginized', () => {
+      expect(transformSelectionToRowDistance()).toEqual([]);
+      expect(transformSelectionToRowDistance(0)).toEqual([]);
+      expect(transformSelectionToRowDistance(true)).toEqual([]);
+      expect(transformSelectionToRowDistance([])).toEqual([]);
+      expect(transformSelectionToRowDistance([1])).toEqual([]);
+      expect(transformSelectionToRowDistance([[1], [3, 3, 3, 5]])).toEqual([]);
+    });
+
+    it('should translate selection ranges passed as an array of arrays to row distances', () => {
+      expect(transformSelectionToRowDistance([[1, 1, 2, 2]])).toEqual([[1, 2]]);
+      expect(transformSelectionToRowDistance([[1, 1], [3, 3, 5, 3]])).toEqual([[1, 1], [3, 3]]);
+      expect(transformSelectionToRowDistance([[1, -1], [-3, -3, 5, 3]])).toEqual([[0, 6]]);
+      expect(transformSelectionToRowDistance([[1, 1], [3, 3, 5, 3], [1, 5, 3, 6]])).toEqual([[1, 5]]);
+      expect(transformSelectionToRowDistance([[1, 1], [3, 3, 5, 3], [1, 5, 3, 6], [7, 5, 7, 5]]))
+        .toEqual([[1, 5], [7, 1]]);
+    });
+
+    it('should translate selection ranges passed as an array of CellRange objects to row distances', () => {
+      expect(transformSelectionToRowDistance([range(1, 1, 1, 1, 2, 2)])).toEqual([[1, 2]]);
+      expect(transformSelectionToRowDistance([range(0, 0, 1, 1, -2, -2)])).toEqual([[0, 2]]);
+      expect(transformSelectionToRowDistance([range(1, 1, 1, 1, 2, 2), range(3, 3, 3, 3, 5, 3)]))
         .toEqual([[1, 5]]);
     });
   });


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
There was a bug in a function that translates multi-layered selection into consecutive coordinates. The function while building the structure incorrectly included the header row and column as if it were a regular removable index (all because of the negative coordinates generated by header selection).

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I've added unit tests for that function.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7115
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
