### PR TITLE
Fix: fulfill readonly cells with data on UndoRedo.undo

### DIFF
--- a/.changelogs/4754.json
+++ b/.changelogs/4754.json
@@ -1,0 +1,7 @@
+{
+  "title": "fulfill readonly cells with data on UndoRedo.undo",
+  "type": "fixed",
+  "issue": 4754,
+  "breaking": false,
+  "framework": "none"
+}

--- a/src/core.js
+++ b/src/core.js
@@ -878,7 +878,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
                 clen += 1;
                 continue;
               }
-              if (cellMeta.readOnly) {
+              if (cellMeta.readOnly && source !== 'UndoRedo.undo') {
                 current.col += 1;
                 /* eslint-disable no-continue */
                 continue;

--- a/src/plugins/undoRedo/__tests__/UndoRedo.spec.js
+++ b/src/plugins/undoRedo/__tests__/UndoRedo.spec.js
@@ -1994,11 +1994,11 @@ describe('UndoRedo', () => {
         it('should undo removal row with readonly column', () => {
           const HOT = handsontable({
             data: createObjectData().slice(0, 2),
-            cells: function(row, col) {
+            cells(row, col) {
               if (col === 1) {
-                return { readOnly: true }
+                return { readOnly: true };
               }
-              return {}
+              return {};
             }
           });
 
@@ -2023,7 +2023,7 @@ describe('UndoRedo', () => {
           expect(getDataAtRowProp(0, 'surname')).toEqual('Dalton');
           expect(getDataAtRowProp(1, 'name')).toEqual('Sean');
           expect(getDataAtRowProp(1, 'surname')).toEqual('Connery');
-        })
+        });
       });
 
       describe('redo', () => {

--- a/src/plugins/undoRedo/__tests__/UndoRedo.spec.js
+++ b/src/plugins/undoRedo/__tests__/UndoRedo.spec.js
@@ -1990,6 +1990,40 @@ describe('UndoRedo', () => {
           expect(getDataAtRowProp(2, 'surname')).toEqual('Moore');
 
         });
+
+        it('should undo removal row with readonly column', () => {
+          const HOT = handsontable({
+            data: createObjectData().slice(0, 2),
+            cells: function(row, col) {
+              if (col === 1) {
+                return { readOnly: true }
+              }
+              return {}
+            }
+          });
+
+          expect(countRows()).toEqual(2);
+          expect(getDataAtRowProp(0, 'name')).toEqual('Timothy');
+          expect(getDataAtRowProp(0, 'surname')).toEqual('Dalton');
+          expect(getDataAtRowProp(1, 'name')).toEqual('Sean');
+          expect(getDataAtRowProp(1, 'surname')).toEqual('Connery');
+
+          alter('remove_row');
+
+          expect(countRows()).toEqual(1);
+          expect(getDataAtRowProp(0, 'name')).toEqual('Timothy');
+          expect(getDataAtRowProp(0, 'surname')).toEqual('Dalton');
+          expect(getDataAtRowProp(1, 'name')).toBeNull();
+          expect(getDataAtRowProp(1, 'surname')).toBeNull();
+
+          HOT.undo();
+
+          expect(countRows()).toEqual(2);
+          expect(getDataAtRowProp(0, 'name')).toEqual('Timothy');
+          expect(getDataAtRowProp(0, 'surname')).toEqual('Dalton');
+          expect(getDataAtRowProp(1, 'name')).toEqual('Sean');
+          expect(getDataAtRowProp(1, 'surname')).toEqual('Connery');
+        })
       });
 
       describe('redo', () => {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The problem is that when a column is read-only, the "undo" action makes the data from that column erased.
It is fixed within the "populateFromArray" method since there the data were omitting. It should populate every cell with data, even "read-only" cells.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Added new test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #4754 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
