### PR TITLE
Docs: Moving the React "Using the HotColumn component" examples from CodeSandbox to the HoT docs

### DIFF
--- a/docs/11.0/guides/integrate-with-react/react-hot-column.md
+++ b/docs/11.0/guides/integrate-with-react/react-hot-column.md
@@ -87,12 +87,12 @@ const RendererComponent = (props) => {
   // - `TD` (the HTML cell element)
   // - `cellProperties` (the `cellProperties` object for the edited cell)
   return (
-    <>
+    <React.Fragment>
       <i style={{ color: "#a9a9a9" }}>
         Row: {props.row}, column: {props.col},
       </i>{" "}
       value: {props.value}
-    </>
+    </React.Fragment>
   );
 }
 

--- a/docs/11.0/guides/integrate-with-react/react-hot-column.md
+++ b/docs/11.0/guides/integrate-with-react/react-hot-column.md
@@ -17,7 +17,7 @@ You can configure the column-related settings using the `HotColumn` component's 
 
 To declare column-specific settings, pass the settings as `HotColumn` properties, either separately or wrapped as a `settings` property, exactly as you would with `HotTable`.
 
-::: example #example1 :react --html 1 --js 2
+::: example #example1 :react --html 1 --js 2 --tab preview
 ```html
 <!-- a root div in which the component is being rendered -->
 <div id="example1"></div>
@@ -66,7 +66,7 @@ Handsontable's `autoRowSize` and `autoColumnSize` options require calculating th
 Be sure to turn those options off in your Handsontable config, as keeping them enabled may cause unexpected results. Please note that `autoColumnSize` is enabled by default.
 :::
 
-::: example #example2 :react --html 1 --js 2
+::: example #example2 :react --html 1 --js 2 --tab preview
 ```html
 <!-- a root div in which the component is being rendered -->
 <div id="example2"></div>
@@ -75,11 +75,10 @@ Be sure to turn those options off in your Handsontable config, as keeping them e
 ```jsx
 import ReactDOM from "react-dom";
 import Handsontable from "handsontable";
-// import { RendererComponent } from "./rendererComponent";
 import { HotTable, HotColumn } from "@handsontable/react";
 import "handsontable/dist/handsontable.min.css";
 
-// a separate file called `rendererComponent.jsx`
+// your renderer component
 const RendererComponent = (props) => {
   // the available renderer-related props are:
   // - `row` (row index)

--- a/docs/11.0/guides/integrate-with-react/react-hot-column.md
+++ b/docs/11.0/guides/integrate-with-react/react-hot-column.md
@@ -17,12 +17,7 @@ You can configure the column-related settings using the `HotColumn` component's 
 
 To declare column-specific settings, pass the settings as `HotColumn` properties, either separately or wrapped as a `settings` property, exactly as you would with `HotTable`.
 
-::: example #example1 :react --html 1 --js 2 --tab preview
-```html
-<!-- a root div in which the component is being rendered -->
-<div id="example1"></div>
-```
-
+::: example #example1 :react --js 1 --tab preview
 ```jsx
 import ReactDOM from "react-dom";
 import Handsontable from "handsontable";
@@ -61,12 +56,7 @@ Handsontable's `autoRowSize` and `autoColumnSize` options require calculating th
 Be sure to turn those options off in your Handsontable config, as keeping them enabled may cause unexpected results. Please note that `autoColumnSize` is enabled by default.
 :::
 
