### PR TITLE
Add docs to ignore list in the test:ci script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,6 +180,7 @@
     "packages": [
       ".",
       "examples",
+      "docs",
       "wrappers/*"
     ]
   },

--- a/package.json
+++ b/package.json
@@ -180,7 +180,6 @@
     "packages": [
       ".",
       "examples",
-      "docs",
       "wrappers/*"
     ]
   },

--- a/scripts/run-targeted-tests.mjs
+++ b/scripts/run-targeted-tests.mjs
@@ -14,6 +14,7 @@ const IGNORED_PATHS = [
   '.codesandbox',
   '.github',
   'bin',
+  'docs',
   'resources',
   '.editorconfig',
   '.gitattributes',
@@ -181,12 +182,9 @@ async function distributeBetweenPipelines(modifiedProjects) {
     }
   }
 
-  // If there was anything touched except for handsontable or docs, build handsontable for it to be
+  // If there was anything touched except for handsontable, build handsontable for it to be
   // available for import in the other projects.
-  if (
-    touchedProjects.length > 1 ||
-    (touchedProjects.length === 1 && touchedProjects[0] !== 'handsontable' && touchedProjects[0] !== 'docs')
-  ) {
+  if (touchedProjects.length > 1 || (touchedProjects.length === 1 && touchedProjects[0] !== 'handsontable')) {
     await spawnProcess('npm run in handsontable build');
   }
 

--- a/scripts/run-targeted-tests.mjs
+++ b/scripts/run-targeted-tests.mjs
@@ -90,14 +90,14 @@ async function distributeBetweenPipelines(modifiedProjects) {
           !isHandsontableTouched &&
           modifiedProjects.indexOf(projectName) >= Math.floor(modifiedProjects.length / pipelineCount)
         ) {
-          await spawnProcess(`npm run in ${projectName} test -- --if-present`);
+          await spawnProcess(`npm run in ${projectName} test`);
         }
       }
 
       break;
     default:
       for (const projectName of modifiedProjects) {
-        await spawnProcess(`npm run in ${projectName} test -- --if-present`);
+        await spawnProcess(`npm run in ${projectName} test`);
       }
   }
 }


### PR DESCRIPTION
### Context
This PR:
- Add docs to workspaces
- Modifies the `test:ci` script not to trigger all tests when docs/examples changes are recognized in the last commit.

[skip changelog]

### Related issue(s):
1. #7626 
