### PR TITLE
Add a 'push' and 'commit' options to the freeze and release script.

### DIFF
--- a/scripts/freeze.mjs
+++ b/scripts/freeze.mjs
@@ -5,6 +5,8 @@
  * It takes extends the committed changes with a new version and release date, runs builds and tests and pushes the
  * changes to the release branch.
  */
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
 import inquirer from 'inquirer';
 import semver from 'semver';
 import {
@@ -16,6 +18,17 @@ import {
 } from './utils/index.mjs';
 
 const [version, releaseDate] = process.argv.slice(2);
+
+const argv = yargs(hideBin(process.argv))
+  .boolean('commit')
+  .default('commit', false)
+  .describe('commit', '`true` if the state of the repo should be committed automatically at the end of the freeze' +
+    ' process.')
+  .boolean('push')
+  .default('push', false)
+  .describe('push', '`true` if the state of the repo should be pushed to remote automatically at the end of the' +
+    ' freeze process.')
+  .argv;
 
 displaySeparator();
 
@@ -114,13 +127,15 @@ displaySeparator();
   // Create the examples/[version] directory.
   await spawnProcess(`npm run examples:version ${finalVersion}`);
 
-  // Commit the changes to the release branch.
-  await spawnProcess('git add .');
+  if (argv.commit === true) {
+    // Commit the changes to the release branch.
+    await spawnProcess('git add .');
 
-  // Commit the changes to the release branch.
-  await spawnProcess('git add .');
+    await spawnProcess(`git commit -m "${finalVersion}"`);
+  }
 
-  await spawnProcess(`git commit -m "${finalVersion}"`);
-
-  await spawnProcess(`git flow release publish ${finalVersion}`);
+  if (argv.push === true) {
+    // Push the changes to remote.
+    await spawnProcess(`git flow release publish ${finalVersion}`);
+  }
 })();

--- a/scripts/freeze.mjs
+++ b/scripts/freeze.mjs
@@ -17,8 +17,6 @@ import {
   spawnProcess
 } from './utils/index.mjs';
 
-const [version, releaseDate] = process.argv.slice(2);
-
 const argv = yargs(hideBin(process.argv))
   .boolean('commit')
   .default('commit', false)
@@ -30,6 +28,7 @@ const argv = yargs(hideBin(process.argv))
     ' freeze process.')
   .argv;
 
+const [version, releaseDate] = argv._;
 displaySeparator();
 
 (async() => {

--- a/scripts/freeze.mjs
+++ b/scripts/freeze.mjs
@@ -29,6 +29,7 @@ const argv = yargs(hideBin(process.argv))
   .argv;
 
 const [version, releaseDate] = argv._;
+
 displaySeparator();
 
 (async() => {

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -4,12 +4,20 @@
  *
  * It merges the release branch to the `develop` and `master` branches and pushes them, along with the created tags.
  */
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
 import inquirer from 'inquirer';
 import {
   displayErrorMessage,
   displaySeparator,
   spawnProcess,
 } from './utils/index.mjs';
+
+const argv = yargs(hideBin(process.argv))
+  .boolean('push')
+  .default('push', false)
+  .describe('push', '`true` if the release should be pushed to `develop` and `master` along with the tags.')
+  .argv;
 
 displaySeparator();
 
@@ -61,7 +69,7 @@ displaySeparator();
     // Merge the changes to the `develop` and `master` branches.
     await spawnProcess(`git flow release finish -s ${branchName.replace('release/', '')}`);
 
-    if (process.argv.includes('--push')) {
+    if (argv.push === true) {
       await spawnProcess('git checkout develop');
       await spawnProcess('git push origin develop');
       await spawnProcess('git checkout master');


### PR DESCRIPTION
### Context
This PR adds a `--commit` and `--push` options to the freeze script and a `--push` option to the release scripts, and sets them all to `false` by default.

<sup>[skip changelog]</sup>

### How has this been tested?
Tested manually.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality) **(internal change, doesn't require bumping the minor version number)**
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Affected project(s):
- [x] `handsontable`
- [x] `@handsontable/angular`
- [x] `@handsontable/react`
- [x] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
