### PR TITLE
Indicator for the CollapsibleColumns plugin will look good for styled TH element

### DIFF
--- a/.changelogs/7970.json
+++ b/.changelogs/7970.json
@@ -1,0 +1,7 @@
+{
+  "title": "Indicator for the CollapsibleColumns plugin will look good for styled TH element.",
+  "type": "fixed",
+  "issue": 7970,
+  "breaking": false,
+  "framework": "none"
+}

--- a/src/css/handsontable.css
+++ b/src/css/handsontable.css
@@ -377,4 +377,5 @@ TextRenderer placeholder value
   -moz-box-shadow: 0 0 0 6px rgba(238,238,238,1);
   box-shadow: 0 0 0 6px rgba(238,238,238,1);
   background: #eee;
+  text-align: center;
 }


### PR DESCRIPTION
### Context
Minor change described within [the issue](https://github.com/handsontable/handsontable/issues/7970). Forced `text-align` style for HTML element.

### How has this been tested?
I checked code after applying CSS style for `TH` element.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7970

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] My change requires a change to the documentation.
