### PR TITLE
The native selection won't be deselected anymore when `fragmentSelection` option is enabled

### DIFF
--- a/.changelogs/6083.json
+++ b/.changelogs/6083.json
@@ -1,0 +1,7 @@
+{
+  "title": "The native selection won't be deselected anymore when `fragmentSelection` option is enabled",
+  "type": "fixed",
+  "issue": 6083,
+  "breaking": false,
+  "framework": "none"
+}

--- a/src/plugins/copyPaste/copyPaste.js
+++ b/src/plugins/copyPaste/copyPaste.js
@@ -608,7 +608,9 @@ export class CopyPaste extends BasePlugin {
    * @private
    */
   onAfterOnCellMouseUp() {
-    if (!this.hot.isListening() || this.isEditorOpened()) {
+    // Changing focused element will remove current selection. It's unnecessary in case when we give possibility
+    // for fragment selection
+    if (!this.hot.isListening() || this.isEditorOpened() || this.hot.getSettings().fragmentSelection) {
       return;
     }
 

--- a/test/e2e/settings/fragmentSelection.spec.js
+++ b/test/e2e/settings/fragmentSelection.spec.js
@@ -1,6 +1,6 @@
 describe('settings', () => {
 
-  xdescribe('fragmentSelection', () => {
+  describe('fragmentSelection', () => {
     const id = 'testContainer';
 
     beforeEach(function() {
@@ -71,7 +71,10 @@ describe('settings', () => {
 
         selectElementText(spec().$container.find('tr:eq(0) td:eq(1)')[0], 3);
 
-        mouseDown(spec().$container.find('tr:eq(0) td:eq(3)'));
+        // Simulating native selection of DOM elements.
+        mouseDown(spec().$container.find('tr:eq(0) td:eq(1)'));
+        mouseOver(spec().$container.find('tr:eq(0) td:eq(3)'));
+        selectElementText(spec().$container.find('td')[1], 3);
         mouseUp(spec().$container.find('tr:eq(0) td:eq(3)'));
 
         const sel = getSelected();
@@ -86,9 +89,11 @@ describe('settings', () => {
           fragmentSelection: true
         });
 
+        // Simulating native selection of DOM elements.
         mouseDown(spec().$container.find('tr:eq(0) td:eq(1)'));
-        mouseUp(spec().$container.find('tr:eq(0) td:eq(3)'));
+        mouseOver(spec().$container.find('tr:eq(0) td:eq(3)'));
         selectElementText(spec().$container.find('td')[1], 3);
+        mouseUp(spec().$container.find('tr:eq(0) td:eq(3)'));
 
         let sel = getSelected();
         sel = sel.replace(/\s/g, ''); // tabs and spaces between <td>s are inconsistent in browsers, so let's ignore them
@@ -105,8 +110,8 @@ describe('settings', () => {
         const $TD = spec().$container.find('tr:eq(0) td:eq(1)');
 
         mouseDown($TD);
-        mouseUp($TD);
         selectElementText($TD[0], 1);
+        mouseUp($TD);
 
         expect(getSelected().replace(/\s/g, '')).toEqual('B1');
       });
@@ -116,10 +121,10 @@ describe('settings', () => {
           data: Handsontable.helper.createSpreadsheetData(4, 4),
           fragmentSelection: 'cell'
         });
-        selectElementText(spec().$container.find('td')[1], 1);
 
         mouseDown(spec().$container.find('tr:eq(0) td:eq(1)'));
         mouseOver(spec().$container.find('tr:eq(0) td:eq(2)'));
+        selectElementText(spec().$container.find('td')[1], 1);
         mouseMove(spec().$container.find('tr:eq(0) td:eq(2)'));
         mouseUp(spec().$container.find('tr:eq(0) td:eq(2)'));
 
@@ -163,32 +168,34 @@ describe('settings', () => {
           data: Handsontable.helper.createSpreadsheetData(4, 4),
           fragmentSelection: true
         });
-        // updateSettings({ fragmentSelection: false });
-        selectElementText(spec().$container.find('tr:eq(0) td:eq(1)')[0], 3);
+
+        updateSettings({ fragmentSelection: false });
 
         mouseDown(spec().$container.find('tr:eq(0) td:eq(3)'));
+        selectElementText(spec().$container.find('tr:eq(0) td:eq(1)')[0], 3);
         mouseUp(spec().$container.find('tr:eq(0) td:eq(3)'));
 
         const sel = getSelected();
         expect(sel).toEqual(' '); // copyPaste has selected space in textarea
       });
 
-      xit('should allow fragmentSelection when set to true', () => {
-        // We have to try another way to simulate text selection.
+      it('should allow fragmentSelection when set to true', () => {
         handsontable({
           data: Handsontable.helper.createSpreadsheetData(4, 4),
           fragmentSelection: false
         });
+
         updateSettings({ fragmentSelection: true });
-        selectElementText(spec().$container.find('td')[1], 3);
 
         mouseDown(spec().$container.find('tr:eq(0) td:eq(3)'));
+        selectElementText(spec().$container.find('tr:eq(0) td:eq(1)')[0], 3);
         mouseUp(spec().$container.find('tr:eq(0) td:eq(3)'));
 
-        let sel = getSelected();
-        sel = sel.replace(/\s/g, ''); // tabs and spaces between <td>s are inconsistent in browsers, so let's ignore them
+        // tabs and spaces between <td>s are inconsistent in browsers, so let's ignore them
+        const sel = getSelected().replace(/\s/g, '');
+
         expect(sel).toEqual('B1C1D1');
       });
     });
-  }).pend('Temporarily disabled, due to #6083, needs to be rewritten to work properly.');
+  });
 });

--- a/test/e2e/settings/fragmentSelection.spec.js
+++ b/test/e2e/settings/fragmentSelection.spec.js
@@ -34,36 +34,30 @@ describe('settings', () => {
 
     /**
      * Selects a <fromEl> node at as many siblings as given in the <cells> value
-     * Note: IE8 fallback assumes that a node contains exactly one word.
      *
      * @param {HTMLElement} fromEl An element from the selection starts.
      * @param {number} siblings The number of siblings to process.
      */
     function selectElementText(fromEl, siblings) {
-      const doc = window.document;
       let element = fromEl;
       let numOfSiblings = siblings;
-      let sel;
-      let range;
 
-      if (window.getSelection && doc.createRange) { // standards
-        sel = window.getSelection();
-        range = doc.createRange();
-        range.setStartBefore(element, 0);
+      const sel = window.getSelection();
+      const range = window.document.createRange();
+      range.setStartBefore(element, 0);
 
-        while (numOfSiblings > 1) {
-          element = element.nextSibling;
-          numOfSiblings -= 1;
-        }
-
-        range.setEndAfter(element, 0);
-        sel.removeAllRanges();
-        sel.addRange(range);
+      while (numOfSiblings > 1) {
+        element = element.nextSibling;
+        numOfSiblings -= 1;
       }
+
+      range.setEndAfter(element, 0);
+      sel.removeAllRanges();
+      sel.addRange(range);
     }
 
     describe('constructor', () => {
-      it('should disallow fragmentSelection when set to false', () => {
+      it('should disallow fragmentSelection when set to false', async() => {
         handsontable({
           data: Handsontable.helper.createSpreadsheetData(4, 4),
           fragmentSelection: false


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Issue #5390 introduced big change in a way how the `CopyPaste` plugin works. However, [extra `focus`](https://github.com/handsontable/handsontable/pull/5390/files#diff-b6b6d41117204c41cc8741658c5038ab1b35a559ee272cfd17ef809bcfadded2R545) call introduced within the issue changes focused element unnecessary. We should base on native selection when `fragmentSelection` option is enabled.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I compared how Handsontable `6.0.1` and current Handsontable works for `fragmentSelection` set to `cell`, `true` and `false` values.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #6083
2. #6372
3. #5810

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] My change requires a change to the documentation.
