### PR TITLE
Introduce a braking change by modifying {before,after}Render hooks

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1002,8 +1002,15 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
   }
 
   this.init = function() {
-    dataSource.setData(tableMeta.data);
+    if (firstRun) {
+      instance.addHook('beforeRender', (forceFullRender) => {
+        if (forceFullRender) {
+          cellMetaMemo.clear();
+        }
+      });
+    }
 
+    dataSource.setData(tableMeta.data);
     instance.runHooks('beforeInit');
 
     if (isMobileBrowser() || isIpadOS()) {
@@ -2963,7 +2970,8 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
       });
     }
 
-    instance._clearCellMetaMemo();
+    // TODO(temp)
+    cellMetaMemo.clear();
   };
 
   /**
@@ -3098,13 +3106,6 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
     cellMetaMemo.set(key, cellProperties);
 
     return cellProperties;
-  };
-
-  /**
-   * Proof of concept - work in progress.
-   */
-  this._clearCellMetaMemo = function() {
-    cellMetaMemo.clear();
   };
 
   /**

--- a/src/pluginHooks.js
+++ b/src/pluginHooks.js
@@ -421,11 +421,11 @@ const REGISTERED_HOOKS = [
   /**
    * Fired after the Handsontable table is rendered.
    *
-   * @event Hooks#afterRender
+   * @event Hooks#afterViewRender
    * @param {boolean} isForced Is `true` if rendering was triggered by a change of settings or data; or `false` if
    *                           rendering was triggered by scrolling or moving selection.
    */
-  'afterRender',
+  'afterViewRender',
 
   /**
    * Fired before starting rendering the cell.
@@ -884,12 +884,15 @@ const REGISTERED_HOOKS = [
   /**
    * Fired before the Handsontable table is rendered.
    *
-   * @event Hooks#beforeRender
+   * @event Hooks#beforeViewRender
    * @param {boolean} isForced If `true` rendering was triggered by a change of settings or data; or `false` if
    *                           rendering was triggered by scrolling or moving selection.
    * @param {object} skipRender Object with `skipRender` property, if it is set to `true ` the next rendering cycle will be skipped.
    */
+  'beforeViewRender',
+
   'beforeRender',
