### PR TITLE
Fixed bugs in navigation by HOME and END keys when there are some hidden rows/columns

### DIFF
--- a/.changelogs/7454.json
+++ b/.changelogs/7454.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fixed bugs in navigation by HOME and END keys when there are some hidden rows/columns",
+  "type": "fixed",
+  "issue": 7454,
+  "breaking": false,
+  "framework": "none"
+}

--- a/src/editorManager.js
+++ b/src/editorManager.js
@@ -506,9 +506,14 @@ class EditorManager {
 
       case KEY_CODES.HOME:
         if (event.ctrlKey || event.metaKey) {
-          rangeModifier.call(this.selection, new CellCoords(0, this.selection.selectedRange.current().from.col));
+          rangeModifier.call(this.selection,
+            new CellCoords(
+              this.instance.rowIndexMapper.getFirstNotHiddenIndex(0, 1),
+              this.selection.selectedRange.current().from.col));
         } else {
-          rangeModifier.call(this.selection, new CellCoords(this.selection.selectedRange.current().from.row, 0));
+          rangeModifier.call(this.selection,
+            new CellCoords(this.selection.selectedRange.current().from.row,
+              this.instance.columnIndexMapper.getFirstNotHiddenIndex(0, 1)));
         }
         event.preventDefault(); // don't scroll the window
         event.stopPropagation();
@@ -518,12 +523,14 @@ class EditorManager {
         if (event.ctrlKey || event.metaKey) {
           rangeModifier.call(
             this.selection,
-            new CellCoords(this.instance.countRows() - 1, this.selection.selectedRange.current().from.col)
+            new CellCoords(this.instance.rowIndexMapper.getFirstNotHiddenIndex(this.instance.countRows() - 1, -1),
+              this.selection.selectedRange.current().from.col)
           );
         } else {
           rangeModifier.call(
             this.selection,
-            new CellCoords(this.selection.selectedRange.current().from.row, this.instance.countCols() - 1)
+            new CellCoords(this.selection.selectedRange.current().from.row,
+              this.instance.columnIndexMapper.getFirstNotHiddenIndex(this.instance.countCols() - 1, -1))
           );
         }
         event.preventDefault(); // don't scroll the window

--- a/src/plugins/hiddenColumns/__tests__/navigation.spec.js
+++ b/src/plugins/hiddenColumns/__tests__/navigation.spec.js
@@ -969,5 +969,181 @@ describe('HiddenColumns', () => {
         });
       });
     });
