### PR TITLE
Fix Pikaday positioning in RTL

### DIFF
--- a/handsontable/.config/test-e2e.js
+++ b/handsontable/.config/test-e2e.js
@@ -46,6 +46,7 @@ module.exports.create = function create(envArgs) {
         externalCssFiles: [
           'lib/normalize.css',
           '../dist/handsontable.css',
+          `${getClosest('../node_modules/pikaday', true)}/css/pikaday.css`,
           'helpers/common.css',
         ],
         externalJsFiles: [

--- a/handsontable/.config/test-production.js
+++ b/handsontable/.config/test-production.js
@@ -28,6 +28,7 @@ module.exports.create = function create(envArgs) {
         externalCssFiles: [
           'lib/normalize.css',
           '../dist/handsontable.full.min.css',
+          `${getClosest('../node_modules/pikaday', true)}/css/pikaday.css`,
           'helpers/common.css',
         ],
         externalJsFiles: [

--- a/handsontable/src/editors/dateEditor/__tests__/dateEditor.spec.js
+++ b/handsontable/src/editors/dateEditor/__tests__/dateEditor.spec.js
@@ -293,7 +293,7 @@ describe('DateEditor', () => {
     expect(window.getComputedStyle(editor, 'focus').getPropertyValue('outline-style')).toBe('none');
   });
 
-  it('should display Pikday calendar', () => {
+  it('should display Pikaday calendar', () => {
     handsontable({
       data: getDates(),
       columns: [
@@ -311,7 +311,7 @@ describe('DateEditor', () => {
     expect($('.pika-single').is(':visible')).toBe(true);
   });
 
-  it('should pass date picker config object to Pikday', () => {
+  it('should pass date picker config object to Pikaday', () => {
     const onOpenSpy = jasmine.createSpy('open');
     const onCloseSpy = jasmine.createSpy('close');
     const hot = handsontable({
@@ -355,6 +355,28 @@ describe('DateEditor', () => {
     expect(config.i18n.nextMonth).toBe('Następny');
     expect(onOpenSpy).toHaveBeenCalled();
     expect(onCloseSpy).toHaveBeenCalled();
+  });
+
+  it('should set isRTL option as `false` when it\'s opened in LTR mode', () => {
+    handsontable({
+      data: getDates(),
+      columns: [
+        {
+          type: 'date',
+          datePickerConfig: {
+            isRTL: true, // read only - shouldn't overwrite
+          }
+        }
+      ]
+    });
+
+    selectCell(0, 0);
+    keyDown('enter');
+    keyDown('esc');
+
+    const config = getActiveEditor().$datePicker.config();
+
+    expect(config.isRTL).toBe(false);
   });
 
   it('should remove any HTML connected with Pikaday Calendar', () => {
@@ -668,8 +690,8 @@ describe('DateEditor', () => {
     expect(moment(resultDate).month()).toEqual(moment().month());
   });
 
-  it('should display Pikaday Calendar bottom of the selected cell', () => {
-    const hot = handsontable({
+  it('should display Pikaday Calendar right-bottom of the selected cell', () => {
+    handsontable({
       data: Handsontable.helper.createSpreadsheetData(5, 2),
       columns: [
         { type: 'date' },
@@ -680,7 +702,7 @@ describe('DateEditor', () => {
     selectCell(1, 1);
     keyDown('enter');
 
-    const cellOffset = $(hot.getActiveEditor().TD).offset();
+    const cellOffset = $(getActiveEditor().TD).offset();
     const datePickerOffset = $('.pika-single').offset();
 
     // 23 is a height of the editor cell
@@ -688,14 +710,14 @@ describe('DateEditor', () => {
     expect(cellOffset.left).toBeCloseTo(datePickerOffset.left, 0);
   });
 
-  it('should display Pikaday Calendar bottom of the selected cell when table have scrolls', () => {
+  it('should display Pikaday Calendar right-bottom of the selected cell when table have scrolls', () => {
     const container = $('#testContainer');
 
     container[0].style.height = '300px';
     container[0].style.width = '200px';
     container[0].style.overflow = 'hidden';
 
-    const hot = handsontable({
+    handsontable({
       data: Handsontable.helper.createSpreadsheetData(30, 10),
       colWidths: 60,
       columns: [
@@ -712,7 +734,7 @@ describe('DateEditor', () => {
     selectCell(20, 6);
     keyDown('enter');
 
-    const cellOffset = $(hot.getActiveEditor().TD).offset();
+    const cellOffset = $(getActiveEditor().TD).offset();
     const datePickerOffset = $('.pika-single').offset();
 
     expect(cellOffset.top + 23).toBeCloseTo(datePickerOffset.top, 0);
@@ -744,7 +766,7 @@ describe('DateEditor', () => {
     expect(editor.TEXTAREA.value).toEqual(cellValue);
   });
 
-  it('should use the default Pikaday\'s cofiguration if cell does not customize picker', async() => {
+  it('should use the default Pikaday\'s configuration if cell does not customize picker', async() => {
     handsontable({
       data: [['10/12/2020', '01/14/2017']],
       columns: [

--- a/handsontable/src/editors/dateEditor/__tests__/rtl/dateEditor.spec.js
+++ b/handsontable/src/editors/dateEditor/__tests__/rtl/dateEditor.spec.js
@@ -15,6 +15,16 @@ describe('DateEditor (RTL mode)', () => {
     }
   });
 
+  function getDates() {
+    return [
+      ['01/14/2006'],
+      ['12/01/2008'],
+      ['11/19/2011'],
+      ['02/02/2004'],
+      ['07/24/2011']
+    ];
+  }
+
   it('should render an editable editor\'s element without messing with "dir" attribute', () => {
     handsontable({
       data: Handsontable.helper.createSpreadsheetData(2, 5),
@@ -26,5 +36,85 @@ describe('DateEditor (RTL mode)', () => {
     const editableElement = getActiveEditor().TEXTAREA;
 
     expect(editableElement.getAttribute('dir')).toBeNull();
+  });
+
+  it('should set isRTL option as `true` when it\'s opened in RTL mode', () => {
+    handsontable({
+      data: getDates(),
+      columns: [
+        {
+          type: 'date',
+          datePickerConfig: {
+            isRTL: false, // read only - shouldn't overwrite
+          }
+        }
+      ]
+    });
+
+    selectCell(0, 0);
+    keyDown('enter');
+    keyDown('esc');
+
+    const config = getActiveEditor().$datePicker.config();
+
+    expect(config.isRTL).toBe(true);
+  });
+
+  it('should display Pikaday Calendar left-bottom of the selected cell', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(5, 2),
+      columns: [
+        { type: 'date' },
+        { type: 'date' }
+      ]
+    });
+
+    selectCell(1, 1);
+    keyDown('enter');
+
+    const cellOffset = $(getActiveEditor().TD).offset();
+    const cellWidth = $(getActiveEditor().TD).outerWidth();
+    const $datePicker = $('.htDatepickerHolder');
+    const datePickerOffset = $datePicker.offset();
+    const datePickerWidth = $datePicker.outerWidth();
+
+    // 23 is a height of the editor's cell
+    expect(cellOffset.top + 23).toBeCloseTo(datePickerOffset.top, 0);
+    expect(cellOffset.left).toBeCloseTo(datePickerOffset.left + datePickerWidth - cellWidth, 0);
+  });
+
+  it('should display Pikaday Calendar left-bottom of the selected cell when table have scrolls', () => {
+    const container = $('#testContainer');
+
+    container[0].style.height = '300px';
+    container[0].style.width = '200px';
+    container[0].style.overflow = 'hidden';
+
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(30, 10),
+      colWidths: 60,
+      columns: [
+        { type: 'date' },
+        { type: 'date' },
+        { type: 'date' },
+        { type: 'date' },
+        { type: 'date' },
+        { type: 'date' },
+        { type: 'date' }
+      ]
+    });
+
+    selectCell(20, 6);
+    keyDown('enter');
+
+    const cellOffset = $(getActiveEditor().TD).offset();
+    const cellWidth = $(getActiveEditor().TD).outerWidth();
+    const $datePicker = $('.htDatepickerHolder');
+    const datePickerOffset = $datePicker.offset();
+    const datePickerWidth = $datePicker.outerWidth();
+
+    // 23 is a height of the editor's cell
+    expect(cellOffset.top + 23).toBeCloseTo(datePickerOffset.top, 0);
+    expect(cellOffset.left).toBeCloseTo(datePickerOffset.left + datePickerWidth - cellWidth, 0);
   });
 });

--- a/handsontable/src/editors/dateEditor/dateEditor.js
+++ b/handsontable/src/editors/dateEditor/dateEditor.js
@@ -1,11 +1,12 @@
 import moment from 'moment';
 import Pikaday from 'pikaday';
-import 'pikaday/css/pikaday.css';
 import { TextEditor } from '../textEditor';
 import EventManager from '../../eventManager';
-import { addClass, outerHeight } from '../../helpers/dom/element';
+import { addClass, outerHeight, outerWidth } from '../../helpers/dom/element';
 import { deepExtend } from '../../helpers/object';
 import { isFunctionKey } from '../../helpers/unicode';
+
+import 'pikaday/css/pikaday.css';
 
 export const EDITOR_TYPE = 'date';
 
@@ -159,11 +160,22 @@ export class DateEditor extends TextEditor {
     const isMeta = event ? isFunctionKey(event.keyCode) : false;
     let dateStr;
 
-    this.datePickerStyle.top = `${this.hot.rootWindow.pageYOffset + offset.top + outerHeight(this.TD)}px`;
-    this.datePickerStyle.left = `${this.hot.rootWindow.pageXOffset + offset.left}px`;
+    this.datePicker.style.display = 'block';
 
     this.$datePicker = new Pikaday(this.getDatePickerConfig());
     this.$datePicker._onInputFocus = function() {};
+
+    this.datePickerStyle.top = `${this.hot.rootWindow.pageYOffset + offset.top + outerHeight(this.TD)}px`;
+
+    let pickerLeftPosition = this.hot.rootWindow.pageXOffset;
+
+    if (this.hot.isRtl()) {
+      pickerLeftPosition = offset.right - outerWidth(this.datePicker);
+    } else {
+      pickerLeftPosition = offset.left;
+    }
+
+    this.datePickerStyle.left = `${pickerLeftPosition}px`;
 
     if (this.originalValue) {
       dateStr = this.originalValue;
@@ -196,8 +208,6 @@ export class DateEditor extends TextEditor {
       // datepicker, but don't fill the editor input
       this.$datePicker.gotoToday();
     }
-
-    this.datePickerStyle.display = 'block';
   }
 
   /**
@@ -229,6 +239,7 @@ export class DateEditor extends TextEditor {
     options.bound = false;
     options.format = options.format || this.defaultDateFormat;
     options.reposition = options.reposition || false;
+    options.isRTL = this.hot.isRtl();
     options.onSelect = (value) => {
       let dateStr = value;
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the Pikaday (date picker) positioning in RTL document mode. Moreover, I synchronized the RTL flag with the calendar. So, when the Handsontable detects that it's executed in RTL document mode its flag is passed to the Pikaday config object (https://github.com/handsontable/handsontable/pull/9088/files#diff-e0a0d81eeeedd01921d00d6732206f8545cf1d4208438b6fcb3f30f87fd071e8R242).

It's worth mentioning that the Pikaday has a bug. It renders the days in the LTR order when the lib runs in the RTL document mode (`<HTML dir="rtl">`). The issue is already reported by someone else https://github.com/Pikaday/Pikaday/issues/647.

LTR mode:
![Kapture 2022-01-05 at 15 08 33](https://user-images.githubusercontent.com/571316/148230961-882b2a3b-12f5-4337-86ec-d56b522e1daf.gif)

RTL mode:
![Kapture 2022-01-05 at 15 09 51](https://user-images.githubusercontent.com/571316/148231109-f3d6008a-b9e4-408b-86fc-2f0564babc70.gif)

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and I covered the feature with new E2E tests.

While writing the tests I noticed that the Pikaday CSS file was not loaded to the runner HTML. I fixed that within the PR.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. #8800
2.
3.

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
