### PR TITLE
Fix jsdoc types according to usage

### DIFF
--- a/src/helpers/dom/element.js
+++ b/src/helpers/dom/element.js
@@ -1042,8 +1042,8 @@ export function hasHorizontalScrollbar(element) {
  * Sets overlay position depending on it's type and used browser.
  *
  * @param {HTMLElement} overlayElem An element to process.
- * @param {number} left The left position of the overlay.
- * @param {number} top The top position of the overlay.
+ * @param {number|string} left The left position of the overlay.
+ * @param {number|string} top The top position of the overlay.
  */
 export function setOverlayPosition(overlayElem, left, top) {
   if (isIE9()) {


### PR DESCRIPTION
### Context

While I'm working on RTL, I found jsdoc types mismatch. This PR fix that.

https://github.com/handsontable/handsontable/blob/7730d1086b051425cec7ddc3a0e9972ea8a5636d/src/3rdparty/walkontable/src/overlay/left.js#L88-L90

[skip changelog]


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
