### PR TITLE
Fixes empty widths cache after updateSettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue where the rows were missing their left border after disabling the row headers using `updateSettings`, while there were `fixedColumnsLeft` defined. [#5735](https://github.com/handsontable/handsontable/issues/5735)
 - Fixed an issue where the Handsontable could fall into an infinite loop during vertical scrolling. It only happened when the scrollable element was the `window` object. [#7260](https://github.com/handsontable/handsontable/issues/7260);
 - Fixed an issue with moving rows to the last row of the table, when the Nested Rows plugin was enabled along with some other minor moving-related bugs. [#6067](https://github.com/handsontable/handsontable/issues/6067)
+- Fixed an issue with clipped column headers if they were changed before or within usage `updateSettings`. [#6004](https://github.com/handsontable/handsontable/issues/6004)
 
 ### Changed
 - Updated dependencies to meet security requirements [#7222](https://github.com/handsontable/handsontable/pull/7222)

--- a/handsontable.d.ts
+++ b/handsontable.d.ts
@@ -760,6 +760,7 @@ declare namespace Handsontable {
 
       calculateAllColumnsWidth(rowRange?: number | object): void;
       calculateColumnsWidth(colRange?: number | object, rowRange?: number | object, force?: boolean): void;
+      calculateVisibleColumnsWidth(): void;
       clearCache(columns?: any[]): void;
       findColumnsWhereHeaderWasChanged(): any[];
       getColumnWidth(col: number, defaultWidth?: number, keepMinimum?: boolean): number;

--- a/src/css/handsontable.css
+++ b/src/css/handsontable.css
@@ -1,8 +1,8 @@
 .handsontable.htAutoSize {
-  /* visibility: hidden;
+  visibility: hidden;
   left: -99000px;
   position: absolute;
-  top: -99000px; */
+  top: -99000px;
 }
 
 .handsontable td.htInvalid {

--- a/src/css/handsontable.css
+++ b/src/css/handsontable.css
@@ -1,8 +1,8 @@
 .handsontable.htAutoSize {
-  visibility: hidden;
+  /* visibility: hidden;
   left: -99000px;
   position: absolute;
-  top: -99000px;
+  top: -99000px; */
 }
 
 .handsontable td.htInvalid {

--- a/src/plugins/autoColumnSize/autoColumnSize.js
+++ b/src/plugins/autoColumnSize/autoColumnSize.js
@@ -194,6 +194,7 @@ class AutoColumnSize extends BasePlugin {
     if (changedColumns.length) {
       this.clearCache(changedColumns);
     }
+
     super.updatePlugin();
   }
 
@@ -454,8 +455,9 @@ class AutoColumnSize extends BasePlugin {
     const columnHeaders = this.hot.getColHeader();
     const { cachedColumnHeaders } = privatePool.get(this);
 
-    const changedColumns = arrayReduce(columnHeaders, (acc, columnTitle, physicalColumn) => {
+    const changedColumns = arrayReduce(columnHeaders, (acc, columnTitle, visualColumn) => {
       const cachedColumnsLength = cachedColumnHeaders.length;
+      const physicalColumn = this.hot.toPhysicalColumn(visualColumn);
 
       if (cachedColumnsLength - 1 < physicalColumn || cachedColumnHeaders[physicalColumn] !== columnTitle) {
         acc.push(physicalColumn);
@@ -506,8 +508,8 @@ class AutoColumnSize extends BasePlugin {
    *
    * @private
    */
-  onBeforeRender() {
-    const force = this.hot.renderCall;
+  onBeforeRender(force) {
+    // const force = this.hot.renderCall;
     const rowsCount = this.hot.countRows();
     const firstVisibleColumn = this.getFirstVisibleColumn();
     const lastVisibleColumn = this.getLastVisibleColumn();

--- a/src/plugins/autoColumnSize/autoColumnSize.js
+++ b/src/plugins/autoColumnSize/autoColumnSize.js
@@ -193,7 +193,7 @@ class AutoColumnSize extends BasePlugin {
 
     if (changedColumns.length) {
       this.clearCache(changedColumns);
-      this.calculateVisibleColumns(true);
+      this.calculateVisibleColumns();
     }
 
     super.updatePlugin();
@@ -213,10 +213,8 @@ class AutoColumnSize extends BasePlugin {
 
   /**
    * Calculates visible columns width.
-   *
-   * @param {boolean} [force=false] If `true` the calculation will be processed regardless of whether the width exists in the cache.
    */
-  calculateVisibleColumns(force) {
+  calculateVisibleColumns() {
     const rowsCount = this.hot.countRows();
 
     // Keep last column widths unchanged for situation when all rows was deleted or trimmed (pro #6)
@@ -224,6 +222,7 @@ class AutoColumnSize extends BasePlugin {
       return;
     }
 
+    const force = this.hot.renderCall;
     const firstVisibleColumn = this.getFirstVisibleColumn();
     const lastVisibleColumn = this.getLastVisibleColumn();
 
@@ -530,10 +529,9 @@ class AutoColumnSize extends BasePlugin {
    * On before render listener.
    *
    * @private
-   * @param {boolean} [force] Indicates if the render call was trigered by a change of settings or data.
    */
-  onBeforeRender(force) {
-    this.calculateVisibleColumns(force);
+  onBeforeRender() {
+    this.calculateVisibleColumns();
 
     if (this.isNeedRecalculate() && !this.inProgress) {
       this.calculateAllColumnsWidth();

--- a/src/plugins/autoColumnSize/autoColumnSize.js
+++ b/src/plugins/autoColumnSize/autoColumnSize.js
@@ -193,7 +193,7 @@ class AutoColumnSize extends BasePlugin {
 
     if (changedColumns.length) {
       this.clearCache(changedColumns);
-      this.calculateVisibleColumns();
+      this.calculateVisibleColumnsWidth();
     }
 
     super.updatePlugin();
@@ -214,7 +214,7 @@ class AutoColumnSize extends BasePlugin {
   /**
    * Calculates visible columns width.
    */
-  calculateVisibleColumns() {
+  calculateVisibleColumnsWidth() {
     const rowsCount = this.hot.countRows();
 
     // Keep last column widths unchanged for situation when all rows was deleted or trimmed (pro #6)
@@ -531,7 +531,7 @@ class AutoColumnSize extends BasePlugin {
    * @private
    */
   onBeforeRender() {
-    this.calculateVisibleColumns();
+    this.calculateVisibleColumnsWidth();
 
     if (this.isNeedRecalculate() && !this.inProgress) {
       this.calculateAllColumnsWidth();

--- a/src/plugins/autoColumnSize/test/autoColumnSize.e2e.js
+++ b/src/plugins/autoColumnSize/test/autoColumnSize.e2e.js
@@ -334,6 +334,36 @@ describe('AutoColumnSize', () => {
     expect(width1).toBeLessThan(width2);
   });
 
+  it(`should keep proper topOverlay size after render() -> adjustElementSize() -> updateSettings
+      with a different set of colHeaders`, () => {
+    const getHeaders = () => [
+      'A_longer',
+      'B_longer',
+      'C_longer',
+      'D_longer',
+      'E_longer',
+    ];
+    const hot = handsontable({
+      data: Handsontable.helper.createSpreadsheetData(5, 5),
+      colHeaders: getHeaders(),
+      rowHeaders: true,
+    });
+
+    const topOverlay = spec().$container.find('.ht_clone_top .wtHider');
+    const topOverlayWidthBefore = topOverlay.width();
+
+    // Simulates a sequence of methods used in contextMenu commands for plugins like Hidden*, Freeze*
+    // or internal plugins' methods like Filters, Manual*Move, Manual*Resize.
+    hot.render();
+    hot.view.wt.wtOverlays.adjustElementsSize(true);
+
+    hot.updateSettings({
+      colHeaders: getHeaders().reverse(),
+    });
+
+    expect(topOverlayWidthBefore).toEqual(topOverlay.width());
+  });
+
   it('should consider CSS style of each instance separately', () => {
     const $style = $('<style>.big .htCore td {font-size: 40px; line-height: 1.1;}</style>').appendTo('head');
     const $container1 = $('<div id="hot1"></div>').appendTo('body').handsontable({


### PR DESCRIPTION
### Context
Some contextmenu items for plugins (Hidden, Freeze) and some internal methods in plugins (Filters, Move, Collapsible) calls a sequence of the following methods:
```
hot.render();
hot.view.wt.wtOverlays.adjustElementsSize(true);
```
to provide stable rerender with adjusted overlays.
Unfortunately, if we call updateSettings with a different set of columns' headers then AutoColumnSize will clear its widths cache. The top overlay will calculate its width based on the default column width - if headers are longer than default size then topOverlay's wtHider would clip our headers.

Probably we should consider a better/more efficient sequence of actions to prepare possible widths before we even start any rendering to omit unnecessary multiple rendering in the whole process.

### How has this been tested?
1. Initialize Handsontable with the following configuration:
```
{
  colHeaders: [
    'A_longer',
    'B_longer',
    'C_longer',
    'D_longer',
    'E_longer',
  ],
  rowHeaders: true,
}
```
2. Call the following sequence of methods:
```
hot.render();
hot.view.wt.wtOverlays.adjustElementsSize(true);
```
3. Call `updateSettings` with the following configuration:
```
{
  colHeaders: [
    'E_longer',
    'D_longer',
    'C_longer',
    'B_longer',
    'A_longer',
  ],
}
```

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. #6004
