### PR TITLE
Remove the `areElementSizesAdjusted` flag and some `adjustElementsSize()` calls.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue with moving rows to the last row of the table, when the Nested Rows plugin was enabled along with some other minor moving-related bugs. [#6067](https://github.com/handsontable/handsontable/issues/6067)
 - Fixed an issue with adding unnecessary extra empty line in cells on Safari. [#7262](https://github.com/handsontable/handsontable/issues/7262)
 - Fixed an issue with clipped column headers if they were changed before or within usage `updateSettings`. [#6004](https://github.com/handsontable/handsontable/issues/6004)
+- Fixed an issue the container not being updated after trimming rows. [#7241](https://github.com/handsontable/handsontable/issues/7241)
 
 ### Changed
 - Updated dependencies to meet security requirements [#7222](https://github.com/handsontable/handsontable/pull/7222)

--- a/src/3rdparty/walkontable/src/overlay/_base.js
+++ b/src/3rdparty/walkontable/src/overlay/_base.js
@@ -143,7 +143,6 @@ class Overlay {
     this.holder = holder;
     this.wtRootElement = wtRootElement;
     this.trimmingContainer = getTrimmingContainer(this.hider.parentNode.parentNode);
-    this.areElementSizesAdjusted = false;
     this.updateStateOfRendering();
   }
 

--- a/src/3rdparty/walkontable/src/overlay/bottom.js
+++ b/src/3rdparty/walkontable/src/overlay/bottom.js
@@ -181,10 +181,6 @@ class BottomOverlay extends Overlay {
     if (this.needFullRender || force) {
       this.adjustRootElementSize();
       this.adjustRootChildrenSize();
-
-      if (!force) {
-        this.areElementSizesAdjusted = true;
-      }
     }
   }
 
@@ -240,9 +236,6 @@ class BottomOverlay extends Overlay {
   applyToDOM() {
     const total = this.wot.getSetting('totalRows');
 
-    if (!this.areElementSizesAdjusted) {
-      this.adjustElementsSize();
-    }
     if (typeof this.wot.wtViewport.rowsRenderCalculator.startPosition === 'number') {
       this.spreader.style.top = `${this.wot.wtViewport.rowsRenderCalculator.startPosition}px`;
 

--- a/src/3rdparty/walkontable/src/overlay/left.js
+++ b/src/3rdparty/walkontable/src/overlay/left.js
@@ -154,10 +154,6 @@ class LeftOverlay extends Overlay {
     if (this.needFullRender || force) {
       this.adjustRootElementSize();
       this.adjustRootChildrenSize();
-
-      if (!force) {
-        this.areElementSizesAdjusted = true;
-      }
     }
   }
 
@@ -213,9 +209,6 @@ class LeftOverlay extends Overlay {
   applyToDOM() {
     const total = this.wot.getSetting('totalColumns');
 
-    if (!this.areElementSizesAdjusted) {
-      this.adjustElementsSize();
-    }
     if (typeof this.wot.wtViewport.columnsRenderCalculator.startPosition === 'number') {
       this.spreader.style.left = `${this.wot.wtViewport.columnsRenderCalculator.startPosition}px`;
 

--- a/src/3rdparty/walkontable/src/overlay/top.js
+++ b/src/3rdparty/walkontable/src/overlay/top.js
@@ -179,10 +179,6 @@ class TopOverlay extends Overlay {
     if (this.needFullRender || force) {
       this.adjustRootElementSize();
       this.adjustRootChildrenSize();
-
-      if (!force) {
-        this.areElementSizesAdjusted = true;
-      }
     }
   }
 
@@ -242,9 +238,6 @@ class TopOverlay extends Overlay {
   applyToDOM() {
     const total = this.wot.getSetting('totalRows');
 
-    if (!this.areElementSizesAdjusted) {
-      this.adjustElementsSize();
-    }
     if (typeof this.wot.wtViewport.rowsRenderCalculator.startPosition === 'number') {
       this.spreader.style.top = `${this.wot.wtViewport.rowsRenderCalculator.startPosition}px`;
 

--- a/src/3rdparty/walkontable/src/overlays.js
+++ b/src/3rdparty/walkontable/src/overlays.js
@@ -472,16 +472,14 @@ class Overlays {
    *                                   rendering anyway.
    */
   refresh(fastDraw = false) {
-    if (this.topOverlay.areElementSizesAdjusted && this.leftOverlay.areElementSizesAdjusted) {
-      const container = this.wot.wtTable.wtRootElement.parentNode || this.wot.wtTable.wtRootElement;
-      const width = container.clientWidth;
-      const height = container.clientHeight;
+    const spreader = this.wot.wtTable.spreader;
+    const width = spreader.clientWidth;
+    const height = spreader.clientHeight;
 
-      if (width !== this.spreaderLastSize.width || height !== this.spreaderLastSize.height) {
-        this.spreaderLastSize.width = width;
-        this.spreaderLastSize.height = height;
-        this.adjustElementsSize();
-      }
+    if (width !== this.spreaderLastSize.width || height !== this.spreaderLastSize.height) {
+      this.spreaderLastSize.width = width;
+      this.spreaderLastSize.height = height;
+      this.adjustElementsSize();
     }
 
     if (this.bottomOverlay.clone) {
@@ -549,10 +547,6 @@ class Overlays {
 
     if (!wtTable.isVisible()) {
       return;
-    }
-
-    if (!this.topOverlay.areElementSizesAdjusted || !this.leftOverlay.areElementSizesAdjusted) {
-      this.adjustElementsSize();
     }
 
     this.topOverlay.applyToDOM();

--- a/src/plugins/trimRows/test/settings/fixedRowsTop.e2e.js
+++ b/src/plugins/trimRows/test/settings/fixedRowsTop.e2e.js
@@ -102,5 +102,33 @@ describe('TrimRows', () => {
         <tbody></tbody>
         `);
     });
+
+    it('should resize the container after trimming rows using the `trimRows` API method, when there are fixed rows' +
+      ' declared', async() => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(50, 2),
+        rowHeaders: true,
+        fixedRowsTop: 2,
+        trimRows: true,
+      });
+
+      selectCell(1, 1);
+
+      const initialHeight = spec().$container.height();
+
+      hot().getPlugin('trimRows').trimRows(
+        Array.from(Array(45).keys())
+      );
+      hot().render();
+
+      const resultingHeight = spec().$container.height();
+
+      expect(resultingHeight < initialHeight).toBe(true);
+
+      hot().getPlugin('trimRows').untrimAll();
+      hot().render();
+
+      expect(spec().$container.height()).toEqual(initialHeight);
+    });
   });
 });


### PR DESCRIPTION
### Context
The problem with #7241 seems to have been caused by not calling `adjustElementsSize` in some very specific cases.

In this PR I removed the `areElementSizesAdjusted` flag completely, as it did not seem to work properly. (It was initialized as `false`, then changed to `true` in some places, but never to `false` again. This resulted in it being `true` after the first render.) 

The `adjustElementsSize()` method was called in some unexpected places, like `applyToDOM()`, so I removed those calls, as after the `areElementSizesAdjusted` was gone, it was no longer needed.

### How has this been tested?
Added a test case.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7241 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
