### PR TITLE
[9.0.0] FIX for column auto size when the formulas result has changed width

### DIFF
--- a/.changelogs/8122.json
+++ b/.changelogs/8122.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fixed column resizing when formulas results has changed width",
+  "type": "fixed",
+  "issue": 8122,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/8122.json
+++ b/.changelogs/8122.json
@@ -1,7 +1,0 @@
-{
-  "title": "Fixed column resizing when formulas results has changed width",
-  "type": "fixed",
-  "issue": 8122,
-  "breaking": false,
-  "framework": "none"
-}

--- a/src/plugins/autoColumnSize/__tests__/autoColumnSize.spec.js
+++ b/src/plugins/autoColumnSize/__tests__/autoColumnSize.spec.js
@@ -1,3 +1,5 @@
+import { HyperFormula } from 'hyperformula';
+
 describe('AutoColumnSize', () => {
   const id = 'testContainer';
 
@@ -418,7 +420,7 @@ describe('AutoColumnSize', () => {
     expect(document.querySelector('.htAutoSize')).toBe(null);
   });
 
-  it('should not trigger autoColumnSize when column width is defined (through colWidths)', () => {
+  it('should not trigger autoColumnSize when column width is defined (through colWidths)', async() => {
     handsontable({
       data: arrayOfObjects(),
       autoColumnSize: true,
@@ -429,11 +431,12 @@ describe('AutoColumnSize', () => {
     });
 
     setDataAtCell(0, 0, 'LongLongLongLong');
+    await sleep(50);
 
     expect(colWidth(spec().$container, 0)).toBe(70);
   });
 
-  it('should not trigger autoColumnSize when column width is defined (through columns.width)', () => {
+  it('should not trigger autoColumnSize when column width is defined (through columns.width)', async() => {
     handsontable({
       data: arrayOfObjects(),
       autoColumnSize: true,
@@ -449,6 +452,7 @@ describe('AutoColumnSize', () => {
     });
 
     setDataAtCell(0, 0, 'LongLongLongLong');
+    await sleep(50);
 
     expect(colWidth(spec().$container, 0)).toBe(70);
   });
@@ -875,6 +879,71 @@ describe('AutoColumnSize', () => {
       });
 
       expect(colWidth(spec().$container, 0)).toBeAroundValue(180, 5);
+    });
+  });
+
+  describe('adjust to HyperFormula calculation result', () => {
+    it('should increase width if result become to be longer', async() => {
+      handsontable({
+        data: [
+          [9, '=A1*500'],
+          [8, '=A2*500'],
+          [6, '=A3*500'],
+        ],
+        type: 'numeric',
+        formulas: {
+          engine: HyperFormula
+        }
+      });
+
+      expect(colWidth(spec().$container, 1)).toBe(50);
+
+      setDataAtCell(0, 0, 999999999999);
+      await sleep(50);
+
+      expect(colWidth(spec().$container, 1)).toBe(130);
+    });
+
+    it('should decrease width if result become to be shorter', async() => {
+      handsontable({
+        data: [
+          [999, '=A1*500'],
+          [8, '=A2*500'],
+          [6, '=A3*500'],
+        ],
+        type: 'numeric',
+        formulas: {
+          engine: HyperFormula
+        }
+      });
+
+      expect(colWidth(spec().$container, 1)).toBe(58);
+
+      setDataAtCell(0, 0, 9);
+      await sleep(50);
+
+      expect(colWidth(spec().$container, 1)).toBe(50);
+    });
+
+    it('should change width if result become to be an error', async() => {
+      handsontable({
+        data: [
+          [9, '=A1*500'],
+          [8, '=A2*500'],
+          [6, '=A3*500'],
+        ],
+        type: 'numeric',
+        formulas: {
+          engine: HyperFormula
+        }
+      });
+
+      expect(colWidth(spec().$container, 1)).toBe(50);
+
+      setDataAtCell(0, 0, 'not a number');
+      await sleep(50);
+
+      expect(colWidth(spec().$container, 1)).toBe(76);
     });
   });
 });

--- a/src/plugins/autoColumnSize/autoColumnSize.js
+++ b/src/plugins/autoColumnSize/autoColumnSize.js
@@ -625,7 +625,8 @@ export class AutoColumnSize extends BasePlugin {
   }
 
   onAfterFormulasValuesUpdate(changes) {
-    const changedColumns = arrayMap(changes, (change) => {
+    const filteredChanges = arrayFilter(changes, change => change.address?.col !== undefined ?? false);
+    const changedColumns = arrayMap(filteredChanges, (change) => {
       return this.hot.toPhysicalColumn(this.hot.propToCol(change.address.col));
     });
 

--- a/src/plugins/autoColumnSize/autoColumnSize.js
+++ b/src/plugins/autoColumnSize/autoColumnSize.js
@@ -9,6 +9,7 @@ import SamplesGenerator from '../../utils/samplesGenerator';
 import { isPercentValue } from '../../helpers/string';
 import { ViewportColumnsCalculator } from '../../3rdparty/walkontable/src';
 import { PhysicalIndexToValueMap as IndexToValueMap } from '../../translations';
+import { isDefined } from '../../helpers/mixed';
 
 Hooks.getSingleton().register('modifyAutoColumnSizeSeed');
 
@@ -625,10 +626,8 @@ export class AutoColumnSize extends BasePlugin {
   }
 
   onAfterFormulasValuesUpdate(changes) {
-    const filteredChanges = arrayFilter(changes, change => change.address?.col !== undefined ?? false);
-    const changedColumns = arrayMap(filteredChanges, (change) => {
-      return this.hot.toPhysicalColumn(this.hot.propToCol(change.address.col));
-    });
+    const filteredChanges = arrayFilter(changes, change => isDefined(change.address?.col));
+    const changedColumns = arrayMap(filteredChanges, change => change.address.col);
 
     this.clearCache(Array.from(new Set(changedColumns)));
   }

--- a/src/plugins/autoColumnSize/autoColumnSize.js
+++ b/src/plugins/autoColumnSize/autoColumnSize.js
@@ -625,6 +625,12 @@ export class AutoColumnSize extends BasePlugin {
     privatePool.get(this).cachedColumnHeaders = this.hot.getColHeader();
   }
 
+  /**
+   * After formulas values updated listener.
+   *
+   * @private
+   * @param {Array} changes An array of modified data.
+   */
   onAfterFormulasValuesUpdate(changes) {
     const filteredChanges = arrayFilter(changes, change => isDefined(change.address?.col));
     const changedColumns = arrayMap(filteredChanges, change => change.address.col);

--- a/src/plugins/autoColumnSize/autoColumnSize.js
+++ b/src/plugins/autoColumnSize/autoColumnSize.js
@@ -201,6 +201,7 @@ export class AutoColumnSize extends BasePlugin {
 
     this.addHook('afterLoadData', () => this.onAfterLoadData());
     this.addHook('beforeChange', changes => this.onBeforeChange(changes));
+    this.addHook('afterFormulasValuesUpdate', changes => this.onAfterFormulasValuesUpdate(changes));
     this.addHook('beforeRender', force => this.onBeforeRender(force));
     this.addHook('modifyColWidth', (width, col) => this.getColumnWidth(col, width));
     this.addHook('afterInit', () => this.onAfterInit());
@@ -586,8 +587,9 @@ export class AutoColumnSize extends BasePlugin {
    * @param {Array} changes An array of modified data.
    */
   onBeforeChange(changes) {
-    const changedColumns = arrayMap(changes, ([, columnProperty]) =>
-      this.hot.toPhysicalColumn(this.hot.propToCol(columnProperty)));
+    const changedColumns = arrayMap(changes, ([, columnProperty]) => {
+      return this.hot.toPhysicalColumn(this.hot.propToCol(columnProperty));
+    });
 
     this.clearCache(Array.from(new Set(changedColumns)));
   }
@@ -620,6 +622,14 @@ export class AutoColumnSize extends BasePlugin {
    */
   onAfterInit() {
     privatePool.get(this).cachedColumnHeaders = this.hot.getColHeader();
+  }
+
+  onAfterFormulasValuesUpdate(changes) {
+    const changedColumns = arrayMap(changes, (change) => {
+      return this.hot.toPhysicalColumn(this.hot.propToCol(change.address.col));
+    });
+
+    this.clearCache(Array.from(new Set(changedColumns)));
   }
 
   /**


### PR DESCRIPTION
### Context
resolves: https://github.com/handsontable/handsontable/issues/8061

I added hook handler `afterFormulasValuesUpdate`, which the HyperFormula plugin emits after formulas calculation into the AutoColumnSize plugin. Then the handler maps event props into columns index and cache for further column calculation - it is the same logic as `onBeforeChange`. 

While the `afterFormulasValuesUpdate`is called only if HyperFormula is on, I considered turning off the `onBeforeChange` if HF is on. That reduces some calls on handlers. However, I won't do that because that additional condition is potentially risky and needs to follow another plugin state change. Additionally the `onBeforeChange` and `onAfterFormulasValuesUpdate` have quite simple logic.

![May-27-2021 16-31-35](https://user-images.githubusercontent.com/2893099/119844927-2289d000-bf09-11eb-857d-8127efeac824.gif)

<sup>[skip changelog]</sup>


### How has this been tested?
I added three spec cases.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #8061 
2.
3.

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
