### PR TITLE
 New docs: change the URL of the logo

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -25,7 +25,11 @@ module.exports = {
     ['link', { rel: 'icon', href: 'https://handsontable.com/static/images/template/ModCommon/favicon-32x32.png' }],
     ['meta', { name: 'viewport', content: 'width=device-width, initial-scale=1' }],
     // Cookiebot - cookie consent popup
-    ['script', { id: 'Cookiebot', src: 'https://consent.cookiebot.com/uc.js', 'data-cbid': 'ef171f1d-a288-433f-b680-3cdbdebd5646' }],
+    ['script', {
+      id: 'Cookiebot',
+      src: 'https://consent.cookiebot.com/uc.js',
+      'data-cbid': 'ef171f1d-a288-433f-b680-3cdbdebd5646'
+    }],
     ...environmentHead
   ],
   markdown: {

--- a/docs/.vuepress/containers/examples/examples.js
+++ b/docs/.vuepress/containers/examples/examples.js
@@ -46,7 +46,7 @@ const tab = (tabName, token) => {
   ];
 };
 
-function getPreviewTab(id, cssContent, htmlContent, code) {
+const getPreviewTab = (id, cssContent, htmlContent, code) => {
   return {
     type: 'html_block',
     tag: '',
@@ -67,9 +67,8 @@ function getPreviewTab(id, cssContent, htmlContent, code) {
     meta: null,
     block: true,
     hidden: false
-  }
-  ;
-}
+  };
+};
 
 module.exports = {
   type: 'example',

--- a/docs/.vuepress/theme/components/Navbar.vue
+++ b/docs/.vuepress/theme/components/Navbar.vue
@@ -3,7 +3,7 @@
     <SidebarButton @toggle-sidebar="$emit('toggle-sidebar')" />
 
     <RouterLink
-        :to="$localePath"
+        :to="versionedUrl($localePath)"
         class="home-link"
     >
       <img
@@ -39,6 +39,7 @@ import SearchBox from '@theme/components/SearchBox'
 import SidebarButton from '@theme/components/SidebarButton.vue'
 import NavLinks from '@theme/components/NavLinks.vue'
 import Versions from '@theme/components/Versions.vue'
+import {ensureExt} from "./util";
 export default {
   name: 'Navbar',
   components: {
@@ -47,6 +48,15 @@ export default {
     SearchBox,
     AlgoliaSearchBox,
     Versions
+  },
+  methods: {
+    versionedUrl(url){
+      if (this.$page.currentVersion === this.$page.latestVersion) {
+        return ensureExt(url);
+      } else {
+        return ensureExt('/' + this.$page.currentVersion + url);
+      }
+    }
   },
   data () {
     return {

--- a/docs/next/sidebars.js
+++ b/docs/next/sidebars.js
@@ -1,7 +1,7 @@
 
-const api = require('./api/sidebar.js').sidebar;
-const guides = require('./guides/sidebar.js').sidebar;
-const examples = require('./examples/sidebar.js').sidebar;
+const api = require('./api/sidebar').sidebar;
+const guides = require('./guides/sidebar').sidebar;
+const examples = require('./examples/sidebar').sidebar;
 
 module.exports = {
   api, guides, examples


### PR DESCRIPTION
### Context
Main logo targeting always into current selected docs version.

### How has this been tested?

```bash
npm run docs:version 9.0   
npm run docs:version 9.1
npm run start
```

I.
1. Go into http://localhost:8080/docs/9.0/binding-to-data/
2. Click the logo
3. ASSERT: URL is: http://localhost:8080/docs/9.0/

II.
1. Go into http://localhost:8080/docs/binding-to-data/
2. Click the logo
3. ASSERT: URL is: http://localhost:8080/docs/

III.
1. Go into http://localhost:8080/docs/next/binding-to-data/
2. Click the logo
3. ASSERT: URL is: http://localhost:8080/docs/next/

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. resolves #8163
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [x] `Documentaion`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
