### PR TITLE
Adjusts Walkontable E2E tests to run them in Windows CLI

### DIFF
--- a/.config/test-walkontable.js
+++ b/.config/test-walkontable.js
@@ -55,7 +55,10 @@ module.exports.create = function create(envArgs) {
           'lib/jquery.simulate.js',
           '../dist/walkontable.js',
         ],
-      })
+      }),
+      new webpack.DefinePlugin({
+        '__ENV_ARGS__': JSON.stringify(envArgs),
+      }),
     ],
   };
 

--- a/src/3rdparty/walkontable/test/spec/index.js
+++ b/src/3rdparty/walkontable/test/spec/index.js
@@ -1,8 +1,22 @@
+let testPathRegExp = null;
+
+if (typeof __ENV_ARGS__ === 'object' && __ENV_ARGS__.testPathPattern) {
+  // Remove string between % signs. On Windows' machines an empty env variable was visible as '%{variable_name}%' so it must be stripped.
+  // See https://github.com/handsontable/handsontable/issues/4378).
+  const pattern = __ENV_ARGS__.testPathPattern.replace(/^%(.*)%$/, '');
+
+  if (pattern) {
+    testPathRegExp = new RegExp(pattern, 'i');
+  }
+}
+
 [
   require.context('.', true, /\.spec\.js$/),
 ].forEach((req) => {
-  req.keys().forEach((key) => {
-    req(key);
+  req.keys().forEach((filePath) => {
+    if (testPathRegExp === null || (testPathRegExp instanceof RegExp && testPathRegExp.test(filePath))) {
+      req(filePath);
+    }
   });
 });
 

--- a/src/3rdparty/walkontable/test/spec/overlay.spec.js
+++ b/src/3rdparty/walkontable/test/spec/overlay.spec.js
@@ -1,7 +1,13 @@
 describe('WalkontableOverlay', () => {
+  const BODY_MARGIN = parseInt(getComputedStyle(document.body).margin, 10);
+  const OUTER_WIDTH = 200;
+  const OUTER_HEIGHT = 200;
+  const CLIENT_WIDTH = OUTER_WIDTH - getScrollbarWidth();
+  const CLIENT_HEIGHT = OUTER_HEIGHT - getScrollbarWidth();
+
   beforeEach(function() {
     this.$wrapper = $('<div></div>').addClass('handsontable').css({ overflow: 'hidden' });
-    this.$wrapper.width(200).height(200);
+    this.$wrapper.width(OUTER_WIDTH).height(OUTER_HEIGHT);
     this.$container = $('<div></div>');
     this.$table = $('<table></table>').addClass('htCore'); // create a table that is not attached to document
     this.$wrapper.append(this.$container);
@@ -32,17 +38,17 @@ describe('WalkontableOverlay', () => {
 
     wt.draw();
 
-    expect($(wt.wtTable.holder).width()).toBe(200);
-    expect($(wt.wtTable.holder).height()).toBe(200);
-    expect($(wt.wtOverlays.topOverlay.clone.wtTable.holder).width()).toBe(185); // 200px - 15px scrollbar width
+    expect($(wt.wtTable.holder).width()).toBe(OUTER_WIDTH);
+    expect($(wt.wtTable.holder).height()).toBe(OUTER_HEIGHT);
+    expect($(wt.wtOverlays.topOverlay.clone.wtTable.holder).width()).toBe(CLIENT_WIDTH); // 200px - 15px scrollbar width
     expect($(wt.wtOverlays.topOverlay.clone.wtTable.holder).height()).toBe(47);
     expect($(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable.holder).width()).toBe(100);
     expect($(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable.holder).height()).toBe(47);
     expect($(wt.wtOverlays.leftOverlay.clone.wtTable.holder).width()).toBe(100);
-    expect($(wt.wtOverlays.leftOverlay.clone.wtTable.holder).height()).toBe(185);
+    expect($(wt.wtOverlays.leftOverlay.clone.wtTable.holder).height()).toBe(CLIENT_HEIGHT);
     expect($(wt.wtOverlays.bottomLeftCornerOverlay.clone.wtTable.holder).width()).toBe(100);
     expect($(wt.wtOverlays.bottomLeftCornerOverlay.clone.wtTable.holder).height()).toBe(47);
-    expect($(wt.wtOverlays.bottomOverlay.clone.wtTable.holder).width()).toBe(185);
+    expect($(wt.wtOverlays.bottomOverlay.clone.wtTable.holder).width()).toBe(CLIENT_WIDTH);
     expect($(wt.wtOverlays.bottomOverlay.clone.wtTable.holder).height()).toBe(47);
   });
 
@@ -96,17 +102,17 @@ describe('WalkontableOverlay', () => {
     wt.scrollViewportVertically(getTotalRows() - 3); // -1 - 2 (fixedRowsBottom)
     wt.draw();
 
-    expect($(wt.wtTable.holder).width()).toBe(200);
-    expect($(wt.wtTable.holder).height()).toBe(200);
-    expect($(wt.wtOverlays.topOverlay.clone.wtTable.holder).width()).toBe(185); // 200px - 15px scrollbar width
+    expect($(wt.wtTable.holder).width()).toBe(OUTER_WIDTH);
+    expect($(wt.wtTable.holder).height()).toBe(OUTER_HEIGHT);
+    expect($(wt.wtOverlays.topOverlay.clone.wtTable.holder).width()).toBe(CLIENT_WIDTH); // 200px - 15px scrollbar width
     expect($(wt.wtOverlays.topOverlay.clone.wtTable.holder).height()).toBe(47);
     expect($(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable.holder).width()).toBe(100);
     expect($(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable.holder).height()).toBe(47);
     expect($(wt.wtOverlays.leftOverlay.clone.wtTable.holder).width()).toBe(100);
-    expect($(wt.wtOverlays.leftOverlay.clone.wtTable.holder).height()).toBe(185);
+    expect($(wt.wtOverlays.leftOverlay.clone.wtTable.holder).height()).toBe(CLIENT_HEIGHT);
     expect($(wt.wtOverlays.bottomLeftCornerOverlay.clone.wtTable.holder).width()).toBe(100);
     expect($(wt.wtOverlays.bottomLeftCornerOverlay.clone.wtTable.holder).height()).toBe(47);
-    expect($(wt.wtOverlays.bottomOverlay.clone.wtTable.holder).width()).toBe(185);
+    expect($(wt.wtOverlays.bottomOverlay.clone.wtTable.holder).width()).toBe(CLIENT_WIDTH);
     expect($(wt.wtOverlays.bottomOverlay.clone.wtTable.holder).height()).toBe(47);
   });
 
@@ -161,46 +167,52 @@ describe('WalkontableOverlay', () => {
     wt.draw();
 
     const getTableRect = (wtTable) => {
-      const rect = wtTable.holder.getBoundingClientRect();
+      const {
+        top,
+        bottom,
+        left,
+      } = wtTable.holder.getBoundingClientRect();
 
       return {
-        top: rect.top,
-        bottom: rect.bottom,
-        left: rect.left,
+        top,
+        bottom,
+        left,
       };
     };
 
     const baseRect = getTableRect(wt.wtTable);
 
+    const expectedFixedTopBottomHeight = 47; // 24px + 23px
+
     expect(baseRect).toEqual(jasmine.objectContaining({
-      top: 8,
-      bottom: 208,
-      left: 8,
+      top: BODY_MARGIN,
+      bottom: OUTER_HEIGHT + BODY_MARGIN,
+      left: BODY_MARGIN,
     }));
     expect(getTableRect(wt.wtOverlays.topOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
-      top: 8,
-      bottom: 55,
-      left: 8,
+      top: BODY_MARGIN,
+      bottom: expectedFixedTopBottomHeight + BODY_MARGIN,
+      left: BODY_MARGIN,
     }));
     expect(getTableRect(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
-      top: 8,
-      bottom: 55,
-      left: 8,
+      top: BODY_MARGIN,
+      bottom: expectedFixedTopBottomHeight + BODY_MARGIN,
+      left: BODY_MARGIN,
     }));
     expect(getTableRect(wt.wtOverlays.leftOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
-      top: 8,
-      bottom: 193,
-      left: 8,
+      top: BODY_MARGIN,
+      bottom: CLIENT_HEIGHT + BODY_MARGIN,
+      left: BODY_MARGIN,
     }));
     expect(getTableRect(wt.wtOverlays.bottomLeftCornerOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
-      top: 146,
-      bottom: 193,
-      left: 8,
+      top: CLIENT_HEIGHT + BODY_MARGIN - expectedFixedTopBottomHeight,
+      bottom: CLIENT_HEIGHT + BODY_MARGIN,
+      left: BODY_MARGIN,
     }));
     expect(getTableRect(wt.wtOverlays.bottomOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
-      top: 146,
-      bottom: 193,
-      left: 8,
+      top: CLIENT_HEIGHT + BODY_MARGIN - expectedFixedTopBottomHeight,
+      bottom: CLIENT_HEIGHT + BODY_MARGIN,
+      left: BODY_MARGIN,
     }));
   });
 
@@ -231,39 +243,40 @@ describe('WalkontableOverlay', () => {
       };
     };
 
+    const expectedFixedTopBottomHeight = 47; // 24px + 23px
     const documentClientHeight = document.documentElement.clientHeight;
     const totalRowsHight = (getTotalRows() * 23) + 1; // total columns * 23px + 1px cell top border
     const baseRect = getTableRect(wt.wtTable);
 
     expect(baseRect).toEqual(jasmine.objectContaining({
-      top: 8,
-      bottom: totalRowsHight + 8, // 8 default browser margin
-      left: 8,
+      top: BODY_MARGIN,
+      bottom: totalRowsHight + BODY_MARGIN, // 8 default browser margin
+      left: BODY_MARGIN,
     }));
     expect(getTableRect(wt.wtOverlays.topOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
-      top: 8,
-      bottom: 47 + 8, // 2 fixed top rows * 23px + body margin
-      left: 8,
+      top: BODY_MARGIN,
+      bottom: expectedFixedTopBottomHeight + BODY_MARGIN, // 2 fixed top rows * 23px + body margin
+      left: BODY_MARGIN,
     }));
     expect(getTableRect(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
-      top: 8,
-      bottom: 47 + 8, // 2 fixed top rows * 23px + body margin
-      left: 8,
+      top: BODY_MARGIN,
+      bottom: expectedFixedTopBottomHeight + BODY_MARGIN, // 2 fixed top rows * 23px + body margin
+      left: BODY_MARGIN,
     }));
     expect(getTableRect(wt.wtOverlays.leftOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
-      top: 8,
-      bottom: totalRowsHight + 8, // 8 default browser margin
-      left: 8,
+      top: BODY_MARGIN,
+      bottom: totalRowsHight + BODY_MARGIN, // 8 default browser margin
+      left: BODY_MARGIN,
     }));
     expect(getTableRect(wt.wtOverlays.bottomLeftCornerOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
-      top: documentClientHeight - 47, // 2 fixed bottom rows * 23px + 1px cell top border
+      top: documentClientHeight - expectedFixedTopBottomHeight, // 2 fixed bottom rows * 23px + 1px cell top border
       bottom: documentClientHeight,
-      left: 8,
+      left: BODY_MARGIN,
     }));
     expect(getTableRect(wt.wtOverlays.bottomOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
-      top: documentClientHeight - 47, // 2 fixed bottom rows * 23px + 1px cell top border
+      top: documentClientHeight - expectedFixedTopBottomHeight, // 2 fixed bottom rows * 23px + 1px cell top border
       bottom: documentClientHeight,
-      left: 8,
+      left: BODY_MARGIN,
     }));
   });
 
