### PR TITLE
Remove the 7516.json changelog file.

### DIFF
--- a/.changelogs/7516.json
+++ b/.changelogs/7516.json
@@ -1,7 +1,0 @@
-{
-  "title": "Fixed an issue where the CSS files could be eliminated during tree-shaking",
-  "type": "fixed",
-  "issue": 7516,
-  "breaking": false,
-  "framework": "none"
-}


### PR DESCRIPTION
### Context
One of the changelog files was not removed after the release branch merge for `8.3.1`.

[skip changelog]