### PR TITLE
Add a fixed set of devDependencies for the angular examples.

### DIFF
--- a/examples/next/docs/angular/basic-example/package.json
+++ b/examples/next/docs/angular/basic-example/package.json
@@ -33,8 +33,10 @@
     "zone.js": "0.10.3"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "0.1100.7",
-    "@angular/cli": "11.2.6",
+    "@angular-devkit/build-angular": "0.1102.7",
+    "@angular/localize": "11.2.7",
+    "@angular/service-worker": "11.2.7",
+    "@angular/cli": "11.2.7",
     "@angular/compiler-cli": "11.2.7",
     "@types/jasmine": "3.6.9",
     "@types/node": "12.20.7",

--- a/examples/templates/angular/package.json
+++ b/examples/templates/angular/package.json
@@ -33,8 +33,10 @@
     "zone.js": "0.10.3"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "0.1100.7",
-    "@angular/cli": "11.2.6",
+    "@angular-devkit/build-angular": "0.1102.7",
+    "@angular/localize": "11.2.7",
+    "@angular/service-worker": "11.2.7",
+    "@angular/cli": "11.2.7",
     "@angular/compiler-cli": "11.2.7",
     "@types/jasmine": "3.6.9",
     "@types/node": "12.20.7",


### PR DESCRIPTION
### Context
This PR adds a set of `devDependencies` to the examples for Angular.

Although all the dependency versions were fixed (to `11.2.7`), some of them have their own dependencies declared as `^x.y.z`, which caused conflicts on install. 

For example:

`@angular-devkit/build-angular` installs `@angular/localize@^11.0.0` (resolving to `11.2.9` right now), which requires `@angular/compiler@11.2.9`, thus causing a conflict with our `@angular/compiler@11.2.7`.

etc

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Affected project(s):
- [x] `examples`

[skip changelog]