### PR TITLE
Sanity check for instance destroy after cell validation

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1295,6 +1295,9 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
           cellProperties.valid = valid;
 
           done(valid);
+          if (!instance) {
+            return;
+          }
           instance.runHooks('postAfterValidate', valid, value, cellProperties.visualRow, cellProperties.prop, source);
         });
       });


### PR DESCRIPTION
### Context
We are seeing a rare problem where the instance is somehow destroyed during this `done(valid)` callback. This results in errors like `Cannot read property 'runHooks' of null`.

### How has this been tested?
We can't reproduce in development environment, but we are using the react wrapper and it seems to happen around unmount events.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
