### PR TITLE
Turn on `skipLibCheck` for angular wrapper, to allows it to build.

### DIFF
--- a/wrappers/angular/tsconfig.json
+++ b/wrappers/angular/tsconfig.json
@@ -2,6 +2,7 @@
   "compileOnSave": false,
   "compilerOptions": {
     "noUnusedLocals": true,
+    "skipLibCheck": true, // issue: https://github.com/handsontable/handsontable/issues/8099
     "baseUrl": "./",
     "outDir": "./dist/out-tsc",
     "sourceMap": true,


### PR DESCRIPTION
### Context

ref: https://github.com/handsontable/handsontable/issues/8099

We are using an older version of Angular for @handsontable/angular, and it doesn't support the newer TS syntax. It causes errors during building that wrapper.

The `skipLibCheck` ignores errors from dependencies and writes them as a warning. This allows us to build the wrapper without any code changes. Using `skipLibCheck` could not be tracked as best practice. However, it is enough until we migrate to the newer Angular/TS version.

Possible that requires our client apps to will should also use this flag must be checked/described.

### How has this been tested?
I tried to reproduce how @jansiegel described in #8099, and build passes.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [?] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #8099 
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [x] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md), and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
