### PR TITLE
Make the Vue wrapper react properly to the alter-based CRUD actions.

### DIFF
--- a/.changelogs/8148.json
+++ b/.changelogs/8148.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fixed an issue, where adding rows to the Handsontable instance wrapped for Vue resulted in additional rows being inserted at the end of the table.",
+  "type": "fixed",
+  "issue": 8148,
+  "breaking": false,
+  "framework": "vue"
+}

--- a/wrappers/vue/src/HotTable.vue
+++ b/wrappers/vue/src/HotTable.vue
@@ -39,7 +39,7 @@
             )
           ) {
             // If the dataset dimensions change, update the index mappers.
-            this.matchHotMappersSize(value.data);
+            this.matchHotMappersSize();
 
             // Data is automatically synchronized by reference.
             delete value.data;
@@ -71,8 +71,6 @@
       return {
         __internalEdit: false,
         miscCache: {
-          // TODO: A workaround for #7548; data.length !== rowIndexMapper.getNumberOfIndexes() for NestedRows plugin.
-          dataLength: 0,
           currentSourceColumns: null
         },
         hotInstance: null,
@@ -115,19 +113,19 @@
 
         preventInternalEditWatch(this);
 
-        this.miscCache.dataLength = newSettings?.data?.length ?? 0;
         this.miscCache.currentSourceColumns = this.hotInstance.countSourceCols();
       },
-      matchHotMappersSize: function (data: any[][]): void {
+      matchHotMappersSize: function(): void {
+        const data: Handsontable.CellValue[][] = this.hotInstance.getSourceData();
         const rowsToRemove: number[] = [];
         const columnsToRemove: number[] = [];
-        const oldDataLength = this.miscCache.dataLength;
+        const indexMapperRowCount = this.hotInstance.rowIndexMapper.getNumberOfIndexes();
         const isColumnModificationAllowed = this.hotInstance.isColumnModificationAllowed();
         let indexMapperColumnCount = 0;
 
-        if (data && data.length !== oldDataLength) {
-          if (data.length < oldDataLength) {
-            for (let r = data.length; r < oldDataLength; r++) {
+        if (data && data.length !== indexMapperRowCount) {
+          if (data.length < indexMapperRowCount) {
+            for (let r = data.length; r < indexMapperRowCount; r++) {
               rowsToRemove.push(r);
             }
           }
@@ -148,12 +146,10 @@
 
         this.hotInstance.batch(() => {
           if (rowsToRemove.length > 0) {
-            this.miscCache.dataLength -= rowsToRemove.length;
             this.hotInstance.rowIndexMapper.removeIndexes(rowsToRemove);
 
           } else {
-            this.miscCache.dataLength += data.length - oldDataLength;
-            this.hotInstance.rowIndexMapper.insertIndexes(oldDataLength - 1, data.length - oldDataLength);
+            this.hotInstance.rowIndexMapper.insertIndexes(indexMapperRowCount - 1, data.length - indexMapperRowCount);
           }
 
           if (isColumnModificationAllowed && data.length !== 0) {

--- a/wrappers/vue/src/types.ts
+++ b/wrappers/vue/src/types.ts
@@ -20,7 +20,7 @@ export interface HotTableMethods {
   getGlobalEditorVNode: () => VNode | void,
   getRendererWrapper: (vNode: VNode, containerComponent: Vue) => (...args) => HTMLElement,
   getEditorClass: (vNode: VNode, containerComponent: Vue) => typeof Handsontable.editors.BaseEditor,
-  matchHotMappersSize: (data: any[][]) => void
+  matchHotMappersSize: () => void
 }
 
 export interface HotTableProps extends Handsontable.GridSettings {

--- a/wrappers/vue/test/hotTable.spec.ts
+++ b/wrappers/vue/test/hotTable.spec.ts
@@ -648,6 +648,46 @@ describe('HOT-based CRUD actions', () => {
   });
 });
 
+describe('Non-HOT based CRUD actions', () => {
+  it('should should not add/remove any additional rows when modifying a data array passed to the wrapper', async() => {
+    const externalData = createSampleData(4, 4);
+    const testWrapper = mount(HotTable, {
+      propsData: {
+        data: externalData,
+        rowHeaders: true,
+        colHeaders: true,
+      }
+    });
+    const hotInstance = testWrapper.vm.hotInstance;
+
+    externalData.push(externalData[0], externalData[0]);
+    externalData[0].push('test', 'test');
+
+    await Vue.nextTick();
+
+    expect(hotInstance.countRows()).toEqual(6);
+    expect(hotInstance.countSourceRows()).toEqual(6);
+    expect(hotInstance.countCols()).toEqual(6);
+    expect(hotInstance.countSourceCols()).toEqual(6);
+    expect(hotInstance.getSourceData().length).toEqual(6);
+    expect(hotInstance.getSourceData()[0].length).toEqual(6);
+
+    externalData.pop();
+    externalData.pop();
+    externalData[0].pop();
+    externalData[0].pop();
+
+    await Vue.nextTick();
+
+    expect(hotInstance.countRows()).toEqual(4);
+    expect(hotInstance.countSourceRows()).toEqual(4);
+    expect(hotInstance.countCols()).toEqual(4);
+    expect(hotInstance.countSourceCols()).toEqual(4);
+    expect(hotInstance.getSourceData().length).toEqual(4);
+    expect(hotInstance.getSourceData()[0].length).toEqual(4);
+  });
+});
+
 describe('cooperation with NestedRows plugin', () => {
   it('should display dataset properly #7548', async() => {
     const testWrapper = mount(HotTable, {

--- a/wrappers/vue/test/hotTable.spec.ts
+++ b/wrappers/vue/test/hotTable.spec.ts
@@ -613,6 +613,41 @@ it('should be possible to pass props to the editor and renderer components', () 
   testWrapper.destroy();
 });
 
+describe('HOT-based CRUD actions', () => {
+  it('should should not add/remove any additional rows when calling `alter` on the HOT instance', async() => {
+    const testWrapper = mount(HotTable, {
+      propsData: {
+        data: createSampleData(4, 4),
+        rowHeaders: true,
+        colHeaders: true,
+      }
+    });
+    const hotInstance = testWrapper.vm.hotInstance;
+
+    hotInstance.alter('insert_row', 2, 2);
+    hotInstance.alter('insert_col', 2, 2);
+
+    await Vue.nextTick();
+
+    expect(hotInstance.countRows()).toEqual(6);
+    expect(hotInstance.countSourceRows()).toEqual(6);
+    expect(hotInstance.countCols()).toEqual(6);
+    expect(hotInstance.countSourceCols()).toEqual(6);
+    expect(hotInstance.getSourceData().length).toEqual(6);
+    expect(hotInstance.getSourceData()[0].length).toEqual(6);
+
+    hotInstance.alter('remove_row', 2, 2);
+    hotInstance.alter('remove_col', 2, 2);
+
+    expect(hotInstance.countRows()).toEqual(4);
+    expect(hotInstance.countSourceRows()).toEqual(4);
+    expect(hotInstance.countCols()).toEqual(4);
+    expect(hotInstance.countSourceCols()).toEqual(4);
+    expect(hotInstance.getSourceData().length).toEqual(4);
+    expect(hotInstance.getSourceData()[0].length).toEqual(4);
+  });
+});
+
 describe('cooperation with NestedRows plugin', () => {
   it('should display dataset properly #7548', async() => {
     const testWrapper = mount(HotTable, {


### PR DESCRIPTION
### Context
This PR reverts changes from #7720 in favor of reading the source data directly from the instance when checking if the `indexMapper`s need to be updated.

### How has this been tested?
Apart from test cases from #7720, added additional test for #8148.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #8148 
2. #7548

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [x] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
