### PR TITLE
Add modularization support for Angular wrapper

### DIFF
--- a/.changelogs/8818.json
+++ b/.changelogs/8818.json
@@ -1,0 +1,7 @@
+{
+  "title": "Added support for modularize Angular wrapper",
+  "type": "added",
+  "issue": 8818,
+  "breaking": true,
+  "framework": "angular"
+}

--- a/wrappers/angular/projects/hot-table/ng-package.json
+++ b/wrappers/angular/projects/hot-table/ng-package.json
@@ -5,7 +5,7 @@
   "lib": {
     "entryFile": "src/public_api.ts",
     "umdModuleIds": {
-      "handsontable": "Handsontable"
+      "handsontable/base": "Handsontable"
     }
   }
 }

--- a/wrappers/angular/projects/hot-table/src/lib/helpers.ts
+++ b/wrappers/angular/projects/hot-table/src/lib/helpers.ts
@@ -1,0 +1,36 @@
+/**
+ * Generates spreadsheet-like column names: A, B, C, ..., Z, AA, AB, etc.
+ */
+export function spreadsheetColumnLabel(index: number): string {
+  let dividend = index + 1;
+  let columnLabel = '';
+  let modulo;
+
+  while (dividend > 0) {
+    modulo = (dividend - 1) % 26;
+    columnLabel = String.fromCharCode(65 + modulo) + columnLabel;
+    dividend = parseInt(((dividend - modulo) / 26).toFixed(0), 10);
+  }
+
+  return columnLabel;
+}
+
+/**
+ * Creates 2D array of Excel-like values "A1", "A2", ...
+ */
+export function createSpreadsheetData(rows: number = 100, columns: number = 4): string[][] {
+  const _rows = [];
+  let i;
+  let j;
+
+  for (i = 0; i < rows; i++) {
+    const row = [];
+
+    for (j = 0; j < columns; j++) {
+      row.push(spreadsheetColumnLabel(j) + (i + 1));
+    }
+    _rows.push(row);
+  }
+
+  return _rows;
+}

