### PR TITLE
Issue:7309:Extra cells are produced after merging and unmerging cells when using toHTML()

### DIFF
--- a/src/plugins/mergeCells/mergeCells.js
+++ b/src/plugins/mergeCells/mergeCells.js
@@ -446,8 +446,10 @@ export class MergeCells extends BasePlugin {
           this.hot.removeCellMeta(currentCollection.row + i, currentCollection.col + j, 'hidden');
         });
       });
-
+      
       this.hot.removeCellMeta(currentCollection.row, currentCollection.col, 'spanned');
+      this.hot.removeCellMeta(currentCollection.row, currentCollection.col, 'rowspan');
+      this.hot.removeCellMeta(currentCollection.row, currentCollection.col, 'colspan');
     });
 
     this.hot.runHooks('afterUnmergeCells', cellRange, auto);


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The toHTML() function to convert Handsontable to HTML Table uses rowspan and colspan meta of the cell which is not reset after unmerging the cells thus producing extra cells after unmerge.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
toHTML() function was tested  after merging and unmerging the cells.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. Issue 7309


### Affected project(s):
- [X] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [X] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog] 
