### PR TITLE
Fixed an issue with triggering wrong coords by `afterOnCellMouseDown` and `afterOnCellMouseDown` hooks

### DIFF
--- a/.changelogs/8498.json
+++ b/.changelogs/8498.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fixed an issue with triggering wrong coords by `afterOnCellMouseDown` and `afterOnCellMouseDown` hooks ",
+  "type": "fixed",
+  "issue": 8498,
+  "breaking": false,
+  "framework": "none"
+}

--- a/src/plugins/hiddenColumns/__tests__/plugins/mergeCells.spec.js
+++ b/src/plugins/hiddenColumns/__tests__/plugins/mergeCells.spec.js
@@ -1833,5 +1833,65 @@ describe('HiddenColumns', () => {
       expect($(mergeArea).hasClass('fullySelectedMergedCell-6')).toBeFalse();
       expect($(mergeArea).hasClass('fullySelectedMergedCell-7')).toBeFalse();
     });
+
+    describe('Hooks', () => {
+      it('should trigger the `beforeOnCellMouseDown` hook with proper coords', () => {
+        let rowOnCellMouseDown;
+        let columnOnCellMouseDown;
+        let coordsOnCellMouseDown;
+
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(5, 5),
+          rowHeaders: true,
+          colHeaders: true,
+          hiddenColumns: {
+            columns: [0, 1],
+            indicators: true
+          },
+          mergeCells: [{ row: 0, col: 0, rowspan: 2, colspan: 4 }],
+          beforeOnCellMouseDown(_, coords) {
+            coordsOnCellMouseDown = coords;
+            rowOnCellMouseDown = coords.row;
+            columnOnCellMouseDown = coords.col;
+          }
+        });
+
+        // Click on the first visible cell (merged area).
+        simulateClick(spec().$container.find('tr:eq(1) td:eq(0)'));
+
+        expect(rowOnCellMouseDown).toEqual(0);
+        expect(columnOnCellMouseDown).toEqual(2);
+        expect(coordsOnCellMouseDown).toEqual(jasmine.objectContaining({ row: 0, col: 2 }));
+      });
+
+      it('should trigger the `afterOnCellMouseDown` hook with proper coords', () => {
+        let rowOnCellMouseDown;
+        let columnOnCellMouseDown;
+        let coordsOnCellMouseDown;
+
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(5, 5),
+          rowHeaders: true,
+          colHeaders: true,
+          hiddenColumns: {
+            columns: [0, 1],
+            indicators: true
+          },
+          mergeCells: [{ row: 0, col: 0, rowspan: 2, colspan: 4 }],
+          afterOnCellMouseDown(_, coords) {
+            coordsOnCellMouseDown = coords;
+            rowOnCellMouseDown = coords.row;
+            columnOnCellMouseDown = coords.col;
+          }
+        });
+
+        // Click on the first visible cell (merged area).
+        simulateClick(spec().$container.find('tr:eq(1) td:eq(0)'));
+
+        expect(rowOnCellMouseDown).toEqual(0);
+        expect(columnOnCellMouseDown).toEqual(2);
+        expect(coordsOnCellMouseDown).toEqual(jasmine.objectContaining({ row: 0, col: 2 }));
+      });
+    });
   });
 });

--- a/src/plugins/hiddenRows/__tests__/plugins/mergeCells.spec.js
+++ b/src/plugins/hiddenRows/__tests__/plugins/mergeCells.spec.js
@@ -1845,5 +1845,65 @@ describe('HiddenRows', () => {
       expect($(mergeArea).hasClass('fullySelectedMergedCell-6')).toBeFalse();
       expect($(mergeArea).hasClass('fullySelectedMergedCell-7')).toBeFalse();
     });
+
+    describe('Hooks', () => {
+      it('should trigger the `beforeOnCellMouseDown` hook with proper coords', () => {
+        let rowOnCellMouseDown;
+        let columnOnCellMouseDown;
+        let coordsOnCellMouseDown;
+
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(5, 5),
+          rowHeaders: true,
+          colHeaders: true,
+          hiddenRows: {
+            rows: [0, 1],
+            indicators: true
+          },
+          mergeCells: [{ row: 0, col: 0, rowspan: 4, colspan: 2 }],
+          beforeOnCellMouseDown(_, coords) {
+            coordsOnCellMouseDown = coords;
+            rowOnCellMouseDown = coords.row;
+            columnOnCellMouseDown = coords.col;
+          }
+        });
+
+        // Click on the first visible cell (merged area).
+        simulateClick(spec().$container.find('tr:eq(1) td:eq(0)'));
+
+        expect(rowOnCellMouseDown).toEqual(2);
+        expect(columnOnCellMouseDown).toEqual(0);
+        expect(coordsOnCellMouseDown).toEqual(jasmine.objectContaining({ row: 2, col: 0 }));
+      });
+
+      it('should trigger the `afterOnCellMouseDown` hook with proper coords', () => {
+        let rowOnCellMouseDown;
+        let columnOnCellMouseDown;
+        let coordsOnCellMouseDown;
+
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(5, 5),
+          rowHeaders: true,
+          colHeaders: true,
+          hiddenRows: {
+            rows: [0, 1],
+            indicators: true
+          },
+          mergeCells: [{ row: 0, col: 0, rowspan: 4, colspan: 2 }],
+          afterOnCellMouseDown(_, coords) {
+            coordsOnCellMouseDown = coords;
+            rowOnCellMouseDown = coords.row;
+            columnOnCellMouseDown = coords.col;
+          }
+        });
+
+        // Click on the first visible cell (merged area).
+        simulateClick(spec().$container.find('tr:eq(1) td:eq(0)'));
+
+        expect(rowOnCellMouseDown).toEqual(2);
+        expect(columnOnCellMouseDown).toEqual(0);
+        expect(coordsOnCellMouseDown).toEqual(jasmine.objectContaining({ row: 2, col: 0 }));
+      });
+    });
   });
 });

