### PR TITLE
`transform` `scale` PR IE `updateSettings`/window resize problem hot fix

### DIFF
--- a/src/helpers/dom/element.js
+++ b/src/helpers/dom/element.js
@@ -798,6 +798,9 @@ export function computeScaleX(element) {
   const dummyRect = dummy.getBoundingClientRect();
   const scaleX = dummyRect.width / factor;
 
+  // IE doesn't support `HTMLElement#remove()`
+  dummy.parentNode.removeChild(dummy);
+
   // On certain browsers (ehm, IE11 and below) if it is attempted to add
   // the dummy element to a `<table>` element, the browser won't treat is
   // as a proper element, as in `document.body.contains(dummy) === true`,

--- a/src/helpers/dom/element.js
+++ b/src/helpers/dom/element.js
@@ -775,6 +775,9 @@ export function outerWidth(element) {
  * element, relative to the root document. Involves adding a dummy element of a
  * constant size to the DOM, be cautious about performance.
  *
+ * Note that this will always return `1` on IE, see the lengthy comment
+ * inside the function body.
+ *
  * @param {HTMLElement} element An element to get the `scaleX` from.
  * @returns {number} `scaleX` value.
  */
@@ -795,8 +798,19 @@ export function computeScaleX(element) {
   const dummyRect = dummy.getBoundingClientRect();
   const scaleX = dummyRect.width / factor;
 
-  // IE doesn't support `HTMLElement#remove()`
-  dummy.parentNode.removeChild(dummy);
+  // On certain browsers (ehm, IE11 and below) if it is attempted to add
+  // the dummy element to a `<table>` element, the browser won't treat is
+  // as a proper element, as in `document.body.contains(dummy) === true`,
+  // but `dummy.getBoundingClientRect().width === 0`, always.
+  //
+  // The workaround will set the `scaleX` constant to 1, as on IE
+  // `.getBoundingClientRect()` doesn't need to be adjusted for any
+  // transforms since the browser already does it for us (in contrast to
+  // normal browsers where `.getBoundingClientRect()` always returns
+  // dimensions relative to the whole viewport).
+  if (scaleX === 0) {
+    return 1;
+  }
 
   return scaleX;
 }


### PR DESCRIPTION
### Context
It seems like with #7496 a problem was introduced on IE11 and below, where running `updateSettings` or resizing the browser window, causing the table to repaint, would cut out a column with the config option `data` set to `Handsontable.helper.createSpreadsheetData(4, 2)` (or similar).

In short, the problem was caused by IE not adding `div` elements to `<table>`'s the same way modern browsers do.

See the comment added inside the `preciseOuterWidth` function's body for more info.

### How has this been tested?
Tested manually on IE.

[skip changelog]