### PR TITLE
Fix demo and icon styles for dark theme

### DIFF
--- a/docs/.vuepress/theme/styles/theme-dark.styl
+++ b/docs/.vuepress/theme/styles/theme-dark.styl
@@ -314,7 +314,7 @@ html.theme-dark {
     scrollbar()
   }
 
-  table:not(.selected-preview *) {
+  table:not(.selected-preview *):not(.pika-table) {
     tr:nth-child(2n) {
       background-color $tableEvenRowBackgroundColor
     }

--- a/docs/.vuepress/theme/styles/theme-dark.styl
+++ b/docs/.vuepress/theme/styles/theme-dark.styl
@@ -21,7 +21,7 @@ html.theme-dark {
   h1, h2, h3, h4, h5, h6, p {
     border-bottom-color $sectionBorderColor
   }
-  
+
   #handsontable-logo {
     path {
       fill #ffffff
@@ -215,7 +215,7 @@ html.theme-dark {
     .tabs-component-panels {
       background-color $tabsComponentPanels
       border-radius 0
-      
+
       &.selected-preview {
         color $tabsComponentBackgroundColor /* Related to issue #8355 */
         background-color white; /* Related to issue #8355 */
@@ -261,6 +261,10 @@ html.theme-dark {
     color $fontColor
   }
 
+  .icons-wrapper svg {
+    fill: $fontColor
+  }
+
   /* Tip markdown component */
   .custom-block.tip {
     background-color $customBlockTipBackgroundColor
@@ -277,7 +281,7 @@ html.theme-dark {
   }
 
   /* Code element */
-  code {
+  code:not(.selected-preview *) {
     color $codeFontColor
     background $codeBackground
   }
@@ -297,7 +301,7 @@ html.theme-dark {
   }
 
   /* Version alert badge */
-  .version-alert { 
+  .version-alert {
     border-color $versionAlertBorderColor
 
     p {
@@ -310,7 +314,7 @@ html.theme-dark {
     scrollbar()
   }
 
-  table:not(.htCore):not(.pika-table) {
+  table:not(.selected-preview *) {
     tr:nth-child(2n) {
       background-color $tableEvenRowBackgroundColor
     }

--- a/docs/9.0/guides/integrate-with-vue/vue-vuex-example.md
+++ b/docs/9.0/guides/integrate-with-vue/vue-vuex-example.md
@@ -22,9 +22,11 @@ Toggle `readOnly` for the entire table.
 <div id="example1">
   <div id="example-preview">
     <div id="toggle-boxes">
+      <br/>
       <input v-on:click="toggleReadOnly" checked id="readOnlyCheck" type="checkbox"/>
       <label for="readOnlyCheck"> Toggle <code>readOnly</code> for the entire table</label>
     </div>
+    <br/>
     <hot-table ref="wrapper" :settings="hotSettings"></hot-table>
   </div>
   <div id="vuex-preview">

--- a/docs/next/guides/integrate-with-vue/vue-vuex-example.md
+++ b/docs/next/guides/integrate-with-vue/vue-vuex-example.md
@@ -22,9 +22,11 @@ Toggle `readOnly` for the entire table.
 <div id="example1">
   <div id="example-preview">
     <div id="toggle-boxes">
+      <br/>
       <input v-on:click="toggleReadOnly" checked id="readOnlyCheck" type="checkbox"/>
       <label for="readOnlyCheck"> Toggle <code>readOnly</code> for the entire table</label>
     </div>
+    <br/>
     <hot-table ref="wrapper" :settings="hotSettings"></hot-table>
   </div>
   <div id="vuex-preview">


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the dark theme pollution that wades into the preview tab's content. While checking the dark theme I've spotted that icons from the Icons Pack page are not adjusted to the theme so I [fixed that too ](https://github.com/handsontable/handsontable/pull/8395/files#diff-2f7212b29dc3023aa15a555ce1ee2e4d452f562eff0dcda015d71d0393465c93R264).

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #8371
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
