### PR TITLE
Fixes checkboxes' state management for non-built-in elements.

### DIFF
--- a/.changelogs/5934.json
+++ b/.changelogs/5934.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fixed state changes resolving for non-built-in checkboxes",
+  "type": "fixed",
+  "issue": 5934,
+  "breaking": false,
+  "framework": "none"
+}

--- a/src/renderers/checkboxRenderer/__tests__/checkboxRenderer.spec.js
+++ b/src/renderers/checkboxRenderer/__tests__/checkboxRenderer.spec.js
@@ -757,7 +757,7 @@ describe('CheckboxRenderer', () => {
       .toHaveBeenCalledWith([[0, 0, 'foo', false]], 'edit', undefined, undefined, undefined, undefined);
   });
 
-  it('shouldn\'t change checkbo notate after hitting other keys then DELETE or BACKSPACE (from #bad-value# state)', () => {
+  it('should not change checkbox state after hitting other keys then DELETE or BACKSPACE (from #bad-value# state)', () => {
     handsontable({
       data: [['foo'], ['bar']],
       columns: [
@@ -1059,6 +1059,58 @@ describe('CheckboxRenderer', () => {
     plugin.onCut(cutEvent);
 
     expect(td.textContent).toBe('');
+  });
+
+  it('should allow to change state of checkboxes in column headers', () => {
+    const spy = jasmine.createSpyObj('error', ['test']);
+    const prevError = window.onerror;
+
+    window.onerror = function() {
+      spy.test();
+    };
+
+    handsontable({
+      data: [[true]],
+      type: 'checkbox',
+      colHeaders: ['<input type="checkbox"/> A'],
+    });
+
+    const headerCheckbox = getTopClone().find('input[type="checkbox"]')[0];
+
+    expect(headerCheckbox.checked).toBe(false);
+
+    headerCheckbox.click();
+
+    expect(headerCheckbox.checked).toBe(true);
+    expect(spy.test.calls.count()).toBe(0);
+
+    window.onerror = prevError;
+  });
+
+  it('should allow to change state of checkboxes in row headers', () => {
+    const spy = jasmine.createSpyObj('error', ['test']);
+    const prevError = window.onerror;
+
+    window.onerror = function() {
+      spy.test();
+    };
+
+    handsontable({
+      data: [[true]],
+      type: 'checkbox',
+      rowHeaders: ['<input type="checkbox"/> 1'],
+    });
+
+    const headerCheckbox = getLeftClone().find('input[type="checkbox"]')[0];
+
+    expect(headerCheckbox.checked).toBe(false);
+
+    headerCheckbox.click();
+
+    expect(headerCheckbox.checked).toBe(true);
+    expect(spy.test.calls.count()).toBe(0);
+
+    window.onerror = prevError;
   });
 
   describe('CheckboxRenderer with ContextMenu', () => {

--- a/src/renderers/checkboxRenderer/checkboxRenderer.js
+++ b/src/renderers/checkboxRenderer/checkboxRenderer.js
@@ -16,6 +16,8 @@ import Hooks from '../../pluginHooks';
 const isListeningKeyDownEvent = new WeakMap();
 const isCheckboxListenerAdded = new WeakMap();
 const BAD_VALUE_CLASS = 'htBadValue';
+const ATTR_ROW = 'data-row';
+const ATTR_COLUMN = 'data-col';
 
 export const RENDERER_TYPE = 'checkbox';
 
@@ -91,8 +93,8 @@ export function checkboxRenderer(instance, TD, row, col, prop, value, cellProper
     badValue = true;
   }
 
-  input.setAttribute('data-row', row);
-  input.setAttribute('data-col', col);
+  input.setAttribute(ATTR_ROW, row);
+  input.setAttribute(ATTR_COLUMN, col);
 
   if (!badValue && labelOptions) {
     let labelText = '';
@@ -341,9 +343,15 @@ function createLabel(rootDocument, text) {
  * @param {Core} instance The Handsontable instance.
  */
 function onMouseUp(event, instance) {
-  if (!isCheckboxInput(event.target)) {
+  const { target } = event;
+
+  if (!isCheckboxInput(target)) {
     return;
   }
+  if (!target.hasAttribute(ATTR_ROW) || !target.hasAttribute(ATTR_COLUMN)) {
+    return;
+  }
+
   setTimeout(instance.listen, 10);
 }
 
@@ -351,17 +359,21 @@ function onMouseUp(event, instance) {
  * `click` callback.
  *
  * @private
- * @param {Event} event `click` event.
+ * @param {MouseEvent} event `click` event.
  * @param {Core} instance The Handsontable instance.
- * @returns {boolean|undefined}
  */
 function onClick(event, instance) {
-  if (!isCheckboxInput(event.target)) {
-    return false;
+  const { target } = event;
+
+  if (!isCheckboxInput(target)) {
+    return;
+  }
+  if (!target.hasAttribute(ATTR_ROW) || !target.hasAttribute(ATTR_COLUMN)) {
+    return;
   }
 
-  const row = parseInt(event.target.getAttribute('data-row'), 10);
-  const col = parseInt(event.target.getAttribute('data-col'), 10);
+  const row = parseInt(event.target.getAttribute(ATTR_ROW), 10);
+  const col = parseInt(event.target.getAttribute(ATTR_COLUMN), 10);
   const cellProperties = instance.getCellMeta(row, col);
 
   if (cellProperties.readOnly) {
@@ -374,15 +386,19 @@ function onClick(event, instance) {
  *
  * @param {Event} event `change` event.
  * @param {Core} instance The Handsontable instance.
- * @returns {boolean}
  */
 function onChange(event, instance) {
-  if (!isCheckboxInput(event.target)) {
-    return false;
+  const { target } = event;
+
+  if (!isCheckboxInput(target)) {
+    return;
+  }
+  if (!target.hasAttribute(ATTR_ROW) || !target.hasAttribute(ATTR_COLUMN)) {
+    return;
   }
 
-  const row = parseInt(event.target.getAttribute('data-row'), 10);
-  const col = parseInt(event.target.getAttribute('data-col'), 10);
+  const row = parseInt(target.getAttribute(ATTR_ROW), 10);
+  const col = parseInt(target.getAttribute(ATTR_COLUMN), 10);
   const cellProperties = instance.getCellMeta(row, col);
 
   if (!cellProperties.readOnly) {

--- a/src/renderers/checkboxRenderer/checkboxRenderer.js
+++ b/src/renderers/checkboxRenderer/checkboxRenderer.js
@@ -372,8 +372,8 @@ function onClick(event, instance) {
     return;
   }
 
-  const row = parseInt(event.target.getAttribute(ATTR_ROW), 10);
-  const col = parseInt(event.target.getAttribute(ATTR_COLUMN), 10);
+  const row = parseInt(target.getAttribute(ATTR_ROW), 10);
+  const col = parseInt(target.getAttribute(ATTR_COLUMN), 10);
   const cellProperties = instance.getCellMeta(row, col);
 
   if (cellProperties.readOnly) {

--- a/src/renderers/checkboxRenderer/checkboxRenderer.js
+++ b/src/renderers/checkboxRenderer/checkboxRenderer.js
@@ -348,6 +348,7 @@ function onMouseUp(event, instance) {
   if (!isCheckboxInput(target)) {
     return;
   }
+
   if (!target.hasAttribute(ATTR_ROW) || !target.hasAttribute(ATTR_COLUMN)) {
     return;
   }
@@ -368,6 +369,7 @@ function onClick(event, instance) {
   if (!isCheckboxInput(target)) {
     return;
   }
+
   if (!target.hasAttribute(ATTR_ROW) || !target.hasAttribute(ATTR_COLUMN)) {
     return;
   }
@@ -393,6 +395,7 @@ function onChange(event, instance) {
   if (!isCheckboxInput(target)) {
     return;
   }
+
   if (!target.hasAttribute(ATTR_ROW) || !target.hasAttribute(ATTR_COLUMN)) {
     return;
   }


### PR DESCRIPTION
### Context
Our built-in checkbox renderer adds listeners for `click`, `mouseup` and `change` events. We verify if `event.target` is a checkbox element, but we don't verify if that element comes from our checkbox renderer.
This PR adds additional verification for checkboxes. We have to be sure that elements have proper data attributes, which are necessary to get coordinates.
I know we should rewrite this cell type (especially editor and renderer). Here, I want to fix only this small part to allow end developers to implement something like the "check all" feature (without workarounds).

### How has this been tested?
- two E2E tests for column and row headers,
- manually tested scenario from the related issue

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. #5934

### Affected project(s):
- [x] `handsontable`
- [x] `@handsontable/angular`
- [x] `@handsontable/react`
- [x] `@handsontable/vue`