### PR TITLE
Update TS definition for `setDataAtCell` method

### DIFF
--- a/.changelogs/8601.json
+++ b/.changelogs/8601.json
@@ -1,0 +1,7 @@
+{
+  "title": "Updated the TypeScript definition for `setDataAtCell` method.",
+  "type": "changed",
+  "issue": 8601,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/types/core.d.ts
+++ b/handsontable/types/core.d.ts
@@ -133,8 +133,8 @@ export default class Core {
   setCellMeta<K extends keyof CellMeta>(row: number, col: number, key: K, val: CellMeta[K]): void;
   setCellMetaObject(row: number, col: number, prop: CellMeta): void;
   setData(data: CellValue[][] | RowObject[], source?: string): void;
-  setDataAtCell(changes: Array<[number, string | number, CellValue]>, source?: string): void;
-  setDataAtCell(row: number, col: string | number, value: CellValue, source?: string): void;
+  setDataAtCell(changes: Array<[number, number, CellValue]>, source?: string): void;
+  setDataAtCell(row: number, col: number, value: CellValue, source?: string): void;
   setDataAtRowProp(changes: Array<[number, string | number, CellValue]>, source?: string): void;
   setDataAtRowProp(row: number, prop: string, value: CellValue, source?: string): void;
   setSourceDataAtCell(changes: Array<[number, string | number, CellValue]>): void;


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR updates the TypeScript types for the `setDataAtCell` method. The second argument (column index) has to be passed as `number`. Otherwise, the exception is thrown.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I checked the compatibility with what happens in the runtime and what TS allows to pass to the method.  

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. #8601

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
