### PR TITLE
Update .ts file with missing option for OperationType type

### DIFF
--- a/handsontable.d.ts
+++ b/handsontable.d.ts
@@ -404,14 +404,14 @@ declare namespace Handsontable {
   namespace plugins {
     // utils for Filters
     namespace FiltersPlugin {
-      type OperationType = 'conjunction' | 'disjunction' | undefined;
+      type OperationType = 'conjunction' | 'disjunction';
       type ConditionName = 'begins_with' | 'between' | 'by_value' | 'contains' | 'empty' | 'ends_with' | 'eq' | 'gt' |
         'gte' | 'lt' | 'lte' | 'not_between' | 'not_contains' | 'not_empty' | 'neq';
 
       type ColumnConditions = {
         column: number;
         conditions: Handsontable.plugins.FiltersPlugin.ConditionId[];
-        operation: Handsontable.plugins.FiltersPlugin.OperationType;
+        operation?: Handsontable.plugins.FiltersPlugin.OperationType;
       }
 
       interface ConditionId {

--- a/handsontable.d.ts
+++ b/handsontable.d.ts
@@ -404,7 +404,7 @@ declare namespace Handsontable {
   namespace plugins {
     // utils for Filters
     namespace FiltersPlugin {
-      type OperationType = 'conjunction' | 'disjunction';
+      type OperationType = 'conjunction' | 'disjunction' | undefined;
       type ConditionName = 'begins_with' | 'between' | 'by_value' | 'contains' | 'empty' | 'ends_with' | 'eq' | 'gt' |
         'gte' | 'lt' | 'lte' | 'not_between' | 'not_contains' | 'not_empty' | 'neq';
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
This pull request adds an ability for `OperationType` type of the `FiltersPlugin` namespace to be `undefined`.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Details on the reproduction of a missing option are described by https://github.com/handsontable/handsontable/issues/7244

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/7244

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
