### PR TITLE
[RTL] Custom Borders direction-less API

### DIFF
--- a/handsontable/src/3rdparty/walkontable/src/border.js
+++ b/handsontable/src/3rdparty/walkontable/src/border.js
@@ -38,14 +38,14 @@ class Border {
     this.main = null;
 
     this.top = null;
-    this.inlineStart = null;
     this.bottom = null;
-    this.inlineEnd = null;
+    this.start = null;
+    this.end = null;
 
     this.topStyle = null;
-    this.inlineStartStyle = null;
     this.bottomStyle = null;
-    this.inlineEndStyle = null;
+    this.startStyle = null;
+    this.endStyle = null;
 
     this.cornerDefaultStyle = {
       width: '6px',
@@ -161,7 +161,7 @@ class Border {
 
     this.main = rootDocument.createElement('div');
 
-    const borderDivs = ['top', 'left', 'bottom', 'right', 'corner'];
+    const borderDivs = ['top', 'start', 'bottom', 'end', 'corner'];
     let style = this.main.style;
 
     style.position = 'absolute';
@@ -188,14 +188,14 @@ class Border {
       this.main.appendChild(div);
     }
     this.top = this.main.childNodes[0];
-    this.inlineStart = this.main.childNodes[1];
+    this.start = this.main.childNodes[1];
     this.bottom = this.main.childNodes[2];
-    this.inlineEnd = this.main.childNodes[3];
+    this.end = this.main.childNodes[3];
 
     this.topStyle = this.top.style;
-    this.inlineStartStyle = this.inlineStart.style;
+    this.startStyle = this.start.style;
     this.bottomStyle = this.bottom.style;
-    this.inlineEndStyle = this.inlineEnd.style;
+    this.endStyle = this.end.style;
 
     this.corner = this.main.childNodes[4];
     this.corner.className += ' corner';
@@ -494,10 +494,10 @@ class Border {
     this.topStyle.width = `${width}px`;
     this.topStyle.display = 'block';
 
-    this.inlineStartStyle.top = `${top}px`;
-    this.inlineStartStyle[inlinePosProperty] = `${inlineStartPos}px`;
-    this.inlineStartStyle.height = `${height}px`;
-    this.inlineStartStyle.display = 'block';
+    this.startStyle.top = `${top}px`;
+    this.startStyle[inlinePosProperty] = `${inlineStartPos}px`;
+    this.startStyle.height = `${height}px`;
+    this.startStyle.display = 'block';
 
     const delta = Math.floor(this.settings.border.width / 2);
 
@@ -506,10 +506,10 @@ class Border {
     this.bottomStyle.width = `${width}px`;
     this.bottomStyle.display = 'block';
 
-    this.inlineEndStyle.top = `${top}px`;
-    this.inlineEndStyle[inlinePosProperty] = `${inlineStartPos + width - delta}px`;
-    this.inlineEndStyle.height = `${height + 1}px`;
-    this.inlineEndStyle.display = 'block';
+    this.endStyle.top = `${top}px`;
+    this.endStyle[inlinePosProperty] = `${inlineStartPos + width - delta}px`;
+    this.endStyle.height = `${height + 1}px`;
+    this.endStyle.display = 'block';
 
     let cornerVisibleSetting = this.settings.border.cornerVisible;
 
@@ -676,7 +676,7 @@ class Border {
    * Change border style.
    *
    * @private
-   * @param {string} borderElement Coordinate where add/remove border: top, right, bottom, left.
+   * @param {string} borderElement Coordinate where add/remove border: top, bottom, start, end.
    * @param {object} border The border object descriptor.
    */
   changeBorderStyle(borderElement, border) {
@@ -697,7 +697,7 @@ class Border {
         style.height = `${borderStyle.width}px`;
       }
 
-      if (borderElement === 'right' || borderElement === 'left') {
+      if (borderElement === 'start' || borderElement === 'end') {
         style.width = `${borderStyle.width}px`;
       }
     }
@@ -707,7 +707,7 @@ class Border {
    * Change border style to default.
    *
    * @private
-   * @param {string} position The position type ("top", "bottom", "left", "right") to change.
+   * @param {string} position The position type ("top", "bottom", "start", "end") to change.
    */
   changeBorderToDefaultStyle(position) {
     const defaultBorder = {
@@ -725,7 +725,7 @@ class Border {
    * Toggle class 'hidden' to element.
    *
    * @private
-   * @param {string} borderElement Coordinate where add/remove border: top, right, bottom, left.
+   * @param {string} borderElement Coordinate where add/remove border: top, bottom, start, end.
    * @param {boolean} [remove] Defines type of the action to perform.
    */
   toggleHiddenClass(borderElement, remove) {
@@ -743,9 +743,9 @@ class Border {
    */
   disappear() {
     this.topStyle.display = 'none';
-    this.inlineStartStyle.display = 'none';
     this.bottomStyle.display = 'none';
-    this.inlineEndStyle.display = 'none';
+    this.startStyle.display = 'none';
+    this.endStyle.display = 'none';
     this.cornerStyle.display = 'none';
 
     if (isMobileBrowser()) {

--- a/handsontable/src/3rdparty/walkontable/test/spec/border.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/border.spec.js
@@ -46,39 +46,39 @@ describe('WalkontableBorder', () => {
 
     const $td2 = spec().$table.find('tbody tr:eq(2) td:eq(1)');
     const $top = $(wt.selections.getCell().getBorder(wt).top);
-    const $inlineEnd = $(wt.selections.getCell().getBorder(wt).inlineEnd);
+    const $end = $(wt.selections.getCell().getBorder(wt).end);
     const $bottom = $(wt.selections.getCell().getBorder(wt).bottom);
-    const $inlineStart = $(wt.selections.getCell().getBorder(wt).inlineStart);
+    const $start = $(wt.selections.getCell().getBorder(wt).start);
 
     $td1.simulate('mousedown');
 
     expect($top.css('height')).toBe('1px');
     expect($top.position().top).toBe(23);
     expect($top.position().left).toBe(0);
-    expect($inlineEnd.css('width')).toBe('1px');
-    expect($inlineEnd.position().top).toBe(23);
-    expect($inlineEnd.position().left).toBe(49);
+    expect($end.css('width')).toBe('1px');
+    expect($end.position().top).toBe(23);
+    expect($end.position().left).toBe(49);
     expect($bottom.css('height')).toBe('1px');
     expect($bottom.position().top).toBe(46);
     expect($bottom.position().left).toBe(0);
-    expect($inlineStart.css('width')).toBe('1px');
-    expect($inlineStart.position().top).toBe(23);
-    expect($inlineStart.position().left).toBe(0);
+    expect($start.css('width')).toBe('1px');
+    expect($start.position().top).toBe(23);
+    expect($start.position().left).toBe(0);
 
     $td2.simulate('mousedown');
 
     expect($top.css('height')).toBe('1px');
     expect($top.position().top).toBe(46);
     expect($top.position().left).toBe(49);
-    expect($inlineEnd.css('width')).toBe('1px');
-    expect($inlineEnd.position().top).toBe(46);
-    expect($inlineEnd.position().left).toBe(99);
+    expect($end.css('width')).toBe('1px');
+    expect($end.position().top).toBe(46);
+    expect($end.position().left).toBe(99);
     expect($bottom.css('height')).toBe('1px');
     expect($bottom.position().top).toBe(69);
     expect($bottom.position().left).toBe(49);
-    expect($inlineStart.css('width')).toBe('1px');
-    expect($inlineStart.position().top).toBe(46);
-    expect($inlineStart.position().left).toBe(49);
+    expect($start.css('width')).toBe('1px');
+    expect($start.position().top).toBe(46);
+    expect($start.position().left).toBe(49);
   });
 
   it('should add/remove border to selection when cell is clicked and the table has only one column', () => {
@@ -105,24 +105,24 @@ describe('WalkontableBorder', () => {
 
     const $td1 = spec().$table.find('tbody tr:eq(1) td:eq(0)');
     const $top = $(wt.selections.getCell().getBorder(wt).top);
-    const $inlineEnd = $(wt.selections.getCell().getBorder(wt).inlineEnd);
+    const $end = $(wt.selections.getCell().getBorder(wt).end);
     const $bottom = $(wt.selections.getCell().getBorder(wt).bottom);
-    const $inlineStart = $(wt.selections.getCell().getBorder(wt).inlineStart);
+    const $start = $(wt.selections.getCell().getBorder(wt).start);
 
     $td1.simulate('mousedown');
 
     expect($top.css('height')).toBe('1px');
     expect($top.position().top).toBe(23);
     expect($top.position().left).toBe(0);
-    expect($inlineEnd.css('width')).toBe('1px');
-    expect($inlineEnd.position().top).toBe(23);
-    expect($inlineEnd.position().left).toBe(49);
+    expect($end.css('width')).toBe('1px');
+    expect($end.position().top).toBe(23);
+    expect($end.position().left).toBe(49);
     expect($bottom.css('height')).toBe('1px');
     expect($bottom.position().top).toBe(46);
     expect($bottom.position().left).toBe(0);
-    expect($inlineStart.css('width')).toBe('1px');
-    expect($inlineStart.position().top).toBe(23);
-    expect($inlineStart.position().left).toBe(0);
+    expect($start.css('width')).toBe('1px');
+    expect($start.position().top).toBe(23);
+    expect($start.position().left).toBe(0);
   });
 
   it('should properly add a selection border on an entirely selected column', () => {
@@ -152,22 +152,22 @@ describe('WalkontableBorder', () => {
     wt.draw(true);
 
     const $top = $(wt.selections.getCell().getBorder(wt).top);
-    const $inlineEnd = $(wt.selections.getCell().getBorder(wt).inlineEnd);
+    const $end = $(wt.selections.getCell().getBorder(wt).end);
     const $bottom = $(wt.selections.getCell().getBorder(wt).bottom);
-    const $inlineStart = $(wt.selections.getCell().getBorder(wt).inlineStart);
+    const $start = $(wt.selections.getCell().getBorder(wt).start);
 
     expect($top.css('height')).toBe('1px');
     expect($top.position().top).toBe(0);
     expect($top.position().left).toBe(0);
-    expect($inlineEnd.css('width')).toBe('1px');
-    expect($inlineEnd.position().top).toBe(0);
-    expect($inlineEnd.position().left).toBe(49);
+    expect($end.css('width')).toBe('1px');
+    expect($end.position().top).toBe(0);
+    expect($end.position().left).toBe(49);
     expect($bottom.css('height')).toBe('1px');
     expect($bottom.position().top).toBe(115);
     expect($bottom.position().left).toBe(0);
-    expect($inlineStart.css('width')).toBe('1px');
-    expect($inlineStart.position().top).toBe(0);
-    expect($inlineStart.position().left).toBe(0);
+    expect($start.css('width')).toBe('1px');
+    expect($start.position().top).toBe(0);
+    expect($start.position().left).toBe(0);
   });
 
   it('should add/remove corner to selection when cell is clicked', () => {

--- a/handsontable/src/3rdparty/walkontable/test/spec/rtl/border.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/rtl/border.spec.js
@@ -50,39 +50,39 @@ describe('WalkontableBorder (RTL mode)', () => {
 
     const $td2 = spec().$table.find('tbody tr:eq(2) td:eq(1)');
     const $top = $(wt.selections.getCell().getBorder(wt).top);
-    const $inlineEnd = $(wt.selections.getCell().getBorder(wt).inlineEnd);
+    const $end = $(wt.selections.getCell().getBorder(wt).end);
     const $bottom = $(wt.selections.getCell().getBorder(wt).bottom);
-    const $inlineStart = $(wt.selections.getCell().getBorder(wt).inlineStart);
+    const $start = $(wt.selections.getCell().getBorder(wt).start);
 
     $td1.simulate('mousedown');
 
     expect($top.css('height')).toBe('1px');
     expect($top.css('top')).toBe('23px');
     expect($top.css('right')).toBe('0px');
-    expect($inlineEnd.css('width')).toBe('1px');
-    expect($inlineEnd.css('top')).toBe('23px');
-    expect($inlineEnd.css('right')).toBe('49px');
+    expect($end.css('width')).toBe('1px');
+    expect($end.css('top')).toBe('23px');
+    expect($end.css('right')).toBe('49px');
     expect($bottom.css('height')).toBe('1px');
     expect($bottom.css('top')).toBe('46px');
     expect($bottom.css('right')).toBe('0px');
-    expect($inlineStart.css('width')).toBe('1px');
-    expect($inlineStart.css('top')).toBe('23px');
-    expect($inlineStart.css('right')).toBe('0px');
+    expect($start.css('width')).toBe('1px');
+    expect($start.css('top')).toBe('23px');
+    expect($start.css('right')).toBe('0px');
 
     $td2.simulate('mousedown');
 
     expect($top.css('height')).toBe('1px');
     expect($top.css('top')).toBe('46px');
     expect($top.css('right')).toBe('49px');
-    expect($inlineEnd.css('width')).toBe('1px');
-    expect($inlineEnd.css('top')).toBe('46px');
-    expect($inlineEnd.css('right')).toBe('99px');
+    expect($end.css('width')).toBe('1px');
+    expect($end.css('top')).toBe('46px');
+    expect($end.css('right')).toBe('99px');
     expect($bottom.css('height')).toBe('1px');
     expect($bottom.css('top')).toBe('69px');
     expect($bottom.css('right')).toBe('49px');
-    expect($inlineStart.css('width')).toBe('1px');
-    expect($inlineStart.css('top')).toBe('46px');
-    expect($inlineStart.css('right')).toBe('49px');
+    expect($start.css('width')).toBe('1px');
+    expect($start.css('top')).toBe('46px');
+    expect($start.css('right')).toBe('49px');
   });
 
   it('should add/remove border to selection when cell is clicked and the table has only one column', () => {
@@ -110,24 +110,24 @@ describe('WalkontableBorder (RTL mode)', () => {
 
     const $td1 = spec().$table.find('tbody tr:eq(1) td:eq(0)');
     const $top = $(wt.selections.getCell().getBorder(wt).top);
-    const $inlineEnd = $(wt.selections.getCell().getBorder(wt).inlineEnd);
+    const $end = $(wt.selections.getCell().getBorder(wt).end);
     const $bottom = $(wt.selections.getCell().getBorder(wt).bottom);
-    const $inlineStart = $(wt.selections.getCell().getBorder(wt).inlineStart);
+    const $start = $(wt.selections.getCell().getBorder(wt).start);
 
     $td1.simulate('mousedown');
 
     expect($top.css('height')).toBe('1px');
     expect($top.css('top')).toBe('23px');
     expect($top.css('right')).toBe('0px');
-    expect($inlineEnd.css('width')).toBe('1px');
-    expect($inlineEnd.css('top')).toBe('23px');
-    expect($inlineEnd.css('right')).toBe('49px');
+    expect($end.css('width')).toBe('1px');
+    expect($end.css('top')).toBe('23px');
+    expect($end.css('right')).toBe('49px');
     expect($bottom.css('height')).toBe('1px');
     expect($bottom.css('top')).toBe('46px');
     expect($bottom.css('right')).toBe('0px');
-    expect($inlineStart.css('width')).toBe('1px');
-    expect($inlineStart.css('top')).toBe('23px');
-    expect($inlineStart.css('right')).toBe('0px');
+    expect($start.css('width')).toBe('1px');
+    expect($start.css('top')).toBe('23px');
+    expect($start.css('right')).toBe('0px');
   });
 
   it('should properly add a selection border on an entirely selected column', () => {
@@ -157,22 +157,22 @@ describe('WalkontableBorder (RTL mode)', () => {
     wt.draw(true);
 
     const $top = $(wt.selections.getCell().getBorder(wt).top);
-    const $inlineEnd = $(wt.selections.getCell().getBorder(wt).inlineEnd);
+    const $end = $(wt.selections.getCell().getBorder(wt).end);
     const $bottom = $(wt.selections.getCell().getBorder(wt).bottom);
-    const $inlineStart = $(wt.selections.getCell().getBorder(wt).inlineStart);
+    const $start = $(wt.selections.getCell().getBorder(wt).start);
 
     expect($top.css('height')).toBe('1px');
     expect($top.css('top')).toBe('0px');
     expect($top.css('right')).toBe('0px');
-    expect($inlineEnd.css('width')).toBe('1px');
-    expect($inlineEnd.css('top')).toBe('0px');
-    expect($inlineEnd.css('right')).toBe('49px');
+    expect($end.css('width')).toBe('1px');
+    expect($end.css('top')).toBe('0px');
+    expect($end.css('right')).toBe('49px');
     expect($bottom.css('height')).toBe('1px');
     expect($bottom.css('top')).toBe('115px');
     expect($bottom.css('right')).toBe('0px');
-    expect($inlineStart.css('width')).toBe('1px');
-    expect($inlineStart.css('top')).toBe('0px');
-    expect($inlineStart.css('right')).toBe('0px');
+    expect($start.css('width')).toBe('1px');
+    expect($start.css('top')).toBe('0px');
+    expect($start.css('right')).toBe('0px');
   });
 
   it('should add/remove corner to selection when cell is clicked', () => {

--- a/handsontable/src/plugins/customBorders/__tests__/backward-compatibility.spec.js
+++ b/handsontable/src/plugins/customBorders/__tests__/backward-compatibility.spec.js
@@ -98,6 +98,29 @@ describe('CustomBorders (using backward compatible "left"/"right" options)', () 
     });
   });
 
+  it('should translate borders declared using new "start"/"end" API to backward compatible format', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(4, 4),
+      customBorders: [{
+        row: 2,
+        col: 2,
+        start: RED_BORDER,
+        end: RED_BORDER,
+        top: GREEN_BORDER
+      }]
+    });
+
+    expect(getCellMeta(2, 2).borders.top).toEqual(GREEN_BORDER);
+    expect(getCellMeta(2, 2).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(2, 2).borders.start).toEqual(RED_BORDER);
+    expect(getCellMeta(2, 2).borders.left).toEqual(RED_BORDER); // The same as "start"
+    expect(getCellMeta(2, 2).borders.end).toEqual(RED_BORDER);
+    expect(getCellMeta(2, 2).borders.right).toEqual(RED_BORDER); // The same as "end"
+
+    expect(countVisibleCustomBorders()).toBe(3);
+    expect(countCustomBorders()).toBe(5);
+  });
+
   it('should render specific borders provided in the configuration', () => {
     handsontable({
       data: Handsontable.helper.createSpreadsheetData(4, 4),

--- a/handsontable/src/plugins/customBorders/__tests__/backward-compatibility.spec.js
+++ b/handsontable/src/plugins/customBorders/__tests__/backward-compatibility.spec.js
@@ -1,0 +1,760 @@
+describe('CustomBorders (using backward compatible "left"/"right" options)', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+    const wrapper = $('<div></div>').css({
+      width: 400,
+      height: 200,
+      overflow: 'scroll'
+    });
+
+    this.$wrapper = this.$container.wrap(wrapper).parent();
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+    this.$wrapper.remove();
+  });
+
+  describe('enabling/disabling plugin', () => {
+    it('should hide borders when disabled using updateSettings', () => {
+      const hot = handsontable({
+        customBorders: [{
+          row: 2,
+          col: 2,
+          left: RED_BORDER,
+          right: RED_BORDER,
+          top: GREEN_BORDER
+        }]
+      });
+
+      hot.updateSettings({
+        customBorders: false
+      });
+
+      expect(countVisibleCustomBorders()).toBe(0);
+      expect(countCustomBorders()).toBe(0);
+    });
+
+    it('should hide borders when disabled using disablePlugin', () => {
+      const hot = handsontable({
+        customBorders: [{
+          row: 2,
+          col: 2,
+          left: RED_BORDER,
+          right: RED_BORDER,
+          top: GREEN_BORDER
+        }]
+      });
+
+      hot.getPlugin('customBorders').disablePlugin();
+
+      expect(countVisibleCustomBorders()).toBe(0);
+      expect(countCustomBorders()).toBe(0);
+    });
+
+    it('should show initial borders when re-enabled using updateSettings', () => {
+      const hot = handsontable({
+        customBorders: [{
+          row: 2,
+          col: 2,
+          left: RED_BORDER,
+          right: RED_BORDER,
+          top: GREEN_BORDER
+        }]
+      });
+
+      hot.updateSettings({
+        customBorders: false
+      });
+      hot.updateSettings({
+        customBorders: true
+      });
+
+      expect(countVisibleCustomBorders()).toBe(3); // TODO this assertion checks current behavior that looks like a bug. I would expect 0
+      expect(countCustomBorders()).toBe(5); // TODO this assertion checks current behavior that looks like a bug. I would expect 0
+    });
+
+    it('should show initial borders when re-enabled using disablePlugin', () => {
+      const hot = handsontable({
+        customBorders: [{
+          row: 2,
+          col: 2,
+          left: RED_BORDER,
+          right: RED_BORDER,
+          top: GREEN_BORDER
+        }]
+      });
+
+      hot.getPlugin('customBorders').disablePlugin();
+      hot.getPlugin('customBorders').enablePlugin();
+
+      expect(countVisibleCustomBorders()).toBe(0); // TODO this assertion checks current behavior that looks like a bug. I would expect 3
+      expect(countCustomBorders()).toBe(0);
+    });
+  });
+
+  it('should render specific borders provided in the configuration', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(4, 4),
+      customBorders: [{
+        row: 2,
+        col: 2,
+        left: RED_BORDER,
+        right: RED_BORDER,
+        top: GREEN_BORDER
+      }]
+    });
+
+    expect(getCellMeta(2, 2).borders.top).toEqual(GREEN_BORDER);
+    expect(getCellMeta(2, 2).borders.left).toEqual(RED_BORDER);
+    expect(getCellMeta(2, 2).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(2, 2).borders.right).toEqual(RED_BORDER);
+
+    expect(getCellMeta(0, 0).borders).toBeUndefined();
+    expect(getCellMeta(0, 1).borders).toBeUndefined();
+    expect(getCellMeta(0, 2).borders).toBeUndefined();
+    expect(getCellMeta(0, 3).borders).toBeUndefined();
+
+    expect(getCellMeta(1, 0).borders).toBeUndefined();
+    expect(getCellMeta(1, 1).borders).toBeUndefined();
+    expect(getCellMeta(1, 2).borders).toBeUndefined();
+    expect(getCellMeta(1, 3).borders).toBeUndefined();
+
+    expect(getCellMeta(2, 0).borders).toBeUndefined();
+    expect(getCellMeta(2, 1).borders).toBeUndefined();
+    expect(getCellMeta(2, 3).borders).toBeUndefined();
+
+    expect(getCellMeta(3, 0).borders).toBeUndefined();
+    expect(getCellMeta(3, 1).borders).toBeUndefined();
+    expect(getCellMeta(3, 2).borders).toBeUndefined();
+    expect(getCellMeta(3, 3).borders).toBeUndefined();
+
+    expect(countVisibleCustomBorders()).toBe(3);
+    expect(countCustomBorders()).toBe(5);
+  });
+
+  it('should draw new borders by use setBorders method (while selected)', () => {
+    const hot = handsontable({
+      data: Handsontable.helper.createSpreadsheetData(4, 4),
+      customBorders: true
+    });
+
+    const customBorders = hot.getPlugin('customBorders');
+
+    selectCells([[1, 1, 2, 2]]);
+    customBorders.setBorders(getSelected(), {
+      left: GREEN_BORDER,
+      right: RED_BORDER
+    });
+    deselectCell();
+
+    expect(getCellMeta(1, 1).borders.top).toEqual(EMPTY);
+    expect(getCellMeta(1, 1).borders.left).toEqual(GREEN_BORDER);
+    expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(1, 1).borders.right).toEqual(RED_BORDER);
+
+    expect(getCellMeta(1, 2).borders.top).toEqual(EMPTY);
+    expect(getCellMeta(1, 2).borders.left).toEqual(GREEN_BORDER);
+    expect(getCellMeta(1, 2).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(1, 2).borders.right).toEqual(RED_BORDER);
+
+    expect(getCellMeta(2, 1).borders.top).toEqual(EMPTY);
+    expect(getCellMeta(2, 1).borders.left).toEqual(GREEN_BORDER);
+    expect(getCellMeta(2, 1).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(2, 1).borders.right).toEqual(RED_BORDER);
+
+    expect(getCellMeta(2, 2).borders.top).toEqual(EMPTY);
+    expect(getCellMeta(2, 2).borders.left).toEqual(GREEN_BORDER);
+    expect(getCellMeta(2, 2).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(2, 2).borders.right).toEqual(RED_BORDER);
+
+    expect(countVisibleCustomBorders()).toBe(8);
+    expect(countCustomBorders()).toBe(4 * 5); // there are 4 cells in the provided range
+  });
+
+  it('should draw new borders by use setBorders method (while deselected)', () => {
+    const hot = handsontable({
+      data: Handsontable.helper.createSpreadsheetData(4, 4),
+      customBorders: true
+    });
+
+    const customBorders = hot.getPlugin('customBorders');
+
+    customBorders.setBorders([[1, 1, 2, 2]], {
+      left: GREEN_BORDER,
+      right: RED_BORDER
+    });
+
+    expect(getCellMeta(1, 1).borders.top).toEqual(EMPTY);
+    expect(getCellMeta(1, 1).borders.left).toEqual(GREEN_BORDER);
+    expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(1, 1).borders.right).toEqual(RED_BORDER);
+
+    expect(getCellMeta(1, 2).borders.top).toEqual(EMPTY);
+    expect(getCellMeta(1, 2).borders.left).toEqual(GREEN_BORDER);
+    expect(getCellMeta(1, 2).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(1, 2).borders.right).toEqual(RED_BORDER);
+
+    expect(getCellMeta(2, 1).borders.top).toEqual(EMPTY);
+    expect(getCellMeta(2, 1).borders.left).toEqual(GREEN_BORDER);
+    expect(getCellMeta(2, 1).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(2, 1).borders.right).toEqual(RED_BORDER);
+
+    expect(getCellMeta(2, 2).borders.top).toEqual(EMPTY);
+    expect(getCellMeta(2, 2).borders.left).toEqual(GREEN_BORDER);
+    expect(getCellMeta(2, 2).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(2, 2).borders.right).toEqual(RED_BORDER);
+
+    expect(countVisibleCustomBorders()).toBe(8);
+    expect(countCustomBorders()).toBe(4 * 5); // there are 4 cells in the provided range
+  });
+
+  it('should redraw existing borders by use setBorders method (while selected)', () => {
+    const hot = handsontable({
+      data: Handsontable.helper.createSpreadsheetData(4, 4),
+      customBorders: [{
+        row: 2,
+        col: 2,
+        left: RED_BORDER,
+        top: GREEN_BORDER,
+        bottom: GREEN_BORDER,
+      }]
+    });
+
+    const customBorders = hot.getPlugin('customBorders');
+
+    selectCell(2, 2);
+    customBorders.setBorders(getSelectedRange(), {
+      left: GREEN_BORDER,
+      right: RED_BORDER
+    });
+    deselectCell();
+
+    expect(getCellMeta(2, 2).borders.top).toEqual(GREEN_BORDER);
+    expect(getCellMeta(2, 2).borders.left).toEqual(GREEN_BORDER);
+    expect(getCellMeta(2, 2).borders.bottom).toEqual(GREEN_BORDER);
+    expect(getCellMeta(2, 2).borders.right).toEqual(RED_BORDER);
+    expect(countVisibleCustomBorders()).toBe(4);
+    expect(countCustomBorders()).toBe(5);
+  });
+
+  it('should redraw existing borders by use setBorders method (while deselected)', () => {
+    const hot = handsontable({
+      data: Handsontable.helper.createSpreadsheetData(4, 4),
+      customBorders: [{
+        row: 2,
+        col: 2,
+        left: RED_BORDER,
+        top: GREEN_BORDER,
+        bottom: GREEN_BORDER,
+      }]
+    });
+
+    const customBorders = hot.getPlugin('customBorders');
+
+    customBorders.setBorders([[2, 2]], {
+      left: GREEN_BORDER,
+      right: RED_BORDER
+    });
+
+    expect(getCellMeta(2, 2).borders.top).toEqual(GREEN_BORDER);
+    expect(getCellMeta(2, 2).borders.left).toEqual(GREEN_BORDER);
+    expect(getCellMeta(2, 2).borders.bottom).toEqual(GREEN_BORDER);
+    expect(getCellMeta(2, 2).borders.right).toEqual(RED_BORDER);
+    expect(countVisibleCustomBorders()).toBe(4);
+    expect(countCustomBorders()).toBe(5);
+  });
+
+  it('should hide only specific border by use setBorders method with {hide: true} (while selected)', () => {
+    const hot = handsontable({
+      data: Handsontable.helper.createSpreadsheetData(4, 4),
+      customBorders: [{
+        row: 2,
+        col: 2,
+        left: RED_BORDER,
+        right: RED_BORDER,
+        top: GREEN_BORDER
+      }]
+    });
+
+    const customBorders = hot.getPlugin('customBorders');
+
+    selectCell(2, 2);
+    customBorders.setBorders(getSelected(), {
+      right: EMPTY
+    });
+    deselectCell();
+
+    expect(getCellMeta(2, 2).borders.top).toEqual(GREEN_BORDER);
+    expect(getCellMeta(2, 2).borders.left).toEqual(RED_BORDER);
+    expect(getCellMeta(2, 2).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(2, 2).borders.right).toEqual(EMPTY);
+    expect(countVisibleCustomBorders()).toBe(2);
+    expect(countCustomBorders()).toBe(5);
+  });
+
+  it('should hide only specific border by use setBorders method with {hide: true} (while deselected)', () => {
+    const hot = handsontable({
+      data: Handsontable.helper.createSpreadsheetData(4, 4),
+      customBorders: [{
+        row: 2,
+        col: 2,
+        left: RED_BORDER,
+        right: RED_BORDER,
+        top: GREEN_BORDER
+      }]
+    });
+
+    const customBorders = hot.getPlugin('customBorders');
+
+    customBorders.setBorders([[2, 2]], {
+      right: EMPTY
+    });
+
+    expect(getCellMeta(2, 2).borders.top).toEqual(GREEN_BORDER);
+    expect(getCellMeta(2, 2).borders.left).toEqual(RED_BORDER);
+    expect(getCellMeta(2, 2).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(2, 2).borders.right).toEqual(EMPTY);
+    expect(countVisibleCustomBorders()).toBe(2);
+    expect(countCustomBorders()).toBe(5);
+  });
+
+  it('should hide only specific border by use setBorders method with {right: false} (while selected)', () => {
+    const hot = handsontable({
+      data: Handsontable.helper.createSpreadsheetData(4, 4),
+      customBorders: [{
+        row: 2,
+        col: 2,
+        left: RED_BORDER,
+        right: RED_BORDER,
+        top: GREEN_BORDER
+      }]
+    });
+
+    const customBorders = hot.getPlugin('customBorders');
+
+    selectCell(2, 2);
+    customBorders.setBorders(getSelected(), {
+      right: false
+    });
+    deselectCell();
+
+    expect(getCellMeta(2, 2).borders.top).toEqual(GREEN_BORDER);
+    expect(getCellMeta(2, 2).borders.left).toEqual(RED_BORDER);
+    expect(getCellMeta(2, 2).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(2, 2).borders.right).toEqual(EMPTY);
+
+    expect(getCellMeta(0, 0).borders).toBeUndefined();
+    expect(getCellMeta(0, 1).borders).toBeUndefined();
+    expect(getCellMeta(0, 2).borders).toBeUndefined();
+    expect(getCellMeta(0, 3).borders).toBeUndefined();
+
+    expect(getCellMeta(1, 0).borders).toBeUndefined();
+    expect(getCellMeta(1, 1).borders).toBeUndefined();
+    expect(getCellMeta(1, 2).borders).toBeUndefined();
+    expect(getCellMeta(1, 3).borders).toBeUndefined();
+
+    expect(getCellMeta(2, 0).borders).toBeUndefined();
+    expect(getCellMeta(2, 1).borders).toBeUndefined();
+    expect(getCellMeta(2, 3).borders).toBeUndefined();
+
+    expect(getCellMeta(3, 0).borders).toBeUndefined();
+    expect(getCellMeta(3, 1).borders).toBeUndefined();
+    expect(getCellMeta(3, 2).borders).toBeUndefined();
+    expect(getCellMeta(3, 3).borders).toBeUndefined();
+
+    expect(countVisibleCustomBorders()).toBe(2);
+    expect(countCustomBorders()).toBe(5);
+  });
+
+  it('should hide only specific border by use setBorders method with {right: false} (while deselected)', () => {
+    const hot = handsontable({
+      data: Handsontable.helper.createSpreadsheetData(4, 4),
+      customBorders: [{
+        row: 2,
+        col: 2,
+        left: RED_BORDER,
+        right: RED_BORDER,
+        top: GREEN_BORDER
+      }]
+    });
+
+    const customBorders = hot.getPlugin('customBorders');
+
+    customBorders.setBorders([[2, 2]], {
+      right: false
+    });
+
+    expect(getCellMeta(2, 2).borders.top).toEqual(GREEN_BORDER);
+    expect(getCellMeta(2, 2).borders.left).toEqual(RED_BORDER);
+    expect(getCellMeta(2, 2).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(2, 2).borders.right).toEqual(EMPTY);
+
+    expect(getCellMeta(0, 0).borders).toBeUndefined();
+    expect(getCellMeta(0, 1).borders).toBeUndefined();
+    expect(getCellMeta(0, 2).borders).toBeUndefined();
+    expect(getCellMeta(0, 3).borders).toBeUndefined();
+
+    expect(getCellMeta(1, 0).borders).toBeUndefined();
+    expect(getCellMeta(1, 1).borders).toBeUndefined();
+    expect(getCellMeta(1, 2).borders).toBeUndefined();
+    expect(getCellMeta(1, 3).borders).toBeUndefined();
+
+    expect(getCellMeta(2, 0).borders).toBeUndefined();
+    expect(getCellMeta(2, 1).borders).toBeUndefined();
+    expect(getCellMeta(2, 3).borders).toBeUndefined();
+
+    expect(getCellMeta(3, 0).borders).toBeUndefined();
+    expect(getCellMeta(3, 1).borders).toBeUndefined();
+    expect(getCellMeta(3, 2).borders).toBeUndefined();
+    expect(getCellMeta(3, 3).borders).toBeUndefined();
+
+    expect(countVisibleCustomBorders()).toBe(2);
+    expect(countCustomBorders()).toBe(5);
+  });
+
+  it('should return borders from the selected area by use getBorders method', () => {
+    const hot = handsontable({
+      data: Handsontable.helper.createSpreadsheetData(4, 4),
+      customBorders: [{
+        row: 2,
+        col: 2,
+        left: RED_BORDER,
+        right: GREEN_BORDER,
+        top: GREEN_BORDER
+      }]
+    });
+
+    const customBorders = hot.getPlugin('customBorders');
+
+    hot.selectCells([[1, 1, 2, 2]]);
+    const borders = customBorders.getBorders(getSelected());
+
+    deselectCell();
+
+    expect(borders.length).toEqual(1);
+    expect(borders[0].top).toEqual(GREEN_BORDER);
+    expect(borders[0].bottom).toEqual(EMPTY);
+    expect(borders[0].left).toEqual(RED_BORDER);
+    expect(borders[0].right).toEqual(GREEN_BORDER);
+    expect(countVisibleCustomBorders()).toBe(3);
+    expect(countCustomBorders()).toBe(5);
+  });
+
+  it('should return all borders by use getBorders method without parameter', () => {
+    const hot = handsontable({
+      data: Handsontable.helper.createSpreadsheetData(4, 4),
+      customBorders: [{
+        range: {
+          from: {
+            row: 1,
+            col: 1
+          },
+          to: {
+            row: 3,
+            col: 3
+          }
+        },
+        top: BLUE_BORDER,
+        left: ORANGE_BORDER,
+        bottom: RED_BORDER,
+        right: MAGENTA_BORDER
+      },
+      {
+        row: 2,
+        col: 2,
+        left: RED_BORDER,
+        right: GREEN_BORDER,
+        top: GREEN_THICK_BORDER
+      }]
+    });
+
+    const customBorders = hot.getPlugin('customBorders');
+
+    const borders = customBorders.getBorders();
+
+    expect(borders.length).toEqual(9);
+    expect(countVisibleCustomBorders()).toBe(15); // there are 9 cells in the provided range, some of which have 1, 2 or 3 rendered borders
+    expect(countCustomBorders()).toBe(9 * 5); // there are 9 cells in the provided range
+  });
+
+  it('should clear borders from area by use clearBorders method (while selected)', () => {
+    const hot = handsontable({
+      data: Handsontable.helper.createSpreadsheetData(4, 4),
+      customBorders: [{
+        range: {
+          from: {
+            row: 1,
+            col: 1
+          },
+          to: {
+            row: 3,
+            col: 3
+          }
+        },
+        top: BLUE_BORDER,
+        left: ORANGE_BORDER,
+        bottom: RED_BORDER,
+        right: MAGENTA_BORDER
+      },
+      {
+        row: 2,
+        col: 2,
+        left: RED_BORDER,
+        right: GREEN_BORDER,
+        top: GREEN_THICK_BORDER
+      }]
+    });
+
+    const customBorders = hot.getPlugin('customBorders');
+
+    /*
+    Was:
+    0000
+    0111
+    0111
+    0111
+    */
+
+    selectCells([[0, 0, 2, 2]]);
+    customBorders.clearBorders(getSelectedRange());
+    deselectCell();
+
+    /*
+    Is:
+    0000
+    0001
+    0001
+    0111
+    */
+
+    expect(getCellMeta(1, 1).borders).toBeUndefined();
+    expect(getCellMeta(1, 2).borders).toBeUndefined();
+    expect(getCellMeta(2, 1).borders).toBeUndefined();
+    expect(getCellMeta(2, 2).borders).toBeUndefined();
+
+    expect(getCellMeta(1, 3).borders.top).toEqual(BLUE_BORDER);
+    expect(getCellMeta(1, 3).borders.right).toEqual(MAGENTA_BORDER);
+    expect(getCellMeta(2, 3).borders.right).toEqual(MAGENTA_BORDER);
+    expect(getCellMeta(3, 1).borders.left).toEqual(ORANGE_BORDER);
+    expect(getCellMeta(3, 1).borders.bottom).toEqual(RED_BORDER);
+    expect(getCellMeta(3, 2).borders.bottom).toEqual(RED_BORDER);
+    expect(getCellMeta(3, 3).borders.right).toEqual(MAGENTA_BORDER);
+    expect(getCellMeta(3, 3).borders.bottom).toEqual(RED_BORDER);
+    expect(countVisibleCustomBorders()).toBe(8);
+    expect(countCustomBorders()).toBe(5 * 5);
+  });
+
+  it('should clear borders from area by use clearBorders method (while deselected)', () => {
+    const hot = handsontable({
+      data: Handsontable.helper.createSpreadsheetData(4, 4),
+      customBorders: [{
+        range: {
+          from: {
+            row: 1,
+            col: 1
+          },
+          to: {
+            row: 3,
+            col: 3
+          }
+        },
+        top: BLUE_BORDER,
+        left: ORANGE_BORDER,
+        bottom: RED_BORDER,
+        right: MAGENTA_BORDER
+      },
+      {
+        row: 2,
+        col: 2,
+        left: RED_BORDER,
+        right: GREEN_BORDER,
+        top: GREEN_THICK_BORDER
+      }]
+    });
+
+    const customBorders = hot.getPlugin('customBorders');
+
+    /*
+    Was:
+    0000
+    0111
+    0111
+    0111
+    */
+
+    customBorders.clearBorders([[0, 0, 2, 2]]);
+
+    /*
+    Is:
+    0000
+    0001
+    0001
+    0111
+    */
+
+    expect(getCellMeta(1, 1).borders).toBeUndefined();
+    expect(getCellMeta(1, 2).borders).toBeUndefined();
+    expect(getCellMeta(2, 1).borders).toBeUndefined();
+    expect(getCellMeta(2, 2).borders).toBeUndefined();
+
+    expect(getCellMeta(1, 3).borders.top).toEqual(BLUE_BORDER);
+    expect(getCellMeta(1, 3).borders.right).toEqual(MAGENTA_BORDER);
+    expect(getCellMeta(2, 3).borders.right).toEqual(MAGENTA_BORDER);
+    expect(getCellMeta(3, 1).borders.left).toEqual(ORANGE_BORDER);
+    expect(getCellMeta(3, 1).borders.bottom).toEqual(RED_BORDER);
+    expect(getCellMeta(3, 2).borders.bottom).toEqual(RED_BORDER);
+    expect(getCellMeta(3, 3).borders.right).toEqual(MAGENTA_BORDER);
+    expect(getCellMeta(3, 3).borders.bottom).toEqual(RED_BORDER);
+    expect(countVisibleCustomBorders()).toBe(8);
+    expect(countCustomBorders()).toBe(5 * 5);
+  });
+
+  it('should clear all borders by use clearBorders method without parameter', () => {
+    const hot = handsontable({
+      data: Handsontable.helper.createSpreadsheetData(4, 4),
+      customBorders: [{
+        range: {
+          from: {
+            row: 1,
+            col: 1
+          },
+          to: {
+            row: 3,
+            col: 3
+          }
+        },
+        top: BLUE_BORDER,
+        left: ORANGE_BORDER,
+        bottom: RED_BORDER,
+        right: MAGENTA_BORDER
+      },
+      {
+        row: 2,
+        col: 2,
+        left: RED_BORDER,
+        right: GREEN_BORDER,
+        top: GREEN_THICK_BORDER
+      }]
+    });
+
+    const customBorders = hot.getPlugin('customBorders');
+
+    customBorders.clearBorders();
+
+    expect(getCellMeta(1, 1).borders).toBeUndefined();
+    expect(getCellMeta(1, 2).borders).toBeUndefined();
+    expect(getCellMeta(2, 1).borders).toBeUndefined();
+    expect(getCellMeta(2, 2).borders).toBeUndefined();
+
+    expect(getCellMeta(1, 3).borders).toBeUndefined();
+    expect(getCellMeta(2, 3).borders).toBeUndefined();
+    expect(getCellMeta(3, 1).borders).toBeUndefined();
+    expect(getCellMeta(3, 2).borders).toBeUndefined();
+    expect(getCellMeta(3, 3).borders).toBeUndefined();
+
+    expect(countVisibleCustomBorders()).toBe(0);
+    expect(countCustomBorders()).toBe(0);
+  });
+
+  it('should draw top border from context menu options', async() => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(4, 4),
+      contextMenu: true,
+      customBorders: true
+    });
+
+    await selectContextSubmenuOption('Borders', 'Top');
+    deselectCell();
+
+    expect(getCellMeta(0, 0).borders.top).toEqual(DEFAULT_BORDER);
+    expect(getCellMeta(0, 0).borders.left).toEqual(EMPTY);
+    expect(getCellMeta(0, 0).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(0, 0).borders.right).toEqual(EMPTY);
+
+    expect(countVisibleCustomBorders()).toBe(1);
+    expect(countCustomBorders()).toBe(5);
+  });
+
+  it('should draw left border from context menu options', async() => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(4, 4),
+      contextMenu: true,
+      customBorders: true
+    });
+
+    await selectContextSubmenuOption('Borders', 'Left');
+    deselectCell();
+
+    expect(getCellMeta(0, 0).borders.top).toEqual(EMPTY);
+    expect(getCellMeta(0, 0).borders.left).toEqual(DEFAULT_BORDER);
+    expect(getCellMeta(0, 0).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(0, 0).borders.right).toEqual(EMPTY);
+    expect(countVisibleCustomBorders()).toBe(1);
+    expect(countCustomBorders()).toBe(5);
+  });
+
+  it('should draw right border from context menu options', async() => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(4, 4),
+      contextMenu: true,
+      customBorders: true
+    });
+
+    await selectContextSubmenuOption('Borders', 'Right');
+    deselectCell();
+
+    expect(getCellMeta(0, 0).borders.top).toEqual(EMPTY);
+    expect(getCellMeta(0, 0).borders.left).toEqual(EMPTY);
+    expect(getCellMeta(0, 0).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(0, 0).borders.right).toEqual(DEFAULT_BORDER);
+    expect(countVisibleCustomBorders()).toBe(1);
+    expect(countCustomBorders()).toBe(5);
+  });
+
+  it('should draw bottom border from context menu options', async() => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(4, 4),
+      contextMenu: true,
+      customBorders: true
+    });
+
+    await selectContextSubmenuOption('Borders', 'Bottom');
+    deselectCell();
+
+    expect(getCellMeta(0, 0).borders.top).toEqual(EMPTY);
+    expect(getCellMeta(0, 0).borders.left).toEqual(EMPTY);
+    expect(getCellMeta(0, 0).borders.bottom).toEqual(DEFAULT_BORDER);
+    expect(getCellMeta(0, 0).borders.right).toEqual(EMPTY);
+    expect(countVisibleCustomBorders()).toBe(1);
+    expect(countCustomBorders()).toBe(5);
+  });
+
+  it('should remove all bottoms border from context menu options', async() => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(4, 4),
+      contextMenu: true,
+      customBorders: [
+        {
+          row: 0,
+          col: 0,
+          left: RED_BORDER,
+          right: GREEN_BORDER
+        }]
+    });
+    expect(countVisibleCustomBorders()).toBe(2);
+    expect(countCustomBorders()).toBe(5);
+
+    await selectContextSubmenuOption('Borders', 'Remove border');
+    deselectCell();
+
+    expect(getCellMeta(0, 0).borders).toBeUndefined();
+    expect(countVisibleCustomBorders()).toBe(0);
+    expect(countCustomBorders()).toBe(0);
+  });
+});

--- a/handsontable/src/plugins/customBorders/__tests__/customBorders.spec.js
+++ b/handsontable/src/plugins/customBorders/__tests__/customBorders.spec.js
@@ -1,50 +1,5 @@
 describe('CustomBorders', () => {
   const id = 'testContainer';
-  const DEFAULT_BORDER = { color: '#000', width: 1 };
-  const GREEN_BORDER = { color: 'green', width: 1 };
-  const GREEN_THICK_BORDER = { color: 'green', width: 2 };
-  const RED_BORDER = { color: 'red', width: 2 };
-  const MAGENTA_BORDER = { color: 'magenta', width: 2 };
-  const BLUE_BORDER = { color: 'blue', width: 2 };
-  const ORANGE_BORDER = { color: 'orange', width: 2 };
-  const YELLOW_BORDER = { color: 'yellow', width: 2 };
-  const EMPTY = { hide: true };
-
-  const CUSTOM_BORDER_SELECTOR = '.wtBorder:not(.fill, .current, .area)';
-
-  /**
-   * Returns number of custom borders in DOM. There are 5 borders per
-   * cell (top, left, bottom right, corner), some of which are hidden
-   * TODO this seems redundant that we always render borders that are not visible.
-   */
-  function countCustomBorders() {
-    return $(CUSTOM_BORDER_SELECTOR).length;
-  }
-  /**
-   * Returns number of visible custom borders in DOM.
-   */
-  function countVisibleCustomBorders() {
-    return $(`${CUSTOM_BORDER_SELECTOR}:visible`).length;
-  }
-
-  /**
-   * @param numRows
-   */
-  function generateCustomBordersForAllRows(numRows) {
-    const bordersConfig = [];
-
-    for (let i = 0; i < numRows; i++) {
-      const cellBorder = {
-        row: i,
-        col: 0,
-        top: GREEN_BORDER
-      };
-
-      bordersConfig.push(cellBorder);
-    }
-
-    return bordersConfig;
-  }
 
   beforeEach(function() {
     this.$container = $(`<div id="${id}"></div>`).appendTo('body');
@@ -147,8 +102,8 @@ describe('CustomBorders', () => {
         customBorders: [{
           row: 2,
           col: 2,
-          left: RED_BORDER,
-          right: RED_BORDER,
+          start: RED_BORDER,
+          end: RED_BORDER,
           top: GREEN_BORDER
         }]
       });
@@ -166,8 +121,8 @@ describe('CustomBorders', () => {
         customBorders: [{
           row: 2,
           col: 2,
-          left: RED_BORDER,
-          right: RED_BORDER,
+          start: RED_BORDER,
+          end: RED_BORDER,
           top: GREEN_BORDER
         }]
       });
@@ -183,8 +138,8 @@ describe('CustomBorders', () => {
         customBorders: [{
           row: 2,
           col: 2,
-          left: RED_BORDER,
-          right: RED_BORDER,
+          start: RED_BORDER,
+          end: RED_BORDER,
           top: GREEN_BORDER
         }]
       });
@@ -205,8 +160,8 @@ describe('CustomBorders', () => {
         customBorders: [{
           row: 2,
           col: 2,
-          left: RED_BORDER,
-          right: RED_BORDER,
+          start: RED_BORDER,
+          end: RED_BORDER,
           top: GREEN_BORDER
         }]
       });
@@ -216,6 +171,88 @@ describe('CustomBorders', () => {
 
       expect(countVisibleCustomBorders()).toBe(0); // TODO this assertion checks current behavior that looks like a bug. I would expect 3
       expect(countCustomBorders()).toBe(0);
+    });
+
+    it('should throw an error while initialization if the mixed API is used ("start"/"end" and "left"/"right")', () => {
+      expect(() => {
+        handsontable({
+          customBorders: [{
+            row: 2,
+            col: 2,
+            start: RED_BORDER,
+            right: RED_BORDER,
+            top: GREEN_BORDER
+          }]
+        });
+      }).toThrowError('The "left"/"right" and "start"/"end" options should not be used together. Please use only the option "start"/"end".');
+    });
+
+    it('should throw an error while calling the `updateSettings` method when the mixed API is used ("start"/"end" and "left"/"right")', () => {
+      handsontable({
+        customBorders: [{
+          row: 2,
+          col: 2,
+          start: RED_BORDER,
+          top: GREEN_BORDER
+        }]
+      });
+
+      expect(() => {
+        updateSettings({
+          customBorders: [{
+            row: 2,
+            col: 2,
+            start: RED_BORDER,
+            right: RED_BORDER,
+          }]
+        });
+      }).toThrowError('The "left"/"right" and "start"/"end" options should not be used together. Please use only the option "start"/"end".');
+    });
+
+    it('should be possible to update borders using backward compatible API ("left"/"right") even when Handsontable was initialized using new API ("start"/"end")', () => {
+      handsontable({
+        customBorders: [{
+          row: 2,
+          col: 2,
+          start: RED_BORDER,
+          top: GREEN_BORDER
+        }]
+      });
+
+      updateSettings({
+        customBorders: [{
+          row: 2,
+          col: 2,
+          left: RED_BORDER,
+          right: RED_BORDER,
+        }]
+      });
+
+      expect(countVisibleCustomBorders()).toBe(2);
+      expect(countCustomBorders()).toBe(5);
+    });
+
+    it('should be possible to update borders using new API ("start"/"end") even when Handsontable was initialized using backward compatible API ("left"/"right")', () => {
+      handsontable({
+        customBorders: [{
+          row: 2,
+          col: 2,
+          left: RED_BORDER,
+          top: GREEN_BORDER
+        }]
+      });
+
+      updateSettings({
+        customBorders: [{
+          row: 2,
+          col: 2,
+          start: RED_BORDER,
+          end: RED_BORDER,
+        }]
+      });
+
+      expect(countVisibleCustomBorders()).toBe(2);
+      expect(countCustomBorders()).toBe(5);
     });
   });
 
@@ -252,16 +289,16 @@ describe('CustomBorders', () => {
       customBorders: [{
         row: 2,
         col: 2,
-        left: RED_BORDER,
-        right: RED_BORDER,
+        start: RED_BORDER,
+        end: RED_BORDER,
         top: GREEN_BORDER
       }]
     });
 
     expect(getCellMeta(2, 2).borders.top).toEqual(GREEN_BORDER);
-    expect(getCellMeta(2, 2).borders.left).toEqual(RED_BORDER);
     expect(getCellMeta(2, 2).borders.bottom).toEqual(EMPTY);
-    expect(getCellMeta(2, 2).borders.right).toEqual(RED_BORDER);
+    expect(getCellMeta(2, 2).borders.start).toEqual(RED_BORDER);
+    expect(getCellMeta(2, 2).borders.end).toEqual(RED_BORDER);
 
     expect(getCellMeta(0, 0).borders).toBeUndefined();
     expect(getCellMeta(0, 1).borders).toBeUndefined();
@@ -297,29 +334,29 @@ describe('CustomBorders', () => {
     selectCells([[1, 1, 2, 2]]);
     customBorders.setBorders(getSelected(), {
       top: RED_BORDER,
-      bottom: RED_BORDER
+      end: RED_BORDER
     });
     deselectCell();
 
     expect(getCellMeta(1, 1).borders.top).toEqual(RED_BORDER);
-    expect(getCellMeta(1, 1).borders.left).toEqual(EMPTY);
-    expect(getCellMeta(1, 1).borders.bottom).toEqual(RED_BORDER);
-    expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
+    expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(1, 1).borders.start).toEqual(EMPTY);
+    expect(getCellMeta(1, 1).borders.end).toEqual(RED_BORDER);
 
     expect(getCellMeta(1, 2).borders.top).toEqual(RED_BORDER);
-    expect(getCellMeta(1, 2).borders.left).toEqual(EMPTY);
-    expect(getCellMeta(1, 2).borders.bottom).toEqual(RED_BORDER);
-    expect(getCellMeta(1, 2).borders.right).toEqual(EMPTY);
+    expect(getCellMeta(1, 2).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(1, 2).borders.start).toEqual(EMPTY);
+    expect(getCellMeta(1, 2).borders.end).toEqual(RED_BORDER);
 
     expect(getCellMeta(2, 1).borders.top).toEqual(RED_BORDER);
-    expect(getCellMeta(2, 1).borders.left).toEqual(EMPTY);
-    expect(getCellMeta(2, 1).borders.bottom).toEqual(RED_BORDER);
-    expect(getCellMeta(2, 1).borders.right).toEqual(EMPTY);
+    expect(getCellMeta(2, 1).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(2, 1).borders.start).toEqual(EMPTY);
+    expect(getCellMeta(2, 1).borders.end).toEqual(RED_BORDER);
 
     expect(getCellMeta(2, 2).borders.top).toEqual(RED_BORDER);
-    expect(getCellMeta(2, 2).borders.left).toEqual(EMPTY);
-    expect(getCellMeta(2, 2).borders.bottom).toEqual(RED_BORDER);
-    expect(getCellMeta(2, 2).borders.right).toEqual(EMPTY);
+    expect(getCellMeta(2, 2).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(2, 2).borders.start).toEqual(EMPTY);
+    expect(getCellMeta(2, 2).borders.end).toEqual(RED_BORDER);
 
     expect(countVisibleCustomBorders()).toBe(8);
     expect(countCustomBorders()).toBe(4 * 5); // there are 4 cells in the provided range
@@ -335,28 +372,28 @@ describe('CustomBorders', () => {
 
     customBorders.setBorders([[1, 1, 2, 2]], {
       top: RED_BORDER,
-      bottom: RED_BORDER
+      end: RED_BORDER
     });
 
     expect(getCellMeta(1, 1).borders.top).toEqual(RED_BORDER);
-    expect(getCellMeta(1, 1).borders.left).toEqual(EMPTY);
-    expect(getCellMeta(1, 1).borders.bottom).toEqual(RED_BORDER);
-    expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
+    expect(getCellMeta(1, 1).borders.start).toEqual(EMPTY);
+    expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(1, 1).borders.end).toEqual(RED_BORDER);
 
     expect(getCellMeta(1, 2).borders.top).toEqual(RED_BORDER);
-    expect(getCellMeta(1, 2).borders.left).toEqual(EMPTY);
-    expect(getCellMeta(1, 2).borders.bottom).toEqual(RED_BORDER);
-    expect(getCellMeta(1, 2).borders.right).toEqual(EMPTY);
+    expect(getCellMeta(1, 2).borders.start).toEqual(EMPTY);
+    expect(getCellMeta(1, 2).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(1, 2).borders.end).toEqual(RED_BORDER);
 
     expect(getCellMeta(2, 1).borders.top).toEqual(RED_BORDER);
-    expect(getCellMeta(2, 1).borders.left).toEqual(EMPTY);
-    expect(getCellMeta(2, 1).borders.bottom).toEqual(RED_BORDER);
-    expect(getCellMeta(2, 1).borders.right).toEqual(EMPTY);
+    expect(getCellMeta(2, 1).borders.start).toEqual(EMPTY);
+    expect(getCellMeta(2, 1).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(2, 1).borders.end).toEqual(RED_BORDER);
 
     expect(getCellMeta(2, 2).borders.top).toEqual(RED_BORDER);
-    expect(getCellMeta(2, 2).borders.left).toEqual(EMPTY);
-    expect(getCellMeta(2, 2).borders.bottom).toEqual(RED_BORDER);
-    expect(getCellMeta(2, 2).borders.right).toEqual(EMPTY);
+    expect(getCellMeta(2, 2).borders.start).toEqual(EMPTY);
+    expect(getCellMeta(2, 2).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(2, 2).borders.end).toEqual(RED_BORDER);
 
     expect(countVisibleCustomBorders()).toBe(8);
     expect(countCustomBorders()).toBe(4 * 5); // there are 4 cells in the provided range
@@ -368,8 +405,8 @@ describe('CustomBorders', () => {
       customBorders: [{
         row: 2,
         col: 2,
-        left: RED_BORDER,
-        right: GREEN_BORDER,
+        start: RED_BORDER,
+        end: GREEN_BORDER,
         top: GREEN_THICK_BORDER
       }]
     });
@@ -379,14 +416,15 @@ describe('CustomBorders', () => {
     selectCell(2, 2);
     customBorders.setBorders(getSelectedRange(), {
       top: RED_BORDER,
-      bottom: RED_BORDER
+      bottom: GREEN_BORDER,
+      end: RED_BORDER
     });
     deselectCell();
 
     expect(getCellMeta(2, 2).borders.top).toEqual(RED_BORDER);
-    expect(getCellMeta(2, 2).borders.left).toEqual(RED_BORDER);
-    expect(getCellMeta(2, 2).borders.bottom).toEqual(RED_BORDER);
-    expect(getCellMeta(2, 2).borders.right).toEqual(GREEN_BORDER);
+    expect(getCellMeta(2, 2).borders.start).toEqual(RED_BORDER);
+    expect(getCellMeta(2, 2).borders.bottom).toEqual(GREEN_BORDER);
+    expect(getCellMeta(2, 2).borders.end).toEqual(RED_BORDER);
     expect(countVisibleCustomBorders()).toBe(4);
     expect(countCustomBorders()).toBe(5);
   });
@@ -397,8 +435,8 @@ describe('CustomBorders', () => {
       customBorders: [{
         row: 2,
         col: 2,
-        left: RED_BORDER,
-        right: GREEN_BORDER,
+        start: RED_BORDER,
+        end: GREEN_BORDER,
         top: GREEN_THICK_BORDER
       }]
     });
@@ -407,13 +445,14 @@ describe('CustomBorders', () => {
 
     customBorders.setBorders([[2, 2]], {
       top: RED_BORDER,
-      bottom: RED_BORDER
+      bottom: GREEN_BORDER,
+      end: RED_BORDER
     });
 
     expect(getCellMeta(2, 2).borders.top).toEqual(RED_BORDER);
-    expect(getCellMeta(2, 2).borders.left).toEqual(RED_BORDER);
-    expect(getCellMeta(2, 2).borders.bottom).toEqual(RED_BORDER);
-    expect(getCellMeta(2, 2).borders.right).toEqual(GREEN_BORDER);
+    expect(getCellMeta(2, 2).borders.start).toEqual(RED_BORDER);
+    expect(getCellMeta(2, 2).borders.bottom).toEqual(GREEN_BORDER);
+    expect(getCellMeta(2, 2).borders.end).toEqual(RED_BORDER);
     expect(countVisibleCustomBorders()).toBe(4);
     expect(countCustomBorders()).toBe(5);
   });
@@ -424,8 +463,8 @@ describe('CustomBorders', () => {
       customBorders: [{
         row: 2,
         col: 2,
-        left: RED_BORDER,
-        right: RED_BORDER,
+        start: RED_BORDER,
+        end: RED_BORDER,
         top: GREEN_BORDER
       }]
     });
@@ -434,15 +473,16 @@ describe('CustomBorders', () => {
 
     selectCell(2, 2);
     customBorders.setBorders(getSelected(), {
-      top: EMPTY
+      top: EMPTY,
+      end: EMPTY,
     });
     deselectCell();
 
     expect(getCellMeta(2, 2).borders.top).toEqual(EMPTY);
-    expect(getCellMeta(2, 2).borders.left).toEqual(RED_BORDER);
+    expect(getCellMeta(2, 2).borders.start).toEqual(RED_BORDER);
     expect(getCellMeta(2, 2).borders.bottom).toEqual(EMPTY);
-    expect(getCellMeta(2, 2).borders.right).toEqual(RED_BORDER);
-    expect(countVisibleCustomBorders()).toBe(2);
+    expect(getCellMeta(2, 2).borders.end).toEqual(EMPTY);
+    expect(countVisibleCustomBorders()).toBe(1);
     expect(countCustomBorders()).toBe(5);
   });
 
@@ -452,8 +492,8 @@ describe('CustomBorders', () => {
       customBorders: [{
         row: 2,
         col: 2,
-        left: RED_BORDER,
-        right: RED_BORDER,
+        start: RED_BORDER,
+        end: RED_BORDER,
         top: GREEN_BORDER
       }]
     });
@@ -461,14 +501,15 @@ describe('CustomBorders', () => {
     const customBorders = hot.getPlugin('customBorders');
 
     customBorders.setBorders([[2, 2]], {
-      top: EMPTY
+      top: EMPTY,
+      end: EMPTY,
     });
 
     expect(getCellMeta(2, 2).borders.top).toEqual(EMPTY);
-    expect(getCellMeta(2, 2).borders.left).toEqual(RED_BORDER);
+    expect(getCellMeta(2, 2).borders.start).toEqual(RED_BORDER);
     expect(getCellMeta(2, 2).borders.bottom).toEqual(EMPTY);
-    expect(getCellMeta(2, 2).borders.right).toEqual(RED_BORDER);
-    expect(countVisibleCustomBorders()).toBe(2);
+    expect(getCellMeta(2, 2).borders.end).toEqual(EMPTY);
+    expect(countVisibleCustomBorders()).toBe(1);
     expect(countCustomBorders()).toBe(5);
   });
 
@@ -478,8 +519,8 @@ describe('CustomBorders', () => {
       customBorders: [{
         row: 2,
         col: 2,
-        left: RED_BORDER,
-        right: RED_BORDER,
+        start: RED_BORDER,
+        end: RED_BORDER,
         top: GREEN_BORDER
       }]
     });
@@ -488,14 +529,15 @@ describe('CustomBorders', () => {
 
     selectCell(2, 2);
     customBorders.setBorders(getSelected(), {
-      top: false
+      top: false,
+      end: false,
     });
     deselectCell();
 
     expect(getCellMeta(2, 2).borders.top).toEqual(EMPTY);
-    expect(getCellMeta(2, 2).borders.left).toEqual(RED_BORDER);
+    expect(getCellMeta(2, 2).borders.start).toEqual(RED_BORDER);
     expect(getCellMeta(2, 2).borders.bottom).toEqual(EMPTY);
-    expect(getCellMeta(2, 2).borders.right).toEqual(RED_BORDER);
+    expect(getCellMeta(2, 2).borders.end).toEqual(EMPTY);
 
     expect(getCellMeta(0, 0).borders).toBeUndefined();
     expect(getCellMeta(0, 1).borders).toBeUndefined();
@@ -516,7 +558,7 @@ describe('CustomBorders', () => {
     expect(getCellMeta(3, 2).borders).toBeUndefined();
     expect(getCellMeta(3, 3).borders).toBeUndefined();
 
-    expect(countVisibleCustomBorders()).toBe(2);
+    expect(countVisibleCustomBorders()).toBe(1);
     expect(countCustomBorders()).toBe(5);
   });
 
@@ -526,8 +568,8 @@ describe('CustomBorders', () => {
       customBorders: [{
         row: 2,
         col: 2,
-        left: RED_BORDER,
-        right: RED_BORDER,
+        start: RED_BORDER,
+        end: RED_BORDER,
         top: GREEN_BORDER
       }]
     });
@@ -535,13 +577,14 @@ describe('CustomBorders', () => {
     const customBorders = hot.getPlugin('customBorders');
 
     customBorders.setBorders([[2, 2]], {
-      top: false
+      top: false,
+      end: false,
     });
 
     expect(getCellMeta(2, 2).borders.top).toEqual(EMPTY);
-    expect(getCellMeta(2, 2).borders.left).toEqual(RED_BORDER);
+    expect(getCellMeta(2, 2).borders.start).toEqual(RED_BORDER);
     expect(getCellMeta(2, 2).borders.bottom).toEqual(EMPTY);
-    expect(getCellMeta(2, 2).borders.right).toEqual(RED_BORDER);
+    expect(getCellMeta(2, 2).borders.end).toEqual(EMPTY);
 
     expect(getCellMeta(0, 0).borders).toBeUndefined();
     expect(getCellMeta(0, 1).borders).toBeUndefined();
@@ -562,7 +605,7 @@ describe('CustomBorders', () => {
     expect(getCellMeta(3, 2).borders).toBeUndefined();
     expect(getCellMeta(3, 3).borders).toBeUndefined();
 
-    expect(countVisibleCustomBorders()).toBe(2);
+    expect(countVisibleCustomBorders()).toBe(1);
     expect(countCustomBorders()).toBe(5);
   });
 
@@ -572,8 +615,8 @@ describe('CustomBorders', () => {
       customBorders: [{
         row: 2,
         col: 2,
-        left: RED_BORDER,
-        right: GREEN_BORDER,
+        start: RED_BORDER,
+        end: GREEN_BORDER,
         top: GREEN_BORDER
       }]
     });
@@ -587,9 +630,9 @@ describe('CustomBorders', () => {
 
     expect(borders.length).toEqual(1);
     expect(borders[0].top).toEqual(GREEN_BORDER);
-    expect(borders[0].left).toEqual(RED_BORDER);
     expect(borders[0].bottom).toEqual(EMPTY);
-    expect(borders[0].right).toEqual(GREEN_BORDER);
+    expect(borders[0].start).toEqual(RED_BORDER);
+    expect(borders[0].end).toEqual(GREEN_BORDER);
     expect(countVisibleCustomBorders()).toBe(3);
     expect(countCustomBorders()).toBe(5);
   });
@@ -609,15 +652,15 @@ describe('CustomBorders', () => {
           }
         },
         top: BLUE_BORDER,
-        left: ORANGE_BORDER,
+        start: ORANGE_BORDER,
         bottom: RED_BORDER,
-        right: MAGENTA_BORDER
+        end: MAGENTA_BORDER
       },
       {
         row: 2,
         col: 2,
-        left: RED_BORDER,
-        right: GREEN_BORDER,
+        start: RED_BORDER,
+        end: GREEN_BORDER,
         top: GREEN_THICK_BORDER
       }]
     });
@@ -646,15 +689,15 @@ describe('CustomBorders', () => {
           }
         },
         top: BLUE_BORDER,
-        left: ORANGE_BORDER,
+        start: ORANGE_BORDER,
         bottom: RED_BORDER,
-        right: MAGENTA_BORDER
+        end: MAGENTA_BORDER
       },
       {
         row: 2,
         col: 2,
-        left: RED_BORDER,
-        right: GREEN_BORDER,
+        start: RED_BORDER,
+        end: GREEN_BORDER,
         top: GREEN_THICK_BORDER
       }]
     });
@@ -687,12 +730,12 @@ describe('CustomBorders', () => {
     expect(getCellMeta(2, 2).borders).toBeUndefined();
 
     expect(getCellMeta(1, 3).borders.top).toEqual(BLUE_BORDER);
-    expect(getCellMeta(1, 3).borders.right).toEqual(MAGENTA_BORDER);
-    expect(getCellMeta(2, 3).borders.right).toEqual(MAGENTA_BORDER);
-    expect(getCellMeta(3, 1).borders.left).toEqual(ORANGE_BORDER);
+    expect(getCellMeta(1, 3).borders.end).toEqual(MAGENTA_BORDER);
+    expect(getCellMeta(2, 3).borders.end).toEqual(MAGENTA_BORDER);
+    expect(getCellMeta(3, 1).borders.start).toEqual(ORANGE_BORDER);
     expect(getCellMeta(3, 1).borders.bottom).toEqual(RED_BORDER);
     expect(getCellMeta(3, 2).borders.bottom).toEqual(RED_BORDER);
-    expect(getCellMeta(3, 3).borders.right).toEqual(MAGENTA_BORDER);
+    expect(getCellMeta(3, 3).borders.end).toEqual(MAGENTA_BORDER);
     expect(getCellMeta(3, 3).borders.bottom).toEqual(RED_BORDER);
     expect(countVisibleCustomBorders()).toBe(8);
     expect(countCustomBorders()).toBe(5 * 5);
@@ -713,15 +756,15 @@ describe('CustomBorders', () => {
           }
         },
         top: BLUE_BORDER,
-        left: ORANGE_BORDER,
+        start: ORANGE_BORDER,
         bottom: RED_BORDER,
-        right: MAGENTA_BORDER
+        end: MAGENTA_BORDER
       },
       {
         row: 2,
         col: 2,
-        left: RED_BORDER,
-        right: GREEN_BORDER,
+        start: RED_BORDER,
+        end: GREEN_BORDER,
         top: GREEN_THICK_BORDER
       }]
     });