@@ -292,37 +305,38 @@ describe('WalkontableOverlay', () => {
       };
     };
 
+    const expectedFixedTopBottomHeight = 47; // 24px + 23px
     const baseRect = getTableRect(wt.wtTable);
 
     expect(baseRect).toEqual(jasmine.objectContaining({
-      top: 8,
-      bottom: 208,
-      left: 8,
+      top: BODY_MARGIN,
+      bottom: OUTER_HEIGHT + BODY_MARGIN,
+      left: BODY_MARGIN,
     }));
     expect(getTableRect(wt.wtOverlays.topOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
-      top: 8,
-      bottom: 55,
-      left: 8,
+      top: BODY_MARGIN,
+      bottom: expectedFixedTopBottomHeight + BODY_MARGIN,
+      left: BODY_MARGIN,
     }));
     expect(getTableRect(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
-      top: 8,
-      bottom: 55,
-      left: 8,
+      top: BODY_MARGIN,
+      bottom: expectedFixedTopBottomHeight + BODY_MARGIN,
+      left: BODY_MARGIN,
     }));
     expect(getTableRect(wt.wtOverlays.leftOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
-      top: 8,
-      bottom: 193,
-      left: 8,
+      top: BODY_MARGIN,
+      bottom: CLIENT_HEIGHT + BODY_MARGIN,
+      left: BODY_MARGIN,
     }));
     expect(getTableRect(wt.wtOverlays.bottomLeftCornerOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
-      top: 146,
-      bottom: 193,
-      left: 8,
+      top: CLIENT_HEIGHT - expectedFixedTopBottomHeight + BODY_MARGIN,
+      bottom: CLIENT_HEIGHT + BODY_MARGIN,
+      left: BODY_MARGIN,
     }));
     expect(getTableRect(wt.wtOverlays.bottomOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
-      top: 146,
-      bottom: 193,
-      left: 8,
+      top: CLIENT_HEIGHT - expectedFixedTopBottomHeight + BODY_MARGIN,
+      bottom: CLIENT_HEIGHT + BODY_MARGIN,
+      left: BODY_MARGIN,
     }));
   });
 
