### PR TITLE
Added synchronization with source data when HF's `setCellContents` is executed

### DIFF
--- a/handsontable/src/plugins/formulas/__tests__/formulas.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/formulas.spec.js
@@ -2720,4 +2720,19 @@ describe('Formulas general', () => {
       [9, 8, 7, 6, '#NAME?'],
     ]);
   });
+
+  it('should re-render upon changes to the engine from the outside', () => {
+    const hot = handsontable({
+      formulas: {
+        engine: HyperFormula
+      },
+      data: [['x', 'x', 'x']]
+    });
+
+    const engine = hot.getPlugin('formulas').engine;
+
+    engine.setCellContents({ sheet: 0, row: 0, col: 0 }, 10);
+
+    expect(document.querySelector('.ht_master td:first-child').textContent).toEqual('10');
+  });
 });


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
After investigation I've determined that every change on HyperFormula's engine isn't handled by updating Handsontable's source data. It seems that it haven't been addressed by release introducing integration of HOT with HF.

This PR just fix problem described within #8391 issue.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Manual tests of setting HyperFormula's `setCellContents` also when there is more than one instance of Handsontable using the same engine.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #8391 

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] My change requires a change to the documentation.
