### PR TITLE
Skip from copying to dist directory languages with ES format

### DIFF
--- a/.config/languages-development.js
+++ b/.config/languages-development.js
@@ -94,14 +94,15 @@ module.exports.create = function create() {
         const indexFileName = 'index.js';
         const allLanguagesFileName = 'all.js';
 
-        // copy files from `languages` directory to `dist/languages` directory
+        // Copy files from `languages` directory to `dist/languages` directory
         filesInOutputLanguagesDirectory.forEach((fileName) => {
-          if (fileName !== indexFileName) {
+          // Copy only UMD language files (ignore ES files that with .mjs extension)
+          if (fileName !== indexFileName && fileName.endsWith('.js')) {
             fsExtra.copySync(`${OUTPUT_LANGUAGES_DIRECTORY}/${fileName}`, `dist/languages/${fileName}`);
           }
         });
 
-        // copy from `languages/all.js` to `languages/index.js`
+        // Copy from `languages/all.js` to `languages/index.js`
         if (filesInOutputLanguagesDirectory.includes(allLanguagesFileName)) {
           fsExtra.copySync(`${OUTPUT_LANGUAGES_DIRECTORY}/${allLanguagesFileName}`, `${OUTPUT_LANGUAGES_DIRECTORY}/${indexFileName}`);
         }


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes an issue where the languages in ES format are copied to the dist directory (which should hold only files in UMD format).

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Tested locally.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7477

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
