### PR TITLE
Mark "main" Handsontable package as external dependency

### DIFF
--- a/wrappers/angular/projects/hot-table/ng-package.json
+++ b/wrappers/angular/projects/hot-table/ng-package.json
@@ -5,6 +5,7 @@
   "lib": {
     "entryFile": "src/public_api.ts",
     "umdModuleIds": {
+      "handsontable": "Handsontable",
       "handsontable/base": "Handsontable"
     }
   }


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the Angular wrapper UMD distribution file by adding `"handsontable"` npm package to the `"umdModuleIds"` option. The option is responsible for aliasing the package with the namespace in the `global` environment (browser). The namespace in 11.0.0 is changed from `global.Handsontable.angular` to `global.handsontable.angular` [handsontable-angular.umd.js](https://cdn.jsdelivr.net/npm/@handsontable/angular@11.0.0/bundles/handsontable-angular.umd.js) which is a breaking change. This PR reverts that.

I've left two ids as removing the "base" (and leaving the main package name only) prints warning while building the wrapper
 ![2021-11-17 o 14 27 35](https://user-images.githubusercontent.com/571316/142211009-9c0f7133-9846-4265-874f-ba0b128b828b.png)

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I've built and manually check the code of the UMD file. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Affected project(s):
- [x] `@handsontable/angular`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
