### PR TITLE
[hf] Fix initialization with an array of objects

### DIFF
--- a/src/plugins/formulas/__tests__/formulas.spec.js
+++ b/src/plugins/formulas/__tests__/formulas.spec.js
@@ -19,6 +19,51 @@ describe('Formulas general', () => {
     }
   });
 
+  it('should initialize the plugin properly with an array of arrays', () => {
+    const hot = handsontable({
+      data: [['10', '=A1 * 2']],
+      formulas: {
+        engine: HyperFormula
+      }
+    });
+
+    expect(hot.getSourceData()).toEqual([['10', '=A1 * 2']]);
+  });
+
+  it('should initialize the plugin properly with an array of objects', () => {
+    const hot = handsontable({
+      data: [
+        { num: 1, double: '=A1 * 2' },
+        { num: 2, double: '=A2 * 2' },
+        { num: 3, double: '=A3 * 2' },
+        { num: 4, double: '=A4 * 2' },
+        { num: 5, double: '=A5 * 2' },
+      ],
+      formulas: {
+        engine: HyperFormula
+      },
+      columns: [{ data: 'num' }, { data: 'double' }]
+    });
+
+    expect(hot.getSourceDataArray()).toEqual([
+      [1, '=A1 * 2'],
+      [2, '=A2 * 2'],
+      [3, '=A3 * 2'],
+      [4, '=A4 * 2'],
+      [5, '=A5 * 2']
+    ]);
+
+    hot.setDataAtCell(0, 0, 10);
+
+    expect(hot.getSourceDataArray()).toEqual([
+      [10, '=A1 * 2'],
+      [2, '=A2 * 2'],
+      [3, '=A3 * 2'],
+      [4, '=A4 * 2'],
+      [5, '=A5 * 2']
+    ]);
+  });
+
   it('should calculate table (simple example)', () => {
     const hot = handsontable({
       data: getDataSimpleExampleFormulas(),

--- a/src/plugins/formulas/formulas.js
+++ b/src/plugins/formulas/formulas.js
@@ -357,7 +357,7 @@ export class Formulas extends BasePlugin {
 
     const address = {
       row: this.hot.toVisualRow(row),
-      col,
+      col: this.hot.propToCol(col),
       sheet: this.engine.getSheetId(this.sheetName)
     };
 


### PR DESCRIPTION
### Context

Initializing the plugin alongside `data` in the form of an array of objects would yield in a bug where cell source data would be null which resulted in always empty editors. This PR fixes the above.

This seems to be wrong https://github.com/handsontable/handsontable/blob/e8e8f30bbe1677cda0b2ab62e166f77b64531994/src/pluginHooks.js#L1023

[skip changelog]