### PR TITLE
Documentation: Handling production build mode

### DIFF
--- a/.github/workflows/documentation-prod.yml
+++ b/.github/workflows/documentation-prod.yml
@@ -27,11 +27,7 @@ jobs:
 
       - name: Dependencies
         run: |
-          npm ci 
-
-      - name: Generate API references
-        run: |
-          npm run docs:api
+          npm ci
 
       - name: Docker build
         run: |

--- a/docs/.vuepress/plugins/assets-versioning/index.js
+++ b/docs/.vuepress/plugins/assets-versioning/index.js
@@ -37,7 +37,7 @@ module.exports = (options, context) => {
       $page.lastUpdatedFormat = formatDate($page.lastUpdated);
       $page.frontmatter.canonicalUrl = `https://handsontable.com/docs/${$page.frontmatter.canonicalUrl}`;
 
-      if ((!DOCS_VERSION || $page.currentVersion === $page.latestVersion) && $page.frontmatter.permalink) {
+      if ((DOCS_VERSION || $page.currentVersion === $page.latestVersion) && $page.frontmatter.permalink) {
         $page.frontmatter.permalink = $page.frontmatter.permalink.replace(/^\/[^/]*\//, '/');
       }
 

--- a/docs/.vuepress/tools/build.mjs
+++ b/docs/.vuepress/tools/build.mjs
@@ -49,7 +49,8 @@ const buildApp = async() => {
   const startedAt = new Date().toString();
 
   logger.info('Build started at', startedAt);
-  if(buildMode){
+
+  if (buildMode) {
     logger.info('buildMode: ', buildMode);
   }
   cleanUp();

--- a/docs/.vuepress/tools/build.mjs
+++ b/docs/.vuepress/tools/build.mjs
@@ -6,6 +6,7 @@ import { getVersions } from '../helpers.js';
 
 const { logger, spawnProcess } = utils;
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const buildMode = process.env.BUILD_MODE;
 
 const cleanUp = () => {
   logger.info('Clean up dist');
@@ -48,8 +49,11 @@ const buildApp = async() => {
   const startedAt = new Date().toString();
 
   logger.info('Build started at', startedAt);
+  if(buildMode){
+    logger.info('buildMode: ', buildMode);
+  }
   cleanUp();
-  moveNext(getVersions()) // next shouldn't be at the first position.
+  moveNext(getVersions(buildMode)) // next shouldn't be at the first position.
     .map(buildVersion)
     .forEach(concatenate);
   logger.log('Build has started at', startedAt);

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -24,6 +24,7 @@
         "broken-link-checker": "^0.7.8",
         "chalk": "^4.1.1",
         "copy-webpack-plugin": "^5.1.2",
+        "cross-env": "^7.0.3",
         "dmd": "^6.0.0",
         "fs-extra": "^9.1.0",
         "inquirer": "^8.1.1",
@@ -6039,6 +6040,83 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/cross-env/node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cross-env/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cross-env/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cross-env/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cross-env/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/cross-spawn": {
@@ -22866,6 +22944,58 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
       }
     },
     "cross-spawn": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -21,7 +21,7 @@
     "docs:build:no-split-versions": "vuepress build -d .vuepress/dist/docs ./",
     "docs:docker:build": "npm run docs:docker:build:staging",
     "docs:docker:build:staging": "npm run docs:build:no-check-links && docker build -f docker/Dockerfile -t docs-md ./",
-    "docs:docker:build:production": "npm run docs:build:no-check-links && docker build -f docker/Dockerfile -t docs-md:production ./",
+    "docs:docker:build:production": "cross-env BUILD_MODE=production npm run docs:build:no-check-links && docker build -f docker/Dockerfile -t docs-md:production ./",
     "docs:version": "cd .vuepress/tools/version && node rollup-a-version.js && npm run docs:scripts:generate-legacy-docs-versions",
     "docs:api": "node .vuepress/tools/jsdoc-convert/index.mjs",
     "docs:check-links": "node .vuepress/tools/check-links.js"
@@ -43,6 +43,7 @@
     "broken-link-checker": "^0.7.8",
     "chalk": "^4.1.1",
     "copy-webpack-plugin": "^5.1.2",
+    "cross-env": "^7.0.3",
     "dmd": "^6.0.0",
     "fs-extra": "^9.1.0",
     "inquirer": "^8.1.1",


### PR DESCRIPTION
### Context

After #8208, on the navbar was displayed version `next`. Also, there was an issue with v9.0 permalinks.
I deploy the previous build and in this PR I fixed that issues.
[skip changelog]

### How has this been tested?
```
 BUILD_MODE=production npm run docs:build:no-check-links
http-server ./.vuepress/dist
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1).
