### PR TITLE
New docs: Add support for current page preserving

### DIFF
--- a/docs/.vuepress/theme/components/Versions.vue
+++ b/docs/.vuepress/theme/components/Versions.vue
@@ -24,11 +24,13 @@ export default {
       return version;
     },
     getLink(version) {
+      const pathWithoutVersion = this.$route.path.replace(/^\/(\d+\.\d+|next)/, '');
+
       if (version === this.$page.latestVersion) {
-        return '/';
+        return pathWithoutVersion;
       }
 
-      return `/${version}/`;
+      return `/${version}${pathWithoutVersion}`;
     },
     getLegacyVersions() {
       return [


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR improves the UI experience by preserving the currently viewed page while switching the documentation version.

![Kapture 2021-06-22 at 10 16 08](https://user-images.githubusercontent.com/571316/122889238-e77d8f80-d342-11eb-943f-7936a7e5ba57.gif)

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #8253
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
