### PR TITLE
Docs: Adding SonarCloud badge

### DIFF
--- a/docs/10.0/guides/security/security.md
+++ b/docs/10.0/guides/security/security.md
@@ -11,7 +11,11 @@ canonicalUrl: /security
 
 ## Overview
 
-We take security very seriously at Handsontable. We integrate with Security Tools and Policies to provide a secure js grid. This document provides information on our Security Certification, Audits, and Policies.
+At Handsontable, security is our utmost priority. To provide a secure and trustworthy JavaScript component, we integrate with various security tools and implement industry-standard security policies. 
+
+### SonarCloud results
+
+[![Quality gate](https://sonarcloud.io/api/project_badges/quality_gate?project=handsontable_handsontable)](https://sonarcloud.io/dashboard?id=handsontable_handsontable)
 
 ## Secure data transportation
 
@@ -66,7 +70,7 @@ Snyk provides security status notifications via email or Slack to:
 
 ## Insurance
 
-We are insured by Lloyds of London. Our policy protects Handsontable and our customers:
+Our insurance protects our customers in the following areas:
 
 | Our Customers | Handsoncode (Us)  |
 |--|--|


### PR DESCRIPTION
This PR:
- Adds a SonarCloud badge to the [Security](https://handsontable.com/docs/security/) page
- Rewrites the introduction
- Rewrites the insurance introduction