### PR TITLE
Remove misleading info in autoRowSize [DOCS]

### DIFF
--- a/src/dataMap/metaManager/metaSchema.js
+++ b/src/dataMap/metaManager/metaSchema.js
@@ -2294,7 +2294,7 @@ export default () => {
      *
      * @memberof Options#
      * @type {object|boolean}
-     * @default {syncLimit: 500}
+     * @default undefined
      *
      * @example
      * ```js

--- a/src/dataMap/metaManager/metaSchema.js
+++ b/src/dataMap/metaManager/metaSchema.js
@@ -2253,7 +2253,8 @@ export default () => {
     selectOptions: void 0,
 
     /**
-     * Enables or disables the {@link AutoColumnSize} plugin. Default value is `undefined`, which has the same effect as `true`.
+     * Enables or disables the {@link AutoColumnSize} plugin. Default value is `undefined`, which has the same effect as `true`,
+     * meaning, the `syncLimit` is set to 50.
      * Disabling this plugin can increase performance, as no size-related calculations would be done.
      *
      * Column width calculations are divided into sync and async part. Each of those parts has their own advantages and
@@ -2285,6 +2286,8 @@ export default () => {
     /**
      * Enables or disables {@link AutoRowSize} plugin. Default value is `undefined`, which has the same effect as `false`
      * (disabled). Enabling this plugin can decrease performance, as size-related calculations would be performed.
+     *
+     * __Note:__ the default `syncLimit` value is set to 500 when the plugin is manually enabled by declaring it as: `autoRowSize: true`.
      *
      * Row height calculations are divided into sync and async stages. Each of these stages has their own advantages and
      * disadvantages. Synchronous calculations are faster but they block the browser UI, while the slower asynchronous


### PR DESCRIPTION
### Context
There was a mismatch between the description of `autoRowSize` and its `@default`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] A change in the documentation.

### Related issue(s):
https://github.com/handsontable/docs/issues/40