### PR TITLE
Fix wrappers issue templates name

### DIFF
--- a/.github/ISSUE_TEMPLATE/angular-handsontable.md
+++ b/.github/ISSUE_TEMPLATE/angular-handsontable.md
@@ -1,9 +1,9 @@
 ---
-name: @handsontable/angular
+name: "@handsontable/angular"
 about: Issues regarding the Angular wrapper for Handsontable.
-title: ''
-labels: 'angular'
-assignees: ''
+title: ""
+labels: "angular"
+assignees: ""
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/angular-handsontable.md
+++ b/.github/ISSUE_TEMPLATE/angular-handsontable.md
@@ -1,10 +1,9 @@
 ---
-name: "@handsontable/angular"
+name: "Handsontable for Angular"
 about: Issues regarding the Angular wrapper for Handsontable.
 title: ""
 labels: "angular"
 assignees: ""
-
 ---
 
 ### Description

--- a/.github/ISSUE_TEMPLATE/handsontable.md
+++ b/.github/ISSUE_TEMPLATE/handsontable.md
@@ -1,10 +1,9 @@
 ---
-name: handsontable
+name: Handsontable
 about: Issues regarding Handsontable.
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
 ### Description
@@ -24,5 +23,3 @@ https://jsfiddle.net/handsoncode/8ffpsqt6/
 * Handsontable version:
 * Browser Name and version:
 * Operating System:
-
-

--- a/.github/ISSUE_TEMPLATE/react-handsontable.md
+++ b/.github/ISSUE_TEMPLATE/react-handsontable.md
@@ -1,10 +1,9 @@
 ---
-name: "@handsontable/react"
+name: "Handsontable for React"
 about: Issues regarding the React wrapper for Handsontable.
 title: ""
 labels: "react"
 assignees: ""
-
 ---
 
 ### Description

--- a/.github/ISSUE_TEMPLATE/react-handsontable.md
+++ b/.github/ISSUE_TEMPLATE/react-handsontable.md
@@ -1,9 +1,9 @@
 ---
-name: @handsontable/react
+name: "@handsontable/react"
 about: Issues regarding the React wrapper for Handsontable.
-title: ''
-labels: 'react'
-assignees: ''
+title: ""
+labels: "react"
+assignees: ""
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/vue-handsontable.md
+++ b/.github/ISSUE_TEMPLATE/vue-handsontable.md
@@ -1,10 +1,9 @@
 ---
-name: "@handsontable/vue"
+name: "Handsontable for Vue"
 about: Issues regarding the Vue wrapper for Handsontable.
 title: ""
 labels: "vue"
 assignees: ""
-
 ---
 
 ### Description

--- a/.github/ISSUE_TEMPLATE/vue-handsontable.md
+++ b/.github/ISSUE_TEMPLATE/vue-handsontable.md
@@ -1,9 +1,9 @@
 ---
-name: @handsontable/vue
+name: "@handsontable/vue"
 about: Issues regarding the Vue wrapper for Handsontable.
-title: ''
-labels: 'vue'
-assignees: ''
+title: ""
+labels: "vue"
+assignees: ""
 
 ---
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
GitHub didn't see the templates when the name contains special characters. The name should be put into quotes.

**_[skip changelog]_** The PR does not change the source code or anything related to the build or publishing process so the changelog is not necessary here. 

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
