### PR TITLE
Add a separate collection for related sheets for Formula plugin

### DIFF
--- a/src/plugins/formulas/__tests__/initialization.spec.js
+++ b/src/plugins/formulas/__tests__/initialization.spec.js
@@ -79,8 +79,6 @@ describe('Formulas general', () => {
       const staticRegister = hot.getPlugin('formulas').staticRegister;
       const hotInstances = staticRegister.getItem('engine_relationship');
       const sharedHotIds = staticRegister.getItem('shared_engine_usage');
-      const relatedHotInstanceEntry = hotInstances.get(hot.getPlugin('formulas').engine);
-      const sharedHotIdsEntry = sharedHotIds.get(hot.getPlugin('formulas').engine);
 
       expect(hotInstances.size).toBe(1);
       expect(sharedHotIds.size).toBe(1);
@@ -123,8 +121,6 @@ describe('Formulas general', () => {
       const staticRegister = hot.getPlugin('formulas').staticRegister;
       const hotInstances = staticRegister.getItem('engine_relationship');
       const sharedHotIds = staticRegister.getItem('shared_engine_usage');
-      const relatedHotInstanceEntry = hotInstances.get(hot.getPlugin('formulas').engine);
-      const sharedHotIdsEntry = sharedHotIds.get(hot.getPlugin('formulas').engine);
 
       expect(hotInstances.size).toBe(1);
       expect(sharedHotIds.size).toBe(0);
@@ -244,7 +240,6 @@ describe('Formulas general', () => {
       }).data('handsontable');
 
       const formulasPlugin1 = hot1.getPlugin('formulas');
-      const formulasPlugin2 = hot2.getPlugin('formulas');
       const staticRegister = formulasPlugin1.staticRegister;
       const hotInstances = staticRegister.getItem('engine_relationship');
       const sharedHotIds = staticRegister.getItem('shared_engine_usage');
@@ -304,7 +299,6 @@ describe('Formulas general', () => {
       }).data('handsontable');
 
       const formulasPlugin1 = hot1.getPlugin('formulas');
-      const formulasPlugin2 = hot2.getPlugin('formulas');
       const staticRegister = formulasPlugin1.staticRegister;
       const hotInstances = staticRegister.getItem('engine_relationship');
       const sharedHotIds = staticRegister.getItem('shared_engine_usage');

--- a/src/plugins/formulas/engine/register.js
+++ b/src/plugins/formulas/engine/register.js
@@ -4,7 +4,37 @@ import { warn } from '../../../helpers/console';
 import { PLUGIN_KEY } from '../formulas';
 import { DEFAULT_LICENSE_KEY, getEngineSettingsWithDefaultsAndOverrides } from './settings';
 
-const ENGINE_KEY = 'engine';
+/**
+ * Prepares and returns the collection for the engine relationship with the HoT instances.
+ *
+ * @returns {Map}
+ */
+function getEngineRelationshipRegistry() {
+  const registryKey = 'engine_relationship';
+  const pluginStaticRegistry = staticRegister(PLUGIN_KEY);
+
+  if (!pluginStaticRegistry.hasItem(registryKey)) {
+    pluginStaticRegistry.register(registryKey, new Map());
+  }
+
+  return pluginStaticRegistry.getItem(registryKey);
+}
+
+/**
+ * Prepares and returns the collection for the engine shared usage.
+ *
+ * @returns {Map}
+ */
+function getSharedEngineUsageRegistry() {
+  const registryKey = 'shared_engine_usage';
+  const pluginStaticRegistry = staticRegister(PLUGIN_KEY);
+
+  if (!pluginStaticRegistry.hasItem(registryKey)) {
+    pluginStaticRegistry.register(registryKey, new Map());
+  }
+
+  return pluginStaticRegistry.getItem(registryKey);
+}
 
 /**
  * Setups the engine instance. It either creates a new (possibly shared) engine instance, or attaches
@@ -35,11 +65,17 @@ export function setupEngine(hotInstance) {
 
     // `engine` is the engine instance
   } else if (typeof engineConfigItem === 'object' && isUndefined(engineConfigItem.hyperformula)) {
-    const engineRegistry = staticRegister(PLUGIN_KEY).getItem(ENGINE_KEY);
-    const sharedEngineUsage = engineRegistry?.get(engineConfigItem);
+    const engineRelationship = getEngineRelationshipRegistry();
+    const sharedEngineUsage = getSharedEngineUsageRegistry().get(engineConfigItem);
+
+    if (!engineRelationship.has(engineConfigItem)) {
+      engineRelationship.set(engineConfigItem, []);
+    }
+
+    engineRelationship.get(engineConfigItem).push(hotInstance);
 
     if (sharedEngineUsage) {
-      sharedEngineUsage.push(hotInstance);
+      sharedEngineUsage.push(hotInstance.guid);
     }
 
     if (!engineConfigItem.getConfig().licenseKey) {
@@ -63,13 +99,10 @@ export function setupEngine(hotInstance) {
  * @returns {object} Returns the engine instance.
  */
 export function registerEngine(engineClass, hotSettings, hotInstance) {
-  if (!staticRegister(PLUGIN_KEY).hasItem(ENGINE_KEY)) {
-    staticRegister(PLUGIN_KEY).register(ENGINE_KEY, new Map());
-  }
-
   const pluginSettings = hotSettings[PLUGIN_KEY];
   const engineSettings = getEngineSettingsWithDefaultsAndOverrides(hotSettings);
-  const engineRegistry = staticRegister(PLUGIN_KEY).getItem(ENGINE_KEY);
+  const engineRegistry = getEngineRelationshipRegistry();
+  const sharedEngineRegistry = getSharedEngineUsageRegistry();
 
   registerCustomFunctions(engineClass, pluginSettings.functions);
 
@@ -80,6 +113,7 @@ export function registerEngine(engineClass, hotSettings, hotInstance) {
 
   // Add it to global registry
   engineRegistry.set(engineInstance, [hotInstance]);
+  sharedEngineRegistry.set(engineInstance, [hotInstance.guid]);
 
   registerNamedExpressions(engineInstance, pluginSettings.namedExpressions);
 
@@ -100,11 +134,7 @@ export function registerEngine(engineClass, hotSettings, hotInstance) {
  * @returns {Handsontable[]} Returns an array with Handsontable instances.
  */
 export function getRegisteredHotInstances(engine) {
-  if (!staticRegister(PLUGIN_KEY).hasItem(ENGINE_KEY)) {
-    staticRegister(PLUGIN_KEY).register(ENGINE_KEY, new Map());
-  }
-
-  const engineRegistry = staticRegister(PLUGIN_KEY).getItem(ENGINE_KEY);
+  const engineRegistry = getEngineRelationshipRegistry();
 
   return engineRegistry.size === 0 ? [] : Array.from(engineRegistry.get(engine) ?? []);
 }
@@ -118,14 +148,24 @@ export function getRegisteredHotInstances(engine) {
  */
 export function unregisterEngine(engine, hotInstance) {
   if (engine) {
-    const engineRegistry = staticRegister(PLUGIN_KEY).getItem(ENGINE_KEY);
-    const sharedEngineUsage = engineRegistry?.get(engine);
+    const engineRegistry = getEngineRelationshipRegistry();
+    const engineHotRelationship = engineRegistry.get(engine);
+    const sharedEngineRegistry = getSharedEngineUsageRegistry();
+    const sharedEngineUsage = sharedEngineRegistry.get(engine);
 
-    if (sharedEngineUsage && sharedEngineUsage.includes(hotInstance)) {
-      sharedEngineUsage.splice(sharedEngineUsage.indexOf(hotInstance), 1);
+    if (engineHotRelationship && engineHotRelationship.includes(hotInstance)) {
+      engineHotRelationship.splice(engineHotRelationship.indexOf(hotInstance), 1);
+
+      if (engineHotRelationship.length === 0) {
+        engineRegistry.delete(engine);
+      }
+    }
+
+    if (sharedEngineUsage && sharedEngineUsage.includes(hotInstance.guid)) {
+      sharedEngineUsage.splice(sharedEngineUsage.indexOf(hotInstance.guid), 1);
 
       if (sharedEngineUsage.length === 0) {
-        engineRegistry.delete(engine);
+        sharedEngineRegistry.delete(engine);
         engine.destroy();
       }
     }

--- a/src/plugins/formulas/formulas.js
+++ b/src/plugins/formulas/formulas.js
@@ -162,6 +162,8 @@ export class Formulas extends BasePlugin {
    * Disables the plugin functionality for this Handsontable instance.
    */
   disablePlugin() {
+    unregisterEngine(this.engine, this.hot);
+
     super.disablePlugin();
   }
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes an error that occurs when the HF engine instance was passed to the _Formulas_ plugin configuration. For that kind of configuration, the collection that holds the Handsontable instances was not created properly. Hence, the table that depends on the changed formulas could not be updated.

To solve that issue and with support passing HF instances and Hyperformula classes in mind, I added a separate collection (based on static registered module) for connecting HoT instances with the engine. Previously the collection was mixed with `sharedEngineUsage` but that collection has a different meaning.

Moreover, I found a memory leak [(missing `unregisterEngine` call)](https://github.com/handsontable/handsontable/pull/8100/files#diff-75a3f65e47cad775c4d9cef1c98b6ef3ad0ad696c9aaa6b62eaf9fe45a09833cR165) that occurs while calling the `updateSettings` method. I fixed that and cover the changes with the tests.

Demo to reproduce:
```js
const hyperformulaInstance = HyperFormula.buildEmpty();

const hot1 = new Handsontable(document.getElementById('example'), {
  data: [
    ['10.26', '', 'Sum', '=SUM(A:A)'],
    ['20.12', '', 'Average', '=AVERAGE(A:A)'],
    ['30.01', '', 'Median', '=MEDIAN(A:A)'],
    ['40.29', '', 'MAX', '=MAX(A:A)'],
    ['50.18', '', 'MIN', '=MIN(A:A)'],
  ],
  colHeaders: true,
  rowHeaders: true,
  formulas: {
    engine: hyperformulaInstance,
    sheetName: 'Sheet1',
  },
});
const hot2 = new Handsontable(document.getElementById('example2'), {
  data: [
    ['Is A1 in Sheet1 > 10?', '=IF(Sheet1!A1>10,"TRUE","FALSE")'],
    ['Is A:A in Sheet > 150?', '=IF(SUM(Sheet1!A:A)>150,"TRUE","FALSE")'],
    ['How many blank cells are in the Sheet1?', '=COUNTBLANK(Sheet1!A1:E5)'],
    ['Generate a random number', '=RAND()'],
    ['Number of sheets in this workbook', '=SHEETS()'],
  ],
  colHeaders: true,
  rowHeaders: true,
  formulas: {
    engine: hyperformulaInstance,
    sheetName: 'Sheet2',
  },
});
```
While editing the Sheet1 the error occurred.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I added new E2E tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #8097
2.
3.

### Affected project(s):
- [x] `handsontable`
- [x] `@handsontable/angular`
- [x] `@handsontable/react`
- [x] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
