### PR TITLE
Fix calculation of the number of columns.

### DIFF
--- a/src/3rdparty/walkontable/src/calculator/viewportColumns.js
+++ b/src/3rdparty/walkontable/src/calculator/viewportColumns.js
@@ -125,7 +125,7 @@ class ViewportColumnsCalculator {
       if (calculationType !== FULLY_VISIBLE_TYPE) {
         this.endColumn = i;
       }
-      if (sum >= scrollOffset + viewportWidth) {
+      if (sum > scrollOffset + viewportWidth) {
         needReverse = false;
         break;
       }

--- a/src/3rdparty/walkontable/src/calculator/viewportColumns.js
+++ b/src/3rdparty/walkontable/src/calculator/viewportColumns.js
@@ -125,7 +125,7 @@ class ViewportColumnsCalculator {
       if (calculationType !== FULLY_VISIBLE_TYPE) {
         this.endColumn = i;
       }
-      if (sum > scrollOffset + viewportWidth) {
+      if (sum >= scrollOffset + viewportWidth && viewportWidth !== ViewportColumnsCalculator.DEFAULT_WIDTH) {
         needReverse = false;
         break;
       }

--- a/src/3rdparty/walkontable/test/unit/calculator/viewportColumns.spec.js
+++ b/src/3rdparty/walkontable/test/unit/calculator/viewportColumns.spec.js
@@ -465,4 +465,20 @@ describe('ViewportColumnsCalculator', () => {
     expect(partiallyVisibleCalc.startColumn).toBe(0);
     expect(partiallyVisibleCalc.endColumn).toBe(3);
   });
+
+  it('should render 2 columns when handsontable cell type is set on first column', () => {
+    const options = {
+      viewportSize: 50,
+      scrollOffset: 0,
+      totalItems: 2,
+      itemSizeFn: () => 50,
+      overrideFn: void 0,
+      stretchMode: 'none',
+      stretchingItemWidthFn: void 0,
+    };
+    const renderedCalc = new ViewportColumnsCalculator({ ...options, calculationType: RENDER_TYPE });
+    expect(renderedCalc.startColumn).toBe(0);
+    expect(renderedCalc.endColumn).toBe(1);
+    expect(renderedCalc.count).toBe(2);
+  });
 });


### PR DESCRIPTION
Fix #7217

### Context
<!--- Why is this change required? What problem does it solve? -->
The `calculate()` function did not take into account the second column of the handsontable type.

This is related to the fact that for the first column 
`columnWidth` === `viewportWidth`

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7217

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
