### PR TITLE
New docs: Fix the Internationalization page

### DIFF
--- a/docs/next/guides/internationalization/internationalization-i18n.md
+++ b/docs/next/guides/internationalization/internationalization-i18n.md
@@ -20,24 +20,24 @@ To properly use the internationalization feature, you'll need to load the langua
 1. **ES modules (ESM)**
   ```js
   import Handsontable from 'handsontable/base';
-  import { registerLanguageDictionary, daDK } from 'handsontable/i18n';
+  import { registerLanguageDictionary, deDE } from 'handsontable/i18n';
 
-  registerLanguageDictionary(daDK);
+  registerLanguageDictionary(deDE);
 
   const hot = new Handsontable(container, {
-    language: daDK.languageCode,
+    language: deDE.languageCode,
   });
   ```
 
 2. **CommonJS (CJS)**
   ```js
   const Handsontable = require('handsontable/base').default;
-  const { registerLanguageDictionary, daDK } = require('handsontable/i18n');
+  const { registerLanguageDictionary, deDE } = require('handsontable/i18n');
 
-  registerLanguageDictionary(daDK);
+  registerLanguageDictionary(deDE);
 
   const hot = new Handsontable(container, {
-    language: daDK.languageCode,
+    language: deDE.languageCode,
   });
   ```
 
@@ -46,10 +46,10 @@ To properly use the internationalization feature, you'll need to load the langua
   Languages included this way are ready to use immediately after loading the file. Each file contains a UMD loader that looks for `Handsontable` in a global/externals context. If `Handsontable` is available then it registers itself in the proper context.
   ```html
   <script type="text/javascript" src="dist/handsontable.full.js"></script>
-  <script type="text/javascript" src="dist/languages/da-DK.js"></script>
+  <script type="text/javascript" src="dist/languages/de-DE.js"></script>
   <script>
     const hot = new Handsontable(container, {
-      language: 'da-DK',
+      language: 'de-DE',
     });
   </script>
   ```
@@ -73,7 +73,7 @@ const data = [
 const hot = new Handsontable(container, {
   data,
   contextMenu: true,
-  language: 'pl-PL',
+  language: 'de-DE',
   licenseKey: 'non-commercial-and-evaluation'
 });
 ```


### PR DESCRIPTION
### Context

As the `da-DK` does not work, I change to the `de-DE`.
 
ref: #8149 "First we write about da-DK a then we display pl-PL in the demo. Display da-DK in the demo to stay consistent with the content."

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #8149 
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
