### PR TITLE
Prevent errors when destroying the underlying Handsontable instance of the wrappers.

### DIFF
--- a/.changelogs/8311-angular.json
+++ b/.changelogs/8311-angular.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fixed a problem in the Angular wrapper, where destroying the underlying Handsontable instance caused it to throw errors and crash.",
+  "type": "fixed",
+  "issue": 8311,
+  "breaking": false,
+  "framework": "angular"
+}

--- a/.changelogs/8311-react.json
+++ b/.changelogs/8311-react.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fixed a problem in the React wrapper, where destroying the underlying Handsontable instance caused it to throw errors and crash.",
+  "type": "fixed",
+  "issue": 8311,
+  "breaking": false,
+  "framework": "react"
+}

--- a/.changelogs/8311-vue.json
+++ b/.changelogs/8311-vue.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fixed a problem in the Vue wrapper, where destroying the underlying Handsontable instance caused it to throw errors and crash.",
+  "type": "fixed",
+  "issue": 8311,
+  "breaking": false,
+  "framework": "vue"
+}

--- a/.changelogs/8311.json
+++ b/.changelogs/8311.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fixed a problem in the wrappers, where destroying the underlying Handsontable instance caused them to throw errors and crash.",
+  "type": "fixed",
+  "issue": 8311,
+  "breaking": false,
+  "framework": "angular"
+}

--- a/.changelogs/8311.json
+++ b/.changelogs/8311.json
@@ -1,7 +1,0 @@
-{
-  "title": "Fixed a problem in the wrappers, where destroying the underlying Handsontable instance caused them to throw errors and crash.",
-  "type": "fixed",
-  "issue": 8311,
-  "breaking": false,
-  "framework": "angular"
-}

--- a/wrappers/angular/projects/hot-table/src/lib/hot-table-registerer.service.ts
+++ b/wrappers/angular/projects/hot-table/src/lib/hot-table-registerer.service.ts
@@ -3,10 +3,17 @@ import Handsontable from 'handsontable';
 
 const instances = new Map<string, Handsontable>();
 
+export const HOT_DESTROYED_WARNING = 'The Handsontable instance bound to this component was destroyed and cannot be' +
+  ' used properly.';
+
 @Injectable()
 export class HotTableRegisterer {
   public getInstance(id: string): Handsontable {
-    return instances.get(id);
+    const hotInstance = instances.get(id);
+
+    console.warn(HOT_DESTROYED_WARNING);
+
+    return hotInstance.isDestroyed ? null : hotInstance;
   }
 
   public registerInstance(id: string, instance: Handsontable): Map<string, Handsontable> {

--- a/wrappers/angular/projects/hot-table/src/lib/hot-table.component.spec.ts
+++ b/wrappers/angular/projects/hot-table/src/lib/hot-table.component.spec.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import Handsontable from 'handsontable';
 import { HotTableModule, HotTableRegisterer } from '@handsontable/angular';
+import { HOT_DESTROYED_WARNING } from '../lib/hot-table-registerer.service';
 
 @Component({
   selector: 'hot-test-component',
@@ -320,6 +321,46 @@ describe('HotTableComponent', () => {
         app.getHotInstance(app.id).setDataAtCell(0, 0, 'test');
 
         expect(afterChangeResult).toBe(false);
+      });
+    });
+  });
+
+  describe(`internal Handsontable instance`, () => {
+    it(`should display a warning and not throw any errors, when the underlying Handsontable instance ` +
+      `has been destroyed`, async() => {
+      const warnFunc = console.warn;
+      const warnCalls = [];
+      TestBed.overrideComponent(TestComponent, {
+        set: {
+          template: `<hot-table [hotId]="id" [settings]="prop.settings"></hot-table>`
+        }
+      });
+
+      console.warn = (warningMessage) => {
+        warnCalls.push(warningMessage);
+      };
+
+      await TestBed.compileComponents().then(() => {
+        fixture = TestBed.createComponent(TestComponent);
+        const app = fixture.componentInstance;
+
+        app.prop['settings'] = {
+          data: Handsontable.helper.createSpreadsheetData(5, 5)
+        };
+
+        fixture.detectChanges();
+
+        expect(app.getHotInstance(app.id).isDestroyed).toEqual(false);
+
+        app.getHotInstance(app.id).destroy();
+
+        expect(app.getHotInstance(app.id)).toEqual(null);
+        expect(warnCalls.length).toBeGreaterThan(0);
+        warnCalls.forEach((message) => {
+          expect(message).toEqual(HOT_DESTROYED_WARNING);
+        });
+
+        console.warn = warnFunc;
       });
     });
   });