--- a/src/plugins/mergeCells/__tests__/mergeCells.spec.js
+++ b/src/plugins/mergeCells/__tests__/mergeCells.spec.js
@@ -1582,4 +1582,56 @@ describe('MergeCells', () => {
       expect($(getHtCore())[0].offsetHeight).toBe(24 + (4 * 23)); // First row is 1px higher than others.
     });
   });
+
+  describe('Hooks', () => {
+    it('should trigger the `beforeOnCellMouseDown` hook with proper coords', () => {
+      let rowOnCellMouseDown;
+      let columnOnCellMouseDown;
+      let coordsOnCellMouseDown;
+
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        mergeCells: [{ row: 0, col: 0, rowspan: 2, colspan: 4 }],
+        beforeOnCellMouseDown(_, coords) {
+          coordsOnCellMouseDown = coords;
+          rowOnCellMouseDown = coords.row;
+          columnOnCellMouseDown = coords.col;
+        }
+      });
+
+      // Click on the first visible cell (merged area).
+      simulateClick(spec().$container.find('tr:eq(1) td:eq(0)'));
+
+      expect(rowOnCellMouseDown).toEqual(0);
+      expect(columnOnCellMouseDown).toEqual(0);
+      expect(coordsOnCellMouseDown).toEqual(jasmine.objectContaining({ row: 0, col: 0 }));
+    });
+
+    it('should trigger the `afterOnCellMouseDown` hook with proper coords', () => {
+      let rowOnCellMouseDown;
+      let columnOnCellMouseDown;
+      let coordsOnCellMouseDown;
+
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        mergeCells: [{ row: 0, col: 0, rowspan: 2, colspan: 4 }],
+        afterOnCellMouseDown(_, coords) {
+          coordsOnCellMouseDown = coords;
+          rowOnCellMouseDown = coords.row;
+          columnOnCellMouseDown = coords.col;
+        }
+      });
+
+      // Click on the first visible cell (merged area).
+      simulateClick(spec().$container.find('tr:eq(1) td:eq(0)'));
+
+      expect(rowOnCellMouseDown).toEqual(0);
+      expect(columnOnCellMouseDown).toEqual(0);
+      expect(coordsOnCellMouseDown).toEqual(jasmine.objectContaining({ row: 0, col: 0 }));
+    });
+  });
 });

--- a/src/selection/selection.js
+++ b/src/selection/selection.js
@@ -167,15 +167,19 @@ class Selection {
     const isRowNegative = coords.row < 0;
     const isColumnNegative = coords.col < 0;
     const selectedByCorner = isRowNegative && isColumnNegative;
+    // We are creating copy. We would like to modify just the start of the selection by below hook. Then original coords
+    // should be handled by next methods.
+    const coordsClone = coords.clone();
 
     this.selectedByCorner = selectedByCorner;
-    this.runLocalHooks(`beforeSetRangeStart${fragment ? 'Only' : ''}`, coords);
+
+    this.runLocalHooks(`beforeSetRangeStart${fragment ? 'Only' : ''}`, coordsClone);
 
     if (!isMultipleMode || (isMultipleMode && !isMultipleSelection && isUndefined(multipleSelection))) {
       this.selectedRange.clear();
     }
 
-    this.selectedRange.add(coords);
+    this.selectedRange.add(coordsClone);
 
     if (this.getLayerLevel() === 0) {
       this.selectedByRowHeader.clear();
@@ -216,13 +220,17 @@ class Selection {
       return;
     }
 
-    this.runLocalHooks('beforeSetRangeEnd', coords);
+    // We are creating copy. We would like to modify just the end of the selection by below hook. Then original coords
+    // should be handled by next methods.
+    const coordsClone = coords.clone();
+
+    this.runLocalHooks('beforeSetRangeEnd', coordsClone);
     this.begin();
 
     const cellRange = this.selectedRange.current();
 
     if (this.settings.selectionMode !== 'single') {
-      cellRange.setTo(new CellCoords(coords.row, coords.col));
+      cellRange.setTo(new CellCoords(coordsClone.row, coordsClone.col));
     }
 
     // Set up current selection.


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The `MergeCells` plugin is using hooks such as `beforeSetRangeStart`, `beforeSetRangeStartOnly` and `beforeSetRangeEnd` for overriding coords for the purpose of extending the selection range. However, there were side effects. 

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I've tested code on different configurations, also while using `HiddenRows` and `HiddenColumns` plugins.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #8498

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] My change requires a change to the documentation.