### PR TITLE
Fix a button that was incorrectly rendered in the docs cookie consent

### DIFF
--- a/docs/.vuepress/theme/styles/cookiebot.styl
+++ b/docs/.vuepress/theme/styles/cookiebot.styl
@@ -22,6 +22,12 @@
     border-color: #2456f2;
   }
 
+  /* main message "Customize" button, dialog "Allow selection" button */
+  #CybotCookiebotDialogFooter #CybotCookiebotDialogBodyLevelButtonCustomize,
+  #CybotCookiebotDialogBodyButtonsWrapper #CybotCookiebotDialogBodyLevelButtonLevelOptinAllowallSelection {
+    color: #FFF;
+  }
+
   /* footer and navigation background color */
   #CybotCookiebotDialogFooter .CybotCookiebotDialogBodyButton, 
   #CybotCookiebotDialogNav .CybotCookiebotDialogNavItemLink {


### PR DESCRIPTION
### Context

Fix a button that was incorrectly rendered in the docs cookie consent content in the dark mode.

### How has this been tested?

Locally in Edge/Mac.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/8987#issuecomment-1041350792
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]