### PR TITLE
[hf] Always use physical indexes for updating/accessing HyperFormula

### DIFF
--- a/src/plugins/formulas/formulas.js
+++ b/src/plugins/formulas/formulas.js
@@ -332,13 +332,15 @@ export class Formulas extends BasePlugin {
       return;
     }
 
+    // `toPhysicalColumn` is here because of inconsistencies related to hook execution in `src/dataMap`.
     const address = {
-      row: this.hot.toVisualRow(row),
-      col: column,
+      row,
+      col: this.hot.toPhysicalColumn(column),
       sheet: this.sheetId
     };
 
     if (ioMode === 'get') {
+
       const cellValue = this.engine.getCellValue(address);
 
       // If `cellValue` is an object it is expected to be an error
@@ -365,12 +367,12 @@ export class Formulas extends BasePlugin {
    *
    * @private
    * @param {number} row Physical row index.
-   * @param {number} col Physical column index.
+   * @param {number} column Physical column index.
    * @param {object} valueHolder Object which contains original value which can be modified by overwriting `.value`
    *   property.
    * @param {string} ioMode String which indicates for what operation hook is fired (`get` or `set`).
    */
-  onModifySourceData(row, col, valueHolder, ioMode) {
+  onModifySourceData(row, column, valueHolder, ioMode) {
     if (!this.enabled || this.#internalOperationPending) {
       return;
     }
@@ -385,15 +387,25 @@ export class Formulas extends BasePlugin {
       return;
     }
 
-    const address = {
-      row: this.hot.toVisualRow(row),
-      col: this.hot.propToCol(col),
-      sheet: this.sheetId
-    };
-
     if (ioMode === 'get') {
+      const address = {
+        row,
+
+        // Workaround for inconsistencies in `src/dataSource.js`
+        col: this.hot.toPhysicalColumn(this.hot.colToProp(column)),
+        sheet: this.sheetId
+      };
+
       valueHolder.value = this.engine.getCellSerialized(address);
     } else if (ioMode === 'set') {
+      const address = {
+        row,
+
+        // Workaround for inconsistencies in `src/dataSource.js`
+        col: this.hot.toPhysicalColumn(column),
+        sheet: this.sheetId
+      };
+
       if (
         !this.engine.isItPossibleToSetCellContents(address)
       ) {

--- a/src/plugins/formulas/formulas.js
+++ b/src/plugins/formulas/formulas.js
@@ -392,7 +392,7 @@ export class Formulas extends BasePlugin {
         row,
 
         // Workaround for inconsistencies in `src/dataSource.js`
-        col: this.hot.toPhysicalColumn(this.hot.colToProp(column)),
+        col: this.hot.toPhysicalColumn(this.hot.propToCol(column)),
         sheet: this.sheetId
       };
 


### PR DESCRIPTION
### Context
The handling of the indexes used to access HyperFormula's data before the change was inconsistent. Party due to a wrong assumption that we want to use visual rows inside hf, partly due to buggy `modifyData`/`modifySourceData` hook implementation.

This PR simply makes it so that HyperFormula always receives physical indexes from us.

Still work in progress as I'm writing tests to check if the below issues were actually fixed.

- [x] Closes #8060
- [x] Closes #8046
- [x] Closes #8049
- [x] Closes #8058
- [ ] ~#8048~

<sup>[skip changelog]</sup>