### PR TITLE
Fix circular dependencies in the i18n module

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -27,8 +27,8 @@ import { IndexMapper } from './translations';
 import { registerAsRootInstance, hasValidParameter, isRootInstance } from './utils/rootInstance';
 import { CellCoords, ViewportColumnsCalculator } from './3rdparty/walkontable/src';
 import Hooks from './pluginHooks';
-import { hasLanguageDictionary, getTranslatedPhrase } from './i18n/registry';
-import { warnUserAboutLanguageRegistration, getValidLanguageCode, normalizeLanguageCode } from './i18n/utils';
+import { hasLanguageDictionary, getValidLanguageCode, getTranslatedPhrase } from './i18n/registry';
+import { warnUserAboutLanguageRegistration, normalizeLanguageCode } from './i18n/utils';
 import {
   startObserving as keyStateStartObserving,
   stopObserving as keyStateStopObserving

--- a/src/i18n/__tests__/moduleInterface.unit.js
+++ b/src/i18n/__tests__/moduleInterface.unit.js
@@ -3,6 +3,7 @@ import {
   getLanguageDictionary,
   getLanguagesDictionaries,
   getTranslatedPhrase,
+  getValidLanguageCode,
   hasLanguageDictionary,
   registerLanguageDictionary,
   dictionaryKeys,
@@ -31,6 +32,7 @@ describe('i18n', () => {
     expect(getLanguageDictionary).toBeFunction();
     expect(getLanguagesDictionaries).toBeFunction();
     expect(getTranslatedPhrase).toBeFunction();
+    expect(getValidLanguageCode).toBeFunction();
     expect(hasLanguageDictionary).toBeFunction();
     expect(registerLanguageDictionary).toBeFunction();
   });

--- a/src/i18n/__tests__/registry.unit.js
+++ b/src/i18n/__tests__/registry.unit.js
@@ -1,9 +1,10 @@
 import {
+  dictionaryKeys,
   getLanguageDictionary,
   getLanguagesDictionaries,
-  registerLanguageDictionary,
+  getValidLanguageCode,
   hasLanguageDictionary,
-  dictionaryKeys,
+  registerLanguageDictionary,
   DEFAULT_LANGUAGE_CODE
 } from 'handsontable/i18n';
 import plPL from 'handsontable/i18n/languages/pl-PL';
@@ -89,5 +90,32 @@ describe('i18n registry', () => {
 
     expect(registeredLanguage[dictionaryKey1]).toEqual('Hello world');
     expect(registeredLanguage[dictionaryKey2]).toEqual(defaultLanguageDictionary[dictionaryKey2]);
+  });
+
+  describe('getValidLanguageCode', () => {
+    beforeAll(() => {
+      // Note: please keep in mind that this language will be registered also for next unit tests (within this file)!
+      // It's stored globally for already loaded Handsontable library.
+
+      registerLanguageDictionary(plPL);
+    });
+
+    it('should returns valid language code', () => {
+      expect(getValidLanguageCode(plPL.languageCode)).toEqual(plPL.languageCode);
+    });
+
+    it('should returns default language code when provided valid code not exist in the registered languages', () => {
+      spyOn(console, 'error');
+
+      expect(getValidLanguageCode('aa-BB')).toEqual(DEFAULT_LANGUAGE_CODE);
+    });
+
+    it('should log error when handling not existing language', () => {
+      const spy = spyOn(console, 'error');
+
+      getValidLanguageCode('aa-BB');
+
+      expect(spy).toHaveBeenCalled();
+    });
   });
 });

--- a/src/i18n/__tests__/utils.unit.js
+++ b/src/i18n/__tests__/utils.unit.js
@@ -3,14 +3,7 @@ import {
   createCellHeadersRange,
   normalizeLanguageCode,
   warnUserAboutLanguageRegistration,
-  getValidLanguageCode
 } from 'handsontable/i18n/utils';
