### PR TITLE
Fix manualRowResizing issue, Also include the feature support for non-contiguous selected rows

### DIFF
--- a/src/plugins/manualColumnResize/manualColumnResize.js
+++ b/src/plugins/manualColumnResize/manualColumnResize.js
@@ -261,8 +261,15 @@ class ManualColumnResize extends BasePlugin {
           start = to.col;
           end = from.col;
         }
-        rangeEach(start, end, i => this.selectedCols.push(i));
+        rangeEach(start, end, (i) => {
+          if (!this.selectedCols.includes(i)) {
+            this.selectedCols.push(i);
+          }
+        });
       }
+    }
+    if (this.hot.selection.isSelected() && !this.selectedCols.includes(this.currentCol)) {
+      this.selectedCols = [this.currentCol];
     } else {
       this.selectedCols.push(this.currentCol);
     }

--- a/src/plugins/manualColumnResize/manualColumnResize.js
+++ b/src/plugins/manualColumnResize/manualColumnResize.js
@@ -248,23 +248,21 @@ class ManualColumnResize extends BasePlugin {
     this.currentCol = this.hot.columnIndexMapper.getVisualFromRenderableIndex(col);
     this.selectedCols = [];
 
-    if (this.hot.selection.isSelected() && this.hot.selection.isSelectedByColumnHeader()) {
-      const { from, to } = this.hot.getSelectedRangeLast();
-      let start = from.col;
-      let end = to.col;
+    if (this.hot.selection.isSelected()) {
+      const selColumnRange = this.hot.getSelectedRange();
+      for (let key = 0; key < selColumnRange.length; key++) {
+        const from = selColumnRange[key].getTopLeftCorner();
+        const to = selColumnRange[key].getBottomRightCorner();
 
-      if (start >= end) {
-        start = to.col;
-        end = from.col;
-      }
+        let start = from.col;
+        let end = to.col;
 
-      if (this.currentCol >= start && this.currentCol <= end) {
+        if (start >= end) {
+          start = to.col;
+          end = from.col;
+        }
         rangeEach(start, end, i => this.selectedCols.push(i));
-
-      } else {
-        this.selectedCols.push(this.currentCol);
       }
-
     } else {
       this.selectedCols.push(this.currentCol);
     }
@@ -451,6 +449,7 @@ class ManualColumnResize extends BasePlugin {
    */
   onMouseDown(event) {
     if (hasClass(event.target, 'manualColumnResizer')) {
+      this.setupHandlePosition(this.currentTH);
       this.setupGuidePosition();
       this.pressed = true;
 

--- a/src/plugins/manualColumnResize/test/manualColumnResize.e2e.js
+++ b/src/plugins/manualColumnResize/test/manualColumnResize.e2e.js
@@ -708,6 +708,61 @@ describe('manualColumnResize', () => {
     expect($colHeader.offset().top).toBeCloseTo($handle.offset().top, 0);
   });
 
+  it('should resize all columns after selecting all column headers by clicking at top corner header', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(3, 3),
+      rowHeaders: true,
+      colHeaders: true,
+      manualColumnResize: true
+    });
+
+    expect(colWidth(spec().$container, 0)).toBe(50);
+    expect(colWidth(spec().$container, 1)).toBe(50);
+    expect(colWidth(spec().$container, 2)).toBe(50);
+
+    const $cornerHeader = spec().$container.find('.ht_clone_top_left_corner thead tr:eq(0) th:eq(0)');
+    $cornerHeader.simulate('mousedown');
+    $cornerHeader.simulate('mouseup');
+
+    getTopClone().find('thead tr:eq(0) th:eq(1)').simulate('mouseover');
+    const $resizer = spec().$container.find('.manualColumnResizer');
+    const resizerPosition = $resizer.position();
+    $resizer.simulate('mousedown', { clientX: resizerPosition.left });
+    $resizer.simulate('mousemove', { clientX: resizerPosition.left + 30 });
+    $resizer.simulate('mouseup');
+
+    expect(colWidth(spec().$container, 0)).toBe(80);
+    expect(colWidth(spec().$container, 1)).toBe(80);
+    expect(colWidth(spec().$container, 2)).toBe(80);
+  });
+
+  it('should resize all columns after selecting all columns by selecting single cell & hitting CTRL+A', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(3, 3),
+      rowHeaders: true,
+      colHeaders: true,
+      manualColumnResize: true
+    });
+
+    expect(colWidth(spec().$container, 0)).toBe(50);
+    expect(colWidth(spec().$container, 1)).toBe(50);
+    expect(colWidth(spec().$container, 2)).toBe(50);
+
+    selectCell(1, 1);
+    keyDown('ctrl+a');
+
+    getTopClone().find('thead tr:eq(0) th:eq(2)').simulate('mouseover');
+    const $resizer = spec().$container.find('.manualColumnResizer');
+    const resizerPosition = $resizer.position();
+    $resizer.simulate('mousedown', { clientX: resizerPosition.left });
+    $resizer.simulate('mousemove', { clientX: resizerPosition.left + 30 });
+    $resizer.simulate('mouseup');
+
+    expect(colWidth(spec().$container, 0)).toBe(80);
+    expect(colWidth(spec().$container, 1)).toBe(80);
+    expect(colWidth(spec().$container, 2)).toBe(80);
+  });
+
   describe('handle position in a table positioned using CSS\'s `transform`', () => {
     it('should display the handles in the correct position, with holder as a scroll parent', async() => {
       spec().$container.css('transform', 'translate(50px, 120px)');
@@ -837,6 +892,65 @@ describe('manualColumnResize', () => {
       expect(getTopClone().find('thead tr:eq(0) th:eq(11)').width()).toBe(79);
 
       $(window).scrollLeft(0);
+    });
+  });
+
+  describe('contiguous/non-contiguous selected columns resizing in a table', () => {
+    it('should resize (expanding) width of selected contiguous columns', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(10, 50),
+        colHeaders: true,
+        rowHeaders: true,
+        manualColumnResize: true
+      });
+
+      selectColumns(3, 5);
+      getTopClone().find('thead tr:eq(0) th:eq(4)').simulate('mouseover'); // Select 3rd Column
+
+      const $resizer = spec().$container.find('.manualColumnResizer');
+      const resizerPosition = $resizer.position();
+      $resizer.simulate('mousedown', { clientX: resizerPosition.left });
+      $resizer.simulate('mousemove', { clientX: resizerPosition.left + 30 });
+      $resizer.simulate('mouseup');
+
+      expect(colWidth(spec().$container, 2)).toBe(50);
+      expect(colWidth(spec().$container, 3)).toBe(80);
+      expect(colWidth(spec().$container, 4)).toBe(80);
+      expect(colWidth(spec().$container, 5)).toBe(80);
+      expect(colWidth(spec().$container, 6)).toBe(50);
+    });
+
+    it('should resize (expanding) width of selected non-contiguous columns', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(10, 50),
+        colHeaders: true,
+        rowHeaders: true,
+        manualColumnResize: true
+      });
+
+      selectColumns(3);
+      keyDown('ctrl');
+      selectColumns(7);
+      selectColumns(10);
+      keyUp('ctrl');
+      getTopClone().find('thead tr:eq(0) th:eq(11)').simulate('mouseover'); // Select 10th Column
+
+      const $resizer = spec().$container.find('.manualColumnResizer');
+      const resizerPosition = $resizer.position();
+      $resizer.simulate('mousedown', { clientX: resizerPosition.left });
+      $resizer.simulate('mousemove', { clientX: resizerPosition.left + 30 });
+      $resizer.simulate('mouseup');
+
+      expect(colWidth(spec().$container, 2)).toBe(50);
+      expect(colWidth(spec().$container, 3)).toBe(80);
+      expect(colWidth(spec().$container, 4)).toBe(50);
+      expect(colWidth(spec().$container, 5)).toBe(50);
+      expect(colWidth(spec().$container, 6)).toBe(50);
+      expect(colWidth(spec().$container, 7)).toBe(80);
+      expect(colWidth(spec().$container, 8)).toBe(50);
+      expect(colWidth(spec().$container, 9)).toBe(50);
+      expect(colWidth(spec().$container, 10)).toBe(80);
+      expect(colWidth(spec().$container, 11)).toBe(50);
     });
   });
 

