### PR TITLE
Fix a bug, where it was impossible to add a child to a collapsed row in the Nested Rows plugin.

### DIFF
--- a/src/plugins/nestedRows/data/dataManager.js
+++ b/src/plugins/nestedRows/data/dataManager.js
@@ -454,6 +454,8 @@ class DataManager {
 
     const newRowIndex = this.getRowIndex(childElement);
 
+    this.hot.rowIndexMapper.insertIndexes(newRowIndex, 1);
+
     this.hot.runHooks('afterCreateRow', newRowIndex, 1);
     this.hot.runHooks('afterAddChild', parent, childElement);
   }

--- a/src/plugins/nestedRows/test/data/dataManager.e2e.js
+++ b/src/plugins/nestedRows/test/data/dataManager.e2e.js
@@ -280,6 +280,32 @@ describe('NestedRows Data Manager', () => {
         expect(parentElement.__children[1].b).toEqual('test-b');
       });
 
+      it('should add a new child to the provided parent, when the parent is collapsed', () => {
+        const data = getSimplerNestedData();
+        const hot = handsontable({
+          data,
+          nestedRows: true,
+          rowHeaders: true,
+          colHeaders: true
+        });
+
+        const startRowCount = hot.countRows();
+        const plugin = hot.getPlugin('nestedRows');
+        const lastRowParentObject = plugin.dataManager.getRowParent(hot.countRows() - 1);
+        const lastRowParentIndex = plugin.dataManager.getRowIndex(lastRowParentObject);
+        const startLastRowChildCount = plugin.dataManager.countChildren(lastRowParentObject);
+
+        plugin.collapsingUI.collapseChildren(lastRowParentIndex);
+
+        plugin.dataManager.addChild(lastRowParentObject);
+
+        expect(plugin.dataManager.countChildren(lastRowParentObject)).toEqual(startLastRowChildCount + 1);
+
+        plugin.collapsingUI.expandAll();
+
+        expect(hot.countRows()).toEqual(startRowCount + 1);
+        expect(hot.getDataAtRow(hot.countRows() - 1)).toEqual([null, null, null, null]);
+      });
     });
 
     describe('detachFromParent', () => {

--- a/src/plugins/nestedRows/ui/contextMenu.js
+++ b/src/plugins/nestedRows/ui/contextMenu.js
@@ -54,7 +54,6 @@ class ContextMenuUI extends BaseUI {
           const translatedRowIndex = this.dataManager.translateTrimmedRow(this.hot.getSelectedLast()[0]);
           const parent = this.dataManager.getDataObject(translatedRowIndex);
 
-          this.hot.rowIndexMapper.insertIndexes(translatedRowIndex, 1);
           this.dataManager.addChild(parent);
         },
         disabled: () => {


### PR DESCRIPTION
### Context
Fix a bug, where it was impossible to add a child to a collapsed row in the Nested Rows plugin, by moving the `indexMapper` modification from the Context Menu callback to the `addChild` method of Nested Rows' Data Manager, with a proper new row index.

### How has this been tested?
- Added a test case for the scenario.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7123