### PR TITLE
Data won't be corrupted anymore when there are performed some alterations

### DIFF
--- a/.changelogs/8614.json
+++ b/.changelogs/8614.json
@@ -1,0 +1,7 @@
+{
+  "title": "Data won't be corrupted anymore when there are performed some alterations",
+  "type": "fixed",
+  "issue": 8614,
+  "breaking": false,
+  "framework": "none"
+}

--- a/src/dataMap.js
+++ b/src/dataMap.js
@@ -428,15 +428,10 @@ class DataMap {
       return false;
     }
 
-    const data = this.dataSource;
     // List of removed indexes might be changed in the `beforeRemoveRow` hook. There may be new values.
     const numberOfRemovedIndexes = removedPhysicalIndexes.length;
-    const newData = this.filterData(rowIndex, numberOfRemovedIndexes, removedPhysicalIndexes);
 
-    if (newData) {
-      data.length = 0;
-      Array.prototype.push.apply(data, newData);
-    }
+    this.filterData(rowIndex, numberOfRemovedIndexes, removedPhysicalIndexes);
 
     // TODO: Function `removeRow` should validate fully, probably above.
     if (rowIndex < this.instance.countRows()) {
@@ -597,16 +592,18 @@ class DataMap {
    * @param {number} index Visual index of the element to remove.
    * @param {number} amount Number of rows to add/remove.
    * @param {number} physicalRows Physical row indexes.
-   * @returns {Array}
    */
   filterData(index, amount, physicalRows) {
-    const continueSplicing = this.instance.runHooks('beforeDataFilter', index, amount, physicalRows);
+    // Custom data filtering (run as a consequence of calling the below hook) provide an array containing new data.
+    let data = this.instance.runHooks('filterData', index, amount, physicalRows);
 
-    if (continueSplicing !== false) {
-      const newData = this.dataSource.filter((row, rowIndex) => physicalRows.indexOf(rowIndex) === -1);
-
-      return newData;
+    // Hooks by default returns first argument (when there is no callback changing execution result).
+    if (Array.isArray(data) === false) {
+      data = this.dataSource.filter((row, rowIndex) => physicalRows.indexOf(rowIndex) === -1);
     }
+
+    this.dataSource.length = 0;
+    Array.prototype.push.apply(this.dataSource, data);
   }
 
   /**

--- a/src/plugins/nestedRows/__tests__/nestedRows.spec.js
+++ b/src/plugins/nestedRows/__tests__/nestedRows.spec.js
@@ -1087,4 +1087,26 @@ describe('NestedRows', () => {
 
     expect(rowHeaders).toEqual(['A', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'R', 'S']);
   });
+
+  it('should work properly when multiple alters have been performed', () => {
+    handsontable({
+      data: getSimplerNestedData(),
+      nestedRows: true,
+      rowHeaders: true
+    });
+
+    const dataAtStart = getData();
+
+    alter('insert_row', 0, 2);
+
+    expect(getData()).toEqual([[null, null, null, null], [null, null, null, null], ...dataAtStart]);
+
+    alter('remove_row', 0, 2);
+
+    expect(getData()).toEqual(dataAtStart);
+
+    alter('insert_row', 0, 2);
+
+    expect(getData()).toEqual([[null, null, null, null], [null, null, null, null], ...dataAtStart]);
+  });
 });

--- a/src/plugins/nestedRows/nestedRows.js
+++ b/src/plugins/nestedRows/nestedRows.js
@@ -100,7 +100,7 @@ export class NestedRows extends BasePlugin {
     this.addHook('modifyRowData', (...args) => this.onModifyRowData(...args));
     this.addHook('modifySourceLength', (...args) => this.onModifySourceLength(...args));
     this.addHook('beforeDataSplice', (...args) => this.onBeforeDataSplice(...args));
-    this.addHook('beforeDataFilter', (...args) => this.onBeforeDataFilter(...args));
+    this.addHook('filterData', (...args) => this.onFilterData(...args));
     this.addHook('afterContextMenuDefaultOptions', (...args) => this.onAfterContextMenuDefaultOptions(...args));
     this.addHook('afterGetRowHeader', (...args) => this.onAfterGetRowHeader(...args));
     this.addHook('beforeOnCellMouseDown', (...args) => this.onBeforeOnCellMouseDown(...args));
@@ -245,15 +245,15 @@ export class NestedRows extends BasePlugin {
   }
 
   /**
-   * Called before the source data filtering. Returning `false` stops the native filtering.
+   * Provide custom source data filtering. It's handled by core method and replaces the native filtering.
    *
    * @private
    * @param {number} index The index where the data filtering starts.
    * @param {number} amount An amount of rows which filtering applies to.
    * @param {number} physicalRows Physical row indexes.
-   * @returns {boolean}
+   * @returns {Array}
    */
-  onBeforeDataFilter(index, amount, physicalRows) {
+  onFilterData(index, amount, physicalRows) {
     const priv = privatePool.get(this);
 
     this.collapsingUI.collapsedRowsStash.stash();
@@ -263,7 +263,7 @@ export class NestedRows extends BasePlugin {
 
     priv.skipRender = true;
 
-    return false;
+    return this.dataManager.getData().slice(); // Data contains reference sometimes.
   }
 
   /**


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
There is problem related to the fact that source data isn't updated after some alter actions. Until Handsontable `8.0.0` release the `remove_col` action has been working on source data by reference.

https://github.com/handsontable/handsontable/blob/b19a70ab69d8f3d431653076e4744781dc6d472a/src/plugins/nestedRows/data/dataManager.js#L667

From that moment, we shouldn't base on reference. Responsibility for custom handling of source data was completely moved to `Core` within the PR. It's done by handling a response for `filterData` hook (previously, `beforeDataFilter` hook).

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Tested on more complex examples of nested headers.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #8614 

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] My change requires a change to the documentation.
