### PR TITLE
Fixed an issue where maxRows nad maxCols options haven't cooperated with hidden indexes properly

### DIFF
--- a/.changelogs/7350.json
+++ b/.changelogs/7350.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fixed an issue where maxRows nad maxCols options haven't cooperated with hidden indexes properly.",
+  "type": "fixed",
+  "issue": 7350,
+  "breaking": false,
+  "framework": "none"
+}

--- a/src/plugins/hiddenColumns/test/maxCols.e2e.js
+++ b/src/plugins/hiddenColumns/test/maxCols.e2e.js
@@ -1,0 +1,194 @@
+describe('HiddenColumns', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  describe('maxCols', () => {
+    it('all columns are hidden', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        maxCols: 3,
+        hiddenColumns: {
+          columns: [0, 1, 2],
+          indicators: true
+        },
+        colHeaders: true,
+        rowHeaders: true
+      });
+
+      expect(getData()).toEqual([
+        ['A1', 'B1', 'C1'],
+        ['A2', 'B2', 'C2'],
+        ['A3', 'B3', 'C3'],
+        ['A4', 'B4', 'C4'],
+        ['A5', 'B5', 'C5'],
+      ]);
+
+      expect(spec().$container.find('.ht_master thead th').length).toBe(1); // corner
+      expect(spec().$container.find('.ht_master tbody th').length).toBe(5); // row headers
+      expect(spec().$container.find('.ht_master tbody td').length).toBe(0); // cells
+    });
+
+    it('just some columns are hidden', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        maxCols: 3,
+        hiddenColumns: {
+          columns: [0],
+          indicators: true
+        },
+        colHeaders: true,
+        rowHeaders: true
+      });
+
+      expect(getData()).toEqual([
+        ['A1', 'B1', 'C1'],
+        ['A2', 'B2', 'C2'],
+        ['A3', 'B3', 'C3'],
+        ['A4', 'B4', 'C4'],
+        ['A5', 'B5', 'C5'],
+      ]);
+
+      expect(getCell(0, 0)).toBe(null); // Hidden column
+      expect(getCell(1, 0)).toBe(null); // Hidden column
+      expect(getCell(2, 0)).toBe(null); // Hidden column
+      expect(getCell(3, 0)).toBe(null); // Hidden column
+      expect(getCell(4, 0)).toBe(null); // Hidden column
+
+      expect(getCell(0, 1).innerText).toBe('B1');
+      expect(getCell(1, 1).innerText).toBe('B2');
+      expect(getCell(2, 1).innerText).toBe('B3');
+      expect(getCell(3, 1).innerText).toBe('B4');
+      expect(getCell(4, 1).innerText).toBe('B5');
+
+      expect(getCell(0, 2).innerText).toBe('C1');
+      expect(getCell(1, 2).innerText).toBe('C2');
+      expect(getCell(2, 2).innerText).toBe('C3');
+      expect(getCell(3, 2).innerText).toBe('C4');
+      expect(getCell(4, 2).innerText).toBe('C5');
+
+      expect(spec().$container.find('.ht_master thead th').length).toBe(3); // corner + column headers
+      expect(spec().$container.find('.ht_master tbody th').length).toBe(5); // row headers
+      expect(spec().$container.find('.ht_master tbody td').length).toBe(10); // cells
+    });
+
+    it('is set to Infinity value', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        maxCols: Infinity,
+        hiddenColumns: {
+          columns: [0, 1, 2],
+          indicators: true
+        },
+        colHeaders: true,
+        rowHeaders: true
+      });
+
+      expect(getCell(0, 0)).toBe(null); // Hidden column
+      expect(getCell(1, 0)).toBe(null); // Hidden column
+      expect(getCell(2, 0)).toBe(null); // Hidden column
+      expect(getCell(3, 0)).toBe(null); // Hidden column
+      expect(getCell(4, 0)).toBe(null); // Hidden column
+
+      expect(getCell(0, 1)).toBe(null); // Hidden column
+      expect(getCell(1, 1)).toBe(null); // Hidden column
+      expect(getCell(2, 1)).toBe(null); // Hidden column
+      expect(getCell(3, 1)).toBe(null); // Hidden column
+      expect(getCell(4, 1)).toBe(null); // Hidden column
+
+      expect(getCell(0, 2)).toBe(null); // Hidden column
+      expect(getCell(1, 2)).toBe(null); // Hidden column
+      expect(getCell(2, 2)).toBe(null); // Hidden column
+      expect(getCell(3, 2)).toBe(null); // Hidden column
+      expect(getCell(4, 2)).toBe(null); // Hidden column
+
+      expect(getCell(0, 3).innerText).toBe('D1');
+      expect(getCell(1, 3).innerText).toBe('D2');
+      expect(getCell(2, 3).innerText).toBe('D3');
+      expect(getCell(3, 3).innerText).toBe('D4');
+      expect(getCell(4, 3).innerText).toBe('D5');
+
+      expect(getCell(0, 4).innerText).toBe('E1');
+      expect(getCell(1, 4).innerText).toBe('E2');
+      expect(getCell(2, 4).innerText).toBe('E3');
+      expect(getCell(3, 4).innerText).toBe('E4');
+      expect(getCell(4, 4).innerText).toBe('E5');
+
+      expect(getData()).toEqual([
+        ['A1', 'B1', 'C1', 'D1', 'E1'],
+        ['A2', 'B2', 'C2', 'D2', 'E2'],
+        ['A3', 'B3', 'C3', 'D3', 'E3'],
+        ['A4', 'B4', 'C4', 'D4', 'E4'],
+        ['A5', 'B5', 'C5', 'D5', 'E5'],
+      ]);
+
+      expect(spec().$container.find('.ht_master thead th').length).toBe(3); // corner + column headers
+      expect(spec().$container.find('.ht_master tbody th').length).toBe(5); // row headers
+      expect(spec().$container.find('.ht_master tbody td').length).toBe(10); // cells
+    });
+
+    it('is set to value > nr of columns', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        maxCols: 10,
+        hiddenColumns: {
+          columns: [0, 1, 2],
+          indicators: true
+        },
+        colHeaders: true,
+        rowHeaders: true
+      });
+
+      expect(getCell(0, 0)).toBe(null); // Hidden column
+      expect(getCell(1, 0)).toBe(null); // Hidden column
+      expect(getCell(2, 0)).toBe(null); // Hidden column
+      expect(getCell(3, 0)).toBe(null); // Hidden column
+      expect(getCell(4, 0)).toBe(null); // Hidden column
+
+      expect(getCell(0, 1)).toBe(null); // Hidden column
+      expect(getCell(1, 1)).toBe(null); // Hidden column
+      expect(getCell(2, 1)).toBe(null); // Hidden column
+      expect(getCell(3, 1)).toBe(null); // Hidden column
+      expect(getCell(4, 1)).toBe(null); // Hidden column
+
+      expect(getCell(0, 2)).toBe(null); // Hidden column
+      expect(getCell(1, 2)).toBe(null); // Hidden column
+      expect(getCell(2, 2)).toBe(null); // Hidden column
+      expect(getCell(3, 2)).toBe(null); // Hidden column
+      expect(getCell(4, 2)).toBe(null); // Hidden column
+
+      expect(getCell(0, 3).innerText).toBe('D1');
+      expect(getCell(1, 3).innerText).toBe('D2');
+      expect(getCell(2, 3).innerText).toBe('D3');
+      expect(getCell(3, 3).innerText).toBe('D4');
+      expect(getCell(4, 3).innerText).toBe('D5');
+
+      expect(getCell(0, 4).innerText).toBe('E1');
+      expect(getCell(1, 4).innerText).toBe('E2');
+      expect(getCell(2, 4).innerText).toBe('E3');
+      expect(getCell(3, 4).innerText).toBe('E4');
+      expect(getCell(4, 4).innerText).toBe('E5');
+
+      expect(getData()).toEqual([
+        ['A1', 'B1', 'C1', 'D1', 'E1'],
+        ['A2', 'B2', 'C2', 'D2', 'E2'],
+        ['A3', 'B3', 'C3', 'D3', 'E3'],
+        ['A4', 'B4', 'C4', 'D4', 'E4'],
+        ['A5', 'B5', 'C5', 'D5', 'E5'],
+      ]);
+
+      expect(spec().$container.find('.ht_master thead th').length).toBe(3); // corner + column headers
+      expect(spec().$container.find('.ht_master tbody th').length).toBe(5); // row headers
+      expect(spec().$container.find('.ht_master tbody td').length).toBe(10); // cells
+    });
+  });
+});

