### PR TITLE
ColumnSummary should not throw an error after column/row alteration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ://github.com/handsontable/handsontable/pull/7162)
 - Fixed an issue where the column headers were cut off after hiding and then showing columns using the Hidden Columns
  plugin. [#6395](https://github.com/handsontable/handsontable/issues/6395)
+- Fixed an issue where after column or row alteration, Handsontable threw an error if ColumnSummary was enabled without defined rows ranges [#7174](https://github.com/handsontable/handsontable/pull/7174)
 
 ### Changed
 - Updated dependencies to meet security requirements [#7222](https://github.com/handsontable/handsontable/pull/7222)

--- a/src/plugins/columnSummary/endpoints.js
+++ b/src/plugins/columnSummary/endpoints.js
@@ -497,10 +497,12 @@ class Endpoints {
       this.hot.toVisualColumn(endpoint.destinationColumn)
     ];
 
-    // Clear the meta on the "old" indexes
-    const cellMeta = this.hot.getCellMeta(visualRowIndex, visualColumnIndex);
-    cellMeta.readOnly = false;
-    cellMeta.className = '';
+    if (visualColumnIndex !== null && visualRowIndex !== null) {
+      // Clear the meta on the "old" indexes
+      const cellMeta = this.hot.getCellMeta(visualRowIndex, visualColumnIndex);
+      cellMeta.readOnly = false;
+      cellMeta.className = '';
+    }
 
     this.cellsToSetCache.push([
       this.hot.toVisualRow(endpoint.destinationRow + (useOffset ? alterRowOffset : 0)),
@@ -527,14 +529,18 @@ class Endpoints {
       return;
     }
 
-    const cellMeta = this.hot.getCellMeta(
-      this.hot.toVisualRow(endpoint.destinationRow + reverseRowOffset),
-      endpoint.destinationColumn + reverseColOffset
-    );
+    const destinationVisualRow = this.hot.toVisualRow(endpoint.destinationRow + reverseRowOffset);
 
-    if (source === 'init' || cellMeta.readOnly !== endpoint.readOnly) {
-      cellMeta.readOnly = endpoint.readOnly;
-      cellMeta.className = 'columnSummaryResult';
+    if (destinationVisualRow !== null) {
+      const cellMeta = this.hot.getCellMeta(
+        destinationVisualRow,
+        endpoint.destinationColumn + reverseColOffset
+      );
+
+      if (source === 'init' || cellMeta.readOnly !== endpoint.readOnly) {
+        cellMeta.readOnly = endpoint.readOnly;
+        cellMeta.className = 'columnSummaryResult';
+      }
     }
 
     if (endpoint.roundFloat && !isNaN(endpoint.result)) {

--- a/src/plugins/columnSummary/test/columnSummary.e2e.js
+++ b/src/plugins/columnSummary/test/columnSummary.e2e.js
@@ -474,6 +474,42 @@ describe('ColumnSummarySpec', () => {
       expect(getCellMeta(0, 2).readOnly).toEqual(true);
     });
 
+    describe('if range is undefined', () => {
+      it('should not throw an error if removing column', () => {
+        const hot = handsontable({
+          data: createNumericData(3, 3),
+          height: 200,
+          width: 200,
+          columnSummary: [{
+            destinationRow: 2,
+            destinationColumn: 2,
+            type: 'sum'
+          }],
+        });
+
+        expect(() => {
+          hot.alter('remove_col', 0, 1);
+        }).not.toThrow();
+      });
+
+      it('should not throw an error if removing row', () => {
+        const hot = handsontable({
+          data: createNumericData(3, 3),
+          height: 200,
+          width: 200,
+          columnSummary: [{
+            destinationRow: 2,
+            destinationColumn: 2,
+            type: 'sum'
+          }],
+        });
+
+        expect(() => {
+          hot.alter('remove_row', 0, 1);
+        }).not.toThrow();
+      });
+    });
+
     it('should modify the calculation row range when a row was moved outside the range', () => {
       const hot = handsontable({
         data: createNumericData(40, 40),


### PR DESCRIPTION
### Context
Changes in this PR fixes a regression which was introduced in v8. If the user used ColumnSorting without defined ranges, after column or row alteration, then the table threw an error.

Fix will not solve the rest of the ColumnSummary-related issues like miscalculated value after alterations.

### How has this been tested?
1. Use the following configuration:
```
const hot = new Handsontable(container, {
    data: [
        [1, 2],
        [3, 4],
        []
    ],
    columnSummary: [{
        destinationRow: 2,
        destinationColumn: 1,
        type: 'sum'
    }],
     type: 'numeric',
});
2. Remove first row: `hot.alter('remove_row', 0, 1)`

Expected result: no errors after remove
```

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. #7174
