### PR TITLE
[RTL] Fix handler positioning for ManualRowResize plugin

### DIFF
--- a/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
+++ b/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
@@ -383,39 +383,6 @@ describe('manualRowResize', () => {
     expect(rowHeight(spec().$container, 0)).toEqual(defaultRowHeight + 2);
   });
 
-  it('should display the resize handle in the correct place after the table has been scrolled', async() => {
-    const hot = handsontable({
-      data: Handsontable.helper.createSpreadsheetData(20, 20),
-      rowHeaders: true,
-      manualRowResize: true,
-      height: 100,
-      width: 200
-    });
-
-    const mainHolder = hot.view.wt.wtTable.holder;
-    let $rowHeader = getLeftClone().find('tbody tr:eq(2) th:eq(0)');
-
-    $rowHeader.simulate('mouseover');
-
-    const $handle = spec().$container.find('.manualRowResizer');
-
-    $handle[0].style.background = 'red';
-
-    expect($rowHeader.offset().left).toBeCloseTo($handle.offset().left, 0);
-    expect($rowHeader.offset().top + $rowHeader.height() - 5).toBeCloseTo($handle.offset().top, 0);
-
-    $(mainHolder).scrollTop(200);
-    $(mainHolder).scroll();
-
-    await sleep(400);
-
-    $rowHeader = getLeftClone().find('tbody tr:eq(10) th:eq(0)');
-    $rowHeader.simulate('mouseover');
-
-    expect($rowHeader.offset().left).toBeCloseTo($handle.offset().left, 0);
-    expect($rowHeader.offset().top + $rowHeader.height() - 5).toBeCloseTo($handle.offset().top, 0);
-  });
-
   it('should autosize row after double click (when initial height is not defined)', async() => {
     handsontable({
       data: Handsontable.helper.createSpreadsheetData(3, 3),
@@ -861,6 +828,7 @@ describe('manualRowResize', () => {
 
       expect($handle.offset().top)
         .toBeCloseTo($headerTH.offset().top + $headerTH.outerHeight() - $handle.outerHeight() - 1, 0);
+      expect($handle.offset().left).toBeCloseTo($headerTH.offset().left, 0);
       expect($handle.width()).toBeCloseTo($headerTH.outerWidth(), 0);
     });
 
@@ -908,6 +876,39 @@ describe('manualRowResize', () => {
       // eslint-disable-next-line no-console
       expect(console.warn.calls.mostRecent().args)
         .toEqual(['The provided element is not a child of the bottom_left_corner overlay']);
+    });
+
+    it('should display the resize handle in the correct place after the table has been scrolled', async() => {
+      const hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(20, 20),
+        rowHeaders: true,
+        manualRowResize: true,
+        height: 100,
+        width: 200
+      });
+
+      const mainHolder = hot.view.wt.wtTable.holder;
+      let $rowHeader = getLeftClone().find('tbody tr:eq(2) th:eq(0)');
+
+      $rowHeader.simulate('mouseover');
+
+      const $handle = spec().$container.find('.manualRowResizer');
+
+      $handle[0].style.background = 'red';
+
+      expect($rowHeader.offset().left).toBeCloseTo($handle.offset().left, 0);
+      expect($rowHeader.offset().top + $rowHeader.height() - 5).toBeCloseTo($handle.offset().top, 0);
+
+      $(mainHolder).scrollTop(200);
+      $(mainHolder).scroll();
+
+      await sleep(400);
+
+      $rowHeader = getLeftClone().find('tbody tr:eq(10) th:eq(0)');
+      $rowHeader.simulate('mouseover');
+
+      expect($rowHeader.offset().left).toBeCloseTo($handle.offset().left, 0);
+      expect($rowHeader.offset().top + $rowHeader.height() - 5).toBeCloseTo($handle.offset().top, 0);
     });
   });
 

