### PR TITLE
Set type for activeEditor in editorManager.js

### DIFF
--- a/src/editorManager.js
+++ b/src/editorManager.js
@@ -59,7 +59,7 @@ class EditorManager {
      * A reference to an instance of the activeEditor.
      *
      * @private
-     * @type {*}
+     * @type {BaseEditor}
      */
     this.activeEditor = void 0;
     /**
@@ -130,7 +130,7 @@ class EditorManager {
   /**
    * Get active editor.
    *
-   * @returns {*}
+   * @returns {BaseEditor}
    */
   getActiveEditor() {
     return this.activeEditor;


### PR DESCRIPTION
### Context
Set type for activeEditor in editorManager.js
[skip changelog] - this is only a jsdoc update, changelog entry is redundant.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)


### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

