### PR TITLE
Fix mobile tests that fail on mobile devices

### DIFF
--- a/.changelogs/8749.json
+++ b/.changelogs/8749.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fixed some tests that fail on mobile devices.",
+  "type": "fixed",
+  "issue": 8749,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/touchScroll/touchScroll.js
+++ b/handsontable/src/plugins/touchScroll/touchScroll.js
@@ -134,7 +134,7 @@ export class TouchScroll extends BasePlugin {
       this.scrollbars.push(bottomLeftCornerOverlay);
     }
 
-    this.clones.length = 0;
+    this.clones = [];
 
     if (topOverlay.needFullRender) {
       this.clones.push(topOverlay.clone.wtTable.holder.parentNode);
@@ -179,7 +179,7 @@ export class TouchScroll extends BasePlugin {
       addClass(clone, 'show-tween');
     });
 
-    setTimeout(() => {
+    this.hot._registerTimeout(() => {
       arrayEach(this.clones, (clone) => {
         removeClass(clone, 'show-tween');
       });

--- a/handsontable/test/e2e/mobile/events.spec.js
+++ b/handsontable/test/e2e/mobile/events.spec.js
@@ -78,7 +78,15 @@ describe('Events', () => {
 
       const event = triggerTouchEvent('touchend', cell);
 
-      expect(event.defaultPrevented).toBeFalse();
+      // In the WebKit-based engines the second touch event is not prevent defaulted.
+      // See ./handsontable/src/3rdparty/walkontable/src/event.js#L327
+      if (Handsontable.helper.isIOS() &&
+        (Handsontable.helper.isChromeWebKit() || Handsontable.helper.isFirefoxWebKit())) {
+        expect(event.defaultPrevented).toBeTrue();
+
+      } else {
+        expect(event.defaultPrevented).toBeFalse();
+      }
     }
   });
 

--- a/handsontable/test/e2e/mobile/selection.spec.js
+++ b/handsontable/test/e2e/mobile/selection.spec.js
@@ -53,7 +53,7 @@ describe('Selection', () => {
 
     expect(topLeftSelectionHandle.style.display).toBe('block');
     expect(bottomRightSelectionHandle.style.display).toBe('block');
-    expect(hot.getSelected()).toEqual([[1, 1, 1, 2]]);
+    expect(hot.getSelected()).toEqual([[1, 1, 1, 3]]);
   });
 
   it('should not call the `select` method on the "focusable" textarea when selecting a cell', async() => {

--- a/handsontable/test/e2e/mobile/textEditor.spec.js
+++ b/handsontable/test/e2e/mobile/textEditor.spec.js
@@ -12,29 +12,30 @@ describe('Text Editor', () => {
     }
   });
 
-  it('should save text value after click "Done" on iOS (focusout event)', async() => {
-    const hot = handsontable({
-      columns: [
-        {
-          type: 'text',
-        }
-      ]
+  if (Handsontable.helper.isIOS()) {
+    it('should save text value after click "Done" on iOS (focusout event)', async() => {
+      const hot = handsontable({
+        columns: [
+          {
+            type: 'text',
+          }
+        ]
+      });
+
+      const cell = hot.getCell(0, 0);
+
+      selectCell(0, 0);
+
+      keyDown('enter');
+
+      const editor = getActiveEditor();
+
+      editor.setValue('test');
+
+      // simulate "Done" click on iOS keyboard
+      editor.eventManager.fireEvent(editor.TEXTAREA, 'focusout');
+
+      expect(cell.textContent).toBe('test');
     });
-
-    const cell = hot.getCell(0, 0);
-
-    selectCell(0, 0);
-
-    keyDown('enter');
-
-    const editor = getActiveEditor();
-
-    editor.setValue('test');
-
-    // simulate "Done" click on iOS keyboard
-    editor.eventManager.fireEvent(editor.TEXTAREA, 'focusout');
-
-    expect(cell.textContent).toBe('test');
-  });
-
+  }
 });

--- a/handsontable/test/helpers/common.js
+++ b/handsontable/test/helpers/common.js
@@ -730,6 +730,8 @@ function sendTouchEvent(x, y, element, eventType) {
     target: element,
     clientX: x,
     clientY: y,
+    screenX: x,
+    screenY: y,
     radiusX: 2.5,
     radiusY: 2.5,
   });


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the mobile tests/source code that fails on mobile devices.

According to https://github.com/handsontable/handsontable/issues/8749, the PR fixes most of the tests errors. The exception is iPad that since releasing the iPad OS on 24th September 2019 the device is no longer detected as a mobile device (at least by HoT). Thus, it should not be used to run `./handsontable/test/MobileRunner.html` file, otherwise, it will always fail some of the tests.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I've tested the changes on the iPhone 12 mini (Safari, Chrome, FF), and Android 11 (Chrome). It seems that everything works.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. #8749

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
