### PR TITLE
Mention disableSelection and isCommand options for context menu [DOCS]

### DIFF
--- a/src/dataMap/metaManager/metaSchema.js
+++ b/src/dataMap/metaManager/metaSchema.js
@@ -1643,6 +1643,10 @@ export default () => {
      * * an array of [predefined options](https://docs.handsontable.com/demo-context-menu.html#page-specific),
      * * an object [with defined structure](https://docs.handsontable.com/demo-context-menu.html#page-custom).
      *
+     * If the value is an object, you can also customize the options with:
+     * * `disableSelection` - a `boolean`, if set to true it prevents mouseover from highlighting the item for selection
+     * * `isCommand` - a `boolean`, if set to false it prevents clicks from executing the command and closing the menu.
+     *
      * See [the context menu demo](https://docs.handsontable.com/demo-context-menu.html) for examples.
      *
      * @memberof Options#


### PR DESCRIPTION
### Context
As the title says; the options were mentioned only in the example down below in https://handsontable.com/docs/8.0.0/demo-context-menu.html. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] A change in the documentation.

### Related issue(s):
https://github.com/handsontable/docs/issues/14
