### PR TITLE
Docs: Changing the cookiebot buttons' colors in dark theme

### DIFF
--- a/docs/.vuepress/theme/styles/cookiebot.styl
+++ b/docs/.vuepress/theme/styles/cookiebot.styl
@@ -2,20 +2,11 @@
   related to issue #8987
 */
 
-.theme-dark #CybotCookiebotDialogFooter .CybotCookiebotDialogBodyButton {
+.theme-dark #CybotCookiebotDialogFooter .CybotCookiebotDialogBodyButton, .theme-dark #CybotCookiebotDialogNav .CybotCookiebotDialogNavItemLink {
   background-color: #fff;
   border-color: #fff;
 }
 
-.theme-dark #CybotCookiebotDialogNav .CybotCookiebotDialogNavItemLink {
-  background-color: #fff;
-  border-color: #fff;
-}
-
-.theme-dark #CybotCookiebotDialogDetailBodyContentCookieContainerTypes .CybotCookiebotDialogDetailBodyContentCookieProvider:not(.CybotCookiebotDialogDetailBodyContentCookieInfoCount) {
-  color: #fff;
-}
-
-.theme-dark #CybotCookiebotDialogDetailBulkConsentLink {
+.theme-dark #CybotCookiebotDialogDetailBodyContentCookieContainerTypes .CybotCookiebotDialogDetailBodyContentCookieProvider:not(.CybotCookiebotDialogDetailBodyContentCookieInfoCount), .theme-dark #CybotCookiebotDialogDetailBulkConsentLink {
   color: #fff;
 }

--- a/docs/.vuepress/theme/styles/cookiebot.styl
+++ b/docs/.vuepress/theme/styles/cookiebot.styl
@@ -1,0 +1,8 @@
+/*
+  related to issue #8987
+*/
+
+.theme-dark #CybotCookiebotDialogFooter .CybotCookiebotDialogBodyButton {
+  background-color: #fff;
+  border-color: #fff;
+}

--- a/docs/.vuepress/theme/styles/cookiebot.styl
+++ b/docs/.vuepress/theme/styles/cookiebot.styl
@@ -3,15 +3,19 @@
   (related to issue #8987)
 */
 
-/* footer and navigation background color */
-.theme-dark #CybotCookiebotDialogFooter .CybotCookiebotDialogBodyButton, .theme-dark #CybotCookiebotDialogNav .CybotCookiebotDialogNavItemLink {
-  background-color: #fff;
-  border-color: #fff;
-}
+.theme-dark {
+  /* footer and navigation background color */
+  #CybotCookiebotDialogFooter .CybotCookiebotDialogBodyButton, 
+  #CybotCookiebotDialogNav .CybotCookiebotDialogNavItemLink {
+    background-color: #fff;
+    border-color: #fff;
+  }
 
-/* cookie providers' links' color */
-.theme-dark #CybotCookiebotDialogDetailBodyContentCookieContainerTypes .CybotCookiebotDialogDetailBodyContentCookieProvider:not(.CybotCookiebotDialogDetailBodyContentCookieInfoCount), .theme-dark #CybotCookiebotDialogDetailBulkConsentLink {
-  color: #fff;
+  /* cookie providers' links' color */
+  #CybotCookiebotDialogDetailBodyContentCookieContainerTypes .CybotCookiebotDialogDetailBodyContentCookieProvider:not(.CybotCookiebotDialogDetailBodyContentCookieInfoCount), 
+  #CybotCookiebotDialogDetailBulkConsentLink {
+    color: #fff;
+  }
 }
 
 /* removing the fader */

--- a/docs/.vuepress/theme/styles/cookiebot.styl
+++ b/docs/.vuepress/theme/styles/cookiebot.styl
@@ -11,3 +11,11 @@
   background-color: #fff;
   border-color: #fff;
 }
+
+.theme-dark #CybotCookiebotDialogDetailBodyContentCookieContainerTypes .CybotCookiebotDialogDetailBodyContentCookieProvider {
+  color: #fff;
+}
+
+.theme-dark #CybotCookiebotDialogDetailBulkConsentLink .CybotExpandLink {
+  color: #fff;
+}

--- a/docs/.vuepress/theme/styles/cookiebot.styl
+++ b/docs/.vuepress/theme/styles/cookiebot.styl
@@ -1,16 +1,20 @@
 /*
-  related to issue #8987
+  a stylesheet to make sure that all cookiebot elements are visible in the dark theme
+  (related to issue #8987)
 */
 
+/* footer and navigation background color */
 .theme-dark #CybotCookiebotDialogFooter .CybotCookiebotDialogBodyButton, .theme-dark #CybotCookiebotDialogNav .CybotCookiebotDialogNavItemLink {
   background-color: #fff;
   border-color: #fff;
 }
 
+/* cookie providers' links' color */
 .theme-dark #CybotCookiebotDialogDetailBodyContentCookieContainerTypes .CybotCookiebotDialogDetailBodyContentCookieProvider:not(.CybotCookiebotDialogDetailBodyContentCookieInfoCount), .theme-dark #CybotCookiebotDialogDetailBulkConsentLink {
   color: #fff;
 }
 
+/* removing the fader */
 .CybotCookiebotFader {
   display: none!important
 }

--- a/docs/.vuepress/theme/styles/cookiebot.styl
+++ b/docs/.vuepress/theme/styles/cookiebot.styl
@@ -62,6 +62,11 @@
   #CybotCookiebotDialogDetailBulkConsentLink:hover {
     color: #fff;
   }
+
+  /* Cookiebot logo */
+  #CybotCookiebotDialogPoweredbyCybot svg {
+    fill: #f5f6f7;
+  }
 }
 
 /* removing the fader */

