### PR TITLE
Fixed support for row and columns headers in `parseTable` utility

### DIFF
--- a/.changelogs/8041.json
+++ b/.changelogs/8041.json
@@ -1,0 +1,7 @@
+{
+  "title": "\"Fixed support for row and columns headers in parseTable utility.\"",
+  "type": "fixed",
+  "issue": 8041,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/8041.json
+++ b/.changelogs/8041.json
@@ -1,5 +1,5 @@
 {
-  "title": "\"Fixed support for row and columns headers in parseTable utility.\"",
+  "title": "Fixed support for row and columns headers in parseTable utility.",
   "type": "fixed",
   "issue": 8041,
   "breaking": false,

--- a/src/utils/__tests__/parseTable.unit.js
+++ b/src/utils/__tests__/parseTable.unit.js
@@ -1,9 +1,8 @@
-import { instanceToHTML, _dataToHTML, htmlToGridSettings } from 'handsontable/utils/parseTable';
-import Handsontable from 'handsontable';
-import { registerCellType } from 'handsontable/cellTypes';
-import { CELL_TYPE, TextCellType } from 'handsontable/cellTypes/textType';
+import { instanceToHTML, _dataToHTML, htmlToGridSettings } from '../parseTable';
+import Handsontable from '../../index';
+import { registerCellType, TextCellType } from '../../cellTypes';
 
-registerCellType(CELL_TYPE, TextCellType);
+registerCellType(TextCellType);
 
 describe('instanceToHTML', () => {
   it('should convert clear instance into HTML table', () => {
@@ -20,7 +19,43 @@ describe('instanceToHTML', () => {
     ].join(''));
   });
 
-  it('should convert headers into HTML table', () => {
+  it('should convert column headers into HTML table', () => {
+    const hot = new Handsontable(document.createElement('div'), {
+      colHeaders: true,
+      data: [
+        ['A1', 'B1'],
+        ['A2', 'B2'],
+      ],
+    });
+
+    expect(instanceToHTML(hot)).toBe([
+      '<table><thead>',
+      '<tr><th>A</th><th>B</th></tr>',
+      '</thead><tbody>',
+      '<tr><td >A1</td><td >B1</td></tr>',
+      '<tr><td >A2</td><td >B2</td></tr>',
+      '</tbody></table>',
+    ].join(''));
+  });
+
+  it('should convert row headers into HTML table', () => {
+    const hot = new Handsontable(document.createElement('div'), {
+      rowHeaders: true,
+      data: [
+        ['A1', 'B1'],
+        ['A2', 'B2'],
+      ],
+    });
+
+    expect(instanceToHTML(hot)).toBe([
+      '<table><tbody>',
+      '<tr><th>1</th><td >A1</td><td >B1</td></tr>',
+      '<tr><th>2</th><td >A2</td><td >B2</td></tr>',
+      '</tbody></table>',
+    ].join(''));
+  });
+
+  it('should convert column and rows headers into HTML table', () => {
     const hot = new Handsontable(document.createElement('div'), {
       colHeaders: true,
       rowHeaders: true,

--- a/src/utils/parseTable.js
+++ b/src/utils/parseTable.js
@@ -58,7 +58,7 @@ export function instanceToHTML(instance) {
 
       } else {
         const cellData = data[row][column];
-        const { hidden, rowspan, colspan } = instance.getCellMeta(row - rowModifier, column - columnModifier);
+        const { hidden, rowspan, colspan } = instance.getCellMeta(row - columnModifier, column - rowModifier);
 
         if (!hidden) {
           const attrs = [];


### PR DESCRIPTION
### Context
Parser to generate HTMLTable from Handsontable's instance uses incorrect modifiers to calculate headers offset. Tests were based on headers enabled for rows and column at once what hid the problem.

### How has this been tested?
Initialize Handsontable with *only* one of the headers options:
- `colHeaders`
- `rowHeaders`

Run `toHTML()` method on your Handsontable's instance.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. Fixes #8041

### Affected project(s):
- [x] `handsontable`