### PR TITLE
Remove optional marking for params in setDataAtCell [DOCS]

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1303,8 +1303,8 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
    * @memberof Core#
    * @function setDataAtCell
    * @param {number|Array} row Visual row index or array of changes in format `[[row, col, value],...]`.
-   * @param {number} [column] Visual column index.
-   * @param {string} [value] New value.
+   * @param {number} column Visual column index.
+   * @param {string} value New value.
    * @param {string} [source] String that identifies how this change will be described in the changes array (useful in onAfterChange or onBeforeChange callback).
    */
   this.setDataAtCell = function(row, column, value, source) {


### PR DESCRIPTION
### Context
Two params are no longer optional, remove the misleading information.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement in the documentation

### Related issue(s):
1. https://github.com/handsontable/docs/issues/181