### PR TITLE
Fix H1 header scroll positioning

### DIFF
--- a/docs/.vuepress/theme/styles/index.styl
+++ b/docs/.vuepress/theme/styles/index.styl
@@ -29,7 +29,11 @@ body, html, #app {
   min-height 100vh;
 }
 
-.hidden{
+body div {
+  user-select: initial;
+}
+
+.hidden {
   display none
 }
 
@@ -41,14 +45,15 @@ a.source-code-link{
   color #444
 }
 
-body div {
-  user-select: initial;
-}
-  
-.theme-default-content:not(.custom) > h1, .theme-default-content:not(.custom) > h2, .theme-default-content:not(.custom) > h3, .theme-default-content:not(.custom) > h4, .theme-default-content:not(.custom) > h5, .theme-default-content:not(.custom) > h6 {
+.theme-default-content:not(.custom) > h1,
+.theme-default-content:not(.custom) > h2,
+.theme-default-content:not(.custom) > h3,
+.theme-default-content:not(.custom) > h4,
+.theme-default-content:not(.custom) > h5,
+.theme-default-content:not(.custom) > h6 {
   margin-top: -2.8rem;
 }
-  
+
 /* Layout */
 
 .navbar {
@@ -68,11 +73,11 @@ body div {
     padding: 0 2.5rem 0 5rem!important;
   }
 }
-  
+
 .page-nav {
   margin-top: 1rem!important;
 }
-  
+
 .page-edit {
   margin-top: 20px!important;
 }
@@ -126,6 +131,9 @@ body div {
 h1 {
   font-size: 2rem;
   margin-bottom: 2rem!important;
+  /* Fix for anchor correct scroll positioning */
+  padding-top: 3.6rem!important;
+  margin-top: -2.8rem!important;
 }
 
 h2 {
@@ -243,7 +251,7 @@ div.js-fiddle-link {
   }
 }
 
-.page-edit .edit-link a, .page-edit .last-updated .prefix, 
+.page-edit .edit-link a, .page-edit .last-updated .prefix,
 .page-edit .last-updated .time {
 //color: #2c3e50!important;
 }
@@ -251,7 +259,7 @@ div.js-fiddle-link {
 .page-nav .inner {
   border-color: #e9eef2!important;
 }
-  
+
 /* A navigation element containing clickable fields (columns) */
 .row-items-container {
   margin: 30px 0 30px;
@@ -277,17 +285,17 @@ div.js-fiddle-link {
       width: calc(50% - 28px);
       margin-bottom: 10px;
     }
-    
+
     &:hover {
       text-decoration: none!important;
       box-shadow: 0 3px 12px #e9eef2;
     }
-    
+
     img {
       margin-top: 14px;
       max-height: 45px;
     }
-    
+
     h3 {
       margin-top: 10px;
       padding-top: 0!important;
@@ -311,26 +319,26 @@ kbd {
   border-bottom-width: 2px;
   background: #fafbff;
 }
-  
+
 /* Styles for the icon-pack page */
 
 .icons-wrapper {
   margin-top: 30px;
   text-align: center;
-  
+
   & > div {
     display: inline-block;
     width: 19%;
     margin: 0 0 2.4rem 0;
     line-height: 1;
   }
-  
+
   svg {
     width: 48px;
     height: 48px;
     fill: #282c34;
   }
-  
+
   span {
     padding: 0 10px;
     display: block;

--- a/docs/.vuepress/theme/styles/index.styl
+++ b/docs/.vuepress/theme/styles/index.styl
@@ -37,7 +37,7 @@ body div {
   display none
 }
 
-a.source-code-link{
+a.source-code-link {
   font-size 12px
   float right
   top -34px
@@ -45,15 +45,11 @@ a.source-code-link{
   color #444
 }
 
-.theme-default-content:not(.custom) > h1,
-.theme-default-content:not(.custom) > h2,
-.theme-default-content:not(.custom) > h3,
 .theme-default-content:not(.custom) > h4,
 .theme-default-content:not(.custom) > h5,
 .theme-default-content:not(.custom) > h6 {
   margin-top: -2.8rem;
 }
-
 /* Layout */
 
 .navbar {
@@ -70,16 +66,16 @@ a.source-code-link{
   padding: 0 2rem 0;
 
   @media (min-width: $MQNarrow) {
-    padding: 0 2.5rem 0 5rem!important;
+    padding: 0 2.5rem 0 5rem !important;
   }
 }
 
 .page-nav {
-  margin-top: 1rem!important;
+  margin-top: 1rem !important;
 }
 
 .page-edit {
-  margin-top: 20px!important;
+  margin-top: 20px !important;
 }
 
 .theme-default-content:not(.custom) {
@@ -130,24 +126,28 @@ a.source-code-link{
 /* Larger bottom gap of H1, H2, H3 */
 h1 {
   font-size: 2rem;
-  margin-bottom: 2rem!important;
+  margin-bottom: 2rem !important;
   /* Fix for anchor correct scroll positioning */
-  padding-top: 3.6rem!important;
-  margin-top: -2.8rem!important;
+  padding-top: 4.6rem !important;
+  margin-top: -3.8rem !important;
 }
 
 h2 {
-  margin-bottom: 1rem!important;
+  margin-bottom: 1rem !important;
   padding-bottom: 6px;
-  padding-top: 3.6rem!important;
   font-size: 1.55rem;
   border-color: #e9eef2;
+  /* Fix for anchor correct scroll positioning */
+  padding-top: 5rem !important;
+  margin-top: -4.1rem !important;
 }
 
 h3 {
-  margin-bottom: 1rem!important;
-  padding-top: 3.6rem!important;
+  margin-bottom: 1rem !important;
   font-size: 1.25rem;
+  /* Fix for anchor correct scroll positioning */
+  padding-top: 5.1rem !important;
+  margin-top: -4.6rem !important;
 }
 
 .page {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
I fixed the H1 header scroll positioning by applying the `margin-top` and `padding-top` CSS properties. The original position of the header is the same as previously. Only the scroll position is changed when the anchor link is clicked.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #8006
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