@@ -752,12 +795,12 @@ describe('CustomBorders', () => {
     expect(getCellMeta(2, 2).borders).toBeUndefined();
 
     expect(getCellMeta(1, 3).borders.top).toEqual(BLUE_BORDER);
-    expect(getCellMeta(1, 3).borders.right).toEqual(MAGENTA_BORDER);
-    expect(getCellMeta(2, 3).borders.right).toEqual(MAGENTA_BORDER);
-    expect(getCellMeta(3, 1).borders.left).toEqual(ORANGE_BORDER);
+    expect(getCellMeta(1, 3).borders.end).toEqual(MAGENTA_BORDER);
+    expect(getCellMeta(2, 3).borders.end).toEqual(MAGENTA_BORDER);
+    expect(getCellMeta(3, 1).borders.start).toEqual(ORANGE_BORDER);
     expect(getCellMeta(3, 1).borders.bottom).toEqual(RED_BORDER);
     expect(getCellMeta(3, 2).borders.bottom).toEqual(RED_BORDER);
-    expect(getCellMeta(3, 3).borders.right).toEqual(MAGENTA_BORDER);
+    expect(getCellMeta(3, 3).borders.end).toEqual(MAGENTA_BORDER);
     expect(getCellMeta(3, 3).borders.bottom).toEqual(RED_BORDER);
     expect(countVisibleCustomBorders()).toBe(8);
     expect(countCustomBorders()).toBe(5 * 5);
@@ -778,15 +821,15 @@ describe('CustomBorders', () => {
           }
         },
         top: BLUE_BORDER,
-        left: ORANGE_BORDER,
+        start: ORANGE_BORDER,
         bottom: RED_BORDER,
-        right: MAGENTA_BORDER
+        end: MAGENTA_BORDER
       },
       {
         row: 2,
         col: 2,
-        left: RED_BORDER,
-        right: GREEN_BORDER,
+        start: RED_BORDER,
+        end: GREEN_BORDER,
         top: GREEN_THICK_BORDER
       }]
     });
