### PR TITLE
Fix double tap to zoom gesture preventing editor from opening

### DIFF
--- a/.changelogs/7142.json
+++ b/.changelogs/7142.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fixed double tap to zoom gesture preventing the editor from opening properly on some mobile devices",
+  "type": "fixed",
+  "issue": 7142,
+  "breaking": false,
+  "framework": "none"
+}

--- a/src/css/handsontable.css
+++ b/src/css/handsontable.css
@@ -1,3 +1,7 @@
+.handsontable {
+  touch-action: manipulation;
+}
+
 .handsontable.htAutoSize {
   visibility: hidden;
   left: -99000px;


### PR DESCRIPTION
### Context
As described in https://github.com/handsontable/handsontable/issues/7142 & https://github.com/handsontable/handsontable/issues/6961, the double tap to zoom gesture is causing problems with how handsontable opens its editor on double tap. To circumvent this problem we have to somehow disable the native browser gesture so that the tap events would come through to our event handlers.

Using a [`touch-action: manipulation`](https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action) property to the whole table should fix the problem for any browser that supports the property (which should be most modern iOS versions (according to [stack overflow](https://stackoverflow.com/a/47131647) at least).

### How has this been tested?
Browserstack iPhone 11 iOS 13 & local iPhone X iOS 14.

I was able to kind of reproduce it locally (iOS 14 does have a similar problem but not so severe where the editor wouldn't open at all). Would you mind testing it locally to confirm that this PR fixes the problem @aninde please? Setting this PR as a draft till then.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7142
2. #6961
