### PR TITLE
[RTL] support for sorting by columns

### DIFF
--- a/handsontable/.config/loader/sass-rtl-loader.js
+++ b/handsontable/.config/loader/sass-rtl-loader.js
@@ -8,9 +8,13 @@ const trim = (properties) => {
 const polyfillDirection = (direction, source) => {
   switch (direction) {
     case 'ltr':
-      return source.replace(/inline-start/g, 'left').replace(/inline-end/g, 'right');
+      return source
+        .replace(/inset-inline-start/g, 'left').replace(/inset-inline-end/g, 'right')
+        .replace(/inline-start/g, 'left').replace(/inline-end/g, 'right');
     case 'rtl':
-      return source.replace(/inline-start/g, 'right').replace(/inline-end/g, 'left');
+      return source
+        .replace(/inset-inline-start/g, 'right').replace(/inset-inline-end/g, 'left')
+        .replace(/inline-start/g, 'right').replace(/inline-end/g, 'left');
     default:
       return source;
   }
@@ -26,7 +30,7 @@ ${polyfillDirection('rtl', `${selector}{${trim(properties)}}`)}
 
 const applyRtlStyles = (source) => {
   return source.replace(
-    /([^}/]*){([^{]*(inline-end|inline-start)[^}]*)}/gm, // detect ltr/rtl dependent properties
+    /([^}/]*){([^{]*(inset-inline-end|inset-inline-start|inline-end|inline-start)[^}]*)}/gm, // detect ltr/rtl dependent properties
     appendRtl
   );
 };

--- a/handsontable/src/css/handsontable.scss
+++ b/handsontable/src/css/handsontable.scss
@@ -115,8 +115,8 @@
   padding-inline-start: 8px;
   padding-inline-end: 0;
   position: absolute;
-  inline-end: -9px;
-  inline-start: unset;
+  inset-inline-end: -9px;
+  inset-inline-start: unset;
 
   content: '';
   height: 10px;

--- a/handsontable/src/css/handsontable.scss
+++ b/handsontable/src/css/handsontable.scss
@@ -112,16 +112,18 @@
   /* Centering end */
 
   /* For purpose of continuous mouse over experience, when moving between the `span` and the `::before` elements */
-  padding-left: 8px;
+  padding-inline-start: 8px;
+  padding-inline-end: 0;
   position: absolute;
-  right: -9px;
+  inline-end: -9px;
+  inline-start: unset;
 
   content: '';
   height: 10px;
   width: 5px;
   background-size: contain;
   background-repeat: no-repeat;
