### PR TITLE
Fix wrong default type [DOCS]

### DIFF
--- a/src/dataMap/metaManager/metaSchema.js
+++ b/src/dataMap/metaManager/metaSchema.js
@@ -945,7 +945,7 @@ export default () => {
      *
      * @memberof Options#
      * @type {boolean}
-     * @default false
+     * @default undefined
      *
      * @example
      * ```js

--- a/src/dataMap/metaManager/metaSchema.js
+++ b/src/dataMap/metaManager/metaSchema.js
@@ -2128,7 +2128,7 @@ export default () => {
      *
      * @memberof Options#
      * @type {boolean|string|number}
-     * @default true
+     * @default undefined
      *
      * @example
      * ```js
@@ -2145,7 +2145,7 @@ export default () => {
      *
      * @memberof Options#
      * @type {boolean|string|number}
-     * @default false
+     * @default undefined
      *
      * @example
      * ```js

--- a/src/dataMap/metaManager/metaSchema.js
+++ b/src/dataMap/metaManager/metaSchema.js
@@ -730,7 +730,7 @@ export default () => {
      *
      * @memberof Options#
      * @type {boolean|string|object}
-     * @default true
+     * @default false
      *
      * @example
      * ```js


### PR DESCRIPTION
### Context
Fix the wrong default type in the documentation.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Documentation improvement

### Related issue(s):
1. https://github.com/handsontable/docs/issues/196
2. https://github.com/handsontable/docs/issues/194
3. https://github.com/handsontable/docs/issues/192 (to double-check)
