### PR TITLE
New Docs: FIX search shortcuts after route changed.

### DIFF
--- a/docs/.vuepress/theme/components/SearchBox.vue
+++ b/docs/.vuepress/theme/components/SearchBox.vue
@@ -52,8 +52,9 @@
 
 <script>
 /* global SEARCH_MAX_SUGGESTIONS, SEARCH_HOTKEYS */
-
 import get from 'lodash/get';
+
+const ALLOWED_TAGS = ['BODY', 'A', 'BUTTON'];
 
 const matchTest = (query, domain, isFuzzySearch = false) => {
   const escapeRegExp = str => str.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
@@ -294,7 +295,8 @@ export default {
     },
 
     onHotkey(event) {
-      const isValidElement = event.srcElement === document.body || event.srcElement.tagName === 'A';
+      const isValidElement = ALLOWED_TAGS.includes(event.srcElement.tagName)
+        || event.srcElement.id === 'slider'; // theme switcher;
 
       if (isValidElement && SEARCH_HOTKEYS.includes(event.key)) {
         this.$refs.input.focus();

--- a/docs/.vuepress/theme/components/SearchBox.vue
+++ b/docs/.vuepress/theme/components/SearchBox.vue
@@ -294,7 +294,9 @@ export default {
     },
 
     onHotkey(event) {
-      if (event.srcElement === document.body && SEARCH_HOTKEYS.includes(event.key)) {
+      const isValidElement = event.srcElement === document.body || event.srcElement.tagName === 'A';
+
+      if (isValidElement && SEARCH_HOTKEYS.includes(event.key)) {
         this.$refs.input.focus();
         event.preventDefault();
       }


### PR DESCRIPTION
### Context
In the listener, I changed the logic of which source elements are valid. It still ignores textareas and other kinds of inputs.

### How has this been tested?
Tried to reproduce as described in #8374 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #8374 
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
