### PR TITLE
Fix Comments editor appearance stability

### DIFF
--- a/.changelogs/9075.json
+++ b/.changelogs/9075.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fixed editor appearance stability for the Comments plugin.",
+  "type": "fixed",
+  "issue": 9075,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/comments/commentEditor.js
+++ b/handsontable/src/plugins/comments/commentEditor.js
@@ -93,7 +93,10 @@ class CommentEditor {
    * Hide the comments editor.
    */
   hide() {
-    this.editorStyle.display = 'none';
+    if (!this.hidden) {
+      this.editorStyle.display = 'none';
+    }
+
     this.hidden = true;
   }
 
@@ -150,6 +153,8 @@ class CommentEditor {
   createEditor() {
     const editor = this.rootDocument.createElement('div');
     const textArea = this.rootDocument.createElement('textarea');
+
+    editor.style.display = 'none';
 
     this.container = this.rootDocument.createElement('div');
     addClass(this.container, CommentEditor.CLASS_EDITOR_CONTAINER);


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes an issue where the comments editor disappears right after the "Add comment" context menu entry is clicked.

The PR contains some plugin's cleanup things:
 * I merged the plugin's internal flags (`mouseDown`, `contextMenuEvent`) to single one `preventEditorAutoSwitch`;
 * The internal API calls like `this.hot.view.wt.wtTable.getCoords` are replaced with public one `this.hot.getCoords`;
 * By shifting the [line](https://github.com/handsontable/handsontable/pull/9076/files#diff-862c2b234f3f48b084fa06efe037f2b1b642e8490796841ba31f07cda117df67R582) below the `if` logic, the `hide/show` methods are not called every time the "mouseover" event is triggered but only if the next element is different than previous one.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes on macOS Big Sur with the latest Chrome, FF, and Safari. I covered the changes with a test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/9075
2. #6661
3.

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
