### PR TITLE
Correct a typo in a helper method from the Column Sorting plugin.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Corrected a typo in a helper method from the Column Sorting plugin. [#7375](https://github.com/handsontable/handsontable/issue/7375)
+
+## [8.2.0] - 2020-11-12
+
 ### Added
 - Added new type of Index Map named `LinkedPhysicalIndexToValueMap` [#7276](https://github.com/handsontable/handsontable/pull/7276)
 - Added an external dependency, `DOMPurify`, to add HTML sanitization what should minimize the risk of inserting insecure code using Handsontable built-in functionalities. [#7292](https://github.com/handsontable/handsontable/issues/7292)

--- a/src/plugins/columnSorting/columnSorting.js
+++ b/src/plugins/columnSorting/columnSorting.js
@@ -19,7 +19,7 @@ import {
   isFirstLevelColumnHeader,
   wasHeaderClickedProperly
 } from './utils';
-import { getClassedToRemove, getClassesToAdd } from './domHelpers';
+import { getClassesToRemove, getClassesToAdd } from './domHelpers';
 import { rootComparator } from './rootComparator';
 import { registerRootComparator, sort } from './sortService';
 
@@ -676,7 +676,7 @@ class ColumnSorting extends BasePlugin {
    * @param {...*} args Extra arguments for helpers.
    */
   updateHeaderClasses(headerSpanElement, ...args) {
-    removeClass(headerSpanElement, getClassedToRemove(headerSpanElement));
+    removeClass(headerSpanElement, getClassesToRemove(headerSpanElement));
 
     if (this.enabled !== false) {
       addClass(headerSpanElement, getClassesToAdd(...args));

--- a/src/plugins/columnSorting/domHelpers.js
+++ b/src/plugins/columnSorting/domHelpers.js
@@ -48,7 +48,7 @@ export function getClassesToAdd(columnStatesManager, column, showSortIndicator, 
  *
  * @returns {Array} Array of CSS classes.
  */
-export function getClassedToRemove() {
+export function getClassesToRemove() {
   return Array.from(orderToCssClass.values())
     .concat(HEADER_ACTION_CLASS, HEADER_CLASS_INDICATOR_DISABLED, HEADER_SORT_CLASS);
 }

--- a/src/plugins/columnSorting/test/domHelpers.unit.js
+++ b/src/plugins/columnSorting/test/domHelpers.unit.js
@@ -1,6 +1,6 @@
 import { ColumnStatesManager } from 'handsontable/plugins/columnSorting/columnStatesManager';
 import { DESC_SORT_STATE, ASC_SORT_STATE } from 'handsontable/plugins/columnSorting/utils';
-import { getClassesToAdd, getClassedToRemove } from 'handsontable/plugins/columnSorting/domHelpers';
+import { getClassesToAdd, getClassesToRemove } from 'handsontable/plugins/columnSorting/domHelpers';
 import { IndexMapper } from 'handsontable/translations';
 
 const hotMock = {
@@ -70,7 +70,7 @@ describe('ColumnSorting DOM helpers', () => {
     });
   });
 
-  describe('getClassedToRemove', () => {
+  describe('getClassesToRemove', () => {
     it('should return all calculated classes', () => {
       const columnStatesManager = new ColumnStatesManager(hotMock);
 
@@ -80,12 +80,12 @@ describe('ColumnSorting DOM helpers', () => {
 
       const htmlElementMock = { className: 'columnSorting sortAction' };
 
-      expect(getClassedToRemove(htmlElementMock).length).toEqual(5);
-      expect(getClassedToRemove(htmlElementMock).includes('columnSorting')).toBeTruthy();
-      expect(getClassedToRemove(htmlElementMock).includes('indicatorDisabled')).toBeTruthy();
-      expect(getClassedToRemove(htmlElementMock).includes('sortAction')).toBeTruthy();
-      expect(getClassedToRemove(htmlElementMock).includes('ascending')).toBeTruthy();
-      expect(getClassedToRemove(htmlElementMock).includes('descending')).toBeTruthy();
+      expect(getClassesToRemove(htmlElementMock).length).toEqual(5);
+      expect(getClassesToRemove(htmlElementMock).includes('columnSorting')).toBeTruthy();
+      expect(getClassesToRemove(htmlElementMock).includes('indicatorDisabled')).toBeTruthy();
+      expect(getClassesToRemove(htmlElementMock).includes('sortAction')).toBeTruthy();
+      expect(getClassesToRemove(htmlElementMock).includes('ascending')).toBeTruthy();
+      expect(getClassesToRemove(htmlElementMock).includes('descending')).toBeTruthy();
 
       columnStatesManager.destroy(); // Unregister already registered Index Map.
     });

--- a/src/plugins/multiColumnSorting/domHelpers.js
+++ b/src/plugins/multiColumnSorting/domHelpers.js
@@ -30,7 +30,7 @@ export function getClassesToAdd(columnStatesManager, column, showSortIndicator) 
  * @param {HTMLElement} htmlElement An element to process.
  * @returns {Array} Array of CSS classes.
  */
-export function getClassedToRemove(htmlElement) {
+export function getClassesToRemove(htmlElement) {
   const cssClasses = htmlElement.className.split(' ');
   const sortSequenceRegExp = new RegExp(`^${COLUMN_ORDER_PREFIX}-[0-9]{1,2}$`);
 

--- a/src/plugins/multiColumnSorting/multiColumnSorting.js
+++ b/src/plugins/multiColumnSorting/multiColumnSorting.js
@@ -6,7 +6,7 @@ import { isPressedCtrlKey } from '../../utils/keyStateObserver';
 import { addClass, removeClass } from '../../helpers/dom/element';
 import { rootComparator } from './rootComparator';
 import { warnAboutPluginsConflict } from './utils';
-import { getClassesToAdd, getClassedToRemove } from './domHelpers';
+import { getClassesToAdd, getClassesToRemove } from './domHelpers';
 
 import './multiColumnSorting.css';
 
@@ -217,7 +217,7 @@ class MultiColumnSorting extends ColumnSorting {
   updateHeaderClasses(headerSpanElement, ...args) {
     super.updateHeaderClasses(headerSpanElement, ...args);
 
-    removeClass(headerSpanElement, getClassedToRemove(headerSpanElement));
+    removeClass(headerSpanElement, getClassesToRemove(headerSpanElement));
 
     if (this.enabled !== false) {
       addClass(headerSpanElement, getClassesToAdd(...args));

--- a/src/plugins/multiColumnSorting/test/domHelpers.unit.js
+++ b/src/plugins/multiColumnSorting/test/domHelpers.unit.js
@@ -1,6 +1,6 @@
 import { ColumnStatesManager } from 'handsontable/plugins/columnSorting/columnStatesManager';
 import { DESC_SORT_STATE, ASC_SORT_STATE } from 'handsontable/plugins/columnSorting/utils';
-import { getClassesToAdd, getClassedToRemove } from 'handsontable/plugins/multiColumnSorting/domHelpers';
+import { getClassesToAdd, getClassesToRemove } from 'handsontable/plugins/multiColumnSorting/domHelpers';
 import { IndexMapper } from 'handsontable/translations';
 
 const hotMock = {
@@ -32,7 +32,7 @@ describe('MultiColumnSorting DOM helpers', () => {
     });
   });
 
-  describe('getClassedToRemove', () => {
+  describe('getClassesToRemove', () => {
     it('should return all calculated classes', () => {
       const columnStatesManager = new ColumnStatesManager(hotMock);
 
@@ -45,11 +45,11 @@ describe('MultiColumnSorting DOM helpers', () => {
 
       const htmlElementMock = { className: 'columnSorting sort-1 sort-2 sort-3 sort-4 sortAction' };
 
-      expect(getClassedToRemove(htmlElementMock).length).toEqual(4);
-      expect(getClassedToRemove(htmlElementMock).includes('sort-1')).toBeTruthy();
-      expect(getClassedToRemove(htmlElementMock).includes('sort-2')).toBeTruthy();
-      expect(getClassedToRemove(htmlElementMock).includes('sort-3')).toBeTruthy();
-      expect(getClassedToRemove(htmlElementMock).includes('sort-4')).toBeTruthy();
+      expect(getClassesToRemove(htmlElementMock).length).toEqual(4);
+      expect(getClassesToRemove(htmlElementMock).includes('sort-1')).toBeTruthy();
+      expect(getClassesToRemove(htmlElementMock).includes('sort-2')).toBeTruthy();
+      expect(getClassesToRemove(htmlElementMock).includes('sort-3')).toBeTruthy();
+      expect(getClassesToRemove(htmlElementMock).includes('sort-4')).toBeTruthy();
 
       columnStatesManager.destroy(); // Unregister already registered Index Map.
     });


### PR DESCRIPTION
### Context
This PR corrects a typo in a helper method in the Column Sorting and Multi-column Sorting plugins.

### How has this been tested?
n/a

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7375 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