@@ -826,9 +869,9 @@ describe('CustomBorders', () => {
     expect(getCellMeta(0, 1).borders.top).toEqual(DEFAULT_BORDER);
     expect(getCellMeta(0, 2).borders.top).toEqual(DEFAULT_BORDER);
     expect(getCellMeta(0, 3).borders.top).toEqual(DEFAULT_BORDER);
-    expect(getCellMeta(0, 0).borders.left).toEqual(EMPTY);
+    expect(getCellMeta(0, 0).borders.start).toEqual(EMPTY);
     expect(getCellMeta(0, 0).borders.bottom).toEqual(EMPTY);
-    expect(getCellMeta(0, 0).borders.right).toEqual(EMPTY);
+    expect(getCellMeta(0, 0).borders.end).toEqual(EMPTY);
     expect(countVisibleCustomBorders()).toBe(4);
     expect(countCustomBorders()).toBe(40);
   });
@@ -845,13 +888,13 @@ describe('CustomBorders', () => {
 
     deselectCell();
 
-    expect(getCellMeta(0, 0).borders.right).toEqual(DEFAULT_BORDER);
-    expect(getCellMeta(1, 0).borders.right).toEqual(DEFAULT_BORDER);
-    expect(getCellMeta(2, 0).borders.right).toEqual(DEFAULT_BORDER);
-    expect(getCellMeta(3, 0).borders.right).toEqual(DEFAULT_BORDER);
+    expect(getCellMeta(0, 0).borders.end).toEqual(DEFAULT_BORDER);
+    expect(getCellMeta(1, 0).borders.end).toEqual(DEFAULT_BORDER);
+    expect(getCellMeta(2, 0).borders.end).toEqual(DEFAULT_BORDER);
+    expect(getCellMeta(3, 0).borders.end).toEqual(DEFAULT_BORDER);
     expect(getCellMeta(0, 0).borders.top).toEqual(EMPTY);
     expect(getCellMeta(0, 0).borders.bottom).toEqual(EMPTY);
-    expect(getCellMeta(0, 0).borders.left).toEqual(EMPTY);
+    expect(getCellMeta(0, 0).borders.start).toEqual(EMPTY);
     expect(countVisibleCustomBorders()).toBe(4);
     expect(countCustomBorders()).toBe(40);
   });
@@ -863,8 +906,8 @@ describe('CustomBorders', () => {
       customBorders: [{
         row: 0,
         col: 0,
-        left: RED_BORDER,
-        right: GREEN_BORDER,
+        start: RED_BORDER,
+        end: GREEN_BORDER,
         top: GREEN_THICK_BORDER
       }]
     });
@@ -879,9 +922,9 @@ describe('CustomBorders', () => {
     deselectCell();
 
     expect(getCellMeta(0, 0).borders.top).toEqual(DEFAULT_BORDER);
-    expect(getCellMeta(0, 0).borders.left).toEqual(EMPTY);
     expect(getCellMeta(0, 0).borders.bottom).toEqual(EMPTY);
-    expect(getCellMeta(0, 0).borders.right).toEqual(EMPTY);
+    expect(getCellMeta(0, 0).borders.start).toEqual(EMPTY);
+    expect(getCellMeta(0, 0).borders.end).toEqual(EMPTY);
     expect(countVisibleCustomBorders()).toBe(1);
     expect(countCustomBorders()).toBe(5);
   });
@@ -895,8 +938,8 @@ describe('CustomBorders', () => {
       customBorders: [{
         row: 0,
         col: 0,
-        left: RED_BORDER,
-        right: GREEN_BORDER,
+        start: RED_BORDER,
+        end: GREEN_BORDER,
         top: GREEN_THICK_BORDER
       }]
     });
@@ -926,11 +969,10 @@ describe('CustomBorders', () => {
     await selectContextSubmenuOption('Borders', 'Top');
     deselectCell();
 
-    // expect(getCellMeta(0,0).borders.hasOwnProperty('top')).toBe(true);
     expect(getCellMeta(0, 0).borders.top).toEqual(DEFAULT_BORDER);
-    expect(getCellMeta(0, 0).borders.left).toEqual(EMPTY);
     expect(getCellMeta(0, 0).borders.bottom).toEqual(EMPTY);
-    expect(getCellMeta(0, 0).borders.right).toEqual(EMPTY);
+    expect(getCellMeta(0, 0).borders.start).toEqual(EMPTY);
+    expect(getCellMeta(0, 0).borders.end).toEqual(EMPTY);
 
     expect(countVisibleCustomBorders()).toBe(1);
     expect(countCustomBorders()).toBe(5);
@@ -949,9 +991,9 @@ describe('CustomBorders', () => {
     /* eslint-disable no-prototype-builtins */
     expect(getCellMeta(0, 0).borders.hasOwnProperty('left')).toBe(true);
     expect(getCellMeta(0, 0).borders.top).toEqual(EMPTY);
-    expect(getCellMeta(0, 0).borders.left).toEqual(DEFAULT_BORDER);
     expect(getCellMeta(0, 0).borders.bottom).toEqual(EMPTY);
-    expect(getCellMeta(0, 0).borders.right).toEqual(EMPTY);
+    expect(getCellMeta(0, 0).borders.start).toEqual(DEFAULT_BORDER);
+    expect(getCellMeta(0, 0).borders.end).toEqual(EMPTY);
     expect(countVisibleCustomBorders()).toBe(1);
     expect(countCustomBorders()).toBe(5);
   });
@@ -969,9 +1011,9 @@ describe('CustomBorders', () => {
     /* eslint-disable no-prototype-builtins */
     expect(getCellMeta(0, 0).borders.hasOwnProperty('right')).toBe(true); // TODO flaky test. sometimes I get this error on this line: 'Failed: Cannot read property 'hasOwnProperty' of undefined'
     expect(getCellMeta(0, 0).borders.top).toEqual(EMPTY);
-    expect(getCellMeta(0, 0).borders.left).toEqual(EMPTY);
     expect(getCellMeta(0, 0).borders.bottom).toEqual(EMPTY);
-    expect(getCellMeta(0, 0).borders.right).toEqual(DEFAULT_BORDER);
+    expect(getCellMeta(0, 0).borders.start).toEqual(EMPTY);
+    expect(getCellMeta(0, 0).borders.end).toEqual(DEFAULT_BORDER);
     expect(countVisibleCustomBorders()).toBe(1);
     expect(countCustomBorders()).toBe(5);
   });
@@ -989,9 +1031,9 @@ describe('CustomBorders', () => {
     /* eslint-disable no-prototype-builtins */
     expect(getCellMeta(0, 0).borders.hasOwnProperty('right')).toBe(true);
     expect(getCellMeta(0, 0).borders.top).toEqual(EMPTY);
-    expect(getCellMeta(0, 0).borders.left).toEqual(EMPTY);
     expect(getCellMeta(0, 0).borders.bottom).toEqual(DEFAULT_BORDER);
-    expect(getCellMeta(0, 0).borders.right).toEqual(EMPTY);
+    expect(getCellMeta(0, 0).borders.start).toEqual(EMPTY);
+    expect(getCellMeta(0, 0).borders.end).toEqual(EMPTY);
     expect(countVisibleCustomBorders()).toBe(1);
     expect(countCustomBorders()).toBe(5);
   });
@@ -1004,8 +1046,8 @@ describe('CustomBorders', () => {
         {
           row: 0,
           col: 0,
-          left: RED_BORDER,
-          right: GREEN_BORDER
+          start: RED_BORDER,
+          end: GREEN_BORDER
         }]
     });
     expect(countVisibleCustomBorders()).toBe(2);
@@ -1129,1544 +1171,31 @@ describe('CustomBorders', () => {
           }
         },
         top: BLUE_BORDER,
-        left: ORANGE_BORDER,
+        start: ORANGE_BORDER,
         bottom: RED_BORDER,
-        right: MAGENTA_BORDER
+        end: MAGENTA_BORDER
       }]
     });
 
     expect(countVisibleCustomBorders()).toEqual(4 + 4); // 4 rows x 4 columns from one side
     // First cell from the top-left position
