### PR TITLE
Fix a onMouseDown console log error of Comments plugin.

### DIFF
--- a/src/plugins/comments/comments.js
+++ b/src/plugins/comments/comments.js
@@ -243,7 +243,7 @@ export class Comments extends BasePlugin {
    * @returns {boolean}
    */
   targetIsCellWithComment(event) {
-    const closestCell = closest(event.target, 'TD', 'TBODY');
+    const closestCell = closest(event.target, ['TD'], 'TBODY');
 
     return !!(closestCell && hasClass(closestCell, 'htCommentCell') && closest(closestCell, [this.hot.rootElement]));
   }
@@ -558,7 +558,7 @@ export class Comments extends BasePlugin {
     }
 
     if (!this.contextMenuEvent && !this.targetIsCommentTextArea(event)) {
-      const eventCell = closest(event.target, 'TD', 'TBODY');
+      const eventCell = closest(event.target, ['TD'], 'TBODY');
       let coordinates = null;
 
       if (eventCell) {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
This is a code bug of Comments plugin. The function expects a nodes array, yet there are cases ```'TD'``` are passed to it, rather than the expected ```['TD']```.
When I enable Comments plugin and click on elements that are out of the handsontable, the onMouseDown callback will be called, and there're defects when the target is a a.btn-tab, the ```nodes.includes(elementToCheck)``` would somehow returns true, if the nodes is ```'TD'```. When passing the right nodes of ```['TD']```, it would return false as expected.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://forum.handsontable.com/t/issue-with-comments-plugin-and-listener-mousedown/5253/3

### Affected project(s):
- [ x ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ x ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
