### PR TITLE
Fix the URL used in the Demo examples

### DIFF
--- a/docs/11.1/guides/getting-started/demo.md
+++ b/docs/11.1/guides/getting-started/demo.md
@@ -14,27 +14,27 @@ tags:
 
 Play around with Handsontable's source code, in your favorite framework.
 
-<BigExample preview="/examples/next/docs/js/demo/">
+<BigExample preview="/examples/11.1.0/docs/js/demo/">
   <BigExampleSource 
   label="JavaScript"
   icon="js"
-  target="/examples/next/docs/js/demo/"></BigExampleSource>
+  target="/examples/11.1.0/docs/js/demo/"></BigExampleSource>
   <BigExampleSource 
   label="TypeScript"
   icon="ts"
-  target="/examples/next/docs/ts/demo/"></BigExampleSource>
+  target="/examples/11.1.0/docs/ts/demo/"></BigExampleSource>
   <BigExampleSource 
   label="Angular"    
   icon="angular"
-  target="/examples/next/docs/angular/demo/"></BigExampleSource>
+  target="/examples/11.1.0/docs/angular/demo/"></BigExampleSource>
   <BigExampleSource 
   label="React"
   icon="react"
-  target="/examples/next/docs/react/demo/"></BigExampleSource>
+  target="/examples/11.1.0/docs/react/demo/"></BigExampleSource>
   <BigExampleSource 
   label="Vue"
   icon="vue"
-  target="/examples/next/docs/vue/demo/"></BigExampleSource>
+  target="/examples/11.1.0/docs/vue/demo/"></BigExampleSource>
 </BigExample>
 
 ## Try out the demo's features


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->

Change the Demo example URLs to use the `11.1.0` version of the example (not the `next`) in the 11.1 version of the docs.

This is a problem introduced in https://github.com/handsontable/handsontable/pull/8982

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/pull/8982
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]