### PR TITLE
Exclude DOMPurify lib from the handsontable.js build

### DIFF
--- a/.config/development.js
+++ b/.config/development.js
@@ -43,7 +43,13 @@ module.exports.create = function create(envArgs) {
         commonjs2: 'hot-formula-parser',
         commonjs: 'hot-formula-parser',
         amd: 'hot-formula-parser',
-      }
+      },
+      dompurify: {
+        root: 'DOMPurify',
+        commonjs2: 'dompurify',
+        commonjs: 'dompurify',
+        amd: 'dompurify',
+      },
     };
     c.module.rules.unshift({
       test: [

--- a/.config/production.js
+++ b/.config/production.js
@@ -46,37 +46,70 @@ module.exports.create = function create(envArgs) {
         new CopyWebpackPlugin({
           patterns: [
             { // hot-formula-parser
-              from: 'node_modules/hot-formula-parser/LICENSE', to: 'hot-formula-parser', flatten: true
+              from: 'node_modules/hot-formula-parser/LICENSE',
+              to: 'hot-formula-parser',
+              flatten: true,
+              force: true,
             },
             {
-              from: 'node_modules/hot-formula-parser/dist/formula-parser.js', to: 'hot-formula-parser', flatten: true
+              from: 'node_modules/hot-formula-parser/dist/formula-parser.js',
+              to: 'hot-formula-parser',
+              flatten: true,
+              force: true,
             },
             { // moment
-              from: 'node_modules/moment/@(moment.js|LICENSE)', to: 'moment', flatten: true
+              from: 'node_modules/moment/@(moment.js|LICENSE)',
+              to: 'moment',
+              flatten: true,
+              force: true,
             },
             {
-              from: 'node_modules/moment/locale/*.js', to: 'moment/locale', flatten: true
+              from: 'node_modules/moment/locale/*.js',
+              to: 'moment/locale',
+              flatten: true,
+              force: true,
             },
             { // numbro
-              from: 'node_modules/numbro/@(LICENSE-Numeraljs|LICENSE)', to: 'numbro', flatten: true
+              from: 'node_modules/numbro/@(LICENSE-Numeraljs|LICENSE)',
+              to: 'numbro',
+              flatten: true,
+              force: true,
             },
             {
-              from: 'node_modules/numbro/dist/@(numbro.js|languages.min.js)', to: 'numbro', flatten: true
+              from: 'node_modules/numbro/dist/@(numbro.js|languages.min.js)',
+              to: 'numbro',
+              flatten: true,
+              force: true,
             },
             {
-              from: 'node_modules/numbro/dist/languages/*.js', to: 'numbro/languages', flatten: true
+              from: 'node_modules/numbro/dist/languages/*.js',
+              to: 'numbro/languages',
+              flatten: true,
+              force: true,
             },
             { // pikaday
-              from: 'node_modules/pikaday/@(LICENSE|pikaday.js)', to: 'pikaday', flatten: true
+              from: 'node_modules/pikaday/@(LICENSE|pikaday.js)',
+              to: 'pikaday',
+              flatten: true,
+              force: true,
             },
             {
-              from: 'node_modules/pikaday/css/pikaday.css', to: 'pikaday', flatten: true
+              from: 'node_modules/pikaday/css/pikaday.css',
+              to: 'pikaday',
+              flatten: true,
+              force: true,
             },
             { // dompurify
-              from: 'node_modules/dompurify/@(LICENSE)', to: 'dompurify', flatten: true
+              from: 'node_modules/dompurify/@(LICENSE)',
+              to: 'dompurify',
+              flatten: true,
+              force: true,
             },
             {
-              from: 'node_modules/dompurify/dist/@(purify.js|purify.js.map)', to: 'dompurify', flatten: true
+              from: 'node_modules/dompurify/dist/@(purify.js|purify.js.map)',
+              to: 'dompurify',
+              flatten: true,
+              force: true,
             },
           ]
         })

--- a/.config/production.js
+++ b/.config/production.js
@@ -72,6 +72,12 @@ module.exports.create = function create(envArgs) {
             {
               from: 'node_modules/pikaday/css/pikaday.css', to: 'pikaday', flatten: true
             },
+            { // dompurify
+              from: 'node_modules/dompurify/@(LICENSE)', to: 'dompurify', flatten: true
+            },
+            {
+              from: 'node_modules/dompurify/dist/@(purify.js|purify.js.map)', to: 'dompurify', flatten: true
+            },
           ]
         })
       );

--- a/.config/test-e2e.js
+++ b/.config/test-e2e.js
@@ -52,7 +52,7 @@ module.exports.create = function create(envArgs) {
           '../node_modules/moment/moment.js',
           '../node_modules/pikaday/pikaday.js',
           '../node_modules/hot-formula-parser/dist/formula-parser.js',
-          '../node_modules/dompurify/purify.js',
+          '../node_modules/dompurify/dist/purify.js',
           '../dist/handsontable.js',
           '../dist/languages/all.js',
         ],

--- a/.config/test-e2e.js
+++ b/.config/test-e2e.js
@@ -52,6 +52,7 @@ module.exports.create = function create(envArgs) {
           '../node_modules/moment/moment.js',
           '../node_modules/pikaday/pikaday.js',
           '../node_modules/hot-formula-parser/dist/formula-parser.js',
+          '../node_modules/dompurify/purify.js',
           '../dist/handsontable.js',
           '../dist/languages/all.js',
         ],

--- a/.config/test-handsontable.js
+++ b/.config/test-handsontable.js
@@ -55,6 +55,7 @@ module.exports.create = function create(envArgs) {
           '../dist/moment/moment.js',
           '../dist/pikaday/pikaday.js',
           '../dist/hot-formula-parser/formula-parser.js',
+          '../node_modules/dompurify/purify.js',
           '../dist/handsontable.js',
           '../dist/languages/all.js',
         ],

--- a/.config/test-handsontable.js
+++ b/.config/test-handsontable.js
@@ -55,7 +55,7 @@ module.exports.create = function create(envArgs) {
           '../dist/moment/moment.js',
           '../dist/pikaday/pikaday.js',
           '../dist/hot-formula-parser/formula-parser.js',
-          '../node_modules/dompurify/purify.js',
+          '../node_modules/dompurify/dist/purify.js',
           '../dist/handsontable.js',
           '../dist/languages/all.js',
         ],

--- a/.config/test-mobile.js
+++ b/.config/test-mobile.js
@@ -36,6 +36,7 @@ module.exports.create = function create(envArgs) {
           '../dist/moment/moment.js',
           '../dist/pikaday/pikaday.js',
           '../dist/hot-formula-parser/formula-parser.js',
+          '../node_modules/dompurify/purify.js',
           '../dist/handsontable.js',
           '../dist/languages/all.js',
         ],

--- a/.config/test-mobile.js
+++ b/.config/test-mobile.js
@@ -36,7 +36,7 @@ module.exports.create = function create(envArgs) {
           '../dist/moment/moment.js',
           '../dist/pikaday/pikaday.js',
           '../dist/hot-formula-parser/formula-parser.js',
-          '../node_modules/dompurify/purify.js',
+          '../node_modules/dompurify/dist/purify.js',
           '../dist/handsontable.js',
           '../dist/languages/all.js',
         ],

--- a/.config/watch.js
+++ b/.config/watch.js
@@ -41,7 +41,13 @@ module.exports.create = function create(envArgs) {
         commonjs2: 'hot-formula-parser',
         commonjs: 'hot-formula-parser',
         amd: 'hot-formula-parser',
-      }
+      },
+      dompurify: {
+        root: 'DOMPurify',
+        commonjs2: 'dompurify',
+        commonjs: 'dompurify',
+        amd: 'dompurify',
+      },
     };
     c.module.rules.unshift({
       test: [

--- a/dist/README.md
+++ b/dist/README.md
@@ -25,13 +25,14 @@ If you are a "Bob the Builder" kind of hacker, you will need to load Handsontabl
 <script src="https://cdn.jsdelivr.net/npm/pikaday@1.5.1/pikaday.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/numbro@2/dist/numbro.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/hot-formula-parser@3.0.0/dist/formula-parser.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/dompurify@2.0.8/dist/purify.js"></script>
 
 <!-- Handsontable bare files -->
 <script src="dist/handsontable.js"></script>
 <link href="dist/handsontable.css" rel="stylesheet">
 ```
 
-**handsontable.js** and **handsontable.css** are compiled ___without___ the needed dependencies. You will have to include `pikaday.js`, `moment.js`, `numbro.js` and `hot-formula-parser.js` on your own ie. from JSDelivr CDN.
+**handsontable.js** and **handsontable.css** are compiled ___without___ the needed dependencies. You will have to include `pikaday.js`, `moment.js`, `numbro.js`, `hot-formula-parser.js` and `dompurify` on your own ie. from JSDelivr CDN.
 
 ## Internationalization
 It is possible to include files which will register languages dictionaries. They allow to translate parts of Handsontable UI. You can either use only particular languages files or include all of them at once as a single file.


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Exclude DOMPurify lib from the `dist/handsontable.js` build. Adds the lib to the copy script. From now on the dompurify while building the package will be copied to the dist/ directory. And set `force` to `true` for the `CopyWebpackPlugin` webpack plugin to ensure that dependencies copied from the `node_modules` are the same as in the `dist` directory.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
