### PR TITLE
Add missing TS types for the Formulas plugin

### DIFF
--- a/handsontable.d.ts
+++ b/handsontable.d.ts
@@ -1,6 +1,10 @@
 import { PikadayOptions } from 'pikaday';
 import numbro from 'numbro';
-import { HyperFormula, CellType as HyperFormulaCellType } from 'hyperformula';
+import {
+  CellType as HyperFormulaCellType,
+  ConfigParams,
+  HyperFormula,
+} from 'hyperformula';
 
 /**
  * @internal
@@ -1174,12 +1178,12 @@ declare namespace Handsontable {
     type UndoRedoAction = UndoRedoAction.Change | UndoRedoAction.InsertRow | UndoRedoAction.RemoveRow | UndoRedoAction.InsertCol | UndoRedoAction.RemoveCol | UndoRedoAction.Filter;
 
     interface Formulas extends Base {
-      engine: HyperFormula | object | Function;
-      sheetName: string;
-      sheetId: number;
+      engine: HyperFormula | null;
+      sheetName: string | null;
+      sheetId: number | null;
 
       addSheet(sheetName?: string | null, sheetData?: CellValue[][]): boolean | string;
-      getCellType(row: number, col: number, sheet?: number): HyperFormulaCellType
+      getCellType(row: number, col: number, sheet?: number): HyperFormulaCellType;
       switchSheet(sheetName: string): void;
     }
 
@@ -2550,10 +2554,11 @@ declare namespace Handsontable {
   }
 
   namespace formulas {
+    interface HyperFormulaSettings extends Partial<ConfigParams> {
+      hyperformula: typeof HyperFormula | HyperFormula
+    }
     interface Settings {
-      variables?: {
-        [key: string]: any;
-      }
+      engine: typeof HyperFormula | HyperFormula | HyperFormulaSettings
     }
   }
 

--- a/src/plugins/formulas/__tests__/formulas.types.ts
+++ b/src/plugins/formulas/__tests__/formulas.types.ts
@@ -1,0 +1,11 @@
+import Handsontable from 'handsontable';
+
+const formulas = Handsontable.plugins.Formulas;
+
+formulas.engine!.addSheet();
+formulas.sheetName!.toLowerCase();
+formulas.sheetId!.toFixed();
+
+formulas.addSheet('sheet2', [[]]);
+formulas.getCellType(0, 0, 1);
+formulas.switchSheet('sheet2');

--- a/src/plugins/formulas/formulas.js
+++ b/src/plugins/formulas/formulas.js
@@ -83,7 +83,7 @@ export class Formulas extends BasePlugin {
   /**
    * The engine instance that will be used for this instance of Handsontable.
    *
-   * @type {HyperFormula|object}
+   * @type {HyperFormula|null}
    */
   engine = null;
 

--- a/test/types/settings.types.ts
+++ b/test/types/settings.types.ts
@@ -1,4 +1,5 @@
 import Handsontable from 'handsontable';
+import HyperFormula from 'hyperformula';
 
 // Helpers to verify multiple different settings and prevent TS control-flow from eliminating unreachable values
 declare function oneOf<T extends (string | number | boolean | undefined | null | object)[]>(...args: T): T[number];
@@ -218,12 +219,26 @@ const allSettings: Required<Handsontable.GridSettings> = {
   fixedColumnsLeft: 123,
   fixedRowsBottom: 123,
   fixedRowsTop: 123,
-  formulas: oneOf(true, {
-    variables: {
-      FOO: 64,
-      BAR: 'baz',
-    }
-  }),
+  formulas: oneOf(
+    {
+      engine: HyperFormula,
+    },
+    {
+      engine: {
+        hyperformula: HyperFormula,
+        leapYear1900: true,
+      },
+    },
+    {
+      engine: HyperFormula.buildEmpty(),
+    },
+    {
+      engine: {
+        hyperformula: HyperFormula.buildEmpty(),
+        leapYear1900: true,
+      },
+    },
+  ),
   fragmentSelection: oneOf(true, 'cell'),
   height: oneOf(500, () => 500),
   hiddenColumns: oneOf(true, {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adds missing TypeScript definition for the Formulas plugin and its settings.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested using TS in the 3.8.2 version. I added some new tests that cover the changes.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #8108
2.
3.

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
