### PR TITLE
Fix module exports file paths

### DIFF
--- a/.changelogs/7597.json
+++ b/.changelogs/7597.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fixed the cellTypes modules paths in the exports entry in the package.json file",
+  "type": "fixed",
+  "issue": 7597,
+  "breaking": false,
+  "framework": "none"
+}

--- a/package.json
+++ b/package.json
@@ -191,40 +191,40 @@
       "require": "./cellTypes/registry.js"
     },
     "./cellTypes/autocompleteType": {
-      "import": "./editors/autocompleteType/index.mjs",
-      "require": "./editors/autocompleteType/index.js"
+      "import": "./cellTypes/autocompleteType/index.mjs",
+      "require": "./cellTypes/autocompleteType/index.js"
     },
     "./cellTypes/checkboxType": {
-      "import": "./editors/checkboxType/index.mjs",
-      "require": "./editors/checkboxType/index.js"
+      "import": "./cellTypes/checkboxType/index.mjs",
+      "require": "./cellTypes/checkboxType/index.js"
     },
     "./cellTypes/dateType": {
-      "import": "./editors/dateType/index.mjs",
-      "require": "./editors/dateType/index.js"
+      "import": "./cellTypes/dateType/index.mjs",
+      "require": "./cellTypes/dateType/index.js"
     },
     "./cellTypes/dropdownType": {
-      "import": "./editors/dropdownType/index.mjs",
-      "require": "./editors/dropdownType/index.js"
+      "import": "./cellTypes/dropdownType/index.mjs",
+      "require": "./cellTypes/dropdownType/index.js"
     },
     "./cellTypes/handsontableType": {
-      "import": "./editors/handsontableType/index.mjs",
-      "require": "./editors/handsontableType/index.js"
+      "import": "./cellTypes/handsontableType/index.mjs",
+      "require": "./cellTypes/handsontableType/index.js"
     },
     "./cellTypes/numericType": {
-      "import": "./editors/numericType/index.mjs",
-      "require": "./editors/numericType/index.js"
+      "import": "./cellTypes/numericType/index.mjs",
+      "require": "./cellTypes/numericType/index.js"
     },
     "./cellTypes/passwordType": {
-      "import": "./editors/passwordType/index.mjs",
-      "require": "./editors/passwordType/index.js"
+      "import": "./cellTypes/passwordType/index.mjs",
+      "require": "./cellTypes/passwordType/index.js"
     },
     "./cellTypes/textType": {
-      "import": "./editors/textType/index.mjs",
-      "require": "./editors/textType/index.js"
+      "import": "./cellTypes/textType/index.mjs",
+      "require": "./cellTypes/textType/index.js"
     },
     "./cellTypes/timeType": {
-      "import": "./editors/timeType/index.mjs",
-      "require": "./editors/timeType/index.js"
+      "import": "./cellTypes/timeType/index.mjs",
+      "require": "./cellTypes/timeType/index.js"
     },
     "./editors": {
       "import": "./editors/index.mjs",


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes module exports file paths. The cellTypes modules were pointed to the editors instead of cellTypes.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7597
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
