### PR TITLE
Docs: adding info on differences between the two getRowHeight() methods #2822

### DIFF
--- a/docs/9.0/api/autoRowSize.md
+++ b/docs/9.0/api/autoRowSize.md
@@ -262,7 +262,9 @@ Gets the last visible row.
 
 _autoRowSize.getRowHeight(row, [defaultHeight]) ⇒ number_
 
-Gets the calculated row height.
+Gets the calculated row height (returns the actual height in pixels).
+
+Mind that this method is different from the [Core](@/api/core.md)'s [`getRowHeight()`](@/api/core.md#getrowheight) method.
 
 
 | Param | Type | Description |

--- a/docs/9.0/api/core.md
+++ b/docs/9.0/api/core.md
@@ -973,7 +973,9 @@ Returns an array of row headers' values (if they are enabled). If param `row` wa
 
 _core.getRowHeight(row) ⇒ number_
 
-Returns the row height.
+Returns values set by the [`rowHeights`](@/api/options.md#rowheights) [configuration option](@/guides/getting-started/setting-options.md).
+
+Mind that this method is different from the [AutoRowSize](@/api/auto-row-size.md) plugin's [`getRowHeight()`](@/api/auto-row-size.md#getrowheight) method.
 
 **Emits**: [`Hooks#event:modifyRowHeight`](@/api/pluginHooks.md#modifyrowheight)  
 

--- a/src/core.js
+++ b/src/core.js
@@ -3507,7 +3507,9 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
   };
 
   /**
-   * Returns the row height.
+   * Returns values set by the [`rowHeights`](@/api/options.md#rowheights) [configuration option](@/guides/getting-started/setting-options.md).
+   *
+   * Mind that this method is different from the [AutoRowSize](@/api/auto-row-size.md) plugin's [`getRowHeight()`](@/api/auto-row-size.md#getrowheight) method.
    *
    * @memberof Core#
    * @function getRowHeight

--- a/src/core.js
+++ b/src/core.js
@@ -3509,7 +3509,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
   /**
    * Returns values set by the [`rowHeights`](@/api/options.md#rowheights) [configuration option](@/guides/getting-started/setting-options.md).
    *
-   * Mind that this method is different from the [AutoRowSize](@/api/auto-row-size.md) plugin's [`getRowHeight()`](@/api/auto-row-size.md#getrowheight) method.
+   * Mind that this method is different from the [AutoRowSize](@/api/autorowsize.md) plugin's [`getRowHeight()`](@/api/autorowsize.md#getrowheight) method.
    *
    * @memberof Core#
    * @function getRowHeight

--- a/src/plugins/autoRowSize/autoRowSize.js
+++ b/src/plugins/autoRowSize/autoRowSize.js
@@ -362,7 +362,9 @@ export class AutoRowSize extends BasePlugin {
   }
 
   /**
-   * Gets the calculated row height.
+   * Gets the calculated row height (returns the actual height in pixels).
+   *
+   * Mind that this method is different from the [Core](@/api/core.md)'s [`getRowHeight()`](@/api/core.md#getrowheight) method.
    *
    * @param {number} row Visual row index.
    * @param {number} [defaultHeight] Default row height. It will be picked up if no calculated height found.


### PR DESCRIPTION
This PR:
- Modifies the descriptions of the `AutoRowSize` plugin's [`getRowHeight()`](https://handsontable.com/docs/api/auto-row-size/#getrowheight) method, and of the Core's [`getRowHeight()`](https://handsontable.com/docs/api/core/#getrowheight) method