### PR TITLE
Fix code block style on dark theme

### DIFF
--- a/docs/.vuepress/theme/styles/theme-dark.styl
+++ b/docs/.vuepress/theme/styles/theme-dark.styl
@@ -281,7 +281,7 @@ html.theme-dark {
   }
 
   /* Code element */
-  code:not(.selected-preview *) {
+  code:not(.selected-preview *):not(pre *) {
     color $codeFontColor
     background $codeBackground
   }


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the CSS that overwrites the background color of the code block. The bug can be seen at https://handsontable.com/docs/internationalization-i18n/#language-file.

Before:
![image](https://user-images.githubusercontent.com/571316/125419201-4b8e1578-dab1-4eca-ae47-849967f6a175.png)

After:
![image](https://user-images.githubusercontent.com/571316/125419239-3dfda590-e25b-4d68-860b-75648022e4cc.png)

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
\-

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. fixes #8409
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