--- a/src/plugins/manualRowResize/manualRowResize.js
+++ b/src/plugins/manualRowResize/manualRowResize.js
@@ -207,23 +207,21 @@ class ManualRowResize extends BasePlugin {
     this.currentRow = rowIndexMapper.getVisualFromRenderableIndex(row);
     this.selectedRows = [];
 
-    if (this.hot.selection.isSelected() && this.hot.selection.isSelectedByRowHeader()) {
-      const { from, to } = this.hot.getSelectedRangeLast();
-      let start = from.row;
-      let end = to.row;
+    if (this.hot.selection.isSelected()) {
+      const selRowRange = this.hot.getSelectedRange();
+      for (let key = 0; key < selRowRange.length; key++) {
+        const from = selRowRange[key].getTopLeftCorner();
+        const to = selRowRange[key].getBottomLeftCorner();
 
-      if (start >= end) {
-        start = to.row;
-        end = from.row;
-      }
+        let start = from.row;
+        let end = to.row;
 
-      if (this.currentRow >= start && this.currentRow <= end) {
+        if (start >= end) {
+          start = to.row;
+          end = from.row;
+        }
         rangeEach(start, end, i => this.selectedRows.push(i));
-
-      } else {
-        this.selectedRows.push(this.currentRow);
       }
-
     } else {
       this.selectedRows.push(this.currentRow);
     }
@@ -415,6 +413,7 @@ class ManualRowResize extends BasePlugin {
    */
   onMouseDown(event) {
     if (hasClass(event.target, 'manualRowResizer')) {
+      this.setupHandlePosition(this.currentTH);
       this.setupGuidePosition();
       this.pressed = true;
 

--- a/src/plugins/manualRowResize/manualRowResize.js
+++ b/src/plugins/manualRowResize/manualRowResize.js
@@ -220,8 +220,15 @@ class ManualRowResize extends BasePlugin {
           start = to.row;
           end = from.row;
         }
-        rangeEach(start, end, i => this.selectedRows.push(i));
+        rangeEach(start, end, (i) => {
+          if (!this.selectedRows.includes(i)) {
+            this.selectedRows.push(i);
+          }
+        });
       }
+    }
+    if (this.hot.selection.isSelected() && !this.selectedRows.includes(this.currentRow)) {
+      this.selectedRows = [this.currentRow];
     } else {
       this.selectedRows.push(this.currentRow);
     }

--- a/src/plugins/manualRowResize/test/manualRowResize.e2e.js
+++ b/src/plugins/manualRowResize/test/manualRowResize.e2e.js
@@ -525,6 +525,61 @@ describe('manualRowResize', () => {
     expect($rowsHeaders.eq(3).height()).toEqual(35);
   });
 
+  it('should resize all rows after selecting all row headers by clicking at top corner header', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(3, 3),
+      rowHeaders: true,
+      colHeaders: true,
+      manualRowResize: true
+    });
+
+    expect(getLeftClone().find('tbody tr:eq(0) th:eq(0)').height()).toBe(22);
+    expect(getLeftClone().find('tbody tr:eq(1) th:eq(0)').height()).toBe(22);
+    expect(getLeftClone().find('tbody tr:eq(2) th:eq(0)').height()).toBe(22);
+
+    const $cornerHeader = spec().$container.find('.ht_clone_top_left_corner thead tr:eq(0) th:eq(0)');
+    $cornerHeader.simulate('mousedown');
+    $cornerHeader.simulate('mouseup');
+
+    getLeftClone().find('tbody tr:eq(1) th:eq(0)').simulate('mouseover');
+    const $resizer = spec().$container.find('.manualRowResizer');
+    const resizerPosition = $resizer.position();
+    $resizer.simulate('mousedown', { clientY: resizerPosition.top });
+    $resizer.simulate('mousemove', { clientY: resizerPosition.top + 30 });
+    $resizer.simulate('mouseup');
+
+    expect(getLeftClone().find('tbody tr:eq(0) th:eq(0)').height()).toBe(52);
+    expect(getLeftClone().find('tbody tr:eq(1) th:eq(0)').height()).toBe(52);
+    expect(getLeftClone().find('tbody tr:eq(2) th:eq(0)').height()).toBe(52);
+  });
+
+  it('should resize all rows after selecting all rows by selecting single cell & hitting CTRL+A', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(3, 3),
+      rowHeaders: true,
+      colHeaders: true,
+      manualRowResize: true
+    });
+
+    expect(getLeftClone().find('tbody tr:eq(0) th:eq(0)').height()).toBe(22);
+    expect(getLeftClone().find('tbody tr:eq(1) th:eq(0)').height()).toBe(22);
+    expect(getLeftClone().find('tbody tr:eq(2) th:eq(0)').height()).toBe(22);
+
+    selectCell(1, 1);
+    keyDown('ctrl+a');
+
+    getLeftClone().find('tbody tr:eq(2) th:eq(0)').simulate('mouseover');
+    const $resizer = spec().$container.find('.manualRowResizer');
+    const resizerPosition = $resizer.position();
+    $resizer.simulate('mousedown', { clientY: resizerPosition.top });
+    $resizer.simulate('mousemove', { clientY: resizerPosition.top + 30 });
+    $resizer.simulate('mouseup');
+
+    expect(getLeftClone().find('tbody tr:eq(0) th:eq(0)').height()).toBe(52);
+    expect(getLeftClone().find('tbody tr:eq(1) th:eq(0)').height()).toBe(52);
+    expect(getLeftClone().find('tbody tr:eq(2) th:eq(0)').height()).toBe(52);
+  });
+
   describe('handle position in a table positioned using CSS\'s `transform`', () => {
     it('should display the handles in the correct position, with holder as a scroll parent', async() => {
       spec().$container.css('transform', 'translate(50px, 120px)');
@@ -652,6 +707,63 @@ describe('manualRowResize', () => {
       expect(getLeftClone().find('tbody tr:eq(14) th:eq(0)').height()).toBe(52);
 
       $(window).scrollTop(0);
+    });
+  });
+
+  describe('contiguous/non-contiguous selected rows resizing in a table', () => {
+    it('should resize (expanding) height of selected contiguous rows', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(50, 10),
+        rowHeaders: true,
+        manualRowResize: true
+      });
+
+      selectRows(3, 5);
+      getLeftClone().find('tbody tr:eq(5) th:eq(0)').simulate('mouseover');
+
+      const $resizer = spec().$container.find('.manualRowResizer');
+      const resizerPosition = $resizer.position();
+      $resizer.simulate('mousedown', { clientY: resizerPosition.top });
+      $resizer.simulate('mousemove', { clientY: resizerPosition.top + 30 });
+      $resizer.simulate('mouseup');
+
+      expect(getLeftClone().find('tbody tr:eq(2) th:eq(0)').height()).toBe(22);
+      expect(getLeftClone().find('tbody tr:eq(3) th:eq(0)').height()).toBe(52);
+      expect(getLeftClone().find('tbody tr:eq(4) th:eq(0)').height()).toBe(52);
+      expect(getLeftClone().find('tbody tr:eq(5) th:eq(0)').height()).toBe(52);
+      expect(getLeftClone().find('tbody tr:eq(6) th:eq(0)').height()).toBe(22);
+    });
+
+    it('should resize (expanding) height of selected non-contiguous rows', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(50, 10),
+        rowHeaders: true,
+        manualRowResize: true
+      });
+
+      selectRows(3);
+      keyDown('ctrl');
+      selectRows(7);
+      selectRows(10);
+      keyUp('ctrl');
+      getLeftClone().find('tbody tr:eq(10) th:eq(0)').simulate('mouseover');
+
+      const $resizer = spec().$container.find('.manualRowResizer');
+      const resizerPosition = $resizer.position();
+      $resizer.simulate('mousedown', { clientY: resizerPosition.top });
+      $resizer.simulate('mousemove', { clientY: resizerPosition.top + 30 });
+      $resizer.simulate('mouseup');
+
+      expect(getLeftClone().find('tbody tr:eq(2) th:eq(0)').height()).toBe(22);
+      expect(getLeftClone().find('tbody tr:eq(3) th:eq(0)').height()).toBe(52);
+      expect(getLeftClone().find('tbody tr:eq(4) th:eq(0)').height()).toBe(22);
+      expect(getLeftClone().find('tbody tr:eq(5) th:eq(0)').height()).toBe(22);
+      expect(getLeftClone().find('tbody tr:eq(6) th:eq(0)').height()).toBe(22);
+      expect(getLeftClone().find('tbody tr:eq(7) th:eq(0)').height()).toBe(52);
+      expect(getLeftClone().find('tbody tr:eq(8) th:eq(0)').height()).toBe(22);
+      expect(getLeftClone().find('tbody tr:eq(9) th:eq(0)').height()).toBe(22);
+      expect(getLeftClone().find('tbody tr:eq(10) th:eq(0)').height()).toBe(52);
+      expect(getLeftClone().find('tbody tr:eq(11) th:eq(0)').height()).toBe(22);
     });
   });
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
- Fix for #7139
- Enhance the manualRowResizing feature for non-contiguous rows
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/8414798/89134383-58fbf600-d557-11ea-8d91-bf9f85951ae3.gif)


### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Tested it on some of the demos to ensure that it working properly without affecting others.
Also added an e2e test for the related changes.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7139

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
