### PR TITLE
Add ESlint config that require new line before return keyword

### DIFF
--- a/.changelogs/7691.json
+++ b/.changelogs/7691.json
@@ -1,0 +1,7 @@
+{
+  "title": "Enhanced the ESLint config file by adding a rule that checks if there are missing new lines before some keywords or statements.",
+  "type": "changed",
+  "issue": 7691,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -88,7 +88,9 @@ module.exports = {
       "error",
       { blankLine: "always", prev: "*", next: "return" },
       { blankLine: "always", prev: "*", next: ["if", "for", "switch", "while"] },
-      { blankLine: "any", prev: "block-like", next: ["if", "for", "switch", "while"] }
+      { blankLine: "any", prev: "block-like", next: ["if", "for", "switch", "while"] },
+      { blankLine: "always", prev: ["const", "let", "var"], next: "*" },
+      { blankLine: "any", prev: ["const", "let", "var"], next: ["const", "let", "var"] }
     ],
     "jsdoc/check-access": "error",
     "jsdoc/check-alignment": "error",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -86,7 +86,9 @@ module.exports = {
     "space-before-function-paren": ["error", "never"],
     "padding-line-between-statements": [
       "error",
-      { blankLine: "always", prev: "*", next: "return" }
+      { blankLine: "always", prev: "*", next: "return" },
+      { blankLine: "always", prev: "*", next: "if" },
+      { blankLine: "any", prev: "block-like", next: "if" }
     ],
     "jsdoc/check-access": "error",
     "jsdoc/check-alignment": "error",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -87,8 +87,8 @@ module.exports = {
     "padding-line-between-statements": [
       "error",
       { blankLine: "always", prev: "*", next: "return" },
-      { blankLine: "always", prev: "*", next: "if" },
-      { blankLine: "any", prev: "block-like", next: "if" }
+      { blankLine: "always", prev: "*", next: ["if", "for", "switch", "while"] },
+      { blankLine: "any", prev: "block-like", next: ["if", "for", "switch", "while"] }
     ],
     "jsdoc/check-access": "error",
     "jsdoc/check-alignment": "error",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -84,6 +84,10 @@ module.exports = {
     "padded-blocks": "off",
     "quotes": [ "error", "single" ],
     "space-before-function-paren": ["error", "never"],
+    "padding-line-between-statements": [
+      "error",
+      { blankLine: "always", prev: "*", next: "return" }
+    ],
     "jsdoc/check-access": "error",
     "jsdoc/check-alignment": "error",
     "jsdoc/check-examples": "off",

--- a/src/3rdparty/SheetClip/SheetClip.js
+++ b/src/3rdparty/SheetClip/SheetClip.js
@@ -81,6 +81,7 @@ export function parse(str) {
 
       } else {
         const matchedText = str.match(regNextCellNoQuotes);
+
         nextCell = matchedText ? matchedText[0] : '';
         str = str.slice(nextCell.length);
       }

--- a/src/3rdparty/walkontable/src/border.js
+++ b/src/3rdparty/walkontable/src/border.js
@@ -113,6 +113,7 @@ class Border {
     const _this = this;
     const documentBody = this.wot.rootDocument.body;
     const bounds = parentElement.getBoundingClientRect();
+
     // Hide border to prevents selection jumping when fragmentSelection is enabled.
     parentElement.style.display = 'none';
 
@@ -155,10 +156,12 @@ class Border {
    */
   createBorders(settings) {
     const { rootDocument } = this.wot;
+
     this.main = rootDocument.createElement('div');
 
     const borderDivs = ['top', 'left', 'bottom', 'right', 'corner'];
     let style = this.main.style;
+
     style.position = 'absolute';
     style.top = 0;
     style.left = 0;
@@ -483,6 +486,7 @@ class Border {
     this.rightStyle.display = 'block';
 
     let cornerVisibleSetting = this.settings.border.cornerVisible;
+
     cornerVisibleSetting = typeof cornerVisibleSetting === 'function' ?
       cornerVisibleSetting(this.settings.layerLevel) : cornerVisibleSetting;
 

--- a/src/3rdparty/walkontable/src/calculator/viewportColumns.js
+++ b/src/3rdparty/walkontable/src/calculator/viewportColumns.js
@@ -175,6 +175,7 @@ class ViewportColumnsCalculator {
       return;
     }
     let totalColumnsWidth = totalWidth;
+
     this.totalTargetWidth = totalColumnsWidth;
 
     const priv = privatePool.get(this);

--- a/src/3rdparty/walkontable/src/cell/range.js
+++ b/src/3rdparty/walkontable/src/cell/range.js
@@ -359,6 +359,7 @@ class CellRange {
    */
   flipDirectionVertically() {
     const direction = this.getDirection();
+
     switch (direction) {
       case 'NW-SE':
         this.setDirection('SW-NE');
@@ -382,6 +383,7 @@ class CellRange {
    */
   flipDirectionHorizontally() {
     const direction = this.getDirection();
+
     switch (direction) {
       case 'NW-SE':
         this.setDirection('NE-SW');

--- a/src/3rdparty/walkontable/src/cell/range.js
+++ b/src/3rdparty/walkontable/src/cell/range.js
@@ -599,6 +599,7 @@ class CellRange {
         }
       }
     }
+
     return out;
   }
 

--- a/src/3rdparty/walkontable/src/overlay/_base.js
+++ b/src/3rdparty/walkontable/src/overlay/_base.js
@@ -203,6 +203,7 @@ export class Overlay {
     if (onFixedRowBottom) {
       const absoluteRootElementPosition = this.wot.wtTable.wtRootElement.getBoundingClientRect();
       const absoluteOverlayPosition = this.clone.wtTable.TABLE.getBoundingClientRect();
+
       verticalOffset = (absoluteOverlayPosition.top * (-1)) + absoluteRootElementPosition.top;
 
     } else if (!onFixedRowTop) {

--- a/src/3rdparty/walkontable/src/overlay/top.js
+++ b/src/3rdparty/walkontable/src/overlay/top.js
@@ -320,6 +320,7 @@ export class TopOverlay extends Overlay {
       return this.wot.wtTable.holderOffset.top;
 
     }
+
     return 0;
 
   }

--- a/src/3rdparty/walkontable/src/settings.js
+++ b/src/3rdparty/walkontable/src/settings.js
@@ -151,6 +151,7 @@ class Settings {
     } else { // if value is defined then settings is the key
       this.settings[settings] = value;
     }
+
     return this.wot;
   }
 

--- a/src/3rdparty/walkontable/src/table.js
+++ b/src/3rdparty/walkontable/src/table.js
@@ -274,6 +274,7 @@ class Table {
       }
       const startRow = totalRows > 0 ? this.getFirstRenderedRow() : 0;
       const startColumn = totalColumns > 0 ? this.getFirstRenderedColumn() : 0;
+
       this.rowFilter = new RowFilter(startRow, totalRows, columnHeadersCount);
       this.columnFilter = new ColumnFilter(startColumn, totalColumns, rowHeadersCount);
 
@@ -283,6 +284,7 @@ class Table {
       if (this.isMaster) {
         this.alignOverlaysWithTrimmingContainer();
         const skipRender = {};
+
         this.wot.getSetting('beforeDraw', true, skipRender);
         performRedraw = skipRender.skipRender !== true;
       }

--- a/src/3rdparty/walkontable/src/table.js
+++ b/src/3rdparty/walkontable/src/table.js
@@ -278,6 +278,7 @@ class Table {
       this.columnFilter = new ColumnFilter(startColumn, totalColumns, rowHeadersCount);
 
       let performRedraw = true;
+
       // Only master table rendering can be skipped
       if (this.isMaster) {
         this.alignOverlaysWithTrimmingContainer();
@@ -452,6 +453,7 @@ class Table {
    */
   resetOversizedRows() {
     const { wot } = this;
+
     if (!this.isMaster && !this.is(CLONE_BOTTOM)) {
       return;
     }

--- a/src/3rdparty/walkontable/src/table/mixin/calculatedColumns.js
+++ b/src/3rdparty/walkontable/src/table/mixin/calculatedColumns.js
@@ -22,6 +22,7 @@ const calculatedColumns = {
     if (startColumn === null) {
       return -1;
     }
+
     return startColumn;
   },
 
@@ -36,6 +37,7 @@ const calculatedColumns = {
     if (startColumn === null) {
       return -1;
     }
+
     return startColumn;
   },
 
@@ -50,6 +52,7 @@ const calculatedColumns = {
     if (endColumn === null) {
       return -1;
     }
+
     return endColumn;
   },
 
@@ -64,6 +67,7 @@ const calculatedColumns = {
     if (endColumn === null) {
       return -1;
     }
+
     return endColumn;
   },
 

--- a/src/3rdparty/walkontable/src/table/mixin/calculatedRows.js
+++ b/src/3rdparty/walkontable/src/table/mixin/calculatedRows.js
@@ -22,6 +22,7 @@ const calculatedRows = {
     if (startRow === null) {
       return -1;
     }
+
     return startRow;
   },
 
@@ -36,6 +37,7 @@ const calculatedRows = {
     if (startRow === null) {
       return -1;
     }
+
     return startRow;
   },
 
@@ -50,6 +52,7 @@ const calculatedRows = {
     if (endRow === null) {
       return -1;
     }
+
     return endRow;
   },
 
@@ -64,6 +67,7 @@ const calculatedRows = {
     if (endRow === null) {
       return -1;
     }
+
     return endRow;
   },
 

--- a/src/3rdparty/walkontable/src/table/mixin/stickyColumnsLeft.js
+++ b/src/3rdparty/walkontable/src/table/mixin/stickyColumnsLeft.js
@@ -22,6 +22,7 @@ const stickyColumnsLeft = {
     if (totalColumns === 0) {
       return -1;
     }
+
     return 0;
   },
 

--- a/src/3rdparty/walkontable/src/table/mixin/stickyRowsTop.js
+++ b/src/3rdparty/walkontable/src/table/mixin/stickyRowsTop.js
@@ -22,6 +22,7 @@ const stickyRowsTop = {
     if (totalRows === 0) {
       return -1;
     }
+
     return 0;
   },
 

--- a/src/3rdparty/walkontable/src/viewport.js
+++ b/src/3rdparty/walkontable/src/viewport.js
@@ -188,6 +188,7 @@ class Viewport {
    */
   getWorkspaceActualWidth() {
     const { wtTable } = this.wot;
+
     return outerWidth(wtTable.TABLE) ||
       outerWidth(wtTable.TBODY) ||
       outerWidth(wtTable.THEAD); // IE8 reports 0 as <table> offsetWidth;

--- a/src/3rdparty/walkontable/src/viewport.js
+++ b/src/3rdparty/walkontable/src/viewport.js
@@ -54,6 +54,7 @@ class Viewport {
 
     } else {
       const elemHeight = outerHeight(trimmingContainer);
+
       // returns height without DIV scrollbar
       height = (elemHeight > 0 && trimmingContainer.clientHeight > 0) ? trimmingContainer.clientHeight : Infinity;
     }
@@ -251,6 +252,7 @@ class Viewport {
 
       if (rowHeaders.length) {
         let TH = this.instance.wtTable.TABLE.querySelector('TH');
+
         this.rowHeaderWidth = 0;
 
         for (let i = 0, len = rowHeaders.length; i < len; i++) {
@@ -382,6 +384,7 @@ class Viewport {
 
     if (fixedColumnsLeft) {
       const fixedColumnsWidth = wtOverlays.leftOverlay.sumCellSizes(0, fixedColumnsLeft);
+
       pos += fixedColumnsWidth;
       width -= fixedColumnsWidth;
     }

--- a/src/3rdparty/walkontable/test/helpers/common.js
+++ b/src/3rdparty/walkontable/test/helpers/common.js
@@ -377,6 +377,7 @@ export function walkontableCalculateScrollbarWidth() {
   const w1 = inner.offsetWidth;
   outer.style.overflow = 'scroll';
   let w2 = inner.offsetWidth;
+
   if (w1 === w2) {
     w2 = outer.clientWidth;
   }

--- a/src/3rdparty/walkontable/test/helpers/common.js
+++ b/src/3rdparty/walkontable/test/helpers/common.js
@@ -359,10 +359,12 @@ export function spreadsheetColumnLabel(index) {
  */
 export function walkontableCalculateScrollbarWidth() {
   const inner = document.createElement('div');
+
   inner.style.height = '200px';
   inner.style.width = '100%';
 
   const outer = document.createElement('div');
+
   outer.style.boxSizing = 'content-box';
   outer.style.height = '150px';
   outer.style.left = '0px';
@@ -375,6 +377,7 @@ export function walkontableCalculateScrollbarWidth() {
 
   (document.body || document.documentElement).appendChild(outer);
   const w1 = inner.offsetWidth;
+
   outer.style.overflow = 'scroll';
   let w2 = inner.offsetWidth;
 

--- a/src/3rdparty/walkontable/test/spec/border.spec.js
+++ b/src/3rdparty/walkontable/test/spec/border.spec.js
@@ -39,6 +39,7 @@ describe('WalkontableBorder', () => {
         wt.draw();
       }
     });
+
     wt.draw();
 
     const $td1 = spec().$table.find('tbody tr:eq(1) td:eq(0)');
@@ -99,6 +100,7 @@ describe('WalkontableBorder', () => {
         wt.draw();
       }
     });
+
     wt.draw();
 
     const $td1 = spec().$table.find('tbody tr:eq(1) td:eq(0)');
@@ -142,6 +144,7 @@ describe('WalkontableBorder', () => {
         wt.draw();
       }
     });
+
     wt.draw();
 
     wt.selections.getCell().add(new Walkontable.CellCoords(0, 0));
@@ -190,6 +193,7 @@ describe('WalkontableBorder', () => {
         wt.draw();
       }
     });
+
     wt.draw();
 
     const $td1 = spec().$table.find('tbody tr:eq(1) td:eq(0)');
@@ -235,6 +239,7 @@ describe('WalkontableBorder', () => {
         wt.draw();
       }
     });
+
     wt.draw();
 
     const $td1 = spec().$table.find('tbody tr:eq(2) td:eq(1)');
@@ -271,6 +276,7 @@ describe('WalkontableBorder', () => {
         wt.draw();
       }
     });
+
     wt.draw();
 
     const $td1 = spec().$table.find('tbody tr:eq(1) td:eq(1)');
@@ -343,6 +349,7 @@ describe('WalkontableBorder', () => {
         wt.draw();
       }
     });
+
     wt.draw();
 
     const $td1 = spec().$table.find('tbody tr:eq(1) td:eq(0)');

--- a/src/3rdparty/walkontable/test/spec/cell/coords.spec.js
+++ b/src/3rdparty/walkontable/test/spec/cell/coords.spec.js
@@ -23,6 +23,7 @@ describe('Walkontable.CellCoords', () => {
     it('should be false if one of the arguments is smaller than 0', () => {
       let cellCoords = new Walkontable.CellCoords(-1, 0);
       let result = cellCoords.isValid(spec().wot);
+
       expect(result).toBe(false);
 
       cellCoords = new Walkontable.CellCoords(0, -1);
@@ -33,24 +34,28 @@ describe('Walkontable.CellCoords', () => {
     it('should be true if row is within the total number of rows', () => {
       const cellCoords = new Walkontable.CellCoords(9, 1);
       const result = cellCoords.isValid(spec().wot);
+
       expect(result).toBe(true);
     });
 
     it('should be false if row is greater than total number of rows', () => {
       const cellCoords = new Walkontable.CellCoords(10, 1);
       const result = cellCoords.isValid(spec().wot);
+
       expect(result).toBe(false);
     });
 
     it('should be true if column is within the total number of columns', () => {
       const cellCoords = new Walkontable.CellCoords(1, 4);
       const result = cellCoords.isValid(spec().wot);
+
       expect(result).toBe(true);
     });
 
     it('should be false if column is greater than total number of columns', () => {
       const cellCoords = new Walkontable.CellCoords(1, 5);
       const result = cellCoords.isValid(spec().wot);
+
       expect(result).toBe(false);
     });
   });
@@ -59,6 +64,7 @@ describe('Walkontable.CellCoords', () => {
     it('should be equal to itself', () => {
       const cellCoords = new Walkontable.CellCoords(1, 1);
       const result = cellCoords.isEqual(cellCoords);
+
       expect(result).toBe(true);
     });
 
@@ -66,6 +72,7 @@ describe('Walkontable.CellCoords', () => {
       const cellCoords = new Walkontable.CellCoords(1, 1);
       const cellCoords2 = new Walkontable.CellCoords(1, 1);
       const result = cellCoords.isEqual(cellCoords2);
+
       expect(result).toBe(true);
     });
 
@@ -73,6 +80,7 @@ describe('Walkontable.CellCoords', () => {
       const cellCoords = new Walkontable.CellCoords(1, 1);
       const cellCoords2 = new Walkontable.CellCoords(2, 1);
       const result = cellCoords.isEqual(cellCoords2);
+
       expect(result).toBe(false);
     });
   });

--- a/src/3rdparty/walkontable/test/spec/cell/range.spec.js
+++ b/src/3rdparty/walkontable/test/spec/cell/range.spec.js
@@ -1240,6 +1240,7 @@ describe('Walkontable.CellRange', () => {
       let callCount = 0;
       range.forAll(() => {
         callCount += 1;
+
         if (callCount === 2) {
           return false;
         }

--- a/src/3rdparty/walkontable/test/spec/cell/range.spec.js
+++ b/src/3rdparty/walkontable/test/spec/cell/range.spec.js
@@ -5,6 +5,7 @@ describe('Walkontable.CellRange', () => {
       const to = new Walkontable.CellCoords(3, 3);
       const range = new Walkontable.CellRange(from, from, to);
       const all = range.getAll();
+
       expect(all.length).toBe(9);
       expect(all[0].row).toBe(from.row);
       expect(all[0].col).toBe(from.col);
@@ -19,6 +20,7 @@ describe('Walkontable.CellRange', () => {
       const to = new Walkontable.CellCoords(1, 1);
       const range = new Walkontable.CellRange(from, from, to);
       const all = range.getAll();
+
       expect(all.length).toBe(9);
       expect(all[0].row).toBe(to.row);
       expect(all[0].col).toBe(to.col);
@@ -35,6 +37,7 @@ describe('Walkontable.CellRange', () => {
       const to = new Walkontable.CellCoords(3, 3);
       const range = new Walkontable.CellRange(from, from, to);
       const inner = range.getInner();
+
       expect(inner.length).toBe(7);
       expect(inner[1].row).toBe(1);
       expect(inner[1].col).toBe(3);
@@ -45,6 +48,7 @@ describe('Walkontable.CellRange', () => {
       const to = new Walkontable.CellCoords(1, 1);
       const range = new Walkontable.CellRange(from, from, to);
       const inner = range.getInner();
+
       expect(inner.length).toBe(7);
       expect(inner[1].row).toBe(1);
       expect(inner[1].col).toBe(3);
@@ -56,6 +60,7 @@ describe('Walkontable.CellRange', () => {
       const from = new Walkontable.CellCoords(0, 0);
       const to = new Walkontable.CellCoords(0, 0);
       const range = new Walkontable.CellRange(from, from, to);
+
       expect(range.includes(new Walkontable.CellCoords(0, 0))).toBe(true);
     });
 
@@ -63,6 +68,7 @@ describe('Walkontable.CellRange', () => {
       const from = new Walkontable.CellCoords(1, 1);
       const to = new Walkontable.CellCoords(3, 3);
       const range = new Walkontable.CellRange(from, from, to);
+
       expect(range.includes(new Walkontable.CellCoords(1, 1))).toBe(true);
       expect(range.includes(new Walkontable.CellCoords(3, 1))).toBe(true);
       expect(range.includes(new Walkontable.CellCoords(3, 3))).toBe(true);
@@ -76,6 +82,7 @@ describe('Walkontable.CellRange', () => {
       const from = new Walkontable.CellCoords(1, 1);
       const to = new Walkontable.CellCoords(3, 3);
       const range = new Walkontable.CellRange(from, from, to);
+
       expect(range.includes(new Walkontable.CellCoords(0, 0))).toBe(false);
       expect(range.includes(new Walkontable.CellCoords(4, 4))).toBe(false);
       expect(range.includes(new Walkontable.CellCoords(1, 4))).toBe(false);
@@ -432,9 +439,11 @@ describe('Walkontable.CellRange', () => {
 
       const expander = new Walkontable.CellCoords(3, 1);
       const res = range.expand(expander);
+
       expect(res).toBe(false);
       const topLeft2 = range.getTopLeftCorner();
       const bottomRight2 = range.getBottomRightCorner();
+
       expect(topLeft2).toEqual(topLeft);
       expect(bottomRight2).toEqual(bottomRight);
     });
@@ -448,9 +457,11 @@ describe('Walkontable.CellRange', () => {
 
       const expander = new Walkontable.CellCoords(4, 4);
       const res = range.expand(expander);
+
       expect(res).toBe(true);
       const topLeft2 = range.getTopLeftCorner();
       const bottomRight2 = range.getBottomRightCorner();
+
       expect(topLeft2).toEqual(topLeft);
       expect(bottomRight2).toEqual(expander);
     });
@@ -464,9 +475,11 @@ describe('Walkontable.CellRange', () => {
 
       const expander = new Walkontable.CellCoords(4, 4);
       const res = range.expand(expander);
+
       expect(res).toBe(true);
       const topLeft2 = range.getTopLeftCorner();
       const bottomRight2 = range.getBottomRightCorner();
+
       expect(topLeft2).toEqual(topLeft);
       expect(bottomRight2).toEqual(expander);
     });
@@ -478,9 +491,11 @@ describe('Walkontable.CellRange', () => {
 
       const expander = new Walkontable.CellCoords(3, 0);
       const res = range.expand(expander);
+
       expect(res).toBe(true);
       const topLeft2 = range.getTopLeftCorner();
       const bottomRight2 = range.getBottomRightCorner();
+
       expect(topLeft2).toEqual(new Walkontable.CellCoords(1, 0));
       expect(bottomRight2).toEqual(new Walkontable.CellCoords(3, 3));
     });
@@ -492,9 +507,11 @@ describe('Walkontable.CellRange', () => {
 
       const expander = new Walkontable.CellCoords(1, 1);
       const res = range.expand(expander);
+
       expect(res).toBe(true);
       const topLeft2 = range.getTopLeftCorner();
       const bottomRight2 = range.getBottomRightCorner();
+
       expect(topLeft2).toEqual(new Walkontable.CellCoords(1, 0));
       expect(bottomRight2).toEqual(new Walkontable.CellCoords(2, 1));
     });
@@ -506,9 +523,11 @@ describe('Walkontable.CellRange', () => {
 
       const expander = new Walkontable.CellCoords(3, 0);
       const res = range.expand(expander);
+
       expect(res).toBe(true);
       const topLeft2 = range.getTopLeftCorner();
       const bottomRight2 = range.getBottomRightCorner();
+
       expect(topLeft2).toEqual(new Walkontable.CellCoords(1, 0));
       expect(bottomRight2).toEqual(new Walkontable.CellCoords(3, 1));
     });
@@ -1214,6 +1233,7 @@ describe('Walkontable.CellRange', () => {
       const to = new Walkontable.CellCoords(3, 3);
       const range = new Walkontable.CellRange(from, from, to);
       const forAllCallback = jasmine.createSpy('beforeColumnSortHandler');
+
       range.forAll(forAllCallback);
 
       expect(forAllCallback.calls.count()).toBe(9);
@@ -1225,6 +1245,7 @@ describe('Walkontable.CellRange', () => {
       const range = new Walkontable.CellRange(from, from, to);
       const rows = [];
       const cols = [];
+
       range.forAll((row, col) => {
         rows.push(row);
         cols.push(col);
@@ -1238,6 +1259,7 @@ describe('Walkontable.CellRange', () => {
       const to = new Walkontable.CellCoords(2, 2);
       const range = new Walkontable.CellRange(from, from, to);
       let callCount = 0;
+
       range.forAll(() => {
         callCount += 1;
 

--- a/src/3rdparty/walkontable/test/spec/core.spec.js
+++ b/src/3rdparty/walkontable/test/spec/core.spec.js
@@ -26,8 +26,10 @@ describe('WalkontableCore', () => {
       totalRows: getTotalRows,
       totalColumns: getTotalColumns
     });
+
     wt.draw();
     const TDs = spec().$table.find('tbody tr:first td');
+
     expect(TDs[0].innerHTML).toBe('0');
     expect(TDs[1].innerHTML).toBe('a');
   });
@@ -41,6 +43,7 @@ describe('WalkontableCore', () => {
       totalColumns: getTotalColumns,
       renderAllRows: true
     });
+
     wt.draw();
 
     expect(spec().$table.find('td').length).toBe(400);
@@ -60,6 +63,7 @@ describe('WalkontableCore', () => {
         TH.innerHTML = row + 1;
       }]
     });
+
     wt.draw();
 
     expect(spec().$table.find('thead th').length).toBe(5); // include corner TH
@@ -75,6 +79,7 @@ describe('WalkontableCore', () => {
       totalRows: getTotalRows,
       totalColumns: getTotalColumns
     });
+
     wt.draw();
     expect(spec().$table.find('tbody tr:first td').length).toBe(2);
   });
@@ -86,6 +91,7 @@ describe('WalkontableCore', () => {
       totalRows: getTotalRows,
       totalColumns: getTotalColumns
     });
+
     wt.draw();
     expect(wt.drawn).toBe(false);
     expect(wt.drawInterrupted).toBe(true);
@@ -93,6 +99,7 @@ describe('WalkontableCore', () => {
 
   it('should not render table that is `display: none`', () => {
     const $div = $('<div style="display: none"></div>').appendTo('body');
+
     $div.append(spec().$wrapper);
 
     const wt = walkontable({
@@ -100,6 +107,7 @@ describe('WalkontableCore', () => {
       totalRows: getTotalRows,
       totalColumns: getTotalColumns
     });
+
     wt.draw();
     expect(wt.drawn).toBe(false);
     expect(wt.drawInterrupted).toBe(true);
@@ -115,6 +123,7 @@ describe('WalkontableCore', () => {
       totalRows: getTotalRows,
       totalColumns: getTotalColumns
     });
+
     wt.draw();
 
     expect(() => {
@@ -130,6 +139,7 @@ describe('WalkontableCore', () => {
       totalRows: getTotalRows,
       totalColumns: getTotalColumns
     });
+
     wt.draw();
 
     expect(() => {
@@ -145,6 +155,7 @@ describe('WalkontableCore', () => {
       totalRows: getTotalRows,
       totalColumns: getTotalColumns
     });
+
     wt.draw();
     createDataArray(1, 5);
 
@@ -161,6 +172,7 @@ describe('WalkontableCore', () => {
       totalRows: getTotalRows,
       totalColumns: getTotalColumns
     });
+
     wt.draw();
     createDataArray(1, 5);
 
@@ -177,6 +189,7 @@ describe('WalkontableCore', () => {
       totalRows: getTotalRows,
       totalColumns: getTotalColumns
     });
+
     wt.draw();
 
     expect(spec().$table.find('tbody tr').length).toBe(5);

--- a/src/3rdparty/walkontable/test/spec/scroll.spec.js
+++ b/src/3rdparty/walkontable/test/spec/scroll.spec.js
@@ -1066,6 +1066,7 @@ describe('WalkontableScroll', () => {
       spec().data = createSpreadsheetData(20, 1);
 
       const txt = 'Very very very very very very very very very very very very very very very very very long text.';
+
       spec().data[4][0] = txt;
 
       const wt = walkontable({
@@ -1101,6 +1102,7 @@ describe('WalkontableScroll', () => {
       spec().data = createSpreadsheetData(20, 1);
 
       const txt = 'Very very very very very very very very very very very very very very very very very long text.';
+
       spec().data[19][0] = txt;
 
       const wt = walkontable({

--- a/src/3rdparty/walkontable/test/spec/scrollbar.spec.js
+++ b/src/3rdparty/walkontable/test/spec/scrollbar.spec.js
@@ -26,6 +26,7 @@ describe('WalkontableScrollbar', () => {
       totalRows: getTotalRows,
       totalColumns: getTotalColumns
     });
+
     wt.draw();
 
     expect(spec().$table.parents('.wtHolder').length).toEqual(1);
@@ -40,6 +41,7 @@ describe('WalkontableScrollbar', () => {
         totalRows: getTotalRows,
         totalColumns: getTotalColumns
       });
+
       wt.draw();
 
       wt.wtOverlays.topOverlay.onScroll(1);

--- a/src/3rdparty/walkontable/test/spec/scrollbarNative.spec.js
+++ b/src/3rdparty/walkontable/test/spec/scrollbarNative.spec.js
@@ -29,9 +29,11 @@ describe('WalkontableScrollbarNative', () => {
       totalRows: getTotalRows,
       totalColumns: getTotalColumns
     });
+
     wt.draw();
 
     const tds = spec().$table.find('td').length;
+
     wt.draw();
 
     expect(spec().$table.find('td').length).toEqual(tds);
@@ -45,9 +47,11 @@ describe('WalkontableScrollbarNative', () => {
       totalRows: getTotalRows,
       totalColumns: getTotalColumns
     });
+
     wt.draw();
 
     const tds = spec().$table.find('td').length;
+
     wt.draw();
 
     expect(spec().$table.find('td').length).toEqual(tds);
@@ -61,6 +65,7 @@ describe('WalkontableScrollbarNative', () => {
       totalRows: getTotalRows,
       totalColumns: getTotalColumns
     });
+
     wt.draw();
 
     const lastRenderedRow = wt.wtTable.getLastRenderedRow();
@@ -83,6 +88,7 @@ describe('WalkontableScrollbarNative', () => {
       totalRows: getTotalRows,
       totalColumns: getTotalColumns
     });
+
     wt.draw();
 
     wt.wtOverlays.topOverlay.scrollTo(3);

--- a/src/3rdparty/walkontable/test/spec/selection.spec.js
+++ b/src/3rdparty/walkontable/test/spec/selection.spec.js
@@ -73,6 +73,7 @@ describe('Walkontable.Selection', () => {
 
     const tds = spec().$wrapper.find('td:contains(B2), td:contains(B3), td:contains(C2), td:contains(C3)');
     expect(tds.length).toBeGreaterThan(4);
+
     for (let i = 0, ilen = tds.length; i < ilen; i++) {
       expect(tds[i].className).toContain('area');
     }

--- a/src/3rdparty/walkontable/test/spec/selection.spec.js
+++ b/src/3rdparty/walkontable/test/spec/selection.spec.js
@@ -33,6 +33,7 @@ describe('Walkontable.Selection', () => {
         wt.draw();
       }
     });
+
     wt.draw();
 
     const $td1 = spec().$table.find('tbody td:eq(0)');
@@ -72,6 +73,7 @@ describe('Walkontable.Selection', () => {
     wt.draw();
 
     const tds = spec().$wrapper.find('td:contains(B2), td:contains(B3), td:contains(C2), td:contains(C3)');
+
     expect(tds.length).toBeGreaterThan(4);
 
     for (let i = 0, ilen = tds.length; i < ilen; i++) {
@@ -86,10 +88,12 @@ describe('Walkontable.Selection', () => {
       totalColumns: getTotalColumns,
       selections: createSelectionController(),
     });
+
     wt.draw();
     wt.selections.getCell().add(new Walkontable.CellCoords(0, 0));
 
     const $td1 = spec().$table.find('tbody td:eq(0)');
+
     expect($td1.hasClass('current')).toEqual(false);
 
     wt.draw();
@@ -108,15 +112,18 @@ describe('Walkontable.Selection', () => {
         wt.draw();
       }
     });
+
     wt.draw();
 
     await sleep(1500);
     const $td1 = spec().$table.find('tbody tr:eq(1) td:eq(0)');
     const $td2 = spec().$table.find('tbody tr:eq(2) td:eq(1)');
     const $top = $(wt.selections.getCell().getBorder(wt).top); // cheat... get border for ht_master
+
     $td1.simulate('mousedown');
 
     const pos1 = $top.position();
+
     expect(pos1.top).toBeGreaterThan(0);
     expect(pos1.left).toBe(0);
 
@@ -134,6 +141,7 @@ describe('Walkontable.Selection', () => {
       totalColumns: getTotalColumns,
       selections: createSelectionController(),
     });
+
     wt.draw();
 
     wt.selections.getCell().add(new Walkontable.CellCoords(20, 0));
@@ -144,6 +152,7 @@ describe('Walkontable.Selection', () => {
 
   it('should not scroll the viewport after selection is cleared', () => {
     const scrollbarWidth = getScrollbarWidth(); // normalize viewport size disregarding of the scrollbar size on any OS
+
     spec().$wrapper.width(100 + scrollbarWidth).height(200 + scrollbarWidth);
 
     const wt = walkontable({
@@ -179,6 +188,7 @@ describe('Walkontable.Selection', () => {
       totalColumns: getTotalColumns,
       selections: createSelectionController(),
     });
+
     wt.draw();
 
     wt.selections.getCell().add(new Walkontable.CellCoords(0, 0));
@@ -195,6 +205,7 @@ describe('Walkontable.Selection', () => {
       highlightRowClassName: 'highlightRow',
       highlightColumnClassName: 'highlightColumn'
     });
+
     customSelection.add(new Walkontable.CellCoords(0, 0));
     customSelection.add(new Walkontable.CellCoords(0, 1));
 
@@ -206,6 +217,7 @@ describe('Walkontable.Selection', () => {
         custom: [customSelection],
       }),
     });
+
     wt.draw();
 
     expect(spec().$table.find('.highlightRow').length).toEqual(2);
@@ -237,6 +249,7 @@ describe('Walkontable.Selection', () => {
         custom: [customSelection1, customSelection2],
       }),
     });
+
     wt.draw();
 
     expect(spec().$table.find('.highlightRow').length).toEqual(3);
@@ -255,6 +268,7 @@ describe('Walkontable.Selection', () => {
         }),
       }),
     });
+
     wt.draw();
 
     wt.selections.getCell().add(new Walkontable.CellCoords(0, 0));
@@ -289,6 +303,7 @@ describe('Walkontable.Selection', () => {
         }),
       }),
     });
+
     wt.draw();
 
     wt.selections.getCell().add(new Walkontable.CellCoords(1, 1));
@@ -340,6 +355,7 @@ describe('Walkontable.Selection', () => {
         totalColumns: getTotalColumns,
         selections: createSelectionController(),
       });
+
       wt.selections.getCell().add(new Walkontable.CellCoords(1, 1));
       wt.selections.getCell().add(new Walkontable.CellCoords(3, 3));
 

--- a/src/3rdparty/walkontable/test/spec/settings/columnHeaders.spec.js
+++ b/src/3rdparty/walkontable/test/spec/settings/columnHeaders.spec.js
@@ -27,6 +27,7 @@ describe('columnHeaders option', () => {
       totalRows: getTotalRows,
       totalColumns: getTotalColumns
     });
+
     wt.draw();
 
     expect(spec().$wrapper.hasClass('htColumnHeaders')).toBe(false);
@@ -41,6 +42,7 @@ describe('columnHeaders option', () => {
         TH.innerHTML = col + 1;
       }]
     });
+
     wt.draw();
 
     expect(spec().$wrapper.hasClass('htColumnHeaders')).toBe(true);
@@ -55,6 +57,7 @@ describe('columnHeaders option', () => {
         TH.innerHTML = col + 1;
       }]
     });
+
     wt.draw();
 
     expect(spec().$wrapper.find('.ht_clone_left colgroup col').length).toBe(0);
@@ -79,6 +82,7 @@ describe('columnHeaders option', () => {
       }],
       columnWidth: 80
     });
+
     wt.draw();
 
     expect(spec().$wrapper.find('.ht_clone_top thead tr').height()).toBe(43);
@@ -95,6 +99,7 @@ describe('columnHeaders option', () => {
       }],
       columnWidth: 80
     });
+
     wt.draw();
 
     expect(spec().$wrapper.find('.ht_clone_top thead tr').height()).toBe(23);
@@ -110,6 +115,7 @@ describe('columnHeaders option', () => {
         TH.innerHTML = headers[column];
       }]
     });
+
     wt.draw();
 
     const visibleHeaders = headers.slice(0, wt.wtTable.getLastRenderedColumn() + 1); // headers for rendered columns only

--- a/src/3rdparty/walkontable/test/spec/settings/preventOverflow.spec.js
+++ b/src/3rdparty/walkontable/test/spec/settings/preventOverflow.spec.js
@@ -27,6 +27,7 @@ describe('preventOverflow option', () => {
       totalRows: getTotalRows,
       totalColumns: getTotalColumns
     });
+
     wt.draw();
 
     expect(spec().$table.parents('.wtHolder').css('overflow')).toBe('visible');
@@ -42,6 +43,7 @@ describe('preventOverflow option', () => {
         return 'horizontal';
       }
     });
+
     wt.draw();
 
     expect(spec().$table.parents('.wtHolder').css('overflow')).toBe('auto');
@@ -60,6 +62,7 @@ describe('preventOverflow option', () => {
         return 'horizontal';
       }
     });
+
     wt.draw();
 
     expect($(wt.wtTable.wtRootElement.parentNode).find('.ht_clone_top .wtHolder').css('overflow-x')).toBe('hidden');

--- a/src/3rdparty/walkontable/test/spec/settings/rowHeaders.spec.js
+++ b/src/3rdparty/walkontable/test/spec/settings/rowHeaders.spec.js
@@ -27,6 +27,7 @@ describe('rowHeaders option', () => {
       totalRows: getTotalRows,
       totalColumns: getTotalColumns
     });
+
     wt.draw();
 
     expect(spec().$wrapper.hasClass('htRowHeaders')).toBe(false);
@@ -41,6 +42,7 @@ describe('rowHeaders option', () => {
         TH.innerHTML = row + 1;
       }]
     });
+
     wt.draw();
 
     expect(spec().$wrapper.hasClass('htRowHeaders')).toBe(true);
@@ -55,6 +57,7 @@ describe('rowHeaders option', () => {
         TH.innerHTML = row + 1;
       }]
     });
+
     wt.draw();
 
     expect(spec().$wrapper.find('.ht_clone_left colgroup col').length).toBe(1);
@@ -80,6 +83,7 @@ describe('rowHeaders option', () => {
 
     wt.draw();
     const potentialRowCount = 9;
+
     expect(spec().$table.find('tbody td').length).toBe(potentialRowCount * wt.wtTable.getRenderedColumnsCount()); // displayed cells
     expect(spec().$table.find('tbody th').length).toBe(potentialRowCount); // 9*1=9 displayed row headers
     expect(spec().$table.find('tbody tr:first th').length).toBe(1); // only one th per row
@@ -98,6 +102,7 @@ describe('rowHeaders option', () => {
         TH.innerHTML = col + 1;
       }]
     });
+
     wt.draw();
 
     expect(spec().$table.find('col:first').hasClass('rowHeader')).toBe(true);

--- a/src/3rdparty/walkontable/test/spec/settings/stretchH.spec.js
+++ b/src/3rdparty/walkontable/test/spec/settings/stretchH.spec.js
@@ -35,6 +35,7 @@ describe('stretchH option', () => {
         TH.innerHTML = row + 1;
       }]
     });
+
     wt.draw();
 
     expect(spec().$table.outerWidth()).toBeAroundValue(wt.wtTable.holder.clientWidth);
@@ -56,9 +57,11 @@ describe('stretchH option', () => {
         TH.innerHTML = row + 1;
       }]
     });
+
     wt.draw();
 
     const initialTableWidth = spec().$table.outerWidth();
+
     expect(initialTableWidth).toBeAroundValue(spec().$table[0].clientWidth);
 
     spec().$wrapper.width(600).height(500);
@@ -72,6 +75,7 @@ describe('stretchH option', () => {
     await sleep(300);
 
     const currentTableWidth = spec().$table.outerWidth();
+
     expect(currentTableWidth).toBeAroundValue(spec().$table[0].clientWidth);
     expect(currentTableWidth).toBeGreaterThan(initialTableWidth);
   });
@@ -96,12 +100,15 @@ describe('stretchH option', () => {
       totalColumns: getTotalColumns,
       stretchH: 'all'
     });
+
     wt.draw();
 
     let expectedColWidth = ((300 - getScrollbarWidth()) / 2);
+
     expectedColWidth = Math.floor(expectedColWidth);
 
     const wtHider = spec().$table.parents('.wtHider');
+
     expect(wtHider.find('col:eq(0)').width()).toBeAroundValue(expectedColWidth);
     expect(wtHider.find('col:eq(1)').width() - expectedColWidth).toBeInArray([0, 1]); // fix differences between Mac and Linux PhantomJS
   });
@@ -120,9 +127,11 @@ describe('stretchH option', () => {
         TH.innerHTML = row + 1;
       }]
     });
+
     wt.draw();
 
     const wtHider = spec().$table.parents('.wtHider');
+
     expect(wtHider.outerWidth()).toBe(getTableWidth(spec().$table));
     expect(wtHider.find('col:eq(1)').width()).toBeLessThan(wtHider.find('col:eq(2)').width());
   });
@@ -169,9 +178,11 @@ describe('stretchH option', () => {
         TH.innerHTML = row + 1;
       }]
     });
+
     wt.draw();
 
     const wtHider = spec().$table.parents('.wtHider');
+
     expect(wtHider.outerWidth()).toBe(getTableWidth(spec().$table));
     expect(wtHider.find('col:eq(1)').width()).toBeLessThan(wtHider.find('col:eq(2)').width());
   });
@@ -189,6 +200,7 @@ describe('stretchH option', () => {
         TH.innerHTML = row + 1;
       }]
     });
+
     wt.draw();
 
     expect(spec().$table.width()).toBeLessThan(spec().$wrapper.width());

--- a/src/3rdparty/walkontable/test/spec/table.spec.js
+++ b/src/3rdparty/walkontable/test/spec/table.spec.js
@@ -5,6 +5,7 @@ describe('WalkontableTable', () => {
     const hotParent = TH.parentElement.parentElement.parentElement.parentElement.parentElement
       .parentElement.parentElement;
     const classes = hotParent.className.split(' ');
+
     return classes[0];
   }
 
@@ -984,6 +985,7 @@ describe('WalkontableTable', () => {
       totalColumns: getTotalColumns,
       cellRenderer(row, column, TD) {
         count += 1;
+
         return wt.wtSettings.defaults.cellRenderer(row, column, TD);
       }
     });

--- a/src/3rdparty/walkontable/test/spec/table.spec.js
+++ b/src/3rdparty/walkontable/test/spec/table.spec.js
@@ -116,6 +116,7 @@ describe('WalkontableTable', () => {
     expect(wt.wtTable.getCell(new Walkontable.CellCoords(7, 21))).toBe(-4); // exit code - after rendered column
 
     let results = [];
+
     for (let i = 0; i < 20; i++) {
       const result = wt.wtTable.getCell(new Walkontable.CellCoords(10, i));
       results.push(result instanceof HTMLElement ? HTMLElement : result);
@@ -124,6 +125,7 @@ describe('WalkontableTable', () => {
       .toEqual([-3, -3, -3, -3, -3, HTMLElement, HTMLElement, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4]);
 
     results = [];
+
     for (let i = 0; i < 20; i++) {
       const result = wt.wtTable.getCell(new Walkontable.CellCoords(i, 6));
       results.push(result instanceof HTMLElement ? HTMLElement : result);

--- a/src/3rdparty/walkontable/test/spec/table.spec.js
+++ b/src/3rdparty/walkontable/test/spec/table.spec.js
@@ -35,6 +35,7 @@ describe('WalkontableTable', () => {
       totalRows: getTotalRows,
       totalColumns: getTotalColumns
     });
+
     wt.draw();
     expect(spec().$table.find('tbody tr').length).toBe(9);
   });
@@ -47,6 +48,7 @@ describe('WalkontableTable', () => {
       totalRows: getTotalRows,
       totalColumns: getTotalColumns
     });
+
     wt.draw();
     expect(spec().$table.find('tbody tr').length).toBe(5);
   });
@@ -60,6 +62,7 @@ describe('WalkontableTable', () => {
         TH.innerHTML = col + 1;
       }]
     });
+
     wt.draw();
     expect(spec().$table.find('tbody tr:first td').length).toBe(spec().$table.find('thead th').length);
   });
@@ -84,6 +87,7 @@ describe('WalkontableTable', () => {
         }
       ]
     });
+
     wt.draw();
     expect(spec().$table.find('thead tr:first th').length).toBe(wt.wtTable.getRenderedColumnsCount() + 1); // 4 columns in THEAD + 1 empty cell in the corner
     expect(spec().$table.find('thead tr:first th:eq(0)')[0].innerHTML.replace(/&nbsp;/, '')).toBe(''); // corner row is empty (or contains only &nbsp;)
@@ -93,6 +97,7 @@ describe('WalkontableTable', () => {
 
   it('getCell should only return cells from rendered rows and columns', function() {
     const scrollbarWidth = getScrollbarWidth(); // normalize viewport size disregarding of the scrollbar size on any OS
+
     spec().$wrapper.width(100 + scrollbarWidth).height(201 + scrollbarWidth);
 
     createDataArray(20, 20);
@@ -101,6 +106,7 @@ describe('WalkontableTable', () => {
       totalRows: getTotalRows,
       totalColumns: getTotalColumns
     });
+
     wt.draw();
 
     expect(wt.wtTable.getCell(new Walkontable.CellCoords(7, 0)) instanceof HTMLElement).toBe(true);
@@ -119,6 +125,7 @@ describe('WalkontableTable', () => {
 
     for (let i = 0; i < 20; i++) {
       const result = wt.wtTable.getCell(new Walkontable.CellCoords(10, i));
+
       results.push(result instanceof HTMLElement ? HTMLElement : result);
     }
     expect(results)
@@ -128,6 +135,7 @@ describe('WalkontableTable', () => {
 
     for (let i = 0; i < 20; i++) {
       const result = wt.wtTable.getCell(new Walkontable.CellCoords(i, 6));
+
       results.push(result instanceof HTMLElement ? HTMLElement : result);
     }
 
@@ -147,9 +155,11 @@ describe('WalkontableTable', () => {
       totalRows: getTotalRows,
       totalColumns: getTotalColumns
     });
+
     wt.draw();
 
     const bottomTable = wt.wtOverlays.bottomOverlay.clone.wtTable;
+
     expect(bottomTable.getCell(new Walkontable.CellCoords(18, 0)) instanceof HTMLTableCellElement).toBe(true);
     expect(bottomTable.getCell(new Walkontable.CellCoords(19, 0)) instanceof HTMLTableCellElement).toBe(true);
   });
@@ -169,6 +179,7 @@ describe('WalkontableTable', () => {
         TH.innerHTML = `${hotParentName(TH)}-header-of-row-${row}`;
       }]
     });
+
     wt.draw();
 
     expectWtTable(wt, wtTable => wtTable.getCell({ row: -1, col: -1 }).innerHTML, 'master')
@@ -341,6 +352,7 @@ describe('WalkontableTable', () => {
         TH.innerHTML = `${hotParentName(TH)}-header-of-row-${row}`;
       }]
     });
+
     wt.draw();
 
     expectWtTable(wt, wtTable => wtTable.getCell({ row: -1, col: -1 }), 'master').toBe(-1);
@@ -572,6 +584,7 @@ describe('WalkontableTable', () => {
         TH.innerHTML = `${hotParentName(TH)}-header-of-row-${row}`;
       }]
     });
+
     wt.draw();
 
     expectWtTable(wt, wtTable => wtTable.getFirstRenderedRow(), 'master').toBe(-1);
@@ -640,6 +653,7 @@ describe('WalkontableTable', () => {
         TH.innerHTML = `${hotParentName(TH)}-header-of-row-${row}`;
       }]
     });
+
     wt.draw();
 
     expectWtTable(wt, wtTable => wtTable.getFirstRenderedRow(), 'master').toBe(2);
@@ -696,9 +710,11 @@ describe('WalkontableTable', () => {
       totalRows: getTotalRows,
       totalColumns: getTotalColumns
     });
+
     wt.draw();
 
     const $td2 = spec().$table.find('tbody tr:eq(1) td:eq(1)');
+
     expect(wt.wtTable.getCoords($td2[0])).toEqual(new Walkontable.CellCoords(1, 1));
   });
 
@@ -717,9 +733,11 @@ describe('WalkontableTable', () => {
         TH.innerHTML = plusOne(row);
       }]
     });
+
     wt.draw();
 
     const $td2 = spec().$table.find('tbody tr:eq(1) td:eq(1)');
+
     expect(wt.wtTable.getCoords($td2[0])).toEqual(new Walkontable.CellCoords(1, 1));
   });
 
@@ -734,9 +752,11 @@ describe('WalkontableTable', () => {
         TH.innerHTML = col + 1;
       }]
     });
+
     wt.draw();
 
     const $th2 = spec().$table.find('thead tr:first th:eq(1)');
+
     expect(wt.wtTable.getCoords($th2[0])).toEqual(new Walkontable.CellCoords(-1, 1));
   });
 
@@ -750,10 +770,12 @@ describe('WalkontableTable', () => {
         TH.innerHTML = col + 1;
       }]
     });
+
     wt.draw();
 
     const $cloneLeft = $('.ht_clone_left');
     const $td2 = $cloneLeft.find('tbody tr:eq(1) td:eq(1)');
+
     expect(wt.wtTable.getCoords($td2[0])).toEqual(new Walkontable.CellCoords(1, 1));
   });
 
@@ -767,6 +789,7 @@ describe('WalkontableTable', () => {
       }],
       stretchH: 'all'
     });
+
     wt.draw();
     wt.wtViewport.columnsRenderCalculator.refreshStretching(502);
 
@@ -786,6 +809,7 @@ describe('WalkontableTable', () => {
       }],
       stretchH: 'last'
     });
+
     wt.draw();
     wt.wtViewport.columnsRenderCalculator.refreshStretching(502);
 
@@ -812,6 +836,7 @@ describe('WalkontableTable', () => {
         TD.style.backgroundColor = 'yellow';
       }
     });
+
     wt.draw();
     expect(spec().$table.find('td:first')[0].style.backgroundColor).toBe('yellow');
   });
