### PR TITLE
New docs: Split production and stage dockerfiles.

### DIFF
--- a/docs/.vuepress/plugins/assets-versioning/index.js
+++ b/docs/.vuepress/plugins/assets-versioning/index.js
@@ -25,7 +25,7 @@ module.exports = (options, context) => {
         return `${shortMonthName} ${twoDigitDay}, ${date.getFullYear()}`;
       };
 
-      $page.versions = helpers.getVersions();
+      $page.versions = helpers.getVersions(buildMode);
       $page.latestVersion = helpers.getLatestVersion();
       $page.currentVersion = helpers.parseVersion($page.path);
       $page.lastUpdatedFormat = formatDate($page.lastUpdated);

--- a/docs/.vuepress/tools/jsdoc-convert/jsdoc.js
+++ b/docs/.vuepress/tools/jsdoc-convert/jsdoc.js
@@ -20,7 +20,7 @@ const whitelist = [
   'editors/baseEditor/baseEditor.js',
   '3rdparty/walkontable/src/cell/coords.js',
   'plugins/copyPaste/focusableElement.js',
-  'DataMap.js',
+  'dataMap.js',
   'translations/maps/hidingMap.js',
   'translations/maps/indexesSequence.js',
   'translations/maps/trimmingMap.js',

--- a/docs/docker/Dockerfile.production
+++ b/docs/docker/Dockerfile.production
@@ -1,5 +1,5 @@
 FROM node:15 as build
-ENV BUILD_MODE=stage
+ENV BUILD_MODE=production
 
 WORKDIR /app
 
@@ -16,12 +16,13 @@ RUN npm ci
 
 # app
 WORKDIR /app
-COPY src ./src
 COPY docs ./docs
 
 WORKDIR /app/docs
 
-RUN npm run docs:api
+RUN rm -rf ./next/
+RUN rm ./.vuepress/public/handsontable.js ./.vuepress/public/handsontable.css
+
 RUN npm run docs:build
 
 # server image

--- a/docs/package.json
+++ b/docs/package.json
@@ -19,7 +19,7 @@
     "docs:build:no-check-links": "vuepress build -d .vuepress/dist/docs ./",
     "docs:docker:build": "npm run docs:docker:build:staging",
     "docs:docker:build:staging": "npm run docs:assets:next && docker build -f docker/Dockerfile -t docs-md ../",
-    "docs:docker:build:production": "docker build -f docker/Dockerfile -t docs-md --build-arg BUILD_MODE=production ../",
+    "docs:docker:build:production": "docker build -f docker/Dockerfile.production -t docs-md:production ../",
     "docs:version": "cd .vuepress/tools/version && node rollup-a-version.js",
     "docs:api": "cd .vuepress/tools/jsdoc-convert && node jsdoc.js",
     "docs:check-links": "node .vuepress/tools/check-links.js"


### PR DESCRIPTION
### Context
I make a separate docker file for the production build.
I added logic to generating API references for the next version for the stage, which is required to fix deployment.

### How has this been tested?
I build them both and deploy them on the staging server. All works.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
