### PR TITLE
[hf] Autofill implementation rework

### DIFF
--- a/.changelogs/7987.json
+++ b/.changelogs/7987.json
@@ -1,0 +1,7 @@
+{
+  "title": "Changed `afterAutofill` & `beforeAutofill` hooks' signatures",
+  "type": "changed",
+  "issue": 7987,
+  "breaking": true,
+  "framework": "none"
+}

--- a/handsontable.d.ts
+++ b/handsontable.d.ts
@@ -1743,9 +1743,19 @@ declare namespace Handsontable {
       classNames: string[];
     }
 
+    interface CellCoords {
+      col: number;
+      row: number;
+    }
+
+    interface CellRange {
+      from: CellCoords;
+      to: CellCoords;
+    }
+
     interface Events {
       afterAddChild?: (parent: RowObject, element: RowObject | void, index: number | void) => void;
-      afterAutofill?: (start: wot.CellCoords, end: wot.CellCoords, data: CellValue[][]) => void;
+      afterAutofill?: (fillData: CellValue[][], sourceRange: CellRange, targetRange: CellRange, direction: 'up' | 'down' | 'left' | 'right') => void;
       afterBeginEditing?: (row: number, column: number) => void;
       afterCellMetaReset?: () => void;
       afterChange?: (changes: CellChange[] | null, source: ChangeSource) => void;
@@ -1833,7 +1843,7 @@ declare namespace Handsontable {
       afterViewportColumnCalculatorOverride?: (calc: ViewportColumnsCalculator) => void;
       afterViewportRowCalculatorOverride?: (calc: ViewportColumnsCalculator) => void;
       beforeAddChild?: (parent: RowObject, element: RowObject | void, index: number | void) => void;
-      beforeAutofill?: (start: wot.CellCoords, end: wot.CellCoords, data: CellValue[][]) => void | boolean;
+      beforeAutofill?: (selectionData: CellValue[][], sourceRange: CellRange, targetRange: CellRange, direction: 'up' | 'down' | 'left' | 'right') => CellValue[][] | boolean | void;
       beforeAutofillInsidePopulate?: (index: wot.CellCoords, direction: 'up' | 'down' | 'left' | 'right', input: CellValue[][], deltas: any[]) => void;
       beforeCellAlignment?: (stateBefore: { [row: number]: string[] }, range: wot.CellRange[], type: 'horizontal' | 'vertical', alignmentClass: 'htLeft' | 'htCenter' | 'htRight' | 'htJustify' | 'htTop' | 'htMiddle' | 'htBottom') => void;
       beforeChange?: (changes: CellChange[], source: ChangeSource) => void | boolean;

--- a/src/pluginHooks.js
+++ b/src/pluginHooks.js
@@ -665,7 +665,7 @@ const REGISTERED_HOOKS = [
    * @event Hooks#afterAutofill
    * @since 8.0.0
    * @param {Array[]} fillData The data that was used to fill the `targetRange`. If `beforeAutofill` was used
-   *                            and returned data, this will be the same object that was returned from `beforeAutofill`.
+   *                            and returned `[[]]`, this will be the same object that was returned from `beforeAutofill`.
    * @param {CellRange} sourceRange The range values will be filled from.
    * @param {CellRange} targetRange The range new values will be filled into.
    * @param {string} direction Declares the direction of the autofill. Possible values: `up`, `down`, `left`, `right`.

--- a/src/pluginHooks.js
+++ b/src/pluginHooks.js
@@ -647,12 +647,12 @@ const REGISTERED_HOOKS = [
    * {@link Options#fillHandle} option is enabled.
    *
    * @event Hooks#beforeAutofill
-   * @param {Array[][]} selectionData Data the autofill operation will start from.
+   * @param {Array[]} selectionData Data the autofill operation will start from.
    * @param {CellRange} sourceRange The range values will be filled from.
    * @param {CellRange} targetRange The range new values will be filled into.
    * @param {string} direction Declares the direction of the autofill. Possible values: `up`, `down`, `left`, `right`.
    *
-   * @returns {boolean|Array[][]} If false, the operation is cancelled. If array of arrays, the returned data
+   * @returns {boolean|Array[]} If false, the operation is cancelled. If array of arrays, the returned data
    *                              will be passed into `populateFromArray` instead of the default autofill
    *                              algorithm's result.
    */
@@ -664,7 +664,7 @@ const REGISTERED_HOOKS = [
    *
    * @event Hooks#afterAutofill
    * @since 8.0.0
-   * @param {fillData} fillData The data that was used to fill the `targetRange`. If `beforeAutofill` was used
+   * @param {Array[]} fillData The data that was used to fill the `targetRange`. If `beforeAutofill` was used
    *                            and returned data, this will be the same object that was returned from `beforeAutofill`.
    * @param {CellRange} sourceRange The range values will be filled from.
    * @param {CellRange} targetRange The range new values will be filled into.

--- a/src/pluginHooks.js
+++ b/src/pluginHooks.js
@@ -647,10 +647,14 @@ const REGISTERED_HOOKS = [
    * {@link Options#fillHandle} option is enabled.
    *
    * @event Hooks#beforeAutofill
-   * @param {CellCoords} start Object containing information about first filled cell: `{row: 2, col: 0}`.
-   * @param {CellCoords} end Object containing information about last filled cell: `{row: 4, col: 1}`.
-   * @param {Array[]} data 2D array containing information about fill pattern: `[["1", "Ted"], ["1", "John"]]`.
-   * @returns {*|boolean} If false is returned the action is canceled.
+   * @param {Array[][]} selectionData Data the autofill operation will start from.
+   * @param {CellRange} sourceRange The range values will be filled from.
+   * @param {CellRange} targetRange The range new values will be filled into.
+   * @param {string} direction Declares the direction of the autofill. Possible values: `up`, `down`, `left`, `right`.
+   *
+   * @returns {boolean|Array[][]} If false, the operation is cancelled. If array of arrays, the returned data
+   *                              will be passed into `populateFromArray` instead of the default autofill
+   *                              algorithm's result.
    */
   'beforeAutofill',
 
@@ -660,9 +664,11 @@ const REGISTERED_HOOKS = [
    *
    * @event Hooks#afterAutofill
    * @since 8.0.0
-   * @param {CellCoords} start Object containing information about first filled cell: `{row: 2, col: 0}`.
-   * @param {CellCoords} end Object containing information about last filled cell: `{row: 4, col: 1}`.
-   * @param {Array[]} data 2D array containing information about fill pattern: `[["1", "Ted"], ["1", "John"]]`.
+   * @param {fillData} fillData The data that was used to fill the `targetRange`. If `beforeAutofill` was used
+   *                            and returned data, this will be the same object that was returned from `beforeAutofill`.
+   * @param {CellRange} sourceRange The range values will be filled from.
+   * @param {CellRange} targetRange The range new values will be filled into.
+   * @param {string} direction Declares the direction of the autofill. Possible values: `up`, `down`, `left`, `right`.
    */
   'afterAutofill',
 

--- a/src/plugins/autofill/__tests__/autofill.spec.js
+++ b/src/plugins/autofill/__tests__/autofill.spec.js
@@ -456,6 +456,42 @@ describe('AutoFill', () => {
         [7, 8, 7, 8, 5, 6]
       ]);
     });
+
+    it('should use input from `beforeAutofill` if data is returned, in the correct order, upwards', () => {
+      const hot = handsontable({
+        data: [
+          ['x'],
+          ['x'],
+          ['x'],
+          ['x'],
+          ['x'],
+          [1],
+          [1]
+        ],
+        beforeAutofill() {
+          return [
+            ['a'],
+            ['b'],
+          ];
+        }
+      });
+
+      selectCell(5, 0, 6, 0);
+
+      spec().$container.find('.wtBorder.corner').simulate('mousedown');
+      spec().$container.find('tr:eq(0) td:eq(0)').simulate('mouseover');
+      spec().$container.find('.wtBorder.corner').simulate('mouseup');
+
+      expect(hot.getData()).toEqual([
+        ['b'],
+        ['a'],
+        ['b'],
+        ['a'],
+        ['b'],
+        [1],
+        [1]
+      ]);
+    });
   });
 
   it('should pass correct arguments to `afterAutofill`', () => {
@@ -514,7 +550,7 @@ describe('AutoFill', () => {
     );
   });
 
-  it('should pass the same fillData to `afterAutofill` as in the one from `beforeAutofill` by identity', () => {
+  it('should pass the same fillData to `afterAutofill` as in the one from `beforeAutofill` by identity if it\'s empty', () => {
     const afterAutofill = jasmine.createSpy();
 
     const fillData = [[]];

--- a/src/plugins/autofill/__tests__/autofill.spec.js
+++ b/src/plugins/autofill/__tests__/autofill.spec.js
@@ -398,7 +398,7 @@ describe('AutoFill', () => {
         sourceRange,
         targetRange,
         direction,
-        undefined, // TODO ???
+        undefined,
         undefined
       );
     });
@@ -509,7 +509,7 @@ describe('AutoFill', () => {
       sourceRange,
       targetRange,
       direction,
-      undefined, // TODO ??
+      undefined,
       undefined
     );
   });

--- a/src/plugins/autofill/autofill.js
+++ b/src/plugins/autofill/autofill.js
@@ -275,31 +275,29 @@ export class Autofill extends BasePlugin {
       const deltas = getDeltas(startOfDragCoords, endOfDragCoords, selectionData, directionOfDrag);
 
       let fillData = beforeAutofillHookResult;
+      const res = beforeAutofillHookResult;
 
-      if (['up', 'left'].indexOf(directionOfDrag) > -1 && beforeAutofillHookResult === selectionData) {
+      if (['up', 'left'].indexOf(directionOfDrag) > -1 && res.length > 0 && res[0].length > 0) {
         fillData = [];
 
-        let dragLength = null;
-        let fillOffset = null;
-
         if (directionOfDrag === 'up') {
-          dragLength = endOfDragCoords.row - startOfDragCoords.row + 1;
-          fillOffset = dragLength % selectionData.length;
+          const dragLength = endOfDragCoords.row - startOfDragCoords.row + 1;
+          const fillOffset = dragLength % res.length;
 
           for (let i = 0; i < dragLength; i++) {
-            fillData.push(selectionData[(i + (selectionData.length - fillOffset)) % selectionData.length]);
+            fillData.push(res[(i + (res.length - fillOffset)) % res.length]);
           }
 
         } else {
-          dragLength = endOfDragCoords.col - startOfDragCoords.col + 1;
-          fillOffset = dragLength % selectionData[0].length;
+          const dragLength = endOfDragCoords.col - startOfDragCoords.col + 1;
+          const fillOffset = dragLength % res[0].length;
 
-          for (let i = 0; i < selectionData.length; i++) {
+          for (let i = 0; i < res.length; i++) {
             fillData.push([]);
 
             for (let j = 0; j < dragLength; j++) {
               fillData[i]
-                .push(selectionData[i][(j + (selectionData[i].length - fillOffset)) % selectionData[i].length]);
+                .push(res[i][(j + (res[i].length - fillOffset)) % res[i].length]);
             }
           }
         }

--- a/src/plugins/autofill/autofill.js
+++ b/src/plugins/autofill/autofill.js
@@ -305,6 +305,8 @@ export class Autofill extends BasePlugin {
         }
       }
 
+      this.hot.suspendRender();
+
       this.hot.populateFromArray(
         startOfDragCoords.row,
         startOfDragCoords.col,
@@ -319,6 +321,8 @@ export class Autofill extends BasePlugin {
 
       this.setSelection(cornersOfSelectionAndDragAreas);
       this.hot.runHooks('afterAutofill', fillData, sourceRange, targetRange, directionOfDrag);
+
+      this.hot.resumeRender();
 
     } else {
       // reset to avoid some range bug

--- a/src/plugins/autofill/autofill.js
+++ b/src/plugins/autofill/autofill.js
@@ -277,7 +277,10 @@ export class Autofill extends BasePlugin {
       let fillData = beforeAutofillHookResult;
       const res = beforeAutofillHookResult;
 
-      if (['up', 'left'].indexOf(directionOfDrag) > -1 && res.length > 0 && res[0].length > 0) {
+      if (
+        ['up', 'left'].indexOf(directionOfDrag) > -1 &&
+        !(res.length === 1 && res[0].length === 0)
+      ) {
         fillData = [];
 
         if (directionOfDrag === 'up') {

--- a/src/plugins/formulas/__tests__/formulas.spec.js
+++ b/src/plugins/formulas/__tests__/formulas.spec.js
@@ -1164,6 +1164,40 @@ describe('Formulas general', () => {
         .simulate('mouseup');
     };
 
+    it('should not autofill if `beforeAutofill` returned false', () => {
+      const hot = handsontable({
+        data: [
+          ['=A1', 'x', 'x'],
+        ],
+        formulas: {
+          engine: HyperFormula
+        },
+        beforeAutofill: () => false
+      });
+
+      selectCell(0, 0);
+      autofill(0, 2);
+
+      expect(hot.getSourceData()).toEqual([['=A1', 'x', 'x']]);
+    });
+
+    it('should not autofill if `beforeAutofill` returned values', () => {
+      const hot = handsontable({
+        data: [
+          ['=A1', 'x', 'x'],
+        ],
+        formulas: {
+          engine: HyperFormula
+        },
+        beforeAutofill: () => [['a']]
+      });
+
+      selectCell(0, 0);
+      autofill(0, 2);
+
+      expect(hot.getSourceData()).toEqual([['=A1', 'a', 'a']]);
+    });
+
     it('should not autofill if there\'s a matrix in the way', () => {
       const hot = handsontable({
         data: [
@@ -1274,6 +1308,7 @@ describe('Formulas general', () => {
           ['x', 'x'],
           ['x', 'x'],
           ['x', 'x'],
+          ['y', 'y'],
         ],
         formulas: {
           engine: HyperFormula
@@ -1293,15 +1328,16 @@ describe('Formulas general', () => {
         ['=E12', '=E16'],
         ['=G12', '=G16'],
         ['=I12', '=I16'],
+        ['y', 'y'],
       ]);
     });
 
     it('should correctly autofill - range, right, partial', () => {
       const hot = handsontable({
         data: [
-          ['=E6', '=E10', 'x'],
-          ['=G6', '=G10', 'x'],
-          ['=I6', '=I10', 'x'],
+          ['=E6', '=E10', 'x', 'y'],
+          ['=G6', '=G10', 'x', 'y'],
+          ['=I6', '=I10', 'x', 'y'],
         ],
         formulas: {
           engine: HyperFormula
@@ -1312,18 +1348,18 @@ describe('Formulas general', () => {
       autofill(2, 2);
 
       expect(hot.getSourceData()).toEqual([
-        ['=E6', '=E10', '=G6'],
-        ['=G6', '=G10', '=I6'],
-        ['=I6', '=I10', '=K6'],
+        ['=E6', '=E10', '=G6', 'y'],
+        ['=G6', '=G10', '=I6', 'y'],
+        ['=I6', '=I10', '=K6', 'y'],
       ]);
     });
 
     it('should correctly autofill - range, right, overflow', () => {
       const hot = handsontable({
         data: [
-          ['=E6', '=E10', 'x', 'x', 'x'],
-          ['=G6', '=G10', 'x', 'x', 'x'],
-          ['=I6', '=I10', 'x', 'x', 'x']
+          ['=E6', '=E10', 'x', 'x', 'x', 'y'],
+          ['=G6', '=G10', 'x', 'x', 'x', 'y'],
+          ['=I6', '=I10', 'x', 'x', 'x', 'y']
         ],
         formulas: {
           engine: HyperFormula
@@ -1334,69 +1370,69 @@ describe('Formulas general', () => {
       autofill(2, 4);
 
       expect(hot.getSourceData()).toEqual([
-        ['=E6', '=E10', '=G6', '=G10', '=I6'],
-        ['=G6', '=G10', '=I6', '=I10', '=K6'],
-        ['=I6', '=I10', '=K6', '=K10', '=M6']
+        ['=E6', '=E10', '=G6', '=G10', '=I6', 'y'],
+        ['=G6', '=G10', '=I6', '=I10', '=K6', 'y'],
+        ['=I6', '=I10', '=K6', '=K10', '=M6', 'y']
       ]);
     });
 
     it('should correctly autofill - range, left, partial', () => {
       const hot = handsontable({
         data: [
-          ['x', '=E6', '=E10'],
-          ['x', '=G6', '=G10'],
-          ['x', '=I6', '=I10'],
+          ['y', 'x', '=E6', '=E10'],
+          ['y', 'x', '=G6', '=G10'],
+          ['y', 'x', '=I6', '=I10'],
         ],
         formulas: {
           engine: HyperFormula
         }
       });
 
-      selectCell(0, 1, 2, 2);
-      autofill(2, 0);
+      selectCell(0, 2, 2, 3);
+      autofill(2, 1);
 
       expect(hot.getSourceData()).toEqual([
-        ['=C10', '=E6', '=E10'],
-        ['=E10', '=G6', '=G10'],
-        ['=G10', '=I6', '=I10'],
+        ['y', '=C10', '=E6', '=E10'],
+        ['y', '=E10', '=G6', '=G10'],
+        ['y', '=G10', '=I6', '=I10'],
       ]);
     });
 
     it('should correctly autofill - range, left, overflow', () => {
       const hot = handsontable({
         data: [
-          ['x', 'x', 'x', '=E6', '=E10'],
-          ['x', 'x', 'x', '=G6', '=G10'],
-          ['x', 'x', 'x', '=I6', '=I10'],
+          ['y', 'x', 'x', 'x', '=E6', '=E10'],
+          ['y', 'x', 'x', 'x', '=G6', '=G10'],
+          ['y', 'x', 'x', 'x', '=I6', '=I10'],
         ],
         formulas: {
           engine: HyperFormula
         }
       });
 
-      selectCell(0, 3, 2, 4);
-      autofill(2, 0);
+      selectCell(0, 4, 2, 5);
+      autofill(2, 1);
 
       expect(hot.getSourceData()).toEqual([
-        ['=A10', '=C6', '=C10', '=E6', '=E10'],
-        ['=C10', '=E6', '=E10', '=G6', '=G10'],
-        ['=E10', '=G6', '=G10', '=I6', '=I10'],
+        ['y', '=A10', '=C6', '=C10', '=E6', '=E10'],
+        ['y', '=C10', '=E6', '=E10', '=G6', '=G10'],
+        ['y', '=E10', '=G6', '=G10', '=I6', '=I10'],
       ]);
     });
 
     it('should correctly autofill - range, left, odd', () => {
       const hot = handsontable({
-        data: [['x', 'x', 'x', 'x', 'x', 'x', '=Z3', '=Z5', '=Z8']],
+        data: [['y', 'x', 'x', 'x', 'x', 'x', 'x', '=Z3', '=Z5', '=Z8']],
         formulas: {
           engine: HyperFormula
         }
       });
 
-      selectCell(0, 6, 0, 8);
-      autofill(0, 0);
+      selectCell(0, 7, 0, 9);
+      autofill(0, 1);
 
       expect(hot.getSourceData()).toEqual([
-        ['=T3', '=T5', '=T8', '=W3', '=W5', '=W8', '=Z3', '=Z5', '=Z8']
+        ['y', '=T3', '=T5', '=T8', '=W3', '=W5', '=W8', '=Z3', '=Z5', '=Z8']
       ]);
     });
 
@@ -1427,6 +1463,7 @@ describe('Formulas general', () => {
     it('should correctly autofill - range, up, overflow', () => {
       const hot = handsontable({
         data: [
+          ['y', 'y'],
           ['x', 'x'],
           ['x', 'x'],
           ['x', 'x'],
@@ -1441,10 +1478,11 @@ describe('Formulas general', () => {
         }
       });
 
-      selectCell(5, 0, 7, 1);
-      autofill(0, 1);
+      selectCell(6, 0, 8, 1);
+      autofill(1, 1);
 
       expect(hot.getSourceData()).toEqual([
+        ['y', 'y'],
         ['=G1', '=G4'],
         ['=I1', '=I4'],
         ['=E4', '=E7'],
@@ -1458,17 +1496,17 @@ describe('Formulas general', () => {
 
     it('should correctly autofill - range, up, even', () => {
       const hot = handsontable({
-        data: [['x'], ['x'], ['x'], ['x'], ['x'], ['x'], ['=A9'], ['=A12']],
+        data: [['y'], ['x'], ['x'], ['x'], ['x'], ['x'], ['x'], ['=A9'], ['=A12']],
         formulas: {
           engine: HyperFormula
         }
       });
 
-      selectCell(6, 0, 7, 0);
-      autofill(0, 0);
+      selectCell(7, 0, 8, 0);
+      autofill(1, 0);
 
       expect(hot.getSourceData()).toEqual([
-        ['=A3'], ['=A6'], ['=A5'], ['=A8'], ['=A7'], ['=A10'], ['=A9'], ['=A12']
+        ['y'], ['=A3'], ['=A6'], ['=A5'], ['=A8'], ['=A7'], ['=A10'], ['=A9'], ['=A12']
       ]);
     });
   });

--- a/src/plugins/formulas/__tests__/formulas.spec.js
+++ b/src/plugins/formulas/__tests__/formulas.spec.js
@@ -1181,7 +1181,7 @@ describe('Formulas general', () => {
       expect(hot.getSourceData()).toEqual([['=A1', 'x', 'x']]);
     });
 
-    it('should not autofill if `beforeAutofill` returned values', () => {
+    it('should not use the plugin\'s autofill if `beforeAutofill` returned values', () => {
       const hot = handsontable({
         data: [
           ['=A1', 'x', 'x'],

--- a/src/plugins/formulas/autofill.js
+++ b/src/plugins/formulas/autofill.js
@@ -4,151 +4,152 @@
  * @param {object} pluginInstance The formulas plugin instance.
  */
 export const registerAutofillHooks = (pluginInstance) => {
-  const lastAutofillSource = { value: undefined };
+  /**
+   * The array of arrays used to check if no values were returned from
+   * `beforeAutofill`, other than our own.
+   * */
+  const sentinel = [[]];
 
   // Block autofill operation if at least one of the underlying's cell
   // contents cannot be set, e.g. if there's a matrix underneath.
-  pluginInstance.addHook('beforeAutofill', (start, end) => {
-    const width = Math.abs(start.col - end.col) + 1;
-    const height = Math.abs(start.row - end.row) + 1;
+  pluginInstance.addHook('beforeAutofill', (_, __, target) => {
+    const width = target.to.col - target.from.col + 1;
+    const height = target.to.row - target.from.row + 1;
 
-    const row = Math.min(start.row, end.row);
-    const col = Math.min(start.col, end.col);
+    const row = target.from.row;
+    const col = target.from.col;
 
     if (
-      !pluginInstance.engine.isItPossibleToSetCellContents({
+      pluginInstance.engine.isItPossibleToSetCellContents({
         sheet: pluginInstance.engine.getSheetId(pluginInstance.sheetName),
         row,
         col
       }, width, height)
     ) {
-      return false;
+      return sentinel;
     }
   });
 
-  // Abuse the `modifyAutofillRange` hook to get the autofill start coordinates.
-  pluginInstance.addHook('modifyAutofillRange', (_, entireArea) => {
-    const [startRow, startCol, endRow, endCol] = entireArea;
+  pluginInstance.addHook('afterAutofill', (fillData, source, target, direction) => {
+    // Check that the `fillData` used for autofill was the same that we
+    // returned from `beforeAutofill`. This lets end users override this
+    // plugin's autofill with their own behaviors.
+    if (fillData !== sentinel) {
+      return;
+    }
 
-    lastAutofillSource.value = {
-      start: {
-        row: startRow,
-        col: startCol
-      },
-      end: {
-        row: endRow,
-        col: endCol
-      }
-    };
-  });
-
-  // Abuse pluginInstance hook to easily figure out the direction of the autofill
-  pluginInstance.addHook('beforeAutofillInsidePopulate', (index, direction, _input, _deltas, _, selected) => {
-    const autofillTargetSize = {
-      width: selected.col,
-      height: selected.row
+    const sourceSize = {
+      width: source.to.col - source.from.col + 1,
+      height: source.to.row - source.from.row + 1
     };
 
-    const autofillSourceSize = {
-      width: Math.abs(lastAutofillSource.value.start.col - lastAutofillSource.value.end.col) + 1,
-      height: Math.abs(lastAutofillSource.value.start.row - lastAutofillSource.value.end.row) + 1
+    const targetSize = {
+      width: target.to.col - target.from.col + 1,
+      height: target.to.row - target.from.row + 1
     };
 
-    const paste = (
-      // The cell we're copy'ing to let HyperFormula adjust the references properly
-      sourceCellCoordinates,
+    const sheet = pluginInstance.engine.getSheetId(pluginInstance.sheetName);
 
-      // The cell we're pasting into
-      targetCellCoordinates
-    ) => {
-      pluginInstance.engine.copy({
-        sheet: pluginInstance.engine.getSheetId(pluginInstance.sheetName),
-        row: sourceCellCoordinates.row,
-        col: sourceCellCoordinates.col
-      }, 1, 1);
-
-      const [{ address }] = pluginInstance.engine.paste({
-        sheet: pluginInstance.engine.getSheetId(pluginInstance.sheetName),
-        row: targetCellCoordinates.row,
-        col: targetCellCoordinates.col
-      });
-
-      const value = pluginInstance.engine.getCellSerialized(address);
-
-      return { value };
-    };
-
-    // Pretty much reimplements the logic from `src/plugins/autofill/autofill.js#fillIn`
     switch (direction) {
       case 'right': {
-        const targetCellCoordinates = {
-          row: lastAutofillSource.value.start.row + index.row,
-          col: lastAutofillSource.value.start.col + index.col + autofillSourceSize.width
-        };
+        const pasteRow = source.from.row;
 
-        const sourceCellCoordinates = {
-          row: lastAutofillSource.value.start.row + index.row,
-          col: (index.col % autofillSourceSize.width) + lastAutofillSource.value.start.col
-        };
+        for (let pasteCol = target.from.col; pasteCol <= target.to.col; pasteCol += sourceSize.width) {
+          const remaining = target.to.col - pasteCol + 1;
+          const width = Math.min(sourceSize.width, remaining);
 
-        return paste(sourceCellCoordinates, targetCellCoordinates);
-      }
+          pluginInstance.engine.copy({
+            sheet,
+            row: source.from.row,
+            col: source.from.col
+          }, width, sourceSize.height);
 
-      case 'left': {
-        const targetCellCoordinates = {
-          row: lastAutofillSource.value.start.row + index.row,
-          col: lastAutofillSource.value.start.col + index.col - autofillTargetSize.width
-        };
+          pluginInstance.engine.paste({
+            sheet,
+            row: pasteRow,
+            col: pasteCol
+          });
+        }
 
-        const fillOffset = autofillTargetSize.width % autofillSourceSize.width;
-
-        const sourceCellCoordinates = {
-          row: lastAutofillSource.value.start.row + index.row,
-          col:
-          ((autofillSourceSize.width - fillOffset + index.col) %
-            autofillSourceSize.width) +
-          lastAutofillSource.value.start.col,
-        };
-
-        return paste(sourceCellCoordinates, targetCellCoordinates);
+        break;
       }
 
       case 'down': {
-        const targetCellCoordinates = {
-          row: lastAutofillSource.value.start.row + index.row + autofillSourceSize.height,
-          col: lastAutofillSource.value.start.col + index.col
-        };
+        const pasteCol = source.from.col;
 
-        const sourceCellCoordinates = {
-          row: (index.row % autofillSourceSize.height) + lastAutofillSource.value.start.row,
-          col: lastAutofillSource.value.start.col + index.col
-        };
+        for (let pasteRow = target.from.row; pasteRow <= target.to.row; pasteRow += sourceSize.height) {
+          const remaining = target.to.row - pasteRow + 1;
+          const height = Math.min(sourceSize.height, remaining);
 
-        return paste(sourceCellCoordinates, targetCellCoordinates);
+          pluginInstance.engine.copy({
+            sheet,
+            row: source.from.row,
+            col: source.from.col
+          }, sourceSize.width, height);
+
+          pluginInstance.engine.paste({
+            sheet,
+            row: pasteRow,
+            col: pasteCol
+          });
+        }
+
+        break;
+      }
+
+      case 'left': {
+        const pasteRow = source.from.row;
+
+        for (let pasteCol = target.from.col; pasteCol <= target.to.col; pasteCol++) {
+          const offset = targetSize.width % sourceSize.width;
+          const copyCol =
+            ((sourceSize.width - offset + (pasteCol - target.from.col)) % sourceSize.width) + source.from.col;
+
+          pluginInstance.engine.copy({
+            sheet,
+            row: source.from.row,
+            col: copyCol
+          }, 1, sourceSize.height);
+
+          pluginInstance.engine.paste({
+            sheet,
+            row: pasteRow,
+            col: pasteCol
+          });
+        }
+
+        break;
       }
 
       case 'up': {
-        const targetCellCoordinates = {
-          row: lastAutofillSource.value.start.row + index.row - autofillTargetSize.height,
-          col: lastAutofillSource.value.start.col + index.col
-        };
+        const pasteCol = source.from.col;
 
-        const fillOffset = autofillTargetSize.height % autofillSourceSize.height;
+        for (let pasteRow = target.from.row; pasteRow <= target.to.row; pasteRow++) {
+          const offset = targetSize.height % sourceSize.height;
+          const copyRow =
+            ((sourceSize.height - offset + (pasteRow - target.from.row)) % sourceSize.height) + source.from.row;
 
-        const sourceCellCoordinates = {
-          row:
-          ((autofillSourceSize.height - fillOffset + index.row) %
-            autofillSourceSize.height) +
-          lastAutofillSource.value.start.row,
-          col: lastAutofillSource.value.start.col + index.col,
-        };
+          pluginInstance.engine.copy({
+            sheet,
+            row: copyRow,
+            col: source.from.col
+          }, sourceSize.width, 1);
 
-        return paste(sourceCellCoordinates, targetCellCoordinates);
+          pluginInstance.engine.paste({
+            sheet,
+            row: pasteRow,
+            col: pasteCol
+          });
+        }
+
+        break;
       }
 
       default: {
         throw new Error('Unexpected direction parameter');
       }
     }
+
+    pluginInstance.hot.render();
   });
 };

--- a/src/plugins/formulas/autofill.js
+++ b/src/plugins/formulas/autofill.js
@@ -48,7 +48,7 @@ export const registerAutofillHooks = (pluginInstance) => {
       height: target.to.row - target.from.row + 1
     };
 
-    const sheet = pluginInstance.engine.getSheetId(pluginInstance.sheetName);
+    const sheet = pluginInstance.sheetId;
 
     switch (direction) {
       case 'right': {

--- a/src/plugins/formulas/autofill.js
+++ b/src/plugins/formulas/autofill.js
@@ -149,7 +149,5 @@ export const registerAutofillHooks = (pluginInstance) => {
         throw new Error('Unexpected direction parameter');
       }
     }
-
-    pluginInstance.hot.render();
   });
 };

--- a/src/plugins/formulas/autofill.js
+++ b/src/plugins/formulas/autofill.js
@@ -30,6 +30,8 @@ export const registerAutofillHooks = (pluginInstance) => {
     ) {
       return sentinel;
     }
+
+    return false;
   });
 
   pluginInstance.addHook('afterAutofill', (fillData, source, target, direction) => {

--- a/src/plugins/formulas/formulas.js
+++ b/src/plugins/formulas/formulas.js
@@ -488,6 +488,10 @@ export class Formulas extends BasePlugin {
       return change?.address?.sheet === this.sheetId;
     });
 
+    // TODO, important - skip during autofill. Possible solutions include:
+    // 1. rewriting the autofill logic in so that it calls `copy` at most twice,
+    // 2. allowing `copy` in hyperformula batching.
+    // 3. use the internal operation property, but it might be error prone.
     if (isAffectedByChange) {
       this.hot.render();
     }

--- a/src/plugins/formulas/formulas.js
+++ b/src/plugins/formulas/formulas.js
@@ -488,10 +488,6 @@ export class Formulas extends BasePlugin {
       return change?.address?.sheet === this.sheetId;
     });
 
-    // TODO, important - skip during autofill. Possible solutions include:
-    // 1. rewriting the autofill logic in so that it calls `copy` at most twice,
-    // 2. allowing `copy` in hyperformula batching.
-    // 3. use the internal operation property, but it might be error prone.
     if (isAffectedByChange) {
       this.hot.render();
     }


### PR DESCRIPTION
### Context
Implements changes requested in https://github.com/handsontable/handsontable/pull/7648#discussion_r616770532.

The gut of the change was to rework the signatures of both `beforeAutofill` and `afterAutofill`, in order to pass all needed information to the autofill implementation in the hf plugin in a mannered way.

Also changed the autofill logic to not work on singular cells anymore, but rather on larger ranges.

Please see the `TODO` in `src/plugins/formulas/formulas.js`.