### PR TITLE
Fixed a bug where there was no possibility to use `disableVisualSelection` for particular cell/column

### DIFF
--- a/.changelogs/5082.json
+++ b/.changelogs/5082.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fixed a bug where there was no possibility to use `disableVisualSelection` for particular cell/column",
+  "type": "fixed",
+  "issue": 5082,
+  "breaking": false,
+  "framework": "none"
+}

--- a/src/core.js
+++ b/src/core.js
@@ -207,7 +207,9 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
     countColsTranslated: () => this.view.countRenderableColumns(),
     countRowsTranslated: () => this.view.countRenderableRows(),
     visualToRenderableCoords,
-    renderableToVisualCoords
+    renderableToVisualCoords,
+    isDisabledCellSelection: (visualRow, visualColumn) =>
+      instance.getCellMeta(visualRow, visualColumn).disableVisualSelection
   });
 
   this.selection = selection;

--- a/src/selection/highlight/highlight.js
+++ b/src/selection/highlight/highlight.js
@@ -90,12 +90,14 @@ class Highlight {
    * Check if highlight cell rendering is disabled for specified highlight type.
    *
    * @param {string} highlightType Highlight type. Possible values are: `cell`, `area`, `fill` or `header`.
+   * @param {CellCoords} coords The CellCoords instance with defined visual coordinates.
    * @returns {boolean}
    */
-  isEnabledFor(highlightType) {
+  isEnabledFor(highlightType, coords) {
     // Legacy compatibility.
     const type = highlightType === 'current' ? CELL_TYPE : highlightType;
-    let disableHighlight = this.options.disableHighlight;
+
+    let disableHighlight = this.options.disabledCellSelection(coords.row, coords.col);
 
     if (typeof disableHighlight === 'string') {
       disableHighlight = [disableHighlight];

--- a/src/selection/selection.js
+++ b/src/selection/selection.js
@@ -76,7 +76,7 @@ class Selection {
       activeHeaderClassName: settings.activeHeaderClassName,
       rowClassName: settings.currentRowClassName,
       columnClassName: settings.currentColClassName,
-      disableHighlight: this.settings.disableVisualSelection,
+      disabledCellSelection: (row, column) => this.tableProps.isDisabledCellSelection(row, column),
       cellCornerVisible: (...args) => this.isCellCornerVisible(...args),
       areaCornerVisible: (...args) => this.isAreaCornerVisible(...args),
       visualToRenderableCoords: coords => this.tableProps.visualToRenderableCoords(coords),
@@ -223,7 +223,7 @@ class Selection {
     // Set up current selection.
     this.highlight.getCell().clear();
 
-    if (this.highlight.isEnabledFor(CELL_TYPE)) {
+    if (this.highlight.isEnabledFor(CELL_TYPE, cellRange.highlight)) {
       this.highlight.getCell()
         .add(this.selectedRange.current().highlight)
         .commit()
@@ -250,7 +250,7 @@ class Selection {
     headerHighlight.clear();
     activeHeaderHighlight.clear();
 
-    if (this.highlight.isEnabledFor(AREA_TYPE) && (this.isMultiple() || layerLevel >= 1)) {
+    if (this.highlight.isEnabledFor(AREA_TYPE, cellRange.highlight) && (this.isMultiple() || layerLevel >= 1)) {
       areaHighlight
         .add(cellRange.from)
         .add(cellRange.to)
@@ -274,7 +274,7 @@ class Selection {
       }
     }
 
-    if (this.highlight.isEnabledFor(HEADER_TYPE)) {
+    if (this.highlight.isEnabledFor(HEADER_TYPE, cellRange.highlight)) {
       // The header selection generally contains cell selection. In a case when all rows (or columns)
       // are hidden that visual coordinates are translated to renderable coordinates that do not exist.
       // Hence no header highlight is generated. In that case, to make a column (or a row) header
@@ -573,9 +573,9 @@ class Selection {
     const isValid = !selectionRanges.some((selection) => {
       const [rowStart, columnStart, rowEnd, columnEnd] = selectionSchemaNormalizer(selection);
       const _isValid = isValidCoord(rowStart, nrOfRows) &&
-                      isValidCoord(columnStart, nrOfColumns) &&
-                      isValidCoord(rowEnd, nrOfRows) &&
-                      isValidCoord(columnEnd, nrOfColumns);
+        isValidCoord(columnStart, nrOfColumns) &&
+        isValidCoord(rowEnd, nrOfRows) &&
+        isValidCoord(columnEnd, nrOfColumns);
 
       return !_isValid;
     });

--- a/test/e2e/Core_selection.spec.js
+++ b/test/e2e/Core_selection.spec.js
@@ -1832,9 +1832,13 @@ describe('Core_selection', () => {
           rowHeaders: true,
           colHeaders: true,
           cells(row) {
-            return {
-              disableVisualSelection: row === 1
-            };
+            const cellProperties = {};
+
+            if (row === 1) {
+              cellProperties.disableVisualSelection = true;
+            }
+
+            return cellProperties;
           },
           columns: [
             {},

--- a/test/e2e/Core_selection.spec.js
+++ b/test/e2e/Core_selection.spec.js
@@ -1832,11 +1832,9 @@ describe('Core_selection', () => {
           rowHeaders: true,
           colHeaders: true,
           cells(row) {
-            const cellProperties = {
+            return {
               disableVisualSelection: row === 1
             };
-
-            return cellProperties;
           },
           columns: [
             {},

--- a/test/e2e/Core_selection.spec.js
+++ b/test/e2e/Core_selection.spec.js
@@ -1729,6 +1729,103 @@ describe('Core_selection', () => {
     expect(getSelected()).toEqual([[-1, 1, 1, 1]]);
   });
 
+  describe('cooperation with `disableVisualSelection` option', () => {
+    describe('is set globally', () => {
+      it('to value `true`', () => {
+        handsontable({
+          rowHeaders: true,
+          colHeaders: true,
+          startRows: 5,
+          startCols: 5,
+          disableVisualSelection: true
+        });
+
+        // Cell selection (header isn't selected?)
+        // TODO: Should it not select headers?
+        simulateClick($(getCell(1, 1)), 'LMB');
+
+        expect(getSelected()).toEqual([[1, 1, 1, 1]]);
+        expect(getSelectedRangeLast().highlight.row).toBe(1);
+        expect(getSelectedRangeLast().highlight.col).toBe(1);
+        expect(getSelectedRangeLast().from.row).toBe(1);
+        expect(getSelectedRangeLast().from.col).toBe(1);
+        expect(getSelectedRangeLast().to.row).toBe(1);
+        expect(getSelectedRangeLast().to.col).toBe(1);
+        expect(`
+        |   ║   :   :   :   :   |
+        |===:===:===:===:===:===|
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        `).toBeMatchToSelectionPattern();
+
+        // Area selection (headers are selected).
+        $(getCell(1, 1)).simulate('mousedown');
+        $(getCell(4, 4)).simulate('mouseover');
+        $(getCell(4, 4)).simulate('mouseup');
+
+        expect(getSelected()).toEqual([[1, 1, 4, 4]]);
+        expect(getSelectedRangeLast().highlight.row).toBe(1);
+        expect(getSelectedRangeLast().highlight.col).toBe(1);
+        expect(getSelectedRangeLast().from.row).toBe(1);
+        expect(getSelectedRangeLast().from.col).toBe(1);
+        expect(getSelectedRangeLast().to.row).toBe(4);
+        expect(getSelectedRangeLast().to.col).toBe(4);
+        expect(`
+        |   ║   :   :   :   :   |
+        |===:===:===:===:===:===|
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        `).toBeMatchToSelectionPattern();
+
+        // Column header selection.
+        simulateClick($(getCell(-1, 1)), 'LMB');
+
+        expect(getSelected()).toEqual([[-1, 1, 4, 1]]);
+        expect(getSelectedRangeLast().highlight.row).toBe(0);
+        expect(getSelectedRangeLast().highlight.col).toBe(1);
+        expect(getSelectedRangeLast().from.row).toBe(-1);
+        expect(getSelectedRangeLast().from.col).toBe(1);
+        expect(getSelectedRangeLast().to.row).toBe(4);
+        expect(getSelectedRangeLast().to.col).toBe(1);
+        expect(`
+        |   ║   : * :   :   :   |
+        |===:===:===:===:===:===|
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        `).toBeMatchToSelectionPattern();
+
+        // Row header selection.
+        simulateClick($(getCell(1, -1)), 'LMB');
+
+        expect(getSelected()).toEqual([[1, -1, 1, 4]]);
+        expect(getSelectedRangeLast().highlight.row).toBe(1);
+        expect(getSelectedRangeLast().highlight.col).toBe(0);
+        expect(getSelectedRangeLast().from.row).toBe(1);
+        expect(getSelectedRangeLast().from.col).toBe(-1);
+        expect(getSelectedRangeLast().to.row).toBe(1);
+        expect(getSelectedRangeLast().to.col).toBe(4);
+        expect(`
+        |   ║   :   :   :   :   |
+        |===:===:===:===:===:===|
+        |   ║   :   :   :   :   |
+        | * ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        `).toBeMatchToSelectionPattern();
+      });
+    });
+  });
+
   describe('multiple selection mode', () => {
     it('should select cells by using two layers when CTRL key is pressed (default mode of the selectionMode option)', () => {
       handsontable({

--- a/test/e2e/Core_selection.spec.js
+++ b/test/e2e/Core_selection.spec.js
@@ -1741,7 +1741,117 @@ describe('Core_selection', () => {
         });
 
         // Cell selection (header isn't selected?)
-        // TODO: Should it not select headers?
+        // TODO: Should it not select headers? Documentation says that value set to `true` disables any type of
+        // visual selection (current and area selection)
+        simulateClick($(getCell(1, 1)), 'LMB');
+
+        expect(getSelected()).toEqual([[1, 1, 1, 1]]);
+        expect(getSelectedRangeLast().highlight.row).toBe(1);
+        expect(getSelectedRangeLast().highlight.col).toBe(1);
+        expect(getSelectedRangeLast().from.row).toBe(1);
+        expect(getSelectedRangeLast().from.col).toBe(1);
+        expect(getSelectedRangeLast().to.row).toBe(1);
+        expect(getSelectedRangeLast().to.col).toBe(1);
+        expect(`
+        |   ║   :   :   :   :   |
+        |===:===:===:===:===:===|
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        `).toBeMatchToSelectionPattern();
+
+        // Area selection (headers are selected).
+        $(getCell(1, 1)).simulate('mousedown');
+        $(getCell(4, 4)).simulate('mouseover');
+        $(getCell(4, 4)).simulate('mouseup');
+
+        expect(getSelected()).toEqual([[1, 1, 4, 4]]);
+        expect(getSelectedRangeLast().highlight.row).toBe(1);
+        expect(getSelectedRangeLast().highlight.col).toBe(1);
+        expect(getSelectedRangeLast().from.row).toBe(1);
+        expect(getSelectedRangeLast().from.col).toBe(1);
+        expect(getSelectedRangeLast().to.row).toBe(4);
+        expect(getSelectedRangeLast().to.col).toBe(4);
+        expect(`
+        |   ║   :   :   :   :   |
+        |===:===:===:===:===:===|
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        `).toBeMatchToSelectionPattern();
+
+        // Column header selection.
+        simulateClick($(getCell(-1, 1)), 'LMB');
+
+        expect(getSelected()).toEqual([[-1, 1, 4, 1]]);
+        expect(getSelectedRangeLast().highlight.row).toBe(0);
+        expect(getSelectedRangeLast().highlight.col).toBe(1);
+        expect(getSelectedRangeLast().from.row).toBe(-1);
+        expect(getSelectedRangeLast().from.col).toBe(1);
+        expect(getSelectedRangeLast().to.row).toBe(4);
+        expect(getSelectedRangeLast().to.col).toBe(1);
+        expect(`
+        |   ║   : * :   :   :   |
+        |===:===:===:===:===:===|
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        `).toBeMatchToSelectionPattern();
+
+        // Row header selection.
+        simulateClick($(getCell(1, -1)), 'LMB');
+
+        expect(getSelected()).toEqual([[1, -1, 1, 4]]);
+        expect(getSelectedRangeLast().highlight.row).toBe(1);
+        expect(getSelectedRangeLast().highlight.col).toBe(0);
+        expect(getSelectedRangeLast().from.row).toBe(1);
+        expect(getSelectedRangeLast().from.col).toBe(-1);
+        expect(getSelectedRangeLast().to.row).toBe(1);
+        expect(getSelectedRangeLast().to.col).toBe(4);
+        expect(`
+        |   ║   :   :   :   :   |
+        |===:===:===:===:===:===|
+        |   ║   :   :   :   :   |
+        | * ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
+        `).toBeMatchToSelectionPattern();
+      });
+    });
+
+    describe('is set for single cell/column', () => {
+      it('to value `true`', () => {
+        handsontable({
+          rowHeaders: true,
+          colHeaders: true,
+          cells(row) {
+            const cellProperties = {};
+
+            if (row === 1) {
+              cellProperties.disableVisualSelection = true;
+            }
+
+            return cellProperties;
+          },
+          columns: [
+            {},
+            { disableVisualSelection: true },
+            {},
+            {},
+            {},
+          ]
+        });
+
+        // Cell selection (header isn't selected?)
+        // TODO: Should it not select headers? Documentation says that value set to `true` disables any type of
+        // visual selection (current and area selection)
         simulateClick($(getCell(1, 1)), 'LMB');
 
         expect(getSelected()).toEqual([[1, 1, 1, 1]]);

--- a/test/e2e/Core_selection.spec.js
+++ b/test/e2e/Core_selection.spec.js
@@ -1832,11 +1832,9 @@ describe('Core_selection', () => {
           rowHeaders: true,
           colHeaders: true,
           cells(row) {
-            const cellProperties = {};
-
-            if (row === 1) {
-              cellProperties.disableVisualSelection = true;
-            }
+            const cellProperties = {
+              disableVisualSelection: row === 1
+            };
 
             return cellProperties;
           },


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Release `0.36.0` (Handsontable Pro `1.16.0`) introduced big refactor of selection within https://github.com/handsontable/handsontable/issues/4708. However, it introduced also regression. Since the release there have been no possibility to use `disableVisualSelection` option for just some cells/columns. This PR change it and restores described functionality.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Manual tests of `disableVisualSelection` option in [all configurations](https://handsontable.com/docs/Options.html#disableVisualSelection). Please keep in mind that there is bug for `current` value, but it will be fixed within https://github.com/handsontable/handsontable/issues/5869.



### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #5082 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
