### PR TITLE
Show forking instructions in the example's README

### DIFF
--- a/examples/next/docs/angular/demo/README.md
+++ b/examples/next/docs/angular/demo/README.md
@@ -4,11 +4,7 @@
 
 This is a general purpose demo that showcases the most popular features of Handsontable in Angular.
 
-## Live preview
-
-You can preview this template on CodeSandbox  under the URL: https://githubbox.com/handsontable/handsontable/tree/master/{{ PATH TO THE EXAMPLE }}
-
-## How to run this project
+## How to run this example
 
 ### Installation
 
@@ -21,6 +17,30 @@ To start local development server call `npm run start`. Now you can visit http:/
 ### Testing
 
 In order to run tests for this project call `npm run start` which will launch the development server and after the server is running, call `npm run test` to run test specs.
+
+### Forking
+
+This example is one of the projects in a [large monorepo](https://github.com/handsontable/handsontable/). If you want to modify it, you can fork the entire monorepo on GitHub. 
+
+But for some use cases, it will be desired to copy only one specific example into a new repository. To do it, simply extract this folder alone. You can do that by running all of the commands listed below while being in the folder of the example:
+
+```bash
+# verify that you are in the folder of the example by checking that the README.md file is the one that you are reading right now
+cat README.md
+# if it exists, delete the "node_modules" folder of the example, because our NPM workspace sets it up as a symlink in the monorepo (which will not be useful in your fork)
+rm -rf node_modules
+# copy the example into a new folder called "forked-example" that is a sibling folder of the monorepo
+cp -r . ../../../../../../forked-example
+# go to your fork
+cd ../../../../../../forked-example
+# if you want, initiate a new Git repository there
+git init
+git add .
+git commit -m "initial commit in my fork of the Handsontable example"
+# install dependencies and start the example
+npm install
+npm run start
+```
 
 ## License
 


### PR DESCRIPTION
This PR is my attempt of implementing the point:

   3. Make these examples runnable by anyone who knows how to clone a git repo by writing actionable README.md files for every example.

from https://github.com/handsontable/handsontable/issues/8980.

Now looking at it, I am not sure if the forking information that I wrote here is that useful. @kirszenbaum, @AMBudnik WDYT? This will be displayed to anyone who hits the "Show source" button on the Demo page.

### Context
<!--- Why is this change required? What problem does it solve? -->

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/8980
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
