### PR TITLE
Docs: quick fixes

### DIFF
--- a/docs/9.0/guides/technical-specification/supported-browsers.md
+++ b/docs/9.0/guides/technical-specification/supported-browsers.md
@@ -19,15 +19,15 @@ Tests are run in [BrowserStack](https://www.browserstack.com/) as well as on a l
 
 ## List of browsers
 
-| Desktop Browsers | Mobile Browsers |
-| :--- | :--- |
-| Chrome | Chrome |
-| Firefox | Firefox for Android |
-| Safari | Firefox for iOS |
-| Edge Chromium | Safari iOS |
-| Edge | Samsung Internet |
-| Opera | Opera |
-| QQ browser | Opera |
-| Internet Explorer 11* |  |
+| Desktop Browsers      | Mobile Browsers     |
+| :-------------------- | :------------------ |
+| Chrome                | Chrome              |
+| Firefox               | Firefox for Android |
+| Safari                | Firefox for iOS     |
+| Edge Chromium         | Safari iOS          |
+| Edge                  | Samsung Internet    |
+| Opera                 | Opera               |
+| QQ browser            |                     |
+| Internet Explorer 11* |                     |
 
 *We plan to drop the support for Internet Explorer 11 in the future.

--- a/docs/9.0/guides/technical-specification/third-party-licenses.md
+++ b/docs/9.0/guides/technical-specification/third-party-licenses.md
@@ -42,9 +42,9 @@ canonicalUrl: /third-party-licenses
     License: Open source (Apache 2.0)<br>
     [https://github.com/cure53/DOMPurify](https://github.com/cure53/DOMPurify)
 
-### Dependencies of the formula calculation plugin
+### Dependencies of the [`Formulas`](@/api/formulas.md) plugin
 
-The below dependencies apply only if you use the new formula calculation plugin.
+The dependencies below apply only if you use the [`Formulas`](@/api/formulas.md) [calculation plugin](@/guides/formulas/formula-calculation.md):
 
 - **bessel**<br>
     Author: SheetJS<br>

--- a/docs/next/guides/technical-specification/supported-browsers.md
+++ b/docs/next/guides/technical-specification/supported-browsers.md
@@ -19,15 +19,15 @@ Tests are run in [BrowserStack](https://www.browserstack.com/) as well as on a l
 
 ## List of browsers
 
-| Desktop Browsers | Mobile Browsers |
-| :--- | :--- |
-| Chrome | Chrome |
-| Firefox | Firefox for Android |
-| Safari | Firefox for iOS |
-| Edge Chromium | Safari iOS |
-| Edge | Samsung Internet |
-| Opera | Opera |
-| QQ browser |  |
-| Internet Explorer 11* |  |
+| Desktop Browsers      | Mobile Browsers     |
+| :-------------------- | :------------------ |
+| Chrome                | Chrome              |
+| Firefox               | Firefox for Android |
+| Safari                | Firefox for iOS     |
+| Edge Chromium         | Safari iOS          |
+| Edge                  | Samsung Internet    |
+| Opera                 | Opera               |
+| QQ browser            |                     |
+| Internet Explorer 11* |                     |
 
 *We plan to drop the support for Internet Explorer 11 in the future.

--- a/docs/next/guides/technical-specification/third-party-licenses.md
+++ b/docs/next/guides/technical-specification/third-party-licenses.md
@@ -42,9 +42,9 @@ canonicalUrl: /third-party-licenses
     License: Open source (Apache 2.0)<br>
     [https://github.com/cure53/DOMPurify](https://github.com/cure53/DOMPurify)
 
-### Dependencies of the formula calculation plugin
+### Dependencies of the [`Formulas`](@/api/formulas.md) plugin
 
-The below dependencies apply only if you use the new formula calculation plugin.
+The dependencies below apply only if you use the [`Formulas`](@/api/formulas.md) [calculation plugin](@/guides/formulas/formula-calculation.md):
 
 - **bessel**<br>
     Author: SheetJS<br>


### PR DESCRIPTION
This PR makes changed requested by Krzysiek:
- Removes duplicate "Opera" from the "Supported browsers" section (actually, it seems like it's already been fixed)
- Changes the sentence about HF dependences from the "Third-party licenses" section

[skip changelog]