### PR TITLE
New Docs:  Fix video loading at IME support page.

### DIFF
--- a/docs/next/guides/internationalization/ime-support.md
+++ b/docs/next/guides/internationalization/ime-support.md
@@ -29,4 +29,4 @@ To test the IME support, you will need to change your language preferences for y
 
 ## Watch IME in action
 
-<video controls loop src="/img/pages/ime-support/ime-support-in-handsontable.mp4" width="100%"></video>
+<video controls loop src="/docs/img/pages/ime-support/ime-support-in-handsontable.mp4" width="100%"></video>


### PR DESCRIPTION
### Context
Video didn't load, I fix it by setting the correct path.

### How has this been tested?
Go into: http://localhost:8080/docs/next/ime-support/#ime-support-in-handsontable
Video is available at the bottom of the page

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. resolves: https://github.com/handsontable/handsontable/issues/8158
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [x] `Documentation`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
