### PR TITLE
Docs: Removing a sentence about Vue 3

### DIFF
--- a/docs/11.1/guides/integrate-with-vue3/vue3-hot-column.md
+++ b/docs/11.1/guides/integrate-with-vue3/vue3-hot-column.md
@@ -11,7 +11,7 @@ canonicalUrl: /vue3-hot-column
 
 ## Overview
 
-You can configure the column-related settings using the `HotColumn` component's attributes. You can also create custom renderers and editors using Vue 3 components.
+You can configure column-related settings using the `HotColumn` component's attributes.
 
 [Find out which Vue 3 versions are supported &#8594;](@/guides/integrate-with-vue3/vue3-installation.md#vue-3-version-support)
 

--- a/docs/next/guides/integrate-with-vue3/vue3-hot-column.md
+++ b/docs/next/guides/integrate-with-vue3/vue3-hot-column.md
@@ -11,7 +11,7 @@ canonicalUrl: /vue3-hot-column
 
 ## Overview
 
-You can configure the column-related settings using the `HotColumn` component's attributes. You can also create custom renderers and editors using Vue 3 components.
+You can configure column-related settings using the `HotColumn` component's attributes.
 
 [Find out which Vue 3 versions are supported &#8594;](@/guides/integrate-with-vue3/vue3-installation.md#vue-3-version-support)
 


### PR DESCRIPTION
This PR:
- Removes an incorrect sentence from the **Using the HotColumn component in Vue 3** page

[skip changelog]