### PR TITLE
The UndoRedo plugin will also restore fixed rows/columns

### DIFF
--- a/handsontable.d.ts
+++ b/handsontable.d.ts
@@ -85,7 +85,7 @@ declare namespace _Handsontable {
     isColumnModificationAllowed(): boolean;
     isDestroyed: boolean
     isEmptyCol(col: number): boolean;
-    isEmptyRow(row: number): boolean;;
+    isEmptyRow(row: number): boolean;
     isListening(): boolean;
     isRedoAvailable(): boolean;
     isUndoAvailable(): boolean;
@@ -174,8 +174,7 @@ declare namespace Handsontable {
   /**
    * The default sources for which the table triggers hooks.
    */
-  type ChangeSource = 'auto' | 'edit' | 'loadData' | 'populateFromArray' | 'spliceCol' | 'spliceRow' | 'timeValidate' | 'dateValidate' | 'validateCells' | 'Autofill.fill' | 'Autofill.fill' | 'ContextMenu.clearColumns' | 'ContextMenu.columnLeft' | 'ContextMenu.columnRight' | 'ContextMenu.removeColumn' | 'ContextMenu.removeRow' | 'ContextMenu.rowAbove' | 'ContextMenu.rowBelow' | 'CopyPaste.paste' | 'ObserveChanges.change' | 'UndoRedo.redo' | 'UndoRedo.undo' | 'GantChart.loadData' | 'ColumnSummary.set' | 'ColumnSummary.reset';
-
+  type ChangeSource = 'auto' | 'edit' | 'loadData' | 'populateFromArray' | 'spliceCol' | 'spliceRow' | 'timeValidate' | 'dateValidate' | 'validateCells' | 'Autofill.fill' | 'Autofill.fill' | 'ContextMenu.clearColumns' | 'ContextMenu.columnLeft' | 'ContextMenu.columnRight' | 'ContextMenu.removeColumn' | 'ContextMenu.removeRow' | 'ContextMenu.rowAbove' | 'ContextMenu.rowBelow' | 'CopyPaste.paste' | 'ObserveChanges.change' | 'UndoRedo.redo' | 'UndoRedo.undo' | 'ColumnSummary.set' | 'ColumnSummary.reset';
   /**
    * The default cell type aliases the table has built-in.
    */

--- a/src/plugins/undoRedo/test/UndoRedo.e2e.js
+++ b/src/plugins/undoRedo/test/UndoRedo.e2e.js
@@ -238,40 +238,6 @@ describe('UndoRedo', () => {
           expect(getDataAtCell(2, 1)).toEqual('B1');
         });
 
-        it('should undo removal of fixed row on the bottom', () => {
-          const hot = handsontable({
-            data: Handsontable.helper.createSpreadsheetData(3, 3),
-            columns: [
-              {}, {}, {}
-            ],
-            colHeaders: true,
-            rowHeaders: true,
-            fixedRowsBottom: 1,
-          });
-
-          alter('remove_row', 0, 3);
-          undo();
-
-          expect(hot.getSettings().fixedRowsBottom).toBe(1);
-          // Extra border has stayed after row removal in very specific case (`columns` defined, the Formula plugin enabled) #7146
-          expect($('.innerBorderBottom').length).toBe(0);
-          expect($('.innerBorderTop').length).toBe(0);
-        });
-
-        it('should undo removal of fixed row on the top', () => {
-          const hot = handsontable({
-            data: Handsontable.helper.createSpreadsheetData(3, 3),
-            colHeaders: true,
-            rowHeaders: true,
-            fixedRowsTop: 1,
-          });
-
-          alter('remove_row', 0, 3);
-          undo();
-
-          expect(hot.getSettings().fixedRowsTop).toBe(1);
-        });
-
         it('should undo creation of a single column (colHeaders: undefined)', () => {
           const HOT = handsontable({
             data: Handsontable.helper.createSpreadsheetData(2, 3)
@@ -657,20 +623,6 @@ describe('UndoRedo', () => {
           expect(getDataAtCell(1, 2)).toBe('C2');
           expect(getDataAtCell(1, 3)).toBe('D2');
           expect(getColHeader()).toEqual(['Header1', 'Header2', 'Header3', 'Header4']);
-        });
-
-        it('should undo removal of fixed column on the left', () => {
-          const hot = handsontable({
-            data: Handsontable.helper.createSpreadsheetData(3, 3),
-            colHeaders: true,
-            rowHeaders: true,
-            fixedColumnsLeft: 1,
-          });
-
-          alter('remove_col', 0, 3);
-          undo();
-
-          expect(hot.getSettings().fixedColumnsLeft).toBe(1);
         });
 
         it('should undo removal of multiple columns (with a used manualColumnMove)', () => {
@@ -1751,6 +1703,40 @@ describe('UndoRedo', () => {
           expect(getDataAtRowProp(1, 'surname')).toEqual('Connery');
           expect(getDataAtRowProp(2, 'name')).toEqual('Roger');
           expect(getDataAtRowProp(2, 'surname')).toEqual('Moore');
+        });
+
+        it('should undo removal of fixed row on the bottom', () => {
+          const hot = handsontable({
+            data: Handsontable.helper.createSpreadsheetData(3, 3),
+            columns: [
+              {}, {}, {}
+            ],
+            colHeaders: true,
+            rowHeaders: true,
+            fixedRowsBottom: 1,
+          });
+
+          alter('remove_row', 0, 3);
+          undo();
+
+          expect(hot.getSettings().fixedRowsBottom).toBe(1);
+          // Extra border has stayed after row removal in very specific case (`columns` defined, the Formula plugin enabled) #7146
+          expect($('.innerBorderBottom').length).toBe(0);
+          expect($('.innerBorderTop').length).toBe(0);
+        });
+
+        it('should undo removal of fixed row on the top', () => {
+          const hot = handsontable({
+            data: Handsontable.helper.createSpreadsheetData(3, 3),
+            colHeaders: true,
+            rowHeaders: true,
+            fixedRowsTop: 1,
+          });
+
+          alter('remove_row', 0, 3);
+          undo();
+
+          expect(hot.getSettings().fixedRowsTop).toBe(1);
         });
 
         it('should undo multiple changes', () => {
@@ -3070,6 +3056,20 @@ describe('UndoRedo', () => {
         |   ║   :   :   :   :   :   :   :   :   :   |
         |   ║   :   :   :   :   :   :   :   :   :   |
       `).toBeMatchToSelectionPattern();
+    });
+
+    it('should undo removal of fixed column on the left', () => {
+      const hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(3, 3),
+        colHeaders: true,
+        rowHeaders: true,
+        fixedColumnsLeft: 1,
+      });
+
+      alter('remove_col', 0, 3);
+      undo();
+
+      expect(hot.getSettings().fixedColumnsLeft).toBe(1);
     });
   });
 });

--- a/src/plugins/undoRedo/test/UndoRedo.e2e.js
+++ b/src/plugins/undoRedo/test/UndoRedo.e2e.js
@@ -238,6 +238,40 @@ describe('UndoRedo', () => {
           expect(getDataAtCell(2, 1)).toEqual('B1');
         });
 
+        it('should undo removal of fixed row on the bottom', () => {
+          const hot = handsontable({
+            data: Handsontable.helper.createSpreadsheetData(3, 3),
+            columns: [
+              {}, {}, {}
+            ],
+            colHeaders: true,
+            rowHeaders: true,
+            fixedRowsBottom: 1,
+          });
+
+          alter('remove_row', 0, 3);
+          undo();
+
+          expect(hot.getSettings().fixedRowsBottom).toBe(1);
+          // Extra border has stayed after row removal in very specific case (`columns` defined, the Formula plugin enabled) #7146
+          expect($('.innerBorderBottom').length).toBe(0);
+          expect($('.innerBorderTop').length).toBe(0);
+        });
+
+        it('should undo removal of fixed row on the top', () => {
+          const hot = handsontable({
+            data: Handsontable.helper.createSpreadsheetData(3, 3),
+            colHeaders: true,
+            rowHeaders: true,
+            fixedRowsTop: 1,
+          });
+
+          alter('remove_row', 0, 3);
+          undo();
+
+          expect(hot.getSettings().fixedRowsTop).toBe(1);
+        });
+
         it('should undo creation of a single column (colHeaders: undefined)', () => {
           const HOT = handsontable({
             data: Handsontable.helper.createSpreadsheetData(2, 3)
@@ -623,6 +657,20 @@ describe('UndoRedo', () => {
           expect(getDataAtCell(1, 2)).toBe('C2');
           expect(getDataAtCell(1, 3)).toBe('D2');
           expect(getColHeader()).toEqual(['Header1', 'Header2', 'Header3', 'Header4']);
+        });
+
+        it('should undo removal of fixed column on the left', () => {
+          const hot = handsontable({
+            data: Handsontable.helper.createSpreadsheetData(3, 3),
+            colHeaders: true,
+            rowHeaders: true,
+            fixedColumnsLeft: 1,
+          });
+
+          alter('remove_col', 0, 3);
+          undo();
+
+          expect(hot.getSettings().fixedColumnsLeft).toBe(1);
         });
 
         it('should undo removal of multiple columns (with a used manualColumnMove)', () => {


### PR DESCRIPTION
### Context
There has been a problem for both rows and columns related to the fact that fixed elements haven't been restored after triggering the undo action. It was partially described within #6869. This PR fixed that problem and allows code modified by @budnix within https://github.com/handsontable/handsontable/pull/7075 and https://github.com/handsontable/handsontable/pull/7109 to draw also properly borders. We have reported issues for very specific cases within #7146. They should be fixed also.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Manual tests of `fixedRowsBottom`, `fixedRowsTop`, `fixedColumnsLeft` options.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #6869
2. #7146 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.