### PR TITLE
Update typescript types in order to allow undefined for colWidths.

### DIFF
--- a/handsontable.d.ts
+++ b/handsontable.d.ts
@@ -1656,7 +1656,7 @@ declare namespace Handsontable {
     columns?: ColumnSettings[] | ((index: number) => ColumnSettings);
     columnSorting?: boolean | columnSorting.Settings;
     columnSummary?: columnSummary.Settings[] | (() => columnSummary.Settings[]);
-    colWidths?: number | number[] | string | string[] | ((index: number) => string | number);
+    colWidths?: number | (number | undefined)[] | string | (string | undefined)[] | ((index: number) => string | number | undefined);
     commentedCellClassName?: string;
     comments?: boolean | comments.Settings | comments.CommentConfig[];
     contextMenu?: boolean | contextMenu.PredefinedMenuItemKey[] | contextMenu.Settings;

--- a/src/dataMap/metaManager/metaSchema.js
+++ b/src/dataMap/metaManager/metaSchema.js
@@ -286,9 +286,11 @@ export default () => {
      * Defines column widths in pixels. Accepts number, string (that will be converted to a number), array of numbers
      * (if you want to define column width separately for each column) or a function (if you want to set column width
      * dynamically on each render).
+     * 
+     * Note that this option will disable {@link AutoColumnSize} plugin.
      *
      * @memberof Options#
-     * @type {number|number[]|string|string[]|Function}
+     * @type {number|(number|undefined)[]|string|(string|undefined)[]|Function}
      * @default undefined
      *
      * @example
@@ -299,8 +301,8 @@ export default () => {
      * // as a string, for each column.
      * colWidths: '100px',
      *
-     * // as an array, based on visual indexes. The rest of the columns have a default width.
-     * colWidths: [100, 120, 90],
+     * // as an array, based on visual indexes. Unspecified columns have a default width.
+     * colWidths: [100, 120, undefined, 90],
      *
      * // as a function, based on visual indexes.
      * colWidths: function(index) {


### PR DESCRIPTION
### Context
The PR partially fixes #7507 by allowing `undefined` to be given in `colWidths` for Typescript users.

The crucial part is to modify the `handsontable.d.ts` file in order to allow `undefined` to be given. I then made a suggestion for the documentation but I have not been able to see how it actually renders. I also explained that activating the `colWidths` option would disabled the `autoColumnSize` plugin because that's an information I would like to see but maybe that's irrelevant. I'll let you be the judge of that, I can only ship the `handsontable.d.ts` modification and let you handle the documentation.


### How has this been tested?
No test was added.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7507 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [X] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [X] My change requires a change to the documentation.
