### PR TITLE
Missing param description [DOCS]

### DIFF
--- a/src/pluginHooks.js
+++ b/src/pluginHooks.js
@@ -874,6 +874,7 @@ const REGISTERED_HOOKS = [
    * @event Hooks#beforeRender
    * @param {boolean} isForced If `true` rendering was triggered by a change of settings or data; or `false` if
    *                           rendering was triggered by scrolling or moving selection.
+   * @param {boolean} skipRender If `true ` the next rendering cycle will be skipped.
    */
   'beforeRender',
 


### PR DESCRIPTION
### Context
As per description form the issue: "Our current description doesn't contain information about a second argument - which allows skipping the next render cycle."

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] A change in the documentation.

### Related issue(s):
https://github.com/handsontable/docs/issues/31