### PR TITLE
Fix render issues for hot

### DIFF
--- a/docs/.vuepress/components/ScriptLoader.vue
+++ b/docs/.vuepress/components/ScriptLoader.vue
@@ -22,8 +22,9 @@ export default {
   props: ['code'],
   mounted() {
     const [ append, remove ] = useCodePreview(decode(this.$props.code));
+
     append(this.$el);
-    this.unmount = remove();
+    remove();
   },
   methods:{
     decode

--- a/docs/.vuepress/containers/examples/examples.js
+++ b/docs/.vuepress/containers/examples/examples.js
@@ -56,10 +56,10 @@ function getPreviewTab(id, cssContent, htmlContent, code) {
     level: 1,
     children: null,
     content: `
-      <tab name="Preview" hot-example-id="${id}">
+      <tab name="Preview">
         <style v-pre>${cssContent}</style>
         <div v-pre>${htmlContent}</div>
-        <ScriptLoader code="${code}"></ScriptLoader>
+        <ScriptLoader v-if="$parent.$parent.isScriptLoaderActivated('${id}')" code="${code}"></ScriptLoader>
       </tab>
     `,
     markup: '',
@@ -123,8 +123,8 @@ module.exports = {
 
       return `
           ${jsfiddle(id, htmlContent, jsContent, cssContent, version, preset)}
-          <tabs 
-            :options="{ useUrlFragment: false, defaultTabHash: '${activeTab}' }" 
+          <tabs
+            :options="{ useUrlFragment: false, defaultTabHash: '${activeTab}' }"
             cache-lifetime="0"
             @changed="$parent.$parent.codePreviewTabChanged(...arguments, '${id}')"
           >

--- a/docs/.vuepress/handsontable-manager/register.js
+++ b/docs/.vuepress/handsontable-manager/register.js
@@ -9,7 +9,7 @@ register.listen = () => {
       Handsontable.hooks.add('afterInit', function() {
         // Collect only HoT main instances. Skip context menu, dropdown menu
         // and other internal HoT-based components.
-        if (this.rootElement.classList.contains('hot')) {
+        if (!this.rootElement.id.startsWith('ht_')) {
           register.add(this);
         }
       });

--- a/docs/.vuepress/handsontable-manager/register.js
+++ b/docs/.vuepress/handsontable-manager/register.js
@@ -1,17 +1,17 @@
 /* eslint-disable no-restricted-globals, no-undef, no-console, no-unused-vars */
 
-const register = new Map();
+const register = new Set();
 
 register.listen = () => {
   try {
     if (typeof Handsontable !== 'undefined' && Handsontable._instanceRegisterInstalled === undefined) {
       Handsontable._instanceRegisterInstalled = true;
       Handsontable.hooks.add('afterInit', function() {
-        const hotId = this.rootElement
-          .closest('[hot-example-id]')
-          .getAttribute('hot-example-id');
-
-        register.set(hotId, this);
+        // Collect only HoT main instances. Skip context menu, dropdown menu
+        // and other internal HoT-based components.
+        if (this.rootElement.classList.contains('hot')) {
+          register.add(this);
+        }
       });
     }
   } catch (e) {

--- a/docs/.vuepress/theme/components/Page.vue
+++ b/docs/.vuepress/theme/components/Page.vue
@@ -12,10 +12,8 @@
 </template>
 
 <script>
-import Vue from 'vue'
 import PageEdit from '@theme/components/PageEdit.vue'
 import PageNav from '@theme/components/PageNav.vue'
-import ScriptLoader from '../../components/ScriptLoader.vue'
 
 export default {
   components: { PageEdit, PageNav },

--- a/docs/.vuepress/theme/components/Page.vue
+++ b/docs/.vuepress/theme/components/Page.vue
@@ -12,24 +12,37 @@
 </template>
 
 <script>
+import Vue from 'vue'
 import PageEdit from '@theme/components/PageEdit.vue'
 import PageNav from '@theme/components/PageNav.vue'
+import ScriptLoader from '../../components/ScriptLoader.vue'
 
 export default {
   components: { PageEdit, PageNav },
   props: ['sidebarItems'],
+  watch: {
+    $route() {
+      this.activatedExamples = [];
+    }
+  },
+  data() {
+    return {
+      activatedExamples: [],
+    }
+  },
   computed:{
     isApi() {
       return this.$route.fullPath.match(/([^/]*\/)?api\//);
-    }
+    },
   },
   methods: {
-    codePreviewTabChanged(selectedTab, hotId) {
-      const hot = window.instanceRegister.get(hotId);
-
-      if (selectedTab.tab.computedId === 'preview' && hot) {
-        hot.render();
+    codePreviewTabChanged(selectedTab, exampleId) {
+      if (selectedTab.tab.computedId === 'preview') {
+        this.activatedExamples.push(exampleId);
       }
+    },
+    isScriptLoaderActivated(exampleId) {
+      return this.activatedExamples.includes(exampleId);
     }
   },
 }


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The issue fixes the problem with initializing Handsontable within the hidden element. The PR adds code that initializes the Handsontable on-demand - after clicking the  "Preview" tab. Thanks to that the Handsontable always starts in the visible element, thus there are no more visual glitches.

The bonus of loading script on-demand is that the overall page loading time should be improved. Especially on that pages where there is a lot of demos.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #8157
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
