### PR TITLE
[RTL] Fix the positioning of the dropdownMenu header button

### DIFF
--- a/handsontable/src/plugins/dropdownMenu/__tests__/UI.spec.js
+++ b/handsontable/src/plugins/dropdownMenu/__tests__/UI.spec.js
@@ -1,0 +1,28 @@
+describe('DropdownMenu', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  describe('UI', () => {
+    it('should render the dropdown button on the right side of the header', () => {
+      handsontable({
+        dropdownMenu: true,
+        colHeaders: true,
+        height: 100
+      });
+
+      const dropdownButton = $(getCell(-1, 2));
+
+      expect(dropdownButton.find('.changeType').css('float')).toBe('right');
+    });
+  });
+});

--- a/handsontable/src/plugins/dropdownMenu/__tests__/rtl/UI.spec.js
+++ b/handsontable/src/plugins/dropdownMenu/__tests__/rtl/UI.spec.js
@@ -1,0 +1,31 @@
+describe('DropdownMenu (RTL mode)', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    $('html').attr('dir', 'rtl');
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    $('html').attr('dir', 'ltr');
+
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  describe('UI', () => {
+    it('should render the dropdown button on the left side of the header', () => {
+      handsontable({
+        dropdownMenu: true,
+        colHeaders: true,
+        height: 100
+      });
+
+      const dropdownButton = $(getCell(-1, 2));
+
+      expect(dropdownButton.find('.changeType').css('float')).toBe('left');
+    });
+  });
+});

--- a/handsontable/src/plugins/dropdownMenu/dropdownMenu.scss
+++ b/handsontable/src/plugins/dropdownMenu/dropdownMenu.scss
@@ -10,7 +10,7 @@
   line-height: 9px;
   padding: 2px;
   margin: 3px 1px 0 5px;
-  float: right;
+  float: inline-end;
 }
 .handsontable .changeType:before {
   content: '\25BC\ ';


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the positioning of the _DropdownMenu_ plugin's button.

LTR:
![image](https://user-images.githubusercontent.com/571316/152498390-e8305a6a-050b-4514-9a64-2e29cdba490e.png)

RTL:
![image](https://user-images.githubusercontent.com/571316/152498446-d24770b3-f30c-4e90-88cb-2854aea32ebb.png)

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the change locally and covered the fix with E2E tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. resolves #9186

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
