### PR TITLE
Fix comments editor while destroying some HOT instance

### DIFF
--- a/.changelogs/7091.json
+++ b/.changelogs/7091.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fix comments editor while destroying some HOT instance",
+  "type": "fixed",
+  "issue": 7091,
+  "breaking": false,
+  "framework": "none"
+}

--- a/src/plugins/comments/__tests__/comments.spec.js
+++ b/src/plugins/comments/__tests__/comments.spec.js
@@ -864,4 +864,69 @@ describe('Comments', () => {
       expect(plugin.getComment()).toEqual('Bar');
     });
   });
+
+  describe('Destroying the plugin with two instances of Handsontable', () => {
+    it('should create two containers for comments for two HOT instances', () => {
+      const container1 = $('<div id="hot1"></div>').appendTo(spec().$container).handsontable({
+        data: Handsontable.helper.createSpreadsheetData(6, 6),
+        cell: [
+          { row: 1, col: 1, comment: { value: 'Hello world!' } },
+          { row: 1, col: 2, comment: { value: 'Yes!' } }
+        ],
+        rowHeaders: true,
+        colHeaders: true,
+        comments: true,
+        licenseKey: 'non-commercial-and-evaluation'
+      });
+
+      const container2 = $('<div id="hot2"></div>').appendTo(spec().$container).handsontable({
+        data: Handsontable.helper.createSpreadsheetData(6, 6),
+        cell: [{ row: 1, col: 1, comment: { value: 'Hello world!' } }],
+        rowHeaders: true,
+        colHeaders: true,
+        comments: true,
+        licenseKey: 'non-commercial-and-evaluation'
+      });
+
+      const commentContainers = document.querySelectorAll('.htCommentsContainer');
+
+      expect(commentContainers.length).toEqual(2);
+
+      // cleanup HOT instances
+      container1.handsontable('destroy');
+      container2.handsontable('destroy');
+    });
+
+    it('should delete one container when one HOT instance is destroyed', () => {
+      const container1 = $('<div id="hot1"></div>').appendTo(spec().$container).handsontable({
+        data: Handsontable.helper.createSpreadsheetData(6, 6),
+        cell: [
+          { row: 1, col: 1, comment: { value: 'Hello world!' } },
+          { row: 1, col: 2, comment: { value: 'Yes!' } }
+        ],
+        rowHeaders: true,
+        colHeaders: true,
+        comments: true,
+        licenseKey: 'non-commercial-and-evaluation'
+      });
+
+      const container2 = $('<div id="hot2"></div>').appendTo(spec().$container).handsontable({
+        data: Handsontable.helper.createSpreadsheetData(6, 6),
+        cell: [{ row: 1, col: 1, comment: { value: 'Hello world!' } }],
+        rowHeaders: true,
+        colHeaders: true,
+        comments: true,
+        licenseKey: 'non-commercial-and-evaluation'
+      });
+
+      container2.handsontable('destroy');
+
+      const commentContainers = document.querySelectorAll('.htCommentsContainer');
+
+      expect(commentContainers.length).toEqual(1);
+
+      // cleanup HOT instance
+      container1.handsontable('destroy');
+    });
+  });
 });

--- a/src/plugins/comments/__tests__/comments.spec.js
+++ b/src/plugins/comments/__tests__/comments.spec.js
@@ -888,15 +888,19 @@ describe('Comments', () => {
         licenseKey: 'non-commercial-and-evaluation'
       });
 
-      const commentContainers = document.querySelectorAll('.htCommentsContainer');
+      let commentContainersLength = document.querySelectorAll('.htCommentsContainer').length;
 
-      expect(commentContainers.length).toEqual(2);
+      expect(commentContainersLength).toEqual(2);
 
-      // cleanup HOT instances
+      // cleanup first HOT instance
       container1.handsontable('destroy');
-      expect(commentContainers.length).toEqual(1);
+      commentContainersLength = document.querySelectorAll('.htCommentsContainer').length;
+      expect(commentContainersLength).toEqual(1);
+
+      // cleanup second HOT instance
       container2.handsontable('destroy');
-      expect(commentContainers.length).toEqual(0);
+      commentContainersLength = document.querySelectorAll('.htCommentsContainer').length;
+      expect(commentContainersLength).toEqual(0);
     });
 
     it('should delete one container when one HOT instance is destroyed', () => {
@@ -923,13 +927,14 @@ describe('Comments', () => {
 
       container2.handsontable('destroy');
 
-      const commentContainers = document.querySelectorAll('.htCommentsContainer');
+      let commentContainersLength = document.querySelectorAll('.htCommentsContainer').length;
 
-      expect(commentContainers.length).toEqual(1);
+      expect(commentContainersLength).toEqual(1);
 
       // cleanup HOT instance
       container1.handsontable('destroy');
-      expect(commentContainers.length).toEqual(0);
+      commentContainersLength = document.querySelectorAll('.htCommentsContainer').length;
+      expect(commentContainersLength).toEqual(0);
     });
   });
 });

--- a/src/plugins/comments/__tests__/comments.spec.js
+++ b/src/plugins/comments/__tests__/comments.spec.js
@@ -894,7 +894,9 @@ describe('Comments', () => {
 
       // cleanup HOT instances
       container1.handsontable('destroy');
+      expect(commentContainers.length).toEqual(1);
       container2.handsontable('destroy');
+      expect(commentContainers.length).toEqual(0);
     });
 
     it('should delete one container when one HOT instance is destroyed', () => {
@@ -927,6 +929,7 @@ describe('Comments', () => {
 
       // cleanup HOT instance
       container1.handsontable('destroy');
+      expect(commentContainers.length).toEqual(0);
     });
   });
 });

--- a/src/plugins/comments/commentEditor.js
+++ b/src/plugins/comments/commentEditor.js
@@ -150,7 +150,6 @@ class CommentEditor {
   createEditor() {
     const editor = this.rootDocument.createElement('div');
     const textArea = this.rootDocument.createElement('textarea');
-    this.container = this.rootDocument.querySelector(`.${CommentEditor.CLASS_EDITOR_CONTAINER}`);
 
     this.container = this.rootDocument.createElement('div');
     addClass(this.container, CommentEditor.CLASS_EDITOR_CONTAINER);

--- a/src/plugins/comments/commentEditor.js
+++ b/src/plugins/comments/commentEditor.js
@@ -152,11 +152,9 @@ class CommentEditor {
     const textArea = this.rootDocument.createElement('textarea');
     this.container = this.rootDocument.querySelector(`.${CommentEditor.CLASS_EDITOR_CONTAINER}`);
 
-    if (!this.container) {
-      this.container = this.rootDocument.createElement('div');
-      addClass(this.container, CommentEditor.CLASS_EDITOR_CONTAINER);
-      this.rootDocument.body.appendChild(this.container);
-    }
+    this.container = this.rootDocument.createElement('div');
+    addClass(this.container, CommentEditor.CLASS_EDITOR_CONTAINER);
+    this.rootDocument.body.appendChild(this.container);
 
     addClass(editor, CommentEditor.CLASS_EDITOR);
     addClass(textArea, CommentEditor.CLASS_INPUT);


### PR DESCRIPTION
### Context

When one of two HOT instances is destroyed, the comment editor for one instance should be preserved. The problem is that when one HOT instance is destroyed, the comments container was removed for both instances.

It was solved by creating a comment container for every HOT instance created.

### How has this been tested?

New tests were added to the `src/plugins/comments/__tests__/comments.spec.js` file.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/7091

