### PR TITLE
Docs: Adding information on Vue 3 version support

### DIFF
--- a/docs/11.1/guides/formulas/formula-calculation.md
+++ b/docs/11.1/guides/formulas/formula-calculation.md
@@ -37,7 +37,7 @@ This plugin comes with a library of 386 functions grouped into categories, such 
 *   Online calculators
 *   Low connectivity apps
 
-### Version support
+### HyperFormula version support
 
 Different [versions of Handsontable](https://github.com/handsontable/handsontable/releases) support different [versions of HyperFormula](https://github.com/handsontable/hyperformula/releases).
 

--- a/docs/11.1/guides/integrate-with-vue3/vue3-custom-context-menu-example.md
+++ b/docs/11.1/guides/integrate-with-vue3/vue3-custom-context-menu-example.md
@@ -11,6 +11,8 @@ canonicalUrl: /vue3-custom-context-menu-example
 
 The following example implements the `@handsontable/vue3` component, adding a custom Context Menu.
 
+[Find out which Vue 3 versions are supported &#8594;](@/guides/integrate-with-vue3/vue3-installation.md#vue-3-version-support)
+
 ## Example
 
 ::: example #example1 :vue3 --html 1 --js 2

--- a/docs/11.1/guides/integrate-with-vue3/vue3-custom-editor-example.md
+++ b/docs/11.1/guides/integrate-with-vue3/vue3-custom-editor-example.md
@@ -13,6 +13,8 @@ canonicalUrl: /vue3-custom-editor-example
 
 You can declare a custom editor for the `HotTable` component by declaring it as a class and passing it to the Handsontable options or creating an editor component. You can use it many times and with different properties. To differentiate between editor instances, pass a `key` attribute.
 
+[Find out which Vue 3 versions are supported &#8594;](@/guides/integrate-with-vue3/vue3-installation.md#vue-3-version-support)
+
 ## Example - Declaring an editor as a class
 
 The following example implements the `@handsontable/vue3` component with a custom editor added, utilizing the `placeholder` attribute in the editor's `input` element.

--- a/docs/11.1/guides/integrate-with-vue3/vue3-custom-id-class-style.md
+++ b/docs/11.1/guides/integrate-with-vue3/vue3-custom-id-class-style.md
@@ -12,6 +12,8 @@ canonicalUrl: /vue3-custom-id-class-style
 Custom `id`, `class`, `style`, and other attributes can be passed into the `hot-table` wrapper element.
 Each of them will be applied to the root Handsontable element, allowing further customization of the table.
 
+[Find out which Vue 3 versions are supported &#8594;](@/guides/integrate-with-vue3/vue3-installation.md#vue-3-version-support)
+
 ## Example
 
 ::: example #example1 :vue3 --html 1 --js 2

--- a/docs/11.1/guides/integrate-with-vue3/vue3-custom-renderer-example.md
+++ b/docs/11.1/guides/integrate-with-vue3/vue3-custom-renderer-example.md
@@ -13,6 +13,8 @@ canonicalUrl: /vue3-custom-renderer-example
 
 You can declare a custom renderer for the `HotTable` component by declaring it as a function in the Handsontable options or creating a rendering component.
 
+[Find out which Vue 3 versions are supported &#8594;](@/guides/integrate-with-vue3/vue3-installation.md#vue-3-version-support)
+
 ## Example - Declaring a renderer as a function
 
 The following example is an implementation of `@handsontable/vue3` with a custom renderer added. It takes an image URL as the input and renders the image in the edited cell.

--- a/docs/11.1/guides/integrate-with-vue3/vue3-hot-column.md
+++ b/docs/11.1/guides/integrate-with-vue3/vue3-hot-column.md
@@ -13,6 +13,8 @@ canonicalUrl: /vue3-hot-column
 
 You can configure the column-related settings using the `HotColumn` component's attributes. You can also create custom renderers and editors using Vue 3 components.
 
+[Find out which Vue 3 versions are supported &#8594;](@/guides/integrate-with-vue3/vue3-installation.md#vue-3-version-support)
+
 ## Declaring column settings
 
 To declare column-specific settings, pass the settings as `hot-column` properties, either separately or wrapped as a `settings` property, exactly as you would for `hot-table`.

--- a/docs/11.1/guides/integrate-with-vue3/vue3-hot-reference.md
+++ b/docs/11.1/guides/integrate-with-vue3/vue3-hot-reference.md
@@ -12,6 +12,8 @@ permalink: /11.1/vue3-hot-reference
 
 The following example implements the `@handsontable/vue3`, showing how to reference the Handsontable instance from the wrapper component.
 
+[Find out which Vue 3 versions are supported &#8594;](@/guides/integrate-with-vue3/vue3-installation.md#vue-3-version-support)
+
 ## Example
 
 ::: example #example1 :vue3 --html 1 --js 2

--- a/docs/11.1/guides/integrate-with-vue3/vue3-installation.md
+++ b/docs/11.1/guides/integrate-with-vue3/vue3-installation.md
@@ -13,6 +13,19 @@ canonicalUrl: /vue3-installation
 
 Vue 3 installation and basic usage guide.
 
+### Vue 3 version support
+
+To find out which Vue 3 versions are supported by Handsontable, see the table below:
+
+::: details Vue 3 version support
+
+| Handsontable version                                                                    | Vue 3 version      |
+| --------------------------------------------------------------------------------------- | ------------------ |
+| [`11.0.0`](https://github.com/handsontable/handsontable/releases/tag/11.0.0) and lower  | No Vue 3 support   |
+| [`11.1.0`](https://github.com/handsontable/handsontable/releases/tag/11.1.0) and higher | `3.2.0` and higher |
+
+:::
+
 ## Install with npm
 
 This component needs the Handsontable library to work. Use [npm](https://www.npmjs.com/package/@handsontable/vue3) to install the packages.

--- a/docs/11.1/guides/integrate-with-vue3/vue3-language-change-example.md
+++ b/docs/11.1/guides/integrate-with-vue3/vue3-language-change-example.md
@@ -13,6 +13,8 @@ The following example implements the `@handsontable/vue3` component with the opt
 Note that the `language` property is bound to the component separately using `language={this.language}"`, but it could be included in the `settings` property just as well.
 :::
 
+[Find out which Vue 3 versions are supported &#8594;](@/guides/integrate-with-vue3/vue3-installation.md#vue-3-version-support)
+
 ## Example - Select language
 
 ::: example #example1 :vue3-languages --html 1 --js 2

--- a/docs/11.1/guides/integrate-with-vue3/vue3-modules.md
+++ b/docs/11.1/guides/integrate-with-vue3/vue3-modules.md
@@ -13,6 +13,8 @@ canonicalUrl: /vue3-modules
 
 To reduce the size of your app, you can use Handsontable by importing individual [modules](@/guides/building-and-testing/modules.md).
 
+[Find out which Vue 3 versions are supported &#8594;](@/guides/integrate-with-vue3/vue3-installation.md#vue-3-version-support)
+
 ## Using modules with Vue 3
 
 To use modules with Handsontable's [Vue 3 wrapper](@/guides/integrate-with-vue3/vue3-installation.md), follow the steps below:

--- a/docs/11.1/guides/integrate-with-vue3/vue3-setting-up-a-language.md
+++ b/docs/11.1/guides/integrate-with-vue3/vue3-setting-up-a-language.md
@@ -11,6 +11,8 @@ canonicalUrl: /vue3-setting-up-a-language
 
 The following example shows a Handsontable instance with translations set up in Vue 3.
 
+[Find out which Vue 3 versions are supported &#8594;](@/guides/integrate-with-vue3/vue3-installation.md#vue-3-version-support)
+
 ## Example
 
 ::: example #example1 :vue3-numbro --html 1 --js 2

--- a/docs/11.1/guides/integrate-with-vue3/vue3-simple-example.md
+++ b/docs/11.1/guides/integrate-with-vue3/vue3-simple-example.md
@@ -11,6 +11,8 @@ canonicalUrl: /vue3-simple-example
 
 The following example is a simple implementation of the `@handsontable/vue3` component.
 
+[Find out which Vue 3 versions are supported &#8594;](@/guides/integrate-with-vue3/vue3-installation.md#vue-3-version-support)
+
 ## Example
 
 In this example, a `div` element of `id="example1"` where the `@handsontable/vue3` component will be rendered.

--- a/docs/11.1/guides/integrate-with-vue3/vue3-vuex-example.md
+++ b/docs/11.1/guides/integrate-with-vue3/vue3-vuex-example.md
@@ -13,6 +13,8 @@ canonicalUrl: /vue3-vuex-example
 
 The following example implements the `@handsontable/vue3` component with a `readOnly` toggle switch and the Vuex state manager.
 
+[Find out which Vue 3 versions are supported &#8594;](@/guides/integrate-with-vue3/vue3-installation.md#vue-3-version-support)
+
 ## Example - Vuex store dump:
 
 Toggle `readOnly` for the entire table.

--- a/docs/next/guides/formulas/formula-calculation.md
+++ b/docs/next/guides/formulas/formula-calculation.md
@@ -37,7 +37,7 @@ This plugin comes with a library of 386 functions grouped into categories, such 
 *   Online calculators
 *   Low connectivity apps
 
-### Version support
+### HyperFormula version support
 
 Different [versions of Handsontable](https://github.com/handsontable/handsontable/releases) support different [versions of HyperFormula](https://github.com/handsontable/hyperformula/releases).
 

--- a/docs/next/guides/integrate-with-vue3/vue3-custom-context-menu-example.md
+++ b/docs/next/guides/integrate-with-vue3/vue3-custom-context-menu-example.md
@@ -11,6 +11,8 @@ canonicalUrl: /vue3-custom-context-menu-example
 
 The following example implements the `@handsontable/vue3` component, adding a custom Context Menu.
 
+[Find out which Vue 3 versions are supported &#8594;](@/guides/integrate-with-vue3/vue3-installation.md#vue-3-version-support)
+
 ## Example
 
 ::: example #example1 :vue3 --html 1 --js 2

--- a/docs/next/guides/integrate-with-vue3/vue3-custom-editor-example.md
+++ b/docs/next/guides/integrate-with-vue3/vue3-custom-editor-example.md
@@ -13,6 +13,8 @@ canonicalUrl: /vue3-custom-editor-example
 
 You can declare a custom editor for the `HotTable` component by declaring it as a class and passing it to the Handsontable options or creating an editor component. You can use it many times and with different properties. To differentiate between editor instances, pass a `key` attribute.
 
+[Find out which Vue 3 versions are supported &#8594;](@/guides/integrate-with-vue3/vue3-installation.md#vue-3-version-support)
+
 ## Example - Declaring an editor as a class
 
 The following example implements the `@handsontable/vue3` component with a custom editor added, utilizing the `placeholder` attribute in the editor's `input` element.

--- a/docs/next/guides/integrate-with-vue3/vue3-custom-id-class-style.md
+++ b/docs/next/guides/integrate-with-vue3/vue3-custom-id-class-style.md
@@ -12,6 +12,8 @@ canonicalUrl: /vue3-custom-id-class-style
 Custom `id`, `class`, `style`, and other attributes can be passed into the `hot-table` wrapper element.
 Each of them will be applied to the root Handsontable element, allowing further customization of the table.
 
+[Find out which Vue 3 versions are supported &#8594;](@/guides/integrate-with-vue3/vue3-installation.md#vue-3-version-support)
+
 ## Example
 
 ::: example #example1 :vue3 --html 1 --js 2

--- a/docs/next/guides/integrate-with-vue3/vue3-custom-renderer-example.md
+++ b/docs/next/guides/integrate-with-vue3/vue3-custom-renderer-example.md
@@ -13,6 +13,8 @@ canonicalUrl: /vue3-custom-renderer-example
 
 You can declare a custom renderer for the `HotTable` component by declaring it as a function in the Handsontable options or creating a rendering component.
 
+[Find out which Vue 3 versions are supported &#8594;](@/guides/integrate-with-vue3/vue3-installation.md#vue-3-version-support)
+
 ## Example - Declaring a renderer as a function
 
 The following example is an implementation of `@handsontable/vue3` with a custom renderer added. It takes an image URL as the input and renders the image in the edited cell.

--- a/docs/next/guides/integrate-with-vue3/vue3-hot-column.md
+++ b/docs/next/guides/integrate-with-vue3/vue3-hot-column.md
@@ -13,6 +13,8 @@ canonicalUrl: /vue3-hot-column
 
 You can configure the column-related settings using the `HotColumn` component's attributes. You can also create custom renderers and editors using Vue 3 components.
 
+[Find out which Vue 3 versions are supported &#8594;](@/guides/integrate-with-vue3/vue3-installation.md#vue-3-version-support)
+
 ## Declaring column settings
 
 To declare column-specific settings, pass the settings as `hot-column` properties, either separately or wrapped as a `settings` property, exactly as you would for `hot-table`.

--- a/docs/next/guides/integrate-with-vue3/vue3-hot-reference.md
+++ b/docs/next/guides/integrate-with-vue3/vue3-hot-reference.md
@@ -12,6 +12,8 @@ permalink: /next/vue3-hot-reference
 
 The following example implements the `@handsontable/vue3`, showing how to reference the Handsontable instance from the wrapper component.
 
+[Find out which Vue 3 versions are supported &#8594;](@/guides/integrate-with-vue3/vue3-installation.md#vue-3-version-support)
+
 ## Example
 
 ::: example #example1 :vue3 --html 1 --js 2

--- a/docs/next/guides/integrate-with-vue3/vue3-installation.md
+++ b/docs/next/guides/integrate-with-vue3/vue3-installation.md
@@ -13,6 +13,19 @@ canonicalUrl: /vue3-installation
 
 Vue 3 installation and basic usage guide.
 
+### Vue 3 version support
+
+To find out which Vue 3 versions are supported by Handsontable, see the table below:
+
+::: details Vue 3 version support
+
+| Handsontable version                                                                    | Vue 3 version      |
+| --------------------------------------------------------------------------------------- | ------------------ |
+| [`11.0.0`](https://github.com/handsontable/handsontable/releases/tag/11.0.0) and lower  | No Vue 3 support   |
+| [`11.1.0`](https://github.com/handsontable/handsontable/releases/tag/11.1.0) and higher | `3.2.0` and higher |
+
+:::
+
 ## Install with npm
 
 This component needs the Handsontable library to work. Use [npm](https://www.npmjs.com/package/@handsontable/vue3) to install the packages.

--- a/docs/next/guides/integrate-with-vue3/vue3-language-change-example.md
+++ b/docs/next/guides/integrate-with-vue3/vue3-language-change-example.md
@@ -13,6 +13,8 @@ The following example implements the `@handsontable/vue3` component with the opt
 Note that the `language` property is bound to the component separately using `language={this.language}"`, but it could be included in the `settings` property just as well.
 :::
 
+[Find out which Vue 3 versions are supported &#8594;](@/guides/integrate-with-vue3/vue3-installation.md#vue-3-version-support)
+
 ## Example - Select language
 
 ::: example #example1 :vue3-languages --html 1 --js 2

--- a/docs/next/guides/integrate-with-vue3/vue3-modules.md
+++ b/docs/next/guides/integrate-with-vue3/vue3-modules.md
@@ -13,6 +13,8 @@ canonicalUrl: /vue3-modules
 
 To reduce the size of your app, you can use Handsontable by importing individual [modules](@/guides/building-and-testing/modules.md).
 
+[Find out which Vue 3 versions are supported &#8594;](@/guides/integrate-with-vue3/vue3-installation.md#vue-3-version-support)
+
 ## Using modules with Vue 3
 
 To use modules with Handsontable's [Vue 3 wrapper](@/guides/integrate-with-vue3/vue3-installation.md), follow the steps below:

--- a/docs/next/guides/integrate-with-vue3/vue3-setting-up-a-language.md
+++ b/docs/next/guides/integrate-with-vue3/vue3-setting-up-a-language.md
@@ -11,6 +11,8 @@ canonicalUrl: /vue3-setting-up-a-language
 
 The following example shows a Handsontable instance with translations set up in Vue 3.
 
+[Find out which Vue 3 versions are supported &#8594;](@/guides/integrate-with-vue3/vue3-installation.md#vue-3-version-support)
+
 ## Example
 
 ::: example #example1 :vue3-numbro --html 1 --js 2

--- a/docs/next/guides/integrate-with-vue3/vue3-simple-example.md
+++ b/docs/next/guides/integrate-with-vue3/vue3-simple-example.md
@@ -11,6 +11,8 @@ canonicalUrl: /vue3-simple-example
 
 The following example is a simple implementation of the `@handsontable/vue3` component.
 
+[Find out which Vue 3 versions are supported &#8594;](@/guides/integrate-with-vue3/vue3-installation.md#vue-3-version-support)
+
 ## Example
 
 In this example, a `div` element of `id="example1"` where the `@handsontable/vue3` component will be rendered.

--- a/docs/next/guides/integrate-with-vue3/vue3-vuex-example.md
+++ b/docs/next/guides/integrate-with-vue3/vue3-vuex-example.md
@@ -13,6 +13,8 @@ canonicalUrl: /vue3-vuex-example
 
 The following example implements the `@handsontable/vue3` component with a `readOnly` toggle switch and the Vuex state manager.
 
+[Find out which Vue 3 versions are supported &#8594;](@/guides/integrate-with-vue3/vue3-installation.md#vue-3-version-support)
+
 ## Example - Vuex store dump:
 
 Toggle `readOnly` for the entire table.


### PR DESCRIPTION
This PR:
- Adds information on which Vue 3 versions are supported by Handsontable