### PR TITLE
Add information about returned values for some hooks [DOCS]

### DIFF
--- a/src/pluginHooks.js
+++ b/src/pluginHooks.js
@@ -649,6 +649,7 @@ const REGISTERED_HOOKS = [
    * @param {CellCoords} start Object containing information about first filled cell: `{row: 2, col: 0}`.
    * @param {CellCoords} end Object containing information about last filled cell: `{row: 4, col: 1}`.
    * @param {Array[]} data 2D array containing information about fill pattern: `[["1", "Ted"], ["1", "John"]]`.
+   * @returns {*|boolean} If false, then the the autofill action will be canceled.
    */
   'beforeAutofill',
 

--- a/src/pluginHooks.js
+++ b/src/pluginHooks.js
@@ -208,6 +208,7 @@ const REGISTERED_HOOKS = [
    * @param {number} amount Number of newly created rows in the data source array.
    * @param {string} [source] String that identifies source of hook call
    *                          ([list of all available sources]{@link https://handsontable.com/docs/tutorial-using-callbacks.html#page-source-definition}).
+   * @returns {*|boolean} If false, then the create rows action will be canceled.
    */
   'beforeCreateRow',
 
@@ -755,6 +756,7 @@ const REGISTERED_HOOKS = [
    * @param {number} column Visual column index.
    * @param {string} key The removed meta key.
    * @param {*} value Value which is under removed key of cell meta.
+   * @returns {*|boolean} If false, then the cell meta will not be removed.
    */
   'beforeRemoveCellMeta',
 
@@ -857,6 +859,7 @@ const REGISTERED_HOOKS = [
    * @param {number} amount Amount of columns to be removed.
    * @param {number[]} physicalColumns An array of physical columns removed from the data source.
    * @param {string} [source] String that identifies source of hook call ([list of all available sources]{@link https://handsontable.com/docs/tutorial-using-callbacks.html#page-source-definition}).
+   * @returns {*|boolean} If false, then the remove column action will be canceled.
    */
   'beforeRemoveCol',
 
@@ -868,6 +871,7 @@ const REGISTERED_HOOKS = [
    * @param {number} amount Amount of rows to be removed.
    * @param {number[]} physicalRows An array of physical rows removed from the data source.
    * @param {string} [source] String that identifies source of hook call ([list of all available sources]{@link https://handsontable.com/docs/tutorial-using-callbacks.html#page-source-definition}).
+   * @returns {*|boolean} If false, then the remove row action will be canceled.
    */
   'beforeRemoveRow',
 
@@ -890,6 +894,7 @@ const REGISTERED_HOOKS = [
    * @param {number} column Visual column index.
    * @param {string} key The updated meta key.
    * @param {*} value The updated meta value.
+   * @returns {*|boolean} If false, then the set cell meta action will be canceled.
    */
   'beforeSetCellMeta',
 
@@ -1275,6 +1280,7 @@ const REGISTERED_HOOKS = [
    * @param {number} finalIndex Visual row index, being a start index for the moved rows. Points to where the elements will be placed after the moving action. To check visualization of final index please take a look at [documentation](/docs/demo-moving.html).
    * @param {number|undefined} dropIndex Visual row index, being a drop index for the moved rows. Points to where we are going to drop the moved elements. To check visualization of drop index please take a look at [documentation](/docs/demo-moving.html). It's `undefined` when `dragRows` function wasn't called.
    * @param {boolean} movePossible Indicates if it's possible to move rows to the desired position.
+   * @returns {*|boolean} If false, then the move row action will be canceled.
    */
   'beforeRowMove',
 
@@ -1434,6 +1440,7 @@ const REGISTERED_HOOKS = [
    * @event Hooks#beforeUndo
    * @param {object} action The action object. Contains information about the action being undone. The `actionType`
    *                        property of the object specifies the type of the action in a String format. (e.g. `'remove_row'`).
+   * @returns {*|boolean} If false, then the undo action will be canceled.
    */
   'beforeUndo',
 
@@ -1454,6 +1461,7 @@ const REGISTERED_HOOKS = [
    * @event Hooks#beforeRedo
    * @param {object} action The action object. Contains information about the action being redone. The `actionType`
    *                        property of the object specifies the type of the action in a String format (e.g. `'remove_row'`).
+   * @returns {*|boolean} If false, then the redo action will be canceled.
    */
   'beforeRedo',
 

--- a/src/pluginHooks.js
+++ b/src/pluginHooks.js
@@ -757,7 +757,7 @@ const REGISTERED_HOOKS = [
    * @param {number} column Visual column index.
    * @param {string} key The removed meta key.
    * @param {*} value Value which is under removed key of cell meta.
-   * @returns {*|boolean} If false, then the cell meta will not be removed.
+   * @returns {*|boolean} If false, then the remove cell meta action will be canceled.
    */
   'beforeRemoveCellMeta',
 

--- a/src/pluginHooks.js
+++ b/src/pluginHooks.js
@@ -208,7 +208,7 @@ const REGISTERED_HOOKS = [
    * @param {number} amount Number of newly created rows in the data source array.
    * @param {string} [source] String that identifies source of hook call
    *                          ([list of all available sources]{@link https://handsontable.com/docs/tutorial-using-callbacks.html#page-source-definition}).
-   * @returns {*|boolean} If false, then the create rows action will be canceled.
+   * @returns {*|boolean} If false is returned the action is canceled.
    */
   'beforeCreateRow',
 
@@ -649,7 +649,7 @@ const REGISTERED_HOOKS = [
    * @param {CellCoords} start Object containing information about first filled cell: `{row: 2, col: 0}`.
    * @param {CellCoords} end Object containing information about last filled cell: `{row: 4, col: 1}`.
    * @param {Array[]} data 2D array containing information about fill pattern: `[["1", "Ted"], ["1", "John"]]`.
-   * @returns {*|boolean} If false, then the the autofill action will be canceled.
+   * @returns {*|boolean} If false is returned the action is canceled.
    */
   'beforeAutofill',
 
@@ -757,7 +757,7 @@ const REGISTERED_HOOKS = [
    * @param {number} column Visual column index.
    * @param {string} key The removed meta key.
    * @param {*} value Value which is under removed key of cell meta.
-   * @returns {*|boolean} If false, then the remove cell meta action will be canceled.
+   * @returns {*|boolean} If false is returned the action is canceled.
    */
   'beforeRemoveCellMeta',
 
@@ -860,7 +860,7 @@ const REGISTERED_HOOKS = [
    * @param {number} amount Amount of columns to be removed.
    * @param {number[]} physicalColumns An array of physical columns removed from the data source.
    * @param {string} [source] String that identifies source of hook call ([list of all available sources]{@link https://handsontable.com/docs/tutorial-using-callbacks.html#page-source-definition}).
-   * @returns {*|boolean} If false, then the remove column action will be canceled.
+   * @returns {*|boolean} If false is returned the action is canceled.
    */
   'beforeRemoveCol',
 
@@ -872,7 +872,7 @@ const REGISTERED_HOOKS = [
    * @param {number} amount Amount of rows to be removed.
    * @param {number[]} physicalRows An array of physical rows removed from the data source.
    * @param {string} [source] String that identifies source of hook call ([list of all available sources]{@link https://handsontable.com/docs/tutorial-using-callbacks.html#page-source-definition}).
-   * @returns {*|boolean} If false, then the remove row action will be canceled.
+   * @returns {*|boolean} If false is returned the action is canceled.
    */
   'beforeRemoveRow',
 
@@ -895,7 +895,7 @@ const REGISTERED_HOOKS = [
    * @param {number} column Visual column index.
    * @param {string} key The updated meta key.
    * @param {*} value The updated meta value.
-   * @returns {*|boolean} If false, then the set cell meta action will be canceled.
+   * @returns {*|boolean} If false is returned the action is canceled.
    */
   'beforeSetCellMeta',
 
@@ -1281,7 +1281,7 @@ const REGISTERED_HOOKS = [
    * @param {number} finalIndex Visual row index, being a start index for the moved rows. Points to where the elements will be placed after the moving action. To check visualization of final index please take a look at [documentation](/docs/demo-moving.html).
    * @param {number|undefined} dropIndex Visual row index, being a drop index for the moved rows. Points to where we are going to drop the moved elements. To check visualization of drop index please take a look at [documentation](/docs/demo-moving.html). It's `undefined` when `dragRows` function wasn't called.
    * @param {boolean} movePossible Indicates if it's possible to move rows to the desired position.
-   * @returns {*|boolean} If false, then the move row action will be canceled.
+   * @returns {*|boolean} If false is returned the action is canceled.
    */
   'beforeRowMove',
 
@@ -1441,7 +1441,7 @@ const REGISTERED_HOOKS = [
    * @event Hooks#beforeUndo
    * @param {object} action The action object. Contains information about the action being undone. The `actionType`
    *                        property of the object specifies the type of the action in a String format. (e.g. `'remove_row'`).
-   * @returns {*|boolean} If false, then the undo action will be canceled.
+   * @returns {*|boolean} If false is returned the action is canceled.
    */
   'beforeUndo',
 
@@ -1462,7 +1462,7 @@ const REGISTERED_HOOKS = [
    * @event Hooks#beforeRedo
    * @param {object} action The action object. Contains information about the action being redone. The `actionType`
    *                        property of the object specifies the type of the action in a String format (e.g. `'remove_row'`).
-   * @returns {*|boolean} If false, then the redo action will be canceled.
+   * @returns {*|boolean} If false is returned the action is canceled.
    */
   'beforeRedo',
 


### PR DESCRIPTION
### Context
For some hooks, we can describe what does return value do.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement in the documentation.

### Related issue(s):
1. https://github.com/handsontable/docs/issues/156
2. https://github.com/handsontable/docs/issues/160
3. https://github.com/handsontable/docs/issues/163
4. https://github.com/handsontable/docs/issues/165
5. https://github.com/handsontable/docs/issues/167
6. https://github.com/handsontable/docs/issues/168
7. https://github.com/handsontable/docs/issues/169
8. https://github.com/handsontable/docs/issues/170
9. https://github.com/handsontable/docs/issues/171

@pnowak can we say those are "actions"? I wanted to find a pattern we can re-use in sentences.