### PR TITLE
Fix AutoFill data handling

### DIFF
--- a/src/plugins/autofill/autofill.js
+++ b/src/plugins/autofill/autofill.js
@@ -192,17 +192,24 @@ class Autofill extends BasePlugin {
     // the end is.
     const [fillStartRow, fillStartColumn, fillEndRow, fillEndColumn] =
       this.hot.selection.highlight.getFill().getVisualCorners();
-    const [selectionStartRow, selectionStartColumn, selectionEndRow, selectionEndColumn] = this.hot.getSelectedLast();
+    const selectionRangeLast = this.hot.getSelectedRangeLast();
+    const topLeftCorner = selectionRangeLast.getTopLeftCorner();
+    const bottomRightCorner = selectionRangeLast.getBottomRightCorner();
     let cornersOfSelectionAndDragAreas = [
-      Math.min(selectionStartRow, fillStartRow),
-      Math.min(selectionStartColumn, fillStartColumn),
-      Math.max(selectionEndRow, fillEndRow),
-      Math.max(selectionEndColumn, fillEndColumn)
+      Math.min(topLeftCorner.row, fillStartRow),
+      Math.min(topLeftCorner.col, fillStartColumn),
+      Math.max(bottomRightCorner.row, fillEndRow),
+      Math.max(bottomRightCorner.col, fillEndColumn),
     ];
 
     this.resetSelectionOfDraggedArea();
 
-    const cornersOfSelectedCells = this.hot.getSelectedLast();
+    const cornersOfSelectedCells = [
+      topLeftCorner.row,
+      topLeftCorner.col,
+      bottomRightCorner.row,
+      bottomRightCorner.col,
+    ];
 
     cornersOfSelectionAndDragAreas = this.hot
       .runHooks('modifyAutofillRange', cornersOfSelectionAndDragAreas, cornersOfSelectedCells);

--- a/src/plugins/autofill/test/autofill.e2e.js
+++ b/src/plugins/autofill/test/autofill.e2e.js
@@ -855,7 +855,7 @@ describe('AutoFill', () => {
     expect(hot.countRows()).toBe(4);
   });
 
-  it('should populate the filled data in the correct order, when dragging the fill handle upwards', () => {
+  it('should populate the filled data in the correct order, when dragging the fill handle upwards (selection from left to right)', () => {
     handsontable({
       data: [
         [null, null, null, null],
@@ -869,34 +869,198 @@ describe('AutoFill', () => {
       ]
     });
 
-    expect(JSON.stringify(getData(0, 1, 3, 2)))
-      .toEqual(JSON.stringify([[null, null], [null, null], [null, null], [null, null]]));
-
     selectCell(4, 1, 6, 2);
     spec().$container.find('.wtBorder.area.corner').simulate('mousedown');
-    $(getCell(0, 2, true)).simulate('mouseover').simulate('mouseup');
+    $(getCell(0, 2)).simulate('mouseover').simulate('mouseup');
 
-    expect(JSON.stringify(getData(0, 1, 3, 2))).toEqual(JSON.stringify([[0, 5], [2, 3], [1, 4], [0, 5]]));
+    expect(getData()).toEqual([
+      [null, 0, 5, null],
+      [null, 2, 3, null],
+      [null, 1, 4, null],
+      [null, 0, 5, null],
+      [null, 2, 3, null],
+      [null, 1, 4, null],
+      [null, 0, 5, null],
+      [null, null, null, null],
+    ]);
   });
 
-  it('should populate the filled data in the correct order, when dragging the fill handle towards left', () => {
+  it('should populate the filled data in the correct order, when dragging the fill handle upwards (selection from right to left)', () => {
+    handsontable({
+      data: [
+        [null, null, null, null],
+        [null, null, null, null],
+        [null, null, null, null],
+        [null, null, null, null],
+        [null, 2, 3, null],
+        [null, 1, 4, null],
+        [null, 0, 5, null],
+        [null, null, null, null],
+      ]
+    });
+
+    selectCell(6, 2, 4, 1);
+    spec().$container.find('.wtBorder.area.corner').simulate('mousedown');
+    $(getCell(0, 2)).simulate('mouseover').simulate('mouseup');
+
+    expect(getData()).toEqual([
+      [null, 0, 5, null],
+      [null, 2, 3, null],
+      [null, 1, 4, null],
+      [null, 0, 5, null],
+      [null, 2, 3, null],
+      [null, 1, 4, null],
+      [null, 0, 5, null],
+      [null, null, null, null],
+    ]);
+  });
+
+  it('should populate the filled data in the correct order, when dragging the fill handle downward (selection from left to right)', () => {
+    handsontable({
+      data: [
+        [null, null, null, null],
+        [null, 2, 3, null],
+        [null, 1, 4, null],
+        [null, 0, 5, null],
+        [null, null, null, null],
+        [null, null, null, null],
+        [null, null, null, null],
+        [null, null, null, null],
+      ]
+    });
+
+    selectCell(1, 1, 3, 2);
+    spec().$container.find('.wtBorder.area.corner').simulate('mousedown');
+    $(getCell(7, 2)).simulate('mouseover').simulate('mouseup');
+
+    expect(getData()).toEqual([
+      [null, null, null, null],
+      [null, 2, 3, null],
+      [null, 1, 4, null],
+      [null, 0, 5, null],
+      [null, 2, 3, null],
+      [null, 1, 4, null],
+      [null, 0, 5, null],
+      [null, 2, 3, null],
+    ]);
+  });
+
+  it('should populate the filled data in the correct order, when dragging the fill handle downward (selection from right to left)', () => {
+    handsontable({
+      data: [
+        [null, null, null, null],
+        [null, 2, 3, null],
+        [null, 1, 4, null],
+        [null, 0, 5, null],
+        [null, null, null, null],
+        [null, null, null, null],
+        [null, null, null, null],
+        [null, null, null, null],
+      ]
+    });
+
+    selectCell(3, 2, 1, 1);
+    spec().$container.find('.wtBorder.area.corner').simulate('mousedown');
+    $(getCell(7, 2)).simulate('mouseover').simulate('mouseup');
+
+    expect(getData()).toEqual([
+      [null, null, null, null],
+      [null, 2, 3, null],
+      [null, 1, 4, null],
+      [null, 0, 5, null],
+      [null, 2, 3, null],
+      [null, 1, 4, null],
+      [null, 0, 5, null],
+      [null, 2, 3, null],
+    ]);
+  });
+
+  it('should populate the filled data in the correct order, when dragging the fill handle towards left (selection from left to right)', () => {
     handsontable({
       data: [
         [null, null, null, null, null, null, null, null],
-        [null, null, null, null, null, 0, 1, 2],
-        [null, null, null, null, null, 3, 4, 5],
+        [null, null, null, null, 0, 1, 2, null],
+        [null, null, null, null, 3, 4, 5, null],
         [null, null, null, null, null, null, null, null],
       ]
     });
 
-    expect(JSON.stringify(getData(1, 1, 2, 4)))
-      .toEqual(JSON.stringify([[null, null, null, null], [null, null, null, null]]));
-
-    selectCell(1, 5, 2, 7);
+    selectCell(1, 4, 2, 6);
     spec().$container.find('.wtBorder.area.corner').simulate('mousedown');
-    $(getCell(2, 1, true)).simulate('mouseover').simulate('mouseup');
+    $(getCell(2, 0)).simulate('mouseover').simulate('mouseup');
 
-    expect(JSON.stringify(getData(1, 1, 2, 4))).toEqual(JSON.stringify([[2, 0, 1, 2], [5, 3, 4, 5]]));
+    expect(getData()).toEqual([
+      [null, null, null, null, null, null, null, null],
+      [2, 0, 1, 2, 0, 1, 2, null],
+      [5, 3, 4, 5, 3, 4, 5, null],
+      [null, null, null, null, null, null, null, null],
+    ]);
+  });
+
+  it('should populate the filled data in the correct order, when dragging the fill handle towards left (selection from right to left)', () => {
+    handsontable({
+      data: [
+        [null, null, null, null, null, null, null, null],
+        [null, null, null, null, 0, 1, 2, null],
+        [null, null, null, null, 3, 4, 5, null],
+        [null, null, null, null, null, null, null, null],
+      ]
+    });
+
+    selectCell(2, 6, 1, 4);
+    spec().$container.find('.wtBorder.area.corner').simulate('mousedown');
+    $(getCell(2, 0)).simulate('mouseover').simulate('mouseup');
+
+    expect(getData()).toEqual([
+      [null, null, null, null, null, null, null, null],
+      [2, 0, 1, 2, 0, 1, 2, null],
+      [5, 3, 4, 5, 3, 4, 5, null],
+      [null, null, null, null, null, null, null, null],
+    ]);
+  });
+
+  it('should populate the filled data in the correct order, when dragging the fill handle towards right (selection from left to right)', () => {
+    handsontable({
+      data: [
+        [null, null, null, null, null, null, null, null],
+        [null, 0, 1, 2, null, null, null, null],
+        [null, 3, 4, 5, null, null, null, null],
+        [null, null, null, null, null, null, null, null],
+      ]
+    });
+
+    selectCell(1, 1, 2, 3);
+    spec().$container.find('.wtBorder.area.corner').simulate('mousedown');
+    $(getCell(2, 7)).simulate('mouseover').simulate('mouseup');
+
+    expect(getData()).toEqual([
+      [null, null, null, null, null, null, null, null],
+      [null, 0, 1, 2, 0, 1, 2, 0],
+      [null, 3, 4, 5, 3, 4, 5, 3],
+      [null, null, null, null, null, null, null, null],
+    ]);
+  });
+
+  it('should populate the filled data in the correct order, when dragging the fill handle towards right (selection from right to left)', () => {
+    handsontable({
+      data: [
+        [null, null, null, null, null, null, null, null],
+        [null, 0, 1, 2, null, null, null, null],
+        [null, 3, 4, 5, null, null, null, null],
+        [null, null, null, null, null, null, null, null],
+      ]
+    });
+
+    selectCell(2, 3, 1, 1);
+    spec().$container.find('.wtBorder.area.corner').simulate('mousedown');
+    $(getCell(2, 7)).simulate('mouseover').simulate('mouseup');
+
+    expect(getData()).toEqual([
+      [null, null, null, null, null, null, null, null],
+      [null, 0, 1, 2, 0, 1, 2, 0],
+      [null, 3, 4, 5, 3, 4, 5, 3],
+      [null, null, null, null, null, null, null, null],
+    ]);
   });
 
   it('should omit data propagation for hidden cells - fill vertically (option `copyPasteEnabled` set to `false` for the both plugins)', () => {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
This commit fixes and issue about the Autofill handler, which in some cases won't fill the data by dragging the fill handler over the cell. Additionally, there was some weird behavior with filling the data when the selection was created from right to left or from bottom to top direction. After normalization of the selection direction, the AutoFill plugin starts working as expected.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7118
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
