### PR TITLE
Set light color as background for Preview tab in dark theme #8355

### DIFF
--- a/docs/.vuepress/theme/components/Page.vue
+++ b/docs/.vuepress/theme/components/Page.vue
@@ -38,8 +38,15 @@ export default {
   },
   methods: {
     codePreviewTabChanged(selectedTab, exampleId) {
+      const changedClass = 'selected-preview';
+      const parentContainer = selectedTab.tab.$el.parentElement;
+
+      // Removing class by method compatible with IE
+      parentContainer.className = parentContainer.className.replace(new RegExp(` ?${changedClass}`), '');
+
       if (selectedTab.tab.computedId.startsWith('preview-tab')) {
         this.activatedExamples.push(exampleId);
+        parentContainer.className += ` ${changedClass}`; // Adding class by method compatible with IE
       }
     },
     isScriptLoaderActivated(exampleId) {

--- a/docs/.vuepress/theme/styles/theme-dark.styl
+++ b/docs/.vuepress/theme/styles/theme-dark.styl
@@ -218,8 +218,8 @@ html.theme-dark {
 
       section {
         &[id*="preview-"] {
-          color $fontColor
-          background-color $tabsComponentBackgroundColor
+          color $tabsComponentBackgroundColor /* Related to issue #8355 */
+          background-color white; /* Related to issue #8355 */
         }
 
         &#code {

--- a/docs/.vuepress/theme/styles/theme-dark.styl
+++ b/docs/.vuepress/theme/styles/theme-dark.styl
@@ -215,6 +215,11 @@ html.theme-dark {
     .tabs-component-panels {
       background-color $tabsComponentPanels
       border-radius 0
+      
+      &.selected-preview {
+        color $tabsComponentBackgroundColor /* Related to issue #8355 */
+        background-color white; /* Related to issue #8355 */
+      }
 
       section {
         &[id*="preview-"] {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
There were applied change for style of whole `Preview` tab element.


Pages: http://localhost:8080/docs/next/row-virtualization/#overview, https://dev.handsontable.com/docs/next/row-virtualization/#overview

Was:

![dark](https://user-images.githubusercontent.com/141330/124468188-19f2a800-dd99-11eb-8239-c61525ff2a6f.gif)

Is:

![light](https://user-images.githubusercontent.com/141330/124468218-2119b600-dd99-11eb-91c1-0aeba6db8640.gif)

Pages: http://localhost:8080/docs/next/grid-size/#manual-resizing, https://dev.handsontable.com/docs/next/grid-size/#manual-resizing

Was:

![Screenshot 2021-07-05 at 13 34 00](https://user-images.githubusercontent.com/141330/124467193-cfbcf700-dd97-11eb-90c0-dc005b99ed4a.png)

Is:

![image](https://user-images.githubusercontent.com/141330/124467250-e4998a80-dd97-11eb-8251-19dd26008e44.png)

Pages: http://localhost:8080/docs/next/events-and-hooks/#hooks, https://dev.handsontable.com/docs/next/events-and-hooks/#hooks

Was:

![Screenshot 2021-07-05 at 13 34 19](https://user-images.githubusercontent.com/141330/124467296-f418d380-dd97-11eb-94f0-644c578efef7.png)

Is:

![Screenshot 2021-07-05 at 13 34 29](https://user-images.githubusercontent.com/141330/124467286-f11de300-dd97-11eb-8875-87feb7dfb60b.png)

[skip changelog]

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #8355

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] My change requires a change to the documentation.
