### PR TITLE
Add a `adjustElementsSize` call after showing columns.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed an issue where if the first part of the merged area was hidden the value did not show [#6871](https://github.com/handsontable/handsontable/issues/6871) along with refactor and bug fix introduced within #6871 PR [#7220](https://github.com/handsontable/handsontable/pull/7220)
-- Fixed an issue where after selecting the top-left element the row range resizing was not possible [#7162](https://github.com/handsontable/handsontable/pull/7162)
+- Fixed an issue where after selecting the top-left element the row range resizing was not possible [#7162](https
+://github.com/handsontable/handsontable/pull/7162)
+- Fixed an issue where the column headers were cut off after hiding and then showing columns using the Hidden Columns
+ plugin. [#6395](https://github.com/handsontable/handsontable/issues/6395)
 
 ### Changed
 - Updated dependencies to meet security requirements [#7222](https://github.com/handsontable/handsontable/pull/7222)

--- a/src/plugins/hiddenColumns/hiddenColumns.js
+++ b/src/plugins/hiddenColumns/hiddenColumns.js
@@ -175,6 +175,9 @@ class HiddenColumns extends BasePlugin {
       });
     }
 
+    // @TODO Should call once per render cycle, currently fired separately in different plugins
+    this.hot.view.wt.wtOverlays.adjustElementsSize();
+
     this.hot.runHooks('afterUnhideColumns', currentHideConfig, destinationHideConfig, isConfigValid,
       isConfigValid && destinationHideConfig.length < currentHideConfig.length);
   }

--- a/src/plugins/hiddenColumns/test/publicAPI.e2e.js
+++ b/src/plugins/hiddenColumns/test/publicAPI.e2e.js
@@ -27,7 +27,9 @@ describe('HiddenColumns', () => {
 
         expect(getCell(0, 1)).toBe(null);
       });
+    });
 
+    describe('showColumn()', () => {
       it('should show column by passing the visual column index', () => {
         handsontable({
           data: Handsontable.helper.createSpreadsheetData(1, 3),
@@ -42,6 +44,29 @@ describe('HiddenColumns', () => {
         render();
 
         expect(getCell(0, 1).innerText).toBe('B1');
+      });
+    });
+
+    describe('showColumns', () => {
+      it('should update the table width, when calling `showColumns` after running `hideColumns` beforehand', () => {
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(5, 7),
+          colHeaders: true,
+          rowHeaders: true,
+          hiddenColumns: {
+            columns: [],
+          },
+        });
+
+        const hot = spec().$container.handsontable('getInstance');
+        const initialHiderWidth = $(hot.view.wt.wtTable.hider).width();
+
+        getPlugin('hiddenColumns').hideColumns([2, 3, 4, 5]);
+        render();
+        getPlugin('hiddenColumns').showColumns([2, 3, 4, 5]);
+        render();
+
+        expect($(hot.view.wt.wtTable.hider).width()).toEqual(initialHiderWidth);
       });
     });
 

--- a/src/plugins/hiddenColumns/test/publicAPI.e2e.js
+++ b/src/plugins/hiddenColumns/test/publicAPI.e2e.js
@@ -58,15 +58,14 @@ describe('HiddenColumns', () => {
           },
         });
 
-        const hot = spec().$container.handsontable('getInstance');
-        const initialHiderWidth = $(hot.view.wt.wtTable.hider).width();
+        const initialHiderWidth = $(hot().view.wt.wtTable.hider).width();
 
         getPlugin('hiddenColumns').hideColumns([2, 3, 4, 5]);
         render();
         getPlugin('hiddenColumns').showColumns([2, 3, 4, 5]);
         render();
 
-        expect($(hot.view.wt.wtTable.hider).width()).toEqual(initialHiderWidth);
+        expect($(hot().view.wt.wtTable.hider).width()).toEqual(initialHiderWidth);
       });
     });
 

--- a/test/scripts/run-puppeteer.js
+++ b/test/scripts/run-puppeteer.js
@@ -58,7 +58,7 @@ const cleanupFactory = (browser, server) => async(exitCode) => {
   page.setCacheEnabled(false);
   page.setViewport({
     width: 1200,
-    height: 1000,
+    height: 1200,
   });
 
   const server = http.createServer(ecstatic({


### PR DESCRIPTION
### Context
The problem in #6395 is caused by the `hider` element not updating its dimensions after hiding -> showing columns. It doesn't happen for rows, as the table height doesn't need to be udpated.

Initially, I tried to do a small refactor for the usage of `adjustElementsSize` (which is annotated with a refactor `TODO` comment in many places), but it turned out the rendering/re-adjusting-elements process is pretty complicated, and it would require more time to make it work for all the plugins (and core features). Additionally, with the eco-renderers coming up, I didn't want to spend too much time on an architecture that would soon be out-of-date.

I ended up adding another `adjustElementsSize` to the plugin (along with the `TODO` comment about a refactor)

**Changes in this PR:**
- Add a `adjustElementsSize` call to the Hidden Columns plugin
- Add a test case
- Expand the default viewport height for the tests (some tests from the Nested Rows plugin randomly failed because of that)

### How has this been tested?
- Added a test case

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #6395
