### PR TITLE
Warn about resetting the state [DOCS]

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1669,6 +1669,8 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
 
   /**
    * Loads new data to Handsontable. Loading new data resets the cell meta.
+   * Since 8.0.0 loading new data also resets states corresponding to rows and columns
+   * (ie. Row/column sequence, column width, row height, freezed columns etc.).
    *
    * @memberof Core#
    * @function loadData
@@ -1885,6 +1887,9 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
    *
    * __Note__, that although the `updateSettings` method doesn't overwrite the previously declared settings, it might reset
    * the settings made post-initialization. (for example - ignore changes made using the columnResize feature).
+   *
+   * Since 8.0.0 passing `columns` or `data` inside `settings` objects will result in resetting states corresponding to rows and columns
+   * (ie. Row/column sequence, column width, row height, freezed columns etc.).
    *
    * @memberof Core#
    * @function updateSettings

--- a/src/core.js
+++ b/src/core.js
@@ -1670,7 +1670,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
   /**
    * Loads new data to Handsontable. Loading new data resets the cell meta.
    * Since 8.0.0 loading new data also resets states corresponding to rows and columns
-   * (ie. Row/column sequence, column width, row height, freezed columns etc.).
+   * (ie. row/column sequence, column width, row height, freezed columns etc.).
    *
    * @memberof Core#
    * @function loadData
@@ -1889,7 +1889,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
    * the settings made post-initialization. (for example - ignore changes made using the columnResize feature).
    *
    * Since 8.0.0 passing `columns` or `data` inside `settings` objects will result in resetting states corresponding to rows and columns
-   * (ie. Row/column sequence, column width, row height, freezed columns etc.).
+   * (ie. row/column sequence, column width, row height, freezed columns etc.).
    *
    * @memberof Core#
    * @function updateSettings

--- a/src/core.js
+++ b/src/core.js
@@ -1670,7 +1670,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
   /**
    * Loads new data to Handsontable. Loading new data resets the cell meta.
    * Since 8.0.0 loading new data also resets states corresponding to rows and columns
-   * (ie. row/column sequence, column width, row height, freezed columns etc.).
+   * (for example, row/column sequence, column width, row height, frozen columns etc.).
    *
    * @memberof Core#
    * @function loadData
@@ -1889,7 +1889,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
    * the settings made post-initialization. (for example - ignore changes made using the columnResize feature).
    *
    * Since 8.0.0 passing `columns` or `data` inside `settings` objects will result in resetting states corresponding to rows and columns
-   * (ie. row/column sequence, column width, row height, freezed columns etc.).
+   * (for example, row/column sequence, column width, row height, frozen columns etc.).
    *
    * @memberof Core#
    * @function updateSettings


### PR DESCRIPTION
### Context
https://github.com/handsontable/handsontable/pull/6547 introduced a breaking change. We need to warn the developer about resetting the state under specific circumstances.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] An improvement to the documentation

### Related issue(s):
1. https://github.com/handsontable/docs/issues/157

@wszymanski please check if the wording is correct, this is the API part of the change, I will look into tutorials as well.
