### PR TITLE
Fix the external HyperFormula instance license issue for the HF plugin.

### DIFF
--- a/src/plugins/formulas/__tests__/initialization.spec.js
+++ b/src/plugins/formulas/__tests__/initialization.spec.js
@@ -565,6 +565,34 @@ describe('Formulas general', () => {
       expect(hfConfig.useColumnIndex).toEqual(true);
       expect(hfConfig.useStats).toEqual(true);
     });
+
+    it('should update the external HyperFormula instance config with the Handsontable/HF licenseKey, if none was' +
+      ' provided', () => {
+      const hfInstance1 = HyperFormula.buildEmpty();
+
+      handsontable({
+        formulas: {
+          engine: hfInstance1
+        },
+        licenseKey: 'non-commercial-and-evaluation'
+      });
+
+      expect(hfInstance1.getConfig().licenseKey).toEqual('internal-use-in-handsontable');
+    });
+
+    it('should NOT update the external HyperFormula instance config with the Handsontable/HF licenseKey, if it was' +
+      ' provided beforehand', () => {
+      const hfInstance1 = HyperFormula.buildEmpty({ licenseKey: 'dummy-license-key' });
+
+      handsontable({
+        formulas: {
+          engine: hfInstance1
+        },
+        licenseKey: 'non-commercial-and-evaluation'
+      });
+
+      expect(hfInstance1.getConfig().licenseKey).toEqual('dummy-license-key');
+    });
   });
 
   describe('Cross-referencing', () => {

--- a/src/plugins/formulas/engine/register.js
+++ b/src/plugins/formulas/engine/register.js
@@ -2,7 +2,7 @@ import staticRegister from '../../../utils/staticRegister';
 import { isUndefined } from '../../../helpers/mixed';
 import { warn } from '../../../helpers/console';
 import { PLUGIN_KEY } from '../formulas';
-import { mergeEngineSettings } from './settings';
+import { DEFAULT_SETTINGS, mergeEngineSettings } from './settings';
 
 /**
  * Setups the engine instance. It either creates a new (possibly shared) engine instance, or attaches
@@ -37,6 +37,12 @@ export function setupEngine(hotSettings, hotId) {
 
     if (sharedEngineUsage) {
       sharedEngineUsage.push(hotId);
+    }
+
+    if (!engineConfigItem.getConfig().licenseKey) {
+      engineConfigItem.updateConfig({
+        licenseKey: DEFAULT_SETTINGS.licenseKey
+      });
     }
 
     return engineConfigItem;

--- a/src/plugins/formulas/engine/settings.js
+++ b/src/plugins/formulas/engine/settings.js
@@ -1,6 +1,6 @@
 import { PLUGIN_KEY } from '../formulas';
 
-const DEFAULT_SETTINGS = {
+export const DEFAULT_SETTINGS = {
   licenseKey: 'internal-use-in-handsontable',
 
   binarySearchThreshold: 20,


### PR DESCRIPTION
### Context
Force-update the `licenseKey` in the external HF instance, if it was not provided beforehand.

### How has this been tested?
Added test cases.

### Related issue(s):
1. #7648 

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

[skip changelog]