### PR TITLE
Fixed problem with using style for docs site for Handsontable instance #8405

### DIFF
--- a/docs/.vuepress/theme/styles/theme-dark.styl
+++ b/docs/.vuepress/theme/styles/theme-dark.styl
@@ -314,7 +314,7 @@ html.theme-dark {
     scrollbar()
   }
 
-  table:not(.pika-table):not(.htCore) {
+  table:not(.selected-preview *):not(.pika-table):not(.htCore) {
     tr:nth-child(2n) {
       background-color $tableEvenRowBackgroundColor
     }

--- a/docs/.vuepress/theme/styles/theme-dark.styl
+++ b/docs/.vuepress/theme/styles/theme-dark.styl
@@ -314,7 +314,7 @@ html.theme-dark {
     scrollbar()
   }
 
-  table:not(.selected-preview *):not(.pika-table) {
+  table:not(.pika-table):not(.htCore) {
     tr:nth-child(2n) {
       background-color $tableEvenRowBackgroundColor
     }


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Every `table` on documentation site, instead of those created by `Pikaday`, `Handsontable` and placed in the preview tab will styled. Some instances of Handsontable (`context menu`, `drop-down menu`, `filters UI`) are placed just right into `body` (not in the preview tab). Thus, the current code hasn't worked.

[skip changelog]

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I've checked in dark theme:

- tables in documentation, i.e.: `/docs/context-menu/#context-menu-with-default-options`, `/docs/supported-browsers/#testing-compatibility`
- context menu
- drop-down menu
- filters
- date picker
- Handsontable in Handsontable
- created table in preview tab (see a screen below)

![Screenshot 2021-07-09 at 13 15 20](https://user-images.githubusercontent.com/141330/125070001-cd201180-e0b7-11eb-9e9c-5dde0f55c570.png)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #8405 

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] My change requires a change to the documentation.