### PR TITLE
Docs: changing grammar in a docs-links.js error message

### DIFF
--- a/docs/.vuepress/docs-links.js
+++ b/docs/.vuepress/docs-links.js
@@ -20,7 +20,7 @@ module.exports = function(src) {
       }
     } catch (e) {
       // eslint-disable-next-line
-      console.warn(`Error occurs when trying to find "${full}" permalink. Is this file exists?`);
+      console.warn(`Can't find the "${full}" permalink. Does this file exist?`);
     }
 
     return `(${permalink})`;


### PR DESCRIPTION
This PR:
- Rewrites an error message displayed by the [docs/.vuepress/docs-links.js](https://github.com/handsontable/handsontable/blob/master/docs/.vuepress/docs-links.js) tool.

[skip changelog]