-    expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
     expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
     expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
-    expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
+    expect(getCellMeta(1, 1).borders.start).toEqual(ORANGE_BORDER);
+    expect(getCellMeta(1, 1).borders.end).toEqual(EMPTY);
     // First cell from the top-right position
-    expect(getCellMeta(1, 4).borders.left).toEqual(EMPTY);
     expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
     expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
-    expect(getCellMeta(1, 4).borders.right).toEqual(EMPTY);
+    expect(getCellMeta(1, 4).borders.start).toEqual(EMPTY);
+    expect(getCellMeta(1, 4).borders.end).toEqual(EMPTY);
     // // First cell from the bottom-left position
-    expect(getCellMeta(4, 1).borders.left).toEqual(ORANGE_BORDER);
     expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
     expect(getCellMeta(4, 1).borders.bottom).toEqual(EMPTY);
-    expect(getCellMeta(4, 1).borders.right).toEqual(EMPTY);
+    expect(getCellMeta(4, 1).borders.start).toEqual(ORANGE_BORDER);
+    expect(getCellMeta(4, 1).borders.end).toEqual(EMPTY);
     // // First cell from the bottom-right position
     expect(getCellMeta(4, 4).borders).toBeUndefined();
     // Cell in the middle of area without borders
     expect(getCellMeta(2, 3).borders).toBeUndefined();
-  });
-
-  // TODO: Should it work in this way? Probably some warn would be helpful.
-  it('should draw borders properly when some of them are beyond the table boundaries (drawing single borders)', () => {
-    handsontable({
-      data: Handsontable.helper.createSpreadsheetData(5, 5),
-      rowHeaders: true,
-      colHeaders: true,
-      hiddenColumns: {
-        columns: [1],
-        indicators: true
-      },
-      customBorders: [{
-        row: 0,
-        col: 0,
-        top: BLUE_BORDER,
-        left: ORANGE_BORDER,
-        bottom: RED_BORDER,
-        right: MAGENTA_BORDER
-      }, {
-        row: 7,
-        col: 7,
-        top: BLUE_BORDER,
-        left: ORANGE_BORDER,
-        bottom: RED_BORDER,
-        right: MAGENTA_BORDER
-      }]
-    });
-
-    expect(countVisibleCustomBorders()).toEqual(4);
-    expect(getCellMeta(0, 0).borders.left).toEqual(ORANGE_BORDER);
-    expect(getCellMeta(0, 0).borders.top).toEqual(BLUE_BORDER);
-    expect(getCellMeta(0, 0).borders.bottom).toEqual(RED_BORDER);
-    expect(getCellMeta(0, 0).borders.right).toEqual(MAGENTA_BORDER);
-    expect(getCellMeta(2, 2).borders).toBeUndefined();
-  });
-
-  describe('should cooperate with the `HiddenColumns` plugin properly', () => {
-    it('should display custom borders (drawing range) properly when some columns are hidden ' +
-      '(range starts from hidden column)', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
-        rowHeaders: true,
-        colHeaders: true,
-        hiddenColumns: {
-          columns: [1],
-          indicators: true
-        },
-        customBorders: [{
-          range: {
-            from: {
-              row: 1,
-              col: 1
-            },
-            to: {
-              row: 4,
-              col: 4
-            }
-          },
-          top: BLUE_BORDER,
-          left: ORANGE_BORDER,
-          bottom: RED_BORDER,
-          right: MAGENTA_BORDER
-        }]
-      });
-
-      expect(countVisibleCustomBorders()).toEqual((3 * 2) + 4); // 4 rows x 3 columns without left border
-      // First cell from the top-left position
-      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
-      // First cell from the top-right position
-      expect(getCellMeta(1, 4).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(1, 4).borders.right).toEqual(MAGENTA_BORDER);
-      // // First cell from the bottom-left position
-      expect(getCellMeta(4, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
-      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(4, 1).borders.right).toEqual(EMPTY);
-      // // First cell from the bottom-right position
-      expect(getCellMeta(4, 4).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
-      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(4, 4).borders.right).toEqual(MAGENTA_BORDER);
-      // Cell in the middle of area without borders
-      expect(getCellMeta(2, 2).borders).toBeUndefined();
-    });
-
-    it('should display custom borders (drawing range) properly when hiding columns that have been visible ' +
-      '(hiding column at the start of the range)', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
-        rowHeaders: true,
-        colHeaders: true,
-        hiddenColumns: true,
-        customBorders: [{
-          range: {
-            from: {
-              row: 1,
-              col: 1
-            },
-            to: {
-              row: 4,
-              col: 4
-            }
-          },
-          top: BLUE_BORDER,
-          left: ORANGE_BORDER,
-          bottom: RED_BORDER,
-          right: MAGENTA_BORDER
-        }]
-      });
-
-      getPlugin('hiddenColumns').hideColumn(1);
-      render();
-
-      expect(countVisibleCustomBorders()).toEqual((3 * 2) + 4); // 4 rows x 3 columns without left border
-      // First cell from the top-left position
-      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
-      // First cell from the top-right position
-      expect(getCellMeta(1, 4).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(1, 4).borders.right).toEqual(MAGENTA_BORDER);
-      // // First cell from the bottom-left position
-      expect(getCellMeta(4, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
-      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(4, 1).borders.right).toEqual(EMPTY);
-      // // First cell from the bottom-right position
-      expect(getCellMeta(4, 4).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
-      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(4, 4).borders.right).toEqual(MAGENTA_BORDER);
-      // Cell in the middle of area without borders
-      expect(getCellMeta(2, 2).borders).toBeUndefined();
-    });
-
-    it('should display custom borders (drawing range) properly when showing columns that have been hidden ' +
-      '(range starts from hidden column)', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
-        rowHeaders: true,
-        colHeaders: true,
-        hiddenColumns: {
-          columns: [1],
-          indicators: true
-        },
-        customBorders: [{
-          range: {
-            from: {
-              row: 1,
-              col: 1
-            },
-            to: {
-              row: 4,
-              col: 4
-            }
-          },
-          top: BLUE_BORDER,
-          left: ORANGE_BORDER,
-          bottom: RED_BORDER,
-          right: MAGENTA_BORDER
-        }]
-      });
-
-      getPlugin('hiddenColumns').showColumn(1);
-      render();
-
-      expect(countVisibleCustomBorders()).toEqual(4 * 4); // 4 rows x 4 columns
-      // First cell from the top-left position
-      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
-      // First cell from the top-right position
-      expect(getCellMeta(1, 4).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(1, 4).borders.right).toEqual(MAGENTA_BORDER);
-      // // First cell from the bottom-left position
-      expect(getCellMeta(4, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
-      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(4, 1).borders.right).toEqual(EMPTY);
-      // // First cell from the bottom-right position
-      expect(getCellMeta(4, 4).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
-      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(4, 4).borders.right).toEqual(MAGENTA_BORDER);
-      // Cell in the middle of area without borders
-      expect(getCellMeta(2, 2).borders).toBeUndefined();
-    });
-
-    it('should display custom borders (drawing range) properly when some columns are hidden ' +
-      '(range ends at hidden column)', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
-        rowHeaders: true,
-        colHeaders: true,
-        hiddenColumns: {
-          columns: [4],
-          indicators: true
-        },
-        customBorders: [{
-          range: {
-            from: {
-              row: 1,
-              col: 1
-            },
-            to: {
-              row: 4,
-              col: 4
-            }
-          },
-          top: BLUE_BORDER,
-          left: ORANGE_BORDER,
-          bottom: RED_BORDER,
-          right: MAGENTA_BORDER
-        }]
-      });
-
-      expect(countVisibleCustomBorders()).toEqual((3 * 2) + 4); // 4 rows x 3 columns without right border
-      // First cell from the top-left position
-      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
-      // First cell from the top-right position
-      expect(getCellMeta(1, 4).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(1, 4).borders.right).toEqual(MAGENTA_BORDER);
-      // // First cell from the bottom-left position
-      expect(getCellMeta(4, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
-      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(4, 1).borders.right).toEqual(EMPTY);
-      // // First cell from the bottom-right position
-      expect(getCellMeta(4, 4).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
-      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(4, 4).borders.right).toEqual(MAGENTA_BORDER);
-      // Cell in the middle of area without borders
-      expect(getCellMeta(2, 2).borders).toBeUndefined();
-    });
-
-    it('should display custom borders (drawing range) properly when hiding columns that have been visible ' +
-      '(hiding column at the end of the range)', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
-        rowHeaders: true,
-        colHeaders: true,
-        hiddenColumns: true,
-        customBorders: [{
-          range: {
-            from: {
-              row: 1,
-              col: 1
-            },
-            to: {
-              row: 4,
-              col: 4
-            }
-          },
-          top: BLUE_BORDER,
-          left: ORANGE_BORDER,
-          bottom: RED_BORDER,
-          right: MAGENTA_BORDER
-        }]
-      });
-
-      getPlugin('hiddenColumns').hideColumn(4);
-      render();
-
-      expect(countVisibleCustomBorders()).toEqual((3 * 2) + 4); // 4 rows x 3 columns without right border
-      // First cell from the top-left position
-      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
-      // First cell from the top-right position
-      expect(getCellMeta(1, 4).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(1, 4).borders.right).toEqual(MAGENTA_BORDER);
-      // // First cell from the bottom-left position
-      expect(getCellMeta(4, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
-      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(4, 1).borders.right).toEqual(EMPTY);
-      // // First cell from the bottom-right position
-      expect(getCellMeta(4, 4).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
-      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(4, 4).borders.right).toEqual(MAGENTA_BORDER);
-      // Cell in the middle of area without borders
-      expect(getCellMeta(2, 2).borders).toBeUndefined();
-    });
-
-    it('should display custom borders (drawing range) properly when showing columns that have been hidden ' +
-      '(range ends at hidden column)', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
-        rowHeaders: true,
-        colHeaders: true,
-        hiddenColumns: {
-          columns: [4],
-          indicators: true
-        },
-        customBorders: [{
-          range: {
-            from: {
-              row: 1,
-              col: 1
-            },
-            to: {
-              row: 4,
-              col: 4
-            }
-          },
-          top: BLUE_BORDER,
-          left: ORANGE_BORDER,
-          bottom: RED_BORDER,
-          right: MAGENTA_BORDER
-        }]
-      });
-
-      getPlugin('hiddenColumns').showColumn(4);
-      render();
-
-      expect(countVisibleCustomBorders()).toEqual(4 * 4); // 4 rows x 4 columns
-      // First cell from the top-left position
-      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
-      // First cell from the top-right position
-      expect(getCellMeta(1, 4).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(1, 4).borders.right).toEqual(MAGENTA_BORDER);
-      // // First cell from the bottom-left position
-      expect(getCellMeta(4, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
-      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(4, 1).borders.right).toEqual(EMPTY);
-      // // First cell from the bottom-right position
-      expect(getCellMeta(4, 4).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
-      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(4, 4).borders.right).toEqual(MAGENTA_BORDER);
-      // Cell in the middle of area without borders
-      expect(getCellMeta(2, 2).borders).toBeUndefined();
-    });
-
-    it('should display custom borders (drawing range) properly when some columns are hidden ' +
-      '(hidden column in the middle of the range)', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
-        rowHeaders: true,
-        colHeaders: true,
-        hiddenColumns: {
-          columns: [2],
-          indicators: true
-        },
-        customBorders: [{
-          range: {
-            from: {
-              row: 1,
-              col: 1
-            },
-            to: {
-              row: 4,
-              col: 4
-            }
-          },
-          top: BLUE_BORDER,
-          left: ORANGE_BORDER,
-          bottom: RED_BORDER,
-          right: MAGENTA_BORDER
-        }]
-      });
-
-      expect(countVisibleCustomBorders()).toEqual((3 * 2) + (4 * 2)); // 4 rows x 3 columns
-      // First cell from the top-left position
-      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
-      // First cell from the top-right position
-      expect(getCellMeta(1, 4).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(1, 4).borders.right).toEqual(MAGENTA_BORDER);
-      // // First cell from the bottom-left position
-      expect(getCellMeta(4, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
-      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(4, 1).borders.right).toEqual(EMPTY);
-      // // First cell from the bottom-right position
-      expect(getCellMeta(4, 4).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
-      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(4, 4).borders.right).toEqual(MAGENTA_BORDER);
-      // Cell in the middle of area without borders
-      expect(getCellMeta(2, 2).borders).toBeUndefined();
-    });
-
-    it('should display custom borders (drawing range) properly when hiding columns that have been visible ' +
-      '(hiding column in the middle of the range)', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
-        rowHeaders: true,
-        colHeaders: true,
-        hiddenColumns: true,
-        customBorders: [{
-          range: {
-            from: {
-              row: 1,
-              col: 1
-            },
-            to: {
-              row: 4,
-              col: 4
-            }
-          },
-          top: BLUE_BORDER,
-          left: ORANGE_BORDER,
-          bottom: RED_BORDER,
-          right: MAGENTA_BORDER
-        }]
-      });
-
-      getPlugin('hiddenColumns').hideColumn(2);
-      render();
-
-      expect(countVisibleCustomBorders()).toEqual((3 * 2) + (4 * 2)); // 4 rows x 3 columns
-      // First cell from the top-left position
-      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
-      // First cell from the top-right position
-      expect(getCellMeta(1, 4).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(1, 4).borders.right).toEqual(MAGENTA_BORDER);
-      // // First cell from the bottom-left position
-      expect(getCellMeta(4, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
-      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(4, 1).borders.right).toEqual(EMPTY);
-      // // First cell from the bottom-right position
-      expect(getCellMeta(4, 4).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
-      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(4, 4).borders.right).toEqual(MAGENTA_BORDER);
-      // Cell in the middle of area without borders
-      expect(getCellMeta(2, 2).borders).toBeUndefined();
-    });
-
-    it('should display custom borders (drawing range) properly when showing columns that have been hidden ' +
-      '(hidden column in the middle of the range)', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
-        rowHeaders: true,
-        colHeaders: true,
-        hiddenColumns: {
-          columns: [4],
-          indicators: true
-        },
-        customBorders: [{
-          range: {
-            from: {
-              row: 1,
-              col: 1
-            },
-            to: {
-              row: 4,
-              col: 4
-            }
-          },
-          top: BLUE_BORDER,
-          left: ORANGE_BORDER,
-          bottom: RED_BORDER,
-          right: MAGENTA_BORDER
-        }]
-      });
-
-      getPlugin('hiddenColumns').showColumn(4);
-      render();
-
-      expect(countVisibleCustomBorders()).toEqual(4 * 4); // 4 rows x 4 columns
-      // First cell from the top-left position
-      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
-      // First cell from the top-right position
-      expect(getCellMeta(1, 4).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(1, 4).borders.right).toEqual(MAGENTA_BORDER);
-      // // First cell from the bottom-left position
-      expect(getCellMeta(4, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
-      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(4, 1).borders.right).toEqual(EMPTY);
-      // // First cell from the bottom-right position
-      expect(getCellMeta(4, 4).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
-      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(4, 4).borders.right).toEqual(MAGENTA_BORDER);
-      // Cell in the middle of area without borders
-      expect(getCellMeta(2, 2).borders).toBeUndefined();
-    });
-
-    it('should display borders properly when hiding cells separating another cells with borders (they will stick together) #1', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
-        rowHeaders: true,
-        colHeaders: true,
-        hiddenColumns: true,
-        customBorders: [{
-          row: 1,
-          col: 0,
-          top: GREEN_BORDER,
-          left: GREEN_BORDER,
-          bottom: GREEN_BORDER,
-          right: GREEN_BORDER
-        }, {
-          row: 1,
-          col: 2,
-          top: BLUE_BORDER,
-          left: BLUE_BORDER,
-          bottom: BLUE_BORDER,
-          right: BLUE_BORDER
-        }, {
-          row: 1,
-          col: 4,
-          top: YELLOW_BORDER,
-          left: YELLOW_BORDER,
-          bottom: YELLOW_BORDER,
-          right: YELLOW_BORDER
-        }]
-      });
-
-      getPlugin('hiddenColumns').hideColumns([1, 3]);
-      render();
-
-      expect(countVisibleCustomBorders()).toEqual(3 * 4); // It isn't ok probably. There is no specification.
-      // expect(countVisibleCustomBorders()).toEqual((4 * 2) + 2); // TODO: It should work.
-      expect(getCellMeta(1, 0).borders.left).toEqual(GREEN_BORDER);
-      expect(getCellMeta(1, 0).borders.top).toEqual(GREEN_BORDER);
-      expect(getCellMeta(1, 0).borders.bottom).toEqual(GREEN_BORDER);
-      expect(getCellMeta(1, 0).borders.right).toEqual(GREEN_BORDER); // Is it ok?
-
-      expect(getCellMeta(1, 2).borders.left).toEqual(BLUE_BORDER); // Is it ok?
-      expect(getCellMeta(1, 2).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 2).borders.bottom).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 2).borders.right).toEqual(BLUE_BORDER); // Is it ok?
-
-      expect(getCellMeta(1, 4).borders.left).toEqual(YELLOW_BORDER); // Is it ok?
-      expect(getCellMeta(1, 4).borders.top).toEqual(YELLOW_BORDER);
-      expect(getCellMeta(1, 4).borders.bottom).toEqual(YELLOW_BORDER);
-      expect(getCellMeta(1, 4).borders.right).toEqual(YELLOW_BORDER);
-    });
-
-    it('should display borders properly when hiding cells separating another cells with borders (they will stick together) #2', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
-        rowHeaders: true,
-        colHeaders: true,
-        hiddenColumns: true,
-        customBorders: [{
-          row: 1,
-          col: 0,
-          top: GREEN_BORDER,
-          left: GREEN_BORDER,
-          bottom: GREEN_BORDER,
-          right: GREEN_BORDER
-        }, {
-          row: 1,
-          col: 2,
-          top: BLUE_BORDER,
-          left: BLUE_BORDER,
-          bottom: BLUE_BORDER,
-          right: BLUE_BORDER
-        }, {
-          row: 1,
-          col: 4,
-          top: YELLOW_BORDER,
-          left: YELLOW_BORDER,
-          bottom: YELLOW_BORDER,
-          right: YELLOW_BORDER
-        }]
-      });
-
-      getPlugin('hiddenColumns').hideColumns([1, 2, 3]);
-      render();
-
-      expect(countVisibleCustomBorders()).toEqual(2 * 4); // It isn't ok probably. There is no specification.
-      // expect(countVisibleCustomBorders()).toEqual((4 + 3)); // TODO: It should work.
-      expect(getCellMeta(1, 0).borders.left).toEqual(GREEN_BORDER);
-      expect(getCellMeta(1, 0).borders.top).toEqual(GREEN_BORDER);
-      expect(getCellMeta(1, 0).borders.bottom).toEqual(GREEN_BORDER);
-      expect(getCellMeta(1, 0).borders.right).toEqual(GREEN_BORDER); // Is it ok?
-
-      expect(getCellMeta(1, 2).borders.left).toEqual(BLUE_BORDER); // Is it ok?
-      expect(getCellMeta(1, 2).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 2).borders.bottom).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 2).borders.right).toEqual(BLUE_BORDER); // Is it ok?
-
-      expect(getCellMeta(1, 4).borders.left).toEqual(YELLOW_BORDER); // Is it ok?
-      expect(getCellMeta(1, 4).borders.top).toEqual(YELLOW_BORDER);
-      expect(getCellMeta(1, 4).borders.bottom).toEqual(YELLOW_BORDER);
-      expect(getCellMeta(1, 4).borders.right).toEqual(YELLOW_BORDER);
-    });
-
-    it('should not display custom border for single cell when it is placed on the hidden column', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
-        rowHeaders: true,
-        colHeaders: true,
-        hiddenColumns: {
-          columns: [1],
-          indicators: true
-        },
-        customBorders: [{
-          row: 1,
-          col: 1,
-          top: BLUE_BORDER,
-          left: ORANGE_BORDER,
-          bottom: RED_BORDER,
-          right: MAGENTA_BORDER
-        }]
-      });
-
-      // Just the meta is defined.
-      expect(countVisibleCustomBorders()).toEqual(0);
-      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 1).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(1, 1).borders.right).toEqual(MAGENTA_BORDER);
-      expect(getCellMeta(2, 2).borders).toBeUndefined();
-    });
-
-    it('should display custom borders for single cells properly when one of them is placed on the hidden column', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
-        rowHeaders: true,
-        colHeaders: true,
-        hiddenColumns: {
-          columns: [1, 3],
-          indicators: true
-        },
-        customBorders: true
-      });
-
-      getPlugin('customBorders').setBorders([[1, 1, 3, 3]], {
-        top: BLUE_BORDER,
-        left: ORANGE_BORDER,
-        bottom: RED_BORDER,
-        right: MAGENTA_BORDER
-      });
-
-      expect(countVisibleCustomBorders()).toEqual(3 * 4); // Just 3 cells (2 columns are hidden), all of them with 4 borders
-      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 1).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(1, 1).borders.right).toEqual(MAGENTA_BORDER);
-
-      expect(getCellMeta(1, 2).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(1, 2).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 2).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(1, 2).borders.right).toEqual(MAGENTA_BORDER);
-
-      expect(getCellMeta(2, 2).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(2, 2).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(2, 2).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(2, 2).borders.right).toEqual(MAGENTA_BORDER);
-
-      expect(getCellMeta(3, 2).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(3, 2).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(3, 2).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(3, 2).borders.right).toEqual(MAGENTA_BORDER);
-    });
-
-    it('should not display custom border for single cell when column containing border is hidden by API call', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
-        rowHeaders: true,
-        colHeaders: true,
-        hiddenColumns: true,
-        customBorders: [{
-          row: 1,
-          col: 1,
-          top: BLUE_BORDER,
-          left: ORANGE_BORDER,
-          bottom: RED_BORDER,
-          right: MAGENTA_BORDER
-        }]
-      });
-
-      getPlugin('hiddenColumns').hideColumn(1);
-      render();
-
-      // Just the meta is defined.
-      expect(countVisibleCustomBorders()).toEqual(0);
-      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 1).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(1, 1).borders.right).toEqual(MAGENTA_BORDER);
-    });
-
-    it('should display custom border for single cell when hidden column containing border has been shown by API call', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
-        rowHeaders: true,
-        colHeaders: true,
-        hiddenColumns: {
-          columns: [1],
-          indicators: true
-        },
-        customBorders: [{
-          row: 1,
-          col: 1,
-          top: BLUE_BORDER,
-          left: ORANGE_BORDER,
-          bottom: RED_BORDER,
-          right: MAGENTA_BORDER
-        }]
-      });
-
-      getPlugin('hiddenColumns').showColumn(1);
-      render();
-
-      expect(countVisibleCustomBorders()).toEqual(4);
-      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 1).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(1, 1).borders.right).toEqual(MAGENTA_BORDER);
-      expect(getCellMeta(2, 2).borders).toBeUndefined();
-    });
-
-    it('should draw border from context menu options in proper place when there are some hidden columns before ' +
-      'a place where the border is added', async() => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
-        contextMenu: true,
-        customBorders: true,
-        hiddenColumns: {
-          columns: [0, 1]
-        }
-      });
-
-      await selectContextSubmenuOption('Borders', 'Top', getCell(0, 2));
-      deselectCell();
-
-      expect(getCellMeta(0, 2).borders.top).toEqual(DEFAULT_BORDER);
-      expect(getCellMeta(0, 2).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(0, 2).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(0, 2).borders.right).toEqual(EMPTY);
-
-      expect(countVisibleCustomBorders()).toBe(1);
-      expect(countCustomBorders()).toBe(5);
-    });
-  });
-
-  describe('should cooperate with the `HiddenRows` plugin properly', () => {
-    it('should display custom borders (drawing range) properly when some rows are hidden ' +
-      '(range starts from hidden row)', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
-        rowHeaders: true,
-        colHeaders: true,
-        hiddenRows: {
-          rows: [1],
-          indicators: true
-        },
-        customBorders: [{
-          range: {
-            from: {
-              row: 1,
-              col: 1
-            },
-            to: {
-              row: 4,
-              col: 4
-            }
-          },
-          top: BLUE_BORDER,
-          left: ORANGE_BORDER,
-          bottom: RED_BORDER,
-          right: MAGENTA_BORDER
-        }]
-      });
-
-      expect(countVisibleCustomBorders()).toEqual((3 * 2) + 4); // 3 rows x 4 columns without top border
-      // First cell from the top-left position
-      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
-      // First cell from the top-right position
-      expect(getCellMeta(1, 4).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(1, 4).borders.right).toEqual(MAGENTA_BORDER);
-      // // First cell from the bottom-left position
-      expect(getCellMeta(4, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
-      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(4, 1).borders.right).toEqual(EMPTY);
-      // // First cell from the bottom-right position
-      expect(getCellMeta(4, 4).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
-      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(4, 4).borders.right).toEqual(MAGENTA_BORDER);
-      // Cell in the middle of area without borders
-      expect(getCellMeta(2, 2).borders).toBeUndefined();
-    });
-
-    it('should display custom borders (drawing range) properly when hiding rows that have been visible ' +
-      '(hiding row at the start of the range)', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
-        rowHeaders: true,
-        colHeaders: true,
-        hiddenRows: true,
-        customBorders: [{
-          range: {
-            from: {
-              row: 1,
-              col: 1
-            },
-            to: {
-              row: 4,
-              col: 4
-            }
-          },
-          top: BLUE_BORDER,
-          left: ORANGE_BORDER,
-          bottom: RED_BORDER,
-          right: MAGENTA_BORDER
-        }]
-      });
-
-      getPlugin('hiddenRows').hideRow(1);
-      render();
-
-      expect(countVisibleCustomBorders()).toEqual((3 * 2) + 4); // 3 rows x 4 columns without top border
-      // First cell from the top-left position
-      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
-      // First cell from the top-right position
-      expect(getCellMeta(1, 4).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(1, 4).borders.right).toEqual(MAGENTA_BORDER);
-      // // First cell from the bottom-left position
-      expect(getCellMeta(4, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
-      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(4, 1).borders.right).toEqual(EMPTY);
-      // // First cell from the bottom-right position
-      expect(getCellMeta(4, 4).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
-      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(4, 4).borders.right).toEqual(MAGENTA_BORDER);
-      // Cell in the middle of area without borders
-      expect(getCellMeta(2, 2).borders).toBeUndefined();
-    });
-
-    it('should display custom borders (drawing range) properly when showing rows that have been hidden ' +
-      '(range starts from hidden row)', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
-        rowHeaders: true,
-        colHeaders: true,
-        hiddenRows: {
-          rows: [1],
-          indicators: true
-        },
-        customBorders: [{
-          range: {
-            from: {
-              row: 1,
-              col: 1
-            },
-            to: {
-              row: 4,
-              col: 4
-            }
-          },
-          top: BLUE_BORDER,
-          left: ORANGE_BORDER,
-          bottom: RED_BORDER,
-          right: MAGENTA_BORDER
-        }]
-      });
-
-      getPlugin('hiddenRows').showRow(1);
-      render();
-
-      expect(countVisibleCustomBorders()).toEqual(4 * 4); // 4 rows x 4 columns
-      // First cell from the top-left position
-      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
-      // First cell from the top-right position
-      expect(getCellMeta(1, 4).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(1, 4).borders.right).toEqual(MAGENTA_BORDER);
-      // // First cell from the bottom-left position
-      expect(getCellMeta(4, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
-      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(4, 1).borders.right).toEqual(EMPTY);
-      // // First cell from the bottom-right position
-      expect(getCellMeta(4, 4).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
-      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(4, 4).borders.right).toEqual(MAGENTA_BORDER);
-      // Cell in the middle of area without borders
-      expect(getCellMeta(2, 2).borders).toBeUndefined();
-    });
-
-    it('should display custom borders (drawing range) properly when some rows are hidden ' +
-      '(range ends at hidden row)', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
-        rowHeaders: true,
-        colHeaders: true,
-        hiddenRows: {
-          rows: [4],
-          indicators: true
-        },
-        customBorders: [{
-          range: {
-            from: {
-              row: 1,
-              col: 1
-            },
-            to: {
-              row: 4,
-              col: 4
-            }
-          },
-          top: BLUE_BORDER,
-          left: ORANGE_BORDER,
-          bottom: RED_BORDER,
-          right: MAGENTA_BORDER
-        }]
-      });
-
-      expect(countVisibleCustomBorders()).toEqual((3 * 2) + 4); // 3 rows x 4 columns without bottom border
-      // First cell from the top-left position
-      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
-      // First cell from the top-right position
-      expect(getCellMeta(1, 4).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(1, 4).borders.right).toEqual(MAGENTA_BORDER);
-      // // First cell from the bottom-left position
-      expect(getCellMeta(4, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
-      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(4, 1).borders.right).toEqual(EMPTY);
-      // // First cell from the bottom-right position
-      expect(getCellMeta(4, 4).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
-      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(4, 4).borders.right).toEqual(MAGENTA_BORDER);
-      // Cell in the middle of area without borders
-      expect(getCellMeta(2, 2).borders).toBeUndefined();
-    });
-
-    it('should display custom borders (drawing range) properly when hiding rows that have been visible ' +
-      '(hiding row at the end of the range)', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
-        rowHeaders: true,
-        colHeaders: true,
-        hiddenRows: true,
-        customBorders: [{
-          range: {
-            from: {
-              row: 1,
-              col: 1
-            },
-            to: {
-              row: 4,
-              col: 4
-            }
-          },
-          top: BLUE_BORDER,
-          left: ORANGE_BORDER,
-          bottom: RED_BORDER,
-          right: MAGENTA_BORDER
-        }]
-      });
-
-      getPlugin('hiddenRows').hideRow(4);
-      render();
-
-      expect(countVisibleCustomBorders()).toEqual((3 * 2) + 4); // 3 rows x 4 columns without right border
-      // First cell from the top-left position
-      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
-      // First cell from the top-right position
-      expect(getCellMeta(1, 4).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(1, 4).borders.right).toEqual(MAGENTA_BORDER);
-      // // First cell from the bottom-left position
-      expect(getCellMeta(4, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
-      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(4, 1).borders.right).toEqual(EMPTY);
-      // // First cell from the bottom-right position
-      expect(getCellMeta(4, 4).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
-      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(4, 4).borders.right).toEqual(MAGENTA_BORDER);
-      // Cell in the middle of area without borders
-      expect(getCellMeta(2, 2).borders).toBeUndefined();
-    });
-
-    it('should display custom borders (drawing range) properly when showing rows that have been hidden ' +
-      '(range ends at hidden row)', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
-        rowHeaders: true,
-        colHeaders: true,
-        hiddenRows: {
-          rows: [4],
-          indicators: true
-        },
-        customBorders: [{
-          range: {
-            from: {
-              row: 1,
-              col: 1
-            },
-            to: {
-              row: 4,
-              col: 4
-            }
-          },
-          top: BLUE_BORDER,
-          left: ORANGE_BORDER,
-          bottom: RED_BORDER,
-          right: MAGENTA_BORDER
-        }]
-      });
-
-      getPlugin('hiddenRows').showRow(4);
-      render();
-
-      expect(countVisibleCustomBorders()).toEqual(4 * 4); // 4 rows x 4 columns
-      // First cell from the top-left position
-      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
-      // First cell from the top-right position
-      expect(getCellMeta(1, 4).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(1, 4).borders.right).toEqual(MAGENTA_BORDER);
-      // // First cell from the bottom-left position
-      expect(getCellMeta(4, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
-      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(4, 1).borders.right).toEqual(EMPTY);
-      // // First cell from the bottom-right position
-      expect(getCellMeta(4, 4).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
-      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(4, 4).borders.right).toEqual(MAGENTA_BORDER);
-      // Cell in the middle of area without borders
-      expect(getCellMeta(2, 2).borders).toBeUndefined();
-    });
-
-    it('should display custom borders (drawing range) properly when some rows are hidden ' +
-      '(hidden row in the middle of the range)', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
-        rowHeaders: true,
-        colHeaders: true,
-        hiddenRows: {
-          rows: [2],
-          indicators: true
-        },
-        customBorders: [{
-          range: {
-            from: {
-              row: 1,
-              col: 1
-            },
-            to: {
-              row: 4,
-              col: 4
-            }
-          },
-          top: BLUE_BORDER,
-          left: ORANGE_BORDER,
-          bottom: RED_BORDER,
-          right: MAGENTA_BORDER
-        }]
-      });
-
-      expect(countVisibleCustomBorders()).toEqual((3 * 2) + (4 * 2)); // 3 rows x 4 columns
-      // First cell from the top-left position
-      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
-      // First cell from the top-right position
-      expect(getCellMeta(1, 4).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(1, 4).borders.right).toEqual(MAGENTA_BORDER);
-      // // First cell from the bottom-left position
-      expect(getCellMeta(4, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
-      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(4, 1).borders.right).toEqual(EMPTY);
-      // // First cell from the bottom-right position
-      expect(getCellMeta(4, 4).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
-      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(4, 4).borders.right).toEqual(MAGENTA_BORDER);
-      // Cell in the middle of area without borders
-      expect(getCellMeta(2, 2).borders).toBeUndefined();
-    });
-
-    it('should display custom borders (drawing range) properly when hiding rows that have been visible ' +
-      '(hiding row in the middle of the range)', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
-        rowHeaders: true,
-        colHeaders: true,
-        hiddenRows: true,
-        customBorders: [{
-          range: {
-            from: {
-              row: 1,
-              col: 1
-            },
-            to: {
-              row: 4,
-              col: 4
-            }
-          },
-          top: BLUE_BORDER,
-          left: ORANGE_BORDER,
-          bottom: RED_BORDER,
-          right: MAGENTA_BORDER
-        }]
-      });
-
-      getPlugin('hiddenRows').hideRow(2);
-      render();
-
-      expect(countVisibleCustomBorders()).toEqual((3 * 2) + (4 * 2)); // 3 rows x 4 columns
-      // First cell from the top-left position
-      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
-      // First cell from the top-right position
-      expect(getCellMeta(1, 4).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(1, 4).borders.right).toEqual(MAGENTA_BORDER);
-      // // First cell from the bottom-left position
-      expect(getCellMeta(4, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
-      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(4, 1).borders.right).toEqual(EMPTY);
-      // // First cell from the bottom-right position
-      expect(getCellMeta(4, 4).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
-      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(4, 4).borders.right).toEqual(MAGENTA_BORDER);
-      // Cell in the middle of area without borders
-      expect(getCellMeta(2, 2).borders).toBeUndefined();
-    });
-
-    it('should display custom borders (drawing range) properly when showing rows that have been hidden ' +
-      '(hidden row in the middle of the range)', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
-        rowHeaders: true,
-        colHeaders: true,
-        hiddenRows: {
-          rows: [4],
-          indicators: true
-        },
-        customBorders: [{
-          range: {
-            from: {
-              row: 1,
-              col: 1
-            },
-            to: {
-              row: 4,
-              col: 4
-            }
-          },
-          top: BLUE_BORDER,
-          left: ORANGE_BORDER,
-          bottom: RED_BORDER,
-          right: MAGENTA_BORDER
-        }]
-      });
-
-      getPlugin('hiddenRows').showRow(4);
-      render();
-
-      expect(countVisibleCustomBorders()).toEqual(4 * 4); // 4 rows x 4 columns
-      // First cell from the top-left position
-      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(1, 1).borders.right).toEqual(EMPTY);
-      // First cell from the top-right position
-      expect(getCellMeta(1, 4).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(1, 4).borders.right).toEqual(MAGENTA_BORDER);
-      // // First cell from the bottom-left position
-      expect(getCellMeta(4, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
-      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(4, 1).borders.right).toEqual(EMPTY);
-      // // First cell from the bottom-right position
-      expect(getCellMeta(4, 4).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
-      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(4, 4).borders.right).toEqual(MAGENTA_BORDER);
-      // Cell in the middle of area without borders
-      expect(getCellMeta(2, 2).borders).toBeUndefined();
-    });
-
-    it('should display borders properly when hiding cells separating another cells with borders (they will stick together) #1', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
-        rowHeaders: true,
-        colHeaders: true,
-        hiddenRows: true,
-        customBorders: [{
-          row: 0,
-          col: 1,
-          top: GREEN_BORDER,
-          left: GREEN_BORDER,
-          bottom: GREEN_BORDER,
-          right: GREEN_BORDER
-        }, {
-          row: 2,
-          col: 1,
-          top: BLUE_BORDER,
-          left: BLUE_BORDER,
-          bottom: BLUE_BORDER,
-          right: BLUE_BORDER
-        }, {
-          row: 4,
-          col: 1,
-          top: YELLOW_BORDER,
-          left: YELLOW_BORDER,
-          bottom: YELLOW_BORDER,
-          right: YELLOW_BORDER
-        }]
-      });
-
-      getPlugin('hiddenRows').hideRows([1, 3]);
-      render();
-
-      expect(countVisibleCustomBorders()).toEqual(3 * 4); // It isn't ok probably. There is no specification.
-      // expect(countVisibleCustomBorders()).toEqual((4 * 2) + 2); // TODO: It should work.
-      expect(getCellMeta(0, 1).borders.left).toEqual(GREEN_BORDER);
-      expect(getCellMeta(0, 1).borders.top).toEqual(GREEN_BORDER);
-      expect(getCellMeta(0, 1).borders.bottom).toEqual(GREEN_BORDER); // Is it ok?
-      expect(getCellMeta(0, 1).borders.right).toEqual(GREEN_BORDER);
-
-      expect(getCellMeta(2, 1).borders.left).toEqual(BLUE_BORDER);
-      expect(getCellMeta(2, 1).borders.top).toEqual(BLUE_BORDER); // Is it ok?
-      expect(getCellMeta(2, 1).borders.bottom).toEqual(BLUE_BORDER); // Is it ok?
-      expect(getCellMeta(2, 1).borders.right).toEqual(BLUE_BORDER);
-
-      expect(getCellMeta(4, 1).borders.left).toEqual(YELLOW_BORDER);
-      expect(getCellMeta(4, 1).borders.top).toEqual(YELLOW_BORDER); // Is it ok?
-      expect(getCellMeta(4, 1).borders.bottom).toEqual(YELLOW_BORDER);
-      expect(getCellMeta(4, 1).borders.right).toEqual(YELLOW_BORDER);
-    });
-
-    it('should display borders properly when hiding cells separating another cells with borders (they will stick together) #2', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
-        rowHeaders: true,
-        colHeaders: true,
-        hiddenRows: true,
-        customBorders: [{
-          row: 0,
-          col: 1,
-          top: GREEN_BORDER,
-          left: GREEN_BORDER,
-          bottom: GREEN_BORDER,
-          right: GREEN_BORDER
-        }, {
-          row: 2,
-          col: 1,
-          top: BLUE_BORDER,
-          left: BLUE_BORDER,
-          bottom: BLUE_BORDER,
-          right: BLUE_BORDER
-        }, {
-          row: 4,
-          col: 1,
-          top: YELLOW_BORDER,
-          left: YELLOW_BORDER,
-          bottom: YELLOW_BORDER,
-          right: YELLOW_BORDER
-        }]
-      });
-
-      getPlugin('hiddenRows').hideRows([1, 2, 3]);
-      render();
-
-      expect(countVisibleCustomBorders()).toEqual(2 * 4); // It isn't ok probably. There is no specification.
-      // expect(countVisibleCustomBorders()).toEqual((4 + 3)); // TODO: It should work.
-      expect(getCellMeta(0, 1).borders.left).toEqual(GREEN_BORDER);
-      expect(getCellMeta(0, 1).borders.top).toEqual(GREEN_BORDER);
-      expect(getCellMeta(0, 1).borders.bottom).toEqual(GREEN_BORDER); // Is it ok?
-      expect(getCellMeta(0, 1).borders.right).toEqual(GREEN_BORDER);
-
-      expect(getCellMeta(2, 1).borders.left).toEqual(BLUE_BORDER);
-      expect(getCellMeta(2, 1).borders.top).toEqual(BLUE_BORDER); // Is it ok?
-      expect(getCellMeta(2, 1).borders.bottom).toEqual(BLUE_BORDER); // Is it ok?
-      expect(getCellMeta(2, 1).borders.right).toEqual(BLUE_BORDER);
-
-      expect(getCellMeta(4, 1).borders.left).toEqual(YELLOW_BORDER);
-      expect(getCellMeta(4, 1).borders.top).toEqual(YELLOW_BORDER); // Is it ok?
-      expect(getCellMeta(4, 1).borders.bottom).toEqual(YELLOW_BORDER);
-      expect(getCellMeta(4, 1).borders.right).toEqual(YELLOW_BORDER);
-    });
-
-    it('should not display custom border for single cell when it is placed on the hidden row', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
-        rowHeaders: true,
-        colHeaders: true,
-        hiddenRows: {
-          rows: [1],
-          indicators: true
-        },
-        customBorders: [{
-          row: 1,
-          col: 1,
-          top: BLUE_BORDER,
-          left: ORANGE_BORDER,
-          bottom: RED_BORDER,
-          right: MAGENTA_BORDER
-        }]
-      });
-
-      // Just the meta is defined.
-      expect(countVisibleCustomBorders()).toEqual(0);
-      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 1).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(1, 1).borders.right).toEqual(MAGENTA_BORDER);
-      expect(getCellMeta(2, 2).borders).toBeUndefined();
-    });
-
-    it('should display custom borders for single cells properly when one of them is placed on the hidden row', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
-        rowHeaders: true,
-        colHeaders: true,
-        hiddenRows: {
-          rows: [1, 3],
-          indicators: true
-        },
-        customBorders: true
-      });
-
-      getPlugin('customBorders').setBorders([[1, 1, 3, 3]], {
-        top: BLUE_BORDER,
-        left: ORANGE_BORDER,
-        bottom: RED_BORDER,
-        right: MAGENTA_BORDER
-      });
-
-      expect(countVisibleCustomBorders()).toEqual(3 * 4); // Just 3 cells (2 rows are hidden), all of them with 4 borders
-      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 1).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(1, 1).borders.right).toEqual(MAGENTA_BORDER);
-
-      expect(getCellMeta(1, 2).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(1, 2).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 2).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(1, 2).borders.right).toEqual(MAGENTA_BORDER);
-
-      expect(getCellMeta(2, 2).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(2, 2).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(2, 2).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(2, 2).borders.right).toEqual(MAGENTA_BORDER);
-
-      expect(getCellMeta(3, 2).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(3, 2).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(3, 2).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(3, 2).borders.right).toEqual(MAGENTA_BORDER);
-    });
-
-    it('should not display custom border for single cell when row containing border is hidden by API call', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
-        rowHeaders: true,
-        colHeaders: true,
-        hiddenRows: true,
-        customBorders: [{
-          row: 1,
-          col: 1,
-          top: BLUE_BORDER,
-          left: ORANGE_BORDER,
-          bottom: RED_BORDER,
-          right: MAGENTA_BORDER
-        }]
-      });
-
-      getPlugin('hiddenRows').hideRow(1);
-      render();
-
-      // Just the meta is defined.
-      expect(countVisibleCustomBorders()).toEqual(0);
-      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 1).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(1, 1).borders.right).toEqual(MAGENTA_BORDER);
-    });
-
-    it('should display custom border for single cell when hidden row containing border has been shown by API call', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
-        rowHeaders: true,
-        colHeaders: true,
-        hiddenRows: {
-          rows: [1],
-          indicators: true
-        },
-        customBorders: [{
-          row: 1,
-          col: 1,
-          top: BLUE_BORDER,
-          left: ORANGE_BORDER,
-          bottom: RED_BORDER,
-          right: MAGENTA_BORDER
-        }]
-      });
-
-      getPlugin('hiddenRows').showRow(1);
-      render();
-
-      expect(countVisibleCustomBorders()).toEqual(4);
-      expect(getCellMeta(1, 1).borders.left).toEqual(ORANGE_BORDER);
-      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
-      expect(getCellMeta(1, 1).borders.bottom).toEqual(RED_BORDER);
-      expect(getCellMeta(1, 1).borders.right).toEqual(MAGENTA_BORDER);
-      expect(getCellMeta(2, 2).borders).toBeUndefined();
-    });
-
-    it('should draw border from context menu options in proper place when there are some hidden rows before ' +
-      'a place where the border is added', async() => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
-        contextMenu: true,
-        customBorders: true,
-        hiddenRows: {
-          rows: [0, 1]
-        }
-      });
-
-      await selectContextSubmenuOption('Borders', 'Top', getCell(2, 0));
-      deselectCell();
-
-      expect(getCellMeta(2, 0).borders.top).toEqual(DEFAULT_BORDER);
-      expect(getCellMeta(2, 0).borders.left).toEqual(EMPTY);
-      expect(getCellMeta(2, 0).borders.bottom).toEqual(EMPTY);
-      expect(getCellMeta(2, 0).borders.right).toEqual(EMPTY);
-
-      expect(countVisibleCustomBorders()).toBe(1);
-      expect(countCustomBorders()).toBe(5);
-    });
   });
 });

