### PR TITLE
[RTL] Fix manual column freezing

### DIFF
--- a/handsontable/src/plugins/manualColumnFreeze/__tests__/manualColumnFreeze.spec.js
+++ b/handsontable/src/plugins/manualColumnFreeze/__tests__/manualColumnFreeze.spec.js
@@ -13,6 +13,19 @@ describe('manualColumnFreeze', () => {
   });
 
   describe('freezeColumn', () => {
+    it('should not throw an exception when the "fixedColumnsLeft" option is used', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(10, 10),
+        fixedColumnsLeft: 2,
+        manualColumnFreeze: true
+      });
+      const plugin = getPlugin('manualColumnFreeze');
+
+      expect(() => {
+        plugin.freezeColumn(4);
+      }).not.toThrowError();
+    });
+
     it('should increase fixedColumnsStart setting', () => {
       const hot = handsontable({
         data: Handsontable.helper.createSpreadsheetData(10, 10),
@@ -53,6 +66,19 @@ describe('manualColumnFreeze', () => {
   });
 
   describe('unfreezeColumn', () => {
+    it('should not throw an exception when the "fixedColumnsLeft" option is used', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(10, 10),
+        fixedColumnsLeft: 2,
+        manualColumnFreeze: true
+      });
+      const plugin = getPlugin('manualColumnFreeze');
+
+      expect(() => {
+        plugin.unfreezeColumn(0);
+      }).not.toThrowError();
+    });
+
     it('should decrease fixedColumnsStart setting', () => {
       const hot = handsontable({
         data: Handsontable.helper.createSpreadsheetData(10, 10),

--- a/handsontable/src/plugins/manualColumnFreeze/manualColumnFreeze.js
+++ b/handsontable/src/plugins/manualColumnFreeze/manualColumnFreeze.js
@@ -106,7 +106,11 @@ export class ManualColumnFreeze extends BasePlugin {
 
     this.hot.columnIndexMapper.moveIndexes(column, settings.fixedColumnsStart);
 
-    settings.fixedColumnsStart += 1;
+    // Since 12.0.0, the "fixedColumnsLeft" is replaced with the "fixedColumnsStart" option.
+    // However, keeping the old name still in effect. When both option names are used together,
+    // the error is thrown. To prevent that, the plugin needs to modify the original option key
+    // to bypass the validation.
+    settings._fixedColumnsStart += 1;
   }
 
   /**
@@ -126,7 +130,11 @@ export class ManualColumnFreeze extends BasePlugin {
       return; // not fixed
     }
 
-    settings.fixedColumnsStart -= 1;
+    // Since 12.0.0, the "fixedColumnsLeft" is replaced with the "fixedColumnsStart" option.
+    // However, keeping the old name still in effect. When both option names are used together,
+    // the error is thrown. To prevent that, the plugin needs to modify the original option key
+    // to bypass the validation.
+    settings._fixedColumnsStart -= 1;
 
     this.hot.columnIndexMapper.moveIndexes(column, settings.fixedColumnsStart);
   }


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes an error where the plugin throws an error when the column is frozen or unfrozen. The error only occurs when the `fixedColumnsLeft` option is used together with `manualColumnFreeze`.

Configuration to test:
```js
new Handsontable(document.querySelector('#example'), {
  data: Handsontable.helper.createSpreadsheetData(100, 25),
  fixedColumnsLeft: 2,
  rowHeaders: true,
  colHeaders: true,
  contextMenu: true,
  manualColumnFreeze: true,
});
```

The issue:
![Kapture 2022-01-28 at 11 43 45](https://user-images.githubusercontent.com/571316/151533326-19888ac1-984e-46c8-859e-c44ce37545b4.gif)

The issue can be also reproduced by calling the API e.g. `hot.getPlugin('manualColumnFreeze').freezeColumn(5)`.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and cover the fix with new tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. resolves #8832 

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
