### PR TITLE
Fix the `docs:api` script on the post-#8759 develop.

### DIFF
--- a/docs/.vuepress/tools/jsdoc-convert/configuration.mjs
+++ b/docs/.vuepress/tools/jsdoc-convert/configuration.mjs
@@ -1,5 +1,5 @@
 export default {
-  pathToSource: '../../../../src',
+  pathToSource: '../../../../handsontable/src',
   pathToDist: '../../../next/api',
   urlPrefix: '/next/api/',
   seo: {


### PR DESCRIPTION
### Context
On the current `develop` branch (after merging #8759), the `docs:api` script for the `docs` doesn't work. This PR corrects the Handsontable's src path in the docs config.

### How has this been tested?
Run `docs:api` to check if it's working alright.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<sub>[skip changelog]</sub>