### PR TITLE
Add support for IE

### DIFF
--- a/docs/.vuepress/components/ScriptLoader.vue
+++ b/docs/.vuepress/components/ScriptLoader.vue
@@ -13,8 +13,8 @@ const useCodePreview = (code) => {
   scriptElement.innerHTML = code;
 
   return [
-    (container) => { container.append(scriptElement); },
-    () => { scriptElement.remove(); },
+    (container) => { container.appendChild(scriptElement); },
+    () => { scriptElement.parentElement.removeChild(scriptElement); },
   ];
 };
 

--- a/docs/.vuepress/containers/examples/jsfiddle.js
+++ b/docs/.vuepress/containers/examples/jsfiddle.js
@@ -14,26 +14,24 @@ const jsfiddle = (id, html, code, css, version, preset) => {
 
   return `
     <form
-      id="jsfiddle-${id}"
       action=${JSFIDDLE_ENDPOINT}
       method="post"
       target="_blank"
-      style="display:none;"
     >
-      <input type="text" name="title" readOnly value="Handsontable example" />
-      <input type="text" name="wrap" readOnly value="d" />
-      <textarea name="js" readOnly v-pre>${code}</textarea>
-      <textarea name="html" readOnly v-pre>
+      <input type="hidden" name="title" readOnly value="Handsontable example" />
+      <input type="hidden" name="wrap" readOnly value="d" />
+      <textarea class="hidden" name="js" readOnly v-pre>${code}</textarea>
+      <textarea class="hidden" name="html" readOnly v-pre>
 ${imports}
 ${html}
       </textarea>
-      <textarea name="css" readOnly>${css}</textarea>
-      ${isBabelPanel || isAngularPanel ? '<input type="text" name="panel_js" value="3" readOnly>' : ''}
-  }
+      <textarea class="hidden" name="css" readOnly v-pre>${css}</textarea>
+      ${isBabelPanel || isAngularPanel ? '<input type="hidden" name="panel_js" value="3" readOnly>' : ''}
+
+      <div class="js-fiddle-link">
+        <button type="submit">Edit</button>
+      </div>
     </form>
-    <div class="js-fiddle-link">
-      <button type="submit" form="jsfiddle-${id}">Edit</button>
-    </div>
   `;
 };
 

--- a/docs/.vuepress/handsontable-manager/use-handsontable.js
+++ b/docs/.vuepress/handsontable-manager/use-handsontable.js
@@ -38,7 +38,7 @@ const useHandsontable = (version, callback = () => {}, preset = 'hot') => {
         script.loaded = true;
       });
 
-      _document.head.append(script);
+      _document.head.appendChild(script);
 
       if (cssUrl) {
         _document.head.insertAdjacentHTML(


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adds support for IE browsers. Moreover, I've spotted that the jsFiddle "Edit" button does not work as well. The `"form"` attribute is not supported by IE and Edge <=16. I moved the `button` inside the `form` and hide all `input` and `textarea` elements.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #8257
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