--- a/wrappers/angular/projects/hot-table/src/lib/hot-column.component.spec.ts
+++ b/wrappers/angular/projects/hot-table/src/lib/hot-column.component.spec.ts
@@ -1,6 +1,12 @@
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HotTableModule, HotTableRegisterer } from '@handsontable/angular';
+import {
+  registerCellType,
+  DateCellType,
+} from 'handsontable/cellTypes';
+
+registerCellType(DateCellType);
 
 @Component({
   selector: 'hot-test-component',

--- a/wrappers/angular/projects/hot-table/src/lib/hot-column.component.ts
+++ b/wrappers/angular/projects/hot-table/src/lib/hot-column.component.ts
@@ -6,7 +6,7 @@ import {
   Input,
 } from '@angular/core';
 import { HotTableComponent } from './hot-table.component';
-import Handsontable from 'handsontable';
+import Handsontable from 'handsontable/base';
 
 @Component({
   selector: 'hot-column',

--- a/wrappers/angular/projects/hot-table/src/lib/hot-settings-resolver.service.ts
+++ b/wrappers/angular/projects/hot-table/src/lib/hot-settings-resolver.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, SimpleChanges } from '@angular/core';
-import Handsontable from 'handsontable';
+import Handsontable from 'handsontable/base';
 
 const AVAILABLE_OPTIONS: string[] = Object.keys(Handsontable.DefaultSettings);
 const AVAILABLE_HOOKS: string[] = Handsontable.hooks.getRegistered();

--- a/wrappers/angular/projects/hot-table/src/lib/hot-table-registerer.service.spec.ts
+++ b/wrappers/angular/projects/hot-table/src/lib/hot-table-registerer.service.spec.ts
@@ -1,7 +1,6 @@
-
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import Handsontable from 'handsontable';
+import Handsontable from 'handsontable/base';
 import { HotTableModule, HotTableRegisterer } from '@handsontable/angular';
 
 @Component({

--- a/wrappers/angular/projects/hot-table/src/lib/hot-table-registerer.service.ts
+++ b/wrappers/angular/projects/hot-table/src/lib/hot-table-registerer.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import Handsontable from 'handsontable';
+import Handsontable from 'handsontable/base';
 
 const instances = new Map<string, Handsontable>();
 

--- a/wrappers/angular/projects/hot-table/src/lib/hot-table.component.spec.ts
+++ b/wrappers/angular/projects/hot-table/src/lib/hot-table.component.spec.ts
@@ -1,8 +1,15 @@
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import Handsontable from 'handsontable';
+import Handsontable from 'handsontable/base';
 import { HotTableModule, HotTableRegisterer } from '@handsontable/angular';
 import { HOT_DESTROYED_WARNING } from '../lib/hot-table-registerer.service';
+import { createSpreadsheetData } from './helpers';
+import {
+  registerPlugin,
+  CopyPaste,
+} from 'handsontable/plugins';
+
+registerPlugin(CopyPaste);
 
 @Component({
   selector: 'hot-test-component',
@@ -60,7 +67,7 @@ describe('HotTableComponent', () => {
       const app = fixture.componentInstance;
 
       app.prop['settings'] = {
-        data: Handsontable.helper.createSpreadsheetData(5, 5)
+        data: createSpreadsheetData(5, 5)
       };
 
       fixture.detectChanges();
@@ -345,7 +352,7 @@ describe('HotTableComponent', () => {
         const app = fixture.componentInstance;
 
         app.prop['settings'] = {
-          data: Handsontable.helper.createSpreadsheetData(5, 5)
+          data: createSpreadsheetData(5, 5)
         };
 
         fixture.detectChanges();

--- a/wrappers/angular/projects/hot-table/src/lib/hot-table.component.ts
+++ b/wrappers/angular/projects/hot-table/src/lib/hot-table.component.ts
@@ -9,7 +9,7 @@ import {
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
-import Handsontable from 'handsontable';
+import Handsontable from 'handsontable/base';
 import {
   HotTableRegisterer,
   HOT_DESTROYED_WARNING


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR modifies the wrapper to use a Base version of the Handsontable instead of a full-packed version. Thanks to that the wrapper can be customized. The developer can exclude the modules that are not used within the app thus decreasing the final size of the vendor chunk file.

The first stage of that feature adds support for providing the modules globally.

#### Providing modules globally
Register the necessary modules in the entry point file of your application. All `hot-table` components within App from now on have access to that modules.
```typescript
// main.ts
import { enableProdMode } from '@angular/core';
import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';

import { AppModule } from './app/app.module';
import { environment } from './environments/environment';

import Handsontable from 'handsontable/base';
import {
  registerCellType,
  NumericCellType,
} from 'handsontable/cellTypes';
import {
  registerPlugin,
  UndoRedo,
} from 'handsontable/plugins';

registerCellType(NumericCellType);
registerPlugin(UndoRedo);

if (environment.production) {
  enableProdMode();
}

platformBrowserDynamic().bootstrapModule(AppModule)
  .catch(err => console.error(err));
```

#### Providing modules to individual components (at the moment not fully supported)
There is a possibility to add modules individually but there is a side effect. The side effect is about an order of loading multiple `hot-table` components. 

When the `Grid1` will be rendered first it loads the Handsontable Base without any registered components. The vendor chunk size for that page would be as low as should be. Then the `Grid2` is rendered that loads additional Handsontable modules. At this point, everything looks good. The first Grid does not have access to modules that the second Grid asked for. 

The situation looks different when the second Grid (`Grid2`) is loaded as first. Then the Handsontable Base with additional modules is loaded - which is Ok, but other grids that will be rendered after that will get access to modules that they are not asked for. This can cause some misunderstanding of what is happening where registering some modules within one file can enable some features (some of the plugins are by default enabled) in another one.
```typescript
// grid1.component.ts
import { Component } from '@angular/core';
import Handsontable from 'handsontable/base';

@Component({
  selector: 'grid1',
  templateUrl: './grid1.component.html',
})
export class Grid1Component {
  settings: Handsontable.GridSettings = {
    colHeaders: true,
  }
}
```
```typescript
// grid2.component.ts
import { Component } from '@angular/core';
import Handsontable from 'handsontable/base';
import { registerPlugin, Filters, DropdownMenu, HiddenRows, ContextMenu } from 'handsontable/plugins';

registerPlugin(Filters);
registerPlugin(DropdownMenu);
registerPlugin(HiddenRows);
registerPlugin(ContextMenu);

@Component({
  selector: 'grid2',
  templateUrl: './grid2.component.html',
})
export class Grid2Component {
  settings: Handsontable.GridSettings = {
    colHeaders: true,
  }
}
```

#### Migration guide
By default, the `hot-table` component includes only the Base version of the Handsontable. That is a breaking change. To load the full-featured version of the Handsontable the developer should import and call the `registerAllModules` function.
```typescript
// main.ts
import { enableProdMode } from '@angular/core';
import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';

import { AppModule } from './app/app.module';
import { environment } from './environments/environment';

import { registerAllModules } from 'handsontable/registry';

registerAllModules();

if (environment.production) {
  enableProdMode();
}

platformBrowserDynamic().bootstrapModule(AppModule)
  .catch(err => console.error(err));
```

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the produced vendor chunk sizes and it seems to work. All tests I run on `@angular/cli` stack using dev and prod build.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #8818 
2. #8816
3.

### Affected project(s):
- [ ] `handsontable`
- [x] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