--- a/wrappers/react/src/helpers.tsx
+++ b/wrappers/react/src/helpers.tsx
@@ -11,6 +11,12 @@ export const AUTOSIZE_WARNING = 'Your `HotTable` configuration includes `autoRow
   ' the component-based renderers`. Disable `autoRowSize` and `autoColumnSize` to prevent row and column misalignment.';
 
 /**
+ * Message for the warning thrown if the Handsontable instance has been destroyed.
+ */
+export const HOT_DESTROYED_WARNING = 'The Handsontable instance bound to this component was destroyed and cannot be' +
+  ' used properly.';
+
+/**
  * Default classname given to the wrapper container.
  */
 const DEFAULT_CLASSNAME = 'hot-wrapper-editor-container';

--- a/wrappers/react/test/componentInternals.spec.tsx
+++ b/wrappers/react/test/componentInternals.spec.tsx
@@ -3,18 +3,13 @@ import {
   mount,
   ReactWrapper
 } from 'enzyme';
-import {
-  HotTable
-} from '../src/hotTable';
-import {
-  HotColumn
-} from '../src/hotColumn';
+import { HotTable } from '../src/hotTable';
+import { HotColumn } from '../src/hotColumn';
 import {
   mockElementDimensions,
   sleep,
-  RendererComponent,
-  EditorComponent
 } from './_helpers';
+import { HOT_DESTROYED_WARNING } from "../src/helpers";
 import { BaseEditorComponent } from '../src/baseEditorComponent';
 import Handsontable from 'handsontable';
 
@@ -345,6 +340,42 @@ describe('Component lifecyle', () => {
     });
 
     wrapper.detach();
+    done();
+  });
+
+  it('should display a warning and not throw any errors, when the underlying Handsontable instance ' +
+    'has been destroyed', async(done) => {
+    const warnFunc = console.warn;
+    const wrapper: ReactWrapper<{}, {}, typeof HotTable> = mount(
+      <HotTable
+        id="test-hot"
+        data={[[2]]}
+        licenseKey="non-commercial-and-evaluation"
+      />, {attachTo: document.body.querySelector('#hotContainer')}
+    );
+    const warnCalls = [];
+
+    await sleep(300);
+
+    console.warn = (warningMessage) => {
+      warnCalls.push(warningMessage);
+    };
+
+    expect(wrapper.instance().hotInstance.isDestroyed).toEqual(false);
+
+    wrapper.instance().hotInstance.destroy();
+
+    expect(wrapper.instance().hotInstance).toEqual(null);
+
+    expect(warnCalls.length).toBeGreaterThan(0);
+    warnCalls.forEach((message) => {
+      expect(message).toEqual(HOT_DESTROYED_WARNING);
+    });
+
+    wrapper.detach();
+
+    console.warn = warnFunc;
+
     done();
   });
 });

