### PR TITLE
Add support for Comments plugin for RTL mode

### DIFF
--- a/handsontable/src/plugins/comments/__tests__/comments.spec.js
+++ b/handsontable/src/plugins/comments/__tests__/comments.spec.js
@@ -87,23 +87,34 @@ describe('Comments', () => {
         ]
       });
 
-      expect(getCell(1, 1).className.indexOf('htCommentCell')).toBeGreaterThan(-1);
-      expect(getCell(2, 2).className.indexOf('htCommentCell')).toBeGreaterThan(-1);
+      expect(getCell(1, 1).classList.contains('htCommentCell')).toBeTrue();
+      expect(getComputedStyle(getCell(1, 1), ':after').left).toBe('43px');
+      expect(getComputedStyle(getCell(1, 1), ':after').right).toBe('0px');
+      expect(getComputedStyle(getCell(1, 1), ':after').borderLeftWidth).toBe('6px');
+      expect(getComputedStyle(getCell(1, 1), ':after').borderRightWidth).toBe('0px');
+      expect(getCell(2, 2).classList.contains('htCommentCell')).toBeTrue();
+      expect(getComputedStyle(getCell(1, 1), ':after').left).toBe('43px');
+      expect(getComputedStyle(getCell(1, 1), ':after').right).toBe('0px');
+      expect(getComputedStyle(getCell(2, 2), ':after').borderLeftWidth).toBe('6px');
+      expect(getComputedStyle(getCell(2, 2), ':after').borderRightWidth).toBe('0px');
     });
 
     it('should display the comment editor in the correct place', () => {
-      const hot = handsontable({
+      handsontable({
         data: Handsontable.helper.createSpreadsheetData(4, 4),
         comments: true,
       });
 
-      const plugin = hot.getPlugin('comments');
-      const editor = plugin.editor.getInputElement();
+      const plugin = getPlugin('comments');
+      const $editor = $(plugin.editor.getInputElement());
 
       plugin.showAtCell(0, 1);
 
-      expect($(editor.parentNode).offset().top).toBeCloseTo($(getCell(0, 2)).offset().top, 0);
-      expect($(editor.parentNode).offset().left).toBeCloseTo($(getCell(0, 2)).offset().left, 0);
+      const cellOffset = $(getCell(0, 2)).offset();
+      const editorOffset = $editor.offset();
+
+      expect(editorOffset.top).toBeCloseTo(cellOffset.top, 0);
+      expect(editorOffset.left).toBeCloseTo(cellOffset.left, 0);
     });
   });
 

--- a/handsontable/src/plugins/comments/__tests__/rtl/comments.spec.js
+++ b/handsontable/src/plugins/comments/__tests__/rtl/comments.spec.js
@@ -1,0 +1,60 @@
+describe('Comments (RTL mode)', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    $('html').attr('dir', 'rtl');
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    $('html').attr('dir', 'ltr');
+
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  describe('Styling', () => {
+    it('should display comment indicators in the appropriate cells', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(4, 4),
+        comments: true,
+        cell: [
+          { row: 1, col: 1, comment: { value: 'test' } },
+          { row: 2, col: 2, comment: { value: 'test' } }
+        ]
+      });
+
+      expect(getCell(1, 1).classList.contains('htCommentCell')).toBeTrue();
+      expect(getComputedStyle(getCell(1, 1), ':after').left).toBe('0px');
+      expect(getComputedStyle(getCell(1, 1), ':after').right).toBe('43px');
+      expect(getComputedStyle(getCell(1, 1), ':after').borderLeftWidth).toBe('0px');
+      expect(getComputedStyle(getCell(1, 1), ':after').borderRightWidth).toBe('6px');
+      expect(getCell(2, 2).classList.contains('htCommentCell')).toBeTrue();
+      expect(getComputedStyle(getCell(1, 1), ':after').left).toBe('0px');
+      expect(getComputedStyle(getCell(1, 1), ':after').right).toBe('43px');
+      expect(getComputedStyle(getCell(2, 2), ':after').borderLeftWidth).toBe('0px');
+      expect(getComputedStyle(getCell(2, 2), ':after').borderRightWidth).toBe('6px');
+    });
+
+    it('should display the comment editor in the correct place', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(4, 4),
+        comments: true,
+      });
+
+      const plugin = getPlugin('comments');
+      const $editor = $(plugin.editor.getInputElement());
+
+      plugin.showAtCell(0, 1);
+
+      const cellOffset = $(getCell(0, 1)).offset();
+      const editorOffset = $editor.offset();
+      const editorWidth = $editor.outerWidth();
+
+      expect(editorOffset.top).toBeCloseTo(cellOffset.top, 0);
+      expect(editorOffset.left).toBeCloseTo(cellOffset.left - editorWidth, 0);
+    });
+  });
+});

