### PR TITLE
Missing basePlugin types (#9175)

### DIFF
--- a/.changelogs/9175.json
+++ b/.changelogs/9175.json
@@ -1,0 +1,7 @@
+{
+  "title": "Wrong TypeScript definition in the BasePlugin class",
+  "type": "fixed",
+  "issue": 9175,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/base/__tests__/base.types.ts
+++ b/handsontable/src/plugins/base/__tests__/base.types.ts
@@ -8,12 +8,13 @@ const pluginKey: string = BasePlugin.PLUGIN_KEY;
 const settingKeys: string[] | boolean = BasePlugin.SETTING_KEYS;
 
 const basePlugin = new BasePlugin(hot);
+const hotPlugin: Handsontable = basePlugin.hot;
 
 basePlugin.init();
 basePlugin.enablePlugin();
 basePlugin.disablePlugin();
-basePlugin.addHook('name', () => {});
-basePlugin.removeHooks('name');
+basePlugin.addHook('beforeKeyDown', (event: any) => false);
+basePlugin.removeHooks('beforeKeyDown');
 basePlugin.clearHooks();
 basePlugin.callOnPluginsReady(() => {});
 basePlugin.destroy();

--- a/handsontable/types/plugins/base/base.d.ts
+++ b/handsontable/types/plugins/base/base.d.ts
@@ -1,6 +1,9 @@
 import Core from '../../core';
+import { Events } from '../../pluginHooks';
 
 export class BasePlugin {
+  readonly hot: Core;
+
   constructor(hotInstance: Core);
 
   static get PLUGIN_KEY(): string;
@@ -16,8 +19,8 @@ export class BasePlugin {
   enablePlugin(): void;
   disablePlugin(): void;
   updatePlugin(): void;
-  addHook(name: string, callback: () => void): void;
-  removeHooks(name: string): void;
+  addHook<K extends keyof Events>(key: K, callback: Events[K] | Array<Events[K]>): void;
+  removeHooks(name: keyof Events): void;
   clearHooks(): void;
   callOnPluginsReady(callback: () => void): void;
   destroy(): void;


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Some properties were missing from the typescript definition of the BasePlugin class 

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Tested manually typescript definitions 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/9175

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
