### PR TITLE
Prevent the Formulas plugin depednant cell validator logic from validating cells outside of the schema.

### DIFF
--- a/src/plugins/formulas/__tests__/formulas.spec.js
+++ b/src/plugins/formulas/__tests__/formulas.spec.js
@@ -2356,33 +2356,4 @@ describe('Formulas general', () => {
       });
     });
   });
-
-  it('should not try to validate cells outside of the table boundaries', () => {
-    let validatorCallsCount = 0;
-    const hot = handsontable({
-      data: [
-        [100, '=A1'],
-        ['=A1', '=A1', '=A1'],
-      ],
-      formulas: {
-        engine: HyperFormula
-      },
-      validator: () => {},
-      beforeValidate: () => {
-        validatorCallsCount += 1;
-      }
-    });
-    const errorList = [];
-
-    try {
-      hot.setDataAtCell(0, 0, 1);
-
-    } catch (e) {
-      errorList.push(e);
-    }
-
-    expect(errorList.length).toEqual(0);
-    // 3 from the visible cells + 1 from setDataAtCell
-    expect(validatorCallsCount).toEqual(4);
-  });
 });

--- a/src/plugins/formulas/__tests__/formulas.spec.js
+++ b/src/plugins/formulas/__tests__/formulas.spec.js
@@ -2356,4 +2356,33 @@ describe('Formulas general', () => {
       });
     });
   });
+
+  it('should not try to validate cells outside of the table boundaries', () => {
+    let validatorCallsCount = 0;
+    const hot = handsontable({
+      data: [
+        [100, '=A1'],
+        ['=A1', '=A1', '=A1'],
+      ],
+      formulas: {
+        engine: HyperFormula
+      },
+      validator: () => {},
+      beforeValidate: () => {
+        validatorCallsCount += 1;
+      }
+    });
+    const errorList = [];
+
+    try {
+      hot.setDataAtCell(0, 0, 1);
+
+    } catch (e) {
+      errorList.push(e);
+    }
+
+    expect(errorList.length).toEqual(0);
+    // 3 from the visible cells + 1 from setDataAtCell
+    expect(validatorCallsCount).toEqual(4);
+  });
 });

--- a/src/plugins/formulas/__tests__/validation.spec.js
+++ b/src/plugins/formulas/__tests__/validation.spec.js
@@ -342,5 +342,34 @@ describe('Formulas general', () => {
       expect(beforeValidate).toHaveBeenCalledWith(6, 0, 0, void 0, void 0, void 0);
       expect(beforeValidate).toHaveBeenCalledWith(9, 3, 4, void 0, void 0, void 0);
     });
+
+    it('should not try to validate cells outside of the table boundaries', () => {
+      let validatorCallsCount = 0;
+      const hot = handsontable({
+        data: [
+          [100, '=A1'],
+          ['=A1', '=A1', '=A1'],
+        ],
+        formulas: {
+          engine: HyperFormula
+        },
+        validator: () => {},
+        beforeValidate: () => {
+          validatorCallsCount += 1;
+        }
+      });
+      const errorList = [];
+
+      try {
+        hot.setDataAtCell(0, 0, 1);
+
+      } catch (e) {
+        errorList.push(e);
+      }
+
+      expect(errorList.length).toEqual(0);
+      // 3 from the visible cells + 1 from setDataAtCell
+      expect(validatorCallsCount).toEqual(4);
+    });
   });
 });

--- a/src/plugins/formulas/formulas.js
+++ b/src/plugins/formulas/formulas.js
@@ -436,6 +436,15 @@ export class Formulas extends BasePlugin {
     const changedCellsSet = new Set(changedCells.map(change => stringifyAddress(change)));
 
     dependentCells.forEach((change) => {
+      const { row, col } = change.address;
+      const visualRow = this.hot.toVisualRow(row);
+      const visualColumn = this.hot.toVisualColumn(col);
+
+      // Don't try to validate cells outside of the visual part of the table.
+      if (visualRow === null || visualColumn === null) {
+        return;
+      }
+
       // For the Named expression the address is empty, hence the `sheetId` is undefined.
       const sheetId = change?.address?.sheet;
       const addressId = stringifyAddress(change);
@@ -443,9 +452,6 @@ export class Formulas extends BasePlugin {
       // Validate the cells that depend on the calculated formulas. Skip that cells
       // where the user directly changes the values - the Core triggers those validators.
       if (sheetId !== void 0 && !changedCellsSet.has(addressId)) {
-        const { row, col } = change.address;
-        const visualRow = this.hot.toVisualRow(row);
-        const visualColumn = this.hot.toVisualColumn(col);
         const hot = getRegisteredHotInstances(this.engine).get(sheetId);
 
         // It will just re-render certain cell when necessary.

--- a/src/plugins/formulas/formulas.js
+++ b/src/plugins/formulas/formulas.js
@@ -436,9 +436,9 @@ export class Formulas extends BasePlugin {
     const changedCellsSet = new Set(changedCells.map(change => stringifyAddress(change)));
 
     dependentCells.forEach((change) => {
-      const { row, col } = change.address;
-      const visualRow = this.hot.toVisualRow(row);
-      const visualColumn = this.hot.toVisualColumn(col);
+      const { row, col } = change.address ?? {};
+      const visualRow = isDefined(row) ? this.hot.toVisualRow(row) : null;
+      const visualColumn = isDefined(col) ? this.hot.toVisualColumn(col) : null;
 
       // Don't try to validate cells outside of the visual part of the table.
       if (visualRow === null || visualColumn === null) {


### PR DESCRIPTION
### Context
This issue fixes a problem described in #8215. 

<sup>[skip changelog]</sup>

### How has this been tested?
Added a test case for #8215.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #8215 

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
