### PR TITLE
Refactor the moving logic of the Nested Rows plugin.

### DIFF
--- a/src/plugins/nestedRows/nestedRows.js
+++ b/src/plugins/nestedRows/nestedRows.js
@@ -1,9 +1,5 @@
 import BasePlugin from '../_base';
 import { registerPlugin } from '../../plugins';
-import { isUndefined } from '../../helpers/mixed';
-import { warn } from '../../helpers/console';
-import { toSingleLine } from '../../helpers/templateLiteralTag';
-import { CellCoords } from '../../3rdparty/walkontable/src';
 import DataManager from './data/dataManager';
 import CollapsingUI from './ui/collapsing';
 import HeadersUI from './ui/headers';
@@ -11,6 +7,7 @@ import ContextMenuUI from './ui/contextMenu';
 
 import './nestedRows.css';
 import { TrimmingMap } from '../../translations';
+import RowMoveController from './utils/rowMoveController';
 
 const privatePool = new WeakMap();
 
@@ -47,8 +44,6 @@ class NestedRows extends BasePlugin {
     this.collapsedRowsMap = null;
 
     privatePool.set(this, {
-      changeSelection: false,
-      movedToFirstChild: false,
       movedToCollapsed: false,
       skipRender: null,
       skipCoreAPIModifiers: false
@@ -80,6 +75,7 @@ class NestedRows extends BasePlugin {
     this.collapsingUI = new CollapsingUI(this, this.hot);
     this.headersUI = new HeadersUI(this, this.hot);
     this.contextMenuUI = new ContextMenuUI(this, this.hot);
+    this.rowMoveController = new RowMoveController(this);
 
     this.addHook('afterInit', (...args) => this.onAfterInit(...args));
     this.addHook('beforeRender', (...args) => this.onBeforeRender(...args));
@@ -133,216 +129,23 @@ class NestedRows extends BasePlugin {
    *
    * @private
    * @param {Array} rows Array of visual row indexes to be moved.
-   * @param {number} finalIndex Visual row index, being a start index for the moved rows. Points to where the elements will be placed after the moving action.
-   * To check the visualization of the final index, please take a look at [documentation](/docs/demo-moving.html).
-   * @param {undefined|number} dropIndex Visual row index, being a drop index for the moved rows. Points to where we are going to drop the moved elements.
-   * To check visualization of drop index please take a look at [documentation](/docs/demo-moving.html).
+   * @param {number} finalIndex Visual row index, being a start index for the moved rows. Points to where the elements
+   *   will be placed after the moving action. To check the visualization of the final index, please take a look at
+   *   [documentation](/docs/demo-moving.html).
+   * @param {undefined|number} dropIndex Visual row index, being a drop index for the moved rows. Points to where we
+   *   are going to drop the moved elements. To check visualization of drop index please take a look at
+   *   [documentation](/docs/demo-moving.html).
    * @param {boolean} movePossible Indicates if it's possible to move rows to the desired position.
    * @fires Hooks#afterRowMove
    * @returns {boolean}
    */
   onBeforeRowMove(rows, finalIndex, dropIndex, movePossible) {
-    if (isUndefined(dropIndex)) {
-      warn(toSingleLine`Since version 8.0.0 of the Handsontable the 'moveRows' method isn't used for moving rows\x20
-      when the NestedRows plugin is enabled. Please use the 'dragRows' method instead.`);
-
-      // TODO: Trying to mock real work of the `ManualRowMove` plugin. It was blocked by returning `false` below.
-      this.hot.runHooks('afterRowMove', rows, finalIndex, dropIndex, movePossible, false);
-
-      return false;
-    }
-
-    const priv = privatePool.get(this);
-    const rowsLen = rows.length;
-    const translatedStartIndexes = [];
-
-    let translatedDropIndex = this.dataManager.translateTrimmedRow(dropIndex);
-    let allowMove = true;
-    let i;
-    let fromParent = null;
-    let toParent = null;
-    let sameParent = null;
-
-    // We can't move rows when any of them is a parent or a top-level element
-    for (i = 0; i < rowsLen; i++) {
-      const rowIndex = rows[i];
-      translatedStartIndexes.push(this.dataManager.translateTrimmedRow(rowIndex));
-
-      if (this.dataManager.isParent(rowIndex) || this.dataManager.isRowHighestLevel(rowIndex)) {
-        allowMove = false;
-      }
-    }
-
-    // We can't move rows when any of them is tried to be moved to the position of moved row
-    // TODO: Another work than the `ManualRowMove` plugin.
-    if (translatedStartIndexes.indexOf(translatedDropIndex) > -1 || !allowMove) {
-      return false;
-    }
-
-    fromParent = this.dataManager.getRowParent(translatedStartIndexes[0]);
-    toParent = this.dataManager.getRowParent(translatedDropIndex);
-
-    // We move row to the first parent of destination row whether there was a try of moving it on the row being a parent
-    if (toParent === null || toParent === void 0) {
-      toParent = this.dataManager.getRowParent(translatedDropIndex - 1);
-    }
-
-    // We add row to element as child whether there is no parent of final destination row
-    if (toParent === null || toParent === void 0) {
-      toParent = this.dataManager.getDataObject(translatedDropIndex - 1);
-      priv.movedToFirstChild = true;
-    }
-
-    // Can't move row whether there was a try of moving it on the row being a parent and it has no rows above.
-    if (!toParent) {
-      return false;
-    }
-
-    sameParent = fromParent === toParent;
-    priv.movedToCollapsed = this.collapsingUI.areChildrenCollapsed(toParent);
-    this.collapsingUI.collapsedRowsStash.stash();
-
-    if (!sameParent) {
-      if (Math.max(...translatedStartIndexes) <= translatedDropIndex) {
-        this.collapsingUI.collapsedRowsStash.shiftStash(translatedStartIndexes[0], (-1) * rows.length);
-
-      } else {
-        this.collapsingUI.collapsedRowsStash.shiftStash(translatedDropIndex, rows.length);
-      }
-    }
-
-    priv.changeSelection = true;
-
-    if (translatedStartIndexes[rowsLen - 1] <= translatedDropIndex && sameParent || priv.movedToFirstChild === true) {
-      rows.reverse();
-      translatedStartIndexes.reverse();
-
-      if (priv.movedToFirstChild !== true) {
-        translatedDropIndex -= 1;
-      }
-    }
-
-    let hasDataChanged = false;
-
-    for (i = 0; i < rowsLen; i++) {
-      this.dataManager.moveRow(translatedStartIndexes[i], translatedDropIndex, true);
-      hasDataChanged = hasDataChanged || translatedStartIndexes[i] !== translatedDropIndex;
-    }
-
-    if (!hasDataChanged) {
-      return false;
-    }
-
-    const movingDown = translatedStartIndexes[translatedStartIndexes.length - 1] < translatedDropIndex;
-
-    if (movingDown) {
-      for (i = rowsLen - 1; i >= 0; i--) {
-        this.dataManager.moveCellMeta(translatedStartIndexes[i], sameParent ?
-          translatedDropIndex : translatedDropIndex - 1);
-      }
-    } else {
-      for (i = 0; i < rowsLen; i++) {
-        this.dataManager.moveCellMeta(translatedStartIndexes[i], translatedDropIndex);
-      }
-    }
-
-    if ((translatedStartIndexes[rowsLen - 1] <= translatedDropIndex && sameParent) ||
-        this.dataManager.isParent(translatedDropIndex)) {
-      rows.reverse();
-    }
-
-    this.dataManager.updateWithData(this.dataManager.getRawSourceData());
-
-    // TODO: Trying to mock real work of the `ManualRowMove` plugin. It was blocked by returning `false` below.
-    this.hot.runHooks('afterRowMove',
-      rows, finalIndex, dropIndex, movePossible, movePossible && this.isRowOrderChanged(rows, finalIndex));
-
-    this.selectCells(rows, dropIndex);
-
-    return false;
-  }
-
-  // TODO: Reimplementation of function which is inside the `ManualRowMove` plugin.
-  /**
-   * Indicates if order of rows was changed.
-   *
-   * @private
-   * @param {Array} movedRows Array of visual row indexes to be moved.
-   * @param {number} finalIndex Visual row index, being a start index for the moved rows. Points to where the elements will be placed after the moving action.
-   * To check the visualization of the final index, please take a look at [documentation](/docs/demo-moving.html).
-   * @returns {boolean}
-   */
-  isRowOrderChanged(movedRows, finalIndex) {
-    return movedRows.some((row, nrOfMovedElement) => row - nrOfMovedElement !== finalIndex);
+    return this.rowMoveController.onBeforeRowMove(rows, finalIndex, dropIndex, movePossible);
   }
 
   /**
-   * Select cells after the move.
-   *
-   * @private
-   * @param {Array} rows Array of visual row indexes to be moved.
-   * @param {undefined|number} dropIndex Visual row index, being a drop index for the moved rows. Points to where we are going to drop the moved elements.
-   * To check visualization of drop index please take a look at [documentation](/docs/demo-moving.html).
-   */
-  selectCells(rows, dropIndex) {
-    const priv = privatePool.get(this);
-
-    if (!priv.changeSelection) {
-      return;
-    }
-
-    const rowsLen = rows.length;
-    let startRow = 0;
-    let endRow = 0;
-    let translatedDropIndex = null;
-    let selection = null;
-    let lastColIndex = null;
-
-    this.collapsingUI.collapsedRowsStash.applyStash();
-
-    translatedDropIndex = this.dataManager.translateTrimmedRow(dropIndex);
-
-    if (priv.movedToFirstChild) {
-      priv.movedToFirstChild = false;
-
-      startRow = dropIndex;
-      endRow = dropIndex + rowsLen - 1;
-
-      if (dropIndex >= Math.max(...rows)) {
-        startRow -= rowsLen;
-        endRow -= rowsLen;
-      }
-
-    } else if (priv.movedToCollapsed) {
-      let parentObject = this.dataManager.getRowParent(translatedDropIndex - 1);
-      if (parentObject === null || parentObject === void 0) {
-        parentObject = this.dataManager.getDataObject(translatedDropIndex - 1);
-      }
-      const parentIndex = this.dataManager.getRowIndex(parentObject);
-
-      startRow = parentIndex;
-      endRow = startRow;
-
-    } else if (rows[rowsLen - 1] < dropIndex) {
-      endRow = dropIndex - 1;
-      startRow = endRow - rowsLen + 1;
-
-    } else {
-      startRow = dropIndex;
-      endRow = startRow + rowsLen - 1;
-    }
-
-    selection = this.hot.selection;
-    lastColIndex = this.hot.countCols() - 1;
-
-    selection.setRangeStart(new CellCoords(startRow, 0));
-    selection.setRangeEnd(new CellCoords(endRow, lastColIndex), true);
-
-    priv.changeSelection = false;
-  }
-
-  /**
-   * Enable the modify hook skipping flag - allows retrieving the data from Handsontable without this plugin's modifications.
+   * Enable the modify hook skipping flag - allows retrieving the data from Handsontable without this plugin's
+   * modifications.
    */
   disableCoreAPIModifiers() {
     const priv = privatePool.get(this);
@@ -437,7 +240,7 @@ class NestedRows extends BasePlugin {
 
     this.collapsingUI.collapsedRowsStash.stash();
     this.collapsingUI.collapsedRowsStash.trimStash(physicalRows[0], amount);
-    this.collapsingUI.collapsedRowsStash.shiftStash(physicalRows[0], (-1) * amount);
+    this.collapsingUI.collapsedRowsStash.shiftStash(physicalRows[0], null, (-1) * amount);
     this.dataManager.filterData(index, amount, physicalRows);
 
     priv.skipRender = true;
@@ -573,7 +376,7 @@ class NestedRows extends BasePlugin {
    * @param {object} element New child element.
    */
   onAfterDetachChild(parent, element) {
-    this.collapsingUI.collapsedRowsStash.shiftStash(this.dataManager.getRowIndex(element));
+    this.collapsingUI.collapsedRowsStash.shiftStash(this.dataManager.getRowIndex(element), null, -1);
     this.collapsingUI.collapsedRowsStash.applyStash();
 
     this.headersUI.updateRowHeaderWidth();

--- a/src/plugins/nestedRows/nestedRows.js
+++ b/src/plugins/nestedRows/nestedRows.js
@@ -308,6 +308,7 @@ class NestedRows extends BasePlugin {
    * Callback for the `beforeRemoveRow` change list of removed physical indexes by reference. Removing parent node
    * has effect in removing children nodes.
    *
+   * @private
    * @param {number} index Visual index of starter row.
    * @param {number} amount Amount of rows to be removed.
    * @param {Array} physicalRows List of physical indexes.

--- a/src/plugins/nestedRows/test/nestedRows.e2e.js
+++ b/src/plugins/nestedRows/test/nestedRows.e2e.js
@@ -47,7 +47,8 @@ describe('NestedRows', () => {
       expect(hot.countRows()).toEqual(18);
     });
 
-    it('should display all nested structure elements in correct order (parent, its children, its children children, next parent etc)', () => {
+    it('should display all nested structure elements in correct order (parent, its children, ' +
+      'its children children, next parent etc)', () => {
       const hot = handsontable({
         data: getMoreComplexNestedData(),
         nestedRows: true
@@ -177,7 +178,8 @@ describe('NestedRows', () => {
       expect(getData()).toEqual(dataInOrder);
     });
 
-    it('should move row to the first parent of destination row whether there was a try of moving it on the row being a parent #1', () => {
+    it('should move row to the first parent of destination row when there was a try ' +
+      'of moving it on the row being a parent #1', () => {
       handsontable({
         data: getMoreComplexNestedData(),
         nestedRows: true,
@@ -194,14 +196,17 @@ describe('NestedRows', () => {
       expect(getDataAtCell(3, 0)).toEqual('a0-a2');
       expect(getPlugin('nestedRows').dataManager.isParent(3)).toBeTruthy();
 
-      expect(getDataAtCell(4, 0)).toEqual('a0-a2-a0');
-      expect(getPlugin('nestedRows').dataManager.isParent(4)).toBeTruthy();
+      expect(getDataAtCell(4, 0)).toEqual('a2-a1-a1');
+      expect(getPlugin('nestedRows').dataManager.isParent(4)).toBeFalsy();
 
-      expect(getDataAtCell(5, 0)).toEqual('a0-a2-a0-a0');
-      expect(getPlugin('nestedRows').dataManager.isParent(5)).toBeFalsy();
+      expect(getDataAtCell(5, 0)).toEqual('a0-a2-a0');
+      expect(getPlugin('nestedRows').dataManager.isParent(5)).toBeTruthy();
+
+      expect(getDataAtCell(6, 0)).toEqual('a0-a2-a0-a0');
+      expect(getPlugin('nestedRows').dataManager.isParent(6)).toBeFalsy();
 
       // Moved row.
-      expect(getDataAtCell(6, 0)).toEqual('a2-a1-a1');
+      expect(getDataAtCell(4, 0)).toEqual('a2-a1-a1');
 
       // Previous parent of moved row.
       expect(getDataAtCell(11, 0)).toEqual('a2-a1');
@@ -209,7 +214,8 @@ describe('NestedRows', () => {
       expect(getPlugin('nestedRows').dataManager.countChildren(firstParent)).toBe(1);
     });
 
-    it('should move row to the first parent of destination row whether there was a try of moving it on the row being a parent #2', () => {
+    it('should move row to the first parent of destination row when there was a try ' +
+      'of moving it on the row being a parent #2', () => {
       handsontable({
         data: getMoreComplexNestedData(),
         nestedRows: true,
@@ -229,22 +235,19 @@ describe('NestedRows', () => {
       expect(getDataAtCell(9, 0)).toEqual('a2-a0');
       expect(getPlugin('nestedRows').dataManager.isParent(9)).toBeFalsy();
 
-      // Previous parent of moved row.
-      expect(getDataAtCell(10, 0)).toEqual('a2-a1');
+      expect(getDataAtCell(10, 0)).toEqual('a2-a1-a1');
+      expect(getPlugin('nestedRows').dataManager.isParent(10)).toBeFalsy();
 
-      expect(getPlugin('nestedRows').dataManager.isParent(10)).toBeTruthy();
+      // Previous parent of moved row.
+      expect(getDataAtCell(11, 0)).toEqual('a2-a1');
+      expect(getPlugin('nestedRows').dataManager.isParent(11)).toBeTruthy();
       expect(getPlugin('nestedRows').dataManager.countChildren(firstParent)).toBe(1);
 
-      expect(getDataAtCell(11, 0)).toEqual('a2-a1-a0');
-      expect(getPlugin('nestedRows').dataManager.isParent(11)).toBeFalsy();
-
-      // Moved row.
-      expect(getDataAtCell(12, 0)).toEqual('a2-a1-a1');
-
+      expect(getDataAtCell(12, 0)).toEqual('a2-a1-a0');
       expect(getPlugin('nestedRows').dataManager.isParent(12)).toBeFalsy();
     });
 
-    it('should add row to element as child whether there is no parent of final destination row', () => {
+    it('should add row to element as child when there is no parent of final destination row', () => {
       const hot = handsontable({
         data: getMoreComplexNestedData(),
         nestedRows: true,
@@ -270,7 +273,8 @@ describe('NestedRows', () => {
       expect(getDataAtCell(7, 0)).toEqual('a0-a0');
     });
 
-    it('should not move row whether there was a try of moving it on the row being a parent and it has no rows above', () => {
+    it('should not move row when there was a try of moving it on the row ' +
+      'being a parent and it has no rows above', () => {
       handsontable({
         data: getMoreComplexNestedData(),
         nestedRows: true,
@@ -315,7 +319,6 @@ describe('NestedRows', () => {
       expect(getSelectedLast()).toEqual([6, 0, 6, 3]);
     });
 
-    // TODO: This test sometimes fail in the browser?
     it('should move single row between parents properly (moving from the bottom to the top)', () => {
       handsontable({
         data: getSimplerNestedData(),
@@ -355,9 +358,9 @@ describe('NestedRows', () => {
         height: 1000
       });
 
-      let firstBaseHeader = spec().$container.find('tbody tr:eq(2) th:eq(0)');
-      let secondBaseHeader = spec().$container.find('tbody tr:eq(3) th:eq(0)');
-      let $targetHeader = spec().$container.find('tbody tr:eq(5) th:eq(0)');
+      let firstBaseHeader = spec().$container.find('.ht_clone_left tbody tr:eq(2) th:eq(0)');
+      let secondBaseHeader = spec().$container.find('.ht_clone_left tbody tr:eq(3) th:eq(0)');
+      let $targetHeader = spec().$container.find('.ht_clone_left tbody tr:eq(5) th:eq(0)');
 
       firstBaseHeader.simulate('mousedown');
       secondBaseHeader.simulate('mouseover');
@@ -378,9 +381,9 @@ describe('NestedRows', () => {
       expect(getDataAtCell(4, 1)).toEqual('Foo Fighters');
       expect(getDataAtCell(5, 1)).toEqual('Wolf Alice');
 
-      firstBaseHeader = spec().$container.find('tbody tr:eq(7) th:eq(0)');
-      secondBaseHeader = spec().$container.find('tbody tr:eq(9) th:eq(0)');
-      $targetHeader = spec().$container.find('tbody tr:eq(5) th:eq(0)');
+      firstBaseHeader = spec().$container.find('.ht_clone_left tbody tr:eq(7) th:eq(0)');
+      secondBaseHeader = spec().$container.find('.ht_clone_left tbody tr:eq(9) th:eq(0)');
+      $targetHeader = spec().$container.find('.ht_clone_left tbody tr:eq(5) th:eq(0)');
 
       firstBaseHeader.simulate('mousedown');
       secondBaseHeader.simulate('mouseover');
@@ -447,6 +450,245 @@ describe('NestedRows', () => {
       expect(dataManager.countChildren(4)).toEqual(3);
       expect(dataManager.countChildren(12)).toEqual(0);
     });
+
+    it('should be possible to move rows to the last row of the table', () => {
+      handsontable({
+        data: getMoreComplexNestedData(),
+        nestedRows: true,
+        manualRowMove: true,
+        rowHeaders: true,
+        width: 500,
+        height: 500
+      });
+
+      const firstBaseHeader = spec().$container.find('.ht_clone_left tbody tr:eq(1) th:eq(0)');
+      const secondBaseHeader = spec().$container.find('.ht_clone_left tbody tr:eq(2) th:eq(0)');
+      const $targetHeader = spec().$container.find('.ht_clone_left tbody tr:eq(12) th:eq(0)');
+
+      firstBaseHeader.simulate('mousedown');
+      secondBaseHeader.simulate('mouseover');
+      secondBaseHeader.simulate('mousemove');
+      secondBaseHeader.simulate('mouseup');
+      secondBaseHeader.simulate('mousedown');
+
+      $targetHeader.simulate('mouseover');
+      $targetHeader.simulate('mousemove', {
+        clientY: $targetHeader.offset().top + 15
+      });
+
+      $targetHeader.simulate('mouseup');
+
+      expect(getDataAtCell(0, 0)).toEqual('a0');
+      expect(getDataAtCell(1, 0)).toEqual('a0-a2');
+      expect(getDataAtCell(11, 0)).toEqual('a0-a0');
+      expect(getDataAtCell(12, 0)).toEqual('a0-a1');
+
+      const dataManager = getPlugin('nestedRows').dataManager;
+
+      expect(dataManager.countChildren(0)).toEqual(4);
+      expect(dataManager.countChildren(8)).toEqual(4);
+    });
+
+    it('should be possible to move rows after the last child of a parent', () => {
+      const hot = handsontable({
+        data: getSimplerNestedData(),
+        nestedRows: true,
+        manualRowMove: true,
+        rowHeaders: true,
+        width: 500,
+        height: 500
+      });
+
+      hot.getPlugin('nestedRows').collapsingUI.collapseChildren(6);
+
+      const firstBaseHeader = spec().$container.find('.ht_clone_left tbody tr:eq(10) th:eq(0)');
+      const secondBaseHeader = spec().$container.find('.ht_clone_left tbody tr:eq(11) th:eq(0)');
+      const $targetHeader = spec().$container.find('.ht_clone_left tbody tr:eq(6) th:eq(0)');
+
+      firstBaseHeader.simulate('mousedown');
+      secondBaseHeader.simulate('mouseover');
+      secondBaseHeader.simulate('mousemove');
+      secondBaseHeader.simulate('mouseup');
+      secondBaseHeader.simulate('mousedown');
+
+      $targetHeader.simulate('mouseover');
+      $targetHeader.simulate('mousemove', {
+        clientY: $targetHeader.offset().top + 5
+      });
+
+      $targetHeader.simulate('mouseup');
+
+      expect(getDataAtCell(6, 1)).toEqual('James Bay');
+      expect(getDataAtCell(7, 1)).toEqual('Highly Suspect');
+      expect(getDataAtCell(11, 1)).toEqual('Elle King');
+      expect(getDataAtCell(12, 1)).toEqual('Florence & The Machine');
+    });
+
+    it('should be possible to move rows after the last child of a parent along with its meta data', () => {
+      const hot = handsontable({
+        data: getSimplerNestedData(),
+        nestedRows: true,
+        manualRowMove: true,
+        rowHeaders: true,
+        width: 500,
+        height: 500
+      });
+
+      hot.setCellMeta(1, 0, 'className', 'htSearchResult');
+      hot.setCellMeta(2, 0, 'className', 'htSearchResult');
+
+      const firstBaseHeader = spec().$container.find('.ht_clone_left tbody tr:eq(1) th:eq(0)');
+      const secondBaseHeader = spec().$container.find('.ht_clone_left tbody tr:eq(2) th:eq(0)');
+      const $targetHeader = spec().$container.find('.ht_clone_left tbody tr:eq(6) th:eq(0)');
+
+      firstBaseHeader.simulate('mousedown');
+      secondBaseHeader.simulate('mouseover');
+      secondBaseHeader.simulate('mousemove');
+      secondBaseHeader.simulate('mouseup');
+      secondBaseHeader.simulate('mousedown');
+
+      $targetHeader.simulate('mouseover');
+      $targetHeader.simulate('mousemove', {
+        clientY: $targetHeader.offset().top + 5
+      });
+
+      $targetHeader.simulate('mouseup');
+
+      expect(hot.getCellMeta(4, 0).className.includes('htSearchResult')).toBe(true);
+      expect(hot.getCellMeta(5, 0).className.includes('htSearchResult')).toBe(true);
+    });
+
+    it('should be possible to move rows into a collapsed parent (they should be placed as their last child)', () => {
+      const hot = handsontable({
+        data: getSimplerNestedData(),
+        nestedRows: true,
+        manualRowMove: true,
+        rowHeaders: true,
+        width: 500,
+        height: 500
+      });
+
+      hot.getPlugin('nestedRows').collapsingUI.collapseChildren(6);
+
+      const firstBaseHeader = spec().$container.find('.ht_clone_left tbody tr:eq(11) th:eq(0)');
+      const secondBaseHeader = spec().$container.find('.ht_clone_left tbody tr:eq(12) th:eq(0)');
+      const $targetHeader = spec().$container.find('.ht_clone_left tbody tr:eq(6) th:eq(0)');
+
+      firstBaseHeader.simulate('mousedown');
+      secondBaseHeader.simulate('mouseover');
+      secondBaseHeader.simulate('mousemove');
+      secondBaseHeader.simulate('mouseup');
+      secondBaseHeader.simulate('mousedown');
+
+      $targetHeader.simulate('mouseover');
+      $targetHeader.simulate('mousemove', {
+        clientY: $targetHeader.offset().top + 15
+      });
+
+      $targetHeader.simulate('mouseup');
+
+      expect(getDataAtCell(9, 1)).toEqual('Elle King');
+      expect(getDataAtCell(10, 1)).toEqual('James Bay');
+
+      const dataManager = getPlugin('nestedRows').dataManager;
+
+      expect(dataManager.countChildren(6)).toEqual(7);
+      expect(dataManager.countChildren(14)).toEqual(3);
+
+      expect(dataManager.getDataObject(6).__children.pop().artist).toEqual('Florence & The Machine');
+      expect(dataManager.getDataObject(6).__children.pop().artist).toEqual('Highly Suspect');
+    });
+
+    it('should not expand and parents, if they were collapsed at the time of moving rows', () => {
+      const hot = handsontable({
+        data: getSimplerNestedData(),
+        nestedRows: true,
+        manualRowMove: true,
+        rowHeaders: true,
+        width: 500,
+        height: 500
+      });
+
+      hot.getPlugin('nestedRows').collapsingUI.collapseChildren(6);
+      hot.getPlugin('nestedRows').collapsingUI.collapseChildren(12);
+
+      const firstBaseHeader = spec().$container.find('.ht_clone_left tbody tr:eq(1) th:eq(0)');
+      const secondBaseHeader = spec().$container.find('.ht_clone_left tbody tr:eq(2) th:eq(0)');
+      const $targetHeader = spec().$container.find('.ht_clone_left tbody tr:eq(7) th:eq(0)');
+
+      firstBaseHeader.simulate('mousedown');
+      secondBaseHeader.simulate('mouseover');
+      secondBaseHeader.simulate('mousemove');
+      secondBaseHeader.simulate('mouseup');
+      secondBaseHeader.simulate('mousedown');
+
+      $targetHeader.simulate('mouseover');
+      $targetHeader.simulate('mousemove', {
+        clientY: $targetHeader.offset().top + 5
+      });
+
+      $targetHeader.simulate('mouseup');
+
+      expect(getDataAtCell(4, 0)).toEqual('Best Metal Performance');
+      expect(getDataAtCell(5, 0)).toEqual('Best Rock Song');
+
+      const collapsingUI = getPlugin('nestedRows').collapsingUI;
+
+      expect(collapsingUI.areChildrenCollapsed(4)).toBe(true);
+      expect(collapsingUI.areChildrenCollapsed(12)).toBe(true);
+    });
+
+    it('should select the collapsed parent after rows were moved inside of it', () => {
+      const hot = handsontable({
+        data: getSimplerNestedData(),
+        nestedRows: true,
+        manualRowMove: true,
+        rowHeaders: true,
+        width: 500,
+        height: 500
+      });
+
+      hot.getPlugin('nestedRows').collapsingUI.collapseChildren(6);
+      hot.getPlugin('nestedRows').collapsingUI.collapseChildren(12);
+
+      let firstBaseHeader = spec().$container.find('.ht_clone_left tbody tr:eq(1) th:eq(0)');
+      let secondBaseHeader = spec().$container.find('.ht_clone_left tbody tr:eq(2) th:eq(0)');
+      let $targetHeader = spec().$container.find('.ht_clone_left tbody tr:eq(7) th:eq(0)');
+
+      firstBaseHeader.simulate('mousedown');
+      secondBaseHeader.simulate('mouseover');
+      secondBaseHeader.simulate('mousemove');
+      secondBaseHeader.simulate('mouseup');
+      secondBaseHeader.simulate('mousedown');
+
+      $targetHeader.simulate('mouseover');
+      $targetHeader.simulate('mousemove', {
+        clientY: $targetHeader.offset().top + 5
+      });
+
+      $targetHeader.simulate('mouseup');
+
+      expect(getSelected()[0]).toEqual([4, 0, 4, 3]);
+
+      firstBaseHeader = spec().$container.find('.ht_clone_left tbody tr:eq(1) th:eq(0)');
+      secondBaseHeader = spec().$container.find('.ht_clone_left tbody tr:eq(2) th:eq(0)');
+      $targetHeader = spec().$container.find('.ht_clone_left tbody tr:eq(5) th:eq(0)');
+
+      firstBaseHeader.simulate('mousedown');
+      secondBaseHeader.simulate('mouseover');
+      secondBaseHeader.simulate('mousemove');
+      secondBaseHeader.simulate('mouseup');
+      secondBaseHeader.simulate('mousedown');
+
+      $targetHeader.simulate('mouseover');
+      $targetHeader.simulate('mousemove', {
+        clientY: $targetHeader.offset().top + 15
+      });
+
+      $targetHeader.simulate('mouseup');
+
+      expect(getSelected()[0]).toEqual([3, 0, 3, 3]);
+    });
   });
 
   it('should remove collapsed indexes properly', async() => {
@@ -485,7 +727,8 @@ describe('NestedRows', () => {
 
   describe('API', () => {
     describe('disableCoreAPIModifiers and enableCoreAPIModifiers', () => {
-      it('should kill the runtime of the core API modifying hook callbacks - onModifyRowData, onModifySourceLength and onBeforeDataSplice', () => {
+      it('should kill the runtime of the core API modifying hook callbacks - ' +
+        'onModifyRowData, onModifySourceLength and onBeforeDataSplice', () => {
         handsontable({
           data: getSimplerNestedData(),
           nestedRows: true,
@@ -676,7 +919,8 @@ describe('NestedRows', () => {
     expect(getData()).toEqual(dataAtStart);
   });
 
-  it('should display the right amount of entries when calling loadData after being initialized with empty data', (done) => {
+  it('should display the right amount of entries when calling loadData ' +
+    'after being initialized with empty data', (done) => {
     const hot = handsontable({
       data: [],
       nestedRows: true
@@ -702,7 +946,8 @@ describe('NestedRows', () => {
     }, 100);
   });
 
-  it('should display proper row headers after collapsing one parent - cooperation with the `BindRowsWithHeaders` plugin #5874', () => {
+  it('should display proper row headers after collapsing one parent - ' +
+    'cooperation with the `BindRowsWithHeaders` plugin #5874', () => {
     handsontable({
       data: getSimplerNestedData(),
       nestedRows: true,

--- a/src/plugins/nestedRows/ui/contextMenu.js
+++ b/src/plugins/nestedRows/ui/contextMenu.js
@@ -10,6 +10,7 @@ const privatePool = new WeakMap();
  *
  * @class ContextMenuUI
  * @util
+ * @private
  * @augments BaseUI
  */
 class ContextMenuUI extends BaseUI {

--- a/src/plugins/nestedRows/ui/headers.js
+++ b/src/plugins/nestedRows/ui/headers.js
@@ -7,6 +7,7 @@ import BaseUI from './_base';
  * Class responsible for the UI in the Nested Rows' row headers.
  *
  * @class HeadersUI
+ * @private
  * @util
  * @augments BaseUI
  */

--- a/src/plugins/nestedRows/utils/rowMoveController.js
+++ b/src/plugins/nestedRows/utils/rowMoveController.js
@@ -14,21 +14,25 @@ export default class RowMoveController {
   constructor(plugin) {
     /**
      * Reference to the Nested Rows plugin instance.
+     *
      * @type {NestedRows}
      */
     this.plugin = plugin;
     /**
      * Reference to the Handsontable instance.
+     *
      * @type {Handsontable.Core}
      */
     this.hot = plugin.hot;
     /**
      * Reference to the Data Manager class instance.
+     *
      * @type {DataManager}
      */
     this.dataManager = plugin.dataManager;
     /**
-     * Referencje to the Collapsing UI class instance.
+     * Reference to the Collapsing UI class instance.
+     *
      * @type {CollapsingUI}
      */
     this.collapsingUI = plugin.collapsingUI;

--- a/src/plugins/nestedRows/utils/rowMoveController.js
+++ b/src/plugins/nestedRows/utils/rowMoveController.js
@@ -12,9 +12,25 @@ import { CellCoords } from '../../../3rdparty/walkontable/src';
  */
 export default class RowMoveController {
   constructor(plugin) {
+    /**
+     * Reference to the Nested Rows plugin instance.
+     * @type {NestedRows}
+     */
     this.plugin = plugin;
+    /**
+     * Reference to the Handsontable instance.
+     * @type {Handsontable.Core}
+     */
     this.hot = plugin.hot;
+    /**
+     * Reference to the Data Manager class instance.
+     * @type {DataManager}
+     */
     this.dataManager = plugin.dataManager;
+    /**
+     * Referencje to the Collapsing UI class instance.
+     * @type {CollapsingUI}
+     */
     this.collapsingUI = plugin.collapsingUI;
   }
 

--- a/src/plugins/nestedRows/utils/rowMoveController.js
+++ b/src/plugins/nestedRows/utils/rowMoveController.js
@@ -1,0 +1,295 @@
+import { isUndefined } from '../../../helpers/mixed';
+import { warn } from '../../../helpers/console';
+import { toSingleLine } from '../../../helpers/templateLiteralTag';
+import { CellCoords } from '../../../3rdparty/walkontable/src';
+
+/**
+ * Helper class for the row-move-related operations.
+ *
+ * @class RowMoveController
+ * @plugin NestedRows
+ * @private
+ */
+export default class RowMoveController {
+  constructor(plugin) {
+    this.plugin = plugin;
+    this.hot = plugin.hot;
+    this.dataManager = plugin.dataManager;
+    this.collapsingUI = plugin.collapsingUI;
+  }
+
+  /**
+   * `beforeRowMove` hook callback.
+   *
+   * @param {Array} rows Array of visual row indexes to be moved.
+   * @param {number} finalIndex Visual row index, being a start index for the moved rows. Points to where the elements
+   *   will be placed after the moving action. To check the visualization of the final index, please take a look at
+   *   [documentation](/docs/demo-moving.html).
+   * @param {undefined|number} dropIndex Visual row index, being a drop index for the moved rows. Points to where we
+   *   are going to drop the moved elements. To check visualization of drop index please take a look at
+   *   [documentation](/docs/demo-moving.html).
+   * @param {boolean} movePossible Indicates if it's possible to move rows to the desired position.
+   * @fires Hooks#afterRowMove
+   * @returns {boolean}
+   */
+  onBeforeRowMove(rows, finalIndex, dropIndex, movePossible) {
+    const improperUsage = this.displayAPICompatibilityWarning({ rows, finalIndex, dropIndex, movePossible });
+
+    if (improperUsage) {
+      return false;
+    }
+
+    this.movedToCollapsed = false;
+    const dropToLastRow = dropIndex === this.hot.countRows();
+    const physicalDropIndex = dropToLastRow ?
+      this.hot.countSourceRows() :
+      this.dataManager.translateTrimmedRow(dropIndex);
+    let allowMove = true;
+    const physicalStartIndexes = rows.map((rowIndex) => {
+      // Don't do the logic for the rest of the rows, as it's bound to fail anyway.
+      if (!allowMove) {
+        return false;
+      }
+
+      const physicalRowIndex = this.dataManager.translateTrimmedRow(rowIndex);
+
+      allowMove = this.shouldAllowMoving(physicalRowIndex, physicalDropIndex);
+
+      return physicalRowIndex;
+    });
+    const willDataChange = physicalStartIndexes.indexOf(physicalDropIndex) === -1;
+
+    if (!allowMove || !willDataChange) {
+      return false;
+    }
+
+    const baseParent = this.getBaseParent(physicalStartIndexes);
+    const targetParent = this.getTargetParent(dropToLastRow, physicalDropIndex);
+    const sameParent = baseParent === targetParent;
+
+    this.movedToCollapsed = this.collapsingUI.areChildrenCollapsed(targetParent);
+
+    // Stash the current state of collapsed rows
+    this.collapsingUI.collapsedRowsStash.stash();
+
+    this.shiftCollapsibleParentsLocations(physicalStartIndexes, physicalDropIndex, sameParent);
+
+    this.moveRows(physicalStartIndexes, physicalDropIndex, targetParent);
+
+    this.dataManager.updateWithData(this.dataManager.getRawSourceData());
+
+    this.moveCellsMeta(physicalStartIndexes, physicalDropIndex);
+
+    this.collapsingUI.collapsedRowsStash.applyStash(false);
+
+    // TODO: Trying to mock real work of the `ManualRowMove` plugin. It was blocked by returning `false` below.
+    this.hot.runHooks('afterRowMove',
+      rows, finalIndex, dropIndex, movePossible, movePossible && this.isRowOrderChanged(rows, finalIndex));
+
+    // Not necessary - added to keep compatibility with other plugins (namely: columnSummary).
+    this.hot.render();
+
+    this.selectCells(rows, dropIndex);
+
+    return false;
+  }
+
+  /**
+   * Display a `dragRows`/`moveRows` method compatibility warning if needed.
+   *
+   * @param {object} beforeMoveRowHookArgs A set of arguments from the `beforeMoveRow` hook.
+   * @returns {boolean} `true` if is a result of an improper usage of the moving API.
+   */
+  displayAPICompatibilityWarning(beforeMoveRowHookArgs) {
+    const {
+      rows,
+      finalIndex,
+      dropIndex,
+      movePossible
+    } = beforeMoveRowHookArgs;
+    let shouldTerminate = false;
+
+    if (isUndefined(dropIndex)) {
+      warn(toSingleLine`Since version 8.0.0 of the Handsontable the 'moveRows' method isn't used for moving rows\x20
+      when the NestedRows plugin is enabled. Please use the 'dragRows' method instead.`);
+
+      // TODO: Trying to mock real work of the `ManualRowMove` plugin. It was blocked by returning `false` below.
+      this.hot.runHooks('afterRowMove', rows, finalIndex, dropIndex, movePossible, false);
+
+      shouldTerminate = true;
+    }
+
+    return shouldTerminate;
+  }
+
+  /**
+   * Check if the moving action should be allowed.
+   *
+   * @param {number} physicalRowIndex Physical start row index.
+   * @param {number} physicalDropIndex Physical drop index.
+   * @returns {boolean} `true` if it should continue with the moving action.
+   */
+  shouldAllowMoving(physicalRowIndex, physicalDropIndex) {
+    /*
+       We can't move rows when any of them is:
+       - a parent
+       - a top-level element
+       - is being moved to the top level
+       - is being moved to the position of any of the moved rows (not changing position)
+    */
+
+    return !(
+      this.dataManager.isParent(physicalRowIndex) ||
+      this.dataManager.isRowHighestLevel(physicalRowIndex) ||
+      physicalRowIndex === physicalDropIndex ||
+      physicalDropIndex === 0
+    );
+  }
+
+  /**
+   * Get the base row parent.
+   *
+   * @param {number} physicalStartIndexes Physical start row index.
+   * @returns {object|null} The base row parent.
+   */
+  getBaseParent(physicalStartIndexes) {
+    return this.dataManager.getRowParent(physicalStartIndexes[0]);
+  }
+
+  /**
+   * Get the target row parent.
+   *
+   * @param {boolean} dropToLastRow `true` if the row is moved to the last row of the table.
+   * @param {number} physicalDropIndex Physical drop row index.
+   * @returns {object|null} The target row parent.
+   */
+  getTargetParent(dropToLastRow, physicalDropIndex) {
+    let targetParent = this.dataManager.getRowParent(dropToLastRow ? physicalDropIndex - 1 : physicalDropIndex);
+
+    // If we try to move an element to the place of a top-level parent, snap the element to the previous top-level
+    // parent's children instead
+    if (targetParent === null || targetParent === void 0) {
+      targetParent = this.dataManager.getRowParent(physicalDropIndex - 1);
+    }
+
+    return targetParent;
+  }
+
+  /**
+   * Shift the cached collapsible rows position according to the move action.
+   *
+   * @param {number[]} physicalStartIndexes Physical start row indexes.
+   * @param {number} physicalDropIndex Physical drop index.
+   * @param {boolean} sameParent `true` if the row's being moved between siblings of the same parent.
+   */
+  shiftCollapsibleParentsLocations(physicalStartIndexes, physicalDropIndex, sameParent) {
+    if (!sameParent) {
+      if (Math.max(...physicalStartIndexes) <= physicalDropIndex) {
+        this.collapsingUI.collapsedRowsStash.shiftStash(physicalStartIndexes[0], physicalDropIndex,
+          (-1) * physicalStartIndexes.length);
+
+      } else {
+        this.collapsingUI.collapsedRowsStash.shiftStash(physicalDropIndex, physicalStartIndexes[0],
+          physicalStartIndexes.length);
+      }
+    }
+  }
+
+  /**
+   * Move the rows at the provided coordinates.
+   *
+   * @param {number[]} physicalStartIndexes Physical indexes of the rows about to be moved.
+   * @param {number} physicalDropIndex Physical drop index.
+   * @param {object} targetParent Parent of the destination row.
+   */
+  moveRows(physicalStartIndexes, physicalDropIndex, targetParent) {
+    const moveToLastChild = physicalDropIndex === this.dataManager.getRowIndex(targetParent) +
+      this.dataManager.countChildren(targetParent) + 1;
+
+    physicalStartIndexes.forEach((physicalStartIndex) => {
+      this.dataManager.moveRow(physicalStartIndex, physicalDropIndex, this.movedToCollapsed, moveToLastChild, true);
+    });
+  }
+
+  /**
+   * Move the cell meta for multiple rows.
+   *
+   * @param {number[]} baseIndexes Array of indexes for the rows being moved.
+   * @param {number} targetIndex Index of the destination of the move.
+   */
+  moveCellsMeta(baseIndexes, targetIndex) {
+    const rowsOfMeta = [];
+    const movingDown = Math.max(...baseIndexes) < targetIndex;
+
+    baseIndexes.forEach((baseIndex) => {
+      rowsOfMeta.push(this.hot.getCellMetaAtRow(baseIndex));
+    });
+
+    this.hot.spliceCellsMeta(baseIndexes[0], baseIndexes.length);
+
+    this.hot.spliceCellsMeta(targetIndex - (movingDown ? rowsOfMeta.length : 0), 0, ...rowsOfMeta);
+  }
+
+  /**
+   * Select cells after the move.
+   *
+   * @param {Array} rows Array of visual row indexes to be moved.
+   * @param {undefined|number} dropIndex Visual row index, being a drop index for the moved rows. Points to where we
+   *   are going to drop the moved elements. To check visualization of drop index please take a look at
+   *   [documentation](/docs/demo-moving.html).
+   */
+  selectCells(rows, dropIndex) {
+    const rowsLen = rows.length;
+    let startRow = 0;
+    let endRow = 0;
+    let selection = null;
+    let lastColIndex = null;
+
+    if (this.movedToCollapsed) {
+      let physicalDropIndex = null;
+
+      if (rows[rowsLen - 1] < dropIndex) {
+        physicalDropIndex = this.dataManager.translateTrimmedRow(dropIndex - rowsLen);
+
+      } else {
+        physicalDropIndex = this.dataManager.translateTrimmedRow(dropIndex);
+      }
+
+      const parentObject = this.dataManager.getRowParent(
+        physicalDropIndex === null ? this.hot.countSourceRows() - 1 : physicalDropIndex - 1
+      );
+      const parentIndex = this.dataManager.getRowIndex(parentObject);
+
+      startRow = this.dataManager.untranslateTrimmedRow(parentIndex);
+      endRow = startRow;
+
+    } else if (rows[rowsLen - 1] < dropIndex) {
+      endRow = dropIndex - 1;
+      startRow = endRow - rowsLen + 1;
+
+    } else {
+      startRow = dropIndex;
+      endRow = startRow + rowsLen - 1;
+    }
+
+    selection = this.hot.selection;
+    lastColIndex = this.hot.countCols() - 1;
+
+    selection.setRangeStart(new CellCoords(startRow, 0));
+    selection.setRangeEnd(new CellCoords(endRow, lastColIndex), true);
+  }
+
+  // TODO: Reimplementation of function which is inside the `ManualRowMove` plugin.
+  /**
+   * Indicates if order of rows was changed.
+   *
+   * @param {Array} movedRows Array of visual row indexes to be moved.
+   * @param {number} finalIndex Visual row index, being a start index for the moved rows. Points to where the elements
+   *   will be placed after the moving action. To check the visualization of the final index, please take a look at
+   *   [documentation](/docs/demo-moving.html).
+   * @returns {boolean}
+   */
+  isRowOrderChanged(movedRows, finalIndex) {
+    return movedRows.some((row, nrOfMovedElement) => row - nrOfMovedElement !== finalIndex);
+  }
+}


### PR DESCRIPTION
### Context
While working on a fix for #6067 I hit a wall and decided I needed to do a small refactor of the moving logic in the Nested Rows plugin, or the ugly workarounds would pile up.
This change contains a cleanup of the moving logic, fixes #6067 and some other move-related bugs. Each of the fixed bugs has it's own test case added.

### How has this been tested?
Added test cases for the resolved issues.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #6067 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
