### PR TITLE
Make `updateSettings` utilize `updateData`.

### DIFF
--- a/.changelogs/7263.json
+++ b/.changelogs/7263.json
@@ -1,5 +1,5 @@
 {
-  "title": "Changed the way `updateSettings` handles data buy introducing `updateData` instead of `loadData` in the majority of cases.",
+  "title": "Changed the way `updateSettings` handles data by introducing `updateData` instead of `loadData` in the majority of cases.",
   "type": "changed",
   "issue": 7263,
   "breaking": true,

--- a/.changelogs/7263.json
+++ b/.changelogs/7263.json
@@ -1,0 +1,7 @@
+{
+  "title": "Changed the way `updateSettings` handles data buy introducing `updateData` instead of `loadData` in the majority of cases.",
+  "type": "changed",
+  "issue": 7263,
+  "breaking": true,
+  "framework": "none"
+}

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -2263,12 +2263,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
    * @fires Hooks#afterUpdateSettings
    */
   this.updateSettings = function(settings, init = false) {
-    // TODO: uncomment the next line with the next major version update
-    // Do not forget to re-enable the pending tests that cover the change:
-    //  * https://github.com/handsontable/handsontable/blob/9f62c282a1c951b27cd8406aa27105bd32b05bb6/handsontable/test/e2e/core/toPhysicalColumn.spec.js#L70
-    //  * https://github.com/handsontable/handsontable/blob/9f62c282a1c951b27cd8406aa27105bd32b05bb6/handsontable/test/e2e/core/toVisualColumn.spec.js#L70
-    // const dataUpdateFunction = (firstRun ? instance.loadData : instance.updateData).bind(this);
-    const dataUpdateFunction = instance.loadData.bind(this);
+    const dataUpdateFunction = (firstRun ? instance.loadData : instance.updateData).bind(this);
     let columnsAsFunc = false;
     let i;
     let j;

--- a/handsontable/src/dataMap/replaceData.js
+++ b/handsontable/src/dataMap/replaceData.js
@@ -50,12 +50,6 @@ function replaceData(data, setDataMapFunction, callbackFunction, config) {
 
   data = hotInstance.runHooks(`before${capitalizedInternalSource}`, data, firstRun, source);
 
-  // TODO: deprecated, will be eventually removed, leaving only the `beforeUpdateData` hook.
-  //  Triggers an additional `afterLoadData` hook for the `updateSettings` calls for backward compatibility.
-  if (internalSource !== 'loadData' && source === 'updateSettings') {
-    data = hotInstance.runHooks('beforeLoadData', data, firstRun, source);
-  }
-
   const newDataMap = new DataMap(hotInstance, data, tableMeta);
 
   // We need to apply the new dataMap immediately, because of some asynchronous logic in the
@@ -120,17 +114,9 @@ function replaceData(data, setDataMapFunction, callbackFunction, config) {
 
   hotInstance.runHooks(`after${capitalizedInternalSource}`, data, firstRun, source);
 
-  // TODO: deprecated, will be eventually removed, leaving only the `afterUpdateData` hook.
-  //  Triggers an additional `afterLoadData` hook for the `updateSettings` calls for backward compatibility.
-  if (internalSource !== 'loadData' && source === 'updateSettings') {
-    hotInstance.runHooks('afterLoadData', data, firstRun, source);
-  }
-
   // TODO: rethink the way the `afterChange` hook is being run here in the core `init` method.
   if (!firstRun) {
-    // TODO: `afterChange` still needs to provide `loadData` as a `source` when called from `updateSettings` to keep
-    //  backward compatibility - to be changed after removing `loadData`.
-    hotInstance.runHooks('afterChange', null, (source === 'updateSettings' ? 'loadData' : internalSource));
+    hotInstance.runHooks('afterChange', null, internalSource);
     hotInstance.render();
   }
 }

--- a/handsontable/test/e2e/core/toPhysicalColumn.spec.js
+++ b/handsontable/test/e2e/core/toPhysicalColumn.spec.js
@@ -53,8 +53,7 @@ describe('Core.toPhysicalColumn', () => {
     });
   });
 
-  // TODO: uncomment with the next major version
-  xdescribe('should NOT reset physical indexes when user updates data', () => {
+  describe('should NOT reset physical indexes when user updates data', () => {
     it('by updating settings', () => {
       const hot = handsontable({
         data: Handsontable.helper.createSpreadsheetData(5, 5),

--- a/handsontable/test/e2e/core/toVisualColumn.spec.js
+++ b/handsontable/test/e2e/core/toVisualColumn.spec.js
@@ -53,8 +53,7 @@ describe('Core.toVisualColumn', () => {
     });
   });
 
-  // TODO: uncomment with the next major version
-  xdescribe('should NOT reset visual indexes when user updates data', () => {
+  describe('should NOT reset visual indexes when user updates data', () => {
     it('by updating settings', () => {
       const hot = handsontable({
         data: Handsontable.helper.createSpreadsheetData(5, 5),


### PR DESCRIPTION
### Context
This PR should reintroduce the breaking parts of #7263, namely:
* makes the `updateSettings` method use `loadData` **only** when initializing the table (as there's not yet any data to be updated) - in all other instances, it should use `updateData`
* the `updateData` method will not trigger the `after`/`beforeLoadData` hooks when called from `updateSettings`, as it was implemented only as a temporary solution to prevent #7263 from being a breaking change.
* the `updateData` method will no longer pass `loadData` as a `source` in the `afterChange` hook, as it was implemented only as a temporary solution to prevent #7263 from being a breaking change.

### How has this been tested?
The test cases were already added in #8972, this PR uncomments them.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7263 
2. #8972
3. #9037

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
