### PR TITLE
Fixes plugins page

### DIFF
--- a/docs/next/guides/building-and-testing/plugins.md
+++ b/docs/next/guides/building-and-testing/plugins.md
@@ -13,17 +13,19 @@ tags:
 
 # Plugins
 
+[[toc]]
+
 ## Overview
 
 Plugin is a one great way to extend the capabilities of Handsontable. In fact, most of the features available in this library are provided by plugins.
 
-### Plugin template
+## Plugin template
 
 There are two types of plugins: internal and external. While both extend Handsontable's functionality, the former is incorporated into the Handsontable build, and the latter needs to be included from a separate file.
 
 Regardless of which plugin you are going to build, using a template will save you lots of time.
 
-#### Internal plugin
+### Internal plugin
 
 The source code of this template is [available on GitHub](https://github.com/handsontable/handsontable-skeleton/tree/master/plugins/internal). Start off by cloning the entire project or copying the code to your application.
 
@@ -131,7 +133,7 @@ registerPlugin('internalPluginSkeleton', InternalPluginSkeleton);
 
 ```
 
-#### External plugin
+### External plugin
 
 Similarly to the above, this template is [hosted on GitHub](https://github.com/handsontable/handsontable-skeleton/tree/master/plugins/external).
 


### PR DESCRIPTION


### Context
Fixes:

> Plugins - we miss the “table of contents” on the right hand side here.

> Turning “internal plugin” and “external plugin” into headers

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #8149 
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
