### PR TITLE
[formulas] Pending tests for `beforeChange` & external rerender

### DIFF
--- a/src/plugins/formulas/__tests__/formulas.spec.js
+++ b/src/plugins/formulas/__tests__/formulas.spec.js
@@ -2514,4 +2514,63 @@ describe('Formulas general', () => {
       expect($(getCell(0, 3)).hasClass(hot.getSettings().invalidCellClassName)).toBe(true);
     });
   });
+
+  it('shout allow for blocking changes in `onBeforeChange` via `return false`', () => {
+    const hot = handsontable({
+      formulas: {
+        engine: HyperFormula
+      },
+      data: [['x', 'x', 'x']],
+      beforeChange: () => false
+    });
+
+    // This seems to work, but only when using the editor in ui,
+    // probably because of `core.js#L1091`:
+    //
+    // ---
+    // if (beforeChangeResult === false) {
+
+    //   if (activeEditor) {
+    //     activeEditor.cancelChanges();
+    //   }
+
+    //   return;
+    // }
+    // ---
+
+    hot.setDataAtCell(0, 0, 'y');
+
+    expect(hot.getData()).toEqual([['x', 'x', 'x']]);
+  });
+
+  it('should respect user defined changes in `onBeforeChange`', () => {
+    const hot = handsontable({
+      formulas: {
+        engine: HyperFormula
+      },
+      data: [['x', 'x', 'x']],
+      beforeChange(changes) {
+        changes[0] = null;
+      }
+    });
+
+    hot.setDataAtCell(0, 0, 'y');
+
+    expect(hot.getData()).toEqual([['x', 'x', 'x']]);
+  });
+
+  it('should re-render upon changes to the engine from the outside', () => {
+    const hot = handsontable({
+      formulas: {
+        engine: HyperFormula
+      },
+      data: [['x', 'x', 'x']]
+    });
+
+    const engine = hot.getPlugin('formulas').engine;
+
+    engine.setCellContents({ sheet: 0, row: 0, col: 0 }, 10);
+
+    expect(document.querySelector('.ht_master td:first-child').textContent).toEqual('10');
+  });
 });


### PR DESCRIPTION
### Context
This PR currently adds a few failing tests which are expected to pass but aren't due to known limitations in the formulas plugin. Can serve as a base for the solution.

The added requirements are:
1. `beforeChange` must be cancellable & have its changes be overridable when `formulas` are enabled
2. Handsontable should trigger a re-render if HyperFormula gets its data changed from the outside.

Related: #8125 

cc @wojciechczerniak @budnix 
