### PR TITLE
[9.0.0] Extra tests for the Autofill plugin

### DIFF
--- a/src/plugins/formulas/__tests__/formulas.spec.js
+++ b/src/plugins/formulas/__tests__/formulas.spec.js
@@ -1224,6 +1224,74 @@ describe('Formulas general', () => {
         .simulate('mouseup');
     };
 
+    it('should not override result of simple autofill (populating one cell) #8050', async() => {
+      handsontable({
+        data: [
+          { car: 'Mercedes A 160', year: 2017 },
+          { car: 'Citroen C4 Coupe', year: 2018 },
+          { car: 'Audi A4 Avant', year: 2019 },
+          { car: 'Opel Astra', year: 2020 },
+          { car: 'BMW 320i Coupe', year: 2021 }
+        ],
+        columns: [
+          {
+            data: 'car'
+          },
+          {
+            data: 'year',
+            type: 'numeric'
+          },
+        ],
+        formulas: {
+          engine: HyperFormula
+        },
+      });
+
+      selectCell(0, 0);
+      autofill(0, 1);
+
+      await sleep(100);
+
+      expect(getData()).toEqual([
+        ['Mercedes A 160', 'Mercedes A 160'],
+        ['Citroen C4 Coupe', 2018],
+        ['Audi A4 Avant', 2019],
+        ['Opel Astra', 2020],
+        ['BMW 320i Coupe', 2021],
+      ]);
+    });
+
+    it('should not override result of simple autofill (populating more cells) #8050', () => {
+      handsontable({
+        data: [
+          [1, 2, 3, 5, 7],
+          [6, 7, 9, 7, 8],
+          [5, 7, 9, 0, 4],
+          [null],
+          [1, 2, 3, 5, 7],
+          [6, 7, 9, 7, 8],
+          [5, 7, 9, 0, 4]
+        ],
+        colHeaders: true,
+        formulas: {
+          engine: HyperFormula
+        },
+      });
+
+      selectColumns(0, 1);
+      autofill(6, 4);
+
+      expect(getData()).toEqual([
+        [1, 2, 1, 2, 1],
+        [6, 7, 6, 7, 6],
+        [5, 7, 5, 7, 5],
+        [null, null, null, null, null],
+        [1, 2, 1, 2, 1],
+        [6, 7, 6, 7, 6],
+        [5, 7, 5, 7, 5]
+      ]);
+    });
+
     it('should not autofill if `beforeAutofill` returned false', () => {
       const hot = handsontable({
         data: [


### PR DESCRIPTION
### Context
It seems that some extra breaking changes introduced within https://github.com/handsontable/handsontable/pull/7648 were bugged. PR https://github.com/handsontable/handsontable/pull/8077 introduced change in hook arguments. It fixed problems described within #8050.

[skip changelog]

### How has this been tested?
Manual tests of the plugin.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #8050
2. #8077

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] My change requires a change to the documentation.
