### PR TITLE
Add `layoutDirection` option to Angular wrapper

### DIFF
--- a/wrappers/angular/projects/hot-table/src/lib/hot-table.component.ts
+++ b/wrappers/angular/projects/hot-table/src/lib/hot-table.component.ts
@@ -91,6 +91,7 @@ export class HotTableComponent implements AfterViewInit, OnChanges, OnDestroy {
   @Input() invalidCellClassName: Handsontable.GridSettings['invalidCellClassName'];
   @Input() label: Handsontable.GridSettings['label'];
   @Input() language: Handsontable.GridSettings['language'];
+  @Input() layoutDirection: Handsontable.GridSettings['layoutDirection'];
   @Input() licenseKey: Handsontable.GridSettings['licenseKey'];
   @Input() manualColumnFreeze: Handsontable.GridSettings['manualColumnFreeze'];
   @Input() manualColumnMove: Handsontable.GridSettings['manualColumnMove'];


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adds support for `layoutDirection` option to the `hot-table` Angular component.

_[skip changelog]_

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. resolves #9198 
2.
3.

### Affected project(s):
- [x] `@handsontable/angular`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)