--- a/handsontable/src/plugins/customBorders/__tests__/customBorders.spec.js
+++ b/handsontable/src/plugins/customBorders/__tests__/customBorders.spec.js
@@ -184,7 +184,8 @@ describe('CustomBorders', () => {
             top: GREEN_BORDER
           }]
         });
-      }).toThrowError('The "left"/"right" and "start"/"end" options should not be used together. Please use only the option "start"/"end".');
+      }).toThrowError('The "left"/"right" and "start"/"end" options should not be used together. ' +
+                      'Please use only the option "start"/"end".');
     });
 
     it('should throw an error while calling the `updateSettings` method when the mixed API is used ("start"/"end" and "left"/"right")', () => {
@@ -206,7 +207,8 @@ describe('CustomBorders', () => {
             right: RED_BORDER,
           }]
         });
-      }).toThrowError('The "left"/"right" and "start"/"end" options should not be used together. Please use only the option "start"/"end".');
+      }).toThrowError('The "left"/"right" and "start"/"end" options should not be used together. ' +
+                      'Please use only the option "start"/"end".');
     });
 
     it('should be possible to update borders using backward compatible API ("left"/"right") even when Handsontable was initialized using new API ("start"/"end")', () => {

--- a/handsontable/src/plugins/customBorders/__tests__/helpers/utils.js
+++ b/handsontable/src/plugins/customBorders/__tests__/helpers/utils.js
@@ -1,0 +1,46 @@
+export const DEFAULT_BORDER = { color: '#000', width: 1 };
+export const GREEN_BORDER = { color: 'green', width: 1 };
+export const GREEN_THICK_BORDER = { color: 'green', width: 2 };
+export const RED_BORDER = { color: 'red', width: 2 };
+export const MAGENTA_BORDER = { color: 'magenta', width: 2 };
+export const BLUE_BORDER = { color: 'blue', width: 2 };
+export const ORANGE_BORDER = { color: 'orange', width: 2 };
+export const YELLOW_BORDER = { color: 'yellow', width: 2 };
+export const EMPTY = { hide: true };
+
+export const CUSTOM_BORDER_SELECTOR = '.wtBorder:not(.fill, .current, .area)';
+
+/**
+ * Returns number of custom borders in DOM. There are 5 borders per
+ * cell (top, left, bottom right, corner), some of which are hidden
+ * TODO this seems redundant that we always render borders that are not visible.
+ */
+export function countCustomBorders() {
+  return $(CUSTOM_BORDER_SELECTOR).length;
+}
+
+/**
+ * Returns number of visible custom borders in DOM.
+ */
+ export function countVisibleCustomBorders() {
+  return $(`${CUSTOM_BORDER_SELECTOR}:visible`).length;
+}
+
+/**
+ * @param numRows
+ */
+ export function generateCustomBordersForAllRows(numRows) {
+  const bordersConfig = [];
+
+  for (let i = 0; i < numRows; i++) {
+    const cellBorder = {
+      row: i,
+      col: 0,
+      top: GREEN_BORDER
+    };
+
+    bordersConfig.push(cellBorder);
+  }
+
+  return bordersConfig;
+}

--- a/handsontable/src/plugins/customBorders/__tests__/helpers/utils.js
+++ b/handsontable/src/plugins/customBorders/__tests__/helpers/utils.js
@@ -14,6 +14,8 @@ export const CUSTOM_BORDER_SELECTOR = '.wtBorder:not(.fill, .current, .area)';
  * Returns number of custom borders in DOM. There are 5 borders per
  * cell (top, left, bottom right, corner), some of which are hidden
  * TODO this seems redundant that we always render borders that are not visible.
+ *
+ * @returns {number}
  */
 export function countCustomBorders() {
   return $(CUSTOM_BORDER_SELECTOR).length;
@@ -21,15 +23,18 @@ export function countCustomBorders() {
 
 /**
  * Returns number of visible custom borders in DOM.
+ *
+ * @returns {number}
  */
- export function countVisibleCustomBorders() {
+export function countVisibleCustomBorders() {
   return $(`${CUSTOM_BORDER_SELECTOR}:visible`).length;
 }
 
 /**
- * @param numRows
+ * @param {number} numRows The number of rows to generate.
+ * @returns {{row: number, col: number, top: any}[]}
  */
- export function generateCustomBordersForAllRows(numRows) {
+export function generateCustomBordersForAllRows(numRows) {
   const bordersConfig = [];
 
   for (let i = 0; i < numRows; i++) {

--- a/handsontable/src/plugins/customBorders/__tests__/hidingColumns.spec.js
+++ b/handsontable/src/plugins/customBorders/__tests__/hidingColumns.spec.js
@@ -1,0 +1,796 @@
+describe('CustomBorders', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+    const wrapper = $('<div></div>').css({
+      width: 400,
+      height: 200,
+      overflow: 'scroll'
+    });
+
+    this.$wrapper = this.$container.wrap(wrapper).parent();
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+    this.$wrapper.remove();
+  });
+
+  describe('cooperation with the `HiddenColumns` plugin', () => {
+    // TODO: Should it work in this way? Probably some warn would be helpful.
+    it('should draw borders properly when some of them are beyond the table boundaries (drawing single borders)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenColumns: {
+          columns: [1],
+          indicators: true
+        },
+        customBorders: [{
+          row: 0,
+          col: 0,
+          top: BLUE_BORDER,
+          start: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          end: MAGENTA_BORDER
+        }, {
+          row: 7,
+          col: 7,
+          top: BLUE_BORDER,
+          start: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          end: MAGENTA_BORDER
+        }]
+      });
+
+      expect(countVisibleCustomBorders()).toEqual(4);
+      expect(getCellMeta(0, 0).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(0, 0).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(0, 0).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(0, 0).borders.end).toEqual(MAGENTA_BORDER);
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
+    it('should display custom borders (drawing range) properly when some columns are hidden ' +
+      '(range starts from hidden column)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenColumns: {
+          columns: [1],
+          indicators: true
+        },
+        customBorders: [{
+          range: {
+            from: {
+              row: 1,
+              col: 1
+            },
+            to: {
+              row: 4,
+              col: 4
+            }
+          },
+          top: BLUE_BORDER,
+          start: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          end: MAGENTA_BORDER
+        }]
+      });
+
+      expect(countVisibleCustomBorders()).toEqual((3 * 2) + 4); // 4 rows x 3 columns without left border
+      // First cell from the top-left position
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.end).toEqual(EMPTY);
+      // First cell from the top-right position
+      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.start).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.end).toEqual(MAGENTA_BORDER);
+      // // First cell from the bottom-left position
+      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(4, 1).borders.end).toEqual(EMPTY);
+      // // First cell from the bottom-right position
+      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 4).borders.start).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.end).toEqual(MAGENTA_BORDER);
+      // Cell in the middle of area without borders
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
+    it('should display custom borders (drawing range) properly when hiding columns that have been visible ' +
+      '(hiding column at the start of the range)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenColumns: true,
+        customBorders: [{
+          range: {
+            from: {
+              row: 1,
+              col: 1
+            },
+            to: {
+              row: 4,
+              col: 4
+            }
+          },
+          top: BLUE_BORDER,
+          start: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          end: MAGENTA_BORDER
+        }]
+      });
+
+      getPlugin('hiddenColumns').hideColumn(1);
+      render();
+
+      expect(countVisibleCustomBorders()).toEqual((3 * 2) + 4); // 4 rows x 3 columns without left border
+      // First cell from the top-left position
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.end).toEqual(EMPTY);
+      // First cell from the top-right position
+      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.start).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.end).toEqual(MAGENTA_BORDER);
+      // // First cell from the bottom-left position
+      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(4, 1).borders.end).toEqual(EMPTY);
+      // // First cell from the bottom-right position
+      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 4).borders.start).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.end).toEqual(MAGENTA_BORDER);
+      // Cell in the middle of area without borders
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
+    it('should display custom borders (drawing range) properly when showing columns that have been hidden ' +
+      '(range starts from hidden column)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenColumns: {
+          columns: [1],
+          indicators: true
+        },
+        customBorders: [{
+          range: {
+            from: {
+              row: 1,
+              col: 1
+            },
+            to: {
+              row: 4,
+              col: 4
+            }
+          },
+          top: BLUE_BORDER,
+          start: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          end: MAGENTA_BORDER
+        }]
+      });
+
+      getPlugin('hiddenColumns').showColumn(1);
+      render();
+
+      expect(countVisibleCustomBorders()).toEqual(4 * 4); // 4 rows x 4 columns
+      // First cell from the top-left position
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.end).toEqual(EMPTY);
+      // First cell from the top-right position
+      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.start).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.end).toEqual(MAGENTA_BORDER);
+      // // First cell from the bottom-left position
+      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(4, 1).borders.end).toEqual(EMPTY);
+      // // First cell from the bottom-right position
+      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 4).borders.start).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.end).toEqual(MAGENTA_BORDER);
+      // Cell in the middle of area without borders
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
+    it('should display custom borders (drawing range) properly when some columns are hidden ' +
+      '(range ends at hidden column)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenColumns: {
+          columns: [4],
+          indicators: true
+        },
+        customBorders: [{
+          range: {
+            from: {
+              row: 1,
+              col: 1
+            },
+            to: {
+              row: 4,
+              col: 4
+            }
+          },
+          top: BLUE_BORDER,
+          start: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          end: MAGENTA_BORDER
+        }]
+      });
+
+      expect(countVisibleCustomBorders()).toEqual((3 * 2) + 4); // 4 rows x 3 columns without right border
+      // First cell from the top-left position
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.end).toEqual(EMPTY);
+      // First cell from the top-right position
+      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.start).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.end).toEqual(MAGENTA_BORDER);
+      // // First cell from the bottom-left position
+      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(4, 1).borders.end).toEqual(EMPTY);
+      // // First cell from the bottom-right position
+      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 4).borders.start).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.end).toEqual(MAGENTA_BORDER);
+      // Cell in the middle of area without borders
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
+    it('should display custom borders (drawing range) properly when hiding columns that have been visible ' +
+      '(hiding column at the end of the range)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenColumns: true,
+        customBorders: [{
+          range: {
+            from: {
+              row: 1,
+              col: 1
+            },
+            to: {
+              row: 4,
+              col: 4
+            }
+          },
+          top: BLUE_BORDER,
+          start: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          end: MAGENTA_BORDER
+        }]
+      });
+
+      getPlugin('hiddenColumns').hideColumn(4);
+      render();
+
+      expect(countVisibleCustomBorders()).toEqual((3 * 2) + 4); // 4 rows x 3 columns without right border
+      // First cell from the top-left position
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.end).toEqual(EMPTY);
+      // First cell from the top-right position
+      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.start).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.end).toEqual(MAGENTA_BORDER);
+      // // First cell from the bottom-left position
+      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(4, 1).borders.end).toEqual(EMPTY);
+      // // First cell from the bottom-right position
+      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 4).borders.start).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.end).toEqual(MAGENTA_BORDER);
+      // Cell in the middle of area without borders
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
+    it('should display custom borders (drawing range) properly when showing columns that have been hidden ' +
+      '(range ends at hidden column)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenColumns: {
+          columns: [4],
+          indicators: true
+        },
+        customBorders: [{
+          range: {
+            from: {
+              row: 1,
+              col: 1
+            },
+            to: {
+              row: 4,
+              col: 4
+            }
+          },
+          top: BLUE_BORDER,
+          start: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          end: MAGENTA_BORDER
+        }]
+      });
+
+      getPlugin('hiddenColumns').showColumn(4);
+      render();
+
+      expect(countVisibleCustomBorders()).toEqual(4 * 4); // 4 rows x 4 columns
+      // First cell from the top-left position
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.end).toEqual(EMPTY);
+      // First cell from the top-right position
+      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.start).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.end).toEqual(MAGENTA_BORDER);
+      // // First cell from the bottom-left position
+      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(4, 1).borders.end).toEqual(EMPTY);
+      // // First cell from the bottom-right position
+      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 4).borders.start).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.end).toEqual(MAGENTA_BORDER);
+      // Cell in the middle of area without borders
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
+    it('should display custom borders (drawing range) properly when some columns are hidden ' +
+      '(hidden column in the middle of the range)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenColumns: {
+          columns: [2],
+          indicators: true
+        },
+        customBorders: [{
+          range: {
+            from: {
+              row: 1,
+              col: 1
+            },
+            to: {
+              row: 4,
+              col: 4
+            }
+          },
+          top: BLUE_BORDER,
+          start: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          end: MAGENTA_BORDER
+        }]
+      });
+
+      expect(countVisibleCustomBorders()).toEqual((3 * 2) + (4 * 2)); // 4 rows x 3 columns
+      // First cell from the top-left position
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.end).toEqual(EMPTY);
+      // First cell from the top-right position
+      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.start).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.end).toEqual(MAGENTA_BORDER);
+      // // First cell from the bottom-left position
+      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(4, 1).borders.end).toEqual(EMPTY);
+      // // First cell from the bottom-right position
+      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 4).borders.start).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.end).toEqual(MAGENTA_BORDER);
+      // Cell in the middle of area without borders
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
+    it('should display custom borders (drawing range) properly when hiding columns that have been visible ' +
+      '(hiding column in the middle of the range)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenColumns: true,
+        customBorders: [{
+          range: {
+            from: {
+              row: 1,
+              col: 1
+            },
+            to: {
+              row: 4,
+              col: 4
+            }
+          },
+          top: BLUE_BORDER,
+          start: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          end: MAGENTA_BORDER
+        }]
+      });
+
+      getPlugin('hiddenColumns').hideColumn(2);
+      render();
+
+      expect(countVisibleCustomBorders()).toEqual((3 * 2) + (4 * 2)); // 4 rows x 3 columns
+      // First cell from the top-left position
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.end).toEqual(EMPTY);
+      // First cell from the top-right position
+      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.start).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.end).toEqual(MAGENTA_BORDER);
+      // // First cell from the bottom-left position
+      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(4, 1).borders.end).toEqual(EMPTY);
+      // // First cell from the bottom-right position
+      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 4).borders.start).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.end).toEqual(MAGENTA_BORDER);
+      // Cell in the middle of area without borders
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
+    it('should display custom borders (drawing range) properly when showing columns that have been hidden ' +
+      '(hidden column in the middle of the range)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenColumns: {
+          columns: [4],
+          indicators: true
+        },
+        customBorders: [{
+          range: {
+            from: {
+              row: 1,
+              col: 1
+            },
+            to: {
+              row: 4,
+              col: 4
+            }
+          },
+          top: BLUE_BORDER,
+          start: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          end: MAGENTA_BORDER
+        }]
+      });
+
+      getPlugin('hiddenColumns').showColumn(4);
+      render();
+
+      expect(countVisibleCustomBorders()).toEqual(4 * 4); // 4 rows x 4 columns
+      // First cell from the top-left position
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.end).toEqual(EMPTY);
+      // First cell from the top-right position
+      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.start).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.end).toEqual(MAGENTA_BORDER);
+      // // First cell from the bottom-left position
+      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(4, 1).borders.end).toEqual(EMPTY);
+      // // First cell from the bottom-right position
+      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 4).borders.start).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.end).toEqual(MAGENTA_BORDER);
+      // Cell in the middle of area without borders
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
+    it('should display borders properly when hiding cells separating another cells with borders (they will stick together) #1', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenColumns: true,
+        customBorders: [{
+          row: 1,
+          col: 0,
+          top: GREEN_BORDER,
+          start: GREEN_BORDER,
+          bottom: GREEN_BORDER,
+          end: GREEN_BORDER
+        }, {
+          row: 1,
+          col: 2,
+          top: BLUE_BORDER,
+          start: BLUE_BORDER,
+          bottom: BLUE_BORDER,
+          end: BLUE_BORDER
+        }, {
+          row: 1,
+          col: 4,
+          top: YELLOW_BORDER,
+          start: YELLOW_BORDER,
+          bottom: YELLOW_BORDER,
+          end: YELLOW_BORDER
+        }]
+      });
+
+      getPlugin('hiddenColumns').hideColumns([1, 3]);
+      render();
+
+      expect(countVisibleCustomBorders()).toEqual(3 * 4); // It isn't ok probably. There is no specification.
+      // expect(countVisibleCustomBorders()).toEqual((4 * 2) + 2); // TODO: It should work.
+      expect(getCellMeta(1, 0).borders.top).toEqual(GREEN_BORDER);
+      expect(getCellMeta(1, 0).borders.bottom).toEqual(GREEN_BORDER);
+      expect(getCellMeta(1, 0).borders.start).toEqual(GREEN_BORDER);
+      expect(getCellMeta(1, 0).borders.end).toEqual(GREEN_BORDER); // Is it ok?
+
+      expect(getCellMeta(1, 2).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 2).borders.bottom).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 2).borders.start).toEqual(BLUE_BORDER); // Is it ok?
+      expect(getCellMeta(1, 2).borders.end).toEqual(BLUE_BORDER); // Is it ok?
+
+      expect(getCellMeta(1, 4).borders.top).toEqual(YELLOW_BORDER);
+      expect(getCellMeta(1, 4).borders.bottom).toEqual(YELLOW_BORDER);
+      expect(getCellMeta(1, 4).borders.start).toEqual(YELLOW_BORDER); // Is it ok?
+      expect(getCellMeta(1, 4).borders.end).toEqual(YELLOW_BORDER);
+    });
+
+    it('should display borders properly when hiding cells separating another cells with borders (they will stick together) #2', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenColumns: true,
+        customBorders: [{
+          row: 1,
+          col: 0,
+          top: GREEN_BORDER,
+          start: GREEN_BORDER,
+          bottom: GREEN_BORDER,
+          end: GREEN_BORDER
+        }, {
+          row: 1,
+          col: 2,
+          top: BLUE_BORDER,
+          start: BLUE_BORDER,
+          bottom: BLUE_BORDER,
+          end: BLUE_BORDER
+        }, {
+          row: 1,
+          col: 4,
+          top: YELLOW_BORDER,
+          start: YELLOW_BORDER,
+          bottom: YELLOW_BORDER,
+          end: YELLOW_BORDER
+        }]
+      });
+
+      getPlugin('hiddenColumns').hideColumns([1, 2, 3]);
+      render();
+
+      expect(countVisibleCustomBorders()).toEqual(2 * 4); // It isn't ok probably. There is no specification.
+      // expect(countVisibleCustomBorders()).toEqual((4 + 3)); // TODO: It should work.
+      expect(getCellMeta(1, 0).borders.top).toEqual(GREEN_BORDER);
+      expect(getCellMeta(1, 0).borders.bottom).toEqual(GREEN_BORDER);
+      expect(getCellMeta(1, 0).borders.start).toEqual(GREEN_BORDER);
+      expect(getCellMeta(1, 0).borders.end).toEqual(GREEN_BORDER); // Is it ok?
+
+      expect(getCellMeta(1, 2).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 2).borders.bottom).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 2).borders.start).toEqual(BLUE_BORDER); // Is it ok?
+      expect(getCellMeta(1, 2).borders.end).toEqual(BLUE_BORDER); // Is it ok?
+
+      expect(getCellMeta(1, 4).borders.top).toEqual(YELLOW_BORDER);
+      expect(getCellMeta(1, 4).borders.bottom).toEqual(YELLOW_BORDER);
+      expect(getCellMeta(1, 4).borders.start).toEqual(YELLOW_BORDER); // Is it ok?
+      expect(getCellMeta(1, 4).borders.end).toEqual(YELLOW_BORDER);
+    });
+
+    it('should not display custom border for single cell when it is placed on the hidden column', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenColumns: {
+          columns: [1],
+          indicators: true
+        },
+        customBorders: [{
+          row: 1,
+          col: 1,
+          top: BLUE_BORDER,
+          start: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          end: MAGENTA_BORDER
+        }]
+      });
+
+      // Just the meta is defined.
+      expect(countVisibleCustomBorders()).toEqual(0);
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(1, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.end).toEqual(MAGENTA_BORDER);
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
+    it('should display custom borders for single cells properly when one of them is placed on the hidden column', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenColumns: {
+          columns: [1, 3],
+          indicators: true
+        },
+        customBorders: true
+      });
+
+      getPlugin('customBorders').setBorders([[1, 1, 3, 3]], {
+        top: BLUE_BORDER,
+        start: ORANGE_BORDER,
+        bottom: RED_BORDER,
+        end: MAGENTA_BORDER
+      });
+
+      expect(countVisibleCustomBorders()).toEqual(3 * 4); // Just 3 cells (2 columns are hidden), all of them with 4 borders
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(1, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.end).toEqual(MAGENTA_BORDER);
+
+      expect(getCellMeta(1, 2).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 2).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(1, 2).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 2).borders.end).toEqual(MAGENTA_BORDER);
+
+      expect(getCellMeta(2, 2).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(2, 2).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(2, 2).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(2, 2).borders.end).toEqual(MAGENTA_BORDER);
+
+      expect(getCellMeta(3, 2).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(3, 2).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(3, 2).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(3, 2).borders.end).toEqual(MAGENTA_BORDER);
+    });
+
+    it('should not display custom border for single cell when column containing border is hidden by API call', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenColumns: true,
+        customBorders: [{
+          row: 1,
+          col: 1,
+          top: BLUE_BORDER,
+          start: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          end: MAGENTA_BORDER
+        }]
+      });
+
+      getPlugin('hiddenColumns').hideColumn(1);
+      render();
+
+      // Just the meta is defined.
+      expect(countVisibleCustomBorders()).toEqual(0);
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(1, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.end).toEqual(MAGENTA_BORDER);
+    });
+
+    it('should display custom border for single cell when hidden column containing border has been shown by API call', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenColumns: {
+          columns: [1],
+          indicators: true
+        },
+        customBorders: [{
+          row: 1,
+          col: 1,
+          top: BLUE_BORDER,
+          start: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          end: MAGENTA_BORDER
+        }]
+      });
+
+      getPlugin('hiddenColumns').showColumn(1);
+      render();
+
+      expect(countVisibleCustomBorders()).toEqual(4);
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(1, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.end).toEqual(MAGENTA_BORDER);
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
+    it('should draw border from context menu options in proper place when there are some hidden columns before ' +
+      'a place where the border is added', async() => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        contextMenu: true,
+        customBorders: true,
+        hiddenColumns: {
+          columns: [0, 1]
+        }
+      });
+
+      await selectContextSubmenuOption('Borders', 'Top', getCell(0, 2));
+      deselectCell();
+
+      expect(getCellMeta(0, 2).borders.top).toEqual(DEFAULT_BORDER);
+      expect(getCellMeta(0, 2).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(0, 2).borders.start).toEqual(EMPTY);
+      expect(getCellMeta(0, 2).borders.end).toEqual(EMPTY);
+
+      expect(countVisibleCustomBorders()).toBe(1);
+      expect(countCustomBorders()).toBe(5);
+    });
+  });
+});