@@ -824,6 +849,7 @@ describe('WalkontableTable', () => {
       totalRows: getTotalRows,
       totalColumns: getTotalColumns
     });
+
     wt.draw();
     expect(spec().$table.find('tbody tr').length).toBe(8);
 
@@ -841,6 +867,7 @@ describe('WalkontableTable', () => {
         TH.innerHTML = col + 1;
       }]
     });
+
     wt.draw();
     expect(spec().$table.find('thead tr:first').children().length).toBe(2);
     expect(spec().$table.find('tbody tr:first').children().length).toBe(2);
@@ -863,6 +890,7 @@ describe('WalkontableTable', () => {
         TH.innerHTML = col + 1;
       }]
     });
+
     wt.draw();
     expect(spec().$table.find('thead tr:first').children().length).toBe(2);
     expect(spec().$table.find('tbody tr:first').children().length).toBe(2);
@@ -890,6 +918,7 @@ describe('WalkontableTable', () => {
         return (column + 1) * 50;
       }
     });
+
     wt.draw();
     expect(spec().$table.find('tbody tr:first td:eq(0)').outerWidth()).toBe(50);
     expect(spec().$table.find('tbody tr:first td:eq(1)').outerWidth()).toBe(100);
@@ -912,6 +941,7 @@ describe('WalkontableTable', () => {
       }],
       columnWidth: [50, 100, 150, 201]
     });
+
     wt.draw();
     expect(spec().$table.find('tbody tr:first td:eq(0)').outerWidth()).toBe(50);
     expect(spec().$table.find('tbody tr:first td:eq(1)').outerWidth()).toBe(100);
@@ -934,6 +964,7 @@ describe('WalkontableTable', () => {
       }],
       columnWidth: 100
     });
+
     wt.draw();
     expect(spec().$table.find('tbody tr:first td:eq(0)').outerWidth()).toBe(100);
     expect(spec().$table.find('tbody tr:first td:eq(1)').outerWidth()).toBe(100);
@@ -958,6 +989,7 @@ describe('WalkontableTable', () => {
       }],
       columnWidth: 100
     });
+
     wt.draw();
     // start from eq(1) because eq(0) is corner header
     expect(spec().$table.find('thead tr:first th:eq(1)').outerWidth()).toBe(100);
@@ -972,6 +1004,7 @@ describe('WalkontableTable', () => {
       totalRows: getTotalRows,
       totalColumns: getTotalColumns
     });
+
     wt.draw();
     spec().$table.find('tbody td').html('');
     wt.draw();
@@ -991,8 +1024,10 @@ describe('WalkontableTable', () => {
         return wt.wtSettings.defaults.cellRenderer(row, column, TD);
       }
     });
+
     wt.draw();
     const oldCount = count;
+
     wt.draw(true);
 
     expect(count).toBe(oldCount);
@@ -1012,6 +1047,7 @@ describe('WalkontableTable', () => {
         calc.endRow += 10;
       }
     });
+
     wt.draw();
 
     const oldCount = count;
@@ -1036,6 +1072,7 @@ describe('WalkontableTable', () => {
         calc.endRow += 10;
       }
     });
+
     wt.draw();
 
     const oldCount = count;
@@ -1066,6 +1103,7 @@ describe('WalkontableTable', () => {
         calc.endColumn += 10;
       }
     });
+
     wt.draw();
     const oldCount = count;
 
@@ -1090,6 +1128,7 @@ describe('WalkontableTable', () => {
         calc.endColumn += 10;
       }
     });
+
     wt.draw();
 
     const oldCount = count;
@@ -1118,6 +1157,7 @@ describe('WalkontableTable', () => {
         fixedColumnsLeft: 2,
         columnHeaders: [function() {}]
       });
+
       wt.draw();
 
       expect($('.ht_clone_top_left_corner thead tr th').eq(0).css('border-left-width')).toBe('1px');
@@ -1138,6 +1178,7 @@ describe('WalkontableTable', () => {
         totalRows: getTotalRows,
         totalColumns: getTotalColumns
       });
+
       wt.draw();
 
       expect(wt.wtTable.isLastRowFullyVisible()).toBe(false);
@@ -1152,6 +1193,7 @@ describe('WalkontableTable', () => {
         totalRows: getTotalRows,
         totalColumns: getTotalColumns
       });
+
       wt.draw();
       wt.scrollViewportVertically(7);
       wt.draw();
@@ -1170,6 +1212,7 @@ describe('WalkontableTable', () => {
         totalRows: getTotalRows,
         totalColumns: getTotalColumns
       });
+
       wt.draw();
 
       expect(wt.wtTable.isLastColumnFullyVisible()).toBe(false);
@@ -1203,6 +1246,7 @@ describe('WalkontableTable', () => {
         totalRows: getTotalRows,
         totalColumns: getTotalColumns
       });
+
       wt.draw();
 
       expect(wt.wtTable.getFirstVisibleRow()).toBe(0);
@@ -1217,6 +1261,7 @@ describe('WalkontableTable', () => {
         totalRows: getTotalRows,
         totalColumns: getTotalColumns
       });
+
       wt.draw();
       wt.scrollViewportVertically(10);
       wt.draw();
@@ -1236,6 +1281,7 @@ describe('WalkontableTable', () => {
         fixedRowsBottom: 2,
         fixedColumnsLeft: 2
       });
+
       wt.draw();
 
       expectWtTable(wt, wtTable => wtTable.getFirstVisibleRow(), 'master').toBe(2);
@@ -1257,6 +1303,7 @@ describe('WalkontableTable', () => {
         totalRows: getTotalRows,
         totalColumns: getTotalColumns
       });
+
       wt.draw();
 
       expect(wt.wtTable.getLastVisibleRow()).toBe(5);
@@ -1271,6 +1318,7 @@ describe('WalkontableTable', () => {
         totalRows: getTotalRows,
         totalColumns: getTotalColumns
       });
+
       wt.draw();
       wt.scrollViewportVertically(7);
       wt.draw();
@@ -1290,6 +1338,7 @@ describe('WalkontableTable', () => {
         fixedRowsBottom: 2,
         fixedColumnsLeft: 2
       });
+
       wt.draw();
 
       expectWtTable(wt, wtTable => wtTable.getLastVisibleRow(), 'master').toBe(4);
@@ -1311,6 +1360,7 @@ describe('WalkontableTable', () => {
         totalRows: getTotalRows,
         totalColumns: getTotalColumns
       });
+
       wt.draw();
 
       expect(wt.wtTable.getFirstVisibleColumn()).toBe(0);
@@ -1325,6 +1375,7 @@ describe('WalkontableTable', () => {
         totalRows: getTotalRows,
         totalColumns: getTotalColumns
       });
+
       wt.draw();
       wt.scrollViewportHorizontally(7);
       wt.draw();
@@ -1344,6 +1395,7 @@ describe('WalkontableTable', () => {
         fixedRowsBottom: 2,
         fixedColumnsLeft: 2
       });
+
       wt.draw();
 
       expectWtTable(wt, wtTable => wtTable.getFirstVisibleColumn(), 'master').toBe(2);
@@ -1365,6 +1417,7 @@ describe('WalkontableTable', () => {
         totalRows: getTotalRows,
         totalColumns: getTotalColumns
       });
+
       wt.draw();
 
       expect(wt.wtTable.getLastVisibleColumn()).toBe(2);
@@ -1379,6 +1432,7 @@ describe('WalkontableTable', () => {
         totalRows: getTotalRows,
         totalColumns: getTotalColumns
       });
+
       wt.draw();
       wt.scrollViewportHorizontally(7);
       wt.draw();
@@ -1398,6 +1452,7 @@ describe('WalkontableTable', () => {
         fixedRowsBottom: 2,
         fixedColumnsLeft: 2
       });
+
       wt.draw();
 
       expectWtTable(wt, wtTable => wtTable.getLastVisibleColumn(), 'master').toBe(4); // TODO I think this should be 3 not 4, because 4 is only partially visible, but for now I am only testing actual behavior
@@ -1419,6 +1474,7 @@ describe('WalkontableTable', () => {
         totalRows: getTotalRows,
         totalColumns: getTotalColumns
       });
+
       wt.draw();
 
       expect(wt.wtTable.getFirstRenderedRow()).toBe(0);
@@ -1433,6 +1489,7 @@ describe('WalkontableTable', () => {
         totalRows: getTotalRows,
         totalColumns: getTotalColumns
       });
+
       wt.draw();
       wt.scrollViewportVertically(10);
       wt.draw();
@@ -1452,6 +1509,7 @@ describe('WalkontableTable', () => {
         fixedRowsBottom: 2,
         fixedColumnsLeft: 2
       });
+
       wt.draw();
 
       expectWtTable(wt, wtTable => wtTable.getFirstRenderedRow(), 'master').toBe(2);
@@ -1472,6 +1530,7 @@ describe('WalkontableTable', () => {
         totalColumns: 1,
         fixedRowsBottom: 3,
       });
+
       wt.draw();
 
       expectWtTable(wt, wtTable => wtTable.getFirstRenderedRow(), 'master').toBe(0);
@@ -1492,6 +1551,7 @@ describe('WalkontableTable', () => {
         fixedRowsBottom: 2,
         fixedColumnsLeft: 2
       });
+
       wt.draw();
       wt.scrollViewportVertically(10);
       wt.draw();
@@ -1533,6 +1593,7 @@ describe('WalkontableTable', () => {
         fixedRowsBottom: 2,
         fixedColumnsLeft: 2
       });
+
       wt.draw();
       wt.scrollViewportVertically(10);
       wt.draw();
@@ -1576,6 +1637,7 @@ describe('WalkontableTable', () => {
         fixedRowsBottom: 2,
         fixedColumnsLeft: 2
       });
+
       wt.draw();
       wt.scrollViewportVertically(10);
       wt.draw();
@@ -1616,6 +1678,7 @@ describe('WalkontableTable', () => {
         totalRows: getTotalRows,
         totalColumns: getTotalColumns
       });
+
       wt.draw();
 
       expect(wt.wtTable.getLastRenderedRow()).toBe(7);
@@ -1630,6 +1693,7 @@ describe('WalkontableTable', () => {
         totalRows: getTotalRows,
         totalColumns: getTotalColumns
       });
+
       wt.draw();
       wt.scrollViewportVertically(10);
       wt.draw();
@@ -1649,6 +1713,7 @@ describe('WalkontableTable', () => {
         fixedRowsBottom: 2,
         fixedColumnsLeft: 2
       });
+
       wt.draw();
 
       expectWtTable(wt, wtTable => wtTable.getLastRenderedRow(), 'master').toBe(5);
@@ -1670,6 +1735,7 @@ describe('WalkontableTable', () => {
         totalRows: getTotalRows,
         totalColumns: getTotalColumns
       });
+
       wt.draw();
 
       expect(wt.wtTable.getFirstRenderedColumn()).toBe(0);
@@ -1684,6 +1750,7 @@ describe('WalkontableTable', () => {
         totalRows: getTotalRows,
         totalColumns: getTotalColumns
       });
+
       wt.draw();
       wt.scrollViewportHorizontally(7);
       wt.draw();
@@ -1703,6 +1770,7 @@ describe('WalkontableTable', () => {
         fixedRowsBottom: 2,
         fixedColumnsLeft: 2
       });
+
       wt.draw();
 
       expectWtTable(wt, wtTable => wtTable.getFirstRenderedColumn(), 'master').toBe(2);
@@ -1724,6 +1792,7 @@ describe('WalkontableTable', () => {
         totalRows: getTotalRows,
         totalColumns: getTotalColumns
       });
+
       wt.draw();
 
       expect(wt.wtTable.getLastRenderedColumn()).toBe(4);
@@ -1738,6 +1807,7 @@ describe('WalkontableTable', () => {
         totalRows: getTotalRows,
         totalColumns: getTotalColumns
       });
+
       wt.draw();
       wt.scrollViewportHorizontally(7);
       wt.draw();
@@ -1757,6 +1827,7 @@ describe('WalkontableTable', () => {
         fixedRowsBottom: 2,
         fixedColumnsLeft: 2
       });
+
       wt.draw();
 
       expectWtTable(wt, wtTable => wtTable.getLastRenderedColumn(), 'master').toBe(4);
@@ -1778,6 +1849,7 @@ describe('WalkontableTable', () => {
         totalRows: getTotalRows,
         totalColumns: getTotalColumns
       });
+
       wt.draw();
 
       expect(wt.wtTable.getVisibleRowsCount()).toBe(7);
@@ -1806,6 +1878,7 @@ describe('WalkontableTable', () => {
         fixedRowsBottom: 2,
         fixedColumnsLeft: 2
       });
+
       wt.draw();
 
       expectWtTable(wt, wtTable => wtTable.getVisibleRowsCount(), 'master').toBe(3);
@@ -1827,6 +1900,7 @@ describe('WalkontableTable', () => {
         totalRows: getTotalRows,
         totalColumns: getTotalColumns
       });
+
       wt.draw();
 
       expect(wt.wtTable.getVisibleColumnsCount()).toBe(3);
@@ -1855,6 +1929,7 @@ describe('WalkontableTable', () => {
         fixedRowsBottom: 2,
         fixedColumnsLeft: 2
       });
+
       wt.draw();
 
       expectWtTable(wt, wtTable => wtTable.getVisibleColumnsCount(), 'master').toBe(3);
@@ -1876,6 +1951,7 @@ describe('WalkontableTable', () => {
         totalRows: getTotalRows,
         totalColumns: getTotalColumns
       });
+
       wt.draw();
 
       expect(wt.wtTable.getRenderedRowsCount()).toBe(9);
@@ -1904,6 +1980,7 @@ describe('WalkontableTable', () => {
         fixedRowsBottom: 2,
         fixedColumnsLeft: 2
       });
+
       wt.draw();
 
       expectWtTable(wt, wtTable => wtTable.getRenderedRowsCount(), 'master').toBe(4);
@@ -1925,6 +2002,7 @@ describe('WalkontableTable', () => {
         totalRows: getTotalRows,
         totalColumns: getTotalColumns
       });
+
       wt.draw();
 
       expect(wt.wtTable.getRenderedColumnsCount()).toBe(5);
@@ -1953,6 +2031,7 @@ describe('WalkontableTable', () => {
         fixedRowsBottom: 2,
         fixedColumnsLeft: 2
       });
+
       wt.draw();
 
       expectWtTable(wt, wtTable => wtTable.getRenderedColumnsCount(), 'master').toBe(3);
@@ -1971,6 +2050,7 @@ describe('WalkontableTable', () => {
         totalRows: getTotalRows,
         totalColumns: getTotalColumns,
       });
+
       wt.draw();
 
       expect(wt.wtTable.isVisible()).toBe(true);
@@ -1989,6 +2069,7 @@ describe('WalkontableTable', () => {
         totalRows: getTotalRows,
         totalColumns: getTotalColumns,
       });
+
       wt.draw();
 
       expect(wt.wtTable.hasDefinedSize()).toBe(true);

--- a/src/core.js
+++ b/src/core.js
@@ -2018,6 +2018,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
 
     } else if (data === null) {
       const dataSchema = datamap.getSchema();
+
       // eslint-disable-next-line no-param-reassign
       data = [];
       let row;
@@ -4233,6 +4234,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
    */
   this.toTableElement = () => {
     const tempElement = this.rootDocument.createElement('div');
+
     tempElement.insertAdjacentHTML('afterbegin', instanceToHTML(this));
 
     return tempElement.firstElementChild;

--- a/src/core.js
+++ b/src/core.js
@@ -2319,11 +2319,13 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
     instance.runHooks('afterCellMetaReset');
 
     let currentHeight = instance.rootElement.style.height;
+
     if (currentHeight !== '') {
       currentHeight = parseInt(instance.rootElement.style.height, 10);
     }
 
     let height = settings.height;
+
     if (isFunction(height)) {
       height = height();
     }

--- a/src/core.js
+++ b/src/core.js
@@ -1253,6 +1253,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
       // Fixes GH#3903
       if (!canBeValidated || cellProperties.hidden === true) {
         callback(valid);
+
         return;
       }
 

--- a/src/dataMap.js
+++ b/src/dataMap.js
@@ -131,6 +131,7 @@ class DataMap {
         if (isObject(column)) {
           if (typeof column.data !== 'undefined') {
             const index = columnsAsFunc ? filteredIndex : i;
+
             this.colToPropCache[index] = column.data;
             this.propToColCache.set(column.data, index);
           }

--- a/src/dataMap.js
+++ b/src/dataMap.js
@@ -538,6 +538,7 @@ class DataMap {
 
     extendArray(elements, after);
     let i = 0;
+
     while (i < amount) {
       elements.push(null); // add null in place of removed elements
       i += 1;
@@ -564,6 +565,7 @@ class DataMap {
 
     extendArray(elements, after);
     let i = 0;
+
     while (i < amount) {
       elements.push(null); // add null in place of removed elements
       i += 1;

--- a/src/dataMap.js
+++ b/src/dataMap.js
@@ -250,6 +250,7 @@ class DataMap {
       if (typeof schema === 'function') {
         return schema();
       }
+
       return schema;
     }
 

--- a/src/dataMap/metaManager/metaSchema.js
+++ b/src/dataMap/metaManager/metaSchema.js
@@ -1118,6 +1118,7 @@ export default () => {
 
             return isObjectEqual(this.getSchema()[meta.prop], value);
           }
+
           return false;
         }
       }

--- a/src/editors/__tests__/noEditor.spec.js
+++ b/src/editors/__tests__/noEditor.spec.js
@@ -92,6 +92,7 @@ describe('noEditor', () => {
 
     const cell = $(getCell(0, 0));
     let clicks = 0;
+
     window.scrollTo(0, cell.offset().top);
 
     setTimeout(() => {

--- a/src/editors/autocompleteEditor/__tests__/autocompleteEditor.spec.js
+++ b/src/editors/autocompleteEditor/__tests__/autocompleteEditor.spec.js
@@ -438,6 +438,7 @@ describe('AutocompleteEditor', () => {
           }
         ]
       });
+
       selectCell(0, 0);
       source.calls.reset();
       keyDownUp('enter');
@@ -466,6 +467,7 @@ describe('AutocompleteEditor', () => {
       });
       selectCell(0, 0);
       const editor = $('.autocompleteEditor');
+
       syncSources.calls.reset();
       keyDownUp('enter');
 
@@ -525,6 +527,7 @@ describe('AutocompleteEditor', () => {
           }
         ]
       });
+
       selectCell(0, 0);
       const editor = hot.getActiveEditor();
 
@@ -555,8 +558,10 @@ describe('AutocompleteEditor', () => {
           }
         ]
       });
+
       selectCell(0, 0);
       const editor = hot.getActiveEditor();
+
       updateChoicesList.calls.reset();
 
       keyDownUp('enter');
@@ -596,8 +601,10 @@ describe('AutocompleteEditor', () => {
           }
         ]
       });
+
       selectCell(0, 0);
       const editor = hot.getActiveEditor();
+
       updateChoicesList.calls.reset();
 
       keyDownUp('enter');
@@ -719,6 +726,7 @@ describe('AutocompleteEditor', () => {
           }
         ]
       });
