### PR TITLE
Fix double-tap issue

### DIFF
--- a/.changelogs/6961.json
+++ b/.changelogs/6961.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fixed the double-tap issue on iOS",
+  "type": "fixed",
+  "issue": 6961,
+  "breaking": false,
+  "framework": "none"
+}

--- a/src/3rdparty/walkontable/src/event.js
+++ b/src/3rdparty/walkontable/src/event.js
@@ -297,11 +297,6 @@ class Event {
     priv.selectedCellBeforeTouchEnd = this.instance.selections.getCell().cellRange;
     this.instance.touchApplied = true;
 
-    // This fixes the double tab issue (#7659). By `preventDefault` call on the touch event, we
-    // tell the browser that we don't want to rely on the native 300ms delay. Hence the touch
-    // events can be triggered as fast as the user can (https://webkit.org/blog/5610/more-responsive-tapping-on-ios/).
-    event.preventDefault();
-
     this.onMouseDown(event);
   }
 
@@ -312,15 +307,20 @@ class Event {
    * @param {MouseEvent} event The mouse event object.
    */
   onTouchEnd(event) {
-    const excludeTags = ['A', 'BUTTON', 'INPUT'];
+    const interactiveElements = ['A', 'BUTTON', 'INPUT'];
     const target = event.target;
     const parentCellCoords = this.parentCell(target)?.coords;
     const isHeader = isDefined(parentCellCoords) && (parentCellCoords.row < 0 || parentCellCoords.col < 0);
 
-    // When the standard event was performed on the link element (a cell which contains HTML `a` element) then here
-    // we check if it should be canceled. Click is blocked in a situation when the element is rendered outside
-    // selected cells. This prevents accidentally page reloads while selecting adjacent cells.
-    if (isHeader === false && this.selectedCellWasTouched(target) === false && excludeTags.includes(target.tagName)) {
+    // When the cells contain interactive HTML tags do not "preventDefault" the event. Thanks to
+    // that, users can interact with the UI element (e.q. click on the link opens a new page).
+    // For non-interactive elements, the event is always prevented to tell the browser that we
+    // don't want to rely on the native 300ms delay. Hence the touch events can be triggered as
+    // fast as the user can (https://webkit.org/blog/5610/more-responsive-tapping-on-ios/).
+    // Related issue #7659.
+    if (event.cancelable &&
+        !isHeader &&
+        !(interactiveElements.includes(target.tagName) && this.selectedCellWasTouched(target))) {
       event.preventDefault();
     }
 

--- a/src/3rdparty/walkontable/src/event.js
+++ b/src/3rdparty/walkontable/src/event.js
@@ -297,6 +297,11 @@ class Event {
     priv.selectedCellBeforeTouchEnd = this.instance.selections.getCell().cellRange;
     this.instance.touchApplied = true;
 
+    // This fixes the double tab issue (#7659). By `preventDefault` call on the touch event, we
+    // tell the browser that we don't want to rely on the native 300ms delay. Hence the touch
+    // events can be triggered as fast as the user can (https://webkit.org/blog/5610/more-responsive-tapping-on-ios/).
+    event.preventDefault();
+
     this.onMouseDown(event);
   }
 

--- a/test/e2e/mobile/events.spec.js
+++ b/test/e2e/mobile/events.spec.js
@@ -59,12 +59,9 @@ describe('Events', () => {
   });
 
   it('should preventDefault the touchstart event (double-tap issue #7824)', async() => {
-    const afterOnCellMouseDown = jasmine.createSpy('onAfterOnCellMouseDown');
-
     const hot = handsontable({
       width: 400,
       height: 400,
-      afterOnCellMouseDown
     });
 
     const cell = hot.getCell(1, 1);

--- a/test/e2e/mobile/events.spec.js
+++ b/test/e2e/mobile/events.spec.js
@@ -65,6 +65,7 @@ describe('Events', () => {
     });
 
     const cell = hot.getCell(1, 1);
+
     {
       triggerTouchEvent('touchstart', cell);
 

--- a/test/e2e/mobile/events.spec.js
+++ b/test/e2e/mobile/events.spec.js
@@ -58,6 +58,21 @@ describe('Events', () => {
     expect(onCellDblClick).toHaveBeenCalled();
   });
 
+  it('should preventDefault the touchstart event (double-tap issue #7824)', async() => {
+    const afterOnCellMouseDown = jasmine.createSpy('onAfterOnCellMouseDown');
+
+    const hot = handsontable({
+      width: 400,
+      height: 400,
+      afterOnCellMouseDown
+    });
+
+    const cell = hot.getCell(1, 1);
+    const event = triggerTouchEvent('touchstart', cell);
+
+    expect(event.defaultPrevented).toBeTrue();
+  });
+
   it('should block default action related to link touch and translate from the touch to click on a cell', async() => {
     const hot = handsontable({
       data: [['<a href="#justForTest">click me!</a>'], []],

--- a/test/e2e/mobile/events.spec.js
+++ b/test/e2e/mobile/events.spec.js
@@ -58,14 +58,26 @@ describe('Events', () => {
     expect(onCellDblClick).toHaveBeenCalled();
   });
 
-  it('should preventDefault the touchstart event (double-tap issue #7824)', async() => {
+  it('should preventDefault the touchend event (double-tap issue #7824)', async() => {
     const hot = handsontable({
       width: 400,
       height: 400,
     });
 
     const cell = hot.getCell(1, 1);
-    const event = triggerTouchEvent('touchstart', cell);
+    const event = triggerTouchEvent('touchend', cell);
+
+    expect(event.defaultPrevented).toBeTrue();
+  });
+
+  it('should not preventDefault the touchend event when interactive element is clicked', async() => {
+    const hot = handsontable({
+      width: 400,
+      height: 400,
+    });
+
+    const cell = hot.getCell(1, 1);
+    const event = triggerTouchEvent('touchend', cell);
 
     expect(event.defaultPrevented).toBeTrue();
   });
@@ -94,7 +106,7 @@ describe('Events', () => {
     expect(location.hash).toBe('');
     expect(getSelected()).toEqual([[0, 0, 0, 0]]);
 
-    await sleep(100); // To prevents double-click detection (emulation)
+    await sleep(600); // To prevents double-click detection (emulation)
 
     // Second touch
     simulateTouch(linkElement);
@@ -109,7 +121,7 @@ describe('Events', () => {
     // First touch
     simulateTouch(anotherCell);
 
-    await sleep(100); // To prevents double-click detection (emulation)
+    await sleep(550); // To prevents double-click detection (emulation)
 
     expect(location.hash).toBe('');
     expect(getSelected()).toEqual([[1, 0, 1, 0]]);

--- a/test/e2e/mobile/events.spec.js
+++ b/test/e2e/mobile/events.spec.js
@@ -58,28 +58,53 @@ describe('Events', () => {
     expect(onCellDblClick).toHaveBeenCalled();
   });
 
-  it('should preventDefault the touchend event (double-tap issue #7824)', async() => {
+  it('should "preventDefault" the "touchend" event (double-tap issue #7824)', () => {
     const hot = handsontable({
       width: 400,
       height: 400,
     });
 
     const cell = hot.getCell(1, 1);
-    const event = triggerTouchEvent('touchend', cell);
+    {
+      triggerTouchEvent('touchstart', cell);
 
-    expect(event.defaultPrevented).toBeTrue();
+      const event = triggerTouchEvent('touchend', cell);
+
+      expect(event.defaultPrevented).toBeTrue();
+    }
+    {
+      triggerTouchEvent('touchstart', cell);
+
+      const event = triggerTouchEvent('touchend', cell);
+
+      expect(event.defaultPrevented).toBeTrue();
+    }
   });
 
-  it('should not preventDefault the touchend event when interactive element is clicked', async() => {
+  it('should not "preventDefault" the second "touchend" event when interactive element is clicked', () => {
     const hot = handsontable({
+      data: [['<a href="#justForTest">click me!</a>'], []],
       width: 400,
       height: 400,
+      renderer: 'html',
     });
 
-    const cell = hot.getCell(1, 1);
-    const event = triggerTouchEvent('touchend', cell);
+    const linkElement = hot.getCell(0, 0).firstChild;
 
-    expect(event.defaultPrevented).toBeTrue();
+    {
+      triggerTouchEvent('touchstart', linkElement);
+
+      const event = triggerTouchEvent('touchend', linkElement);
+
+      expect(event.defaultPrevented).toBeTrue();
+    }
+    {
+      triggerTouchEvent('touchstart', linkElement);
+
+      const event = triggerTouchEvent('touchend', linkElement);
+
+      expect(event.defaultPrevented).toBeFalse();
+    }
   });
 
   it('should block default action related to link touch and translate from the touch to click on a cell', async() => {
@@ -89,11 +114,7 @@ describe('Events', () => {
       colHeaders: true,
       width: 600,
       height: 400,
-      columns: [
-        {
-          renderer: 'html'
-        }
-      ]
+      renderer: 'html',
     });
 
     const linkElement = hot.getCell(0, 0).firstChild;

--- a/test/helpers/common.js
+++ b/test/helpers/common.js
@@ -879,8 +879,7 @@ export function swapDisplayedColumns(container, from, to) {
  * @param {number} y The page y coordinates.
  * @param {HTMLElement} element An element for which event will be triggered.
  * @param {string} eventType Type of touch event, ie. 'touchstart', 'touchmove', 'touchend'.
- * @returns {boolean} The return value is `false` if event is cancelable and at least one of the event handlers which
- * received event called `preventDefault()`. Otherwise it returns `true`.
+ * @returns {Event} Returns the Event instance used to trigger the event.
  */
 function sendTouchEvent(x, y, element, eventType) {
   const touchObj = new Touch({
@@ -901,7 +900,9 @@ function sendTouchEvent(x, y, element, eventType) {
     shiftKey: false,
   });
 
-  return element.dispatchEvent(touchEvent);
+  element.dispatchEvent(touchEvent);
+
+  return touchEvent;
 }
 
 /**
@@ -909,8 +910,7 @@ function sendTouchEvent(x, y, element, eventType) {
  * @param {HTMLElement} target The target element from the event was triggered.
  * @param {number} pageX The page x coordinates.
  * @param {number} pageY The page y coordinates.
- * @returns {boolean} The return value is `false` if event is cancelable and at least one of the event handlers which
- * received event called `preventDefault()`. Otherwise it returns `true`.
+ * @returns {Event} Returns the Event instance used to trigger the event.
  */
 export function triggerTouchEvent(type, target, pageX, pageY) {
   const targetCoords = target.getBoundingClientRect();

--- a/test/helpers/common.js
+++ b/test/helpers/common.js
@@ -933,11 +933,11 @@ export function triggerTouchEvent(type, target, pageX, pageY) {
 export function simulateTouch(target) {
   const touchStartRun = triggerTouchEvent('touchstart', target);
 
-  if (touchStartRun === true) {
+  if (!touchStartRun.defaultPrevented) {
     const touchEndRun = triggerTouchEvent('touchend', target);
 
     // If the `preventDefault` is called for below event emulation doesn't reflects "native" behaviour.
-    if (touchEndRun === true) {
+    if (!touchEndRun.defaultPrevented) {
       $(target).simulate('mousedown');
       $(target).simulate('mouseup');
       $(target).simulate('click');


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the double-tab issue. It turned out that after calling the `preventDefault` method on `touchend` event the tap can be triggered as fast as a user can. On the latest Safari, it works cause of the recently added CSS `touch-action` property (https://github.com/handsontable/handsontable/commit/b805b23e3a0a46c1d724524c86a160239ae8cbbd) but for other browsers that use the WebView component, the `preventDefault` has to be used. 

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Tested on the latest Chrome, FF, and Safari (iOS 14.4). As well as on Safari using the iOS 13.5.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7659
2. #6961
3. #6588

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
