### PR TITLE
Information about ObserveChanges deprecation & fix for plugin's docs

### DIFF
--- a/src/dataMap/metaManager/metaSchema.js
+++ b/src/dataMap/metaManager/metaSchema.js
@@ -2789,6 +2789,7 @@ export default () => {
      * @memberof Options#
      * @type {boolean}
      * @default undefined
+     * @deprecated This plugin is deprecated and will be removed in the next major release.
      *
      * @example
      * ```js

--- a/src/plugins/observeChanges/observeChanges.js
+++ b/src/plugins/observeChanges/observeChanges.js
@@ -8,17 +8,18 @@ import { registerPlugin } from './../../plugins';
 
 /**
  * @plugin ObserveChanges
- * @deprecated This plugin is deprecated and will be removed in the next major release.
  *
+ * @deprecated This plugin is deprecated and will be removed in the next major release.
  * @description
  * This plugin allows to observe data source changes. By default, the plugin is declared as `undefined`, which makes it
  * disabled. Enabling this plugin switches the table into one-way data binding where changes are applied into the data
  * source (outside from the table) will be automatically reflected in the table.
  *
+ * @example
  * ```js
  * // as a boolean
  * observeChanges: true,
- * ```.
+ * ```
  *
  * To configure this plugin see {@link Options#observeChanges}.
  */


### PR DESCRIPTION
### Context
Just small adjustment. There was no information about plugin deprecation as @aninde [reported](https://github.com/handsontable/docs/pull/122#pullrequestreview-460715570). What's more site for the plugin hasn't looked the best (see an image below).

<img width="714" alt="Screenshot 2020-08-04 at 16 36 11" src="https://user-images.githubusercontent.com/141330/89306801-a5872480-d670-11ea-8b73-ded076c3012c.png">
