### PR TITLE
Extend the description of className [DOCS] 

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -97,6 +97,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
    * @private
    * @type {HTMLElement}
    */
+  /* eslint-enable jsdoc/require-description-complete-sentence */
   this.rootElement = rootElement;
   /**
    * The nearest document over container.

--- a/src/core.js
+++ b/src/core.js
@@ -58,7 +58,7 @@ let activeGuid = null;
  *
  * // now, to use setDataAtCell method, you can either:
  * hot.setDataAtCell(0, 0, 'new value');
- * ```.
+ * ```
  *
  * Alternatively, you can call the method using jQuery wrapper (__obsolete__, requires initialization using our jQuery guide
  * ```js

--- a/src/core.js
+++ b/src/core.js
@@ -39,6 +39,7 @@ import { MetaManager, DataMap } from './dataMap/index';
 
 let activeGuid = null;
 
+/* eslint-disable jsdoc/require-description-complete-sentence */
 /**
  * Handsontable constructor.
  *
@@ -47,7 +48,6 @@ let activeGuid = null;
  * @description
  * After Handsontable is constructed, you can modify the grid behavior using the available public methods.
  *
- * ---.
  * ## How to call methods.
  *
  * These are 2 equal ways to call a Handsontable method:
@@ -64,7 +64,7 @@ let activeGuid = null;
  * ```js
  * $('#example1').handsontable('setDataAtCell', 0, 0, 'new value');
  * ```
- * ---.
+ *
  * @param {HTMLElement} rootElement The element to which the Handsontable instance is injected.
  * @param {object} userSettings The user defined options.
  * @param {boolean} [rootInstanceSymbol=false] Indicates if the instance is root of all later instances created.

--- a/src/core.js
+++ b/src/core.js
@@ -97,8 +97,8 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
    * @private
    * @type {HTMLElement}
    */
-  /* eslint-enable jsdoc/require-description-complete-sentence */
   this.rootElement = rootElement;
+  /* eslint-enable jsdoc/require-description-complete-sentence */
   /**
    * The nearest document over container.
    *

--- a/src/dataMap/metaManager/metaSchema.js
+++ b/src/dataMap/metaManager/metaSchema.js
@@ -1265,6 +1265,7 @@ export default () => {
      */
     readOnlyCellClassName: 'htDimmed',
 
+    /* eslint-disable jsdoc/require-description-complete-sentence */
     /**
      * @description
      * If a string is provided, it may be one of the following predefined values:

--- a/src/dataMap/metaManager/metaSchema.js
+++ b/src/dataMap/metaManager/metaSchema.js
@@ -46,7 +46,7 @@ import { isObjectEqual } from '../../helpers/object';
  *     return cellProperties;
  *   }
  * });
- * ```.
+ * ```
  *
  * The above notation will result in all TDs being *read only*, except for first column TDs which will be *editable*, except for the TD in top left corner which will still be *read only*.
  *
@@ -1281,7 +1281,7 @@ export default () => {
      * If a function is provided, it will receive the following arguments:
      * ```js
      * function(instance, TD, row, col, prop, value, cellProperties) {}
-     * ```.
+     * ```
      *
      * You can read more about custom renderes [in the documentation](https://docs.handsontable.com/demo-custom-renderers.html).
      *

--- a/src/dataMap/metaManager/metaSchema.js
+++ b/src/dataMap/metaManager/metaSchema.js
@@ -1019,6 +1019,8 @@ export default () => {
 
     /**
      * Class name for the Handsontable container element.
+     * It can also be used to assign class names for table cells,
+     * for example, if it is provided in `cells` or `columns` options.
      *
      * @memberof Options#
      * @type {string|string[]}

--- a/src/dataMap/metaManager/metaSchema.js
+++ b/src/dataMap/metaManager/metaSchema.js
@@ -1318,6 +1318,7 @@ export default () => {
      * ],
      * ```
      */
+    /* eslint-enable jsdoc/require-description-complete-sentence */
     renderer: void 0,
 
     /**

--- a/src/dataMap/metaManager/metaSchema.js
+++ b/src/dataMap/metaManager/metaSchema.js
@@ -1018,9 +1018,10 @@ export default () => {
     activeHeaderClassName: 'ht__active_highlight',
 
     /**
-     * Class name for the Handsontable container element.
-     * It can also be used to assign class names for table cells,
-     * for example, if it is provided in `cells` or `columns` options.
+     * Class name for the current element.
+     * The interpretation depends on the level on which this option is provided in the [cascading configuration](https://handsontable.com/docs/Options.html).
+     * If `className` is provided on the first (constructor) level, it is the applied to the Handsontable container.
+     * If `className` is provided on the second (`column`) or the third (`cell` or `cells`) level, it is applied to the table cell.
      *
      * @memberof Options#
      * @type {string|string[]}
@@ -1028,10 +1029,10 @@ export default () => {
      *
      * @example
      * ```js
-     * // set custom class for table container
+     * // can be set as a string
      * className: 'your__class--name',
      *
-     * // or
+     * // or as an array of strings
      * className: ['first-class-name', 'second-class-name'],
      * ```
      */

