### PR TITLE
Fix validation when the Formulas is enabled

### DIFF
--- a/src/plugins/formulas/__tests__/formulas.spec.js
+++ b/src/plugins/formulas/__tests__/formulas.spec.js
@@ -1937,7 +1937,7 @@ describe('Formulas general', () => {
       hot.getPlugin('filters').addCondition(0, 'eq', ['orci']);
       hot.getPlugin('filters').filter();
 
-      expect(hot.getData()).toEqual([['orci', 'et', 'dignissim', 'hendrerit', 42381, 8.5]]);
+      expect(hot.getData()).toEqual([['orci', 'et', 'dignissim', 'hendrerit', '12/1/2016', 8.5]]);
     });
 
     it('should filter by value', () => {
@@ -1969,7 +1969,7 @@ describe('Formulas general', () => {
       hot.getPlugin('filters').addCondition(0, 'by_value', [['orci']]);
       hot.getPlugin('filters').filter();
 
-      expect(hot.getData()).toEqual([['orci', 'et', 'dignissim', 'hendrerit', 42381, 8.5]]);
+      expect(hot.getData()).toEqual([['orci', 'et', 'dignissim', 'hendrerit', '12/1/2016', 8.5]]);
     });
   });
 
@@ -2354,164 +2354,6 @@ describe('Formulas general', () => {
           ['a', null, null, 2, 'b', '2c']
         ]);
       });
