### PR TITLE
Fix double-tap issue on iOS

### DIFF
--- a/src/3rdparty/walkontable/src/event.js
+++ b/src/3rdparty/walkontable/src/event.js
@@ -6,7 +6,7 @@ import {
 } from './../../../helpers/dom/element';
 import { partial } from './../../../helpers/function';
 import { isTouchSupported } from './../../../helpers/feature';
-import { isMobileBrowser } from './../../../helpers/browser';
+import { isMobileBrowser, isChrome, isFirefox, isIOS } from './../../../helpers/browser';
 import EventManager from './../../../eventManager';
 import { isDefined } from '../../../helpers/mixed';
 
@@ -307,21 +307,34 @@ class Event {
    * @param {MouseEvent} event The mouse event object.
    */
   onTouchEnd(event) {
-    const interactiveElements = ['A', 'BUTTON', 'INPUT'];
     const target = event.target;
     const parentCellCoords = this.parentCell(target)?.coords;
-    const isHeader = isDefined(parentCellCoords) && (parentCellCoords.row < 0 || parentCellCoords.col < 0);
+    const isCellsRange = isDefined(parentCellCoords) && (parentCellCoords.row >= 0 && parentCellCoords.col >= 0);
+    const isEventCancelable = event.cancelable && isCellsRange && this.instance.getSetting('isDataViewInstance');
 
-    // When the cells contain interactive HTML tags do not "preventDefault" the event. Thanks to
-    // that, users can interact with the UI element (e.q. click on the link opens a new page).
-    // For non-interactive elements, the event is always prevented to tell the browser that we
-    // don't want to rely on the native 300ms delay. Hence the touch events can be triggered as
-    // fast as the user can (https://webkit.org/blog/5610/more-responsive-tapping-on-ios/).
-    // Related issue #7659.
-    if (event.cancelable &&
-        !isHeader &&
-        !(interactiveElements.includes(target.tagName) && this.selectedCellWasTouched(target))) {
-      event.preventDefault();
+    // To prevent accidental redirects or other actions that the interactive elements (e.q "A" link) do
+    // while the cell is highlighted, all touch events that are triggered on different cells are
+    // "preventDefault"'ed. The user can interact with the element (e.q. click on the link that opens
+    // a new page) only when the same cell was previously selected (see related issue #7659).
+    if (isEventCancelable) {
+      const interactiveElements = ['A', 'BUTTON', 'INPUT'];
+
+      // For browsers that use the WebKit as an engine (excluding Safari), there is a bug. The prevent
+      // default has to be called all the time. Otherwise, the second tap won't be triggered (probably
+      // caused by the native ~300ms delay - https://webkit.org/blog/5610/more-responsive-tapping-on-ios/).
+      // To make the interactive elements work, the event target element has to be check. If the element
+      // matches the allow-list, the event is not prevented.
+      if (isIOS() &&
+          (isChrome() || isFirefox()) &&
+          this.selectedCellWasTouched(target) &&
+          !interactiveElements.includes(target.tagName)) {
+        event.preventDefault();
+
+      } else if (!this.selectedCellWasTouched(target)) {
+        // For other browsers, prevent default is fired only for the first tap and only when the previous
+        // highlighted cell was different.
+        event.preventDefault();
+      }
     }
 
     this.onMouseUp(event);

--- a/src/3rdparty/walkontable/src/event.js
+++ b/src/3rdparty/walkontable/src/event.js
@@ -6,7 +6,7 @@ import {
 } from './../../../helpers/dom/element';
 import { partial } from './../../../helpers/function';
 import { isTouchSupported } from './../../../helpers/feature';
-import { isMobileBrowser, isChrome, isFirefox, isIOS } from './../../../helpers/browser';
+import { isMobileBrowser, isChromeWebKit, isFirefoxWebKit, isIOS } from './../../../helpers/browser';
 import EventManager from './../../../eventManager';
 import { isDefined } from '../../../helpers/mixed';
 
@@ -315,7 +315,7 @@ class Event {
     // To prevent accidental redirects or other actions that the interactive elements (e.q "A" link) do
     // while the cell is highlighted, all touch events that are triggered on different cells are
     // "preventDefault"'ed. The user can interact with the element (e.q. click on the link that opens
-    // a new page) only when the same cell was previously selected (see related issue #7659).
+    // a new page) only when the same cell was previously selected (see related PR #7980).
     if (isEventCancelable) {
       const interactiveElements = ['A', 'BUTTON', 'INPUT'];
 
@@ -325,7 +325,7 @@ class Event {
       // To make the interactive elements work, the event target element has to be check. If the element
       // matches the allow-list, the event is not prevented.
       if (isIOS() &&
-          (isChrome() || isFirefox()) &&
+          (isChromeWebKit() || isFirefoxWebKit()) &&
           this.selectedCellWasTouched(target) &&
           !interactiveElements.includes(target.tagName)) {
         event.preventDefault();

--- a/src/3rdparty/walkontable/src/settings.js
+++ b/src/3rdparty/walkontable/src/settings.js
@@ -19,6 +19,9 @@ class Settings {
     this.defaults = {
       table: void 0,
 
+      // Determines whether the Walkontable instance is used as dataset viewer. When its instance is used as
+      // a context menu, autocomplete list, etc, the returned value is `false`.
+      isDataViewInstance: true,
       // presentation mode
       externalRowCalculator: false,
       stretchH: 'none', // values: all, last, none

--- a/src/css/mobile.handsontable.css
+++ b/src/css/mobile.handsontable.css
@@ -6,13 +6,13 @@
 
 .handsontable.mobile,
 .handsontable.mobile .wtHolder {
-  -webkit-touch-callout:none;
-  -webkit-user-select:none;
-  -khtml-user-select:none;
-  -moz-user-select:none;
-  -ms-user-select:none;
-  user-select:none;
-  -webkit-tap-highlight-color:rgba(0,0,0,0);
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-tap-highlight-color: rgba(0,0,0,0);
   -webkit-overflow-scrolling: touch;
 }
 

--- a/src/helpers/browser.js
+++ b/src/helpers/browser.js
@@ -13,16 +13,17 @@ const tester = (testerFunc) => {
 };
 
 const browsers = {
-  // CriOS - Chrome on iOS
-  chrome: tester(ua => /Chrome|CriOS/.test(ua)),
+  chrome: tester((ua, vendor) => /Chrome/.test(ua) && /Google/.test(vendor)),
+  chromeWebKit: tester(ua => /CriOS/.test(ua)),
   edge: tester(ua => /Edge/.test(ua)),
-  // FxiOS - Firefox on iOS
-  firefox: tester(ua => /Firefox|FxiOS/.test(ua)),
+  edgeWebKit: tester(ua => /EdgiOS/.test(ua)),
+  firefox: tester(ua => /Firefox/.test(ua)),
+  firefoxWebKit: tester(ua => /FxiOS/.test(ua)),
   ie: tester(ua => /Trident/.test(ua)),
   // eslint-disable-next-line no-restricted-globals
   ie9: tester(() => !!(document.documentMode)),
   mobile: tester(ua => /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(ua)),
-  safari: tester(ua => /Safari/.test(ua)),
+  safari: tester((ua, vendor) => /Safari/.test(ua) && /Apple Computer/.test(vendor)),
 };
 
 const platforms = {
@@ -62,8 +63,43 @@ export function isChrome() {
 /**
  * @returns {boolean}
  */
+export function isChromeWebKit() {
+  return browsers.chromeWebKit.value;
+}
+
+/**
+ * @returns {boolean}
+ */
+export function isFirefox() {
+  return browsers.firefox.value;
+}
+
+/**
+ * @returns {boolean}
+ */
+export function isFirefoxWebKit() {
+  return browsers.firefoxWebKit.value;
+}
+
+/**
+ * @returns {boolean}
+ */
+export function isSafari() {
+  return browsers.safari.value;
+}
+
+/**
+ * @returns {boolean}
+ */
 export function isEdge() {
   return browsers.edge.value;
+}
+
+/**
+ * @returns {boolean}
+ */
+export function isEdgeWebKit() {
+  return browsers.edgeWebKit.value;
 }
 
 /**
@@ -111,20 +147,6 @@ export function isIOS() {
  */
 export function isIpadOS({ maxTouchPoints } = navigator) {
   return maxTouchPoints > 2 && platforms.mac.value;
-}
-
-/**
- * @returns {boolean}
- */
-export function isSafari() {
-  return browsers.safari.value;
-}
-
-/**
- * @returns {boolean}
- */
-export function isFirefox() {
-  return browsers.firefox.value;
 }
 
 /**

--- a/src/helpers/browser.js
+++ b/src/helpers/browser.js
@@ -13,14 +13,16 @@ const tester = (testerFunc) => {
 };
 
 const browsers = {
-  chrome: tester((ua, vendor) => /Chrome/.test(ua) && /Google/.test(vendor)),
+  // CriOS - Chrome on iOS
+  chrome: tester(ua => /Chrome|CriOS/.test(ua)),
   edge: tester(ua => /Edge/.test(ua)),
-  firefox: tester(ua => /Firefox/.test(ua)),
+  // FxiOS - Firefox on iOS
+  firefox: tester(ua => /Firefox|FxiOS/.test(ua)),
   ie: tester(ua => /Trident/.test(ua)),
   // eslint-disable-next-line no-restricted-globals
   ie9: tester(() => !!(document.documentMode)),
   mobile: tester(ua => /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(ua)),
-  safari: tester((ua, vendor) => /Safari/.test(ua) && /Apple Computer/.test(vendor)),
+  safari: tester(ua => /Safari/.test(ua)),
 };
 
 const platforms = {

--- a/src/plugins/contextMenu/menu.js
+++ b/src/plugins/contextMenu/menu.js
@@ -12,7 +12,7 @@ import {
 import Core from '../../core';
 import EventManager from '../../eventManager';
 import { arrayEach, arrayFilter, arrayReduce } from '../../helpers/array';
-import { isWindowsOS } from '../../helpers/browser';
+import { isWindowsOS, isMobileBrowser, isIpadOS } from '../../helpers/browser';
 import {
   addClass,
   empty,
@@ -220,7 +220,16 @@ class Menu {
         // after the "contextmenu". So then "mouseup" closes the menu. Otherwise, the closing
         // menu responsibility is forwarded to "afterOnCellContextMenu" callback (#6507#issuecomment-582392301).
         if ((!isWindowsOS() || !isRightClick(event)) && shouldAutoCloseMenu && this.hasSelectedItem()) {
-          this.close(true);
+          // The timeout is necessary only for mobile devices. For desktop, the click event that is fired
+          // right after the mouseup event gets the event element target the same as the mouseup event.
+          // For mobile devices, the click event is triggered with native delay (~300ms), so when the mouseup
+          // event hides the tapped element, the click event grabs the element below. As a result, the filter
+          // by condition menu is closed and immediately open on tapping the "None" item.
+          if (isMobileBrowser() || isIpadOS()) {
+            setTimeout(() => this.close(true), 325);
+          } else {
+            this.close(true);
+          }
         }
       },
       afterUnlisten: () => {

--- a/src/tableView.js
+++ b/src/tableView.js
@@ -14,6 +14,7 @@ import EventManager from './eventManager';
 import { isImmediatePropagationStopped, isRightClick, isLeftClick } from './helpers/dom/event';
 import Walkontable, { CellCoords } from './3rdparty/walkontable/src';
 import { handleMouseEvent } from './selection/mouseEventHandler';
+import { isRootInstance } from './utils/rootInstance';
 
 const privatePool = new WeakMap();
 
@@ -518,6 +519,7 @@ class TableView {
       externalRowCalculator: this.instance.getPlugin('autoRowSize') &&
         this.instance.getPlugin('autoRowSize').isEnabled(),
       table: priv.table,
+      isDataViewInstance: () => isRootInstance(this.instance),
       preventOverflow: () => this.settings.preventOverflow,
       preventWheel: () => this.settings.preventWheel,
       stretchH: () => this.settings.stretchH,

--- a/test/e2e/mobile/core.spec.js
+++ b/test/e2e/mobile/core.spec.js
@@ -12,7 +12,7 @@ describe('Core', () => {
     }
   });
 
-  it('should apply "mobile" class to the HOT container', () => {
+  it('should apply "mobile" class to the HOT root element', () => {
     const hot = handsontable({
       columns: [
         {
@@ -21,9 +21,8 @@ describe('Core', () => {
       ]
     });
 
-    const hasMobileClass = hot.container.classList.contains('mobile');
+    const hasMobileClass = hot.rootElement.classList.contains('mobile');
 
     expect(hasMobileClass).toBeTruthy();
   });
-
 });

--- a/test/e2e/mobile/events.spec.js
+++ b/test/e2e/mobile/events.spec.js
@@ -58,7 +58,7 @@ describe('Events', () => {
     expect(onCellDblClick).toHaveBeenCalled();
   });
 
-  it('should "preventDefault" the "touchend" event (double-tap issue #7824)', () => {
+  it('should "preventDefault" only the second "touchend" event while double-tapping (issue #7824)', () => {
     const hot = handsontable({
       width: 400,
       height: 400,
@@ -78,11 +78,11 @@ describe('Events', () => {
 
       const event = triggerTouchEvent('touchend', cell);
 
-      expect(event.defaultPrevented).toBeTrue();
+      expect(event.defaultPrevented).toBeFalse();
     }
   });
 
-  it('should not "preventDefault" the second "touchend" event when interactive element is clicked', () => {
+  it('should not "preventDefault" the second "touchend" event when interactive element is clicked (PR#7980)', () => {
     const hot = handsontable({
       data: [['<a href="#justForTest">click me!</a>'], []],
       width: 400,
@@ -108,7 +108,7 @@ describe('Events', () => {
     }
   });
 
-  it('should block default action related to link touch and translate from the touch to click on a cell', async() => {
+  it('should "preventDefault" the link element (block its default action) when the cell is not highlighted', async() => {
     const hot = handsontable({
       data: [['<a href="#justForTest">click me!</a>'], []],
       rowHeaders: true,

--- a/test/unit/helpers/Browser.unit.js
+++ b/test/unit/helpers/Browser.unit.js
@@ -1,7 +1,10 @@
 import {
   isChrome,
+  isChromeWebKit,
   isEdge,
+  isEdgeWebKit,
   isFirefox,
+  isFirefoxWebKit,
   isIE,
   isMobileBrowser,
   isMSBrowser,
@@ -260,6 +263,70 @@ describe('Browser helper', () => {
       });
 
       expect(isEdge()).toBeTruthy();
+
+      setBrowserMeta({
+        userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 15_5_1 like Mac OS X) ' +
+          'AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 EdgiOS/46.3.13 Mobile/15E148 Safari/605.1.15'
+      });
+
+      expect(isEdge()).toBeFalsy();
+    });
+  });
+
+  describe('isEdgeWebKit', () => {
+    it('should recognize browser properly', () => {
+      setBrowserMeta({
+        userAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) ' +
+          'Chrome/38.0.2125.111 Safari/537.36'
+      });
+
+      expect(isEdgeWebKit()).toBeFalsy();
+
+      setBrowserMeta({
+        userAgent: 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:33.0) Gecko/20100101 Firefox/33.0'
+      });
+
+      expect(isEdgeWebKit()).toBeFalsy();
+
+      setBrowserMeta({
+        userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) ' +
+          'AppleWebKit/600.1.17 (KHTML, like Gecko) Version/7.1 Safari/537.85.10'
+      });
+
+      expect(isEdgeWebKit()).toBeFalsy();
+
+      setBrowserMeta({
+        userAgent: 'Mozilla/5.0 (iPad; CPU OS 8_1 like Mac OS X) ' +
+          'AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B410 Safari/600.1.4'
+      });
+
+      expect(isEdgeWebKit()).toBeFalsy();
+
+      setBrowserMeta({
+        userAgent: 'Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko'
+      });
+
+      expect(isEdgeWebKit()).toBeFalsy();
+
+      setBrowserMeta({
+        userAgent: 'Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.0; Trident/3.1; IEMobile/7.0; Nokia;N70)'
+      });
+
+      expect(isEdgeWebKit()).toBeFalsy();
+
+      setBrowserMeta({
+        userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) ' +
+          'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.79 Safari/537.36 Edge/14.14393'
+      });
+
+      expect(isEdgeWebKit()).toBeFalsy();
+
+      setBrowserMeta({
+        userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 15_5_1 like Mac OS X) ' +
+          'AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 EdgiOS/46.3.13 Mobile/15E148 Safari/605.1.15'
+      });
+
+      expect(isEdgeWebKit()).toBeTruthy();
     });
   });
 
@@ -424,6 +491,77 @@ describe('Browser helper', () => {
       });
 
       expect(isChrome()).toBeTruthy();
+
+      setBrowserMeta({
+        userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 14_5 like Mac OS X) ' +
+          'AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/87.0.4280.163 Mobile/15E148 Safari/604.1',
+      });
+
+      expect(isChrome()).toBeFalsy();
+    });
+  });
+
+  describe('isChromeWebKit', () => {
+    it('should recognize browser properly', () => {
+      setBrowserMeta({
+        userAgent: 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:33.0) Gecko/20100101 Firefox/33.0',
+        vendor: 'Apple Computer',
+      });
+
+      expect(isChromeWebKit()).toBeFalsy();
+
+      setBrowserMeta({
+        userAgent: 'Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko',
+        vendor: 'Apple Computer',
+      });
+
+      expect(isChromeWebKit()).toBeFalsy();
+
+      setBrowserMeta({
+        userAgent: 'Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.0; Trident/3.1; IEMobile/7.0; Nokia;N70)',
+        vendor: 'Apple Computer',
+      });
+
+      expect(isChromeWebKit()).toBeFalsy();
+
+      setBrowserMeta({
+        userAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) ' +
+          'Chrome/38.0.2125.111 Safari/537.36',
+        vendor: 'Apple Computer',
+      });
+
+      expect(isChromeWebKit()).toBeFalsy();
+
+      setBrowserMeta({
+        userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) ' +
+          'AppleWebKit/600.1.17 (KHTML, like Gecko) Version/7.1 Safari/537.85.10',
+        vendor: 'Apple Computer',
+      });
+
+      expect(isChromeWebKit()).toBeFalsy();
+
+      setBrowserMeta({
+        userAgent: 'Mozilla/5.0 (iPad; CPU OS 8_1 like Mac OS X) ' +
+          'AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B410 Safari/600.1.4',
+        vendor: 'Apple Computer',
+      });
+
+      expect(isChromeWebKit()).toBeFalsy();
+
+      setBrowserMeta({
+        userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) ' +
+          'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.79 Safari/537.36 Edge/14.14393',
+        vendor: 'Google Inc.',
+      });
+
+      expect(isChromeWebKit()).toBeFalsy();
+
+      setBrowserMeta({
+        userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 14_5 like Mac OS X) ' +
+          'AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/87.0.4280.163 Mobile/15E148 Safari/604.1',
+      });
+
+      expect(isChromeWebKit()).toBeTruthy();
     });
   });
 
@@ -481,6 +619,79 @@ describe('Browser helper', () => {
       });
 
       expect(isFirefox()).toBeFalsy();
+
+      setBrowserMeta({
+        userAgent: 'Mozilla/5.0 (iPhone; CPU OS 14_5_1 like Mac OS X) ' +
+          'AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/33.1 Mobile/15E148 Safari/605.1.15',
+        vendor: 'Google Inc.',
+      });
+
+      expect(isFirefox()).toBeFalsy();
+    });
+  });
+
+  describe('isFirefoxWebKit', () => {
+    it('should recognize browser properly', () => {
+      setBrowserMeta({
+        userAgent: 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:33.0) Gecko/20100101 Firefox/33.0',
+        vendor: 'Apple Computer',
+      });
+
+      expect(isFirefoxWebKit()).toBeFalsy();
+
+      setBrowserMeta({
+        userAgent: 'Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko',
+        vendor: 'Apple Computer',
+      });
+
+      expect(isFirefoxWebKit()).toBeFalsy();
+
+      setBrowserMeta({
+        userAgent: 'Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.0; Trident/3.1; IEMobile/7.0; Nokia;N70)',
+        vendor: 'Apple Computer',
+      });
+
+      expect(isFirefoxWebKit()).toBeFalsy();
+
+      setBrowserMeta({
+        userAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) ' +
+          'Chrome/38.0.2125.111 Safari/537.36',
+        vendor: 'Apple Computer',
+      });
+
+      expect(isFirefoxWebKit()).toBeFalsy();
+
+      setBrowserMeta({
+        userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) ' +
+          'AppleWebKit/600.1.17 (KHTML, like Gecko) Version/7.1 Safari/537.85.10',
+        vendor: 'Apple Computer',
+      });
+
+      expect(isFirefoxWebKit()).toBeFalsy();
+
+      setBrowserMeta({
+        userAgent: 'Mozilla/5.0 (iPad; CPU OS 8_1 like Mac OS X) ' +
+          'AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B410 Safari/600.1.4',
+        vendor: 'Apple Computer',
+      });
+
+      expect(isFirefoxWebKit()).toBeFalsy();
+
+      setBrowserMeta({
+        userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) ' +
+          'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.79 Safari/537.36 Edge/14.14393',
+        vendor: 'Google Inc.',
+      });
+
+      expect(isFirefoxWebKit()).toBeFalsy();
+
+      setBrowserMeta({
+        userAgent: 'Mozilla/5.0 (iPhone; CPU OS 14_5_1 like Mac OS X) ' +
+          'AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/33.1 Mobile/15E148 Safari/605.1.15',
+        vendor: 'Google Inc.',
+      });
+
+      expect(isFirefoxWebKit()).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes [another PR](https://github.com/handsontable/handsontable/pull/7824) that adds support for double-tap actions. There is a bug for mobile browsers that use the WebKit as an engine (excluding the latest Safari that uses a newer version of that engine). The bug causes that a cell editor can not be open using double-tap events. It's fixed by calling the "preventDefault" on the "touchend" events. By doing that, the second tap can be triggered as fast as the user is able to. The technique removes the restriction where the browsers apply the native delay ~300ms (https://webkit.org/blog/5610/more-responsive-tapping-on-ios/).

The "preventDefault" call is not necessary for the newest browsers. However, it provides a second desired effect. The cells that contain interactive elements such as "a" link or "button" elements will not be triggered until the previous highlight cell is the same.

_[skip changelog]_ The PR fixes [another PR](https://github.com/handsontable/handsontable/pull/7824) with the same meaning so the changelog for that PR is not necessary.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes - it includes scrolling, dropdown menu checking, filter by condition menu checking, cell editing (double-tap cases when the cell was previously selected or not selected at all), and checking how the interactive elements behave (e.q. cell renderer with `a` - link element).

I tested on iPhone 12 iOS 14.5 with Safari, Chrome, FF, and Edge. iOS simulator iOS 14.3 with Safari. Android 9 simulator with Chrome 69 and 90 and Android 11 with Chrome 83 and 90 and I didn't found any issues.    

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7973
2. #7824
3.

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
