### PR TITLE
Fixed problems with `headers` value for the `disableVisualSelection` option

### DIFF
--- a/.changelogs/6025.json
+++ b/.changelogs/6025.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fixed problems with `header` value for the `disableVisualSelection` option",
+  "type": "fixed",
+  "issue": 6025,
+  "breaking": false,
+  "framework": "none"
+}

--- a/src/dataMap/metaManager/metaSchema.js
+++ b/src/dataMap/metaManager/metaSchema.js
@@ -2028,7 +2028,7 @@ export default () => {
      * Disables visual cells selection.
      *
      * Possible values:
-     *  * `true` - Disables any type of visual selection (current and area selection),
+     *  * `true` - Disables any type of visual selection (current, header and area selection),
      *  * `false` - Enables any type of visual selection. This is default value.
      *  * `'current'` - Disables the selection of a currently selected cell, the area selection is still present.
      *  * `'area'` - Disables the area selection, the currently selected cell selection is still present.

--- a/src/selection/selection.js
+++ b/src/selection/selection.js
@@ -308,29 +308,29 @@ class Selection {
           .add(headerCellRange.to)
           .commit();
       }
-    }
 
-    if (this.isEntireRowSelected()) {
-      const isRowSelected = this.tableProps.countCols() === cellRange.getWidth();
+      if (this.isEntireRowSelected()) {
+        const isRowSelected = this.tableProps.countCols() === cellRange.getWidth();
 
-      // Make sure that the whole row is selected (in case where selectionMode is set to 'single')
-      if (isRowSelected) {
-        activeHeaderHighlight
-          .add(new CellCoords(cellRange.from.row, -1))
-          .add(new CellCoords(cellRange.to.row, -1))
-          .commit();
+        // Make sure that the whole row is selected (in case where selectionMode is set to 'single')
+        if (isRowSelected) {
+          activeHeaderHighlight
+            .add(new CellCoords(cellRange.from.row, -1))
+            .add(new CellCoords(cellRange.to.row, -1))
+            .commit();
+        }
       }
-    }
 
-    if (this.isEntireColumnSelected()) {
-      const isColumnSelected = this.tableProps.countRows() === cellRange.getHeight();
+      if (this.isEntireColumnSelected()) {
+        const isColumnSelected = this.tableProps.countRows() === cellRange.getHeight();
 
-      // Make sure that the whole column is selected (in case where selectionMode is set to 'single')
-      if (isColumnSelected) {
-        activeHeaderHighlight
-          .add(new CellCoords(-1, cellRange.from.col))
-          .add(new CellCoords(-1, cellRange.to.col))
-          .commit();
+        // Make sure that the whole column is selected (in case where selectionMode is set to 'single')
+        if (isColumnSelected) {
+          activeHeaderHighlight
+            .add(new CellCoords(-1, cellRange.from.col))
+            .add(new CellCoords(-1, cellRange.to.col))
+            .commit();
+        }
       }
     }
 

--- a/test/e2e/Core_selection.spec.js
+++ b/test/e2e/Core_selection.spec.js
@@ -1795,7 +1795,7 @@ describe('Core_selection', () => {
         expect(getSelectedRangeLast().to.row).toBe(4);
         expect(getSelectedRangeLast().to.col).toBe(1);
         expect(`
-        |   ║   : * :   :   :   |
+        |   ║   :   :   :   :   |
         |===:===:===:===:===:===|
         |   ║   :   :   :   :   |
         |   ║   :   :   :   :   |
@@ -1818,7 +1818,7 @@ describe('Core_selection', () => {
         |   ║   :   :   :   :   |
         |===:===:===:===:===:===|
         |   ║   :   :   :   :   |
-        | * ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
         |   ║   :   :   :   :   |
         |   ║   :   :   :   :   |
         |   ║   :   :   :   :   |
@@ -2072,7 +2072,7 @@ describe('Core_selection', () => {
         expect(getSelectedRangeLast().to.row).toBe(4);
         expect(getSelectedRangeLast().to.col).toBe(1);
         expect(`
-        |   ║   : * :   :   :   |
+        |   ║   :   :   :   :   |
         |===:===:===:===:===:===|
         |   ║   : A :   :   :   |
         |   ║   : 0 :   :   :   |
@@ -2096,7 +2096,7 @@ describe('Core_selection', () => {
         |   ║   :   :   :   :   |
         |===:===:===:===:===:===|
         |   ║   :   :   :   :   |
-        | * ║ A : 0 : 0 : 0 : 0 |
+        |   ║ A : 0 : 0 : 0 : 0 |
         |   ║   :   :   :   :   |
         |   ║   :   :   :   :   |
         |   ║   :   :   :   :   |
@@ -2127,9 +2127,6 @@ describe('Core_selection', () => {
           ]
         });
 
-        // Cell selection (header isn't selected?)
-        // TODO: Should it not select headers? Documentation says that value set to `true` disables any type of
-        // visual selection (current and area selection)
         simulateClick($(getCell(1, 1)), 'LMB');
 
         expect(getSelected()).toEqual([[1, 1, 1, 1]]);
@@ -2182,7 +2179,7 @@ describe('Core_selection', () => {
         expect(getSelectedRangeLast().to.row).toBe(4);
         expect(getSelectedRangeLast().to.col).toBe(1);
         expect(`
-        |   ║   : * :   :   :   |
+        |   ║   :   :   :   :   |
         |===:===:===:===:===:===|
         |   ║   :   :   :   :   |
         |   ║   :   :   :   :   |
@@ -2205,7 +2202,7 @@ describe('Core_selection', () => {
         |   ║   :   :   :   :   |
         |===:===:===:===:===:===|
         |   ║   :   :   :   :   |
-        | * ║   :   :   :   :   |
+        |   ║   :   :   :   :   |
         |   ║   :   :   :   :   |
         |   ║   :   :   :   :   |
         |   ║   :   :   :   :   |
@@ -2604,7 +2601,7 @@ describe('Core_selection', () => {
         expect(getSelectedRangeLast().to.row).toBe(4);
         expect(getSelectedRangeLast().to.col).toBe(1);
         expect(`
-        |   ║   : * :   :   :   |
+        |   ║   :   :   :   :   |
         |===:===:===:===:===:===|
         |   ║   : A :   :   :   |
         |   ║   : 0 :   :   :   |
@@ -2628,7 +2625,7 @@ describe('Core_selection', () => {
         |   ║   :   :   :   :   |
         |===:===:===:===:===:===|
         |   ║   :   :   :   :   |
-        | * ║ A : 0 : 0 : 0 : 0 |
+        |   ║ A : 0 : 0 : 0 : 0 |
         |   ║   :   :   :   :   |
         |   ║   :   :   :   :   |
         |   ║   :   :   :   :   |


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The `disableVisualSelection` option set to value `header` doesn't work properly for clicks on row and column headers.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Tested `disableVisualSelection` with `'header'`, `['header']`, `['header', 'area'], ['header', 'current']` and `['header', 'area', 'current']` values.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #6025
2. https://github.com/handsontable/handsontable/pull/7480

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