@@ -411,12 +425,12 @@ describe('WalkontableOverlay', () => {
 
     expect($(wt.wtTable.holder).width()).toBe(200);
     expect($(wt.wtTable.holder).height()).toBe(200);
-    expect($(wt.wtOverlays.topOverlay.clone.wtTable.holder).width()).toBe(185); // 200px - 15px scrollbar width
+    expect($(wt.wtOverlays.topOverlay.clone.wtTable.holder).width()).toBe(200 - getScrollbarWidth()); // 200px - 15px scrollbar width
     expect($(wt.wtOverlays.topOverlay.clone.wtTable.holder).height()).toBe(23);
     expect($(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable.holder).width()).toBe(50);
     expect($(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable.holder).height()).toBe(23);
     expect($(wt.wtOverlays.leftOverlay.clone.wtTable.holder).width()).toBe(50);
-    expect($(wt.wtOverlays.leftOverlay.clone.wtTable.holder).height()).toBe(185);
+    expect($(wt.wtOverlays.leftOverlay.clone.wtTable.holder).height()).toBe(200 - getScrollbarWidth());
   });
 
   it('should cloned header overlays have to have proper dimensions (window object as scrollable element)', () => {
@@ -473,12 +487,12 @@ describe('WalkontableOverlay', () => {
 
     expect($(wt.wtTable.holder).width()).toBe(200);
     expect($(wt.wtTable.holder).height()).toBe(200);
-    expect($(wt.wtOverlays.topOverlay.clone.wtTable.holder).width()).toBe(185); // 200px - 15px scrollbar width
+    expect($(wt.wtOverlays.topOverlay.clone.wtTable.holder).width()).toBe(200 - getScrollbarWidth()); // 200px - 15px scrollbar width
     expect($(wt.wtOverlays.topOverlay.clone.wtTable.holder).height()).toBe(24); // 23px + 1px (innerBorderTop)
     expect($(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable.holder).width()).toBe(50);
     expect($(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable.holder).height()).toBe(24); // 23px + 1px (innerBorderTop)
     expect($(wt.wtOverlays.leftOverlay.clone.wtTable.holder).width()).toBe(50);
-    expect($(wt.wtOverlays.leftOverlay.clone.wtTable.holder).height()).toBe(185);
+    expect($(wt.wtOverlays.leftOverlay.clone.wtTable.holder).height()).toBe(200 - getScrollbarWidth());
   });
 
   it('should cloned header overlays have to have proper dimensions after table scroll (window object as scrollable element)', () => {
@@ -547,24 +561,24 @@ describe('WalkontableOverlay', () => {
     const baseRect = getTableRect(wt.wtTable);
 
     expect(baseRect).toEqual(jasmine.objectContaining({
-      top: 8,
-      bottom: 208,
-      left: 8,
+      top: BODY_MARGIN,
+      bottom: OUTER_WIDTH + BODY_MARGIN,
+      left: BODY_MARGIN,
     }));
     expect(getTableRect(wt.wtOverlays.topOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
-      top: 8,
+      top: BODY_MARGIN,
       bottom: 31,
-      left: 8,
+      left: BODY_MARGIN,
     }));
     expect(getTableRect(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
-      top: 8,
+      top: BODY_MARGIN,
       bottom: 31,
-      left: 8,
+      left: BODY_MARGIN,
     }));
     expect(getTableRect(wt.wtOverlays.leftOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
-      top: 8,
-      bottom: 193,
-      left: 8,
+      top: BODY_MARGIN,
+      bottom: CLIENT_HEIGHT + BODY_MARGIN,
+      left: BODY_MARGIN,
     }));
   });
 
@@ -603,24 +617,24 @@ describe('WalkontableOverlay', () => {
     const baseRect = getTableRect(wt.wtTable);
 
     expect(baseRect).toEqual(jasmine.objectContaining({
-      top: 8,
-      bottom: totalRowsHight + 8, // 8 default browser margin
-      left: 8,
+      top: BODY_MARGIN,
+      bottom: totalRowsHight + BODY_MARGIN, // 8 default browser margin
+      left: BODY_MARGIN,
     }));
     expect(getTableRect(wt.wtOverlays.topOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
-      top: 8,
-      bottom: 23 + 8, // 1 top row * 23px + body margin
-      left: 8,
+      top: BODY_MARGIN,
+      bottom: 23 + BODY_MARGIN, // 1 top row * 23px + body margin
+      left: BODY_MARGIN,
     }));
     expect(getTableRect(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
-      top: 8,
-      bottom: 23 + 8, // 1 top row * 23px + body margin
-      left: 8,
+      top: BODY_MARGIN,
+      bottom: 23 + BODY_MARGIN, // 1 top row * 23px + body margin
+      left: BODY_MARGIN,
     }));
     expect(getTableRect(wt.wtOverlays.leftOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
-      top: 8,
-      bottom: totalRowsHight + 8, // 8 default browser margin
-      left: 8,
+      top: BODY_MARGIN,
+      bottom: totalRowsHight + BODY_MARGIN, // 8 default browser margin
+      left: BODY_MARGIN,
     }));
   });
 
