### PR TITLE
Nested rows will be displayed properly and no error will be thrown while removing last table element #7548

### DIFF
--- a/.changelogs/7548.json
+++ b/.changelogs/7548.json
@@ -1,0 +1,7 @@
+{
+  "title": "Nested rows will be displayed properly and no error will be thrown while removing last table element",
+  "type": "fixed",
+  "issue": 7548,
+  "breaking": false,
+  "framework": "vue"
+}

--- a/wrappers/vue/src/HotTable.vue
+++ b/wrappers/vue/src/HotTable.vue
@@ -156,7 +156,7 @@
             this.hotInstance.rowIndexMapper.insertIndexes(oldDataLength - 1, data.length - oldDataLength);
           }
 
-          if (isColumnModificationAllowed) {
+          if (isColumnModificationAllowed && data.length !== 0) {
             if (columnsToRemove.length > 0) {
               this.hotInstance.columnIndexMapper.removeIndexes(columnsToRemove);
 

--- a/wrappers/vue/src/HotTable.vue
+++ b/wrappers/vue/src/HotTable.vue
@@ -115,7 +115,7 @@
 
         preventInternalEditWatch(this);
 
-        this.miscCache.dataLength = newSettings.data.length;
+        this.miscCache.dataLength = newSettings?.data?.length ?? 0;
         this.miscCache.currentSourceColumns = this.hotInstance.countSourceCols();
       },
       matchHotMappersSize: function (data: any[][]): void {
@@ -148,9 +148,11 @@
 
         this.hotInstance.batch(() => {
           if (rowsToRemove.length > 0) {
+            this.miscCache.dataLength -= rowsToRemove.length;
             this.hotInstance.rowIndexMapper.removeIndexes(rowsToRemove);
 
           } else {
+            this.miscCache.dataLength += data.length - oldDataLength;
             this.hotInstance.rowIndexMapper.insertIndexes(oldDataLength - 1, data.length - oldDataLength);
           }
 

--- a/wrappers/vue/src/HotTable.vue
+++ b/wrappers/vue/src/HotTable.vue
@@ -71,6 +71,8 @@
       return {
         __internalEdit: false,
         miscCache: {
+          // TODO: A workaround for #7548; data.length !== rowIndexMapper.getNumberOfIndexes() for NestedRows plugin.
+          dataLength: 0,
           currentSourceColumns: null
         },
         hotInstance: null,
@@ -113,18 +115,19 @@
 
         preventInternalEditWatch(this);
 
+        this.miscCache.dataLength = newSettings.data.length;
         this.miscCache.currentSourceColumns = this.hotInstance.countSourceCols();
       },
       matchHotMappersSize: function (data: any[][]): void {
         const rowsToRemove: number[] = [];
         const columnsToRemove: number[] = [];
-        const indexMapperRowCount = this.hotInstance.rowIndexMapper.getNumberOfIndexes();
+        const oldDataLength = this.miscCache.dataLength;
         const isColumnModificationAllowed = this.hotInstance.isColumnModificationAllowed();
         let indexMapperColumnCount = 0;
 
-        if (data && data.length !== indexMapperRowCount) {
-          if (data.length < indexMapperRowCount) {
-            for (let r = data.length; r < indexMapperRowCount; r++) {
+        if (data && data.length !== oldDataLength) {
+          if (data.length < oldDataLength) {
+            for (let r = data.length; r < oldDataLength; r++) {
               rowsToRemove.push(r);
             }
           }
@@ -148,7 +151,7 @@
             this.hotInstance.rowIndexMapper.removeIndexes(rowsToRemove);
 
           } else {
-            this.hotInstance.rowIndexMapper.insertIndexes(indexMapperRowCount - 1, data.length - indexMapperRowCount);
+            this.hotInstance.rowIndexMapper.insertIndexes(oldDataLength - 1, data.length - oldDataLength);
           }
 
           if (isColumnModificationAllowed) {

--- a/wrappers/vue/test/hotTable.spec.ts
+++ b/wrappers/vue/test/hotTable.spec.ts
@@ -206,6 +206,13 @@ describe('Updating the Handsontable settings', () => {
 
     expect(testWrapper.vm.$children[0].hotInstance.getData()).toEqual([[22, 32, 42]]);
     expect(newHotSettings).toBe(null);
+
+    testWrapper.vm.removeRow();
+
+    await Vue.nextTick();
+
+    expect(testWrapper.vm.$children[0].hotInstance.getData()).toEqual([]);
+    expect(newHotSettings).toBe(null);
   });
 
   it('should call Handsontable\'s `updateSettings` method, when the table data was changed by reference while the' +

--- a/wrappers/vue/test/hotTable.spec.ts
+++ b/wrappers/vue/test/hotTable.spec.ts
@@ -605,3 +605,42 @@ it('should be possible to pass props to the editor and renderer components', () 
 
   testWrapper.destroy();
 });
+
+describe('cooperation with NestedRows plugin', () => {
+  it('should display dataset properly #7548', async() => {
+    const testWrapper = mount(HotTable, {
+      propsData: {
+        data: [{
+          col1: 'parent1',
+          __children: [
+            {
+              col1: 'p1.c1',
+            }, {
+              col1: 'p1.c2',
+            }
+          ]
+        }, {
+          col1: 'parent2',
+          __children: [
+            {
+              col1: 'p2.c1',
+            }, {
+              col1: 'p2.c2',
+            }, {
+              col1: 'p2.c3',
+            }
+          ]
+        }],
+        rowHeaders: true,
+        colHeaders: true,
+        nestedRows: true,
+      }
+    });
+
+    expect(testWrapper.vm.hotInstance.countRows()).toEqual(7);
+
+    await Vue.nextTick();
+
+    expect(testWrapper.vm.hotInstance.countRows()).toEqual(7);
+  });
+});


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
This PR is fixing 2 problems:
- improper displaying nested rows at start - described with #7548 (some CRUD actions still doesn't work)
- removing last row has thrown error

For the first problem, there has been provided a workaround. Since Handsontable 8.0.0 there is a problem with proper handling of changes from external sources, ie. modifying table's data through changing data feeding the table, provided by wrapper. [Very simple solution](https://github.com/handsontable/vue-handsontable-official/blob/12a2d8cb4b17db6e2b7dd97489a6d91b3d374b06/src/HotTable.vue#L31-L34) which has worked until Handsontable 8 release won't be appropriate anymore. We can't just call an `updateSettings` with `data` key as it resets sequence of indexes for **every change**. Code [provided here](handsontable/vue-handsontable-official@886703c#diff-868ba4f09336612013cd40b69c3fc77b3724064bbe38ef887d4ab83100525608R42) isn't perfect. However, the problem seems to be out of the scope of the task.

Some other improvements could be done after developing https://github.com/handsontable/handsontable/issues/7263.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Manual tests in application bundled by Parcel (Handsontable with nested rows and simpler data).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7548 

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [x] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] My change requires a change to the documentation.
