### PR TITLE
afterSetDataAtRowProp more info in the description [DOCS]

### DIFF
--- a/src/pluginHooks.js
+++ b/src/pluginHooks.js
@@ -577,6 +577,7 @@ const REGISTERED_HOOKS = [
 
   /**
    * Fired after cell data was changed.
+   * Caled only when `setDataAtRowProp` was executed.
    *
    * @event Hooks#afterSetDataAtRowProp
    * @param {Array} changes An array of changes in format `[[row, prop, oldValue, value], ...]`.

--- a/src/pluginHooks.js
+++ b/src/pluginHooks.js
@@ -577,7 +577,7 @@ const REGISTERED_HOOKS = [
 
   /**
    * Fired after cell data was changed.
-   * Caled only when `setDataAtRowProp` was executed.
+   * Called only when `setDataAtRowProp` was executed.
    *
    * @event Hooks#afterSetDataAtRowProp
    * @param {Array} changes An array of changes in format `[[row, prop, oldValue, value], ...]`.


### PR DESCRIPTION
### Context
Mention `setDataAtRowProp` execution in the description.
@AMBudnik do you think that's sufficient or should we tell the user more?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] A change in the documentation.

### Related issue(s):
https://github.com/handsontable/docs/issues/51