### PR TITLE
Allow customisable ignores for undo/redo

### DIFF
--- a/.changelogs/7500.json
+++ b/.changelogs/7500.json
@@ -1,0 +1,7 @@
+{
+  "title": "Added a flexible source option to UndoRedo. You can now specify custom sources to allow changes to skip the undo/redo buffer.",
+  "type": "added",
+  "issue": 7500,
+  "breaking": false,
+  "framework": "none"
+}

--- a/src/plugins/undoRedo/undoRedo.js
+++ b/src/plugins/undoRedo/undoRedo.js
@@ -31,7 +31,7 @@ function UndoRedo(instance) {
   instance.addHook('afterChange', function(changes, source) {
     const changesLen = changes && changes.length;
 
-    if (!changesLen || ['UndoRedo.undo', 'UndoRedo.redo', 'MergeCells'].includes(source)) {
+    if (!changesLen || ['UndoRedo.undo', 'UndoRedo.redo', 'MergeCells'].includes(source) || source.startsWith("UndoRedo.Ignore.")) {
       return;
     }
     const hasDifferences = changes.find((change) => {


### PR DESCRIPTION
### Context
I am managing real time replication between several Handsontable instances, each in a different users browser. Without a way of storing row meta I have to resort to using a hidden column at the beginning of the row to store some state about that row (e.g. 'who last edited the row'?)

It's hard to push updates to this hidden column and keep undo/redo working. I've been using `MergeCells' as a source to avoid things being logged in the undo/redo buffers but I need more flexibility.

This relatively minor change gives a flexible 'startsWith' key that's clearly only specific to the UndoRedo plugin so that I can more flexibly ignore undo/redo events whilst still specifying unique sources for things like `afterChange` to use to make different decisions depending on the action.

### How has this been tested?
Locally, I built this branch and used the change

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. Allows me to work around https://github.com/handsontable/handsontable/issues/4901 and has many other applications for people updating columns programmatically who don't want to break the user's undo/redo

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [X] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation
