### PR TITLE
Execute the changelog check only on `pull_request` events

### DIFF
--- a/.github/scripts/check-changelog.js
+++ b/.github/scripts/check-changelog.js
@@ -13,27 +13,19 @@ const skipCheckString = '[skip changelog]';
 
 const changelogsPath = '.changelogs/';
 
-const { owner, repo } = github.context.repo;
-const { sha } = github.context;
+const {owner, repo} = github.context.repo
+const octokit = github.getOctokit(token);
 
 const run = async() => {
-  const octokit = github.getOctokit(token);
-
-  const result = await octokit.repos.listPullRequestsAssociatedWithCommit({
-    owner,
-    repo,
-    commit_sha: sha
-  });
-
-  console.log(`Found ${result.data.length} PR's associated with this commit`);
-  const pr = result.data[0];
+  const pr = github.context.payload.pull_request
 
   if (pr === undefined) {
-    console.log('No PR found associated with this commit, exiting.');
-    process.exit(0);
+    return core.setFailed(
+      'This script can only run within GitHub Action `pull_request` events.'
+    )
   }
 
-  if (pr.body.includes(skipCheckString)) {
+  if ((pr.body || '').includes(skipCheckString)) {
     console.log('The PR body (description) includes a string to disable this check, exiting.');
     process.exit(0);
   }

--- a/.github/scripts/check-changelog.js
+++ b/.github/scripts/check-changelog.js
@@ -13,16 +13,16 @@ const skipCheckString = '[skip changelog]';
 
 const changelogsPath = '.changelogs/';
 
-const {owner, repo} = github.context.repo
+const { owner, repo } = github.context.repo;
 const octokit = github.getOctokit(token);
 
 const run = async() => {
-  const pr = github.context.payload.pull_request
+  const pr = github.context.payload.pull_request;
 
   if (pr === undefined) {
     return core.setFailed(
       'This script can only run within GitHub Action `pull_request` events.'
-    )
+    );
   }
 
   if ((pr.body || '').includes(skipCheckString)) {

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,6 +1,19 @@
+# This workflow asserts that new changelog entries get added within pull requests.
+# See `/.changelogs/README.md` for more information.
+
 name: Changelog
 
-on: [push]
+on:
+  pull_request: [
+    # When new commits get pushed to the associated PR
+    synchronize,
+
+    # When a PR gets first opened
+    opened,
+
+    # When a PR gets edited, as in the title, body or the base branch gets changed
+    edited
+  ]
 
 jobs:
   check:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -4,16 +4,16 @@
 name: Changelog
 
 on:
-  pull_request: [
-    # When new commits get pushed to the associated PR
-    synchronize,
+  pull_request:
+    types:
+      # When new commits get pushed to the associated PR
+      - synchronize
 
-    # When a PR gets first opened
-    opened,
+      # When a PR gets first opened
+      - opened
 
-    # When a PR gets edited, as in the title, body or the base branch gets changed
-    edited
-  ]
+      # When a PR gets edited, as in the title, body or the base branch gets changed
+      - edited
 
 jobs:
   check:


### PR DESCRIPTION
### Context

The following events now trigger the changelog check:
- Opening a new PR
- Modifying the PR description (or title, but that's because you can't discern between the two events on gh easily)

The following events now *don't* trigger a changelog check:
- When a commit is pushed to a branch that doesn't belong to any PR (which lets
  us remove the "no associated PR's were found" check from the
  `check-changelog.js` script).

This wouldn't be that big of a problem, but both @budnix and @wszymanski raised
concerns about it asking me why the script had passed when they didn't expect
it to, so I took the time to get this working properly.

### How has this been tested?
Tested all previous and new functionalities inside of a private repo.

cc @wojciechczerniak 

[skip changelog]