### PR TITLE
Update the definition file

### DIFF
--- a/handsontable.d.ts
+++ b/handsontable.d.ts
@@ -1801,7 +1801,7 @@ declare namespace Handsontable {
       afterRefreshDimensions?: (previousDimensions: object, currentDimensions: object, stateChanged: boolean) => void;
       afterRemoveCellMeta?: (row: number, column: number, key: string, value: any) => void;
       afterRemoveCol?: (index: number, amount: number, physicalColumns: number[], source?: ChangeSource) => void;
-      afterRemoveRow?: (index: number, amount: number, physicalColumns: number[], source?: ChangeSource) => void;
+      afterRemoveRow?: (index: number, amount: number, physicalRows: number[], source?: ChangeSource) => void;
       afterRender?: (isForced: boolean) => void;
       afterRenderer?: (TD: HTMLTableCellElement, row: number, col: number, prop: string | number, value: string, cellProperties: CellProperties) => void;
       afterRowMove?: (movedRows: number[], finalIndex: number, dropIndex: number | void, movePossible: boolean, orderChanged: boolean) => void;


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
This Pull Request fixes a typo for `afterRemoveRow` hook, where columns where referenced instead of rows.

![Zrzut ekranu 2020-08-7 o 13 02 46](https://user-images.githubusercontent.com/10757813/89639688-529ab080-d8ae-11ea-89e0-88758f36d1d3.png)

The issue has been reported by @happy15 here https://github.com/handsontable/handsontable/pull/7155 but was closed due to the lack of the CLA signature.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations) 

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/7179

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
