### PR TITLE
Fix infinite loop while scrolling the table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug, where trying to move collapsed parent rows with the Nested Rows plugin enabled threw an error. [#7132](https://github.com/handsontable/handsontable/issues/7132)
 - Fixed an issue where using updateSettings() has been breaking column sorting in specific cases [#7228](https://github.com/handsontable/handsontable/issues/7228)
 - Fixed an issue where the rows were missing their left border after disabling the row headers using `updateSettings`, while there were `fixedColumnsLeft` defined. [#5735](https://github.com/handsontable/handsontable/issues/5735)
-- Fixed an issue where the Handsontable could fall into an infinite loop during vertical scrolling. It happens only when the scrollable element was the `window` object [#7260](https://github.com/handsontable/handsontable/issues/7260);
+- Fixed an issue where the Handsontable could fall into an infinite loop during vertical scrolling. It only happened when the scrollable element was the `window` object. [#7260](https://github.com/handsontable/handsontable/issues/7260);
 
 ### Changed
 - Updated dependencies to meet security requirements [#7222](https://github.com/handsontable/handsontable/pull/7222)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug, where trying to move collapsed parent rows with the Nested Rows plugin enabled threw an error. [#7132](https://github.com/handsontable/handsontable/issues/7132)
 - Fixed an issue where using updateSettings() has been breaking column sorting in specific cases [#7228](https://github.com/handsontable/handsontable/issues/7228)
 - Fixed an issue where the rows were missing their left border after disabling the row headers using `updateSettings`, while there were `fixedColumnsLeft` defined. [#5735](https://github.com/handsontable/handsontable/issues/5735)
+- Fixed an issue where the Handsontable could fall into an infinite loop during vertical scrolling. It happens only when the scrollable element was the `window` object [#7260](https://github.com/handsontable/handsontable/issues/7260);
 
 ### Changed
 - Updated dependencies to meet security requirements [#7222](https://github.com/handsontable/handsontable/pull/7222)

--- a/src/3rdparty/walkontable/src/overlay/bottom.js
+++ b/src/3rdparty/walkontable/src/overlay/bottom.js
@@ -350,19 +350,6 @@ class BottomOverlay extends Overlay {
         removeClass(masterParent, 'innerBorderBottom');
         positionChanged = previousState;
       }
-
-      if (!previousState && position || previousState && !position) {
-        this.wot.wtOverlays.adjustElementsSize();
-      }
-    }
-
-    // nasty workaround for double border in the header, TODO: find a pure-css solution
-    if (this.wot.getSetting('rowHeaders').length === 0) {
-      const secondHeaderCell = this.clone.wtTable.THEAD.querySelector('th:nth-of-type(2)');
-
-      if (secondHeaderCell) {
-        secondHeaderCell.style['border-left-width'] = 0;
-      }
     }
 
     return positionChanged;

--- a/src/3rdparty/walkontable/src/overlay/left.js
+++ b/src/3rdparty/walkontable/src/overlay/left.js
@@ -332,10 +332,6 @@ class LeftOverlay extends Overlay {
         removeClass(masterParent, 'innerBorderLeft');
         positionChanged = previousState;
       }
-
-      if (!previousState && position || previousState && !position) {
-        this.wot.wtOverlays.adjustElementsSize();
-      }
     }
 
     return positionChanged;

--- a/src/3rdparty/walkontable/src/table.js
+++ b/src/3rdparty/walkontable/src/table.js
@@ -360,6 +360,7 @@ class Table {
         // remove `innerBorderTop` and `innerBorderLeft` CSS classes to the DOM element. This happens
         // when there is a switch between rendering from 0 to N rows/columns and vice versa).
         wtOverlays.refreshAll();
+        wtOverlays.adjustElementsSize();
       }
     }
 

--- a/src/3rdparty/walkontable/test/spec/overlay.spec.js
+++ b/src/3rdparty/walkontable/test/spec/overlay.spec.js
@@ -20,7 +20,7 @@ describe('WalkontableOverlay', () => {
     this.wotInstance.destroy();
   });
 
-  it('cloned overlays have to have proper dimensions (overflow hidden)', () => {
+  it('should cloned overlays have to have proper dimensions (overflow hidden)', () => {
     const wt = walkontable({
       data: getData,
       totalRows: getTotalRows,
@@ -46,7 +46,7 @@ describe('WalkontableOverlay', () => {
     expect($(wt.wtOverlays.bottomOverlay.clone.wtTable.holder).height()).toBe(47);
   });
 
-  it('cloned overlays have to have proper dimensions (window object as scrollable element)', () => {
+  it('should cloned overlays have to have proper dimensions (window object as scrollable element)', () => {
     spec().$wrapper
       .css('overflow', '')
       .css('width', '')
@@ -81,7 +81,7 @@ describe('WalkontableOverlay', () => {
     expect($(wt.wtOverlays.bottomOverlay.clone.wtTable.holder).height()).toBe(47);
   });
 
-  it('cloned overlays have to have proper dimensions after table scroll (overflow hidden)', () => {
+  it('should cloned overlays have to have proper dimensions after table scroll (overflow hidden)', () => {
     const wt = walkontable({
       data: getData,
       totalRows: getTotalRows,
@@ -110,7 +110,7 @@ describe('WalkontableOverlay', () => {
     expect($(wt.wtOverlays.bottomOverlay.clone.wtTable.holder).height()).toBe(47);
   });
 
-  it('cloned overlays have to have proper dimensions after table scroll (window object as scrollable element)', () => {
+  it('should cloned overlays have to have proper dimensions after table scroll (window object as scrollable element)', () => {
     spec().$wrapper
       .css('overflow', '')
       .css('width', '')
@@ -148,7 +148,7 @@ describe('WalkontableOverlay', () => {
     expect($(wt.wtOverlays.bottomOverlay.clone.wtTable.holder).height()).toBe(47);
   });
 
-  it('cloned overlays have to have proper positions (overflow hidden)', () => {
+  it('should cloned overlays have to have proper positions (overflow hidden)', () => {
     const wt = walkontable({
       data: getData,
       totalRows: getTotalRows,
@@ -204,7 +204,7 @@ describe('WalkontableOverlay', () => {
     }));
   });
 
-  it('cloned overlays have to have proper positions (window object as scrollable element)', () => {
+  it('should cloned overlays have to have proper positions (window object as scrollable element)', () => {
     spec().$wrapper
       .css('overflow', '')
       .css('width', '')
@@ -267,7 +267,7 @@ describe('WalkontableOverlay', () => {
     }));
   });
 
-  it('cloned overlays have to have proper positions after table scroll (overflow hidden)', () => {
+  it('should cloned overlays have to have proper positions after table scroll (overflow hidden)', () => {
     const wt = walkontable({
       data: getData,
       totalRows: getTotalRows,
@@ -326,7 +326,7 @@ describe('WalkontableOverlay', () => {
     }));
   });
 
-  it('cloned overlays have to have proper positions after table scroll (window object as scrollable element)', () => {
+  it('should cloned overlays have to have proper positions after table scroll (window object as scrollable element)', () => {
     spec().$wrapper
       .css('overflow', '')
       .css('width', '')
@@ -394,7 +394,395 @@ describe('WalkontableOverlay', () => {
     }));
   });
 
-  it('cloned overlays have to have all borders when an empty dataset is passed', () => {
+  it('should cloned header overlays have to have proper dimensions (overflow hidden)', () => {
+    const wt = walkontable({
+      data: getData,
+      totalRows: getTotalRows,
+      totalColumns: getTotalColumns,
+      rowHeaders: [function(row, TH) { // makes top overlay
+        TH.innerHTML = row + 1;
+      }],
+      columnHeaders: [function(column, TH) { // makes left overlay
+        TH.innerHTML = column + 1;
+      }],
+    });
+
+    wt.draw();
+
+    expect($(wt.wtTable.holder).width()).toBe(200);
+    expect($(wt.wtTable.holder).height()).toBe(200);
+    expect($(wt.wtOverlays.topOverlay.clone.wtTable.holder).width()).toBe(185); // 200px - 15px scrollbar width
+    expect($(wt.wtOverlays.topOverlay.clone.wtTable.holder).height()).toBe(23);
+    expect($(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable.holder).width()).toBe(50);
+    expect($(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable.holder).height()).toBe(23);
+    expect($(wt.wtOverlays.leftOverlay.clone.wtTable.holder).width()).toBe(50);
+    expect($(wt.wtOverlays.leftOverlay.clone.wtTable.holder).height()).toBe(185);
+  });
+
+  it('should cloned header overlays have to have proper dimensions (window object as scrollable element)', () => {
+    spec().$wrapper
+      .css('overflow', '')
+      .css('width', '')
+      .css('height', '');
+
+    const wt = walkontable({
+      data: getData,
+      totalRows: getTotalRows,
+      totalColumns: getTotalColumns,
+      rowHeaders: [function(row, TH) { // makes top overlay
+        TH.innerHTML = row + 1;
+      }],
+      columnHeaders: [function(column, TH) { // makes left overlay
+        TH.innerHTML = column + 1;
+      }],
+    });
+
+    wt.draw();
+
+    const clientWidth = document.body.clientWidth;
+    const clientHeight = document.body.clientHeight;
+    const totalColumnsWidth = (getTotalColumns() * 50) + 50; // total columns * 50px (cell width) + 50 (row header)
+
+    expect($(wt.wtTable.holder).width()).toBe(clientWidth);
+    expect($(wt.wtTable.holder).height()).toBe(clientHeight);
+    expect($(wt.wtOverlays.topOverlay.clone.wtTable.holder).width()).toBe(totalColumnsWidth);
+    expect($(wt.wtOverlays.topOverlay.clone.wtTable.holder).height()).toBe(23);
+    expect($(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable.holder).width()).toBe(50);
+    expect($(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable.holder).height()).toBe(23);
+    expect($(wt.wtOverlays.leftOverlay.clone.wtTable.holder).width()).toBe(50);
+    expect($(wt.wtOverlays.leftOverlay.clone.wtTable.holder).height()).toBe(clientHeight);
+  });
+
+  it('should cloned header overlays have to have proper dimensions after table scroll (overflow hidden)', () => {
+    const wt = walkontable({
+      data: getData,
+      totalRows: getTotalRows,
+      totalColumns: getTotalColumns,
+      rowHeaders: [function(row, TH) { // makes top overlay
+        TH.innerHTML = row + 1;
+      }],
+      columnHeaders: [function(column, TH) { // makes left overlay
+        TH.innerHTML = column + 1;
+      }],
+    });
+
+    wt.draw();
+    wt.scrollViewportHorizontally(getTotalColumns() - 1);
+    wt.scrollViewportVertically(getTotalRows() - 1);
+    wt.draw();
+
+    expect($(wt.wtTable.holder).width()).toBe(200);
+    expect($(wt.wtTable.holder).height()).toBe(200);
+    expect($(wt.wtOverlays.topOverlay.clone.wtTable.holder).width()).toBe(185); // 200px - 15px scrollbar width
+    expect($(wt.wtOverlays.topOverlay.clone.wtTable.holder).height()).toBe(24); // 23px + 1px (innerBorderTop)
+    expect($(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable.holder).width()).toBe(50);
+    expect($(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable.holder).height()).toBe(24); // 23px + 1px (innerBorderTop)
+    expect($(wt.wtOverlays.leftOverlay.clone.wtTable.holder).width()).toBe(50);
+    expect($(wt.wtOverlays.leftOverlay.clone.wtTable.holder).height()).toBe(185);
+  });
+
+  it('should cloned header overlays have to have proper dimensions after table scroll (window object as scrollable element)', () => {
+    spec().$wrapper
+      .css('overflow', '')
+      .css('width', '')
+      .css('height', '');
+
+    const wt = walkontable({
+      data: getData,
+      totalRows: getTotalRows,
+      totalColumns: getTotalColumns,
+      rowHeaders: [function(row, TH) { // makes top overlay
+        TH.innerHTML = row + 1;
+      }],
+      columnHeaders: [function(column, TH) { // makes left overlay
+        TH.innerHTML = column + 1;
+      }],
+    });
+
+    wt.draw();
+    wt.scrollViewportHorizontally(getTotalColumns() - 1);
+    wt.scrollViewportVertically(getTotalRows() - 1);
+    wt.draw();
+
+    const clientWidth = document.body.clientWidth;
+    const clientHeight = document.body.clientHeight;
+    // total columns * 50px (cell width) + 50px (row header) + 1px (header border left width)
+    const totalColumnsWidth = (getTotalColumns() * 50) + 50 + 1;
+
+    expect($(wt.wtTable.holder).width()).toBe(clientWidth);
+    expect($(wt.wtTable.holder).height()).toBe(clientHeight);
+    expect($(wt.wtOverlays.topOverlay.clone.wtTable.holder).width()).toBe(totalColumnsWidth);
+    expect($(wt.wtOverlays.topOverlay.clone.wtTable.holder).height()).toBe(24); // 23px + 1px (innerBorderTop)
+    expect($(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable.holder).width()).toBe(50);
+    expect($(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable.holder).height()).toBe(24); // 23px + 1px (innerBorderTop)
+    expect($(wt.wtOverlays.leftOverlay.clone.wtTable.holder).width()).toBe(50);
+    expect($(wt.wtOverlays.leftOverlay.clone.wtTable.holder).height()).toBe(clientHeight);
+  });
+
+  it('should cloned header overlays have to have proper positions (overflow hidden)', () => {
+    const wt = walkontable({
+      data: getData,
+      totalRows: getTotalRows,
+      totalColumns: getTotalColumns,
+      rowHeaders: [function(row, TH) { // makes top overlay
+        TH.innerHTML = row + 1;
+      }],
+      columnHeaders: [function(column, TH) { // makes left overlay
+        TH.innerHTML = column + 1;
+      }],
+    });
+
+    wt.draw();
+
+    const getTableRect = (wtTable) => {
+      const rect = wtTable.holder.getBoundingClientRect();
+
+      return {
+        top: rect.top,
+        bottom: rect.bottom,
+        left: rect.left,
+      };
+    };
+
+    const baseRect = getTableRect(wt.wtTable);
+
+    expect(baseRect).toEqual(jasmine.objectContaining({
+      top: 8,
+      bottom: 208,
+      left: 8,
+    }));
+    expect(getTableRect(wt.wtOverlays.topOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
+      top: 8,
+      bottom: 31,
+      left: 8,
+    }));
+    expect(getTableRect(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
+      top: 8,
+      bottom: 31,
+      left: 8,
+    }));
+    expect(getTableRect(wt.wtOverlays.leftOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
+      top: 8,
+      bottom: 193,
+      left: 8,
+    }));
+  });
+
+  it('should cloned header overlays have to have proper positions (window object as scrollable element)', () => {
+    spec().$wrapper
+      .css('overflow', '')
+      .css('width', '')
+      .css('height', '');
+
+    const wt = walkontable({
+      data: getData,
+      totalRows: getTotalRows,
+      totalColumns: getTotalColumns,
+      rowHeaders: [function(row, TH) { // makes top overlay
+        TH.innerHTML = row + 1;
+      }],
+      columnHeaders: [function(column, TH) { // makes left overlay
+        TH.innerHTML = column + 1;
+      }],
+    });
+
+    wt.draw();
+
+    const getTableRect = (wtTable) => {
+      const rect = wtTable.holder.getBoundingClientRect();
+
+      return {
+        top: rect.top,
+        bottom: rect.bottom,
+        left: rect.left,
+      };
+    };
+
+    // total columns * 23px + 23px (top header) + 1px (cell top border)
+    const totalRowsHight = (getTotalRows() * 23) + 23 + 1;
+    const baseRect = getTableRect(wt.wtTable);
+
+    expect(baseRect).toEqual(jasmine.objectContaining({
+      top: 8,
+      bottom: totalRowsHight + 8, // 8 default browser margin
+      left: 8,
+    }));
+    expect(getTableRect(wt.wtOverlays.topOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
+      top: 8,
+      bottom: 23 + 8, // 1 top row * 23px + body margin
+      left: 8,
+    }));
+    expect(getTableRect(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
+      top: 8,
+      bottom: 23 + 8, // 1 top row * 23px + body margin
+      left: 8,
+    }));
+    expect(getTableRect(wt.wtOverlays.leftOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
+      top: 8,
+      bottom: totalRowsHight + 8, // 8 default browser margin
+      left: 8,
+    }));
+  });
+
+  it('should cloned header overlays have to have proper positions after table scroll (overflow hidden)', () => {
+    const wt = walkontable({
+      data: getData,
+      totalRows: getTotalRows,
+      totalColumns: getTotalColumns,
+      rowHeaders: [function(row, TH) { // makes top overlay
+        TH.innerHTML = row + 1;
+      }],
+      columnHeaders: [function(column, TH) { // makes left overlay
+        TH.innerHTML = column + 1;
+      }],
+    });
+
+    wt.draw();
+    wt.scrollViewportHorizontally(getTotalColumns() - 1);
+    wt.scrollViewportVertically(getTotalRows() - 1);
+    wt.draw();
+
+    const getTableRect = (wtTable) => {
+      const rect = wtTable.holder.getBoundingClientRect();
+
+      return {
+        top: rect.top,
+        bottom: rect.bottom,
+        left: rect.left,
+      };
+    };
+
+    const baseRect = getTableRect(wt.wtTable);
+
+    expect(baseRect).toEqual(jasmine.objectContaining({
+      top: 8,
+      bottom: 208,
+      left: 8,
+    }));
+    expect(getTableRect(wt.wtOverlays.topOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
+      top: 8,
+      bottom: 23 + 8 + 1, // 1 top row * 23px + body margin + 1px (innerBorderTop)
+      left: 8,
+    }));
+    expect(getTableRect(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
+      top: 8,
+      bottom: 23 + 8 + 1, // 1 top row * 23px + body margin + 1px (innerBorderTop)
+      left: 8,
+    }));
+    expect(getTableRect(wt.wtOverlays.leftOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
+      top: 8,
+      bottom: 193,
+      left: 8,
+    }));
+  });
+
+  it('should cloned header overlays have to have proper positions after table scroll (window object as scrollable element)', () => {
+    spec().$wrapper
+      .css('overflow', '')
+      .css('width', '')
+      .css('height', '');
+
+    const wt = walkontable({
+      data: getData,
+      totalRows: getTotalRows,
+      totalColumns: getTotalColumns,
+      rowHeaders: [function(row, TH) { // makes top overlay
+        TH.innerHTML = row + 1;
+      }],
+      columnHeaders: [function(column, TH) { // makes left overlay
+        TH.innerHTML = column + 1;
+      }],
+    });
+
+    wt.draw();
+    wt.scrollViewportHorizontally(getTotalColumns() - 1);
+    wt.scrollViewportVertically(getTotalRows() - 1);
+    wt.draw();
+
+    const getTableRect = (wtTable) => {
+      const rect = wtTable.holder.getBoundingClientRect();
+
+      return {
+        top: rect.top,
+        bottom: rect.bottom,
+        left: rect.left,
+      };
+    };
+
+    const documentClientHeight = document.documentElement.clientHeight;
+    const documentClientWidth = document.documentElement.clientWidth;
+    // total columns * 23px + 23px (column header) + 1px (innerBorderTop)
+    const totalRowsHeight = (getTotalRows() * 23) + 23 + 1;
+    // total columns * 50px (cell width) + 50px (row header)
+    const totalColumnsWidth = (getTotalColumns() * 50) + 50;
+    const baseRect = getTableRect(wt.wtTable);
+
+    expect(baseRect).toEqual(jasmine.objectContaining({
+      top: documentClientHeight - totalRowsHeight,
+      bottom: documentClientHeight + 1, // +1 innerBorderTop
+      left: documentClientWidth - totalColumnsWidth,
+    }));
+    expect(getTableRect(wt.wtOverlays.topOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
+      top: 0,
+      bottom: 24,
+      left: documentClientWidth - totalColumnsWidth,
+    }));
+    expect(getTableRect(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
+      top: 0,
+      bottom: 24,
+      left: 0,
+    }));
+    expect(getTableRect(wt.wtOverlays.leftOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
+      top: documentClientHeight - totalRowsHeight,
+      bottom: documentClientHeight + 1, // +1 innerBorderTop
+      left: 0,
+    }));
+  });
+
+  it('should adjust the header overlays sizes after table scroll (window object as scrollable element)', () => {
+    spec().$wrapper
+      .css('overflow', '')
+      .css('width', '')
+      .css('height', '');
+
+    const $expander = $('<div></div>').css({ paddingBottom: '20000px' });
+
+    spec().$wrapper.after($expander);
+
+    createDataArray(5, 5);
+
+    const wt = walkontable({
+      data: getData,
+      totalRows: getTotalRows,
+      totalColumns: getTotalColumns,
+      rowHeaders: [function(row, TH) { // makes top overlay
+        TH.innerHTML = row + 1;
+      }],
+      columnHeaders: [function(column, TH) { // makes left overlay
+        TH.innerHTML = column + 1;
+      }],
+    });
+
+    wt.draw();
+    window.scrollTo(0, 20);
+    wt.draw();
+
+    // total columns * 50px (cell width) + 50px (row header)
+    const totalColumnsWidth = (getTotalColumns() * 50) + 50;
+    // total rows * 23px (cell height) + 24px (column header) + 1px (border top for the first header)
+    const totalRowsHeight = (getTotalRows() * 23) + 24 + 1;
+
+    expect($(wt.wtOverlays.topOverlay.clone.wtTable.holder).width()).toBe(totalColumnsWidth);
+    expect($(wt.wtOverlays.topOverlay.clone.wtTable.holder).height()).toBe(24); // 23px + 1px (innerBorderTop)
+    expect($(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable.holder).width()).toBe(50);
+    expect($(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable.holder).height()).toBe(24); // 23px + 1px (innerBorderTop)
+    expect($(wt.wtOverlays.leftOverlay.clone.wtTable.holder).width()).toBe(50);
+    expect($(wt.wtOverlays.leftOverlay.clone.wtTable.holder).height()).toBe(totalRowsHeight);
+
+    $expander.remove();
+  });
+
+  it('should cloned overlays have to have all borders when an empty dataset is passed', () => {
     createDataArray(0, 0);
 
     const wt = walkontable({


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adds additional logic, which checks if the top overlay is going to an infinite loop caused by added (or removed) `innerBorderTop` class name. Toggling the class name shifts the viewport by 1px and triggers the `scroll` event. It causes the table to render. The new render cycle takes into account the shift and toggles the class name again. This causes the next loops.

The issue is fixed by checking if the table bottom position is the same as the overlay bottom position. If true then the loop is interrupted by skipping adjusting the border-top width through `innerBorderTop` class name.

The issue occurs only on Chrome.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I've tested on latest browsers. Additionally, I've covered the changes with new tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7256
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
