### PR TITLE
Fixed wrong paddings for multi-level headers

### DIFF
--- a/.changelogs/5086.json
+++ b/.changelogs/5086.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fixed wrong paddings for multi-level headers",
+  "type": "fixed",
+  "issue": 5086,
+  "breaking": false,
+  "framework": "none"
+}

--- a/src/css/bootstrap.css
+++ b/src/css/bootstrap.css
@@ -45,7 +45,7 @@
 .handsontable .table > thead > tr > td,
 .handsontable .table > thead > tr > th {
   line-height: 21px;
-  padding: 0 4px;
+  padding: 0;
 }
 
 .col-lg-1.handsontable, .col-lg-10.handsontable, .col-lg-11.handsontable, .col-lg-12.handsontable,


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The `0.36.0-beta1`/`1.11.0-beta1` release of Handsontable introduced change in a way how reset CSS for Bootstrap is provided. Within #4070 issue previous `boootstrap.css` file **started to be included** as part of the bundle (https://github.com/handsontable/handsontable/commit/059215b6fc25740a6d80d8d81542b18e137781ed#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556R3).

A user defined `table` class for an instance of Handsontable. Bootstrap is using this class and the reset CSS defines it also. Thus, it affected user application.

I've checked how padding works when there is included Bootstrap 2+. For every version of library it hasn't looked good. Thus, I don't know what was a reason for adding padding with value `0 4 px`. I can't see any reason for leaving it. That's why I changed it.


<table>
</table>

<table>

<tr>
  <th colspan=2>Bootstrap 2
<tr>
  <th>before change
  <th>after change
<tr>
	<td><img src="https://user-images.githubusercontent.com/141330/106745029-dc8ac280-6620-11eb-9a6b-fc571823232c.png">
	<td><img src="https://user-images.githubusercontent.com/141330/106745033-ddbbef80-6620-11eb-8cfe-044fe74051ad.png">

<tr>
  <th colspan=2>Bootstrap 3
<tr>
  <th>before change
  <th>after change
<tr>
	<td><img src="https://user-images.githubusercontent.com/141330/106744856-959ccd00-6620-11eb-9bfc-1596efae7332.png">
	<td><img src="https://user-images.githubusercontent.com/141330/106744853-946ba000-6620-11eb-991e-6c7ba187783f.png">


<tr>
  <th colspan=2>Bootstrap 4
<tr>
  <th>before change
  <th>after change
<tr>
	<td><img src="https://user-images.githubusercontent.com/141330/106745889-05f81e00-6622-11eb-8cc0-3bf553167db9.png">
	<td><img src="https://user-images.githubusercontent.com/141330/106745880-04c6f100-6622-11eb-97e6-58949978fe12.png">


<tr>
  <th colspan=2>Bootstrap 5.0.0-beta1
<tr>
  <th>before change
  <th>after change
<tr>
	<td><img src="https://user-images.githubusercontent.com/141330/106746254-90d91880-6622-11eb-9027-b3863704100a.png">
	<td><img src="https://user-images.githubusercontent.com/141330/106746251-90408200-6622-11eb-906f-1474cce05b13.png">
</table>

Please keep in mind that Handsontable doesn't look good with Boostrap. However, I haven't touched it as it is beyond scope of the task.


### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I've checked the change on every supported browser with/without Bootstrap 2+ library.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #5086 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] My change requires a change to the documentation.
