### PR TITLE
[RTL] Add new `layoutDirection` Handsontable option

### DIFF
--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -140,7 +140,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
    * @returns {boolean} True if RTL.
    */
   this.isRtl = function() {
-    return instance.rootWindow.getComputedStyle(instance.rootElement).direction === 'rtl';
+    return instance.rootElement.getAttribute('dir') === 'rtl';
   };
 
   /**
@@ -2416,6 +2416,16 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
 
       if (initialStyle) {
         instance.rootElement.setAttribute('data-initialstyle', instance.rootElement.getAttribute('style'));
+      }
+
+      const layoutDirection = settings.layoutDirection;
+
+      if (['rtl', 'ltr', 'inherit'].includes(layoutDirection)) {
+        const direction = layoutDirection === 'inherit' ?
+          instance.rootWindow.getComputedStyle(instance.rootElement).direction :
+          layoutDirection;
+
+        instance.rootElement.setAttribute('dir', direction);
       }
     }
 

--- a/handsontable/src/dataMap/metaManager/metaSchema.js
+++ b/handsontable/src/dataMap/metaManager/metaSchema.js
@@ -4539,7 +4539,32 @@ export default () => {
      */
     wordWrap: true,
 
-    /* eslint-enable jsdoc/require-description-complete-sentence */
+    /**
+     * The `layoutDirection` option configures whether Handsontable should be rendered from Left-to-right or
+     * Right-to-left depending on the passed settings.
+     *
+     * __Warning:__ The `layoutDirection` option can only be passed when Handsontable is initialized. Nothing
+     * will happen when the option is passed to the `updateSettings` method. Every time the setting is passed
+     * to the method warning message is printed in the console to prevent confusion.
+     *
+     * | Setting          | Description                                             |
+     * | ---------------- | ------------------------------------------------------- |
+     * | `inherit` (default) | Handsontable detects automatically the document layout direction |
+     * | `rtl`            | Renders the table in Right-to-left mode even when the document is served as LTR |
+     * | `ltr`            | Renders the table in Left-to-right mode even when the document is served as RTL |
+     *
+     * @memberof Options#
+     * @type {string}
+     * @default 'inherit'
+     * @category Core
+     *
+     * @example
+     * ```js
+     * layoutDirection: 'rtl',
+     * ```
+     */
+    layoutDirection: 'inherit',
 
+    /* eslint-enable jsdoc/require-description-complete-sentence */
   };
 };

--- a/handsontable/src/dataMap/metaManager/mods/__tests__/extendMetaProperties.unit.js
+++ b/handsontable/src/dataMap/metaManager/mods/__tests__/extendMetaProperties.unit.js
@@ -4,168 +4,216 @@ import { ExtendMetaPropertiesMod } from '../extendMetaProperties';
 
 jest.mock('handsontable');
 
