### PR TITLE
Remove a duplicated hook call in the Undo/Redo plugin.

### DIFF
--- a/.changelogs/8076.json
+++ b/.changelogs/8076.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fixed a problem with duplicated `afterCreateCol` hooks being triggered after undoing a removal of a column.",
+  "type": "fixed",
+  "issue": 8076,
+  "breaking": false,
+  "framework": "none"
+}

--- a/src/plugins/undoRedo/__tests__/UndoRedo.spec.js
+++ b/src/plugins/undoRedo/__tests__/UndoRedo.spec.js
@@ -973,7 +973,7 @@ describe('UndoRedo', () => {
 
           HOT.undo();
 
-          expect(afterCreateColCallback).toHaveBeenCalledWith(1, 1, 'UndoRedo.undo', void 0, void 0, void 0);
+          expect(afterCreateColCallback).toHaveBeenCalledOnceWith(1, 1, 'UndoRedo.undo', void 0, void 0, void 0);
 
           expect(countCols()).toEqual(3);
           expect(getDataAtCell(0, 0)).toEqual('A1');

--- a/src/plugins/undoRedo/undoRedo.js
+++ b/src/plugins/undoRedo/undoRedo.js
@@ -625,9 +625,6 @@ UndoRedo.RemoveColumnAction.prototype.undo = function(instance, undoneCallback) 
 
   instance.addHookOnce('afterRender', undoneCallback);
 
-  // TODO Temporary hook for undo/redo mess
-  instance.runHooks('afterCreateCol', this.indexes[0], this.indexes.length, 'UndoRedo.undo');
-
   instance.render();
 };
 


### PR DESCRIPTION
### Context
The `afterCreateCol` hook was called twice after undoing a removal of a column, this PR removes the extra call.

### How has this been tested?
Refined a test case to check if the hooks are called the correct number of times.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #8076 
2.
3.

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
