### PR TITLE
Trigger `pageview` in the next browser event loop cycle

### DIFF
--- a/docs/.vuepress/enhanceApp.js
+++ b/docs/.vuepress/enhanceApp.js
@@ -1,4 +1,4 @@
-/* global GA_ID, ga, location, document */
+/* global GA_ID, ga */
 const { applyToWindow, instanceRegister } = require('./handsontable-manager');
 const { themeLoader } = require('./themeLoader');
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR improves tracking pageviews for documentation pages. Mostly it fixes an issue where the pageview collects the wrong document title or full address URL (grabs the data from the previous page). The solution is to postpone the `send('pageview')` call to make sure that VuePress renders the new page completely and the GA script grabs fresh title and URL address.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes by seeing what is send to the GA servers throughout the Network tab.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #8804 
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
