### PR TITLE
Fix missing Handsontable files in docs "next" version

### DIFF
--- a/.github/workflows/docs-staging.yml
+++ b/.github/workflows/docs-staging.yml
@@ -35,6 +35,7 @@ jobs:
           npm run docs:api
 
       - name: Docker build
+        working-directory: .
         run: |
           npm run docs:docker:build
 

--- a/.github/workflows/docs-staging.yml
+++ b/.github/workflows/docs-staging.yml
@@ -35,7 +35,6 @@ jobs:
           npm run docs:api
 
       - name: Docker build
-        working-directory: .
         run: |
           npm run docs:docker:build
 

--- a/docs/.vuepress/handsontable-manager/dependencies.js
+++ b/docs/.vuepress/handsontable-manager/dependencies.js
@@ -67,8 +67,7 @@ const buildDependencyGetter = (version) => {
       'angular-platform-browser-dynamic': ['https://cdn.jsdelivr.net/npm/@angular/platform-browser-dynamic@8/bundles/platform-browser-dynamic.umd.min.js', [/* todo */]],
       'hot-angular': [`https://cdn.jsdelivr.net/npm/@handsontable/angular@${mappedVersion}/bundles/handsontable-angular.umd.min.js`, [/* todo */]],
       'hot-vue': [`https://cdn.jsdelivr.net/npm/@handsontable/vue@${mappedVersion}/dist/vue-handsontable.min.js`, [/* todo */]],
-      // TODO: Replace the vue3 build with production one (jsdelivry)
-      'hot-vue3': ['https://gist.githack.com/budnix/0d139fac25311b29570abbe225413bd5/raw/e2c0eab2cb27ed63c1821c8e01c652938e97cacc/vue-handsontable.js', [/* todo */]],
+      'hot-vue3': [`https://cdn.jsdelivr.net/npm/@handsontable/vue3@${mappedVersion}/dist/vue-handsontable.min.js`, [/* todo */]],
       vue: ['https://cdn.jsdelivr.net/npm/vue@2/dist/vue.min.js', [/* todo */]],
       vuex: ['https://cdn.jsdelivr.net/npm/vuex@3/dist/vuex.min.js', [/* todo */]],
       'vue-color': ['https://cdn.jsdelivr.net/npm/vue-color@2/dist/vue-color.min.js', [/* todo */]],

--- a/docs/package.json
+++ b/docs/package.json
@@ -20,7 +20,7 @@
     "docs:build:no-check-links": "node .vuepress/tools/build.mjs",
     "docs:build:no-split-versions": "vuepress build -d .vuepress/dist/docs ./",
     "docs:docker:build": "npm run docs:docker:build:staging",
-    "docs:docker:build:staging": "npm run docs:build:no-check-links && docker build -f docker/Dockerfile -t docs-md ./",
+    "docs:docker:build:staging": "npm run docs:scripts:link-assets && npm run docs:build:no-check-links && docker build -f docker/Dockerfile -t docs-md ./",
     "docs:docker:build:production": "cross-env BUILD_MODE=production npm run docs:build:no-check-links && docker build -f docker/Dockerfile -t docs-md:production ./",
     "docs:version": "cd .vuepress/tools/version && node rollup-a-version.js && npm run docs:scripts:generate-legacy-docs-versions",
     "docs:api": "node .vuepress/tools/jsdoc-convert/index.mjs",


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Fix the https://dev.handsontable.com/docs/next/ version of the docs. There was an issue where the `handsontable.{js,css}` files are not available in demos.

Additionally, the PR replaces the custom-crafted URL for Vue3 wrapper demos to jsDelivr one. 

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
\-

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Affected project(s):
- [x] `docs`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