--- a/src/plugins/hiddenColumns/test/maxCols.e2e.js
+++ b/src/plugins/hiddenColumns/test/maxCols.e2e.js
@@ -38,7 +38,7 @@ describe('HiddenColumns', () => {
       expect(spec().$container.find('.ht_master tbody td').length).toBe(0); // cells
     });
 
-    it('just some columns are hidden', () => {
+    it('just some column is hidden #1', () => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(5, 5),
         maxCols: 3,
@@ -79,6 +79,135 @@ describe('HiddenColumns', () => {
       expect(spec().$container.find('.ht_master thead th').length).toBe(3); // corner + column headers
       expect(spec().$container.find('.ht_master tbody th').length).toBe(5); // row headers
       expect(spec().$container.find('.ht_master tbody td').length).toBe(10); // cells
+    });
+
+    it('just some column is hidden #2', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        maxCols: 3,
+        hiddenColumns: {
+          columns: [1],
+          indicators: true
+        },
+        colHeaders: true,
+        rowHeaders: true
+      });
+
+      expect(getData()).toEqual([
+        ['A1', 'B1', 'C1'],
+        ['A2', 'B2', 'C2'],
+        ['A3', 'B3', 'C3'],
+        ['A4', 'B4', 'C4'],
+        ['A5', 'B5', 'C5'],
+      ]);
+
+      expect(getCell(0, 0).innerText).toBe('A1');
+      expect(getCell(1, 0).innerText).toBe('A2');
+      expect(getCell(2, 0).innerText).toBe('A3');
+      expect(getCell(3, 0).innerText).toBe('A4');
+      expect(getCell(4, 0).innerText).toBe('A5');
+
+      expect(getCell(0, 1)).toBe(null); // Hidden column
+      expect(getCell(1, 1)).toBe(null); // Hidden column
+      expect(getCell(2, 1)).toBe(null); // Hidden column
+      expect(getCell(3, 1)).toBe(null); // Hidden column
+      expect(getCell(4, 1)).toBe(null); // Hidden column
+
+      expect(getCell(0, 2).innerText).toBe('C1');
+      expect(getCell(1, 2).innerText).toBe('C2');
+      expect(getCell(2, 2).innerText).toBe('C3');
+      expect(getCell(3, 2).innerText).toBe('C4');
+      expect(getCell(4, 2).innerText).toBe('C5');
+
+      expect(spec().$container.find('.ht_master thead th').length).toBe(3); // corner + column headers
+      expect(spec().$container.find('.ht_master tbody th').length).toBe(5); // row headers
+      expect(spec().$container.find('.ht_master tbody td').length).toBe(10); // cells
+    });
+
+    it('just some columns are hidden #1', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        maxCols: 3,
+        hiddenColumns: {
+          columns: [1, 2],
+          indicators: true
+        },
+        colHeaders: true,
+        rowHeaders: true
+      });
+
+      expect(getData()).toEqual([
+        ['A1', 'B1', 'C1'],
+        ['A2', 'B2', 'C2'],
+        ['A3', 'B3', 'C3'],
+        ['A4', 'B4', 'C4'],
+        ['A5', 'B5', 'C5'],
+      ]);
+
+      expect(getCell(0, 0).innerText).toBe('A1');
+      expect(getCell(1, 0).innerText).toBe('A2');
+      expect(getCell(2, 0).innerText).toBe('A3');
+      expect(getCell(3, 0).innerText).toBe('A4');
+      expect(getCell(4, 0).innerText).toBe('A5');
+
+      expect(getCell(0, 1)).toBe(null); // Hidden column
+      expect(getCell(1, 1)).toBe(null); // Hidden column
+      expect(getCell(2, 1)).toBe(null); // Hidden column
+      expect(getCell(3, 1)).toBe(null); // Hidden column
+      expect(getCell(4, 1)).toBe(null); // Hidden column
+
+      expect(getCell(0, 2)).toBe(null); // Hidden column
+      expect(getCell(1, 2)).toBe(null); // Hidden column
+      expect(getCell(2, 2)).toBe(null); // Hidden column
+      expect(getCell(3, 2)).toBe(null); // Hidden column
+      expect(getCell(4, 2)).toBe(null); // Hidden column
+
+      expect(spec().$container.find('.ht_master thead th').length).toBe(2); // corner + column headers
+      expect(spec().$container.find('.ht_master tbody th').length).toBe(5); // row headers
+      expect(spec().$container.find('.ht_master tbody td').length).toBe(5); // cells
+    });
+
+    it('just some columns are hidden #2', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        maxCols: 3,
+        hiddenColumns: {
+          columns: [0, 1],
+          indicators: true
+        },
+        colHeaders: true,
+        rowHeaders: true
+      });
+
+      expect(getData()).toEqual([
+        ['A1', 'B1', 'C1'],
+        ['A2', 'B2', 'C2'],
+        ['A3', 'B3', 'C3'],
+        ['A4', 'B4', 'C4'],
+        ['A5', 'B5', 'C5'],
+      ]);
+
+      expect(getCell(0, 0)).toBe(null); // Hidden column
+      expect(getCell(1, 0)).toBe(null); // Hidden column
+      expect(getCell(2, 0)).toBe(null); // Hidden column
+      expect(getCell(3, 0)).toBe(null); // Hidden column
+      expect(getCell(4, 0)).toBe(null); // Hidden column
+
+      expect(getCell(0, 1)).toBe(null); // Hidden column
+      expect(getCell(1, 1)).toBe(null); // Hidden column
+      expect(getCell(2, 1)).toBe(null); // Hidden column
+      expect(getCell(3, 1)).toBe(null); // Hidden column
+      expect(getCell(4, 1)).toBe(null); // Hidden column
+
+      expect(getCell(0, 2).innerText).toBe('C1');
+      expect(getCell(1, 2).innerText).toBe('C2');
+      expect(getCell(2, 2).innerText).toBe('C3');
+      expect(getCell(3, 2).innerText).toBe('C4');
+      expect(getCell(4, 2).innerText).toBe('C5');
+
+      expect(spec().$container.find('.ht_master thead th').length).toBe(2); // corner + column headers
+      expect(spec().$container.find('.ht_master tbody th').length).toBe(5); // row headers
+      expect(spec().$container.find('.ht_master tbody td').length).toBe(5); // cells
     });
 
     it('is set to Infinity value', () => {

--- a/src/plugins/hiddenRows/test/maxRows.e2e.js
+++ b/src/plugins/hiddenRows/test/maxRows.e2e.js
@@ -1,0 +1,190 @@
+describe('HiddenRows', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  describe('maxRows', () => {
+    it('all rows are hidden', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        maxRows: 3,
+        hiddenRows: {
+          rows: [0, 1, 2],
+          indicators: true
+        },
+        colHeaders: true,
+        rowHeaders: true
+      });
+
+      expect(getData()).toEqual([
+        ['A1', 'B1', 'C1', 'D1', 'E1'],
+        ['A2', 'B2', 'C2', 'D2', 'E2'],
+        ['A3', 'B3', 'C3', 'D3', 'E3']
+      ]);
+
+      expect(spec().$container.find('.ht_master thead th').length).toBe(6); // corner + column headers
+      expect(spec().$container.find('.ht_master tbody th').length).toBe(0); // row headers
+      expect(spec().$container.find('.ht_master tbody td').length).toBe(0); // cells
+    });
+
+    it('just some rows are hidden', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        maxRows: 3,
+        hiddenRows: {
+          rows: [0],
+          indicators: true
+        },
+        colHeaders: true,
+        rowHeaders: true
+      });
+
+      expect(getData()).toEqual([
+        ['A1', 'B1', 'C1', 'D1', 'E1'],
+        ['A2', 'B2', 'C2', 'D2', 'E2'],
+        ['A3', 'B3', 'C3', 'D3', 'E3']
+      ]);
+
+      expect(getCell(0, 0)).toBe(null); // Hidden row
+      expect(getCell(0, 1)).toBe(null); // Hidden row
+      expect(getCell(0, 2)).toBe(null); // Hidden row
+      expect(getCell(0, 3)).toBe(null); // Hidden row
+      expect(getCell(0, 4)).toBe(null); // Hidden row
+
+      expect(getCell(1, 0).innerText).toBe('A2');
+      expect(getCell(1, 1).innerText).toBe('B2');
+      expect(getCell(1, 2).innerText).toBe('C2');
+      expect(getCell(1, 3).innerText).toBe('D2');
+      expect(getCell(1, 4).innerText).toBe('E2');
+
+      expect(getCell(2, 0).innerText).toBe('A3');
+      expect(getCell(2, 1).innerText).toBe('B3');
+      expect(getCell(2, 2).innerText).toBe('C3');
+      expect(getCell(2, 3).innerText).toBe('D3');
+      expect(getCell(2, 4).innerText).toBe('E3');
+
+      expect(spec().$container.find('.ht_master thead th').length).toBe(6); // corner + column headers
+      expect(spec().$container.find('.ht_master tbody th').length).toBe(2); // row headers
+      expect(spec().$container.find('.ht_master tbody td').length).toBe(10); // cells
+    });
+
+    it('is set to Infinity value', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        maxRows: Infinity,
+        hiddenRows: {
+          rows: [0, 1, 2],
+          indicators: true
+        },
+        colHeaders: true,
+        rowHeaders: true
+      });
+
+      expect(getCell(0, 0)).toBe(null); // Hidden row
+      expect(getCell(0, 1)).toBe(null); // Hidden row
+      expect(getCell(0, 2)).toBe(null); // Hidden row
+      expect(getCell(0, 3)).toBe(null); // Hidden row
+      expect(getCell(0, 4)).toBe(null); // Hidden row
+
+      expect(getCell(1, 0)).toBe(null); // Hidden row
+      expect(getCell(1, 1)).toBe(null); // Hidden row
+      expect(getCell(1, 2)).toBe(null); // Hidden row
+      expect(getCell(1, 3)).toBe(null); // Hidden row
+      expect(getCell(1, 4)).toBe(null); // Hidden row
+
+      expect(getCell(2, 0)).toBe(null); // Hidden row
+      expect(getCell(2, 1)).toBe(null); // Hidden row
+      expect(getCell(2, 2)).toBe(null); // Hidden row
+      expect(getCell(2, 3)).toBe(null); // Hidden row
+      expect(getCell(2, 4)).toBe(null); // Hidden row
+
+      expect(getCell(3, 0).innerText).toBe('A4');
+      expect(getCell(3, 1).innerText).toBe('B4');
+      expect(getCell(3, 2).innerText).toBe('C4');
+      expect(getCell(3, 3).innerText).toBe('D4');
+      expect(getCell(3, 4).innerText).toBe('E4');
+
+      expect(getCell(4, 0).innerText).toBe('A5');
+      expect(getCell(4, 1).innerText).toBe('B5');
+      expect(getCell(4, 2).innerText).toBe('C5');
+      expect(getCell(4, 3).innerText).toBe('D5');
+      expect(getCell(4, 4).innerText).toBe('E5');
+
+      expect(getData()).toEqual([
+        ['A1', 'B1', 'C1', 'D1', 'E1'],
+        ['A2', 'B2', 'C2', 'D2', 'E2'],
+        ['A3', 'B3', 'C3', 'D3', 'E3'],
+        ['A4', 'B4', 'C4', 'D4', 'E4'],
+        ['A5', 'B5', 'C5', 'D5', 'E5'],
+      ]);
+
+      expect(spec().$container.find('.ht_master thead th').length).toBe(6); // corner + column headers
+      expect(spec().$container.find('.ht_master tbody th').length).toBe(2); // row headers
+      expect(spec().$container.find('.ht_master tbody td').length).toBe(10); // cells
+    });
+
+    it('is set to value > nr of columns', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        maxRows: 10,
+        hiddenRows: {
+          rows: [0, 1, 2],
+          indicators: true
+        },
+        colHeaders: true,
+        rowHeaders: true
+      });
+
+      expect(getCell(0, 0)).toBe(null); // Hidden row
+      expect(getCell(0, 1)).toBe(null); // Hidden row
+      expect(getCell(0, 2)).toBe(null); // Hidden row
+      expect(getCell(0, 3)).toBe(null); // Hidden row
+      expect(getCell(0, 4)).toBe(null); // Hidden row
+
+      expect(getCell(1, 0)).toBe(null); // Hidden row
+      expect(getCell(1, 1)).toBe(null); // Hidden row
+      expect(getCell(1, 2)).toBe(null); // Hidden row
+      expect(getCell(1, 3)).toBe(null); // Hidden row
+      expect(getCell(1, 4)).toBe(null); // Hidden row
+
+      expect(getCell(2, 0)).toBe(null); // Hidden row
+      expect(getCell(2, 1)).toBe(null); // Hidden row
+      expect(getCell(2, 2)).toBe(null); // Hidden row
+      expect(getCell(2, 3)).toBe(null); // Hidden row
+      expect(getCell(2, 4)).toBe(null); // Hidden row
+
+      expect(getCell(3, 0).innerText).toBe('A4');
+      expect(getCell(3, 1).innerText).toBe('B4');
+      expect(getCell(3, 2).innerText).toBe('C4');
+      expect(getCell(3, 3).innerText).toBe('D4');
+      expect(getCell(3, 4).innerText).toBe('E4');
+
+      expect(getCell(4, 0).innerText).toBe('A5');
+      expect(getCell(4, 1).innerText).toBe('B5');
+      expect(getCell(4, 2).innerText).toBe('C5');
+      expect(getCell(4, 3).innerText).toBe('D5');
+      expect(getCell(4, 4).innerText).toBe('E5');
+
+      expect(getData()).toEqual([
+        ['A1', 'B1', 'C1', 'D1', 'E1'],
+        ['A2', 'B2', 'C2', 'D2', 'E2'],
+        ['A3', 'B3', 'C3', 'D3', 'E3'],
+        ['A4', 'B4', 'C4', 'D4', 'E4'],
+        ['A5', 'B5', 'C5', 'D5', 'E5'],
+      ]);
+
+      expect(spec().$container.find('.ht_master thead th').length).toBe(6); // corner + column headers
+      expect(spec().$container.find('.ht_master tbody th').length).toBe(2); // row headers
+      expect(spec().$container.find('.ht_master tbody td').length).toBe(10); // cells
+    });
+  });
+});