-    });
-  });
-
-  describe('cooperation with validation', () => {
-    it('should validate result of formula properly (opening and closing an editor)', async() => {
-      const hot = handsontable({
-        data: [
-          ['=B1+5', 2, '=D1', 'text']
-        ],
-        formulas: {
-          engine: HyperFormula
-        },
-        type: 'numeric',
-      });
-
-      selectCell(0, 0);
-      // Opening an editor
-      keyDown('enter');
-      // Closing the editor and saving changes.
-      keyDown('enter');
-
-      await sleep(100); // Validator is asynchronous.
-
-      expect($(getCell(0, 0)).hasClass(hot.getSettings().invalidCellClassName)).toBe(false);
-
-      selectCell(0, 2);
-      // Opening an editor
-      keyDown('enter');
-      // Closing the editor and saving changes.
-      keyDown('enter');
-
-      await sleep(100); // Validator is asynchronous.
-
-      expect($(getCell(0, 2)).hasClass(hot.getSettings().invalidCellClassName)).toBe(true);
-    });
-
-    it('should validate result of formula for dependant cells properly (formula returns text)', async() => {
-      const hot = handsontable({
-        data: [
-          [0, '=A1', '=B1', '=C1']
-        ],
-        formulas: {
-          engine: HyperFormula
-        },
-        type: 'numeric'
-      });
-
-      hot.setDataAtCell(0, 0, 'text');
-
-      await sleep(100); // Validator is asynchronous.
-
-      expect($(getCell(0, 0)).hasClass(hot.getSettings().invalidCellClassName)).toBe(true);
-      expect($(getCell(0, 1)).hasClass(hot.getSettings().invalidCellClassName)).toBe(true);
-      expect($(getCell(0, 2)).hasClass(hot.getSettings().invalidCellClassName)).toBe(true);
-      expect($(getCell(0, 3)).hasClass(hot.getSettings().invalidCellClassName)).toBe(true);
-    });
-
-    it('should validate result of formula and dependant cells properly (formula returns error)', async() => {
-      const hot = handsontable({
-        data: [
-          ['=B1+5', 2, '=A1', '=C1']
-        ],
-        formulas: {
-          engine: HyperFormula
-        },
-        type: 'numeric'
-      });
-
-      hot.setDataAtCell(0, 0, '=B1+5a');
-
-      await sleep(100); // Validator is asynchronous.
-
-      expect($(getCell(0, 0)).hasClass(hot.getSettings().invalidCellClassName)).toBe(true);
-      expect($(getCell(0, 2)).hasClass(hot.getSettings().invalidCellClassName)).toBe(true);
-      expect($(getCell(0, 3)).hasClass(hot.getSettings().invalidCellClassName)).toBe(true);
-
-      hot.setDataAtCell(0, 0, '=B1+5');
-
-      await sleep(100); // Validator is asynchronous.
-
-      expect($(getCell(0, 0)).hasClass(hot.getSettings().invalidCellClassName)).toBe(false);
-      expect($(getCell(0, 2)).hasClass(hot.getSettings().invalidCellClassName)).toBe(false);
-      expect($(getCell(0, 3)).hasClass(hot.getSettings().invalidCellClassName)).toBe(false);
-    });
-
-    it('should validate result of formula and dependant cells properly (formula create circular dependency)', async() => {
-      const hot = handsontable({
-        data: [
-          ['=B1+5', 2, '=A1', '=C1']
-        ],
-        formulas: {
-          engine: HyperFormula
-        },
-        type: 'numeric'
-      });
-
-      hot.setDataAtCell(0, 0, '=C1');
-
-      await sleep(100); // Validator is asynchronous.
-
-      expect($(getCell(0, 0)).hasClass(hot.getSettings().invalidCellClassName)).toBe(true);
-      expect($(getCell(0, 2)).hasClass(hot.getSettings().invalidCellClassName)).toBe(true);
-      expect($(getCell(0, 3)).hasClass(hot.getSettings().invalidCellClassName)).toBe(true);
-
-      hot.setDataAtCell(0, 0, '=B1+5');
-
-      await sleep(100); // Validator is asynchronous.
-
-      expect($(getCell(0, 0)).hasClass(hot.getSettings().invalidCellClassName)).toBe(false);
-      expect($(getCell(0, 2)).hasClass(hot.getSettings().invalidCellClassName)).toBe(false);
-      expect($(getCell(0, 3)).hasClass(hot.getSettings().invalidCellClassName)).toBe(false);
-    });
-
-    it('should validate result of formula and dependant cells properly (formula create #REF! error)', async() => {
-      const hot = handsontable({
-        data: [
-          ['=E1', 2, '=A1', '=C1', 22]
-        ],
-        formulas: {
-          engine: HyperFormula
-        },
-        type: 'numeric'
-      });
-
-      hot.alter('remove_col', 4);
-
-      await sleep(100); // Validator is asynchronous.
-
-      expect($(getCell(0, 0)).hasClass(hot.getSettings().invalidCellClassName)).toBe(true);
-      expect($(getCell(0, 2)).hasClass(hot.getSettings().invalidCellClassName)).toBe(true);
-      expect($(getCell(0, 3)).hasClass(hot.getSettings().invalidCellClassName)).toBe(true);
-    });
-
-    it('should not automatically validate changes when the engine is modified from the outside code', async() => {
-      const hot = handsontable({
-        data: [
-          ['=E1', 'text', '=A1', '=C1', 22]
-        ],
-        formulas: {
-          engine: HyperFormula
-        },
-        type: 'numeric'
-      });
-
-      hot.getPlugin('formulas').engine.setCellContents({ sheet: 0, row: 0, col: 0 }, '=B1');
-
-      await sleep(100); // Validator is asynchronous.
-
-      expect($(getCell(0, 0)).hasClass(hot.getSettings().invalidCellClassName)).toBe(false);
-      expect($(getCell(0, 2)).hasClass(hot.getSettings().invalidCellClassName)).toBe(false);
-      expect($(getCell(0, 3)).hasClass(hot.getSettings().invalidCellClassName)).toBe(false);
-
-      hot.validateCells();
-      await sleep(100); // Validator is asynchronous.
-
-      expect($(getCell(0, 0)).hasClass(hot.getSettings().invalidCellClassName)).toBe(true);
-      expect($(getCell(0, 2)).hasClass(hot.getSettings().invalidCellClassName)).toBe(true);
-      expect($(getCell(0, 3)).hasClass(hot.getSettings().invalidCellClassName)).toBe(true);
     });
   });
 });