@@ -655,24 +669,24 @@ describe('WalkontableOverlay', () => {
     const baseRect = getTableRect(wt.wtTable);
 
     expect(baseRect).toEqual(jasmine.objectContaining({
-      top: 8,
-      bottom: 208,
-      left: 8,
+      top: BODY_MARGIN,
+      bottom: OUTER_HEIGHT + BODY_MARGIN,
+      left: BODY_MARGIN,
     }));
     expect(getTableRect(wt.wtOverlays.topOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
-      top: 8,
-      bottom: 23 + 8 + 1, // 1 top row * 23px + body margin + 1px (innerBorderTop)
-      left: 8,
+      top: BODY_MARGIN,
+      bottom: 23 + BODY_MARGIN + 1, // 1 top row * 23px + body margin + 1px (innerBorderTop)
+      left: BODY_MARGIN,
     }));
     expect(getTableRect(wt.wtOverlays.topLeftCornerOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
-      top: 8,
-      bottom: 23 + 8 + 1, // 1 top row * 23px + body margin + 1px (innerBorderTop)
-      left: 8,
+      top: BODY_MARGIN,
+      bottom: 23 + BODY_MARGIN + 1, // 1 top row * 23px + body margin + 1px (innerBorderTop)
+      left: BODY_MARGIN,
     }));
     expect(getTableRect(wt.wtOverlays.leftOverlay.clone.wtTable)).toEqual(jasmine.objectContaining({
-      top: 8,
-      bottom: 193,
-      left: 8,
+      top: BODY_MARGIN,
+      bottom: CLIENT_HEIGHT + BODY_MARGIN,
+      left: BODY_MARGIN,
     }));
   });
 


### PR DESCRIPTION
### Context
In this PR I added a few adjustments to Walkontable overlay tests. It helps to run Walkontable tests on Windows and is a small step to make tests OS-agnostic.

### How has this been tested?
Run `npm run test:walkontable` on windows env.

### Types of changes
- [x] Tests improvement

### Related issue(s):
1. #5043 