### PR TITLE
Start of the merge area will be shown properly also when first row from the area is hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed an issue where if the first part of the merged area is hidden the value does not show [6871](https://github.com/handsontable/handsontable/issues/6871)
+
 ## [8.0.0] - 2020-08-05
 
 ### Added

--- a/src/plugins/hiddenColumns/test/hiddenColumns.e2e.js
+++ b/src/plugins/hiddenColumns/test/hiddenColumns.e2e.js
@@ -4517,9 +4517,7 @@ describe('HiddenColumns', () => {
       // Merged from visual column index 0 (invisible) to visual column index 3 (visible).
       //                         |        merge         |
       expect(getData()).toEqual([['A1', null, null, null, 'E1']]);
-
-      // TODO: It should work when issue #6871 will be fixed.
-      // expect($(getHtCore()).find('td')[0].innerText).toBe('A1');
+      expect($(getHtCore()).find('td')[0].innerText).toBe('A1');
 
       // Only two columns have been visible from the start.
       expect($(getHtCore())[0].offsetWidth).toBe(100);
@@ -4609,9 +4607,7 @@ describe('HiddenColumns', () => {
       // Merged from visual column index 0 (invisible) to visual column index 4 (invisible).
       //                          |           merge           |
       expect(getData()).toEqual([['A1', null, null, null, null]]);
-
-      // TODO: It should work when issue #6871 will be fixed.
-      // expect($(getHtCore()).find('td')[0].innerText).toBe('A1');
+      expect($(getHtCore()).find('td')[0].innerText).toBe('A1');
 
       // Only two columns have been visible from the start.
       expect($(getHtCore())[0].offsetWidth).toBe(100);
@@ -4695,6 +4691,36 @@ describe('HiddenColumns', () => {
       // Still the same width for the whole table.
       expect($(getHtCore())[0].offsetWidth).toBe(250);
       expect($(getHtCore()).find('td')[1].offsetWidth).toBe(150);
+    });
+
+    // Please keep in mind that this test doesn't fulfil checks for all types of renderers. Change code carefully
+    // when something is failing.
+    it('should show start of the merge area properly also when first column from the area is hidden', () => {
+      handsontable({
+        data: [
+          ['<b>Hello world</b>', 'Hello!', 123, 'not numeric', 'secret', 'not secret']
+        ],
+        columns: [
+          { renderer: 'html' },
+          {},
+          { renderer: 'numeric' },
+          {},
+          { renderer: 'password' },
+          {},
+        ],
+        mergeCells: [
+          { row: 0, col: 0, rowspan: 1, colspan: 2 },
+          { row: 0, col: 2, rowspan: 1, colspan: 2 },
+          { row: 0, col: 4, rowspan: 1, colspan: 2 },
+        ],
+        hiddenColumns: {
+          columns: [0, 2, 4]
+        }
+      });
+
+      expect($(getHtCore()).find('td')[0].innerHTML).toBe('<b>Hello world</b>');
+      expect($(getHtCore()).find('td')[1].innerText).toBe('123');
+      expect($(getHtCore()).find('td')[2].innerText).toBe('******');
     });
 
     it('should select proper cells when calling the `selectCell` within area of merge ' +

--- a/src/plugins/hiddenRows/test/plugins/mergeCells.e2e.js
+++ b/src/plugins/hiddenRows/test/plugins/mergeCells.e2e.js
@@ -102,8 +102,7 @@ describe('HiddenRows', () => {
       //                         ↓        merged data         ↓
       expect(getData()).toEqual([['A1'], [null], [null], [null], ['A5']]);
 
-      // TODO: It should show value from the hidden row?
-      // expect(getHtCore().find('td:eq(0)').text()).toBe('A1');
+      expect(getHtCore().find('td:eq(0)').text()).toBe('A1');
 
       expect(getHtCore().outerHeight()).toBe(47);
       expect(getHtCore().find('td:eq(0)').outerHeight()).toBe(47);
@@ -193,9 +192,7 @@ describe('HiddenRows', () => {
       // Merged from visual row index 0 (invisible) to visual row index 4 (invisible).
       //                         ↓           merged data               ↓
       expect(getData()).toEqual([['A1'], [null], [null], [null], [null]]);
-
-      // TODO: It should show value from the hidden row?
-      // expect(getHtCore().find('td:eq(0)').text()).toBe('A1');
+      expect(getHtCore().find('td:eq(0)').text()).toBe('A1');
 
       expect(getHtCore().outerHeight()).toBe(47);
       expect(getHtCore().find('td:eq(0)').outerHeight()).toBe(47);
@@ -278,6 +275,34 @@ describe('HiddenRows', () => {
       // Still the same height for the whole table.
       expect(getHtCore().outerHeight()).toBe(116);
       expect(getHtCore().find('td:eq(1)').outerHeight()).toBe(69);
+    });
+
+    // Please keep in mind that this test doesn't fulfil checks for all types of renderers. Change code carefully
+    // when something is failing.
+    it('should show start of the merge area properly also when first row from the area is hidden', () => {
+      handsontable({
+        data: [
+          ['<b>Hello world</b>', 123, 'secret'],
+          ['Hello!', 'not numeric', 'secret too']
+        ],
+        columns: [
+          { renderer: 'html' },
+          { renderer: 'numeric' },
+          { renderer: 'password' },
+        ],
+        mergeCells: [
+          { row: 0, col: 0, rowspan: 2, colspan: 1 },
+          { row: 0, col: 1, rowspan: 2, colspan: 1 },
+          { row: 0, col: 2, rowspan: 2, colspan: 1 },
+        ],
+        hiddenRows: {
+          rows: [0]
+        }
+      });
+
+      expect($(getHtCore()).find('td')[0].innerHTML).toBe('<b>Hello world</b>');
+      expect($(getHtCore()).find('td')[1].innerText).toBe('123');
+      expect($(getHtCore()).find('td')[2].innerText).toBe('******');
     });
 
     it('should select proper cells when calling the `selectCell` within area of merge ' +

--- a/src/tableView.js
+++ b/src/tableView.js
@@ -560,9 +560,20 @@ class TableView {
       cellRenderer: (renderedRowIndex, renderedColumnIndex, TD) => {
         const [visualRowIndex, visualColumnIndex] = this
           .translateFromRenderableToVisualIndex(renderedRowIndex, renderedColumnIndex);
-        const cellProperties = this.instance.getCellMeta(visualRowIndex, visualColumnIndex);
-        const prop = this.instance.colToProp(visualColumnIndex);
-        let value = this.instance.getDataAtRowProp(visualRowIndex, prop);
+
+        // Coords may be modified. For example, by the `MergeCells` plugin. It should affect cell value and cell meta.
+        const modifiedCellCoords = this.instance.runHooks('modifyGetCellCoords', visualRowIndex, visualColumnIndex);
+
+        let visualRowToCheck = visualRowIndex;
+        let visualColumnToCheck = visualColumnIndex;
+
+        if (Array.isArray(modifiedCellCoords)) {
+          [visualRowToCheck, visualColumnToCheck] = modifiedCellCoords;
+        }
+
+        const cellProperties = this.instance.getCellMeta(visualRowToCheck, visualColumnToCheck);
+        const prop = this.instance.colToProp(visualColumnToCheck);
+        let value = this.instance.getDataAtRowProp(visualRowToCheck, prop);
 
         if (this.instance.hasHook('beforeValueRender')) {
           value = this.instance.runHooks('beforeValueRender', value, cellProperties);


### PR DESCRIPTION
### Context
We have seen an empty cell for a merged cell when the first part of it was hidden. 

We use `modifyGetCellCoords` more often since `8.0.0` release and one call was missed. It has been done globally in the `TableView`. It should work for [all renderers](https://handsontable.com/docs/8.0.0/demo-custom-renderers.html).

### How has this been tested?
Tested manually with some renderers.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #6871 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
