### PR TITLE
Fixed an issue where redundant row has been added during copy/paste operations in some case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed an issue where if the first part of the merged area was hidden the value did not show [#6871](https://github.com/handsontable/handsontable/issues/6871) along with refactor and bug fix introduced within #6871 PR [#7220](https://github.com/handsontable/handsontable/pull/7220)
-- Fixed an issue where after selecting the top-left element the row range resizing was not possible [#7162](https
-://github.com/handsontable/handsontable/pull/7162)
-- Fixed an issue where the column headers were cut off after hiding and then showing columns using the Hidden Columns
- plugin. [#6395](https://github.com/handsontable/handsontable/issues/6395)
+- Fixed an issue where after selecting the top-left element the row range resizing was not possible [#7162](https://github.com/handsontable/handsontable/pull/7162)
+- Fixed an issue where the column headers were cut off after hiding and then showing columns using the Hidden Columns plugin. [#6395](https://github.com/handsontable/handsontable/issues/6395)
 
 ### Changed
 - Updated dependencies to meet security requirements [#7222](https://github.com/handsontable/handsontable/pull/7222)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue where if the first part of the merged area was hidden the value did not show [#6871](https://github.com/handsontable/handsontable/issues/6871) along with refactor and bug fix introduced within #6871 PR [#7220](https://github.com/handsontable/handsontable/pull/7220)
 - Fixed an issue where after selecting the top-left element the row range resizing was not possible [#7162](https://github.com/handsontable/handsontable/pull/7162)
 - Fixed an issue where the column headers were cut off after hiding and then showing columns using the Hidden Columns plugin. [#6395](https://github.com/handsontable/handsontable/issues/6395)
+- Fixed an issue where redundant row has been added during copy/paste operations in some case [#5961](https://github.com/handsontable/handsontable/issues/5961)
 
 ### Changed
 - Updated dependencies to meet security requirements [#7222](https://github.com/handsontable/handsontable/pull/7222)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue where after selecting the top-left element the row range resizing was not possible [#7162](https://github.com/handsontable/handsontable/pull/7162)
 - Fixed an issue where the column headers were cut off after hiding and then showing columns using the Hidden Columns plugin. [#6395](https://github.com/handsontable/handsontable/issues/6395)
 - Fixed an issue where redundant row has been added during copy/paste operations in some case [#5961](https://github.com/handsontable/handsontable/issues/5961)
+- Fixed an issue where too many values have been pasted when column was hidden [#6743](https://github.com/handsontable/handsontable/issues/6743)
 - Fixed a bug, where trying to move collapsed parent rows with the Nested Rows plugin enabled threw an error. [#7132](https://github.com/handsontable/handsontable/issues/7132)
 
 ### Changed

--- a/src/plugins/copyPaste/test/copyPaste.e2e.js
+++ b/src/plugins/copyPaste/test/copyPaste.e2e.js
@@ -836,5 +836,45 @@ describe('CopyPaste', () => {
       expect(getDataAtCell(1, 1)).toEqual(null);
       expect(getDataAtCell(1, 2)).toEqual('C2');
     });
+
+    it('should populate data just within selection - there was bug #5961', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(10, 10),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenRows: {
+          copyPasteEnabled: false,
+          rows: [1, 2]
+        },
+        hiddenColumns: {
+          copyPasteEnabled: false,
+          columns: [4, 5]
+        },
+      });
+
+      const copyEvent = getClipboardEvent();
+      const plugin = getPlugin('CopyPaste');
+
+      selectCell(0, 0, 9, 0);
+
+      plugin.onCopy(copyEvent);
+
+      selectColumns(1, 9);
+
+      plugin.onPaste(copyEvent);
+
+      expect(getData()).toEqual([
+        ['A1', 'A1', 'A1', 'A1', 'E1', 'F1', 'A1', 'A1', 'A1', 'A1'],
+        ['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2', 'H2', 'I2', 'J2'],
+        ['A3', 'B3', 'C3', 'D3', 'E3', 'F3', 'G3', 'H3', 'I3', 'J3'],
+        ['A4', 'A4', 'A4', 'A4', 'E4', 'F4', 'A4', 'A4', 'A4', 'A4'],
+        ['A5', 'A5', 'A5', 'A5', 'E5', 'F5', 'A5', 'A5', 'A5', 'A5'],
+        ['A6', 'A6', 'A6', 'A6', 'E6', 'F6', 'A6', 'A6', 'A6', 'A6'],
+        ['A7', 'A7', 'A7', 'A7', 'E7', 'F7', 'A7', 'A7', 'A7', 'A7'],
+        ['A8', 'A8', 'A8', 'A8', 'E8', 'F8', 'A8', 'A8', 'A8', 'A8'],
+        ['A9', 'A9', 'A9', 'A9', 'E9', 'F9', 'A9', 'A9', 'A9', 'A9'],
+        ['A10', 'A10', 'A10', 'A10', 'E10', 'F10', 'A10', 'A10', 'A10', 'A10'],
+      ]);
+    });
   });
 });

--- a/src/plugins/copyPaste/test/copyPaste.e2e.js
+++ b/src/plugins/copyPaste/test/copyPaste.e2e.js
@@ -875,6 +875,14 @@ describe('CopyPaste', () => {
         ['A9', 'A9', 'A9', 'A9', 'E9', 'F9', 'A9', 'A9', 'A9', 'A9'],
         ['A10', 'A10', 'A10', 'A10', 'E10', 'F10', 'A10', 'A10', 'A10', 'A10'],
       ]);
+
+      expect(getSelected()).toEqual([[0, 1, 9, 9]]);
+      expect(getSelectedRangeLast().highlight.row).toBe(0);
+      expect(getSelectedRangeLast().highlight.col).toBe(1);
+      expect(getSelectedRangeLast().from.row).toBe(0);
+      expect(getSelectedRangeLast().from.col).toBe(1);
+      expect(getSelectedRangeLast().to.row).toBe(9);
+      expect(getSelectedRangeLast().to.col).toBe(9);
     });
   });
 });

--- a/src/plugins/hiddenColumns/test/plugins/copyPaste.e2e.js
+++ b/src/plugins/hiddenColumns/test/plugins/copyPaste.e2e.js
@@ -211,5 +211,42 @@ describe('hiddenColumns', () => {
         |   :   :   :   :   :   |
         `).toBeMatchToSelectionPattern();
     });
+
+    it('should paste data properly when populating data within a selection in specific case #6743', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        hiddenColumns: {
+          columns: [1],
+          copyPasteEnabled: false,
+        },
+      });
+
+      const copyEvent = getClipboardEvent();
+      const plugin = getPlugin('CopyPaste');
+
+      selectCell(0, 0, 0, 0);
+
+      plugin.onCopy(copyEvent);
+
+      selectCell(0, 0, 0, 2);
+
+      plugin.onPaste(copyEvent);
+
+      expect(getData()).toEqual([
+        ['A1', 'B1', 'A1', 'D1', 'E1'],
+        ['A2', 'B2', 'C2', 'D2', 'E2'],
+        ['A3', 'B3', 'C3', 'D3', 'E3'],
+        ['A4', 'B4', 'C4', 'D4', 'E4'],
+        ['A5', 'B5', 'C5', 'D5', 'E5'],
+      ]);
+
+      expect(getSelected()).toEqual([[0, 0, 0, 2]]);
+      expect(getSelectedRangeLast().highlight.row).toBe(0);
+      expect(getSelectedRangeLast().highlight.col).toBe(0);
+      expect(getSelectedRangeLast().from.row).toBe(0);
+      expect(getSelectedRangeLast().from.col).toBe(0);
+      expect(getSelectedRangeLast().to.row).toBe(0);
+      expect(getSelectedRangeLast().to.col).toBe(2);
+    });
   });
 });

--- a/src/plugins/hiddenRows/test/plugins/copyPaste.e2e.js
+++ b/src/plugins/hiddenRows/test/plugins/copyPaste.e2e.js
@@ -236,5 +236,42 @@ describe('HiddenRows', () => {
         |   :   :   |
         `).toBeMatchToSelectionPattern();
     });
