### PR TITLE
[hf] Fix performance on `HyperFormula#setCellContents`

### DIFF
--- a/src/plugins/formulas/__tests__/formulas.spec.js
+++ b/src/plugins/formulas/__tests__/formulas.spec.js
@@ -1714,6 +1714,27 @@ describe('Formulas general', () => {
     });
   });
 
+  it('should not render multiple times when updating many cells', () => {
+    const afterRender = jasmine.createSpy();
+
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(10, 10),
+      formulas: {
+        engine: HyperFormula
+      },
+      afterRender
+    });
+
+    expect(afterRender).toHaveBeenCalledTimes(1);
+
+    selectCell(1, 1, 5, 5);
+
+    spec().$container.find('textarea.handsontableInput').simulate('keydown', { keyCode: 46 });
+    spec().$container.find('textarea.handsontableInput').simulate('keyup', { keyCode: 46 });
+
+    expect(afterRender).toHaveBeenCalledTimes(2);
+  });
+
   xdescribe('column sorting', () => {
     it('should recalculate all formulas and update theirs cell coordinates if needed', () => {
       const hot = handsontable({


### PR DESCRIPTION
### Context
Before the changes in this PR, when updating a range of cells, every single cell within the range would result in a `hot.render()` call. This of course made the table unusable after operations such as clearing the whole table with `cmd+a` -> `delete` as it would cause as many extra re-renders as there were cells in the table.

This PR should make everything feel snappy again.

I didn't implement the solution proposed in https://github.com/handsontable/handsontable/issues/7663#issuecomment-820729437 as this approach was just a lot less time consuming.

[skip changelog]