--- a/handsontable/src/plugins/comments/commentEditor.js
+++ b/handsontable/src/plugins/comments/commentEditor.js
@@ -1,4 +1,4 @@
-import { addClass } from '../../helpers/dom/element';
+import { addClass, outerWidth, outerHeight } from '../../helpers/dom/element';
 
 /**
  * Comment editor for the Comments plugin.
@@ -58,6 +58,18 @@ class CommentEditor {
       input.style.width = `${width}px`;
       input.style.height = `${height}px`;
     }
+  }
+
+  /**
+   * Returns the size of the comments editor.
+   *
+   * @returns {{ width: number, height: number }}
+   */
+  getSize() {
+    return {
+      width: outerWidth(this.editor),
+      height: outerHeight(this.editor),
+    };
   }
 
   /**

--- a/handsontable/src/plugins/comments/comments.js
+++ b/handsontable/src/plugins/comments/comments.js
@@ -16,7 +16,7 @@ import { checkSelectionConsistency, markLabelAsSelected } from '../contextMenu/u
 import DisplaySwitch from './displaySwitch';
 import * as C from '../../i18n/constants';
 
-import './comments.css';
+import './comments.scss';
 
 export const PLUGIN_KEY = 'comments';
 export const PLUGIN_PRIORITY = 60;
@@ -369,12 +369,9 @@ export class Comments extends BasePlugin {
 
     const meta = this.hot.getCellMeta(this.range.from.row, this.range.from.col);
 
-    this.refreshEditor(true);
     this.editor.setValue(meta[META_COMMENT] ? meta[META_COMMENT][META_COMMENT_VALUE] : null || '');
-
-    if (this.editor.hidden) {
-      this.editor.show();
-    }
+    this.editor.show();
+    this.refreshEditor(true);
 
     return true;
   }
@@ -458,8 +455,14 @@ export class Comments extends BasePlugin {
       cellLeftOffset -= wtOverlays.leftOverlay.getScrollPosition();
     }
 
-    const x = cellLeftOffset + lastColWidth;
     const y = cellTopOffset + lastRowHeight;
+    let x = cellLeftOffset;
+
+    if (this.hot.isRtl()) {
+      x -= this.editor.getSize().width;
+    } else {
+      x += lastColWidth;
+    }
 
     const commentStyle = this.getCommentMeta(visualRow, visualColumn, META_STYLE);
     const readOnly = this.getCommentMeta(visualRow, visualColumn, META_READONLY);
@@ -472,7 +475,6 @@ export class Comments extends BasePlugin {
     }
 
     this.editor.setReadOnlyState(readOnly);
-
     this.editor.setPosition(x, y);
   }
 

--- a/handsontable/src/plugins/comments/comments.scss
+++ b/handsontable/src/plugins/comments/comments.scss
@@ -7,8 +7,14 @@
   position: absolute;
   top: 0;
   right: 0;
-  border-left: 6px solid transparent;
+  border-inline-start: 6px solid transparent;
+  border-inline-end: none;
   border-top: 6px solid black;
+}
+
+[dir=rtl] .htCommentCell:after {
+  right: initial;
+  left: 0;
 }
 
 .htComments {
@@ -23,7 +29,8 @@
   -moz-box-sizing: border-box;
   box-sizing: border-box;
   border: none;
-  border-left: 3px solid #ccc;
+  border-inline-start: 3px solid #ccc;
+  border-inline-end: none;
   background-color: #fff;
   width: 215px;
   height: 90px;
@@ -35,5 +42,6 @@
 
 .htCommentTextArea:focus {
   box-shadow: rgba(0, 0, 0, 0.117647) 0 1px 3px, rgba(0, 0, 0, 0.239216) 0 1px 2px, inset 0 0 0 1px #5292f7;
-  border-left: 3px solid #5292f7;
+  border-inline-start: 3px solid #5292f7;
+  border-inline-end: none;
 }


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adds support for _Comments_ plugin in RTL mode. From now on depends on the `dir` attribute of the document the Comments indicator and Comments editor are positioned on the right (in LTR) or on the left (in RTL) of the cell that contains comments metadata. 

LTR mode:
![Kapture 2022-01-05 at 12 41 32](https://user-images.githubusercontent.com/571316/148212202-a6441ba3-eaaf-4b65-bb1f-707c1cb731e6.gif)

RTL mode:
![Kapture 2022-01-05 at 12 42 28](https://user-images.githubusercontent.com/571316/148212302-c7d34e8a-6d30-4ff2-9a60-628331ec9a3e.gif)

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally on FF, Safari, and Chrome (macOS). Moreover, I covered the fix with new E2E tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. #8822
2.
3.

### Affected project(s):
- [x] `handsontable`
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
