### PR TITLE
New Docs: Fixing grid-size example and controls sticked the hot instance

### DIFF
--- a/docs/.vuepress/theme/styles/form.styl
+++ b/docs/.vuepress/theme/styles/form.styl
@@ -11,6 +11,7 @@
 /* BUTTON */
 
 .controls {
+  margin-top: 10px;
   padding-bottom: 10px;
 }
 

--- a/docs/next/guides/getting-started/grid-size.md
+++ b/docs/next/guides/getting-started/grid-size.md
@@ -83,7 +83,9 @@ You can listen for two hooks, `beforeRefreshDimensions` and `afterRefreshDimensi
 
 ::: example #example --html 1 --js 2
 ```html
-<div id="example" class="hot"></div>
+<div><!-- sliceElement with dynamicly added styles-->
+  <div id="example"></div>
+</div>
 
 <div class="controls">
   <button id="expander" className="button button--primary">Expand container</button>
@@ -105,7 +107,7 @@ const hot = new Handsontable(example, {
   licenseKey: 'non-commercial-and-evaluation'
 });
 
-sliceElem.style = "transition: height 0.5s; height: 150px;"
+sliceElem.style = "transition: height 0.5s; height: 150px; margin-bottom: 10px;"
 hot.refreshDimensions();
 
 triggerBtn.addEventListener('click', () => {

--- a/docs/next/guides/getting-started/grid-size.md
+++ b/docs/next/guides/getting-started/grid-size.md
@@ -107,7 +107,7 @@ const hot = new Handsontable(example, {
   licenseKey: 'non-commercial-and-evaluation'
 });
 
-sliceElem.style = "transition: height 0.5s; height: 150px; margin-bottom: 10px;"
+sliceElem.style = "transition: height 0.5s; height: 150px;"
 hot.refreshDimensions();
 
 triggerBtn.addEventListener('click', () => {

--- a/docs/next/guides/getting-started/grid-size.md
+++ b/docs/next/guides/getting-started/grid-size.md
@@ -83,7 +83,7 @@ You can listen for two hooks, `beforeRefreshDimensions` and `afterRefreshDimensi
 
 ::: example #example --html 1 --js 2
 ```html
-<div><!-- sliceElement with dynamicly added styles-->
+<div><!-- slice element with dynamically added styles -->
   <div id="example"></div>
 </div>
 


### PR DESCRIPTION
### Context
Wrap handsontable instance into a div, which is getting and modified by a script.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.  https://github.com/handsontable/handsontable/issues/8149 (`The button HTML is outside the HTML tree (?) weird (see screen recording below)` and `buttons are sticked to the grid`)
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
