### PR TITLE
Add `fit `& `fdescribe `to restricted globals in test files

### DIFF
--- a/.changelogs/8088.json
+++ b/.changelogs/8088.json
@@ -1,0 +1,7 @@
+{
+  "title": "Added `fit` & `fdescribe` to restricted globals in test files",
+  "type": "changed",
+  "issue": 8088,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -184,7 +184,11 @@ module.exports = {
           'error',
           { ignore: ['handsontable', 'walkontable'] }
         ],
-        'no-restricted-globals': 'off',
+        'no-restricted-globals': [
+          'error',
+          'fit',
+          'fdescribe'
+        ],
         'no-undef': 'off',
         'handsontable/restricted-module-imports': 'off',
       }
@@ -192,7 +196,6 @@ module.exports = {
     {
       files: ['*.unit.js', '*.spec.js'],
       rules: {
-        'no-restricted-globals': 'off',
         'no-undef': 'off',
         'jsdoc/require-description-complete-sentence': 'off',
         'jsdoc/require-jsdoc': 'off',


### PR DESCRIPTION
### Context
When testing I almost exclusively use [`fdescribe`](https://jasmine.github.io/api/3.4/global.html#fdescribe) & [`fit`](https://jasmine.github.io/api/3.4/global.html#fit) to select which tests I want to run. The problem is that I have a poor memory and I often forget to replace them with non-focused versions before comitting.

This PR simply bans all usages of `fit` and `fdescribe` from all test files, whilst keeping all other rules as they were before.

Example of **correct** code in a test file:
```js
describe('something', () => {
	window.hot = 0;
	it('should *', () => {
		window.hot = 0;
	});
});
```

Example of **incorrect** code in a test file:
```js
fdescribe('something', () => {
	fit('should *', () => {
		window.hot = 0;
	});
});
```

### How has this been tested?
Manually, by me.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Affected project(s):
- [x] `handsontable`
- [x] `@handsontable/angular`
- [x] `@handsontable/react`
- [x] `@handsontable/vue`