-  background-position-x: right;
+  background-position-x: inline-end;
 }
 
 .handsontable span.colHeader.columnSorting.ascending::before {

--- a/handsontable/src/plugins/columnSorting/__tests__/columnSorting.spec.js
+++ b/handsontable/src/plugins/columnSorting/__tests__/columnSorting.spec.js
@@ -213,6 +213,7 @@ describe('ColumnSorting', () => {
     const sortedColumn = spec().$container.find('th span.columnSorting')[1];
 
     expect(window.getComputedStyle(sortedColumn, ':before').getPropertyValue('background-image')).toMatch(/url/);
+    expect(window.getComputedStyle(sortedColumn, ':before').getPropertyValue('right')).toEqual('-9px');
   });
 
   it('should clear indicator after disabling plugin', () => {

--- a/handsontable/src/plugins/columnSorting/__tests__/rtl/columnSorting.spec.js
+++ b/handsontable/src/plugins/columnSorting/__tests__/rtl/columnSorting.spec.js
@@ -5,20 +5,6 @@ describe('ColumnSorting (RTL)', () => {
     $('html').attr('dir', 'rtl');
 
     this.$container = $(`<div id="${id}" style="overflow: auto; width: 300px; height: 200px;"></div>`).appendTo('body');
-
-    this.sortByClickOnColumnHeader = (columnIndex) => {
-      const hot = this.$container.data('handsontable');
-      const $columnHeader = $(hot.view.wt.wtTable.getColumnHeader(columnIndex));
-      const $spanInsideHeader = $columnHeader.find('.columnSorting');
-
-      if ($spanInsideHeader.length === 0) {
-        throw Error('Please check the test scenario. The header doesn\'t exist.');
-      }
-
-      $spanInsideHeader.simulate('mousedown');
-      $spanInsideHeader.simulate('mouseup');
-      $spanInsideHeader.simulate('click');
-    };
   });
 
   afterEach(function() {

--- a/handsontable/src/plugins/columnSorting/__tests__/rtl/columnSorting.spec.js
+++ b/handsontable/src/plugins/columnSorting/__tests__/rtl/columnSorting.spec.js
@@ -30,31 +30,6 @@ describe('ColumnSorting (RTL)', () => {
     }
   });
 
-  const arrayOfObjects = () => [
-    { id: 1, name: 'Ted', lastName: 'Right' },
-    { id: 2, name: 'Frank', lastName: 'Honest' },
-    { id: 3, name: 'Joan', lastName: 'Well' },
-    { id: 4, name: 'Sid', lastName: 'Strong' },
-    { id: 5, name: 'Jane', lastName: 'Neat' },
-    { id: 6, name: 'Chuck', lastName: 'Jackson' },
-    { id: 7, name: 'Meg', lastName: 'Jansen' },
-    { id: 8, name: 'Rob', lastName: 'Norris' },
-    { id: 9, name: 'Sean', lastName: 'O\'Hara' },
-    { id: 10, name: 'Eve', lastName: 'Branson' }
-  ];
-
-  const arrayOfArrays = () => [
-    ['Mary', 'Brown', '01/14/2017', 6999.95, 'aa'],
-    ['Henry', 'Jones', '12/01/2018', 8330, 'aaa'],
-    ['Ann', 'Evans', '07/24/2021', 30500, null],
-    ['Robert', 'Evans', '07/24/2019', 12464, 'abaa'],
-    ['Ann', 'Williams', '01/14/2017', 33.9, 'aab'],
-    ['David', 'Taylor', '02/02/2020', 7000, 'bbbb'],
-    ['John', 'Brown', '07/24/2020', 2984, null],
-    ['Mary', 'Brown', '01/14/2017', 4000, ''],
-    ['Robert', 'Evans', '07/24/2020', 30500, undefined]
-  ];
-
   it('should display indicator properly after changing sorted column sequence', () => {
     const hot = handsontable({
       data: [

--- a/handsontable/src/plugins/columnSorting/__tests__/rtl/columnSorting.spec.js
+++ b/handsontable/src/plugins/columnSorting/__tests__/rtl/columnSorting.spec.js
@@ -1,0 +1,84 @@
+describe('ColumnSorting (RTL)', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    $('html').attr('dir', 'rtl');
+
+    this.$container = $(`<div id="${id}" style="overflow: auto; width: 300px; height: 200px;"></div>`).appendTo('body');
+
+    this.sortByClickOnColumnHeader = (columnIndex) => {
+      const hot = this.$container.data('handsontable');
+      const $columnHeader = $(hot.view.wt.wtTable.getColumnHeader(columnIndex));
+      const $spanInsideHeader = $columnHeader.find('.columnSorting');
+
+      if ($spanInsideHeader.length === 0) {
+        throw Error('Please check the test scenario. The header doesn\'t exist.');
+      }
+
+      $spanInsideHeader.simulate('mousedown');
+      $spanInsideHeader.simulate('mouseup');
+      $spanInsideHeader.simulate('click');
+    };
+  });
+
+  afterEach(function() {
+    $('html').attr('dir', 'ltr');
+
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  const arrayOfObjects = () => [
+    { id: 1, name: 'Ted', lastName: 'Right' },
+    { id: 2, name: 'Frank', lastName: 'Honest' },
+    { id: 3, name: 'Joan', lastName: 'Well' },
+    { id: 4, name: 'Sid', lastName: 'Strong' },
+    { id: 5, name: 'Jane', lastName: 'Neat' },
+    { id: 6, name: 'Chuck', lastName: 'Jackson' },
+    { id: 7, name: 'Meg', lastName: 'Jansen' },
+    { id: 8, name: 'Rob', lastName: 'Norris' },
+    { id: 9, name: 'Sean', lastName: 'O\'Hara' },
+    { id: 10, name: 'Eve', lastName: 'Branson' }
+  ];
+
+  const arrayOfArrays = () => [
+    ['Mary', 'Brown', '01/14/2017', 6999.95, 'aa'],
+    ['Henry', 'Jones', '12/01/2018', 8330, 'aaa'],
+    ['Ann', 'Evans', '07/24/2021', 30500, null],
+    ['Robert', 'Evans', '07/24/2019', 12464, 'abaa'],
+    ['Ann', 'Williams', '01/14/2017', 33.9, 'aab'],
+    ['David', 'Taylor', '02/02/2020', 7000, 'bbbb'],
+    ['John', 'Brown', '07/24/2020', 2984, null],
+    ['Mary', 'Brown', '01/14/2017', 4000, ''],
+    ['Robert', 'Evans', '07/24/2020', 30500, undefined]
+  ];
+
+  it('should display indicator properly after changing sorted column sequence', () => {
+    const hot = handsontable({
+      data: [
+        [1, 9, 3, 4, 5, 6, 7, 8, 9],
+        [9, 8, 7, 6, 5, 4, 3, 2, 1],
+        [8, 7, 6, 5, 4, 3, 3, 1, 9],
+        [0, 3, 0, 5, 6, 7, 8, 9, 1]
+      ],
+      colHeaders: true,
+      columnSorting: {
+        indicator: true
+      }
+    });
+
+    getPlugin('columnSorting').sort({ column: 0, sortOrder: 'asc' });
+
+    // changing column sequence: 0 <-> 1
+    hot.columnIndexMapper.moveIndexes([1], 0);
+    hot.render();
+
+    const sortedColumn = spec().$container.find('th span.columnSorting')[1];
+
+    expect(window.getComputedStyle(sortedColumn, ':before').getPropertyValue('background-image')).toMatch(/url/);
+    expect(window.getComputedStyle(sortedColumn, ':before').getPropertyValue('left')).toEqual('-9px');
+  });
+
+});

--- a/handsontable/src/plugins/multiColumnSorting/__tests__/multiColumnSorting.spec.js
+++ b/handsontable/src/plugins/multiColumnSorting/__tests__/multiColumnSorting.spec.js
@@ -2745,6 +2745,55 @@ describe('MultiColumnSorting', () => {
   });
 
   describe('Numbers presenting sorting sequence', () => {
+    it('should be properly position the number when multi columns are sorted', () => {
+      spec().$container[0].style.width = 'auto';
+      spec().$container[0].style.height = 'auto';
+
+      handsontable({
+        data: createSpreadsheetData(10, 10),
+        colHeaders: true,
+        multiColumnSorting: {
+          indicator: true,
+          initialConfig: [{
+            column: 1,
+            sortOrder: 'asc'
+          }, {
+            column: 0,
+            sortOrder: 'asc'
+          }, {
+            column: 2,
+            sortOrder: 'asc'
+          }, {
+            column: 3,
+            sortOrder: 'asc'
+          }, {
+            column: 4,
+            sortOrder: 'asc'
+          }, {
+            column: 5,
+            sortOrder: 'asc'
+          }, {
+            column: 6,
+            sortOrder: 'asc'
+          }, {
+            column: 7,
+            sortOrder: 'asc'
+          }, {
+            column: 8,
+            sortOrder: 'asc'
+          }, {
+            column: 9,
+            sortOrder: 'asc'
+          }]
+        }
+      });
+
+      expect(window.getComputedStyle(spec().$container.find('th span.columnSorting')[0], ':after')
+        .getPropertyValue('right')).toEqual('-15px');
+      expect(window.getComputedStyle(spec().$container.find('th span.columnSorting')[0], ':after')
+        .getPropertyValue('padding-left')).toEqual('5px');
+    });
+
     it('should be properly presented on the UI when more than 7 columns are sorted', () => {
       spec().$container[0].style.width = 'auto';
       spec().$container[0].style.height = 'auto';

--- a/handsontable/src/plugins/multiColumnSorting/__tests__/rtl/multiColumnSorting.spec.js
+++ b/handsontable/src/plugins/multiColumnSorting/__tests__/rtl/multiColumnSorting.spec.js
@@ -1,0 +1,68 @@
+describe('MultiColumnSorting (RTL)', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    $('html').attr('dir', 'rtl');
+    this.$container = $(`<div id="${id}" style="overflow: auto; width: 300px; height: 200px;"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    $('html').attr('dir', 'ltr');
+
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  describe('Numbers presenting sorting sequence', () => {
+    it('should be properly position the number when multi columns are sorted', () => {
+      spec().$container[0].style.width = 'auto';
+      spec().$container[0].style.height = 'auto';
+
+      handsontable({
+        data: createSpreadsheetData(10, 10),
+        colHeaders: true,
+        multiColumnSorting: {
+          indicator: true,
+          initialConfig: [{
+            column: 1,
+            sortOrder: 'asc'
+          }, {
+            column: 0,
+            sortOrder: 'asc'
+          }, {
+            column: 2,
+            sortOrder: 'asc'
+          }, {
+            column: 3,
+            sortOrder: 'asc'
+          }, {
+            column: 4,
+            sortOrder: 'asc'
+          }, {
+            column: 5,
+            sortOrder: 'asc'
+          }, {
+            column: 6,
+            sortOrder: 'asc'
+          }, {
+            column: 7,
+            sortOrder: 'asc'
+          }, {
+            column: 8,
+            sortOrder: 'asc'
+          }, {
+            column: 9,
+            sortOrder: 'asc'
+          }]
+        }
+      });
+
+      expect(window.getComputedStyle(spec().$container.find('th span.columnSorting')[0], ':after')
+        .getPropertyValue('left')).toEqual('-15px');
+      expect(window.getComputedStyle(spec().$container.find('th span.columnSorting')[0], ':after')
+        .getPropertyValue('padding-right')).toEqual('5px');
+    });
+  });
+});

--- a/handsontable/src/plugins/multiColumnSorting/multiColumnSorting.js
+++ b/handsontable/src/plugins/multiColumnSorting/multiColumnSorting.js
@@ -7,7 +7,7 @@ import { rootComparator } from './rootComparator';
 import { warnAboutPluginsConflict } from './utils';
 import { getClassesToAdd, getClassesToRemove } from './domHelpers';
 
-import './multiColumnSorting.css';
+import './multiColumnSorting.scss';
 
 export const PLUGIN_KEY = 'multiColumnSorting';
 export const PLUGIN_PRIORITY = 170;

--- a/handsontable/src/plugins/multiColumnSorting/multiColumnSorting.scss
+++ b/handsontable/src/plugins/multiColumnSorting/multiColumnSorting.scss
@@ -7,8 +7,8 @@
   /* Centering end */
 
   position: absolute;
-  inline-end: -15px;
-  inline-start: unset;
+  inset-inline-end: -15px;
+  inset-inline-start: unset;
   /* For purpose of continuous mouse over experience, when moving between the `::before` and the `::after` elements */
   padding-inline-start: 5px;
   padding-inline-end: unset;

--- a/handsontable/src/plugins/multiColumnSorting/multiColumnSorting.scss
+++ b/handsontable/src/plugins/multiColumnSorting/multiColumnSorting.scss
@@ -7,9 +7,11 @@
   /* Centering end */
 
   position: absolute;
-  right: -15px;
+  inline-end: -15px;
+  inline-start: unset;
   /* For purpose of continuous mouse over experience, when moving between the `::before` and the `::after` elements */
-  padding-left: 5px;
+  padding-inline-start: 5px;
+  padding-inline-end: unset;
 
   font-size: 8px;
   height: 8px;


### PR DESCRIPTION
### Context
Following issue #8813, the sorting arrows are always on the right. This pr fix positioning of the arrows. 
[skip changelog]

### How has this been tested?
Tested manually and it works, I added assertions which check the position of the indicator.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. resolves #8813 
2.
3.

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