+
+    it('should paste data properly when populating data within a selection in specific case #6743', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        hiddenRows: {
+          rows: [1],
+          copyPasteEnabled: false,
+        },
+      });
+
+      const copyEvent = getClipboardEvent();
+      const plugin = getPlugin('CopyPaste');
+
+      selectCell(0, 0, 0, 0);
+
+      plugin.onCopy(copyEvent);
+
+      selectCell(0, 0, 2, 0);
+
+      plugin.onPaste(copyEvent);
+
+      expect(getData()).toEqual([
+        ['A1', 'B1', 'C1', 'D1', 'E1'],
+        ['A2', 'B2', 'C2', 'D2', 'E2'],
+        ['A1', 'B3', 'C3', 'D3', 'E3'],
+        ['A4', 'B4', 'C4', 'D4', 'E4'],
+        ['A5', 'B5', 'C5', 'D5', 'E5'],
+      ]);
+
+      expect(getSelected()).toEqual([[0, 0, 2, 0]]);
+      expect(getSelectedRangeLast().highlight.row).toBe(0);
+      expect(getSelectedRangeLast().highlight.col).toBe(0);
+      expect(getSelectedRangeLast().from.row).toBe(0);
+      expect(getSelectedRangeLast().from.col).toBe(0);
+      expect(getSelectedRangeLast().to.row).toBe(2);
+      expect(getSelectedRangeLast().to.col).toBe(0);
+    });
   });
 });


### PR DESCRIPTION
### Context
We try to act like Google Spreadsheet for the case described in the issue. However, there was a bug. I've totally rewritten the logic of `populateValues` method. So far, it has been assuming in advance whether selection or populated data is bigger (we try just populate data or repeat it within a selection.

I removed this part of the code as it's impossible to assume the above relationship before checking whether some cells have `skipRowOnPaste`/`skipColumnOnPaste` option defined as `true`.

### How has this been tested?
CopyPaste plugin enabled and option `copyPasteEnabled` set for `HiddenRows` and `HiddenColumns` plugins. Tested also with `maxRows` and `maxCols` option to check whether introduced `while` isn't problematic.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #5961
2. #6743

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
