### PR TITLE
Fix scrolling with "left" key on table with fixed columns and window scroll

### DIFF
--- a/src/3rdparty/walkontable/src/scroll.js
+++ b/src/3rdparty/walkontable/src/scroll.js
@@ -196,39 +196,9 @@ class Scroll {
    * @returns {number}
    */
   getFirstVisibleColumn() {
-    const {
-      leftOverlay,
-      wtTable,
-      wtViewport,
-      totalColumns,
-    } = this._getVariables();
-    const rootWindow = this.wot.rootWindow;
+    const { wtTable } = this._getVariables();
 
-    let firstVisibleColumn = wtTable.getFirstVisibleColumn();
-
-    if (leftOverlay.mainTableScrollableElement === rootWindow) {
-      const rootElementOffset = offset(wtTable.wtRootElement);
-      const totalTableWidth = innerWidth(wtTable.hider);
-      const windowWidth = innerWidth(rootWindow);
-      const windowScrollLeft = getScrollLeft(rootWindow, rootWindow);
-
-      // Only calculate firstVisibleColumn when table didn't filled (from left) whole viewport space
-      if (rootElementOffset.left + totalTableWidth - windowWidth <= windowScrollLeft) {
-        let columnsWidth = wtViewport.getRowHeaderWidth();
-
-        for (let column = totalColumns; column > 0; column--) {
-          columnsWidth += leftOverlay.sumCellSizes(column - 1, column);
-
-          if (rootElementOffset.left + totalTableWidth - columnsWidth <= windowScrollLeft) {
-            // Return physical column + 1
-            firstVisibleColumn = column;
-            break;
-          }
-        }
-      }
-    }
-
-    return firstVisibleColumn;
+    return wtTable.getFirstVisibleColumn();
   }
 
   /**

--- a/test/scripts/run-puppeteer.js
+++ b/test/scripts/run-puppeteer.js
@@ -57,8 +57,8 @@ const cleanupFactory = (browser, server) => async(exitCode) => {
 
   page.setCacheEnabled(false);
   page.setViewport({
-    width: 1280,
-    height: 720,
+    width: 1920,
+    height: 1080,
   });
 
   const server = http.createServer(ecstatic({


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->

The problem is that the keyboard "left" key does not scroll the viewport where there are fixed columns and window scroll is used.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7451 
