### PR TITLE
Remove `height: 'auto'` option from HoT

### DIFF
--- a/docs/9.0/guides/cell-features/disabled-cells.md
+++ b/docs/9.0/guides/cell-features/disabled-cells.md
@@ -35,7 +35,6 @@ const hot = new Handsontable(container, {
   ],
   colHeaders: ['Car', 'Year', 'Chassis color', 'Bumper color'],
   licenseKey: 'non-commercial-and-evaluation',
-  height: 'auto',
   columns: [
     {
       data: 'car',
@@ -65,10 +64,10 @@ const container = document.querySelector('#example2');
 
 const hot = new Handsontable(container, {
   data: [
-    {car: 'Tesla', year: 2017, chassis: 'black', bumper: 'black'},
-    {car: 'Nissan', year: 2018, chassis: 'blue', bumper: 'blue'},
-    {car: 'Chrysler', year: 2019, chassis: 'yellow', bumper: 'black'},
-    {car: 'Volvo', year: 2020, chassis: 'white', bumper: 'gray'}
+    { car: 'Tesla', year: 2017, chassis: 'black', bumper: 'black' },
+    { car: 'Nissan', year: 2018, chassis: 'blue', bumper: 'blue' },
+    { car: 'Chrysler', year: 2019, chassis: 'yellow', bumper: 'black' },
+    { car: 'Volvo', year: 2020, chassis: 'white', bumper: 'gray' }
   ],
   colHeaders: ['Car', 'Year', 'Chassis color', 'Bumper color'],
   height: 'auto',
@@ -112,7 +111,6 @@ const hot = new Handsontable(container, {
   ],
   colHeaders: ['Car', 'Year', 'Chassis color', 'Bumper color'],
   licenseKey: 'non-commercial-and-evaluation',
-  height: 'auto',
   columns: [
     {
       data: 'car',
@@ -145,10 +143,10 @@ const container = document.querySelector('#example4');
 
 const hot = new Handsontable(container, {
   data: [
-    {car: 'Tesla', year: 2017, chassis: 'black', bumper: 'black'},
-    {car: 'Nissan', year: 2018, chassis: 'blue', bumper: 'blue'},
-    {car: 'Chrysler', year: 2019, chassis: 'yellow', bumper: 'black'},
-    {car: 'Volvo', year: 2020, chassis: 'white', bumper: 'gray'}
+    { car: 'Tesla', year: 2017, chassis: 'black', bumper: 'black' },
+    { car: 'Nissan', year: 2018, chassis: 'blue', bumper: 'blue' },
+    { car: 'Chrysler', year: 2019, chassis: 'yellow', bumper: 'black' },
+    { car: 'Volvo', year: 2020, chassis: 'white', bumper: 'gray' }
   ],
   colHeaders: ['Car', 'Year', 'Chassis color', 'Bumper color'],
   height: 'auto',

--- a/docs/9.0/guides/cell-functions/cell-renderer.md
+++ b/docs/9.0/guides/cell-functions/cell-renderer.md
@@ -140,7 +140,6 @@ const container = document.getElementById('example1');
 const hot = new Handsontable(container, {
   data,
   colWidths: [200, 200, 200, 80],
-  height: 'auto',
   colHeaders: ['Title', 'Description', 'Comments', 'Cover'],
   columns: [
     { data: 'title', renderer: 'html' },
@@ -196,7 +195,6 @@ const hot = new Handsontable(container, {
     {},
     { renderer: customRenderer }
   ],
-  height: 'auto',
   colHeaders(col) {
     switch (col) {
       case 0:

--- a/docs/9.0/guides/cell-functions/cell-validator.md
+++ b/docs/9.0/guides/cell-functions/cell-validator.md
@@ -171,7 +171,6 @@ const hot = new Handsontable(container, {
     }
   },
   colHeaders: ['ID', 'First name', 'Last name', 'IP', 'E-mail'],
-  height: 'auto',
   licenseKey: 'non-commercial-and-evaluation',
   columns: [
     { data: 'id', type: 'numeric' },

--- a/docs/9.0/guides/cell-types/autocomplete-cell-type.md
+++ b/docs/9.0/guides/cell-types/autocomplete-cell-type.md
@@ -25,7 +25,6 @@ const colors = ['yellow', 'red', 'orange and another color', 'green',
   'blue', 'gray', 'black', 'white', 'purple', 'lime', 'olive', 'cyan'];
 
 const hot = new Handsontable(container, {
-  height: 'auto',
   licenseKey: 'non-commercial-and-evaluation',
   data: [
     ['BMW', 2017, 'black', 'black'],
@@ -79,7 +78,6 @@ const cars = ['BMW', 'Chrysler', 'Nissan', 'Suzuki', 'Toyota', 'Volvo'];
 
 const hot = new Handsontable(container, {
   licenseKey: 'non-commercial-and-evaluation',
-  height: 'auto',
   data: [
     ['BMW', 2017, 'black', 'black'],
     ['Nissan', 2018, 'blue', 'blue'],
@@ -123,7 +121,6 @@ const container = document.querySelector('#example3');
 
 const hot = new Handsontable(container, {
   licenseKey: 'non-commercial-and-evaluation',
-  height: 'auto',
   data: [
     ['BMW', 2017, 'black', 'black'],
     ['Nissan', 2018, 'blue', 'blue'],

--- a/docs/9.0/guides/cell-types/cell-type.md
+++ b/docs/9.0/guides/cell-types/cell-type.md
@@ -281,7 +281,6 @@ const hot = new Handsontable(container, {
     { id: 4, name: 'Ben', isActive: false, color: 'blue', date: null },
   ],
   colHeaders: true,
-  height: 'auto',
   licenseKey: 'non-commercial-and-evaluation',
   columns: [
     { data: 'id', type: 'text' },
@@ -325,7 +324,6 @@ const hot = new Handsontable(container, {
   columnSorting: {
     sortEmptyCells: true
   },
-  height: 'auto',
   columns: [
     {
       columnSorting: {

--- a/docs/9.0/guides/cell-types/checkbox-cell-type.md
+++ b/docs/9.0/guides/cell-types/checkbox-cell-type.md
@@ -29,7 +29,6 @@ const hot = new Handsontable(container, {
     { car: 'BMW 320i Coupe', year: 2021, available: false, comesInBlack: 'no' }
   ],
   colHeaders: ['Car model', 'Year of manufacture', 'Available'],
-  height: 'auto',
   columns: [
     {
       data: 'car'
@@ -65,7 +64,6 @@ const hot = new Handsontable(container, {
     { car: 'BMW 320i Coupe', year: 2021, available: false, comesInBlack: 'no' }
   ],
   colHeaders: ['Car model', 'Year of manufacture', 'Comes in black'],
-  height: 'auto',
   columns: [
     {
       data: 'car'
@@ -103,7 +101,6 @@ const hot = new Handsontable(container, {
     { car: 'BMW 320i Coupe', year: 2021, available: false, comesInBlack: 'no' }
   ],
   colHeaders: ['Car model', 'Accepted', 'Comes in black'],
-  height: 'auto',
   columns: [
     {
       data: 'car'

--- a/docs/9.0/guides/cell-types/date-cell-type.md
+++ b/docs/9.0/guides/cell-types/date-cell-type.md
@@ -42,7 +42,6 @@ const hot = new Handsontable(container, {
     ['BMW', '320i Coupe', '07/24/2022', 30500]
   ],
   colHeaders: ['Car', 'Model', 'Registration date', 'Price'],
-  height: 'auto',
   columns: [
     {
       type: 'autocomplete',

--- a/docs/9.0/guides/cell-types/dropdown-cell-type.md
+++ b/docs/9.0/guides/cell-types/dropdown-cell-type.md
@@ -28,7 +28,6 @@ const hot = new Handsontable(container, {
     ['Volvo', 2020, 'white', 'gray']
   ],
   colHeaders: ['Car', 'Year', 'Chassis color', 'Bumper color'],
-  height: 'auto',
   columns: [
     {},
     { type: 'numeric' },

--- a/docs/9.0/guides/cell-types/handsontable-cell-type.md
+++ b/docs/9.0/guides/cell-types/handsontable-cell-type.md
@@ -55,7 +55,6 @@ const hot = new Handsontable(container, {
     ['Volvo', 2020, 'white', 'gray']
   ],
   colHeaders: ['Car', 'Year', 'Chassis color', 'Bumper color'],
-  height: 'auto',
   columns: [
     {
       type: 'handsontable',

--- a/docs/9.0/guides/cell-types/numeric-cell-type.md
+++ b/docs/9.0/guides/cell-types/numeric-cell-type.md
@@ -46,7 +46,6 @@ const hot = new Handsontable(container, {
   colHeaders: ['Car', 'Year', 'Price ($)', 'Price (€)'],
   columnSorting : true,
   licenseKey: 'non-commercial-and-evaluation',
-  height: 'auto',
   columns: [
     {
       data: 'car'

--- a/docs/9.0/guides/cell-types/password-cell-type.md
+++ b/docs/9.0/guides/cell-types/password-cell-type.md
@@ -25,7 +25,6 @@ const hot = new Handsontable(container, {
   ],
   colHeaders: ['ID', 'First name', 'Last name', 'Password'],
   licenseKey: 'non-commercial-and-evaluation',
-  height: 'auto',
   columns: [
     { data: 'id' },
     { data: 'name.first' },
@@ -52,7 +51,6 @@ const hot = new Handsontable(container, {
   ],
   colHeaders: ['ID', 'First name', 'Last name', 'Password'],
   licenseKey: 'non-commercial-and-evaluation',
-  height: 'auto',
   columns: [
     { data: 'id' },
     { data: 'name.first' },
@@ -79,7 +77,6 @@ const hot = new Handsontable(container, {
   ],
   colHeaders: ['ID', 'First name', 'Last name', 'Password'],
   licenseKey: 'non-commercial-and-evaluation',
-  height: 'auto',
   columns: [
     { data: 'id' },
     { data: 'name.first' },

--- a/docs/9.0/guides/cell-types/select-cell-type.md
+++ b/docs/9.0/guides/cell-types/select-cell-type.md
@@ -27,7 +27,6 @@ const hot = new Handsontable(container, {
   ],
   colWidths: [50, 70, 50],
   colHeaders: true,
-  height: 'auto',
   columns: [
     {},
     {

--- a/docs/9.0/guides/cell-types/time-cell-type.md
+++ b/docs/9.0/guides/cell-types/time-cell-type.md
@@ -44,7 +44,6 @@ const hot = new Handsontable(container, {
   colHeaders: ['Car', 'Model', 'Registration time', 'Price'],
   columnSorting: true,
   licenseKey: 'non-commercial-and-evaluation',
-  height: 'auto',
   columns: [
     {
       type: 'autocomplete',

--- a/docs/9.0/guides/columns/column-filter.md
+++ b/docs/9.0/guides/columns/column-filter.md
@@ -38,7 +38,6 @@ const hot = new Handsontable(container, {
     { type: 'date', dateFormat: 'M/D/YYYY' },
     { type: 'numeric' }
   ],
-  height: 'auto',
   colHeaders: true,
   rowHeaders: true,
   dropdownMenu: true,
@@ -72,7 +71,6 @@ const hot = new Handsontable(container, {
     { type: 'date', dateFormat: 'M/D/YYYY' },
     { type: 'numeric' }
   ],
-  height: 'auto',
   colHeaders: true,
   rowHeaders: true,
   filters: true,

--- a/docs/9.0/guides/columns/column-hiding.md
+++ b/docs/9.0/guides/columns/column-hiding.md
@@ -43,7 +43,6 @@ const hot = new Handsontable(container, {
   colHeaders: true,
   rowHeaders: true,
   contextMenu: true,
-  height: 'auto',
   hiddenColumns: {
     columns: [3, 5, 9],
     indicators: true

--- a/docs/9.0/guides/columns/column-summary.md
+++ b/docs/9.0/guides/columns/column-summary.md
@@ -365,7 +365,6 @@ const hot = new Handsontable(container, {
   nestedRows: true,
   rowHeaders: true,
   colHeaders: ['sum', 'min', 'max', 'count', 'average'],
-  height: 'auto',
   licenseKey: 'non-commercial-and-evaluation',
   columnSummary() {
     const endpoints = [];

--- a/docs/9.0/guides/getting-started/binding-to-data.md
+++ b/docs/9.0/guides/getting-started/binding-to-data.md
@@ -67,8 +67,6 @@ const hot = new Handsontable(container, {
   data,
   colHeaders: true,
   minSpareRows: 1,
-  height: 'auto',
-  width: 'auto',
   columns: [
     { data: 0 },
     // skip the second column
@@ -169,8 +167,6 @@ const data = [
 const hot = new Handsontable(container, {
   data,
   colHeaders: true,
-  height: 'auto',
-  width: 'auto',
   columns: [
     { data: 'id' },
     { data: 'name.first' },
@@ -198,8 +194,6 @@ const hot = new Handsontable(container, {
   dataSchema: { id: null, name: { first: null, last: null }, address: null },
   startRows: 5,
   startCols: 4,
-  height: 'auto',
-  width: 'auto',
   colHeaders: ['ID', 'First Name', 'Last Name', 'Address'],
   columns: [
     { data: 'id' },
@@ -233,8 +227,6 @@ const hot = new Handsontable(container, {
   ],
   dataSchema: model,
   colHeaders: ['ID', 'Name', 'Address'],
-  height: 'auto',
-  width: 'auto',
   columns: [
     { data: property('id') },
     { data: property('name') },

--- a/docs/9.0/guides/getting-started/setting-options.md
+++ b/docs/9.0/guides/getting-started/setting-options.md
@@ -81,8 +81,6 @@ const hot = new Handsontable(container, {
     },
     {},
   ],
-  width: 'auto',
-  height: 'auto',
   rowHeaders: true,
   colHeaders: true,
   licenseKey: 'non-commercial-and-evaluation'
@@ -261,8 +259,6 @@ const hot = new Handsontable(container, {
       }
     }
   },
-  width: 'auto',
-  height: 'auto',
   rowHeaders: true,
   colHeaders: true,
   licenseKey: 'non-commercial-and-evaluation'

--- a/docs/9.0/guides/integrate-with-angular/angular-custom-editor-example.md
+++ b/docs/9.0/guides/integrate-with-angular/angular-custom-editor-example.md
@@ -42,7 +42,6 @@ class AppComponent {
     ],
     colHeaders: true,
     colWidths: 200,
-    height: 'auto',
     licenseKey: 'non-commercial-and-evaluation'
   };
 }

--- a/docs/9.0/guides/integrate-with-react/react-custom-editor-example.md
+++ b/docs/9.0/guides/integrate-with-react/react-custom-editor-example.md
@@ -50,7 +50,6 @@ const hotSettings = {
   ],
   colHeaders: true,
   colWidths: 200,
-  height: 'auto',
   licenseKey: 'non-commercial-and-evaluation'
 };
 

--- a/docs/9.0/guides/integrate-with-react/react-custom-renderer-example.md
+++ b/docs/9.0/guides/integrate-with-react/react-custom-renderer-example.md
@@ -55,7 +55,6 @@ const hotSettings = {
   ],
   colHeaders: true,
   rowHeights: 55,
-  height: 'auto',
   licenseKey: 'non-commercial-and-evaluation'
 };
 

--- a/docs/9.0/guides/integrate-with-vue/vue-custom-editor-example.md
+++ b/docs/9.0/guides/integrate-with-vue/vue-custom-editor-example.md
@@ -58,7 +58,6 @@ new Vue({
         ],
         colHeaders: true,
         colWidths: 200,
-        height: 'auto',
         licenseKey: 'non-commercial-and-evaluation'
       }
     }

--- a/docs/9.0/guides/integrate-with-vue/vue-custom-renderer-example.md
+++ b/docs/9.0/guides/integrate-with-vue/vue-custom-renderer-example.md
@@ -64,7 +64,6 @@ new Vue({
         ],
         colHeaders: true,
         rowHeights: 55,
-        height: 'auto',
         licenseKey: 'non-commercial-and-evaluation'
       }
     }

--- a/docs/next/guides/cell-features/disabled-cells.md
+++ b/docs/next/guides/cell-features/disabled-cells.md
@@ -35,7 +35,6 @@ const hot = new Handsontable(container, {
   ],
   colHeaders: ['Car', 'Year', 'Chassis color', 'Bumper color'],
   licenseKey: 'non-commercial-and-evaluation',
-  height: 'auto',
   columns: [
     {
       data: 'car',
@@ -65,10 +64,10 @@ const container = document.querySelector('#example2');
 
 const hot = new Handsontable(container, {
   data: [
-    {car: 'Tesla', year: 2017, chassis: 'black', bumper: 'black'},
-    {car: 'Nissan', year: 2018, chassis: 'blue', bumper: 'blue'},
-    {car: 'Chrysler', year: 2019, chassis: 'yellow', bumper: 'black'},
-    {car: 'Volvo', year: 2020, chassis: 'white', bumper: 'gray'}
+    { car: 'Tesla', year: 2017, chassis: 'black', bumper: 'black' },
+    { car: 'Nissan', year: 2018, chassis: 'blue', bumper: 'blue' },
+    { car: 'Chrysler', year: 2019, chassis: 'yellow', bumper: 'black' },
+    { car: 'Volvo', year: 2020, chassis: 'white', bumper: 'gray' }
   ],
   colHeaders: ['Car', 'Year', 'Chassis color', 'Bumper color'],
   height: 'auto',
@@ -112,7 +111,6 @@ const hot = new Handsontable(container, {
   ],
   colHeaders: ['Car', 'Year', 'Chassis color', 'Bumper color'],
   licenseKey: 'non-commercial-and-evaluation',
-  height: 'auto',
   columns: [
     {
       data: 'car',
@@ -145,10 +143,10 @@ const container = document.querySelector('#example4');
 
 const hot = new Handsontable(container, {
   data: [
-    {car: 'Tesla', year: 2017, chassis: 'black', bumper: 'black'},
-    {car: 'Nissan', year: 2018, chassis: 'blue', bumper: 'blue'},
-    {car: 'Chrysler', year: 2019, chassis: 'yellow', bumper: 'black'},
-    {car: 'Volvo', year: 2020, chassis: 'white', bumper: 'gray'}
+    { car: 'Tesla', year: 2017, chassis: 'black', bumper: 'black' },
+    { car: 'Nissan', year: 2018, chassis: 'blue', bumper: 'blue' },
+    { car: 'Chrysler', year: 2019, chassis: 'yellow', bumper: 'black' },
+    { car: 'Volvo', year: 2020, chassis: 'white', bumper: 'gray' }
   ],
   colHeaders: ['Car', 'Year', 'Chassis color', 'Bumper color'],
   height: 'auto',

--- a/docs/next/guides/cell-functions/cell-renderer.md
+++ b/docs/next/guides/cell-functions/cell-renderer.md
@@ -140,7 +140,6 @@ const container = document.getElementById('example1');
 const hot = new Handsontable(container, {
   data,
   colWidths: [200, 200, 200, 80],
-  height: 'auto',
   colHeaders: ['Title', 'Description', 'Comments', 'Cover'],
   columns: [
     { data: 'title', renderer: 'html' },
@@ -196,7 +195,6 @@ const hot = new Handsontable(container, {
     {},
     { renderer: customRenderer }
   ],
-  height: 'auto',
   colHeaders(col) {
     switch (col) {
       case 0:

--- a/docs/next/guides/cell-functions/cell-validator.md
+++ b/docs/next/guides/cell-functions/cell-validator.md
@@ -171,7 +171,6 @@ const hot = new Handsontable(container, {
     }
   },
   colHeaders: ['ID', 'First name', 'Last name', 'IP', 'E-mail'],
-  height: 'auto',
   licenseKey: 'non-commercial-and-evaluation',
   columns: [
     { data: 'id', type: 'numeric' },

--- a/docs/next/guides/cell-types/autocomplete-cell-type.md
+++ b/docs/next/guides/cell-types/autocomplete-cell-type.md
@@ -25,7 +25,6 @@ const colors = ['yellow', 'red', 'orange and another color', 'green',
   'blue', 'gray', 'black', 'white', 'purple', 'lime', 'olive', 'cyan'];
 
 const hot = new Handsontable(container, {
-  height: 'auto',
   licenseKey: 'non-commercial-and-evaluation',
   data: [
     ['BMW', 2017, 'black', 'black'],
@@ -79,7 +78,6 @@ const cars = ['BMW', 'Chrysler', 'Nissan', 'Suzuki', 'Toyota', 'Volvo'];
 
 const hot = new Handsontable(container, {
   licenseKey: 'non-commercial-and-evaluation',
-  height: 'auto',
   data: [
     ['BMW', 2017, 'black', 'black'],
     ['Nissan', 2018, 'blue', 'blue'],
@@ -123,7 +121,6 @@ const container = document.querySelector('#example3');
 
 const hot = new Handsontable(container, {
   licenseKey: 'non-commercial-and-evaluation',
-  height: 'auto',
   data: [
     ['BMW', 2017, 'black', 'black'],
     ['Nissan', 2018, 'blue', 'blue'],

--- a/docs/next/guides/cell-types/cell-type.md
+++ b/docs/next/guides/cell-types/cell-type.md
@@ -281,7 +281,6 @@ const hot = new Handsontable(container, {
     { id: 4, name: 'Ben', isActive: false, color: 'blue', date: null },
   ],
   colHeaders: true,
-  height: 'auto',
   licenseKey: 'non-commercial-and-evaluation',
   columns: [
     { data: 'id', type: 'text' },
@@ -325,7 +324,6 @@ const hot = new Handsontable(container, {
   columnSorting: {
     sortEmptyCells: true
   },
-  height: 'auto',
   columns: [
     {
       columnSorting: {

--- a/docs/next/guides/cell-types/checkbox-cell-type.md
+++ b/docs/next/guides/cell-types/checkbox-cell-type.md
@@ -29,7 +29,6 @@ const hot = new Handsontable(container, {
     { car: 'BMW 320i Coupe', year: 2021, available: false, comesInBlack: 'no' }
   ],
   colHeaders: ['Car model', 'Year of manufacture', 'Available'],
-  height: 'auto',
   columns: [
     {
       data: 'car'
@@ -65,7 +64,6 @@ const hot = new Handsontable(container, {
     { car: 'BMW 320i Coupe', year: 2021, available: false, comesInBlack: 'no' }
   ],
   colHeaders: ['Car model', 'Year of manufacture', 'Comes in black'],
-  height: 'auto',
   columns: [
     {
       data: 'car'
@@ -103,7 +101,6 @@ const hot = new Handsontable(container, {
     { car: 'BMW 320i Coupe', year: 2021, available: false, comesInBlack: 'no' }
   ],
   colHeaders: ['Car model', 'Accepted', 'Comes in black'],
-  height: 'auto',
   columns: [
     {
       data: 'car'

--- a/docs/next/guides/cell-types/date-cell-type.md
+++ b/docs/next/guides/cell-types/date-cell-type.md
@@ -42,7 +42,6 @@ const hot = new Handsontable(container, {
     ['BMW', '320i Coupe', '07/24/2022', 30500]
   ],
   colHeaders: ['Car', 'Model', 'Registration date', 'Price'],
-  height: 'auto',
   columns: [
     {
       type: 'autocomplete',

--- a/docs/next/guides/cell-types/dropdown-cell-type.md
+++ b/docs/next/guides/cell-types/dropdown-cell-type.md
@@ -28,7 +28,6 @@ const hot = new Handsontable(container, {
     ['Volvo', 2020, 'white', 'gray']
   ],
   colHeaders: ['Car', 'Year', 'Chassis color', 'Bumper color'],
-  height: 'auto',
   columns: [
     {},
     { type: 'numeric' },

--- a/docs/next/guides/cell-types/handsontable-cell-type.md
+++ b/docs/next/guides/cell-types/handsontable-cell-type.md
@@ -55,7 +55,6 @@ const hot = new Handsontable(container, {
     ['Volvo', 2020, 'white', 'gray']
   ],
   colHeaders: ['Car', 'Year', 'Chassis color', 'Bumper color'],
-  height: 'auto',
   columns: [
     {
       type: 'handsontable',

--- a/docs/next/guides/cell-types/numeric-cell-type.md
+++ b/docs/next/guides/cell-types/numeric-cell-type.md
@@ -46,7 +46,6 @@ const hot = new Handsontable(container, {
   colHeaders: ['Car', 'Year', 'Price ($)', 'Price (€)'],
   columnSorting : true,
   licenseKey: 'non-commercial-and-evaluation',
-  height: 'auto',
   columns: [
     {
       data: 'car'

--- a/docs/next/guides/cell-types/password-cell-type.md
+++ b/docs/next/guides/cell-types/password-cell-type.md
@@ -25,7 +25,6 @@ const hot = new Handsontable(container, {
   ],
   colHeaders: ['ID', 'First name', 'Last name', 'Password'],
   licenseKey: 'non-commercial-and-evaluation',
-  height: 'auto',
   columns: [
     { data: 'id' },
     { data: 'name.first' },
@@ -52,7 +51,6 @@ const hot = new Handsontable(container, {
   ],
   colHeaders: ['ID', 'First name', 'Last name', 'Password'],
   licenseKey: 'non-commercial-and-evaluation',
-  height: 'auto',
   columns: [
     { data: 'id' },
     { data: 'name.first' },
@@ -79,7 +77,6 @@ const hot = new Handsontable(container, {
   ],
   colHeaders: ['ID', 'First name', 'Last name', 'Password'],
   licenseKey: 'non-commercial-and-evaluation',
-  height: 'auto',
   columns: [
     { data: 'id' },
     { data: 'name.first' },

--- a/docs/next/guides/cell-types/select-cell-type.md
+++ b/docs/next/guides/cell-types/select-cell-type.md
@@ -27,7 +27,6 @@ const hot = new Handsontable(container, {
   ],
   colWidths: [50, 70, 50],
   colHeaders: true,
-  height: 'auto',
   columns: [
     {},
     {

--- a/docs/next/guides/cell-types/time-cell-type.md
+++ b/docs/next/guides/cell-types/time-cell-type.md
@@ -44,7 +44,6 @@ const hot = new Handsontable(container, {
   colHeaders: ['Car', 'Model', 'Registration time', 'Price'],
   columnSorting: true,
   licenseKey: 'non-commercial-and-evaluation',
-  height: 'auto',
   columns: [
     {
       type: 'autocomplete',

--- a/docs/next/guides/columns/column-filter.md
+++ b/docs/next/guides/columns/column-filter.md
@@ -38,7 +38,6 @@ const hot = new Handsontable(container, {
     { type: 'date', dateFormat: 'M/D/YYYY' },
     { type: 'numeric' }
   ],
-  height: 'auto',
   colHeaders: true,
   rowHeaders: true,
   dropdownMenu: true,
@@ -72,7 +71,6 @@ const hot = new Handsontable(container, {
     { type: 'date', dateFormat: 'M/D/YYYY' },
     { type: 'numeric' }
   ],
-  height: 'auto',
   colHeaders: true,
   rowHeaders: true,
   filters: true,

--- a/docs/next/guides/columns/column-hiding.md
+++ b/docs/next/guides/columns/column-hiding.md
@@ -43,7 +43,6 @@ const hot = new Handsontable(container, {
   colHeaders: true,
   rowHeaders: true,
   contextMenu: true,
-  height: 'auto',
   hiddenColumns: {
     columns: [3, 5, 9],
     indicators: true

--- a/docs/next/guides/columns/column-summary.md
+++ b/docs/next/guides/columns/column-summary.md
@@ -365,7 +365,6 @@ const hot = new Handsontable(container, {
   nestedRows: true,
   rowHeaders: true,
   colHeaders: ['sum', 'min', 'max', 'count', 'average'],
-  height: 'auto',
   licenseKey: 'non-commercial-and-evaluation',
   columnSummary() {
     const endpoints = [];

--- a/docs/next/guides/getting-started/binding-to-data.md
+++ b/docs/next/guides/getting-started/binding-to-data.md
@@ -67,8 +67,6 @@ const hot = new Handsontable(container, {
   data,
   colHeaders: true,
   minSpareRows: 1,
-  height: 'auto',
-  width: 'auto',
   columns: [
     { data: 0 },
     // skip the second column
@@ -169,8 +167,6 @@ const data = [
 const hot = new Handsontable(container, {
   data,
   colHeaders: true,
-  height: 'auto',
-  width: 'auto',
   columns: [
     { data: 'id' },
     { data: 'name.first' },
@@ -198,8 +194,6 @@ const hot = new Handsontable(container, {
   dataSchema: { id: null, name: { first: null, last: null }, address: null },
   startRows: 5,
   startCols: 4,
-  height: 'auto',
-  width: 'auto',
   colHeaders: ['ID', 'First Name', 'Last Name', 'Address'],
   columns: [
     { data: 'id' },
@@ -233,8 +227,6 @@ const hot = new Handsontable(container, {
   ],
   dataSchema: model,
   colHeaders: ['ID', 'Name', 'Address'],
-  height: 'auto',
-  width: 'auto',
   columns: [
     { data: property('id') },
     { data: property('name') },

--- a/docs/next/guides/getting-started/setting-options.md
+++ b/docs/next/guides/getting-started/setting-options.md
@@ -81,8 +81,6 @@ const hot = new Handsontable(container, {
     },
     {},
   ],
-  width: 'auto',
-  height: 'auto',
   rowHeaders: true,
   colHeaders: true,
   licenseKey: 'non-commercial-and-evaluation'
@@ -261,8 +259,6 @@ const hot = new Handsontable(container, {
       }
     }
   },
-  width: 'auto',
-  height: 'auto',
   rowHeaders: true,
   colHeaders: true,
   licenseKey: 'non-commercial-and-evaluation'

--- a/docs/next/guides/integrate-with-angular/angular-custom-editor-example.md
+++ b/docs/next/guides/integrate-with-angular/angular-custom-editor-example.md
@@ -42,7 +42,6 @@ class AppComponent {
     ],
     colHeaders: true,
     colWidths: 200,
-    height: 'auto',
     licenseKey: 'non-commercial-and-evaluation'
   };
 }

--- a/docs/next/guides/integrate-with-react/react-custom-editor-example.md
+++ b/docs/next/guides/integrate-with-react/react-custom-editor-example.md
@@ -50,7 +50,6 @@ const hotSettings = {
   ],
   colHeaders: true,
   colWidths: 200,
-  height: 'auto',
   licenseKey: 'non-commercial-and-evaluation'
 };
 

--- a/docs/next/guides/integrate-with-react/react-custom-renderer-example.md
+++ b/docs/next/guides/integrate-with-react/react-custom-renderer-example.md
@@ -55,7 +55,6 @@ const hotSettings = {
   ],
   colHeaders: true,
   rowHeights: 55,
-  height: 'auto',
   licenseKey: 'non-commercial-and-evaluation'
 };
 

--- a/docs/next/guides/integrate-with-vue/vue-custom-editor-example.md
+++ b/docs/next/guides/integrate-with-vue/vue-custom-editor-example.md
@@ -58,7 +58,6 @@ new Vue({
         ],
         colHeaders: true,
         colWidths: 200,
-        height: 'auto',
         licenseKey: 'non-commercial-and-evaluation'
       }
     }

--- a/docs/next/guides/integrate-with-vue/vue-custom-renderer-example.md
+++ b/docs/next/guides/integrate-with-vue/vue-custom-renderer-example.md
@@ -64,7 +64,6 @@ new Vue({
         ],
         colHeaders: true,
         rowHeights: 55,
-        height: 'auto',
         licenseKey: 'non-commercial-and-evaluation'
       }
     }


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR removes the `height: 'auto'` option from HoT demos. The option is not necessary when the `columns` option is declared. Moreover, it causes weird, buggy autocomplete-like editor behavior.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
\-

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. fixes #8399
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