--- a/handsontable/src/plugins/customBorders/__tests__/hidingRows.spec.js
+++ b/handsontable/src/plugins/customBorders/__tests__/hidingRows.spec.js
@@ -1,0 +1,761 @@
+describe('CustomBorders', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+    const wrapper = $('<div></div>').css({
+      width: 400,
+      height: 200,
+      overflow: 'scroll'
+    });
+
+    this.$wrapper = this.$container.wrap(wrapper).parent();
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+    this.$wrapper.remove();
+  });
+
+  describe('cooperation with the `HiddenRows` plugin', () => {
+    it('should display custom borders (drawing range) properly when some rows are hidden ' +
+      '(range starts from hidden row)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenRows: {
+          rows: [1],
+          indicators: true
+        },
+        customBorders: [{
+          range: {
+            from: {
+              row: 1,
+              col: 1
+            },
+            to: {
+              row: 4,
+              col: 4
+            }
+          },
+          top: BLUE_BORDER,
+          start: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          end: MAGENTA_BORDER
+        }]
+      });
+
+      expect(countVisibleCustomBorders()).toEqual((3 * 2) + 4); // 3 rows x 4 columns without top border
+      // First cell from the top-left position
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.end).toEqual(EMPTY);
+      // First cell from the top-right position
+      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.start).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.end).toEqual(MAGENTA_BORDER);
+      // // First cell from the bottom-left position
+      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(4, 1).borders.end).toEqual(EMPTY);
+      // // First cell from the bottom-right position
+      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 4).borders.start).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.end).toEqual(MAGENTA_BORDER);
+      // Cell in the middle of area without borders
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
+    it('should display custom borders (drawing range) properly when hiding rows that have been visible ' +
+      '(hiding row at the start of the range)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenRows: true,
+        customBorders: [{
+          range: {
+            from: {
+              row: 1,
+              col: 1
+            },
+            to: {
+              row: 4,
+              col: 4
+            }
+          },
+          top: BLUE_BORDER,
+          start: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          end: MAGENTA_BORDER
+        }]
+      });
+
+      getPlugin('hiddenRows').hideRow(1);
+      render();
+
+      expect(countVisibleCustomBorders()).toEqual((3 * 2) + 4); // 3 rows x 4 columns without top border
+      // First cell from the top-left position
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.end).toEqual(EMPTY);
+      // First cell from the top-right position
+      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.start).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.end).toEqual(MAGENTA_BORDER);
+      // // First cell from the bottom-left position
+      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(4, 1).borders.end).toEqual(EMPTY);
+      // // First cell from the bottom-right position
+      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 4).borders.start).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.end).toEqual(MAGENTA_BORDER);
+      // Cell in the middle of area without borders
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
+    it('should display custom borders (drawing range) properly when showing rows that have been hidden ' +
+      '(range starts from hidden row)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenRows: {
+          rows: [1],
+          indicators: true
+        },
+        customBorders: [{
+          range: {
+            from: {
+              row: 1,
+              col: 1
+            },
+            to: {
+              row: 4,
+              col: 4
+            }
+          },
+          top: BLUE_BORDER,
+          start: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          end: MAGENTA_BORDER
+        }]
+      });
+
+      getPlugin('hiddenRows').showRow(1);
+      render();
+
+      expect(countVisibleCustomBorders()).toEqual(4 * 4); // 4 rows x 4 columns
+      // First cell from the top-left position
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.end).toEqual(EMPTY);
+      // First cell from the top-right position
+      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.start).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.end).toEqual(MAGENTA_BORDER);
+      // // First cell from the bottom-left position
+      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(4, 1).borders.end).toEqual(EMPTY);
+      // // First cell from the bottom-right position
+      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 4).borders.start).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.end).toEqual(MAGENTA_BORDER);
+      // Cell in the middle of area without borders
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
+    it('should display custom borders (drawing range) properly when some rows are hidden ' +
+      '(range ends at hidden row)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenRows: {
+          rows: [4],
+          indicators: true
+        },
+        customBorders: [{
+          range: {
+            from: {
+              row: 1,
+              col: 1
+            },
+            to: {
+              row: 4,
+              col: 4
+            }
+          },
+          top: BLUE_BORDER,
+          start: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          end: MAGENTA_BORDER
+        }]
+      });
+
+      expect(countVisibleCustomBorders()).toEqual((3 * 2) + 4); // 3 rows x 4 columns without bottom border
+      // First cell from the top-left position
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.end).toEqual(EMPTY);
+      // First cell from the top-right position
+      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.start).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.end).toEqual(MAGENTA_BORDER);
+      // // First cell from the bottom-left position
+      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(4, 1).borders.end).toEqual(EMPTY);
+      // // First cell from the bottom-right position
+      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 4).borders.start).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.end).toEqual(MAGENTA_BORDER);
+      // Cell in the middle of area without borders
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
+    it('should display custom borders (drawing range) properly when hiding rows that have been visible ' +
+      '(hiding row at the end of the range)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenRows: true,
+        customBorders: [{
+          range: {
+            from: {
+              row: 1,
+              col: 1
+            },
+            to: {
+              row: 4,
+              col: 4
+            }
+          },
+          top: BLUE_BORDER,
+          start: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          end: MAGENTA_BORDER
+        }]
+      });
+
+      getPlugin('hiddenRows').hideRow(4);
+      render();
+
+      expect(countVisibleCustomBorders()).toEqual((3 * 2) + 4); // 3 rows x 4 columns without right border
+      // First cell from the top-left position
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.end).toEqual(EMPTY);
+      // First cell from the top-right position
+      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.start).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.end).toEqual(MAGENTA_BORDER);
+      // // First cell from the bottom-left position
+      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(4, 1).borders.end).toEqual(EMPTY);
+      // // First cell from the bottom-right position
+      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 4).borders.start).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.end).toEqual(MAGENTA_BORDER);
+      // Cell in the middle of area without borders
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
+    it('should display custom borders (drawing range) properly when showing rows that have been hidden ' +
+      '(range ends at hidden row)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenRows: {
+          rows: [4],
+          indicators: true
+        },
+        customBorders: [{
+          range: {
+            from: {
+              row: 1,
+              col: 1
+            },
+            to: {
+              row: 4,
+              col: 4
+            }
+          },
+          top: BLUE_BORDER,
+          start: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          end: MAGENTA_BORDER
+        }]
+      });
+
+      getPlugin('hiddenRows').showRow(4);
+      render();
+
+      expect(countVisibleCustomBorders()).toEqual(4 * 4); // 4 rows x 4 columns
+      // First cell from the top-left position
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.end).toEqual(EMPTY);
+      // First cell from the top-right position
+      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.start).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.end).toEqual(MAGENTA_BORDER);
+      // // First cell from the bottom-left position
+      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(4, 1).borders.end).toEqual(EMPTY);
+      // // First cell from the bottom-right position
+      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 4).borders.start).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.end).toEqual(MAGENTA_BORDER);
+      // Cell in the middle of area without borders
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
+    it('should display custom borders (drawing range) properly when some rows are hidden ' +
+      '(hidden row in the middle of the range)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenRows: {
+          rows: [2],
+          indicators: true
+        },
+        customBorders: [{
+          range: {
+            from: {
+              row: 1,
+              col: 1
+            },
+            to: {
+              row: 4,
+              col: 4
+            }
+          },
+          top: BLUE_BORDER,
+          start: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          end: MAGENTA_BORDER
+        }]
+      });
+
+      expect(countVisibleCustomBorders()).toEqual((3 * 2) + (4 * 2)); // 3 rows x 4 columns
+      // First cell from the top-left position
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.end).toEqual(EMPTY);
+      // First cell from the top-right position
+      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.start).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.end).toEqual(MAGENTA_BORDER);
+      // // First cell from the bottom-left position
+      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(4, 1).borders.end).toEqual(EMPTY);
+      // // First cell from the bottom-right position
+      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 4).borders.start).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.end).toEqual(MAGENTA_BORDER);
+      // Cell in the middle of area without borders
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
+    it('should display custom borders (drawing range) properly when hiding rows that have been visible ' +
+      '(hiding row in the middle of the range)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenRows: true,
+        customBorders: [{
+          range: {
+            from: {
+              row: 1,
+              col: 1
+            },
+            to: {
+              row: 4,
+              col: 4
+            }
+          },
+          top: BLUE_BORDER,
+          start: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          end: MAGENTA_BORDER
+        }]
+      });
+
+      getPlugin('hiddenRows').hideRow(2);
+      render();
+
+      expect(countVisibleCustomBorders()).toEqual((3 * 2) + (4 * 2)); // 3 rows x 4 columns
+      // First cell from the top-left position
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.end).toEqual(EMPTY);
+      // First cell from the top-right position
+      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.start).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.end).toEqual(MAGENTA_BORDER);
+      // // First cell from the bottom-left position
+      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(4, 1).borders.end).toEqual(EMPTY);
+      // // First cell from the bottom-right position
+      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 4).borders.start).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.end).toEqual(MAGENTA_BORDER);
+      // Cell in the middle of area without borders
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
+    it('should display custom borders (drawing range) properly when showing rows that have been hidden ' +
+      '(hidden row in the middle of the range)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenRows: {
+          rows: [4],
+          indicators: true
+        },
+        customBorders: [{
+          range: {
+            from: {
+              row: 1,
+              col: 1
+            },
+            to: {
+              row: 4,
+              col: 4
+            }
+          },
+          top: BLUE_BORDER,
+          start: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          end: MAGENTA_BORDER
+        }]
+      });
+
+      getPlugin('hiddenRows').showRow(4);
+      render();
+
+      expect(countVisibleCustomBorders()).toEqual(4 * 4); // 4 rows x 4 columns
+      // First cell from the top-left position
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.end).toEqual(EMPTY);
+      // First cell from the top-right position
+      expect(getCellMeta(1, 4).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 4).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.start).toEqual(EMPTY);
+      expect(getCellMeta(1, 4).borders.end).toEqual(MAGENTA_BORDER);
+      // // First cell from the bottom-left position
+      expect(getCellMeta(4, 1).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(4, 1).borders.end).toEqual(EMPTY);
+      // // First cell from the bottom-right position
+      expect(getCellMeta(4, 4).borders.top).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(4, 4).borders.start).toEqual(EMPTY);
+      expect(getCellMeta(4, 4).borders.end).toEqual(MAGENTA_BORDER);
+      // Cell in the middle of area without borders
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
+    it('should display borders properly when hiding cells separating another cells with borders (they will stick together) #1', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenRows: true,
+        customBorders: [{
+          row: 0,
+          col: 1,
+          top: GREEN_BORDER,
+          start: GREEN_BORDER,
+          bottom: GREEN_BORDER,
+          end: GREEN_BORDER
+        }, {
+          row: 2,
+          col: 1,
+          top: BLUE_BORDER,
+          start: BLUE_BORDER,
+          bottom: BLUE_BORDER,
+          end: BLUE_BORDER
+        }, {
+          row: 4,
+          col: 1,
+          top: YELLOW_BORDER,
+          start: YELLOW_BORDER,
+          bottom: YELLOW_BORDER,
+          end: YELLOW_BORDER
+        }]
+      });
+
+      getPlugin('hiddenRows').hideRows([1, 3]);
+      render();
+
+      expect(countVisibleCustomBorders()).toEqual(3 * 4); // It isn't ok probably. There is no specification.
+      // expect(countVisibleCustomBorders()).toEqual((4 * 2) + 2); // TODO: It should work.
+      expect(getCellMeta(0, 1).borders.top).toEqual(GREEN_BORDER);
+      expect(getCellMeta(0, 1).borders.bottom).toEqual(GREEN_BORDER); // Is it ok?
+      expect(getCellMeta(0, 1).borders.start).toEqual(GREEN_BORDER);
+      expect(getCellMeta(0, 1).borders.end).toEqual(GREEN_BORDER);
+
+      expect(getCellMeta(2, 1).borders.top).toEqual(BLUE_BORDER); // Is it ok?
+      expect(getCellMeta(2, 1).borders.bottom).toEqual(BLUE_BORDER); // Is it ok?
+      expect(getCellMeta(2, 1).borders.start).toEqual(BLUE_BORDER);
+      expect(getCellMeta(2, 1).borders.end).toEqual(BLUE_BORDER);
+
+      expect(getCellMeta(4, 1).borders.top).toEqual(YELLOW_BORDER); // Is it ok?
+      expect(getCellMeta(4, 1).borders.bottom).toEqual(YELLOW_BORDER);
+      expect(getCellMeta(4, 1).borders.start).toEqual(YELLOW_BORDER);
+      expect(getCellMeta(4, 1).borders.end).toEqual(YELLOW_BORDER);
+    });
+
+    it('should display borders properly when hiding cells separating another cells with borders (they will stick together) #2', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenRows: true,
+        customBorders: [{
+          row: 0,
+          col: 1,
+          top: GREEN_BORDER,
+          start: GREEN_BORDER,
+          bottom: GREEN_BORDER,
+          end: GREEN_BORDER
+        }, {
+          row: 2,
+          col: 1,
+          top: BLUE_BORDER,
+          start: BLUE_BORDER,
+          bottom: BLUE_BORDER,
+          end: BLUE_BORDER
+        }, {
+          row: 4,
+          col: 1,
+          top: YELLOW_BORDER,
+          start: YELLOW_BORDER,
+          bottom: YELLOW_BORDER,
+          end: YELLOW_BORDER
+        }]
+      });
+
+      getPlugin('hiddenRows').hideRows([1, 2, 3]);
+      render();
+
+      expect(countVisibleCustomBorders()).toEqual(2 * 4); // It isn't ok probably. There is no specification.
+      // expect(countVisibleCustomBorders()).toEqual((4 + 3)); // TODO: It should work.
+      expect(getCellMeta(0, 1).borders.top).toEqual(GREEN_BORDER);
+      expect(getCellMeta(0, 1).borders.bottom).toEqual(GREEN_BORDER); // Is it ok?
+      expect(getCellMeta(0, 1).borders.start).toEqual(GREEN_BORDER);
+      expect(getCellMeta(0, 1).borders.end).toEqual(GREEN_BORDER);
+
+      expect(getCellMeta(2, 1).borders.top).toEqual(BLUE_BORDER); // Is it ok?
+      expect(getCellMeta(2, 1).borders.bottom).toEqual(BLUE_BORDER); // Is it ok?
+      expect(getCellMeta(2, 1).borders.start).toEqual(BLUE_BORDER);
+      expect(getCellMeta(2, 1).borders.end).toEqual(BLUE_BORDER);
+
+      expect(getCellMeta(4, 1).borders.top).toEqual(YELLOW_BORDER); // Is it ok?
+      expect(getCellMeta(4, 1).borders.bottom).toEqual(YELLOW_BORDER);
+      expect(getCellMeta(4, 1).borders.start).toEqual(YELLOW_BORDER);
+      expect(getCellMeta(4, 1).borders.end).toEqual(YELLOW_BORDER);
+    });
+
+    it('should not display custom border for single cell when it is placed on the hidden row', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenRows: {
+          rows: [1],
+          indicators: true
+        },
+        customBorders: [{
+          row: 1,
+          col: 1,
+          top: BLUE_BORDER,
+          start: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          end: MAGENTA_BORDER
+        }]
+      });
+
+      // Just the meta is defined.
+      expect(countVisibleCustomBorders()).toEqual(0);
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(1, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.end).toEqual(MAGENTA_BORDER);
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
+    it('should display custom borders for single cells properly when one of them is placed on the hidden row', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenRows: {
+          rows: [1, 3],
+          indicators: true
+        },
+        customBorders: true
+      });
+
+      getPlugin('customBorders').setBorders([[1, 1, 3, 3]], {
+        top: BLUE_BORDER,
+        start: ORANGE_BORDER,
+        bottom: RED_BORDER,
+        end: MAGENTA_BORDER
+      });
+
+      expect(countVisibleCustomBorders()).toEqual(3 * 4); // Just 3 cells (2 rows are hidden), all of them with 4 borders
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(1, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.end).toEqual(MAGENTA_BORDER);
+
+      expect(getCellMeta(1, 2).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 2).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(1, 2).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 2).borders.end).toEqual(MAGENTA_BORDER);
+
+      expect(getCellMeta(2, 2).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(2, 2).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(2, 2).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(2, 2).borders.end).toEqual(MAGENTA_BORDER);
+
+      expect(getCellMeta(3, 2).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(3, 2).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(3, 2).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(3, 2).borders.end).toEqual(MAGENTA_BORDER);
+    });
+
+    it('should not display custom border for single cell when row containing border is hidden by API call', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenRows: true,
+        customBorders: [{
+          row: 1,
+          col: 1,
+          top: BLUE_BORDER,
+          start: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          end: MAGENTA_BORDER
+        }]
+      });
+
+      getPlugin('hiddenRows').hideRow(1);
+      render();
+
+      // Just the meta is defined.
+      expect(countVisibleCustomBorders()).toEqual(0);
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(1, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.end).toEqual(MAGENTA_BORDER);
+    });
+
+    it('should display custom border for single cell when hidden row containing border has been shown by API call', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenRows: {
+          rows: [1],
+          indicators: true
+        },
+        customBorders: [{
+          row: 1,
+          col: 1,
+          top: BLUE_BORDER,
+          start: ORANGE_BORDER,
+          bottom: RED_BORDER,
+          end: MAGENTA_BORDER
+        }]
+      });
+
+      getPlugin('hiddenRows').showRow(1);
+      render();
+
+      expect(countVisibleCustomBorders()).toEqual(4);
+      expect(getCellMeta(1, 1).borders.top).toEqual(BLUE_BORDER);
+      expect(getCellMeta(1, 1).borders.bottom).toEqual(RED_BORDER);
+      expect(getCellMeta(1, 1).borders.start).toEqual(ORANGE_BORDER);
+      expect(getCellMeta(1, 1).borders.end).toEqual(MAGENTA_BORDER);
+      expect(getCellMeta(2, 2).borders).toBeUndefined();
+    });
+
+    it('should draw border from context menu options in proper place when there are some hidden rows before ' +
+      'a place where the border is added', async() => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        contextMenu: true,
+        customBorders: true,
+        hiddenRows: {
+          rows: [0, 1]
+        }
+      });
+
+      await selectContextSubmenuOption('Borders', 'Top', getCell(2, 0));
+      deselectCell();
+
+      expect(getCellMeta(2, 0).borders.start).toEqual(EMPTY);
+      expect(getCellMeta(2, 0).borders.bottom).toEqual(EMPTY);
+      expect(getCellMeta(2, 0).borders.top).toEqual(DEFAULT_BORDER);
+      expect(getCellMeta(2, 0).borders.end).toEqual(EMPTY);
+
+      expect(countVisibleCustomBorders()).toBe(1);
+      expect(countCustomBorders()).toBe(5);
+    });
+  });
+});