-::: example #example2 :react --html 1 --js 2 --tab preview
-```html
-<!-- a root div in which the component is being rendered -->
-<div id="example2"></div>
-```
-
+::: example #example2 :react --js 1 --tab preview
 ```jsx
 import ReactDOM from "react-dom";
 import Handsontable from "handsontable";

--- a/docs/11.0/guides/integrate-with-react/react-hot-column.md
+++ b/docs/11.0/guides/integrate-with-react/react-hot-column.md
@@ -66,13 +66,56 @@ Handsontable's `autoRowSize` and `autoColumnSize` options require calculating th
 Be sure to turn those options off in your Handsontable config, as keeping them enabled may cause unexpected results. Please note that `autoColumnSize` is enabled by default.
 :::
 
-<iframe src="https://codesandbox.io/embed/declaring-a-custom-renderer-as-a-component-4yv9m?fontsize=14&theme=dark" title="Declaring a custom renderer as a component" allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb" 
-  style="width: 100%;
-  height: 390px;
-  border: 0;
-  borderRadius: 4;
-  overflow: hidden;"
-  sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
+::: example #example2 :react --html 1 --js 2
+```html
+<!-- a root div in which the component is being rendered -->
+<div id="example2"></div>
+```
+
+```jsx
+import ReactDOM from "react-dom";
+import Handsontable from "handsontable";
+// import { RendererComponent } from "./rendererComponent";
+import { HotTable, HotColumn } from "@handsontable/react";
+import "handsontable/dist/handsontable.min.css";
+
+// a separate file called `rendererComponent.jsx`
+const RendererComponent = (props) => {
+  // the available renderer-related props are:
+  // - `row` (row index)
+  // - `col` (column index)
+  // - `prop` (column property name)
+  // - `TD` (the HTML cell element)
+  // - `cellProperties` (the `cellProperties` object for the edited cell)
+  return (
+    <>
+      <i style={{ color: "#a9a9a9" }}>
+        Row: {props.row}, column: {props.col},
+      </i>{" "}
+      value: {props.value}
+    </>
+  );
+}
+
+const hotData = Handsontable.helper.createSpreadsheetData(10, 5);
+
+// to mark the `RendererComponent` component as a Handsontable renderer,
+// add a `hot-renderer` attribute to it
+const App = () => {
+  return (
+    <div>
+    <HotTable data={hotData} licenseKey="non-commercial-and-evaluation">
+      <HotColumn width={250}>
+        <RendererComponent hot-renderer />
+      </HotColumn>
+    </HotTable>
+    </div>
+  );
+};
+
+ReactDOM.render(<App />, document.getElementById('example2'));
+```
+:::
  
 ## Object data source
 

--- a/docs/11.0/guides/integrate-with-react/react-hot-column.md
+++ b/docs/11.0/guides/integrate-with-react/react-hot-column.md
@@ -37,15 +37,10 @@ const secondColumnSettings = {
 
 const App = () => {
   return (
-    <div>
     <HotTable data={hotData} licenseKey="non-commercial-and-evaluation">
       <HotColumn title="First column header" />
       <HotColumn settings={secondColumnSettings} />
-      <HotColumn title="Third column header" />
-      <HotColumn title="Fourth column header" />
-      <HotColumn title="Fifth column header" />
     </HotTable>
-    </div>
   );
 };
 

--- a/docs/11.0/guides/integrate-with-react/react-hot-column.md
+++ b/docs/11.0/guides/integrate-with-react/react-hot-column.md
@@ -17,13 +17,41 @@ You can configure the column-related settings using the `HotColumn` component's 
 
 To declare column-specific settings, pass the settings as `HotColumn` properties, either separately or wrapped as a `settings` property, exactly as you would with `HotTable`.
 
-<iframe src="https://codesandbox.io/embed/declaring-column-settings-seg0l?fontsize=14&theme=dark" title="Declaring column settings" allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb" 
-  style="width: 100%;
-  height: 390px;
-  border: 0;
-  borderRadius: 4;
-  overflow: hidden;" 
-  sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
+::: example #example1 :react --html 1 --js 2
+```html
+<!-- a root div in which the component is being rendered -->
+<div id="example1"></div>
+```
+
+```jsx
+import ReactDOM from "react-dom";
+import Handsontable from "handsontable";
+import { HotTable, HotColumn } from "@handsontable/react";
+import "handsontable/dist/handsontable.min.css";
+
+const hotData = Handsontable.helper.createSpreadsheetData(10, 5);
+const secondColumnSettings = {
+  title: "Second column header",
+  readOnly: true
+};
+
+const App = () => {
+  return (
+    <div>
+    <HotTable data={hotData} licenseKey="non-commercial-and-evaluation">
+      <HotColumn title="First column header" />
+      <HotColumn settings={secondColumnSettings} />
+      <HotColumn title="Third column header" />
+      <HotColumn title="Fourth column header" />
+      <HotColumn title="Fifth column header" />
+    </HotTable>
+    </div>
+  );
+};
+
+ReactDOM.render(<App />, document.getElementById('example1'));
+```
+:::
 
 ## Declaring a custom renderer as a component
 

--- a/docs/next/guides/integrate-with-react/react-hot-column.md
+++ b/docs/next/guides/integrate-with-react/react-hot-column.md
@@ -17,7 +17,7 @@ You can configure the column-related settings using the `HotColumn` component's 
 
 To declare column-specific settings, pass the settings as `HotColumn` properties, either separately or wrapped as a `settings` property, exactly as you would with `HotTable`.
 
-::: example #example1 :react --html 1 --js 2
+::: example #example1 :react --html 1 --js 2 --tab preview
 ```html
 <!-- a root div in which the component is being rendered -->
 <div id="example1"></div>
@@ -66,7 +66,7 @@ Handsontable's `autoRowSize` and `autoColumnSize` options require calculating th
 Be sure to turn those options off in your Handsontable config, as keeping them enabled may cause unexpected results. Please note that `autoColumnSize` is enabled by default.
 :::
 
