### PR TITLE
Fix failing E2E test on IE

### DIFF
--- a/src/plugins/formulas/__tests__/initialization.spec.js
+++ b/src/plugins/formulas/__tests__/initialization.spec.js
@@ -51,14 +51,7 @@ describe('Formulas general', () => {
 
   describe('Single Handsontable setup', () => {
     it('should throw a warning, when no `hyperformula` key was passed to the `formulas` settings', () => {
-      /* eslint-disable no-console */
-      const warnSpy = jasmine.createSpyObj('warning', ['test']);
-      const prevWarn = console.warn;
-
-      console.warn = (...args) => {
-        warnSpy.test(...args);
-        prevWarn(...args);
-      };
+      spyOn(console, 'warn');
 
       const hot = handsontable({
         data: getDataSimpleExampleFormulas(),
@@ -66,12 +59,10 @@ describe('Formulas general', () => {
         licenseKey: 'non-commercial-and-evaluation'
       });
 
-      expect(warnSpy.test).toHaveBeenCalledWith('Missing the required `engine` key in the Formulas settings. ' +
+      // eslint-disable-next-line no-console
+      expect(console.warn).toHaveBeenCalledWith('Missing the required `engine` key in the Formulas settings. ' +
         'Please fill it with either an engine class or an engine instance.');
       expect(hot.getPlugin('formulas').enabled).toBe(false);
-
-      console.warn = prevWarn;
-      /* eslint-enable no-console */
     });
 
     it('should initialize a single working Handsontable instance and a single HyperFormula instance, when HF class' +
@@ -722,14 +713,7 @@ describe('Formulas general', () => {
 
     it('should throw a warning when trying to register two named expressions under the same name (and register only' +
       ' the first one)', () => {
-      /* eslint-disable no-console */
-      const warnSpy = jasmine.createSpyObj('warning', ['test']);
-      const prevWarn = console.warn;
-
-      console.warn = (...args) => {
-        warnSpy.test(...args);
-        prevWarn(...args);
-      };
+      spyOn(console, 'warn');
 
       handsontable({
         data: [['=MyLocal']],
@@ -751,10 +735,8 @@ describe('Formulas general', () => {
       });
 
       expect(getDataAtCell(0, 0)).toEqual(1234);
-      expect(warnSpy.test).toHaveBeenCalledTimes(1);
-
-      console.warn = prevWarn;
-      /* eslint-enable no-console */
+      // eslint-disable-next-line no-console
+      expect(console.warn).toHaveBeenCalledTimes(1);
     });
 
     it('should register custom function plugins before creating the HF instance', () => {
@@ -799,14 +781,7 @@ describe('Formulas general', () => {
     // TODO: uncomment after it's throwing a duplicated name error on HF's side.
     xit('should throw a warning when trying to register two custom functions under the same name (and register only' +
       ' the first one)', () => {
-      /* eslint-disable no-console */
-      const warnSpy = jasmine.createSpyObj('warning', ['test']);
-      const prevWarn = console.warn;
-
-      console.warn = (...args) => {
-        warnSpy.test(...args);
-        prevWarn(...args);
-      };
+      spyOn(console, 'warn');
 
       class CustomFP extends FunctionPlugin {
         customFP() {
@@ -850,10 +825,8 @@ describe('Formulas general', () => {
       });
 
       expect(getDataAtCell(0, 0)).toEqual('customFP output');
-      expect(warnSpy.test).toHaveBeenCalledTimes(1);
-
-      console.warn = prevWarn;
-      /* eslint-enable no-console */
+      // eslint-disable-next-line no-console
+      expect(console.warn).toHaveBeenCalledTimes(1);
 
       // cleanup
       HyperFormula.unregisterFunction('CUSTOMFP');
@@ -878,14 +851,7 @@ describe('Formulas general', () => {
 
     it('should throw a warning when trying to register two languages under the same name (and register only' +
       ' the first one)', () => {
-      /* eslint-disable no-console */
-      const warnSpy = jasmine.createSpyObj('warning', ['test']);
-      const prevWarn = console.warn;
-
-      console.warn = (...args) => {
-        warnSpy.test(...args);
-        prevWarn(...args);
-      };
+      spyOn(console, 'warn');
 
       HyperFormula.registerLanguage(plPL.langCode, plPL);
 
@@ -900,10 +866,8 @@ describe('Formulas general', () => {
       });
 
       expect(getDataAtCell(1, 0)).toEqual('test');
-      expect(warnSpy.test).toHaveBeenCalledTimes(1);
-
-      console.warn = prevWarn;
-      /* eslint-enable no-console */
+      // eslint-disable-next-line no-console
+      expect(console.warn).toHaveBeenCalledTimes(1);
 
       // cleanup
       HyperFormula.unregisterLanguage(plPL.langCode);


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the E2E tests that fail on the IE.

**Note for the reviewer:** The errors about missing the `normalize` method are fixed within another [PR](https://github.com/handsontable/hyperformula/pull/675). All other errors are fixed within this PR.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes on IE11.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #8051
2.
3.

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
