### PR TITLE
Change the default limit for copy/paste dataset sizes

### DIFF
--- a/src/plugins/copyPaste/__tests__/copyPaste.spec.js
+++ b/src/plugins/copyPaste/__tests__/copyPaste.spec.js
@@ -36,6 +36,52 @@ describe('CopyPaste', () => {
 
       expect($('.HandsontableCopyPaste').length).toEqual(0);
     });
+
+    it('should do not create textarea element if copyPaste is disabled on initialization', () => {
+      handsontable({
+        copyPaste: false
+      });
+
+      expect($('.HandsontableCopyPaste').length).toEqual(0);
+    });
+  });
+
+  describe('`copyPaste` settings', () => {
+    it('should `rowsLimit` be set to its default `Infinity` value', () => {
+      handsontable({
+        copyPaste: true
+      });
+
+      expect(getPlugin('CopyPaste').rowsLimit).toBe(Infinity);
+    });
+
+    it('should be possible to set custom rows limit', () => {
+      handsontable({
+        copyPaste: {
+          rowsLimit: 100,
+        }
+      });
+
+      expect(getPlugin('CopyPaste').rowsLimit).toBe(100);
+    });
+
+    it('should `columnsLimit` be set to its default `Infinity` value', () => {
+      handsontable({
+        copyPaste: true
+      });
+
+      expect(getPlugin('CopyPaste').columnsLimit).toBe(Infinity);
+    });
+
+    it('should be possible to set custom columns limit', () => {
+      handsontable({
+        copyPaste: {
+          columnsLimit: 100,
+        }
+      });
+
+      expect(getPlugin('CopyPaste').columnsLimit).toBe(100);
+    });
   });
 
   describe('focusable element', () => {

--- a/src/plugins/copyPaste/copyPaste.js
+++ b/src/plugins/copyPaste/copyPaste.js
@@ -24,8 +24,8 @@ Hooks.getSingleton().register('afterCopy');
 
 export const PLUGIN_KEY = 'copyPaste';
 export const PLUGIN_PRIORITY = 80;
-const ROWS_LIMIT = 1000;
-const COLUMNS_LIMIT = 1000;
+const ROWS_LIMIT = Infinity;
+const COLUMNS_LIMIT = Infinity;
 const privatePool = new WeakMap();
 const META_HEAD = [
   '<meta name="generator" content="Handsontable"/>',
@@ -80,7 +80,7 @@ export class CopyPaste extends BasePlugin {
      * Maximum number of columns than can be copied to clipboard using <kbd>CTRL</kbd> + <kbd>C</kbd>.
      *
      * @type {number}
-     * @default 1000
+     * @default Infinity
      */
     this.columnsLimit = COLUMNS_LIMIT;
     /**
@@ -110,7 +110,7 @@ export class CopyPaste extends BasePlugin {
      * Maximum number of rows than can be copied to clipboard using <kbd>CTRL</kbd> + <kbd>C</kbd>.
      *
      * @type {number}
-     * @default 1000
+     * @default Infinity
      */
     this.rowsLimit = ROWS_LIMIT;
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR changes the default values for the `rowsLimit` and `columnsLimit` options of the _CopyPaste_ plugin. Now the limit is unlimited.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I cover the changes with new tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. fixes #8660
2.
3.

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
