### PR TITLE
Update walkontableCalculateScrollbarWidth

### DIFF
--- a/src/helpers/dom/element.js
+++ b/src/helpers/dom/element.js
@@ -974,11 +974,13 @@ let cachedScrollbarWidth;
 function walkontableCalculateScrollbarWidth(rootDocument = document) {
   const inner = rootDocument.createElement('div');
 
+  inner.className = 'handsontable';
   inner.style.height = '200px';
   inner.style.width = '100%';
 
   const outer = rootDocument.createElement('div');
 
+  outer.className = 'handsontable';
   outer.style.boxSizing = 'content-box';
   outer.style.height = '150px';
   outer.style.left = '0px';


### PR DESCRIPTION
### Context
The method `helpers/dom/element.js/walkontableCalculateScrollbarWidth()' resolves global scroll bar width, but `3rdparty/walkontable/overlays.js` use for both scroll bar width and height. When using `fixedColumnsLeft`, the height of left fixed part is not calculated correctly. Here is the [demo](https://jsfiddle.net/k9psv4am)

With this change, we could use
```
.handsontable::-webkit-scrollbar {
  width: 7px;
  height: 7px;
}
```
to override the global scroll bar style, by making width and height have the size for handsontable only, to walkaround this issue.

I am aware this is not the best solution. It's better to change `Overlays.scrollbarSize`(3rdparty/walkontable/src/overlays.js) to `Overlays.scrollbarWidth` and `Overlays.scrollbarHeight`, but I not quite sure how many place these changes might impact. So I choose this safest solution.

Related forum topic [here](https://forum.handsontable.com/t/fixedcolumn-height-is-not-calculated-correctly/5487)

### How has this been tested?
I made a local patch to handsontable and confirmed it's working.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):


### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
