### PR TITLE
Fix autocomplete suggest list for older version of FF

### DIFF
--- a/.changelogs/7570.json
+++ b/.changelogs/7570.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fixed an issue where the suggestion list of the autocomplete editor could be not correctly update.",
+  "type": "fixed",
+  "issue": 7570,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/editors/autocompleteEditor/__tests__/autocompleteEditor.spec.js
+++ b/handsontable/src/editors/autocompleteEditor/__tests__/autocompleteEditor.spec.js
@@ -3428,7 +3428,7 @@ describe('AutocompleteEditor', () => {
 
     await sleep(100);
 
-    spyOn(hot, '_registerTimeout').and.callThrough;
+    spyOn(hot, '_registerTimeout');
 
     keyDownUp('x');
 

--- a/handsontable/src/editors/autocompleteEditor/__tests__/autocompleteEditor.spec.js
+++ b/handsontable/src/editors/autocompleteEditor/__tests__/autocompleteEditor.spec.js
@@ -3411,6 +3411,31 @@ describe('AutocompleteEditor', () => {
     }, 200);
   });
 
+  it('should update the suggestion list after minimal delay (FF issue, see #9077)', async() => {
+    const hot = handsontable({
+      columns: [
+        {
+          type: 'autocomplete',
+          source: choices,
+        },
+        {}
+      ]
+    });
+
+    selectCell(1, 0);
+
+    keyDownUp('x'); // Trigger quick edit mode
+
+    await sleep(100);
+
+    spyOn(hot, '_registerTimeout').and.callThrough;
+
+    keyDownUp('x');
+
+    expect(hot._registerTimeout).toHaveBeenCalledTimes(1);
+    expect(hot._registerTimeout).toHaveBeenCalledWith(jasmine.anything(), 10);
+  });
+
   describe('IME support', () => {
     it('should focus editable element after selecting the cell', async() => {
       handsontable({

--- a/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
+++ b/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
@@ -466,7 +466,8 @@ export class AutocompleteEditor extends HandsontableEditor {
       event.keyCode === KEY_CODES.DELETE || event.keyCode === KEY_CODES.INSERT) {
       // for Windows 10 + FF86 there is need to add delay to make sure that the value taken from
       // the textarea is the freshest value. Otherwise the list of choices does not update correctly (see #7570).
-      // On the more modern version of the FF (~ >=91) it seems that the issue is not present.
+      // On the more modern version of the FF (~ >=91) it seems that the issue is not present or it is
+      // more difficult to induce.
       let timeOffset = 10;
 
       // on ctl+c / cmd+c don't update suggestion list

--- a/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
+++ b/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
@@ -465,7 +465,7 @@ export class AutocompleteEditor extends HandsontableEditor {
     if (isPrintableChar(event.keyCode) || event.keyCode === KEY_CODES.BACKSPACE ||
       event.keyCode === KEY_CODES.DELETE || event.keyCode === KEY_CODES.INSERT) {
       // for Windows 10 + FF86 there is need to add delay to make sure that the value taken from
-      // the textarea is the freshed value. Otherwise the list of choices do not update correctly (see #7570).
+      // the textarea is the freshest value. Otherwise the list of choices does not update correctly (see #7570).
       // On the more modern version of the FF (~ >=91) it seems that the issue is not present.
       let timeOffset = 10;
 

--- a/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
+++ b/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
@@ -464,7 +464,10 @@ export class AutocompleteEditor extends HandsontableEditor {
 
     if (isPrintableChar(event.keyCode) || event.keyCode === KEY_CODES.BACKSPACE ||
       event.keyCode === KEY_CODES.DELETE || event.keyCode === KEY_CODES.INSERT) {
-      let timeOffset = 0;
+      // for Windows 10 + FF86 there is need to add delay to make sure that the value taken from
+      // the textarea is the freshed value. Otherwise the list of choices do not update correctly (see #7570).
+      // On the more modern version of the FF (~ >=91) it seems that the issue is not present.
+      let timeOffset = 10;
 
       // on ctl+c / cmd+c don't update suggestion list
       if (event.keyCode === KEY_CODES.C && (event.ctrlKey || event.metaKey)) {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes an issue where the suggestion list of the autocomplete cell editors is not updated correctly. I think that the issue is reproducible only on the older versions of Firefox like 86, 88 (on Windows). On the v91 and newer, I'm not able to recreate the issue (or it is more difficult to induce).

The PR adds a slight delay to the `queryChoices` method. Thanks to the delay the value taken from the textarea element is the freshest value and the list is updated always based on the full sentence typed into cell editor.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested on Windows 7 with FF 88 and 95. I added a new test that covers the changes to the delay (`timeOffset`).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/7570
2.
3.

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
