### PR TITLE
Introduced new hook triggered just before any type of selection and giving ability to block the action. Fixed problem related to cooperation of CollapsibleColumns and DropdownMenu plugins.

### DIFF
--- a/.changelogs/8640.json
+++ b/.changelogs/8640.json
@@ -1,0 +1,7 @@
+{
+  "title": "Introduced new hook triggered just before any type of selection and giving ability to block the action. Fixed problem related to cooperation of CollapsibleColumns and DropdownMenu plugins.",
+  "type": "added",
+  "issue": 8640,
+  "breaking": false,
+  "framework": "none"
+}

--- a/src/core.js
+++ b/src/core.js
@@ -203,6 +203,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
     countRowsTranslated: () => this.view.countRenderableRows(),
     visualToRenderableCoords,
     renderableToVisualCoords,
+    skipSelection: () => this.runHooks('beforeSelection') === false,
     isDisabledCellSelection: (visualRow, visualColumn) =>
       instance.getCellMeta(visualRow, visualColumn).disableVisualSelection
   });

--- a/src/pluginHooks.js
+++ b/src/pluginHooks.js
@@ -892,6 +892,15 @@ const REGISTERED_HOOKS = [
   'beforeRender',
 
   /**
+   * Fired before any type of selection.
+   *
+   * @event Hooks#beforeSelect
+   * @since 10.0.0
+   * @returns {*|boolean} If false is returned the selection is canceled.
+   */
+  'beforeSetCellMeta',
+
+  /**
    * Fired before cell meta is changed.
    *
    * @event Hooks#beforeSetCellMeta

--- a/src/plugins/collapsibleColumns/__tests__/collapsibleColumns.spec.js
+++ b/src/plugins/collapsibleColumns/__tests__/collapsibleColumns.spec.js
@@ -3960,5 +3960,42 @@ describe('CollapsibleColumns', () => {
         expect(getCell(-1, 2)).toBeNull();
       });
     });
+
+    describe('drop-down menu', () => {
+      it('should close drop-down menu after click on indicator which shows a column', () => {
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(5, 10),
+          colHeaders: true,
+          rowHeaders: true,
+          nestedHeaders: [
+            ['A', { label: 'B', colspan: 8 }, 'C'],
+            ['D', { label: 'E', colspan: 4 }, { label: 'F', colspan: 4 }, 'G'],
+            ['H',
+              { label: 'I', colspan: 2 }, { label: 'J', colspan: 2 }, { label: 'K', colspan: 2 },
+              { label: 'L', colspan: 2 }, 'M'], ['N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W']
+          ],
+          collapsibleColumns: [
+            { row: -4, col: 1, collapsible: true },
+            { row: -3, col: 1, collapsible: true },
+            { row: -2, col: 1, collapsible: true },
+            { row: -2, col: 3, collapsible: true }
+          ],
+          dropdownMenu: true,
+        });
+
+        const $dropDownIndicator = $(getCell(-1, 0)).find('.changeType');
+
+        $dropDownIndicator.simulate('mousedown');
+        $dropDownIndicator.simulate('mouseup');
+        $dropDownIndicator.simulate('click');
+
+        $(getCell(-4, 1).querySelector('.collapsibleIndicator'))
+          .simulate('mousedown')
+          .simulate('mouseup')
+          .simulate('click');
+
+        expect(getPlugin('dropdownMenu').menu.container.style.display).not.toBe('block');
+      });
+    });
   });
 });

--- a/src/plugins/collapsibleColumns/collapsibleColumns.js
+++ b/src/plugins/collapsibleColumns/collapsibleColumns.js
@@ -8,7 +8,6 @@ import {
   fastInnerText
 } from '../../helpers/dom/element';
 import EventManager from '../../eventManager';
-import { stopImmediatePropagation } from '../../helpers/dom/event';
 
 export const PLUGIN_KEY = 'collapsibleColumns';
 export const PLUGIN_PRIORITY = 290;

--- a/src/plugins/collapsibleColumns/collapsibleColumns.js
+++ b/src/plugins/collapsibleColumns/collapsibleColumns.js
@@ -450,13 +450,15 @@ export class CollapsibleColumns extends BasePlugin {
       if (hasClass(event.target, 'expanded')) {
         this.eventManager.fireEvent(event.target, 'mouseup');
         this.toggleCollapsibleSection([coords], 'collapse');
+        // This callback will skip next, "custom" selection performed by the `NestedHeaders` plugin within `onAfterOnCellMouseDown` hook.
+        this.hot.addHookOnce('beforeSelection', () => false);
 
       } else if (hasClass(event.target, 'collapsed')) {
         this.eventManager.fireEvent(event.target, 'mouseup');
         this.toggleCollapsibleSection([coords], 'expand');
+        // This callback will skip next, "custom" selection performed by the `NestedHeaders` plugin within `onAfterOnCellMouseDown` hook.
+        this.hot.addHookOnce('beforeSelection', () => false);
       }
-
-      stopImmediatePropagation(event);
     }
   }
 

--- a/src/selection/selection.js
+++ b/src/selection/selection.js
@@ -529,7 +529,7 @@ class Selection {
    */
   selectAll(includeRowHeaders = false, includeColumnHeaders = false) {
     if (this.tableProps.skipSelection()) {
-      return false;
+      return;
     }
 
     const nrOfRows = this.tableProps.countRows();

--- a/src/selection/selection.js
+++ b/src/selection/selection.js
@@ -528,6 +528,10 @@ class Selection {
    * otherwise.
    */
   selectAll(includeRowHeaders = false, includeColumnHeaders = false) {
+    if (this.tableProps.skipSelection()) {
+      return false;
+    }
+
     const nrOfRows = this.tableProps.countRows();
     const nrOfColumns = this.tableProps.countCols();
 
@@ -556,6 +560,10 @@ class Selection {
    * @returns {boolean} Returns `true` if selection was successful, `false` otherwise.
    */
   selectCells(selectionRanges) {
+    if (this.tableProps.skipSelection()) {
+      return false;
+    }
+
     const selectionType = detectSelectionType(selectionRanges);
 
     if (selectionType === SELECTION_TYPE_EMPTY) {
@@ -615,6 +623,10 @@ class Selection {
     const start = typeof startColumn === 'string' ? this.tableProps.propToCol(startColumn) : startColumn;
     const end = typeof endColumn === 'string' ? this.tableProps.propToCol(endColumn) : endColumn;
 
+    if (this.tableProps.skipSelection()) {
+      return false;
+    }
+
     const nrOfColumns = this.tableProps.countCols();
     const nrOfRows = this.tableProps.countRows();
     const isValid = isValidCoord(start, nrOfColumns) && isValidCoord(end, nrOfColumns);
@@ -639,6 +651,10 @@ class Selection {
    * @returns {boolean} Returns `true` if selection was successful, `false` otherwise.
    */
   selectRows(startRow, endRow = startRow, headerLevel = -1) {
+    if (this.tableProps.skipSelection()) {
+      return false;
+    }
+
     const nrOfRows = this.tableProps.countRows();
     const nrOfColumns = this.tableProps.countCols();
     const isValid = isValidCoord(startRow, nrOfRows) && isValidCoord(endRow, nrOfRows);


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
PR #8639 fixed problem related to not closing drop-down menu, when header is re-rendered (after some action which change UI). However, it doesn't patched a way how the `DropDownMenu` plugin cooperates with the `CollapsibleColumns` plugin.

The `NestedHeaders` plugin, which is part of `CollapsibleColumns` plugin is responsible for handling selection on headers in a custom way.

https://github.com/handsontable/handsontable/blob/8b96d19d0606a50d617c3bcc103182249a89b7b7/src/plugins/nestedHeaders/nestedHeaders.js#L409
https://github.com/handsontable/handsontable/blob/8b96d19d0606a50d617c3bcc103182249a89b7b7/src/plugins/nestedHeaders/nestedHeaders.js#L446

However, the `CollapsibleColumns` is so conceived that click on indicator shouldn't introduce selection for the whole column. 

![130603258-20b5fffc-3dc3-457c-b581-b02df5ff008b](https://user-images.githubusercontent.com/141330/130603868-d9219504-01e0-4dab-97d3-10f509eea179.png)
![Screenshot 2021-08-24 at 12 42 49](https://user-images.githubusercontent.com/141330/130603873-053a56b0-34a7-44aa-b751-7dc70acb763a.png)

It was achieved by introducing action stopping propagation.

https://github.com/handsontable/handsontable/blob/f513f882c0a28b2cbde48ae74a4fdf3ef00b6dd4/src/plugins/collapsibleColumns/collapsibleColumns.js#L459

Thus, the `onAfterOnCellMouseDown` callback from the `NestedHeaders` plugin hasn't been invoked. Although it has been working properly for the selection it have had side effects [described within the issue](https://github.com/handsontable/handsontable/issues/8640).

This PR introduces new `beforeSelection` hook which is triggered just before any kind of selection (when selecting single or multiple cells, rows, columns). The hook, returning `false` blocks execution of the selection  in some case. This approach allows us to refuse custom selections maintained by one plugin from another plugin. Please keep in mind that we have `disableVisualSelection` option for handling selection. However, it's not such flexible as the hook may be.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Just some test when `CollapsibleColumns` and `DropdownMenu` plugins are enabled and selecting/deselecting some cell(s) and performing actions on indicators/headers.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #8640
2. https://github.com/handsontable/handsontable/pull/8639

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] My change requires a change to the documentation.
