### PR TITLE
[RTL] Fix "Insert on left/right" context menu commands

### DIFF
--- a/handsontable/src/plugins/contextMenu/__tests__/predefinedItems/rtl/insertColumnLeft.spec.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/predefinedItems/rtl/insertColumnLeft.spec.js
@@ -1,0 +1,135 @@
+describe('ContextMenu (RTL mode)', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    $('html').attr('dir', 'rtl');
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    $('html').attr('dir', 'ltr');
+
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  describe('insert column left', () => {
+    it('should insert column on the left of the clicked column header', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(-1, 1, true));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(2); // "Insert column left"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(false);
+      expect(getDataAtRow(0)).toEqual(['A1', 'B1', null, 'C1', 'D1', 'E1']);
+      expect(`
+        |   ║   : * :   :   :   :   |
+        |===:===:===:===:===:===:===|
+        | - ║   : A :   :   :   :   |
+        | - ║   : 0 :   :   :   :   |
+        | - ║   : 0 :   :   :   :   |
+        | - ║   : 0 :   :   :   :   |
+        | - ║   : 0 :   :   :   :   |
+        `).toBeMatchToSelectionPattern();
+    });
+
+    it('should insert column on the left when the menu is triggered by corner', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(-1, -1, true));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(2); // "Insert column left"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(false);
+      expect(getDataAtRow(0)).toEqual(['A1', 'B1', 'C1', 'D1', 'E1', null]);
+      expect(`
+        |   ║ * : * : * : * : * : * |
+        |===:===:===:===:===:===:===|
+        | * ║ A : 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
+        `).toBeMatchToSelectionPattern();
+    });
+
+    it('should insert column on the left when the menu is triggered by corner and all rows are trimmed', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: [1, 2, 3, 4, 5],
+        rowHeaders: true,
+        contextMenu: true,
+        trimRows: [0, 1, 2, 3, 4],
+      });
+
+      contextMenu(getCell(-1, -1, true));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(2); // "Insert column left"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(false);
+      expect(getColHeader()).toEqual([1, 2, 3, 4, 5, 'F']);
+      expect(`
+        |   ║ - : - : - : - : - : - |
+        |===:===:===:===:===:===:===|
+        `).toBeMatchToSelectionPattern();
+    });
+
+    it('should insert column on the left of the clicked cell', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(1, 1));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(2); // "Insert column left"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(false);
+      expect(getDataAtRow(0)).toEqual(['A1', 'B1', null, 'C1', 'D1', 'E1']);
+      expect(`
+        |   ║   : - :   :   :   :   |
+        |===:===:===:===:===:===:===|
+        |   ║   :   :   :   :   :   |
+        | - ║   : # :   :   :   :   |
+        |   ║   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   |
+        `).toBeMatchToSelectionPattern();
+    });
+  });
+});

--- a/handsontable/src/plugins/contextMenu/__tests__/predefinedItems/rtl/insertColumnRight.spec.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/predefinedItems/rtl/insertColumnRight.spec.js
@@ -1,0 +1,190 @@
+describe('ContextMenu (RTL mode)', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    $('html').attr('dir', 'rtl');
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    $('html').attr('dir', 'ltr');
+
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  describe('insert column right', () => {
+    it('should insert column on the right of the clicked column header', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(-1, 1, true));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(3); // "Insert column right"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(false);
+      expect(getDataAtRow(0)).toEqual(['A1', null, 'B1', 'C1', 'D1', 'E1']);
+      expect(`
+        |   ║   :   : * :   :   :   |
+        |===:===:===:===:===:===:===|
+        | - ║   :   : A :   :   :   |
+        | - ║   :   : 0 :   :   :   |
+        | - ║   :   : 0 :   :   :   |
+        | - ║   :   : 0 :   :   :   |
+        | - ║   :   : 0 :   :   :   |
+        `).toBeMatchToSelectionPattern();
+    });
+
+    it('should insert column on the right when the menu is triggered by corner', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(-1, -1, true));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(3); // "Insert column right"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(false);
+      expect(getDataAtRow(0)).toEqual([null, 'A1', 'B1', 'C1', 'D1', 'E1']);
+      expect(`
+        |   ║ * : * : * : * : * : * |
+        |===:===:===:===:===:===:===|
+        | * ║ A : 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 : 0 |
+        `).toBeMatchToSelectionPattern();
+    });
+
+    it('should insert column on the right when the menu is triggered by corner and all rows are trimmed', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: [1, 2, 3, 4, 5],
+        rowHeaders: true,
+        contextMenu: true,
+        trimRows: [0, 1, 2, 3, 4],
+      });
+
+      contextMenu(getCell(-1, -1, true));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(3); // "Insert column right"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(false);
+      expect(getColHeader()).toEqual(['A', 1, 2, 3, 4, 5]);
+      expect(`
+        |   ║ - : - : - : - : - : - |
+        |===:===:===:===:===:===:===|
+        `).toBeMatchToSelectionPattern();
+    });
+
+    it('should insert column on the right when the menu is triggered by corner and all columns are trimmed', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 0),
+        dataSchema: [], // Unlocks adding new rows through the context menu.
+        colHeaders: true,
+        rowHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(-1, -1, true));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(3); // "Insert column right"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(false);
+      expect(`
+        |   ║ * |
+        |===:===|
+        | * ║ A |
+        | * ║ 0 |
+        | * ║ 0 |
+        | * ║ 0 |
+        | * ║ 0 |
+        `).toBeMatchToSelectionPattern();
+    });
+
+    it('should insert column on the right when the menu is triggered by corner and dataset is empty', () => {
+      handsontable({
+        data: createSpreadsheetData(0, 0),
+        dataSchema: [], // Unlocks adding new rows through the context menu.
+        colHeaders: true,
+        rowHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(-1, -1, true));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(3); // "Insert column right"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(false);
+      expect(`
+        |   ║ - |
+        |===:===|
+        `).toBeMatchToSelectionPattern();
+    });
+
+    it('should insert column on the right of the clicked cell', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        contextMenu: true,
+      });
+
+      contextMenu(getCell(1, 1));
+
+      const item = $('.htContextMenu .ht_master .htCore tbody')
+        .find('td')
+        .not('.htSeparator')
+        .eq(3); // "Insert column right"
+
+      simulateClick(item);
+
+      expect(item.hasClass('htDisabled')).toBe(false);
+      expect(getDataAtRow(0)).toEqual(['A1', null, 'B1', 'C1', 'D1', 'E1']);
+      expect(`
+        |   ║   :   : - :   :   :   |
+        |===:===:===:===:===:===:===|
+        |   ║   :   :   :   :   :   |
+        | - ║   :   : # :   :   :   |
+        |   ║   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   |
+        |   ║   :   :   :   :   :   |
+        `).toBeMatchToSelectionPattern();
+    });
+  });
+});

