### PR TITLE
New docs: improve table responsiveness

### DIFF
--- a/docs/.vuepress/theme/styles/index.styl
+++ b/docs/.vuepress/theme/styles/index.styl
@@ -177,6 +177,7 @@ a {
 table {
   width: 100%;
   display: table;
+  word-break:break-all;
   overflow: scroll;
 
   tr {

--- a/docs/.vuepress/theme/styles/index.styl
+++ b/docs/.vuepress/theme/styles/index.styl
@@ -177,7 +177,7 @@ a {
 table {
   width: 100%;
   display: table;
-  word-break:break-all;
+  word-break: break-word;
   overflow: scroll;
 
   tr {


### PR DESCRIPTION
### Context
I enable word-break for tables to prevent that the table is wider than a container.

### How has this been tested?
I opened dev tools with responsive mode, then I was changing the width tighter and tighter. All works ok.
Example table which has problem before: http://localhost:8080/docs/next/context-menu/#context-menu-with-specific-options

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #8296
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
