### PR TITLE
Improve the Selection demos and fix visual glitches

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -69,7 +69,6 @@ module.exports = {
 
         // overwrite markdown `render` function to allow extending tokens array (remove caching before loop).
         md.renderer.render = (tokens, options, env) => render.call(md.renderer, tokens, options, env);
-
       },
       chainMarkdown(config) {
         // inject custom markdown highlight with our snippet runner

--- a/docs/.vuepress/containers/examples/examples.js
+++ b/docs/.vuepress/containers/examples/examples.js
@@ -100,7 +100,7 @@ module.exports = {
           ${jsfiddle(id, htmlContent, jsContent, cssContent, version, preset)}
           <tabs :options="{ useUrlFragment: false, defaultTabHash: 'code' }"
             @changed="$parent.$parent.codePreviewTabChanged(...arguments, '${id}')">
-          <tab name="Preview">
+          <tab name="Preview" hot-example-id="${id}">
             <style v-pre>${cssContent}</style>
             <div v-pre>${htmlContent}</div>
             <script data-jsfiddle="${id}" v-pre>

--- a/docs/.vuepress/containers/examples/examples.js
+++ b/docs/.vuepress/containers/examples/examples.js
@@ -98,13 +98,14 @@ module.exports = {
 
       return `
           ${jsfiddle(id, htmlContent, jsContent, cssContent, version, preset)}
-          <tabs :options="{ useUrlFragment: false, defaultTabHash: 'code' }">
+          <tabs :options="{ useUrlFragment: false, defaultTabHash: 'code' }"
+            @changed="$parent.$parent.codePreviewTabChanged(...arguments, '${id}')">
           <tab name="Preview">
-              <style v-pre>${cssContent}</style>
-              <div v-pre>${htmlContent}</div>
-              <script data-jsfiddle="${id}" v-pre>
-                  useHandsontable('${version}', function(){${code}}, '${preset}');
-              </script>
+            <style v-pre>${cssContent}</style>
+            <div v-pre>${htmlContent}</div>
+            <script data-jsfiddle="${id}" v-pre>
+                useHandsontable('${version}', function(){${code}}, '${preset}');
+            </script>
           </tab>
         `;
     } else { // close preview

--- a/docs/.vuepress/handsontable-manager/register.js
+++ b/docs/.vuepress/handsontable-manager/register.js
@@ -7,7 +7,11 @@ register.listen = () => {
     if (typeof Handsontable !== 'undefined' && Handsontable._instanceRegisterInstalled === undefined) {
       Handsontable._instanceRegisterInstalled = true;
       Handsontable.hooks.add('afterInit', function() {
-        register.set(this.rootElement.id, this);
+        const hotId = this.rootElement
+          .closest('[hot-example-id]')
+          .getAttribute('hot-example-id');
+
+        register.set(hotId, this);
       });
     }
   } catch (e) {

--- a/docs/.vuepress/handsontable-manager/register.js
+++ b/docs/.vuepress/handsontable-manager/register.js
@@ -1,13 +1,13 @@
 /* eslint-disable no-restricted-globals, no-undef, no-console, no-unused-vars */
 
-const register = new Set();
+const register = new Map();
 
 register.listen = () => {
   try {
     if (typeof Handsontable !== 'undefined' && Handsontable._instanceRegisterInstalled === undefined) {
       Handsontable._instanceRegisterInstalled = true;
       Handsontable.hooks.add('afterInit', function() {
-        register.add(this);
+        register.set(this.rootElement.id, this);
       });
     }
   } catch (e) {

--- a/docs/.vuepress/theme/components/Page.vue
+++ b/docs/.vuepress/theme/components/Page.vue
@@ -19,10 +19,19 @@ export default {
   components: { PageEdit, PageNav },
   props: ['sidebarItems'],
   computed:{
-    isApi(){
+    isApi() {
       return this.$route.fullPath.match(/([^/]*\/)?api\//);
     }
-  }
+  },
+  methods: {
+    codePreviewTabChanged(selectedTab, hotId) {
+      const hot = window.instanceRegister.get(hotId);
+
+      if (selectedTab.tab.computedId === 'preview' && hot) {
+        hot.render();
+      }
+    }
+  },
 }
 </script>
 

--- a/docs/next/guides/cell-features/selection.md
+++ b/docs/next/guides/cell-features/selection.md
@@ -84,7 +84,7 @@ To retrieve the selected cells as an array of arrays, you should use the `getSel
 </div>
 ```
 ```css
-#output{
+#output {
   margin: 16px 0 7px;
   width: 100%;
   height: 160px;
@@ -116,13 +116,13 @@ const settings = {
 const hot = new Handsontable(container, settings);
 
 getButton.addEventListener('click', event => {
-  const selected = hot.getSelected();
+  const selected = hot.getSelected() || [];
   const data = [];
 
   for (let i = 0; i < selected.length; i += 1) {
     const item = selected[i];
-    
-    data.push(hot.getData.apply(hot, item));
+
+    data.push(hot.getData(...item));
   }
 
   output.innerText = JSON.stringify(data, null, 2);
@@ -139,8 +139,8 @@ You may want to delete, format, or otherwise change the selected cells. For exam
 <div id="example3" class="hot"></div>
 
 <div id="buttons" class="controls" style="margin-top: 10px">
-  <button id="setButton">Set data</button>
-  <button id="addButton">Add class</button>
+  <button id="set-data-action">Change selected data</button>
+  <button id="add-css-class-action">Make selected cells red</button>
 </div>
 ```
 ```css
@@ -168,23 +168,25 @@ const settings = {
 const hot = new Handsontable(container, settings);
 
 buttons.addEventListener('click', event => {
-  const selected = hot.getSelected();
+  const selected = hot.getSelected() || [];
   const target = event.target.id;
 
+  hot.suspendRender();
+
   for (let index = 0; index < selected.length; index += 1) {
-    const item = selected[index];
-    const startRow = Math.min(item[0], item[2]);
-    const endRow = Math.max(item[0], item[2]);
-    const startCol = Math.min(item[1], item[3]);
-    const endCol = Math.max(item[1], item[3]);
+    const [row1, column1, row2, column2] = selected[index];
+    const startRow = Math.max(Math.min(row1, row2), 0);
+    const endRow = Math.max(row1, row2);
+    const startCol = Math.max(Math.min(column1, column2), 0);
+    const endCol = Math.max(column1, column2);
 
     for (let rowIndex = startRow; rowIndex <= endRow; rowIndex += 1) {
       for (let columnIndex = startCol; columnIndex <= endCol; columnIndex += 1) {
-        if (target === 'setButton') {
+        if (target === 'set-data-action') {
           hot.setDataAtCell(rowIndex, columnIndex, 'data changed');
         }
 
-        if (target === 'addButton') {
+        if (target === 'add-css-class-action') {
           hot.setCellMeta(rowIndex, columnIndex, 'className', 'c-red');
         }
       }
@@ -192,6 +194,7 @@ buttons.addEventListener('click', event => {
   }
 
   hot.render();
+  hot.resumeRender();
 });
 ```
 :::
@@ -211,5 +214,3 @@ By default, the cell selection "jumps" to the other end of the row or column dur
 Select any cell in the first row and press <kbd>ARROW UP</kbd> to jump to the last cell in the current column. The same thing happens when you are in first column and press <kbd>ARROW LEFT</kbd> - the selection jumps to the last column.
 
  This behavior can be disabled by setting `autoWrapCol: false` and `autoWrapRow: false`.
-
-


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The commit improves the demo that is used to show how the cells data or cells meta influences the table. I increase the demo main loop performance by using the suspend rendering API.

Additionally, the commit includes a fix for demo preview tabs. Currently, tabs Vue component remembers the last selected tab. When the remembered tab is other than "Preview", the Handsontable is initialized within a hidden element. That causes glitches that appear after switching to the "Preview" tab. The fix internally calls the `render` method of the Handsontable instance. Thanks to that, the table can be appropriately calculated.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #8027
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
