### PR TITLE
Docs: Fixing the lack of API ref for validateCell()

### DIFF
--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -1268,6 +1268,8 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
   /**
    * Validate a single cell.
    *
+   * @memberof Core#
+   * @function validateCell
    * @param {string|number} value The value to validate.
    * @param {object} cellProperties The cell meta which corresponds with the value.
    * @param {Function} callback The callback function.


### PR DESCRIPTION
This PR:
- Fixes the lack of API reference docs for the `validateCell()` method (fixing #8849)

[skip changelog]