### PR TITLE
Fix typo in the `valueAccordingPercent` helper

### DIFF
--- a/.changelogs/9006.json
+++ b/.changelogs/9006.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fixed a typo in the `valueAccordingPercent` helper.",
+  "type": "fixed",
+  "issue": 9006,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/helpers/__tests__/number.unit.js
+++ b/handsontable/src/helpers/__tests__/number.unit.js
@@ -3,6 +3,7 @@ import {
   rangeEachReverse,
   isNumeric,
   isNumericLike,
+  valueAccordingPercent,
 } from 'handsontable/helpers/number';
 
 describe('Number helper', () => {
@@ -277,6 +278,50 @@ describe('Number helper', () => {
       expect(isNumericLike('   .2e+26   ')).toBeTruthy();
       expect(isNumericLike('   0,2e+26   ')).toBeTruthy();
       expect(isNumericLike('   ,2e+26   ')).toBeTruthy();
+    });
+  });
+
+  //
+  // Handsontable.helper.valueAccordingPercent
+  //
+  describe('valueAccordingPercent', () => {
+    it('should correctly calculate value when the percent (the second argument) is passed as number', () => {
+      expect(valueAccordingPercent(100, 0)).toBe(0);
+      expect(valueAccordingPercent(200, 0)).toBe(0);
+      expect(valueAccordingPercent(1000, 1)).toBe(10);
+      expect(valueAccordingPercent(1000, 2)).toBe(20);
+      expect(valueAccordingPercent(1000, 20)).toBe(200);
+      expect(valueAccordingPercent(1000, 80)).toBe(800);
+      expect(valueAccordingPercent(1000, 99)).toBe(990);
+      expect(valueAccordingPercent(1000, 100)).toBe(1000);
+      expect(valueAccordingPercent(1000, 101)).toBe(1010);
+      expect(valueAccordingPercent(1000, 199)).toBe(1990);
+    });
+
+    it('should correctly calculate value when the percent (the second argument) is passed as string', () => {
+      expect(valueAccordingPercent(100, '0')).toBe(0);
+      expect(valueAccordingPercent(200, '0')).toBe(0);
+      expect(valueAccordingPercent(1000, '1')).toBe(10);
+      expect(valueAccordingPercent(1000, '2')).toBe(20);
+      expect(valueAccordingPercent(1000, '20')).toBe(200);
+      expect(valueAccordingPercent(1000, '80')).toBe(800);
+      expect(valueAccordingPercent(1000, '99')).toBe(990);
+      expect(valueAccordingPercent(1000, '100')).toBe(1000);
+      expect(valueAccordingPercent(1000, '101')).toBe(1010);
+      expect(valueAccordingPercent(1000, '199')).toBe(1990);
+    });
+
+    it('should correctly calculate value when the percent (the second argument) is passed as string with percent sign at the end', () => {
+      expect(valueAccordingPercent(100, '0%')).toBe(0);
+      expect(valueAccordingPercent(200, '0%')).toBe(0);
+      expect(valueAccordingPercent(1000, '1%')).toBe(10);
+      expect(valueAccordingPercent(1000, '2%')).toBe(20);
+      expect(valueAccordingPercent(1000, '20%')).toBe(200);
+      expect(valueAccordingPercent(1000, '80%')).toBe(800);
+      expect(valueAccordingPercent(1000, '99%')).toBe(990);
+      expect(valueAccordingPercent(1000, '100%')).toBe(1000);
+      expect(valueAccordingPercent(1000, '101%')).toBe(1010);
+      expect(valueAccordingPercent(1000, '199%')).toBe(1990);
     });
   });
 });

--- a/handsontable/src/helpers/number.js
+++ b/handsontable/src/helpers/number.js
@@ -111,8 +111,8 @@ export function rangeEachReverse(rangeFrom, rangeTo, iteratee) {
  * @returns {number}
  */
 export function valueAccordingPercent(value, percent) {
-  percent = parseInt(percent.tostring().replace('%', ''), 10);
-  percent = parseInt(value * percent / 100, 10);
+  percent = parseInt(percent.toString().replace('%', ''), 10);
+  percent = isNaN(percent) ? 0 : percent;
 
-  return percent;
+  return parseInt(value * percent / 100, 10);
 }


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes a typo that was introduced as regression within Handsontable 10 release.

The first argument of the `valueAccordingPercent` helper function is badly handled. The `tostring()` method is called on it, it should be `toString()`; 

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I cover the changes with unit tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. #9006

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement]
