### PR TITLE
Docs: Changing a Hello World link

### DIFF
--- a/docs/11.0/guides/getting-started/introduction.md
+++ b/docs/11.0/guides/getting-started/introduction.md
@@ -14,7 +14,7 @@ Welcome 👋&nbsp; to Handsontable's Guides. Here you will learn how Handsontabl
 ## Get started with sample apps
 
 <div class="row-items-container">
-    <a href="/docs/binding-to-data" class="row-item">
+    <a href="/docs/11.0/binding-to-data" class="row-item">
      <img class="integration-framework-logo" src="/docs/11.0/img/pages/introduction/javascript.svg" alt="JavaScript logo" />
      <h3>JavaScript</h3>
     </a>

--- a/docs/11.1/guides/getting-started/introduction.md
+++ b/docs/11.1/guides/getting-started/introduction.md
@@ -14,7 +14,7 @@ Welcome 👋&nbsp; to Handsontable's Guides. Here you will learn how Handsontabl
 ## Get started with sample apps
 
 <div class="row-items-container">
-    <a href="/docs/11.1/hello-world" class="row-item">
+    <a href="/docs/11.1/binding-to-data" class="row-item">
      <img class="integration-framework-logo" src="/docs/11.1/img/pages/introduction/javascript.svg" alt="JavaScript logo" />
      <h3>JavaScript</h3>
     </a>

--- a/docs/next/guides/getting-started/introduction.md
+++ b/docs/next/guides/getting-started/introduction.md
@@ -14,7 +14,7 @@ Welcome 👋&nbsp; to Handsontable's Guides. Here you will learn how Handsontabl
 ## Get started with sample apps
 
 <div class="row-items-container">
-    <a href="/docs/next/hello-world" class="row-item">
+    <a href="/docs/next/binding-to-data" class="row-item">
      <img class="integration-framework-logo" src="/docs/next/img/pages/introduction/javascript.svg" alt="JavaScript logo" />
      <h3>JavaScript</h3>
     </a>


### PR DESCRIPTION
This PR:
- Changes a Hello World link to point to the **Binding to data** demo instead (it'll be brought back in #8989)

Links tested on the [Staging](https://dev.handsontable.com/docs) environment.

[skip changelog]