-
-import {
-  DEFAULT_LANGUAGE_CODE,
-  registerLanguageDictionary,
-} from 'handsontable/i18n/registry';
-import plPL from 'handsontable/i18n/languages/pl-PL';
 
 describe('i18n helpers', () => {
   describe('extendNotExistingKeys', () => {
@@ -91,33 +84,6 @@ describe('i18n helpers', () => {
 
     it('should normlize properly langage code #3', () => {
       expect(normalizeLanguageCode('PL-PL')).toEqual('pl-PL');
-    });
-  });
-
-  describe('getValidLanguageCode', () => {
-    beforeAll(() => {
-      // Note: please keep in mind that this language will be registered also for next unit tests (within this file)!
-      // It's stored globally for already loaded Handsontable library.
-
-      registerLanguageDictionary(plPL);
-    });
-
-    it('should returns valid language code', () => {
-      expect(getValidLanguageCode(plPL.languageCode)).toEqual(plPL.languageCode);
-    });
-
-    it('should returns default language code when provided valid code not exist in the registered languages', () => {
-      spyOn(console, 'error');
-
-      expect(getValidLanguageCode('aa-BB')).toEqual(DEFAULT_LANGUAGE_CODE);
-    });
-
-    it('should log error when handling not existing language', () => {
-      const spy = spyOn(console, 'error');
-
-      getValidLanguageCode('aa-BB');
-
-      expect(spy).toHaveBeenCalled();
     });
   });
 

--- a/src/i18n/registry.js
+++ b/src/i18n/registry.js
@@ -1,7 +1,7 @@
 import { isObject, deepClone } from '../helpers/object';
 import { arrayEach } from './../helpers/array';
 import { isUndefined } from '../helpers/mixed';
-import { extendNotExistingKeys } from './utils';
+import { extendNotExistingKeys, normalizeLanguageCode, warnUserAboutLanguageRegistration } from './utils';
 import staticRegister from '../utils/staticRegister';
 import { getPhraseFormatters } from './phraseFormatters';
 import DEFAULT_DICTIONARY from './languages/en-US';
@@ -150,4 +150,22 @@ function getFormattedPhrase(phrasePropositions, argumentsForFormatters) {
   });
 
   return formattedPhrasePropositions;
+}
+
+/**
+ * Returns valid language code. If the passed language code doesn't exist default one will be used.
+ *
+ * @param {string} languageCode Language code for specific language i.e. 'en-US', 'pt-BR', 'de-DE'.
+ * @returns {string}
+ */
+export function getValidLanguageCode(languageCode) {
+  let normalizedLanguageCode = normalizeLanguageCode(languageCode);
+
+  if (!hasLanguageDictionary(normalizedLanguageCode)) {
+    normalizedLanguageCode = DEFAULT_LANGUAGE_CODE;
+
+    warnUserAboutLanguageRegistration(languageCode);
+  }
+
+  return normalizedLanguageCode;
 }

--- a/src/i18n/registry.js
+++ b/src/i18n/registry.js
@@ -4,12 +4,11 @@ import { isUndefined } from '../helpers/mixed';
 import { extendNotExistingKeys } from './utils';
 import staticRegister from '../utils/staticRegister';
 import { getPhraseFormatters } from './phraseFormatters';
-import { getLanguageDictionary } from './registry';
 import DEFAULT_DICTIONARY from './languages/en-US';
 
 export * as dictionaryKeys from './constants';
 
-const DEFAULT_LANGUAGE_CODE = DEFAULT_DICTIONARY.languageCode;
+export const DEFAULT_LANGUAGE_CODE = DEFAULT_DICTIONARY.languageCode;
 
 const {
   register: registerGloballyLanguageDictionary,
@@ -21,7 +20,7 @@ const {
 /**
  * Register automatically the default language dictionary.
  */
-registerLanguage(DEFAULT_DICTIONARY);
+registerLanguageDictionary(DEFAULT_DICTIONARY);
 
 /**
  * Register language dictionary for specific language code.
@@ -30,7 +29,7 @@ registerLanguage(DEFAULT_DICTIONARY);
  * @param {object} dictionary Dictionary for specific language (optional if first parameter has already dictionary).
  * @returns {object}
  */
-function registerLanguage(languageCodeOrDictionary, dictionary) {
+export function registerLanguageDictionary(languageCodeOrDictionary, dictionary) {
   let languageCode = languageCodeOrDictionary;
   let dictionaryObject = dictionary;
 
@@ -48,40 +47,6 @@ function registerLanguage(languageCodeOrDictionary, dictionary) {
 }
 
 /**
- * Get language dictionary for specific language code.
- *
- * @param {string} languageCode Language code.
- * @returns {object} Object with constants representing identifiers for translation (as keys) and corresponding translation phrases (as values).
- */
-function getLanguage(languageCode) {
-  if (!hasLanguage(languageCode)) {
-    return null;
-  }
-
-  return deepClone(getGlobalLanguageDictionary(languageCode));
-}
-
-/**
- *
- * Get if language with specified language code was registered.
- *
- * @param {string} languageCode Language code for specific language i.e. 'en-US', 'pt-BR', 'de-DE'.
- * @returns {boolean}
- */
-function hasLanguage(languageCode) {
-  return hasGlobalLanguageDictionary(languageCode);
-}
-
-/**
- * Get default language dictionary.
- *
- * @returns {object} Object with constants representing identifiers for translation (as keys) and corresponding translation phrases (as values).
- */
-function getDefaultLanguage() {
-  return DEFAULT_DICTIONARY;
-}
-
-/**
  * Extend handled dictionary by default language dictionary. As result, if any dictionary key isn't defined for specific language, it will be filled with default language value ("dictionary gaps" are supplemented).
  *
  * @private
@@ -95,11 +60,45 @@ function extendLanguageDictionary(languageCode, dictionary) {
 }
 
 /**
+ * Get language dictionary for specific language code.
+ *
+ * @param {string} languageCode Language code.
+ * @returns {object} Object with constants representing identifiers for translation (as keys) and corresponding translation phrases (as values).
+ */
+export function getLanguageDictionary(languageCode) {
+  if (!hasLanguageDictionary(languageCode)) {
+    return null;
+  }
+
+  return deepClone(getGlobalLanguageDictionary(languageCode));
+}
+
+/**
+ *
+ * Get if language with specified language code was registered.
+ *
+ * @param {string} languageCode Language code for specific language i.e. 'en-US', 'pt-BR', 'de-DE'.
+ * @returns {boolean}
+ */
+export function hasLanguageDictionary(languageCode) {
+  return hasGlobalLanguageDictionary(languageCode);
+}
+
+/**
+ * Get default language dictionary.
+ *
+ * @returns {object} Object with constants representing identifiers for translation (as keys) and corresponding translation phrases (as values).
+ */
+export function getDefaultLanguageDictionary() {
+  return DEFAULT_DICTIONARY;
+}
+
+/**
  * Get registered language dictionaries.
  *
  * @returns {Array}
  */
-function getLanguages() {
+export function getLanguagesDictionaries() {
   return getGlobalLanguagesDictionaries();
 }
 
@@ -112,7 +111,7 @@ function getLanguages() {
  *
  * @returns {string}
  */
-function getTranslatedPhrase(languageCode, dictionaryKey, argumentsForFormatters) {
+export function getTranslatedPhrase(languageCode, dictionaryKey, argumentsForFormatters) {
   const languageDictionary = getLanguageDictionary(languageCode);
 
   if (languageDictionary === null) {
@@ -152,13 +151,3 @@ function getFormattedPhrase(phrasePropositions, argumentsForFormatters) {
 
   return formattedPhrasePropositions;
 }
-
-export {
-  registerLanguage as registerLanguageDictionary,
-  getLanguage as getLanguageDictionary,
-  hasLanguage as hasLanguageDictionary,
-  getDefaultLanguage as getDefaultLanguageDictionary,
-  getLanguages as getLanguagesDictionaries,
-  getTranslatedPhrase,
-  DEFAULT_LANGUAGE_CODE,
-};

--- a/src/i18n/utils.js
+++ b/src/i18n/utils.js
@@ -2,7 +2,6 @@ import { isUndefined, isDefined } from './../helpers/mixed';
 import { objectEach } from './../helpers/object';
 import { error } from './../helpers/console';
 import { toSingleLine } from './../helpers/templateLiteralTag';
-import { DEFAULT_LANGUAGE_CODE, hasLanguageDictionary } from './registry';
 
 /**
  * Perform shallow extend of a target object with only this extension's properties which doesn't exist in the target.
@@ -64,24 +63,6 @@ export function normalizeLanguageCode(languageCode) {
   }
 
   return languageCode;
-}
-
-/**
- * Returns valid language code. If the passed language code doesn't exist default one will be used.
- *
- * @param {string} languageCode Language code for specific language i.e. 'en-US', 'pt-BR', 'de-DE'.
- * @returns {string}
- */
-export function getValidLanguageCode(languageCode) {
-  let normalizedLanguageCode = normalizeLanguageCode(languageCode);
-
-  if (!hasLanguageDictionary(normalizedLanguageCode)) {
-    normalizedLanguageCode = DEFAULT_LANGUAGE_CODE;
-
-    warnUserAboutLanguageRegistration(languageCode);
-  }
-
-  return normalizedLanguageCode;
 }
 
 /**


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes circular dependencies which can be found in the i18n module.

Additionally, the PR fixes the code formatting by splitting the summary exports into export assigned to particular functions. This prevents jumping between function declaration or so, and exports.

Rollup report:
![image](https://user-images.githubusercontent.com/571316/105844102-f69d2300-5fd8-11eb-91d8-1f8929eae1c6.png)

Moreover, the PR fixes an issue that would show up after the update eslint. This happens in the [monorepo project](https://github.com/handsontable/handsontable/pull/7434) ([eslint error](https://github.com/handsontable/handsontable/pull/7434/checks?check_run_id=1768731871#step:5:22)).

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested distribution files with Rollup and Webpack.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
