### PR TITLE
New docs: Fixes info containers

### DIFF
--- a/docs/next/guides/advanced-topics/performance.md
+++ b/docs/next/guides/advanced-topics/performance.md
@@ -30,7 +30,9 @@ const hot = new Handsontable(obj, {
 
 For more information, see [our documentation](api/dataMap/metaManager/metaSchema.md#colwidths).
 
-:::tip When using this setting, Handsontable won't perform the column width calculations, so you will need to ensure that your table contents fit inside the columns with the provided widths.
+::: tip
+When using this setting, Handsontable won't perform the column width calculations, so you will need to ensure that your table contents fit inside the columns with the provided widths.
+:::
 
 ## Turn off autoRowSize and/or autoColumnSize
 

--- a/docs/next/guides/rows/row-virtualization.md
+++ b/docs/next/guides/rows/row-virtualization.md
@@ -19,7 +19,9 @@ Virtualization allows Handsontable to process hundreds of thousands of records w
 
 This feature is enabled by default and can be turned off by setting the `renderAllRows` to `true`. 
 
-::: tip Note that the data grid without virtualization enabled will only work with relatively small data sets. :::
+::: tip 
+Note that the data grid without virtualization enabled will only work with relatively small data sets. 
+:::
 
 ## Configuring row virtualization
 


### PR DESCRIPTION
### Context
Two `::: info` containers were used in wrong way, this PR fix that.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #8149 
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
