### PR TITLE
Fix Typescript return type in React wrapper

### DIFF
--- a/.changelogs/9000.json
+++ b/.changelogs/9000.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fixed return type in React wrapper",
+  "type": "fixed",
+  "issue": 9000,
+  "breaking": false,
+  "framework": "react"
+}

--- a/wrappers/react/src/types.tsx
+++ b/wrappers/react/src/types.tsx
@@ -47,7 +47,7 @@ export interface HotColumnProps extends Handsontable.ColumnSettings {
   _emitColumnSettings?: (columnSettings: Handsontable.ColumnSettings, columnIndex: number) => void;
   _columnIndex?: number,
   _getChildElementByType?: (children: React.ReactNode, type: string) => React.ReactElement;
-  _getRendererWrapper?: (rendererNode: React.ReactElement) => Handsontable.renderers.Base;
+  _getRendererWrapper?: (rendererNode: React.ReactElement) => typeof Handsontable.renderers.BaseRenderer;
   _getEditorClass?: (editorElement: React.ReactElement, editorColumnScope: EditorScopeIdentifier) => typeof Handsontable.editors.BaseEditor;
   _getEditorCache?: () => HotEditorCache;
   _getOwnerDocument?: () => Document;


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->

The React wrapper was throwing this TS error:

```
src/types.tsx:50:86 - error TS2694: Namespace 'Handsontable.renderers' has no exported member 'Base'.

50   _getRendererWrapper?: (rendererNode: React.ReactElement) => Handsontable.renderers.Base;
                                                                                        ~~~~
```

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

Ran `npx tsc` to compile the React wrapper

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [x] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
