### PR TITLE
Correct typo

### DIFF
--- a/docs/next/guides/cell-functions/cell-validator.md
+++ b/docs/next/guides/cell-functions/cell-validator.md
@@ -56,7 +56,7 @@ That's better.
 
 ## Using an alias
 
-The final touch is to using the registered aliases, so that users can easily refer to it without the need to now the actual validator function is.
+The final touch is using the registered aliases, so that users can easily refer to it without the need to now the actual validator function is.
 
 To sum up, a well prepared validator function should look like this:
 


### PR DESCRIPTION
Remove excess `to` from a sentence in the Cell Validator tutorial.



### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]