### PR TITLE
Fixed problems with displaying double border when `window` is is a scrollable container

### DIFF
--- a/.changelogs/7356.json
+++ b/.changelogs/7356.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fixed problems with displaying double border when `window` is is a scrollable container",
+  "type": "fixed",
+  "issue": 7356,
+  "breaking": false,
+  "framework": "none"
+}

--- a/src/3rdparty/walkontable/src/overlay/bottom.js
+++ b/src/3rdparty/walkontable/src/overlay/bottom.js
@@ -22,17 +22,19 @@ export class BottomOverlay extends Overlay {
   }
 
   /**
+   * Cached value which holds the previous value of the `fixedRowsBottom` option.
+   * It is used as a comparison value that can be used to detect changes in that value.
+   *
+   * @type {number}
+   */
+  cachedFixedRowsBottom = -1;
+
+  /**
    * @param {Walkontable} wotInstance The Walkontable instance.
    */
   constructor(wotInstance) {
     super(wotInstance);
     this.clone = this.makeClone(CLONE_BOTTOM);
-    /**
-     * Cached value which holds the previous value of the `fixedRowsBottom` option.
-     * It is used as a comparison value that can be used to detect changes in that value.
-     *
-     * @type {number}
-     */
     this.cachedFixedRowsBottom = this.wot.getSetting('fixedRowsBottom');
   }
 

--- a/src/3rdparty/walkontable/src/overlay/bottom.js
+++ b/src/3rdparty/walkontable/src/overlay/bottom.js
@@ -22,19 +22,18 @@ export class BottomOverlay extends Overlay {
   }
 
   /**
-   * Cached value which holds the previous value of the `fixedRowsBottom` option.
-   * It is used as a comparison value that can be used to detect changes in that value.
-   *
-   * @type {number}
-   */
-  cachedFixedRowsBottom = -1;
-
-  /**
    * @param {Walkontable} wotInstance The Walkontable instance.
    */
   constructor(wotInstance) {
     super(wotInstance);
     this.clone = this.makeClone(CLONE_BOTTOM);
+    /**
+     * Cached value which holds the previous value of the `fixedRowsBottom` option.
+     * It is used as a comparison value that can be used to detect changes in that value.
+     *
+     * @type {number}
+     */
+    this.cachedFixedRowsBottom = this.wot.getSetting('fixedRowsBottom');
   }
 
   /**

--- a/src/3rdparty/walkontable/src/overlay/top.js
+++ b/src/3rdparty/walkontable/src/overlay/top.js
@@ -24,17 +24,19 @@ export class TopOverlay extends Overlay {
   }
 
   /**
+   * Cached value which holds the previous value of the `fixedRowsTop` option.
+   * It is used as a comparison value that can be used to detect changes in this value.
+   *
+   * @type {number}
+   */
+  cachedFixedRowsTop = -1;
+
+  /**
    * @param {Walkontable} wotInstance The Walkontable instance.
    */
   constructor(wotInstance) {
     super(wotInstance);
     this.clone = this.makeClone(CLONE_TOP);
-    /**
-     * Cached value which holds the previous value of the `fixedRowsTop` option.
-     * It is used as a comparison value that can be used to detect changes in this value.
-     *
-     * @type {number}
-     */
     this.cachedFixedRowsTop = this.wot.getSetting('fixedRowsTop');
   }
 

--- a/src/3rdparty/walkontable/src/overlay/top.js
+++ b/src/3rdparty/walkontable/src/overlay/top.js
@@ -24,19 +24,18 @@ export class TopOverlay extends Overlay {
   }
 
   /**
-   * Cached value which holds the previous value of the `fixedRowsTop` option.
-   * It is used as a comparison value that can be used to detect changes in this value.
-   *
-   * @type {number}
-   */
-  cachedFixedRowsTop = -1;
-
-  /**
    * @param {Walkontable} wotInstance The Walkontable instance.
    */
   constructor(wotInstance) {
     super(wotInstance);
     this.clone = this.makeClone(CLONE_TOP);
+    /**
+     * Cached value which holds the previous value of the `fixedRowsTop` option.
+     * It is used as a comparison value that can be used to detect changes in this value.
+     *
+     * @type {number}
+     */
+    this.cachedFixedRowsTop = this.wot.getSetting('fixedRowsTop');
   }
 
   /**

--- a/test/e2e/settings/fixedRowsBottom.spec.js
+++ b/test/e2e/settings/fixedRowsBottom.spec.js
@@ -242,7 +242,8 @@ describe('settings', () => {
 
       updateSettings({ data: [] });
 
-      expect(getTopClone().height()).toBe(26);
+      // The only header (when there is no cells - even when the `fixedRowsBottom` isn't defined) has such height.
+      expect(getTopClone().height()).toBe(27);
     });
   });
 });

--- a/test/e2e/settings/fixedRowsBottom.spec.js
+++ b/test/e2e/settings/fixedRowsBottom.spec.js
@@ -221,5 +221,28 @@ describe('settings', () => {
       expect(getBottomClone().height()).toBe(47);
       expect(getBottomLeftClone().height()).toBe(47);
     });
+
+    it('should not display double border when `window` is a scrollable container', () => {
+      handsontable({
+        startRows: 200,
+        colHeaders: true,
+        fixedRowsBottom: 1,
+        columns: [{}]
+      });
+
+      expect(getTopClone().height()).toBe(26);
+
+      updateSettings({ fixedRowsBottom: 0 });
+
+      expect(getTopClone().height()).toBe(26);
+
+      updateSettings({ fixedRowsBottom: 1 });
+
+      expect(getTopClone().height()).toBe(26);
+
+      updateSettings({ data: [] });
+
+      expect(getTopClone().height()).toBe(26);
+    });
   });
 });


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
In some configuration, described within #7356, there was problem with displaying double border. After investigation I changed part of code related to `bottom` overlay. I did similar change for `top` overlay although it probably doesn't change anything (I did it for objects consistency).


### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Tested with `updateSettings` containing `fixedRowsBottom`/`fixedRowsTop`/`data` key and `TrimRows` & `HiddenRows` plugins hiding/trimming all rows.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7356

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