--- a/docs/.vuepress/theme/styles/cookiebot.styl
+++ b/docs/.vuepress/theme/styles/cookiebot.styl
@@ -10,3 +10,7 @@
 .theme-dark #CybotCookiebotDialogDetailBodyContentCookieContainerTypes .CybotCookiebotDialogDetailBodyContentCookieProvider:not(.CybotCookiebotDialogDetailBodyContentCookieInfoCount), .theme-dark #CybotCookiebotDialogDetailBulkConsentLink {
   color: #fff;
 }
+
+.CybotCookiebotFader {
+  display: none!important
+}

--- a/docs/.vuepress/theme/styles/cookiebot.styl
+++ b/docs/.vuepress/theme/styles/cookiebot.styl
@@ -4,6 +4,24 @@
 */
 
 .theme-dark {
+  /* main message "Show details" link */
+  #CybotCookiebotDialog.CybotEdge #CybotCookiebotDialogBodyEdgeMoreDetails a {
+    color: #4b92ff;
+  }
+
+  /* main message "Show details" link arrow */
+  #CybotCookiebotDialog.CybotEdge #CybotCookiebotDialogBodyEdgeMoreDetails a:after {
+    color: #fff;
+  }
+
+  /* main message "Allow all" link */
+  #CybotCookiebotDialogFooter #CybotCookiebotDialogBodyButtonAccept, 
+  #CybotCookiebotDialogFooter #CybotCookiebotDialogBodyLevelButtonAccept, 
+  #CybotCookiebotDialogFooter #CybotCookiebotDialogBodyLevelButtonLevelOptinAllowAll {
+    background-color: #2456f2;
+    border-color: #2456f2;
+  }
+
   /* footer and navigation background color */
   #CybotCookiebotDialogFooter .CybotCookiebotDialogBodyButton, 
   #CybotCookiebotDialogNav .CybotCookiebotDialogNavItemLink {
@@ -14,6 +32,34 @@
   /* cookie providers' links' color */
   #CybotCookiebotDialogDetailBodyContentCookieContainerTypes .CybotCookiebotDialogDetailBodyContentCookieProvider:not(.CybotCookiebotDialogDetailBodyContentCookieInfoCount), 
   #CybotCookiebotDialogDetailBulkConsentLink {
+    color: #fff;
+  }
+
+  /* cookie providers' accordion title hover color  */
+  #CybotCookiebotDialog .CookieCard .CybotCookiebotDialogDetailBodyContentCookieContainerButton:hover, 
+  #CybotCookiebotDialog .CookieCard .CybotCookiebotDialogDetailBodyContentIABv2Tab:hover, 
+  #CybotCookiebotDialogDetailBodyContentCookieContainerTypes .CybotCookiebotDialogDetailBodyContentCookieProvider:not(.CybotCookiebotDialogDetailBodyContentCookieInfoCount):hover {
+    color: #fff;
+  }
+
+  /* cookie providers' accordion title counter text  */
+  #CybotCookiebotDialogTabContent .CybotCookiebotDialogDetailBulkConsentCount {
+    color: #000;
+  }
+
+  /* cookie provider's footer link */
+  #CybotCookiebotDialog #CybotCookiebotDialogBodyContentText a, 
+  #CybotCookiebotDialog #CybotCookiebotDialogBodyLevelButtonIABHeaderViewPartnersLink, 
+  #CybotCookiebotDialog #CybotCookiebotDialogDetailBulkConsentList dt a, 
+  #CybotCookiebotDialog #CybotCookiebotDialogDetailFooter a, 
+  #CybotCookiebotDialog .CybotCookiebotDialogBodyLevelButtonIABDescription a, 
+  #CybotCookiebotDialog .CybotCookiebotDialogDetailBodyContentCookieLink, 
+  #CybotCookiebotDialogDetailBodyContentTextAbout a {
+    color: #4b92ff;
+  }
+
+  /* cookie provider's cross domain consent */
+  #CybotCookiebotDialogDetailBulkConsentLink:hover {
     color: #fff;
   }
 }

--- a/docs/.vuepress/theme/styles/cookiebot.styl
+++ b/docs/.vuepress/theme/styles/cookiebot.styl
@@ -6,3 +6,8 @@
   background-color: #fff;
   border-color: #fff;
 }
+
+.theme-dark #CybotCookiebotDialogNav .CybotCookiebotDialogNavItemLink {
+  background-color: #fff;
+  border-color: #fff;
+}

--- a/docs/.vuepress/theme/styles/cookiebot.styl
+++ b/docs/.vuepress/theme/styles/cookiebot.styl
@@ -12,10 +12,10 @@
   border-color: #fff;
 }
 
-.theme-dark #CybotCookiebotDialogDetailBodyContentCookieContainerTypes .CybotCookiebotDialogDetailBodyContentCookieProvider {
+.theme-dark #CybotCookiebotDialogDetailBodyContentCookieContainerTypes .CybotCookiebotDialogDetailBodyContentCookieProvider:not(.CybotCookiebotDialogDetailBodyContentCookieInfoCount) {
   color: #fff;
 }
 
-.theme-dark #CybotCookiebotDialogDetailBulkConsentLink .CybotExpandLink {
+.theme-dark #CybotCookiebotDialogDetailBulkConsentLink {
   color: #fff;
 }

--- a/docs/.vuepress/theme/styles/index.styl
+++ b/docs/.vuepress/theme/styles/index.styl
@@ -23,6 +23,9 @@
 /* Themes */
 @import 'theme-dark'
 
+/* Cookiebot */
+@import 'cookiebot'
+
 
 body {
   font-size: 15px;


### PR DESCRIPTION
This PR:
- Adds a new `.styl` file to change a few cookiebot colors in dark theme (fixing #8598)

[skip changelog]