### PR TITLE
Fix building of the docs on Windows

### DIFF
--- a/.changelogs/8677.json
+++ b/.changelogs/8677.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fixed not working docs building script on Windows",
+  "type": "fixed",
+  "issue": 8677,
+  "breaking": false,
+  "framework": "none"
+}

--- a/docs/.vuepress/docs-links.js
+++ b/docs/.vuepress/docs-links.js
@@ -2,7 +2,8 @@ const { fs, path, parseFrontmatter } = require('@vuepress/shared-utils');
 const helpers = require('./helpers');
 
 module.exports = function(src) {
-  const version = this.resourcePath.split('/docs/').pop().split('/')[0];
+  const resourcePathNormalized = path.sep === '\\' ? this.resourcePath.replace(/\\/g, '/') : this.resourcePath;
+  const version = resourcePathNormalized.split('/docs/').pop().split('/')[0];
   const latest = helpers.getLatestVersion();
   const basePath = this.rootContext;
 


### PR DESCRIPTION
The fix introduces path separator awareness to the `docs-links.js` script. Without this fix, building failed with errors like:

```
Can't find the "@/api/indexMapper.md" permalink. Does this file exist?
```

```
Error while processing resourcePath "C:\Users\warpe\www\handsontable\docs\10.0\api\core.md"
```

As explained in the issue #8677

### Context
<!--- Why is this change required? What problem does it solve? -->

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. Fixes #8677 
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