-describe('fixedColumnsProperties', () => {
-  describe('when LTR mode', () => {
+describe('ExtendMetaPropertiesMod', () => {
+  describe('fixedColumnsLeft/fixedColumnsStart', () => {
+    describe('when LTR mode', () => {
+      beforeEach(() => {
+        Handsontable.mockImplementation(() => {
+          return {
+            colToProp: visualCol => `prop_${visualCol}`,
+            runHooks: () => {},
+            hasHook: () => {},
+            isRtl: () => false,
+          };
+        });
+      });
+
+      it('when set nothing should equal 0', () => {
+        const hotMock = new Handsontable();
+        const metaManager = new MetaManager(hotMock, {}, [ExtendMetaPropertiesMod]);
+
+        expect(metaManager.getTableMeta().fixedColumnsLeft).toEqual(0);
+        expect(metaManager.getTableMeta().fixedColumnsStart).toEqual(0);
+      });
+
+      it('when set `fixedColumnsLeft` = 0 should equal 0', () => {
+        const hotMock = new Handsontable();
+        const metaManager = new MetaManager(hotMock, {}, [ExtendMetaPropertiesMod]);
+
+        metaManager.getTableMeta().fixedColumnsLeft = 0;
+
+        expect(metaManager.getTableMeta().fixedColumnsLeft).toEqual(0);
+        expect(metaManager.getTableMeta().fixedColumnsStart).toEqual(0);
+      });
+
+      it('when set `fixedColumnsLeft` = 0 and `fixedColumnsStart` = 0 should throws', () => {
+        const hotMock = new Handsontable();
+        const metaManager = new MetaManager(hotMock, {}, [ExtendMetaPropertiesMod]);
+
+        expect(() => {
+          metaManager.getTableMeta().fixedColumnsLeft = 0;
+          metaManager.getTableMeta().fixedColumnsStart = 0;
+        }).toThrow();
+      });
+
+      it('when set `fixedColumnsStart` = 0 should equal 0', () => {
+        const hotMock = new Handsontable();
+        const metaManager = new MetaManager(hotMock, {}, [ExtendMetaPropertiesMod]);
+
+        metaManager.getTableMeta().fixedColumnsStart = 0;
+
+        expect(metaManager.getTableMeta().fixedColumnsLeft).toEqual(0);
+        expect(metaManager.getTableMeta().fixedColumnsStart).toEqual(0);
+      });
+
+      it('when set `fixedColumnsLeft` = 1 should equal 1', () => {
+        const hotMock = new Handsontable();
+        const metaManager = new MetaManager(hotMock, {}, [ExtendMetaPropertiesMod]);
+
+        metaManager.getTableMeta().fixedColumnsLeft = 1;
+
+        expect(metaManager.getTableMeta().fixedColumnsLeft).toEqual(1);
+        expect(metaManager.getTableMeta().fixedColumnsStart).toEqual(1);
+      });
+
+      it('when set `fixedColumnsLeft` = 1 and `fixedColumnsStart` = 2 should throws', () => {
+        const hotMock = new Handsontable();
+        const metaManager = new MetaManager(hotMock, {}, [ExtendMetaPropertiesMod]);
+
+        expect(() => {
+          metaManager.getTableMeta().fixedColumnsLeft = 1;
+          metaManager.getTableMeta().fixedColumnsStart = 2;
+        }).toThrow();
+      });
+
+      it('when set `fixedColumnsStart` = 2 should equal 2', () => {
+        const hotMock = new Handsontable();
+        const metaManager = new MetaManager(hotMock, {}, [ExtendMetaPropertiesMod]);
+
+        metaManager.getTableMeta().fixedColumnsStart = 2;
+
+        expect(metaManager.getTableMeta().fixedColumnsLeft).toEqual(2);
+        expect(metaManager.getTableMeta().fixedColumnsStart).toEqual(2);
+      });
+    });
+
+    describe('when RTL mode', () => {
+      beforeEach(() => {
+        Handsontable.mockImplementation(() => {
+          return {
+            colToProp: visualCol => `prop_${visualCol}`,
+            runHooks: () => {},
+            hasHook: () => {},
+            isRtl: () => true,
+          };
+        });
+      });
+
+      it('when RTL, set nothing should equal 0', () => {
+        const hotMock = new Handsontable();
+        const metaManager = new MetaManager(hotMock, {}, [ExtendMetaPropertiesMod]);
+
+        expect(metaManager.getTableMeta().fixedColumnsLeft).toEqual(0);
+        expect(metaManager.getTableMeta().fixedColumnsStart).toEqual(0);
+      });
+
+      it('when RTL, set `fixedColumnsLeft` = 0 and RTL should throws', () => {
+        const hotMock = new Handsontable();
+        const metaManager = new MetaManager(hotMock, {}, [ExtendMetaPropertiesMod]);
+
+        expect(() => {
+          metaManager.getTableMeta().fixedColumnsLeft = 0;
+        }).toThrow();
+      });
+
+      it('when RTL, set `fixedColumnsLeft` = 0 and `fixedColumnsStart` = 0 and RTL should throws', () => {
+        const hotMock = new Handsontable();
+        const metaManager = new MetaManager(hotMock, {}, [ExtendMetaPropertiesMod]);
+
+        expect(() => {
+          metaManager.getTableMeta().fixedColumnsLeft = 0;
+          metaManager.getTableMeta().fixedColumnsStart = 0;
+        }).toThrow();
+      });
+
+      it('when RTL, set `fixedColumnsStart` = 0 should equal 0', () => {
+        const hotMock = new Handsontable();
+        const metaManager = new MetaManager(hotMock, {}, [ExtendMetaPropertiesMod]);
+
+        metaManager.getTableMeta().fixedColumnsStart = 0;
+
+        expect(metaManager.getTableMeta().fixedColumnsLeft).toEqual(0);
+        expect(metaManager.getTableMeta().fixedColumnsStart).toEqual(0);
+      });
+
+      it('when RTL, set `fixedColumnsLeft` = 1 and RTL should throws', () => {
+        const hotMock = new Handsontable();
+        const metaManager = new MetaManager(hotMock, {}, [ExtendMetaPropertiesMod]);
+
+        expect(() => {
+          metaManager.getTableMeta().fixedColumnsLeft = 1;
+        }).toThrow();
+      });
+
+      it('when RTL, set `fixedColumnsLeft` = 1 and `fixedColumnsStart` = 2 and RTL should throws', () => {
+        const hotMock = new Handsontable();
+        const metaManager = new MetaManager(hotMock, {}, [ExtendMetaPropertiesMod]);
+
+        expect(() => {
+          metaManager.getTableMeta().fixedColumnsLeft = 1;
+          metaManager.getTableMeta().fixedColumnsStart = 2;
+        }).toThrow();
+      });
+
+      it('when RTL, set `fixedColumnsStart` = 2 should equal 2', () => {
+        const hotMock = new Handsontable();
+        const metaManager = new MetaManager(hotMock, {}, [ExtendMetaPropertiesMod]);
+
+        metaManager.getTableMeta().fixedColumnsStart = 2;
+
+        expect(metaManager.getTableMeta().fixedColumnsLeft).toEqual(2);
+        expect(metaManager.getTableMeta().fixedColumnsStart).toEqual(2);
+      });
+    });
+  });
+
+  describe('layoutDirection', () => {
     beforeEach(() => {
       Handsontable.mockImplementation(() => {
         return {
           colToProp: visualCol => `prop_${visualCol}`,
-          runHooks: () => {
-          },
-          hasHook: () => {
-          },
+          runHooks: () => {},
+          hasHook: () => {},
           isRtl: () => false,
         };
       });
     });
 
-    it('when set nothing should equal 0', () => {
+    it('should be possible to set initial value', () => {
       const hotMock = new Handsontable();
-      const metaManager = new MetaManager(hotMock, {}, [ExtendMetaPropertiesMod]);
 
-      expect(metaManager.getTableMeta().fixedColumnsLeft).toEqual(0);
-      expect(metaManager.getTableMeta().fixedColumnsStart).toEqual(0);
+      {
+        const metaManager = new MetaManager(hotMock, {
+          layoutDirection: 'rtl',
+        }, [ExtendMetaPropertiesMod]);
+
+        expect(metaManager.getTableMeta().layoutDirection).toBe('rtl');
+      }
+      {
+        const metaManager = new MetaManager(hotMock, {
+          layoutDirection: 'ltr',
+        }, [ExtendMetaPropertiesMod]);
+
+        expect(metaManager.getTableMeta().layoutDirection).toBe('ltr');
+      }
     });
 
-    it('when set `fixedColumnsLeft` = 0 should equal 0', () => {
+    it('should not be possible to set value after the Handsontable initialization', () => {
       const hotMock = new Handsontable();
-      const metaManager = new MetaManager(hotMock, {}, [ExtendMetaPropertiesMod]);
-
-      metaManager.getTableMeta().fixedColumnsLeft = 0;
-
-      expect(metaManager.getTableMeta().fixedColumnsLeft).toEqual(0);
-      expect(metaManager.getTableMeta().fixedColumnsStart).toEqual(0);
-    });
-
-    it('when set `fixedColumnsLeft` = 0 and `fixedColumnsStart` = 0 should throws', () => {
-      const hotMock = new Handsontable();
-      const metaManager = new MetaManager(hotMock, {}, [ExtendMetaPropertiesMod]);
+      const metaManager = new MetaManager(hotMock, {
+        layoutDirection: 'rtl'
+      }, [ExtendMetaPropertiesMod]);
 
       expect(() => {
-        metaManager.getTableMeta().fixedColumnsLeft = 0;
-        metaManager.getTableMeta().fixedColumnsStart = 0;
-      }).toThrow();
-    });
-
-    it('when set `fixedColumnsStart` = 0 should equal 0', () => {
-      const hotMock = new Handsontable();
-      const metaManager = new MetaManager(hotMock, {}, [ExtendMetaPropertiesMod]);
-
-      metaManager.getTableMeta().fixedColumnsStart = 0;
-
-      expect(metaManager.getTableMeta().fixedColumnsLeft).toEqual(0);
-      expect(metaManager.getTableMeta().fixedColumnsStart).toEqual(0);
-    });
-
-    it('when set `fixedColumnsLeft` = 1 should equal 1', () => {
-      const hotMock = new Handsontable();
-      const metaManager = new MetaManager(hotMock, {}, [ExtendMetaPropertiesMod]);
-
-      metaManager.getTableMeta().fixedColumnsLeft = 1;
-
-      expect(metaManager.getTableMeta().fixedColumnsLeft).toEqual(1);
-      expect(metaManager.getTableMeta().fixedColumnsStart).toEqual(1);
-    });
-
-    it('when set `fixedColumnsLeft` = 1 and `fixedColumnsStart` = 2 should throws', () => {
-      const hotMock = new Handsontable();
-      const metaManager = new MetaManager(hotMock, {}, [ExtendMetaPropertiesMod]);
-
+        metaManager.updateGlobalMeta({ layoutDirection: 'ltr' });
+      }).toThrow('The `layoutDirection` option can not be updated after the Handsontable is initialized.');
       expect(() => {
-        metaManager.getTableMeta().fixedColumnsLeft = 1;
-        metaManager.getTableMeta().fixedColumnsStart = 2;
-      }).toThrow();
-    });
-
-    it('when set `fixedColumnsStart` = 2 should equal 2', () => {
-      const hotMock = new Handsontable();
-      const metaManager = new MetaManager(hotMock, {}, [ExtendMetaPropertiesMod]);
-
-      metaManager.getTableMeta().fixedColumnsStart = 2;
-
-      expect(metaManager.getTableMeta().fixedColumnsLeft).toEqual(2);
-      expect(metaManager.getTableMeta().fixedColumnsStart).toEqual(2);
-    });
-  });
-
-  describe('when RTL mode', () => {
-    beforeEach(() => {
-      Handsontable.mockImplementation(() => {
-        return {
-          colToProp: visualCol => `prop_${visualCol}`,
-          runHooks: () => {
-          },
-          hasHook: () => {
-          },
-          isRtl: () => true,
-        };
-      });
-    });
-
-    it('when RTL, set nothingshould equal 0', () => {
-      const hotMock = new Handsontable();
-      const metaManager = new MetaManager(hotMock, {}, [ExtendMetaPropertiesMod]);
-
-      expect(metaManager.getTableMeta().fixedColumnsLeft).toEqual(0);
-      expect(metaManager.getTableMeta().fixedColumnsStart).toEqual(0);
-    });
-
-    it('when RTL, set `fixedColumnsLeft` = 0 and RTL should throws', () => {
-      const hotMock = new Handsontable();
-      const metaManager = new MetaManager(hotMock, {}, [ExtendMetaPropertiesMod]);
-
+        metaManager.updateTableMeta({ layoutDirection: 'ltr' });
+      }).toThrow('The `layoutDirection` option can not be updated after the Handsontable is initialized.');
       expect(() => {
-        metaManager.getTableMeta().fixedColumnsLeft = 0;
-      }).toThrow();
-    });
-
-    it('when RTL, set `fixedColumnsLeft` = 0 and `fixedColumnsStart` = 0 and RTL should throws', () => {
-      const hotMock = new Handsontable();
-      const metaManager = new MetaManager(hotMock, {}, [ExtendMetaPropertiesMod]);
-
-      expect(() => {
-        metaManager.getTableMeta().fixedColumnsLeft = 0;
-        metaManager.getTableMeta().fixedColumnsStart = 0;
-      }).toThrow();
-    });
-
-    it('when RTL, set `fixedColumnsStart` = 0 should equal 0', () => {
-      const hotMock = new Handsontable();
-      const metaManager = new MetaManager(hotMock, {}, [ExtendMetaPropertiesMod]);
-
-      metaManager.getTableMeta().fixedColumnsStart = 0;
-
-      expect(metaManager.getTableMeta().fixedColumnsLeft).toEqual(0);
-      expect(metaManager.getTableMeta().fixedColumnsStart).toEqual(0);
-    });
-
-    it('when RTL, set `fixedColumnsLeft` = 1 and RTL should throws', () => {
-      const hotMock = new Handsontable();
-      const metaManager = new MetaManager(hotMock, {}, [ExtendMetaPropertiesMod]);
-
-      expect(() => {
-        metaManager.getTableMeta().fixedColumnsLeft = 1;
-      }).toThrow();
-    });
-
-    it('when RTL, set `fixedColumnsLeft` = 1 and `fixedColumnsStart` = 2 and RTL should throws', () => {
-      const hotMock = new Handsontable();
-      const metaManager = new MetaManager(hotMock, {}, [ExtendMetaPropertiesMod]);
-
-      expect(() => {
-        metaManager.getTableMeta().fixedColumnsLeft = 1;
-        metaManager.getTableMeta().fixedColumnsStart = 2;
-      }).toThrow();
-    });
-
-    it('when RTL, set `fixedColumnsStart` = 2 should equal 2', () => {
-      const hotMock = new Handsontable();
-      const metaManager = new MetaManager(hotMock, {}, [ExtendMetaPropertiesMod]);
-
-      metaManager.getTableMeta().fixedColumnsStart = 2;
-
-      expect(metaManager.getTableMeta().fixedColumnsLeft).toEqual(2);
-      expect(metaManager.getTableMeta().fixedColumnsStart).toEqual(2);
+        metaManager.updateColumnMeta(0, { layoutDirection: 'ltr' });
+      }).toThrow('The `layoutDirection` option can not be updated after the Handsontable is initialized.');
+      expect(metaManager.getTableMeta().layoutDirection).toBe('rtl');
     });
   });
 });

--- a/handsontable/src/editors/handsontableEditor/__tests__/handsontableEditor.spec.js
+++ b/handsontable/src/editors/handsontableEditor/__tests__/handsontableEditor.spec.js
@@ -713,6 +713,19 @@ describe('HandsontableEditor', () => {
     expect(editableElement.getAttribute('dir')).toBeNull();
   });
 
+  it('should inherit the actual layout direction option from the root Handsontable instance', async() => {
+    handsontable({
+      data: createSpreadsheetData(4, 4),
+      editor: 'handsontable',
+      layoutDirection: 'inherit',
+    });
+
+    selectCell(0, 0);
+    keyDownUp('enter');
+
+    expect(getActiveEditor().htEditor.getSettings().layoutDirection).toBe('ltr');
+  });
+
   describe('IME support', () => {
     it('should focus editable element after selecting the cell', async() => {
       handsontable({

--- a/handsontable/src/editors/handsontableEditor/handsontableEditor.js
+++ b/handsontable/src/editors/handsontableEditor/handsontableEditor.js
@@ -32,7 +32,7 @@ export class HandsontableEditor extends TextEditor {
       this.htContainer.style.display = '';
     }
 
-    // Construct and initialise a new Handsontable
+    // Constructs and initializes a new Handsontable instance
     this.htEditor = new this.hot.constructor(this.htContainer, this.htOptions);
     this.htEditor.init();
     this.htEditor.rootElement.style.display = '';
@@ -96,6 +96,7 @@ export class HandsontableEditor extends TextEditor {
         parent.instance.destroyEditor();
       },
       preventWheel: true,
+      layoutDirection: this.hot.isRtl() ? 'rtl' : 'ltr',
     };
 
     if (this.cellProperties.handsontable) {

--- a/handsontable/src/plugins/contextMenu/__tests__/contextMenu.spec.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/contextMenu.spec.js
@@ -3870,4 +3870,17 @@ describe('ContextMenu', () => {
 
     expect(errorSpy).not.toHaveBeenCalled();
   });
+
+  it('should inherit the actual layout direction option from the root Handsontable instance', async() => {
+    handsontable({
+      data: createSpreadsheetData(4, 4),
+      contextMenu: true,
+      height: 400,
+      layoutDirection: 'inherit',
+    });
+
+    contextMenu();
+
+    expect(getPlugin('contextMenu').menu.hotMenu.getSettings().layoutDirection).toBe('ltr');
+  });
 });

--- a/handsontable/src/plugins/contextMenu/menu.js
+++ b/handsontable/src/plugins/contextMenu/menu.js
@@ -205,6 +205,7 @@ class Menu {
       fragmentSelection: false,
       outsideClickDeselects: false,
       disableVisualSelection: 'area',
+      layoutDirection: this.hot.isRtl() ? 'rtl' : 'ltr',
       beforeKeyDown: event => this.onBeforeKeyDown(event),
       afterOnCellMouseOver: (event, coords) => {
         if (this.isAllSubMenusClosed()) {

--- a/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
@@ -4319,4 +4319,19 @@ describe('Filters UI', () => {
 
     expect(text).toEqual(['Furkan İnanç']);
   });
+
+  it('should inherit the actual layout direction option from the root Handsontable instance to the multiple ' +
+     'select component', async() => {
+    handsontable({
+      data: createSpreadsheetData(4, 4),
+      colHeaders: true,
+      filters: true,
+      dropdownMenu: true,
+      layoutDirection: 'inherit',
+    });
+
+    dropdownMenu(0);
+
+    expect(byValueMultipleSelect().itemsBox.getSettings().layoutDirection).toBe('ltr');
+  });
 });

--- a/handsontable/src/plugins/filters/ui/multipleSelect.js
+++ b/handsontable/src/plugins/filters/ui/multipleSelect.js
@@ -166,7 +166,7 @@ class MultipleSelectUI extends BaseUI {
       }
 
       addClass(wrapper, 'htUIMultipleSelectHot');
-      // Construct and initialise a new Handsontable
+      // Constructs and initializes a new Handsontable instance
       this.itemsBox = new this.hot.constructor(wrapper, {
         data: this.items,
         columns: [
@@ -185,7 +185,8 @@ class MultipleSelectUI extends BaseUI {
         fillHandle: false,
         fragmentSelection: 'cell',
         tabMoves: { row: 1, col: 0 },
-        beforeKeyDown: event => this.onItemsBoxBeforeKeyDown(event)
+        beforeKeyDown: event => this.onItemsBoxBeforeKeyDown(event),
+        layoutDirection: this.hot.isRtl() ? 'rtl' : 'ltr',
       });
       this.itemsBox.init();
     };

--- a/handsontable/src/tableView.js
+++ b/handsontable/src/tableView.js
@@ -519,7 +519,7 @@ class TableView {
   initializeWalkontable() {
     const priv = privatePool.get(this);
     const walkontableConfig = {
-      rtlMode: () => this.instance.isRtl(),
+      rtlMode: this.instance.isRtl(),
       externalRowCalculator: this.instance.getPlugin('autoRowSize') &&
         this.instance.getPlugin('autoRowSize').isEnabled(),
       table: priv.table,

--- a/handsontable/test/e2e/settings/layoutDirection.spec.js
+++ b/handsontable/test/e2e/settings/layoutDirection.spec.js
@@ -1,0 +1,76 @@
+describe('settings', () => {
+  describe('layoutDirection', () => {
+    const id = 'testContainer';
+
+    beforeEach(function() {
+      this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+    });
+
+    afterEach(function() {
+      $('html').attr('dir', 'ltr');
+      this.$container.attr('dir', 'ltr');
+
+      if (this.$container) {
+        destroy();
+        this.$container.remove();
+      }
+    });
+
+    it('should set dir="rtl" attribute to the root element no matter in what document direction the table is initialized', () => {
+      handsontable({
+        layoutDirection: 'rtl'
+      });
+
+      expect(hot().rootElement.getAttribute('dir')).toBe('rtl');
+      expect(hot().isRtl()).toBe(true);
+    });
+
+    it('should set dir="ltr" attribute to the root element no matter in what document direction the table is initialized', () => {
+      $('html').attr('dir', 'rtl');
+      handsontable({
+        layoutDirection: 'ltr'
+      });
+
+      expect(hot().rootElement.getAttribute('dir')).toBe('ltr');
+      expect(hot().isRtl()).toBe(false);
+    });
+
+    it('should set a proper "dir" attribute to the root element based on the detected document direction ' +
+       '("dir" defined in the HTML element)', () => {
+      $('html').attr('dir', 'rtl');
+      handsontable({
+        layoutDirection: 'inherit'
+      });
+
+      expect(hot().rootElement.getAttribute('dir')).toBe('rtl');
+      expect(hot().isRtl()).toBe(true);
+    });
+
+    it('should set a proper "dir" attribute to the root element based on the detected document direction ' +
+       '("dir" defined in the nearest component\'s parent element)', () => {
+      spec().$container.attr('dir', 'rtl');
+      handsontable({
+        layoutDirection: 'inherit'
+      });
+
+      expect(hot().rootElement.getAttribute('dir')).toBe('rtl');
+      expect(hot().isRtl()).toBe(true);
+    });
+
+    it('should not be possible to change the layout direction after the table is initialized', () => {
+      spec().$container.attr('dir', 'rtl');
+      handsontable({
+        layoutDirection: 'ltr'
+      });
+
+      expect(() => {
+        updateSettings({
+          layoutDirection: 'rtl'
+        });
+      }).toThrowError();
+
+      expect(hot().rootElement.getAttribute('dir')).toBe('ltr');
+      expect(hot().isRtl()).toBe(false);
+    });
+  });
+});

--- a/handsontable/test/helpers/common.js
+++ b/handsontable/test/helpers/common.js
@@ -154,7 +154,7 @@ export function hot() {
 /**
  * Creates the Handsontable instance.
  *
- * @param {object} options The Handsontale options.
+ * @param {object} options The Handsontable options.
  * @returns {Handsontable}
  */
 export function handsontable(options) {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adds a new `layoutDirection` Handsontable option. Thanks to that there is possible to initialize the table that will be correctly rendered in the LTR and RTL document modes. The new option follows the rules described in the #9132 issue.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and I added new E2E tests that cover the fix.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. resolves #9132

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