--- a/src/plugins/formulas/__tests__/publicAPI.spec.js
+++ b/src/plugins/formulas/__tests__/publicAPI.spec.js
@@ -1,0 +1,94 @@
+import HyperFormula from 'hyperformula';
+
+describe('Formulas public API', () => {
+  const debug = false;
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (debug) {
+      return;
+    }
+
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  describe('isFormulaCellType()', () => {
+    it('should return `true` when under the cell is formula (including matrix cell types)', () => {
+      handsontable({
+        data: [
+          ['1', '2'],
+          ['3', '4'],
+          ['', ''],
+          ['', ''],
+          ['=A1', '\'=A1'],
+          [0, true],
+          [null, void 0],
+        ],
+        formulas: {
+          engine: HyperFormula
+        }
+      });
+
+      setDataAtCell(2, 0, '{=TRANSPOSE(A1:B2)}');
+
+      const formulas = getPlugin('formulas');
+
+      expect(formulas.isFormulaCellType(0, 0)).toBe(false);
+      expect(formulas.isFormulaCellType(0, 1)).toBe(false);
+      expect(formulas.isFormulaCellType(1, 0)).toBe(false);
+      expect(formulas.isFormulaCellType(2, 0)).toBe(true);
+      expect(formulas.isFormulaCellType(3, 0)).toBe(true);
+      expect(formulas.isFormulaCellType(4, 0)).toBe(true);
+      expect(formulas.isFormulaCellType(4, 1)).toBe(false);
+      expect(formulas.isFormulaCellType(5, 0)).toBe(false);
+      expect(formulas.isFormulaCellType(5, 1)).toBe(false);
+      expect(formulas.isFormulaCellType(6, 0)).toBe(false);
+      expect(formulas.isFormulaCellType(6, 1)).toBe(false);
+    });
+  });
+
+  describe('getCellType()', () => {
+    it('should detect cells correctly', () => {
+      handsontable({
+        data: [
+          ['1', '2'],
+          ['3', '4'],
+          ['', ''],
+          ['', ''],
+          ['=A1', '\'=A1'],
+          [0, true],
+          [null, void 0],
+          ['', 1.1],
+        ],
+        formulas: {
+          engine: HyperFormula
+        }
+      });
+
+      setDataAtCell(2, 0, '{=TRANSPOSE(A1:B2)}');
+
+      const formulas = getPlugin('formulas');
+
+      expect(formulas.getCellType(0, 0)).toBe('VALUE');
+      expect(formulas.getCellType(0, 1)).toBe('VALUE');
+      expect(formulas.getCellType(1, 0)).toBe('VALUE');
+      expect(formulas.getCellType(2, 0)).toBe('MATRIX');
+      expect(formulas.getCellType(3, 0)).toBe('MATRIX');
+      expect(formulas.getCellType(4, 0)).toBe('FORMULA');
+      expect(formulas.getCellType(4, 1)).toBe('VALUE');
+      expect(formulas.getCellType(5, 0)).toBe('VALUE');
+      expect(formulas.getCellType(5, 1)).toBe('VALUE');
+      expect(formulas.getCellType(6, 0)).toBe('EMPTY');
+      expect(formulas.getCellType(6, 1)).toBe('EMPTY');
+      expect(formulas.getCellType(7, 0)).toBe('VALUE');
+      expect(formulas.getCellType(7, 1)).toBe('VALUE');
+    });
+  });
+});

--- a/src/plugins/formulas/__tests__/utils.unit.js
+++ b/src/plugins/formulas/__tests__/utils.unit.js
@@ -1,0 +1,28 @@
+import {
+  isEscapedFormulaExpression,
+  unescapeFormulaExpression,
+} from '../utils';
+
+describe('Formulas utils', () => {
+  describe('isEscapedFormulaExpression', () => {
+    it('should correctly detect escaped formula expressions', () => {
+      expect(isEscapedFormulaExpression('12345')).toBe(false);
+      expect(isEscapedFormulaExpression('=12345')).toBe(false);
+      expect(isEscapedFormulaExpression('\'=12345')).toBe(true);
+      expect(isEscapedFormulaExpression('\'=a1:B15')).toBe(true);
+      expect(isEscapedFormulaExpression('=SUM(23, A55, "a55")')).toBe(false);
+      expect(isEscapedFormulaExpression('\'=SUM(23, A55, "a55")')).toBe(true);
+    });
+  });
+
+  describe('unescapeFormulaExpression', () => {
+    it('should correctly detect escaped formula expressions', () => {
+      expect(unescapeFormulaExpression('12345')).toBe('12345');
+      expect(unescapeFormulaExpression('=12345')).toBe('=12345');
+      expect(unescapeFormulaExpression('\'=12345')).toBe('=12345');
+      expect(unescapeFormulaExpression('\'=a1:B15')).toBe('=a1:B15');
+      expect(unescapeFormulaExpression('=SUM(23, A55, "a55")')).toBe('=SUM(23, A55, "a55")');
+      expect(unescapeFormulaExpression('\'=SUM(23, A55, "a55")')).toBe('=SUM(23, A55, "a55")');
+    });
+  });
+});

