### PR TITLE
Sorting of checkboxes will work + fixed not proper way of displaying some empty cells

### DIFF
--- a/.changelogs/4047.json
+++ b/.changelogs/4047.json
@@ -1,5 +1,5 @@
 {
-  "title": "Sorting checkboxes will work + fixed not proper way of displaying some empty cells",
+  "title": "Sorting of checkboxes will work + fixed not proper way of displaying some empty cells",
   "type": "fixed",
   "issue": 4047,
   "breaking": false,

--- a/.changelogs/4047.json
+++ b/.changelogs/4047.json
@@ -1,0 +1,7 @@
+{
+  "title": "Sorting checkboxes will work + fixed not proper way of displaying some empty cells",
+  "type": "fixed",
+  "issue": 4047,
+  "breaking": false,
+  "framework": "none"
+}

--- a/src/dataMap/metaManager/metaSchema.js
+++ b/src/dataMap/metaManager/metaSchema.js
@@ -1,4 +1,4 @@
-import { isDefined } from '../../helpers/mixed';
+import { isEmpty } from '../../helpers/mixed';
 import { isObjectEqual } from '../../helpers/object';
 
 /* eslint-disable jsdoc/require-description-complete-sentence */
@@ -1112,7 +1112,7 @@ export default () => {
       for (col = 0, colLen = this.countCols(); col < colLen; col++) {
         value = this.getDataAtCell(row, col);
 
-        if (value !== '' && value !== null && isDefined(value)) {
+        if (isEmpty(value) === false) {
           if (typeof value === 'object') {
             meta = this.getCellMeta(row, col);
 
@@ -1149,7 +1149,7 @@ export default () => {
       for (row = 0, rowLen = this.countRows(); row < rowLen; row++) {
         value = this.getDataAtCell(row, col);
 
-        if (value !== '' && value !== null && isDefined(value)) {
+        if (isEmpty(value) === false) {
           return false;
         }
       }

--- a/src/dataMap/metaManager/metaSchema.js
+++ b/src/dataMap/metaManager/metaSchema.js
@@ -1759,7 +1759,7 @@ export default () => {
      * * `headerAction` - allow to click on the headers to sort
      *   * `true` = turn on possibility to click on the headers to sort
      *   * `false` = turn off possibility to click on the headers to sort
-     * * `sortEmptyCells` - how empty values (by default: '', null and undefined) should be handled
+     * * `sortEmptyCells` - how empty values (more information here: https://handsontable.com/docs/tutorial-cell-types.html#empty-cells) should be handled
      *   * `true` = the table sorts empty cells
      *   * `false` = the table moves all empty cells to the end of the table
      * * `compareFunctionFactory` - curry function returning compare function; compare function should work in the same way as function which is handled by native `Array.sort` method); please take a look at below examples for more information.
@@ -1913,7 +1913,7 @@ export default () => {
      * * `headerAction` - allow to click on the headers to sort
      *   * `true` = turn on possibility to click on the headers to sort
      *   * `false` = turn off possibility to click on the headers to sort
-     * * `sortEmptyCells` - how empty values (by default: '', null and undefined) should be handled
+     * * `sortEmptyCells` - how empty values (more information here: https://handsontable.com/docs/tutorial-cell-types.html#empty-cells) should be handled
      *   * `true` = the table sorts empty cells
      *   * `false` = the table moves all empty cells to the end of the table
      * * `compareFunctionFactory` - curry function returning compare function; compare function should work in the same way as function which is handled by native `Array.sort` method); please take a look at below examples for more information.

--- a/src/dataMap/metaManager/metaSchema.js
+++ b/src/dataMap/metaManager/metaSchema.js
@@ -1759,7 +1759,7 @@ export default () => {
      * * `headerAction` - allow to click on the headers to sort
      *   * `true` = turn on possibility to click on the headers to sort
      *   * `false` = turn off possibility to click on the headers to sort
-     * * `sortEmptyCells` - how empty values should be handled
+     * * `sortEmptyCells` - how empty values (by default: '', null and undefined) should be handled
      *   * `true` = the table sorts empty cells
      *   * `false` = the table moves all empty cells to the end of the table
      * * `compareFunctionFactory` - curry function returning compare function; compare function should work in the same way as function which is handled by native `Array.sort` method); please take a look at below examples for more information.
@@ -1913,7 +1913,7 @@ export default () => {
      * * `headerAction` - allow to click on the headers to sort
      *   * `true` = turn on possibility to click on the headers to sort
      *   * `false` = turn off possibility to click on the headers to sort
-     * * `sortEmptyCells` - how empty values should be handled
+     * * `sortEmptyCells` - how empty values (by default: '', null and undefined) should be handled
      *   * `true` = the table sorts empty cells
      *   * `false` = the table moves all empty cells to the end of the table
      * * `compareFunctionFactory` - curry function returning compare function; compare function should work in the same way as function which is handled by native `Array.sort` method); please take a look at below examples for more information.

--- a/src/plugins/columnSorting/__tests__/columnSorting.spec.js
+++ b/src/plugins/columnSorting/__tests__/columnSorting.spec.js
@@ -1148,7 +1148,7 @@ describe('ColumnSorting', () => {
       ]);
     });
 
-    it('should sort checkboxes properly when `checkedTemplate` and `checkedTemplate` options are set (non-string templates)', () => {
+    it('should sort checkboxes properly when `checkedTemplate` and `checkedTemplate` options are set (non-string templates) #1', () => {
       handsontable({
         data: [
           { car: 'Mercedes A 160', damaged: true },
@@ -1195,16 +1195,65 @@ describe('ColumnSorting', () => {
       ]);
     });
 
+    it('should sort checkboxes properly when `checkedTemplate` and `checkedTemplate` options are set (non-string templates) #2', () => {
+      handsontable({
+        data: [
+          { car: 'Mercedes A 160', damaged: 1 },
+          { car: 'Citroen C4 Coupe', damaged: 0 },
+          { car: 'Audi A4 Avant', damaged: 0 },
+          { car: 'Opel Astra', damaged: 1 },
+          { car: 'BMW 320i Coupe', damaged: 0 }
+        ],
+        columns: [
+          {
+            data: 'car'
+          },
+          {
+            data: 'damaged',
+            type: 'checkbox',
+            checkedTemplate: 0,
+            uncheckedTemplate: 1,
+          }
+        ],
+        columnSorting: true,
+        colHeaders: ['Name', 'works?']
+      });
+
+      getPlugin('columnSorting').sort({ column: 1, sortOrder: 'asc' });
+
+      // Sorting by visual state of checkbox.
+      expect(getData()).toEqual([
+        ['Mercedes A 160', 1],
+        ['Opel Astra', 1],
+        ['Citroen C4 Coupe', 0],
+        ['Audi A4 Avant', 0],
+        ['BMW 320i Coupe', 0],
+      ]);
+
+      getPlugin('columnSorting').sort({ column: 1, sortOrder: 'desc' });
+
+      // Sorting by visual state of checkbox.
+      expect(getData()).toEqual([
+        ['Citroen C4 Coupe', 0],
+        ['Audi A4 Avant', 0],
+        ['BMW 320i Coupe', 0],
+        ['Mercedes A 160', 1],
+        ['Opel Astra', 1],
+      ]);
+    });
+
     it('should sort #bad_value# elements in a proper way', () => {
       handsontable({
         data: [
           ['b', 0],
           ['a', 1],
           [1, 2],
-          ['a', 3],
-          ['aaaa', 4],
-          [0, 5],
-          ['a', 6],
+          ['A', 3], // to lower case while sorting by default
+          ['a', 4],
+          ['aaaa', 5],
+          [0, 6],
+          ['a', 7],
+          [-2, 8],
         ],
         columns: [
           { type: 'checkbox' },
@@ -1216,12 +1265,14 @@ describe('ColumnSorting', () => {
       getPlugin('columnSorting').sort({ column: 0, sortOrder: 'asc' });
 
       expect(getData()).toEqual([
-        [0, 5],
+        [-2, 8],
+        [0, 6],
         [1, 2],
         ['a', 1],
-        ['a', 3],
-        ['a', 6],
-        ['aaaa', 4],
+        ['A', 3],
+        ['a', 4],
+        ['a', 7],
+        ['aaaa', 5],
         ['b', 0],
       ]);
 
@@ -1229,12 +1280,14 @@ describe('ColumnSorting', () => {
 
       expect(getData()).toEqual([
         ['b', 0],
-        ['aaaa', 4],
+        ['aaaa', 5],
         ['a', 1],
-        ['a', 3],
-        ['a', 6],
+        ['A', 3],
+        ['a', 4],
+        ['a', 7],
         [1, 2],
-        [0, 5],
+        [0, 6],
+        [-2, 8],
       ]);
     });
 

--- a/src/plugins/columnSorting/__tests__/columnSorting.spec.js
+++ b/src/plugins/columnSorting/__tests__/columnSorting.spec.js
@@ -1100,7 +1100,7 @@ describe('ColumnSorting', () => {
       ]);
     });
 
-    it('should sort checkboxes properly when `checkedTemplate` and `checkedTemplate` options are set', () => {
+    it('should sort checkboxes properly when `checkedTemplate` and `checkedTemplate` options are set (string templates)', () => {
       handsontable({
         data: [
           { car: 'Mercedes A 160', year: 2017, comesInBlack: 'yes' },
@@ -1145,6 +1145,96 @@ describe('ColumnSorting', () => {
         ['Opel Astra', 2020, 'yes'],
         ['Audi A4 Avant', 2019, 'no'],
         ['BMW 320i Coupe', 2021, 'no'],
+      ]);
+    });
+
+    it('should sort checkboxes properly when `checkedTemplate` and `checkedTemplate` options are set (non-string templates)', () => {
+      handsontable({
+        data: [
+          { car: 'Mercedes A 160', damaged: true },
+          { car: 'Citroen C4 Coupe', damaged: false },
+          { car: 'Audi A4 Avant', damaged: false },
+          { car: 'Opel Astra', damaged: true },
+          { car: 'BMW 320i Coupe', damaged: false }
+        ],
+        columns: [
+          {
+            data: 'car'
+          },
+          {
+            data: 'damaged',
+            type: 'checkbox',
+            checkedTemplate: false,
+            uncheckedTemplate: true,
+          }
+        ],
+        columnSorting: true,
+        colHeaders: ['Name', 'is working?']
+      });
+
+      getPlugin('columnSorting').sort({ column: 1, sortOrder: 'asc' });
+
+      // Sorting by visual state of checkbox.
+      expect(getData()).toEqual([
+        ['Mercedes A 160', true],
+        ['Opel Astra', true],
+        ['Citroen C4 Coupe', false],
+        ['Audi A4 Avant', false],
+        ['BMW 320i Coupe', false],
+      ]);
+
+      getPlugin('columnSorting').sort({ column: 1, sortOrder: 'desc' });
+
+      // Sorting by visual state of checkbox.
+      expect(getData()).toEqual([
+        ['Citroen C4 Coupe', false],
+        ['Audi A4 Avant', false],
+        ['BMW 320i Coupe', false],
+        ['Mercedes A 160', true],
+        ['Opel Astra', true],
+      ]);
+    });
+
+    it('should sort #bad_value# elements in a proper way', () => {
+      handsontable({
+        data: [
+          ['b', 0],
+          ['a', 1],
+          [1, 2],
+          ['a', 3],
+          ['aaaa', 4],
+          [0, 5],
+          ['a', 6],
+        ],
+        columns: [
+          { type: 'checkbox' },
+          {}
+        ],
+        columnSorting: true,
+      });
+
+      getPlugin('columnSorting').sort({ column: 0, sortOrder: 'asc' });
+
+      expect(getData()).toEqual([
+        [0, 5],
+        [1, 2],
+        ['a', 1],
+        ['a', 3],
+        ['a', 6],
+        ['aaaa', 4],
+        ['b', 0],
+      ]);
+
+      getPlugin('columnSorting').sort({ column: 0, sortOrder: 'desc' });
+
+      expect(getData()).toEqual([
+        ['b', 0],
+        ['aaaa', 4],
+        ['a', 1],
+        ['a', 3],
+        ['a', 6],
+        [1, 2],
+        [0, 5],
       ]);
     });
   });

--- a/src/plugins/columnSorting/__tests__/columnSorting.spec.js
+++ b/src/plugins/columnSorting/__tests__/columnSorting.spec.js
@@ -1294,13 +1294,19 @@ describe('ColumnSorting', () => {
     it('should sort elements in a proper way when `sortEmptyCells` is set to `false` (by default)', () => {
       handsontable({
         data: [
-          [false, 0],
+          [null, 0], // empty cell
           ['', 1], // empty cell
-          [true, 2],
-          ['a', 3],
+          [false, 2],
+          [undefined, 3], // empty cell
           [null, 4], // empty cell
-          [undefined, 5], // empty cell
-          [1, 6],
+          [true, 5],
+          ['a', 6],
+          ['', 7], // empty cell
+          [null, 8], // empty cell
+          [1, 9],
+          [undefined, 10], // empty cell
+          ['', 11], // empty cell
+          [null, 12], // empty cell
         ],
         columnSorting: true,
         columns: [
@@ -1312,38 +1318,58 @@ describe('ColumnSorting', () => {
       getPlugin('columnSorting').sort({ column: 0, sortOrder: 'asc' });
 
       expect(getData()).toEqual([
-        [1, 6],
-        ['a', 3],
-        [false, 0],
-        [true, 2],
+        [1, 9],
+        ['a', 6],
+        [false, 2],
+        [true, 5],
+        // Not sorting in place.
+        [null, 0], // empty cell
         ['', 1], // empty cell
+        [undefined, 3], // empty cell
         [null, 4], // empty cell
-        [undefined, 5], // empty cell
+        ['', 7], // empty cell
+        [null, 8], // empty cell
+        [undefined, 10], // empty cell
+        ['', 11], // empty cell
+        [null, 12], // empty cell
       ]);
 
       getPlugin('columnSorting').sort({ column: 0, sortOrder: 'desc' });
 
       expect(getData()).toEqual([
-        [true, 2],
-        [false, 0],
-        ['a', 3],
-        [1, 6],
+        [true, 5],
+        [false, 2],
+        ['a', 6],
+        [1, 9],
+        // Not sorting in place.
+        [null, 0], // empty cell
         ['', 1], // empty cell
+        [undefined, 3], // empty cell
         [null, 4], // empty cell
-        [undefined, 5], // empty cell
+        ['', 7], // empty cell
+        [null, 8], // empty cell
+        [undefined, 10], // empty cell
+        ['', 11], // empty cell
+        [null, 12], // empty cell
       ]);
     });
 
     it('should sort elements in a proper way when `sortEmptyCells` is set to `true`', () => {
       handsontable({
         data: [
-          [false, 0],
+          [null, 0], // empty cell
           ['', 1], // empty cell
-          [true, 2],
-          ['a', 3],
+          [false, 2],
+          [undefined, 3], // empty cell
           [null, 4], // empty cell
-          [undefined, 5], // empty cell
-          [1, 6],
+          [true, 5],
+          ['a', 6],
+          ['', 7], // empty cell
+          [null, 8], // empty cell
+          [1, 9],
+          [undefined, 10], // empty cell
+          ['', 11], // empty cell
+          [null, 12], // empty cell
         ],
         columnSorting: {
           sortEmptyCells: true
@@ -1357,25 +1383,37 @@ describe('ColumnSorting', () => {
       getPlugin('columnSorting').sort({ column: 0, sortOrder: 'asc' });
 
       expect(getData()).toEqual([
-        [1, 6],
-        ['a', 3],
-        [false, 0],
+        [1, 9],
+        ['a', 6],
+        [null, 0], // empty cell
         ['', 1], // empty cell
+        [false, 2],
+        [undefined, 3], // empty cell
         [null, 4], // empty cell
-        [undefined, 5], // empty cell
-        [true, 2],
+        ['', 7], // empty cell
+        [null, 8], // empty cell
+        [undefined, 10], // empty cell
+        ['', 11], // empty cell
+        [null, 12], // empty cell
+        [true, 5],
       ]);
 
       getPlugin('columnSorting').sort({ column: 0, sortOrder: 'desc' });
 
       expect(getData()).toEqual([
-        [true, 2],
-        [false, 0],
+        [true, 5],
+        [null, 0], // empty cell
         ['', 1], // empty cell
+        [false, 2],
+        [undefined, 3], // empty cell
         [null, 4], // empty cell
-        [undefined, 5], // empty cell
-        ['a', 3],
-        [1, 6],
+        ['', 7], // empty cell
+        [null, 8], // empty cell
+        [undefined, 10], // empty cell
+        ['', 11], // empty cell
+        [null, 12], // empty cell
+        ['a', 6],
+        [1, 9],
       ]);
     });
   });

--- a/src/plugins/columnSorting/__tests__/columnSorting.spec.js
+++ b/src/plugins/columnSorting/__tests__/columnSorting.spec.js
@@ -2,7 +2,7 @@ describe('ColumnSorting', () => {
   const id = 'testContainer';
 
   beforeEach(function() {
-    this.$container = $(`<div id='${id}' style='overflow: auto; width: 300px; height: 200px;'></div>`).appendTo('body');
+    this.$container = $(`<div id="${id}" style="overflow: auto; width: 300px; height: 200px;"></div>`).appendTo('body');
 
     this.sortByClickOnColumnHeader = (columnIndex) => {
       const hot = this.$container.data('handsontable');
@@ -1169,7 +1169,7 @@ describe('ColumnSorting', () => {
           }
         ],
         columnSorting: true,
-        colHeaders: ['Name', 'is working?']
+        colHeaders: ['Name', 'works?']
       });
 
       getPlugin('columnSorting').sort({ column: 1, sortOrder: 'asc' });
@@ -1235,6 +1235,94 @@ describe('ColumnSorting', () => {
         ['a', 6],
         [1, 2],
         [0, 5],
+      ]);
+    });
+
+    it('should sort elements in a proper way when `sortEmptyCells` is set to `false` (by default)', () => {
+      handsontable({
+        data: [
+          [false, 0],
+          ['', 1], // empty cell
+          [true, 2],
+          ['a', 3],
+          [null, 4], // empty cell
+          [undefined, 5], // empty cell
+          [1, 6],
+        ],
+        columnSorting: true,
+        columns: [
+          { type: 'checkbox' },
+          {}
+        ]
+      });
+
+      getPlugin('columnSorting').sort({ column: 0, sortOrder: 'asc' });
+
+      expect(getData()).toEqual([
+        [1, 6],
+        ['a', 3],
+        [false, 0],
+        [true, 2],
+        ['', 1], // empty cell
+        [null, 4], // empty cell
+        [undefined, 5], // empty cell
+      ]);
+
+      getPlugin('columnSorting').sort({ column: 0, sortOrder: 'desc' });
+
+      expect(getData()).toEqual([
+        [true, 2],
+        [false, 0],
+        ['a', 3],
+        [1, 6],
+        ['', 1], // empty cell
+        [null, 4], // empty cell
+        [undefined, 5], // empty cell
+      ]);
+    });
+
+    it('should sort elements in a proper way when `sortEmptyCells` is set to `true`', () => {
+      handsontable({
+        data: [
+          [false, 0],
+          ['', 1], // empty cell
+          [true, 2],
+          ['a', 3],
+          [null, 4], // empty cell
+          [undefined, 5], // empty cell
+          [1, 6],
+        ],
+        columnSorting: {
+          sortEmptyCells: true
+        },
+        columns: [
+          { type: 'checkbox' },
+          {}
+        ]
+      });
+
+      getPlugin('columnSorting').sort({ column: 0, sortOrder: 'asc' });
+
+      expect(getData()).toEqual([
+        [1, 6],
+        ['a', 3],
+        [false, 0],
+        ['', 1], // empty cell
+        [null, 4], // empty cell
+        [undefined, 5], // empty cell
+        [true, 2],
+      ]);
+
+      getPlugin('columnSorting').sort({ column: 0, sortOrder: 'desc' });
+
+      expect(getData()).toEqual([
+        [true, 2],
+        [false, 0],
+        ['', 1], // empty cell
+        [null, 4], // empty cell
+        [undefined, 5], // empty cell
+        ['a', 3],
+        [1, 6],
       ]);
     });
   });

--- a/src/plugins/columnSorting/__tests__/columnSorting.spec.js
+++ b/src/plugins/columnSorting/__tests__/columnSorting.spec.js
@@ -2,7 +2,7 @@ describe('ColumnSorting', () => {
   const id = 'testContainer';
 
   beforeEach(function() {
-    this.$container = $(`<div id="${id}" style="overflow: auto; width: 300px; height: 200px;"></div>`).appendTo('body');
+    this.$container = $(`<div id='${id}' style='overflow: auto; width: 300px; height: 200px;'></div>`).appendTo('body');
 
     this.sortByClickOnColumnHeader = (columnIndex) => {
       const hot = this.$container.data('handsontable');
@@ -1050,6 +1050,102 @@ describe('ColumnSorting', () => {
       await sleep(100);
 
       expect(getDataAtCell(0, 0)).toEqual('7:55:00 pm');
+    });
+  });
+
+  describe('data type: checkbox', () => {
+    it('should sort checkboxes properly when `checkedTemplate` and `checkedTemplate` options are not set', () => {
+      handsontable({
+        data: [
+          { car: 'Mercedes A 160', year: 2017, available: true },
+          { car: 'Citroen C4 Coupe', year: 2018, available: false },
+          { car: 'Audi A4 Avant', year: 2019, available: true },
+          { car: 'Opel Astra', year: 2020, available: false },
+          { car: 'BMW 320i Coupe', year: 2021, available: false }
+        ],
+        columns: [
+          {
+            data: 'car'
+          },
+          {
+            data: 'year',
+            type: 'numeric'
+          },
+          {
+            data: 'available',
+            type: 'checkbox'
+          }
+        ],
+        columnSorting: true,
+      });
+
+      getPlugin('columnSorting').sort({ column: 2, sortOrder: 'asc' });
+
+      expect(getData()).toEqual([
+        ['Citroen C4 Coupe', 2018, false],
+        ['Opel Astra', 2020, false],
+        ['BMW 320i Coupe', 2021, false],
+        ['Mercedes A 160', 2017, true],
+        ['Audi A4 Avant', 2019, true]
+      ]);
+
+      getPlugin('columnSorting').sort({ column: 2, sortOrder: 'desc' });
+
+      expect(getData()).toEqual([
+        ['Mercedes A 160', 2017, true],
+        ['Audi A4 Avant', 2019, true],
+        ['Citroen C4 Coupe', 2018, false],
+        ['Opel Astra', 2020, false],
+        ['BMW 320i Coupe', 2021, false]
+      ]);
+    });
+
+    it('should sort checkboxes properly when `checkedTemplate` and `checkedTemplate` options are set', () => {
+      handsontable({
+        data: [
+          { car: 'Mercedes A 160', year: 2017, comesInBlack: 'yes' },
+          { car: 'Citroen C4 Coupe', year: 2018, comesInBlack: 'yes' },
+          { car: 'Audi A4 Avant', year: 2019, comesInBlack: 'no' },
+          { car: 'Opel Astra', year: 2020, comesInBlack: 'yes' },
+          { car: 'BMW 320i Coupe', year: 2021, comesInBlack: 'no' }
+        ],
+        columns: [
+          {
+            data: 'car'
+          },
+          {
+            data: 'year',
+            type: 'numeric'
+          },
+          {
+            data: 'comesInBlack',
+            type: 'checkbox',
+            checkedTemplate: 'yes',
+            uncheckedTemplate: 'no',
+          }
+        ],
+        columnSorting: true,
+      });
+
+      getPlugin('columnSorting').sort({ column: 2, sortOrder: 'asc' });
+
+      expect(getData()).toEqual([
+        ['Audi A4 Avant', 2019, 'no'],
+        ['BMW 320i Coupe', 2021, 'no'],
+        ['Mercedes A 160', 2017, 'yes'],
+        ['Citroen C4 Coupe', 2018, 'yes'],
+        ['Opel Astra', 2020, 'yes']
+      ]);
+
+      getPlugin('columnSorting').sort({ column: 2, sortOrder: 'desc' });
+
+      expect(getData()).toEqual([
+        ['Mercedes A 160', 2017, 'yes'],
+        ['Citroen C4 Coupe', 2018, 'yes'],
+        ['Opel Astra', 2020, 'yes'],
+        ['Audi A4 Avant', 2019, 'no'],
+        ['BMW 320i Coupe', 2021, 'no'],
+      ]);
     });
   });
 

--- a/src/plugins/columnSorting/__tests__/sortFunction/checkbox.unit.js
+++ b/src/plugins/columnSorting/__tests__/sortFunction/checkbox.unit.js
@@ -1,0 +1,29 @@
+import { compareFunctionFactory as checkboxSort } from 'handsontable/plugins/columnSorting/sortFunction/checkbox';
+
+it('checkbox comparing function shouldn\'t change order when comparing empty string, null and undefined', () => {
+  const defaultTemplates = { checkedTemplate: true, uncheckedTemplate: false };
+
+  expect(checkboxSort('asc', defaultTemplates, {})(null, null)).toEqual(0);
+  expect(checkboxSort('desc', defaultTemplates, {})(null, null)).toEqual(0);
+
+  expect(checkboxSort('asc', defaultTemplates, {})('', '')).toEqual(0);
+  expect(checkboxSort('desc', defaultTemplates, {})('', '')).toEqual(0);
+
+  expect(checkboxSort('asc', defaultTemplates, {})(undefined, undefined)).toEqual(0);
+  expect(checkboxSort('desc', defaultTemplates, {})(undefined, undefined)).toEqual(0);
+
+  expect(checkboxSort('asc', defaultTemplates, {})('', null)).toEqual(0);
+  expect(checkboxSort('desc', defaultTemplates, {})('', null)).toEqual(0);
+  expect(checkboxSort('asc', defaultTemplates, {})(null, '')).toEqual(0);
+  expect(checkboxSort('desc', defaultTemplates, {})(null, '')).toEqual(0);
+
+  expect(checkboxSort('asc', defaultTemplates, {})('', undefined)).toEqual(0);
+  expect(checkboxSort('desc', defaultTemplates, {})('', undefined)).toEqual(0);
+  expect(checkboxSort('asc', defaultTemplates, {})(undefined, '')).toEqual(0);
+  expect(checkboxSort('desc', defaultTemplates, {})(undefined, '')).toEqual(0);
+
+  expect(checkboxSort('asc', defaultTemplates, {})(null, undefined)).toEqual(0);
+  expect(checkboxSort('desc', defaultTemplates, {})(null, undefined)).toEqual(0);
+  expect(checkboxSort('asc', defaultTemplates, {})(undefined, null)).toEqual(0);
+  expect(checkboxSort('desc', defaultTemplates, {})(undefined, null)).toEqual(0);
+});

--- a/src/plugins/columnSorting/sortFunction/checkbox.js
+++ b/src/plugins/columnSorting/sortFunction/checkbox.js
@@ -1,4 +1,5 @@
 import { DO_NOT_SWAP, FIRST_BEFORE_SECOND, FIRST_AFTER_SECOND } from '../sortService';
+import { compareFunctionFactory as defaultCompareFunctionFactory } from '../sortFunction/default';
 import { isEmpty } from '../../../helpers/mixed';
 
 const emptyCellToFalsyValue = (value, falsyValue) => {
@@ -57,6 +58,12 @@ export function compareFunctionFactory(sortOrder, columnMeta, columnPluginSettin
       }
 
       return FIRST_BEFORE_SECOND;
+    }
+
+    // 1st value === #BAD_VALUE# && 2nd value === #BAD_VALUE#
+    if (isValueFromTemplate === false && isNextValueFromTemplate === false) {
+      // Sorting by values (not just by visual representation).
+      return defaultCompareFunctionFactory(sortOrder, columnMeta, columnPluginSettings)(value, nextValue);
     }
 
     if (unifiedValue === uncheckedTemplate && unifiedNextValue === checkedTemplate) {

--- a/src/plugins/columnSorting/sortFunction/checkbox.js
+++ b/src/plugins/columnSorting/sortFunction/checkbox.js
@@ -1,18 +1,52 @@
 import { DO_NOT_SWAP, FIRST_BEFORE_SECOND, FIRST_AFTER_SECOND } from '../sortService';
+import { isUndefined } from '../../../helpers/mixed';
+
+const isEmptyCell = (value) => {
+  return value === '' || value === null || isUndefined(value);
+};
+
+const emptyCellToFalsyValue = (value, falsyValue) => {
+  if (isEmptyCell(value)) {
+    return falsyValue;
+  }
+
+  return value;
+};
 
 /**
  * Checkbox sorting compare function factory. Method get as parameters `sortOrder` and `columnMeta` and return compare function.
  *
  * @param {string} sortOrder Sort order (`asc` for ascending, `desc` for descending).
  * @param {object} columnMeta Column meta object.
+ * @param {object} columnPluginSettings Plugin settings for the column.
  * @returns {Function} The compare function.
  */
-export function compareFunctionFactory(sortOrder, columnMeta) {
+export function compareFunctionFactory(sortOrder, columnMeta, columnPluginSettings) {
   const checkedTemplate = columnMeta.checkedTemplate;
   const uncheckedTemplate = columnMeta.uncheckedTemplate;
+  const { sortEmptyCells } = columnPluginSettings;
 
   return function(value, nextValue) {
-    if (value === uncheckedTemplate && nextValue === checkedTemplate) {
+    const unifiedValue = emptyCellToFalsyValue(value, uncheckedTemplate);
+    const unifiedNextValue = emptyCellToFalsyValue(nextValue, uncheckedTemplate);
+    const isValueFromTemplate = unifiedValue === uncheckedTemplate || unifiedValue === checkedTemplate;
+    const isNextValueFromTemplate = unifiedNextValue === uncheckedTemplate || unifiedNextValue === checkedTemplate;
+
+    // As an empty cell we recognize cells with undefined, null and '' values.
+    if (sortEmptyCells === false && (isEmptyCell(value) || isEmptyCell(nextValue))) {
+      if (isEmptyCell(value) && isEmptyCell(nextValue) === false) {
+        return FIRST_AFTER_SECOND;
+      }
+
+      if (isEmptyCell(value) === false && isEmptyCell(nextValue)) {
+        return FIRST_BEFORE_SECOND;
+      }
+
+      return DO_NOT_SWAP;
+    }
+
+    // 1st value === #BAD_VALUE#
+    if (isValueFromTemplate === false && isNextValueFromTemplate) {
       if (sortOrder === 'asc') {
         return FIRST_BEFORE_SECOND;
       }
@@ -20,7 +54,24 @@ export function compareFunctionFactory(sortOrder, columnMeta) {
       return FIRST_AFTER_SECOND;
     }
 
-    if (value === checkedTemplate && nextValue === uncheckedTemplate) {
+    // 2nd value === #BAD_VALUE#
+    if (isValueFromTemplate && isNextValueFromTemplate === false) {
+      if (sortOrder === 'asc') {
+        return FIRST_AFTER_SECOND;
+      }
+
+      return FIRST_BEFORE_SECOND;
+    }
+
+    if (unifiedValue === uncheckedTemplate && unifiedNextValue === checkedTemplate) {
+      if (sortOrder === 'asc') {
+        return FIRST_BEFORE_SECOND;
+      }
+
+      return FIRST_AFTER_SECOND;
+    }
+
+    if (unifiedValue === checkedTemplate && unifiedNextValue === uncheckedTemplate) {
       if (sortOrder === 'asc') {
         return FIRST_AFTER_SECOND;
       }

--- a/src/plugins/columnSorting/sortFunction/checkbox.js
+++ b/src/plugins/columnSorting/sortFunction/checkbox.js
@@ -1,4 +1,3 @@
-import { isEmpty } from '../../../helpers/mixed';
 import { DO_NOT_SWAP, FIRST_BEFORE_SECOND, FIRST_AFTER_SECOND } from '../sortService';
 
 /**
@@ -6,21 +5,18 @@ import { DO_NOT_SWAP, FIRST_BEFORE_SECOND, FIRST_AFTER_SECOND } from '../sortSer
  *
  * @param {string} sortOrder Sort order (`asc` for ascending, `desc` for descending).
  * @param {object} columnMeta Column meta object.
- * @param {object} columnPluginSettings Plugin settings for the column.
  * @returns {Function} The compare function.
  */
-export function compareFunctionFactory(sortOrder, columnMeta, columnPluginSettings) {
+export function compareFunctionFactory(sortOrder, columnMeta) {
   const checkedTemplate = columnMeta.checkedTemplate;
   const uncheckedTemplate = columnMeta.uncheckedTemplate;
-  
-  return function(value, nextValue) {
-    const { sortEmptyCells } = columnPluginSettings;
 
+  return function(value, nextValue) {
     if (value === uncheckedTemplate && nextValue === checkedTemplate) {
       if (sortOrder === 'asc') {
         return FIRST_BEFORE_SECOND;
       }
-      
+
       return FIRST_AFTER_SECOND;
     }
 
@@ -31,7 +27,7 @@ export function compareFunctionFactory(sortOrder, columnMeta, columnPluginSettin
 
       return FIRST_BEFORE_SECOND;
     }
-    
+
     return DO_NOT_SWAP;
   };
 }

--- a/src/plugins/columnSorting/sortFunction/checkbox.js
+++ b/src/plugins/columnSorting/sortFunction/checkbox.js
@@ -1,0 +1,39 @@
+import { isEmpty } from '../../../helpers/mixed';
+import { DO_NOT_SWAP, FIRST_BEFORE_SECOND, FIRST_AFTER_SECOND } from '../sortService';
+
+/**
+ * Checkbox sorting compare function factory. Method get as parameters `sortOrder` and `columnMeta` and return compare function.
+ *
+ * @param {string} sortOrder Sort order (`asc` for ascending, `desc` for descending).
+ * @param {object} columnMeta Column meta object.
+ * @param {object} columnPluginSettings Plugin settings for the column.
+ * @returns {Function} The compare function.
+ */
+export function compareFunctionFactory(sortOrder, columnMeta, columnPluginSettings) {
+  const checkedTemplate = columnMeta.checkedTemplate;
+  const uncheckedTemplate = columnMeta.uncheckedTemplate;
+  
+  return function(value, nextValue) {
+    const { sortEmptyCells } = columnPluginSettings;
+
+    if (value === uncheckedTemplate && nextValue === checkedTemplate) {
+      if (sortOrder === 'asc') {
+        return FIRST_BEFORE_SECOND;
+      }
+      
+      return FIRST_AFTER_SECOND;
+    }
+
+    if (value === checkedTemplate && nextValue === uncheckedTemplate) {
+      if (sortOrder === 'asc') {
+        return FIRST_AFTER_SECOND;
+      }
+
+      return FIRST_BEFORE_SECOND;
+    }
+    
+    return DO_NOT_SWAP;
+  };
+}
+
+export const COLUMN_DATA_TYPE = 'checkbox';

--- a/src/plugins/columnSorting/sortFunction/checkbox.js
+++ b/src/plugins/columnSorting/sortFunction/checkbox.js
@@ -2,14 +2,6 @@ import { DO_NOT_SWAP, FIRST_BEFORE_SECOND, FIRST_AFTER_SECOND } from '../sortSer
 import { compareFunctionFactory as defaultCompareFunctionFactory } from '../sortFunction/default';
 import { isEmpty } from '../../../helpers/mixed';
 
-const emptyCellToFalsyValue = (value, falsyValue) => {
-  if (isEmpty(value)) {
-    return falsyValue;
-  }
-
-  return value;
-};
-
 /**
  * Checkbox sorting compare function factory. Method get as parameters `sortOrder` and `columnMeta` and return compare function.
  *
@@ -24,40 +16,32 @@ export function compareFunctionFactory(sortOrder, columnMeta, columnPluginSettin
   const { sortEmptyCells } = columnPluginSettings;
 
   return function(value, nextValue) {
-    const unifiedValue = emptyCellToFalsyValue(value, uncheckedTemplate);
-    const unifiedNextValue = emptyCellToFalsyValue(nextValue, uncheckedTemplate);
+    const isEmptyValue = isEmpty(value);
+    const isEmptyNextValue = isEmpty(nextValue);
+    const unifiedValue = isEmptyValue ? uncheckedTemplate : value;
+    const unifiedNextValue = isEmptyNextValue ? uncheckedTemplate : nextValue;
     const isValueFromTemplate = unifiedValue === uncheckedTemplate || unifiedValue === checkedTemplate;
     const isNextValueFromTemplate = unifiedNextValue === uncheckedTemplate || unifiedNextValue === checkedTemplate;
 
     // As an empty cell we recognize cells with undefined, null and '' values.
-    if (sortEmptyCells === false && (isEmpty(value) || isEmpty(nextValue))) {
-      if (isEmpty(value) && isEmpty(nextValue) === false) {
+    if (sortEmptyCells === false) {
+      if (isEmptyValue && isEmptyNextValue === false) {
         return FIRST_AFTER_SECOND;
       }
 
-      if (isEmpty(value) === false && isEmpty(nextValue)) {
+      if (isEmptyValue === false && isEmptyNextValue) {
         return FIRST_BEFORE_SECOND;
       }
-
-      return DO_NOT_SWAP;
     }
 
     // 1st value === #BAD_VALUE#
     if (isValueFromTemplate === false && isNextValueFromTemplate) {
-      if (sortOrder === 'asc') {
-        return FIRST_BEFORE_SECOND;
-      }
-
-      return FIRST_AFTER_SECOND;
+      return sortOrder === 'asc' ? FIRST_BEFORE_SECOND : FIRST_AFTER_SECOND;
     }
 
     // 2nd value === #BAD_VALUE#
     if (isValueFromTemplate && isNextValueFromTemplate === false) {
-      if (sortOrder === 'asc') {
-        return FIRST_AFTER_SECOND;
-      }
-
-      return FIRST_BEFORE_SECOND;
+      return sortOrder === 'asc' ? FIRST_AFTER_SECOND : FIRST_BEFORE_SECOND;
     }
 
     // 1st value === #BAD_VALUE# && 2nd value === #BAD_VALUE#
@@ -67,19 +51,11 @@ export function compareFunctionFactory(sortOrder, columnMeta, columnPluginSettin
     }
 
     if (unifiedValue === uncheckedTemplate && unifiedNextValue === checkedTemplate) {
-      if (sortOrder === 'asc') {
-        return FIRST_BEFORE_SECOND;
-      }
-
-      return FIRST_AFTER_SECOND;
+      return sortOrder === 'asc' ? FIRST_BEFORE_SECOND : FIRST_AFTER_SECOND;
     }
 
     if (unifiedValue === checkedTemplate && unifiedNextValue === uncheckedTemplate) {
-      if (sortOrder === 'asc') {
-        return FIRST_AFTER_SECOND;
-      }
-
-      return FIRST_BEFORE_SECOND;
+      return sortOrder === 'asc' ? FIRST_AFTER_SECOND : FIRST_BEFORE_SECOND;
     }
 
     return DO_NOT_SWAP;

--- a/src/plugins/columnSorting/sortFunction/checkbox.js
+++ b/src/plugins/columnSorting/sortFunction/checkbox.js
@@ -1,12 +1,8 @@
 import { DO_NOT_SWAP, FIRST_BEFORE_SECOND, FIRST_AFTER_SECOND } from '../sortService';
-import { isUndefined } from '../../../helpers/mixed';
-
-const isEmptyCell = (value) => {
-  return value === '' || value === null || isUndefined(value);
-};
+import { isEmpty } from '../../../helpers/mixed';
 
 const emptyCellToFalsyValue = (value, falsyValue) => {
-  if (isEmptyCell(value)) {
+  if (isEmpty(value)) {
     return falsyValue;
   }
 
@@ -33,12 +29,12 @@ export function compareFunctionFactory(sortOrder, columnMeta, columnPluginSettin
     const isNextValueFromTemplate = unifiedNextValue === uncheckedTemplate || unifiedNextValue === checkedTemplate;
 
     // As an empty cell we recognize cells with undefined, null and '' values.
-    if (sortEmptyCells === false && (isEmptyCell(value) || isEmptyCell(nextValue))) {
-      if (isEmptyCell(value) && isEmptyCell(nextValue) === false) {
+    if (sortEmptyCells === false && (isEmpty(value) || isEmpty(nextValue))) {
+      if (isEmpty(value) && isEmpty(nextValue) === false) {
         return FIRST_AFTER_SECOND;
       }
 
-      if (isEmptyCell(value) === false && isEmptyCell(nextValue)) {
+      if (isEmpty(value) === false && isEmpty(nextValue)) {
         return FIRST_BEFORE_SECOND;
       }
 

--- a/src/plugins/columnSorting/sortService/registry.js
+++ b/src/plugins/columnSorting/sortService/registry.js
@@ -1,6 +1,9 @@
 import { compareFunctionFactory as defaultSort, COLUMN_DATA_TYPE as DEFAULT_DATA_TYPE } from '../sortFunction/default';
 import { compareFunctionFactory as numericSort, COLUMN_DATA_TYPE as NUMERIC_DATA_TYPE } from '../sortFunction/numeric';
-import { compareFunctionFactory as checkboxSort, COLUMN_DATA_TYPE as CHECKBOX_DATA_TYPE } from '../sortFunction/checkbox';
+import {
+  compareFunctionFactory as checkboxSort,
+  COLUMN_DATA_TYPE as CHECKBOX_DATA_TYPE
+} from '../sortFunction/checkbox';
 import { compareFunctionFactory as dateSort, COLUMN_DATA_TYPE as DATE_DATA_TYPE } from '../sortFunction/date';
 import staticRegister from '../../../utils/staticRegister';
 

--- a/src/plugins/columnSorting/sortService/registry.js
+++ b/src/plugins/columnSorting/sortService/registry.js
@@ -1,5 +1,6 @@
 import { compareFunctionFactory as defaultSort, COLUMN_DATA_TYPE as DEFAULT_DATA_TYPE } from '../sortFunction/default';
 import { compareFunctionFactory as numericSort, COLUMN_DATA_TYPE as NUMERIC_DATA_TYPE } from '../sortFunction/numeric';
+import { compareFunctionFactory as checkboxSort, COLUMN_DATA_TYPE as CHECKBOX_DATA_TYPE } from '../sortFunction/checkbox';
 import { compareFunctionFactory as dateSort, COLUMN_DATA_TYPE as DATE_DATA_TYPE } from '../sortFunction/date';
 import staticRegister from '../../../utils/staticRegister';
 
@@ -29,6 +30,7 @@ export function getCompareFunctionFactory(type) {
 }
 
 registerCompareFunctionFactory(NUMERIC_DATA_TYPE, numericSort);
+registerCompareFunctionFactory(CHECKBOX_DATA_TYPE, checkboxSort);
 registerCompareFunctionFactory(DATE_DATA_TYPE, dateSort);
 registerCompareFunctionFactory(DEFAULT_DATA_TYPE, defaultSort);
 

--- a/src/plugins/filters/condition/empty.js
+++ b/src/plugins/filters/condition/empty.js
@@ -1,5 +1,6 @@
 import * as C from '../../../i18n/constants';
 import { registerCondition } from '../conditionRegisterer';
+import { isEmpty } from '../../../helpers/mixed';
 
 export const CONDITION_NAME = 'empty';
 
@@ -8,7 +9,7 @@ export const CONDITION_NAME = 'empty';
  * @returns {boolean}
  */
 export function condition(dataRow) {
-  return dataRow.value === '' || dataRow.value === null || dataRow.value === void 0;
+  return isEmpty(dataRow.value);
 }
 
 registerCondition(CONDITION_NAME, condition, {

--- a/src/plugins/multiColumnSorting/__tests__/multiColumnSorting.spec.js
+++ b/src/plugins/multiColumnSorting/__tests__/multiColumnSorting.spec.js
@@ -1082,7 +1082,7 @@ describe('MultiColumnSorting', () => {
       ]);
     });
 
-    it('should sort checkboxes properly when `checkedTemplate` and `checkedTemplate` options are set', () => {
+    it('should sort checkboxes properly when `checkedTemplate` and `checkedTemplate` options are set (string templates)', () => {
       handsontable({
         data: [
           { car: 'Mercedes A 160', year: 2017, comesInBlack: 'yes' },
@@ -1127,6 +1127,96 @@ describe('MultiColumnSorting', () => {
         ['Opel Astra', 2020, 'yes'],
         ['Audi A4 Avant', 2019, 'no'],
         ['BMW 320i Coupe', 2021, 'no'],
+      ]);
+    });
+
+    it('should sort checkboxes properly when `checkedTemplate` and `checkedTemplate` options are set (non-string templates)', () => {
+      handsontable({
+        data: [
+          { car: 'Mercedes A 160', damaged: true },
+          { car: 'Citroen C4 Coupe', damaged: false },
+          { car: 'Audi A4 Avant', damaged: false },
+          { car: 'Opel Astra', damaged: true },
+          { car: 'BMW 320i Coupe', damaged: false }
+        ],
+        columns: [
+          {
+            data: 'car'
+          },
+          {
+            data: 'damaged',
+            type: 'checkbox',
+            checkedTemplate: false,
+            uncheckedTemplate: true,
+          }
+        ],
+        multiColumnSorting: true,
+        colHeaders: ['Name', 'is working?']
+      });
+
+      getPlugin('multiColumnSorting').sort({ column: 1, sortOrder: 'asc' });
+
+      // Sorting by visual state of checkbox.
+      expect(getData()).toEqual([
+        ['Mercedes A 160', true],
+        ['Opel Astra', true],
+        ['Citroen C4 Coupe', false],
+        ['Audi A4 Avant', false],
+        ['BMW 320i Coupe', false],
+      ]);
+
+      getPlugin('multiColumnSorting').sort({ column: 1, sortOrder: 'desc' });
+
+      // Sorting by visual state of checkbox.
+      expect(getData()).toEqual([
+        ['Citroen C4 Coupe', false],
+        ['Audi A4 Avant', false],
+        ['BMW 320i Coupe', false],
+        ['Mercedes A 160', true],
+        ['Opel Astra', true],
+      ]);
+    });
+
+    it('should sort #bad_value# elements in a proper way', () => {
+      handsontable({
+        data: [
+          ['b', 0],
+          ['a', 1],
+          [1, 2],
+          ['a', 3],
+          ['aaaa', 4],
+          [0, 5],
+          ['a', 6],
+        ],
+        columns: [
+          { type: 'checkbox' },
+          {}
+        ],
+        multiColumnSorting: true,
+      });
+
+      getPlugin('multiColumnSorting').sort({ column: 0, sortOrder: 'asc' });
+
+      expect(getData()).toEqual([
+        [0, 5],
+        [1, 2],
+        ['a', 1],
+        ['a', 3],
+        ['a', 6],
+        ['aaaa', 4],
+        ['b', 0],
+      ]);
+
+      getPlugin('multiColumnSorting').sort({ column: 0, sortOrder: 'desc' });
+
+      expect(getData()).toEqual([
+        ['b', 0],
+        ['aaaa', 4],
+        ['a', 1],
+        ['a', 3],
+        ['a', 6],
+        [1, 2],
+        [0, 5],
       ]);
     });
   });

--- a/src/plugins/multiColumnSorting/__tests__/multiColumnSorting.spec.js
+++ b/src/plugins/multiColumnSorting/__tests__/multiColumnSorting.spec.js
@@ -1151,7 +1151,7 @@ describe('MultiColumnSorting', () => {
           }
         ],
         multiColumnSorting: true,
-        colHeaders: ['Name', 'is working?']
+        colHeaders: ['Name', 'works?']
       });
 
       getPlugin('multiColumnSorting').sort({ column: 1, sortOrder: 'asc' });
@@ -1217,6 +1217,94 @@ describe('MultiColumnSorting', () => {
         ['a', 6],
         [1, 2],
         [0, 5],
+      ]);
+    });
+
+    it('should sort elements in a proper way when `sortEmptyCells` is set to `false` (by default)', () => {
+      handsontable({
+        data: [
+          [false, 0],
+          ['', 1], // empty cell
+          [true, 2],
+          ['a', 3],
+          [null, 4], // empty cell
+          [undefined, 5], // empty cell
+          [1, 6],
+        ],
+        multiColumnSorting: true,
+        columns: [
+          { type: 'checkbox' },
+          {}
+        ]
+      });
+
+      getPlugin('multiColumnSorting').sort({ column: 0, sortOrder: 'asc' });
+
+      expect(getData()).toEqual([
+        [1, 6],
+        ['a', 3],
+        [false, 0],
+        [true, 2],
+        ['', 1], // empty cell
+        [null, 4], // empty cell
+        [undefined, 5], // empty cell
+      ]);
+
+      getPlugin('multiColumnSorting').sort({ column: 0, sortOrder: 'desc' });
+
+      expect(getData()).toEqual([
+        [true, 2],
+        [false, 0],
+        ['a', 3],
+        [1, 6],
+        ['', 1], // empty cell
+        [null, 4], // empty cell
+        [undefined, 5], // empty cell
+      ]);
+    });
+
+    it('should sort elements in a proper way when `sortEmptyCells` is set to `true`', () => {
+      handsontable({
+        data: [
+          [false, 0],
+          ['', 1], // empty cell
+          [true, 2],
+          ['a', 3],
+          [null, 4], // empty cell
+          [undefined, 5], // empty cell
+          [1, 6],
+        ],
+        multiColumnSorting: {
+          sortEmptyCells: true
+        },
+        columns: [
+          { type: 'checkbox' },
+          {}
+        ]
+      });
+
+      getPlugin('multiColumnSorting').sort({ column: 0, sortOrder: 'asc' });
+
+      expect(getData()).toEqual([
+        [1, 6],
+        ['a', 3],
+        [false, 0],
+        ['', 1], // empty cell
+        [null, 4], // empty cell
+        [undefined, 5], // empty cell
+        [true, 2],
+      ]);
+
+      getPlugin('multiColumnSorting').sort({ column: 0, sortOrder: 'desc' });
+
+      expect(getData()).toEqual([
+        [true, 2],
+        [false, 0],
+        ['', 1], // empty cell
+        [null, 4], // empty cell
+        [undefined, 5], // empty cell
+        ['a', 3],
+        [1, 6],
       ]);
     });
   });

--- a/src/plugins/multiColumnSorting/__tests__/multiColumnSorting.spec.js
+++ b/src/plugins/multiColumnSorting/__tests__/multiColumnSorting.spec.js
@@ -1035,6 +1035,102 @@ describe('MultiColumnSorting', () => {
     });
   });
 
+  describe('data type: checkbox', () => {
+    it('should sort checkboxes properly when `checkedTemplate` and `checkedTemplate` options are not set', () => {
+      handsontable({
+        data: [
+          { car: 'Mercedes A 160', year: 2017, available: true },
+          { car: 'Citroen C4 Coupe', year: 2018, available: false },
+          { car: 'Audi A4 Avant', year: 2019, available: true },
+          { car: 'Opel Astra', year: 2020, available: false },
+          { car: 'BMW 320i Coupe', year: 2021, available: false }
+        ],
+        columns: [
+          {
+            data: 'car'
+          },
+          {
+            data: 'year',
+            type: 'numeric'
+          },
+          {
+            data: 'available',
+            type: 'checkbox'
+          }
+        ],
+        multiColumnSorting: true,
+      });
+
+      getPlugin('multiColumnSorting').sort({ column: 2, sortOrder: 'asc' });
+
+      expect(getData()).toEqual([
+        ['Citroen C4 Coupe', 2018, false],
+        ['Opel Astra', 2020, false],
+        ['BMW 320i Coupe', 2021, false],
+        ['Mercedes A 160', 2017, true],
+        ['Audi A4 Avant', 2019, true]
+      ]);
+
+      getPlugin('multiColumnSorting').sort({ column: 2, sortOrder: 'desc' });
+
+      expect(getData()).toEqual([
+        ['Mercedes A 160', 2017, true],
+        ['Audi A4 Avant', 2019, true],
+        ['Citroen C4 Coupe', 2018, false],
+        ['Opel Astra', 2020, false],
+        ['BMW 320i Coupe', 2021, false]
+      ]);
+    });
+
+    it('should sort checkboxes properly when `checkedTemplate` and `checkedTemplate` options are set', () => {
+      handsontable({
+        data: [
+          { car: 'Mercedes A 160', year: 2017, comesInBlack: 'yes' },
+          { car: 'Citroen C4 Coupe', year: 2018, comesInBlack: 'yes' },
+          { car: 'Audi A4 Avant', year: 2019, comesInBlack: 'no' },
+          { car: 'Opel Astra', year: 2020, comesInBlack: 'yes' },
+          { car: 'BMW 320i Coupe', year: 2021, comesInBlack: 'no' }
+        ],
+        columns: [
+          {
+            data: 'car'
+          },
+          {
+            data: 'year',
+            type: 'numeric'
+          },
+          {
+            data: 'comesInBlack',
+            type: 'checkbox',
+            checkedTemplate: 'yes',
+            uncheckedTemplate: 'no',
+          }
+        ],
+        multiColumnSorting: true,
+      });
+
+      getPlugin('multiColumnSorting').sort({ column: 2, sortOrder: 'asc' });
+
+      expect(getData()).toEqual([
+        ['Audi A4 Avant', 2019, 'no'],
+        ['BMW 320i Coupe', 2021, 'no'],
+        ['Mercedes A 160', 2017, 'yes'],
+        ['Citroen C4 Coupe', 2018, 'yes'],
+        ['Opel Astra', 2020, 'yes']
+      ]);
+
+      getPlugin('multiColumnSorting').sort({ column: 2, sortOrder: 'desc' });
+
+      expect(getData()).toEqual([
+        ['Mercedes A 160', 2017, 'yes'],
+        ['Citroen C4 Coupe', 2018, 'yes'],
+        ['Opel Astra', 2020, 'yes'],
+        ['Audi A4 Avant', 2019, 'no'],
+        ['BMW 320i Coupe', 2021, 'no'],
+      ]);
+    });
+  });
+
   it('should properly sort numeric data', () => {
     handsontable({
       data: [

--- a/src/plugins/multiColumnSorting/__tests__/multiColumnSorting.spec.js
+++ b/src/plugins/multiColumnSorting/__tests__/multiColumnSorting.spec.js
@@ -1130,7 +1130,7 @@ describe('MultiColumnSorting', () => {
       ]);
     });
 
-    it('should sort checkboxes properly when `checkedTemplate` and `checkedTemplate` options are set (non-string templates)', () => {
+    it('should sort checkboxes properly when `checkedTemplate` and `checkedTemplate` options are set (non-string templates) #1', () => {
       handsontable({
         data: [
           { car: 'Mercedes A 160', damaged: true },
@@ -1177,16 +1177,65 @@ describe('MultiColumnSorting', () => {
       ]);
     });
 
+    it('should sort checkboxes properly when `checkedTemplate` and `checkedTemplate` options are set (non-string templates) #2', () => {
+      handsontable({
+        data: [
+          { car: 'Mercedes A 160', damaged: 1 },
+          { car: 'Citroen C4 Coupe', damaged: 0 },
+          { car: 'Audi A4 Avant', damaged: 0 },
+          { car: 'Opel Astra', damaged: 1 },
+          { car: 'BMW 320i Coupe', damaged: 0 }
+        ],
+        columns: [
+          {
+            data: 'car'
+          },
+          {
+            data: 'damaged',
+            type: 'checkbox',
+            checkedTemplate: 0,
+            uncheckedTemplate: 1,
+          }
+        ],
+        multiColumnSorting: true,
+        colHeaders: ['Name', 'works?']
+      });
+
+      getPlugin('multiColumnSorting').sort({ column: 1, sortOrder: 'asc' });
+
+      // Sorting by visual state of checkbox.
+      expect(getData()).toEqual([
+        ['Mercedes A 160', 1],
+        ['Opel Astra', 1],
+        ['Citroen C4 Coupe', 0],
+        ['Audi A4 Avant', 0],
+        ['BMW 320i Coupe', 0],
+      ]);
+
+      getPlugin('multiColumnSorting').sort({ column: 1, sortOrder: 'desc' });
+
+      // Sorting by visual state of checkbox.
+      expect(getData()).toEqual([
+        ['Citroen C4 Coupe', 0],
+        ['Audi A4 Avant', 0],
+        ['BMW 320i Coupe', 0],
+        ['Mercedes A 160', 1],
+        ['Opel Astra', 1],
+      ]);
+    });
+
     it('should sort #bad_value# elements in a proper way', () => {
       handsontable({
         data: [
           ['b', 0],
           ['a', 1],
           [1, 2],
-          ['a', 3],
-          ['aaaa', 4],
-          [0, 5],
-          ['a', 6],
+          ['A', 3], // to lower case while sorting by default
+          ['a', 4],
+          ['aaaa', 5],
+          [0, 6],
+          ['a', 7],
+          [-2, 8],
         ],
         columns: [
           { type: 'checkbox' },
@@ -1198,12 +1247,14 @@ describe('MultiColumnSorting', () => {
       getPlugin('multiColumnSorting').sort({ column: 0, sortOrder: 'asc' });
 
       expect(getData()).toEqual([
-        [0, 5],
+        [-2, 8],
+        [0, 6],
         [1, 2],
         ['a', 1],
-        ['a', 3],
-        ['a', 6],
-        ['aaaa', 4],
+        ['A', 3],
+        ['a', 4],
+        ['a', 7],
+        ['aaaa', 5],
         ['b', 0],
       ]);
 
@@ -1211,12 +1262,14 @@ describe('MultiColumnSorting', () => {
 
       expect(getData()).toEqual([
         ['b', 0],
-        ['aaaa', 4],
+        ['aaaa', 5],
         ['a', 1],
-        ['a', 3],
-        ['a', 6],
+        ['A', 3],
+        ['a', 4],
+        ['a', 7],
         [1, 2],
-        [0, 5],
+        [0, 6],
+        [-2, 8],
       ]);
     });
 

--- a/src/plugins/multiColumnSorting/__tests__/multiColumnSorting.spec.js
+++ b/src/plugins/multiColumnSorting/__tests__/multiColumnSorting.spec.js
@@ -1276,13 +1276,19 @@ describe('MultiColumnSorting', () => {
     it('should sort elements in a proper way when `sortEmptyCells` is set to `false` (by default)', () => {
       handsontable({
         data: [
-          [false, 0],
+          [null, 0], // empty cell
           ['', 1], // empty cell
-          [true, 2],
-          ['a', 3],
+          [false, 2],
+          [undefined, 3], // empty cell
           [null, 4], // empty cell
-          [undefined, 5], // empty cell
-          [1, 6],
+          [true, 5],
+          ['a', 6],
+          ['', 7], // empty cell
+          [null, 8], // empty cell
+          [1, 9],
+          [undefined, 10], // empty cell
+          ['', 11], // empty cell
+          [null, 12], // empty cell
         ],
         multiColumnSorting: true,
         columns: [
@@ -1294,38 +1300,58 @@ describe('MultiColumnSorting', () => {
       getPlugin('multiColumnSorting').sort({ column: 0, sortOrder: 'asc' });
 
       expect(getData()).toEqual([
-        [1, 6],
-        ['a', 3],
-        [false, 0],
-        [true, 2],
+        [1, 9],
+        ['a', 6],
+        [false, 2],
+        [true, 5],
+        // Not sorting in place.
+        [null, 0], // empty cell
         ['', 1], // empty cell
+        [undefined, 3], // empty cell
         [null, 4], // empty cell
-        [undefined, 5], // empty cell
+        ['', 7], // empty cell
+        [null, 8], // empty cell
+        [undefined, 10], // empty cell
+        ['', 11], // empty cell
+        [null, 12], // empty cell
       ]);
 
       getPlugin('multiColumnSorting').sort({ column: 0, sortOrder: 'desc' });
 
       expect(getData()).toEqual([
-        [true, 2],
-        [false, 0],
-        ['a', 3],
-        [1, 6],
+        [true, 5],
+        [false, 2],
+        ['a', 6],
+        [1, 9],
+        // Not sorting in place.
+        [null, 0], // empty cell
         ['', 1], // empty cell
+        [undefined, 3], // empty cell
         [null, 4], // empty cell
-        [undefined, 5], // empty cell
+        ['', 7], // empty cell
+        [null, 8], // empty cell
+        [undefined, 10], // empty cell
+        ['', 11], // empty cell
+        [null, 12], // empty cell
       ]);
     });
 
     it('should sort elements in a proper way when `sortEmptyCells` is set to `true`', () => {
       handsontable({
         data: [
-          [false, 0],
+          [null, 0], // empty cell
           ['', 1], // empty cell
-          [true, 2],
-          ['a', 3],
+          [false, 2],
+          [undefined, 3], // empty cell
           [null, 4], // empty cell
-          [undefined, 5], // empty cell
-          [1, 6],
+          [true, 5],
+          ['a', 6],
+          ['', 7], // empty cell
+          [null, 8], // empty cell
+          [1, 9],
+          [undefined, 10], // empty cell
+          ['', 11], // empty cell
+          [null, 12], // empty cell
         ],
         multiColumnSorting: {
           sortEmptyCells: true
@@ -1339,25 +1365,37 @@ describe('MultiColumnSorting', () => {
       getPlugin('multiColumnSorting').sort({ column: 0, sortOrder: 'asc' });
 
       expect(getData()).toEqual([
-        [1, 6],
-        ['a', 3],
-        [false, 0],
+        [1, 9],
+        ['a', 6],
+        [null, 0], // empty cell
         ['', 1], // empty cell
+        [false, 2],
+        [undefined, 3], // empty cell
         [null, 4], // empty cell
-        [undefined, 5], // empty cell
-        [true, 2],
+        ['', 7], // empty cell
+        [null, 8], // empty cell
+        [undefined, 10], // empty cell
+        ['', 11], // empty cell
+        [null, 12], // empty cell
+        [true, 5],
       ]);
 
       getPlugin('multiColumnSorting').sort({ column: 0, sortOrder: 'desc' });
 
       expect(getData()).toEqual([
-        [true, 2],
-        [false, 0],
+        [true, 5],
+        [null, 0], // empty cell
         ['', 1], // empty cell
+        [false, 2],
+        [undefined, 3], // empty cell
         [null, 4], // empty cell
-        [undefined, 5], // empty cell
-        ['a', 3],
-        [1, 6],
+        ['', 7], // empty cell
+        [null, 8], // empty cell
+        [undefined, 10], // empty cell
+        ['', 11], // empty cell
+        [null, 12], // empty cell
+        ['a', 6],
+        [1, 9],
       ]);
     });
   });

--- a/src/renderers/checkboxRenderer/checkboxRenderer.js
+++ b/src/renderers/checkboxRenderer/checkboxRenderer.js
@@ -7,6 +7,7 @@ import {
 } from '../../helpers/dom/event';
 import { partial } from '../../helpers/function';
 import { equalsIgnoreCase } from '../../helpers/string';
+import { isUndefined } from '../../helpers/mixed';
 import { isKey } from '../../helpers/unicode';
 
 import './checkboxRenderer.css';
@@ -53,7 +54,7 @@ export function checkboxRenderer(instance, TD, row, col, prop, value, cellProper
   } else if (value === cellProperties.uncheckedTemplate || equalsIgnoreCase(value, cellProperties.uncheckedTemplate)) {
     input.checked = false;
 
-  } else if (value === null) { // default value
+  } else if (value === null || isUndefined(value) || value === '') { // default value (considered as empty cell)
     addClass(input, 'noValue');
 
   } else {

--- a/src/renderers/checkboxRenderer/checkboxRenderer.js
+++ b/src/renderers/checkboxRenderer/checkboxRenderer.js
@@ -7,7 +7,7 @@ import {
 } from '../../helpers/dom/event';
 import { partial } from '../../helpers/function';
 import { equalsIgnoreCase } from '../../helpers/string';
-import { isUndefined } from '../../helpers/mixed';
+import { isEmpty } from '../../helpers/mixed';
 import { isKey } from '../../helpers/unicode';
 
 import './checkboxRenderer.css';
@@ -54,7 +54,7 @@ export function checkboxRenderer(instance, TD, row, col, prop, value, cellProper
   } else if (value === cellProperties.uncheckedTemplate || equalsIgnoreCase(value, cellProperties.uncheckedTemplate)) {
     input.checked = false;
 
-  } else if (value === null || isUndefined(value) || value === '') { // default value (considered as empty cell)
+  } else if (isEmpty(value)) { // default value
     addClass(input, 'noValue');
 
   } else {


### PR DESCRIPTION
### Context

Sorting of checkboxes doesn't work. We described some requirements for the bug fix:

- [x] Values such as empty string (`''`) and `undefined` will become unchecked checkbox (consistency with other data types)

![113283103-1eb24680-92e8-11eb-9687-c764dcff935d](https://user-images.githubusercontent.com/141330/113885909-85d86b00-97c0-11eb-92ba-17cc3ca9158f.png)


- [x]  We will display above values as an unchecked checkboxes - the same as for `null` (not as "fully" empty cells - alternative solution); It's worth to mention that `delete` and `backspace` keys on the cell of type `checkbox` doesn't remove checkbox, but just uncheck it.

`Note:` This approach won't make breaking change and what's more won't complicate sorting (there will be no need to determine how "fully" empty cell behave when there has been applied sorting).

- [x] The `sortEmptyCells` option will configure how empty cells are sorted. As an "emptyCell" we will recognize cells with `undefined`, `null` and `''` values.
- [x] We will do sorting of `#bad-value` the same as do it GS.
- [ ] There may be needed refactor of checkbox renderer (move validation to another place) and change in validation process to make it similar to another data types and to GS. However, it should be done within another task, as it is a breaking change.

Now
![image](https://user-images.githubusercontent.com/141330/113284154-8321d580-92e9-11eb-9a4e-c06c2c67d2a4.png)

- [x] Empty cells and unchecked cells won't be moved between themselves. Sorting will behave as stable sorting algorithm for them.
- [x] Sorting will work for `checkedTemplate` and `uncheckedTemplate`.
- [x] Docs for sorting checkboxes updated within https://github.com/handsontable/docs/issues/305.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Manual tests with different `checkedTemplate`, `uncheckedTemplate` and `sortEmptyCells` configurations and different values.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #4047

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] My change requires a change to the documentation.
