### PR TITLE
Fix `timer` assignment

### DIFF
--- a/docs/next/guides/getting-started/events-and-hooks.md
+++ b/docs/next/guides/getting-started/events-and-hooks.md
@@ -12,7 +12,7 @@ tags:
 - after
 - before
 - events
-- hooks 
+- hooks
 ---
 
 # Events and hooks
@@ -20,7 +20,7 @@ tags:
 [[toc]]
 
 ## Overview
-Callbacks are used to react before or after actions occur. We refer to them as hooks. Hooks share some characteristics with events and middleware, combining them both in a unique structure. 
+Callbacks are used to react before or after actions occur. We refer to them as hooks. Hooks share some characteristics with events and middleware, combining them both in a unique structure.
 
 ## Events
 
@@ -62,7 +62,7 @@ hot.addHook('beforeCreateRow', (row, amount) => {
 })
 ```
 
-The first argument may be modified and passed on through the hooks that are next in the queue. This characteristic is shared between `before` and `after` hooks but is more common with the former. Before something happens, we can run the data through a pipeline of hooks that may modify or reject the operation. This provides many possibilities to extend the default Handsontable functionality and customize it for your application. 
+The first argument may be modified and passed on through the hooks that are next in the queue. This characteristic is shared between `before` and `after` hooks but is more common with the former. Before something happens, we can run the data through a pipeline of hooks that may modify or reject the operation. This provides many possibilities to extend the default Handsontable functionality and customize it for your application.
 
 ## All available hooks example
 
@@ -187,7 +187,7 @@ function log_events(event, data) {
     div.appendChild(text);
     example1Events.appendChild(div);
     clearTimeout(timer);
-    const timer = setTimeout(function() {
+    timer = setTimeout(function() {
       example1Events.scrollTop = example1Events.scrollHeight;
     }, 10);
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Fix demo code logic by removing the `const` keyword from the `timer` variable. The variable is reassignable and it's already defined in the upper scope. The PR fixes an error that was when the code is run on jsFiddle. 

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
