### PR TITLE
Extend timeout in a multiColumnSorting test case for Firefox and Safari.

### DIFF
--- a/src/plugins/multiColumnSorting/__tests__/multiColumnSorting.spec.js
+++ b/src/plugins/multiColumnSorting/__tests__/multiColumnSorting.spec.js
@@ -1027,6 +1027,9 @@ describe('MultiColumnSorting', () => {
         }
       });
 
+      // Firefox and Safari seem to take more time for the sorting to finish.
+      await sleep(600);
+
       setDataAtCell(0, 0, '19:55', 'edit');
 
       await sleep(200);


### PR DESCRIPTION
### Context
This PR adds a `600ms` timeout in a `multiColumnSorting` test case for Firefox and Safari to pass. 

<sup>[skip changelog]</sup>

### How has this been tested?
Run the test case on Firefox and Safari.

### Related issue(s):
1. #8106 

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

