### PR TITLE
Get rid of an error when trying to move collapsed parent rows.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed an issue where if the first part of the merged area was hidden the value did not show [#6871](https://github.com/handsontable/handsontable/issues/6871) along with refactor and bug fix introduced within #6871 PR [#7220](https://github.com/handsontable/handsontable/pull/7220)
-- Fixed an issue where after selecting the top-left element the row range resizing was not possible [#7162](https
-://github.com/handsontable/handsontable/pull/7162)
-- Fixed an issue where the column headers were cut off after hiding and then showing columns using the Hidden Columns
- plugin. [#6395](https://github.com/handsontable/handsontable/issues/6395)
+- Fixed an issue where after selecting the top-left element the row range resizing was not possible [#7162](https://github.com/handsontable/handsontable/pull/7162)
+- Fixed an issue where the column headers were cut off after hiding and then showing columns using the Hidden Columns plugin. [#6395](https://github.com/handsontable/handsontable/issues/6395)
+- Fixed a bug, where trying to move collapsed parent rows with the Nested Rows plugin enabled threw an error. [#7132](https://github.com/handsontable/handsontable/issues/7132)
 
 ### Changed
 - Updated dependencies to meet security requirements [#7222](https://github.com/handsontable/handsontable/pull/7222)

--- a/src/plugins/nestedRows/nestedRows.js
+++ b/src/plugins/nestedRows/nestedRows.js
@@ -166,9 +166,10 @@ class NestedRows extends BasePlugin {
     // We can't move rows when any of them is a parent or a top-level element
     for (i = 0; i < rowsLen; i++) {
       const rowIndex = rows[i];
-      translatedStartIndexes.push(this.dataManager.translateTrimmedRow(rowIndex));
+      const translatedStartIndex = this.dataManager.translateTrimmedRow(rowIndex);
+      translatedStartIndexes.push(translatedStartIndex);
 
-      if (this.dataManager.isParent(rowIndex) || this.dataManager.isRowHighestLevel(rowIndex)) {
+      if (this.dataManager.isParent(translatedStartIndex) || this.dataManager.isRowHighestLevel(translatedStartIndex)) {
         allowMove = false;
       }
     }

--- a/src/plugins/nestedRows/nestedRows.js
+++ b/src/plugins/nestedRows/nestedRows.js
@@ -167,6 +167,7 @@ class NestedRows extends BasePlugin {
     for (i = 0; i < rowsLen; i++) {
       const rowIndex = rows[i];
       const translatedStartIndex = this.dataManager.translateTrimmedRow(rowIndex);
+      
       translatedStartIndexes.push(translatedStartIndex);
 
       if (this.dataManager.isParent(translatedStartIndex) || this.dataManager.isRowHighestLevel(translatedStartIndex)) {

--- a/src/plugins/nestedRows/test/nestedRows.e2e.js
+++ b/src/plugins/nestedRows/test/nestedRows.e2e.js
@@ -87,7 +87,8 @@ describe('NestedRows', () => {
       expect(getDataAtCell(2, 0)).toEqual('a0-a1');
     });
 
-    it('should not move rows when any of them is a parent', () => {
+    it('should not move rows when any of them is a parent, regardless of if it\'s collapsed or not (and not throw any' +
+      ' errors in the process)', () => {
       handsontable({
         data: getMoreComplexNestedData(),
         nestedRows: true,
@@ -95,13 +96,37 @@ describe('NestedRows', () => {
         rowHeaders: true
       });
 
-      getPlugin('manualRowMove').dragRows([0, 1], 2);
+      let errorCount = 0;
+
+      try {
+        getPlugin('manualRowMove').dragRows([0, 1], 2);
+
+        expect(getData()).toEqual(dataInOrder);
+
+        getPlugin('manualRowMove').dragRows([1, 0], 2);
+
+        expect(getData()).toEqual(dataInOrder);
+
+      } catch (err) {
+        errorCount += 1;
+      }
+
+      hot().getPlugin('nestedRows').collapsingUI.collapseChildren(0);
+      hot().getPlugin('nestedRows').collapsingUI.collapseChildren(8);
+
+      try {
+        getPlugin('manualRowMove').dragRows([1], 2);
+
+      } catch (err) {
+        errorCount += 1;
+      }
+
+      hot().getPlugin('nestedRows').collapsingUI.expandChildren(0);
+      hot().getPlugin('nestedRows').collapsingUI.expandChildren(8);
 
       expect(getData()).toEqual(dataInOrder);
 
-      getPlugin('manualRowMove').dragRows([1, 0], 2);
-
-      expect(getData()).toEqual(dataInOrder);
+      expect(errorCount).toEqual(0);
     });
 
     it('should not move rows when they are on the highest level of nesting (don\'t have a parent)', () => {
@@ -270,7 +295,8 @@ describe('NestedRows', () => {
       expect(getDataAtCell(7, 0)).toEqual('a0-a0');
     });
 
-    it('should not move row whether there was a try of moving it on the row being a parent and it has no rows above', () => {
+    it('should not move any rows, when trying to move a row above a parent, when the parent is the first row in the' +
+      ' table', () => {
       handsontable({
         data: getMoreComplexNestedData(),
         nestedRows: true,
@@ -315,7 +341,6 @@ describe('NestedRows', () => {
       expect(getSelectedLast()).toEqual([6, 0, 6, 3]);
     });
 
-    // TODO: This test sometimes fail in the browser?
     it('should move single row between parents properly (moving from the bottom to the top)', () => {
       handsontable({
         data: getSimplerNestedData(),


### PR DESCRIPTION
### Context
Logic for recognizing parent rows while moving them was broken in the Nested Rows plugin, which caused an error to be thrown in some specific cases.

### How has this been tested?
Extended a test case with error recognition.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7132 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
