### PR TITLE
Fix Docs redirects for the deleted "Hello World" page in the older versions

### DIFF
--- a/docs/11.1/guides/getting-started/introduction.md
+++ b/docs/11.1/guides/getting-started/introduction.md
@@ -5,7 +5,7 @@ permalink: /11.1/
 canonicalUrl: /
 ---
 
-# Handsontable guides (revert me)
+# Handsontable guides
 
 [[toc]]
 

--- a/docs/11.1/guides/getting-started/introduction.md
+++ b/docs/11.1/guides/getting-started/introduction.md
@@ -5,7 +5,7 @@ permalink: /11.1/
 canonicalUrl: /
 ---
 
-# Handsontable guides
+# Handsontable guides (revert me)
 
 [[toc]]
 

--- a/docs/docker/redirects.conf
+++ b/docs/docker/redirects.conf
@@ -64,7 +64,8 @@ rewrite ^/((\d+\.\d+|next)/)?tutorial-performance-tips/?$ /docs/$1performance/ p
 rewrite ^/((\d+\.\d+|next)/)?tutorial-release-notes/?$ /docs/$1release-notes/ permanent;
 rewrite ^/((\d+\.\d+|next)/)?tutorial-migration-guide/?$ /docs/$1migration-from-7.4-to-8.0/ permanent;
 rewrite ^/((\d+\.\d+|next)/)?tutorial-known-limitations/?$ /docs/$1third-party-licenses/ permanent;
-rewrite ^/((\d+\.\d+|next)/)?hello-world/?$ /docs/$1demo/ permanent;
+rewrite ^/((11\.1|next)/)?hello-world/?$ /docs/$1demo/ permanent;
+rewrite ^/\d+\.\d+/hello-world/?$ /docs/ permanent;
 
 # --- demos ---
 rewrite ^/((\d+\.\d+|next)/)?demo-scrolling/?$ /docs/$1row-virtualization/ permanent;

--- a/docs/docker/redirects.conf
+++ b/docs/docker/redirects.conf
@@ -64,8 +64,9 @@ rewrite ^/((\d+\.\d+|next)/)?tutorial-performance-tips/?$ /docs/$1performance/ p
 rewrite ^/((\d+\.\d+|next)/)?tutorial-release-notes/?$ /docs/$1release-notes/ permanent;
 rewrite ^/((\d+\.\d+|next)/)?tutorial-migration-guide/?$ /docs/$1migration-from-7.4-to-8.0/ permanent;
 rewrite ^/((\d+\.\d+|next)/)?tutorial-known-limitations/?$ /docs/$1third-party-licenses/ permanent;
-rewrite ^/((11\.1|next)/)?hello-world/?$ /docs/$1demo/ permanent;
-rewrite ^/\d+\.\d+/hello-world/?$ /docs/ permanent;
+rewrite ^/hello-world/?$ /docs/demo/ permanent;
+rewrite ^/(11\.1|next)/hello-world/?$ /docs/$1/demo/ permanent;
+rewrite ^/(11\.0|10\.0|9\.0)/(hello-world|demo)/?$ /docs/$1/ permanent;
 
 # --- demos ---
 rewrite ^/((\d+\.\d+|next)/)?demo-scrolling/?$ /docs/$1row-virtualization/ permanent;


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->

This PR fixes incorrect redirects introduced in https://github.com/handsontable/handsontable/pull/8982

The "Hello World" page was deleted in all versions of the docs. Only in `11.1` and `next` there is a new page "Docs", to which the "Hello World" links should redirect.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
The regexp was tested in https://regex101.com/

The redirections were tested in the staging docs environment using a manually triggered workflow.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/pull/8982
2. https://github.com/handsontable/handsontable/issues/8980
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]