### PR TITLE
[Win10/Firefox]: Increase timeout to fix autocomplete (#7570)

### DIFF
--- a/.changelogs/7570.json
+++ b/.changelogs/7570.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fixed bug with autocomplete on Firefox in Win10",
+  "type": "fixed",
+  "issue": 7570,
+  "breaking": false,
+  "framework": "none"
+}

--- a/src/editors/autocompleteEditor/autocompleteEditor.js
+++ b/src/editors/autocompleteEditor/autocompleteEditor.js
@@ -463,7 +463,7 @@ export class AutocompleteEditor extends HandsontableEditor {
 
     if (isPrintableChar(event.keyCode) || event.keyCode === KEY_CODES.BACKSPACE ||
       event.keyCode === KEY_CODES.DELETE || event.keyCode === KEY_CODES.INSERT) {
-      let timeOffset = 0;
+      let timeOffset = 10;
 
       // on ctl+c / cmd+c don't update suggestion list
       if (event.keyCode === KEY_CODES.C && (event.ctrlKey || event.metaKey)) {


### PR DESCRIPTION
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### How has this been tested?

Manual tests

### Related issue(s):
1. #7570 
