### PR TITLE
Prevent collect double page view for the initial page load

### DIFF
--- a/docs/.vuepress/enhanceApp.js
+++ b/docs/.vuepress/enhanceApp.js
@@ -40,7 +40,7 @@ const buildActiveHeaderLinkHandler = () => {
  * For the first page load, the GA automatically registers pageview. For other
  * route changes, the event is triggered manually.
  */
-let isFirstPageLoad = true;
+let isFirstPageLoaded = true;
 
 export default ({ router, isServer }) => {
   if (!isServer) {
@@ -48,7 +48,7 @@ export default ({ router, isServer }) => {
 
     if (typeof window.ga === 'function') {
       router.afterEach((to) => {
-        if (!isFirstPageLoad) {
+        if (!isFirstPageLoaded) {
           ga.getAll().forEach((tracker) => {
             if (tracker.get('trackingId') === GA_ID) {
               tracker.set('page', router.app.$withBase(to.fullPath));
@@ -57,7 +57,7 @@ export default ({ router, isServer }) => {
           });
         }
 
-        isFirstPageLoad = false;
+        isFirstPageLoaded = false;
       });
     }
 

--- a/docs/.vuepress/enhanceApp.js
+++ b/docs/.vuepress/enhanceApp.js
@@ -35,18 +35,29 @@ const buildActiveHeaderLinkHandler = () => {
   };
 };
 
+/**
+ * The variable prevents collect double page views for the initial page load.
+ * For the first page load, the GA automatically registers pageview. For other
+ * route changes, the event is triggered manually.
+ */
+let isFirstPageLoad = true;
+
 export default ({ router, isServer }) => {
   if (!isServer) {
     themeLoader();
 
     if (typeof window.ga === 'function') {
       router.afterEach((to) => {
-        ga.getAll().forEach((tracker) => {
-          if (tracker.get('trackingId') === GA_ID) {
-            tracker.set('page', router.app.$withBase(to.fullPath));
-            tracker.send('pageview');
-          }
-        });
+        if (!isFirstPageLoad) {
+          ga.getAll().forEach((tracker) => {
+            if (tracker.get('trackingId') === GA_ID) {
+              tracker.set('page', router.app.$withBase(to.fullPath));
+              tracker.send('pageview');
+            }
+          });
+        }
+
+        isFirstPageLoad = false;
       });
     }
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR is a continuation of the issue related to the GA (https://github.com/handsontable/handsontable/issues/8804). The PR fixes the initial implementation of the GA introduced within https://github.com/handsontable/handsontable/pull/8808. There is a bug where the page views are collected twice for the initial page load. These changes fixed that.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #8804
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
