### PR TITLE
fix typo of parameter for afterRemoveRow

### DIFF
--- a/handsontable.d.ts
+++ b/handsontable.d.ts
@@ -1865,7 +1865,7 @@ declare namespace Handsontable {
       afterRefreshDimensions?: (previousDimensions: object, currentDimensions: object, stateChanged: boolean) => void;
       afterRemoveCellMeta?: (row: number, column: number, key: string, value: any) => void;
       afterRemoveCol?: (index: number, amount: number, physicalColumns: number[], source?: ChangeSource) => void;
-      afterRemoveRow?: (index: number, amount: number, physicalColumns: number[], source?: ChangeSource) => void;
+      afterRemoveRow?: (index: number, amount: number, physicalRows: number[], source?: ChangeSource) => void;
       afterRender?: (isForced: boolean) => void;
       afterRenderer?: (TD: HTMLTableCellElement, row: number, col: number, prop: string | number, value: string, cellProperties: CellProperties) => void;
       afterRowMove?: (startRow: number, endRow: number) => void;


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
According to the [doc](https://handsontable.com/docs/7.4.2/Hooks.html#event:afterRemoveRow), the name of the third parameter should be "physicalRows" instead of "physicalColumns"

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
none AFAIK

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
none AFAIK

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
