### PR TITLE
Value population from an edited cell won't result in a console error

### DIFF
--- a/.changelogs/7382.json
+++ b/.changelogs/7382.json
@@ -1,0 +1,7 @@
+{
+  "title": "Value population from an edited cell won't result in a console error",
+  "type": "fixed",
+  "issue": 7382,
+  "breaking": false,
+  "framework": "none"
+}

--- a/src/editors/baseEditor/baseEditor.js
+++ b/src/editors/baseEditor/baseEditor.js
@@ -197,8 +197,8 @@ export class BaseEditor {
     if (ctrlDown) {
       const selectedLast = this.hot.getSelectedLast();
 
-      visualRowFrom = Math.min(selectedLast[0], selectedLast[2]);
-      visualColumnFrom = Math.min(selectedLast[1], selectedLast[3]);
+      visualRowFrom = Math.max(Math.min(selectedLast[0], selectedLast[2]), 0); // Math.max eliminate headers coords.
+      visualColumnFrom = Math.max(Math.min(selectedLast[1], selectedLast[3]), 0); // Math.max eliminate headers coords.
       visualRowTo = Math.max(selectedLast[0], selectedLast[2]);
       visualColumnTo = Math.max(selectedLast[1], selectedLast[3]);
 

--- a/src/plugins/hiddenColumns/__tests__/editors.spec.js
+++ b/src/plugins/hiddenColumns/__tests__/editors.spec.js
@@ -35,6 +35,60 @@ describe('HiddenColumns', () => {
 
       expect($mainHolder.scrollLeft()).toBe(startScrollLeft);
     });
+
+    it('should populate value from an editor properly when there are some hidden columns & row header was selected', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        hiddenColumns: {
+          columns: [0, 1],
+          indicators: true
+        }
+      });
+
+      const firstHeader = spec().$container.find('.ht_clone_left tr:eq(1) th:eq(0)');
+
+      simulateClick(firstHeader, 'LMB');
+
+      keyDownUp('enter');
+      keyDownUp('ctrl+enter');
+
+      expect(getData()).toEqual([
+        ['C1', 'C1', 'C1', 'C1', 'C1'],
+        ['A2', 'B2', 'C2', 'D2', 'E2'],
+        ['A3', 'B3', 'C3', 'D3', 'E3'],
+        ['A4', 'B4', 'C4', 'D4', 'E4'],
+        ['A5', 'B5', 'C5', 'D5', 'E5'],
+      ]);
+    });
+
+    it('should populate value from an editor properly when there are some hidden columns & corner was selected', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        hiddenColumns: {
+          columns: [0, 1],
+          indicators: true
+        }
+      });
+
+      const corner = $('.ht_clone_top_left_corner .htCore').find('thead').find('th').eq(0);
+
+      simulateClick(corner, 'LMB');
+
+      keyDownUp('enter');
+      keyDownUp('ctrl+enter');
+
+      expect(getData()).toEqual([
+        ['C1', 'C1', 'C1', 'C1', 'C1'],
+        ['C1', 'C1', 'C1', 'C1', 'C1'],
+        ['C1', 'C1', 'C1', 'C1', 'C1'],
+        ['C1', 'C1', 'C1', 'C1', 'C1'],
+        ['C1', 'C1', 'C1', 'C1', 'C1'],
+      ]);
+    });
   });
 
   describe('Data change by typing with hiddenColumns', () => {

--- a/src/plugins/hiddenRows/__tests__/editors.spec.js
+++ b/src/plugins/hiddenRows/__tests__/editors.spec.js
@@ -35,5 +35,59 @@ describe('HiddenRows', () => {
 
       expect($mainHolder.scrollTop()).toBe(startScrollTop);
     });
+
+    it('should populate value from an editor properly when there are some hidden rows & column header was selected', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        hiddenRows: {
+          rows: [0, 1],
+          indicators: true
+        }
+      });
+
+      const firstHeader = spec().$container.find('.ht_clone_top tr:eq(0) th:eq(1)');
+
+      simulateClick(firstHeader, 'LMB');
+
+      keyDownUp('enter');
+      keyDownUp('ctrl+enter');
+
+      expect(getData()).toEqual([
+        ['A3', 'B1', 'C1', 'D1', 'E1'],
+        ['A3', 'B2', 'C2', 'D2', 'E2'],
+        ['A3', 'B3', 'C3', 'D3', 'E3'],
+        ['A3', 'B4', 'C4', 'D4', 'E4'],
+        ['A3', 'B5', 'C5', 'D5', 'E5'],
+      ]);
+    });
+
+    it('should populate value from an editor properly when there are some hidden rows & corner was selected', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        hiddenRows: {
+          rows: [0, 1],
+          indicators: true
+        }
+      });
+
+      const corner = $('.ht_clone_top_left_corner .htCore').find('thead').find('th').eq(0);
+
+      simulateClick(corner, 'LMB');
+
+      keyDownUp('enter');
+      keyDownUp('ctrl+enter');
+
+      expect(getData()).toEqual([
+        ['A3', 'A3', 'A3', 'A3', 'A3'],
+        ['A3', 'A3', 'A3', 'A3', 'A3'],
+        ['A3', 'A3', 'A3', 'A3', 'A3'],
+        ['A3', 'A3', 'A3', 'A3', 'A3'],
+        ['A3', 'A3', 'A3', 'A3', 'A3'],
+      ]);
+    });
   });
 });


### PR DESCRIPTION
### Context
Handsontable `8.0.0` introduced change in a way how selection is represented (it returns also coords for headers). There was not found attempt to read cell meta from header (they don't have meta). Therefore an error has been thrown.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Manual tests - selecting cells by headers and corner also when there are some hidden rows/columns.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7382 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] My change requires a change to the documentation.
