### PR TITLE
Replaced offsetWidth with getBoundingClientRect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue where the rows were missing their left border after disabling the row headers using `updateSettings`, while there were `fixedColumnsLeft` defined. [#5735](https://github.com/handsontable/handsontable/issues/5735)
 - Fixed an issue where the Handsontable could fall into an infinite loop during vertical scrolling. It only happened when the scrollable element was the `window` object. [#7260](https://github.com/handsontable/handsontable/issues/7260);
 - Fixed an issue with moving rows to the last row of the table, when the Nested Rows plugin was enabled along with some other minor moving-related bugs. [#6067](https://github.com/handsontable/handsontable/issues/6067)
+- Fixed an issue with adding unnecessary extra empty line in cells on Safari. [#7262](https://github.com/handsontable/handsontable/issues/7262)
 
 ### Changed
 - Updated dependencies to meet security requirements [#7222](https://github.com/handsontable/handsontable/pull/7222)

--- a/src/helpers/dom/element.js
+++ b/src/helpers/dom/element.js
@@ -763,7 +763,7 @@ export function getComputedStyle(element, rootWindow = window) {
  * @returns {number} Element's outer width.
  */
 export function outerWidth(element) {
-  return element.offsetWidth;
+  return Math.ceil(element.getBoundingClientRect().width);
 }
 
 /**

--- a/test/e2e/Dom.spec.js
+++ b/test/e2e/Dom.spec.js
@@ -157,6 +157,37 @@ describe('Handsontable.Dom', () => {
     });
   });
 
+  describe('outerWidth', () => {
+    let element;
+
+    beforeEach(() => {
+      element = $('<div/>').appendTo('body');
+    });
+
+    afterEach(() => {
+      element.remove();
+      element = null;
+    });
+
+    it('should properly calculate element\'s width if it\'s an integer value', () => {
+      element.css({ width: '10px' });
+
+      expect(Handsontable.dom.outerWidth(element[0])).toBe(10);
+    });
+
+    it('should properly calculate element\'s width if it\'s a floating value (less than x.5)', () => {
+      element.css({ width: '10.25px' });
+
+      expect(Handsontable.dom.outerWidth(element[0])).toBe(11);
+    });
+
+    it('should properly calculate element\'s width if it\'s a floating value (equal or greater than x.5)', () => {
+      element.css({ width: '10.5px' });
+
+      expect(Handsontable.dom.outerWidth(element[0])).toBe(11);
+    });
+  });
+
   xit('should return correct offset for table cell (table with caption)', () => {
     const $table = $('<table style="border-width: 0;"><caption style="padding: 0; margin:0">' +
                      '<div style="height: 30px">caption</div></caption><tbody>' +


### PR DESCRIPTION
### Context
In some cases (as requested in #7262) cell's value might be rendered with an unnecessary extra line. It's that due to fractional width (between x.0 and <x.5) in the computed size in a browser.

Currently, we use `offsetWidth` value, which one contains an integer. Unfortunately, it might clip rect in case its real value has floating-point between `x.0` and `<x.5`. In result, the browser adds additional line (because of the fact that it moves `\n` white char into the next line).

In proposed solution, I've replaced `offsetWidth` with a `Math.ceil(...getBoundingClientRect().width)`. This solution should give us a stable way to calculate proper `outerWidth` in any use case and each supported browser. Although, we know that `getBoundingClientRect` might have an impact on overall performance. In ours `performance-lab` I noticed the average increased execution time by `~2ms` - in my opinion, it's worth to use more accurate way to measure size by almost unnoticeable performance decrease.

### How has this been tested?
1. Initialize Handsontable in Safari with a default columns width and default editors.
2. Open any editor in the first column and insert:
```
Longer
text
```
Result: Edited cell should be rendered with only 2 lines.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. #7262