--- a/src/dataMap/metaManager/metaSchema.js
+++ b/src/dataMap/metaManager/metaSchema.js
@@ -1319,8 +1319,9 @@ export default () => {
      * ],
      * ```
      */
-    /* eslint-enable jsdoc/require-description-complete-sentence */
     renderer: void 0,
+
+    /* eslint-enable jsdoc/require-description-complete-sentence */
 
     /**
      * CSS class name added to the commented cells.

--- a/src/pluginHooks.js
+++ b/src/pluginHooks.js
@@ -1394,7 +1394,7 @@ const REGISTERED_HOOKS = [
    *     operation: 'conjunction'
    *   },
    * ]
-   * ```.
+   * ```
    * @returns {boolean} If hook returns `false` value then filtering won't be applied on the UI side (server-side filtering).
    */
   'beforeFilter',
@@ -1423,7 +1423,7 @@ const REGISTERED_HOOKS = [
    *     operation: 'conjunction'
    *   },
    * ]
-   * ```.
+   * ```
    */
   'afterFilter',
 
@@ -1939,13 +1939,13 @@ const REMOVED_HOOKS = new Map([
  * printed out when the hook is used.
  *
  * Usage:
- * ```.
+ * ```js
  * ...
  * New Map([
  *   ['beforeColumnExpand', 'The plugin hook "beforeColumnExpand" is deprecated. Use "beforeColumnExpand2" instead.'],
  * ])
  * ...
- * ```.
+ * ```
  *
  *
  * @type {Map<string, string>}

--- a/src/pluginHooks.js
+++ b/src/pluginHooks.js
@@ -1398,6 +1398,7 @@ const REGISTERED_HOOKS = [
    * ```
    * @returns {boolean} If hook returns `false` value then filtering won't be applied on the UI side (server-side filtering).
    */
+  /* eslint-enable jsdoc/require-description-complete-sentence */
   'beforeFilter',
 
   /* eslint-disable jsdoc/require-description-complete-sentence */
@@ -1427,6 +1428,7 @@ const REGISTERED_HOOKS = [
    * ]
    * ```
    */
+  /* eslint-enable jsdoc/require-description-complete-sentence */
   'afterFilter',
 
   /**
@@ -1953,6 +1955,7 @@ const REMOVED_HOOKS = new Map([
  *
  * @type {Map<string, string>}
  */
+/* eslint-enable jsdoc/require-description-complete-sentence */
 const DEPRECATED_HOOKS = new Map([]);
 
 class Hooks {

--- a/src/pluginHooks.js
+++ b/src/pluginHooks.js
@@ -1370,6 +1370,7 @@ const REGISTERED_HOOKS = [
    */
   'beforeStretchingColumnWidth',
 
+  /* eslint-disable jsdoc/require-description-complete-sentence */
   /**
    * Fired by {@link Filters} plugin before applying [filtering]{@link https://handsontable.com/docs/demo-filtering.html}. This hook is fired when
    * {@link Options#filters} option is enabled.
@@ -1399,6 +1400,7 @@ const REGISTERED_HOOKS = [
    */
   'beforeFilter',
 
+  /* eslint-disable jsdoc/require-description-complete-sentence */
   /**
    * Fired by {@link Filters} plugin after applying [filtering]{@link https://handsontable.com/docs/demo-filtering.html}. This hook is fired when
    * {@link Options#filters} option is enabled.
@@ -1931,6 +1933,7 @@ const REMOVED_HOOKS = new Map([
   ['hiddenRow', '8.0.0'],
 ]);
 
+/* eslint-disable jsdoc/require-description-complete-sentence */
 /**
  * The list of the hooks which are deprecated. The warning message is printed out in
  * the developer console when the hook is used.

--- a/src/pluginHooks.js
+++ b/src/pluginHooks.js
@@ -1398,8 +1398,9 @@ const REGISTERED_HOOKS = [
    * ```
    * @returns {boolean} If hook returns `false` value then filtering won't be applied on the UI side (server-side filtering).
    */
-  /* eslint-enable jsdoc/require-description-complete-sentence */
   'beforeFilter',
+
+  /* eslint-enable jsdoc/require-description-complete-sentence */
 
   /* eslint-disable jsdoc/require-description-complete-sentence */
   /**
@@ -1428,8 +1429,9 @@ const REGISTERED_HOOKS = [
    * ]
    * ```
    */
-  /* eslint-enable jsdoc/require-description-complete-sentence */
   'afterFilter',
