### PR TITLE
Fixed an issue where using updateSettings() has been breaking column sorting in specific cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added e2e tests and reorganized already existing ones [#6491](https://github.com/handsontable/handsontable/issues/6491)
 
 ### Fixed
-- Fixed an issue where if the first part of the merged area was hidden the value did not show [#6871](https://github.com/handsontable/handsontable/issues/6871) along with refactor and bug fix introduced within #6871 PR [#7220](https://github.com/handsontable/handsontable/pull/7220)
-- Fixed an issue where after selecting the top-left element the row range resizing was not possible [#7162](https://github.com/handsontable/handsontable/pull/7162)
+- Fixed an issue where if the first part of the merged area was hidden the value did not show [#6871](https://github.com/handsontable/handsontable/issues/6871)
+- Fixed an issue where after selecting the top-left element the row range resizing was not possible [#7162](https://github.com/handsontable/handsontable/pull/7162) along with refactor and bug fix introduced within #6871 PR [#7220](https://github.com/handsontable/handsontable/pull/7220)
 - Fixed an issue where the column headers were cut off after hiding and then showing columns using the Hidden Columns plugin. [#6395](https://github.com/handsontable/handsontable/issues/6395)
 - Fixed an issue where redundant row has been added during copy/paste operations in some case [#5961](https://github.com/handsontable/handsontable/issues/5961)
 - Fixed an issue where too many values have been pasted when column was hidden [#6743](https://github.com/handsontable/handsontable/issues/6743)
 - Fixed a bug, where trying to move collapsed parent rows with the Nested Rows plugin enabled threw an error. [#7132](https://github.com/handsontable/handsontable/issues/7132)
+- Fixed an issue where using updateSettings() has been breaking column sorting in specific cases
 
 ### Changed
 - Updated dependencies to meet security requirements [#7222](https://github.com/handsontable/handsontable/pull/7222)

--- a/src/plugins/columnSorting/columnSorting.js
+++ b/src/plugins/columnSorting/columnSorting.js
@@ -715,7 +715,8 @@ class ColumnSorting extends BasePlugin {
     super.onUpdateSettings();
 
     if (this.columnMetaCache !== null) {
-      this.columnMetaCache.init(this.hot.countSourceCols());
+      // Column meta cache base on settings, thus we should re-init the map.
+      this.columnMetaCache.init(this.hot.columnIndexMapper.getNumberOfIndexes());
     }
 
     if (isDefined(newSettings[this.pluginKey])) {

--- a/src/plugins/columnSorting/test/columnSorting.e2e.js
+++ b/src/plugins/columnSorting/test/columnSorting.e2e.js
@@ -2651,5 +2651,19 @@ describe('ColumnSorting', () => {
 
       expect(getHtCore().find('tbody tr:eq(0) td').length).toEqual(7);
     });
+
+    it('should not break sorting with UI after `updateSettings` call #7228', () => {
+      const onErrorSpy = spyOn(window, 'onerror');
+
+      handsontable({
+        columns: [{}, {}, {}, {}, {}, {}],
+        columnSorting: true,
+        colHeaders: true
+      });
+
+      updateSettings({});
+
+      expect(onErrorSpy).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/plugins/multiColumnSorting/test/multiColumnSorting.e2e.js
+++ b/src/plugins/multiColumnSorting/test/multiColumnSorting.e2e.js
@@ -2924,5 +2924,19 @@ describe('MultiColumnSorting', () => {
 
       expect(getHtCore().find('tbody tr:eq(0) td').length).toEqual(7);
     });
+
+    it('should not break sorting with UI after `updateSettings` call #7228', () => {
+      const onErrorSpy = spyOn(window, 'onerror');
+
+      handsontable({
+        columns: [{}, {}, {}, {}, {}, {}],
+        multiColumnSorting: true,
+        colHeaders: true
+      });
+
+      updateSettings({});
+
+      expect(onErrorSpy).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
### Context
There was re-initialization of the column meta cache which hasn't taken into account the fact that `columns` property expand the displayed dataset. A callback for `afterGetColHeader` hook tried to get meta related to the indicator from a not existing element in the map.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7228 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
