### PR TITLE
Freeze Node version to 16.13.x

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Use Node.js 16
         uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d # https://github.com/actions/setup-node/releases/tag/v1.4.4
         with:
-          node-version: '16.x'
+          node-version: '16.13.x'
 
       - name: NPM audit
         run: |

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Use Node.js 16
         uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d # https://github.com/actions/setup-node/releases/tag/v1.4.4
         with:
-          node-version: '16.x'
+          node-version: '16.13.x'
 
       - name: Install dependencies
         run: npm ci --no-audit

--- a/.github/workflows/code-examples.yml
+++ b/.github/workflows/code-examples.yml
@@ -42,7 +42,7 @@ on:
       - examples/next/**
 
 env:
-  NODE_VERSION: 16.x
+  NODE_VERSION: 16.13.x
   NODE_MODULES_PATHS: |
     ./node_modules
     ./handsontable/node_modules/

--- a/.github/workflows/docs-linter.yml
+++ b/.github/workflows/docs-linter.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Use Node.js 16
         uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d # https://github.com/actions/setup-node/releases/tag/v1.4.4
         with:
-          node-version: '16.x'
+          node-version: '16.13.x'
 
       - name: Install Handsontable dependencies
         run: |

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Use Node.js 16
         uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d # https://github.com/actions/setup-node/releases/tag/v1.4.4
         with:
-          node-version: '16.x'
+          node-version: '16.13.x'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 env:
-  NODE_VERSION: 16.x
+  NODE_VERSION: 16.13.x
 
 jobs:
   check-scope:

--- a/handsontable/src/3rdparty/walkontable/src/scroll.js
+++ b/handsontable/src/3rdparty/walkontable/src/scroll.js
@@ -39,6 +39,7 @@ class Scroll {
     if (coords.col < 0 || coords.row < 0) {
       return false;
     }
+
     const scrolledHorizontally = this.scrollViewportHorizontally(coords.col, snapToRight, snapToLeft);
     const scrolledVertically = this.scrollViewportVertically(coords.row, snapToTop, snapToBottom);
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Due to the [changes introduced](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V16.md#importing-json-modules-now-requires-experimental-import-assertions-syntax) within Node v16.14, our scripts stopped working. Causing all CI jobs like unit tests, e2e tests, linting, etc to report fails. The PR reverts back the Node version to the latest that supports an old approach to load JSON files (16.13.x).

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
\-

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/9149

### Affected project(s):
- [x] `handsontable`
- [x] `@handsontable/angular`
- [x] `@handsontable/react`
- [x] `@handsontable/vue`
- [x] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