--- a/handsontable/src/plugins/customBorders/__tests__/rtl/customBorders.spec.js
+++ b/handsontable/src/plugins/customBorders/__tests__/rtl/customBorders.spec.js
@@ -35,7 +35,8 @@ describe('CustomBorders (RTL mode)', () => {
             top: GREEN_BORDER
           }]
         });
-      }).toThrowError('The "left"/"right" and "start"/"end" options should not be used together. Please use only the option "start"/"end".');
+      }).toThrowError('The "left"/"right" and "start"/"end" options should not be used together. ' +
+                      'Please use only the option "start"/"end".');
     });
 
     it('should not be possible to use backward compatible API ("left"/"right") in RTL mode (initialization)', () => {

--- a/handsontable/src/plugins/customBorders/__tests__/rtl/customBorders.spec.js
+++ b/handsontable/src/plugins/customBorders/__tests__/rtl/customBorders.spec.js
@@ -1,0 +1,748 @@
+describe('CustomBorders (RTL mode)', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    $('html').attr('dir', 'rtl');
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+    const wrapper = $('<div></div>').css({
+      width: 400,
+      height: 200,
+      overflow: 'scroll'
+    });
+
+    this.$wrapper = this.$container.wrap(wrapper).parent();
+  });
+
+  afterEach(function() {
+    $('html').attr('dir', 'ltr');
+
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+    this.$wrapper.remove();
+  });
+
+  describe('enabling/disabling plugin', () => {
+    it('should throw an error while initialization if the mixed API is used ("start"/"end" and "left"/"right")', () => {
+      expect(() => {
+        handsontable({
+          customBorders: [{
+            row: 2,
+            col: 2,
+            start: RED_BORDER,
+            right: RED_BORDER,
+            top: GREEN_BORDER
+          }]
+        });
+      }).toThrowError('The "left"/"right" and "start"/"end" options should not be used together. Please use only the option "start"/"end".');
+    });
+
+    it('should not be possible to use backward compatible API ("left"/"right") in RTL mode (initialization)', () => {
+      expect(() => {
+        handsontable({
+          customBorders: [{
+            row: 2,
+            col: 2,
+            right: RED_BORDER,
+          }]
+        });
+      }).toThrowError('The "left"/"right" properties are not supported for RTL. Please use option "start"/"end".');
+    });
+
+    it('should not be possible to use backward compatible API ("left"/"right") in RTL mode (updateSettings call)', () => {
+      handsontable({
+        customBorders: [{
+          row: 2,
+          col: 2,
+          start: RED_BORDER,
+        }]
+      });
+
+      expect(() => {
+        updateSettings({
+          customBorders: [{
+            row: 2,
+            col: 2,
+            right: RED_BORDER,
+          }]
+        });
+      }).toThrowError('The "left"/"right" properties are not supported for RTL. Please use option "start"/"end".');
+    });
+  });
+
+  it('should render specific borders provided in the configuration', () => {
+    handsontable({
+      data: createSpreadsheetData(4, 4),
+      customBorders: [{
+        row: 2,
+        col: 2,
+        start: RED_BORDER,
+        end: RED_BORDER,
+        top: GREEN_BORDER
+      }]
+    });
+
+    expect(getCellMeta(2, 2).borders.top).toEqual(GREEN_BORDER);
+    expect(getCellMeta(2, 2).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(2, 2).borders.start).toEqual(RED_BORDER);
+    expect(getCellMeta(2, 2).borders.end).toEqual(RED_BORDER);
+
+    expect(getCellMeta(0, 0).borders).toBeUndefined();
+    expect(getCellMeta(0, 1).borders).toBeUndefined();
+    expect(getCellMeta(0, 2).borders).toBeUndefined();
+    expect(getCellMeta(0, 3).borders).toBeUndefined();
+
+    expect(getCellMeta(1, 0).borders).toBeUndefined();
+    expect(getCellMeta(1, 1).borders).toBeUndefined();
+    expect(getCellMeta(1, 2).borders).toBeUndefined();
+    expect(getCellMeta(1, 3).borders).toBeUndefined();
+
+    expect(getCellMeta(2, 0).borders).toBeUndefined();
+    expect(getCellMeta(2, 1).borders).toBeUndefined();
+    expect(getCellMeta(2, 3).borders).toBeUndefined();
+
+    expect(getCellMeta(3, 0).borders).toBeUndefined();
+    expect(getCellMeta(3, 1).borders).toBeUndefined();
+    expect(getCellMeta(3, 2).borders).toBeUndefined();
+    expect(getCellMeta(3, 3).borders).toBeUndefined();
+
+    expect(countVisibleCustomBorders()).toBe(3);
+    expect(countCustomBorders()).toBe(5);
+  });
+
+  it('should throw an error when the "left"/"right" options are passed to the setBorders method', () => {
+    handsontable({
+      data: createSpreadsheetData(4, 4),
+      customBorders: true
+    });
+
+    const customBorders = getPlugin('customBorders');
+
+    expect(() => {
+      customBorders.setBorders([1, 1, 2, 2], {
+        left: GREEN_BORDER,
+      });
+    }).toThrowError('The "left"/"right" properties are not supported for RTL. Please use option "start"/"end".');
+  });
+
+  it('should draw new borders by use setBorders method (while selected)', () => {
+    handsontable({
+      data: createSpreadsheetData(4, 4),
+      customBorders: true
+    });
+
+    const customBorders = getPlugin('customBorders');
+
+    selectCells([[1, 1, 2, 2]]);
+    customBorders.setBorders(getSelected(), {
+      start: GREEN_BORDER,
+      end: RED_BORDER
+    });
+    deselectCell();
+
+    expect(getCellMeta(1, 1).borders.top).toEqual(EMPTY);
+    expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(1, 1).borders.start).toEqual(GREEN_BORDER);
+    expect(getCellMeta(1, 1).borders.end).toEqual(RED_BORDER);
+
+    expect(getCellMeta(1, 2).borders.top).toEqual(EMPTY);
+    expect(getCellMeta(1, 2).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(1, 2).borders.start).toEqual(GREEN_BORDER);
+    expect(getCellMeta(1, 2).borders.end).toEqual(RED_BORDER);
+
+    expect(getCellMeta(2, 1).borders.top).toEqual(EMPTY);
+    expect(getCellMeta(2, 1).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(2, 1).borders.start).toEqual(GREEN_BORDER);
+    expect(getCellMeta(2, 1).borders.end).toEqual(RED_BORDER);
+
+    expect(getCellMeta(2, 2).borders.top).toEqual(EMPTY);
+    expect(getCellMeta(2, 2).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(2, 2).borders.start).toEqual(GREEN_BORDER);
+    expect(getCellMeta(2, 2).borders.end).toEqual(RED_BORDER);
+
+    expect(countVisibleCustomBorders()).toBe(8);
+    expect(countCustomBorders()).toBe(4 * 5); // there are 4 cells in the provided range
+  });
+
+  it('should draw new borders by use setBorders method (while deselected)', () => {
+    handsontable({
+      data: createSpreadsheetData(4, 4),
+      customBorders: true
+    });
+
+    const customBorders = getPlugin('customBorders');
+
+    customBorders.setBorders([[1, 1, 2, 2]], {
+      start: GREEN_BORDER,
+      end: RED_BORDER
+    });
+
+    expect(getCellMeta(1, 1).borders.top).toEqual(EMPTY);
+    expect(getCellMeta(1, 1).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(1, 1).borders.start).toEqual(GREEN_BORDER);
+    expect(getCellMeta(1, 1).borders.end).toEqual(RED_BORDER);
+
+    expect(getCellMeta(1, 2).borders.top).toEqual(EMPTY);
+    expect(getCellMeta(1, 2).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(1, 2).borders.start).toEqual(GREEN_BORDER);
+    expect(getCellMeta(1, 2).borders.end).toEqual(RED_BORDER);
+
+    expect(getCellMeta(2, 1).borders.top).toEqual(EMPTY);
+    expect(getCellMeta(2, 1).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(2, 1).borders.start).toEqual(GREEN_BORDER);
+    expect(getCellMeta(2, 1).borders.end).toEqual(RED_BORDER);
+
+    expect(getCellMeta(2, 2).borders.top).toEqual(EMPTY);
+    expect(getCellMeta(2, 2).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(2, 2).borders.start).toEqual(GREEN_BORDER);
+    expect(getCellMeta(2, 2).borders.end).toEqual(RED_BORDER);
+
+    expect(countVisibleCustomBorders()).toBe(8);
+    expect(countCustomBorders()).toBe(4 * 5); // there are 4 cells in the provided range
+  });
+
+  it('should redraw existing borders by use setBorders method (while selected)', () => {
+    handsontable({
+      data: createSpreadsheetData(4, 4),
+      customBorders: [{
+        row: 2,
+        col: 2,
+        start: RED_BORDER,
+        top: GREEN_BORDER,
+        bottom: GREEN_BORDER,
+      }]
+    });
+
+    const customBorders = getPlugin('customBorders');
+
+    selectCell(2, 2);
+    customBorders.setBorders(getSelectedRange(), {
+      start: GREEN_BORDER,
+      end: RED_BORDER
+    });
+    deselectCell();
+
+    expect(getCellMeta(2, 2).borders.top).toEqual(GREEN_BORDER);
+    expect(getCellMeta(2, 2).borders.bottom).toEqual(GREEN_BORDER);
+    expect(getCellMeta(2, 2).borders.start).toEqual(GREEN_BORDER);
+    expect(getCellMeta(2, 2).borders.end).toEqual(RED_BORDER);
+    expect(countVisibleCustomBorders()).toBe(4);
+    expect(countCustomBorders()).toBe(5);
+  });
+
+  it('should redraw existing borders by use setBorders method (while deselected)', () => {
+    handsontable({
+      data: createSpreadsheetData(4, 4),
+      customBorders: [{
+        row: 2,
+        col: 2,
+        start: RED_BORDER,
+        top: GREEN_BORDER,
+        bottom: GREEN_BORDER,
+      }]
+    });
+
+    const customBorders = getPlugin('customBorders');
+
+    customBorders.setBorders([[2, 2]], {
+      start: GREEN_BORDER,
+      end: RED_BORDER
+    });
+
+    expect(getCellMeta(2, 2).borders.top).toEqual(GREEN_BORDER);
+    expect(getCellMeta(2, 2).borders.bottom).toEqual(GREEN_BORDER);
+    expect(getCellMeta(2, 2).borders.start).toEqual(GREEN_BORDER);
+    expect(getCellMeta(2, 2).borders.end).toEqual(RED_BORDER);
+    expect(countVisibleCustomBorders()).toBe(4);
+    expect(countCustomBorders()).toBe(5);
+  });
+
+  it('should hide only specific border by use setBorders method with {hide: true} (while selected)', () => {
+    handsontable({
+      data: createSpreadsheetData(4, 4),
+      customBorders: [{
+        row: 2,
+        col: 2,
+        start: RED_BORDER,
+        end: RED_BORDER,
+        top: GREEN_BORDER
+      }]
+    });
+
+    const customBorders = getPlugin('customBorders');
+
+    selectCell(2, 2);
+    customBorders.setBorders(getSelected(), {
+      end: EMPTY
+    });
+    deselectCell();
+
+    expect(getCellMeta(2, 2).borders.top).toEqual(GREEN_BORDER);
+    expect(getCellMeta(2, 2).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(2, 2).borders.start).toEqual(RED_BORDER);
+    expect(getCellMeta(2, 2).borders.end).toEqual(EMPTY);
+    expect(countVisibleCustomBorders()).toBe(2);
+    expect(countCustomBorders()).toBe(5);
+  });
+
+  it('should hide only specific border by use setBorders method with {hide: true} (while deselected)', () => {
+    handsontable({
+      data: createSpreadsheetData(4, 4),
+      customBorders: [{
+        row: 2,
+        col: 2,
+        start: RED_BORDER,
+        end: RED_BORDER,
+        top: GREEN_BORDER
+      }]
+    });
+
+    const customBorders = getPlugin('customBorders');
+
+    customBorders.setBorders([[2, 2]], {
+      end: EMPTY
+    });
+
+    expect(getCellMeta(2, 2).borders.top).toEqual(GREEN_BORDER);
+    expect(getCellMeta(2, 2).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(2, 2).borders.start).toEqual(RED_BORDER);
+    expect(getCellMeta(2, 2).borders.end).toEqual(EMPTY);
+    expect(countVisibleCustomBorders()).toBe(2);
+    expect(countCustomBorders()).toBe(5);
+  });
+
+  it('should hide only specific border by use setBorders method with {end: false} (while selected)', () => {
+    handsontable({
+      data: createSpreadsheetData(4, 4),
+      customBorders: [{
+        row: 2,
+        col: 2,
+        start: RED_BORDER,
+        end: RED_BORDER,
+        top: GREEN_BORDER
+      }]
+    });
+
+    const customBorders = getPlugin('customBorders');
+
+    selectCell(2, 2);
+    customBorders.setBorders(getSelected(), {
+      end: false
+    });
+    deselectCell();
+
+    expect(getCellMeta(2, 2).borders.top).toEqual(GREEN_BORDER);
+    expect(getCellMeta(2, 2).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(2, 2).borders.start).toEqual(RED_BORDER);
+    expect(getCellMeta(2, 2).borders.end).toEqual(EMPTY);
+
+    expect(getCellMeta(0, 0).borders).toBeUndefined();
+    expect(getCellMeta(0, 1).borders).toBeUndefined();
+    expect(getCellMeta(0, 2).borders).toBeUndefined();
+    expect(getCellMeta(0, 3).borders).toBeUndefined();
+
+    expect(getCellMeta(1, 0).borders).toBeUndefined();
+    expect(getCellMeta(1, 1).borders).toBeUndefined();
+    expect(getCellMeta(1, 2).borders).toBeUndefined();
+    expect(getCellMeta(1, 3).borders).toBeUndefined();
+
+    expect(getCellMeta(2, 0).borders).toBeUndefined();
+    expect(getCellMeta(2, 1).borders).toBeUndefined();
+    expect(getCellMeta(2, 3).borders).toBeUndefined();
+
+    expect(getCellMeta(3, 0).borders).toBeUndefined();
+    expect(getCellMeta(3, 1).borders).toBeUndefined();
+    expect(getCellMeta(3, 2).borders).toBeUndefined();
+    expect(getCellMeta(3, 3).borders).toBeUndefined();
+
+    expect(countVisibleCustomBorders()).toBe(2);
+    expect(countCustomBorders()).toBe(5);
+  });
+
+  it('should hide only specific border by use setBorders method with {end: false} (while deselected)', () => {
+    handsontable({
+      data: createSpreadsheetData(4, 4),
+      customBorders: [{
+        row: 2,
+        col: 2,
+        start: RED_BORDER,
+        end: RED_BORDER,
+        top: GREEN_BORDER
+      }]
+    });
+
+    const customBorders = getPlugin('customBorders');
+
+    customBorders.setBorders([[2, 2]], {
+      end: false
+    });
+
+    expect(getCellMeta(2, 2).borders.top).toEqual(GREEN_BORDER);
+    expect(getCellMeta(2, 2).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(2, 2).borders.start).toEqual(RED_BORDER);
+    expect(getCellMeta(2, 2).borders.end).toEqual(EMPTY);
+
+    expect(getCellMeta(0, 0).borders).toBeUndefined();
+    expect(getCellMeta(0, 1).borders).toBeUndefined();
+    expect(getCellMeta(0, 2).borders).toBeUndefined();
+    expect(getCellMeta(0, 3).borders).toBeUndefined();
+
+    expect(getCellMeta(1, 0).borders).toBeUndefined();
+    expect(getCellMeta(1, 1).borders).toBeUndefined();
+    expect(getCellMeta(1, 2).borders).toBeUndefined();
+    expect(getCellMeta(1, 3).borders).toBeUndefined();
+
+    expect(getCellMeta(2, 0).borders).toBeUndefined();
+    expect(getCellMeta(2, 1).borders).toBeUndefined();
+    expect(getCellMeta(2, 3).borders).toBeUndefined();
+
+    expect(getCellMeta(3, 0).borders).toBeUndefined();
+    expect(getCellMeta(3, 1).borders).toBeUndefined();
+    expect(getCellMeta(3, 2).borders).toBeUndefined();
+    expect(getCellMeta(3, 3).borders).toBeUndefined();
+
+    expect(countVisibleCustomBorders()).toBe(2);
+    expect(countCustomBorders()).toBe(5);
+  });
+
+  it('should return borders from the selected area by use getBorders method', () => {
+    handsontable({
+      data: createSpreadsheetData(4, 4),
+      customBorders: [{
+        row: 2,
+        col: 2,
+        start: RED_BORDER,
+        end: GREEN_BORDER,
+        top: GREEN_BORDER
+      }]
+    });
+
+    const customBorders = getPlugin('customBorders');
+
+    selectCells([[1, 1, 2, 2]]);
+    const borders = customBorders.getBorders(getSelected());
+
+    deselectCell();
+
+    expect(borders.length).toEqual(1);
+    expect(borders[0].top).toEqual(GREEN_BORDER);
+    expect(borders[0].bottom).toEqual(EMPTY);
+    expect(borders[0].start).toEqual(RED_BORDER);
+    expect(borders[0].end).toEqual(GREEN_BORDER);
+    expect(countVisibleCustomBorders()).toBe(3);
+    expect(countCustomBorders()).toBe(5);
+  });
+
+  it('should return all borders by use getBorders method without parameter', () => {
+    handsontable({
+      data: createSpreadsheetData(4, 4),
+      customBorders: [{
+        range: {
+          from: {
+            row: 1,
+            col: 1
+          },
+          to: {
+            row: 3,
+            col: 3
+          }
+        },
+        top: BLUE_BORDER,
+        start: ORANGE_BORDER,
+        bottom: RED_BORDER,
+        end: MAGENTA_BORDER
+      },
+      {
+        row: 2,
+        col: 2,
+        start: RED_BORDER,
+        end: GREEN_BORDER,
+        top: GREEN_THICK_BORDER
+      }]
+    });
+
+    const customBorders = getPlugin('customBorders');
+
+    const borders = customBorders.getBorders();
+
+    expect(borders.length).toEqual(9);
+    expect(countVisibleCustomBorders()).toBe(15); // there are 9 cells in the provided range, some of which have 1, 2 or 3 rendered borders
+    expect(countCustomBorders()).toBe(9 * 5); // there are 9 cells in the provided range
+  });
+
+  it('should clear borders from area by use clearBorders method (while selected)', () => {
+    handsontable({
+      data: createSpreadsheetData(4, 4),
+      customBorders: [{
+        range: {
+          from: {
+            row: 1,
+            col: 1
+          },
+          to: {
+            row: 3,
+            col: 3
+          }
+        },
+        top: BLUE_BORDER,
+        start: ORANGE_BORDER,
+        bottom: RED_BORDER,
+        end: MAGENTA_BORDER
+      },
+      {
+        row: 2,
+        col: 2,
+        start: RED_BORDER,
+        end: GREEN_BORDER,
+        top: GREEN_THICK_BORDER
+      }]
+    });
+
+    const customBorders = getPlugin('customBorders');
+
+    /*
+    Was:
+    0000
+    0111
+    0111
+    0111
+    */
+
+    selectCells([[0, 0, 2, 2]]);
+    customBorders.clearBorders(getSelectedRange());
+    deselectCell();
+
+    /*
+    Is:
+    0000
+    0001
+    0001
+    0111
+    */
+
+    expect(getCellMeta(1, 1).borders).toBeUndefined();
+    expect(getCellMeta(1, 2).borders).toBeUndefined();
+    expect(getCellMeta(2, 1).borders).toBeUndefined();
+    expect(getCellMeta(2, 2).borders).toBeUndefined();
+
+    expect(getCellMeta(1, 3).borders.top).toEqual(BLUE_BORDER);
+    expect(getCellMeta(1, 3).borders.end).toEqual(MAGENTA_BORDER);
+    expect(getCellMeta(2, 3).borders.end).toEqual(MAGENTA_BORDER);
+    expect(getCellMeta(3, 1).borders.start).toEqual(ORANGE_BORDER);
+    expect(getCellMeta(3, 1).borders.bottom).toEqual(RED_BORDER);
+    expect(getCellMeta(3, 2).borders.bottom).toEqual(RED_BORDER);
+    expect(getCellMeta(3, 3).borders.end).toEqual(MAGENTA_BORDER);
+    expect(getCellMeta(3, 3).borders.bottom).toEqual(RED_BORDER);
+    expect(countVisibleCustomBorders()).toBe(8);
+    expect(countCustomBorders()).toBe(5 * 5);
+  });
+
+  it('should clear borders from area by use clearBorders method (while deselected)', () => {
+    handsontable({
+      data: createSpreadsheetData(4, 4),
+      customBorders: [{
+        range: {
+          from: {
+            row: 1,
+            col: 1
+          },
+          to: {
+            row: 3,
+            col: 3
+          }
+        },
+        top: BLUE_BORDER,
+        start: ORANGE_BORDER,
+        bottom: RED_BORDER,
+        end: MAGENTA_BORDER
+      },
+      {
+        row: 2,
+        col: 2,
+        start: RED_BORDER,
+        end: GREEN_BORDER,
+        top: GREEN_THICK_BORDER
+      }]
+    });
+
+    const customBorders = getPlugin('customBorders');
+
+    /*
+    Was:
+    0000
+    0111
+    0111
+    0111
+    */
+
+    customBorders.clearBorders([[0, 0, 2, 2]]);
+
+    /*
+    Is:
+    0000
+    0001
+    0001
+    0111
+    */
+
+    expect(getCellMeta(1, 1).borders).toBeUndefined();
+    expect(getCellMeta(1, 2).borders).toBeUndefined();
+    expect(getCellMeta(2, 1).borders).toBeUndefined();
+    expect(getCellMeta(2, 2).borders).toBeUndefined();
+
+    expect(getCellMeta(1, 3).borders.top).toEqual(BLUE_BORDER);
+    expect(getCellMeta(1, 3).borders.end).toEqual(MAGENTA_BORDER);
+    expect(getCellMeta(2, 3).borders.end).toEqual(MAGENTA_BORDER);
+    expect(getCellMeta(3, 1).borders.start).toEqual(ORANGE_BORDER);
+    expect(getCellMeta(3, 1).borders.bottom).toEqual(RED_BORDER);
+    expect(getCellMeta(3, 2).borders.bottom).toEqual(RED_BORDER);
+    expect(getCellMeta(3, 3).borders.end).toEqual(MAGENTA_BORDER);
+    expect(getCellMeta(3, 3).borders.bottom).toEqual(RED_BORDER);
+    expect(countVisibleCustomBorders()).toBe(8);
+    expect(countCustomBorders()).toBe(5 * 5);
+  });
+
+  it('should clear all borders by use clearBorders method without parameter', () => {
+    handsontable({
+      data: createSpreadsheetData(4, 4),
+      customBorders: [{
+        range: {
+          from: {
+            row: 1,
+            col: 1
+          },
+          to: {
+            row: 3,
+            col: 3
+          }
+        },
+        top: BLUE_BORDER,
+        start: ORANGE_BORDER,
+        bottom: RED_BORDER,
+        end: MAGENTA_BORDER
+      },
+      {
+        row: 2,
+        col: 2,
+        start: RED_BORDER,
+        end: GREEN_BORDER,
+        top: GREEN_THICK_BORDER
+      }]
+    });
+
+    const customBorders = getPlugin('customBorders');
+
+    customBorders.clearBorders();
+
+    expect(getCellMeta(1, 1).borders).toBeUndefined();
+    expect(getCellMeta(1, 2).borders).toBeUndefined();
+    expect(getCellMeta(2, 1).borders).toBeUndefined();
+    expect(getCellMeta(2, 2).borders).toBeUndefined();
+
+    expect(getCellMeta(1, 3).borders).toBeUndefined();
+    expect(getCellMeta(2, 3).borders).toBeUndefined();
+    expect(getCellMeta(3, 1).borders).toBeUndefined();
+    expect(getCellMeta(3, 2).borders).toBeUndefined();
+    expect(getCellMeta(3, 3).borders).toBeUndefined();
+
+    expect(countVisibleCustomBorders()).toBe(0);
+    expect(countCustomBorders()).toBe(0);
+  });
+
+  it('should draw top border from context menu options', async() => {
+    handsontable({
+      data: createSpreadsheetData(4, 4),
+      contextMenu: true,
+      customBorders: true
+    });
+
+    await selectContextSubmenuOption('Borders', 'Top');
+    deselectCell();
+
+    expect(getCellMeta(0, 0).borders.top).toEqual(DEFAULT_BORDER);
+    expect(getCellMeta(0, 0).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(0, 0).borders.start).toEqual(EMPTY);
+    expect(getCellMeta(0, 0).borders.end).toEqual(EMPTY);
+
+    expect(countVisibleCustomBorders()).toBe(1);
+    expect(countCustomBorders()).toBe(5);
+  });
+
+  it('should draw left border from context menu options', async() => {
+    handsontable({
+      data: createSpreadsheetData(4, 4),
+      contextMenu: true,
+      customBorders: true
+    });
+
+    await selectContextSubmenuOption('Borders', 'Left');
+    deselectCell();
+
+    expect(getCellMeta(0, 0).borders.top).toEqual(EMPTY);
+    expect(getCellMeta(0, 0).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(0, 0).borders.start).toEqual(EMPTY);
+    expect(getCellMeta(0, 0).borders.end).toEqual(DEFAULT_BORDER);
+    expect(countVisibleCustomBorders()).toBe(1);
+    expect(countCustomBorders()).toBe(5);
+  });
+
+  it('should draw right border from context menu options', async() => {
+    handsontable({
+      data: createSpreadsheetData(4, 4),
+      contextMenu: true,
+      customBorders: true
+    });
+
+    await selectContextSubmenuOption('Borders', 'Right');
+    deselectCell();
+
+    expect(getCellMeta(0, 0).borders.top).toEqual(EMPTY);
+    expect(getCellMeta(0, 0).borders.bottom).toEqual(EMPTY);
+    expect(getCellMeta(0, 0).borders.start).toEqual(DEFAULT_BORDER);
+    expect(getCellMeta(0, 0).borders.end).toEqual(EMPTY);
+    expect(countVisibleCustomBorders()).toBe(1);
+    expect(countCustomBorders()).toBe(5);
+  });
+
+  it('should draw bottom border from context menu options', async() => {
+    handsontable({
+      data: createSpreadsheetData(4, 4),
+      contextMenu: true,
+      customBorders: true
+    });
+
+    await selectContextSubmenuOption('Borders', 'Bottom');
+    deselectCell();
+
+    expect(getCellMeta(0, 0).borders.top).toEqual(EMPTY);
+    expect(getCellMeta(0, 0).borders.bottom).toEqual(DEFAULT_BORDER);
+    expect(getCellMeta(0, 0).borders.start).toEqual(EMPTY);
+    expect(getCellMeta(0, 0).borders.end).toEqual(EMPTY);
+    expect(countVisibleCustomBorders()).toBe(1);
+    expect(countCustomBorders()).toBe(5);
+  });
+
+  it('should remove all bottoms border from context menu options', async() => {
+    handsontable({
+      data: createSpreadsheetData(4, 4),
+      contextMenu: true,
+      customBorders: [
+        {
+          row: 0,
+          col: 0,
+          start: RED_BORDER,
+          end: GREEN_BORDER
+        }]
+    });
+    expect(countVisibleCustomBorders()).toBe(2);
+    expect(countCustomBorders()).toBe(5);
+
+    await selectContextSubmenuOption('Borders', 'Remove border');
+    deselectCell();
+
+    expect(getCellMeta(0, 0).borders).toBeUndefined();
+    expect(countVisibleCustomBorders()).toBe(0);
+    expect(countCustomBorders()).toBe(0);
+  });
+});

