### PR TITLE
[RTL] Fixed nested rows in the RTL mode

### DIFF
--- a/handsontable/src/plugins/nestedRows/__tests__/nestedRows.spec.js
+++ b/handsontable/src/plugins/nestedRows/__tests__/nestedRows.spec.js
@@ -72,6 +72,18 @@ describe('NestedRows', () => {
 
       expect(errors.length).toEqual(0);
     });
+
+    it('should display indicators properly located', () => {
+      const hot = handsontable({
+        data: getMoreComplexNestedData(),
+        nestedRows: true,
+        rowHeaders: true
+      });
+
+      expect(hot.countRows()).toEqual(13);
+      expect(window.getComputedStyle($('.ht_nestingLevel_empty')[0]).float).toEqual('left');
+      expect(window.getComputedStyle($('.ht_nestingCollapse')[0]).right).toEqual('-2px');
+    });
   });
 
   describe('integration', () => {

--- a/handsontable/src/plugins/nestedRows/__tests__/rtl/nestedRows.spec.js
+++ b/handsontable/src/plugins/nestedRows/__tests__/rtl/nestedRows.spec.js
@@ -1,0 +1,121 @@
+describe('NestedRows (RTL)', () => {
+  const id = 'testContainer';
+  const dataInOrder = [
+    ['a0', 'b0'],
+    ['a0-a0', 'b0-b0'],
+    ['a0-a1', 'b0-b1'],
+    ['a0-a2', 'b0-b2'],
+    ['a0-a2-a0', 'b0-b2-b0'],
+    ['a0-a2-a0-a0', 'b0-b2-b0-b0'],
+    ['a0-a3', 'b0-b3'],
+    ['a1', 'b1'],
+    ['a2', 'b2'],
+    ['a2-a0', 'b2-b0'],
+    ['a2-a1', 'b2-b1'],
+    ['a2-a1-a0', 'b2-b1-b0'],
+    ['a2-a1-a1', 'b2-b1-b1']
+  ];
+
+  beforeEach(function() {
+    $('html').attr('dir', 'rtl');
+
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    $('html').attr('dir', 'ltr');
+
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  describe('Displaying a nested structure', () => {
+    it('should display as many rows as there are overall elements in a nested structure', () => {
+      const hot = handsontable({
+        data: getMoreComplexNestedData(),
+        nestedRows: true
+      });
+
+      expect(hot.countRows()).toEqual(13);
+    });
+
+    it('should display all nested structure elements in correct order (parent, its children, ' +
+      'its children children, next parent etc)', () => {
+      const hot = handsontable({
+        data: getMoreComplexNestedData(),
+        nestedRows: true
+      });
+
+      expect(hot.getData()).toEqual(dataInOrder);
+    });
+  });
+
+  it('should allow user to detach already added child', () => {
+    handsontable({
+      data: getSimplerNestedData(),
+      nestedRows: true,
+      contextMenu: true
+    });
+
+    selectCell(0, 0);
+    contextMenu();
+    $('.htContextMenu .ht_master .htCore').find('tbody td').not('.htSeparator').eq(0)
+      .simulate('mousedown').simulate('mouseup'); // Insert child row.
+
+    selectCell(6, 0);
+    contextMenu();
+    $('.htContextMenu .ht_master .htCore').find('tbody td').not('.htSeparator').eq(1)
+      .simulate('mousedown').simulate('mouseup'); // Detach from parent.
+
+    expect(getDataAtCell(6, 0)).toEqual('Best Metal Performance');
+    expect(getDataAtCell(18, 1)).toEqual(null);
+
+    // Added and then detached child.
+    expect(getPlugin('nestedRows').dataManager.isParent(18)).toBeFalsy();
+  });
+
+  it('should allow user to insert row below and above the parent', () => {
+    handsontable({
+      data: getSimplerNestedData(),
+      nestedRows: true,
+      contextMenu: true
+    });
+
+    selectCell(0, 0);
+    contextMenu();
+
+    $('.htContextMenu .ht_master .htCore').find('tbody td').not('.htSeparator').eq(2)
+      .simulate('mousedown').simulate('mouseup'); // Insert row above.
+    expect(getDataAtRow(0)).toEqual([null, null, null, null]);
+    expect(getDataAtRow(1)).toEqual(['Best Rock Performance', null, null, null]);
+    expect(getDataAtRow(2)).toEqual([null, 'Alabama Shakes', 'Don\'t Wanna Fight', 'ATO Records']);
+    expect(getDataAtRow(7)).toEqual(['Best Metal Performance', null, null, null]);
+
+    selectCell(1, 0);
+    contextMenu();
+
+    $('.htContextMenu .ht_master .htCore').find('tbody td').not('.htSeparator').eq(3)
+      .simulate('mousedown').simulate('mouseup'); // Insert row below.
+
+    expect(getDataAtRow(0)).toEqual([null, null, null, null]);
+    expect(getDataAtRow(1)).toEqual(['Best Rock Performance', null, null, null]);
+    expect(getDataAtRow(2)).toEqual([null, 'Alabama Shakes', 'Don\'t Wanna Fight', 'ATO Records']);
+    expect(getDataAtRow(7)).toEqual([null, null, null, null]);
+    expect(getDataAtRow(8)).toEqual(['Best Metal Performance', null, null, null]);
+  });
+
+  it('should display indicators properly located', () => {
+    const hot = handsontable({
+      data: getMoreComplexNestedData(),
+      nestedRows: true,
+      rowHeaders: true
+    });
+
+    expect(hot.countRows()).toEqual(13);
+    expect(window.getComputedStyle($('.ht_nestingLevel_empty')[0]).float).toEqual('right');
+    expect(window.getComputedStyle($('.ht_nestingCollapse')[0]).left).toEqual('-2px');
+  });
+
+});

--- a/handsontable/src/plugins/nestedRows/nestedRows.js
+++ b/handsontable/src/plugins/nestedRows/nestedRows.js
@@ -8,7 +8,7 @@ import { isArrayOfObjects } from '../../helpers/data';
 import { TrimmingMap } from '../../translations';
 import RowMoveController from './utils/rowMoveController';
 
-import './nestedRows.css';
+import './nestedRows.scss';
 
 export const PLUGIN_KEY = 'nestedRows';
 export const PLUGIN_PRIORITY = 300;

--- a/handsontable/src/plugins/nestedRows/nestedRows.scss
+++ b/handsontable/src/plugins/nestedRows/nestedRows.scss
@@ -55,4 +55,5 @@
 .handsontable.innerBorderLeft th div.ht_nestingButton,
 .handsontable.innerBorderLeft ~ .handsontable th div.ht_nestingButton {
   inset-inline-end: 0;
+  inset-inline-start: unset;
 }

--- a/handsontable/src/plugins/nestedRows/nestedRows.scss
+++ b/handsontable/src/plugins/nestedRows/nestedRows.scss
@@ -1,17 +1,19 @@
 .handsontable th.ht_nestingLevels {
-  text-align: left;
-  padding-left: 7px;
+  text-align: inline-start;
+  padding-inline-start: 7px;
 }
 
 .handsontable th div.ht_nestingLevels {
   display: inline-block;
   position: absolute;
-  left: 11px;
+  inset-inline-start: 11px;
+  inset-inline-end: unset;
 }
 
 .handsontable.innerBorderLeft th div.ht_nestingLevels,
 .handsontable.innerBorderLeft ~ .handsontable th div.ht_nestingLevels {
-  right: 10px;
+  inset-inline-end: 10px;
+  inset-inline-start: unset;
 }
 
 .handsontable th span.ht_nestingLevel {
@@ -22,7 +24,7 @@
   display: inline-block;
   width: 10px;
   height: 1px;
-  float: left;
+  float: inline-start;
 }
 
 .handsontable th span.ht_nestingLevel::after {
@@ -37,7 +39,8 @@
 .handsontable th div.ht_nestingButton {
   display: inline-block;
   position: absolute;
-  right: -2px;
+  inset-inline-end: -2px;
+  inset-inline-start: unset;
   cursor: pointer;
 }
 
@@ -51,5 +54,5 @@
 
 .handsontable.innerBorderLeft th div.ht_nestingButton,
 .handsontable.innerBorderLeft ~ .handsontable th div.ht_nestingButton {
-  right: 0;
+  inset-inline-end: 0;
 }


### PR DESCRIPTION
### Context

In this PR I fixed the positioning for rtl. That resolves #8836 .
[skip changelog]
<!--- Why is this change required? What problem does it solve? -->

### How has this been tested?
I added additional test cases which check if the styles positions are correct.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #8836
2.
3.

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
