### PR TITLE
Additional tests cases for parseTable utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue, where calling the validation-triggering methods on a `hiddenColumns`-enabled Handsontable instance rendered the validated cells improperly. [#7301](https://github.com/handsontable/handsontable/issues/7301)
 - Fixed an issue, where adding 0 rows to the table ended with doubled entries in indexMappers' collections. [#7326](https://github.com/handsontable/handsontable/issues/7326)
 - Fix a problem with the inconsistent behavior of the Context Menu's "Clear column" disabled status. [#7003](https://github.com/handsontable/handsontable/issues/7003)
+- Fix a bug with parsing multiline cells on pasting `text/html` mime-type. [#7369](https://github.com/handsontable/handsontable/issues/7369)
 
 ## [8.1.0] - 2020-10-01
 

--- a/src/utils/parseTable.js
+++ b/src/utils/parseTable.js
@@ -1,4 +1,3 @@
-import { matchesCSSRules } from './../helpers/dom/element';
 import { isEmpty } from './../helpers/mixed';
 
 const ESCAPED_HTML_CHARS = {
@@ -181,18 +180,6 @@ export function htmlToGridSettings(element, rootDocument = document) {
     return;
   }
 
-  const styleElem = tempElem.querySelector('style');
-  let styleSheet = null;
-  let styleSheetArr = [];
-
-  if (styleElem) {
-    rootDocument.body.appendChild(styleElem);
-    styleElem.disabled = true;
-    styleSheet = styleElem.sheet;
-    styleSheetArr = styleSheet ? Array.from(styleSheet.cssRules) : [];
-    rootDocument.body.removeChild(styleElem);
-  }
-
   const generator = tempElem.querySelector('meta[name$="enerator"]');
   const hasRowHeaders = checkElement.querySelector('tbody th') !== null;
   const trElement = checkElement.querySelector('tr');
@@ -312,24 +299,9 @@ export function htmlToGridSettings(element, rootDocument = document) {
           }
         }
 
-        const cellStyle = styleSheetArr.reduce((settings, cssRule) => {
-          if (matchesCSSRules(cell, cssRule)) {
-            const { whiteSpace } = cssRule.style;
-
-            if (whiteSpace) {
-              settings.whiteSpace = whiteSpace;
-            }
-          }
-
-          return settings;
-        }, {});
         let cellValue = '';
 
-        if (cellStyle.whiteSpace === 'nowrap') {
-          cellValue = innerHTML.replace(/[\r\n][\x20]{0,2}/gim, '\x20')
-            .replace(/<br(\s*|\/)>/gim, '\r\n');
-
-        } else if (generator && /excel/gi.test(generator.content)) {
+        if (generator && /excel/gi.test(generator.content)) {
           cellValue = innerHTML.replace(/[\r\n][\x20]{0,2}/g, '\x20')
             .replace(/<br(\s*|\/)>[\r\n]?[\x20]{0,3}/gim, '\r\n');
 

--- a/test/unit/utils/parseTable.spec.js
+++ b/test/unit/utils/parseTable.spec.js
@@ -93,8 +93,35 @@ describe('_dataToHTML', () => {
 });
 
 describe('htmlToGridSettings', () => {
+  describe('element validation', () => {
+    it('should properly exit if passed element is undefined', () => {
+      const config = htmlToGridSettings();
+
+      expect(config).toBeUndefined();
+    });
+
+    it('should properly exit if passed element is an empty string', () => {
+      const config = htmlToGridSettings('');
+
+      expect(config).toBeUndefined();
+    });
+
+    it('should properly exit if passed element does not contain table element', () => {
+      const elementToTest = [
+        '<div>',
+        '<p>',
+        '<span>span element</span>',
+        '</p>',
+        '</div>',
+      ].join('');
+      const config = htmlToGridSettings(elementToTest);
+
+      expect(config).toBeUndefined();
+    });
+  });
+
   it('should parse data from HTML table', () => {
-    const tableInnerHTML = [
+    const htmlToParse = [
       '<table><tbody>',
       '<tr><td>A3</td><td>B3</td><td>C3</td></tr>',
       '<tr><td>A4</td><td>B4</td><td>C4</td></tr>',
@@ -102,45 +129,45 @@ describe('htmlToGridSettings', () => {
       '<tr><td>A6</td><td>B6</td><td>C6</td></tr>',
       '</tbody></table>',
     ].join('');
-    const config = htmlToGridSettings(tableInnerHTML);
+    const config = htmlToGridSettings(htmlToParse);
 
     expect(config.data.toString()).toBe('A3,B3,C3,A4,B4,C4,A5,B5,C5,A6,B6,C6');
   });
 
   it('should parse an empty HTML table to an empty config object', () => {
-    const tableInnerHTML = [
+    const htmlToParse = [
       '<table><tbody>',
       '</tbody></table>',
     ].join('');
-    const config = htmlToGridSettings(tableInnerHTML);
+    const config = htmlToGridSettings(htmlToParse);
 
     expect(config).toEqual({});
   });
 
   it('should parse data with special characters', () => {
-    const tableInnerHTML = [
+    const htmlToParse = [
       '<table><tbody>',
       '<tr><td>£§!@#$%^&*()-_=+[{]};:\'\\"|,&lt;.&gt;/?©</td></tr>',
       '</tbody></table>',
     ].join('');
-    const config = htmlToGridSettings(tableInnerHTML);
+    const config = htmlToGridSettings(htmlToParse);
 
     expect(config.data.toString()).toBe('£§!@#$%^&*()-_=+[{]};:\'\\"|,<.>/?©');
   });
 
   it('should parse data without unescaped HTML tags', () => {
-    const tableInnerHTML = [
+    const htmlToParse = [
       '<table><tbody>',
       '<tr><td>1<span class="abc">   </span>2</td></tr>',
       '</tbody></table>',
     ].join('');
-    const config = htmlToGridSettings(tableInnerHTML);
+    const config = htmlToGridSettings(htmlToParse);
 
     expect(config.data.toString()).toBe('1   2');
   });
 
   it('should parse data with HTML-like content', () => {
-    const tableInnerHTML = [
+    const htmlToParse = [
       '<table><tbody>',
       '<tr>' +
         '<td>&lt;div class="test"&gt;A&lt;/div&gt;</td>' +
@@ -148,23 +175,24 @@ describe('htmlToGridSettings', () => {
       '</tr>',
       '</tbody></table>',
     ].join('');
-    const config = htmlToGridSettings(tableInnerHTML);
+    const config = htmlToGridSettings(htmlToParse);
 
     expect(config.data.toString()).toBe('<div class="test">A</div>,<script>var b = 1 && 2 << 1</script>');
   });
 
   it('should parse data with Unicode characters (emoji)', () => {
-    const tableInnerHTML = [
+    const htmlToParse = [
       '<table><tbody>',
       '<tr><td>☺️</td><td>✍️</td><td>☀️</td><td>❤️</td><td>✌️</td></tr>',
       '</tbody></table>',
     ].join('');
-    const config = htmlToGridSettings(tableInnerHTML);
+    const config = htmlToGridSettings(htmlToParse);
 
     expect(config.data.toString()).toBe('☺️,✍️,☀️,❤️,✌️');
   });
+
   it('should parse headers from HTML table', () => {
-    const tableInnerHTML = [
+    const htmlToParse = [
       '<table><thead>',
       '<tr><th></th><th>A</th><th>B</th><th>C</th></tr>',
       '</thead><tbody>',
@@ -173,14 +201,14 @@ describe('htmlToGridSettings', () => {
       '<tr><th>5</th><td>A5</td><td>B5</td><td>C5</td></tr>',
       '</tbody></table>',
     ].join('');
-    const config = htmlToGridSettings(tableInnerHTML);
+    const config = htmlToGridSettings(htmlToParse);
 
     expect(config.colHeaders.toString()).toBe('A,B,C');
     expect(config.rowHeaders.toString()).toBe('3,4,5');
   });
 
   it('should parse fixed rows from HTML table', () => {
-    const tableInnerHTML = [
+    const htmlToParse = [
       '<table><thead>',
       '<tr><td>A1</td><td>B1</td><td>C1</td></tr>',
       '<tr><td>A2</td><td>B2</td><td>C2</td></tr>',
@@ -192,14 +220,14 @@ describe('htmlToGridSettings', () => {
       '<tr><td>A6</td><td>B6</td><td>C6</td></tr>',
       '</tfoot></table>',
     ].join('');
-    const config = htmlToGridSettings(tableInnerHTML);
+    const config = htmlToGridSettings(htmlToParse);
 
     expect(config.fixedRowsTop).toBe(2);
     expect(config.fixedRowsBottom).toBe(3);
   });
 
   it('should parse merged cells from HTML table', () => {
-    const tableInnerHTML = [
+    const htmlToParse = [
       '<table><tbody>',
       '<tr><td rowspan="2" colspan="2">A</td></tr>',
       '<tr></tr>',
@@ -210,7 +238,7 @@ describe('htmlToGridSettings', () => {
       '<tr><td>H</td></tr>',
       '</tbody></table>',
     ].join('');
-    const config = htmlToGridSettings(tableInnerHTML);
+    const config = htmlToGridSettings(htmlToParse);
 
     expect(config.mergeCells.length).toBe(2);
 
@@ -225,27 +253,91 @@ describe('htmlToGridSettings', () => {
     expect(config.mergeCells[1].rowspan).toBe(4);
   });
 
-  it('should parse nested headers from HTML table', () => {
-    const tableInnerHTML = [
-      '<table><thead>',
-      '<tr><th colspan="6" >A</th></tr>',
-      '<tr><th colspan="3">B</th><th colspan="3">C</th></tr>',
-      '<tr><th>D</th><th>E</th><th>F</th><th>G</th><th>H</th><th>I</th></tr>',
-      '</thead><tbody>',
-      '<tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td><td>E1</td><td>F1</td></tr>',
-      '</tbody></table>',
-    ].join('');
-    const config = htmlToGridSettings(tableInnerHTML);
+  describe('nestedHeaders', () => {
+    it('should parse nested headers from HTML table', () => {
+      const htmlToParse = [
+        '<table><thead>',
+        '<tr><th colspan="6" >A</th></tr>',
+        '<tr><th colspan="3">B</th><th colspan="3">C</th></tr>',
+        '<tr><th>D</th><th>E</th><th>F</th><th>G</th><th>H</th><th>I</th></tr>',
+        '</thead><tbody>',
+        '<tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td><td>E1</td><td>F1</td></tr>',
+        '</tbody></table>',
+      ].join('');
+      const config = htmlToGridSettings(htmlToParse);
 
-    expect(config.nestedHeaders.length).toBe(3);
+      expect(config.nestedHeaders.length).toBe(3);
+      expect(config.nestedHeaders[0][0].label).toBe('A');
+      expect(config.nestedHeaders[0][0].colspan).toBe(6);
+      expect(config.nestedHeaders[1][0].label).toBe('B');
+      expect(config.nestedHeaders[1][0].colspan).toBe(3);
+      expect(config.nestedHeaders[1][1].label).toBe('C');
+      expect(config.nestedHeaders[1][1].colspan).toBe(3);
+      expect(config.nestedHeaders[2].toString()).toBe('D,E,F,G,H,I');
+    });
 
-    expect(config.nestedHeaders[0][0].label).toBe('A');
-    expect(config.nestedHeaders[0][0].colspan).toBe(6);
-    expect(config.nestedHeaders[1][0].label).toBe('B');
-    expect(config.nestedHeaders[1][0].colspan).toBe(3);
-    expect(config.nestedHeaders[1][1].label).toBe('C');
-    expect(config.nestedHeaders[1][1].colspan).toBe(3);
+    it('should parse nested headers from HTML table if row headers are present', () => {
+      const htmlToParse = [
+        '<table><thead>',
+        '<tr><th></th><th colspan="2" >A</th></tr>',
+        '<tr><th></th><th>B</th><th>C</th></tr>',
+        '</thead><tbody>',
+        '<tr><th>1</th><td>B1</td><td>C1</td></tr>',
+        '<tr><th>2</th><td>B2</td><td>C2</td></tr>',
+        '<tr><th>3</th><td>B3</td><td>C3</td></tr>',
+        '</tbody></table>',
+      ].join('');
+      const config = htmlToGridSettings(htmlToParse);
 
-    expect(config.nestedHeaders[2].toString()).toBe('D,E,F,G,H,I');
+      expect(config.nestedHeaders.length).toBe(2);
+      expect(config.nestedHeaders[0][0].label).toBe('A');
+      expect(config.nestedHeaders[0][0].colspan).toBe(2);
+      expect(config.nestedHeaders[1].toString()).toBe('B,C');
+    });
+  });
+
+  describe('Excel support', () => {
+    it('should ignore colspan attribute if mso-ignore point that', () => {
+      // Raw clipboard data from Excel
+      const htmlToParse = `
+<table border=0 cellpadding=0 cellspacing=0 width=128 style="border-collapse:
+ collapse;width:96pt">
+<!--StartFragment-->
+ <col width=64 span=2 style="width:48pt">
+ <tr height=20 style="height:15.0pt">
+  <td height=20 colspan=2 width=128 style="height:15.0pt;mso-ignore:colspan;
+  width:96pt">Very long text</td>
+ </tr>
+ <tr height=20 style="height:15.0pt">
+  <td height=20 style="height:15.0pt"></td>
+  <td align=right>1</td>
+ </tr>
+<!--EndFragment-->
+</table>`;
+      const config = htmlToGridSettings(htmlToParse);
+
+      expect(config.mergeCells).toBeUndefined();
+      expect(config.data).toEqual([
+        ['Very long text', null],
+        ['', '1'],
+      ]);
+    });
+
+    it('should standarize cell value if generator is defined', () => {
+      const htmlToParse = [
+        '<meta name=Generator content="Excel">',
+        '<table><tbody><tr><td>',
+        '1 2 3 4\r\n',
+        '  5<br>\r\n',
+        '    br<br>\r\n',
+        '    6 7 8 9 0',
+        '</td></tr></tbody></table>',
+      ].join('');
+      const config = htmlToGridSettings(htmlToParse);
+
+      expect(config.data).toEqual([
+        ['1 2 3 4 5\r\nbr\r\n6 7 8 9 0']
+      ]);
+    });
   });
 });


### PR DESCRIPTION
### Context
As @budnix described in #7369 some lines of code in parseTable utility is no more necessary. Along with introducing value sanitizing to the CopyPaste, we need reading `cssRules` no more.
In this PR I add also missing test cases to unit tests.

### How has this been tested?
Run `npm run test:unit` in terminal.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. #7369