### PR TITLE
Add missing release notes for 9.0.1

### DIFF
--- a/docs/9.0/guides/upgrade-and-migration/release-notes.md
+++ b/docs/9.0/guides/upgrade-and-migration/release-notes.md
@@ -13,6 +13,19 @@ tags:
 
 [[toc]]
 
+## 9.0.1
+
+Released on 17th of June, 2021
+
+**Fixed**
+
+*   Fixed an issue where the validator function was called twice when the Formulas plugin was enabled. ([#8138](https://github.com/handsontable/handsontable/issues/8138))
+*   Introduced a new CSS style for cells of the `checkbox` type to restore previous behaviour. ([#8196](https://github.com/handsontable/handsontable/issues/8196))
+
+**Removed**
+
+*   Removed the redundant internal `jsonpatch` library from the source code. ([#8140](https://github.com/handsontable/handsontable/issues/8140))
+
 ## 9.0.0
 
 Released on 1st of June, 2021
@@ -105,7 +118,7 @@ Released on 16th of March, 2021
 *   Fixed the incorrect `cellTypes` module paths in the `exports` entry of the `package.json` file. ([#7597](https://github.com/handsontable/handsontable/issues/7597))
 *   *Vue:* Fixed Remote Code Execution vulnerability in the dev dependencies. ([#7620](https://github.com/handsontable/handsontable/issues/7620))
 
-### 8.3.1
+## 8.3.1
 
 Released on 10th of February, 2021
 
@@ -113,7 +126,7 @@ Released on 10th of February, 2021
 
 *   Fixed an issue where the CSS files could be eliminated during tree-shaking. ([#7516](https://github.com/handsontable/handsontable/issues/7516))
 
-### 8.3.0
+## 8.3.0
 
 Released on 28th of January, 2021
 

--- a/docs/next/guides/upgrade-and-migration/release-notes.md
+++ b/docs/next/guides/upgrade-and-migration/release-notes.md
@@ -13,6 +13,19 @@ tags:
 
 [[toc]]
 
+## 9.0.1
+
+Released on 17th of June, 2021
+
+**Fixed**
+
+*   Fixed an issue where the validator function was called twice when the Formulas plugin was enabled. ([#8138](https://github.com/handsontable/handsontable/issues/8138))
+*   Introduced a new CSS style for cells of the `checkbox` type to restore previous behaviour. ([#8196](https://github.com/handsontable/handsontable/issues/8196))
+
+**Removed**
+
+*   Removed the redundant internal `jsonpatch` library from the source code. ([#8140](https://github.com/handsontable/handsontable/issues/8140))
+
 ## 9.0.0
 
 Released on 1st of June, 2021
@@ -105,7 +118,7 @@ Released on 16th of March, 2021
 *   Fixed the incorrect `cellTypes` module paths in the `exports` entry of the `package.json` file. ([#7597](https://github.com/handsontable/handsontable/issues/7597))
 *   *Vue:* Fixed Remote Code Execution vulnerability in the dev dependencies. ([#7620](https://github.com/handsontable/handsontable/issues/7620))
 
-### 8.3.1
+## 8.3.1
 
 Released on 10th of February, 2021
 
@@ -113,7 +126,7 @@ Released on 10th of February, 2021
 
 *   Fixed an issue where the CSS files could be eliminated during tree-shaking. ([#7516](https://github.com/handsontable/handsontable/issues/7516))
 
-### 8.3.0
+## 8.3.0
 
 Released on 28th of January, 2021
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adds missing release notes for 9.0.1 and fixes the header leveling mentioned [here](https://github.com/handsontable/handsontable/issues/8397#issuecomment-876380111).

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
\-

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. fixes #8397
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
