### PR TITLE
Fixes adding 0 rows to index mappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixes a bug, where tables' viewport was scrolled if a user opened editor when some columns on the left side of that cell were hidden. [#7322](https://github.com/handsontable/handsontable/issues/7322)
 - Fix a problem when `event.target`'s parent in the `mouseover` event was not defined, the table threw an error when hovering over row/column headers. [#6926](https://github.com/handsontable/handsontable/issues/6926)
 - Fixed an issue, where calling the validation-triggering methods on a `hiddenColumns`-enabled Handsontable instance rendered the validated cells improperly. [#7301](https://github.com/handsontable/handsontable/issues/7301)
+- Fixed an issue, where adding 0 rows to the table ended with doubled entries in indexMappers' collections. [#7326](https://github.com/handsontable/handsontable/issues/7326)
 
 ## [8.1.0] - 2020-10-01
 

--- a/src/translations/maps/utils/physicallyIndexed.js
+++ b/src/translations/maps/utils/physicallyIndexed.js
@@ -12,7 +12,7 @@ import { arrayFilter } from '../../../helpers/array';
  * @returns {Array} List with new mappings.
  */
 export function getListWithInsertedItems(indexedValues, insertionIndex, insertedIndexes, insertedValuesMapping) {
-  const firstInsertedIndex = insertedIndexes[0];
+  const firstInsertedIndex = insertedIndexes.length ? insertedIndexes[0] : void 0;
 
   return [
     ...indexedValues.slice(0, firstInsertedIndex),
@@ -23,7 +23,7 @@ export function getListWithInsertedItems(indexedValues, insertionIndex, inserted
 
       return insertedValuesMapping;
     }),
-    ...indexedValues.slice(firstInsertedIndex)
+    ...(firstInsertedIndex === void 0 ? [] : indexedValues.slice(firstInsertedIndex)),
   ];
 }
 

--- a/test/unit/translations/indexMapper.spec.js
+++ b/test/unit/translations/indexMapper.spec.js
@@ -1489,6 +1489,28 @@ describe('IndexMapper', () => {
 
         expect(indexMapper.getIndexesSequence()).toEqual([5, 6, 3, 4, 2, 1, 0, 7]);
       });
+
+      it('should do nothing if there is nothing to insert', () => {
+        const indexMapper = new IndexMapper();
+        const indexesSequence = new IndexesSequence();
+        const hidingMap = new HidingMap();
+        const pIndexToValueMap = new PIndexToValueMap();
+        const trimmingMap = new TrimmingMap();
+
+        indexMapper.registerMap('indexesSequence', indexesSequence);
+        indexMapper.registerMap('hidingMap', hidingMap);
+        indexMapper.registerMap('pIndexToValueMap', pIndexToValueMap);
+        indexMapper.registerMap('trimmingMap', trimmingMap);
+        indexMapper.initToLength(5);
+
+        trimmingMap.setValues([false, false, false, false, false]);
+
+        indexMapper.insertIndexes(0, 0);
+
+        expect(trimmingMap.getValues()).toEqual([false, false, false, false, false]);
+        expect(hidingMap.getValues()).toEqual([false, false, false, false, false]);
+        expect(pIndexToValueMap.getValues()).toEqual([null, null, null, null, null]);
+      });
     });
 
     describe('with trimmed indexes', () => {

--- a/test/unit/translations/maps/utils/physicallyIndexed.spec.js
+++ b/test/unit/translations/maps/utils/physicallyIndexed.spec.js
@@ -1,0 +1,37 @@
+import { getListWithInsertedItems } from 'handsontable/translations/maps/utils/physicallyIndexed';
+
+describe('physicallyIndexed', () => {
+  describe('getListWithInsertedItems', () => {
+    it('should properly insert new items to the list at the beginning', () => {
+      const startList = [false, false, false, false];
+      const finalList = getListWithInsertedItems(startList, void 0, [0, 1, 2], true);
+
+      expect(finalList.length).toBe(7);
+      expect(finalList).toEqual([true, true, true, false, false, false, false]);
+    });
+
+    it('should properly insert new items to the list at the end', () => {
+      const startList = [false, false, false, false];
+      const finalList = getListWithInsertedItems(startList, void 0, [4, 5, 6], true);
+
+      expect(finalList.length).toBe(7);
+      expect(finalList).toEqual([false, false, false, false, true, true, true]);
+    });
+
+    it('should properly insert new items to the list in the middle of list', () => {
+      const startList = [false, false, false, false];
+      const finalList = getListWithInsertedItems(startList, void 0, [2, 3, 4], true);
+
+      expect(finalList.length).toBe(7);
+      expect(finalList).toEqual([false, false, true, true, true, false, false]);
+    });
+
+    it('should do nothing if insertedIndexes is an empty array', () => {
+      const startList = [false, false, false, false];
+      const finalList = getListWithInsertedItems(startList, void 0, [], true);
+
+      expect(finalList.length).toBe(4);
+      expect(finalList).toEqual([false, false, false, false]);
+    });
+  });
+});


### PR DESCRIPTION
### Context
As @aarondfrancis mentioned in #7326, it's possible to add 0 rows to index mappers what for sure should introduce no changes in mappers

### How has this been tested?
1. Initialize Handsontable with enabled `trimRows` or `hiddenRows` or both
1. Add 0 rows to the table: `hot.alter('insert_row', 0, 0)`
2. Check contents of `hot.rowIndexMapper.trimmingMapsCollection.getMergedValues()`

You can also run `npm run test:unit`

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. #7326