### PR TITLE
New docs: Fix typo on the plugins page

### DIFF
--- a/docs/next/guides/building-and-testing/plugins.md
+++ b/docs/next/guides/building-and-testing/plugins.md
@@ -1,6 +1,6 @@
 ---
 title: Plugins
-metaTitle: Plguins - Guide - Handsontable Documentation
+metaTitle: Plugins - Guide - Handsontable Documentation
 permalink: /next/plugins
 canonicalUrl: /plugins
 tags:
@@ -15,11 +15,11 @@ tags:
 
 ## Overview
 
-Plugin is a one great way to extend the capabilities of Handsontable. In fact, most of features available in tis library are provided by plugins.
+Plugin is a one great way to extend the capabilities of Handsontable. In fact, most of the features available in this library are provided by plugins.
 
 ### Plugin template
 
-There are two types of plugins: internal and external. While both extend Handsontable's functionality, the former is incorporated into the Handsontable build and the latter needs to be included from a separate file.
+There are two types of plugins: internal and external. While both extend Handsontable's functionality, the former is incorporated into the Handsontable build, and the latter needs to be included from a separate file.
 
 Regardless of which plugin you are going to build, using a template will save you lots of time.
 


### PR DESCRIPTION
### Context
Fix typo on the plugins page

### Related issue(s):
1. https://github.com/handsontable/handsontable/projects/6#card-62702673
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [x] `Documentation`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