--- a/wrappers/vue/src/helpers.ts
+++ b/wrappers/vue/src/helpers.ts
@@ -6,6 +6,12 @@ const unassignedPropSymbol = Symbol('unassigned');
 let bulkComponentContainer = null;
 
 /**
+ * Message for the warning thrown if the Handsontable instance has been destroyed.
+ */
+export const HOT_DESTROYED_WARNING = 'The Handsontable instance bound to this component was destroyed and cannot be' +
+  ' used properly.';
+
+/**
  * Rewrite the settings object passed to the watchers to be a clean array/object prepared to use within Handsontable config.
  *
  * @param {*} observerSettings Watcher object containing the changed data.
@@ -44,25 +50,27 @@ export function rewriteSettings(observerSettings): any[] | object {
  * @private
  */
 export function preventInternalEditWatch(component) {
-  component.hotInstance.addHook('beforeChange', () => {
-    component.__internalEdit = true;
-  });
+  if (component.hotInstance) {
+    component.hotInstance.addHook('beforeChange', () => {
+      component.__internalEdit = true;
+    });
 
-  component.hotInstance.addHook('beforeCreateRow', () => {
-    component.__internalEdit = true;
-  });
+    component.hotInstance.addHook('beforeCreateRow', () => {
+      component.__internalEdit = true;
+    });
 
-  component.hotInstance.addHook('beforeCreateCol', () => {
-    component.__internalEdit = true;
-  });
+    component.hotInstance.addHook('beforeCreateCol', () => {
+      component.__internalEdit = true;
+    });
 
-  component.hotInstance.addHook('beforeRemoveRow', () => {
-    component.__internalEdit = true;
-  });
+    component.hotInstance.addHook('beforeRemoveRow', () => {
+      component.__internalEdit = true;
+    });
 
-  component.hotInstance.addHook('beforeRemoveCol', () => {
-    component.__internalEdit = true;
-  });
+    component.hotInstance.addHook('beforeRemoveCol', () => {
+      component.__internalEdit = true;
+    });
+  }
 }
 
 /**

--- a/wrappers/vue/src/types.ts
+++ b/wrappers/vue/src/types.ts
@@ -4,10 +4,11 @@ import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options';
 
 export interface HotTableData {
   __internalEdit: boolean,
+  __hotInstance: Handsontable | null,
   miscCache?: {
     currentSourceColumns?: number
   },
-  hotInstance?: Handsontable,
+  hotInstance?: Handsontable | null,
   columnSettings: HotTableProps[],
   rendererCache: any, // temporary `any`, TODO: use the LRU definition here
   editorCache: Map<string, EditorComponent>

--- a/wrappers/vue/test/hotTable.spec.ts
+++ b/wrappers/vue/test/hotTable.spec.ts
@@ -1,5 +1,6 @@
 import HotTable from '../src/HotTable.vue';
 import BaseEditorComponent from '../src/BaseEditorComponent.vue';
+import { HOT_DESTROYED_WARNING } from '../src/helpers';
 import { mount } from '@vue/test-utils';
 import {
   createDomContainer,
@@ -26,7 +27,7 @@ describe('hotInit', () => {
 describe('Updating the Handsontable settings', () => {
   it('should update the previously initialized Handsontable instance with a single changed property', async() => {
     let updateSettingsCalls = 0;
-    let testWrapper = mount(HotTable, {
+    const testWrapper = mount(HotTable, {
       propsData: {
         data: createSampleData(1, 1),
         licenseKey: 'non-commercial-and-evaluation',
@@ -613,6 +614,37 @@ it('should be possible to pass props to the editor and renderer components', () 
   testWrapper.destroy();
 });
 
+it('should display a warning and not throw any errors, when the underlying Handsontable instance ' +
+  'has been destroyed', () => {
+  const warnFunc = console.warn;
+  const testWrapper = mount(HotTable, {
+    propsData: {
+      data: [[1]],
+      licenseKey: 'non-commercial-and-evaluation',
+    }
+  });
+  const warnCalls = [];
+
+  console.warn = (warningMessage) => {
+    warnCalls.push(warningMessage);
+  }
+
+  expect(testWrapper.vm.hotInstance.isDestroyed).toEqual(false);
+
+  testWrapper.vm.hotInstance.destroy();
+
+  expect(testWrapper.vm.hotInstance).toEqual(null);
+
+  expect(warnCalls.length).toBeGreaterThan(0);
+  warnCalls.forEach((message) => {
+    expect(message).toEqual(HOT_DESTROYED_WARNING);
+  });
+
+  testWrapper.destroy();
+
+  console.warn = warnFunc;
+});
+
 describe('cooperation with NestedRows plugin', () => {
   it('should display dataset properly #7548', async() => {
     const testWrapper = mount(HotTable, {
@@ -649,5 +681,7 @@ describe('cooperation with NestedRows plugin', () => {
     await Vue.nextTick();
 
     expect(testWrapper.vm.hotInstance.countRows()).toEqual(7);
+
+    testWrapper.destroy();
   });
 });


### PR DESCRIPTION
### Context
This PR adds the Handsontable's `isDestroyed` check to all of the wrappers, and makes them display a warning if trying to use an already-destroyed instance.

### How has this been tested?
Added test cases for all of the wrappers.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #8311 
2. #8165

### Affected project(s):
- [ ] `handsontable`
- [x] `@handsontable/angular`
- [x] `@handsontable/react`
- [x] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
