### PR TITLE
Modify the "clear column" Context Menu option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue where sorting indicator moved incorrectly when column was added. [#6397](https://github.com/handsontable/handsontable/issues/6397)
 - Fixed a bug, where untrimming previously trimmed rows would sometimes result in the table instance not refreshing its height, leaving the row headers not properly rendered. [#6276](https://github.com/handsontable/handsontable/issues/6276)
 - Fix a problem when `event.target`'s parent in the `mouseover` event was not defined, the table threw an error when hovering over row/column headers. [#6926](https://github.com/handsontable/handsontable/issues/6926)
+- Fix a problem with the inconsistent behavior of the Context Menu's "Clear column" disabled status. [#7003](https://github.com/handsontable/handsontable/issues/7003)
 
 ## [8.1.0] - 2020-10-01
 

--- a/src/plugins/contextMenu/predefinedItems/clearColumn.js
+++ b/src/plugins/contextMenu/predefinedItems/clearColumn.js
@@ -13,11 +13,12 @@ export default function clearColumnItem() {
       return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_CLEAR_COLUMN);
     },
     callback(key, selection) {
-      const column = selection[0].start.col;
+      const startColumn = selection[0].start.col;
+      const endColumn = selection[0].end.col;
 
       if (this.countRows()) {
-        this.populateFromArray(0, column, [[null]],
-          Math.max(selection[0].start.row, selection[0].end.row), column, 'ContextMenu.clearColumn');
+        this.populateFromArray(0, startColumn, [[null]],
+          Math.max(selection[0].start.row, selection[0].end.row), endColumn, 'ContextMenu.clearColumn');
       }
     },
     disabled() {
@@ -26,11 +27,12 @@ export default function clearColumnItem() {
       if (!selected) {
         return true;
       }
-      const [startRow, startColumn, endRow] = selected[0];
-      const entireRowSelection = [startRow, 0, endRow, this.countCols() - 1];
-      const rowSelected = entireRowSelection.join(',') === selected.join(',');
 
-      return startColumn < 0 || this.countCols() >= this.getSettings().maxCols || rowSelected;
+      const startColumn = selected[0][1];
+
+      return startColumn < 0
+        || this.countCols() >= this.getSettings().maxCols
+        || !this.selection.isEntireColumnSelected();
     }
   };
 }

--- a/src/plugins/contextMenu/predefinedItems/clearColumn.js
+++ b/src/plugins/contextMenu/predefinedItems/clearColumn.js
@@ -28,11 +28,7 @@ export default function clearColumnItem() {
         return true;
       }
 
-      const startColumn = selected[0][1];
-
-      return startColumn < 0
-        || this.countCols() >= this.getSettings().maxCols
-        || !this.selection.isEntireColumnSelected();
+      return !this.selection.isSelectedByColumnHeader();
     }
   };
 }

--- a/src/plugins/contextMenu/test/predefinedItems/clearColumn.e2e.js
+++ b/src/plugins/contextMenu/test/predefinedItems/clearColumn.e2e.js
@@ -1,0 +1,121 @@
+describe('ContextMenu', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  describe('clearColumn', () => {
+    it('should not be possible to use the `clearColumn` option, when anything but entire columns was selected', () => {
+      const hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(4, 4),
+        contextMenu: ['clear_column'],
+        height: 100,
+        rowHeaders: true,
+        colHeaders: true
+      });
+
+      contextMenu();
+
+      const clearColumnTitle = hot.getTranslatedPhrase(
+        Handsontable.languages.dictionaryKeys.CONTEXTMENU_ITEMS_CLEAR_COLUMN
+      );
+      const contextMenuPlugin = hot.getPlugin('contextMenu');
+      const getClearColumnItem = () => {
+        return $('.htContextMenu tbody tr td').filter(function() {
+          return this.textContent === clearColumnTitle;
+        });
+      };
+
+      expect(getClearColumnItem().hasClass('htDisabled')).toBe(true);
+
+      contextMenuPlugin.close();
+
+      hot.selectCell(0, 0);
+
+      contextMenu();
+
+      expect(getClearColumnItem().hasClass('htDisabled')).toBe(true);
+
+      contextMenuPlugin.close();
+
+      hot.selectCell(0, 0, 2, 2);
+
+      contextMenu();
+
+      expect(getClearColumnItem().hasClass('htDisabled')).toBe(true);
+
+      contextMenuPlugin.close();
+
+      hot.selectAll();
+
+      contextMenu();
+
+      expect(getClearColumnItem().hasClass('htDisabled')).toBe(true);
+
+      contextMenuPlugin.close();
+
+      hot.selectColumns(0);
+
+      contextMenu();
+
+      expect(getClearColumnItem().hasClass('htDisabled')).toBe(false);
+
+      contextMenuPlugin.close();
+
+      hot.selectColumns(0, 1);
+
+      contextMenu();
+
+      expect(getClearColumnItem().hasClass('htDisabled')).toBe(false);
+
+      contextMenuPlugin.close();
+    });
+
+    it('should clear the data in the selected column(s)', async() => {
+      const hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(4, 4),
+        contextMenu: ['clear_column'],
+        height: 100,
+        rowHeaders: true,
+        colHeaders: true
+      });
+
+      hot.selectColumns(0);
+
+      contextMenu();
+
+      const contextMenuPlugin = hot.getPlugin('contextMenu');
+      const clearColumnTitle = hot.getTranslatedPhrase(
+        Handsontable.languages.dictionaryKeys.CONTEXTMENU_ITEMS_CLEAR_COLUMN
+      );
+      const getClearColumnItem = () => {
+        return $('.htContextMenu tbody tr td').filter(function() {
+          return this.textContent === clearColumnTitle;
+        });
+      };
+
+      simulateClick(getClearColumnItem());
+
+      contextMenuPlugin.close();
+
+      hot.selectColumns(2, 3);
+
+      contextMenu();
+
+      simulateClick(getClearColumnItem());
+
+      expect(hot.getDataAtCol(0)).toEqual([null, null, null, null]);
+      expect(hot.getDataAtCol(1)).toEqual(['B1', 'B2', 'B3', 'B4']);
+      expect(hot.getDataAtCol(2)).toEqual([null, null, null, null]);
+      expect(hot.getDataAtCol(3)).toEqual([null, null, null, null]);
+    });
+  });
+});


### PR DESCRIPTION
### Context
Currently (`8.1.0`), the "Clear column" Context Menu/Dropdown Menu entry disabled status is not working properly. For example, the CM item is disabled, when there's only one column present, but it's enabled when selecting one or more cells.
What's more, when calling the option on individually selected cells/cell groups, it does not do what it's supposed to do (which is clearing the entire columns).

This change makes the "Clear column" option enabled only when called on a fully selected columns.

### How has this been tested?
- Added a test case for the `disabled` status
- Added a general test case for the CM option.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7003 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
