### PR TITLE
Improve minCols description [DOCS]

### DIFF
--- a/src/dataMap/metaManager/metaSchema.js
+++ b/src/dataMap/metaManager/metaSchema.js
@@ -558,6 +558,8 @@ export default () => {
 
     /**
      * Minimum number of columns. At least that number of columns will be created during initialization.
+     * Works only with an array data source. When data source in an object, you can only have as many columns
+     * as defined in the first data row, data schema, or the `columns` setting.
      *
      * @memberof Options#
      * @type {number}


### PR DESCRIPTION
### Context
If the end-developer attempts to add a `minCols` alongside object data source there will be an error. Add a note in the documentation about the incompatibility of `minCols` and object data source.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] An improvement in the documentation

### Related issue(s):
1. https://github.com/handsontable/docs/issues/266
