### PR TITLE
Misalignment correction when zooming

### DIFF
--- a/src/3rdparty/walkontable/src/renderer/table.js
+++ b/src/3rdparty/walkontable/src/renderer/table.js
@@ -276,9 +276,9 @@ export default class TableRenderer {
 
         if (rowHeight) {
           // Decrease height. 1 pixel will be "replaced" by 1px border top
-          TR.firstChild.style.height = `${rowHeight - 1}px`;
+          TR.style.height = `${rowHeight - 1}px`;
         } else {
-          TR.firstChild.style.height = '';
+          TR.style.height = '';
         }
       }
     }

--- a/src/3rdparty/walkontable/src/table.js
+++ b/src/3rdparty/walkontable/src/table.js
@@ -434,7 +434,7 @@ class Table {
         if (!children[i] || children[i].childNodes.length === 0) {
           return;
         }
-        children[i].childNodes[0].style.height = `${oversizedColumnHeaders[i]}px`;
+        children[i].style.height = `${oversizedColumnHeaders[i]}px`;
       }
     }
   }
@@ -718,9 +718,9 @@ class Table {
       rowHeader = currentTr.querySelector('th');
 
       if (rowHeader) {
-        rowInnerHeight = innerHeight(rowHeader);
+        rowInnerHeight = rowHeader.getBoundingClientRect().height;
       } else {
-        rowInnerHeight = innerHeight(currentTr) - 1;
+        rowInnerHeight = currentTr.getBoundingClientRect().height;
       }
 
       if ((!previousRowHeight && this.wot.wtSettings.settings.defaultRowHeight < rowInnerHeight ||


### PR DESCRIPTION
### Context
When the zoom is changed in the browser (zoom in more than 150% and zoom out less than 80%) HoT will get misalignment between fixed and movable columns.

This is an [adaptation of the larvanitis proposal](https://github.com/handsontable/handsontable/issues/3118#issuecomment-384305625), I manually just tested.

### How has this been tested?
* Changing the zoom from 25% to 500%.
* Tested in browsers Google Chrome, Edge Chromium, Mozilla Firefox

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
[3118](https://github.com/handsontable/handsontable/issues/3118)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
