### PR TITLE
Improve the HoT instances handling

### DIFF
--- a/docs/.vuepress/containers/examples/examples.js
+++ b/docs/.vuepress/containers/examples/examples.js
@@ -91,6 +91,7 @@ module.exports = {
       const htmlContent = htmlToken
         ? htmlToken.content
         : `<div id="${id}" class="hot ${klass}"></div>`;
+      const htmlContentRoot = `<div data-preset-type="${preset}">${htmlContent}</div>`;
 
       const cssPos = args.match(/--css (\d*)/)?.[1];
       const cssIndex = cssPos ? index + Number.parseInt(cssPos, 10) : 0;
@@ -116,7 +117,7 @@ module.exports = {
         ...tab('Code', jsToken),
         ...tab('HTML', htmlToken),
         ...tab('CSS', cssToken),
-        getPreviewTab(id, cssContent, htmlContent, encodedCode)
+        getPreviewTab(id, cssContent, htmlContentRoot, encodedCode)
       ];
 
       tokens.splice(index + 1, 0, ...newTokens);

--- a/docs/9.0/guides/integrate-with-angular/angular-installation.md
+++ b/docs/9.0/guides/integrate-with-angular/angular-installation.md
@@ -55,6 +55,6 @@ Now, you can use the Handsontable component in your HTML files.
   [colHeaders]="true"
   [rowHeaders]="true"
   [data]="dataset"
-  [licenseKey]="non-commercial-and-evaluation">
+  licenseKey="non-commercial-and-evaluation">
 </hot-table>
 ```

--- a/docs/9.0/guides/integrate-with-angular/angular-setting-up-a-locale.md
+++ b/docs/9.0/guides/integrate-with-angular/angular-setting-up-a-locale.md
@@ -36,7 +36,7 @@ type Product = {
   selector: 'app-root',
   template: `
     <div>
-      <hot-table [data]="dataset" [colHeaders]="true" [licenseKey]="'non-commercial-and-evaluation'">
+      <hot-table [data]="dataset" [colHeaders]="true" licenseKey="non-commercial-and-evaluation">
         <hot-column
           data="productName"
           [readOnly]="true"

--- a/docs/9.0/guides/integrate-with-angular/angular-setting-up-a-locale.md
+++ b/docs/9.0/guides/integrate-with-angular/angular-setting-up-a-locale.md
@@ -10,7 +10,7 @@ canonicalUrl: /angular-setting-up-a-locale
 ## Overview
 The following example shows a Handsontable instance with locales set up in Angular.
 
-## Example 
+## Example
 ::: example :angular-numbro --html 1 --js 2
 ```html
 <app-root></app-root>
@@ -36,7 +36,7 @@ type Product = {
   selector: 'app-root',
   template: `
     <div>
-      <hot-table [data]="dataset" [colHeaders]="true" [licenseKey]="non-commercial-and-evaluation">
+      <hot-table [data]="dataset" [colHeaders]="true" [licenseKey]="'non-commercial-and-evaluation'">
         <hot-column
           data="productName"
           [readOnly]="true"

--- a/docs/9.0/guides/integrate-with-vue/vue-simple-example.md
+++ b/docs/9.0/guides/integrate-with-vue/vue-simple-example.md
@@ -13,17 +13,14 @@ The following example is a simple implementation of the `@handsontable/vue` comp
 
 ## Example
 
-In this example, a `div` element of `id="example"` where the `@handsontable/vue` component will be rendered.
+In this example, a `div` element of `id="example1"` where the `@handsontable/vue` component will be rendered.
 
-::: example #example1 :vue --html 1 --js 5 
+::: example #example1 :vue --html 1 --js 2
 ```html
 <div id="example1">
     <hot-table :settings="hotSettings"></hot-table>
 </div>
 ```
-
-Implementing the component:
-
 ```js
 import Vue from 'vue';
 import { HotTable } from '@handsontable/vue';

--- a/docs/next/guides/integrate-with-angular/angular-installation.md
+++ b/docs/next/guides/integrate-with-angular/angular-installation.md
@@ -55,6 +55,6 @@ Now, you can use the Handsontable component in your HTML files.
   [colHeaders]="true"
   [rowHeaders]="true"
   [data]="dataset"
-  [licenseKey]="non-commercial-and-evaluation">
+  licenseKey="non-commercial-and-evaluation">
 </hot-table>
 ```

--- a/docs/next/guides/integrate-with-angular/angular-setting-up-a-locale.md
+++ b/docs/next/guides/integrate-with-angular/angular-setting-up-a-locale.md
@@ -36,7 +36,7 @@ type Product = {
   selector: 'app-root',
   template: `
     <div>
-      <hot-table [data]="dataset" [colHeaders]="true" [licenseKey]="'non-commercial-and-evaluation'">
+      <hot-table [data]="dataset" [colHeaders]="true" licenseKey="non-commercial-and-evaluation">
         <hot-column
           data="productName"
           [readOnly]="true"

--- a/docs/next/guides/integrate-with-angular/angular-setting-up-a-locale.md
+++ b/docs/next/guides/integrate-with-angular/angular-setting-up-a-locale.md
@@ -10,7 +10,7 @@ canonicalUrl: /angular-setting-up-a-locale
 ## Overview
 The following example shows a Handsontable instance with locales set up in Angular.
 
-## Example 
+## Example
 ::: example :angular-numbro --html 1 --js 2
 ```html
 <app-root></app-root>
@@ -36,7 +36,7 @@ type Product = {
   selector: 'app-root',
   template: `
     <div>
-      <hot-table [data]="dataset" [colHeaders]="true" [licenseKey]="non-commercial-and-evaluation">
+      <hot-table [data]="dataset" [colHeaders]="true" [licenseKey]="'non-commercial-and-evaluation'">
         <hot-column
           data="productName"
           [readOnly]="true"

--- a/docs/next/guides/integrate-with-vue/vue-simple-example.md
+++ b/docs/next/guides/integrate-with-vue/vue-simple-example.md
@@ -13,17 +13,14 @@ The following example is a simple implementation of the `@handsontable/vue` comp
 
 ## Example
 
-In this example, a `div` element of `id="example"` where the `@handsontable/vue` component will be rendered.
+In this example, a `div` element of `id="example1"` where the `@handsontable/vue` component will be rendered.
 
-::: example #example1 :vue --html 1 --js 5 
+::: example #example1 :vue --html 1 --js 2
 ```html
 <div id="example1">
     <hot-table :settings="hotSettings"></hot-table>
 </div>
 ```
-
-Implementing the component:
-
 ```js
 import Vue from 'vue';
 import { HotTable } from '@handsontable/vue';


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR improves the code that is responsible for destroying Handsontable instances used within docs demos. The changes from now on support destroying not only vanilla demos but supports destroying demos that use wrappers as well. 

The registry handler depends on the demo, destroys the Handosntable instance directly, or for frameworks manually trigger the "destroy" lifecycle. So under the hood, all framework-related listeners, components, and other resources can be freed.


### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
https://github.com/handsontable/handsontable/pull/8286#issuecomment-868403905

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #8165
2. #8290
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
