### PR TITLE
Fix layout and context menu demos on IE9+

### DIFF
--- a/docs/.vuepress/handsontable-manager/register.js
+++ b/docs/.vuepress/handsontable-manager/register.js
@@ -37,13 +37,17 @@ function createRegister() {
     return;
   }
 
-  const register = new Set();
-
   const domMatches = Element.prototype.matches ||
     Element.prototype.msMatchesSelector ||
     Element.prototype.webkitMatchesSelector;
 
-  // Polyfill (IE9+) for DOM.closest method (https://developer.mozilla.org/en-US/docs/Web/API/Element/closest)
+  /**
+   * Polyfill (IE9+) for DOM.closest method (https://developer.mozilla.org/en-US/docs/Web/API/Element/closest).
+   *
+   * @param {Element} element The element the traversing begins from.
+   * @param {string} selector The selector list.
+   * @returns {Element|null}
+   */
   function closest(element, selector) {
     let el = element;
 
@@ -57,7 +61,7 @@ function createRegister() {
     } while (el !== null && el.nodeType === Node.ELEMENT_NODE);
 
     return null;
-  };
+  }
 
   const register = new Set();
 

--- a/docs/.vuepress/handsontable-manager/register.js
+++ b/docs/.vuepress/handsontable-manager/register.js
@@ -33,6 +33,32 @@ function createDestroyableResource(presetType, { rootExampleElement, hotInstance
  * @returns {object} Returns an object with `listen` and `destroyAll` methods.
  */
 function createRegister() {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const register = new Set();
+
+  const domMatches = Element.prototype.matches ||
+    Element.prototype.msMatchesSelector ||
+    Element.prototype.webkitMatchesSelector;
+
+  // Polyfill (IE9+) for DOM.closest method (https://developer.mozilla.org/en-US/docs/Web/API/Element/closest)
+  function closest(element, selector) {
+    let el = element;
+
+    do {
+      if (domMatches.call(el, selector)) {
+        return el;
+      }
+
+      el = el.parentElement || el.parentNode;
+
+    } while (el !== null && el.nodeType === Node.ELEMENT_NODE);
+
+    return null;
+  };
+
   const register = new Set();
 
   const listen = () => {
@@ -40,7 +66,7 @@ function createRegister() {
       if (typeof Handsontable !== 'undefined' && Handsontable._instanceRegisterInstalled === undefined) {
         Handsontable._instanceRegisterInstalled = true;
         Handsontable.hooks.add('afterInit', function() {
-          const rootExampleElement = this.rootElement.closest('[data-preset-type]');
+          const rootExampleElement = closest(this.rootElement, '[data-preset-type]');
 
           if (rootExampleElement) {
             const examplePresetType = rootExampleElement.getAttribute('data-preset-type');

--- a/docs/.vuepress/theme/styles/index.styl
+++ b/docs/.vuepress/theme/styles/index.styl
@@ -65,6 +65,13 @@ a.source-code-link {
   padding-top: 3.6rem;
 }
 
+// Fix for layout overlapping. Works for IE10+
+@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+  .page {
+    float: left;
+  }
+}
+
 .page-top, .page-edit, .page-nav {
   max-width: 740px;
   margin: 0 auto;


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the context menu/dropdown menu demos that throw an error on IE9+. Moreover, I fixed the overlapped layout on IE10+.

Before:
![Zrzut ekranu 2021-07-13 o 14 59 51](https://user-images.githubusercontent.com/571316/125460443-58e91cf8-6c73-4780-802f-6a81fdcbca40.png)

After:
![Zrzut ekranu 2021-07-13 o 15 06 10](https://user-images.githubusercontent.com/571316/125460454-5ebedf17-a582-4f6a-9be0-7855583a49a6.png)

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested by executing build `npm run docs:build:no-check-links` and serving the content from the `.vuepress/dist/` directory. The `npm run docs:start` is not supported by IE.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. fixes #8412
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
