### PR TITLE
Fix code preview tabs on mobile

### DIFF
--- a/docs/.vuepress/theme/styles/vuepress-tabs-custom.styl
+++ b/docs/.vuepress/theme/styles/vuepress-tabs-custom.styl
@@ -1,21 +1,22 @@
-/* 
-  Customization of the VuePress Tabs plugin 
+/*
+  Customization of the VuePress Tabs plugin
   https://www.npmjs.com/package/vuepress-plugin-tabs
   Copyright (c) 2018 Panagiotis Skordilakis
-  The MIT license 
+  The MIT license
 */
 
 .tabs-component {
   margin 1em 0;
   border: 1px solid #cfdbe4;
-  
+
   ul.tabs-component-tabs {
     margin: 0;
     padding-left: 0;
     border: none;
     border-bottom: 1px solid #cfdbe4;
     background-color: #fafbff;
-    
+    overflow-x: auto;
+
     /* overwrite default styles for all resolutions */
     align-items: stretch;
     display: flex;
@@ -23,7 +24,11 @@
     padding-inline-start: 0;
     width: 100%;
     border-radius: 0!important;
-    
+
+    @media (max-width: $MQMobileNarrow) {
+      display: block;
+    }
+
     li.tabs-component-tab {
       margin-right: 0;
       border-radius: 0;
@@ -33,26 +38,26 @@
       a.tabs-component-tab-a {
         padding: 0.5em 1.4em;
         color: $textColor;
-        
+
         &:hover {
           text-decoration: none;
         }
       }
-      
+
       &.is-disabled a {
         color: #CFDBE4;
       }
-      
+
       &.is-active {
         border-bottom: 2px solid #104bcd;
-        
+
         &:hover a {
           color: $textColor;
         }
       }
     }
   }
-  
+
   .tabs-component-panels {
     // prevent Handsontable's container from expanding rapidly on load
     //min-height: 180px;
@@ -60,10 +65,10 @@
     box-shadow: none;
     border: none;
     background: transparent;
-    
+
     pre {
       margin: 0;
       border-radius: 0;
     }
-  } 
+  }
 }


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR makes the Tabs more responsive on wider screens.

Example for demos (usually max 4 tabs):
![Kapture 2021-06-25 at 15 29 47](https://user-images.githubusercontent.com/571316/123432295-849e2980-d5ca-11eb-97a7-7e2e0993b7d3.gif)

Example for Hello World page. There is added `overflow-x: auto` prop that allows scroll between tabs and selects them. On a narrow screen, the tab switches to the vertical list.
![Kapture 2021-06-25 at 15 31 11](https://user-images.githubusercontent.com/571316/123432476-badba900-d5ca-11eb-9569-2e664f838836.gif)

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. fixes #8275 
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
