### PR TITLE
Docs: Linking `locale` nad `language` options' API ref to guides

### DIFF
--- a/handsontable/src/dataMap/metaManager/metaSchema.js
+++ b/handsontable/src/dataMap/metaManager/metaSchema.js
@@ -2429,7 +2429,7 @@ export default () => {
     label: void 0,
 
     /**
-     * The `language` option configures Handsontable's language.
+     * The `language` option configures Handsontable's [language settings](@/guides/internationalization/internationalization-i18n.md#language-settings).
      *
      * You can set the `language` option to one of the following:
      *
@@ -2452,7 +2452,7 @@ export default () => {
      * | `'zh-TW'`           | Chinese - Taiwan            |
      *
      * Read more:
-     * - [Internationalization (i18n) &#8594;](@/guides/internationalization/internationalization-i18n.md)
+     * - [Internationalization (i18n): Language settings &#8594;](@/guides/internationalization/internationalization-i18n.md#language-settings)
      * - [`locale`](#locale)
      *
      * @memberof Options#
@@ -2498,13 +2498,14 @@ export default () => {
     licenseKey: void 0,
 
     /**
-     * The `locale` option configures Handsontable's locale.
+     * The `locale` option configures Handsontable's [locale settings](@/guides/internationalization/internationalization-i18n.md#locale-settings).
      *
      * You can set the `locale` option to any valid and canonicalized Unicode BCP 47 locale tag,
-     * both for the entire grid, and for individual columns.
+     * both for the [entire grid](@/guides/internationalization/internationalization-i18n.md#setting-the-grid-s-locale),
+     * and for [individual columns](@/guides/internationalization/internationalization-i18n.md#setting-a-column-s-locale).
      *
      * Read more:
-     * - [Internationalization (i18n) &#8594;](@/guides/internationalization/internationalization-i18n.md)
+     * - [Internationalization (i18n): Locale settings &#8594;](@/guides/internationalization/internationalization-i18n.md#locale-settings)
      * - [`language`](#language)
      *
      * @memberof Options#


### PR DESCRIPTION
This PR:
- Adds links from the API ref of the `locale` nad `language` settings to the corresponding sections in the guides