-::: example #example2 :react --html 1 --js 2
+::: example #example2 :react --html 1 --js 2 --tab preview
 ```html
 <!-- a root div in which the component is being rendered -->
 <div id="example2"></div>
@@ -75,11 +75,10 @@ Be sure to turn those options off in your Handsontable config, as keeping them e
 ```jsx
 import ReactDOM from "react-dom";
 import Handsontable from "handsontable";
-// import { RendererComponent } from "./rendererComponent";
 import { HotTable, HotColumn } from "@handsontable/react";
 import "handsontable/dist/handsontable.min.css";
 
-// a separate file called `rendererComponent.jsx`
+// your renderer component
 const RendererComponent = (props) => {
   // the available renderer-related props are:
   // - `row` (row index)

--- a/docs/next/guides/integrate-with-react/react-hot-column.md
+++ b/docs/next/guides/integrate-with-react/react-hot-column.md
@@ -66,13 +66,56 @@ Handsontable's `autoRowSize` and `autoColumnSize` options require calculating th
 Be sure to turn those options off in your Handsontable config, as keeping them enabled may cause unexpected results. Please note that `autoColumnSize` is enabled by default.
 :::
 
-<iframe src="https://codesandbox.io/embed/declaring-a-custom-renderer-as-a-component-4yv9m?fontsize=14&theme=dark" title="Declaring a custom renderer as a component" allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb" 
-  style="width: 100%;
-  height: 390px;
-  border: 0;
-  borderRadius: 4;
-  overflow: hidden;"
-  sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
+::: example #example2 :react --html 1 --js 2
+```html
+<!-- a root div in which the component is being rendered -->
+<div id="example2"></div>
+```
+
+```jsx
+import ReactDOM from "react-dom";
+import Handsontable from "handsontable";
+// import { RendererComponent } from "./rendererComponent";
+import { HotTable, HotColumn } from "@handsontable/react";
+import "handsontable/dist/handsontable.min.css";
+
+// a separate file called `rendererComponent.jsx`
+const RendererComponent = (props) => {
+  // the available renderer-related props are:
+  // - `row` (row index)
+  // - `col` (column index)
+  // - `prop` (column property name)
+  // - `TD` (the HTML cell element)
+  // - `cellProperties` (the `cellProperties` object for the edited cell)
+  return (
+    <>
+      <i style={{ color: "#a9a9a9" }}>
+        Row: {props.row}, column: {props.col},
+      </i>{" "}
+      value: {props.value}
+    </>
+  );
+}
+
+const hotData = Handsontable.helper.createSpreadsheetData(10, 5);
+
+// to mark the `RendererComponent` component as a Handsontable renderer,
+// add a `hot-renderer` attribute to it
+const App = () => {
+  return (
+    <div>
+    <HotTable data={hotData} licenseKey="non-commercial-and-evaluation">
+      <HotColumn width={250}>
+        <RendererComponent hot-renderer />
+      </HotColumn>
+    </HotTable>
+    </div>
+  );
+};
+
+ReactDOM.render(<App />, document.getElementById('example2'));
+```
+:::
  
 ## Object data source
 

--- a/docs/next/guides/integrate-with-react/react-hot-column.md
+++ b/docs/next/guides/integrate-with-react/react-hot-column.md
@@ -17,13 +17,41 @@ You can configure the column-related settings using the `HotColumn` component's 
 
 To declare column-specific settings, pass the settings as `HotColumn` properties, either separately or wrapped as a `settings` property, exactly as you would with `HotTable`.
 
-<iframe src="https://codesandbox.io/embed/declaring-column-settings-seg0l?fontsize=14&theme=dark" title="Declaring column settings" allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb" 
-  style="width: 100%;
-  height: 390px;
-  border: 0;
-  borderRadius: 4;
-  overflow: hidden;" 
-  sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
+::: example #example1 :react --html 1 --js 2
+```html
+<!-- a root div in which the component is being rendered -->
+<div id="example1"></div>
+```
+
+```jsx
+import ReactDOM from "react-dom";
+import Handsontable from "handsontable";
+import { HotTable, HotColumn } from "@handsontable/react";
+import "handsontable/dist/handsontable.min.css";
+
+const hotData = Handsontable.helper.createSpreadsheetData(10, 5);
+const secondColumnSettings = {
+  title: "Second column header",
+  readOnly: true
+};
+
+const App = () => {
+  return (
+    <div>
+    <HotTable data={hotData} licenseKey="non-commercial-and-evaluation">
+      <HotColumn title="First column header" />
+      <HotColumn settings={secondColumnSettings} />
+      <HotColumn title="Third column header" />
+      <HotColumn title="Fourth column header" />
+      <HotColumn title="Fifth column header" />
+    </HotTable>
+    </div>
+  );
+};
+
+ReactDOM.render(<App />, document.getElementById('example1'));
+```
+:::
 
 ## Declaring a custom renderer as a component
 

--- a/docs/next/guides/integrate-with-react/react-hot-column.md
+++ b/docs/next/guides/integrate-with-react/react-hot-column.md
@@ -17,12 +17,7 @@ You can configure the column-related settings using the `HotColumn` component's 
 
 To declare column-specific settings, pass the settings as `HotColumn` properties, either separately or wrapped as a `settings` property, exactly as you would with `HotTable`.
 
-::: example #example1 :react --html 1 --js 2 --tab preview
-```html
-<!-- a root div in which the component is being rendered -->
-<div id="example1"></div>
-```
-
+::: example #example1 :react --js 1 --tab preview
 ```jsx
 import ReactDOM from "react-dom";
 import Handsontable from "handsontable";
@@ -37,15 +32,10 @@ const secondColumnSettings = {
 
 const App = () => {
   return (
-    <div>
     <HotTable data={hotData} licenseKey="non-commercial-and-evaluation">
       <HotColumn title="First column header" />
       <HotColumn settings={secondColumnSettings} />
-      <HotColumn title="Third column header" />
-      <HotColumn title="Fourth column header" />
-      <HotColumn title="Fifth column header" />
     </HotTable>
-    </div>
   );
 };
 
@@ -66,12 +56,7 @@ Handsontable's `autoRowSize` and `autoColumnSize` options require calculating th
 Be sure to turn those options off in your Handsontable config, as keeping them enabled may cause unexpected results. Please note that `autoColumnSize` is enabled by default.
 :::
 
-::: example #example2 :react --html 1 --js 2 --tab preview
-```html
-<!-- a root div in which the component is being rendered -->
-<div id="example2"></div>
-```
-
+::: example #example2 :react --js 1 --tab preview
 ```jsx
 import ReactDOM from "react-dom";
 import Handsontable from "handsontable";
@@ -87,12 +72,12 @@ const RendererComponent = (props) => {
   // - `TD` (the HTML cell element)
   // - `cellProperties` (the `cellProperties` object for the edited cell)
   return (
-    <>
+    <React.Fragment>
       <i style={{ color: "#a9a9a9" }}>
         Row: {props.row}, column: {props.col},
       </i>{" "}
       value: {props.value}
-    </>
+    </React.Fragment>
   );
 }
 


### PR DESCRIPTION
This PR:
- Moves the React examples from the [Using the HotColumn component](https://handsontable.com/docs/react-hot-column/) page from CodeSandbox to the Handsontable docs

### Declaring column settings
- Old CodeSandbox example: https://codesandbox.io/embed/declaring-column-settings-seg0l?fontsize=14&theme=dark
- New docs example: http://localhost:8080/docs/next/react-hot-column/#declaring-column-settings
- Seems to be working fine

### Declaring a custom renderer as a component
- Old CodeSandbox example: https://codesandbox.io/embed/declaring-a-custom-renderer-as-a-component-4yv9m?fontsize=14&theme=dark
- New docs example: http://localhost:8080/docs/next/react-hot-column/#declaring-a-custom-renderer-as-a-component
- Seems to be working fine, but:
  - I had to "merge" the separate `rendererComponent.jsx` file into the main code snippet

### Object data source
- Old CodeSandbox example: https://codesandbox.io/embed/object-data-source-y8xwr?fontsize=14&theme=dark
- New docs example: http://localhost:8080/docs/next/react-hot-column/#object-data-source

### Declaring a custom editor as a component
- Old CodeSandbox example: https://codesandbox.io/embed/declaring-a-custom-editor-as-a-component-qhbnv?fontsize=14&theme=dark
- New docs example: http://localhost:8080/docs/next/react-hot-column/#declaring-a-custom-editor-as-a-component

### Using the renderer/editor components with React's Context
- Old CodeSandbox example: https://codesandbox.io/embed/using-the-renderer-component-with-reacts-context-forked-27pl0?fontsize=14&theme=dark
- New docs example: http://localhost:8080/docs/next/react-hot-column/#using-the-renderer-editor-components-with-react-s-context

### An advanced example
- Old CodeSandbox example: https://codesandbox.io/embed/advanced-handsontablereact-implementation-using-hotcolumn-forked-jgrk2?fontsize=14&theme=dark
- New docs example: http://localhost:8080/docs/next/react-hot-column/#an-advanced-example

[skip changelog]