+
+    describe('should go to the closest not hidden cell while navigating', () => {
+      it('by HOME key', () => {
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(5, 5),
+          hiddenColumns: {
+            columns: [0, 1, 3],
+          },
+        });
+
+        selectCell(4, 4);
+
+        keyDownUp('home');
+
+        expect(`
+        |   :   |
+        |   :   |
+        |   :   |
+        |   :   |
+        | # :   |
+        `).toBeMatchToSelectionPattern();
+        expect(getSelected()).toEqual([[4, 2, 4, 2]]);
+        expect(getSelectedRangeLast().highlight.row).toBe(4);
+        expect(getSelectedRangeLast().highlight.col).toBe(2);
+        expect(getSelectedRangeLast().from.row).toBe(4);
+        expect(getSelectedRangeLast().from.col).toBe(2);
+        expect(getSelectedRangeLast().to.row).toBe(4);
+        expect(getSelectedRangeLast().to.col).toBe(2);
+      });
+
+      it('by ctrl + HOME key', () => {
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(5, 5),
+          hiddenColumns: {
+            columns: [0, 1, 3],
+          },
+        });
+
+        selectCell(4, 4);
+
+        keyDown('ctrl');
+        keyDownUp('home', { ctrlKey: true });
+
+        expect(`
+        |   : A |
+        |   :   |
+        |   :   |
+        |   :   |
+        |   : 0 |
+        `).toBeMatchToSelectionPattern();
+
+        expect(getSelected()).toEqual([[4, 4, 4, 4], [0, 4, 0, 4]]);
+        expect(getSelectedRangeLast().highlight.row).toBe(0);
+        expect(getSelectedRangeLast().highlight.col).toBe(4);
+        expect(getSelectedRangeLast().from.row).toBe(0);
+        expect(getSelectedRangeLast().from.col).toBe(4);
+        expect(getSelectedRangeLast().to.row).toBe(0);
+        expect(getSelectedRangeLast().to.col).toBe(4);
+      });
+
+      it('by shift + HOME key', () => {
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(5, 5),
+          hiddenColumns: {
+            columns: [0, 1, 3],
+          },
+        });
+
+        selectCell(4, 4);
+
+        keyDown('shift');
+        keyDownUp('home', { shiftKey: true });
+
+        expect(`
+        |   :   |
+        |   :   |
+        |   :   |
+        |   :   |
+        | 0 : A |
+        `).toBeMatchToSelectionPattern();
+
+        expect(getSelected()).toEqual([[4, 4, 4, 2]]);
+        expect(getSelectedRangeLast().highlight.row).toBe(4);
+        expect(getSelectedRangeLast().highlight.col).toBe(4);
+        expect(getSelectedRangeLast().from.row).toBe(4);
+        expect(getSelectedRangeLast().from.col).toBe(4);
+        expect(getSelectedRangeLast().to.row).toBe(4);
+        expect(getSelectedRangeLast().to.col).toBe(2);
+      });
+
+      it('by END key', () => {
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(5, 5),
+          hiddenColumns: {
+            columns: [1, 3, 4],
+          },
+        });
+
+        selectCell(0, 0);
+
+        keyDownUp('end');
+
+        expect(`
+        |   : # |
+        |   :   |
+        |   :   |
+        |   :   |
+        |   :   |
+        `).toBeMatchToSelectionPattern();
+        expect(getSelected()).toEqual([[0, 2, 0, 2]]);
+        expect(getSelectedRangeLast().highlight.row).toBe(0);
+        expect(getSelectedRangeLast().highlight.col).toBe(2);
+        expect(getSelectedRangeLast().from.row).toBe(0);
+        expect(getSelectedRangeLast().from.col).toBe(2);
+        expect(getSelectedRangeLast().to.row).toBe(0);
+        expect(getSelectedRangeLast().to.col).toBe(2);
+      });
+
+      it('by ctrl + END key', () => {
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(5, 5),
+          hiddenColumns: {
+            columns: [1, 3, 4],
+          },
+        });
+
+        selectCell(0, 0);
+
+        keyDown('ctrl');
+        keyDownUp('end', { ctrlKey: true });
+
+        expect(`
+        | 0 :   |
+        |   :   |
+        |   :   |
+        |   :   |
+        | A :   |
+        `).toBeMatchToSelectionPattern();
+        expect(getSelected()).toEqual([[0, 0, 0, 0], [4, 0, 4, 0]]);
+        expect(getSelectedRangeLast().highlight.row).toBe(4);
+        expect(getSelectedRangeLast().highlight.col).toBe(0);
+        expect(getSelectedRangeLast().from.row).toBe(4);
+        expect(getSelectedRangeLast().from.col).toBe(0);
+        expect(getSelectedRangeLast().to.row).toBe(4);
+        expect(getSelectedRangeLast().to.col).toBe(0);
+      });
+
+      it('by shift + END key', () => {
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(5, 5),
+          hiddenColumns: {
+            columns: [1, 3, 4],
+          },
+        });
+
+        selectCell(0, 0);
+
+        keyDown('shift');
+        keyDownUp('end', { shiftKey: true });
+
+        expect(`
+        | A : 0 |
+        |   :   |
+        |   :   |
+        |   :   |
+        |   :   |
+        `).toBeMatchToSelectionPattern();
+        expect(getSelected()).toEqual([[0, 0, 0, 2]]);
+        expect(getSelectedRangeLast().highlight.row).toBe(0);
+        expect(getSelectedRangeLast().highlight.col).toBe(0);
+        expect(getSelectedRangeLast().from.row).toBe(0);
+        expect(getSelectedRangeLast().from.col).toBe(0);
+        expect(getSelectedRangeLast().to.row).toBe(0);
+        expect(getSelectedRangeLast().to.col).toBe(2);
+      });
+    });
   });
 });

--- a/src/plugins/hiddenRows/__tests__/navigation.spec.js
+++ b/src/plugins/hiddenRows/__tests__/navigation.spec.js
@@ -868,5 +868,163 @@ describe('HiddenRows', () => {
         });
       });
     });
