### PR TITLE
Docs: Changes related to #6095

### DIFF
--- a/.changelogs/6095.json
+++ b/.changelogs/6095.json
@@ -1,5 +1,5 @@
 {
-  "title": "Fixed an issue with wrong filtering locale-based data while using search input from drop-down menu.",
+  "title": "Fixed an issue with incorrect filtering of locale-based data while using search input from a drop-down menu.",
   "type": "fixed",
   "issue": 6095,
   "breaking": false,

--- a/.changelogs/8897.json
+++ b/.changelogs/8897.json
@@ -1,5 +1,5 @@
 {
-  "title": "Introduced locales for handling properly locale-based data",
+  "title": "Added a new `locale` option, to properly handle locale-based data.",
   "type": "added",
   "issue": 8897,
   "breaking": false,

--- a/docs/10.0/guides/building-and-testing/modules.md
+++ b/docs/10.0/guides/building-and-testing/modules.md
@@ -19,7 +19,7 @@ When you become familiar with Handsontable functionalities you may find out that
 
 Thanks to [modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) the package could be split into smaller pieces and you can **import** them as you need. Essentialy it was divided into two: the base and the optional part. The base of Handsontable holds mandatory parts packed inside `handsontable/base`, and it includes vital parts for the component to run. The rest is customizable based on what you want to import. A mindful use of the modules brings a lot of optimization to the application, yet, it only needs several lines of code.
 
-The graph presents a comparison of size in KB for a full bundle, basic optimization and with optimized locales. The sample code is avaiable just below - it shows sample countries and cities and although it looks small it will generate over 345 KB (Gzipped). [Webpack 5](https://webpack.js.org/) with a default configuration for production builds was used to prepare this example.
+The graph presents a comparison of size in KB for a full bundle, basic optimization and with optimized translations. The sample code is avaiable just below - it shows sample countries and cities and although it looks small it will generate over 345 KB (Gzipped). [Webpack 5](https://webpack.js.org/) with a default configuration for production builds was used to prepare this example.
 
 ![bundle_size_comparison](/docs/10.0/img/bundle_size_comparison.png)
 
@@ -139,7 +139,7 @@ Elements to be imported manually on demand:
 - renderers
 - validators
 - cell types
-- locales
+- languages (translations)
 
 The use cases may wary greatly, this guide will go through the categories and present one example for each.
 
@@ -351,9 +351,9 @@ new Handsontable(container, {
 
 And that is all! You can use the checkbox cell type!
 
-## Importing locales
+## Importing translations
 
-Importing locales works slightly different than in case of other elements. Let's try adding the `pl-PL` locale.
+Importing translations works slightly different than in case of other elements. Let's try adding the `pl-PL` translation.
 
 Start with importing the base and the language code:
 
@@ -375,7 +375,7 @@ registerLanguageDictionary(plPL.languageCode, plPL);
 registerLanguageDictionary(plPL);
 ```
 
-Now, you can use newly registered locale. The full example looks like this:
+Now, you can use newly registered translation. The full example looks like this:
 
 ```js
 import Handsontable from 'handsontable/base';
@@ -383,14 +383,14 @@ import { registerLanguageDictionary, plPL } from 'handsontable/i18n';
 
 registerLanguageDictionary(plPL);
 
-// use the locales
+// use the translation
 new Handsontable(container, {
   language: 'pl-PL',
 // rest of the settings
 });
 ```
 
-And that is all! You can use the PL-pl locale!
+And that is all! You can use the PL-pl translation!
 
 ## Optimizing moment.js locales
 

--- a/docs/10.0/guides/integrate-with-angular/angular-setting-up-a-locale.md
+++ b/docs/10.0/guides/integrate-with-angular/angular-setting-up-a-locale.md
@@ -1,14 +1,14 @@
 ---
-title: Setting up a locale
-metaTitle: Setting up a locale - Guide - Handsontable Documentation
+title: Setting up a translation
+metaTitle: Setting up a translation - Guide - Handsontable Documentation
 permalink: /10.0/angular-setting-up-a-locale
 canonicalUrl: /angular-setting-up-a-locale
 ---
 
-# Setting up a locale
+# Setting up a language
 
 ## Overview
-The following example shows a Handsontable instance with locales set up in Angular.
+The following example shows a Handsontable instance with translations set up in Angular.
 
 ## Example
 ::: example :angular-numbro --html 1 --js 2

--- a/docs/10.0/guides/integrate-with-react/react-setting-up-a-locale.md
+++ b/docs/10.0/guides/integrate-with-react/react-setting-up-a-locale.md
@@ -1,15 +1,15 @@
 ---
-title: Setting up a locale
-metaTitle: Setting up a locale - Guide - Handsontable Documentation
+title: Setting up a translation
+metaTitle: Setting up a translation - Guide - Handsontable Documentation
 permalink: /10.0/react-setting-up-a-locale
 canonicalUrl: /react-setting-up-a-locale
 ---
 
-# Setting up a locale
+# Setting up a translation
 
 ## Overview
 
-The following example shows a Handsontable instance with locales set up in React.
+The following example shows a Handsontable instance with translations set up in React.
 
 ## Example
 

--- a/docs/10.0/guides/integrate-with-vue/vue-setting-up-a-locale.md
+++ b/docs/10.0/guides/integrate-with-vue/vue-setting-up-a-locale.md
@@ -1,15 +1,15 @@
 ---
-title: Setting up a locale
-metaTitle: Setting up a locale - Guide - Handsontable Documentation
+title: Setting up a translation
+metaTitle: Setting up a translation - Guide - Handsontable Documentation
 permalink: /10.0/vue-setting-up-a-locale
 canonicalUrl: /vue-setting-up-a-locale
 ---
 
-# Setting up a locale
+# Setting up a translation
 
 ## Overview
 
-The following example shows a Handsontable instance with locales set up in Vue.
+The following example shows a Handsontable instance with translations set up in Vue.
 
 ## Example
 

--- a/docs/9.0/guides/building-and-testing/modules.md
+++ b/docs/9.0/guides/building-and-testing/modules.md
@@ -19,7 +19,7 @@ When you become familiar with Handsontable functionalities you may find out that
 
 Thanks to [modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) the package could be split into smaller pieces and you can **import** them as you need. Essentialy it was divided into two: the base and the optional part. The base of Handsontable holds mandatory parts packed inside `handsontable/base`, and it includes vital parts for the component to run. The rest is customizable based on what you want to import. A mindful use of the modules brings a lot of optimization to the application, yet, it only needs several lines of code.
 
-The graph presents a comparison of size in KB for a full bundle, basic optimization and with optimized locales. The sample code is avaiable just below - it shows sample countries and cities and although it looks small it will generate over 345 KB (Gzipped). [Webpack 5](https://webpack.js.org/) with a default configuration for production builds was used to prepare this example.
+The graph presents a comparison of size in KB for a full bundle, basic optimization and with optimized translations. The sample code is avaiable just below - it shows sample countries and cities and although it looks small it will generate over 345 KB (Gzipped). [Webpack 5](https://webpack.js.org/) with a default configuration for production builds was used to prepare this example.
 
 ![bundle_size_comparison](/docs/9.0/img/bundle_size_comparison.png)
 
@@ -139,7 +139,7 @@ Elements to be imported manually on demand:
 - renderers
 - validators
 - cell types
-- locales
+- languages (translations)
 
 The use cases may wary greatly, this guide will go through the categories and present one example for each.
 

--- a/docs/next/guides/building-and-testing/modules.md
+++ b/docs/next/guides/building-and-testing/modules.md
@@ -19,7 +19,7 @@ When you become familiar with Handsontable functionalities you may find out that
 
 Thanks to [modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) the package could be split into smaller pieces and you can **import** them as you need. Essentialy it was divided into two: the base and the optional part. The base of Handsontable holds mandatory parts packed inside `handsontable/base`, and it includes vital parts for the component to run. The rest is customizable based on what you want to import. A mindful use of the modules brings a lot of optimization to the application, yet, it only needs several lines of code.
 
-The graph presents a comparison of size in KB for a full bundle, basic optimization and with optimized locales. The sample code is avaiable just below - it shows sample countries and cities and although it looks small it will generate over 345 KB (Gzipped). [Webpack 5](https://webpack.js.org/) with a default configuration for production builds was used to prepare this example.
+The graph presents a comparison of size in KB for a full bundle, basic optimization and with optimized translations. The sample code is avaiable just below - it shows sample countries and cities and although it looks small it will generate over 345 KB (Gzipped). [Webpack 5](https://webpack.js.org/) with a default configuration for production builds was used to prepare this example.
 
 ![bundle_size_comparison](/docs/next/img/bundle_size_comparison.png)
 
@@ -139,7 +139,7 @@ Elements to be imported manually on demand:
 - renderers
 - validators
 - cell types
-- locales
+- languages (translations)
 
 The use cases may wary greatly, this guide will go through the categories and present one example for each.
 
@@ -351,9 +351,9 @@ new Handsontable(container, {
 
 And that is all! You can use the checkbox cell type!
 
-## Importing locales
+## Importing translations
 
-Importing locales works slightly different than in case of other elements. Let's try adding the `pl-PL` locale.
+Importing translations works slightly different than in case of other elements. Let's try adding the `pl-PL` translation.
 
 Start with importing the base and the language code:
 
@@ -383,14 +383,14 @@ import { registerLanguageDictionary, plPL } from 'handsontable/i18n';
 
 registerLanguageDictionary(plPL);
 
-// use the locales
+// use the translation
 new Handsontable(container, {
   language: 'pl-PL',
 // rest of the settings
 });
 ```
 
-And that is all! You can use the PL-pl locale!
+And that is all! You can use the PL-pl translation!
 
 ## Optimizing moment.js locales
 

--- a/docs/next/guides/integrate-with-angular/angular-setting-up-a-locale.md
+++ b/docs/next/guides/integrate-with-angular/angular-setting-up-a-locale.md
@@ -1,14 +1,14 @@
 ---
-title: Setting up a locale
-metaTitle: Setting up a locale - Guide - Handsontable Documentation
+title: Setting up a translation
+metaTitle: Setting up a translation - Guide - Handsontable Documentation
 permalink: /next/angular-setting-up-a-locale
 canonicalUrl: /angular-setting-up-a-locale
 ---
 
-# Setting up a locale
+# Setting up a translation
 
 ## Overview
-The following example shows a Handsontable instance with locales set up in Angular.
+The following example shows a Handsontable instance with translations set up in Angular.
 
 ## Example
 ::: example :angular-numbro --html 1 --js 2

--- a/docs/next/guides/integrate-with-react/react-setting-up-a-locale.md
+++ b/docs/next/guides/integrate-with-react/react-setting-up-a-locale.md
@@ -1,15 +1,15 @@
 ---
-title: Setting up a locale
-metaTitle: Setting up a locale - Guide - Handsontable Documentation
+title: Setting up a translation
+metaTitle: Setting up a translation - Guide - Handsontable Documentation
 permalink: /next/react-setting-up-a-locale
 canonicalUrl: /react-setting-up-a-locale
 ---
 
-# Setting up a locale
+# Setting up a translation
 
 ## Overview
 
-The following example shows a Handsontable instance with locales set up in React.
+The following example shows a Handsontable instance with translations set up in React.
 
 ## Example
 

--- a/docs/next/guides/integrate-with-vue/vue-setting-up-a-locale.md
+++ b/docs/next/guides/integrate-with-vue/vue-setting-up-a-locale.md
@@ -1,15 +1,15 @@
 ---
-title: Setting up a locale
-metaTitle: Setting up a locale - Guide - Handsontable Documentation
+title: Setting up a translation
+metaTitle: Setting up a translation - Guide - Handsontable Documentation
 permalink: /next/vue-setting-up-a-locale
 canonicalUrl: /vue-setting-up-a-locale
 ---
 
-# Setting up a locale
+# Setting up a translation
 
 ## Overview
 
-The following example shows a Handsontable instance with locales set up in Vue.
+The following example shows a Handsontable instance with translations set up in Vue.
 
 ## Example
 

--- a/docs/next/guides/internationalization/internationalization-i18n.md
+++ b/docs/next/guides/internationalization/internationalization-i18n.md
@@ -13,7 +13,13 @@ canonicalUrl: /internationalization-i18n
 
 Internationalization allows Handsontable to easily change the text of the UI for the purpose of translating it to specific languages. We provide the developer with predefined languages, which can be applied by loading the language set and changing just one setting, and an ability to use their own language sets, created using templates of existing language files.
 
-## Loading the prepared language files
+To adjust your internationalization settings, you can configure the following:
+- [Language settings](#language-settings)
+- [Locale settings](#locale-settings)
+
+## Language settings
+
+### Loading the prepared language files
 
 To properly use the internationalization feature, you'll need to load the language sets. It's important that they're included after the Handsontable files. You can do it by getting the necessary files created with the [UMD standard](https://github.com/umdjs/umd):
 
@@ -54,7 +60,7 @@ To properly use the internationalization feature, you'll need to load the langua
   </script>
   ```
 
-## Demo
+#### Demo
 
 Please right click on a cell to see the translated context menu. Language files were loaded after loading Handsontable.
 
@@ -80,7 +86,7 @@ const hot = new Handsontable(container, {
 ```
 :::
 
-## Internationalization for features
+### Internationalization for features
 
 Below you'll find a list of features which can be translated with the internationalization feature.
 
@@ -96,7 +102,7 @@ Below you'll find a list of features which can be translated with the internatio
 * Merge cells
 * Read-only
 
-## List of available languages
+### List of available languages
 
 By default, Handsontable uses the **English - United States** language-country set (`en-US` code) for creating the text of UI elements. However, it can be used like every extra, "non-standard" language file, thus the `en-US.js` file can be found in `/dist/languages`, `/languages` and `/src/languages` folders. Currently, we also distribute extra language-country files:
 
@@ -116,7 +122,7 @@ By default, Handsontable uses the **English - United States** language-country s
 * `zh-CN.js` for **Chinese - China** (`zh-CN` code).
 * `zh-TW.js` for **Chinese - Taiwan** (`zh-TW` code).
 
-## Creating custom languages
+### Creating custom languages
 
 You can create custom language sets for your implementations, or share them, as they're easily appliable to any Handsontable implementation.
 
@@ -202,7 +208,7 @@ You can see a full template of a sample language at the bottom of this paragraph
 
 7.  Voilà! You've created a language which can be used just by you or shared with others. We wait for at least 5 positive feedback from users to accept a created [pull request](@/guides/building-and-testing/building.md).
 
-### Local language
+#### Local language
 
 You can register a language dictionary which is not a part of the `Handsontable` package. To do so, use the static `Handsontable.languages.registerLanguageDictionary` method and the static constant `Handsontable.languages.dictionaryKeys` which are described briefly in the next section.
 
@@ -216,7 +222,7 @@ Handsontable.languages.registerLanguageDictionary({
 });
 ```
 
-## Using custom keys in the translation
+### Using custom keys in the translation
 
 You can register a language dictionary containing custom keys. These entries can be used like any other keys, so you're not limited to using our pre-defined constants (the ones that are present within `src/i18n/constants.js` file and may be accessed by `Handsontable.languages.dictionaryKeys` alias).
 
@@ -229,10 +235,60 @@ Handsontable.languages.registerLanguageDictionary(enUSDictionary); // re-registr
 Handsontable.languages.getTranslatedPhrase('en-US', 'customKey'); // 'Hello world'
 ```
 
-## Using locales
-Handsontable uses by default `en-US` locale for actions performed on data. Operations such as filtering, searching, comparing data sometimes cast text to lower case (for example, while using ignore case option). Without specifying proper locale for data it can work incorrectly.
+## Locale settings
 
-You don't need include any files to handle locales. Just use the `locale` key which should use structurally valid and canonicalized Unicode BCP 47 locale identifier (same as for the `languale` key).  Please keep in mind that different locales may be set for different columns.
+You can configure your locale settings, using the [`locale`](@/api/options.md#locale) [configuration option](@/guides/getting-started/setting-options.md).
+
+The locale setting affects certain actions performed on your data, such as:
+- Filtering
+- Searching
+- Comparing locale-based data
+
+Without a properly-set locale, the above operations can work incorrectly.
+
+By default, Handsontable's locale is `en-US`.
+
+You can configure the locale setting:
+- [For the entire grid](#setting-the-grid-s-locale)
+- [For individual columns](#setting-a-column-s-locale)
+
+### Setting the grid's locale
+
+To configure the locale of the entire grid, set the [`locale`](@/api/options.md#locale) [configuration option](@/guides/getting-started/setting-options.md) as a [top-level grid option](@/guides/getting-started/setting-options.md#setting-grid-options):
+
+```js
+const hot = new Handsontable(container, {
+  // set the entire grid's locale to Polish
+  locale: 'pl-PL',
+});
+```
+
+You can set the [`locale`](@/api/options.md#locale) option to any valid and canonicalized Unicode BCP 47 locale tag.
+
+### Setting a column's locale
+
+To configure the locale of an individual column, set the [`locale`](@/api/options.md#locale) [configuration option](@/guides/getting-started/setting-options.md) as a [mid-level column option](@/guides/getting-started/setting-options.md#setting-column-options):
+
+```js
+const hot = new Handsontable(container, {
+  columns: [
+    {
+      // set the first column's locale to Polish
+      locale: 'pl-PL',
+    },
+    {
+      // set the second column's locale to German
+      locale: 'de-DE',
+    },
+    {
+      // set the third column's locale to Japanese
+      locale: 'ja-JP',
+    },
+  ],
+});
+```
+
+You can set the [`locale`](@/api/options.md#locale) option to any valid and canonicalized Unicode BCP 47 locale tag.
 
 ## Static Handsontable methods and properties
 

--- a/handsontable/src/dataMap/metaManager/metaSchema.js
+++ b/handsontable/src/dataMap/metaManager/metaSchema.js
@@ -3223,6 +3223,7 @@ export default () => {
      *
      * Read more:
      * - [Internationalization (i18n) &#8594;](@/guides/internationalization/internationalization-i18n.md)
+     * - [`locale`](#locale)
      *
      * @memberof Options#
      * @type {string}
@@ -3238,8 +3239,14 @@ export default () => {
     language: 'en-US',
 
     /**
-     * Locale used for actions performed on data (for example, filtering, searching, comparing locale-based data)
-     * which should be structurally valid and canonicalized Unicode BCP 47 locale identifier.
+     * The `locale` option configures Handsontable's locale.
+     *
+     * You can set the `locale` option to any valid and canonicalized Unicode BCP 47 locale tag,
+     * both for the entire grid, and for individual columns.
+     *
+     * Read more:
+     * - [Internationalization (i18n) &#8594;](@/guides/internationalization/internationalization-i18n.md)
+     * - [`language`](#language)
      *
      * @memberof Options#
      * @type {string}
@@ -3248,8 +3255,20 @@ export default () => {
      *
      * @example
      * ```js
-     * // set Polish locale
+     * // set the entire grid's locale to Polish
      * locale: 'pl-PL',
+     *
+     * // set individual columns' locales
+     * columns: [
+     *   {
+     *     // set the first column's locale to Polish
+     *     locale: 'pl-PL',
+     *   },
+     *   {
+     *     // set the second column's locale to German
+     *     locale: 'de-DE',
+     *   },
+     * ],
      * ```
      */
     locale: 'en-US',


### PR DESCRIPTION
This PR makes docs changes related to #6095:
- Adds docs related to the new `locale` option
- Replaces older, incorrect mentions of the "locale" term, to avoid confusion with the new setting
- Makes minor fixes, edits the changelog entries