### PR TITLE
Removed trailing whitespaces in NestedRows file

### DIFF
--- a/src/plugins/nestedRows/nestedRows.js
+++ b/src/plugins/nestedRows/nestedRows.js
@@ -167,7 +167,7 @@ class NestedRows extends BasePlugin {
     for (i = 0; i < rowsLen; i++) {
       const rowIndex = rows[i];
       const translatedStartIndex = this.dataManager.translateTrimmedRow(rowIndex);
-      
+
       translatedStartIndexes.push(translatedStartIndex);
 
       if (this.dataManager.isParent(translatedStartIndex) || this.dataManager.isRowHighestLevel(translatedStartIndex)) {


### PR DESCRIPTION
### Context
The change removes trailing spaces in `nestedRows.js` file - accidentally introduced in #7248.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
It's just a polishing to the non-released changes.

### Related issue(s):
1. #7248

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
