### PR TITLE
Improved documentation of the `search` option

### DIFF
--- a/src/dataMap/metaManager/metaSchema.js
+++ b/src/dataMap/metaManager/metaSchema.js
@@ -1507,7 +1507,7 @@ export default () => {
      * Setting to `true` enables the {@link Search} plugin (see [demo](@/guides/accessories-and-menus/searching-values.md)).
      *
      * @memberof Options#
-     * @type {boolean}
+     * @type {boolean|object}
      * @default false
      * @category Search
      *

--- a/src/dataMap/metaManager/metaSchema.js
+++ b/src/dataMap/metaManager/metaSchema.js
@@ -1504,7 +1504,8 @@ export default () => {
 
     /**
      * @description
-     * Disables or enables the {@link Search} plugin.
+     * If set to `true`, enables the {@link Search} plugin with a default configuration.
+     * If set to an object, enables the {@link Search} plugin with a custom configuration.
      * See the guide on [how to search values in Handsontable](@/guides/accessories-and-menus/searching-values.md).
      *
      * @memberof Options#
@@ -1514,9 +1515,9 @@ export default () => {
      *
      * @example
      * ```js
-     * // enable the Search plugin
+     * // set to `true`, to enable the Search plugin with a default configuration
      * search: true,
-     * // or as an object with detailed configuration
+     * // or set to an object, to enable the Search plugin with a custom configuration
      * search: {
      *   searchResultClass: 'customClass',
      *   queryMethod: function(queryStr, value) {
@@ -1527,7 +1528,7 @@ export default () => {
      *   }
      * }
      *
-     * // disable the Search plugin
+     * // set to `false, to disable the Search plugin
      * search: false,
      * ```
      */

--- a/src/dataMap/metaManager/metaSchema.js
+++ b/src/dataMap/metaManager/metaSchema.js
@@ -1504,7 +1504,8 @@ export default () => {
 
     /**
      * @description
-     * Setting to `true` enables the {@link Search} plugin (see [demo](@/guides/accessories-and-menus/searching-values.md)).
+     * Disables or enables the {@link Search} plugin.
+     * See the guide on [how to search values in Handsontable](@/guides/accessories-and-menus/searching-values.md).
      *
      * @memberof Options#
      * @type {boolean|object}
@@ -1513,11 +1514,9 @@ export default () => {
      *
      * @example
      * ```js
-     * // enable search plugin
+     * // enable the Search plugin
      * search: true,
-     *
-     * // or
-     * // as an object with detailed configuration
+     * // or as an object with detailed configuration
      * search: {
      *   searchResultClass: 'customClass',
      *   queryMethod: function(queryStr, value) {
@@ -1527,6 +1526,9 @@ export default () => {
      *     ...
      *   }
      * }
+     *
+     * // disable the Search plugin
+     * search: false,
      * ```
      */
     search: false,


### PR DESCRIPTION
### Context
As @ mentioned in #8487, the documentation for the `search` option is incomplete. This PR updates that missing information in JSDocs.
TypeScript's definition and tests are correct.

### Related issue(s):
1. #8487

[skip changelog]