### PR TITLE
Extend the `test:ci` script with an option to provide the branch name from the CI.

### DIFF
--- a/scripts/run-targeted-tests.mjs
+++ b/scripts/run-targeted-tests.mjs
@@ -39,6 +39,9 @@ const argv = yargs(hideBin(process.argv))
     '\n - pipeline 2: `unit`, `type`, `walkontable` and `e2e` tests for Handsontable.' +
     '\n\n If HOT was _not_ modified, both pipelines run the other packages\' tests (distributed ~50/50).' +
     '\n\n If no pipeline is defined, all the test run consecutively.')
+  .string('ci-branch')
+  .describe('ci-branch', 'Branch name recognized by the CI. Used to work around the fact, that CI checks out at a' +
+    ' commit hash, not a branch name.')
   .argv;
 
 const workspacePackages = hotPackageJson.workspaces.packages;
@@ -111,7 +114,7 @@ async function distributeBetweenPipelines(modifiedProjects) {
   ).stdout.split('\n');
   const fullTestBranchRegex = new RegExp('^(master|develop|release/.{5,})$');
   const configPathsRegex = new RegExp(`^(${CONFIG_PATHS.join('|').replace(/\./g, '\\.')})`);
-  const fullTestBranchMatch = fullTestBranchRegex.test(currentBranch);
+  const fullTestBranchMatch = fullTestBranchRegex.test(argv.ciBranch || currentBranch);
 
   filesModifiedInLastCommit.shift();
 


### PR DESCRIPTION
### Context
This PR extends the `test:ci` script with a `ci-branch` parameter.
This allows the script to recognize which branch is it triggered on. Getting the branch name from git doesn't work in that case, as CodeShip checks out at a commit hash, instead of a branch name.

This change needs to be paired with:
1. changing the CodeShip config from `npm run test:ci -- -p=X` to `npm run test:ci -- --p=X --ci-branch=$CI_BRANCH`
2. cherry-picking the change to the `develop` branch

<sub>[skip changelog]</sub>

### How has this been tested?
Tested in Codeship's debug mode.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

