### PR TITLE
[RTL] Add missing TS typing for `layoutDirection` option

### DIFF
--- a/handsontable/test/types/settings.types.ts
+++ b/handsontable/test/types/settings.types.ts
@@ -269,6 +269,7 @@ const allSettings: Required<Handsontable.GridSettings> = {
   isEmptyRow: (row) => row === 0,
   label: {property: 'name.last', position: 'after', value: oneOf('My label: ', () => 'My label')},
   language: 'foo',
+  layoutDirection: oneOf('rtl', 'ltr', 'inherit'),
   licenseKey: '',
   manualColumnFreeze: true,
   manualColumnMove: oneOf(true, [1, 4]),

--- a/handsontable/types/settings.d.ts
+++ b/handsontable/types/settings.d.ts
@@ -148,7 +148,7 @@ export interface GridSettings extends Events {
   isEmptyRow?: (this: Core, row: number) => boolean;
   label?: LabelOptions;
   language?: string;
-  layoutDirection? : 'ltr' | 'rtl' | 'inherit';
+  layoutDirection?: 'ltr' | 'rtl' | 'inherit';
   licenseKey?: string | 'non-commercial-and-evaluation';
   manualColumnFreeze?: boolean;
   manualColumnMove?: boolean | number[];

--- a/handsontable/types/settings.d.ts
+++ b/handsontable/types/settings.d.ts
@@ -148,6 +148,7 @@ export interface GridSettings extends Events {
   isEmptyRow?: (this: Core, row: number) => boolean;
   label?: LabelOptions;
   language?: string;
+  layoutDirection? : 'ltr' | 'rtl' | 'inherit';
   licenseKey?: string | 'non-commercial-and-evaluation';
   manualColumnFreeze?: boolean;
   manualColumnMove?: boolean | number[];


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adds missing TS typing for `layoutDirection` option.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I added the TS test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. resolves #9192

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)