+
+    describe('should go to the closest not hidden cell while navigating', () => {
+      it('by HOME key', () => {
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(5, 5),
+          hiddenRows: {
+            rows: [0, 1, 3],
+          },
+        });
+
+        selectCell(4, 4);
+
+        keyDownUp('home');
+
+        expect(`
+        |   :   :   :   :   |
+        | # :   :   :   :   |
+        `).toBeMatchToSelectionPattern();
+        expect(getSelected()).toEqual([[4, 0, 4, 0]]);
+        expect(getSelectedRangeLast().highlight.row).toBe(4);
+        expect(getSelectedRangeLast().highlight.col).toBe(0);
+        expect(getSelectedRangeLast().from.row).toBe(4);
+        expect(getSelectedRangeLast().from.col).toBe(0);
+        expect(getSelectedRangeLast().to.row).toBe(4);
+        expect(getSelectedRangeLast().to.col).toBe(0);
+      });
+
+      it('by ctrl + HOME key', () => {
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(5, 5),
+          hiddenRows: {
+            rows: [0, 1, 3],
+          },
+        });
+
+        selectCell(4, 4);
+
+        keyDown('ctrl');
+        keyDownUp('home', { ctrlKey: true });
+
+        expect(`
+        |   :   :   :   : A |
+        |   :   :   :   : 0 |
+        `).toBeMatchToSelectionPattern();
+
+        expect(getSelected()).toEqual([[4, 4, 4, 4], [2, 4, 2, 4]]);
+        expect(getSelectedRangeLast().highlight.row).toBe(2);
+        expect(getSelectedRangeLast().highlight.col).toBe(4);
+        expect(getSelectedRangeLast().from.row).toBe(2);
+        expect(getSelectedRangeLast().from.col).toBe(4);
+        expect(getSelectedRangeLast().to.row).toBe(2);
+        expect(getSelectedRangeLast().to.col).toBe(4);
+      });
+
+      it('by shift + HOME key', () => {
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(5, 5),
+          hiddenRows: {
+            rows: [0, 1, 3],
+          },
+        });
+
+        selectCell(4, 4);
+
+        keyDown('shift');
+        keyDownUp('home', { shiftKey: true });
+
+        expect(`
+        |   :   :   :   :   |
+        | 0 : 0 : 0 : 0 : A |
+        `).toBeMatchToSelectionPattern();
+
+        expect(getSelected()).toEqual([[4, 4, 4, 0]]);
+        expect(getSelectedRangeLast().highlight.row).toBe(4);
+        expect(getSelectedRangeLast().highlight.col).toBe(4);
+        expect(getSelectedRangeLast().from.row).toBe(4);
+        expect(getSelectedRangeLast().from.col).toBe(4);
+        expect(getSelectedRangeLast().to.row).toBe(4);
+        expect(getSelectedRangeLast().to.col).toBe(0);
+      });
+
+      it('by END key', () => {
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(5, 5),
+          hiddenRows: {
+            rows: [1, 3, 4],
+          },
+        });
+
+        selectCell(0, 0);
+
+        keyDownUp('end');
+
+        expect(`
+        |   :   :   :   : # |
+        |   :   :   :   :   |
+        `).toBeMatchToSelectionPattern();
+        expect(getSelected()).toEqual([[0, 4, 0, 4]]);
+        expect(getSelectedRangeLast().highlight.row).toBe(0);
+        expect(getSelectedRangeLast().highlight.col).toBe(4);
+        expect(getSelectedRangeLast().from.row).toBe(0);
+        expect(getSelectedRangeLast().from.col).toBe(4);
+        expect(getSelectedRangeLast().to.row).toBe(0);
+        expect(getSelectedRangeLast().to.col).toBe(4);
+      });
+
+      it('by ctrl + END key', () => {
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(5, 5),
+          hiddenRows: {
+            rows: [1, 3, 4],
+          },
+        });
+
+        selectCell(0, 0);
+
+        keyDown('ctrl');
+        keyDownUp('end', { ctrlKey: true });
+
+        expect(`
+        | 0 :   :   :   :   |
+        | A :   :   :   :   |
+        `).toBeMatchToSelectionPattern();
+        expect(getSelected()).toEqual([[0, 0, 0, 0], [2, 0, 2, 0]]);
+        expect(getSelectedRangeLast().highlight.row).toBe(2);
+        expect(getSelectedRangeLast().highlight.col).toBe(0);
+        expect(getSelectedRangeLast().from.row).toBe(2);
+        expect(getSelectedRangeLast().from.col).toBe(0);
+        expect(getSelectedRangeLast().to.row).toBe(2);
+        expect(getSelectedRangeLast().to.col).toBe(0);
+      });
+
+      it('by shift + END key', () => {
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(5, 5),
+          hiddenRows: {
+            rows: [1, 3, 4],
+          },
+        });
+
+        selectCell(0, 0);
+
+        keyDown('shift');
+        keyDownUp('end', { shiftKey: true });
+
+        expect(`
+        | A : 0 : 0 : 0 : 0 |
+        |   :   :   :   :   |
+        `).toBeMatchToSelectionPattern();
+        expect(getSelected()).toEqual([[0, 0, 0, 4]]);
+        expect(getSelectedRangeLast().highlight.row).toBe(0);
+        expect(getSelectedRangeLast().highlight.col).toBe(0);
+        expect(getSelectedRangeLast().from.row).toBe(0);
+        expect(getSelectedRangeLast().from.col).toBe(0);
+        expect(getSelectedRangeLast().to.row).toBe(0);
+        expect(getSelectedRangeLast().to.col).toBe(4);
+      });
+    });
   });
 });

--- a/test/helpers/common.js
+++ b/test/helpers/common.js
@@ -444,6 +444,14 @@ export function handsontableKeyTriggerFactory(type) {
           ev.keyCode = 32;
           break;
 
+        case 'home':
+          ev.keyCode = 36;
+          break;
+
+        case 'end':
+          ev.keyCode = 35;
+          break;
+
         case 'x':
           ev.keyCode = 88;
           break;


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Handsontable `8.0.0` introduced change in a way how we navigate when there are some hidden rows or columns. There were some changes which made consistent that UI actions such as clicks and keyboard navigation works only on not hidden indexes. However, some actions (from title of the issue) haven't been completed. This issue provide a fix.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Manual tests with `HOME`, `END`, `shift`, `ctrl`, `cmd` keys.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7454

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] My change requires a change to the documentation.
