### PR TITLE
FIX, wrap warning into if statement to prevent invalid occurring

### DIFF
--- a/wrappers/angular/projects/hot-table/src/lib/hot-table-registerer.service.ts
+++ b/wrappers/angular/projects/hot-table/src/lib/hot-table-registerer.service.ts
@@ -11,9 +11,13 @@ export class HotTableRegisterer {
   public getInstance(id: string): Handsontable {
     const hotInstance = instances.get(id);
 
-    console.warn(HOT_DESTROYED_WARNING);
+    if (hotInstance.isDestroyed) {
+      console.warn(HOT_DESTROYED_WARNING);
 
-    return hotInstance.isDestroyed ? null : hotInstance;
+      return null;
+    }
+
+    return hotInstance;
   }
 
   public registerInstance(id: string, instance: Handsontable): Map<string, Handsontable> {


### PR DESCRIPTION
### Context
Before this change, the warning was always written out because of a lack of checking if an instance was destroyed.
I wrap the warning into if.

[skip changelog]

### How has this been tested?
It was built and run the tests.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. resolves: https://github.com/handsontable/handsontable/issues/8664
2.
3.

### Affected project(s):
- [x] `@handsontable/angular`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md), and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
