### PR TITLE
[RTL] Fix layout direction for date picker

### DIFF
--- a/handsontable/src/editors/dateEditor/__tests__/dateEditor.spec.js
+++ b/handsontable/src/editors/dateEditor/__tests__/dateEditor.spec.js
@@ -357,25 +357,22 @@ describe('DateEditor', () => {
     expect(onCloseSpy).toHaveBeenCalled();
   });
 
-  it('should set isRTL option as `false` when it\'s opened in LTR mode', () => {
+  it('should render Pikaday within element that contains correct "dir" attribute value', () => {
     handsontable({
-      data: getDates(),
+      data: Handsontable.helper.createSpreadsheetData(5, 2),
       columns: [
-        {
-          type: 'date',
-          datePickerConfig: {
-            isRTL: true, // read only - shouldn't overwrite
-          }
-        }
+        { type: 'date' },
+        { type: 'date' }
       ]
     });
 
-    selectCell(0, 0);
+    selectCell(1, 1);
     keyDown('enter');
-    keyDown('esc');
 
+    const datePicker = getActiveEditor().datePicker;
     const config = getActiveEditor().$datePicker.config();
 
+    expect(datePicker.getAttribute('dir')).toBe('ltr');
     expect(config.isRTL).toBe(false);
   });
 

--- a/handsontable/src/editors/dateEditor/__tests__/rtl/dateEditor.spec.js
+++ b/handsontable/src/editors/dateEditor/__tests__/rtl/dateEditor.spec.js
@@ -15,16 +15,6 @@ describe('DateEditor (RTL mode)', () => {
     }
   });
 
-  function getDates() {
-    return [
-      ['01/14/2006'],
-      ['12/01/2008'],
-      ['11/19/2011'],
-      ['02/02/2004'],
-      ['07/24/2011']
-    ];
-  }
-
   it('should render an editable editor\'s element without messing with "dir" attribute', () => {
     handsontable({
       data: Handsontable.helper.createSpreadsheetData(2, 5),
@@ -38,26 +28,25 @@ describe('DateEditor (RTL mode)', () => {
     expect(editableElement.getAttribute('dir')).toBeNull();
   });
 
-  it('should set isRTL option as `true` when it\'s opened in RTL mode', () => {
+  it('should render Pikaday within element that contains correct "dir" attribute value', () => {
     handsontable({
-      data: getDates(),
+      data: Handsontable.helper.createSpreadsheetData(5, 2),
       columns: [
-        {
-          type: 'date',
-          datePickerConfig: {
-            isRTL: false, // read only - shouldn't overwrite
-          }
-        }
+        { type: 'date' },
+        { type: 'date' }
       ]
     });
 
-    selectCell(0, 0);
+    selectCell(1, 1);
     keyDown('enter');
-    keyDown('esc');
 
+    const datePicker = getActiveEditor().datePicker;
     const config = getActiveEditor().$datePicker.config();
 
-    expect(config.isRTL).toBe(true);
+    expect(datePicker.getAttribute('dir')).toBe('rtl');
+    // it's set as `false` in RTL due to https://github.com/Pikaday/Pikaday/issues/647 bug. The Pikaday layout
+    // direction mode is controlled by above "dir" attribute.
+    expect(config.isRTL).toBe(false);
   });
 
   it('should display Pikaday Calendar left-bottom of the selected cell', () => {

--- a/handsontable/src/editors/dateEditor/dateEditor.js
+++ b/handsontable/src/editors/dateEditor/dateEditor.js
@@ -61,6 +61,8 @@ export class DateEditor extends TextEditor {
     this.datePickerStyle.left = 0;
     this.datePickerStyle.zIndex = 9999;
 
+    this.datePicker.setAttribute('dir', this.hot.isRtl() ? 'rtl' : 'ltr');
+
     addClass(this.datePicker, 'htDatepickerHolder');
     this.hot.rootDocument.body.appendChild(this.datePicker);
 
@@ -239,7 +241,10 @@ export class DateEditor extends TextEditor {
     options.bound = false;
     options.format = options.format || this.defaultDateFormat;
     options.reposition = options.reposition || false;
-    options.isRTL = this.hot.isRtl();
+    // Set the RTL to `false`. Due to the https://github.com/Pikaday/Pikaday/issues/647 bug, the layout direction
+    // of the date picker is controlled by juggling the "dir" attribute of the root date picker element.
+    // See line @64 of this file.
+    options.isRTL = false;
     options.onSelect = (value) => {
       let dateStr = value;
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the date picker layout direction mode. So, thanks to the changes it's correctly rendered in RTL document mode.

LTR: 
![image](https://user-images.githubusercontent.com/571316/152519729-8d8c1f84-d3ce-42f0-8554-34fdaeb4ff8a.png)

RTL:
![image](https://user-images.githubusercontent.com/571316/152520006-e578e244-410a-4fc7-9446-da2f5ef46948.png)

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and I covered the fix with E2E tests. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. resolves #9195

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