+
+  /* eslint-enable jsdoc/require-description-complete-sentence */
 
   /**
    * Fired while retrieving the column header height.

--- a/src/plugins/autoColumnSize/autoColumnSize.js
+++ b/src/plugins/autoColumnSize/autoColumnSize.js
@@ -35,7 +35,7 @@ const COLUMN_SIZE_MAP_NAME = 'autoColumnSize';
  *
  * // as a string (percent)
  * autoColumnSize: {syncLimit: '40%'},
- * ```.
+ * ```
  *
  * To configure this plugin see {@link Options#autoColumnSize}.
  *

--- a/src/plugins/autoColumnSize/autoColumnSize.js
+++ b/src/plugins/autoColumnSize/autoColumnSize.js
@@ -13,6 +13,7 @@ import { PhysicalIndexToValueMap as IndexToValueMap } from './../../translations
 const privatePool = new WeakMap();
 const COLUMN_SIZE_MAP_NAME = 'autoColumnSize';
 
+/* eslint-disable jsdoc/require-description-complete-sentence */
 /**
  * @plugin AutoColumnSize
  *

--- a/src/plugins/autoColumnSize/autoColumnSize.js
+++ b/src/plugins/autoColumnSize/autoColumnSize.js
@@ -16,6 +16,7 @@ const COLUMN_SIZE_MAP_NAME = 'autoColumnSize';
 /* eslint-disable jsdoc/require-description-complete-sentence */
 /**
  * @plugin AutoColumnSize
+ * @class AutoColumnSize
  *
  * @description
  * This plugin allows to set column widths based on their widest cells.

--- a/src/plugins/autoColumnSize/autoColumnSize.js
+++ b/src/plugins/autoColumnSize/autoColumnSize.js
@@ -56,6 +56,7 @@ const COLUMN_SIZE_MAP_NAME = 'autoColumnSize';
  * }
  * ```
  */
+/* eslint-enable jsdoc/require-description-complete-sentence */
 class AutoColumnSize extends BasePlugin {
   static get CALCULATION_STEP() {
     return 50;

--- a/src/plugins/autoRowSize/autoRowSize.js
+++ b/src/plugins/autoRowSize/autoRowSize.js
@@ -37,7 +37,7 @@ const ROW_WIDTHS_MAP_NAME = 'autoRowSize';
  *
  * // allow sample duplication
  * autoRowSize: {syncLimit: '40%', allowSampleDuplicates: true},
- * ```.
+ * ```
  *
  * You can also use the `allowSampleDuplicates` option to allow sampling duplicate values when calculating the row
  * height. __Note__, that this might have a negative impact on performance.

--- a/src/plugins/autoRowSize/autoRowSize.js
+++ b/src/plugins/autoRowSize/autoRowSize.js
@@ -62,6 +62,7 @@ const ROW_WIDTHS_MAP_NAME = 'autoRowSize';
  * }
  * ```
  */
+/* eslint-enable jsdoc/require-description-complete-sentence */
 class AutoRowSize extends BasePlugin {
   static get CALCULATION_STEP() {
     return 50;

--- a/src/plugins/autoRowSize/autoRowSize.js
+++ b/src/plugins/autoRowSize/autoRowSize.js
@@ -15,7 +15,7 @@ const ROW_WIDTHS_MAP_NAME = 'autoRowSize';
 /* eslint-disable jsdoc/require-description-complete-sentence */
 /**
  * @plugin AutoRowSize
- *
+ * @class AutoRowSize
  * @description
  * This plugin allows to set row heights based on their highest cells.
  *

--- a/src/plugins/autoRowSize/autoRowSize.js
+++ b/src/plugins/autoRowSize/autoRowSize.js
@@ -12,6 +12,7 @@ import { PhysicalIndexToValueMap as IndexToValueMap } from './../../translations
 
 const ROW_WIDTHS_MAP_NAME = 'autoRowSize';
 
+/* eslint-disable jsdoc/require-description-complete-sentence */
 /**
  * @plugin AutoRowSize
  *

--- a/src/plugins/comments/comments.js
+++ b/src/plugins/comments/comments.js
@@ -37,7 +37,7 @@ const META_READONLY = 'readOnly';
  * To enable the plugin, you'll need to set the comments property of the config object to `true`:
  * ```js
  * comments: true
- * ```.
+ * ```
  *
  * or an object with extra predefined plugin config:
  *
@@ -45,7 +45,7 @@ const META_READONLY = 'readOnly';
  * comments: {
  *   displayDelay: 1000
  * }
- * ```.
+ * ```
  *
  * To add comments at the table initialization, define the `comment` property in the `cell` config array as in an example below.
  *


### PR DESCRIPTION
### Context
`className` configuration option has a short description that does not include important information. Correct it.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] A change in the documentation

### Related issue(s):
1. https://github.com/handsontable/docs/issues/257
