### PR TITLE
FIX for circular running npm scripts & Improvements

### DIFF
--- a/docs/.vuepress/tools/check-links.js
+++ b/docs/.vuepress/tools/check-links.js
@@ -23,12 +23,12 @@ const spawnProcess = (command, options = {}) => {
 // start server
 spawnProcess(`http-server ${path.resolve('.vuepress', 'dist')} -s 8080`);
 const stats = {
-  brokenInternal:0,
-  brokenExternal:0,
-  external:0,
-  internal:0,
+  brokenInternal: 0,
+  brokenExternal: 0,
+  external: 0,
+  internal: 0,
   _set: new Set()
-}
+};
 const siteChecker = new SiteChecker(
   {
     excludeInternalLinks: false,
@@ -50,23 +50,27 @@ const siteChecker = new SiteChecker(
 
     link: (result) => {
       const isUnique = !stats._set.has(result.url.resolved);
+
       stats._set.add(result.url.resolved);
-      
+
+      const status = result.http.response.statusCode;
+
       if (result.broken) {
-        if (result.http.response && !ACCEPTABLE_STATUS_CODES.includes(result.http.response.statusCode)) {
+        if (result.http.response && !ACCEPTABLE_STATUS_CODES.includes(status)) {
           if (result.internal) {
-            logger.error(`on: ${result.base.resolved}  \t  broken internal link ${result.http.response.statusCode} => ${result.url.resolved} \t ${result.url.original} ;`);
-            stats.brokenInternal+=isUnique;
+            // eslint-disable-next-line max-len
+            logger.error(`on: ${result.base.resolved}  \t  broken internal link ${status} => ${result.url.resolved} \t ${result.url.original} ;`);
+            stats.brokenInternal += isUnique;
           } else {
-            logger.warn(`on: ${result.base.resolved}  \t  broken external link ${result.http.response.statusCode} => ${result.url.resolved};`);
-            stats.brokenExternal+=isUnique;
+            logger.warn(`on: ${result.base.resolved}  \t  broken external link ${status} => ${result.url.resolved};`);
+            stats.brokenExternal += isUnique;
           }
         }
       } else if (result.internal) {
-        stats.internal+=isUnique;
+        stats.internal += isUnique;
       } else {
-        logger.log(`on: ${result.base.resolved}  \t  external link ${result.http.response.statusCode} => ${result.url.resolved};`);
-        stats.external+=isUnique;
+        logger.log(`on: ${result.base.resolved}  \t  external link ${status} => ${result.url.resolved};`);
+        stats.external += isUnique;
       }
     },
 
@@ -79,11 +83,11 @@ const siteChecker = new SiteChecker(
         logger.error(`Broken internals: ${stats.brokenInternal}`);
         logger.error(`Broken external: ${stats.brokenExternal}`);
 
-        if(stats.brokenInternal){
-          logger.error('\nINTERNAL BROKEN LINKS DETECTED!')
+        if (stats.brokenInternal) {
+          logger.error('\nINTERNAL BROKEN LINKS DETECTED!');
           process.exit(1);
-        }else{
-          logger.warn('\nEXTERNAL BROKEN LINKS DETECTED!')
+        } else {
+          logger.warn('\nEXTERNAL BROKEN LINKS DETECTED!');
           process.exit(0);
         }
       }

--- a/docs/.vuepress/tools/utils.js
+++ b/docs/.vuepress/tools/utils.js
@@ -4,6 +4,7 @@ const chalk = require('chalk');
 module.exports = {
   logger: {
     log: message => console.log(chalk.white(message)),
+    info: message => console.log(chalk.blue(message)),
     success: message => console.log(chalk.green(message)),
     warn: message => console.warn(chalk.yellow(message)),
     error: message => console.error(chalk.red(message)),

--- a/docs/.vuepress/tools/version/rollup-a-version.js
+++ b/docs/.vuepress/tools/version/rollup-a-version.js
@@ -5,8 +5,9 @@ const semver = require('semver');
 const path = require('path');
 const fs = require('fs');
 const fse = require('fs-extra');
+const replaceInFiles = require('replace-in-files');
 
-const {logger} = require('../utils');
+const { logger } = require('../utils');
 
 const workingDir = path.resolve(__dirname, '../../../');
 
@@ -23,7 +24,6 @@ if (!version) {
 } else if (fs.existsSync(path.join(workingDir, version))) {
   throw new Error('<version> should be unique.');
 }
-const replaceInFiles = require('replace-in-files');
 
 (async() => {
   /// * copy `/next/` to `/${version}/`

--- a/docs/next/examples/sidebar.js
+++ b/docs/next/examples/sidebar.js
@@ -1,12 +1,12 @@
-const basicItems = [
-  'basic/introduction',
-  'basic/b001-basic-one',
-  'basic/b002-basic-two',
-];
-
-const advanceItems = [
-  'advance/a001-advance-one',
-];
+// const basicItems = [
+//   'basic/introduction',
+//   'basic/b001-basic-one',
+//   'basic/b002-basic-two',
+// ];
+//
+// const advanceItems = [
+//   'advance/a001-advance-one',
+// ];
 
 module.exports = {
   sidebar: [

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1675,6 +1675,7 @@
         "merge-source-map": "^1.1.0",
         "postcss": "^7.0.14",
         "postcss-selector-parser": "^6.0.2",
+        "prettier": "^1.18.2",
         "source-map": "~0.6.1",
         "vue-template-es2015-compiler": "^1.9.0"
       },
@@ -3687,6 +3688,7 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
+        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -10393,6 +10395,9 @@
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.23.0.tgz",
       "integrity": "sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==",
       "dev": true,
+      "dependencies": {
+        "clipboard": "^2.0.0"
+      },
       "optionalDependencies": {
         "clipboard": "^2.0.0"
       }
@@ -13921,8 +13926,10 @@
       "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
       "dev": true,
       "dependencies": {
+        "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0"
+        "neo-async": "^2.5.0",
+        "watchpack-chokidar2": "^2.0.1"
       },
       "optionalDependencies": {
         "chokidar": "^3.4.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,15 +16,14 @@
     "docs:assets:next": "cp ../dist/handsontable.full.css .vuepress/public/handsontable.css && cp ../dist/handsontable.full.js .vuepress/public/handsontable.js",
     "docs:start": "npm run docs:assets:next && vuepress dev ./",
     "docs:start:no-cache": "npm run docs:assets:next && vuepress dev --no-cache ./",
-    "docs:build": "vuepress build -d .vuepress/dist/docs ./",
-    "postdocs:build": "npm run docs:check-links",
+    "docs:build": "npm run docs:build:no-check-links && npm run docs:check-links",
+    "docs:build:no-check-links": "vuepress build -d .vuepress/dist/docs ./",
     "docs:docker:build": "npm run docs:docker:build:staging",
     "docs:docker:build:staging": "npm run docs:assets:next && docker build -t docs-md .",
     "docs:docker:build:production": "docker build -t docs-md --build-arg BUILD_MODE=production .",
     "docs:version": "cd .vuepress/tools/version && node rollup-a-version.js",
     "docs:api": "cd .vuepress/tools/jsdoc-convert && node jsdoc.js",
-    "docs:check-links": "npm run docs:build && npm run docs:check-links:no-build",
-    "docs:check-links:no-build": "node .vuepress/tools/check-links.js"
+    "docs:check-links": "node .vuepress/tools/check-links.js"
   },
   "license": "CC BY 4.0",
   "devDependencies": {


### PR DESCRIPTION
## Before

postdocs:build runs docs:check-links, which runs docs:build.

## After

Circular doesn't exist.
Additionally, I've added some more statistics and log output.


Part of #7624 (#7626), connected with #7830 (#7839.