### PR TITLE
Fix a typo in "data" [DOCS]

### DIFF
--- a/src/dataMap/metaManager/metaSchema.js
+++ b/src/dataMap/metaManager/metaSchema.js
@@ -468,7 +468,7 @@ export default () => {
      * // or
      * // enable comments plugin and add predefined comments
      * const hot = new Handsontable(document.getElementById('example'), {
-     *   date: getData(),
+     *   data: getData(),
      *   comments: true,
      *   cell: [
      *     { row: 1, col: 1, comment: { value: 'Foo' } },

--- a/src/plugins/autoColumnSize/autoColumnSize.js
+++ b/src/plugins/autoColumnSize/autoColumnSize.js
@@ -42,7 +42,7 @@ const COLUMN_SIZE_MAP_NAME = 'autoColumnSize';
  * @example
  * ```js
  * const hot = new Handsontable(document.getElementById('example'), {
- *   date: getData(),
+ *   data: getData(),
  *   autoColumnSize: true
  * });
  * // Access to plugin instance:

--- a/src/plugins/autoRowSize/autoRowSize.js
+++ b/src/plugins/autoRowSize/autoRowSize.js
@@ -48,7 +48,7 @@ const ROW_WIDTHS_MAP_NAME = 'autoRowSize';
  *
  * ```js
  * const hot = new Handsontable(document.getElementById('example'), {
- *   date: getData(),
+ *   data: getData(),
  *   autoRowSize: true
  * });
  * // Access to plugin instance:

--- a/src/plugins/bindRowsWithHeaders/bindRowsWithHeaders.js
+++ b/src/plugins/bindRowsWithHeaders/bindRowsWithHeaders.js
@@ -23,7 +23,7 @@ const bindTypeToMapStrategy = new Map([
  * ```js
  * const container = document.getElementById('example');
  * const hot = new Handsontable(container, {
- *   date: getData(),
+ *   data: getData(),
  *   // enable plugin
  *   bindRowsWithHeaders: true
  * });

--- a/src/plugins/comments/comments.js
+++ b/src/plugins/comments/comments.js
@@ -53,7 +53,7 @@ const META_READONLY = 'readOnly';
  *
  * ```js
  * const hot = new Handsontable(document.getElementById('example'), {
- *   date: getData(),
+ *   data: getData(),
  *   comments: true,
  *   cell: [
  *     {row: 1, col: 1, comment: {value: 'Foo'}},

--- a/src/plugins/filters/filters.js
+++ b/src/plugins/filters/filters.js
@@ -293,7 +293,7 @@ class Filters extends BasePlugin {
    * ```js
    * const container = document.getElementById('example');
    * const hot = new Handsontable(container, {
-   *   date: getData(),
+   *   data: getData(),
    *   filters: true
    * });
    *

--- a/src/plugins/headerTooltips/headerTooltips.js
+++ b/src/plugins/headerTooltips/headerTooltips.js
@@ -24,7 +24,7 @@ let isDeprecationMessageShowed = false;
  * ```js
  * const container = document.getElementById('example');
  * const hot = new Handsontable(container, {
- *   date: getData(),
+ *   data: getData(),
  *   // enable and configure header tooltips
  *   headerTooltips: {
  *     rows: true,

--- a/src/plugins/hiddenColumns/hiddenColumns.js
+++ b/src/plugins/hiddenColumns/hiddenColumns.js
@@ -35,7 +35,7 @@ Hooks.getSingleton().register('afterUnhideColumns');
  * ```js
  * const container = document.getElementById('example');
  * const hot = new Handsontable(container, {
- *   date: getData(),
+ *   data: getData(),
  *   hiddenColumns: {
  *     copyPasteEnabled: true,
  *     indicators: true,

--- a/src/plugins/hiddenRows/hiddenRows.js
+++ b/src/plugins/hiddenRows/hiddenRows.js
@@ -36,7 +36,7 @@ Hooks.getSingleton().register('afterUnhideRows');
  * ```js
  * const container = document.getElementById('example');
  * const hot = new Handsontable(container, {
- *   date: getData(),
+ *   data: getData(),
  *   hiddenRows: {
  *     copyPasteEnabled: true,
  *     indicators: true,

--- a/src/plugins/nestedHeaders/nestedHeaders.js
+++ b/src/plugins/nestedHeaders/nestedHeaders.js
@@ -30,7 +30,7 @@ import './nestedHeaders.css';
  * ```js
  * const container = document.getElementById('example');
  * const hot = new Handsontable(container, {
- *   date: getData(),
+ *   data: getData(),
  *   nestedHeaders: [
  *     ['A', {label: 'B', colspan: 8}, 'C'],
  *     ['D', {label: 'E', colspan: 4}, {label: 'F', colspan: 4}, 'G'],

--- a/src/plugins/trimRows/trimRows.js
+++ b/src/plugins/trimRows/trimRows.js
@@ -15,7 +15,7 @@ import { arrayEach, arrayReduce } from '../../helpers/array';
  * ```js
  * const container = document.getElementById('example');
  * const hot = new Handsontable(container, {
- *   date: getData(),
+ *   data: getData(),
  *   // hide selected rows on table initialization
  *   trimRows: [1, 2, 5]
  * });


### PR DESCRIPTION
### Context
Fix the occurrences of `date` (should be `data`) in examples, it can be misleading to the developers.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] A fix in the documentation.

### Related issue(s):
1. https://github.com/handsontable/docs/issues/155