### PR TITLE
New docs: Possibility to set default active tab.

### DIFF
--- a/docs/.vuepress/containers/sourceCodeLink.js
+++ b/docs/.vuepress/containers/sourceCodeLink.js
@@ -1,5 +1,5 @@
 /**
- * Matches into: `example #ID .class :preset --html 0 --js 1 --hidden`.
+ * Matches into: `source-code-link https://github.com/handsontable/handsontable`.
  *
  * @type {RegExp}
  */

--- a/docs/next/guides/getting-started/events-and-hooks.md
+++ b/docs/next/guides/getting-started/events-and-hooks.md
@@ -289,7 +289,6 @@ const hot = new Handsontable(container, {
   colHeaders: true,
   rowHeaders: true,
   minSpareRows: 1,
-  licenseKey: 'non-commercial-and-evaluation',
   beforeChange(changes, source) {
     lastChange = changes;
   },


### PR DESCRIPTION
### Context

* Add possibility to select default active tab by using `--tab` 
* Change the order of tabs,
* Disable selected tab caching: refreshing a page will not cache which tab was open.

### Related issue(s):
1. resolves #8036 
2. resolves https://github.com/handsontable/handsontable/projects/6#card-61110485
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
