### PR TITLE
Introduced new CSS style for cells of `checkbox` type to restore previous behaviour.

### DIFF
--- a/.changelogs/8196.json
+++ b/.changelogs/8196.json
@@ -1,5 +1,5 @@
 {
-  "title": "Introduced new CSS style for cells of `checkbox` type to revert previous behaviour.",
+  "title": "Introduced new CSS style for cells of `checkbox` type to restore previous behaviour.",
   "type": "fixed",
   "issue": 8196,
   "breaking": false,

--- a/.changelogs/8196.json
+++ b/.changelogs/8196.json
@@ -1,0 +1,7 @@
+{
+  "title": "Introduced new CSS style for cells of `checkbox` type to revert previous behaviour.",
+  "type": "fixed",
+  "issue": 8196,
+  "breaking": false,
+  "framework": "none"
+}

--- a/src/renderers/checkboxRenderer/__tests__/checkboxRenderer.spec.js
+++ b/src/renderers/checkboxRenderer/__tests__/checkboxRenderer.spec.js
@@ -846,6 +846,29 @@ describe('CheckboxRenderer', () => {
     expect(getCell(0, 0).querySelector('label').firstChild.textContent).toEqual('myLabel');
   });
 
+  it('should expand label to the cell size when it is not separated from input', () => {
+    handsontable({
+      data: [
+        [true, false, true, false, false, false]
+      ],
+      columns: [
+        { type: 'checkbox', label: { position: 'before', value: 'label1', separated: true } },
+        { type: 'checkbox', label: { position: 'after', value: 'label2', separated: true } },
+        { type: 'checkbox', label: { position: 'before', value: 'label3', separated: false } },
+        { type: 'checkbox', label: { position: 'after', value: 'label4', separated: false } },
+        { type: 'checkbox', label: { position: 'before', value: 'label5' } },
+        { type: 'checkbox', label: { position: 'after', value: 'label6' } },
+      ]
+    });
+
+    // 2 x 4px padding + 1px border === 9px calculated by the `offsetWidth`
+    expect(getCell(0, 0).querySelector('label').offsetWidth).not.toBe(getCell(0, 0).offsetWidth - 9);
+    expect(getCell(0, 1).querySelector('label').offsetWidth).not.toBe(getCell(0, 0).offsetWidth - 9);
+    expect(getCell(0, 2).querySelector('label').offsetWidth).toBe(getCell(0, 0).offsetWidth - 9);
+    expect(getCell(0, 3).querySelector('label').offsetWidth).toBe(getCell(0, 0).offsetWidth - 9);
+    expect(getCell(0, 4).querySelector('label').offsetWidth).toBe(getCell(0, 0).offsetWidth - 9);
+  });
+
   it('should add label on the beginning of a checkbox element where checkbox and label are separated', () => {
     handsontable({
       data: [{ checked: true, label: 'myLabel' }, { checked: false, label: 'myLabel' }],

--- a/src/renderers/checkboxRenderer/__tests__/checkboxRenderer.spec.js
+++ b/src/renderers/checkboxRenderer/__tests__/checkboxRenderer.spec.js
@@ -867,6 +867,7 @@ describe('CheckboxRenderer', () => {
     expect(getCell(0, 2).querySelector('label').offsetWidth).toBe(getCell(0, 0).offsetWidth - 9);
     expect(getCell(0, 3).querySelector('label').offsetWidth).toBe(getCell(0, 0).offsetWidth - 9);
     expect(getCell(0, 4).querySelector('label').offsetWidth).toBe(getCell(0, 0).offsetWidth - 9);
+    expect(getCell(0, 5).querySelector('label').offsetWidth).toBe(getCell(0, 0).offsetWidth - 9);
   });
 
   it('should add label on the beginning of a checkbox element where checkbox and label are separated', () => {

--- a/src/renderers/checkboxRenderer/checkboxRenderer.css
+++ b/src/renderers/checkboxRenderer/checkboxRenderer.css
@@ -13,3 +13,7 @@ CheckboxRenderer
   cursor: pointer;
   display: inline-block;
 }
+
+.handsontable .htCheckboxRendererLabel.fullWidth {
+  width: 100%;
+}

--- a/src/renderers/checkboxRenderer/checkboxRenderer.js
+++ b/src/renderers/checkboxRenderer/checkboxRenderer.js
@@ -109,7 +109,7 @@ export function checkboxRenderer(instance, TD, row, col, prop, value, cellProper
       labelText = labelValue !== null ? labelValue : '';
     }
 
-    const label = createLabel(rootDocument, labelText);
+    const label = createLabel(rootDocument, labelText, labelOptions.separated !== true);
 
     if (labelOptions.position === 'before') {
       if (labelOptions.separated) {
@@ -324,12 +324,13 @@ function createInput(rootDocument) {
  *
  * @param {Document} rootDocument The document owner.
  * @param {string} text The label text.
+ * @param {boolean} fullWidth Determines whether label should have full width.
  * @returns {Node}
  */
-function createLabel(rootDocument, text) {
+function createLabel(rootDocument, text, fullWidth) {
   const label = rootDocument.createElement('label');
 
-  label.className = 'htCheckboxRendererLabel';
+  label.className = `htCheckboxRendererLabel ${fullWidth ? 'fullWidth' : ''}`;
   label.appendChild(rootDocument.createTextNode(text));
 
   return label.cloneNode(true);


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
PR https://github.com/handsontable/handsontable/pull/5539 introduced new feature. However, [removing style for `label`](https://github.com/handsontable/handsontable/pull/5539/files#diff-e4355a985578f809afe932b6d818f06f5fcf121662f1d00de55930ac729a8d71L15) has some side effects. I added new CSS class to restore previous behaviour and fix the bug.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
With different values for label option (cell with type `checkbox`) and for example from the issue.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #8196

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] My change requires a change to the documentation.
