### PR TITLE
FIX anchor links should keep kebab-case

### DIFF
--- a/docs/.vuepress/tools/jsdoc-convert/jsdoc.js
+++ b/docs/.vuepress/tools/jsdoc-convert/jsdoc.js
@@ -240,8 +240,7 @@ const fixLinks = text => text
         return all;
       }
       const fixedAnchor = anchor
-        .toLowerCase()
-        .replace(/-/g, '');
+        .toLowerCase();
 
       if (!target) { // e.g #getData
         return `[${label}](${hash}${fixedAnchor})`;


### PR DESCRIPTION
### Context
This PR is second stage of fixing links generation for API References. 
It makes that anchor links will keep kebab-case

[skip changelog]

### How has this been tested?
1. In the `docs` dir
2. Run `npm run docs:api`
3. Compare `next/api` with `9.0/api` ( for easier/smarter comparing I replace all `fb550d5f16579874852b1c29a60448f48941aff1` to `659ab339a149a32bdd86eea5b599b7eb50c49555`, what reduced diff number)
4. expected result:
`[predefined options](@/guides/accessories-and-menus/context-menu.md#context-menu-with-specific-options)` 
instead of 
`[predefined options](@/guides/accessories-and-menus/context-menu.md#contextmenuwithspecificoptions)`.



### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/8417
2. https://github.com/handsontable/handsontable/pull/8357#pullrequestreview-699113980
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
