### PR TITLE
The `AutoRowSize` plugin won't break the table in specific case

### DIFF
--- a/.changelogs/7424.json
+++ b/.changelogs/7424.json
@@ -1,0 +1,7 @@
+{
+  "title": "The `AutoRowSize` plugin won't break the table in specific case",
+  "type": "fixed",
+  "issue": 7424,
+  "breaking": false,
+  "framework": "none"
+}

--- a/src/plugins/autoRowSize/__tests__/autoRowSize.spec.js
+++ b/src/plugins/autoRowSize/__tests__/autoRowSize.spec.js
@@ -530,4 +530,21 @@ describe('AutoRowSize', () => {
 
     expect(calculateColumnsWidth).not.toHaveBeenCalled();
   });
+
+  it('should not throw error while traversing header\'s DOM elements', () => {
+    const onErrorSpy = spyOn(window, 'onerror');
+
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(5, 5),
+      colHeaders: true,
+      autoRowSize: true,
+      afterGetColHeader(column, TH) {
+        const TR = TH.parentNode;
+
+        return TR.parentNode; // TH element hadn't parent until fix introduction within #7424.
+      }
+    });
+
+    expect(onErrorSpy).not.toHaveBeenCalled();
+  });
 });

--- a/src/utils/ghostTable.js
+++ b/src/utils/ghostTable.js
@@ -273,7 +273,7 @@ class GhostTable {
   }
 
   /**
-   * Creating DOM elements for headers and adding them to the document.
+   * Creates DOM elements for headers and appends them to the THEAD element of the table.
    */
   appendColumnHeadersRow() {
     const { rootDocument } = this.hot;

--- a/src/utils/ghostTable.js
+++ b/src/utils/ghostTable.js
@@ -98,7 +98,9 @@ class GhostTable {
       this.table = this.createTable(this.hot.table.className);
 
       this.table.colGroup.appendChild(this.createColGroupsCol());
-      this.table.tHead.appendChild(this.createColumnHeadersRow());
+
+      this.appendColumnHeadersRow();
+
       this.container.container.appendChild(this.table.fragment);
 
       rowObject.table = this.table.table;
@@ -270,30 +272,40 @@ class GhostTable {
     return fragment;
   }
 
-  createColumnHeadersRow() {
+  /**
+   * Creating DOM elements for headers and adding them to the document.
+   */
+  appendColumnHeadersRow() {
     const { rootDocument } = this.hot;
-    const fragment = rootDocument.createDocumentFragment();
+    const domFragment = rootDocument.createDocumentFragment();
+    const columnHeaders = [];
 
     if (this.hot.hasRowHeaders()) {
       const th = rootDocument.createElement('th');
-      this.hot.view.appendColHeader(-1, th);
-      fragment.appendChild(th);
+
+      columnHeaders.push([-1, th]);
+      domFragment.appendChild(th);
     }
 
     this.samples.forEach((sample) => {
       arrayEach(sample.strings, (string) => {
         const column = string.col;
-
         const th = rootDocument.createElement('th');
 
-        // Please keep in mind that the renderable column index equal to the visual columns index for the GhostTable.
-        // We render all columns.
-        this.hot.view.appendColHeader(column, th);
-        fragment.appendChild(th);
+        columnHeaders.push([column, th]);
+        domFragment.appendChild(th);
       });
     });
 
-    return fragment;
+    // Appending DOM elements for headers
+    this.table.tHead.appendChild(domFragment);
+
+    arrayEach(columnHeaders, (columnHeader) => {
+      const [column, th] = columnHeader;
+
+      // Using source method for filling a header with value.
+      this.hot.view.appendColHeader(column, th);
+    });
   }
 
   /**


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The  `AutoRowSize` is using the `GhosTable` which builds HTML elements to predict size of Handsontable instance. To make prediction quite accurate it executes original function building headers.

https://github.com/handsontable/handsontable/blob/7e59ce2b28153eba08f81d5f5699535cd65019cd/src/utils/ghostTable.js#L279
https://github.com/handsontable/handsontable/blob/7e59ce2b28153eba08f81d5f5699535cd65019cd/src/utils/ghostTable.js#L291

However, the method has been called for HTML element not attached to parent. Thus, some DOM traversing actions have been throwing error. I changed a way how elements are created.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
With `nestedHeaders` & `collapsibleColumns` & `autoRowSize` & `colHeaders` settings.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7424 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] My change requires a change to the documentation.
