### PR TITLE
Protect Autocomplete editor from XSS

### DIFF
--- a/.config/development.js
+++ b/.config/development.js
@@ -65,7 +65,8 @@ module.exports.create = function create(envArgs) {
 
   configFull.forEach(function(c) {
     c.output.filename = PACKAGE_FILENAME + '.full.js';
-    // Export these dependencies to the window object.
+    // Export these dependencies to the window object. So they can be custom configured
+    // before the Handsontable initializiation.
     c.module.rules.unshift({
       test: /numbro/,
       use: [

--- a/.config/development.js
+++ b/.config/development.js
@@ -65,6 +65,7 @@ module.exports.create = function create(envArgs) {
 
   configFull.forEach(function(c) {
     c.output.filename = PACKAGE_FILENAME + '.full.js';
+    // Export these dependencies to the window object.
     c.module.rules.unshift({
       test: /numbro/,
       use: [
@@ -83,6 +84,17 @@ module.exports.create = function create(envArgs) {
           loader: path.resolve(__dirname, 'loader/exports-to-window-loader.js'),
           options: {
             moment: 'moment',
+          }
+        }
+      ]
+    });
+    c.module.rules.unshift({
+      test: /dompurify/,
+      use: [
+        {
+          loader: path.resolve(__dirname, 'loader/exports-to-window-loader.js'),
+          options: {
+            DOMPurify: 'dompurify',
           }
         }
       ]

--- a/src/editors/autocompleteEditor.js
+++ b/src/editors/autocompleteEditor.js
@@ -1,6 +1,6 @@
 import { KEY_CODES, isPrintableChar } from './../helpers/unicode';
 import { stringify, isDefined } from './../helpers/mixed';
-import { sanitize, stripTags } from './../helpers/string';
+import { stripTags } from './../helpers/string';
 import { pivot, arrayMap } from './../helpers/array';
 import { getRenderer } from '../renderers';
 import {
@@ -124,7 +124,7 @@ class AutocompleteEditor extends HandsontableEditor {
           }
         }
 
-        TD.innerHTML = sanitize(cellValue);
+        TD.innerHTML = cellValue;
       },
       autoColumnSize: true,
     });

--- a/src/editors/autocompleteEditor.js
+++ b/src/editors/autocompleteEditor.js
@@ -122,12 +122,9 @@ class AutocompleteEditor extends HandsontableEditor {
             match = cellValue.substr(indexOfMatch, query.length);
             cellValue = cellValue.replace(match, `<strong>${match}</strong>`);
           }
-
-          TD.innerHTML = sanitize(cellValue);
-        } else {
-          TD.innerHTML = cellValue;
         }
 
+        TD.innerHTML = sanitize(cellValue);
       },
       autoColumnSize: true,
     });

--- a/src/helpers/dom/element.js
+++ b/src/helpers/dom/element.js
@@ -407,10 +407,11 @@ export const HTML_CHARACTERS = /(<(.*)>|&(.*);)/;
  *
  * @param {HTMLElement} element An element to write into.
  * @param {string} content The text to write.
+ * @param {boolean} [sanitizeContent=true] If `true`, the content will be sanitized before writing to the element.
  */
-export function fastInnerHTML(element, content) {
+export function fastInnerHTML(element, content, sanitizeContent = true) {
   if (HTML_CHARACTERS.test(content)) {
-    element.innerHTML = sanitize(content);
+    element.innerHTML = sanitizeContent ? sanitize(content) : content;
   } else {
     fastInnerText(element, content);
   }

--- a/src/helpers/string.js
+++ b/src/helpers/string.js
@@ -96,6 +96,6 @@ export function stripTags(string) {
  * @param {object} [options] DOMPurify's configuration object.
  * @returns {string}
  */
-export function sanitize(string, options = { PROFILES: { html: true } }) {
+export function sanitize(string, options) {
   return purifySanitize(string, options);
 }

--- a/src/plugins/copyPaste/test/copyPaste.e2e.js
+++ b/src/plugins/copyPaste/test/copyPaste.e2e.js
@@ -896,7 +896,6 @@ describe('CopyPaste', () => {
         '<table><tr></tr></table><img src onerror="boom()">'
       ].join('\r\n'));
 
-
       selectCell(0, 0);
 
       plugin.onPaste(clipboardEvent);

--- a/src/plugins/copyPaste/test/copyPaste.e2e.js
+++ b/src/plugins/copyPaste/test/copyPaste.e2e.js
@@ -885,9 +885,10 @@ describe('CopyPaste', () => {
       expect(getSelectedRangeLast().to.col).toBe(9);
     });
 
-    it('should sanitize pasted HTML', () => {
+    it('should sanitize pasted HTML', async() => {
       handsontable();
 
+      const onErrorSpy = spyOn(window, 'onerror');
       const clipboardEvent = getClipboardEvent();
       const plugin = getPlugin('CopyPaste');
 
@@ -895,10 +896,14 @@ describe('CopyPaste', () => {
         '<table><tr></tr></table><img src onerror="boom()">'
       ].join('\r\n'));
 
+
       selectCell(0, 0);
 
       plugin.onPaste(clipboardEvent);
 
+      await sleep(100);
+
+      expect(onErrorSpy).not.toHaveBeenCalled();
       expect(getDataAtCell(0, 0)).toEqual(null);
     });
   });

--- a/src/renderers/htmlRenderer.js
+++ b/src/renderers/htmlRenderer.js
@@ -14,7 +14,7 @@ import { getRenderer } from './index';
 function htmlRenderer(instance, TD, row, col, prop, value, cellProperties) {
   getRenderer('base').apply(this, [instance, TD, row, col, prop, value, cellProperties]);
 
-  fastInnerHTML(TD, value === null || value === void 0 ? '' : value);
+  fastInnerHTML(TD, value === null || value === void 0 ? '' : value, false);
 }
 
 export default htmlRenderer;

--- a/test/e2e/editors/autocompleteEditor.spec.js
+++ b/test/e2e/editors/autocompleteEditor.spec.js
@@ -2293,6 +2293,38 @@ describe('AutocompleteEditor', () => {
         done();
       }, 700);
     });
+
+    it('should allow render the html items without sanitizing the content', async () => {
+      const onErrorSpy = spyOn(window, 'onerror');
+      const hot = handsontable({
+        columns: [
+          {
+            type: 'autocomplete',
+            source: ['<b>foo <span>zip</span></b>', '<i>bar</i><img src onerror="boom()">', '<strong>baz</strong>'],
+            allowHtml: true,
+          }
+        ]
+      });
+
+      selectCell(0, 0);
+      const editorInput = $('.handsontableInput');
+
+      expect(getDataAtCell(0, 0)).toBeNull();
+
+      keyDownUp('enter');
+
+      await sleep(200);
+
+      const ac = hot.getActiveEditor();
+      const innerHot = ac.htEditor;
+
+      expect(onErrorSpy).toHaveBeenCalled();
+      expect(innerHot.getData()).toEqual([
+        ['<b>foo <span>zip</span></b>'],
+        ['<i>bar</i><img src onerror="boom()">'],
+        ['<strong>baz</strong>'],
+      ]);
+    });
   });
 
   describe('disallow html mode', () => {

--- a/test/e2e/editors/autocompleteEditor.spec.js
+++ b/test/e2e/editors/autocompleteEditor.spec.js
@@ -2295,12 +2295,15 @@ describe('AutocompleteEditor', () => {
     });
 
     it('should allow render the html items without sanitizing the content', async() => {
-      const onErrorSpy = spyOn(window, 'onerror');
       const hot = handsontable({
         columns: [
           {
             type: 'autocomplete',
-            source: ['<b>foo <span>zip</span></b>', '<i>bar</i><img src onerror="boom()">', '<strong>baz</strong>'],
+            source: [
+              '<b>foo <span>zip</span></b>',
+              '<i>bar</i><img src onerror="__xssTestInjection = true">',
+              '<strong>baz</strong>'
+            ],
             allowHtml: true,
           }
         ]
@@ -2314,12 +2317,14 @@ describe('AutocompleteEditor', () => {
       const ac = hot.getActiveEditor();
       const innerHot = ac.htEditor;
 
-      expect(onErrorSpy).toHaveBeenCalled();
+      expect(window.__xssTestInjection).toBe(true);
       expect(innerHot.getData()).toEqual([
         ['<b>foo <span>zip</span></b>'],
-        ['<i>bar</i><img src onerror="boom()">'],
+        ['<i>bar</i><img src onerror="__xssTestInjection = true">'],
         ['<strong>baz</strong>'],
       ]);
+
+      delete window.__xssTestInjection;
     });
   });
 

--- a/test/e2e/editors/autocompleteEditor.spec.js
+++ b/test/e2e/editors/autocompleteEditor.spec.js
@@ -2294,7 +2294,7 @@ describe('AutocompleteEditor', () => {
       }, 700);
     });
 
-    it('should allow render the html items without sanitizing the content', async () => {
+    it('should allow render the html items without sanitizing the content', async() => {
       const onErrorSpy = spyOn(window, 'onerror');
       const hot = handsontable({
         columns: [
@@ -2307,10 +2307,6 @@ describe('AutocompleteEditor', () => {
       });
 
       selectCell(0, 0);
-      const editorInput = $('.handsontableInput');
-
-      expect(getDataAtCell(0, 0)).toBeNull();
-
       keyDownUp('enter');
 
       await sleep(200);

--- a/test/e2e/editors/dropdownEditor.spec.js
+++ b/test/e2e/editors/dropdownEditor.spec.js
@@ -417,12 +417,15 @@ describe('DropdownEditor', () => {
 
   describe('allow html mode', () => {
     it('should allow render the html items without sanitizing the content', async() => {
-      const onErrorSpy = spyOn(window, 'onerror');
       const hot = handsontable({
         columns: [
           {
             type: 'dropdown',
-            source: ['<b>foo <span>zip</span></b>', '<i>bar</i><img src onerror="boom()">', '<strong>baz</strong>'],
+            source: [
+              '<b>foo <span>zip</span></b>',
+              '<i>bar</i><img src onerror="__xssTestInjection = true">',
+              '<strong>baz</strong>'
+            ],
             allowHtml: true,
           }
         ]
@@ -436,23 +439,28 @@ describe('DropdownEditor', () => {
       const ac = hot.getActiveEditor();
       const innerHot = ac.htEditor;
 
-      expect(onErrorSpy).toHaveBeenCalled();
+      expect(window.__xssTestInjection).toBe(true);
       expect(innerHot.getData()).toEqual([
         ['<b>foo <span>zip</span></b>'],
-        ['<i>bar</i><img src onerror="boom()">'],
+        ['<i>bar</i><img src onerror="__xssTestInjection = true">'],
         ['<strong>baz</strong>'],
       ]);
+
+      delete window.__xssTestInjection;
     });
   });
 
   describe('disallow html mode', () => {
     it('should strip HTML content', async() => {
-      const onErrorSpy = spyOn(window, 'onerror');
       const hot = handsontable({
         columns: [
           {
             type: 'dropdown',
-            source: ['<b>foo <span>zip</span></b>', '<i>bar</i><img src onerror="boom()">', '<strong>baz</strong>'],
+            source: [
+              '<b>foo <span>zip</span></b>',
+              '<i>bar</i><img src onerror="__xssTestInjection = true">',
+              '<strong>baz</strong>'
+            ],
             allowHtml: false,
           }
         ]
@@ -466,12 +474,14 @@ describe('DropdownEditor', () => {
       const ac = hot.getActiveEditor();
       const innerHot = ac.htEditor;
 
-      expect(onErrorSpy).not.toHaveBeenCalled();
+      expect(window.__xssTestInjection).toBeUndefined();
       expect(innerHot.getData()).toEqual([
         ['foo zip'],
         ['bar'],
         ['baz'],
       ]);
+
+      delete window.__xssTestInjection;
     });
   });
 

--- a/test/e2e/renderers/htmlRenderer.spec.js
+++ b/test/e2e/renderers/htmlRenderer.spec.js
@@ -30,12 +30,14 @@ describe('HTMLRenderer', () => {
   });
 
   it('should allow render the html without sanitizing the content', async() => {
-    const onErrorSpy = spyOn(window, 'onerror');
-
     handsontable({
       // target="_blank" - can cause vulnerabilities in access to the window object (filtered by DOMPurify)
       data: [
-        ['<b>foo <span>zip</span></b>', '<i>bar</i><img src onerror="boom()">', '<a href="#" target="_blank">baz</a>']
+        [
+          '<b>foo <span>zip</span></b>',
+          '<i>bar</i><img src onerror="">',
+          '<a href="#" target="_blank">baz</a>'
+        ]
       ],
       colHeaders: true,
       rowHeaders: true,
@@ -44,9 +46,11 @@ describe('HTMLRenderer', () => {
 
     await sleep(100);
 
-    expect(onErrorSpy).toHaveBeenCalled();
-    expect($('.handsontable table tr:last-child td:eq(0)').html()).toEqual('<b>foo <span>zip</span></b>');
-    expect($('.handsontable table tr:last-child td:eq(1)').html()).toEqual('<i>bar</i><img src="" onerror="boom()">');
-    expect($('.handsontable table tr:last-child td:eq(2)').html()).toEqual('<a href="#" target="_blank">baz</a>');
+    expect($('.handsontable table tr:last-child td:eq(0)').html())
+      .toBe('<b>foo <span>zip</span></b>');
+    expect($('.handsontable table tr:last-child td:eq(1)').html())
+      .toBe('<i>bar</i><img src="" onerror="">');
+    expect($('.handsontable table tr:last-child td:eq(2)').html())
+      .toBe('<a href="#" target="_blank">baz</a>');
   });
 });

--- a/test/e2e/renderers/htmlRenderer.spec.js
+++ b/test/e2e/renderers/htmlRenderer.spec.js
@@ -46,11 +46,11 @@ describe('HTMLRenderer', () => {
 
     await sleep(100);
 
-    expect($('.handsontable table tr:last-child td:eq(0)').html())
+    expect(getMaster().find('table tr:last-child td:eq(0)').html())
       .toBe('<b>foo <span>zip</span></b>');
-    expect($('.handsontable table tr:last-child td:eq(1)').html())
+    expect(getMaster().find('table tr:last-child td:eq(1)').html())
       .toBe('<i>bar</i><img src="" onerror="">');
-    expect($('.handsontable table tr:last-child td:eq(2)').html())
+    expect(getMaster().find('table tr:last-child td:eq(2)').html())
       .toBe('<a href="#" target="_blank">baz</a>');
   });
 });

--- a/test/e2e/renderers/htmlRenderer.spec.js
+++ b/test/e2e/renderers/htmlRenderer.spec.js
@@ -28,4 +28,25 @@ describe('HTMLRenderer', () => {
     expect($('.handsontable table tr:last-child td:eq(4)').html()).toEqual('');
     expect($('.handsontable table tr:last-child td:eq(5)').html()).toEqual('');
   });
+
+  it('should allow render the html without sanitizing the content', async() => {
+    const onErrorSpy = spyOn(window, 'onerror');
+
+    handsontable({
+      // target="_blank" - can cause vulnerabilities in access to the window object (filtered by DOMPurify)
+      data: [
+        ['<b>foo <span>zip</span></b>', '<i>bar</i><img src onerror="boom()">', '<a href="#" target="_blank">baz</a>']
+      ],
+      colHeaders: true,
+      rowHeaders: true,
+      renderer: 'html'
+    });
+
+    await sleep(100);
+
+    expect(onErrorSpy).toHaveBeenCalled();
+    expect($('.handsontable table tr:last-child td:eq(0)').html()).toEqual('<b>foo <span>zip</span></b>');
+    expect($('.handsontable table tr:last-child td:eq(1)').html()).toEqual('<i>bar</i><img src="" onerror="boom()">');
+    expect($('.handsontable table tr:last-child td:eq(2)').html()).toEqual('<a href="#" target="_blank">baz</a>');
+  });
 });

--- a/test/unit/helpers/dom/Element.spec.js
+++ b/test/unit/helpers/dom/Element.spec.js
@@ -6,7 +6,8 @@ import {
   hasClass,
   isInput,
   removeClass,
-  selectElementIfAllowed
+  selectElementIfAllowed,
+  fastInnerHTML,
 } from 'handsontable/helpers/dom/element';
 
 describe('DomElement helper', () => {
@@ -436,6 +437,68 @@ describe('DomElement helper', () => {
       expect(spy).not.toHaveBeenCalled();
 
       document.body.removeChild(input);
+    });
+  });
+
+  //
+  // Handsontable.helper.sanitize
+  //
+  describe('fastInnerHTML', () => {
+    it('should be possible to sanitize the HTML (by default the content is sanitized)', () => {
+      const elementMock = {
+        innerHTML: '',
+      };
+
+      fastInnerHTML(elementMock, '<img src onerror=alert(1)>');
+
+      expect(elementMock.innerHTML).toBe('<img src="">');
+
+      fastInnerHTML(elementMock, '<script>alert()</script>');
+
+      expect(elementMock.innerHTML).toBe('');
+
+      fastInnerHTML(elementMock, '<strong>Hello</strong> <span class="my">my <sup>world</span>2</sup>');
+
+      expect(elementMock.innerHTML).toBe('<strong>Hello</strong> <span class="my">my <sup>world</sup></span>2');
+
+      fastInnerHTML(
+        elementMock,
+        '<meta http-equiv="refresh" content="30">This is my <a href="https://handsontable.com">link</a>'
+      );
+
+      expect(elementMock.innerHTML).toBe('This is my <a href="https://handsontable.com">link</a>');
+    });
+
+    it('should be possible to disable content sanitization', () => {
+      const elementMock = {
+        innerHTML: '',
+      };
+
+      fastInnerHTML(elementMock, '<img src onerror=alert(1)>', false);
+
+      expect(elementMock.innerHTML).toBe('<img src onerror=alert(1)>');
+
+      fastInnerHTML(elementMock, '<script>alert()</script>', false);
+
+      expect(elementMock.innerHTML).toBe('<script>alert()</script>');
+
+      fastInnerHTML(
+        elementMock,
+        '<strong>Hello</strong> <span class="my">my <sup>world</span>2</sup>',
+        false,
+      );
+
+      expect(elementMock.innerHTML)
+        .toBe('<strong>Hello</strong> <span class="my">my <sup>world</span>2</sup>');
+
+      fastInnerHTML(
+        elementMock,
+        '<meta http-equiv="refresh" content="30">This is my <a href="https://handsontable.com">link</a>',
+        false,
+      );
+
+      expect(elementMock.innerHTML)
+        .toBe('<meta http-equiv="refresh" content="30">This is my <a href="https://handsontable.com">link</a>');
     });
   });
 });


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the following issues:
 * Disables values sanitizing when the `allowHtml` option is enabled (default value is `false`). It applies to the Autocomplete and Dropdown editors;
 * Disables values sanitizing for HTML renderers.

Additionally, I've exported the DOMPurify lib to the window object. This will allow adjusting the lib and control of how the HTML content should be filtered within the Handsontable settings that accept that kind of strings.

After [that changes](https://github.com/handsontable/handsontable/issues/7292), the Handsontable can stop rendering some of the values. This is true for properties that accept values passed as HTML string. Mostly I'm referring to custom tags, custom attributes, or some of the build-in elements such as `iframe`. To make them working again the custom code for DOMPurify hooks have to be added. It extends the build-in allowlist. 

This allows rendering custom tags and/or attributes:
```js
DOMPurify.addHook('uponSanitizeElement', function(node, data) {
  if (node.nodeName && node.nodeName === 'MY-FANCY-INPUT') {
    data.allowedTags[data.tagName] = true;
  }
});
DOMPurify.addHook('uponSanitizeAttribute', function(node, data) {
  if (node.hasAttribute('my-id')) {
    data.allowedAttributes[data.attrName] = true;
  }
});
```  

The documentation about [custom renderers](https://handsontable.com/docs/7.4.2/demo-custom-renderers.html#page-cell) should be updated. DOMPurify should be used there. 

To summarize the PR, this is a list of fields which are sanitized:
 * The `name` property, part of the _ContextMenu_ plugin configuration;
 * The `name` property, part of the _DropdownMenu_ plugin configuration;
 * The clipboard;
 * The `source` option is sanitized by default. It can be bypassed by setting `allowHtml` as `true`. The option is used by Autocomplete and Dropdown editors.

List of fields which aren't sanitized:
 * `rowHeaders`;
 * `colHeaders`;
 * `title`;
 * The `label` property, part of the _NestedHeaders_ plugin.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [x] My change requires a change to the documentation.