--- a/src/plugins/formulas/__tests__/validation.spec.js
+++ b/src/plugins/formulas/__tests__/validation.spec.js
@@ -1,0 +1,203 @@
+import HyperFormula from 'hyperformula';
+
+describe('Formulas general', () => {
+  const debug = false;
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (debug) {
+      return;
+    }
+
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  describe('cooperation with validation', () => {
+    it('should validate result of formula properly (opening and closing an editor)', async() => {
+      const hot = handsontable({
+        data: [
+          ['=B1+5', 2, '=D1', 'text']
+        ],
+        formulas: {
+          engine: HyperFormula
+        },
+        type: 'numeric',
+      });
+
+      selectCell(0, 0);
+      // Opening an editor
+      keyDown('enter');
+      // Closing the editor and saving changes.
+      keyDown('enter');
+
+      await sleep(100); // Validator is asynchronous.
+
+      expect($(getCell(0, 0)).hasClass(hot.getSettings().invalidCellClassName)).toBe(false);
+
+      selectCell(0, 2);
+      // Opening an editor
+      keyDown('enter');
+      // Closing the editor and saving changes.
+      keyDown('enter');
+
+      await sleep(100); // Validator is asynchronous.
+
+      expect($(getCell(0, 2)).hasClass(hot.getSettings().invalidCellClassName)).toBe(true);
+    });
+
+    it('should validate result of formula for dependant cells properly (formula returns text)', async() => {
+      const hot = handsontable({
+        data: [
+          [0, '=A1', '=B1', '=C1']
+        ],
+        formulas: {
+          engine: HyperFormula
+        },
+        type: 'numeric'
+      });
+
+      hot.setDataAtCell(0, 0, 'text');
+
+      await sleep(100); // Validator is asynchronous.
+
+      expect($(getCell(0, 0)).hasClass(hot.getSettings().invalidCellClassName)).toBe(true);
+      expect($(getCell(0, 1)).hasClass(hot.getSettings().invalidCellClassName)).toBe(true);
+      expect($(getCell(0, 2)).hasClass(hot.getSettings().invalidCellClassName)).toBe(true);
+      expect($(getCell(0, 3)).hasClass(hot.getSettings().invalidCellClassName)).toBe(true);
+    });
+
+    it('should validate result of formula and dependant cells properly (formula returns error)', async() => {
+      const hot = handsontable({
+        data: [
+          ['=B1+5', 2, '=A1', '=C1']
+        ],
+        formulas: {
+          engine: HyperFormula
+        },
+        type: 'numeric'
+      });
+
+      hot.setDataAtCell(0, 0, '=B1+5a');
+
+      await sleep(100); // Validator is asynchronous.
+
+      expect($(getCell(0, 0)).hasClass(hot.getSettings().invalidCellClassName)).toBe(true);
+      expect($(getCell(0, 2)).hasClass(hot.getSettings().invalidCellClassName)).toBe(true);
+      expect($(getCell(0, 3)).hasClass(hot.getSettings().invalidCellClassName)).toBe(true);
+
+      hot.setDataAtCell(0, 0, '=B1+5');
+
+      await sleep(100); // Validator is asynchronous.
+
+      expect($(getCell(0, 0)).hasClass(hot.getSettings().invalidCellClassName)).toBe(false);
+      expect($(getCell(0, 2)).hasClass(hot.getSettings().invalidCellClassName)).toBe(false);
+      expect($(getCell(0, 3)).hasClass(hot.getSettings().invalidCellClassName)).toBe(false);
+    });
+
+    it('should validate result of formula and dependant cells properly (formula create circular dependency)', async() => {
+      const hot = handsontable({
+        data: [
+          ['=B1+5', 2, '=A1', '=C1']
+        ],
+        formulas: {
+          engine: HyperFormula
+        },
+        type: 'numeric'
+      });
+
+      hot.setDataAtCell(0, 0, '=C1');
+
+      await sleep(100); // Validator is asynchronous.
+
+      expect($(getCell(0, 0)).hasClass(hot.getSettings().invalidCellClassName)).toBe(true);
+      expect($(getCell(0, 2)).hasClass(hot.getSettings().invalidCellClassName)).toBe(true);
+      expect($(getCell(0, 3)).hasClass(hot.getSettings().invalidCellClassName)).toBe(true);
+
+      hot.setDataAtCell(0, 0, '=B1+5');
+
+      await sleep(100); // Validator is asynchronous.
+
+      expect($(getCell(0, 0)).hasClass(hot.getSettings().invalidCellClassName)).toBe(false);
+      expect($(getCell(0, 2)).hasClass(hot.getSettings().invalidCellClassName)).toBe(false);
+      expect($(getCell(0, 3)).hasClass(hot.getSettings().invalidCellClassName)).toBe(false);
+    });
+
+    it('should validate result of formula and dependant cells properly (formula create #REF! error)', async() => {
+      const hot = handsontable({
+        data: [
+          ['=E1', 2, '=A1', '=C1', 22]
+        ],
+        formulas: {
+          engine: HyperFormula
+        },
+        type: 'numeric'
+      });
+
+      hot.alter('remove_col', 4);
+
+      await sleep(100); // Validator is asynchronous.
+
+      expect($(getCell(0, 0)).hasClass(hot.getSettings().invalidCellClassName)).toBe(true);
+      expect($(getCell(0, 2)).hasClass(hot.getSettings().invalidCellClassName)).toBe(true);
+      expect($(getCell(0, 3)).hasClass(hot.getSettings().invalidCellClassName)).toBe(true);
+    });
+
+    it('should not automatically validate changes when the engine is modified from the outside code', async() => {
+      const hot = handsontable({
+        data: [
+          ['=E1', 'text', '=A1', '=C1', 22]
+        ],
+        formulas: {
+          engine: HyperFormula
+        },
+        type: 'numeric'
+      });
+
+      hot.getPlugin('formulas').engine.setCellContents({ sheet: 0, row: 0, col: 0 }, '=B1');
+
+      await sleep(100); // Validator is asynchronous.
+
+      expect($(getCell(0, 0)).hasClass(hot.getSettings().invalidCellClassName)).toBe(false);
+      expect($(getCell(0, 2)).hasClass(hot.getSettings().invalidCellClassName)).toBe(false);
+      expect($(getCell(0, 3)).hasClass(hot.getSettings().invalidCellClassName)).toBe(false);
+
+      hot.validateCells();
+      await sleep(100); // Validator is asynchronous.
+
+      expect($(getCell(0, 0)).hasClass(hot.getSettings().invalidCellClassName)).toBe(true);
+      expect($(getCell(0, 2)).hasClass(hot.getSettings().invalidCellClassName)).toBe(true);
+      expect($(getCell(0, 3)).hasClass(hot.getSettings().invalidCellClassName)).toBe(true);
+    });
+
+    it('should change the value type passed to the validator only when it is a formula', async() => {
+      const afterValidate = jasmine.createSpy('afterValidate');
+      const hot = handsontable({
+        data: [
+          ['=E1', 'text', '=A1', '=C1', 22, '23']
+        ],
+        formulas: {
+          engine: HyperFormula
+        },
+        validator: (value, callback) => callback(typeof value === 'number'),
+        afterValidate,
+      });
+
+      await new Promise(resolve => hot.validateCells(resolve));
+
+      expect(afterValidate).toHaveBeenCalledTimes(6);
+      expect(afterValidate).toHaveBeenCalledWith(true, 22, 0, 0, 'validateCells', void 0);
+      expect(afterValidate).toHaveBeenCalledWith(false, 'text', 0, 1, 'validateCells', void 0);
+      expect(afterValidate).toHaveBeenCalledWith(true, 22, 0, 2, 'validateCells', void 0);
+      expect(afterValidate).toHaveBeenCalledWith(true, 22, 0, 3, 'validateCells', void 0);
+      expect(afterValidate).toHaveBeenCalledWith(true, 22, 0, 4, 'validateCells', void 0);
+      expect(afterValidate).toHaveBeenCalledWith(false, '23', 0, 5, 'validateCells', void 0);
+    });
+  });
+});

