### PR TITLE
Firefox: fix e2e test for trimWhitespace

### DIFF
--- a/.changelogs/7593.json
+++ b/.changelogs/7593.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fix \"trimWhitespace\" tests on Firefox",
+  "type": "fixed",
+  "issue": 7593,
+  "breaking": false,
+  "framework": "none"
+}

--- a/test/e2e/settings/trimWhitespace.spec.js
+++ b/test/e2e/settings/trimWhitespace.spec.js
@@ -21,9 +21,9 @@ describe('settings', () => {
         ],
       });
 
-      const outerTextOfCell = getCell(0, 0).outerText;
+      const innerTextOfCell = getCell(0, 0).innerText;
 
-      expect(outerTextOfCell).toEqual('text    with    spaces');
+      expect(innerTextOfCell).toEqual('text    with    spaces');
     });
 
     it('should preserve whitespaces when trimWhitespace options is false', () => {
@@ -34,9 +34,9 @@ describe('settings', () => {
         ],
       });
 
-      const outerTextOfCell = getCell(0, 0).outerText;
+      const innerTextOfCell = getCell(0, 0).innerText;
 
-      expect(outerTextOfCell).toEqual('    text    with    spaces  ');
+      expect(innerTextOfCell).toEqual('    text    with    spaces  ');
     });
   });
 });


### PR DESCRIPTION
### Context

The `outerText` doesn't work in Firefox.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7593 