+
       selectCell(0, 2);
       spyOn(hot.getActiveEditor(), 'beginEditing');
 
@@ -758,6 +766,7 @@ describe('AutocompleteEditor', () => {
       keyDownUp('enter');
       const $autocomplete = autocomplete();
       const $autocompleteHolder = $autocomplete.find('.ht_master .wtHolder').first();
+
       await sleep(100);
 
       expect($autocomplete.find('td').first().text()).toEqual('Acura');
@@ -1248,6 +1257,7 @@ describe('AutocompleteEditor', () => {
 
       setTimeout(() => {
         const editor = $('.handsontableInput');
+
         editor.val('foo');
         keyDownUp('enter');
 
@@ -1276,6 +1286,7 @@ describe('AutocompleteEditor', () => {
 
       setTimeout(() => {
         const editor = $('.handsontableInput');
+
         editor.val('foo');
         spec().$container.find('tbody tr:eq(1) td:eq(0)').simulate('mousedown');
 
@@ -1299,6 +1310,7 @@ describe('AutocompleteEditor', () => {
           }
         ]
       });
+
       selectCell(0, 0);
       const editorInput = $('.handsontableInput');
 
@@ -1884,6 +1896,7 @@ describe('AutocompleteEditor', () => {
           }
         ]
       });
+
       selectCell(0, 0);
       const editorInput = $('.handsontableInput');
 
@@ -2010,6 +2023,7 @@ describe('AutocompleteEditor', () => {
           }
         ]
       });
+
       selectCell(0, 0);
       const editorInput = $('.handsontableInput');
 
@@ -2496,6 +2510,7 @@ describe('AutocompleteEditor', () => {
     const choicesList = [
       'Wayne', 'Draven', 'Banner', 'Stark', 'Parker', 'Kent', 'Gordon', 'Kyle', 'Simmons'
     ];
+
     handsontable({
       columns: [
         {
@@ -2509,6 +2524,7 @@ describe('AutocompleteEditor', () => {
     selectCell(0, 0);
     keyDownUp('enter');
     const $editorInput = $('.handsontableInput');
+
     $editorInput.val('a');
     keyDownUp('a'.charCodeAt(0));
     Handsontable.dom.setCaretPosition($editorInput[0], 1);
@@ -2643,6 +2659,7 @@ describe('AutocompleteEditor', () => {
       minSpareRows: 1,
       afterValidate: afterValidateCallback
     });
+
     selectCell(0, 0);
     expect(hot.getActiveEditor().isOpened()).toBe(false);
 
@@ -2933,6 +2950,7 @@ describe('AutocompleteEditor', () => {
     selectCell(0, 0);
     keyDownUp('enter');
     const $editorInput = $('.handsontableInput');
+
     $editorInput.val('an');
     keyDownUp(65); // a
     keyDownUp(78); // n
@@ -2972,6 +2990,7 @@ describe('AutocompleteEditor', () => {
     selectCell(0, 0);
     keyDownUp('enter');
     const $editorInput = $('.handsontableInput');
+
     $editorInput.val('an');
     keyDownUp(65); // a
     keyDownUp(78); // n
@@ -3014,6 +3033,7 @@ describe('AutocompleteEditor', () => {
     selectCell(1, 0);
     keyDownUp('x'); // trigger quick edit mode
     const $editorInput = $('.handsontableInput');
+
     $editorInput.val('an');
     keyDownUp(65); // a
     keyDownUp(78); // n
@@ -3047,6 +3067,7 @@ describe('AutocompleteEditor', () => {
     selectCell(1, 0);
     keyDownUp('x'); // trigger quick edit mode
     const $editorInput = $('.handsontableInput');
+
     $editorInput.val('an');
     keyDownUp(65); // a
     keyDownUp(78); // n
@@ -3080,6 +3101,7 @@ describe('AutocompleteEditor', () => {
     selectCell(1, 1);
     keyDownUp('x'); // trigger quick edit mode
     const $editorInput = $('.handsontableInput');
+
     $editorInput.val('an');
     keyDownUp(65); // a
     keyDownUp(78); // n
@@ -3114,6 +3136,7 @@ describe('AutocompleteEditor', () => {
     selectCell(1, 0);
     keyDownUp('x'); // trigger quick edit mode
     const $editorInput = $('.handsontableInput');
+
     $editorInput.val('an');
     keyDownUp(65); // a
     keyDownUp(78); // n
@@ -3146,6 +3169,7 @@ describe('AutocompleteEditor', () => {
     selectCell(1, 0);
     keyDownUp('x'); // trigger quick edit mode
     const $editorInput = $('.handsontableInput');
+
     $editorInput.val('anananan');
     keyDownUp(65); // a
     keyDownUp(78); // n
@@ -3184,6 +3208,7 @@ describe('AutocompleteEditor', () => {
     selectCell(1, 0);
     keyDownUp('x'); // trigger quick edit mode
     const $editorInput = $('.handsontableInput');
+
     $editorInput.val('an');
     keyDownUp(65); // a
     keyDownUp(78); // n

--- a/src/editors/autocompleteEditor/autocompleteEditor.js
+++ b/src/editors/autocompleteEditor/autocompleteEditor.js
@@ -168,6 +168,7 @@ export class AutocompleteEditor extends HandsontableEditor {
    */
   queryChoices(query) {
     const source = this.cellProperties.source;
+
     this.query = query;
 
     if (typeof source === 'function') {

--- a/src/editors/autocompleteEditor/autocompleteEditor.js
+++ b/src/editors/autocompleteEditor/autocompleteEditor.js
@@ -507,6 +507,7 @@ AutocompleteEditor.sortByRelevance = function(value, choices, caseSensitive) {
     for (i = 0; i < choicesCount; i++) {
       result.push(i);
     }
+
     return result;
   }
 

--- a/src/editors/dropdownEditor/__tests__/dropdownEditor.spec.js
+++ b/src/editors/dropdownEditor/__tests__/dropdownEditor.spec.js
@@ -344,6 +344,7 @@ describe('DropdownEditor', () => {
 
       hot.view.wt.wtOverlays.topOverlay.scrollTo(1);
       const dropdown = hot.getActiveEditor();
+
       await sleep(50);
 
       expect($(dropdown.htContainer).is(':visible')).toBe(true);

--- a/src/editors/handsontableEditor/__tests__/handsontableEditor.spec.js
+++ b/src/editors/handsontableEditor/__tests__/handsontableEditor.spec.js
@@ -559,6 +559,7 @@ describe('HandsontableEditor', () => {
         }
       ]
     });
+
     selectCell(2, 0);
 
     keyDownUp('enter');
@@ -640,6 +641,7 @@ describe('HandsontableEditor', () => {
           }
         ]
       });
+
       selectCell(2, 0);
 
       keyDownUp('enter');
@@ -665,6 +667,7 @@ describe('HandsontableEditor', () => {
           }
         ]
       });
+
       selectCell(2, 0);
 
       keyDownUp('enter');
@@ -687,6 +690,7 @@ describe('HandsontableEditor', () => {
           }
         ]
       });
+
       selectCell(2, 0);
 
       keyDownUp('enter');

--- a/src/editors/handsontableEditor/handsontableEditor.js
+++ b/src/editors/handsontableEditor/handsontableEditor.js
@@ -128,6 +128,7 @@ export class HandsontableEditor extends TextEditor {
     super.createElements();
 
     const DIV = this.hot.rootDocument.createElement('DIV');
+
     DIV.className = 'handsontableEditor';
     this.TEXTAREA_PARENT.appendChild(DIV);
 
@@ -197,6 +198,7 @@ export class HandsontableEditor extends TextEditor {
 
         } else if (!innerHOT.flipped) {
           const lastRow = innerHOT.countRows() - 1;
+
           selectedRow = innerHOT.getSelectedLast()[0];
           rowToSelect = Math.min(lastRow, selectedRow + 1);
         }

--- a/src/editors/selectEditor/__tests__/selectEditor.spec.js
+++ b/src/editors/selectEditor/__tests__/selectEditor.spec.js
@@ -501,6 +501,7 @@ describe('SelectEditor', () => {
     keyDown('enter');
 
     const selectMouseDownListener = jasmine.createSpy('selectMouseDownListener');
+
     $('body').on('mousedown', selectMouseDownListener);
 
     editor.mousedown();

--- a/src/editors/selectEditor/selectEditor.js
+++ b/src/editors/selectEditor/selectEditor.js
@@ -127,6 +127,7 @@ export class SelectEditor extends BaseEditor {
 
     objectEach(options, (optionValue, key) => {
       const optionElement = this.hot.rootDocument.createElement('OPTION');
+
       optionElement.value = key;
 
       fastInnerHTML(optionElement, optionValue);
@@ -163,6 +164,7 @@ export class SelectEditor extends BaseEditor {
    */
   refreshValue() {
     const sourceData = this.hot.getSourceDataAtCell(this.row, this.prop);
+
     this.originalValue = sourceData;
 
     this.setValue(sourceData);

--- a/src/editors/textEditor/__tests__/textEditor.spec.js
+++ b/src/editors/textEditor/__tests__/textEditor.spec.js
@@ -309,6 +309,7 @@ describe('TextEditor', () => {
     keyDown('enter');
 
     const selection = getSelected();
+
     expect(selection).toEqual([[3, 2, 3, 2]]);
   });
 
@@ -321,6 +322,7 @@ describe('TextEditor', () => {
     keyDown('enter');
 
     const selection = getSelected();
+
     expect(selection).toEqual([[3, 2, 3, 2]]);
     expect(isEditorVisible()).toEqual(false);
   });
@@ -944,6 +946,7 @@ describe('TextEditor', () => {
     }); // CTRL+A should NOT select all table when cell is edited
 
     const selection = getSelected();
+
     expect(selection).toEqual([[2, 2, 2, 2]]);
     expect(isEditorVisible()).toEqual(true);
   });
@@ -1295,6 +1298,7 @@ describe('TextEditor', () => {
     selectCell(1, 1);
     keyDown(Handsontable.helper.KEY_CODES.ENTER);
     const $inputHolder = $('.handsontableInputHolder');
+
     expect($(getCell(1, 1)).offset().left).toEqual($inputHolder.offset().left + 1);
     expect($(getCell(1, 1)).offset().top).toEqual($inputHolder.offset().top + 1);
 
@@ -1333,6 +1337,7 @@ describe('TextEditor', () => {
     });
 
     const $holder = $(hot.view.wt.wtTable.holder);
+
     $holder.scrollTop(100);
     $holder.scrollLeft(100);
 
@@ -1343,6 +1348,7 @@ describe('TextEditor', () => {
     selectCell(1, 1);
     keyDownUp(Handsontable.helper.KEY_CODES.ENTER);
     const $inputHolder = $('.handsontableInputHolder');
+
     expect($(getCell(1, 1, true)).offset().left).toEqual($inputHolder.offset().left + 1);
     expect($(getCell(1, 1, true)).offset().top).toEqual($inputHolder.offset().top + 1);
 
@@ -1386,6 +1392,7 @@ describe('TextEditor', () => {
     keyDownUp(Handsontable.helper.KEY_CODES.ENTER);
     window.scrollBy(-300, -300);
     const $inputHolder = $('.handsontableInputHolder');
+
     expect($(getCell(1, 1, true)).offset().left).toEqual($inputHolder.offset().left + 1);
     expect($(getCell(1, 1, true)).offset().top).toEqual($inputHolder.offset().top + 1);
 
@@ -1435,6 +1442,7 @@ describe('TextEditor', () => {
     const top = $(currentCell).offset().top;
 
     const $inputHolder = $('.handsontableInputHolder');
+
     keyDown(Handsontable.helper.KEY_CODES.ENTER);
     expect(left).toEqual($inputHolder.offset().left + 1);
     expect(top).toEqual($inputHolder.offset().top + 1);
@@ -1463,6 +1471,7 @@ describe('TextEditor', () => {
     const left = $(currentCell).offset().left;
     const top = $(currentCell).offset().top;
     const $inputHolder = $('.handsontableInputHolder');
+
     keyDown(Handsontable.helper.KEY_CODES.ENTER);
 
     expect(left).toEqual($inputHolder.offset().left + 1);
@@ -1492,6 +1501,7 @@ describe('TextEditor', () => {
     const top = $(currentCell).offset().top;
 
     const $inputHolder = $('.handsontableInputHolder');
+
     keyDown(Handsontable.helper.KEY_CODES.ENTER);
     expect(left).toEqual($inputHolder.offset().left + 1);
     expect(top).toEqual($inputHolder.offset().top + 1);
@@ -1518,6 +1528,7 @@ describe('TextEditor', () => {
     const top = $(currentCell).offset().top;
 
     const $inputHolder = $('.handsontableInputHolder');
+
     keyDown(Handsontable.helper.KEY_CODES.ENTER);
     expect(left).toEqual($inputHolder.offset().left + 1);
     expect(top).toEqual($inputHolder.offset().top + 1);
@@ -1707,6 +1718,7 @@ describe('TextEditor', () => {
       ['', '', '', '', '', '', '', '', '', '', ''],
       ['', '', '', '', '', '', '', '', '', '', ''],
     ];
+
     handsontable({
       data,
       colWidths: 40,
@@ -1766,6 +1778,7 @@ describe('TextEditor', () => {
 
   it('should not throw an exception when window.attachEvent is defined but the text area does not have attachEvent', (done) => {
     const hot = handsontable();
+
     window.attachEvent = true;
     selectCell(1, 1);
 

--- a/src/editors/textEditor/textEditor.js
+++ b/src/editors/textEditor/textEditor.js
@@ -313,6 +313,7 @@ export class TextEditor extends BaseEditor {
   refreshValue() {
     const physicalRow = this.hot.toPhysicalRow(this.row);
     const sourceData = this.hot.getSourceDataAtCell(physicalRow, this.col);
+
     this.originalValue = sourceData;
 
     this.setValue(sourceData);

--- a/src/helpers/browser.js
+++ b/src/helpers/browser.js
@@ -4,6 +4,7 @@ const tester = (testerFunc) => {
   const result = {
     value: false,
   };
+
   result.test = (ua, vendor) => {
     result.value = testerFunc(ua, vendor);
   };

--- a/src/helpers/data.js
+++ b/src/helpers/data.js
@@ -104,6 +104,7 @@ export function createEmptySpreadsheetData(rows, columns) {
 
   for (let i = 0; i < rows; i++) {
     row = [];
+
     for (let j = 0; j < columns; j++) {
       row.push('');
     }

--- a/src/helpers/dom/element.js
+++ b/src/helpers/dom/element.js
@@ -952,6 +952,7 @@ export function setCaretPosition(element, pos, endPos) {
     } catch (err) {
       const elementParent = element.parentNode;
       const parentDisplayValue = elementParent.style.display;
+
       elementParent.style.display = 'block';
       element.setSelectionRange(pos, endPos);
       elementParent.style.display = parentDisplayValue;
@@ -972,10 +973,12 @@ let cachedScrollbarWidth;
 // eslint-disable-next-line no-restricted-globals
 function walkontableCalculateScrollbarWidth(rootDocument = document) {
   const inner = rootDocument.createElement('div');
+
   inner.style.height = '200px';
   inner.style.width = '100%';
 
   const outer = rootDocument.createElement('div');
+
   outer.style.boxSizing = 'content-box';
   outer.style.height = '150px';
   outer.style.left = '0px';
@@ -988,6 +991,7 @@ function walkontableCalculateScrollbarWidth(rootDocument = document) {
 
   (rootDocument.body || rootDocument.documentElement).appendChild(outer);
   const w1 = inner.offsetWidth;
+
   outer.style.overflow = 'scroll';
   let w2 = inner.offsetWidth;
 

--- a/src/helpers/dom/element.js
+++ b/src/helpers/dom/element.js
@@ -197,6 +197,7 @@ export function index(element) {
  */
 export function overlayContainsElement(overlayType, element, root) {
   const overlayElement = root.parentElement.querySelector(`.ht_clone_${overlayType}`);
+
   return overlayElement ? overlayElement.contains(element) : null;
 }
 

--- a/src/helpers/dom/element.js
+++ b/src/helpers/dom/element.js
@@ -917,6 +917,7 @@ export function getSelectionText(rootWindow = window) {
 // eslint-disable-next-line no-restricted-globals
 export function clearTextSelection(rootWindow = window) {
   const rootDocument = rootWindow.document;
+
   // http://stackoverflow.com/questions/3169786/clear-text-selection-with-javascript
   if (rootWindow.getSelection) {
     if (rootWindow.getSelection().empty) { // Chrome

--- a/src/helpers/dom/element.js
+++ b/src/helpers/dom/element.js
@@ -380,6 +380,7 @@ export function removeTextNodes(element) {
 
   } else if (['TABLE', 'THEAD', 'TBODY', 'TFOOT', 'TR'].indexOf(element.nodeName) > -1) {
     const childs = element.childNodes;
+
     for (let i = childs.length - 1; i >= 0; i--) {
       removeTextNodes(childs[i], element);
     }
@@ -396,6 +397,7 @@ export function removeTextNodes(element) {
  */
 export function empty(element) {
   let child;
+
   /* eslint-disable no-cond-assign */
   while (child = element.lastChild) {
     element.removeChild(child);

--- a/src/helpers/feature.js
+++ b/src/helpers/feature.js
@@ -18,6 +18,7 @@ if (!_requestAnimationFrame) {
     const id = window.setTimeout(() => {
       callback(currTime + timeToCall);
     }, timeToCall);
+
     lastTime = currTime + timeToCall;
 
     return id;
@@ -83,16 +84,19 @@ let _hasCaptionProblem;
  */
 function detectCaptionProblem() {
   const TABLE = document.createElement('TABLE');
+
   TABLE.style.borderSpacing = '0';
   TABLE.style.borderWidth = '0';
   TABLE.style.padding = '0';
   const TBODY = document.createElement('TBODY');
+
   TABLE.appendChild(TBODY);
   TBODY.appendChild(document.createElement('TR'));
   TBODY.firstChild.appendChild(document.createElement('TD'));
   TBODY.firstChild.firstChild.innerHTML = '<tr><td>t<br>t</td></tr>';
 
   const CAPTION = document.createElement('CAPTION');
+
   CAPTION.innerHTML = 'c<br>c<br>c<br>c';
   CAPTION.style.padding = '0';
   CAPTION.style.margin = '0';
@@ -148,6 +152,7 @@ export function getComparisonFunction(language, options = {}) {
 }
 
 let passiveSupported;
+
 /**
  * Checks if browser supports passive events.
  *

--- a/src/helpers/object.js
+++ b/src/helpers/object.js
@@ -182,6 +182,7 @@ export function mixin(Base, ...mixins) {
             this[propertyName] = newValue;
           };
         };
+
         Object.defineProperty(Base.prototype, key, {
           get: getter(key, value),
           set: setter(key),

--- a/src/plugins/autoColumnSize/__tests__/autoColumnSize.spec.js
+++ b/src/plugins/autoColumnSize/__tests__/autoColumnSize.spec.js
@@ -455,6 +455,7 @@ describe('AutoColumnSize', () => {
 
   it('should consider renderer that uses conditional formatting for specific row & column index', () => {
     const data = arrayOfObjects();
+
     data.push({ id: '2', name: 'Rocket Man', lastName: 'In a tin can' });
     handsontable({
       data,

--- a/src/plugins/autoColumnSize/__tests__/autoColumnSize.spec.js
+++ b/src/plugins/autoColumnSize/__tests__/autoColumnSize.spec.js
@@ -466,6 +466,7 @@ describe('AutoColumnSize', () => {
       renderer(instance, td, row, col, ...args) {
         // taken from demo/renderers.html
         Handsontable.renderers.TextRenderer.apply(this, [instance, td, row, col, ...args]);
+
         if (row === 1 && col === 0) {
           td.style.padding = '100px';
         }

--- a/src/plugins/autoRowSize/__tests__/autoRowSize.spec.js
+++ b/src/plugins/autoRowSize/__tests__/autoRowSize.spec.js
@@ -490,6 +490,7 @@ describe('AutoRowSize', () => {
         if (index === 22) {
           return 'a<br>much<br>longer<br>label';
         }
+
         return 'test';
       },
       autoRowSize: true,

--- a/src/plugins/autoRowSize/__tests__/autoRowSize.spec.js
+++ b/src/plugins/autoRowSize/__tests__/autoRowSize.spec.js
@@ -69,6 +69,7 @@ describe('AutoRowSize', () => {
     await sleep(200);
 
     const newHeight = spec().$container[0].scrollHeight;
+
     expect(oldHeight).toBeLessThan(newHeight);
   });
 
@@ -92,6 +93,7 @@ describe('AutoRowSize', () => {
     await sleep(200);
 
     const newHeight = spec().$container[0].scrollHeight;
+
     expect(oldHeight).toBeLessThan(newHeight);
   });
 
@@ -351,6 +353,7 @@ describe('AutoRowSize', () => {
 
   it('should consider renderer that uses conditional formatting for specific row & column index', () => {
     const data = arrayOfObjects();
+
     data.push({ id: '2', name: 'Rocket Man', lastName: 'In a tin can' });
 
     const hot = handsontable({
@@ -475,6 +478,7 @@ describe('AutoRowSize', () => {
     expect(parseInt(hot.getCell(2, -1).style.height, 10)).toBeInArray([22, 42]); // -1px of cell border
 
     const plugin = hot.getPlugin('manualRowMove');
+
     plugin.moveRow(1, 0);
     hot.render();
 

--- a/src/plugins/autoRowSize/autoRowSize.js
+++ b/src/plugins/autoRowSize/autoRowSize.js
@@ -279,6 +279,7 @@ export class AutoRowSize extends BasePlugin {
 
         // @TODO Should call once per render cycle, currently fired separately in different plugins
         this.hot.view.adjustElementsSize(true);
+
         // tmp
         if (this.hot.view.wt.wtOverlays.leftOverlay.needFullRender) {
           this.hot.view.wt.wtOverlays.leftOverlay.clone.draw();

--- a/src/plugins/autoRowSize/autoRowSize.js
+++ b/src/plugins/autoRowSize/autoRowSize.js
@@ -476,6 +476,7 @@ export class AutoRowSize extends BasePlugin {
     // Calculate rows height synchronously for bottom overlay
     if (fixedRowsBottom) {
       const totalRows = this.hot.countRows() - 1;
+
       this.calculateRowsHeight({ from: totalRows - fixedRowsBottom, to: totalRows });
     }
 

--- a/src/plugins/autofill/__tests__/autofill.spec.js
+++ b/src/plugins/autofill/__tests__/autofill.spec.js
@@ -372,6 +372,7 @@ describe('AutoFill', () => {
 
   it('should use correct cell coordinates also when Handsontable is used inside a TABLE (#355)', () => {
     const $table = $('<table><tr><td></td></tr></table>').appendTo('body');
+
     spec().$container.appendTo($table.find('td'));
 
     handsontable({
@@ -410,6 +411,7 @@ describe('AutoFill', () => {
 
     selectCell(1, 3);
     const fillHandle = spec().$container.find('.wtBorder.current.corner')[0];
+
     mouseDoubleClick(fillHandle);
 
     expect(getDataAtCell(2, 3)).toEqual(null);
@@ -434,6 +436,7 @@ describe('AutoFill', () => {
 
     selectCell(1, 3, 1, 4);
     const fillHandle = spec().$container.find('.wtBorder.area.corner')[0];
+
     mouseDoubleClick(fillHandle);
 
     expect(getDataAtCell(2, 3)).toEqual(null);
@@ -463,6 +466,7 @@ describe('AutoFill', () => {
 
     selectCell(0, 3);
     const fillHandle = spec().$container.find('.wtBorder.current.corner')[0];
+
     mouseDoubleClick(fillHandle);
 
     expect(getDataAtCell(0, 3)).toEqual('3');

--- a/src/plugins/autofill/autofill.js
+++ b/src/plugins/autofill/autofill.js
@@ -625,6 +625,7 @@ export class Autofill extends BasePlugin {
    */
   mapSettings() {
     const mappedSettings = getMappedFillHandleSetting(this.hot.getSettings().fillHandle);
+
     this.directions = mappedSettings.directions;
     this.autoInsertRow = mappedSettings.autoInsertRow;
   }

--- a/src/plugins/autofill/autofill.js
+++ b/src/plugins/autofill/autofill.js
@@ -310,6 +310,7 @@ export class Autofill extends BasePlugin {
     if (coords.col < 0) {
       coords.col = 0;
     }
+
     return coords;
   }
 

--- a/src/plugins/bindRowsWithHeaders/__tests__/bindRowsWithHeaders.spec.js
+++ b/src/plugins/bindRowsWithHeaders/__tests__/bindRowsWithHeaders.spec.js
@@ -14,6 +14,7 @@ describe('BindRowsWithHeaders', () => {
 
   it('should call rowHeader function with correct index as argument (strict mode)', () => {
     const callback = jasmine.createSpy();
+
     handsontable({
       data: Handsontable.helper.createSpreadsheetData(5, 10),
       rowHeaders: callback,
@@ -50,6 +51,7 @@ describe('BindRowsWithHeaders', () => {
       width: 500,
       height: 300
     });
+
     alter('remove_row', 1, 4);
 
     await sleep(100);

--- a/src/plugins/columnSorting/__tests__/columnSorting.spec.js
+++ b/src/plugins/columnSorting/__tests__/columnSorting.spec.js
@@ -211,6 +211,7 @@ describe('ColumnSorting', () => {
     hot.render();
 
     const sortedColumn = spec().$container.find('th span.columnSorting')[1];
+
     expect(window.getComputedStyle(sortedColumn, ':before').getPropertyValue('background-image')).toMatch(/url/);
   });
 
@@ -230,6 +231,7 @@ describe('ColumnSorting', () => {
     updateSettings({ columnSorting: false });
 
     const sortedColumn = spec().$container.find('th span')[0];
+
     expect(window.getComputedStyle(sortedColumn, ':before').getPropertyValue('background-image')).not.toMatch(/url/);
   });
 
@@ -1781,6 +1783,7 @@ describe('ColumnSorting', () => {
     spec().sortByClickOnColumnHeader(2);
 
     let sortedColumn = spec().$container.find('th span.columnSorting')[2];
+
     // not sorted
     expect(window.getComputedStyle(sortedColumn, ':before').getPropertyValue('background-image')).not.toMatch(/url/);
 
@@ -1828,6 +1831,7 @@ describe('ColumnSorting', () => {
 
     // ascending
     let sortedColumn = spec().$container.find('th span.columnSorting')[1];
+
     expect(window.getComputedStyle(sortedColumn, ':before').getPropertyValue('background-image')).toMatch(/url/);
 
     getPlugin('columnSorting').sort({ column: 2, sortOrder: 'asc' });
@@ -1882,6 +1886,7 @@ describe('ColumnSorting', () => {
 
     // descending
     let sortedColumn = spec().$container.find('th span.columnSorting')[1];
+
     expect(window.getComputedStyle(sortedColumn, ':before').getPropertyValue('background-image')).toMatch(/url/);
 
     getPlugin('columnSorting').sort();
@@ -2699,6 +2704,7 @@ describe('ColumnSorting', () => {
       const freezeColumn = $(hot.getPlugin('contextMenu').menu.container).find('div').filter(function() {
         return $(this).text() === 'Freeze column';
       });
+
       simulateClick(freezeColumn);
 
       expect(hot.getSettings().fixedColumnsLeft).toEqual(2);

--- a/src/plugins/columnSorting/columnSorting.js
+++ b/src/plugins/columnSorting/columnSorting.js
@@ -536,6 +536,7 @@ export class ColumnSorting extends BasePlugin {
     const cellMeta = this.hot.getCellMeta(0, column);
 
     const cellMetaCopy = Object.create(cellMeta);
+
     cellMetaCopy[this.pluginKey] = this.columnMetaCache.getValueAtIndex(this.hot.toPhysicalColumn(column));
 
     return cellMetaCopy;

--- a/src/plugins/columnSummary/__tests__/columnSummary.spec.js
+++ b/src/plugins/columnSummary/__tests__/columnSummary.spec.js
@@ -266,6 +266,7 @@ describe('ColumnSummarySpec', () => {
 
                   i -= 1;
                 } while (i >= rowRange[0]);
+
                 return counter;
               }
 
@@ -712,6 +713,7 @@ describe('ColumnSummarySpec', () => {
               forceNumeric: true
             });
           }
+
           return configArray;
         }
       });

--- a/src/plugins/columnSummary/__tests__/columnSummary.spec.js
+++ b/src/plugins/columnSummary/__tests__/columnSummary.spec.js
@@ -271,6 +271,7 @@ describe('ColumnSummarySpec', () => {
               }
 
               let counter = 0;
+
               // go through all declared ranges
               Handsontable.helper.objectEach(endpoint.ranges, (range) => {
                 counter += checkRange(range);
@@ -363,6 +364,7 @@ describe('ColumnSummarySpec', () => {
       });
 
       const plugin = hot.getPlugin('columnSummary');
+
       expect(plugin.endpoints.getEndpoint(0).destinationRow).toEqual(parseInt(hot.countRows() / 2, 10));
       expect(hot.getDataAtCell(parseInt(hot.countRows() / 2, 10), 1)).toEqual(820);
 
@@ -633,6 +635,7 @@ describe('ColumnSummarySpec', () => {
         });
 
         const nestedRowsPlugin = hot.getPlugin('nestedRows');
+
         /**
          * @param row
          */

--- a/src/plugins/columnSummary/__tests__/columnSummary.spec.js
+++ b/src/plugins/columnSummary/__tests__/columnSummary.spec.js
@@ -705,6 +705,7 @@ describe('ColumnSummarySpec', () => {
         maxRows: 5,
         columnSummary() {
           const configArray = [];
+
           for (let i = 0; i < columns; i++) {
             configArray.push({
               sourceColumn: i,

--- a/src/plugins/columnSummary/__tests__/columnSummary.spec.js
+++ b/src/plugins/columnSummary/__tests__/columnSummary.spec.js
@@ -638,6 +638,7 @@ describe('ColumnSummarySpec', () => {
          */
         function toggle(row) {
           const rowIndex = parseInt(row, 10);
+
           if (isNaN(rowIndex)) {
             return false;
           }

--- a/src/plugins/columnSummary/columnSummary.js
+++ b/src/plugins/columnSummary/columnSummary.js
@@ -176,6 +176,7 @@ export class ColumnSummary extends BasePlugin {
     do {
       cellValue = this.getCellValue(i, col) || 0;
       const decimalPlaces = (((`${cellValue}`).split('.')[1] || []).length) || 1;
+
       if (decimalPlaces > biggestDecimalPlacesCount) {
         biggestDecimalPlacesCount = decimalPlaces;
       }

--- a/src/plugins/columnSummary/endpoints.js
+++ b/src/plugins/columnSummary/endpoints.js
@@ -236,6 +236,7 @@ class Endpoints {
 
         return this.refreshAllEndpoints();
       };
+
       this.hot.addHookOnce('beforeRender', beforeRenderCallback);
 
       return;
@@ -347,6 +348,7 @@ class Endpoints {
 
     arrayEach(allIndexes, (range) => {
       let newRange = [];
+
       arrayEach(range, (coord, index) => {
         if (index === 0) {
           newRange.push(coord);
@@ -452,6 +454,7 @@ class Endpoints {
    */
   refreshChangedEndpoints(changes) {
     const needToRefresh = [];
+
     this.cellsToSetCache = [];
 
     arrayEach(changes, (value, key, changesObj) => {
@@ -504,6 +507,7 @@ class Endpoints {
     if (visualColumnIndex !== null && visualRowIndex !== null) {
       // Clear the meta on the "old" indexes
       const cellMeta = this.hot.getCellMeta(visualRowIndex, visualColumnIndex);
+
       cellMeta.readOnly = false;
       cellMeta.className = '';
     }

--- a/src/plugins/columnSummary/endpoints.js
+++ b/src/plugins/columnSummary/endpoints.js
@@ -333,6 +333,7 @@ class Endpoints {
 
     arrayEach(ranges, (range) => {
       const newRange = [];
+
       if (range[1]) {
         for (let i = range[0]; i <= range[1]; i++) {
           newRange.push(this.hot.toPhysicalRow(i));

--- a/src/plugins/columnSummary/endpoints.js
+++ b/src/plugins/columnSummary/endpoints.js
@@ -152,6 +152,7 @@ class Endpoints {
   assignSetting(settings, endpoint, name, defaultValue) {
     if (name === 'ranges' && settings[name] === void 0) {
       endpoint[name] = defaultValue;
+
       return;
     } else if (name === 'ranges' && settings[name].length === 0) {
       return;
@@ -232,9 +233,11 @@ class Endpoints {
       // and it needs to be run to properly calculate the endpoint value.
       const beforeRenderCallback = () => {
         this.hot.removeHook('beforeRender', beforeRenderCallback);
+
         return this.refreshAllEndpoints();
       };
       this.hot.addHookOnce('beforeRender', beforeRenderCallback);
+
       return;
     }
 
@@ -526,6 +529,7 @@ class Endpoints {
 
     if (endpoint.destinationRow >= this.hot.countRows() || endpoint.destinationColumn >= this.hot.countCols()) {
       this.throwOutOfBoundsWarning();
+
       return;
     }
 

--- a/src/plugins/comments/__tests__/comments.spec.js
+++ b/src/plugins/comments/__tests__/comments.spec.js
@@ -341,6 +341,7 @@ describe('Comments', () => {
 
       const plugin = hot.getPlugin('comments');
       const editor = plugin.editor.getInputElement();
+
       plugin.showAtCell(1, 1);
       expect(editor.parentNode.style.display).toEqual('block');
 
@@ -701,6 +702,7 @@ describe('Comments', () => {
       $(editCommentButton).simulate('mouseup');
 
       const textarea = spec().$container[0].parentNode.querySelector('.htCommentTextArea');
+
       textarea.focus();
       textarea.value = 'Edited comment';
 
@@ -744,6 +746,7 @@ describe('Comments', () => {
       $(editCommentButton).simulate('mouseup');
 
       const textarea = spec().$container[0].parentNode.querySelector('.htCommentTextArea');
+
       textarea.focus();
       textarea.value = 'Edited comment';
 

--- a/src/plugins/comments/__tests__/displaySwitch.unit.js
+++ b/src/plugins/comments/__tests__/displaySwitch.unit.js
@@ -16,6 +16,7 @@ describe('Comments', () => {
   describe('DisplaySwitch.show', () => {
     it('should call `showDebounced` function after triggering `show` function', () => {
       const displaySwitch = new DisplaySwitch(200);
+
       displaySwitch.showDebounced = jasmine.createSpy('showDebounced');
       const range = { from: new CellCoords(0, 1) };
 
@@ -26,6 +27,7 @@ describe('Comments', () => {
 
     it('should set `wasLastActionShow` variable to `true`', () => {
       const displaySwitch = new DisplaySwitch(200);
+
       displaySwitch.showDebounced = jasmine.createSpy('showDebounced');
       const range = { from: new CellCoords(0, 1) };
 
@@ -80,6 +82,7 @@ describe('Comments', () => {
 
     it('should set `wasLastActionShow` variable to `false`', () => {
       const displaySwitch = new DisplaySwitch(200);
+
       displaySwitch.showDebounced = jasmine.createSpy('showDebounced');
 
       displaySwitch.hide();
@@ -119,6 +122,7 @@ describe('Comments', () => {
 
     it('should set timer properly', () => {
       const displaySwitch = new DisplaySwitch(700);
+
       displaySwitch.hide();
 
       const savedhidingTimer = displaySwitch.hidingTimer;
@@ -150,6 +154,7 @@ describe('Comments', () => {
       const displaySwitch = new DisplaySwitch(1000);
       const range = { from: new CellCoords(0, 1) };
       const cachedShowDebounced = jasmine.createSpy('cachedShowDebounced');
+
       displaySwitch.showDebounced = cachedShowDebounced;
 
       jest.useFakeTimers();
@@ -203,6 +208,7 @@ describe('Comments', () => {
   describe('DisplaySwitch.destroy', () => {
     it('should clear all `localHooks`', () => {
       const displaySwitch = new DisplaySwitch(1000);
+
       displaySwitch.clearLocalHooks = jasmine.createSpy('clearLocalHooks');
 
       displaySwitch.destroy();

--- a/src/plugins/contextMenu/__tests__/contextMenu.spec.js
+++ b/src/plugins/contextMenu/__tests__/contextMenu.spec.js
@@ -203,6 +203,7 @@ describe('ContextMenu', () => {
 
     it('should be possible to define a custom container for ContextMenu\'s UI elements', () => {
       const uiContainer = $('<div/>').addClass('uiContainer');
+
       spec().$container.append(uiContainer);
 
       handsontable({
@@ -257,6 +258,7 @@ describe('ContextMenu', () => {
       await sleep(400);
 
       const cell = hot.getCell(2, 2);
+
       contextMenu(cell, hot);
 
       const contextMenuElem = $(docOutside.body).find('.htContextMenu');
@@ -606,6 +608,7 @@ describe('ContextMenu', () => {
       const rect = $('.htContextMenu')[0].getBoundingClientRect();
       const x = parseInt(rect.left + (rect.width / 2), 10);
       const y = parseInt(rect.top + rect.height, 10);
+
       mouseDown(document.elementFromPoint(x, y));
 
       expect($('.htContextMenu').is(':visible')).toBe(false);
@@ -720,6 +723,7 @@ describe('ContextMenu', () => {
 
         expect(getData().length).toEqual(4);
       };
+
       test();
 
       destroy();
@@ -818,6 +822,7 @@ describe('ContextMenu', () => {
       contextMenu();
 
       const item = $('.htContextMenu .ht_master .htCore').find('tbody td').not('.htSeparator').eq(9);
+
       item.simulate('mouseover');
       const contextSubMenu = $(`.htContextMenuSub_${item.text()}`).find('tbody td');
 
@@ -1245,6 +1250,7 @@ describe('ContextMenu', () => {
         .find('tbody')
         .find('th')
         .eq(0);
+
       simulateClick(header, 'RMB');
       contextMenu(header);
 
@@ -1333,6 +1339,7 @@ describe('ContextMenu', () => {
       });
 
       const afterCreateRowCallback = jasmine.createSpy('afterCreateRowCallback');
+
       addHook('afterCreateRow', afterCreateRowCallback);
 
       expect(countRows()).toEqual(4);
@@ -3724,6 +3731,7 @@ describe('ContextMenu', () => {
 
       selectCell(15, 3);
       const scrollTop = $mainHolder.scrollTop();
+
       contextMenu();
 
       expect($('.htContextMenu').is(':visible')).toBe(true);
@@ -3988,6 +3996,7 @@ describe('ContextMenu', () => {
       contextMenu();
 
       const item = $('.htContextMenu .ht_master .htCore').find('tbody td').not('.htSeparator').eq(9);
+
       item.simulate('mouseover');
 
       destroy();
@@ -4011,6 +4020,7 @@ describe('ContextMenu', () => {
           .find('tbody')
           .find('th')
           .eq(0);
+
         simulateClick(header, 'RMB');
         contextMenu(header);
 
@@ -4053,6 +4063,7 @@ describe('ContextMenu', () => {
           .find('tbody')
           .find('th')
           .eq(0);
+
         simulateClick(header, 'RMB');
         contextMenu(header);
 

--- a/src/plugins/contextMenu/__tests__/predefinedItems/alignment.spec.js
+++ b/src/plugins/contextMenu/__tests__/predefinedItems/alignment.spec.js
@@ -372,6 +372,7 @@ describe('ContextMenu', () => {
 
     it('should trigger `afterSetCellMeta` callback after changing alignment by context menu', async() => {
       const afterSetCellMetaCallback = jasmine.createSpy('afterSetCellMetaCallback');
+
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(5, 5),
         rowHeaders: true,

--- a/src/plugins/contextMenu/contextMenu.js
+++ b/src/plugins/contextMenu/contextMenu.js
@@ -333,6 +333,7 @@ export class ContextMenu extends BasePlugin {
       return element.nodeName === 'TD' || element.parentNode.nodeName === 'TD';
     }
     const element = event.target;
+
     this.close();
 
     if (hasClass(element, 'handsontableInput')) {

--- a/src/plugins/contextMenu/menu.js
+++ b/src/plugins/contextMenu/menu.js
@@ -202,6 +202,7 @@ class Menu {
       rowHeights: row => (filteredItems[row].name === SEPARATOR ? 1 : 23),
       afterOnCellContextMenu: (event) => {
         event.preventDefault();
+
         // On the Windows platform, the "contextmenu" is triggered after the "mouseup" so that's
         // why the closing menu is here. (#6507#issuecomment-582392301).
         if (isWindowsOS() && shouldAutoCloseMenu && this.hasSelectedItem()) {

--- a/src/plugins/contextMenu/menu.js
+++ b/src/plugins/contextMenu/menu.js
@@ -231,6 +231,7 @@ class Menu {
         }
       },
     };
+
     this.origOutsideClickDeselects = this.hot.getSettings().outsideClickDeselects;
     this.hot.getSettings().outsideClickDeselects = false;
     this.hotMenu = new Core(this.container, settings);
@@ -295,6 +296,7 @@ class Menu {
       keepInViewport: true,
       container: this.options.container,
     });
+
     subMenu.setMenuItems(dataItem.submenu.items);
     subMenu.open();
     subMenu.setPosition(cell.getBoundingClientRect());
@@ -706,6 +708,7 @@ class Menu {
 
     const selection = this.hotMenu.getSelectedLast();
     let stopEvent = false;
+
     this.keyEvent = true;
 
     switch (event.keyCode) {

--- a/src/plugins/contextMenu/predefinedItems/alignment.js
+++ b/src/plugins/contextMenu/predefinedItems/alignment.js
@@ -164,6 +164,7 @@ export default function alignmentItem() {
             if (hasClass) {
               label = markLabelAsSelected(label);
             }
+
             return label;
           },
           callback() {

--- a/src/plugins/contextMenu/utils.js
+++ b/src/plugins/contextMenu/utils.js
@@ -224,6 +224,7 @@ function shiftSeparators(items, separator) {
       break;
     }
   }
+
   return result;
 }
 

--- a/src/plugins/copyPaste/__tests__/copyPaste.spec.js
+++ b/src/plugins/copyPaste/__tests__/copyPaste.spec.js
@@ -204,6 +204,7 @@ describe('CopyPaste', () => {
         data: Handsontable.helper.createSpreadsheetData(2, 2),
         beforeCopy() {
           beforeCopySpy();
+
           return false;
         },
         afterCopy: afterCopySpy,

--- a/src/plugins/copyPaste/__tests__/copyPaste.spec.js
+++ b/src/plugins/copyPaste/__tests__/copyPaste.spec.js
@@ -231,6 +231,7 @@ describe('CopyPaste', () => {
 
       const copyEvent = getClipboardEvent();
       const plugin = hot.getPlugin('CopyPaste');
+
       selectCell(0, 0, 1, 0);
 
       plugin.onCopy(copyEvent);
@@ -413,6 +414,7 @@ describe('CopyPaste', () => {
       await sleep(60);
 
       const expected = arrayOfArrays();
+
       expected[3][4] = 'Kia';
       expect(getData()).toEqual(expected);
     });

--- a/src/plugins/copyPaste/__tests__/focusableElement.unit.js
+++ b/src/plugins/copyPaste/__tests__/focusableElement.unit.js
@@ -121,6 +121,7 @@ describe('CopyPaste', () => {
 
     it('should destroy FocusableWrapper object instance and detach secondary focusable element from DOM if they have different container', () => {
       const testContainer = document.createElement('div');
+
       document.body.appendChild(testContainer);
 
       fw1 = createElement(document.body);

--- a/src/plugins/copyPaste/copyPaste.js
+++ b/src/plugins/copyPaste/copyPaste.js
@@ -199,6 +199,7 @@ export class CopyPaste extends BasePlugin {
    */
   copy() {
     const priv = privatePool.get(this);
+
     priv.isTriggeredByCopy = true;
 
     this.getOrCreateFocusableElement();
@@ -211,6 +212,7 @@ export class CopyPaste extends BasePlugin {
    */
   cut() {
     const priv = privatePool.get(this);
+
     priv.isTriggeredByCut = true;
 
     this.getOrCreateFocusableElement();
@@ -553,6 +555,7 @@ export class CopyPaste extends BasePlugin {
 
       if (textHTML && /(<table)|(<TABLE)/g.test(textHTML)) {
         const parsedConfig = htmlToGridSettings(textHTML, this.hot.rootDocument);
+
         pastedData = parsedConfig.data;
       } else {
         pastedData = event.clipboardData.getData('text/plain');

--- a/src/plugins/copyPaste/focusableElement.js
+++ b/src/plugins/copyPaste/focusableElement.js
@@ -102,6 +102,7 @@ function createElement(container) {
   const focusableWrapper = new FocusableWrapper(container);
 
   let counter = refCounter.get(container);
+
   counter = isNaN(counter) ? 0 : counter;
 
   refCounter.set(container, counter + 1);
@@ -179,6 +180,7 @@ function destroyElement(wrapper) {
   }
 
   let counter = refCounter.get(wrapper.container);
+
   counter = isNaN(counter) ? 0 : counter;
 
   if (counter > 0) {

--- a/src/plugins/customBorders/__tests__/customBorders.spec.js
+++ b/src/plugins/customBorders/__tests__/customBorders.spec.js
@@ -11,6 +11,7 @@ describe('CustomBorders', () => {
   const EMPTY = { hide: true };
 
   const CUSTOM_BORDER_SELECTOR = '.wtBorder:not(.fill, .current, .area)';
+
   /**
    * Returns number of custom borders in DOM. There are 5 borders per
    * cell (top, left, bottom right, corner), some of which are hidden
@@ -38,6 +39,7 @@ describe('CustomBorders', () => {
         col: 0,
         top: GREEN_BORDER
       };
+
       bordersConfig.push(cellBorder);
     }
 
@@ -580,6 +582,7 @@ describe('CustomBorders', () => {
 
     hot.selectCells([[1, 1, 2, 2]]);
     const borders = customBorders.getBorders(getSelected());
+
     deselectCell();
 
     expect(borders.length).toEqual(1);
@@ -1054,6 +1057,7 @@ describe('CustomBorders', () => {
         height: 100,
         viewportRowRenderingOffset: 0
       });
+
       expect(instance.countRenderedRows()).toEqual(5);
       expect(countVisibleCustomBorders()).toEqual(5);
       expect(countCustomBorders()).toEqual(10 * 5); // TODO I think this should be 5 * 5
@@ -1069,6 +1073,7 @@ describe('CustomBorders', () => {
         viewportRowRenderingOffset: 0
       });
       const mainHolder = instance.view.wt.wtTable.holder;
+
       $(mainHolder).scrollTop(400);
       await sleep(300);
       expect(instance.countRenderedRows()).toEqual(5);
@@ -1085,6 +1090,7 @@ describe('CustomBorders', () => {
         height: 100,
         viewportRowRenderingOffset: 20
       });
+
       expect(instance.countRenderedRows()).toEqual(10);
       expect(countVisibleCustomBorders()).toEqual(10);
       expect(countCustomBorders()).toEqual(10 * 5); // TODO I think this should be 5 * 5
@@ -1094,6 +1100,7 @@ describe('CustomBorders', () => {
       spec().$container.remove();
       const data = Handsontable.helper.createSpreadsheetData(10, 2);
       const customBorders = generateCustomBordersForAllRows(data.length);
+
       handsontable({
         data,
         customBorders,

--- a/src/plugins/customBorders/contextMenuItem/bottom.js
+++ b/src/plugins/customBorders/contextMenuItem/bottom.js
@@ -20,6 +20,7 @@ export default function bottom(customBordersPlugin) {
     },
     callback(key, selected) {
       const hasBorder = checkSelectionBorders(this, 'bottom');
+
       customBordersPlugin.prepareBorder(selected, 'bottom', hasBorder);
     }
   };

--- a/src/plugins/customBorders/contextMenuItem/bottom.js
+++ b/src/plugins/customBorders/contextMenuItem/bottom.js
@@ -14,6 +14,7 @@ export default function bottom(customBordersPlugin) {
       if (hasBorder) {
         label = markSelected(label);
       }
+
       return label;
     },
     callback(key, selected) {

--- a/src/plugins/customBorders/contextMenuItem/bottom.js
+++ b/src/plugins/customBorders/contextMenuItem/bottom.js
@@ -11,6 +11,7 @@ export default function bottom(customBordersPlugin) {
     name() {
       let label = this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_BORDERS_BOTTOM);
       const hasBorder = checkSelectionBorders(this, 'bottom');
+
       if (hasBorder) {
         label = markSelected(label);
       }

--- a/src/plugins/customBorders/contextMenuItem/left.js
+++ b/src/plugins/customBorders/contextMenuItem/left.js
@@ -20,6 +20,7 @@ export default function left(customBordersPlugin) {
     },
     callback(key, selected) {
       const hasBorder = checkSelectionBorders(this, 'left');
+
       customBordersPlugin.prepareBorder(selected, 'left', hasBorder);
     }
   };

--- a/src/plugins/customBorders/contextMenuItem/left.js
+++ b/src/plugins/customBorders/contextMenuItem/left.js
@@ -11,6 +11,7 @@ export default function left(customBordersPlugin) {
     name() {
       let label = this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_BORDERS_LEFT);
       const hasBorder = checkSelectionBorders(this, 'left');
+
       if (hasBorder) {
         label = markSelected(label);
       }

--- a/src/plugins/customBorders/contextMenuItem/right.js
+++ b/src/plugins/customBorders/contextMenuItem/right.js
@@ -14,6 +14,7 @@ export default function right(customBordersPlugin) {
       if (hasBorder) {
         label = markSelected(label);
       }
+
       return label;
     },
     callback(key, selected) {

--- a/src/plugins/customBorders/contextMenuItem/right.js
+++ b/src/plugins/customBorders/contextMenuItem/right.js
@@ -11,6 +11,7 @@ export default function right(customBordersPlugin) {
     name() {
       let label = this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_BORDERS_RIGHT);
       const hasBorder = checkSelectionBorders(this, 'right');
+
       if (hasBorder) {
         label = markSelected(label);
       }

--- a/src/plugins/customBorders/contextMenuItem/right.js
+++ b/src/plugins/customBorders/contextMenuItem/right.js
@@ -20,6 +20,7 @@ export default function right(customBordersPlugin) {
     },
     callback(key, selected) {
       const hasBorder = checkSelectionBorders(this, 'right');
+
       customBordersPlugin.prepareBorder(selected, 'right', hasBorder);
     }
   };

--- a/src/plugins/customBorders/contextMenuItem/top.js
+++ b/src/plugins/customBorders/contextMenuItem/top.js
@@ -11,6 +11,7 @@ export default function top(customBordersPlugin) {
     name() {
       let label = this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_BORDERS_TOP);
       const hasBorder = checkSelectionBorders(this, 'top');
+
       if (hasBorder) {
         label = markSelected(label);
       }

--- a/src/plugins/customBorders/contextMenuItem/top.js
+++ b/src/plugins/customBorders/contextMenuItem/top.js
@@ -20,6 +20,7 @@ export default function top(customBordersPlugin) {
     },
     callback(key, selected) {
       const hasBorder = checkSelectionBorders(this, 'top');
+
       customBordersPlugin.prepareBorder(selected, 'top', hasBorder);
     }
   };

--- a/src/plugins/customBorders/utils.js
+++ b/src/plugins/customBorders/utils.js
@@ -160,10 +160,12 @@ export function checkSelectionBorders(hot, direction) {
         if (direction) {
           if (!hasOwnProperty(metaBorders[direction], 'hide') || metaBorders[direction].hide === false) {
             atLeastOneHasBorder = true;
+
             return false; // breaks forAll
           }
         } else {
           atLeastOneHasBorder = true;
+
           return false; // breaks forAll
         }
       }

--- a/src/plugins/dropdownMenu/__tests__/dropdownMenu.spec.js
+++ b/src/plugins/dropdownMenu/__tests__/dropdownMenu.spec.js
@@ -119,6 +119,7 @@ describe('DropdownMenu', () => {
 
     it('should be possible to define a custom container for DropdownMenu\'s UI elements', () => {
       const uiContainer = $('<div/>').addClass('uiContainer');
+
       spec().$container.append(uiContainer);
 
       handsontable({
@@ -315,6 +316,7 @@ describe('DropdownMenu', () => {
       });
 
       const afterCreateColCallback = jasmine.createSpy('afterCreateColCallback');
+
       hot.addHook('afterCreateCol', afterCreateColCallback);
 
       expect(countCols()).toEqual(4);
@@ -340,6 +342,7 @@ describe('DropdownMenu', () => {
       });
 
       const afterCreateColCallback = jasmine.createSpy('afterCreateColCallback');
+
       hot.addHook('afterCreateCol', afterCreateColCallback);
 
       expect(countCols()).toEqual(4);
@@ -461,6 +464,7 @@ describe('DropdownMenu', () => {
 
     it('should have custom items list (defined as a function)', () => {
       let enabled = false;
+
       handsontable({
         dropdownMenu: {
           items: {
@@ -739,6 +743,7 @@ describe('DropdownMenu', () => {
     hot.getPlugin('dropdownMenu').executeCommand('alignment:bottom');
 
     let cellMeta = hot.getCellMeta(0, 0);
+
     expect(cellMeta.className.includes('htCenter')).toBeTruthy();
     expect(cellMeta.className.includes('htMiddle')).toBeTruthy();
 
@@ -829,6 +834,7 @@ describe('DropdownMenu', () => {
     hot.getPlugin('dropdownMenu').executeCommand('alignment:bottom');
 
     let cellMeta = hot.getCellMeta(0, 0);
+
     expect(cellMeta.className.includes('htCenter')).toBeTruthy();
     expect(cellMeta.className.includes('htMiddle')).toBeTruthy();
 

--- a/src/plugins/dropdownMenu/dropdownMenu.js
+++ b/src/plugins/dropdownMenu/dropdownMenu.js
@@ -162,6 +162,7 @@ export class DropdownMenu extends BasePlugin {
     const predefinedItems = {
       items: this.itemsFactory.getItems(settings)
     };
+
     this.registerEvents();
 
     if (typeof settings.callback === 'function') {

--- a/src/plugins/dropdownMenu/dropdownMenu.js
+++ b/src/plugins/dropdownMenu/dropdownMenu.js
@@ -349,6 +349,7 @@ export class DropdownMenu extends BasePlugin {
   onAfterGetColHeader(col, TH) {
     // Corner or a higher-level header
     const headerRow = TH.parentNode;
+
     if (!headerRow) {
       return;
     }

--- a/src/plugins/filters/__tests__/conditionCollection.unit.js
+++ b/src/plugins/filters/__tests__/conditionCollection.unit.js
@@ -449,6 +449,7 @@ describe('ConditionCollection', () => {
       spyOn(conditionCollection, 'getConditions').and.returnValue(conditionsMock);
 
       const result = conditionCollection.hasConditions(3);
+
       expect(result).toBe(true);
     });
 
@@ -459,6 +460,7 @@ describe('ConditionCollection', () => {
       spyOn(conditionCollection, 'getConditions').and.returnValue(conditionsMock);
 
       const result = conditionCollection.hasConditions(3);
+
       expect(result).toBe(false);
     });
 
@@ -469,6 +471,7 @@ describe('ConditionCollection', () => {
       spyOn(conditionCollection, 'getConditions').and.returnValue(conditionsMock);
 
       const result = conditionCollection.hasConditions(3, 'eq');
+
       expect(result).toBe(true);
     });
 

--- a/src/plugins/filters/__tests__/filters.spec.js
+++ b/src/plugins/filters/__tests__/filters.spec.js
@@ -746,6 +746,7 @@ describe('Filters', () => {
         });
 
         const spy = jasmine.createSpy();
+
         hot.addHook('beforeFilter', spy);
         const plugin = hot.getPlugin('filters');
 
@@ -784,6 +785,7 @@ describe('Filters', () => {
         });
 
         const spy = jasmine.createSpy();
+
         spy.and.callFake(() => false);
         hot.addHook('beforeFilter', spy);
         const plugin = hot.getPlugin('filters');
@@ -810,6 +812,7 @@ describe('Filters', () => {
         });
 
         const spy = jasmine.createSpy();
+
         hot.addHook('afterFilter', spy);
         const plugin = hot.getPlugin('filters');
 

--- a/src/plugins/filters/__tests__/filtersUI.spec.js
+++ b/src/plugins/filters/__tests__/filtersUI.spec.js
@@ -77,6 +77,7 @@ describe('Filters UI', () => {
         width: 500,
         height: 300
       });
+
       hot.rootElement.style.marginTop = '1000px';
 
       dropdownMenu(1);
@@ -892,6 +893,7 @@ describe('Filters UI', () => {
 
     it('should display empty values as "(Blank cells)"', () => {
       const data = getDataForFilters();
+
       data[3].name = '';
 
       handsontable({
@@ -915,6 +917,7 @@ describe('Filters UI', () => {
 
     it('should display `null` values as "(Blank cells)"', () => {
       const data = getDataForFilters();
+
       data[3].name = null;
 
       handsontable({
@@ -938,6 +941,7 @@ describe('Filters UI', () => {
 
     it('should display `undefined` values as "(Blank cells)"', () => {
       const data = getDataForFilters();
+
       data[3].name = void 0;
 
       handsontable({
@@ -961,6 +965,7 @@ describe('Filters UI', () => {
 
     it('shouldn\'t break "by value" items in the next filter stacks', (done) => {
       const data = getDataForFilters();
+
       data[3].name = void 0;
 
       handsontable({
@@ -1522,6 +1527,7 @@ describe('Filters UI', () => {
     });
 
     const hot2Container = document.createElement('DIV');
+
     document.body.appendChild(hot2Container);
     const hot2 = new Handsontable(hot2Container, {
       data: getDataForFilters(),
@@ -1542,6 +1548,7 @@ describe('Filters UI', () => {
 
     const th = hot2.view.wt.wtTable.getColumnHeader(1);
     const button = th.querySelector('.changeType');
+
     $(button).simulate('mousedown');
     $(button).simulate('mouseup');
     $(button).simulate('click');
@@ -2651,6 +2658,7 @@ describe('Filters UI', () => {
 
       const $multipleSelectElements = $(byValueMultipleSelect().element
         .querySelectorAll('.htUIMultipleSelectHot td input'));
+
       $multipleSelectElements.eq(0).simulate('click');
       // disjunction
       $(conditionRadioInput(1).element).find('input[type="radio"]').simulate('click');
@@ -2700,6 +2708,7 @@ describe('Filters UI', () => {
 
       const $multipleSelectElements = $(byValueMultipleSelect().element
         .querySelectorAll('.htUIMultipleSelectHot td input'));
+
       $multipleSelectElements.eq(0).simulate('click');
       $(dropdownMenuRootElement().querySelector('.htUIButton.htUIButtonOK input')).simulate('click');
 
@@ -2784,6 +2793,7 @@ describe('Filters UI', () => {
 
       let $multipleSelectElements = $(byValueMultipleSelect().element
         .querySelectorAll('.htUIMultipleSelectHot td input'));
+
       $multipleSelectElements.get(4).scrollIntoView();
 
       $multipleSelectElements = $(byValueMultipleSelect().element.querySelectorAll('.htUIMultipleSelectHot td input'));
@@ -2888,6 +2898,7 @@ describe('Filters UI', () => {
       setTimeout(() => {
         const $multipleSelectElements = $(byValueMultipleSelect().element
           .querySelectorAll('.htUIMultipleSelectHot td input'));
+
         $multipleSelectElements.eq(0).simulate('click');
         $(dropdownMenuRootElement().querySelector('.htUIButton.htUIButtonOK input')).simulate('click');
         dropdownMenu(1);
@@ -2926,6 +2937,7 @@ describe('Filters UI', () => {
       setTimeout(() => {
         const $multipleSelectElements = $(byValueMultipleSelect().element
           .querySelectorAll('.htUIMultipleSelectHot td input'));
+
         $multipleSelectElements.eq(0).simulate('click');
         $(dropdownMenuRootElement().querySelector('.htUIButton.htUIButtonOK input')).simulate('click');
         dropdownMenu(1);

--- a/src/plugins/filters/filters.js
+++ b/src/plugins/filters/filters.js
@@ -171,6 +171,7 @@ export class Filters extends BasePlugin {
         addSeparator: false,
         menuContainer
       });
+
       conditionComponent.addLocalHook('afterClose', () => this.onSelectUIClosed());
 
       this.components.set('filter_by_condition', addConfirmationHooks(conditionComponent));
@@ -190,6 +191,7 @@ export class Filters extends BasePlugin {
         addSeparator: true,
         menuContainer
       });
+
       conditionComponent.addLocalHook('afterClose', () => this.onSelectUIClosed());
 
       this.components.set('filter_by_condition2', addConfirmationHooks(conditionComponent));

--- a/src/plugins/filters/ui/multipleSelect.js
+++ b/src/plugins/filters/ui/multipleSelect.js
@@ -171,6 +171,7 @@ class MultipleSelectUI extends BaseUI {
       });
       this.itemsBox.init();
     };
+
     hotInitializer(itemsBoxWrapper);
     setTimeout(() => hotInitializer(itemsBoxWrapper), 100);
   }

--- a/src/plugins/filters/ui/radioInput.js
+++ b/src/plugins/filters/ui/radioInput.js
@@ -29,9 +29,11 @@ class RadioInputUI extends BaseUI {
   build() {
     super.build();
     const priv = privatePool.get(this);
+
     priv.input = this._element.firstChild;
 
     const label = this.hot.rootDocument.createElement('label');
+
     label.textContent = this.translateIfPossible(this.options.label.textContent);
     label.htmlFor = this.translateIfPossible(this.options.label.htmlFor);
     priv.label = label;

--- a/src/plugins/formulas/__tests__/formulas.spec.js
+++ b/src/plugins/formulas/__tests__/formulas.spec.js
@@ -465,6 +465,7 @@ describe('Formulas general', () => {
       width: 500,
       height: 300
     });
+
     hot.getPlugin('formulas').setVariable('TEST_2', 12345);
     hot.getPlugin('formulas').recalculateFull();
 

--- a/src/plugins/formulas/matrix.js
+++ b/src/plugins/formulas/matrix.js
@@ -102,6 +102,7 @@ class Matrix {
 
       return result;
     };
+
     this.data = arrayFilter(this.data, cell => !isEqual(cell, cellValue));
   }
 

--- a/src/plugins/headerTooltips/__tests__/headerTooltips.spec.js
+++ b/src/plugins/headerTooltips/__tests__/headerTooltips.spec.js
@@ -30,6 +30,7 @@ describe('Header tooltips', () => {
 
       for (let i = 0; i < headers.length; i++) {
         const title = headers[i].getAttribute('title');
+
         expect(headers[i].getAttribute('title')).not.toBe(null);
         expect(title).toEqual(headers[i].textContent);
       }
@@ -55,6 +56,7 @@ describe('Header tooltips', () => {
 
       for (let i = 0; i < headers.length; i++) {
         const title = headers[i].getAttribute('title');
+
         expect(headers[i].getAttribute('title')).not.toBe(null);
         expect(title).toEqual(headers[i].textContent);
       }
@@ -104,6 +106,7 @@ describe('Header tooltips', () => {
 
       for (let i = 0; i < headers.length; i++) {
         const title = headers[i].getAttribute('title');
+
         expect(headers[i].getAttribute('title')).not.toBe(null);
         expect(title).toEqual(headers[i].textContent);
       }

--- a/src/plugins/hiddenColumns/__tests__/configuration.spec.js
+++ b/src/plugins/hiddenColumns/__tests__/configuration.spec.js
@@ -58,6 +58,7 @@ describe('HiddenColumns', () => {
       });
 
       const plugin = getPlugin('hiddenColumns');
+
       plugin.disablePlugin();
       render();
 

--- a/src/plugins/hiddenColumns/__tests__/pluginHooks.spec.js
+++ b/src/plugins/hiddenColumns/__tests__/pluginHooks.spec.js
@@ -69,6 +69,7 @@ describe('HiddenColumns', () => {
         });
 
         const plugin = getPlugin('hiddenColumns');
+
         plugin.hideColumns([0, 5, 10, 15]);
 
         expect(beforeHideColumnsHookCallback).toHaveBeenCalledWith([], [], false, void 0, void 0, void 0);
@@ -88,6 +89,7 @@ describe('HiddenColumns', () => {
         });
 
         const plugin = getPlugin('hiddenColumns');
+
         plugin.hideColumns([0, 5, 1.1]);
 
         expect(beforeHideColumnsHookCallback).toHaveBeenCalledWith([], [], false, void 0, void 0, void 0);
@@ -152,6 +154,7 @@ describe('HiddenColumns', () => {
         });
 
         const plugin = getPlugin('hiddenColumns');
+
         plugin.hideColumns([0, 5]);
 
         expect(afterHideColumnsHookCallback).toHaveBeenCalledWith([0, 5], [0, 5], true, false, void 0, void 0);
@@ -169,6 +172,7 @@ describe('HiddenColumns', () => {
         });
 
         const plugin = getPlugin('hiddenColumns');
+
         plugin.hideColumns([0, 5, 6]);
 
         expect(afterHideColumnsHookCallback).toHaveBeenCalledWith([0, 5], [0, 5, 6], true, true, void 0, void 0);
@@ -185,6 +189,7 @@ describe('HiddenColumns', () => {
         });
 
         const plugin = getPlugin('hiddenColumns');
+
         plugin.hideColumns([0, 5, 10, 15]);
 
         expect(afterHideColumnsHookCallback).toHaveBeenCalledWith([], [], false, false, void 0, void 0);
@@ -204,6 +209,7 @@ describe('HiddenColumns', () => {
         });
 
         const plugin = getPlugin('hiddenColumns');
+
         plugin.hideColumns([0, 5, 1.1]);
 
         expect(afterHideColumnsHookCallback).toHaveBeenCalledWith([], [], false, false, void 0, void 0);
@@ -272,6 +278,7 @@ describe('HiddenColumns', () => {
         });
 
         const plugin = getPlugin('hiddenColumns');
+
         plugin.showColumns([0, 5, 10, 15]);
 
         expect(beforeUnhideColumnsHookCallback).toHaveBeenCalledWith([0, 5], [0, 5], false, void 0, void 0, void 0);
@@ -292,6 +299,7 @@ describe('HiddenColumns', () => {
         });
 
         const plugin = getPlugin('hiddenColumns');
+
         plugin.showColumns([0, 5, 10, 15]);
 
         expect(beforeUnhideColumnsHookCallback).toHaveBeenCalledWith([0, 5], [0, 5], false, void 0, void 0, void 0);
@@ -358,6 +366,7 @@ describe('HiddenColumns', () => {
         });
 
         const plugin = getPlugin('hiddenColumns');
+
         plugin.showColumns([0, 5]);
 
         expect(afterUnhideColumnsHookCallback).toHaveBeenCalledWith([], [], true, false, void 0, void 0);
@@ -375,6 +384,7 @@ describe('HiddenColumns', () => {
         });
 
         const plugin = getPlugin('hiddenColumns');
+
         plugin.showColumns([0, 5, 6]);
 
         expect(afterUnhideColumnsHookCallback).toHaveBeenCalledWith([0, 5], [], true, true, void 0, void 0);
@@ -393,6 +403,7 @@ describe('HiddenColumns', () => {
         });
 
         const plugin = getPlugin('hiddenColumns');
+
         plugin.showColumns([0, 5, 1.1]);
 
         expect(afterUnhideColumnsHookCallback).toHaveBeenCalledWith([0, 5], [0, 5], false, false, void 0, void 0);

--- a/src/plugins/hiddenColumns/__tests__/plugins/contextMenu.spec.js
+++ b/src/plugins/hiddenColumns/__tests__/plugins/contextMenu.spec.js
@@ -873,6 +873,7 @@ describe('HiddenColumns', () => {
               .find('tbody')
               .find('th')
               .eq(0);
+
             simulateClick(header, 'RMB');
             contextMenu(header);
 
@@ -916,6 +917,7 @@ describe('HiddenColumns', () => {
               .find('tbody')
               .find('th')
               .eq(0);
+
             simulateClick(header, 'RMB');
             contextMenu(header);
 
@@ -961,6 +963,7 @@ describe('HiddenColumns', () => {
               .find('tbody')
               .find('th')
               .eq(0);
+
             simulateClick(header, 'RMB');
             contextMenu(header);
 
@@ -1004,6 +1007,7 @@ describe('HiddenColumns', () => {
               .find('tbody')
               .find('th')
               .eq(0);
+
             simulateClick(header, 'RMB');
             contextMenu(header);
 

--- a/src/plugins/hiddenColumns/__tests__/selection.spec.js
+++ b/src/plugins/hiddenColumns/__tests__/selection.spec.js
@@ -123,6 +123,7 @@ describe('HiddenColumns', () => {
         .find('tbody')
         .find('th')
         .eq(0);
+
       simulateClick(header, 'LMB');
 
       expect(getSelected()).toEqual([[0, -1, 0, 4]]);
@@ -299,6 +300,7 @@ describe('HiddenColumns', () => {
           .find('thead')
           .find('th')
           .eq(0);
+
         simulateClick(corner, 'LMB');
 
         expect(getSelected()).toEqual([[-1, -1, 4, 4]]);
@@ -333,6 +335,7 @@ describe('HiddenColumns', () => {
           .find('thead')
           .find('th')
           .eq(0);
+
         simulateClick(corner, 'LMB');
 
         expect(getSelected()).toEqual([[-1, -1, 4, 4]]);

--- a/src/plugins/hiddenRows/__tests__/configuration.spec.js
+++ b/src/plugins/hiddenRows/__tests__/configuration.spec.js
@@ -58,6 +58,7 @@ describe('HiddenRows', () => {
       });
 
       const plugin = getPlugin('hiddenRows');
+
       plugin.disablePlugin();
       render();
 

--- a/src/plugins/manualColumnFreeze/__tests__/manualColumnFreeze.spec.js
+++ b/src/plugins/manualColumnFreeze/__tests__/manualColumnFreeze.spec.js
@@ -180,6 +180,7 @@ describe('manualColumnFreeze', () => {
         if ($(this).text() === 'Freeze column') {
           return true;
         }
+
         return false;
       });
 
@@ -221,6 +222,7 @@ describe('manualColumnFreeze', () => {
         if ($(this).text() === 'Unfreeze column') {
           return true;
         }
+
         return false;
       });
       freezeEntry.eq(0).simulate('mousedown').simulate('mouseup');

--- a/src/plugins/manualColumnFreeze/__tests__/manualColumnFreeze.spec.js
+++ b/src/plugins/manualColumnFreeze/__tests__/manualColumnFreeze.spec.js
@@ -19,6 +19,7 @@ describe('manualColumnFreeze', () => {
         manualColumnFreeze: true
       });
       const plugin = hot.getPlugin('manualColumnFreeze');
+
       plugin.freezeColumn(4);
 
       expect(hot.getSettings().fixedColumnsLeft).toEqual(1);
@@ -210,6 +211,7 @@ describe('manualColumnFreeze', () => {
       let freezeEntry = $(hot.getPlugin('contextMenu').menu.container).find('div').filter(function() {
         return $(this).text() === 'Unfreeze column';
       });
+
       freezeEntry.eq(0).simulate('mousedown').simulate('mouseup');
 
       expect(hot.getSettings().fixedColumnsLeft).toEqual(2);

--- a/src/plugins/manualColumnFreeze/manualColumnFreeze.js
+++ b/src/plugins/manualColumnFreeze/manualColumnFreeze.js
@@ -7,6 +7,7 @@ import './manualColumnFreeze.css';
 export const PLUGIN_KEY = 'manualColumnFreeze';
 export const PLUGIN_PRIORITY = 110;
 const privatePool = new WeakMap();
+
 /**
  * This plugin allows to manually "freeze" and "unfreeze" a column using an entry in the Context Menu or using API.
  * You can turn it on by setting a {@link Options#manualColumnFreeze} property to `true`.

--- a/src/plugins/manualColumnMove/__tests__/manualColumnMoveUI.spec.js
+++ b/src/plugins/manualColumnMove/__tests__/manualColumnMoveUI.spec.js
@@ -22,6 +22,7 @@ describe('manualColumnMove', () => {
       });
 
       const $headerTH = spec().$container.find('thead tr:eq(0) th:eq(0)');
+
       $headerTH.simulate('mousedown');
       $headerTH.simulate('mouseup');
       $headerTH.simulate('mousedown');
@@ -38,6 +39,7 @@ describe('manualColumnMove', () => {
       });
 
       const $headerTH = spec().$container.find('thead tr:eq(0) th:eq(0)');
+
       $headerTH.simulate('mousedown');
       $headerTH.simulate('mouseup');
       $headerTH.simulate('mousedown');
@@ -79,6 +81,7 @@ describe('manualColumnMove', () => {
       });
 
       const $headerTH = spec().$container.find('thead tr:eq(0) th:eq(1)');
+
       $headerTH.simulate('mousedown');
       $headerTH.simulate('mouseup');
       $headerTH.simulate('mousedown');
@@ -116,6 +119,7 @@ describe('manualColumnMove', () => {
       });
 
       const $headerTH = spec().$container.find('thead tr:eq(0) th:eq(6)');
+
       $headerTH.simulate('mousedown');
       $headerTH.simulate('mouseup');
       $headerTH.simulate('mousedown');
@@ -195,6 +199,7 @@ describe('manualColumnMove', () => {
       $headerTH.simulate('mouseup');
 
       const $backlight = spec().$container.find('.ht__manualColumnMove--backlight')[0];
+
       $summaryElement.simulate('mousedown');
 
       const displayProp = $backlight.currentStyle ?

--- a/src/plugins/manualColumnMove/manualColumnMove.js
+++ b/src/plugins/manualColumnMove/manualColumnMove.js
@@ -439,6 +439,7 @@ export class ManualColumnMove extends BasePlugin {
 
     } else if (((priv.target.TD.offsetWidth / 2) + tdOffsetLeft) <= mouseOffsetLeft) {
       const newCoordsCol = priv.coords >= priv.countCols ? priv.countCols - 1 : priv.coords;
+
       // if hover on right part of TD
       priv.target.col = newCoordsCol + 1;
       // unfortunately first column is bigger than rest
@@ -598,6 +599,7 @@ export class ManualColumnMove extends BasePlugin {
     // callback for browser which doesn't supports CSS pointer-event: none
     if (event.target === this.backlight.element) {
       const width = this.backlight.getSize().width;
+
       this.backlight.setSize(0);
 
       setTimeout(function() {

--- a/src/plugins/manualColumnMove/manualColumnMove.js
+++ b/src/plugins/manualColumnMove/manualColumnMove.js
@@ -531,6 +531,7 @@ export class ManualColumnMove extends BasePlugin {
       priv.pressed = false;
       priv.columnsToMove.length = 0;
       removeClass(this.hot.rootElement, [CSS_ON_MOVING, CSS_SHOW_UI]);
+
       return;
     }
 

--- a/src/plugins/manualColumnResize/__tests__/manualColumnResize.spec.js
+++ b/src/plugins/manualColumnResize/__tests__/manualColumnResize.spec.js
@@ -693,6 +693,7 @@ describe('manualColumnResize', () => {
     $colHeader.simulate('mouseover');
 
     const $handle = spec().$container.find('.manualColumnResizer');
+
     $handle[0].style.background = 'red';
 
     expect($colHeader.offset().left + $colHeader.width() - 5).toBeCloseTo($handle.offset().left, 0);
@@ -748,6 +749,7 @@ describe('manualColumnResize', () => {
     getTopClone().find('thead tr:eq(0) th:eq(2)').simulate('mouseover');
     const $resizer = spec().$container.find('.manualColumnResizer');
     const resizerPosition = $resizer.position();
+
     $resizer.simulate('mousedown', { clientX: resizerPosition.left });
     $resizer.simulate('mousemove', { clientX: resizerPosition.left + 30 });
     $resizer.simulate('mouseup');
@@ -882,6 +884,7 @@ describe('manualColumnResize', () => {
       });
 
       const mainHolder = hot.view.wt.wtTable.holder;
+
       $(mainHolder).scrollLeft(200);
 
       await sleep(400);
@@ -893,6 +896,7 @@ describe('manualColumnResize', () => {
 
       const $resizer = spec().$container.find('.manualColumnResizer');
       const resizerPosition = $resizer.position();
+
       $resizer.simulate('mousedown', { clientX: resizerPosition.left });
       $resizer.simulate('mousemove', { clientX: resizerPosition.left + 30 });
       $resizer.simulate('mouseup');
@@ -921,6 +925,7 @@ describe('manualColumnResize', () => {
 
       const $resizer = spec().$container.find('.manualColumnResizer');
       const resizerPosition = $resizer.position();
+
       $resizer.simulate('mousedown', { clientX: resizerPosition.left });
       $resizer.simulate('mousemove', { clientX: resizerPosition.left + 30 });
       $resizer.simulate('mouseup');
@@ -947,6 +952,7 @@ describe('manualColumnResize', () => {
 
       const $resizer = spec().$container.find('.manualColumnResizer');
       const resizerPosition = $resizer.position();
+
       $resizer.simulate('mousedown', { clientX: resizerPosition.left });
       $resizer.simulate('mousemove', { clientX: resizerPosition.left + 30 });
       $resizer.simulate('mouseup');
@@ -975,6 +981,7 @@ describe('manualColumnResize', () => {
 
       const $resizer = spec().$container.find('.manualColumnResizer');
       const resizerPosition = $resizer.position();
+
       $resizer.simulate('mousedown', { clientX: resizerPosition.left });
       $resizer.simulate('mousemove', { clientX: resizerPosition.left + 30 });
       $resizer.simulate('mouseup');
@@ -1004,6 +1011,7 @@ describe('manualColumnResize', () => {
 
       const $resizer = spec().$container.find('.manualColumnResizer');
       const resizerPosition = $resizer.position();
+
       $resizer.simulate('mousedown', { clientX: resizerPosition.left });
       $resizer.simulate('mousemove', { clientX: resizerPosition.left + 30 });
       $resizer.simulate('mouseup');
@@ -1028,6 +1036,7 @@ describe('manualColumnResize', () => {
       });
 
       const $headerTH = getTopClone().find('thead tr:eq(0) th:eq(1)');
+
       $headerTH.simulate('mouseover');
 
       const $handle = $('.manualColumnResizer');
@@ -1051,6 +1060,7 @@ describe('manualColumnResize', () => {
       });
 
       const $headerTH = getTopClone().find('thead tr:eq(0) th:eq(1)');
+
       $headerTH.simulate('mouseover');
 
       const $handle = $('.manualColumnResizer');

--- a/src/plugins/manualColumnResize/manualColumnResize.js
+++ b/src/plugins/manualColumnResize/manualColumnResize.js
@@ -11,6 +11,7 @@ export const PLUGIN_KEY = 'manualColumnResize';
 export const PLUGIN_PRIORITY = 130;
 const PERSISTENT_STATE_KEY = 'manualColumnWidths';
 const privatePool = new WeakMap();
+
 /**
  * @description
  * This plugin allows to change columns width. To make columns width persistent the {@link Options#persistentState}

--- a/src/plugins/manualRowMove/manualRowMove.js
+++ b/src/plugins/manualRowMove/manualRowMove.js
@@ -529,6 +529,7 @@ export class ManualRowMove extends BasePlugin {
       priv.pressed = false;
       priv.rowsToMove.length = 0;
       removeClass(this.hot.rootElement, [CSS_ON_MOVING, CSS_SHOW_UI]);
+
       return;
     }
 

--- a/src/plugins/manualRowMove/manualRowMove.js
+++ b/src/plugins/manualRowMove/manualRowMove.js
@@ -587,6 +587,7 @@ export class ManualRowMove extends BasePlugin {
     // callback for browser which doesn't supports CSS pointer-event: none
     if (event.target === this.backlight.element) {
       const height = this.backlight.getSize().height;
+
       this.backlight.setSize(null, 0);
 
       setTimeout(function() {

--- a/src/plugins/manualRowMove/manualRowMove.js
+++ b/src/plugins/manualRowMove/manualRowMove.js
@@ -477,6 +477,7 @@ export class ManualRowMove extends BasePlugin {
     }
 
     let topOverlayHeight = 0;
+
     if (this.hot.view.wt.wtOverlays.topOverlay) {
       topOverlayHeight = this.hot.view.wt.wtOverlays.topOverlay.clone.wtTable.TABLE.offsetHeight;
     }

--- a/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
+++ b/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
@@ -200,6 +200,7 @@ describe('manualRowResize', () => {
     hot.addHook('beforeRowResize', () => void 0);
 
     const $th = getLeftClone().find('tbody tr:eq(0) th:eq(0)');
+
     $th.simulate('mouseover');
 
     const $resizer = spec().$container.find('.manualRowResizer');
@@ -259,6 +260,7 @@ describe('manualRowResize', () => {
     expect(rowHeight(spec().$container, 0)).toEqual(defaultRowHeight + 2);
 
     const $th = getLeftClone().find('tbody tr:eq(0) th:eq(0)');
+
     $th.simulate('mouseover');
 
     const $resizer = spec().$container.find('.manualRowResizer');
@@ -284,6 +286,7 @@ describe('manualRowResize', () => {
     expect(rowHeight(spec().$container, 0)).toEqual(defaultRowHeight + 2);
 
     const $th = getLeftClone().find('tbody tr:eq(2) th:eq(0)');
+
     $th.simulate('mouseover');
 
     const $resizer = spec().$container.find('.manualRowResizer');
@@ -368,6 +371,7 @@ describe('manualRowResize', () => {
     expect(rowHeight(spec().$container, 0)).toEqual(defaultRowHeight + 2);
 
     const $th = getLeftClone().find('tbody tr:eq(2) th:eq(0)');
+
     $th.simulate('mouseover');
 
     const $resizer = spec().$container.find('.manualRowResizer');
@@ -565,6 +569,7 @@ describe('manualRowResize', () => {
     getLeftClone().find('tbody tr:eq(2) th:eq(0)').simulate('mouseover');
     const $resizer = spec().$container.find('.manualRowResizer');
     const resizerPosition = $resizer.position();
+
     $resizer.simulate('mousedown', { clientY: resizerPosition.top });
     $resizer.simulate('mousemove', { clientY: resizerPosition.top + 30 });
     $resizer.simulate('mouseup');
@@ -700,6 +705,7 @@ describe('manualRowResize', () => {
       });
 
       const mainHolder = hot.view.wt.wtTable.holder;
+
       $(mainHolder).scrollTop(200);
 
       await sleep(400);
@@ -711,6 +717,7 @@ describe('manualRowResize', () => {
 
       const $resizer = spec().$container.find('.manualRowResizer');
       const resizerPosition = $resizer.position();
+
       $resizer.simulate('mousedown', { clientY: resizerPosition.top });
       $resizer.simulate('mousemove', { clientY: resizerPosition.top + 30 });
       $resizer.simulate('mouseup');
@@ -738,6 +745,7 @@ describe('manualRowResize', () => {
 
       const $resizer = spec().$container.find('.manualRowResizer');
       const resizerPosition = $resizer.position();
+
       $resizer.simulate('mousedown', { clientY: resizerPosition.top });
       $resizer.simulate('mousemove', { clientY: resizerPosition.top + 30 });
       $resizer.simulate('mouseup');
@@ -763,6 +771,7 @@ describe('manualRowResize', () => {
 
       const $resizer = spec().$container.find('.manualRowResizer');
       const resizerPosition = $resizer.position();
+
       $resizer.simulate('mousedown', { clientY: resizerPosition.top });
       $resizer.simulate('mousemove', { clientY: resizerPosition.top + 30 });
       $resizer.simulate('mouseup');
@@ -790,6 +799,7 @@ describe('manualRowResize', () => {
 
       const $resizer = spec().$container.find('.manualRowResizer');
       const resizerPosition = $resizer.position();
+
       $resizer.simulate('mousedown', { clientY: resizerPosition.top });
       $resizer.simulate('mousemove', { clientY: resizerPosition.top + 30 });
       $resizer.simulate('mouseup');
@@ -819,6 +829,7 @@ describe('manualRowResize', () => {
 
       const $resizer = spec().$container.find('.manualRowResizer');
       const resizerPosition = $resizer.position();
+
       $resizer.simulate('mousedown', { clientY: resizerPosition.top });
       $resizer.simulate('mousemove', { clientY: resizerPosition.top + 30 });
       $resizer.simulate('mouseup');
@@ -843,6 +854,7 @@ describe('manualRowResize', () => {
       });
 
       const $headerTH = getLeftClone().find('tbody tr:eq(1) th:eq(0)');
+
       $headerTH.simulate('mouseover');
 
       const $handle = $('.manualRowResizer');
@@ -866,6 +878,7 @@ describe('manualRowResize', () => {
       });
 
       const $headerTH = getLeftClone().find('tbody tr:eq(1) th:eq(0)');
+
       $headerTH.simulate('mouseover');
 
       const $handle = $('.manualRowResizer');

--- a/src/plugins/manualRowResize/manualRowResize.js
+++ b/src/plugins/manualRowResize/manualRowResize.js
@@ -115,6 +115,7 @@ export class ManualRowResize extends BasePlugin {
    */
   disablePlugin() {
     const priv = privatePool.get(this);
+
     priv.config = this.rowHeightsMap.getValues();
 
     this.hot.rowIndexMapper.unregisterMap(this.pluginName);
@@ -265,6 +266,7 @@ export class ManualRowResize extends BasePlugin {
     const handleWidth = parseInt(outerWidth(this.handle), 10);
     const handleRightPosition = parseInt(this.handle.style.left, 10) + handleWidth;
     const maximumVisibleElementWidth = parseInt(this.hot.view.maximumVisibleElementWidth(0), 10);
+
     addClass(this.handle, 'active');
     addClass(this.guide, 'active');
 
@@ -483,6 +485,7 @@ export class ManualRowResize extends BasePlugin {
 
       this.hot.runHooks('afterRowResize', this.getActualRowHeight(row), row, false);
     };
+
     if (this.pressed) {
       this.hideHandleAndGuide();
       this.pressed = false;
@@ -513,6 +516,7 @@ export class ManualRowResize extends BasePlugin {
    */
   bindEvents() {
     const { rootElement, rootWindow } = this.hot;
+
     this.eventManager.addEventListener(rootElement, 'mouseover', e => this.onMouseOver(e));
     this.eventManager.addEventListener(rootElement, 'mousedown', e => this.onMouseDown(e));
     this.eventManager.addEventListener(rootWindow, 'mousemove', e => this.onMouseMove(e));

--- a/src/plugins/manualRowResize/manualRowResize.js
+++ b/src/plugins/manualRowResize/manualRowResize.js
@@ -318,6 +318,7 @@ export class ManualRowResize extends BasePlugin {
       if (element.tagName === 'TH') {
         return element;
       }
+
       return this.getClosestTHParent(element.parentNode);
 
     }

--- a/src/plugins/mergeCells/__tests__/autofillCalculations.unit.js
+++ b/src/plugins/mergeCells/__tests__/autofillCalculations.unit.js
@@ -18,6 +18,7 @@ describe('MergeCells-Autofill calculations', () => {
       });
 
       const area = [0, 0, 0, 0];
+
       instance.correctSelectionAreaSize(area);
 
       expect(area).toEqual([0, 0, 2, 2]);
@@ -119,6 +120,7 @@ describe('MergeCells-Autofill calculations', () => {
       const baseArea = [5, 4, 6, 5];
       let dragArea = [5, 4, 10, 5];
       let direction = 'down';
+
       expect(instance.getAutofillSize(baseArea, dragArea, direction)).toEqual(4);
 
       dragArea = [5, 0, 6, 5];

--- a/src/plugins/mergeCells/__tests__/mergeCells.spec.js
+++ b/src/plugins/mergeCells/__tests__/mergeCells.spec.js
@@ -55,6 +55,7 @@ describe('MergeCells', () => {
         ]
       });
       let TD = hot.rootElement.querySelector('td');
+
       expect(TD.getAttribute('rowspan')).toBe('2');
       expect(TD.getAttribute('colspan')).toBe('2');
 
@@ -82,6 +83,7 @@ describe('MergeCells', () => {
         ]
       });
       let TD = hot.rootElement.querySelector('td');
+
       expect(TD.getAttribute('rowspan')).toBe('2');
       expect(TD.getAttribute('colspan')).toBe('2');
 
@@ -102,6 +104,7 @@ describe('MergeCells', () => {
         ]
       });
       let TD = hot.rootElement.querySelector('td');
+
       expect(TD.getAttribute('rowspan')).toBe('2');
       expect(TD.getAttribute('colspan')).toBe('2');
 
@@ -123,6 +126,7 @@ describe('MergeCells', () => {
           { row: 0, col: 0, rowspan: 2, colspan: 2 }
         ]
       });
+
       expect(hot.getCopyableText(0, 0, 2, 2)).toBe('A1\t\tC1\n\t\tC2\nA3\tB3\tC3');
     });
   });
@@ -295,6 +299,7 @@ describe('MergeCells', () => {
       });
 
       const plugin = hot.getPlugin('mergeCells');
+
       hot.selectCell(0, 0, 2, 2);
       plugin.mergeSelection();
 
@@ -335,6 +340,7 @@ describe('MergeCells', () => {
           { row: 8, col: 8, rowspan: 2, colspan: 2 }
         ]
       });
+
       hot.setDataAtCell(8, 8, 'top-left-corner!');
 
       hot.selectCell(7, 9);
@@ -366,6 +372,7 @@ describe('MergeCells', () => {
         autoWrapCol: false,
         autoWrapRow: false
       });
+
       hot.setDataAtCell(8, 8, 'top-left-corner!');
 
       hot.selectCell(9, 7);
@@ -397,6 +404,7 @@ describe('MergeCells', () => {
         autoWrapCol: false,
         autoWrapRow: false
       });
+
       hot.setDataAtCell(0, 0, 'top-left-corner!');
 
       hot.selectCell(2, 1);
@@ -426,6 +434,7 @@ describe('MergeCells', () => {
           { row: 0, col: 0, rowspan: 2, colspan: 2 }
         ]
       });
+
       hot.setDataAtCell(0, 0, 'top-left-corner!');
 
       hot.selectCell(1, 2);
@@ -657,9 +666,11 @@ describe('MergeCells', () => {
       expect(mainHolder.scrollTop).toBe(130);
 
       let TD = hot.getCell(5, 0);
+
       mouseDown(TD);
       mouseUp(TD);
       const mergedCellScrollTop = mainHolder.scrollTop;
+
       expect(mergedCellScrollTop).toBeLessThan(130);
       expect(mergedCellScrollTop).toBeGreaterThan(0);
 
@@ -673,6 +684,7 @@ describe('MergeCells', () => {
       mouseDown(TD);
       mouseUp(TD);
       const regularCellScrollTop = mainHolder.scrollTop;
+
       expect(mergedCellScrollTop).toBe(regularCellScrollTop);
     });
 
@@ -1205,6 +1217,7 @@ describe('MergeCells', () => {
       const currentSelection = new CellRange(coords, coords, coords);
       const mergeCells = new Handsontable.MergeCells(mergeCellsSettings);
       const inDelta = new CellCoords(0, 1);
+
       mergeCells.modifyTransform('modifyTransformStart', currentSelection, inDelta);
 
       expect(inDelta).toEqual(new CellCoords(0, 1));
@@ -1218,6 +1231,7 @@ describe('MergeCells', () => {
       const currentSelection = new CellRange(coords, coords, coords);
       const mergeCells = new Handsontable.MergeCells(mergeCellsSettings);
       const inDelta = new CellCoords(0, 1);
+
       mergeCells.modifyTransform('modifyTransformStart', currentSelection, inDelta);
 
       expect(inDelta).toEqual(new CellCoords(0, 3));
@@ -1232,6 +1246,7 @@ describe('MergeCells', () => {
       let coords = new CellCoords(2, 0);
       let currentSelection = new CellRange(coords, coords, coords);
       let inDelta = new CellCoords(0, 1);
+
       mergeCells.modifyTransform('modifyTransformStart', currentSelection, inDelta);
 
       expect(inDelta).toEqual(new CellCoords(-1, 1));
@@ -1252,6 +1267,7 @@ describe('MergeCells', () => {
       const currentSelection = new CellRange(coords, coords, coords);
       const mergeCells = new Handsontable.MergeCells(mergeCellsSettings);
       const inDelta = new CellCoords(0, -1);
+
       mergeCells.modifyTransform('modifyTransformStart', currentSelection, inDelta);
 
       expect(inDelta).toEqual(new CellCoords(0, -3));
@@ -1265,6 +1281,7 @@ describe('MergeCells', () => {
       const currentSelection = new CellRange(coords, coords, coords);
       const mergeCells = new Handsontable.MergeCells(mergeCellsSettings);
       const inDelta = new CellCoords(0, -1);
+
       mergeCells.modifyTransform('modifyTransformStart', currentSelection, inDelta);
 
       expect(inDelta).toEqual(new CellCoords(0, -1));
@@ -1279,6 +1296,7 @@ describe('MergeCells', () => {
       let coords = new CellCoords(2, 4);
       let currentSelection = new CellRange(coords, coords, coords);
       let inDelta = new CellCoords(0, -1);
+
       mergeCells.modifyTransform('modifyTransformStart', currentSelection, inDelta);
 
       expect(inDelta).toEqual(new CellCoords(-1, -3));
@@ -1299,6 +1317,7 @@ describe('MergeCells', () => {
       const currentSelection = new CellRange(coords, coords, coords);
       const mergeCells = new Handsontable.MergeCells(mergeCellsSettings);
       const inDelta = new CellCoords(0, -1);
+
       mergeCells.modifyTransform('modifyTransformStart', currentSelection, inDelta);
 
       expect(inDelta).toEqual(new CellCoords(0, -1));
@@ -1312,6 +1331,7 @@ describe('MergeCells', () => {
       const currentSelection = new CellRange(coords, coords, coords);
       const mergeCells = new Handsontable.MergeCells(mergeCellsSettings);
       const inDelta = new CellCoords(1, 0);
+
       mergeCells.modifyTransform('modifyTransformStart', currentSelection, inDelta);
 
       expect(inDelta).toEqual(new CellCoords(3, 0));
@@ -1325,6 +1345,7 @@ describe('MergeCells', () => {
       const currentSelection = new CellRange(coords, coords, coords);
       const mergeCells = new Handsontable.MergeCells(mergeCellsSettings);
       const inDelta = new CellCoords(-1, 0);
+
       mergeCells.modifyTransform('modifyTransformStart', currentSelection, inDelta);
 
       expect(inDelta).toEqual(new CellCoords(-3, 0));
@@ -1338,6 +1359,7 @@ describe('MergeCells', () => {
       const currentSelection = new CellRange(coords, coords, coords);
       const mergeCells = new Handsontable.MergeCells(mergeCellsSettings);
       const inDelta = new CellCoords(-1, 0);
+
       mergeCells.modifyTransform('modifyTransformStart', currentSelection, inDelta);
 
       expect(inDelta).toEqual(new CellCoords(-1, 0));
@@ -1467,6 +1489,7 @@ describe('MergeCells', () => {
       });
 
       const plugin = hot.getPlugin('mergeCells');
+
       plugin.merge(0, 0, 3, 3);
       hot.selectCell(4, 4, 7, 7);
       plugin.mergeSelection();
@@ -1485,6 +1508,7 @@ describe('MergeCells', () => {
       });
 
       const plugin = hot.getPlugin('mergeCells');
+
       plugin.merge(0, 0, 3, 3);
       hot.selectCell(4, 4, 7, 7);
       plugin.mergeSelection();

--- a/src/plugins/mergeCells/cellCoords.js
+++ b/src/plugins/mergeCells/cellCoords.js
@@ -232,6 +232,7 @@ class MergedCellCoords {
       // removing the whole merge
       if (changeStart <= mergeStart && changeEnd >= mergeEnd) {
         this.removed = true;
+
         return false;
 
         // removing the merge partially, including the beginning
@@ -281,6 +282,7 @@ class MergedCellCoords {
     } else if (direction === 'left') {
       return mergedCell.col > this.col;
     }
+
     return null;
   }
 

--- a/src/plugins/mergeCells/cellsCollection.js
+++ b/src/plugins/mergeCells/cellsCollection.js
@@ -62,6 +62,7 @@ class MergedCellsCollection {
       if (mergedCell.row <= row && mergedCell.row + mergedCell.rowspan - 1 >= row &&
         mergedCell.col <= column && mergedCell.col + mergedCell.colspan - 1 >= column) {
         result = mergedCell;
+
         return false;
       }
 
@@ -85,6 +86,7 @@ class MergedCellsCollection {
       if (mergedCell.row <= range.from.row && mergedCell.row + mergedCell.rowspan - 1 >= range.to.row &&
         mergedCell.col <= range.from.col && mergedCell.col + mergedCell.colspan - 1 >= range.to.col) {
         result = mergedCell;
+
         return result;
       }
 
@@ -179,6 +181,7 @@ class MergedCellsCollection {
 
     if (wantedCollection && wantedCollectionIndex !== false) {
       mergedCells.splice(wantedCollectionIndex, 1);
+
       return wantedCollection;
     }
 
@@ -250,6 +253,7 @@ class MergedCellsCollection {
 
       if (currentRange.overlaps(mergedCellRange)) {
         result = true;
+
         return false;
       }
 

--- a/src/plugins/mergeCells/cellsCollection.js
+++ b/src/plugins/mergeCells/cellsCollection.js
@@ -111,6 +111,7 @@ class MergedCellsCollection {
     if (!testedRange.includesRange) {
       const from = new CellCoords(testedRange.from.row, testedRange.from.col);
       const to = new CellCoords(testedRange.to.row, testedRange.to.col);
+
       testedRange = new CellRange(from, from, to);
     }
 

--- a/src/plugins/mergeCells/mergeCells.js
+++ b/src/plugins/mergeCells/mergeCells.js
@@ -782,6 +782,7 @@ export class MergeCells extends BasePlugin {
    */
   onBeforeSetRangeEnd(coords) {
     const selRange = this.hot.getSelectedRangeLast();
+
     selRange.highlight = new CellCoords(selRange.highlight.row, selRange.highlight.col); // clone in case we will modify its reference
     selRange.to = coords;
     let rangeExpanded = false;

--- a/src/plugins/multiColumnSorting/__tests__/multiColumnSorting.spec.js
+++ b/src/plugins/multiColumnSorting/__tests__/multiColumnSorting.spec.js
@@ -211,6 +211,7 @@ describe('MultiColumnSorting', () => {
     hot.render();
 
     const sortedColumn = spec().$container.find('th span.columnSorting')[1];
+
     expect(window.getComputedStyle(sortedColumn, ':before').getPropertyValue('background-image')).toMatch(/url/);
   });
 
@@ -230,6 +231,7 @@ describe('MultiColumnSorting', () => {
     updateSettings({ multiColumnSorting: false });
 
     const sortedColumn = spec().$container.find('th span')[0];
+
     expect(window.getComputedStyle(sortedColumn, ':before').getPropertyValue('background-image')).not.toMatch(/url/);
   });
 
@@ -1763,6 +1765,7 @@ describe('MultiColumnSorting', () => {
     spec().sortByClickOnColumnHeader(2);
 
     let sortedColumn = spec().$container.find('th span.columnSorting')[2];
+
     // not sorted
     expect(window.getComputedStyle(sortedColumn, ':before').getPropertyValue('background-image')).not.toMatch(/url/);
 
@@ -1810,6 +1813,7 @@ describe('MultiColumnSorting', () => {
 
     // ascending
     let sortedColumn = spec().$container.find('th span.columnSorting')[1];
+
     expect(window.getComputedStyle(sortedColumn, ':before').getPropertyValue('background-image')).toMatch(/url/);
 
     getPlugin('multiColumnSorting').sort({ column: 2, sortOrder: 'asc' });
@@ -1864,6 +1868,7 @@ describe('MultiColumnSorting', () => {
 
     // descending
     let sortedColumn = spec().$container.find('th span.columnSorting')[1];
+
     expect(window.getComputedStyle(sortedColumn, ':before').getPropertyValue('background-image')).toMatch(/url/);
 
     getPlugin('multiColumnSorting').sort();

--- a/src/plugins/multipleSelectionHandles/multipleSelectionHandles.js
+++ b/src/plugins/multipleSelectionHandles/multipleSelectionHandles.js
@@ -112,6 +112,7 @@ export class MultipleSelectionHandles extends BasePlugin {
         };
 
         event.preventDefault();
+
         return false;
 
       } else if (hasClass(event.target, 'bottomRightSelectionHandle-HitArea')) {
@@ -126,6 +127,7 @@ export class MultipleSelectionHandles extends BasePlugin {
         };
 
         event.preventDefault();
+
         return false;
       }
     });
@@ -137,6 +139,7 @@ export class MultipleSelectionHandles extends BasePlugin {
         _this.touchStartRange = void 0;
 
         event.preventDefault();
+
         return false;
 
       } else if (hasClass(event.target, 'bottomRightSelectionHandle-HitArea')) {
@@ -145,6 +148,7 @@ export class MultipleSelectionHandles extends BasePlugin {
         _this.touchStartRange = void 0;
 
         event.preventDefault();
+
         return false;
       }
     });

--- a/src/plugins/nestedHeaders/__tests__/nestedHeaders.spec.js
+++ b/src/plugins/nestedHeaders/__tests__/nestedHeaders.spec.js
@@ -869,6 +869,7 @@ describe('NestedHeaders', () => {
             </tr>
           </tbody>
           `;
+
         expect(extractDOMStructure(getTopLeftClone(), getLeftClone())).toMatchHTML(htmlPattern);
         expect(extractDOMStructure(getLeftClone(), getLeftClone())).toMatchHTML(htmlPattern);
       }
@@ -897,6 +898,7 @@ describe('NestedHeaders', () => {
             </tr>
           </tbody>
           `;
+
         expect(extractDOMStructure(getTopLeftClone(), getLeftClone())).toMatchHTML(htmlPattern);
         expect(extractDOMStructure(getLeftClone(), getLeftClone())).toMatchHTML(htmlPattern);
       }
@@ -934,6 +936,7 @@ describe('NestedHeaders', () => {
             </tr>
           </tbody>
           `;
+
         expect(extractDOMStructure(getTopLeftClone(), getLeftClone())).toMatchHTML(htmlPattern);
         expect(extractDOMStructure(getLeftClone(), getLeftClone())).toMatchHTML(htmlPattern);
       }

--- a/src/plugins/nestedHeaders/__tests__/nestedHeaders.spec.js
+++ b/src/plugins/nestedHeaders/__tests__/nestedHeaders.spec.js
@@ -951,6 +951,7 @@ describe('NestedHeaders', () => {
 
       const allTHs = function allTHs(row) {
         const headerRows = hot.view.wt.wtTable.THEAD.querySelectorAll('tr');
+
         return headerRows[row].querySelectorAll('th');
       };
       const levels = [nonHiddenTHs(hot, 0), nonHiddenTHs(hot, 1), nonHiddenTHs(hot, 2), nonHiddenTHs(hot, 3)];

--- a/src/plugins/nestedHeaders/utils/ghostTable.js
+++ b/src/plugins/nestedHeaders/utils/ghostTable.js
@@ -100,6 +100,7 @@ class GhostTable {
 
         for (let col = 0; col < maxCols; col++) {
           const td = rootDocument.createElement('th');
+
           tr.appendChild(td);
         }
 

--- a/src/plugins/nestedRows/__tests__/nestedRows.spec.js
+++ b/src/plugins/nestedRows/__tests__/nestedRows.spec.js
@@ -251,6 +251,7 @@ describe('NestedRows', () => {
       });
 
       const firstParent = getPlugin('nestedRows').dataManager.getRowParent(12);
+
       expect(getPlugin('nestedRows').dataManager.countChildren(firstParent)).toBe(2);
 
       getPlugin('manualRowMove').dragRow(12, 4);
@@ -287,6 +288,7 @@ describe('NestedRows', () => {
       });
 
       const firstParent = getPlugin('nestedRows').dataManager.getRowParent(12);
+
       expect(getPlugin('nestedRows').dataManager.countChildren(firstParent)).toBe(2);
 
       getPlugin('manualRowMove').dragRow(12, 10);

--- a/src/plugins/nestedRows/data/dataManager.js
+++ b/src/plugins/nestedRows/data/dataManager.js
@@ -428,6 +428,7 @@ class DataManager {
    */
   addChild(parent, element) {
     let childElement = element;
+
     this.hot.runHooks('beforeAddChild', parent, childElement);
 
     let parentIndex = null;
@@ -544,6 +545,7 @@ class DataManager {
     if (Array.isArray(elements)) {
       rangeEach(elements[0], elements[2], (i) => {
         const translatedIndex = this.translateTrimmedRow(i);
+
         rowObjects.push(this.getDataObject(translatedIndex));
       });
 

--- a/src/plugins/nestedRows/data/dataManager.js
+++ b/src/plugins/nestedRows/data/dataManager.js
@@ -297,6 +297,7 @@ class DataManager {
 
     arrayEach(parentNode.__children, (elem) => {
       rowCount += 1;
+
       if (elem.__children) {
         rowCount += this.countChildren(elem);
       }
@@ -430,6 +431,7 @@ class DataManager {
     this.hot.runHooks('beforeAddChild', parent, childElement);
 
     let parentIndex = null;
+
     if (parent) {
       parentIndex = this.getRowIndex(parent);
     }

--- a/src/plugins/nestedRows/nestedRows.js
+++ b/src/plugins/nestedRows/nestedRows.js
@@ -325,6 +325,7 @@ export class NestedRows extends BasePlugin {
     const modifiedPhysicalRows = Array.from(physicalRows.reduce((removedRows, physicalIndex) => {
       if (this.dataManager.isParent(physicalIndex)) {
         const children = this.dataManager.getDataObject(physicalIndex).__children;
+
         // Preserve a parent in the list of removed rows.
         removedRows.add(physicalIndex);
 

--- a/src/plugins/nestedRows/ui/collapsing.js
+++ b/src/plugins/nestedRows/ui/collapsing.js
@@ -47,6 +47,7 @@ class CollapsingUI extends BaseUI {
       trimStash: (realElementIndex, amount) => {
         rangeEach(realElementIndex, realElementIndex + amount - 1, (i) => {
           const indexOfElement = this.lastCollapsedRows.indexOf(i);
+
           if (indexOfElement > -1) {
             this.lastCollapsedRows.splice(indexOfElement, 1);
           }
@@ -146,6 +147,7 @@ class CollapsingUI extends BaseUI {
 
     arrayEach(rowIndexes, (elem) => {
       rowsToTrim.push(elem);
+
       if (recursive) {
         this.collapseChildRows(elem, rowsToTrim);
       }
@@ -205,6 +207,7 @@ class CollapsingUI extends BaseUI {
 
     arrayEach(rowIndexes, (elem) => {
       rowsToUntrim.push(elem);
+
       if (recursive) {
         this.expandChildRows(elem, rowsToUntrim);
       }

--- a/src/plugins/nestedRows/ui/collapsing.js
+++ b/src/plugins/nestedRows/ui/collapsing.js
@@ -398,6 +398,7 @@ class CollapsingUI extends BaseUI {
 
         if (!this.plugin.collapsedRowsMap.getValueAtIndex(rowIndex)) {
           allCollapsed = false;
+
           return false;
         }
       });

--- a/src/plugins/nestedRows/ui/collapsing.js
+++ b/src/plugins/nestedRows/ui/collapsing.js
@@ -174,6 +174,7 @@ class CollapsingUI extends BaseUI {
 
       arrayEach(parentObject.__children, (elem) => {
         const elemIndex = this.dataManager.getRowIndex(elem);
+
         rowsToTrim.push(elemIndex);
         this.collapseChildRows(elemIndex, rowsToTrim);
       });
@@ -235,6 +236,7 @@ class CollapsingUI extends BaseUI {
       arrayEach(parentObject.__children, (elem) => {
         if (!this.isAnyParentCollapsed(elem)) {
           const elemIndex = this.dataManager.getRowIndex(elem);
+
           rowsToUntrim.push(elemIndex);
           this.expandChildRows(elemIndex, rowsToUntrim);
         }

--- a/src/plugins/nestedRows/ui/headers.js
+++ b/src/plugins/nestedRows/ui/headers.js
@@ -83,10 +83,12 @@ class HeadersUI extends BaseUI {
     if (rowLevel) {
       const { rootDocument } = this.hot;
       const initialContent = innerSpan.cloneNode(true);
+
       innerDiv.innerHTML = '';
 
       rangeEach(0, rowLevel - 1, () => {
         const levelIndicator = rootDocument.createElement('SPAN');
+
         addClass(levelIndicator, HeadersUI.CSS_CLASSES.emptyIndicator);
         innerDiv.appendChild(levelIndicator);
       });
@@ -96,6 +98,7 @@ class HeadersUI extends BaseUI {
 
     if (this.dataManager.hasChildren(rowObject)) {
       const buttonsContainer = this.hot.rootDocument.createElement('DIV');
+
       addClass(TH, HeadersUI.CSS_CLASSES.parent);
 
       if (this.collapsingUI.areChildrenCollapsed(rowIndex)) {

--- a/src/plugins/observeChanges/__tests__/observeChanges.spec.js
+++ b/src/plugins/observeChanges/__tests__/observeChanges.spec.js
@@ -66,6 +66,7 @@ describe('HandsontableObserveChanges', () => {
 
       it('should render removed row', async() => {
         const data = Handsontable.helper.createSpreadsheetData(2, 2);
+
         createHOT(data, true);
         const htCore = getHtCore();
 
@@ -79,6 +80,7 @@ describe('HandsontableObserveChanges', () => {
 
       it('should render removed column', async() => {
         const data = Handsontable.helper.createSpreadsheetData(2, 2);
+
         createHOT(data, true);
         const htCore = getHtCore();
 
@@ -93,6 +95,7 @@ describe('HandsontableObserveChanges', () => {
 
       it('should render cell change from string to string', async() => {
         const data = Handsontable.helper.createSpreadsheetData(2, 2);
+
         createHOT(data, true);
         const htCore = getHtCore();
 
@@ -105,6 +108,7 @@ describe('HandsontableObserveChanges', () => {
 
       it('should render cell change in a new row', async() => {
         const data = Handsontable.helper.createSpreadsheetData(2, 2);
+
         createHOT(data, true);
         const htCore = getHtCore();
 
@@ -122,6 +126,7 @@ describe('HandsontableObserveChanges', () => {
 
       it('should not render cell change when turned off (`observeChanges: false`)', async() => {
         const data = Handsontable.helper.createSpreadsheetData(2, 2);
+
         createHOT(data, false);
         const htCore = getHtCore();
 
@@ -135,6 +140,7 @@ describe('HandsontableObserveChanges', () => {
     describe('object data', () => {
       it('should render newly added row', async() => {
         const data = Handsontable.helper.createSpreadsheetObjectData(2, 2);
+
         createHOT(data, true);
         const htCore = getHtCore();
 
@@ -148,6 +154,7 @@ describe('HandsontableObserveChanges', () => {
 
       it('should render removed row', async() => {
         const data = Handsontable.helper.createSpreadsheetObjectData(2, 2);
+
         createHOT(data, true);
         const htCore = getHtCore();
 
@@ -161,6 +168,7 @@ describe('HandsontableObserveChanges', () => {
 
       it('should render cell change from string to string', async() => {
         const data = Handsontable.helper.createSpreadsheetObjectData(2, 2);
+
         createHOT(data, true);
         const htCore = getHtCore();
 
@@ -173,6 +181,7 @@ describe('HandsontableObserveChanges', () => {
 
       it('should render cell change in a new row', async() => {
         const data = Handsontable.helper.createSpreadsheetObjectData(2, 2);
+
         createHOT(data, true);
         const htCore = getHtCore();
 
@@ -189,6 +198,7 @@ describe('HandsontableObserveChanges', () => {
 
       it('should not break with undefined data properties', () => {
         const data = Handsontable.helper.createSpreadsheetObjectData(2, 2);
+
         data[0].prop0 = undefined;
 
         expect(() => {
@@ -199,6 +209,7 @@ describe('HandsontableObserveChanges', () => {
 
       it('should not render cell change when turned off (`observeChanges: false`)', async() => {
         const data = Handsontable.helper.createSpreadsheetObjectData(2, 2);
+
         createHOT(data, false);
         const htCore = getHtCore();
 
@@ -214,6 +225,7 @@ describe('HandsontableObserveChanges', () => {
   describe('enabling/disabling plugin', () => {
     it('should be possible to enable plugin using updateSettings', async() => {
       const data = Handsontable.helper.createSpreadsheetData(2, 2);
+
       createHOT(data, false);
       const htCore = getHtCore();
 
@@ -314,6 +326,7 @@ describe('HandsontableObserveChanges', () => {
         const hot = createHOT(data, true);
 
         const afterChangesObservedCallback = jasmine.createSpy('afterChangesObservedCallback');
+
         hot.addHook('afterChangesObserved', afterChangesObservedCallback);
 
         data[0][0] = 'new string';
@@ -327,6 +340,7 @@ describe('HandsontableObserveChanges', () => {
         const hot = createHOT(data, true);
 
         const afterCreateRowCallback = jasmine.createSpy('afterCreateRowCallback');
+
         hot.addHook('afterCreateRow', afterCreateRowCallback);
 
         data.push(['A2', 'B2']);
@@ -343,6 +357,7 @@ describe('HandsontableObserveChanges', () => {
         const hot = createHOT(data, true);
 
         const afterRemoveRowCallback = jasmine.createSpy('afterRemoveRowCallback');
+
         hot.addHook('afterRemoveRow', afterRemoveRowCallback);
 
         data.pop();
@@ -358,6 +373,7 @@ describe('HandsontableObserveChanges', () => {
         const hot = createHOT(data, true);
 
         const afterRemoveRowCallback = jasmine.createSpy('afterRemoveRowCallback');
+
         hot.addHook('afterRemoveRow', afterRemoveRowCallback);
 
         data.splice(0, 2);
@@ -367,6 +383,7 @@ describe('HandsontableObserveChanges', () => {
 
         // The order of run hooks depends on whether objectObserve uses native Object.observe or a shim
         const args = [];
+
         args.push(afterRemoveRowCallback.calls.argsFor(0));
         args.push(afterRemoveRowCallback.calls.argsFor(1));
         expect(args).toContain([1, 1, 'ObserveChanges.change', undefined, undefined, undefined]);
@@ -378,6 +395,7 @@ describe('HandsontableObserveChanges', () => {
         const hot = createHOT(data, true);
 
         const afterCreateColCallback = jasmine.createSpy('afterCreateColCallback');
+
         hot.addHook('afterCreateCol', afterCreateColCallback);
 
         data[0].push('C1');
@@ -394,6 +412,7 @@ describe('HandsontableObserveChanges', () => {
         const hot = createHOT(data, true);
 
         const afterRemoveColCallback = jasmine.createSpy('afterRemoveColCallback');
+
         hot.addHook('afterRemoveCol', afterRemoveColCallback);
 
         data[0].pop();
@@ -410,6 +429,7 @@ describe('HandsontableObserveChanges', () => {
         const hot = createHOT(data, true);
 
         const afterRemoveColCallback = jasmine.createSpy('afterRemoveColCallback');
+
         hot.addHook('afterRemoveCol', afterRemoveColCallback);
 
         data[0].pop();
@@ -422,6 +442,7 @@ describe('HandsontableObserveChanges', () => {
 
         // The order of run hooks depends on whether objectObserve uses native Object.observe or a shim
         const args = [];
+
         args.push(afterRemoveColCallback.calls.argsFor(0));
         args.push(afterRemoveColCallback.calls.argsFor(1));
         expect(args).toContain([1, 1, 'ObserveChanges.change', undefined, undefined, undefined]);
@@ -433,6 +454,7 @@ describe('HandsontableObserveChanges', () => {
         const hot = createHOT(data, true);
 
         const afterChangeCallback = jasmine.createSpy('afterChangeCallback');
+
         hot.addHook('afterChange', afterChangeCallback);
 
         data[0][0] = 'new string';
@@ -456,6 +478,7 @@ describe('HandsontableObserveChanges', () => {
         const hot = createHOT(data, true);
 
         const afterChangesObservedCallback = jasmine.createSpy('afterChangesObservedCallback');
+
         hot.addHook('afterChangesObserved', afterChangesObservedCallback);
 
         data[0].prop0 = 'new string';
@@ -469,6 +492,7 @@ describe('HandsontableObserveChanges', () => {
         const hot = createHOT(data, true);
 
         const afterCreateRowCallback = jasmine.createSpy('afterCreateRowCallback');
+
         hot.addHook('afterCreateRow', afterCreateRowCallback);
 
         data.push({ prop0: 'A2', prop1: 'B2' });
@@ -484,6 +508,7 @@ describe('HandsontableObserveChanges', () => {
         const hot = createHOT(data, true);
 
         const afterRemoveRowCallback = jasmine.createSpy('afterRemoveRowCallback');
+
         hot.addHook('afterRemoveRow', afterRemoveRowCallback);
 
         data.pop();
@@ -499,6 +524,7 @@ describe('HandsontableObserveChanges', () => {
         const hot = createHOT(data, true);
 
         const afterRemoveRowCallback = jasmine.createSpy('afterRemoveRowCallback');
+
         hot.addHook('afterRemoveRow', afterRemoveRowCallback);
 
         data.splice(0, 2);
@@ -508,6 +534,7 @@ describe('HandsontableObserveChanges', () => {
 
         // The order of run hooks depends on whether objectObserve uses native Object.observe or a shim
         const args = [];
+
         args.push(afterRemoveRowCallback.calls.argsFor(0));
         args.push(afterRemoveRowCallback.calls.argsFor(1));
         expect(args).toContain([1, 1, 'ObserveChanges.change', undefined, undefined, undefined]);
@@ -519,6 +546,7 @@ describe('HandsontableObserveChanges', () => {
         const hot = createHOT(data, true);
 
         const afterChangeCallback = jasmine.createSpy('afterChangeCallback');
+
         hot.addHook('afterChange', afterChangeCallback);
 
         data[0].prop0 = 'new string';
@@ -544,6 +572,7 @@ describe('HandsontableObserveChanges', () => {
         const hot = createHOT(data, true);
 
         const afterRenderSpy = jasmine.createSpy('afterRenderSpy');
+
         hot.addHook('afterRender', afterRenderSpy);
 
         alter('insert_row');
@@ -558,9 +587,11 @@ describe('HandsontableObserveChanges', () => {
         const hot = createHOT(data, true);
 
         const afterRenderSpy = jasmine.createSpy('afterRenderSpy');
+
         hot.addHook('afterRender', afterRenderSpy);
 
         const afterChangesObservedCallback = jasmine.createSpy('afterChangesObservedCallback');
+
         hot.addHook('afterChangesObserved', afterChangesObservedCallback);
 
         alter('remove_row');
@@ -576,6 +607,7 @@ describe('HandsontableObserveChanges', () => {
         const hot = createHOT(data, true);
 
         const afterRenderSpy = jasmine.createSpy('afterRenderSpy');
+
         hot.addHook('afterRender', afterRenderSpy);
 
         alter('insert_col');
@@ -590,9 +622,11 @@ describe('HandsontableObserveChanges', () => {
         const hot = createHOT(data, true);
 
         const afterRenderSpy = jasmine.createSpy('afterRenderSpy');
+
         hot.addHook('afterRender', afterRenderSpy);
 
         const afterChangesObservedCallback = jasmine.createSpy('afterChangesObservedCallback');
+
         hot.addHook('afterChangesObserved', afterChangesObservedCallback);
 
         alter('remove_col');
@@ -609,9 +643,11 @@ describe('HandsontableObserveChanges', () => {
         const htCore = getHtCore();
 
         const afterRenderSpy = jasmine.createSpy('afterRenderSpy');
+
         hot.addHook('afterRender', afterRenderSpy);
 
         const afterChangesObservedCallback = jasmine.createSpy('afterChangesObservedCallback');
+
         hot.addHook('afterChangesObserved', afterChangesObservedCallback);
 
         setDataAtCell(0, 0, 'new value');
@@ -628,6 +664,7 @@ describe('HandsontableObserveChanges', () => {
         const hot = createHOT(data, true);
 
         const afterRenderSpy = jasmine.createSpy('afterRenderSpy');
+
         hot.addHook('afterRender', afterRenderSpy);
 
         alter('insert_row');
@@ -642,9 +679,11 @@ describe('HandsontableObserveChanges', () => {
         const hot = createHOT(data, true);
 
         const afterRenderSpy = jasmine.createSpy('afterRenderSpy');
+
         hot.addHook('afterRender', afterRenderSpy);
 
         const afterChangesObservedCallback = jasmine.createSpy('afterChangesObservedCallback');
+
         hot.addHook('afterChangesObserved', afterChangesObservedCallback);
 
         alter('remove_row');
@@ -660,9 +699,11 @@ describe('HandsontableObserveChanges', () => {
         const hot = createHOT(data, true);
 
         const afterRenderSpy = jasmine.createSpy('afterRenderSpy');
+
         hot.addHook('afterRender', afterRenderSpy);
 
         const afterChangesObservedCallback = jasmine.createSpy('afterChangesObservedCallback');
+
         hot.addHook('afterChangesObserved', afterChangesObservedCallback);
 
         setDataAtRowProp(0, 'prop0', 'new value');
@@ -681,9 +722,11 @@ describe('HandsontableObserveChanges', () => {
       const newData = Handsontable.helper.createSpreadsheetData(2, 2);
       const hot = createHOT(data, true);
       const htCore = getHtCore();
+
       hot.loadData(newData);
 
       const afterRenderSpy = jasmine.createSpy('afterRenderSpy');
+
       hot.addHook('afterRender', afterRenderSpy);
 
       newData.push(['A3', 'B3']);
@@ -699,9 +742,11 @@ describe('HandsontableObserveChanges', () => {
       const newData = Handsontable.helper.createSpreadsheetData(2, 2);
       const hot = createHOT(data, true);
       const htCore = getHtCore();
+
       hot.loadData(newData);
 
       const afterRenderSpy = jasmine.createSpy('afterRenderSpy');
+
       hot.addHook('afterRender', afterRenderSpy);
 
       data.push(['A3', 'B3']);

--- a/src/plugins/observeChanges/utils.js
+++ b/src/plugins/observeChanges/utils.js
@@ -23,6 +23,7 @@ export function cleanPatches(patches) {
 
     return true;
   });
+
   /**
    * Extend patches with changed cells coords.
    */

--- a/src/plugins/persistentState/__tests__/persistentState.spec.js
+++ b/src/plugins/persistentState/__tests__/persistentState.spec.js
@@ -51,6 +51,7 @@ describe('persistentState', () => {
     hot.runHooks('persistentStateSave', 'testData', 100);
 
     const storedData = {};
+
     hot.runHooks('persistentStateLoad', 'testData', storedData);
 
     expect(storedData.value).toEqual(100);
@@ -66,6 +67,7 @@ describe('persistentState', () => {
     window.localStorage[`${id}_testData`] = JSON.stringify(100);
 
     const storedData = {};
+
     hot.runHooks('persistentStateLoad', 'testData', storedData);
 
     expect(storedData.value).toBeUndefined();
@@ -80,6 +82,7 @@ describe('persistentState', () => {
     hot.runHooks('persistentStateSave', 'testData', 100);
 
     let storedData = {};
+
     hot.runHooks('persistentStateLoad', 'testData', storedData);
 
     expect(storedData.value).toEqual(100);
@@ -120,6 +123,7 @@ describe('persistentState', () => {
       {},
       {}
     ];
+
     hot.runHooks('persistentStateLoad', 'testData0', storedData[0]);
     hot.runHooks('persistentStateLoad', 'testData1', storedData[1]);
     hot.runHooks('persistentStateLoad', 'testData2', storedData[2]);
@@ -152,6 +156,7 @@ describe('persistentState', () => {
     hot.runHooks('persistentStateSave', 'testData', 100);
 
     let storedData = {};
+
     hot.runHooks('persistentStateLoad', 'testData', storedData);
 
     expect(storedData.value).toEqual(100);
@@ -175,6 +180,7 @@ describe('persistentState', () => {
     hot.runHooks('persistentStateSave', 'testData', 100);
 
     let storedData = {};
+
     hot.runHooks('persistentStateLoad', 'testData', storedData);
 
     expect(storedData.value).toBeUndefined();

--- a/src/plugins/search/__tests__/search.spec.js
+++ b/src/plugins/search/__tests__/search.spec.js
@@ -56,6 +56,7 @@ describe('Search plugin', () => {
       const searchResultClass = hot.getPlugin('search').searchResultClass;
 
       let cell = hot.getCell(0, 0);
+
       expect($(cell).hasClass(searchResultClass)).toBe(false);
       cell = hot.getCell(0, 1);
       expect($(cell).hasClass(searchResultClass)).toBe(false);
@@ -419,6 +420,7 @@ describe('Search plugin', () => {
       render();
 
       let cellProperties = hot.getCellMeta(0, 0);
+
       expect(cellProperties.isSearchResult).toBeFalsy();
       cellProperties = hot.getCellMeta(0, 1);
       expect(cellProperties.isSearchResult).toBeFalsy();
@@ -454,6 +456,7 @@ describe('Search plugin', () => {
       const searchResultClass = hot.getPlugin('search').searchResultClass;
 
       let cell = hot.getCell(0, 0);
+
       expect($(cell).hasClass(searchResultClass)).toBe(false);
       cell = hot.getCell(0, 1);
       expect($(cell).hasClass(searchResultClass)).toBe(false);
@@ -486,6 +489,7 @@ describe('Search plugin', () => {
       render();
 
       let cell = hot.getCell(0, 0);
+
       expect($(cell).hasClass('customSearchResultClass')).toBe(false);
       cell = hot.getCell(0, 1);
       expect($(cell).hasClass('customSearchResultClass')).toBe(false);
@@ -544,6 +548,7 @@ describe('Search plugin', () => {
       render();
 
       let cellClassName = hot.getCell(0, 0).className;
+
       expect(cellClassName).toBe('columns cell');
       cellClassName = hot.getCell(0, 1).className;
       expect(cellClassName).toBe('columns cell');
@@ -576,6 +581,7 @@ describe('Search plugin', () => {
       render();
 
       let cellClassName = hot.getCell(0, 0).className;
+
       expect(cellClassName).toBe('cell');
       cellClassName = hot.getCell(0, 1).className;
       expect(cellClassName).toBe('cell');

--- a/src/plugins/search/search.js
+++ b/src/plugins/search/search.js
@@ -105,6 +105,7 @@ export class Search extends BasePlugin {
     }
 
     const searchSettings = this.hot.getSettings()[PLUGIN_KEY];
+
     this.updatePluginSettings(searchSettings);
 
     this.addHook('beforeRenderer', (...args) => this.onBeforeRenderer(...args));

--- a/src/plugins/trimRows/__tests__/trimRows.spec.js
+++ b/src/plugins/trimRows/__tests__/trimRows.spec.js
@@ -110,6 +110,7 @@ describe('TrimRows', () => {
       width: 500,
       height: 300
     });
+
     hot.getPlugin('trimRows').disablePlugin();
     hot.render();
 
@@ -129,6 +130,7 @@ describe('TrimRows', () => {
       width: 500,
       height: 300
     });
+
     hot.getPlugin('hiddenRows').disablePlugin();
     hot.getPlugin('hiddenRows').enablePlugin();
     hot.render();
@@ -376,6 +378,7 @@ describe('TrimRows', () => {
         });
 
         const plugin = getPlugin('trimRows');
+
         plugin.trimRows([0, 5, 10, 15]);
 
         expect(beforeTrimRowHookCallback).toHaveBeenCalledWith([], [], false, void 0, void 0, void 0);
@@ -395,6 +398,7 @@ describe('TrimRows', () => {
         });
 
         const plugin = getPlugin('trimRows');
+
         plugin.trimRows([0, 5, 1.1]);
 
         expect(beforeTrimRowHookCallback).toHaveBeenCalledWith([], [], false, void 0, void 0, void 0);
@@ -457,6 +461,7 @@ describe('TrimRows', () => {
         });
 
         const plugin = getPlugin('trimRows');
+
         plugin.trimRows([0, 5]);
 
         expect(afterTrimRowHookCallback).toHaveBeenCalledWith([0, 5], [0, 5], true, false, void 0, void 0);
@@ -472,6 +477,7 @@ describe('TrimRows', () => {
         });
 
         const plugin = getPlugin('trimRows');
+
         plugin.trimRows([0, 5, 6]);
 
         expect(afterTrimRowHookCallback).toHaveBeenCalledWith([0, 5], [0, 5, 6], true, true, void 0, void 0);
@@ -488,6 +494,7 @@ describe('TrimRows', () => {
         });
 
         const plugin = getPlugin('trimRows');
+
         plugin.trimRows([0, 5, 10, 15]);
 
         expect(afterTrimRowHookCallback).toHaveBeenCalledWith([], [], false, false, void 0, void 0);
@@ -507,6 +514,7 @@ describe('TrimRows', () => {
         });
 
         const plugin = getPlugin('trimRows');
+
         plugin.trimRows([0, 5, 1.1]);
 
         expect(afterTrimRowHookCallback).toHaveBeenCalledWith([], [], false, false, void 0, void 0);
@@ -567,6 +575,7 @@ describe('TrimRows', () => {
         });
 
         const plugin = getPlugin('trimRows');
+
         plugin.untrimRows([0, 5, 10, 15]);
 
         expect(beforeUntrimRowHookCallback).toHaveBeenCalledWith([0, 5], [0, 5], false, void 0, void 0, void 0);
@@ -585,6 +594,7 @@ describe('TrimRows', () => {
         });
 
         const plugin = getPlugin('trimRows');
+
         plugin.untrimRows([0, 5, 10, 15]);
 
         expect(beforeUntrimRowHookCallback).toHaveBeenCalledWith([0, 5], [0, 5], false, void 0, void 0, void 0);
@@ -647,6 +657,7 @@ describe('TrimRows', () => {
         });
 
         const plugin = getPlugin('trimRows');
+
         plugin.untrimRows([0, 5]);
 
         expect(afterUntrimRowHookCallback).toHaveBeenCalledWith([], [], true, false, void 0, void 0);
@@ -662,6 +673,7 @@ describe('TrimRows', () => {
         });
 
         const plugin = getPlugin('trimRows');
+
         plugin.untrimRows([0, 5, 6]);
 
         expect(afterUntrimRowHookCallback).toHaveBeenCalledWith([0, 5], [], true, true, void 0, void 0);
@@ -678,6 +690,7 @@ describe('TrimRows', () => {
         });
 
         const plugin = getPlugin('trimRows');
+
         plugin.untrimRows([0, 5, 1.1]);
 
         expect(afterUntrimRowHookCallback).toHaveBeenCalledWith([0, 5], [0, 5], false, false, void 0, void 0);
@@ -722,6 +735,7 @@ describe('TrimRows', () => {
      */
     function getClipboardEventMock() {
       const event = {};
+
       event.clipboardData = new DataTransferObject();
       event.preventDefault = () => {};
 
@@ -1077,6 +1091,7 @@ describe('TrimRows', () => {
         width: 500,
         height: 300
       });
+
       hot.updateSettings({
         trimRows: [1, 2, 3, 4, 5]
       });

--- a/src/plugins/trimRows/__tests__/trimRows.spec.js
+++ b/src/plugins/trimRows/__tests__/trimRows.spec.js
@@ -724,6 +724,7 @@ describe('TrimRows', () => {
       const event = {};
       event.clipboardData = new DataTransferObject();
       event.preventDefault = () => {};
+
       return event;
     }
 

--- a/src/plugins/undoRedo/__tests__/UndoRedo.spec.js
+++ b/src/plugins/undoRedo/__tests__/UndoRedo.spec.js
@@ -952,6 +952,7 @@ describe('UndoRedo', () => {
           });
 
           const afterCreateColCallback = jasmine.createSpy('afterCreateColCallback');
+
           HOT.addHook('afterCreateCol', afterCreateColCallback);
 
           expect(countCols()).toEqual(3);
@@ -2482,6 +2483,7 @@ describe('UndoRedo', () => {
         hot.getPlugin('contextMenu').executeCommand('alignment:bottom');
 
         let cellMeta = hot.getCellMeta(0, 0);
+
         expect(cellMeta.className.indexOf('htCenter')).toBeGreaterThan(-1);
         expect(cellMeta.className.indexOf('htMiddle')).toBeGreaterThan(-1);
 
@@ -2617,6 +2619,7 @@ describe('UndoRedo', () => {
         hot.getPlugin('contextMenu').executeCommand('alignment:bottom');
 
         let cellMeta = hot.getCellMeta(0, 0);
+
         expect(cellMeta.className.indexOf('htCenter')).toBeGreaterThan(-1);
         expect(cellMeta.className.indexOf('htMiddle')).toBeGreaterThan(-1);
 

--- a/src/plugins/undoRedo/__tests__/UndoRedo.spec.js
+++ b/src/plugins/undoRedo/__tests__/UndoRedo.spec.js
@@ -1998,6 +1998,7 @@ describe('UndoRedo', () => {
               if (col === 1) {
                 return { readOnly: true };
               }
+
               return {};
             }
           });

--- a/src/plugins/undoRedo/__tests__/UndoRedo.spec.js
+++ b/src/plugins/undoRedo/__tests__/UndoRedo.spec.js
@@ -2548,6 +2548,7 @@ describe('UndoRedo', () => {
 
         // check if all cells are either non-adjusted or adjusted to the left (as default)
         let finish;
+
         for (let i = 0; i < 9; i++) {
           for (let j = 0; j < 9; j++) {
             cellMeta = hot.getCellMeta(i, j);
@@ -2647,6 +2648,7 @@ describe('UndoRedo', () => {
 
         // check if all cells are either non-adjusted or adjusted to the left (as default)
         let finish;
+
         for (let i = 0; i < 9; i++) {
           for (let j = 0; j < 9; j++) {
             cellMeta = hot.getCellMeta(i, j);

--- a/src/plugins/undoRedo/undoRedo.js
+++ b/src/plugins/undoRedo/undoRedo.js
@@ -853,6 +853,7 @@ function onBeforeKeyDown(event) {
  */
 function onAfterChange(changes, source) {
   const instance = this;
+
   if (source === 'loadData') {
     return instance.undoRedo.clear();
   }

--- a/src/plugins/undoRedo/undoRedo.js
+++ b/src/plugins/undoRedo/undoRedo.js
@@ -22,6 +22,7 @@ export const PLUGIN_KEY = 'undoRedo';
  */
 function UndoRedo(instance) {
   const plugin = this;
+
   this.instance = instance;
   this.doneActions = [];
   this.undoneActions = [];
@@ -65,6 +66,7 @@ function UndoRedo(instance) {
     }
 
     const action = new UndoRedo.CreateRowAction(index, amount);
+
     plugin.done(action);
   });
 
@@ -131,6 +133,7 @@ function UndoRedo(instance) {
 
   instance.addHook('beforeCellAlignment', (stateBefore, range, type, alignment) => {
     const action = new UndoRedo.CellAlignmentAction(stateBefore, range, type, alignment);
+
     plugin.done(action);
   });
 
@@ -196,6 +199,7 @@ UndoRedo.prototype.undo = function() {
 
     this.ignoreNewActions = true;
     const that = this;
+
     action.undo(this.instance, () => {
       that.ignoreNewActions = false;
       that.undoneActions.push(action);
@@ -227,6 +231,7 @@ UndoRedo.prototype.redo = function() {
 
     this.ignoreNewActions = true;
     const that = this;
+
     action.redo(this.instance, () => {
       that.ignoreNewActions = false;
       that.doneActions.push(action);
@@ -679,6 +684,7 @@ class MergeCellsAction extends UndoRedo.Action {
 
   undo(instance, undoneCallback) {
     const mergeCellsPlugin = instance.getPlugin('mergeCells');
+
     instance.addHookOnce('afterRender', undoneCallback);
 
     mergeCellsPlugin.unmergeRange(this.cellRange, true);
@@ -697,6 +703,7 @@ class MergeCellsAction extends UndoRedo.Action {
 
   redo(instance, redoneCallback) {
     const mergeCellsPlugin = instance.getPlugin('mergeCells');
+
     instance.addHookOnce('afterRender', redoneCallback);
 
     mergeCellsPlugin.mergeRange(this.cellRange);
@@ -717,6 +724,7 @@ class UnmergeCellsAction extends UndoRedo.Action {
 
   undo(instance, undoneCallback) {
     const mergeCellsPlugin = instance.getPlugin('mergeCells');
+
     instance.addHookOnce('afterRender', undoneCallback);
 
     mergeCellsPlugin.mergeRange(this.cellRange, true);
@@ -724,6 +732,7 @@ class UnmergeCellsAction extends UndoRedo.Action {
 
   redo(instance, redoneCallback) {
     const mergeCellsPlugin = instance.getPlugin('mergeCells');
+
     instance.addHookOnce('afterRender', redoneCallback);
 
     mergeCellsPlugin.unmergeRange(this.cellRange, true);

--- a/src/plugins/undoRedo/undoRedo.js
+++ b/src/plugins/undoRedo/undoRedo.js
@@ -44,7 +44,11 @@ function UndoRedo(instance) {
       return;
     }
 
-    const clonedChanges = changes.reduce((arr, change) => { arr.push([...change]); return arr; }, []);
+    const clonedChanges = changes.reduce((arr, change) => {
+      arr.push([...change]);
+
+      return arr;
+    }, []);
 
     arrayEach(clonedChanges, (change) => {
       change[1] = instance.propToCol(change[1]);

--- a/src/renderers/checkboxRenderer/__tests__/checkboxRenderer.spec.js
+++ b/src/renderers/checkboxRenderer/__tests__/checkboxRenderer.spec.js
@@ -59,6 +59,7 @@ describe('CheckboxRenderer', () => {
     const spy = jasmine.createSpyObj('error', ['test']);
     window.onerror = function() {
       spy.test();
+
       return false;
     };
 

--- a/src/renderers/checkboxRenderer/__tests__/checkboxRenderer.spec.js
+++ b/src/renderers/checkboxRenderer/__tests__/checkboxRenderer.spec.js
@@ -57,6 +57,7 @@ describe('CheckboxRenderer', () => {
 
   it('should select cell after checkbox click', async() => {
     const spy = jasmine.createSpyObj('error', ['test']);
+
     window.onerror = function() {
       spy.test();
 
@@ -134,6 +135,7 @@ describe('CheckboxRenderer', () => {
     });
 
     const afterChangeCallback = jasmine.createSpy('afterChangeCallback');
+
     addHook('afterChange', afterChangeCallback);
 
     let checkboxes = spec().$container.find(':checkbox');
@@ -171,6 +173,7 @@ describe('CheckboxRenderer', () => {
     });
 
     const afterChangeCallback = jasmine.createSpy('afterChangeCallback');
+
     addHook('afterChange', afterChangeCallback);
 
     let checkboxes = spec().$container.find(':checkbox');
@@ -273,6 +276,7 @@ describe('CheckboxRenderer', () => {
     });
 
     const afterChangeCallback = jasmine.createSpy('afterChangeCallback');
+
     addHook('afterChange', afterChangeCallback);
 
     let checkboxes = spec().$container.find(':checkbox');
@@ -309,6 +313,7 @@ describe('CheckboxRenderer', () => {
     });
 
     const afterChangeCallback = jasmine.createSpy('afterChangeCallback');
+
     addHook('afterChange', afterChangeCallback);
 
     let checkboxes = spec().$container.find(':checkbox');
@@ -340,6 +345,7 @@ describe('CheckboxRenderer', () => {
     });
 
     const afterChangeCallback = jasmine.createSpy('afterChangeCallback');
+
     addHook('afterChange', afterChangeCallback);
 
     let checkboxes = spec().$container.find(':checkbox');
@@ -371,6 +377,7 @@ describe('CheckboxRenderer', () => {
     });
 
     const afterChangeCallback = jasmine.createSpy('afterChangeCallback');
+
     addHook('afterChange', afterChangeCallback);
 
     let checkboxes = spec().$container.find(':checkbox');
@@ -449,6 +456,7 @@ describe('CheckboxRenderer', () => {
     });
 
     const afterChangeCallback = jasmine.createSpy('afterChangeCallback');
+
     addHook('afterChange', afterChangeCallback);
 
     let checkboxes = spec().$container.find(':checkbox');
@@ -483,6 +491,7 @@ describe('CheckboxRenderer', () => {
     });
 
     const afterChangeCallback = jasmine.createSpy('afterChangeCallback');
+
     addHook('afterChange', afterChangeCallback);
 
     let checkboxes = spec().$container.find(':checkbox');
@@ -498,6 +507,7 @@ describe('CheckboxRenderer', () => {
 
     checkboxes = spec().$container.find(':checkbox');
     const selection = getSelected();
+
     expect(selection).toEqual([[1, 0, 1, 0]]);
     expect(checkboxes.eq(0).prop('checked')).toBe(true);
     expect(checkboxes.eq(1).prop('checked')).toBe(false);
@@ -516,6 +526,7 @@ describe('CheckboxRenderer', () => {
     });
 
     const afterChangeCallback = jasmine.createSpy('afterChangeCallback');
+
     addHook('afterChange', afterChangeCallback);
 
     let checkboxes = spec().$container.find(':checkbox');
@@ -531,6 +542,7 @@ describe('CheckboxRenderer', () => {
 
     checkboxes = spec().$container.find(':checkbox');
     const selection = getSelected();
+
     expect(selection).toEqual([[0, 0, 0, 0]]);
     expect(checkboxes.eq(0).prop('checked')).toBe(false);
     expect(checkboxes.eq(1).prop('checked')).toBe(false);
@@ -552,6 +564,7 @@ describe('CheckboxRenderer', () => {
     });
 
     const afterChangeCallback = jasmine.createSpy('afterChangeCallback');
+
     addHook('afterChange', afterChangeCallback);
 
     let checkboxes = spec().$container.find(':checkbox');
@@ -589,6 +602,7 @@ describe('CheckboxRenderer', () => {
     });
 
     const afterChangeCallback = jasmine.createSpy('afterChangeCallback');
+
     addHook('afterChange', afterChangeCallback);
 
     let checkboxes = spec().$container.find(':checkbox');
@@ -622,6 +636,7 @@ describe('CheckboxRenderer', () => {
     });
 
     const afterChangeCallback = jasmine.createSpy('afterChangeCallback');
+
     addHook('afterChange', afterChangeCallback);
 
     let checkboxes = spec().$container.find(':checkbox');
@@ -657,6 +672,7 @@ describe('CheckboxRenderer', () => {
     });
 
     const afterChangeCallback = jasmine.createSpy('afterChangeCallback');
+
     addHook('afterChange', afterChangeCallback);
 
     let checkboxes = spec().$container.find(':checkbox');
@@ -692,6 +708,7 @@ describe('CheckboxRenderer', () => {
     });
 
     const afterChangeCallback = jasmine.createSpy('afterChangeCallback');
+
     addHook('afterChange', afterChangeCallback);
 
     expect(getDataAtCell(0, 0)).toBe('foo');
@@ -720,6 +737,7 @@ describe('CheckboxRenderer', () => {
     });
 
     const afterChangeCallback = jasmine.createSpy('afterChangeCallback');
+
     addHook('afterChange', afterChangeCallback);
 
     expect(getDataAtCell(0, 0)).toBe('foo');
@@ -748,6 +766,7 @@ describe('CheckboxRenderer', () => {
     });
 
     const afterChangeCallback = jasmine.createSpy('afterChangeCallback');
+
     addHook('afterChange', afterChangeCallback);
 
     expect(getDataAtCell(0, 0)).toBe('foo');
@@ -791,6 +810,7 @@ describe('CheckboxRenderer', () => {
     });
 
     const afterChangeCallback = jasmine.createSpy('afterChangeCallback');
+
     addHook('afterChange', afterChangeCallback);
 
     selectCell(0, 0);
@@ -814,6 +834,7 @@ describe('CheckboxRenderer', () => {
     });
 
     const afterChangeCallback = jasmine.createSpy('afterChangeCallback');
+
     addHook('afterChange', afterChangeCallback);
 
     selectCell(0, 0);
@@ -834,6 +855,7 @@ describe('CheckboxRenderer', () => {
     });
 
     const afterChangeCallback = jasmine.createSpy('afterChangeCallback');
+
     addHook('afterChange', afterChangeCallback);
 
     selectCell(0, 0);
@@ -855,6 +877,7 @@ describe('CheckboxRenderer', () => {
     });
 
     const afterChangeCallback = jasmine.createSpy('afterChangeCallback');
+
     addHook('afterChange', afterChangeCallback);
 
     selectCell(0, 0);
@@ -875,6 +898,7 @@ describe('CheckboxRenderer', () => {
     });
 
     const afterChangeCallback = jasmine.createSpy('afterChangeCallback');
+
     addHook('afterChange', afterChangeCallback);
 
     selectCell(0, 0);
@@ -1061,6 +1085,7 @@ describe('CheckboxRenderer', () => {
 
       setTimeout(() => {
         const contextSubMenu = $(`.htContextMenuSub_${menu.text()}`).find('tbody td').eq(2);
+
         contextSubMenu.simulate('mousedown');
         contextSubMenu.simulate('mouseup');
 

--- a/src/renderers/checkboxRenderer/checkboxRenderer.js
+++ b/src/renderers/checkboxRenderer/checkboxRenderer.js
@@ -35,6 +35,7 @@ Hooks.getSingleton().add('modifyAutoColumnSizeSeed', function(bundleSeed, cellMe
 
     } else if (labelProperty) {
       const labelData = this.getDataAtRowProp(row, labelProperty);
+
       labelText = labelData !== null ? labelData : cellValue;
     }
 
@@ -57,6 +58,7 @@ Hooks.getSingleton().add('modifyAutoColumnSizeSeed', function(bundleSeed, cellMe
  */
 export function checkboxRenderer(instance, TD, row, col, prop, value, cellProperties) {
   const { rootDocument } = instance;
+
   baseRenderer.apply(this, [instance, TD, row, col, prop, value, cellProperties]);
   registerEvents(instance);
 
@@ -100,6 +102,7 @@ export function checkboxRenderer(instance, TD, row, col, prop, value, cellProper
 
     } else if (labelOptions.property) {
       const labelValue = instance.getDataAtRowProp(row, labelOptions.property);
+
       labelText = labelValue !== null ? labelValue : '';
     }
 
@@ -283,6 +286,7 @@ function registerEvents(instance) {
 
   if (!eventManager) {
     const { rootElement } = instance;
+
     eventManager = new EventManager(instance);
 
     eventManager.addEventListener(rootElement, 'click', event => onClick(event, instance));

--- a/src/renderers/numericRenderer/__tests__/numericRenderer.spec.js
+++ b/src/renderers/numericRenderer/__tests__/numericRenderer.spec.js
@@ -75,6 +75,7 @@ describe('NumericRenderer', () => {
     const DIV = document.createElement('DIV');
     const instance = new Handsontable(DIV, {});
     const TD = document.createElement('TD');
+
     TD.className = 'someClass';
     Handsontable.renderers.NumericRenderer(instance, TD, 0, 0, 0, 123, {});
     expect(TD.className).toEqual('someClass htRight htNumeric');
@@ -85,6 +86,7 @@ describe('NumericRenderer', () => {
     const DIV = document.createElement('DIV');
     const instance = new Handsontable(DIV, {});
     const TD = document.createElement('TD');
+
     TD.className = 'someClass';
     Handsontable.renderers.NumericRenderer(instance, TD, 0, 0, 0, '123', {});
     expect(TD.className).toEqual('someClass htRight htNumeric');
@@ -95,6 +97,7 @@ describe('NumericRenderer', () => {
     const DIV = document.createElement('DIV');
     const instance = new Handsontable(DIV, {});
     const TD = document.createElement('TD');
+
     TD.className = 'someClass';
     Handsontable.renderers.NumericRenderer(instance, TD, 0, 0, 0, 'abc', {});
     expect(TD.className).toEqual('someClass');
@@ -105,6 +108,7 @@ describe('NumericRenderer', () => {
     const DIV = document.createElement('DIV');
     const instance = new Handsontable(DIV, {});
     const TD = document.createElement('TD');
+
     Handsontable.renderers.NumericRenderer(instance, TD, 0, 0, 0, 123, {
       readOnly: true,
       readOnlyCellClassName: 'htDimmed',

--- a/src/renderers/textRenderer/__tests__/textRenderer.spec.js
+++ b/src/renderers/textRenderer/__tests__/textRenderer.spec.js
@@ -60,6 +60,7 @@ describe('TextRenderer', () => {
     const instance = new Handsontable.Core(DIV, {});
 
     const TD = document.createElement('TD');
+
     TD.className = 'someClass';
     Handsontable.renderers.TextRenderer(instance, TD, 0, 0, 0, '', {
       readOnly: true,

--- a/src/renderers/textRenderer/textRenderer.js
+++ b/src/renderers/textRenderer/textRenderer.js
@@ -33,6 +33,7 @@ export function textRenderer(instance, TD, row, col, prop, value, cellProperties
   if (cellProperties.rendererTemplate) {
     empty(TD);
     const TEMPLATE = instance.rootDocument.createElement('TEMPLATE');
+
     TEMPLATE.setAttribute('bind', '{{}}');
     TEMPLATE.innerHTML = cellProperties.rendererTemplate;
     HTMLTemplateElement.decorate(TEMPLATE);

--- a/src/selection/transformation.js
+++ b/src/selection/transformation.js
@@ -85,6 +85,7 @@ class Transformation {
       }
 
       const coords = new CellCoords(renderableRow + delta.row, renderableColumn + delta.col);
+
       rowTransformDir = 0;
       colTransformDir = 0;
 

--- a/src/tableView.js
+++ b/src/tableView.js
@@ -255,6 +255,7 @@ class TableView {
 
       if (!this.isTextSelectionAllowed(event.target)) {
         const { rootWindow } = this.instance;
+
         clearTextSelection(rootWindow);
         event.preventDefault();
         rootWindow.focus(); // make sure that window that contains HOT is active. Important when HOT is in iframe.

--- a/src/tableView.js
+++ b/src/tableView.js
@@ -336,6 +336,7 @@ class TableView {
             if (event.isTargetWebComponent) {
               break;
             }
+
             // click on something that was a row but now is detached (possibly because your click triggered a rerender)
             return;
           }
@@ -890,6 +891,7 @@ class TableView {
       rowHeaderWidth: () => this.settings.rowHeaderWidth,
       columnHeaderHeight: () => {
         const columnHeaderHeight = this.instance.runHooks('modifyColumnHeaderHeight');
+
         return this.settings.columnHeaderHeight || columnHeaderHeight;
       }
     };

--- a/src/translations/indexMapper.js
+++ b/src/translations/indexMapper.js
@@ -204,6 +204,7 @@ class IndexMapper {
     }
 
     const numberOfIndexes = this.getNumberOfIndexes();
+
     /*
       We initialize map ony when we have full information about number of indexes and the dataset is not empty.
       Otherwise it's unnecessary. Initialization of empty array would not give any positive changes. After initializing

--- a/src/translations/indexMapper.js
+++ b/src/translations/indexMapper.js
@@ -515,6 +515,7 @@ class IndexMapper {
     if (finalIndex + movedIndexesLength < notTrimmedIndexesLength) {
       // Physical index at final index position.
       const physicalIndex = listWithRemovedItems.filter(index => this.isTrimmed(index) === false)[finalIndex];
+
       destinationPosition = listWithRemovedItems.indexOf(physicalIndex);
     }
 

--- a/src/utils/dataStructures/linkedList.js
+++ b/src/utils/dataStructures/linkedList.js
@@ -188,6 +188,7 @@ class LinkedList {
     }
 
     const temp = this.last;
+
     this.last = this.last.prev;
 
     return temp;
@@ -204,6 +205,7 @@ class LinkedList {
     }
 
     const temp = this.first;
+
     this.first = this.first.next;
 
     return temp;
@@ -233,6 +235,7 @@ class LinkedList {
 
     this.first.next = null;
     const temp = this.first;
+
     this.first = this.last;
     this.last = temp;
   }

--- a/src/utils/ghostTable.js
+++ b/src/utils/ghostTable.js
@@ -69,6 +69,7 @@ class GhostTable {
       this.container = this.createContainer(this.hot.rootElement.className);
     }
     const rowObject = { row };
+
     this.rows.push(rowObject);
 
     this.samples = samples;
@@ -121,6 +122,7 @@ class GhostTable {
       this.container = this.createContainer(this.hot.rootElement.className);
     }
     const columnObject = { col: column };
+
     this.columns.push(columnObject);
 
     this.samples = samples;

--- a/src/utils/ghostTable.js
+++ b/src/utils/ghostTable.js
@@ -208,6 +208,7 @@ class GhostTable {
     if (this.settings) {
       return this.settings[name];
     }
+
     return null;
 
   }

--- a/src/utils/parseTable.js
+++ b/src/utils/parseTable.js
@@ -78,6 +78,7 @@ export function instanceToHTML(instance) {
               .replace(/(<br(\s*|\/)>(\r\n|\n)?|\r\n|\n)/g, '<br>\r\n')
               .replace(/\x20/gi, '&nbsp;')
               .replace(/\t/gi, '&#9;');
+
             cell = `<td ${attrs.join(' ')}>${value}</td>`;
           }
         }
@@ -158,6 +159,7 @@ export function htmlToGridSettings(element, rootDocument = document) {
   const settingsObj = {};
   const fragment = rootDocument.createDocumentFragment();
   const tempElem = rootDocument.createElement('div');
+
   fragment.appendChild(tempElem);
 
   let checkElement = element;

--- a/src/utils/parseTable.js
+++ b/src/utils/parseTable.js
@@ -251,7 +251,9 @@ export function htmlToGridSettings(element, rootDocument = document) {
   const dataRows = [
     ...fixedRowsTop,
     ...Array.from(checkElement.tBodies).reduce((sections, section) => {
-      sections.push(...Array.from(section.rows)); return sections;
+      sections.push(...Array.from(section.rows));
+
+      return sections;
     }, []),
     ...fixedRowsBottom];
 

--- a/src/utils/samplesGenerator.js
+++ b/src/utils/samplesGenerator.js
@@ -55,6 +55,7 @@ class SamplesGenerator {
     if (this.customSampleCount) {
       return this.customSampleCount;
     }
+
     return SamplesGenerator.SAMPLE_COUNT;
   }
 

--- a/src/validators/autocompleteValidator/__tests__/autocompleteValidator.spec.js
+++ b/src/validators/autocompleteValidator/__tests__/autocompleteValidator.spec.js
@@ -15,6 +15,7 @@ describe('autocompleteValidator', () => {
   describe('allowEmpty', () => {
     it('should validate empty cells positively (by default)', (done) => {
       const onAfterValidate = jasmine.createSpy('onAfterValidate');
+
       handsontable({
         data: [
           ['some', 'sample', 'data'],
@@ -49,6 +50,7 @@ describe('autocompleteValidator', () => {
 
     it('should validate empty cells positively when allowEmpty is set to true', (done) => {
       const onAfterValidate = jasmine.createSpy('onAfterValidate');
+
       handsontable({
         data: [
           ['some', 'sample', 'data'],
@@ -84,6 +86,7 @@ describe('autocompleteValidator', () => {
 
     it('should validate empty cells negatively when allowEmpty is set to false', (done) => {
       const onAfterValidate = jasmine.createSpy('onAfterValidate');
+
       handsontable({
         data: [
           ['some', 'sample', 'data'],
@@ -119,6 +122,7 @@ describe('autocompleteValidator', () => {
 
     it('should respect the allowEmpty property for a single column', (done) => {
       const onAfterValidate = jasmine.createSpy('onAfterValidate');
+
       handsontable({
         data: [
           ['some', 'sample', 'data']
@@ -158,6 +162,7 @@ describe('autocompleteValidator', () => {
 
     it('should work for null and undefined values in cells', (done) => {
       const onAfterValidate = jasmine.createSpy('onAfterValidate');
+
       handsontable({
         data: [
           ['some', 'sample', 'data']
@@ -198,6 +203,7 @@ describe('autocompleteValidator', () => {
   describe('strict mode', () => {
     it('sshould validate negatively when chars have different size', (done) => {
       const onAfterValidate = jasmine.createSpy('onAfterValidate');
+
       handsontable({
         data: [
           ['some', 'sample', 'data'],

--- a/src/validators/timeValidator/__tests__/timeValidator.spec.js
+++ b/src/validators/timeValidator/__tests__/timeValidator.spec.js
@@ -303,6 +303,7 @@ describe('timeValidator', () => {
         const addLeadingZero = function(number) {
           return number < 10 ? `0${number}` : number;
         };
+
         expect(getDataAtCell(1, 0))
           .toEqual(`${addLeadingZero(currentDateTime.getHours())}:${addLeadingZero(currentDateTime.getMinutes())}:${
             addLeadingZero(currentDateTime.getSeconds())}`);

--- a/test/e2e/ColHeader.spec.js
+++ b/test/e2e/ColHeader.spec.js
@@ -64,6 +64,7 @@ describe('ColHeader', () => {
     });
 
     const ths = getHtCore().find('thead th');
+
     expect(ths.length).toEqual(startCols);
     expect($.trim(ths.eq(0).text())).toEqual('A');
     expect($.trim(ths.eq(1).text())).toEqual('B');
@@ -82,6 +83,7 @@ describe('ColHeader', () => {
     });
 
     const ths = getHtCore().find('thead th');
+
     expect(ths.length).toEqual(startCols);
     expect($.trim(ths.eq(0).text())).toEqual('A');
     expect($.trim(ths.eq(1).text())).toEqual('B');
@@ -102,6 +104,7 @@ describe('ColHeader', () => {
     });
 
     const ths = getHtCore().find('thead th');
+
     expect(ths.length).toEqual(startCols);
     expect($.trim(ths.eq(0).text())).toEqual('A');
     expect($.trim(ths.eq(1).text())).toEqual('B');
@@ -112,12 +115,14 @@ describe('ColHeader', () => {
 
   it('should show col headers with custom label', () => {
     const startCols = 5;
+
     handsontable({
       startCols,
       colHeaders: ['First', 'Second', 'Third']
     });
 
     const ths = getHtCore().find('thead th');
+
     expect(ths.length).toEqual(startCols);
     expect($.trim(ths.eq(0).text())).toEqual('First');
     expect($.trim(ths.eq(1).text())).toEqual('Second');
@@ -212,6 +217,7 @@ describe('ColHeader', () => {
     });
 
     const htCore = getHtCore();
+
     expect(htCore.find('thead th:eq(0)').text()).toEqual('A');
     expect(htCore.find('thead th:eq(1)').text()).toEqual('B');
     expect(htCore.find('thead th:eq(2)').text()).toEqual('C');
@@ -409,6 +415,7 @@ describe('ColHeader', () => {
         return array;
       }
     });
+
     hot.render();
 
     expect(spec().$container.find('.handsontable.ht_clone_top tr:nth-child(1) th:nth-child(1)').height()).toEqual(45);

--- a/test/e2e/Core_count.spec.js
+++ b/test/e2e/Core_count.spec.js
@@ -17,6 +17,7 @@ describe('Core_count', () => {
         height: 100,
         width: 600
       });
+
       expect(instance.countVisibleRows()).toEqual(4);
     });
 
@@ -26,6 +27,7 @@ describe('Core_count', () => {
         data: Handsontable.helper.createSpreadsheetData(10, 10),
         width: 100
       });
+
       expect(instance.countVisibleRows()).toEqual(-1);
     });
   });
@@ -37,6 +39,7 @@ describe('Core_count', () => {
         height: 100,
         viewportRowRenderingOffset: 0
       });
+
       expect(instance.countRenderedRows()).toEqual(5);
     });
 
@@ -46,6 +49,7 @@ describe('Core_count', () => {
         height: 100,
         viewportRowRenderingOffset: 20
       });
+
       expect(instance.countRenderedRows()).toEqual(25);
     });
 
@@ -55,6 +59,7 @@ describe('Core_count', () => {
         data: Handsontable.helper.createSpreadsheetData(10, 10),
         width: 100
       });
+
       expect(instance.countRenderedRows()).toEqual(-1);
     });
   });
@@ -65,6 +70,7 @@ describe('Core_count', () => {
         data: Handsontable.helper.createSpreadsheetData(10, 10),
         width: 100
       });
+
       expect(instance.countVisibleCols()).toEqual(10);
     });
 

--- a/test/e2e/Core_dataSchema.spec.js
+++ b/test/e2e/Core_dataSchema.spec.js
@@ -114,6 +114,7 @@ describe('Core_dataSchema', () => {
       },
       minSpareRows: 1
     });
+
     expect(JSON.stringify(hot.getSchema())).toEqual(JSON.stringify(schema));
   });
 

--- a/test/e2e/Core_destroy.spec.js
+++ b/test/e2e/Core_destroy.spec.js
@@ -33,6 +33,7 @@ describe('Core_destroy', () => {
     handsontable();
 
     const $tmp = $('<div id="tmp"></div>').appendTo(document.body);
+
     $tmp.handsontable();
     $tmp.handsontable('destroy');
     $tmp.remove();

--- a/test/e2e/Core_init.spec.js
+++ b/test/e2e/Core_init.spec.js
@@ -66,6 +66,7 @@ describe('Core_init', () => {
     doc.close();
 
     const container = $('<div/>').appendTo(doc.body);
+
     expect(() => {
       container.handsontable({});
       container.handsontable('destroy');
@@ -74,6 +75,7 @@ describe('Core_init', () => {
 
   it('should create table even if is launched inside custom element', () => {
     const onErrorSpy = spyOn(window, 'onerror');
+
     spec().$container.remove();
     spec().$container = $(`<hot-table><div id="${id}"></div></hot-table>`).appendTo('body');
 

--- a/test/e2e/Core_isEmpty.spec.js
+++ b/test/e2e/Core_isEmpty.spec.js
@@ -16,6 +16,7 @@ describe('Core.isEmpty*', () => {
     it('should be empty row', () => {
       handsontable();
       const hot = getInstance();
+
       expect(hot.isEmptyRow(0)).toEqual(true);
     });
 
@@ -23,6 +24,7 @@ describe('Core.isEmpty*', () => {
       handsontable();
       setDataAtCell(0, 0, 'test');
       const hot = getInstance();
+
       expect(hot.isEmptyRow(0)).toEqual(false);
     });
 
@@ -30,6 +32,7 @@ describe('Core.isEmpty*', () => {
       handsontable();
       const hot = getInstance();
       const check = hot.isEmptyRow;
+
       expect(check(0)).toEqual(true); // this may be change in future when we switch to define isEmptyCol in prototype
     });
   });
@@ -38,6 +41,7 @@ describe('Core.isEmpty*', () => {
     it('should be empty row', () => {
       handsontable();
       const hot = getInstance();
+
       expect(hot.isEmptyCol(0)).toEqual(true);
     });
 
@@ -45,6 +49,7 @@ describe('Core.isEmpty*', () => {
       handsontable();
       setDataAtCell(0, 0, 'test');
       const hot = getInstance();
+
       expect(hot.isEmptyCol(0)).toEqual(false);
     });
 
@@ -52,6 +57,7 @@ describe('Core.isEmpty*', () => {
       handsontable();
       const hot = getInstance();
       const check = hot.isEmptyCol;
+
       expect(check(0)).toEqual(true); // this may be change in future when we switch to define isEmptyCol in prototype
     });
   });

--- a/test/e2e/Core_listen.spec.js
+++ b/test/e2e/Core_listen.spec.js
@@ -95,8 +95,10 @@ describe('Core_listen', () => {
 
   it('when second instance is created, first should unlisten automatically', () => {
     const $container1 = $('<div id="hot1"></div>').appendTo('body').handsontable();
+
     $container1.handsontable('selectCell', 0, 0);
     const $container2 = $('<div id="hot2"></div>').appendTo('body').handsontable();
+
     $container2.handsontable('selectCell', 0, 0);
 
     expect($container1.handsontable('isListening')).toBe(false);
@@ -110,8 +112,10 @@ describe('Core_listen', () => {
 
   it('when listen is called on first instance, second should unlisten automatically', () => {
     const $container1 = $('<div id="hot1"></div>').appendTo('body').handsontable();
+
     $container1.handsontable('selectCell', 0, 0);
     const $container2 = $('<div id="hot2"></div>').appendTo('body').handsontable();
+
     $container2.handsontable('selectCell', 0, 0);
 
     $container1.handsontable('listen');

--- a/test/e2e/Core_populateFromArray.spec.js
+++ b/test/e2e/Core_populateFromArray.spec.js
@@ -100,6 +100,7 @@ describe('Core_populateFromArray', () => {
     // Resolving issue #5675: https://github.com/handsontable/handsontable/issues/5675
     let output = null;
     const dataArray = arrayOfArrays();
+
     dataArray[0][0] = ['2011'];
 
     handsontable({

--- a/test/e2e/Core_reCreate.spec.js
+++ b/test/e2e/Core_reCreate.spec.js
@@ -19,6 +19,7 @@ describe('Core_reCreate', () => {
         return `Line<br>${col}`;
       }
     };
+
     handsontable(settings);
     destroy();
     handsontable(settings);

--- a/test/e2e/Core_render.spec.js
+++ b/test/e2e/Core_render.spec.js
@@ -36,6 +36,7 @@ describe('Core_render', () => {
     });
 
     const $tds = spec().$container.find('.htCore tbody td');
+
     $tds.each(function() {
       expect(this.style.backgroundColor).toEqual('green');
     });
@@ -60,6 +61,7 @@ describe('Core_render', () => {
     render();
 
     const $td = spec().$container.find('.htCore tbody tr:eq(1) td:eq(1)');
+
     expect(spec().$container.find('.wtBorder.current').width()).toBeGreaterThan($td.width());
   });
 

--- a/test/e2e/Core_selection.spec.js
+++ b/test/e2e/Core_selection.spec.js
@@ -1143,6 +1143,7 @@ describe('Core_selection', () => {
     expect(mainHolder.scrollLeft).toEqual(0);
 
     const lastVisibleColumn = hot.view.wt.wtTable.getLastVisibleColumn();
+
     selectCell(3, lastVisibleColumn);
     keyDownUp('arrow_right');
     expect(hot.view.wt.wtTable.getLastVisibleColumn()).toEqual(lastVisibleColumn + 1);
@@ -1154,6 +1155,7 @@ describe('Core_selection', () => {
     expect(hot.view.wt.wtTable.getLastVisibleColumn()).toEqual(lastVisibleColumn + 3);
 
     const lastVisibleRow = hot.view.wt.wtTable.getLastVisibleRow();
+
     selectCell(lastVisibleRow, 3);
     keyDownUp('arrow_down');
     expect(hot.view.wt.wtTable.getLastVisibleRow()).toEqual(lastVisibleRow + 1);
@@ -1195,6 +1197,7 @@ describe('Core_selection', () => {
     expect(hot.view.wt.wtTable.getLastVisibleColumn()).toEqual(lastVisibleColumn + 3);
 
     const scrollLeft = mainHolder.scrollLeft;
+
     expect(scrollLeft).toBeGreaterThan(0);
     expect(mainHolder.scrollTop).toBe(0);
 
@@ -1723,6 +1726,7 @@ describe('Core_selection', () => {
       data: Handsontable.helper.createSpreadsheetData(2, 2),
       colHeaders: true,
     });
+
     hot.selectAll();
     simulateClick(spec().$container.find('.ht_clone_top tr:eq(0) th:eq(1)'), 'LMB'); // Header "B"
 
@@ -2910,6 +2914,7 @@ describe('Core_selection', () => {
 
     it('should call afterSelection and afterSelectionEnd hooks with proper arguments', () => {
       const hooks = jasmine.createSpyObj('hooks', ['afterSelection', 'afterSelectionEnd']);
+
       handsontable({
         startRows: 21,
         startCols: 30,
@@ -3062,6 +3067,7 @@ describe('Core_selection', () => {
 
     it('should call afterSelectionByProp and afterSelectionEndByProp hooks with proper arguments', () => {
       const hooks = jasmine.createSpyObj('hooks', ['afterSelection', 'afterSelectionEnd']);
+
       handsontable({
         data: Handsontable.helper.createSpreadsheetObjectData(21, 30),
         selectionMode: 'multiple',

--- a/test/e2e/Core_setDataAtCell.spec.js
+++ b/test/e2e/Core_setDataAtCell.spec.js
@@ -38,6 +38,7 @@ describe('Core_setDataAtCell', () => {
     // https://github.com/handsontable/handsontable/issues/147
     handsontable();
     const td = setDataAtCell(0, 0, htmlText);
+
     selectCell(0, 0);
 
     $(td).simulate('dblclick');

--- a/test/e2e/Core_validate.spec.js
+++ b/test/e2e/Core_validate.spec.js
@@ -429,6 +429,7 @@ describe('Core_validate', () => {
       },
       afterValidate: onAfterValidate
     });
+
     expect(() => hot.validateRows()).toThrow();
     expect(() => hot.validateRows(0, () => {})).toThrow();
     expect(() => hot.validateRows({}, () => {})).toThrow();
@@ -445,6 +446,7 @@ describe('Core_validate', () => {
       },
       afterValidate: onAfterValidate
     });
+
     expect(() => hot.validateColumns()).toThrow();
     expect(() => hot.validateColumns(0, () => {})).toThrow();
     expect(() => hot.validateColumns({}, () => {})).toThrow();
@@ -1448,6 +1450,7 @@ describe('Core_validate', () => {
     await sleep(300);
 
     const $cell = $(getCell(0, 0));
+
     expect($cell.hasClass('htInvalid')).toEqual(false);
   });
 
@@ -1476,6 +1479,7 @@ describe('Core_validate', () => {
 
     setTimeout(() => {
       const $cell = $(getCell(0, 0));
+
       expect($cell.hasClass('htInvalid')).toEqual(false);
       done();
     }, 200);

--- a/test/e2e/Core_view.spec.js
+++ b/test/e2e/Core_view.spec.js
@@ -211,24 +211,28 @@ describe('Core_view', () => {
     });
 
     const scrollResult1 = hot.scrollViewportTo(0, 7);
+
     hot.render(); // Renders synchronously so we don't have to put stuff in waits/runs.
 
     expect(scrollResult1).toBe(true);
     expect(hot.view.wt.wtTable.getFirstVisibleColumn()).toBe(8 - 4); // 4 hidden, not rendered elements before.
 
     const scrollResult2 = hot.scrollViewportTo(0, 15);
+
     hot.render();
 
     expect(scrollResult2).toBe(true);
     expect(hot.view.wt.wtTable.getFirstVisibleColumn()).toBe(16 - 5); // 5 hidden, not rendered elements before.
 
     const scrollResult3 = hot.scrollViewportTo(0, 7);
+
     hot.render();
 
     expect(scrollResult3).toBe(true);
     expect(hot.view.wt.wtTable.getFirstVisibleColumn()).toBe(8 - 4); // 4 hidden, not rendered elements before.
 
     const scrollResult4 = hot.scrollViewportTo(0, 0);
+
     hot.render();
 
     expect(scrollResult4).toBe(true);
@@ -248,6 +252,7 @@ describe('Core_view', () => {
     });
 
     const scrollResult1 = hot.scrollViewportTo(0, 15);
+
     hot.render(); // Renders synchronously so we don't have to put stuff in waits/runs.
 
     expect(scrollResult1).toBe(true);
@@ -257,12 +262,14 @@ describe('Core_view', () => {
     hot.render();
 
     const scrollResult2 = hot.scrollViewportTo(0, 17);
+
     hot.render();
 
     expect(scrollResult2).toBe(true);
     expect(hot.view.wt.wtTable.getLastVisibleColumn()).toBe(14 - 4); // 4 hidden, not rendered elements before.
 
     const scrollResult3 = hot.scrollViewportTo(0, 19);
+
     hot.render();
 
     expect(scrollResult3).toBe(true);
@@ -281,24 +288,28 @@ describe('Core_view', () => {
     });
 
     const scrollResult1 = hot.scrollViewportTo(0, 2, false, false, false);
+
     hot.render(); // Renders synchronously so we don't have to put stuff in waits/runs.
 
     expect(scrollResult1).toBe(true);
     expect(hot.view.wt.wtTable.getFirstVisibleColumn()).toBe(2);
 
     const scrollResult2 = hot.scrollViewportTo(0, 14, false, false, false);
+
     hot.render();
 
     expect(scrollResult2).toBe(true);
     expect(hot.view.wt.wtTable.getLastVisibleColumn()).toBe(14);
 
     const scrollResult3 = hot.scrollViewportTo(0, 2, false, false, false);
+
     hot.render();
 
     expect(scrollResult3).toBe(true);
     expect(hot.view.wt.wtTable.getFirstVisibleColumn()).toBe(2);
 
     const scrollResult4 = hot.scrollViewportTo(0, 0, false, false, false);
+
     hot.render();
 
     expect(scrollResult4).toBe(true);
@@ -317,12 +328,14 @@ describe('Core_view', () => {
     });
 
     const scrollResult1 = hot.scrollViewportTo(0, 0);
+
     hot.render(); // Renders synchronously so we don't have to put stuff in waits/runs.
 
     expect(scrollResult1).toBe(false);
     expect(hot.view.wt.wtTable.getFirstVisibleColumn()).toBe(-1);
 
     const scrollResult2 = hot.scrollViewportTo(0, 5);
+
     hot.render();
 
     expect(scrollResult2).toBe(false);
@@ -640,6 +653,7 @@ describe('Core_view', () => {
     });
 
     const afterRenderCallback = jasmine.createSpy('afterRenderCallback');
+
     hot.addHook('afterRender', afterRenderCallback);
     spec().$container.find('.ht_master .wtHolder').first().scrollTop(1000);
 
@@ -687,6 +701,7 @@ describe('Core_view', () => {
 
       const eventManager = new Handsontable.EventManager(hot);
       const spy = jasmine.createSpy();
+
       eventManager.addEventListener(window, 'wheel', spy);
 
       const wheelEvt = new WheelEvent('wheel', {
@@ -933,6 +948,7 @@ describe('Core_view', () => {
 
     it('should be the same as the row heights in the main table (after scroll)', () => {
       const myData = Handsontable.helper.createSpreadsheetData(20, 4);
+
       myData[1][3] = 'very\nlong\ntext';
       myData[5][3] = 'very\nlong\ntext';
       myData[10][3] = 'very\nlong\ntext';
@@ -961,6 +977,7 @@ describe('Core_view', () => {
 
     it('should be the same as the row heights in the main table (after scroll, in corner)', () => {
       const myData = Handsontable.helper.createSpreadsheetData(20, 4);
+
       myData[1][3] = 'very\nlong\ntext';
       myData[5][3] = 'very\nlong\ntext';
       myData[10][3] = 'very\nlong\ntext';
@@ -1100,6 +1117,7 @@ describe('Core_view', () => {
         stretchH: 'all'
       });
       const rowHeaderWidth = hot.view.wt.wtViewport.getRowHeaderWidth();
+
       expect(hot.view.wt.wtOverlays.leftOverlay.getScrollPosition()).toEqual(0);
 
       let expectedCellWidth = (parseInt(spec().$container[0].style.width, 10) - rowHeaderWidth) / 5;

--- a/test/e2e/Dom.spec.js
+++ b/test/e2e/Dom.spec.js
@@ -125,6 +125,7 @@ describe('Handsontable.Dom', () => {
 
       const TD = $table.find('td')[0];
       const TR = TD.parentNode;
+
       expect(Handsontable.dom.isVisible(TD)).toBe(true);
       TR.parentNode.removeChild(TR);
       expect(Handsontable.dom.isVisible(TD)).toBe(false);
@@ -242,6 +243,7 @@ describe('Handsontable.Dom', () => {
 
   it('should set the immediatePropagation properties properly for given event', () => {
     const event = document.createEvent('MouseEvents');
+
     event.initMouseEvent('mousedown', true, true, window, null, null, null, null, null,
       null, null, null, null, null, null);
 

--- a/test/e2e/Performance.spec.js
+++ b/test/e2e/Performance.spec.js
@@ -16,6 +16,7 @@ describe('Performance', () => {
 
   it('should call renderer once for one cell (fixed column width)', () => {
     let count = 0;
+
     handsontable({
       data: Handsontable.helper.createSpreadsheetData(1, 1),
       colWidths: 100,
@@ -31,6 +32,7 @@ describe('Performance', () => {
 
   it('should call renderer twice for one cell (auto column width)', () => {
     let count = 0;
+
     handsontable({
       data: Handsontable.helper.createSpreadsheetData(1, 1),
       rowHeights: 23,
@@ -45,6 +47,7 @@ describe('Performance', () => {
 
   it('should call renderer twice for one cell (auto row height)', () => {
     let count = 0;
+
     handsontable({
       data: Handsontable.helper.createSpreadsheetData(1, 1),
       colWidths: 50,
@@ -59,6 +62,7 @@ describe('Performance', () => {
 
   it('should call renderer triple times for one cell (auto row height, auto column width)', () => {
     let count = 0;
+
     handsontable({
       data: Handsontable.helper.createSpreadsheetData(1, 1),
       autoRowSize: true,
@@ -194,6 +198,7 @@ describe('Performance', () => {
 
   it('should call renderer twice for each cell (auto column width)', () => {
     let count = 0;
+
     handsontable({
       data: Handsontable.helper.createSpreadsheetData(4, 4),
       rowHeights: 23,
@@ -209,6 +214,7 @@ describe('Performance', () => {
 
   it('should call renderer twice for each cell (auto row height)', () => {
     let count = 0;
+
     handsontable({
       data: Handsontable.helper.createSpreadsheetData(4, 4),
       colWidths: 50,
@@ -224,6 +230,7 @@ describe('Performance', () => {
 
   it('should call renderer twice for each cell (auto row height, auto column width)', () => {
     let count = 0;
+
     handsontable({
       data: Handsontable.helper.createSpreadsheetData(4, 4),
       autoRowSize: true,

--- a/test/e2e/RowHeader.spec.js
+++ b/test/e2e/RowHeader.spec.js
@@ -66,12 +66,14 @@ describe('RowHeader', () => {
 
   it('should show row headers with custom label', () => {
     const startRows = 5;
+
     handsontable({
       startRows,
       rowHeaders: ['First', 'Second', 'Third']
     });
 
     const ths = getLeftClone().find('tbody th');
+
     expect(ths.length).toEqual(startRows);
     expect($.trim(ths.eq(0).text())).toEqual('First');
     expect($.trim(ths.eq(1).text())).toEqual('Second');
@@ -240,6 +242,7 @@ describe('RowHeader', () => {
         return array;
       }
     });
+
     hot.render();
 
     expect(spec().$container.find('.handsontable.ht_clone_left tr:nth-child(1) th:nth-child(1)').outerWidth())

--- a/test/e2e/core/batch.spec.js
+++ b/test/e2e/core/batch.spec.js
@@ -18,6 +18,7 @@ describe('Core.batch', () => {
       autoColumnSize: false,
       autoRowSize: false,
     });
+
     spyOn(hot, 'suspendRender').and.callThrough();
     spyOn(hot, 'suspendExecution').and.callThrough();
     spyOn(hot, 'resumeExecution').and.callThrough();

--- a/test/e2e/core/batchRender.spec.js
+++ b/test/e2e/core/batchRender.spec.js
@@ -16,6 +16,7 @@ describe('Core.batchRender', () => {
     const hot = handsontable({
       data: Handsontable.helper.createSpreadsheetData(5, 5),
     });
+
     spyOn(hot, 'suspendRender').and.callThrough();
     spyOn(hot, 'resumeRender').and.callThrough();
     spyOn(hot.view.wt, 'draw');
@@ -43,6 +44,7 @@ describe('Core.batchRender', () => {
     const hot = handsontable({
       data: Handsontable.helper.createSpreadsheetData(5, 5),
     });
+
     spyOn(hot, 'suspendRender').and.callThrough();
     spyOn(hot, 'resumeRender').and.callThrough();
     spyOn(hot.view.wt, 'draw');

--- a/test/e2e/core/getCellMetaAtRow.spec.js
+++ b/test/e2e/core/getCellMetaAtRow.spec.js
@@ -16,6 +16,7 @@ describe('Core.getCellMetaAtRow', () => {
     handsontable();
 
     const rowOfMeta = getCellMetaAtRow(0);
+
     expect(rowOfMeta.length).toBe(5);
     expect(rowOfMeta[0].row).toBe(0);
     expect(rowOfMeta[1].row).toBe(0);

--- a/test/e2e/core/getSelected.spec.js
+++ b/test/e2e/core/getSelected.spec.js
@@ -63,6 +63,7 @@ describe('Core.getSelected', () => {
     await sleep(100);
 
     const bottomClone = getBottomClone();
+
     bottomClone.find('tbody tr:eq(1) td:last-child').simulate('mousedown');
     bottomClone.find('tbody tr:eq(1) td:last-child').simulate('mouseup');
     hot.render(true);

--- a/test/e2e/core/resumeRender.spec.js
+++ b/test/e2e/core/resumeRender.spec.js
@@ -17,6 +17,7 @@ describe('Core.resumeRender', () => {
     const hot = handsontable({
       data: Handsontable.helper.createSpreadsheetData(5, 5),
     });
+
     spyOn(hot.view.wt, 'draw');
     spyOn(hot.view.wt.wtOverlays, 'adjustElementsSize');
 
@@ -36,6 +37,7 @@ describe('Core.resumeRender', () => {
     const hot = handsontable({
       data: Handsontable.helper.createSpreadsheetData(5, 5),
     });
+
     spyOn(hot.view.wt, 'draw');
     spyOn(hot.view.wt.wtOverlays, 'adjustElementsSize');
 
@@ -54,6 +56,7 @@ describe('Core.resumeRender', () => {
     const hot = handsontable({
       data: Handsontable.helper.createSpreadsheetData(5, 5),
     });
+
     spyOn(hot.view.wt, 'draw');
     spyOn(hot.view.wt.wtOverlays, 'adjustElementsSize');
 
@@ -72,6 +75,7 @@ describe('Core.resumeRender', () => {
     const hot = handsontable({
       data: Handsontable.helper.createSpreadsheetData(5, 5),
     });
+
     spyOn(hot.view.wt, 'draw');
     spyOn(hot.view.wt.wtOverlays, 'adjustElementsSize');
 

--- a/test/e2e/core/setSourceDataAtCell.spec.js
+++ b/test/e2e/core/setSourceDataAtCell.spec.js
@@ -132,6 +132,7 @@ describe('Core.setSourceDataAtCell', () => {
     setSourceDataAtCell(0, 'foo', 'foo2', 'caller-custom-source');
 
     let hookArguments = new Array(6).fill(void 0);
+
     hookArguments[0] = [[0, 'foo', 'bar', 'foo2']];
     hookArguments[1] = 'caller-custom-source';
 

--- a/test/e2e/core/suspendRender.spec.js
+++ b/test/e2e/core/suspendRender.spec.js
@@ -16,6 +16,7 @@ describe('Core.suspendRender', () => {
     const hot = handsontable({
       data: Handsontable.helper.createSpreadsheetData(5, 5),
     });
+
     spyOn(hot.view.wt, 'draw');
     spyOn(hot.view.wt.wtOverlays, 'adjustElementsSize');
 
@@ -57,6 +58,7 @@ describe('Core.suspendRender', () => {
     const hot = handsontable({
       data: Handsontable.helper.createSpreadsheetData(5, 5),
     });
+
     spyOn(hot.view.wt, 'draw');
     spyOn(hot.view.wt.wtOverlays, 'adjustElementsSize');
 

--- a/test/e2e/i18n/index.spec.js
+++ b/test/e2e/i18n/index.spec.js
@@ -203,6 +203,7 @@ describe('i18n', () => {
 
     it('should not log error when trying to set directly default language code by updateSettings', () => {
       const spy = spyOn(console, 'error');
+
       handsontable();
 
       updateSettings({ language: DEFAULT_LANGUAGE_CODE });

--- a/test/e2e/mobile/events.spec.js
+++ b/test/e2e/mobile/events.spec.js
@@ -40,6 +40,7 @@ describe('Events', () => {
       width: 400,
       height: 400,
     });
+
     hot.view.wt.update('onCellDblClick', onCellDblClick);
 
     const cell = hot.getCell(1, 1);
@@ -72,6 +73,7 @@ describe('Events', () => {
     });
 
     const linkElement = hot.getCell(0, 0).firstChild;
+
     location.hash = ''; // Resetting before test.
 
     // First touch

--- a/test/e2e/mobile/selection.spec.js
+++ b/test/e2e/mobile/selection.spec.js
@@ -67,6 +67,7 @@ describe('Selection', () => {
 
     const copyPastePlugin = hot.getPlugin('copyPaste');
     const focusableElement = copyPastePlugin.focusableElement.getFocusableElement();
+
     spyOn(focusableElement, 'select');
 
     hot.selectCell(0, 0);

--- a/test/e2e/settings/colWidths.spec.js
+++ b/test/e2e/settings/colWidths.spec.js
@@ -52,6 +52,7 @@ describe('settings', () => {
             if (index === 0) {
               return 123;
             }
+
             return 50;
           }
         });
@@ -65,6 +66,7 @@ describe('settings', () => {
             if (index === 0) {
               return '123';
             }
+
             return '50';
           }
         });
@@ -117,6 +119,7 @@ describe('settings', () => {
             if (index === 0) {
               return 123;
             }
+
             return 50;
           }
         });
@@ -131,6 +134,7 @@ describe('settings', () => {
             if (index === 0) {
               return '123';
             }
+
             return '50';
           }
         });
@@ -196,6 +200,7 @@ describe('settings', () => {
                 if (index === 0) {
                   return 123;
                 }
+
                 return 50;
               }
             }
@@ -213,6 +218,7 @@ describe('settings', () => {
                 if (index === 0) {
                   return '123';
                 }
+
                 return '50';
               }
             }

--- a/test/e2e/settings/columns.spec.js
+++ b/test/e2e/settings/columns.spec.js
@@ -212,6 +212,7 @@ describe('settings', () => {
                 { data: 'name' },
                 { data: 'lastName' }
               ];
+
               return [0, 1, 2].indexOf(column) > -1 ? settings[column] : null;
             },
             afterValidate: onAfterValidate

--- a/test/e2e/settings/editor.spec.js
+++ b/test/e2e/settings/editor.spec.js
@@ -102,6 +102,7 @@ describe('settings', () => {
       it('should use editor from custom string', () => {
         const customEditor = jasmine.createSpy('customEditor');
         const td = document.createElement('td');
+
         customEditor.and.callFake(function() {
           this.prepare = function() {};
           this.getEditedCell = () => td;

--- a/test/e2e/settings/fixedRowsBottom.spec.js
+++ b/test/e2e/settings/fixedRowsBottom.spec.js
@@ -139,6 +139,7 @@ describe('settings', () => {
       expect(getBottomClone().find('tbody tr:eq(0) td:eq(0)').html()).toEqual('A20');
 
       const td = hot.getCell(19, 0, true);
+
       td.innerHTML = 'test';
 
       expect(getBottomClone().find('tbody tr:eq(0) td:eq(0)').html()).toEqual('test');

--- a/test/e2e/settings/fragmentSelection.spec.js
+++ b/test/e2e/settings/fragmentSelection.spec.js
@@ -39,6 +39,7 @@ describe('settings', () => {
 
       const sel = window.getSelection();
       const range = window.document.createRange();
+
       range.setStartBefore(element);
 
       while (numOfSiblings > 1) {
@@ -154,12 +155,14 @@ describe('settings', () => {
           fragmentSelection: false
         });
         const $div = $('<div style="position: absolute; top: 0; left: 0">Text</div>');
+
         spec().$container.append($div);
         selectElementText($div[0], 1);
 
         $($div).simulate('mousedown');
 
         const sel = getSelected();
+
         expect(sel).toEqual('');
       });
 
@@ -169,12 +172,14 @@ describe('settings', () => {
           fragmentSelection: true
         });
         const $div = $('<div style="position: absolute; top: 0; left: 0">Text</div>');
+
         spec().$container.append($div);
         selectElementText($div[0], 1);
 
         $($div).simulate('mousedown');
 
         const sel = getSelected();
+
         expect(sel).toEqual('');
       });
     });
@@ -195,6 +200,7 @@ describe('settings', () => {
         $(spec().$container.find('tr:eq(0) td:eq(3)')).simulate('click');
 
         const sel = getSelected();
+
         expect(sel).toEqual(''); // copyPaste has selected space in textarea
 
         const copyEvent = getClipboardEvent();

--- a/test/e2e/settings/licenseKey.spec.js
+++ b/test/e2e/settings/licenseKey.spec.js
@@ -17,6 +17,7 @@ describe('settings', () => {
       handsontable({});
 
       const info = spec().$container[0].nextSibling;
+
       expect(info.innerText).toBe([
         'The license key for Handsontable is missing. Use your purchased key to activate the product. ',
         'Alternatively, you can activate Handsontable to use for non-commercial purposes ',
@@ -31,6 +32,7 @@ describe('settings', () => {
       });
 
       const info = spec().$container[0].nextSibling;
+
       expect(info.innerText).toBe([
         'The license key for Handsontable is invalid. ',
         'Read more on how to install it properly or contact us at support@handsontable.com.',

--- a/test/e2e/settings/outsideClickDeselects.spec.js
+++ b/test/e2e/settings/outsideClickDeselects.spec.js
@@ -21,6 +21,7 @@ describe('settings', () => {
         width: 400,
         height: 100
       });
+
       selectCell(0, 0);
 
       const holderBoundingBox = hot.view.wt.wtTable.holder.getBoundingClientRect();

--- a/test/e2e/settings/renderer.spec.js
+++ b/test/e2e/settings/renderer.spec.js
@@ -28,10 +28,12 @@ describe('settings', () => {
 
       it('should use renderer from predefined string', () => {
         const originalTextRenderer = Handsontable.renderers.TextRenderer;
+
         spyOn(Handsontable.renderers, 'TextRenderer');
         Handsontable.renderers.registerRenderer('text', Handsontable.renderers.TextRenderer);
 
         const originalCheckboxRenderer = Handsontable.renderers.CheckboxRenderer;
+
         spyOn(Handsontable.renderers, 'CheckboxRenderer');
         Handsontable.renderers.registerRenderer('checkbox', Handsontable.renderers.CheckboxRenderer);
 
@@ -56,6 +58,7 @@ describe('settings', () => {
         Handsontable.renderers.registerRenderer('text', Handsontable.renderers.TextRenderer);
 
         const originalCheckboxRenderer = Handsontable.renderers.CheckboxRenderer;
+
         spyOn(Handsontable.renderers, 'CheckboxRenderer');
         Handsontable.renderers.registerRenderer('checkbox', Handsontable.renderers.CheckboxRenderer);
 

--- a/test/e2e/utils/ghostTable.spec.js
+++ b/test/e2e/utils/ghostTable.spec.js
@@ -25,6 +25,7 @@ describe('GhostTable', () => {
       const hot = handsontable(hotSettings);
       const samples = new Map();
       let exception = false;
+
       gt = new Handsontable.__GhostTable(hot);
 
       gt.addRow(0, samples);
@@ -41,6 +42,7 @@ describe('GhostTable', () => {
     it('should create container element only for first row', () => {
       const hot = handsontable(hotSettings);
       const samples = new Map();
+
       gt = new Handsontable.__GhostTable(hot);
 
       spyOn(gt, 'createContainer').and.callThrough();
@@ -58,6 +60,7 @@ describe('GhostTable', () => {
     it('should add row to rows collection after call `addRow` method', () => {
       const hot = handsontable(hotSettings);
       const samples = new Map();
+
       gt = new Handsontable.__GhostTable(hot);
 
       expect(gt.rows.length).toBe(0);
@@ -91,6 +94,7 @@ describe('GhostTable', () => {
       const hot = handsontable(hotSettings);
       const heightSpy = jasmine.createSpy();
       const samples = new Map();
+
       gt = new Handsontable.__GhostTable(hot);
 
       samples.clear();
@@ -124,6 +128,7 @@ describe('GhostTable', () => {
       const hot = handsontable(hotSettings);
       const samples = new Map();
       let exception = false;
+
       gt = new Handsontable.__GhostTable(hot);
 
       gt.addColumn(0, samples);
@@ -140,6 +145,7 @@ describe('GhostTable', () => {
     it('should create container element only for first column', () => {
       const hot = handsontable(hotSettings);
       const samples = new Map();
+
       gt = new Handsontable.__GhostTable(hot);
 
       spyOn(gt, 'createContainer').and.callThrough();
@@ -157,6 +163,7 @@ describe('GhostTable', () => {
     it('should add column to columns collection after call `addColumn` method', () => {
       const hot = handsontable(hotSettings);
       const samples = new Map();
+
       gt = new Handsontable.__GhostTable(hot);
 
       expect(gt.columns.length).toBe(0);
@@ -192,6 +199,7 @@ describe('GhostTable', () => {
       const hot = handsontable(hotSettings);
       const widthSpy = jasmine.createSpy();
       const samples = new Map();
+
       gt = new Handsontable.__GhostTable(hot);
 
       samples.clear();
@@ -223,6 +231,7 @@ describe('GhostTable', () => {
   it('should reset internal state after call `clean` method', () => {
     const hot = handsontable(hotSettings);
     const samples = new Map();
+
     gt = new Handsontable.__GhostTable(hot);
 
     gt.addColumn(0, samples);
@@ -247,6 +256,7 @@ describe('GhostTable', () => {
   it('should be detected as vertical if at least one row is added', () => {
     const hot = handsontable(hotSettings);
     const samples = new Map();
+
     gt = new Handsontable.__GhostTable(hot);
 
     gt.addRow(0, samples);
@@ -258,6 +268,7 @@ describe('GhostTable', () => {
   it('should be detected as horizontal if at least one column is added', () => {
     const hot = handsontable(hotSettings);
     const samples = new Map();
+
     gt = new Handsontable.__GhostTable(hot);
 
     gt.addColumn(0, samples);

--- a/test/helpers/common.js
+++ b/test/helpers/common.js
@@ -561,6 +561,7 @@ export function setCaretPosition(pos) {
 
   } else if (el.createTextRange) {
     const range = el.createTextRange();
+
     range.collapse(true);
     range.moveEnd('character', pos);
     range.moveStart('character', pos);
@@ -751,6 +752,7 @@ export function resizeColumn(renderableColumnIndex, width) {
 
   const delta = width - $th.width() - 2;
   const newPosition = resizerPosition.left + delta;
+
   $resizer.simulate('mousemove', {
     clientX: newPosition
   });

--- a/test/unit/EventManager.unit.js
+++ b/test/unit/EventManager.unit.js
@@ -136,6 +136,7 @@ describe('EventManager', () => {
     const test = jasmine.createSpy('test');
 
     const clickRemoveEvent = em.addEventListener(window, 'click', test);
+
     em.fireEvent(window, 'click');
 
     expect(test.calls.count()).toEqual(1);

--- a/test/unit/helpers/Console.unit.js
+++ b/test/unit/helpers/Console.unit.js
@@ -20,6 +20,7 @@ describe('Console', () => {
 
     it('should not throw Exception when `console` is not exposed', () => {
       const cachedConsole = console;
+
       console = undefined;
 
       expect(() => {
@@ -40,6 +41,7 @@ describe('Console', () => {
 
     it('should not throw Exception when `console` is not exposed', () => {
       const cachedConsole = console;
+
       console = undefined;
 
       expect(() => {
@@ -60,6 +62,7 @@ describe('Console', () => {
 
     it('should not throw Exception when `console` is not exposed', () => {
       const cachedConsole = console;
+
       console = undefined;
 
       expect(() => {
@@ -80,6 +83,7 @@ describe('Console', () => {
 
     it('should not throw Exception when `console` is not exposed', () => {
       const cachedConsole = console;
+
       console = undefined;
 
       expect(() => {

--- a/test/unit/helpers/Object.unit.js
+++ b/test/unit/helpers/Object.unit.js
@@ -114,6 +114,7 @@ describe('Object helper', () => {
       expect(instance.local).toBe(123);
 
       const initialObject = { a: 1 };
+
       instance.mySetterFunction(initialObject);
 
       expect(instance.myFunction()).toBe(initialObject);

--- a/test/unit/helpers/dom/Element.unit.js
+++ b/test/unit/helpers/dom/Element.unit.js
@@ -232,6 +232,7 @@ describe('DomElement helper', () => {
           contains: jasmine.createSpy('classList'),
         }
       };
+
       hasClass(elementMock);
 
       expect(elementMock.classList.contains).not.toHaveBeenCalled();
@@ -298,6 +299,7 @@ describe('DomElement helper', () => {
           add: jasmine.createSpy('classList'),
         }
       };
+
       addClass(elementMock);
 
       expect(elementMock.classList.add).not.toHaveBeenCalled();
@@ -364,6 +366,7 @@ describe('DomElement helper', () => {
           remove: jasmine.createSpy('classList'),
         }
       };
+
       removeClass(elementMock);
 
       expect(elementMock.classList.remove).not.toHaveBeenCalled();

--- a/test/unit/translations/indexMapper.unit.js
+++ b/test/unit/translations/indexMapper.unit.js
@@ -20,6 +20,7 @@ describe('IndexMapper', () => {
 
   it('should fill mappers with proper values by calling `initToLength` method', () => {
     const indexMapper = new IndexMapper();
+
     indexMapper.initToLength(10);
 
     expect(indexMapper.getIndexesSequence()).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
@@ -1760,6 +1761,7 @@ describe('IndexMapper', () => {
   describe('moving indexes', () => {
     it('should move single, given index', () => {
       const indexMapper = new IndexMapper();
+
       indexMapper.initToLength(10);
 
       indexMapper.moveIndexes([8], 0); // [8, 0, 1, 2, 3, 4, 5, 6, 7, 9]
@@ -1771,6 +1773,7 @@ describe('IndexMapper', () => {
 
     it('should not change order of indexes after specific move', () => {
       const indexMapper = new IndexMapper();
+
       indexMapper.initToLength(10);
 
       indexMapper.moveIndexes([0], 0);
@@ -1800,6 +1803,7 @@ describe('IndexMapper', () => {
 
     it('should change order of indexes in place', () => {
       const indexMapper = new IndexMapper();
+
       indexMapper.initToLength(10);
 
       indexMapper.moveIndexes([9, 8, 7, 6, 5, 4, 3, 0, 1, 2], 0);
@@ -1809,6 +1813,7 @@ describe('IndexMapper', () => {
     describe('should move given indexes properly from the top to the bottom', () => {
       it('ascending order of moved indexes', () => {
         const indexMapper = new IndexMapper();
+
         indexMapper.initToLength(10);
 
         indexMapper.moveIndexes([0, 1, 2, 3], 5);
@@ -1817,6 +1822,7 @@ describe('IndexMapper', () => {
 
       it('descending order of moved indexes', () => {
         const indexMapper = new IndexMapper();
+
         indexMapper.initToLength(10);
 
         indexMapper.moveIndexes([3, 2, 1, 0], 5);
@@ -1825,6 +1831,7 @@ describe('IndexMapper', () => {
 
       it('mixed order of moved indexes', () => {
         const indexMapper = new IndexMapper();
+
         indexMapper.initToLength(10);
 
         indexMapper.moveIndexes([1, 3, 2, 0], 5);
@@ -1835,6 +1842,7 @@ describe('IndexMapper', () => {
     describe('should move given indexes properly from the bottom to the top', () => {
       it('ascending order of moved indexes', () => {
         const indexMapper = new IndexMapper();
+
         indexMapper.initToLength(10);
 
         indexMapper.moveIndexes([4, 5, 6, 7], 2);
@@ -1843,6 +1851,7 @@ describe('IndexMapper', () => {
 
       it('descending order of moved indexes', () => {
         const indexMapper = new IndexMapper();
+
         indexMapper.initToLength(10);
 
         indexMapper.moveIndexes([7, 6, 5, 4], 2);
@@ -1851,6 +1860,7 @@ describe('IndexMapper', () => {
 
       it('mixed order of moved indexes', () => {
         const indexMapper = new IndexMapper();
+
         indexMapper.initToLength(10);
 
         indexMapper.moveIndexes([7, 5, 4, 6], 2);
@@ -1861,6 +1871,7 @@ describe('IndexMapper', () => {
     describe('should move given indexes properly when sequence of moves is mixed', () => {
       it('ascending order of moved indexes', () => {
         const indexMapper = new IndexMapper();
+
         indexMapper.initToLength(10);
 
         indexMapper.moveIndexes([1, 2, 6, 7], 4);
@@ -1869,6 +1880,7 @@ describe('IndexMapper', () => {
 
       it('descending order of moved indexes', () => {
         const indexMapper = new IndexMapper();
+
         indexMapper.initToLength(10);
 
         indexMapper.moveIndexes([7, 6, 2, 1], 4);
@@ -1877,6 +1889,7 @@ describe('IndexMapper', () => {
 
       it('mixed order of moved indexes', () => {
         const indexMapper = new IndexMapper();
+
         indexMapper.initToLength(10);
 
         indexMapper.moveIndexes([7, 2, 1, 6], 4);

--- a/test/unit/utils/Interval.unit.js
+++ b/test/unit/utils/Interval.unit.js
@@ -22,6 +22,7 @@ describe('Interval', () => {
 
   it('should create interval object which is stopped by default', (done) => {
     const spy = jasmine.createSpy();
+
     Interval.create(spy);
 
     setTimeout(() => {

--- a/test/unit/utils/dataStructures/LinkedList.unit.js
+++ b/test/unit/utils/dataStructures/LinkedList.unit.js
@@ -130,6 +130,7 @@ describe('Linked List', () => {
     const linkedList = new LinkedList();
     const last = new NodeStructure(2);
     const first = new NodeStructure(1);
+
     last.next = first;
     last.prev = first;
     first.next = last;


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR enhances the linter config file. The following new rules are added:

#### It's require to add a new line before the `return` keywords ####
👎 
```js
someMethod(num) {
  if (num) {
    return num +1;
  }
  return num;
}
```
👍 
```js
someMethod(num) {
  if (num) {
    return num +1;
  }

  return num;
}
```
#### It's require to add a new line before and after the `const`, `let`, and `var` keywords ####
👎 
```js
someMethod(num) {
  const num1 = num + 1;
  let num2 = num + 2;
  num2 += num;

  return num;
}
```
👍 
```js
someMethod(num) {
  const num1 = num + 1;
  let num2 = num + 2;

  num2 += num;

  return num;
}
```
#### It's require to add a new line before the `if`, `for`, `switch`, and `while` statements ####

👎 
```js
someMethod(num) {
  const num2 = 1;
  if (num) {
    return num +num2;
  }

  return num;
}
```
👍 
```js
someMethod(num) {
  const num2 = 1;

  if (num) {
    return num +num2;
  }

  return num;
}
```
👍  (the new line is not required when the keyword is placed right after another statement block)
```js
someMethod(num) {
  const num2 = 1;
  
  if (num === 2) {
    num = num + 5;
  }
  if (num) {
    return num +num2;
  }

  return num;
}
```

@wojciechczerniak @aninde All changes are applied using `eslint --fix` CLI so the source code is not prone to human error.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
`npm run lint`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7691
2.
3.

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
