### PR TITLE
Docs: expanding columnHeaders export option info (#7651)

### DIFF
--- a/docs/next/guides/accessories-and-menus/export-to-csv.md
+++ b/docs/next/guides/accessories-and-menus/export-to-csv.md
@@ -58,9 +58,11 @@ Default value: `','`
 
 ### columnHeaders `Boolean`
 
-Allows to export data with their column header.
+When set to `true`, includes column headers in the exported data.
 
 You can use this property in all of the [available methods](#available-methods).
+
+The `columnHeaders` option doesn't work with the [`nestedHeaders` plugin](@/api/nestedHeaders.md).
 
 Default value: `false`
 


### PR DESCRIPTION
This PR expands info on the `columnHeaders` option in the "Export to CSV" topic.

#7651 
[skip changelog]