### PR TITLE
New docs: Fix CI deployment by using standard file-system api.

### DIFF
--- a/docs/.vuepress/tools/copy-assets.mjs
+++ b/docs/.vuepress/tools/copy-assets.mjs
@@ -1,5 +1,5 @@
-import fse from 'fs-extra';
 import path from 'path';
+import {copyFileSync} from 'fs'; 
 
 const TARGET_PATH = './.vuepress/public/';
 const filesToMove = [
@@ -10,8 +10,8 @@ const filesToMove = [
 filesToMove.forEach((fileSchema) => {
   const [from, target] = fileSchema;
 
-  fse.copySync(
+  copyFileSync(
     path.resolve(from),
-    path.resolve(`${TARGET_PATH}/${target}`),
-    { overwrite: true });
+    path.resolve(`${TARGET_PATH}/${target}`)
+  );
 });


### PR DESCRIPTION
### Context
After #8055, deployment from the CI stops working. The purpose is missing `fse` package. I adapted the script to use standard file-system API.

### How has this been tested?
Remove node_modules and run :`npm run docs:assets:next`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
