### PR TITLE
Docs: Hiding the "Hello, World!" page from the menu 

### DIFF
--- a/docs/11.1/guides/sidebar.js
+++ b/docs/11.1/guides/sidebar.js
@@ -1,6 +1,5 @@
 const gettingStartedItems = [
   'guides/getting-started/introduction',
-  'guides/getting-started/hello-world',
   'guides/getting-started/installation',
   'guides/getting-started/binding-to-data',
   'guides/getting-started/saving-data',

--- a/docs/next/guides/sidebar.js
+++ b/docs/next/guides/sidebar.js
@@ -1,6 +1,5 @@
 const gettingStartedItems = [
   'guides/getting-started/introduction',
-  'guides/getting-started/hello-world',
   'guides/getting-started/installation',
   'guides/getting-started/binding-to-data',
   'guides/getting-started/saving-data',


### PR DESCRIPTION
This PR:
- Removes the "Hello, World!" page from the menu, for versions `11.1` and `next` (it should be brought back in #8989, after #8980 is done)

Affected content:
- https://handsontable.com/docs/hello-world/ (shouldn't be visible in the menu)

[skip changelog]