### PR TITLE
Dropdown menu will open for Android devices

### DIFF
--- a/.changelogs/6212.json
+++ b/.changelogs/6212.json
@@ -1,0 +1,7 @@
+{
+  "title": "Dropdown menu will open for Android devices",
+  "type": "fixed",
+  "issue": 6212,
+  "breaking": false,
+  "framework": "none"
+}

--- a/src/3rdparty/walkontable/src/event.js
+++ b/src/3rdparty/walkontable/src/event.js
@@ -8,6 +8,7 @@ import { partial } from './../../../helpers/function';
 import { isTouchSupported } from './../../../helpers/feature';
 import { isMobileBrowser } from './../../../helpers/browser';
 import EventManager from './../../../eventManager';
+import {isDefined} from '../../../helpers/mixed';
 
 const privatePool = new WeakMap();
 
@@ -308,11 +309,13 @@ class Event {
   onTouchEnd(event) {
     const excludeTags = ['A', 'BUTTON', 'INPUT'];
     const target = event.target;
+    const parentCellCoords = this.parentCell(target)?.coords;
+    const isHeader = isDefined(parentCellCoords) && (parentCellCoords.row < 0 || parentCellCoords.col < 0);  
 
     // When the standard event was performed on the link element (a cell which contains HTML `a` element) then here
     // we check if it should be canceled. Click is blocked in a situation when the element is rendered outside
     // selected cells. This prevents accidentally page reloads while selecting adjacent cells.
-    if (this.selectedCellWasTouched(target) === false && excludeTags.includes(target.tagName)) {
+    if (isHeader === false && this.selectedCellWasTouched(target) === false && excludeTags.includes(target.tagName)) {
       event.preventDefault();
     }
 

--- a/src/3rdparty/walkontable/src/event.js
+++ b/src/3rdparty/walkontable/src/event.js
@@ -8,7 +8,7 @@ import { partial } from './../../../helpers/function';
 import { isTouchSupported } from './../../../helpers/feature';
 import { isMobileBrowser } from './../../../helpers/browser';
 import EventManager from './../../../eventManager';
-import {isDefined} from '../../../helpers/mixed';
+import { isDefined } from '../../../helpers/mixed';
 
 const privatePool = new WeakMap();
 
@@ -310,7 +310,7 @@ class Event {
     const excludeTags = ['A', 'BUTTON', 'INPUT'];
     const target = event.target;
     const parentCellCoords = this.parentCell(target)?.coords;
-    const isHeader = isDefined(parentCellCoords) && (parentCellCoords.row < 0 || parentCellCoords.col < 0);  
+    const isHeader = isDefined(parentCellCoords) && (parentCellCoords.row < 0 || parentCellCoords.col < 0);
 
     // When the standard event was performed on the link element (a cell which contains HTML `a` element) then here
     // we check if it should be canceled. Click is blocked in a situation when the element is rendered outside

--- a/test/e2e/mobile/events.spec.js
+++ b/test/e2e/mobile/events.spec.js
@@ -90,7 +90,7 @@ describe('Events', () => {
     expect(getSelected()).toEqual([[0, 0, 0, 0]]);
 
     location.hash = ''; // Resetting after test.
-    
+
     const anotherCell = getCell(1, 0);
 
     // First touch
@@ -123,5 +123,5 @@ describe('Events', () => {
     simulateTouch(dropDownIndicator);
 
     expect($('.htDropdownMenu').is(':visible')).toBe(true);
-  })
+  });
 });

--- a/test/e2e/mobile/events.spec.js
+++ b/test/e2e/mobile/events.spec.js
@@ -58,7 +58,7 @@ describe('Events', () => {
   });
 
   // Currently, this test is skipped. There is a problem with opening link from an anchor element using only simulated touch event.
-  xit('should block default action related to link touch and translate from the touch to click on a cell', async() => {
+  it('should block default action related to link touch and translate from the touch to click on a cell', async() => {
     const hot = handsontable({
       data: [['<a href="#justForTest">click me!</a>'], []],
       rowHeaders: true,
@@ -98,9 +98,6 @@ describe('Events', () => {
     // First touch
     triggerTouchEvent('touchstart', anotherCell);
     triggerTouchEvent('touchend', anotherCell);
-    $(anotherCell).simulate('mousedown');
-    $(anotherCell).simulate('mouseup')
-    $(anotherCell).simulate('click');
 
     await sleep(600); // To prevents double-click detection (emulation)
 
@@ -110,9 +107,6 @@ describe('Events', () => {
     // Second touch
     triggerTouchEvent('touchstart', anotherCell);
     triggerTouchEvent('touchend', anotherCell);
-    $(anotherCell).simulate('mousedown');
-    $(anotherCell).simulate('mouseup')
-    $(anotherCell).simulate('click');
 
     expect(location.hash).toBe('');
     expect(getSelected()).toEqual([[1, 0, 1, 0]]);

--- a/test/e2e/mobile/events.spec.js
+++ b/test/e2e/mobile/events.spec.js
@@ -76,17 +76,15 @@ describe('Events', () => {
     location.hash = ''; // Resetting before test.
 
     // First touch
-    triggerTouchEvent('touchstart', linkElement);
-    triggerTouchEvent('touchend', linkElement);
+    simulateTouch(linkElement);
 
     expect(location.hash).toBe('');
     expect(getSelected()).toEqual([[0, 0, 0, 0]]);
 
-    await sleep(600); // To prevents double-click detection (emulation)
+    await sleep(100); // To prevents double-click detection (emulation)
 
     // Second touch
-    triggerTouchEvent('touchstart', linkElement);
-    triggerTouchEvent('touchend', linkElement);
+    simulateTouch(linkElement);
 
     expect(location.hash).toBe('#justForTest');
     expect(getSelected()).toEqual([[0, 0, 0, 0]]);
@@ -96,26 +94,23 @@ describe('Events', () => {
     const anotherCell = getCell(1, 0);
 
     // First touch
-    triggerTouchEvent('touchstart', anotherCell);
-    triggerTouchEvent('touchend', anotherCell);
+    simulateTouch(anotherCell);
 
-    await sleep(600); // To prevents double-click detection (emulation)
+    await sleep(100); // To prevents double-click detection (emulation)
 
     expect(location.hash).toBe('');
     expect(getSelected()).toEqual([[1, 0, 1, 0]]);
 
     // Second touch
-    triggerTouchEvent('touchstart', anotherCell);
-    triggerTouchEvent('touchend', anotherCell);
+    simulateTouch(anotherCell);
 
     expect(location.hash).toBe('');
     expect(getSelected()).toEqual([[1, 0, 1, 0]]);
 
     location.hash = ''; // Resetting after test.
   });
-  
-  // Test doesn't work.
-  xit('touch on button inside header should not block default action  ' +
+
+  it('touch on button inside header should not block default action  ' +
     '(header does not have to be selected at first)', async() => {
     const hot = handsontable({
       data: Handsontable.helper.createSpreadsheetData(3, 7),
@@ -125,8 +120,7 @@ describe('Events', () => {
 
     const dropDownIndicator = $(hot.getCell(-1, 2)).find('button')[0];
 
-    triggerTouchEvent('touchstart', dropDownIndicator);
-    triggerTouchEvent('touchend', dropDownIndicator);
+    simulateTouch(dropDownIndicator);
 
     expect($('.htDropdownMenu').is(':visible')).toBe(true);
   })

--- a/test/e2e/mobile/events.spec.js
+++ b/test/e2e/mobile/events.spec.js
@@ -57,7 +57,6 @@ describe('Events', () => {
     expect(onCellDblClick).toHaveBeenCalled();
   });
 
-  // Currently, this test is skipped. There is a problem with opening link from an anchor element using only simulated touch event.
   it('should block default action related to link touch and translate from the touch to click on a cell', async() => {
     const hot = handsontable({
       data: [['<a href="#justForTest">click me!</a>'], []],

--- a/test/helpers/common.js
+++ b/test/helpers/common.js
@@ -872,12 +872,13 @@ export function swapDisplayedColumns(container, from, to) {
 
 /**
  * Creates touch event and dispatch it for handled element.
- * 
- * @param {number} pageX The page x coordinates.
- * @param {number} pageY The page y coordinates.
+ *
+ * @param {number} x The page x coordinates.
+ * @param {number} y The page y coordinates.
  * @param {HTMLElement} element An element for which event will be triggered.
  * @param {string} eventType Type of touch event, ie. 'touchstart', 'touchmove', 'touchend'.
- * @returns {boolean}
+ * @returns {boolean} The return value is `false` if event is cancelable and at least one of the event handlers which
+ * received event called `preventDefault()`. Otherwise it returns `true`.
  */
 function sendTouchEvent(x, y, element, eventType) {
   const touchObj = new Touch({
@@ -906,6 +907,8 @@ function sendTouchEvent(x, y, element, eventType) {
  * @param {HTMLElement} target The target element from the event was triggered.
  * @param {number} pageX The page x coordinates.
  * @param {number} pageY The page y coordinates.
+ * @returns {boolean} The return value is `false` if event is cancelable and at least one of the event handlers which
+ * received event called `preventDefault()`. Otherwise it returns `true`.
  */
 export function triggerTouchEvent(type, target, pageX, pageY) {
   const targetCoords = target.getBoundingClientRect();
@@ -922,19 +925,19 @@ export function triggerTouchEvent(type, target, pageX, pageY) {
  * Note: MDN docs (https://developer.mozilla.org/en-US/docs/Web/API/Touch_events/Supporting_both_TouchEvent_and_MouseEvent)
  * says: "Browsers typically dispatch emulated mouse and click events when there is only a single active touch point.".
  * This method is working similar.
- * 
- * @param {HTMLElement} element The target element from the event was triggered.
+ *
+ * @param {HTMLElement} target The target element from the event was triggered.
  */
 export function simulateTouch(target) {
   const touchStartRun = triggerTouchEvent('touchstart', target);
-  
+
   if (touchStartRun === true) {
     const touchEndRun = triggerTouchEvent('touchend', target);
 
     // If the `preventDefault` is called for below event emulation doesn't reflects "native" behaviour.
     if (touchEndRun === true) {
       $(target).simulate('mousedown');
-      $(target).simulate('mouseup')
+      $(target).simulate('mouseup');
       $(target).simulate('click');
     }
   }

--- a/test/helpers/common.js
+++ b/test/helpers/common.js
@@ -870,7 +870,15 @@ export function swapDisplayedColumns(container, from, to) {
   $from.simulate('mouseup');
 }
 
-/* eventType is 'touchstart', 'touchmove', 'touchend'... */
+/**
+ * Creates touch event and dispatch it for handled element.
+ * 
+ * @param {number} pageX The page x coordinates.
+ * @param {number} pageY The page y coordinates.
+ * @param {HTMLElement} element An element for which event will be triggered.
+ * @param {string} eventType Type of touch event, ie. 'touchstart', 'touchmove', 'touchend'.
+ * @returns {boolean}
+ */
 function sendTouchEvent(x, y, element, eventType) {
   const touchObj = new Touch({
     identifier: Date.now(),
@@ -890,7 +898,7 @@ function sendTouchEvent(x, y, element, eventType) {
     shiftKey: false,
   });
 
-  element.dispatchEvent(touchEvent);
+  return element.dispatchEvent(touchEvent);
 }
 
 /**
@@ -904,7 +912,32 @@ export function triggerTouchEvent(type, target, pageX, pageY) {
   const targetPageX = pageX || parseInt(targetCoords.left, 10) + 3;
   const targetPageY = pageY || parseInt(targetCoords.top, 10) + 3;
 
-  sendTouchEvent(targetPageX, targetPageY, target, type);
+  return sendTouchEvent(targetPageX, targetPageY, target, type);
+}
+
+/**
+ * Emulates touch on handled HTML element.
+ *
+ * Note: Please keep in mind that this method doesn't reflects fully "native" behaviour.
+ * Note: MDN docs (https://developer.mozilla.org/en-US/docs/Web/API/Touch_events/Supporting_both_TouchEvent_and_MouseEvent)
+ * says: "Browsers typically dispatch emulated mouse and click events when there is only a single active touch point.".
+ * This method is working similar.
+ * 
+ * @param {HTMLElement} element The target element from the event was triggered.
+ */
+export function simulateTouch(target) {
+  const touchStartRun = triggerTouchEvent('touchstart', target);
+  
+  if (touchStartRun === true) {
+    const touchEndRun = triggerTouchEvent('touchend', target);
+
+    // If the `preventDefault` is called for below event emulation doesn't reflects "native" behaviour.
+    if (touchEndRun === true) {
+      $(target).simulate('mousedown');
+      $(target).simulate('mouseup')
+      $(target).simulate('click');
+    }
+  }
 }
 
 /**

--- a/test/helpers/common.js
+++ b/test/helpers/common.js
@@ -870,6 +870,29 @@ export function swapDisplayedColumns(container, from, to) {
   $from.simulate('mouseup');
 }
 
+/* eventType is 'touchstart', 'touchmove', 'touchend'... */
+function sendTouchEvent(x, y, element, eventType) {
+  const touchObj = new Touch({
+    identifier: Date.now(),
+    target: element,
+    clientX: x,
+    clientY: y,
+    radiusX: 2.5,
+    radiusY: 2.5,
+  });
+
+  const touchEvent = new TouchEvent(eventType, {
+    cancelable: true,
+    bubbles: true,
+    touches: eventType === 'touchend' ? [] : [touchObj],
+    targetTouches: eventType === 'touchend' ? [] : [touchObj],
+    changedTouches: [touchObj],
+    shiftKey: false,
+  });
+
+  element.dispatchEvent(touchEvent);
+}
+
 /**
  * @param {string} type A name/type of the event.
  * @param {HTMLElement} target The target element from the event was triggered.
@@ -877,30 +900,11 @@ export function swapDisplayedColumns(container, from, to) {
  * @param {number} pageY The page y coordinates.
  */
 export function triggerTouchEvent(type, target, pageX, pageY) {
-  const e = document.createEvent('TouchEvent');
-
   const targetCoords = target.getBoundingClientRect();
-  const targetPageX = pageX || parseInt(targetCoords.left + 3, 10);
-  const targetPageY = pageY || parseInt(targetCoords.top + 3, 10);
-  let touches;
-  let targetTouches;
-  let changedTouches;
+  const targetPageX = pageX || parseInt(targetCoords.left, 10) + 3;
+  const targetPageY = pageY || parseInt(targetCoords.top, 10) + 3;
 
-  const touch = document.createTouch(window, target, 0, targetPageX, targetPageY, targetPageX, targetPageY);
-
-  if (type === 'touchend') {
-    touches = document.createTouchList();
-    targetTouches = document.createTouchList();
-    changedTouches = document.createTouchList(touch);
-  } else {
-    touches = document.createTouchList(touch);
-    targetTouches = document.createTouchList(touch);
-    changedTouches = document.createTouchList(touch);
-  }
-
-  e.initTouchEvent(type, true, true, window, null, 0, 0, 0, 0, false, false, false, false,
-    touches, targetTouches, changedTouches, 1, 0);
-  target.dispatchEvent(e);
+  sendTouchEvent(targetPageX, targetPageY, target, type);
 }
 
 /**


### PR DESCRIPTION
### Context
Handsontable `2.0.0` introduced change in a way how cells with links, inputs and buttons are handled (PR https://github.com/handsontable/handsontable/pull/4935). From the release, cell with such elements have to be selected at first to allow trigger their default actions. This prevents accidentally page reloads while selecting adjacent cells.


Then, Handsontable `6.2.1` introduced fix for some behaviour of Android devices (https://github.com/handsontable/handsontable/pull/5638). Unfortunately, with provided fix clicks on buttons in headers stopped working.

The provided by me code is fixing not working drop-down menu. It's worth to mention that headers **won't** have to be selected at first to allow trigger their default actions.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Tested change on real Android device (Google Chrome) and using Browserstack on different devices (also with `iOS`) with different browsers.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #6212 
2. https://github.com/handsontable/handsontable/pull/5638
3. https://github.com/handsontable/handsontable/pull/4935

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] My change requires a change to the documentation.
