### PR TITLE
New docs: Hide edit button to broken jsfiddle code.

### DIFF
--- a/docs/.vuepress/containers/examples/examples.js
+++ b/docs/.vuepress/containers/examples/examples.js
@@ -1,5 +1,5 @@
 /**
- * Matches into: `example #ID .class :preset --css 2 --html 0 --js 1 --hidden`.
+ * Matches into: `example #ID .class :preset --css 2 --html 0 --js 1 --no-edit`.
  *
  * @type {RegExp}
  */
@@ -103,6 +103,8 @@ module.exports = {
       const jsContent = jsToken.content;
 
       const activeTab = args.match(/--tab (code|html|css|preview)/)?.[1] || 'code';
+      
+      const noEdit = !!args.match(/--no-edit/)?.[0];
 
       const code = buildCode(id + (preset.includes('angular') ? '.ts' : '.jsx'), jsContent, env.relativePath);
       const encodedCode = encodeURI(`useHandsontable('${version}', function(){${code}}, '${preset}')`);
@@ -121,7 +123,7 @@ module.exports = {
       tokens.splice(index + 1, 0, ...newTokens);
 
       return `
-          ${jsfiddle(id, htmlContent, jsContent, cssContent, version, preset)}
+          ${!noEdit ? jsfiddle(id, htmlContent, jsContent, cssContent, version, preset) : ''}
           <tabs 
             :options="{ useUrlFragment: false, defaultTabHash: '${activeTab}' }" 
             cache-lifetime="0"

--- a/docs/next/guides/integrate-with-react/react-custom-editor-example.md
+++ b/docs/next/guides/integrate-with-react/react-custom-editor-example.md
@@ -17,7 +17,7 @@ You can declare a custom editor for the `HotTable` component by declaring it as 
 
 The following example implements the `@handsontable/react` component with a custom editor added, utilizing the `placeholder` attribute in the editor's `input` element.
 
-::: example #example1 :react
+::: example #example1 :react  --no-edit
 ```jsx
 import React from 'react';
 import ReactDOM from 'react-dom';


### PR DESCRIPTION
### Context
I tried to fix the example code for the https://dev.handsontable.com/docs/next/react-custom-editor-example/ snippet. However, I suppose that is a problem with JSFIDDLE itself. Therefore I implement (as @krzysztofspilka propose at the meeting) a mechanism to remove the edit button by using a flag `--no-edit`.

This PR will not close referenced issue, however, it changes the priority for the issue to low.

### How has this been tested?

**Before:** clean cache or run with no cache by using: `npm run docs:start:no-cache`.

I.
1. Go into http://localhost:8080/docs/next/react-custom-editor-example/
2. ASSERT: Edit button doesn't exist

II. 
1. Go into http://localhost:8080/docs/next/react-setting-up-a-locale/
2. ASSERT: Edit button exists.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #8159 

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [x] Documentation

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
