### PR TITLE
Correct the path to Jasmine for the mobile test suite.

### DIFF
--- a/handsontable/.config/test-mobile.js
+++ b/handsontable/.config/test-mobile.js
@@ -7,6 +7,7 @@ const path = require('path');
 const configFactory = require('./test-e2e');
 const JasmineHtml = require('./plugin/jasmine-html');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const fsExtra = require('fs-extra');
 
 module.exports.create = function create(envArgs) {
   const config = configFactory.create(envArgs);
@@ -21,7 +22,9 @@ module.exports.create = function create(envArgs) {
     c.plugins.push(
       new JasmineHtml({
         filename: path.resolve(__dirname, '../test/MobileRunner.html'),
-        baseJasminePath: '../',
+        baseJasminePath: `${
+          fsExtra.pathExistsSync('./node_modules/jasmine-core') ? '../' : '../../'
+        }`,
         externalCssFiles: [
           'lib/normalize.css',
           '../dist/handsontable.css',


### PR DESCRIPTION
### Context
After the changes in #8851, the path to Jasmine in the test suites was changed. The E2E and E2E:production tests were fixed in #8851, but the mobile suite must have been mistakenly omitted.

This PR applies the analogous change to the `MobileRunner.html` generator.

[skip changelog]

### How has this been tested?
Checked if the mobile test suite recognizes the Jasmine paths correctly.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. Call `npm run test:mobile.dump` from the `handsontable` directory
2. Serve the contents of the root directory
3. Open the `MobileRunner.html` file.

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
