### PR TITLE
Filter cells with formulas using values not source (#5455)

### DIFF
--- a/.changelogs/5455.json
+++ b/.changelogs/5455.json
@@ -2,6 +2,6 @@
   "title": "Filter cells with formulas using values not source",
   "type": "fixed",
   "issue": 5455,
-  "breaking": true,
+  "breaking": false,
   "framework": "none"
 }

--- a/.changelogs/5455.json
+++ b/.changelogs/5455.json
@@ -1,0 +1,7 @@
+{
+  "title": "Filter cells with formulas using values not source",
+  "type": "fixed",
+  "issue": 5455,
+  "breaking": true,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/filters/__tests__/filtersFormulas.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/filtersFormulas.spec.js
@@ -2,20 +2,6 @@ import HyperFormula from 'hyperformula';
 
 describe('Filters with formulas', () => {
   const id = 'testContainer';
-  const data = [
-    ['=SUM(B1:B2)', 1, '=A$1'],
-    ['=$B1', 2, '=SUM(A1:A2)'],
-  ];
-
-  beforeAll(() => {
-    // Note: please keep in mind that this language will be registered for all e2e tests!
-    // It's stored globally for already loaded Handsontable library.
-
-    Handsontable.languages.registerLanguageDictionary({
-      languageCode: 'longerForTests',
-      'Filters:conditions.isEmpty': 'This is very long text for conditional menu item'
-    });
-  });
 
   beforeEach(function() {
     this.$container = $(`<div id="${id}"></div>`).appendTo('body');
@@ -28,83 +14,175 @@ describe('Filters with formulas', () => {
     }
   });
 
-  it('should filter cell with relative formula in the first cell', async() => {
-    const hot = handsontable({
-      data,
-      columnHeaders: true,
-      filters: true,
-      formulas: {
-        engine: HyperFormula
-      },
-      dropdownMenu: true,
-      width: 500,
-      height: 300
+  describe('numeric cells', () => {
+    const data = [
+      ['=SUM(B1:B2)', 1, '=A$1'],
+      ['=$B1', 2, '=SUM(A1:A2)'],
+    ];
+
+    it('should filter cell with relative formula in the first cell', async() => {
+      const hot = handsontable({
+        data,
+        colHeaders: true,
+        filters: true,
+        formulas: {
+          engine: HyperFormula
+        },
+        width: 500,
+        height: 300
+      });
+      const plugin = hot.getPlugin('filters');
+
+      plugin.addCondition(0, 'eq', ['3']);
+      plugin.filter();
+
+      expect(getData()[0][0]).toBe(3);
     });
-    const plugin = hot.getPlugin('filters');
 
-    plugin.addCondition(0, 'eq', ['3']);
-    plugin.filter();
+    it('should filter cell with absolute formula in the first cell', async() => {
+      const hot = handsontable({
+        data,
+        columnHeaders: true,
+        filters: true,
+        formulas: {
+          engine: HyperFormula
+        },
+        dropdownMenu: true,
+        width: 500,
+        height: 300
+      });
+      const plugin = hot.getPlugin('filters');
 
-    expect(getData()[0][0]).toBe(3);
+      plugin.addCondition(1, 'eq', ['1']);
+      plugin.filter();
+
+      expect(getData()[0][0]).toBe(3);
+    });
+
+    it('should filter cell with absolute formula in the cell', async() => {
+      const hot = handsontable({
+        data,
+        columnHeaders: true,
+        filters: true,
+        formulas: {
+          engine: HyperFormula
+        },
+        dropdownMenu: true,
+        width: 500,
+        height: 300
+      });
+      const plugin = hot.getPlugin('filters');
+
+      plugin.addCondition(2, 'eq', ['3']);
+      plugin.filter();
+
+      expect(getData()[0][2]).toBe(3);
+    });
+
+    it('should filter cell with relative formula in the cell', async() => {
+      const hot = handsontable({
+        data,
+        columnHeaders: true,
+        filters: true,
+        formulas: {
+          engine: HyperFormula
+        },
+        dropdownMenu: true,
+        width: 500,
+        height: 300
+      });
+      const plugin = hot.getPlugin('filters');
+
+      plugin.addCondition(2, 'eq', ['4']);
+      plugin.filter();
+
+      expect(getData()[0][2]).toBe(4);
+    });
   });
 
-  it('should filter cell with absolute formula in the first cell', async() => {
-    const hot = handsontable({
-      data,
-      columnHeaders: true,
-      filters: true,
-      formulas: {
-        engine: HyperFormula
-      },
-      dropdownMenu: true,
-      width: 500,
-      height: 300
+  describe('text cells', () => {
+    const data = [
+      ['=B1&B2', 'foo', '=A$1'],
+      ['=$B1', 'bar', '=A1&A2'],
+    ];
+
+    it('should filter cell with relative formula in the first cell', async() => {
+      const hot = handsontable({
+        data,
+        colHeaders: true,
+        filters: true,
+        formulas: {
+          engine: HyperFormula
+        },
+        width: 500,
+        height: 300
+      });
+      const plugin = hot.getPlugin('filters');
+
+      plugin.addCondition(0, 'by_value', [['foobar']]);
+      plugin.filter();
+
+      expect(getData()[0][0]).toBe('foobar');
     });
-    const plugin = hot.getPlugin('filters');
 
-    plugin.addCondition(1, 'eq', ['1']);
-    plugin.filter();
+    it('should filter cell with absolute formula in the first cell', async() => {
+      const hot = handsontable({
+        data,
+        columnHeaders: true,
+        filters: true,
+        formulas: {
+          engine: HyperFormula
+        },
+        dropdownMenu: true,
+        width: 500,
+        height: 300
+      });
+      const plugin = hot.getPlugin('filters');
 
-    expect(getData()[0][0]).toBe(3);
-  });
+      plugin.addCondition(1, 'by_value', [['foo']]);
+      plugin.filter();
 
-  it('should filter cell with absolute formula in the cell', async() => {
-    const hot = handsontable({
-      data,
-      columnHeaders: true,
-      filters: true,
-      formulas: {
-        engine: HyperFormula
-      },
-      dropdownMenu: true,
-      width: 500,
-      height: 300
+      expect(getData()[0][0]).toBe('foobar');
     });
-    const plugin = hot.getPlugin('filters');
 
-    plugin.addCondition(2, 'eq', ['3']);
-    plugin.filter();
+    it('should filter cell with absolute formula in the cell', async() => {
+      const hot = handsontable({
+        data,
+        columnHeaders: true,
+        filters: true,
+        formulas: {
+          engine: HyperFormula
+        },
+        dropdownMenu: true,
+        width: 500,
+        height: 300
+      });
+      const plugin = hot.getPlugin('filters');
 
-    expect(getData()[0][2]).toBe(3);
-  });
+      plugin.addCondition(2, 'by_value', [['foobar']]);
+      plugin.filter();
 
-  it('should filter cell with relative formula in the cell', async() => {
-    const hot = handsontable({
-      data,
-      columnHeaders: true,
-      filters: true,
-      formulas: {
-        engine: HyperFormula
-      },
-      dropdownMenu: true,
-      width: 500,
-      height: 300
+      expect(getData()[0][2]).toBe('foobar');
     });
-    const plugin = hot.getPlugin('filters');
 
-    plugin.addCondition(2, 'eq', ['4']);
-    plugin.filter();
+    it('should filter cell with relative formula in the cell', async() => {
+      const hot = handsontable({
+        data,
+        columnHeaders: true,
+        filters: true,
+        formulas: {
+          engine: HyperFormula
+        },
+        dropdownMenu: true,
+        width: 500,
+        height: 300
+      });
+      const plugin = hot.getPlugin('filters');
 
-    expect(getData()[0][2]).toBe(4);
+      plugin.addCondition(2, 'by_value', [['foobarfoo']]);
+      plugin.filter();
+
+      expect(getData()[0][2]).toBe('foobarfoo');
+    });
   });
 });

--- a/handsontable/src/plugins/filters/__tests__/filtersFormulas.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/filtersFormulas.spec.js
@@ -1,0 +1,110 @@
+import HyperFormula from 'hyperformula';
+
+describe('Filters with formulas', () => {
+  const id = 'testContainer';
+  const data = [
+    ['=SUM(B1:B2)', 1, '=A$1'],
+    ['=$B1', 2, '=SUM(A1:A2)'],
+  ];
+
+  beforeAll(() => {
+    // Note: please keep in mind that this language will be registered for all e2e tests!
+    // It's stored globally for already loaded Handsontable library.
+
+    Handsontable.languages.registerLanguageDictionary({
+      languageCode: 'longerForTests',
+      'Filters:conditions.isEmpty': 'This is very long text for conditional menu item'
+    });
+  });
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should filter cell with relative formula in the first cell', async() => {
+    const hot = handsontable({
+      data,
+      columnHeaders: true,
+      filters: true,
+      formulas: {
+        engine: HyperFormula
+      },
+      dropdownMenu: true,
+      width: 500,
+      height: 300
+    });
+    const plugin = hot.getPlugin('filters');
+
+    plugin.addCondition(0, 'eq', ['3']);
+    plugin.filter();
+
+    expect(getData()[0][0]).toBe(3);
+  });
+
+  it('should filter cell with absolute formula in the first cell', async() => {
+    const hot = handsontable({
+      data,
+      columnHeaders: true,
+      filters: true,
+      formulas: {
+        engine: HyperFormula
+      },
+      dropdownMenu: true,
+      width: 500,
+      height: 300
+    });
+    const plugin = hot.getPlugin('filters');
+
+    plugin.addCondition(1, 'eq', ['1']);
+    plugin.filter();
+
+    expect(getData()[0][0]).toBe(3);
+  });
+
+  it('should filter cell with absolute formula in the cell', async() => {
+    const hot = handsontable({
+      data,
+      columnHeaders: true,
+      filters: true,
+      formulas: {
+        engine: HyperFormula
+      },
+      dropdownMenu: true,
+      width: 500,
+      height: 300
+    });
+    const plugin = hot.getPlugin('filters');
+
+    plugin.addCondition(2, 'eq', ['3']);
+    plugin.filter();
+
+    expect(getData()[0][2]).toBe(3);
+  });
+
+  it('should filter cell with relative formula in the cell', async() => {
+    const hot = handsontable({
+      data,
+      columnHeaders: true,
+      filters: true,
+      formulas: {
+        engine: HyperFormula
+      },
+      dropdownMenu: true,
+      width: 500,
+      height: 300
+    });
+    const plugin = hot.getPlugin('filters');
+
+    plugin.addCondition(2, 'eq', ['4']);
+    plugin.filter();
+
+    expect(getData()[0][2]).toBe(4);
+  });
+});

--- a/handsontable/src/plugins/filters/filters.js
+++ b/handsontable/src/plugins/filters/filters.js
@@ -465,7 +465,7 @@ export class Filters extends BasePlugin {
     arrayEach(this.hot.getSourceDataAtCol(visualColumn), (value, rowIndex) => {
       const { row, col, visualCol, visualRow, type, instance, dateFormat, locale } = this.hot
         .getCellMeta(rowIndex, visualColumn);
-      const dataValue = this.hot.getDataAtCell((this.hot.toVisualRow(rowIndex)), visualColumn) || value;
+      const dataValue = this.hot.getDataAtCell(this.hot.toVisualRow(rowIndex), visualColumn) ?? value;
 
       data.push({
         meta: { row, col, visualCol, visualRow, type, instance, dateFormat, locale },

--- a/handsontable/src/plugins/filters/filters.js
+++ b/handsontable/src/plugins/filters/filters.js
@@ -459,16 +459,17 @@ export class Filters extends BasePlugin {
    * @returns {Array} Returns array of objects where keys as row index.
    */
   getDataMapAtColumn(column) {
-    const visualIndex = this.hot.toVisualColumn(column);
+    const visualColumn = this.hot.toVisualColumn(column);
     const data = [];
 
-    arrayEach(this.hot.getSourceDataAtCol(visualIndex), (value, rowIndex) => {
+    arrayEach(this.hot.getSourceDataAtCol(visualColumn), (value, rowIndex) => {
       const { row, col, visualCol, visualRow, type, instance, dateFormat, locale } = this.hot
-        .getCellMeta(rowIndex, visualIndex);
+        .getCellMeta(rowIndex, visualColumn);
+      const dataValue = this.hot.getDataAtCell((this.hot.toVisualRow(rowIndex)), visualColumn) || value;
 
       data.push({
         meta: { row, col, visualCol, visualRow, type, instance, dateFormat, locale },
-        value: toEmptyString(value),
+        value: toEmptyString(dataValue),
       });
     });
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
This change is providing value of formula cell for filters instead of it's source value (formula itself). 

For example having 4 rows with numbers + formula, like: `[1, 2, 3, '=2+2']` and using any numeric filter previously would always filter out the formula cell as it'd got a string `'=2+2'` and after fix it'll get correct number value of `4`. 

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Added new tests specs for filters plugin with some formulas cells. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/5455

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
