### PR TITLE
Fix undefined for getSelectedRange in the example [DOCS]

### DIFF
--- a/src/plugins/customBorders/customBorders.js
+++ b/src/plugins/customBorders/customBorders.js
@@ -136,9 +136,9 @@ class CustomBorders extends BasePlugin {
    * customBordersPlugin.setBorders([[1, 1, 2, 2], [6, 2, 0, 2]], {left: {width: 2, color: 'blue'}});
    *
    * // Using an array of CellRange objects (produced by `.getSelectedRange()` method).
-   * // You need to select a range first.
+   * //  Selecting a cell range.
    * hot.selectCell(0, 0, 2, 2);
-   * // The range will be returned by the getSelectedRange method
+   * // Returning selected cells' range with the getSelectedRange method and using it.
    * customBordersPlugin.setBorders(hot.getSelectedRange(), {left: {hide: false, width: 2, color: 'blue'}});
    * ```
    *

--- a/src/plugins/customBorders/customBorders.js
+++ b/src/plugins/customBorders/customBorders.js
@@ -138,7 +138,7 @@ class CustomBorders extends BasePlugin {
    * // Using an array of CellRange objects (produced by `.getSelectedRange()` method).
    * //  Selecting a cell range.
    * hot.selectCell(0, 0, 2, 2);
-   * // Returning selected cells' range with the getSelectedRange method and using it.
+   * // Returning selected cells' range with the getSelectedRange method.
    * customBordersPlugin.setBorders(hot.getSelectedRange(), {left: {hide: false, width: 2, color: 'blue'}});
    * ```
    *

--- a/src/plugins/customBorders/customBorders.js
+++ b/src/plugins/customBorders/customBorders.js
@@ -138,7 +138,7 @@ class CustomBorders extends BasePlugin {
    * // Using an array of CellRange objects (produced by `.getSelectedRange()` method).
    * // You need to select a range first.
    * hot.selectCell(0,0,2,2);
-   * // The rangde will be returned by the getSelectedRange method
+   * // The range will be returned by the getSelectedRange method
    * customBordersPlugin.setBorders(hot.getSelectedRange(), {left: {hide: false, width: 2, color: 'blue'}});
    * ```
    *

--- a/src/plugins/customBorders/customBorders.js
+++ b/src/plugins/customBorders/customBorders.js
@@ -134,7 +134,11 @@ class CustomBorders extends BasePlugin {
    *
    * // Using an array of arrays (produced by `.getSelected()` method).
    * customBordersPlugin.setBorders([[1, 1, 2, 2], [6, 2, 0, 2]], {left: {width: 2, color: 'blue'}});
+   *
    * // Using an array of CellRange objects (produced by `.getSelectedRange()` method).
+   * // You need to select a range first.
+   * hot.selectCell(0,0,2,2);
+   * // The rangde will be returned by the getSelectedRange method
    * customBordersPlugin.setBorders(hot.getSelectedRange(), {left: {hide: false, width: 2, color: 'blue'}});
    * ```
    *

--- a/src/plugins/customBorders/customBorders.js
+++ b/src/plugins/customBorders/customBorders.js
@@ -137,7 +137,7 @@ class CustomBorders extends BasePlugin {
    *
    * // Using an array of CellRange objects (produced by `.getSelectedRange()` method).
    * // You need to select a range first.
-   * hot.selectCell(0,0,2,2);
+   * hot.selectCell(0, 0, 2, 2);
    * // The range will be returned by the getSelectedRange method
    * customBordersPlugin.setBorders(hot.getSelectedRange(), {left: {hide: false, width: 2, color: 'blue'}});
    * ```


### PR DESCRIPTION
### Context
Code in the example for custom borders would produce an error. This PR fixes the issue.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] A change in the documentation.

### Related issue(s):
1. https://github.com/handsontable/docs/issues/119

