### PR TITLE
Repair of broken links - 2nd iteration

### DIFF
--- a/docs/next/api/introduction.md
+++ b/docs/next/api/introduction.md
@@ -11,7 +11,7 @@ canonicalUrl: /api/
 
 Welcome to Handsontable API reference. Our goal is make it easy to dive in and start coding from day one.
 
-However, data grids are rather complex libraries, so we assume that you possess a certain level of expertise in JavaScript before moving forward. If you want to grab some basics, we have provided a JavaScript example in the [Hello World](@/hello-world/) section.
+However, data grids are rather complex libraries, so we assume that you possess a certain level of expertise in JavaScript before moving forward. If you want to grab some basics, we have provided a JavaScript example in the [Hello World](@/guides/getting-started/hello-world.md) section.
 
 The API enables you to control the data grid programmatically. With this API, you can:
 

--- a/docs/next/api/introduction.md
+++ b/docs/next/api/introduction.md
@@ -11,7 +11,7 @@ canonicalUrl: /api/
 
 Welcome to Handsontable API reference. Our goal is make it easy to dive in and start coding from day one.
 
-However, data grids are rather complex libraries, so we assume that you possess a certain level of expertise in JavaScript before moving forward. If you want to grab some basics, we have provided a JavaScript example in the [Hello World](../hello-world/) section.
+However, data grids are rather complex libraries, so we assume that you possess a certain level of expertise in JavaScript before moving forward. If you want to grab some basics, we have provided a JavaScript example in the [Hello World](@/hello-world/) section.
 
 The API enables you to control the data grid programmatically. With this API, you can:
 
@@ -23,19 +23,19 @@ The API enables you to control the data grid programmatically. With this API, yo
 
 **This reference comprises four sections:**
 
-### [Core](../api/core/)
+### [Core](@/api/core.md)
 
 The `Handsontable` class controls the essential aspects of the data grid.
 
-### [Hooks](../api/hooks/)
+### [Hooks](@/api/hooks.md)
 
 Hooks are two-directional events that fire whenever a specific action occurs within the instance of Handsontable.
 
-### [Options](../api/options/)
+### [Options](@/api/options.md)
 
 These are the settings available to be registered for the `Core` features, in addition to those provided by plugins.
 
-### [Plugins](../api/plugins/)
+### [Plugins](@/api/plugins.md)
 
 The plugins extend the capabilities of Handsontable.
 

--- a/docs/next/guides/building-and-testing/building.md
+++ b/docs/next/guides/building-and-testing/building.md
@@ -51,7 +51,7 @@ It is advised that you never modify the files mentioned above. Instead, make cha
 Currently, the following tasks are available for building Handsontable:
 
 * `npm run test` - runs several tasks in this order:
-  * `npm run lint` - check if changes applied to the source code adhere to [our code style](https://github.com/handsontable/handsontable/blob/master/.eslintrc).
+  * `npm run lint` - check if changes applied to the source code adhere to [our code style](https://github.com/handsontable/handsontable/blob/master/.eslintrc.js).
   * `npm run test:unit` - runs the test suite in node environment. It uses [Jest](https://facebook.github.io/jest/) as a test runner.
   * `npm run test:types` - runs the tests which check if the code follows TypeScript definition.
   * `npm run test:walkontable` - runs a single build of Walkontable (the Handsontable renderer engine) followed by Jasmine test suite and executes in [Puppeteer](https://github.com/GoogleChrome/puppeteer).

--- a/docs/next/guides/building-and-testing/plugins.md
+++ b/docs/next/guides/building-and-testing/plugins.md
@@ -252,7 +252,7 @@ const hotInstance = new Handsontable(container, {
 ```
 
 ### 5. Get a reference to the plugin's instance
-To use the plugin's API, call the [`getPlugin`](@/../../../api/core/#getplugin) method to get a reference to the plugin's instance.
+To use the plugin's API, call the [`getPlugin`](@/api/core.md#getplugin) method to get a reference to the plugin's instance.
 
 ```js
 const pluginInstance = hotInstance.getPlugin(CustomPlugin.PLUGIN_KEY);

--- a/docs/next/guides/building-and-testing/plugins.md
+++ b/docs/next/guides/building-and-testing/plugins.md
@@ -252,7 +252,7 @@ const hotInstance = new Handsontable(container, {
 ```
 
 ### 5. Get a reference to the plugin's instance
-To use the plugin's API, call the [`getPlugin`](../../api/core/#getplugin) method to get a reference to the plugin's instance.
+To use the plugin's API, call the [`getPlugin`](@/../../../api/core/#getplugin) method to get a reference to the plugin's instance.
 
 ```js
 const pluginInstance = hotInstance.getPlugin(CustomPlugin.PLUGIN_KEY);

--- a/docs/next/guides/building-and-testing/plugins.md
+++ b/docs/next/guides/building-and-testing/plugins.md
@@ -252,7 +252,7 @@ const hotInstance = new Handsontable(container, {
 ```
 
 ### 5. Get a reference to the plugin's instance
-To use the plugin's API, call the [`getPlugin`](../api/core/#getplugin) method to get a reference to the plugin's instance.
+To use the plugin's API, call the [`getPlugin`](../../api/core/#getplugin) method to get a reference to the plugin's instance.
 
 ```js
 const pluginInstance = hotInstance.getPlugin(CustomPlugin.PLUGIN_KEY);


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
It seems that despite the adjustments at https://github.com/handsontable/handsontable/pull/8192 there are still some links to fix. This PR solves this issue by adding `@` where it is missing.
### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Manually after `npm run docs:build`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/8306
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [x] `documentation`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
