### PR TITLE
[RTL] Fix the collapsible columns button placement

### DIFF
--- a/handsontable/src/css/handsontable.scss
+++ b/handsontable/src/css/handsontable.scss
@@ -391,7 +391,8 @@ TextRenderer placeholder value
   position: absolute;
   top: 50%;
   transform: translate(0% ,-50%);
-  right: 5px;
+  inset-inline-start: unset;
+  inset-inline-end: 5px;
   border: 1px solid #A6A6A6;
   line-height: 8px;
   color: #222;

--- a/handsontable/src/plugins/collapsibleColumns/__tests__/collapsibleColumns.spec.js
+++ b/handsontable/src/plugins/collapsibleColumns/__tests__/collapsibleColumns.spec.js
@@ -2533,6 +2533,19 @@ describe('CollapsibleColumns', () => {
   });
 
   describe('collapsible button', () => {
+    it('should be placed in correct place', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(10, 10),
+        nestedHeaders: [
+          ['A1', { label: 'B1', colspan: 4 }, 'F1', 'G1', 'H1', 'I1', 'J1'],
+          ['A2', { label: 'B2', colspan: 2 }, { label: 'D2', colspan: 2 }, 'F2', 'G2', 'H2', 'I2', 'J2'],
+        ],
+        collapsibleColumns: true
+      });
+      expect(window.getComputedStyle(getCell(-1, 3).querySelector('.collapsibleIndicator'))
+        .getPropertyValue('right')).toEqual('5px');
+    });
+
     it('should call "toggleCollapsibleSection" internally with correct toggle state ' +
        '(depends if the clicked header is already collapsed or not)', () => {
       handsontable({

--- a/handsontable/src/plugins/collapsibleColumns/__tests__/rtl/collapsibleColumns.spec.js
+++ b/handsontable/src/plugins/collapsibleColumns/__tests__/rtl/collapsibleColumns.spec.js
@@ -1,0 +1,38 @@
+describe('CollapsibleColumns (RTL)', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    $('html').attr('dir', 'rtl');
+
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    $('html').attr('dir', 'ltr');
+
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+    if (this.$wrapper) {
+      this.$wrapper.remove();
+    }
+  });
+
+  describe('collapsible button', () => {
+    it('should be placed in correct place', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(10, 10),
+        nestedHeaders: [
+          ['A1', { label: 'B1', colspan: 4 }, 'F1', 'G1', 'H1', 'I1', 'J1'],
+          ['A2', { label: 'B2', colspan: 2 }, { label: 'D2', colspan: 2 }, 'F2', 'G2', 'H2', 'I2', 'J2'],
+        ],
+        collapsibleColumns: true
+      });
+
+      expect(window.getComputedStyle(getCell(-1, 3).querySelector('.collapsibleIndicator'))
+        .getPropertyValue('left')).toEqual('5px');
+    });
+  });
+
+});


### PR DESCRIPTION
### Context

This pr fixing the position of collapsible columns button for rtl mode.

[skip changelog]

### How has this been tested?
I tested it locally, and I added two new testing scenarios which covers both the rtl and ltr modes/

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. resolves #8812 
2.
3.

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
