### PR TITLE
Add support for fuzzy search in the API reference

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -135,7 +135,8 @@ module.exports = {
     sidebar: helpers.getSidebars(),
     search: true,
     searchPlaceholder: 'Search guides and API...',
-    searchMaxSuggestions: 15,
+    searchMaxGuidesSuggestions: 5,
+    searchMaxAPISuggestions: 10,
     fuzzySearchDomains: ['Core', 'Hooks', 'Options'],
   }
 };

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -135,6 +135,7 @@ module.exports = {
     sidebar: helpers.getSidebars(),
     search: true,
     searchPlaceholder: 'Search guides and API...',
-    searchMaxSuggestions: 10
+    searchMaxSuggestions: 15,
+    fuzzySearchDomains: ['Core', 'Hooks', 'Options'],
   }
 };


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
The PR adds the ability to turn on/off the fuzzy search mode for the specified context. Currently, I set the fuzzy search mode for API reference for **Core**, **Hooks**, and **Options** props and methods.

I've tested the changes and compared the results with the previous docs engine and the results are similar. 

#### For word "wrap":
Without fuzzy search:
![wrap_before](https://user-images.githubusercontent.com/571316/117940130-0bdc5a00-b309-11eb-97b4-29ebeb0fdd31.png)
With fuzzy search:
![wrap_after](https://user-images.githubusercontent.com/571316/117940178-1a2a7600-b309-11eb-8c60-5782741b5c47.png)

#### For word "prop":
Without fuzzy search:
![prop_before](https://user-images.githubusercontent.com/571316/117940287-34fcea80-b309-11eb-8dba-007832cf9f28.png)
With fuzzy search:
![prop_after](https://user-images.githubusercontent.com/571316/117940301-38907180-b309-11eb-963d-dc2a149fb930.png)

The side-effect of using fuzzy search is that the search suggestion limit can be easily reached. It seems reasonable to increase the limit to `15`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7999
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
