### PR TITLE
Docs: Adding information about license key required when HF used within HoT

### DIFF
--- a/docs/10.0/api/formulas.md
+++ b/docs/10.0/api/formulas.md
@@ -42,7 +42,10 @@ formulas: {
 }
 
 // or, add a HyperFormula instance
-const hyperformulaInstance = HyperFormula.buildEmpty({})
+// initialized with the `'internal-use-in-handsontable'` license key
+const hyperformulaInstance = HyperFormula.buildEmpty({
+  licenseKey: 'internal-use-in-handsontable',
+});
 
 formulas: {
   engine: hyperformulaInstance,

--- a/docs/10.0/api/options.md
+++ b/docs/10.0/api/options.md
@@ -1578,7 +1578,10 @@ formulas: {
 }
 
 // or, add a HyperFormula instance
-const hyperformulaInstance = HyperFormula.buildEmpty({})
+// initialized with the `'internal-use-in-handsontable'` license key
+const hyperformulaInstance = HyperFormula.buildEmpty({
+  licenseKey: 'internal-use-in-handsontable',
+});
 
 formulas: {
   engine: hyperformulaInstance,

--- a/docs/10.0/guides/formulas/formula-calculation.md
+++ b/docs/10.0/guides/formulas/formula-calculation.md
@@ -114,7 +114,11 @@ const data2 = [
   ['Number of sheets in this workbook', '=SHEETS()'],
 ];
 
-const hyperformulaInstance = HyperFormula.buildEmpty();
+const hyperformulaInstance = HyperFormula.buildEmpty({
+  // to use an external HyperFormula instance,
+  // initialize it with the `'internal-use-in-handsontable'` license key
+  licenseKey: 'internal-use-in-handsontable',
+});
 
 const container1 = document.getElementById('example-basic-multi-sheet-1');
 new Handsontable(container1, {
@@ -282,6 +286,19 @@ import { HyperFormula } from 'hyperformula';
 
 There are also other installation methods available. Check out [HyperFormula's installation documentation](https://handsontable.github.io/hyperformula/guide/client-side-installation.html).
 
+::: tip HyperFormula instance
+To use the `Formulas` plugin with an external HyperFormula instance,
+initialize HyperFormula with the `'internal-use-in-handsontable'` license key:
+
+```js
+// create an external HyperFormula instance
+const hyperformulaInstance = HyperFormula.buildEmpty({
+  // initialize it with the `'internal-use-in-handsontable'` license key
+  licenseKey: 'internal-use-in-handsontable',
+});
+```
+:::
+
 ### Passing the HyperFormula class/instance to Handsontable
 
 ```js
@@ -312,7 +329,11 @@ or
 ### Single Handsontable instance with an external HyperFormula instance
 
 ```js
-const hyperformulaInstance = HyperFormula.buildEmpty({})
+const hyperformulaInstance = HyperFormula.buildEmpty({
+  // to use an external HyperFormula instance,
+  // initialize it with the `'internal-use-in-handsontable'` license key
+  licenseKey: 'internal-use-in-handsontable',
+});
 
 {
   formulas: {
@@ -366,7 +387,11 @@ const hyperformulaInstance = HyperFormula.buildEmpty({})
 ### Multiple Handsontable instances with an external shared HyperFormula instance
 
 ```js
-const hyperformulaInstance = HyperFormula.buildEmpty({});
+const hyperformulaInstance = HyperFormula.buildEmpty({
+  // to use an external HyperFormula instance,
+  // initialize it with the `'internal-use-in-handsontable'` license key
+  licenseKey: 'internal-use-in-handsontable',
+});
 
 // Instance 1
 {

--- a/docs/10.0/guides/formulas/formula-calculation.md
+++ b/docs/10.0/guides/formulas/formula-calculation.md
@@ -462,8 +462,8 @@ For more information about named expressions, please refer to the [HyperFormula 
 
 <iframe width="100%" height="425px" src="https://www.youtube.com/embed/JJXUmACTDdk"></iframe>
 
-## Learn more
+## Read more
 
-*   [Plugin API reference](@/api/formulas.md)
-*   [HyperFormula guides](https://handsontable.github.io/hyperformula/)
-*   [HyperFormula API reference](https://handsontable.github.io/hyperformula/api/)
+* [`Formulas` plugin API reference &#8594;](@/api/formulas.md)
+* [HyperFormula guides &#8594;](https://handsontable.github.io/hyperformula/)
+* [HyperFormula API reference &#8594;](https://handsontable.github.io/hyperformula/api/)

--- a/docs/11.0/api/formulas.md
+++ b/docs/11.0/api/formulas.md
@@ -62,7 +62,10 @@ formulas: {
 }
 
 // or, add a HyperFormula instance
-const hyperFormulaInstance = HyperFormula.buildEmpty({})
+// initialized with the `'internal-use-in-handsontable'` license key
+const hyperformulaInstance = HyperFormula.buildEmpty({
+  licenseKey: 'internal-use-in-handsontable',
+});
 
 formulas: {
   // set `engine` to a HyperFormula instance

--- a/docs/11.0/api/options.md
+++ b/docs/11.0/api/options.md
@@ -2133,7 +2133,10 @@ formulas: {
 }
 
 // or, add a HyperFormula instance
-const hyperFormulaInstance = HyperFormula.buildEmpty({})
+// initialized with the `'internal-use-in-handsontable'` license key
+const hyperformulaInstance = HyperFormula.buildEmpty({
+  licenseKey: 'internal-use-in-handsontable',
+});
 
 formulas: {
   // set `engine` to a HyperFormula instance

--- a/docs/11.0/guides/formulas/formula-calculation.md
+++ b/docs/11.0/guides/formulas/formula-calculation.md
@@ -464,6 +464,6 @@ For more information about named expressions, please refer to the [HyperFormula 
 
 ## Read more
 
-* [`Plugin API reference` &#8594;](@/api/formulas.md)
-* [`HyperFormula guides` &#8594;](https://handsontable.github.io/hyperformula/)
-* [`HyperFormula API reference` &#8594;](https://handsontable.github.io/hyperformula/api/)
+* [`Formulas` plugin API reference &#8594;](@/api/formulas.md)
+* [HyperFormula guides &#8594;](https://handsontable.github.io/hyperformula/)
+* [HyperFormula API reference &#8594;](https://handsontable.github.io/hyperformula/api/)

--- a/docs/11.0/guides/formulas/formula-calculation.md
+++ b/docs/11.0/guides/formulas/formula-calculation.md
@@ -114,7 +114,11 @@ const data2 = [
   ['Number of sheets in this workbook', '=SHEETS()'],
 ];
 
-const hyperformulaInstance = HyperFormula.buildEmpty();
+const hyperformulaInstance = HyperFormula.buildEmpty({
+  // to use an external HyperFormula instance,
+  // initialize it with the `'internal-use-in-handsontable'` license key
+  licenseKey: 'internal-use-in-handsontable',
+});
 
 const container1 = document.getElementById('example-basic-multi-sheet-1');
 new Handsontable(container1, {
@@ -282,6 +286,19 @@ import { HyperFormula } from 'hyperformula';
 
 There are also other installation methods available. Check out [HyperFormula's installation documentation](https://handsontable.github.io/hyperformula/guide/client-side-installation.html).
 
+::: tip HyperFormula instance
+To use the `Formulas` plugin with an external HyperFormula instance,
+initialize HyperFormula with the `'internal-use-in-handsontable'` license key:
+
+```js
+// create an external HyperFormula instance
+const hyperformulaInstance = HyperFormula.buildEmpty({
+  // initialize it with the `'internal-use-in-handsontable'` license key
+  licenseKey: 'internal-use-in-handsontable',
+});
+```
+:::
+
 ### Passing the HyperFormula class/instance to Handsontable
 
 ```js
@@ -312,7 +329,11 @@ or
 ### Single Handsontable instance with an external HyperFormula instance
 
 ```js
-const hyperformulaInstance = HyperFormula.buildEmpty({})
+const hyperformulaInstance = HyperFormula.buildEmpty({
+  // to use an external HyperFormula instance,
+  // initialize it with the `'internal-use-in-handsontable'` license key
+  licenseKey: 'internal-use-in-handsontable',
+});
 
 {
   formulas: {
@@ -366,7 +387,11 @@ const hyperformulaInstance = HyperFormula.buildEmpty({})
 ### Multiple Handsontable instances with an external shared HyperFormula instance
 
 ```js
-const hyperformulaInstance = HyperFormula.buildEmpty({});
+const hyperformulaInstance = HyperFormula.buildEmpty({
+  // to use an external HyperFormula instance,
+  // initialize it with the `'internal-use-in-handsontable'` license key
+  licenseKey: 'internal-use-in-handsontable',
+});
 
 // Instance 1
 {

--- a/docs/9.0/api/formulas.md
+++ b/docs/9.0/api/formulas.md
@@ -39,7 +39,10 @@ formulas: {
 }
 
 // or, add a HyperFormula instance
-const hyperformulaInstance = HyperFormula.buildEmpty({})
+// initialized with the `'internal-use-in-handsontable'` license key
+const hyperformulaInstance = HyperFormula.buildEmpty({
+  licenseKey: 'internal-use-in-handsontable',
+});
 
 formulas: {
   engine: hyperformulaInstance,

--- a/docs/9.0/api/metaSchema.md
+++ b/docs/9.0/api/metaSchema.md
@@ -1560,7 +1560,10 @@ formulas: {
 }
 
 // or, add a HyperFormula instance
-const hyperformulaInstance = HyperFormula.buildEmpty({})
+// initialized with the `'internal-use-in-handsontable'` license key
+const hyperformulaInstance = HyperFormula.buildEmpty({
+  licenseKey: 'internal-use-in-handsontable',
+});
 
 formulas: {
   engine: hyperformulaInstance,

--- a/docs/9.0/guides/formulas/formula-calculation.md
+++ b/docs/9.0/guides/formulas/formula-calculation.md
@@ -114,7 +114,11 @@ const data2 = [
   ['Number of sheets in this workbook', '=SHEETS()'],
 ];
 
-const hyperformulaInstance = HyperFormula.buildEmpty();
+const hyperformulaInstance = HyperFormula.buildEmpty({
+  // to use an external HyperFormula instance,
+  // initialize it with the `'internal-use-in-handsontable'` license key
+  licenseKey: 'internal-use-in-handsontable',
+});
 
 const container1 = document.getElementById('example-basic-multi-sheet-1');
 new Handsontable(container1, {
@@ -282,6 +286,19 @@ import { HyperFormula } from 'hyperformula';
 
 There are also other installation methods available. Check out [HyperFormula's installation documentation](https://handsontable.github.io/hyperformula/guide/client-side-installation.html).
 
+::: tip HyperFormula instance
+To use the `Formulas` plugin with an external HyperFormula instance,
+initialize HyperFormula with the `'internal-use-in-handsontable'` license key:
+
+```js
+// create an external HyperFormula instance
+const hyperformulaInstance = HyperFormula.buildEmpty({
+  // initialize it with the `'internal-use-in-handsontable'` license key
+  licenseKey: 'internal-use-in-handsontable',
+});
+```
+:::
+
 ### Passing the HyperFormula class/instance to Handsontable
 
 ```js
@@ -313,7 +330,11 @@ or
 ### Single Handsontable instance with an external HyperFormula instance
 
 ```js
-const hyperformulaInstance = HyperFormula.buildEmpty({})
+const hyperformulaInstance = HyperFormula.buildEmpty({
+  // to use an external HyperFormula instance,
+  // initialize it with the `'internal-use-in-handsontable'` license key
+  licenseKey: 'internal-use-in-handsontable',
+});
 
 {
   formulas: {
@@ -367,7 +388,11 @@ const hyperformulaInstance = HyperFormula.buildEmpty({})
 ### Multiple Handsontable instances with an external shared HyperFormula instance
 
 ```js
-const hyperformulaInstance = HyperFormula.buildEmpty({});
+const hyperformulaInstance = HyperFormula.buildEmpty({
+  // to use an external HyperFormula instance,
+  // initialize it with the `'internal-use-in-handsontable'` license key
+  licenseKey: 'internal-use-in-handsontable',
+});
 
 // Instance 1
 {

--- a/docs/9.0/guides/formulas/formula-calculation.md
+++ b/docs/9.0/guides/formulas/formula-calculation.md
@@ -463,8 +463,8 @@ For more information about named expressions, please refer to the [HyperFormula 
 
 <iframe width="100%" height="425px" src="https://www.youtube.com/embed/JJXUmACTDdk"></iframe>
 
-## Learn more
+## Read more
 
-*   [Plugin API reference](@/api/formulas.md)
-*   [HyperFormula guides](https://handsontable.github.io/hyperformula/)
-*   [HyperFormula API reference](https://handsontable.github.io/hyperformula/api/)
+* [`Formulas` plugin API reference &#8594;](@/api/formulas.md)
+* [HyperFormula guides &#8594;](https://handsontable.github.io/hyperformula/)
+* [HyperFormula API reference &#8594;](https://handsontable.github.io/hyperformula/api/)

--- a/docs/next/guides/formulas/formula-calculation.md
+++ b/docs/next/guides/formulas/formula-calculation.md
@@ -114,7 +114,10 @@ const data2 = [
   ['Number of sheets in this workbook', '=SHEETS()'],
 ];
 
-const hyperformulaInstance = HyperFormula.buildEmpty();
+const hyperformulaInstance = HyperFormula.buildEmpty({
+  // pass the `internal-use-in-handsontable` license key
+  licenseKey: 'internal-use-in-handsontable',
+});
 
 const container1 = document.getElementById('example-basic-multi-sheet-1');
 new Handsontable(container1, {
@@ -464,6 +467,6 @@ For more information about named expressions, please refer to the [HyperFormula 
 
 ## Read more
 
-* [`Plugin API reference` &#8594;](@/api/formulas.md)
-* [`HyperFormula guides` &#8594;](https://handsontable.github.io/hyperformula/)
-* [`HyperFormula API reference` &#8594;](https://handsontable.github.io/hyperformula/api/)
+* [`Formulas` plugin API reference &#8594;](@/api/formulas.md)
+* [HyperFormula guides &#8594;](https://handsontable.github.io/hyperformula/)
+* [HyperFormula API reference &#8594;](https://handsontable.github.io/hyperformula/api/)

--- a/docs/next/guides/formulas/formula-calculation.md
+++ b/docs/next/guides/formulas/formula-calculation.md
@@ -114,8 +114,10 @@ const data2 = [
   ['Number of sheets in this workbook', '=SHEETS()'],
 ];
 
+// create an external HyperFormula instance
 const hyperformulaInstance = HyperFormula.buildEmpty({
-  // pass the `internal-use-in-handsontable` license key
+  // to use an external HyperFormula instance,
+  // initialize it with the `'internal-use-in-handsontable'` license key
   licenseKey: 'internal-use-in-handsontable',
 });
 
@@ -285,6 +287,19 @@ import { HyperFormula } from 'hyperformula';
 
 There are also other installation methods available. Check out [HyperFormula's installation documentation](https://handsontable.github.io/hyperformula/guide/client-side-installation.html).
 
+::: tip HyperFormula instance
+To use the `Formulas` plugin with an external HyperFormula instance,
+initialize HyperFormula with the `'internal-use-in-handsontable'` license key:
+
+```js
+// create an external HyperFormula instance
+const hyperformulaInstance = HyperFormula.buildEmpty({
+  // initialize it with the `'internal-use-in-handsontable'` license key
+  licenseKey: 'internal-use-in-handsontable',
+});
+```
+:::
+
 ### Passing the HyperFormula class/instance to Handsontable
 
 ```js
@@ -315,7 +330,11 @@ or
 ### Single Handsontable instance with an external HyperFormula instance
 
 ```js
-const hyperformulaInstance = HyperFormula.buildEmpty({})
+const hyperformulaInstance = HyperFormula.buildEmpty({
+  // to use an external HyperFormula instance,
+  // initialize it with the `'internal-use-in-handsontable'` license key
+  licenseKey: 'internal-use-in-handsontable',
+});
 
 {
   formulas: {
@@ -369,7 +388,11 @@ const hyperformulaInstance = HyperFormula.buildEmpty({})
 ### Multiple Handsontable instances with an external shared HyperFormula instance
 
 ```js
-const hyperformulaInstance = HyperFormula.buildEmpty({});
+const hyperformulaInstance = HyperFormula.buildEmpty({
+  // to use an external HyperFormula instance,
+  // initialize it with the `'internal-use-in-handsontable'` license key
+  licenseKey: 'internal-use-in-handsontable',
+});
 
 // Instance 1
 {

--- a/handsontable/src/dataMap/metaManager/metaSchema.js
+++ b/handsontable/src/dataMap/metaManager/metaSchema.js
@@ -2081,14 +2081,17 @@ export default () => {
      * ```js
      * // either add the `HyperFormula` class
      * formulas: {
-     *   // set engine to `HyperFormula`
+     *   // set `engine` to `HyperFormula`
      *   engine: HyperFormula,
      *   sheetId: 1,
      *   sheetName: 'Sheet 1'
      * }
      *
      * // or, add a HyperFormula instance
-     * const hyperFormulaInstance = HyperFormula.buildEmpty({})
+     * // initialized with the `'internal-use-in-handsontable'` license key
+     * const hyperformulaInstance = HyperFormula.buildEmpty({
+     *   licenseKey: 'internal-use-in-handsontable',
+     * });
      *
      * formulas: {
      *   // set `engine` to a HyperFormula instance


### PR DESCRIPTION
This PR:
- Adds information about the `'internal-use-in-handsontable'` license key required when using an external HyperFormula instance within Handsontable's `Formulas` plugin (fixing #9045)

Content modified:
- [Formulas](https://handsontable.com/docs/formula-calculation/) (versions `9.0`-`next`)
- [`formulas` API reference](https://handsontable.com/docs/api/options/#formulas) (versions `9.0`-`next`)

[skip changelog]