### PR TITLE
Deprecate the `beforeAutofillInsidePopulate` hook

### DIFF
--- a/.changelogs/8095.json
+++ b/.changelogs/8095.json
@@ -1,0 +1,7 @@
+{
+  "title": "Deprecated the `beforeAutofillInsidePopulate` hook. It will be removed in the next major release.",
+  "type": "deprecated",
+  "issue": 8095,
+  "breaking": false,
+  "framework": "none"
+}

--- a/src/pluginHooks.js
+++ b/src/pluginHooks.js
@@ -1555,6 +1555,7 @@ const REGISTERED_HOOKS = [
   /**
    * Fired from the `populateFromArray` method during the `autofill` process. Fired for each "autofilled" cell individually.
    *
+   * @deprecated
    * @event Hooks#beforeAutofillInsidePopulate
    * @param {object} index Object containing `row` and `col` properties, defining the number of rows/columns from the initial cell of the autofill.
    * @param {string} direction Declares the direction of the autofill. Possible values: `up`, `down`, `left`, `right`.
@@ -2031,7 +2032,12 @@ const REMOVED_HOOKS = new Map([
  * @type {Map<string, string>}
  */
 /* eslint-enable jsdoc/require-description-complete-sentence */
-const DEPRECATED_HOOKS = new Map([]);
+const DEPRECATED_HOOKS = new Map([
+  [
+    'beforeAutofillInsidePopulate',
+    'The plugin hook "beforeAutofillInsidePopulate" is deprecated and will be removed in the next major release.'
+  ]
+]);
 
 class Hooks {
   static getSingleton() {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR deprecates the `beforeAutofillInsidePopulate` hook. It will be removed in the next major release.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Not necessary.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #8095
2.
3.

### Affected project(s):
- [x] `handsontable`
- [x] `@handsontable/angular`
- [x] `@handsontable/react`
- [x] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
