### PR TITLE
fix styles for date picker on dark theme

### DIFF
--- a/docs/.vuepress/theme/styles/theme-dark.styl
+++ b/docs/.vuepress/theme/styles/theme-dark.styl
@@ -299,7 +299,7 @@ html.theme-dark {
     scrollbar()
   }
 
-  table:not(.htCore) {
+  table:not(.htCore, .pika-table) {
     tr:nth-child(2n) {
       background-color $tableEvenRowBackgroundColor
     }


### PR DESCRIPTION
### Context
The date picker had the wrong styles for dark theme mode.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. #8318 
