### PR TITLE
Fix broken demos for Column filter page

### DIFF
--- a/docs/.vuepress/containers/examples/examples.js
+++ b/docs/.vuepress/containers/examples/examples.js
@@ -56,7 +56,7 @@ const getPreviewTab = (id, cssContent, htmlContent, code) => {
     level: 1,
     children: null,
     content: `
-      <tab name="Preview">
+      <tab name="Preview" id="preview-tab-${id}">
         <style v-pre>${cssContent}</style>
         <div v-pre>${htmlContent}</div>
         <ScriptLoader v-if="$parent.$parent.isScriptLoaderActivated('${id}')" code="${code}"></ScriptLoader>

--- a/docs/.vuepress/containers/examples/jsfiddle.js
+++ b/docs/.vuepress/containers/examples/jsfiddle.js
@@ -33,7 +33,7 @@ ${html}
   }
     </form>
     <div class="js-fiddle-link">
-      <button type="submit" form="jsfiddle-${id}"><i class="fa fa-jsfiddle"></i>Edit</button>
+      <button type="submit" form="jsfiddle-${id}">Edit</button>
     </div>
   `;
 };

--- a/docs/.vuepress/theme/components/Page.vue
+++ b/docs/.vuepress/theme/components/Page.vue
@@ -35,7 +35,7 @@ export default {
   },
   methods: {
     codePreviewTabChanged(selectedTab, exampleId) {
-      if (selectedTab.tab.computedId === 'preview') {
+      if (selectedTab.tab.computedId.startsWith('preview-tab')) {
         this.activatedExamples.push(exampleId);
       }
     },

--- a/docs/.vuepress/theme/styles/form.styl
+++ b/docs/.vuepress/theme/styles/form.styl
@@ -1,6 +1,6 @@
-/* 
+/*
   A stylesheet for different form elements:
-  
+
   - button
   - input
   - textarea
@@ -14,7 +14,8 @@
   padding-bottom: 10px;
 }
 
-.page button:not(.theme-code-group__nav-tab), button.controls {
+// select all <button>s that are not descendants of .handsontable container elements
+.page button:not(.theme-code-group__nav-tab, .handsontable *) {
   padding: 8px 14px;
   font-size: 14px;
   display: inline-block;

--- a/docs/.vuepress/theme/styles/handsontable.styl
+++ b/docs/.vuepress/theme/styles/handsontable.styl
@@ -1,4 +1,4 @@
-/* 
+/*
   A stylesheet customizing Handsontable style
 */
 
@@ -10,12 +10,10 @@
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI",
     "Roboto", "Oxygen", "Ubuntu", "Helvetica Neue", Arial, sans-serif;
   font-weight: 400;
-  overflow-y: scroll;
-  max-height: 320px;
   min-height: 100px;
   width: 100%;
 }
-  
+
 .handsontable {
   font-size: 13px;
 }

--- a/docs/next/guides/columns/column-filter.md
+++ b/docs/next/guides/columns/column-filter.md
@@ -31,12 +31,12 @@ const hot = new Handsontable(container, {
     ['orci', 'et', 'dignissim', 'hendrerit', '12/1/2016', 8.5]
   ],
   columns: [
-    {type: 'text'},
-    {type: 'text'},
-    {type: 'text'},
-    {type: 'text'},
-    {type: 'date', dateFormat: 'M/D/YYYY'},
-    {type: 'numeric'}
+    { type: 'text' },
+    { type: 'text' },
+    { type: 'text' },
+    { type: 'text' },
+    { type: 'date', dateFormat: 'M/D/YYYY' },
+    { type: 'numeric' }
   ],
   colHeaders: true,
   rowHeaders: true,
@@ -55,7 +55,7 @@ To display filters while hiding the other elements in the dropdown menu, pass th
 ```js
 const container = document.querySelector('#example2');
 
-const hot2 = new Handsontable(container, {
+const hot = new Handsontable(container, {
   data: [
     ['Lorem', 'ipsum', 'dolor', 'sit', '12/1/2015', 23],
     ['adipiscing', 'elit', 'Ut', 'imperdiet', '5/12/2015', 6],
@@ -64,12 +64,12 @@ const hot2 = new Handsontable(container, {
     ['orci', 'et', 'dignissim', 'hendrerit', '12/1/2016', 8.5]
   ],
   columns: [
-    {type: 'text'},
-    {type: 'text'},
-    {type: 'text'},
-    {type: 'text'},
-    {type: 'date', dateFormat: 'M/D/YYYY'},
-    {type: 'numeric'}
+    { type: 'text' },
+    { type: 'text' },
+    { type: 'text' },
+    { type: 'text' },
+    { type: 'date', dateFormat: 'M/D/YYYY' },
+    { type: 'numeric '}
   ],
   colHeaders: true,
   rowHeaders: true,
@@ -94,7 +94,7 @@ Please note that this demo uses a Handsontable API to a great extent.
 ```js
 // Event for `keydown` event. Add condition after delay of 200 ms which is counted from the time of last pressed key.
 const debounceFn = Handsontable.helper.debounce((colIndex, event) => {
-  const filtersPlugin = hot3.getPlugin('filters');
+  const filtersPlugin = hot.getPlugin('filters');
 
   filtersPlugin.removeConditions(colIndex);
   filtersPlugin.addCondition(colIndex, 'contains', [event.target.value]);
@@ -133,16 +133,9 @@ const addInput = (col, TH) => {
   }
 };
 
-// Deselect the column after clicking on input.
-const doNotSelectColumn = (event, coords) => {
-  if (coords.row === -1 && event.target.nodeName === 'INPUT') {
-    event.stopImmediatePropagation();
-    this.deselectCell();
-  }
-};
 const container = document.querySelector('#example3');
 
-const hot3 = new Handsontable(container, {
+const hot = new Handsontable(container, {
   data: [
     ['Lorem', 'ipsum', 'dolor', 'sit', '12/1/2015', 23],
     ['adipiscing', 'elit', 'Ut', 'imperdiet', '5/12/2015', 6],
@@ -156,7 +149,13 @@ const hot3 = new Handsontable(container, {
   filters: true,
   colWidths: 100,
   afterGetColHeader: addInput,
-  beforeOnCellMouseDown: doNotSelectColumn,
+  beforeOnCellMouseDown(event, coords) {
+    // Deselect the column after clicking on input.
+    if (coords.row === -1 && event.target.nodeName === 'INPUT') {
+      event.stopImmediatePropagation();
+      this.deselectCell();
+    }
+  },
   licenseKey: 'non-commercial-and-evaluation'
 });
 ```
@@ -433,7 +432,7 @@ class Controller {
 
 const container = document.querySelector('#example4');
 
-const hot4 = new Handsontable(container, {
+const hot = new Handsontable(container, {
   data: [
     ['Lorem', 'ipsum', 'dolor', 'sit', '12/1/2015', 23],
     ['adipiscing', 'elit', 'Ut', 'imperdiet', '5/12/2015', 6],


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
 * The PR fixes broken demos for the Columns filter page;
 * Fixes the React-Redux example page by removing the `max-height` CSS property;
![image](https://user-images.githubusercontent.com/571316/121514052-ddc36600-c9eb-11eb-9711-abef3b623d9f.png)
 * Fixes the double scroll on each demos (remove the `overflow-y` CSS property); 
![image](https://user-images.githubusercontent.com/571316/121514395-427ec080-c9ec-11eb-891c-06726d2eb8ac.png)
 * And fixes an issue where multiple HTML elements are created with the same `id` attribute (`id="preview"`).

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #8155
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
