### PR TITLE
Adds an additional scrollTop call to trigger innerBorderTop in manualRowResize test

### DIFF
--- a/src/plugins/manualRowResize/test/manualRowResize.e2e.js
+++ b/src/plugins/manualRowResize/test/manualRowResize.e2e.js
@@ -597,8 +597,8 @@ describe('manualRowResize', () => {
       expect($rowHeader.offset().top + $rowHeader.height() - 5).toBeCloseTo($handle.offset().top, 0);
       expect($rowHeader.offset().left).toBeCloseTo($handle.offset().left, 0);
 
+      $(mainHolder).scrollTop(1); // we have to trigger innerBorderTop before we scroll to correct position
       $(mainHolder).scrollTop(200);
-
       await sleep(400);
 
       $rowHeader = getLeftClone().find('tr:eq(13) th:eq(0)');

--- a/src/plugins/manualRowResize/test/manualRowResize.e2e.js
+++ b/src/plugins/manualRowResize/test/manualRowResize.e2e.js
@@ -598,6 +598,7 @@ describe('manualRowResize', () => {
       expect($rowHeader.offset().left).toBeCloseTo($handle.offset().left, 0);
 
       $(mainHolder).scrollTop(1); // we have to trigger innerBorderTop before we scroll to correct position
+      await sleep(100);
       $(mainHolder).scrollTop(200);
       await sleep(400);
 


### PR DESCRIPTION
### Context
In this PR I added an additional call to trigger adding innerBorderTop to the table. In Firefox scroll by script leads to the misaligned rows between overlays. Stable innerBorderTop and adding border-top in the meantime of scrolling is not a main purpose of `manualRowResize > handle position in a table positioned using CSS's `transform` > should display the handles in the correct position, with holder as a scroll parent` scenario.

I tried to eliminate innerBorderTop, but after a few hours I discussed this thing with @wojciechczerniak and we agreed it should be a separated project.

### How has this been tested?
Run E2E tests in Firefox.

### Types of changes
- [x] Tests improvement.

### Related issue(s):
1. #6601
