### PR TITLE
Change the tests scope for the tslint and dtslint tools

### DIFF
--- a/handsontable/test/types/tsconfig.json
+++ b/handsontable/test/types/tsconfig.json
@@ -9,6 +9,7 @@
     "noEmit": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
     "baseUrl": "./",
     "paths": {
       "handsontable": [ "../../types" ],

--- a/handsontable/types/tsconfig.json
+++ b/handsontable/types/tsconfig.json
@@ -4,6 +4,7 @@
     "lib": ["es2015", "dom"],
     "strict": true,
     "noEmit": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
   }
 }


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adds to the test configuration files the `skipLibCheck` option. Thanks to that the `tslint` and `dtslint` tools do not check types of the external libraries/types (from `node_modules`). This change prevents accidental test failures caused by broken types from dev/prod dependencies.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
\-

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement]