--- a/handsontable/src/plugins/contextMenu/predefinedItems/columnLeft.js
+++ b/handsontable/src/plugins/contextMenu/predefinedItems/columnLeft.js
@@ -1,4 +1,5 @@
 import { getValidSelection } from '../utils';
+import { isDefined } from '../../../helpers/mixed';
 import * as C from '../../../i18n/constants';
 
 export const KEY = 'col_left';
@@ -12,14 +13,19 @@ export default function columnLeftItem() {
     name() {
       return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_INSERT_LEFT);
     },
-    callback(key, normalizedSelection) {
+    callback() {
       const isSelectedByCorner = this.selection.isSelectedByCorner();
-      let columnLeft = 0;
+      let columnLeft = this.isRtl() ? this.countCols() : 0;
 
       if (!isSelectedByCorner) {
-        const latestSelection = normalizedSelection[Math.max(normalizedSelection.length - 1, 0)];
+        const selectedRange = this.getSelectedRangeLast();
 
-        columnLeft = latestSelection.start.col;
+        // If there is no selection we have clicked on the corner and there is no data.
+        if (isDefined(selectedRange)) {
+          const { col } = selectedRange.getTopLeftCorner();
+
+          columnLeft = this.isRtl() ? col + 1 : col;
+        }
       }
 
       this.alter('insert_col', columnLeft, 1, 'ContextMenu.columnLeft');

--- a/handsontable/src/plugins/contextMenu/predefinedItems/columnRight.js
+++ b/handsontable/src/plugins/contextMenu/predefinedItems/columnRight.js
@@ -13,19 +13,19 @@ export default function columnRightItem() {
     name() {
       return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_INSERT_RIGHT);
     },
-    callback(key, normalizedSelection) {
+    callback() {
       const isSelectedByCorner = this.selection.isSelectedByCorner();
-      let columnRight = 0;
+      let columnRight = this.isRtl() ? 0 : this.countCols();
 
-      if (isSelectedByCorner) {
-        columnRight = this.countCols();
-
-      } else {
-        const latestSelection = normalizedSelection[Math.max(normalizedSelection.length - 1, 0)];
-        const selectedColumn = latestSelection?.end?.col;
+      if (!isSelectedByCorner) {
+        const selectedRange = this.getSelectedRangeLast();
 
         // If there is no selection we have clicked on the corner and there is no data.
-        columnRight = isDefined(selectedColumn) ? selectedColumn + 1 : 0;
+        if (isDefined(selectedRange)) {
+          const { col } = selectedRange.getTopRightCorner();
+
+          columnRight = this.isRtl() ? col : col + 1;
+        }
       }
 
       this.alter('insert_col', columnRight, 1, 'ContextMenu.columnRight');


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the _ContextMenu_ "Insert on left/right" commands that in RTL worked in the opposite way.

After the changes it works as expected:
![Kapture 2022-02-04 at 09 24 52](https://user-images.githubusercontent.com/571316/152495972-2e6a330d-7875-4f35-9a1c-e3703f1daf36.gif)

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and covered the fix with new E2E tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. resolves #9178

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