--- a/handsontable/src/plugins/manualRowResize/__tests__/rtl/manualRowResize.spec.js
+++ b/handsontable/src/plugins/manualRowResize/__tests__/rtl/manualRowResize.spec.js
@@ -1,0 +1,187 @@
+describe('manualRowResize (RTL mode)', () => {
+  const id = 'test';
+
+  beforeEach(function() {
+    $('html').attr('dir', 'rtl');
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    $('html').attr('dir', 'ltr');
+
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should resize (expanding and narrowing) selected rows', async() => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(10, 20),
+      rowHeaders: true,
+      manualRowResize: true
+    });
+
+    resizeRow(2, 60);
+    getLeftClone().find('tbody tr:eq(1) th:eq(0)').simulate('mouseover');
+
+    const $rowsHeaders = getLeftClone().find('tr th');
+
+    $rowsHeaders.eq(1).simulate('mousedown');
+    $rowsHeaders.eq(2).simulate('mouseover');
+    $rowsHeaders.eq(3).simulate('mouseover');
+    $rowsHeaders.eq(3).simulate('mousemove');
+    $rowsHeaders.eq(3).simulate('mouseup');
+
+    const $resizer = spec().$container.find('.manualRowResizer');
+    const resizerPosition = $resizer.position();
+
+    await sleep(600);
+
+    $resizer.simulate('mousedown', { clientY: resizerPosition.top });
+    $resizer.simulate('mousemove', { clientY: resizerPosition.top - $rowsHeaders.eq(3).height() + 80 });
+    $resizer.simulate('mouseup');
+
+    expect($rowsHeaders.eq(1).height()).toBe(80);
+    expect($rowsHeaders.eq(2).height()).toBe(80);
+    expect($rowsHeaders.eq(3).height()).toBe(80);
+
+    await sleep(1200);
+
+    $resizer.simulate('mousedown', { clientY: resizerPosition.top });
+    $resizer.simulate('mousemove', { clientY: resizerPosition.top - $rowsHeaders.eq(3).height() + 35 });
+    $resizer.simulate('mouseup');
+
+    expect($rowsHeaders.eq(1).height()).toBe(35);
+    expect($rowsHeaders.eq(2).height()).toBe(35);
+    expect($rowsHeaders.eq(3).height()).toBe(35);
+  });
+
+  describe('handle position in a table positioned using CSS\'s `transform`', () => {
+    it('should display the handles in the correct position, with holder as a scroll parent', async() => {
+      spec().$container.css('transform', 'translate(50px, 120px)');
+
+      const hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(20, 10),
+        colHeaders: true,
+        rowHeaders: true,
+        manualRowResize: true,
+        height: 400,
+        width: 200
+      });
+
+      const mainHolder = hot.view.wt.wtTable.holder;
+      let $rowHeader = getLeftClone().find('tr:eq(2) th:eq(0)');
+
+      $rowHeader.simulate('mouseover');
+
+      const $handle = spec().$container.find('.manualRowResizer');
+
+      expect($rowHeader.offset().top + $rowHeader.height() - 5).toBeCloseTo($handle.offset().top, 0);
+      expect($rowHeader.offset().left).toBeCloseTo($handle.offset().left, 0);
+
+      $(mainHolder).scrollTop(1); // we have to trigger innerBorderTop before we scroll to correct position
+      await sleep(100);
+      $(mainHolder).scrollTop(200);
+      await sleep(400);
+
+      $rowHeader = getLeftClone().find('tr:eq(13) th:eq(0)');
+      $rowHeader.simulate('mouseover');
+
+      expect($rowHeader.offset().top + $rowHeader.height() - 5).toBeCloseTo($handle.offset().top, 0);
+      expect($rowHeader.offset().left).toBeCloseTo($handle.offset().left, 0);
+    });
+
+    it('should display the handles in the correct position, with window as a scroll parent', async() => {
+      spec().$container.css('transform', 'translate(50px, 120px)');
+
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(80, 10),
+        colHeaders: true,
+        rowHeaders: true,
+        manualRowResize: true,
+      });
+
+      let $rowHeader = getLeftClone().find('tr:eq(2) th:eq(0)');
+
+      $rowHeader.simulate('mouseover');
+
+      const $handle = spec().$container.find('.manualRowResizer');
+
+      expect($rowHeader.offset().top + $rowHeader.height() - 5).toBeCloseTo($handle.offset().top, 0);
+      expect($rowHeader.offset().left).toBeCloseTo($handle.offset().left, 0);
+
+      $(window).scrollTop(600);
+
+      await sleep(400);
+
+      $rowHeader = getLeftClone().find('tr:eq(13) th:eq(0)');
+      $rowHeader.simulate('mouseover');
+
+      expect($rowHeader.offset().top + $rowHeader.height() - 5).toBeCloseTo($handle.offset().top, 0);
+      expect($rowHeader.offset().left).toBeCloseTo($handle.offset().left, 0);
+
+      $(window).scrollTop(0);
+    });
+  });
+
+  describe('handle and guide', () => {
+    it('should display the resize handle in the proper position and with a proper size', () => {
+      handsontable({
+        data: [
+          { id: 1, name: 'Ted', lastName: 'Right' },
+          { id: 2, name: 'Frank', lastName: 'Honest' },
+          { id: 3, name: 'Joan', lastName: 'Well' },
+          { id: 4, name: 'Sid', lastName: 'Strong' },
+          { id: 5, name: 'Jane', lastName: 'Neat' }
+        ],
+        rowHeaders: true,
+        manualRowResize: true
+      });
+
+      const $headerTH = getLeftClone().find('tbody tr:eq(1) th:eq(0)');
+
+      $headerTH.simulate('mouseover');
+
+      const $handle = $('.manualRowResizer');
+
+      expect($handle.offset().top)
+        .toBeCloseTo($headerTH.offset().top + $headerTH.outerHeight() - $handle.outerHeight() - 1, 0);
+      expect($handle.offset().left).toBeCloseTo($headerTH.offset().left, 0);
+      expect($handle.width()).toBeCloseTo($headerTH.outerWidth(), 0);
+    });
+
+    it('should display the resize handle in the correct place after the table has been scrolled', async() => {
+      const hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(20, 20),
+        rowHeaders: true,
+        manualRowResize: true,
+        height: 100,
+        width: 200
+      });
+
+      const mainHolder = hot.view.wt.wtTable.holder;
+      let $rowHeader = getLeftClone().find('tbody tr:eq(2) th:eq(0)');
+
+      $rowHeader.simulate('mouseover');
+
+      const $handle = spec().$container.find('.manualRowResizer');
+
+      $handle[0].style.background = 'red';
+
+      expect($rowHeader.offset().left).toBeCloseTo($handle.offset().left, 0);
+      expect($rowHeader.offset().top + $rowHeader.height() - 5).toBeCloseTo($handle.offset().top, 0);
+
+      $(mainHolder).scrollTop(200);
+      $(mainHolder).scroll();
+
+      await sleep(400);
+
+      $rowHeader = getLeftClone().find('tbody tr:eq(10) th:eq(0)');
+      $rowHeader.simulate('mouseover');
+
+      expect($rowHeader.offset().left).toBeCloseTo($handle.offset().left, 0);
+      expect($rowHeader.offset().top + $rowHeader.height() - 5).toBeCloseTo($handle.offset().top, 0);
+    });
+  });
+});

