### PR TITLE
Fix e2e tests for firefox and safarri.

### DIFF
--- a/handsontable/test/e2e/Core_direction.spec.js
+++ b/handsontable/test/e2e/Core_direction.spec.js
@@ -10,7 +10,7 @@ describe('Core_alter', () => {
       destroy();
       this.$container.remove();
     }
-    $('html').removeAttr('dir');
+    $('html').attr('dir', 'ltr');
   });
 
   describe('Direction detection', () => {

--- a/handsontable/test/e2e/Core_navigation.spec.js
+++ b/handsontable/test/e2e/Core_navigation.spec.js
@@ -314,7 +314,7 @@ describe('Core_navigation RTL', () => {
       destroy();
       this.$container.remove();
     }
-    $('html').removeAttr('dir');
+    $('html').attr('dir', 'ltr');
   });
 
   it('should move to the next cell', () => {


### PR DESCRIPTION
### Context

It seems that `removeAttr` doesn't work in the same way for various browsers. Thus, I set the `dir` attribute to `ltr` explicitly.
<!-- [skip changelog] -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. resolves: #8922
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