--- a/src/plugins/formulas/__tests__/validation.spec.js
+++ b/src/plugins/formulas/__tests__/validation.spec.js
@@ -180,7 +180,7 @@ describe('Formulas general', () => {
       const afterValidate = jasmine.createSpy('afterValidate');
       const hot = handsontable({
         data: [
-          ['=E1', 'text', '=A1', '=C1', 22, '23']
+          ['=E1', 'text', '=A1', '=C1', 22, '23', '\'=A1', '12/1/2016']
         ],
         formulas: {
           engine: HyperFormula
@@ -191,13 +191,15 @@ describe('Formulas general', () => {
 
       await new Promise(resolve => hot.validateCells(resolve));
 
-      expect(afterValidate).toHaveBeenCalledTimes(6);
+      expect(afterValidate).toHaveBeenCalledTimes(8);
       expect(afterValidate).toHaveBeenCalledWith(true, 22, 0, 0, 'validateCells', void 0);
       expect(afterValidate).toHaveBeenCalledWith(false, 'text', 0, 1, 'validateCells', void 0);
       expect(afterValidate).toHaveBeenCalledWith(true, 22, 0, 2, 'validateCells', void 0);
       expect(afterValidate).toHaveBeenCalledWith(true, 22, 0, 3, 'validateCells', void 0);
       expect(afterValidate).toHaveBeenCalledWith(true, 22, 0, 4, 'validateCells', void 0);
       expect(afterValidate).toHaveBeenCalledWith(false, '23', 0, 5, 'validateCells', void 0);
+      expect(afterValidate).toHaveBeenCalledWith(false, '=A1', 0, 6, 'validateCells', void 0);
+      expect(afterValidate).toHaveBeenCalledWith(false, '12/1/2016', 0, 7, 'validateCells', void 0);
     });
   });
 });

--- a/src/plugins/formulas/utils.js
+++ b/src/plugins/formulas/utils.js
@@ -1,0 +1,19 @@
+/**
+ * Check if provided formula expression is escaped.
+ *
+ * @param {*} expression Expression to check.
+ * @returns {boolean}
+ */
+export function isEscapedFormulaExpression(expression) {
+  return typeof expression === 'string' && expression.charAt(0) === '\'' && expression.charAt(1) === '=';
+}
+
+/**
+ * Replace escaped formula expression into valid string.
+ *
+ * @param {string} expression Expression to process.
+ * @returns {string}
+ */
+export function unescapeFormulaExpression(expression) {
+  return typeof expression === 'string' ? expression.substr(1) : expression;
+}

--- a/src/plugins/formulas/utils.js
+++ b/src/plugins/formulas/utils.js
@@ -1,5 +1,5 @@
 /**
- * Check if provided formula expression is escaped.
+ * Checks if provided formula expression is escaped.
  *
  * @param {*} expression Expression to check.
  * @returns {boolean}
@@ -9,11 +9,11 @@ export function isEscapedFormulaExpression(expression) {
 }
 
 /**
- * Replace escaped formula expression into valid string.
+ * Replaces escaped formula expression into valid non-unescaped string.
  *
  * @param {string} expression Expression to process.
  * @returns {string}
  */
 export function unescapeFormulaExpression(expression) {
-  return typeof expression === 'string' ? expression.substr(1) : expression;
+  return isEscapedFormulaExpression(expression) ? expression.substr(1) : expression;
 }


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the validation issues when the _Formulas_ plugin is enabled. My suggestion to fix that is to restrict the HF engine to manipulate the Handsontable data only to values that hold formulas. The previous implementation allows manipulating all cells value by the HF engine. That approach causes not only the validation problems where the string values like `'2021'` were transformed to number `2021` but transforms date-like values such as [`'12/1/2016'` to `42381`](https://github.com/handsontable/handsontable/pull/8125/files#diff-78faa2c5759e6c32c070d8dc3e87dcf908894b37649386c18c6d4fe877288eebR1940) (days after Unix epoch?), and maybe more. This causes general data desynchronization with what the user passed to the configuration options.

The PR adds a new method to the public API [`isFormulaCellType`](https://github.com/handsontable/handsontable/pull/8125/files#diff-9fe25bfc8f496ab0eecdbff8833c4d174145124a5d47f6dba4181e619fcd36bcR22).

Moreover, the changes improve the initial execution time by removing unnecessary cell validation calls [(formulas.js#335)](https://github.com/handsontable/handsontable/pull/8125/files#diff-75a3f65e47cad775c4d9cef1c98b6ef3ad0ad696c9aaa6b62eaf9fe45a09833cR335). The changes are covered with the tests. 

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested manually and adds new tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #8115
2.
3.

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
