### PR TITLE
Fix indicators positioning of the HiddenColumns plugin

### DIFF
--- a/handsontable/src/plugins/hiddenColumns/__tests__/rtl/indicators.spec.js
+++ b/handsontable/src/plugins/hiddenColumns/__tests__/rtl/indicators.spec.js
@@ -1,11 +1,14 @@
-describe('HiddenColumns', () => {
+describe('HiddenColumns (RTL mode)', () => {
   const id = 'testContainer';
 
   beforeEach(function() {
+    $('html').attr('dir', 'rtl');
     this.$container = $(`<div id="${id}"></div>`).appendTo('body');
   });
 
   afterEach(function() {
+    $('html').attr('dir', 'ltr');
+
     if (this.$container) {
       destroy();
       this.$container.remove();
@@ -25,15 +28,15 @@ describe('HiddenColumns', () => {
 
       expect(getCell(-1, 0)).toHaveClass(CSS_CLASS_BEFORE_HIDDEN_COLUMN);
       expect(getComputedStyle(getCell(-1, 0), ':before').content).toBe('none');
-      expect(getComputedStyle(getCell(-1, 0), ':after').content).toBe('"◀"');
+      expect(getComputedStyle(getCell(-1, 0), ':after').content).toBe('"▶"');
       expect(getCell(-1, 1)).toBe(null);
       expect(getCell(-1, 2)).toHaveClass(CSS_CLASS_BEFORE_HIDDEN_COLUMN);
       expect(getCell(-1, 2)).toHaveClass(CSS_CLASS_AFTER_HIDDEN_COLUMN);
-      expect(getComputedStyle(getCell(-1, 2), ':before').content).toBe('"▶"');
-      expect(getComputedStyle(getCell(-1, 2), ':after').content).toBe('"◀"');
+      expect(getComputedStyle(getCell(-1, 2), ':before').content).toBe('"◀"');
+      expect(getComputedStyle(getCell(-1, 2), ':after').content).toBe('"▶"');
       expect(getCell(-1, 3)).toBe(null);
       expect(getCell(-1, 4)).toHaveClass(CSS_CLASS_AFTER_HIDDEN_COLUMN);
-      expect(getComputedStyle(getCell(-1, 4), ':before').content).toBe('"▶"');
+      expect(getComputedStyle(getCell(-1, 4), ':before').content).toBe('"◀"');
       expect(getComputedStyle(getCell(-1, 4), ':after').content).toBe('none');
     });
 

--- a/handsontable/src/plugins/hiddenColumns/hiddenColumns.js
+++ b/handsontable/src/plugins/hiddenColumns/hiddenColumns.js
@@ -10,7 +10,7 @@ import hideColumnItem from './contextMenuItem/hideColumn';
 import showColumnItem from './contextMenuItem/showColumn';
 import { HidingMap } from '../../translations';
 
-import './hiddenColumns.css';
+import './hiddenColumns.scss';
 
 Hooks.getSingleton().register('beforeHideColumns');
 Hooks.getSingleton().register('afterHideColumns');

--- a/handsontable/src/plugins/hiddenColumns/hiddenColumns.scss
+++ b/handsontable/src/plugins/hiddenColumns/hiddenColumns.scss
@@ -17,11 +17,25 @@
 .handsontable th.afterHiddenColumn {
   position: relative;
 }
+
 .handsontable th.beforeHiddenColumn::after {
   right: 1px;
-  content: '\25C0';
+  content: '\25C0'; /* left arrow */
 }
+
+[dir=rtl] .handsontable th.beforeHiddenColumn::after {
+  right: initial;
+  left: 1px;
+  content: '\25B6'; /* right arrow */
+}
+
 .handsontable th.afterHiddenColumn::before {
   left: 1px;
-  content: '\25B6';
+  content: '\25B6'; /* right arrow */
+}
+
+[dir=rtl] .handsontable th.afterHiddenColumn::before {
+  right: 1px;
+  left: initial;
+  content: '\25C0'; /* left arrow */
 }


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the positioning of the _HiddenColumns_ plugin's indicators in RTL document mode.

LTR mode:
![Zrzut ekranu 2022-01-10 o 10 43 46](https://user-images.githubusercontent.com/571316/148745599-3a56218b-649d-4e1d-9997-4113b877a4d8.png)

RTL mode:
![Zrzut ekranu 2022-01-10 o 10 43 53](https://user-images.githubusercontent.com/571316/148745612-936663a2-378f-43b2-a5d2-9377cbc9f18c.png)

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and I cover the arrows with the E2E tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/8829

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
