### PR TITLE
Fixed an issue with throwing error while using `populateFromArray` with `shift_right` method in some case

### DIFF
--- a/.changelogs/6929.json
+++ b/.changelogs/6929.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fixed an issue with throwing error while using `populateFromArray` with `shift_right` method in some case",
+  "type": "fixed",
+  "issue": 6929,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/test/e2e/Core_populateFromArray.spec.js
+++ b/handsontable/test/e2e/Core_populateFromArray.spec.js
@@ -400,6 +400,43 @@ describe('Core_populateFromArray', () => {
         [4, 9, undefined, null], [4, 10, undefined, null], [4, 11, undefined, null],
       ], 'populateFromArray');
     });
+
+    it('should expand the dataset properly #6929', () => {
+      const hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(1, 5),
+      });
+
+      const afterChange = jasmine.createSpy('afterChange');
+
+      hot.addHook('afterChange', afterChange);
+
+      hot.populateFromArray(0, 0, [
+        ['test', 'test2'],
+        ['test3', 'test4']
+      ], 3, 3, null, 'shift_right');
+
+      expect(getData()).toEqual([
+        ['test', 'test2', 'test', 'test2', 'A1', 'B1', 'C1', 'D1', 'E1'],
+        ['test3', 'test4', 'test3', 'test4', null, null, null, null, null],
+        ['test', 'test2', 'test', 'test2', null, null, null, null, null],
+        ['test3', 'test4', 'test3', 'test4', null, null, null, null, null],
+      ]);
+
+      expect(afterChange).toHaveBeenCalledTimes(1);
+      expect(afterChange).toHaveBeenCalledWith([
+        [0, 0, 'A1', 'test'], [0, 1, 'B1', 'test2'], [0, 2, 'C1', 'test'], [0, 3, 'D1', 'test2'], [0, 4, 'E1', 'A1'],
+        // TODO: Shouldn't the `undefined` be `null`?
+        [0, 5, undefined, 'B1'], [0, 6, undefined, 'C1'], [0, 7, undefined, 'D1'], [0, 8, undefined, 'E1'],
+        [1, 0, null, 'test3'], [1, 1, null, 'test4'], [1, 2, null, 'test3'], [1, 3, null, 'test4'], [1, 4, null, null],
+        [1, 5, null, null], [1, 6, null, null], [1, 7, null, null], [1, 8, null, null],
+        [2, 0, null, 'test'], [2, 1, null, 'test2'], [2, 2, null, 'test'], [2, 3, null, 'test2'],
+        // TODO: Shouldn't the `undefined` be `null`?
+        [2, 4, null, undefined],
+        [3, 0, null, 'test3'], [3, 1, null, 'test4'], [3, 2, null, 'test3'], [3, 3, null, 'test4'],
+        // TODO: Shouldn't the `undefined` be `null`?
+        [3, 4, null, undefined],
+      ], 'populateFromArray');
+    });
   });
 
   it('should run beforeAutofillInsidePopulate hook for each inserted value', () => {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Added an extra test for bug described within #6929. Related to https://github.com/handsontable/handsontable/pull/8867.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Manually tested just some cases similar to that one from the original issue.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #6929

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] My change requires a change to the documentation.