### PR TITLE
Fix #7599: Adding/updating a property in settings is not used when property is a function

### DIFF
--- a/.changelogs/7599.json
+++ b/.changelogs/7599.json
@@ -1,0 +1,7 @@
+{
+  "title": "Adding/updating a property in settings is not used when property is a function",
+  "type": "fixed",
+  "issue": 7599,
+  "breaking": false,
+  "framework": "vue"
+}

--- a/wrappers/vue/src/helpers.ts
+++ b/wrappers/vue/src/helpers.ts
@@ -245,5 +245,9 @@ export function createVueComponent(vNode: VNode, parent: Vue, props: object, dat
  * @returns {boolean} `true` if they're the same, `false` otherwise.
  */
 function simpleEqual(objectA, objectB) {
+  if (typeof objectA === 'function' && typeof objectB === 'function') {
+    return ''+objectA === ''+objectB;
+  }
+
   return JSON.stringify(objectA) === JSON.stringify(objectB);
 }

--- a/wrappers/vue/src/helpers.ts
+++ b/wrappers/vue/src/helpers.ts
@@ -246,7 +246,7 @@ export function createVueComponent(vNode: VNode, parent: Vue, props: object, dat
  */
 function simpleEqual(objectA, objectB) {
   if (typeof objectA === 'function' && typeof objectB === 'function') {
-    return ''+objectA === ''+objectB;
+    return '' + objectA === '' + objectB;
   }
 
   return JSON.stringify(objectA) === JSON.stringify(objectB);

--- a/wrappers/vue/test/hotTable.spec.ts
+++ b/wrappers/vue/test/hotTable.spec.ts
@@ -49,6 +49,33 @@ describe('Updating the Handsontable settings', () => {
     expect(testWrapper.vm.hotInstance.getSettings().rowHeaders).toEqual(false);
   });
 
+  it('should update the previously initialized Handsontable instance with a single changed property (function)', async() => {
+    let updateSettingsCalls = 0;
+    const cellsFuncA = function() {}
+    const cellsFuncB = function() {}
+    let testWrapper = mount(HotTable, {
+      propsData: {
+        data: createSampleData(1, 1),
+        licenseKey: 'non-commercial-and-evaluation',
+        cells: cellsFuncA,
+        afterUpdateSettings: function () {
+          updateSettingsCalls++;
+        }
+      }
+    });
+
+    expect(testWrapper.vm.hotInstance.getSettings().cells).toEqual(cellsFuncA);
+
+    testWrapper.setProps({
+      cells: cellsFuncB
+    });
+
+    await Vue.nextTick();
+
+    expect(updateSettingsCalls).toEqual(1);
+    expect(testWrapper.vm.hotInstance.getSettings().cells).toEqual(cellsFuncB);
+  });
+
   it('should update the previously initialized Handsontable instance only once with multiple changed properties', async() => {
     let App = Vue.extend({
       data: function () {

--- a/wrappers/vue/test/hotTable.spec.ts
+++ b/wrappers/vue/test/hotTable.spec.ts
@@ -53,7 +53,7 @@ describe('Updating the Handsontable settings', () => {
     let updateSettingsCalls = 0;
     const cellsFuncA = function() {}
     const cellsFuncB = function() {}
-    let testWrapper = mount(HotTable, {
+    const testWrapper = mount(HotTable, {
       propsData: {
         data: createSampleData(1, 1),
         licenseKey: 'non-commercial-and-evaluation',


### PR DESCRIPTION
### Context
When updating a function in the settings object after initializing the grid, the new function is not used.

This PR correct the simpleEqual method in helpers.js

This is a new PR for the closed : https://github.com/handsontable/vue-handsontable-official/pull/212

### How has this been tested?
The following demos highlight the issue and correction :

@handsontable/vue 4.1.1: https://jsfiddle.net/Lxdc950k/2/ 👍
@handonstable/vue 5.1.0 https://jsfiddle.net/541q03zp/ 👎
this version : https://jsfiddle.net/f219rvu6/ 👍
The PR also add a unit test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/7599

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [x] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