+  'afterRender',
 
   /**
    * Fired before cell meta is changed.

--- a/src/plugins/autoColumnSize/autoColumnSize.js
+++ b/src/plugins/autoColumnSize/autoColumnSize.js
@@ -208,7 +208,7 @@ export class AutoColumnSize extends BasePlugin {
     this.addHook('afterLoadData', () => this.onAfterLoadData());
     this.addHook('beforeChange', changes => this.onBeforeChange(changes));
     this.addHook('afterFormulasValuesUpdate', changes => this.onAfterFormulasValuesUpdate(changes));
-    this.addHook('beforeRender', force => this.onBeforeRender(force));
+    this.addHook('beforeViewRender', force => this.onBeforeRender(force));
     this.addHook('modifyColWidth', (width, col) => this.getColumnWidth(col, width));
     this.addHook('afterInit', () => this.onAfterInit());
     super.enablePlugin();

--- a/src/plugins/autoRowSize/autoRowSize.js
+++ b/src/plugins/autoRowSize/autoRowSize.js
@@ -180,7 +180,7 @@ export class AutoRowSize extends BasePlugin {
     this.addHook('afterLoadData', () => this.onAfterLoadData());
     this.addHook('beforeChange', changes => this.onBeforeChange(changes));
     this.addHook('beforeColumnResize', () => this.recalculateAllRowsHeight());
-    this.addHook('beforeRender', force => this.onBeforeRender(force));
+    this.addHook('beforeViewRender', force => this.onBeforeRender(force));
     this.addHook('modifyRowHeight', (height, row) => this.getRowHeight(row, height));
     this.addHook('modifyColumnHeaderHeight', () => this.getColumnHeaderHeight());
 

--- a/src/plugins/columnSorting/columnSorting.js
+++ b/src/plugins/columnSorting/columnSorting.js
@@ -185,7 +185,7 @@ export class ColumnSorting extends BasePlugin {
 
     // Changing header width and removing indicator.
     this.hot.addHook('afterGetColHeader', clearColHeader);
-    this.hot.addHookOnce('afterRender', () => {
+    this.hot.addHookOnce('afterViewRender', () => {
       this.hot.removeHook('afterGetColHeader', clearColHeader);
     });
 

--- a/src/plugins/columnSummary/endpoints.js
+++ b/src/plugins/columnSummary/endpoints.js
@@ -232,12 +232,12 @@ class Endpoints {
       // We need to run it on a next avaiable hook, because the TrimRows' `afterCreateRow` hook triggers after this one,
       // and it needs to be run to properly calculate the endpoint value.
       const beforeRenderCallback = () => {
-        this.hot.removeHook('beforeRender', beforeRenderCallback);
+        this.hot.removeHook('beforeViewRender', beforeRenderCallback);
 
         return this.refreshAllEndpoints();
       };
 
-      this.hot.addHookOnce('beforeRender', beforeRenderCallback);
+      this.hot.addHookOnce('beforeViewRender', beforeRenderCallback);
 
       return;
     }

--- a/src/plugins/formulas/__tests__/formulas.spec.js
+++ b/src/plugins/formulas/__tests__/formulas.spec.js
@@ -1809,24 +1809,24 @@ describe('Formulas general', () => {
   });
 
   it('should not render multiple times when updating many cells', () => {
-    const afterRender = jasmine.createSpy();
+    const afterViewRender = jasmine.createSpy();
 
     handsontable({
       data: Handsontable.helper.createSpreadsheetData(10, 10),
       formulas: {
         engine: HyperFormula
       },
-      afterRender
+      afterViewRender
     });
 
-    expect(afterRender).toHaveBeenCalledTimes(1);
+    expect(afterViewRender).toHaveBeenCalledTimes(1);
 
     selectCell(1, 1, 5, 5);
 
     spec().$container.find('textarea.handsontableInput').simulate('keydown', { keyCode: 46 });
     spec().$container.find('textarea.handsontableInput').simulate('keyup', { keyCode: 46 });
 
-    expect(afterRender).toHaveBeenCalledTimes(2);
+    expect(afterViewRender).toHaveBeenCalledTimes(2);
   });
 
   it('should freeze correct columns with ManualColumnFreeze', () => {

--- a/src/plugins/formulas/__tests__/initialization.spec.js
+++ b/src/plugins/formulas/__tests__/initialization.spec.js
@@ -493,9 +493,9 @@ describe('Formulas general', () => {
       });
 
       it('should render only related sheets when the dependent cells are updated', () => {
-        const afterRender1 = jasmine.createSpy('afterRender1');
-        const afterRender2 = jasmine.createSpy('afterRender2');
-        const afterRender3 = jasmine.createSpy('afterRender3');
+        const afterViewRender1 = jasmine.createSpy('afterViewRender1');
+        const afterViewRender2 = jasmine.createSpy('afterViewRender2');
+        const afterViewRender3 = jasmine.createSpy('afterViewRender3');
 
         const hot1 = handsontable({
           data: [
@@ -506,7 +506,7 @@ describe('Formulas general', () => {
             engine: HyperFormula,
             sheetName: 'Sheet1'
           },
-          afterRender: afterRender1,
+          afterViewRender: afterViewRender1,
           licenseKey: 'non-commercial-and-evaluation'
         });
 
@@ -519,7 +519,7 @@ describe('Formulas general', () => {
             engine: hot1.getPlugin('formulas').engine,
             sheetName: 'Sheet2'
           },
-          afterRender: afterRender2,
+          afterViewRender: afterViewRender2,
           licenseKey: 'non-commercial-and-evaluation'
         }).data('handsontable');
 
@@ -532,67 +532,67 @@ describe('Formulas general', () => {
             engine: hot1.getPlugin('formulas').engine,
             sheetName: 'Sheet3'
           },
-          afterRender: afterRender3,
+          afterViewRender: afterViewRender3,
           licenseKey: 'non-commercial-and-evaluation'
         }).data('handsontable');
 
-        expect(afterRender1).toHaveBeenCalledTimes(2);
-        expect(afterRender2).toHaveBeenCalledTimes(1);
-        expect(afterRender3).toHaveBeenCalledTimes(1);
+        expect(afterViewRender1).toHaveBeenCalledTimes(2);
+        expect(afterViewRender2).toHaveBeenCalledTimes(1);
+        expect(afterViewRender3).toHaveBeenCalledTimes(1);
 
-        afterRender1.calls.reset();
-        afterRender2.calls.reset();
-        afterRender3.calls.reset();
+        afterViewRender1.calls.reset();
+        afterViewRender2.calls.reset();
+        afterViewRender3.calls.reset();
 
         hot1.setDataAtCell(0, 0, 'x');
 
-        expect(afterRender1).toHaveBeenCalledTimes(1);
-        expect(afterRender2).toHaveBeenCalledTimes(0);
-        expect(afterRender3).toHaveBeenCalledTimes(0);
+        expect(afterViewRender1).toHaveBeenCalledTimes(1);
+        expect(afterViewRender2).toHaveBeenCalledTimes(0);
+        expect(afterViewRender3).toHaveBeenCalledTimes(0);
 
-        afterRender1.calls.reset();
-        afterRender2.calls.reset();
-        afterRender3.calls.reset();
+        afterViewRender1.calls.reset();
+        afterViewRender2.calls.reset();
+        afterViewRender3.calls.reset();
 
         // All 3 sheets depends on the B1 value
         hot1.setDataAtCell(0, 1, 'x');
 
-        expect(afterRender1).toHaveBeenCalledTimes(1);
-        expect(afterRender2).toHaveBeenCalledTimes(1);
-        expect(afterRender3).toHaveBeenCalledTimes(1);
+        expect(afterViewRender1).toHaveBeenCalledTimes(1);
+        expect(afterViewRender2).toHaveBeenCalledTimes(1);
+        expect(afterViewRender3).toHaveBeenCalledTimes(1);
 
-        afterRender1.calls.reset();
-        afterRender2.calls.reset();
-        afterRender3.calls.reset();
+        afterViewRender1.calls.reset();
+        afterViewRender2.calls.reset();
+        afterViewRender3.calls.reset();
 
         // Only Sheet3 depends on that value
         hot2.setDataAtCell(0, 0, 'x');
 
-        expect(afterRender1).toHaveBeenCalledTimes(0);
-        expect(afterRender2).toHaveBeenCalledTimes(1);
-        expect(afterRender3).toHaveBeenCalledTimes(1);
+        expect(afterViewRender1).toHaveBeenCalledTimes(0);
+        expect(afterViewRender2).toHaveBeenCalledTimes(1);
+        expect(afterViewRender3).toHaveBeenCalledTimes(1);
 
-        afterRender1.calls.reset();
-        afterRender2.calls.reset();
-        afterRender3.calls.reset();
+        afterViewRender1.calls.reset();
+        afterViewRender2.calls.reset();
+        afterViewRender3.calls.reset();
 
         // Only Sheet3 depends on that value
         hot1.setDataAtCell(1, 0, 'x');
 
-        expect(afterRender1).toHaveBeenCalledTimes(1);
-        expect(afterRender2).toHaveBeenCalledTimes(0);
-        expect(afterRender3).toHaveBeenCalledTimes(1);
+        expect(afterViewRender1).toHaveBeenCalledTimes(1);
+        expect(afterViewRender2).toHaveBeenCalledTimes(0);
+        expect(afterViewRender3).toHaveBeenCalledTimes(1);
 
-        afterRender1.calls.reset();
-        afterRender2.calls.reset();
-        afterRender3.calls.reset();
+        afterViewRender1.calls.reset();
+        afterViewRender2.calls.reset();
+        afterViewRender3.calls.reset();
 
         // No dependant sheets
         hot3.setDataAtCell(0, 0, 'x');
 
-        expect(afterRender1).toHaveBeenCalledTimes(0);
-        expect(afterRender2).toHaveBeenCalledTimes(0);
-        expect(afterRender3).toHaveBeenCalledTimes(1);
+        expect(afterViewRender1).toHaveBeenCalledTimes(0);
+        expect(afterViewRender2).toHaveBeenCalledTimes(0);
+        expect(afterViewRender3).toHaveBeenCalledTimes(1);
       });
     });
 

--- a/src/plugins/nestedRows/nestedRows.js
+++ b/src/plugins/nestedRows/nestedRows.js
@@ -96,7 +96,7 @@ export class NestedRows extends BasePlugin {
     this.rowMoveController = new RowMoveController(this);
 
     this.addHook('afterInit', (...args) => this.onAfterInit(...args));
-    this.addHook('beforeRender', (...args) => this.onBeforeRender(...args));
+    this.addHook('beforeViewRender', (...args) => this.onBeforeRender(...args));
     this.addHook('modifyRowData', (...args) => this.onModifyRowData(...args));
     this.addHook('modifySourceLength', (...args) => this.onModifySourceLength(...args));
     this.addHook('beforeDataSplice', (...args) => this.onBeforeDataSplice(...args));

--- a/src/plugins/search/search.js
+++ b/src/plugins/search/search.js
@@ -121,7 +121,7 @@ export class Search extends BasePlugin {
     const beforeRendererCallback = (...args) => this.onBeforeRenderer(...args);
 
     this.hot.addHook('beforeRenderer', beforeRendererCallback);
-    this.hot.addHookOnce('afterRender', () => {
+    this.hot.addHookOnce('afterViewRender', () => {
       this.hot.removeHook('beforeRenderer', beforeRendererCallback);
     });
 

--- a/src/plugins/touchScroll/touchScroll.js
+++ b/src/plugins/touchScroll/touchScroll.js
@@ -68,7 +68,7 @@ export class TouchScroll extends BasePlugin {
       return;
     }
 
-    this.addHook('afterRender', () => this.onAfterRender());
+    this.addHook('afterViewRender', () => this.onAfterRender());
     this.registerEvents();
 
     super.enablePlugin();

--- a/src/plugins/undoRedo/undoRedo.js
+++ b/src/plugins/undoRedo/undoRedo.js
@@ -522,7 +522,7 @@ UndoRedo.RemoveRowAction.prototype.undo = function(instance, undoneCallback) {
   settings.fixedRowsTop = this.fixedRowsTop;
 
   instance.alter('insert_row', this.index, this.data.length, 'UndoRedo.undo');
-  instance.addHookOnce('afterRender', undoneCallback);
+  instance.addHookOnce('afterViewRender', undoneCallback);
   instance.populateFromArray(this.index, 0, this.data, void 0, void 0, 'UndoRedo.undo');
 };
 UndoRedo.RemoveRowAction.prototype.redo = function(instance, redoneCallback) {
@@ -623,7 +623,7 @@ UndoRedo.RemoveColumnAction.prototype.undo = function(instance, undoneCallback) 
     instance.columnIndexMapper.setIndexesSequence(this.columnPositions);
   }, true);
 
-  instance.addHookOnce('afterRender', undoneCallback);
+  instance.addHookOnce('afterViewRender', undoneCallback);
 
   instance.render();
 };
@@ -658,14 +658,14 @@ UndoRedo.CellAlignmentAction.prototype.undo = function(instance, undoneCallback)
     });
   });
 
-  instance.addHookOnce('afterRender', undoneCallback);
+  instance.addHookOnce('afterViewRender', undoneCallback);
   instance.render();
 };
 UndoRedo.CellAlignmentAction.prototype.redo = function(instance, undoneCallback) {
   align(this.range, this.type, this.alignment, (row, col) => instance.getCellMeta(row, col),
     (row, col, key, value) => instance.setCellMeta(row, col, key, value));
 
-  instance.addHookOnce('afterRender', undoneCallback);
+  instance.addHookOnce('afterViewRender', undoneCallback);
   instance.render();
 };
 
@@ -684,7 +684,7 @@ inherit(UndoRedo.FiltersAction, UndoRedo.Action);
 UndoRedo.FiltersAction.prototype.undo = function(instance, undoneCallback) {
   const filters = instance.getPlugin('filters');
 
-  instance.addHookOnce('afterRender', undoneCallback);
+  instance.addHookOnce('afterViewRender', undoneCallback);
 
   filters.conditionCollection.importAllConditions(this.conditionsStack.slice(0, this.conditionsStack.length - 1));
   filters.filter();
@@ -692,7 +692,7 @@ UndoRedo.FiltersAction.prototype.undo = function(instance, undoneCallback) {
 UndoRedo.FiltersAction.prototype.redo = function(instance, redoneCallback) {
   const filters = instance.getPlugin('filters');
 
-  instance.addHookOnce('afterRender', redoneCallback);
+  instance.addHookOnce('afterViewRender', redoneCallback);
 
   filters.conditionCollection.importAllConditions(this.conditionsStack);
   filters.filter();
@@ -722,7 +722,7 @@ class MergeCellsAction extends UndoRedo.Action {
   undo(instance, undoneCallback) {
     const mergeCellsPlugin = instance.getPlugin('mergeCells');
 
-    instance.addHookOnce('afterRender', undoneCallback);
+    instance.addHookOnce('afterViewRender', undoneCallback);
 
     mergeCellsPlugin.unmergeRange(this.cellRange, true);
 
@@ -741,7 +741,7 @@ class MergeCellsAction extends UndoRedo.Action {
   redo(instance, redoneCallback) {
     const mergeCellsPlugin = instance.getPlugin('mergeCells');
 
-    instance.addHookOnce('afterRender', redoneCallback);
+    instance.addHookOnce('afterViewRender', redoneCallback);
 
     mergeCellsPlugin.mergeRange(this.cellRange);
   }
@@ -762,7 +762,7 @@ class UnmergeCellsAction extends UndoRedo.Action {
   undo(instance, undoneCallback) {
     const mergeCellsPlugin = instance.getPlugin('mergeCells');
 
-    instance.addHookOnce('afterRender', undoneCallback);
+    instance.addHookOnce('afterViewRender', undoneCallback);
 
     mergeCellsPlugin.mergeRange(this.cellRange, true);
   }
@@ -770,7 +770,7 @@ class UnmergeCellsAction extends UndoRedo.Action {
   redo(instance, redoneCallback) {
     const mergeCellsPlugin = instance.getPlugin('mergeCells');
 
-    instance.addHookOnce('afterRender', redoneCallback);
+    instance.addHookOnce('afterViewRender', redoneCallback);
 
     mergeCellsPlugin.unmergeRange(this.cellRange, true);
     instance.render();
@@ -799,7 +799,7 @@ UndoRedo.RowMoveAction.prototype.undo = function(instance, undoneCallback) {
   const rowsMovedDown = copyOfRows.filter(a => a <= this.finalIndex);
   const allMovedRows = rowsMovedUp.sort((a, b) => b - a).concat(rowsMovedDown.sort((a, b) => a - b));
 
-  instance.addHookOnce('afterRender', undoneCallback);
+  instance.addHookOnce('afterViewRender', undoneCallback);
 
   // Moving rows from those with higher indexes to those with lower indexes when action was performed from bottom to top
   // Moving rows from those with lower indexes to those with higher indexes when action was performed from top to bottom
@@ -817,7 +817,7 @@ UndoRedo.RowMoveAction.prototype.undo = function(instance, undoneCallback) {
 UndoRedo.RowMoveAction.prototype.redo = function(instance, redoneCallback) {
   const manualRowMove = instance.getPlugin('manualRowMove');
 
-  instance.addHookOnce('afterRender', redoneCallback);
+  instance.addHookOnce('afterViewRender', redoneCallback);
   manualRowMove.moveRows(this.rows.slice(), this.finalIndex);
   instance.render();
 

--- a/src/tableView.js
+++ b/src/tableView.js
@@ -127,9 +127,7 @@ class TableView {
    */
   render() {
     if (!this.instance.isRenderSuspended()) {
-      if (this.instance.forceFullRender) {
-        this.instance._clearCellMetaMemo();
-      }
+      this.instance.runHooks('beforeRender', this.instance.forceFullRender);
 
       if (this.postponedAdjustElementsSize) {
         this.postponedAdjustElementsSize = false;
@@ -138,6 +136,7 @@ class TableView {
       }
 
       this.wt.draw(!this.instance.forceFullRender);
+      this.instance.runHooks('afterRender', this.instance.forceFullRender);
       this.instance.forceFullRender = false;
       this.instance.renderCall = false;
     }
@@ -1026,7 +1025,7 @@ class TableView {
   beforeRender(force, skipRender) {
     if (force) {
       // this.instance.forceFullRender = did Handsontable request full render?
-      this.instance.runHooks('beforeRender', this.instance.forceFullRender, skipRender);
+      this.instance.runHooks('beforeViewRender', this.instance.forceFullRender, skipRender);
     }
   }
 
@@ -1040,7 +1039,7 @@ class TableView {
   onDraw(force) {
     if (force) {
       // this.instance.forceFullRender = did Handsontable request full render?
-      this.instance.runHooks('afterRender', this.instance.forceFullRender);
+      this.instance.runHooks('afterViewRender', this.instance.forceFullRender);
     }
   }
 

--- a/test/e2e/Core_render.spec.js
+++ b/test/e2e/Core_render.spec.js
@@ -72,7 +72,7 @@ describe('Core_render', () => {
       data: [
         ['Joe Red']
       ],
-      afterRender() {
+      afterViewRender() {
         counter += 1;
       }
     });

--- a/test/e2e/Core_view.spec.js
+++ b/test/e2e/Core_view.spec.js
@@ -624,7 +624,7 @@ describe('Core_view', () => {
     expect(spec().$container.width()).toBeAroundValue(parentWidth * 0.5, 0.5);
   });
 
-  it('should fire beforeRender event after table has been scrolled', async() => {
+  it('should fire beforeViewRender event after table has been scrolled', async() => {
     spec().$container[0].style.width = '400px';
     spec().$container[0].style.height = '60px';
     spec().$container[0].style.overflow = 'hidden';
@@ -635,7 +635,7 @@ describe('Core_view', () => {
 
     const beforeRenderCallback = jasmine.createSpy('beforeRenderCallback');
 
-    hot.addHook('beforeRender', beforeRenderCallback);
+    hot.addHook('beforeViewRender', beforeRenderCallback);
     spec().$container.find('.ht_master .wtHolder').scrollTop(1000);
 
     await sleep(200);
@@ -643,7 +643,7 @@ describe('Core_view', () => {
     expect(beforeRenderCallback.calls.count()).toBe(1);
   });
 
-  it('should fire afterRender event after table has been scrolled', async() => {
+  it('should fire afterViewRender event after table has been scrolled', async() => {
     spec().$container[0].style.width = '400px';
     spec().$container[0].style.height = '60px';
     spec().$container[0].style.overflow = 'hidden';
@@ -654,7 +654,7 @@ describe('Core_view', () => {
 
     const afterRenderCallback = jasmine.createSpy('afterRenderCallback');
 
-    hot.addHook('afterRender', afterRenderCallback);
+    hot.addHook('afterViewRender', afterRenderCallback);
     spec().$container.find('.ht_master .wtHolder').first().scrollTop(1000);
 
     await sleep(200);
@@ -662,7 +662,7 @@ describe('Core_view', () => {
     expect(afterRenderCallback.calls.count()).toBe(1);
   });
 
-  it('should fire afterRender event after table physically rendered', async() => {
+  it('should fire afterViewRender event after table physically rendered', async() => {
     spec().$container[0].style.width = '400px';
     spec().$container[0].style.height = '60px';
     spec().$container[0].style.overflow = 'hidden';
@@ -671,14 +671,14 @@ describe('Core_view', () => {
       data: Handsontable.helper.createSpreadsheetData(20, 3)
     });
 
-    hot.addHook('afterRender', () => {
+    hot.addHook('afterViewRender', () => {
       hot.view.wt.wtTable.holder.style.overflow = 'scroll';
       hot.view.wt.wtTable.holder.style.width = '220px';
     });
     spec().$container.find('.ht_master .wtHolder').first().scrollTop(1000);
 
     await sleep(100);
-    // after afterRender hook triggered element style shouldn't changed
+    // after afterViewRender hook triggered element style shouldn't changed
     expect(hot.view.wt.wtTable.holder.style.overflow).toBe('scroll');
     expect(hot.view.wt.wtTable.holder.style.width).toBe('220px');
   });


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR solves the problem of the `beforeRender` and `afterRender` hooks that are not triggered in expected moments. While working on https://github.com/handsontable/handsontable/pull/8629 I've found that mentioned hooks in the context of the Handsontable are triggered too late - for the `beforeRender` hook, and too soon for `afterRender` hook. They reflect the nature of the Walkontable's life cycle not Handsontable's life cycle.

I scribbled some images describing the problem. 

More or less this is what the hook cycles look like when the Handsontable triggers the table render. It usually triggers a render when the dataset or business logic is changed:
![2021-08-11 o 11 14 11](https://user-images.githubusercontent.com/571316/129011569-5fe59c30-4c98-4cc1-a85e-a94d1601c95d.png) 

That hooks are triggered directly from the Walkontable. So for the changes made within the rendering engine hooks seems to be triggered at the right time:
![2021-08-11 o 11 16 14](https://user-images.githubusercontent.com/571316/129012139-034ae1fa-7a8f-4c0c-af57-0cd23d6145a2.png)

I think that there is a lack of hooks that informs where the render cycle is started and finished from the Handsontable context. It's hard to synchronize cache or custom logic within render cycles. That is why I added two new hooks for the Walkontable's render cycles and renamed their names to `beforeViewRender`, `afterViewRender`. The origin hooks are triggered as previously but at different points of the render cycle.
![2021-08-11 o 11 15 31](https://user-images.githubusercontent.com/571316/129012331-30170e01-d201-40a0-8219-79a6e7321e1e.png)

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
