### PR TITLE
Improved E2E tests stability in browsers

### DIFF
--- a/src/plugins/comments/test/comments.e2e.js
+++ b/src/plugins/comments/test/comments.e2e.js
@@ -704,13 +704,13 @@ describe('Comments', () => {
       textarea.focus();
       textarea.value = 'Edited comment';
 
-      await sleep(150);
+      await sleep(300);
 
       $('body').simulate('mousedown');
       $('body').simulate('mouseup');
       textarea.blur();
 
-      await sleep(500);
+      await sleep(1000);
 
       expect(afterSetCellMetaCallback)
         .toHaveBeenCalledWith(0, 0, 'comment', { value: 'Edited comment' }, undefined, undefined);

--- a/src/plugins/hiddenRows/test/plugins/manualRowMove.e2e.js
+++ b/src/plugins/hiddenRows/test/plugins/manualRowMove.e2e.js
@@ -490,7 +490,8 @@ describe('HiddenRows', () => {
           $secondHeaderTH
             .simulate('mouseover')
             .simulate('mousemove', {
-              clientY: $secondHeaderTH.offset().top,
+              offsetX: 5,
+              offsetY: 5,
             })
           ; // Header "6"
 
@@ -552,7 +553,8 @@ describe('HiddenRows', () => {
           $secondHeaderTH
             .simulate('mouseover')
             .simulate('mousemove', {
-              clientY: $secondHeaderTH.offset().top,
+              offsetX: 5,
+              offsetY: 5,
             })
           ; // Header "4"
 

--- a/src/plugins/manualRowMove/test/manualRowMoveUI.e2e.js
+++ b/src/plugins/manualRowMove/test/manualRowMoveUI.e2e.js
@@ -188,7 +188,8 @@ describe('manualRowMove', () => {
 
         $rowHeader.simulate('mouseover');
         $rowHeader.simulate('mousemove', {
-          clientY: $rowHeader.offset().top
+          offsetX: 5,
+          offsetY: 5,
         });
         $rowHeader.simulate('mouseup');
 
@@ -239,7 +240,8 @@ describe('manualRowMove', () => {
 
           $rowHeader.simulate('mouseover');
           $rowHeader.simulate('mousemove', {
-            clientY: $rowHeader.offset().top
+            offsetX: 5,
+            offsetY: 5,
           });
           $rowHeader.simulate('mouseup');
 
@@ -294,7 +296,8 @@ describe('manualRowMove', () => {
 
           $rowHeader.simulate('mouseover');
           $rowHeader.simulate('mousemove', {
-            clientY: $rowHeader.offset().top
+            offsetX: 5,
+            offsetY: 5,
           });
           $rowHeader.simulate('mouseup');
 

--- a/src/plugins/nestedRows/test/nestedRows.e2e.js
+++ b/src/plugins/nestedRows/test/nestedRows.e2e.js
@@ -579,8 +579,8 @@ describe('NestedRows', () => {
 
       $targetHeader.simulate('mouseover');
       $targetHeader.simulate('mousemove', {
-        offsetX:5,
-        offsetY:5,
+        offsetX: 5,
+        offsetY: 5,
       });
 
       $targetHeader.simulate('mouseup');

--- a/src/plugins/nestedRows/test/nestedRows.e2e.js
+++ b/src/plugins/nestedRows/test/nestedRows.e2e.js
@@ -349,7 +349,7 @@ describe('NestedRows', () => {
         data: getSimplerNestedData(),
         nestedRows: true,
         manualRowMove: true,
-        rowHeaders: true
+        rowHeaders: true,
       });
 
       const $fromHeader = spec().$container.find('tbody tr:eq(7) th:eq(0)');
@@ -361,7 +361,8 @@ describe('NestedRows', () => {
 
       $targetHeader.simulate('mouseover');
       $targetHeader.simulate('mousemove', {
-        clientY: $targetHeader.offset().top
+        offsetX: 5,
+        offsetY: 5,
       });
 
       $targetHeader.simulate('mouseup');
@@ -395,7 +396,8 @@ describe('NestedRows', () => {
 
       $targetHeader.simulate('mouseover');
       $targetHeader.simulate('mousemove', {
-        clientY: $targetHeader.offset().top + 5
+        offsetX: 5,
+        offsetY: 5,
       });
 
       $targetHeader.simulate('mouseup');
@@ -418,7 +420,8 @@ describe('NestedRows', () => {
 
       $targetHeader.simulate('mouseover');
       $targetHeader.simulate('mousemove', {
-        clientY: $targetHeader.offset().top + 5
+        offsetX: 5,
+        offsetY: 5,
       });
 
       $targetHeader.simulate('mouseup');
@@ -460,7 +463,8 @@ describe('NestedRows', () => {
 
       $targetHeader.simulate('mouseover');
       $targetHeader.simulate('mousemove', {
-        clientY: $targetHeader.offset().top + 10
+        offsetX: 5,
+        offsetY: 10,
       });
 
       $targetHeader.simulate('mouseup');
@@ -538,7 +542,8 @@ describe('NestedRows', () => {
 
       $targetHeader.simulate('mouseover');
       $targetHeader.simulate('mousemove', {
-        clientY: $targetHeader.offset().top + 5
+        offsetX: 5,
+        offsetY: 5,
       });
 
       $targetHeader.simulate('mouseup');
@@ -574,7 +579,8 @@ describe('NestedRows', () => {
 
       $targetHeader.simulate('mouseover');
       $targetHeader.simulate('mousemove', {
-        clientY: $targetHeader.offset().top + 5
+        offsetX:5,
+        offsetY:5,
       });
 
       $targetHeader.simulate('mouseup');
@@ -688,7 +694,8 @@ describe('NestedRows', () => {
 
       $targetHeader.simulate('mouseover');
       $targetHeader.simulate('mousemove', {
-        clientY: $targetHeader.offset().top + 5
+        offsetX: 5,
+        offsetY: 5,
       });
 
       $targetHeader.simulate('mouseup');

--- a/src/plugins/undoRedo/test/UndoRedo.e2e.js
+++ b/src/plugins/undoRedo/test/UndoRedo.e2e.js
@@ -1714,6 +1714,8 @@ describe('UndoRedo', () => {
             colHeaders: true,
             rowHeaders: true,
             fixedRowsBottom: 1,
+            width: 500,
+            height: 400,
           });
 
           alter('remove_row', 0, 3);

--- a/test/e2e/core/selectAll.spec.js
+++ b/test/e2e/core/selectAll.spec.js
@@ -14,8 +14,8 @@ describe('Core.selectAll', () => {
     const scrollbarWidth = Handsontable.dom.getScrollbarWidth(); // normalize viewport size disregarding of the scrollbar size on any OS
     const hot = handsontable({
       data: Handsontable.helper.createSpreadsheetObjectData(15, 20),
-      width: 185 + scrollbarWidth,
-      height: 85 + scrollbarWidth,
+      width: Math.min(200 - scrollbarWidth, 185),
+      height: Math.min(100 - scrollbarWidth, 85),
       selectionMode: 'multiple',
       colHeaders: true,
       rowHeaders: true,

--- a/test/scripts/run-puppeteer.js
+++ b/test/scripts/run-puppeteer.js
@@ -57,8 +57,8 @@ const cleanupFactory = (browser, server) => async(exitCode) => {
 
   page.setCacheEnabled(false);
   page.setViewport({
-    width: 1200,
-    height: 1200,
+    width: 1280,
+    height: 720,
   });
 
   const server = http.createServer(ecstatic({


### PR DESCRIPTION
### Context
Our E2E tests might be unstable in some env and browsers.
This PR changes default puppeteer window size to adjust it to the most popular 16:9 resolution ratio.
Moreover, some tests calculate the mouse pointer position by offsetX/offsetY properties to be more stable.

We can consider hiding jasmine UI as we do it in walkontable's overlays tests.

### How has this been tested?
Run E2E tests in CLI and browsers.

### Types of changes
- [x] Tests improvements

### Related issue(s):
1. #7261