### PR TITLE
fix code field styling on mobiles

### DIFF
--- a/docs/.vuepress/theme/styles/index.styl
+++ b/docs/.vuepress/theme/styles/index.styl
@@ -370,3 +370,11 @@ kbd {
     }
   }
 }
+
+/* Code field styling */
+
+@media (max-width: $MQMobileNarrow) {
+  .theme-default-content div[class*="language-"] {
+    margin initial
+  }
+}


### PR DESCRIPTION
The code field was outside the tabs section

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. #8273  