--- a/src/plugins/hiddenRows/test/maxRows.e2e.js
+++ b/src/plugins/hiddenRows/test/maxRows.e2e.js
@@ -36,7 +36,7 @@ describe('HiddenRows', () => {
       expect(spec().$container.find('.ht_master tbody td').length).toBe(0); // cells
     });
 
-    it('just some rows are hidden', () => {
+    it('just some row is hidden #1', () => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(5, 5),
         maxRows: 3,
@@ -75,6 +75,129 @@ describe('HiddenRows', () => {
       expect(spec().$container.find('.ht_master thead th').length).toBe(6); // corner + column headers
       expect(spec().$container.find('.ht_master tbody th').length).toBe(2); // row headers
       expect(spec().$container.find('.ht_master tbody td').length).toBe(10); // cells
+    });
+
+    it('just some row is hidden #2', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        maxRows: 3,
+        hiddenRows: {
+          rows: [1],
+          indicators: true
+        },
+        colHeaders: true,
+        rowHeaders: true
+      });
+
+      expect(getData()).toEqual([
+        ['A1', 'B1', 'C1', 'D1', 'E1'],
+        ['A2', 'B2', 'C2', 'D2', 'E2'],
+        ['A3', 'B3', 'C3', 'D3', 'E3']
+      ]);
+
+      expect(getCell(0, 0).innerText).toBe('A1');
+      expect(getCell(0, 1).innerText).toBe('B1');
+      expect(getCell(0, 2).innerText).toBe('C1');
+      expect(getCell(0, 3).innerText).toBe('D1');
+      expect(getCell(0, 4).innerText).toBe('E1');
+
+      expect(getCell(1, 0)).toBe(null); // Hidden row
+      expect(getCell(1, 1)).toBe(null); // Hidden row
+      expect(getCell(1, 2)).toBe(null); // Hidden row
+      expect(getCell(1, 3)).toBe(null); // Hidden row
+      expect(getCell(1, 4)).toBe(null); // Hidden row
+
+      expect(getCell(2, 0).innerText).toBe('A3');
+      expect(getCell(2, 1).innerText).toBe('B3');
+      expect(getCell(2, 2).innerText).toBe('C3');
+      expect(getCell(2, 3).innerText).toBe('D3');
+      expect(getCell(2, 4).innerText).toBe('E3');
+
+      expect(spec().$container.find('.ht_master thead th').length).toBe(6); // corner + column headers
+      expect(spec().$container.find('.ht_master tbody th').length).toBe(2); // row headers
+      expect(spec().$container.find('.ht_master tbody td').length).toBe(10); // cells
+    });
+
+    it('just some rows are hidden #1', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        maxRows: 3,
+        hiddenRows: {
+          rows: [1, 2],
+          indicators: true
+        },
+        colHeaders: true,
+        rowHeaders: true
+      });
+
+      expect(getData()).toEqual([
+        ['A1', 'B1', 'C1', 'D1', 'E1'],
+        ['A2', 'B2', 'C2', 'D2', 'E2'],
+        ['A3', 'B3', 'C3', 'D3', 'E3']
+      ]);
+
+      expect(getCell(0, 0).innerText).toBe('A1');
+      expect(getCell(0, 1).innerText).toBe('B1');
+      expect(getCell(0, 2).innerText).toBe('C1');
+      expect(getCell(0, 3).innerText).toBe('D1');
+      expect(getCell(0, 4).innerText).toBe('E1');
+
+      expect(getCell(1, 0)).toBe(null); // Hidden row
+      expect(getCell(1, 1)).toBe(null); // Hidden row
+      expect(getCell(1, 2)).toBe(null); // Hidden row
+      expect(getCell(1, 3)).toBe(null); // Hidden row
+      expect(getCell(1, 4)).toBe(null); // Hidden row
+
+      expect(getCell(2, 0)).toBe(null); // Hidden row
+      expect(getCell(2, 1)).toBe(null); // Hidden row
+      expect(getCell(2, 2)).toBe(null); // Hidden row
+      expect(getCell(2, 3)).toBe(null); // Hidden row
+      expect(getCell(2, 4)).toBe(null); // Hidden row
+
+      expect(spec().$container.find('.ht_master thead th').length).toBe(6); // corner + column headers
+      expect(spec().$container.find('.ht_master tbody th').length).toBe(1); // row headers
+      expect(spec().$container.find('.ht_master tbody td').length).toBe(5); // cells
+    });
+
+    it('just some rows are hidden #2', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        maxRows: 3,
+        hiddenRows: {
+          rows: [0, 1],
+          indicators: true
+        },
+        colHeaders: true,
+        rowHeaders: true
+      });
+
+      expect(getData()).toEqual([
+        ['A1', 'B1', 'C1', 'D1', 'E1'],
+        ['A2', 'B2', 'C2', 'D2', 'E2'],
+        ['A3', 'B3', 'C3', 'D3', 'E3']
+      ]);
+
+      expect(getCell(0, 0)).toBe(null); // Hidden row
+      expect(getCell(0, 1)).toBe(null); // Hidden row
+      expect(getCell(0, 2)).toBe(null); // Hidden row
+      expect(getCell(0, 3)).toBe(null); // Hidden row
+      expect(getCell(0, 4)).toBe(null); // Hidden row
+
+      expect(getCell(1, 0)).toBe(null); // Hidden row
+      expect(getCell(1, 1)).toBe(null); // Hidden row
+      expect(getCell(1, 2)).toBe(null); // Hidden row
+      expect(getCell(1, 3)).toBe(null); // Hidden row
+      expect(getCell(1, 4)).toBe(null); // Hidden row
+
+      expect(getCell(2, 0).innerText).toBe('A3');
+      expect(getCell(2, 1).innerText).toBe('B3');
+      expect(getCell(2, 2).innerText).toBe('C3');
+      expect(getCell(2, 3).innerText).toBe('D3');
+      expect(getCell(2, 4).innerText).toBe('E3');
+
+      expect(spec().$container.find('.ht_master thead th').length).toBe(6); // corner + column headers
+      expect(spec().$container.find('.ht_master tbody th').length).toBe(1); // row headers
+      expect(spec().$container.find('.ht_master tbody td').length).toBe(5); // cells
     });
 
     it('is set to Infinity value', () => {

--- a/src/tableView.js
+++ b/src/tableView.js
@@ -411,12 +411,13 @@ class TableView {
    * @returns {number}
    */
   countRenderableColumns() {
-    const numberOfColumns = Math.min(
+    const consideredColumns = Math.min(
       this.instance.columnIndexMapper.getNotTrimmedIndexesLength(), this.settings.maxCols);
-    // Don't take hidden columns into account.
+    // Don't take hidden columns into account. We are looking just for renderable columns.
     const firstNotHiddenColumn = this.instance.columnIndexMapper.getFirstNotHiddenIndex(
-      numberOfColumns - 1, -1);
+      consideredColumns - 1, -1);
 
+    // There are no renderable columns.
     if (firstNotHiddenColumn === null) {
       return 0;
     }
@@ -430,11 +431,13 @@ class TableView {
    * @returns {number}
    */
   countRenderableRows() {
-    const numberOfRows = Math.min(this.instance.rowIndexMapper.getNotTrimmedIndexesLength(), this.settings.maxRows);
-    // Don't take hidden rows into account.
+    const consideredRows = Math.min(
+      this.instance.rowIndexMapper.getNotTrimmedIndexesLength(), this.settings.maxRows);
+    // Don't take hidden rows into account. We are looking just for renderable rows.
     const firstNotHiddenRow = this.instance.rowIndexMapper.getFirstNotHiddenIndex(
-      numberOfRows - 1, -1);
+      consideredRows - 1, -1);
 
+    // There are no renderable rows.
     if (firstNotHiddenRow === null) {
       return 0;
     }

--- a/src/tableView.js
+++ b/src/tableView.js
@@ -411,7 +411,17 @@ class TableView {
    * @returns {number}
    */
   countRenderableColumns() {
-    return Math.min(this.instance.columnIndexMapper.getRenderableIndexesLength(), this.settings.maxCols);
+    const numberOfColumns = Math.min(
+      this.instance.columnIndexMapper.getNotTrimmedIndexesLength(), this.settings.maxCols);
+    // Don't take hidden columns into account.
+    const firstNotHiddenColumn = this.instance.columnIndexMapper.getFirstNotHiddenIndex(
+      numberOfColumns - 1, -1);
+
+    if (firstNotHiddenColumn === null) {
+      return 0;
+    }
+
+    return this.instance.columnIndexMapper.getRenderableFromVisualIndex(firstNotHiddenColumn) + 1;
   }
 
   /**
@@ -420,7 +430,16 @@ class TableView {
    * @returns {number}
    */
   countRenderableRows() {
-    return Math.min(this.instance.rowIndexMapper.getRenderableIndexesLength(), this.settings.maxRows);
+    const numberOfRows = Math.min(this.instance.rowIndexMapper.getNotTrimmedIndexesLength(), this.settings.maxRows);
+    // Don't take hidden rows into account.
+    const firstNotHiddenRow = this.instance.rowIndexMapper.getFirstNotHiddenIndex(
+      numberOfRows - 1, -1);
+
+    if (firstNotHiddenRow === null) {
+      return 0;
+    }
+
+    return this.instance.rowIndexMapper.getRenderableFromVisualIndex(firstNotHiddenRow) + 1;
   }
 
   /**

--- a/src/tableView.js
+++ b/src/tableView.js
@@ -406,23 +406,34 @@ class TableView {
   }
 
   /**
+   * Returns the number of renderable indexes.
+   *
+   * @private
+   * @param {IndexMapper} indexMapper The IndexMapper instance for specific axis.
+   * @param {number} maxElements Maximum number of elements (rows or columns).
+   *
+   * @returns {number|*}
+   */
+  countRenderableIndexes(indexMapper, maxElements) {
+    const consideredElements = Math.min(indexMapper.getNotTrimmedIndexesLength(), maxElements);
+    // Don't take hidden indexes into account. We are looking just for renderable indexes.
+    const firstNotHiddenIndex = indexMapper.getFirstNotHiddenIndex(consideredElements - 1, -1);
+
+    // There are no renderable indexes.
+    if (firstNotHiddenIndex === null) {
+      return 0;
+    }
+
+    return indexMapper.getRenderableFromVisualIndex(firstNotHiddenIndex) + 1;
+  }
+
+  /**
    * Returns the number of renderable columns.
    *
    * @returns {number}
    */
   countRenderableColumns() {
-    const consideredColumns = Math.min(
-      this.instance.columnIndexMapper.getNotTrimmedIndexesLength(), this.settings.maxCols);
-    // Don't take hidden columns into account. We are looking just for renderable columns.
-    const firstNotHiddenColumn = this.instance.columnIndexMapper.getFirstNotHiddenIndex(
-      consideredColumns - 1, -1);
-
-    // There are no renderable columns.
-    if (firstNotHiddenColumn === null) {
-      return 0;
-    }
-
-    return this.instance.columnIndexMapper.getRenderableFromVisualIndex(firstNotHiddenColumn) + 1;
+    return this.countRenderableIndexes(this.instance.columnIndexMapper, this.settings.maxCols);
   }
 
   /**
@@ -431,18 +442,7 @@ class TableView {
    * @returns {number}
    */
   countRenderableRows() {
-    const consideredRows = Math.min(
-      this.instance.rowIndexMapper.getNotTrimmedIndexesLength(), this.settings.maxRows);
-    // Don't take hidden rows into account. We are looking just for renderable rows.
-    const firstNotHiddenRow = this.instance.rowIndexMapper.getFirstNotHiddenIndex(
-      consideredRows - 1, -1);
-
-    // There are no renderable rows.
-    if (firstNotHiddenRow === null) {
-      return 0;
-    }
-
-    return this.instance.rowIndexMapper.getRenderableFromVisualIndex(firstNotHiddenRow) + 1;
+    return this.countRenderableIndexes(this.instance.rowIndexMapper, this.settings.maxRows);
   }
 
   /**


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
This PR fixes problem with `maxRows` and `maxCols` options which haven't took into account information that some indexes are hidden. This resulted in displaying improper number of rows/columns and some glitches described within issue.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Manual test of few configurations for both `maxRows` and `maxCols` options.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7350 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
