### PR TITLE
fix the link to nested rows demo [DOCS]

### DIFF
--- a/src/dataMap/metaManager/metaSchema.js
+++ b/src/dataMap/metaManager/metaSchema.js
@@ -2890,7 +2890,7 @@ export default () => {
      * @description
      * Disable or enable the nested rows functionality - displaying nested structures in a two-dimensional data table.
      *
-     * See [quick setup of the Nested rows](https://handsontable.com/docs/demo-nested-rows.html).
+     * See [quick setup of the Nested rows]({@link https://handsontable.com/docs/demo-nested-rows.html}).
      * @example
      * ```js
      * nestedRows: true,


### PR DESCRIPTION
### Context
There was an old link redirecting to nowhere. Fixed that.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] A change in the documentation.

### Related issue(s):
1. https://github.com/handsontable/docs/issues/104

@budnix is it a proper way to link to docs?
