### PR TITLE
Fix missing collapsible indicator on IE

### DIFF
--- a/.changelogs/8028.json
+++ b/.changelogs/8028.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fixed missing collapsible indicator on IE",
+  "type": "fixed",
+  "issue": 8028,
+  "breaking": false,
+  "framework": "none"
+}

--- a/src/plugins/autoColumnSize/__tests__/autoColumnSize.spec.js
+++ b/src/plugins/autoColumnSize/__tests__/autoColumnSize.spec.js
@@ -899,7 +899,7 @@ describe('AutoColumnSize', () => {
       expect(colWidth(spec().$container, 1)).toBe(50);
 
       setDataAtCell(0, 0, 999999999999);
-      await sleep(50);
+      await sleep(200);
 
       expect(colWidth(spec().$container, 1)).toBe(130);
     });

--- a/src/plugins/nestedHeaders/utils/ghostTable.js
+++ b/src/plugins/nestedHeaders/utils/ghostTable.js
@@ -85,7 +85,13 @@ class GhostTable {
           }
 
           fastInnerHTML(td, headerObj.label);
-          td.colSpan = headerObj.colspan;
+
+          // The guard here is needed because on IE11 an error is thrown if you
+          // try to assign an incorrect value to `td.colSpan` here.
+          if (headerObj.colspan !== undefined) {
+            td.colSpan = headerObj.colspan;
+          }
+
           tr.appendChild(td);
         }
       }


### PR DESCRIPTION
### Context
See the added comment in the diff of this PR.

### How has this been tested?
Manually on IE,

<details>
	<summary>using this config.</summary>

```javascript
{
  data: Handsontable.helper.createSpreadsheetData(5,10),
  colHeaders: true,
  rowHeaders: true,
  colWidths: 60,
  nestedHeaders: [
    ['A', {label: 'B', colspan: 8}, 'C'],
    ['D', {label: 'E', colspan: 4}, {label: 'F', colspan: 4}, 'G'],
    ['H', {label: 'I', colspan: 2}, {label: 'J', colspan: 2}, {label: 'K', colspan: 2}, {label: 'L', colspan: 2}, 'M'],
    ['N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W']
  ],
  collapsibleColumns: [
    {row: -4, col: 1, collapsible: true},
    {row: -3, col: 1, collapsible: true},
    {row: -2, col: 1, collapsible: true},
    {row: -2, col: 3, collapsible: true}
  ]
}
```

Source: https://handsontable.com/docs/8.4.0/demo-collapsing-columns.html
</details>


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
#8028
