### PR TITLE
Suggestions for search box will look properly on mobile devices #8353

### DIFF
--- a/docs/.vuepress/theme/components/SearchBox.vue
+++ b/docs/.vuepress/theme/components/SearchBox.vue
@@ -383,6 +383,7 @@ export default {
         left 24px
   .suggestions
     background #fff
+    max-width calc(100vw - 4rem)
     width 26rem
     position absolute
     top 1.6rem


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Just small fix for the CSS. I set `max-width` for a container. It seems that there is `2rem` margin from the right. Thus, I created element with width `100vh-4rem`

Was:

![Screenshot 2021-07-05 at 15 17 20](https://user-images.githubusercontent.com/141330/124477275-229cab80-dda4-11eb-820e-99e713f428d1.png)

Is:

![Screenshot 2021-07-05 at 15 15 43](https://user-images.githubusercontent.com/141330/124477286-24ff0580-dda4-11eb-9ccb-1b61a2f41dcc.png)

[skip changelog]

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
 Checked how it look like on Google Chrome emulator.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #8353

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] My change requires a change to the documentation.
