### PR TITLE
Add missing setting - skipRowOnPaste

### DIFF
--- a/handsontable.d.ts
+++ b/handsontable.d.ts
@@ -1721,6 +1721,7 @@ declare namespace Handsontable {
     selectionMode?: 'single' | 'range' | 'multiple';
     selectOptions?: string[];
     skipColumnOnPaste?: boolean;
+    skipRowOnPaste?: boolean;
     sortByRelevance?: boolean;
     source?: string[] | number[] | ((this: CellProperties, query: string, callback: (items: string[]) => void) => void);
     startCols?: number;

--- a/test/types/settings.types.ts
+++ b/test/types/settings.types.ts
@@ -292,6 +292,7 @@ const allSettings: Required<Handsontable.GridSettings> = {
   selectionMode: oneOf('single', 'range', 'multiple'),
   selectOptions: ['A', 'B', 'C'],
   skipColumnOnPaste: true,
+  skipRowOnPaste: true,
   sortByRelevance: true,
   source: oneOf(['A', 'B', 'C', 'D'], (query: string, callback: (item: string[]) => void) => callback(['A', 'B', 'C', 'D'])),
   startCols: 123,


### PR DESCRIPTION

### Context
<!--- Why is this change required? What problem does it solve? -->
This pull request adds the missing `skipRowOnPaste` setting.
This option is [mentioned in the docs](https://handsontable.com/docs/8.1.0/Options.html#skipRowOnPaste) but hasn't been added to our .ts files.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7393 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