--- a/handsontable/src/plugins/customBorders/contextMenuItem/left.js
+++ b/handsontable/src/plugins/customBorders/contextMenuItem/left.js
@@ -6,7 +6,7 @@ import { checkSelectionBorders, markSelected } from '../utils';
  * @returns {object}
  */
 export default function left(customBordersPlugin) {
-  const borderDirection = customBordersPlugin.hot.isRtl() ? 'end': 'start';
+  const borderDirection = customBordersPlugin.hot.isRtl() ? 'end' : 'start';
 
   return {
     key: 'borders:left',

--- a/handsontable/src/plugins/customBorders/contextMenuItem/left.js
+++ b/handsontable/src/plugins/customBorders/contextMenuItem/left.js
@@ -6,8 +6,7 @@ import { checkSelectionBorders, markSelected } from '../utils';
  * @returns {object}
  */
 export default function left(customBordersPlugin) {
-  const isRtl = customBordersPlugin.hot.isRtl();
-  const borderDirection = isRtl ? customBordersPlugin.inlineEndProp : customBordersPlugin.inlineStartProp;
+  const borderDirection = customBordersPlugin.hot.isRtl() ? 'end': 'start';
 
   return {
     key: 'borders:left',

--- a/handsontable/src/plugins/customBorders/contextMenuItem/left.js
+++ b/handsontable/src/plugins/customBorders/contextMenuItem/left.js
@@ -6,11 +6,14 @@ import { checkSelectionBorders, markSelected } from '../utils';
  * @returns {object}
  */
 export default function left(customBordersPlugin) {
+  const isRtl = customBordersPlugin.hot.isRtl();
+  const borderDirection = isRtl ? customBordersPlugin.inlineEndProp : customBordersPlugin.inlineStartProp;
+
   return {
     key: 'borders:left',
     name() {
       let label = this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_BORDERS_LEFT);
-      const hasBorder = checkSelectionBorders(this, 'left');
+      const hasBorder = checkSelectionBorders(this, borderDirection);
 
       if (hasBorder) {
         label = markSelected(label);
@@ -19,9 +22,9 @@ export default function left(customBordersPlugin) {
       return label;
     },
     callback(key, selected) {
-      const hasBorder = checkSelectionBorders(this, 'left');
+      const hasBorder = checkSelectionBorders(this, borderDirection);
 
-      customBordersPlugin.prepareBorder(selected, 'left', hasBorder);
+      customBordersPlugin.prepareBorder(selected, borderDirection, hasBorder);
     }
   };
 }

--- a/handsontable/src/plugins/customBorders/contextMenuItem/right.js
+++ b/handsontable/src/plugins/customBorders/contextMenuItem/right.js
@@ -6,7 +6,7 @@ import { checkSelectionBorders, markSelected } from '../utils';
  * @returns {object}
  */
 export default function right(customBordersPlugin) {
-  const borderDirection = customBordersPlugin.hot.isRtl() ? 'start': 'end';
+  const borderDirection = customBordersPlugin.hot.isRtl() ? 'start' : 'end';
 
   return {
     key: 'borders:right',

--- a/handsontable/src/plugins/customBorders/contextMenuItem/right.js
+++ b/handsontable/src/plugins/customBorders/contextMenuItem/right.js
@@ -6,8 +6,7 @@ import { checkSelectionBorders, markSelected } from '../utils';
  * @returns {object}
  */
 export default function right(customBordersPlugin) {
-  const isRtl = customBordersPlugin.hot.isRtl();
-  const borderDirection = isRtl ? customBordersPlugin.inlineStartProp : customBordersPlugin.inlineEndProp;
+  const borderDirection = customBordersPlugin.hot.isRtl() ? 'start': 'end';
 
   return {
     key: 'borders:right',

--- a/handsontable/src/plugins/customBorders/contextMenuItem/right.js
+++ b/handsontable/src/plugins/customBorders/contextMenuItem/right.js
@@ -6,11 +6,14 @@ import { checkSelectionBorders, markSelected } from '../utils';
  * @returns {object}
  */
 export default function right(customBordersPlugin) {
+  const isRtl = customBordersPlugin.hot.isRtl();
+  const borderDirection = isRtl ? customBordersPlugin.inlineStartProp : customBordersPlugin.inlineEndProp;
+
   return {
     key: 'borders:right',
     name() {
       let label = this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_BORDERS_RIGHT);
-      const hasBorder = checkSelectionBorders(this, 'right');
+      const hasBorder = checkSelectionBorders(this, borderDirection);
 
       if (hasBorder) {
         label = markSelected(label);
@@ -19,9 +22,9 @@ export default function right(customBordersPlugin) {
       return label;
     },
     callback(key, selected) {
-      const hasBorder = checkSelectionBorders(this, 'right');
+      const hasBorder = checkSelectionBorders(this, borderDirection);
 
-      customBordersPlugin.prepareBorder(selected, 'right', hasBorder);
+      customBordersPlugin.prepareBorder(selected, borderDirection, hasBorder);
     }
   };
 }

--- a/handsontable/src/plugins/customBorders/utils.js
+++ b/handsontable/src/plugins/customBorders/utils.js
@@ -50,41 +50,45 @@ export function createDefaultHtBorder() {
   };
 }
 
-export function createBorderNormalizer() {
-  function normalize(border) {
-    return Object.assign(
-      {
-        row: border.row,
-        col: border.col,
-      },
-      isDefined(border.id) ? { id: border.id } : {},
-      isDefined(border.border) ? { border: border.border } : {},
-      isDefined(border.top) ? { top: border.top } : {},
-      isDefined(border.bottom) ? { bottom: border.bottom } : {},
-      isDefined(border.start) || isDefined(border.left) ? { start: border.start ?? border.left } : {},
-      isDefined(border.end) || isDefined(border.right) ? { end: border.end ?? border.right } : {},
-    );
-  }
-
-  function denormalize(border) {
-    return Object.assign(
-      {
-        row: border.row,
-        col: border.col,
-      },
-      isDefined(border.id) ? { id: border.id } : {},
-      isDefined(border.border) ? { border: border.border } : {},
-      isDefined(border.top) ? { top: border.top } : {},
-      isDefined(border.bottom) ? { bottom: border.bottom } : {},
-      isDefined(border.start) ? { start: border.start, left: border.start } : {},
-      isDefined(border.end) ? { end: border.end, right: border.end } : {},
-    );
-  }
-
+/**
+ * Normalizes the border object to be compatible with the Border API from the Walkontable.
+ * The function translates the "left"/"right" properties to "start"/"end" prop names.
+ *
+ * @param {object} border The configuration object of the border.
+ * @returns {object}
+ */
+export function normalizeBorder(border) {
   return {
-    normalize,
-    denormalize,
-  }
+    row: border.row,
+    col: border.col,
+    ...(isDefined(border.id) ? { id: border.id } : null),
+    ...(isDefined(border.border) ? { border: border.border } : null),
+    ...(isDefined(border.top) ? { top: border.top } : null),
+    ...(isDefined(border.bottom) ? { bottom: border.bottom } : null),
+    ...(isDefined(border.start) || isDefined(border.left) ? { start: border.start ?? border.left } : null),
+    ...(isDefined(border.end) || isDefined(border.right) ? { end: border.end ?? border.right } : null),
+  };
+}
+
+/**
+ * Denormalizes the border object to be backward compatible with the previous version of the CustomBorders
+ * plugin API. The function extends the border configuration object for the backward compatible "left"/"right"
+ * properties.
+ *
+ * @param {object} border The configuration object of the border.
+ * @returns {object}
+ */
+export function denormalizeBorder(border) {
+  return {
+    row: border.row,
+    col: border.col,
+    ...(isDefined(border.id) ? { id: border.id } : {}),
+    ...(isDefined(border.border) ? { border: border.border } : {}),
+    ...(isDefined(border.top) ? { top: border.top } : {}),
+    ...(isDefined(border.bottom) ? { bottom: border.bottom } : {}),
+    ...(isDefined(border.start) ? { start: border.start, left: border.start } : {}),
+    ...(isDefined(border.end) ? { end: border.end, right: border.end } : {}),
+  };
 }
 
 /**

--- a/handsontable/src/plugins/customBorders/utils.js
+++ b/handsontable/src/plugins/customBorders/utils.js
@@ -58,16 +58,17 @@ export function createDefaultHtBorder() {
  * @returns {object}
  */
 export function normalizeBorder(border) {
-  return {
-    row: border.row,
-    col: border.col,
-    ...(isDefined(border.id) ? { id: border.id } : null),
-    ...(isDefined(border.border) ? { border: border.border } : null),
-    ...(isDefined(border.top) ? { top: border.top } : null),
-    ...(isDefined(border.bottom) ? { bottom: border.bottom } : null),
-    ...(isDefined(border.start) || isDefined(border.left) ? { start: border.start ?? border.left } : null),
-    ...(isDefined(border.end) || isDefined(border.right) ? { end: border.end ?? border.right } : null),
-  };
+  if (isDefined(border.start) || isDefined(border.left)) {
+    border.start = border.start ?? border.left;
+  }
+  if (isDefined(border.end) || isDefined(border.right)) {
+    border.end = border.end ?? border.right;
+  }
+
+  delete border.left;
+  delete border.right;
+
+  return border;
 }
 
 /**
@@ -79,16 +80,14 @@ export function normalizeBorder(border) {
  * @returns {object}
  */
 export function denormalizeBorder(border) {
-  return {
-    row: border.row,
-    col: border.col,
-    ...(isDefined(border.id) ? { id: border.id } : {}),
-    ...(isDefined(border.border) ? { border: border.border } : {}),
-    ...(isDefined(border.top) ? { top: border.top } : {}),
-    ...(isDefined(border.bottom) ? { bottom: border.bottom } : {}),
-    ...(isDefined(border.start) ? { start: border.start, left: border.start } : {}),
-    ...(isDefined(border.end) ? { end: border.end, right: border.end } : {}),
-  };
+  if (isDefined(border.start)) {
+    border.left = border.start;
+  }
+  if (isDefined(border.end)) {
+    border.right = border.end;
+  }
+
+  return border;
 }
 
 /**


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR implements the new API for objects that declares the borders styling. The _CustomBorders_ plugin allows changing the left and right borders using the "left"/"right" property names. That is confusing when the table is run in the RTL document mode.

The new API changes those names, so the `left` property becomes `start` and `right` becomes `end`. The `start` property depends on the document layout direction pointing to the left border in LTR and the right border in RTL.

The proposed changes are backward compatible. It simply means that after the library upgrades the developers do not have to change anything in their apps. The "left"/"right" properties will work as previously. With indication that it would only work in LTR document mode.

![image](https://user-images.githubusercontent.com/571316/151134029-1897efbd-58aa-41f0-a9ff-87386d9523b8.png)

### Backward compatible API
```js
new Handsontable(document.querySelector('#example'), {
  licenseKey: 'non-commercial-and-evaluation',
  data: Handsontable.helper.createSpreadsheetData(100, 100),
  rowHeaders: true,
  colHeaders: true,
  customBorders: [
    {
      row: 2,
      col: 2,
      left: { width: 4,  color: 'red' },
      right: { width: 8,  color: 'green' }
    },
  ],
});

hot.getCellMeta(2, 2).borders
// The "borders" meta contains the "left"/"right" (backward compatibility) 
// and "start"/"end" properties
//   {
//     left: {width: 4, color: 'red'}
//     right: {width: 8, color: 'green'}
//     start: {width: 4, color: 'red'}
//     end: {width: 8, color: 'green'}
//  }
```

### New API (in LTR mode)
```js
new Handsontable(document.querySelector('#example'), {
  licenseKey: 'non-commercial-and-evaluation',
  data: Handsontable.helper.createSpreadsheetData(100, 100),
  rowHeaders: true,
  colHeaders: true,
  customBorders: [
    {
      row: 2,
      col: 2,
      start: { width: 4,  color: 'red' },
      end: { width: 8,  color: 'green' }
    },
  ],
});

hot.getCellMeta(2, 2).borders
// The "borders" meta contains the "start"/"end" properties
// and "left"/"right" (for backward compatibility)
//   {
//     left: {width: 4, color: 'red'}
//     right: {width: 8, color: 'green'}
//     start: {width: 4, color: 'red'}
//     end: {width: 8, color: 'green'}
//  }
```

### New API (in RTL mode)
```js
new Handsontable(document.querySelector('#example'), {
  licenseKey: 'non-commercial-and-evaluation',
  data: Handsontable.helper.createSpreadsheetData(100, 100),
  rowHeaders: true,
  colHeaders: true,
  customBorders: [
    {
      row: 2,
      col: 2,
      start: { width: 4,  color: 'red' },
      end: { width: 8,  color: 'green' }
    },
  ],
});

hot.getCellMeta(2, 2).borders
// The "borders" meta contains only the "start"/"end" properties.
//   {
//     start: {width: 4, color: 'red'}
//     end: {width: 8, color: 'green'}
//  }
```

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and cover the feature (including backward support) with new E2E tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. resolves #9129
2.
3.

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
