### PR TITLE
Add missing jsdoc tag to the Comments plugin

### DIFF
--- a/src/plugins/comments/comments.js
+++ b/src/plugins/comments/comments.js
@@ -27,6 +27,7 @@ const META_READONLY = 'readOnly';
 
 /* eslint-disable jsdoc/require-description-complete-sentence */
 /**
+ * @class Comments
  * @plugin Comments
  *
  * @description


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
In the latest version of documentation the _Comments_ plugin disappears. It'll back after adding the `@class` JSDoc tag to the plugin.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I generated docs after the changes and the plugin showed up.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
