### PR TITLE
Docs: Removing the CodeSandbox button UI text

### DIFF
--- a/docs/next/guides/getting-started/hello-world.md
+++ b/docs/next/guides/getting-started/hello-world.md
@@ -19,7 +19,7 @@ Rather than display "Hello, World!", the demo contains 100 rows and 13 columns p
 - [Sorting](@/guides/rows/row-sorting.md)
 - And way more than that!
 
-Want to play with the code yourself? Select "Open Sandbox" in the frame's bottom right corner.
+Want to play with the code yourself? Select the button in the frame's bottom right corner.
 
 <HelloWorld :demos="[
   {


### PR DESCRIPTION
CodeSandbox seems to constantly change the text in the "Open Sandbox" button. It used to be "Open Sandbox", then sth else, now it's "Open and Fork". I'm removing the UI text to avoid constant updates.