### PR TITLE
Fix TS type for sort method

### DIFF
--- a/.changelogs/9067.json
+++ b/.changelogs/9067.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fixed wrong typescript definition for `sort` method of the MultiColumnSorting plugin.",
+  "type": "fixed",
+  "issue": 9067,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/multiColumnSorting/__tests__/multiColumnSorting.types.ts
+++ b/handsontable/src/plugins/multiColumnSorting/__tests__/multiColumnSorting.types.ts
@@ -1,7 +1,7 @@
 import Handsontable from 'handsontable';
 
 const hot = new Handsontable(document.createElement('div'), {});
-const columnSorting = hot.getPlugin('columnSorting');
+const columnSorting = hot.getPlugin('multiColumnSorting');
 
 columnSorting.clearSort();
 
@@ -29,4 +29,4 @@ columnSorting.setSortConfig([]);
 columnSorting.isSorted();
 
 columnSorting.sort({ column: 0, sortOrder: 'asc' });
-columnSorting.sort([{ column: 0, sortOrder: 'asc' }]);
+columnSorting.sort([{ column: 1, sortOrder: 'desc' }, { column: 2, sortOrder: 'asc' }]);

--- a/handsontable/types/plugins/columnSorting/columnSorting.d.ts
+++ b/handsontable/types/plugins/columnSorting/columnSorting.d.ts
@@ -22,7 +22,7 @@ export type Settings = boolean | DetailedSettings;
 export class ColumnSorting extends BasePlugin {
   constructor(hotInstance: Core);
   isEnabled(): boolean;
-  sort(sortConfig: Config): void;
+  sort(sortConfig: Config | Config[]): void;
   clearSort(): void;
   isSorted(): boolean;
   getSortConfig(column?: number): Config | Config[];


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the TS type for the `sort(config)` method of the _MultiColumnSorting_ plugin. The `config` argument within the method can be passed as a sort configuration object or array of objects. There is a missing type for the second argument type.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I covered the changes with new TS tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/9067

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