--- a/handsontable/src/plugins/manualRowResize/manualRowResize.js
+++ b/handsontable/src/plugins/manualRowResize/manualRowResize.js
@@ -73,6 +73,14 @@ export class ManualRowResize extends BasePlugin {
   }
 
   /**
+   * @private
+   * @returns {string}
+   */
+   get inlineDir() {
+    return this.hot.isRtl() ? 'right' : 'left';
+  }
+
+  /**
    * Checks if the plugin is enabled in the handsontable settings. This method is executed in {@link Hooks#beforeInit}
    * hook and if it returns `true` than the {@link ManualRowResize#enablePlugin} method is called.
    *
@@ -243,7 +251,7 @@ export class ManualRowResize extends BasePlugin {
     this.startHeight = parseInt(box.height, 10);
 
     this.handle.style.top = `${this.startOffset + this.startHeight}px`;
-    this.handle.style.left = `${relativeHeaderPosition.start}px`;
+    this.handle.style[this.inlineDir] = `${relativeHeaderPosition.start}px`;
 
     this.handle.style.width = `${headerWidth}px`;
     this.hot.rootElement.appendChild(this.handle);
@@ -265,14 +273,14 @@ export class ManualRowResize extends BasePlugin {
    */
   setupGuidePosition() {
     const handleWidth = parseInt(outerWidth(this.handle), 10);
-    const handleRightPosition = parseInt(this.handle.style.left, 10) + handleWidth;
+    const handleEndPosition = parseInt(this.handle.style[this.inlineDir], 10) + handleWidth;
     const maximumVisibleElementWidth = parseInt(this.hot.view.maximumVisibleElementWidth(0), 10);
 
     addClass(this.handle, 'active');
     addClass(this.guide, 'active');
 
     this.guide.style.top = this.handle.style.top;
-    this.guide.style.left = `${handleRightPosition}px`;
+    this.guide.style[this.inlineDir] = `${handleEndPosition}px`;
     this.guide.style.width = `${maximumVisibleElementWidth - handleWidth}px`;
     this.hot.rootElement.appendChild(this.guide);
   }

--- a/handsontable/src/plugins/manualRowResize/manualRowResize.js
+++ b/handsontable/src/plugins/manualRowResize/manualRowResize.js
@@ -76,7 +76,7 @@ export class ManualRowResize extends BasePlugin {
    * @private
    * @returns {string}
    */
-   get inlineDir() {
+  get inlineDir() {
     return this.hot.isRtl() ? 'right' : 'left';
   }
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the _ManualRowResize_ handler positioning in RTL.

LTR:
![Kapture 2022-02-04 at 10 07 29](https://user-images.githubusercontent.com/571316/152501987-526badf3-6526-4f92-9230-a2ca9e5957e8.gif)

RTL:
![Kapture 2022-02-04 at 10 08 04](https://user-images.githubusercontent.com/571316/152502079-48a1eb25-e694-4fa7-9878-0858460cb6ef.gif)

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and I covered the fix with new tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. resolves #9177

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
