### PR TITLE
Make the table remove/add the row/column-header-related css classes in updateSettings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed an issue where if the first part of the merged area was hidden the value did not show [#6871](https://github.com/handsontable/handsontable/issues/6871) along with refactor and bug fix introduced within #6871 PR [#7220](https://github.com/handsontable/handsontable/pull/7220)
-- Fixed an issue where after selecting the top-left element the row range resizing was not possible [#7162](https
-://github.com/handsontable/handsontable/pull/7162)
-- Fixed an issue where the column headers were cut off after hiding and then showing columns using the Hidden Columns
- plugin. [#6395](https://github.com/handsontable/handsontable/issues/6395)
-- Fixed an issue where the rows were missing their left border after disabling the row headers using `updateSettings
-`, while there were `fixedColumnsLeft` defined. [#5735](https://github.com/handsontable/handsontable/issues/5735)
+- Fixed an issue where after selecting the top-left element the row range resizing was not possible [#7162](https://github.com/handsontable/handsontable/pull/7162)
+- Fixed an issue where the column headers were cut off after hiding and then showing columns using the Hidden Columns plugin. [#6395](https://github.com/handsontable/handsontable/issues/6395)
+- Fixed an issue where the rows were missing their left border after disabling the row headers using `updateSettings`, while there were `fixedColumnsLeft` defined. [#5735](https://github.com/handsontable/handsontable/issues/5735)
 
 ### Changed
 - Updated dependencies to meet security requirements [#7222](https://github.com/handsontable/handsontable/pull/7222)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ://github.com/handsontable/handsontable/pull/7162)
 - Fixed an issue where the column headers were cut off after hiding and then showing columns using the Hidden Columns
  plugin. [#6395](https://github.com/handsontable/handsontable/issues/6395)
+- Fixed an issue where the rows were missing their left border after disabling the row headers using `updateSettings
+`, while there were `fixedColumnsLeft` defined. [#5735](https://github.com/handsontable/handsontable/issues/5735)
 
 ### Changed
 - Updated dependencies to meet security requirements [#7222](https://github.com/handsontable/handsontable/pull/7222)

--- a/src/core.js
+++ b/src/core.js
@@ -2037,6 +2037,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
     if (!init) {
       if (instance.view) {
         instance.view.wt.wtViewport.resetHasOversizedColumnHeadersMarked();
+        instance.view.wt.exportSettingsAsClassNames();
       }
 
       instance.runHooks('afterUpdateSettings', settings);

--- a/test/e2e/ColHeader.spec.js
+++ b/test/e2e/ColHeader.spec.js
@@ -226,6 +226,30 @@ describe('ColHeader', () => {
 
   });
 
+  it('should remove the column-headers-related css class from the Handsontable container after disabling the' +
+    ' `colHeaders` option using the updateSettings method and add the same css class after re-enabling the option in' +
+    ' the same way', () => {
+    handsontable({
+      startCols: 2,
+      startRows: 2,
+      colHeaders: true
+    });
+
+    expect(hot().rootElement.className).toContain('htColumnHeaders');
+
+    hot().updateSettings({
+      colHeaders: false
+    });
+
+    expect(hot().rootElement.className).not.toContain('htColumnHeaders');
+
+    hot().updateSettings({
+      colHeaders: true
+    });
+
+    expect(hot().rootElement.className).toContain('htColumnHeaders');
+  });
+
   it('should be possible to define colHeaders with a function', () => {
     handsontable({
       startCols: 2,

--- a/test/e2e/RowHeader.spec.js
+++ b/test/e2e/RowHeader.spec.js
@@ -181,6 +181,30 @@ describe('RowHeader', () => {
 
   });
 
+  it('should remove the row-headers-related css class from the Handsontable container after disabling the' +
+    ' `rowHeaders` option using the updateSettings method and add the same css class after re-enabling the option in' +
+    ' the same way', () => {
+    handsontable({
+      startCols: 2,
+      startRows: 2,
+      rowHeaders: true
+    });
+
+    expect(hot().rootElement.className).toContain('htRowHeaders');
+
+    hot().updateSettings({
+      rowHeaders: false
+    });
+
+    expect(hot().rootElement.className).not.toContain('htRowHeaders');
+
+    hot().updateSettings({
+      rowHeaders: true
+    });
+
+    expect(hot().rootElement.className).toContain('htRowHeaders');
+  });
+
   it('should allow defining custom row header width using the rowHeaderWidth config option', () => {
     handsontable({
       startCols: 3,


### PR DESCRIPTION
### Context
The problem in #5735 was caused by `updateSettings` not updating the `rootElement` css classes with the current `rowHeaders`/`colHeaders` state. This PR fixed that.

### How has this been tested?
Added 2 test cases for adding/removing the css classes.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #5735 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
