### PR TITLE
Change the format of the breaking change entries in the changelog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [10.0.0] - 2021-09-29
 
 ### Changed
-- **Breaking change** Unifies fourth argument name and description, `controller`, for selection manipulation in `beforeOnCellMouseDown` and `beforeOnCellMouseOver` hooks. [#4996](https://github.com/handsontable/handsontable/issues/4996)
-- **Breaking change** Changed what the `beforeRender` and `afterRender` hooks are, and when they are triggered. Added two new hooks: `beforeViewRender` and `afterViewRender`. [#6303](https://github.com/handsontable/handsontable/issues/6303)
-- **Breaking change** Changed the optional HyperFormula dependency from 0.6.2 to ^1.1.0, which introduces breaking changes for the `Formulas` plugin users. [#8502](https://github.com/handsontable/handsontable/issues/8502)
-- **Breaking change** Changed the default values for `rowsLimit` and `columnsLimit` options of the _CopyPaste_ plugin. [#8660](https://github.com/handsontable/handsontable/issues/8660)
-- **Breaking change** Add default font size, color, and family.  [#8661](https://github.com/handsontable/handsontable/issues/8661)
-- **Breaking change** Changed the `autoWrapRow` and `autoWrapCol` options` default values from `true` to `false`. [#8662](https://github.com/handsontable/handsontable/issues/8662)
+- Unifies fourth argument name and description, `controller`, for selection manipulation in `beforeOnCellMouseDown` and `beforeOnCellMouseOver` hooks. [#4996](https://github.com/handsontable/handsontable/issues/4996) (**Breaking change**)
+- Changed what the `beforeRender` and `afterRender` hooks are, and when they are triggered. Added two new hooks: `beforeViewRender` and `afterViewRender`. [#6303](https://github.com/handsontable/handsontable/issues/6303) (**Breaking change**)
+- Changed the optional HyperFormula dependency from 0.6.2 to ^1.1.0, which introduces breaking changes for the `Formulas` plugin users. [#8502](https://github.com/handsontable/handsontable/issues/8502) (**Breaking change**)
+- Changed the default values for `rowsLimit` and `columnsLimit` options of the _CopyPaste_ plugin. [#8660](https://github.com/handsontable/handsontable/issues/8660) (**Breaking change**)
+- Add default font size, color, and family.  [#8661](https://github.com/handsontable/handsontable/issues/8661) (**Breaking change**)
+- Changed the `autoWrapRow` and `autoWrapCol` options` default values from `true` to `false`. [#8662](https://github.com/handsontable/handsontable/issues/8662) (**Breaking change**)
 - Improved the performance of the `getCellMeta()` method. [#6303](https://github.com/handsontable/handsontable/issues/6303)
 - Improved the documentation and TypeScript definition of the `selectOptions` option. [#8488](https://github.com/handsontable/handsontable/issues/8488)
 - Improved the arguments forwarding in the hooks [#8668](https://github.com/handsontable/handsontable/issues/8668)

--- a/bin/changelog
+++ b/bin/changelog
@@ -37,14 +37,14 @@ const entryDestination = name =>
 const fileExists = p => fs.access(p).then(() => true).catch(() => false);
 
 const stringifyChangelogEntryObject = ({ title, issue, framework, breaking }) => {
-  const breakingFragment = breaking ? '**Breaking change** ' : '';
+  const breakingFragment = breaking ? ' (**Breaking change**)' : '';
 
   const frameworkFragment = framework === 'none' ? '' : `*${uppercaseFirstLetter(framework)}:* `;
 
   const issueLinkFragment =
     `[#${issue}](https://github.com/handsontable/handsontable/issues/${issue})`;
 
-  return `${breakingFragment}${frameworkFragment}${title} ${issueLinkFragment}`;
+  return `${frameworkFragment}${title} ${issueLinkFragment}${breakingFragment}`;
 };
 
 const extractNumberFromString = (s) => {

--- a/bin/changelog
+++ b/bin/changelog
@@ -37,14 +37,14 @@ const entryDestination = name =>
 const fileExists = p => fs.access(p).then(() => true).catch(() => false);
 
 const stringifyChangelogEntryObject = ({ title, issue, framework, breaking }) => {
-  const breakingFragment = breaking ? ' (**Breaking change**)' : '';
+  const breakingFragment = breaking ? '(**Breaking change**)' : '';
 
   const frameworkFragment = framework === 'none' ? '' : `*${uppercaseFirstLetter(framework)}:* `;
 
   const issueLinkFragment =
     `[#${issue}](https://github.com/handsontable/handsontable/issues/${issue})`;
 
-  return `${frameworkFragment}${title} ${issueLinkFragment}${breakingFragment}`;
+  return `${frameworkFragment}${title} ${issueLinkFragment} ${breakingFragment}`;
 };
 
 const extractNumberFromString = (s) => {


### PR DESCRIPTION
### Context
This PR:
- Moves the "breaking change" note to be a suffix instead of a prefix in the changelog entries
- Modifies the changelog script to make it generate the changelog as described above.

Needs to merged to the `release/10.0.0` branch.

[skip changelog]

### How has this been tested?
Generated a dummy changelog to test if the script works fine.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
