### PR TITLE
Fix the non-clearing `skipRowOnPaste` cell meta property.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue with moving rows to the last row of the table, when the Nested Rows plugin was enabled along with some other minor moving-related bugs. [#6067](https://github.com/handsontable/handsontable/issues/6067)
 - Fixed an issue with adding unnecessary extra empty line in cells on Safari. [#7262](https://github.com/handsontable/handsontable/issues/7262)
 - Fixed an issue with clipped column headers if they were changed before or within usage `updateSettings`. [#6004](https://github.com/handsontable/handsontable/issues/6004)
+- Fixed a problem with data being pasted with an offset compensating the number of previously hidden rows/columns. [#6742](https://github.com/handsontable/handsontable/issues/6742)
 
 ### Changed
 - Updated dependencies to meet security requirements [#7222](https://github.com/handsontable/handsontable/pull/7222)

--- a/src/plugins/hiddenColumns/hiddenColumns.js
+++ b/src/plugins/hiddenColumns/hiddenColumns.js
@@ -329,10 +329,8 @@ class HiddenColumns extends BasePlugin {
    * @param {object} cellProperties Object containing the cell properties.
    */
   onAfterGetCellMeta(row, column, cellProperties) {
-    if (this.#settings.copyPasteEnabled === false && this.isHidden(column)) {
-      // Cell property handled by the `Autofill` and the `CopyPaste` plugins.
-      cellProperties.skipColumnOnPaste = true;
-    }
+    // Cell property handled by the `Autofill` and the `CopyPaste` plugins.
+    cellProperties.skipColumnOnPaste = this.#settings.copyPasteEnabled === false && this.isHidden(column);
 
     if (this.isHidden(column - 1)) {
       cellProperties.className = cellProperties.className || '';

--- a/src/plugins/hiddenColumns/test/plugins/copyPaste.e2e.js
+++ b/src/plugins/hiddenColumns/test/plugins/copyPaste.e2e.js
@@ -248,5 +248,41 @@ describe('hiddenColumns', () => {
       expect(getSelectedRangeLast().to.row).toBe(0);
       expect(getSelectedRangeLast().to.col).toBe(2);
     });
+
+    it('should paste data in the correct place after hiding and un-hiding columns', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        hiddenColumns: {
+          columns: [],
+          copyPasteEnabled: false,
+        },
+      });
+
+      const copyEvent = getClipboardEvent();
+      const hiddenColumns = getPlugin('hiddenColumns');
+      const copyPastePlugin = getPlugin('copyPaste');
+
+      selectCell(0, 1, 0, 1);
+
+      copyPastePlugin.onCopy(copyEvent);
+
+      hiddenColumns.hideColumn(1);
+
+      hot().render();
+
+      hiddenColumns.showColumn(1);
+
+      selectCell(1, 1, 1, 1);
+
+      copyPastePlugin.onPaste(copyEvent);
+
+      expect(getData()).toEqual([
+        ['A1', 'B1', 'C1', 'D1', 'E1'],
+        ['A2', 'B1', 'C2', 'D2', 'E2'],
+        ['A3', 'B3', 'C3', 'D3', 'E3'],
+        ['A4', 'B4', 'C4', 'D4', 'E4'],
+        ['A5', 'B5', 'C5', 'D5', 'E5'],
+      ]);
+    });
   });
 });

--- a/src/plugins/hiddenRows/hiddenRows.js
+++ b/src/plugins/hiddenRows/hiddenRows.js
@@ -319,10 +319,8 @@ class HiddenRows extends BasePlugin {
    * @param {object} cellProperties Object containing the cell properties.
    */
   onAfterGetCellMeta(row, column, cellProperties) {
-    if (this.#settings.copyPasteEnabled === false && this.isHidden(row)) {
-      // Cell property handled by the `Autofill` and the `CopyPaste` plugins.
-      cellProperties.skipRowOnPaste = true;
-    }
+    // Cell property handled by the `Autofill` and the `CopyPaste` plugins.
+    cellProperties.skipRowOnPaste = this.#settings.copyPasteEnabled === false && this.isHidden(row);
 
     if (this.isHidden(row - 1)) {
       cellProperties.className = cellProperties.className || '';

--- a/src/plugins/hiddenRows/test/plugins/copyPaste.e2e.js
+++ b/src/plugins/hiddenRows/test/plugins/copyPaste.e2e.js
@@ -273,5 +273,41 @@ describe('HiddenRows', () => {
       expect(getSelectedRangeLast().to.row).toBe(2);
       expect(getSelectedRangeLast().to.col).toBe(0);
     });
+
+    it('should paste data in the correct place after hiding and un-hiding rows', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        hiddenRows: {
+          columns: [],
+          copyPasteEnabled: false,
+        },
+      });
+
+      const copyEvent = getClipboardEvent();
+      const hiddenColumns = getPlugin('hiddenRows');
+      const copyPastePlugin = getPlugin('copyPaste');
+
+      selectCell(1, 1, 1, 1);
+
+      copyPastePlugin.onCopy(copyEvent);
+
+      hiddenColumns.hideRow(1);
+
+      hot().render();
+
+      hiddenColumns.showRow(1);
+
+      selectCell(1, 0, 1, 0);
+
+      copyPastePlugin.onPaste(copyEvent);
+
+      expect(getData()).toEqual([
+        ['A1', 'B1', 'C1', 'D1', 'E1'],
+        ['B2', 'B2', 'C2', 'D2', 'E2'],
+        ['A3', 'B3', 'C3', 'D3', 'E3'],
+        ['A4', 'B4', 'C4', 'D4', 'E4'],
+        ['A5', 'B5', 'C5', 'D5', 'E5'],
+      ]);
+    });
   });
 });


### PR DESCRIPTION
### Context
The `skipRowOnPaste` meta was not cleared after showing the previously hidden rows/columns.

### How has this been tested?
Added 2 test cases for both rows and columns.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #6742 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
