### PR TITLE
Fix error found by linter

### DIFF
--- a/handsontable/test/scripts/run-puppeteer.js
+++ b/handsontable/test/scripts/run-puppeteer.js
@@ -16,8 +16,7 @@ let verboseReporting = false;
 if (!originalPath) {
   /* eslint-disable no-console */
   console.log('The `path` argument is missing.');
-
-  return;
+  process.exit(1);
 }
 
 if (flags) {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the code error found by the ESLint in the `run-puppeteer.js` script. The error appears in [the CI](https://github.com/handsontable/handsontable/runs/4239336395?check_suite_focus=true#step:5:36) after regenerating the `package-lock.json` file (after deps updates).

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
