### PR TITLE
Fix a jsdoc mistake for the `setSourceDataAtCell` method.

### DIFF
--- a/handsontable.d.ts
+++ b/handsontable.d.ts
@@ -122,7 +122,7 @@ declare namespace _Handsontable {
     setDataAtCell(changes: Array<[number, string | number, Handsontable.CellValue]>, source?: string): void;
     setDataAtRowProp(row: number, prop: string, value: Handsontable.CellValue, source?: string): void;
     setDataAtRowProp(changes: Array<[number, string | number, Handsontable.CellValue]>, source?: string): void;
-    setSourceDataAtCell(row: number, column: number | string, value: Handsontable.CellValue): void;
+    setSourceDataAtCell(row: number, column: number | string, value: Handsontable.CellValue, source?: string): void;
     setSourceDataAtCell(changes: [number, string | number, Handsontable.CellValue][]): void;
     spliceCol(col: number, index: number, amount: number, ...elements: Handsontable.CellValue[]): void;
     spliceRow(row: number, index: number, amount: number, ...elements: Handsontable.CellValue[]): void;

--- a/src/core.js
+++ b/src/core.js
@@ -2421,7 +2421,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
    * Set the provided value in the source data set at the provided coordinates.
    *
    * @memberof Core#
-   * @function getSourceDataAtCol
+   * @function setSourceDataAtCell
    * @param {number|Array} row Physical row index or array of changes in format `[[row, prop, value], ...]`.
    * @param {number|string} column Physical column index / prop name.
    * @param {*} value The value to be set at the provided coordinates.

--- a/test/types/methods.types.ts
+++ b/test/types/methods.types.ts
@@ -106,6 +106,7 @@ hot.setDataAtCell([[123, 123, 'foo'], [123, 123, {myProperty: 'foo'}]], 'foo');
 hot.setDataAtRowProp(123, 'foo', 'foo', 'foo');
 hot.setDataAtRowProp([[123, 'foo', 'foo'], [123, 'foo', 'foo']], 'foo');
 hot.setSourceDataAtCell(123, 123, 'foo');
+hot.setSourceDataAtCell(123, 123, 'foo', 'sourceString');
 hot.setSourceDataAtCell([[1, 'foo', 'foo']]);
 hot.spliceCol(123, 123, 123, 'foo');
 hot.spliceRow(123, 123, 123, 'foo');


### PR DESCRIPTION
### Context
The JSDoc for the `setSourceDataAtCell` method contains a mistake, this PR fixes it.
Also, there was the `source` argument missing from the TS definition file and tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)
