### PR TITLE
Switch Angular examples to Babel env

### DIFF
--- a/docs/.vuepress/containers/examples/jsfiddle.js
+++ b/docs/.vuepress/containers/examples/jsfiddle.js
@@ -28,8 +28,7 @@ ${imports}
 ${html}
       </textarea>
       <textarea name="css" readOnly>${css}</textarea>
-      ${isBabelPanel ? '<input type="text" name="panel_js" value="3" readOnly>' : ''}
-      ${isAngularPanel ? '<input type="text" name="panel_js" value="4" readOnly>' : ''}
+      ${isBabelPanel || isAngularPanel ? '<input type="text" name="panel_js" value="3" readOnly>' : ''}
   }
     </form>
     <div class="js-fiddle-link">


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR switches the Angular examples to the Babel environment. This is the case for examples that runs on jsFiddle. With the TypeScript environment there is a problem with class inheritance, thus some demos don't work.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #8159
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
