### PR TITLE
Fix Comments editor position misalignment

### DIFF
--- a/handsontable/src/plugins/comments/__tests__/comments.spec.js
+++ b/handsontable/src/plugins/comments/__tests__/comments.spec.js
@@ -99,7 +99,7 @@ describe('Comments', () => {
       expect(getComputedStyle(getCell(2, 2), ':after').borderRightWidth).toBe('0px');
     });
 
-    it('should display the comment editor in the correct place', () => {
+    it('should display the comment editor in the correct place when the viewport is not scrolled (the Window object is a scrollable element)', () => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(4, 4),
         comments: true,
@@ -111,6 +111,72 @@ describe('Comments', () => {
       plugin.showAtCell(0, 1);
 
       const cellOffset = $(getCell(0, 2)).offset();
+      const editorOffset = $editor.offset();
+
+      expect(editorOffset.top).toBeCloseTo(cellOffset.top, 0);
+      expect(editorOffset.left).toBeCloseTo(cellOffset.left, 0);
+    });
+
+    it('should display the comment editor in the correct place when the viewport is scrolled (the Window object is a scrollable element)', async() => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(100, 100),
+        comments: true,
+      });
+
+      scrollViewportTo(countRows() - 1, countCols() - 1);
+
+      const plugin = getPlugin('comments');
+      const $editor = $(plugin.editor.getInputElement());
+
+      await sleep(10);
+
+      plugin.showAtCell(countRows() - 10, countCols() - 10);
+
+      const cellOffset = $(getCell(countRows() - 10, countCols() - 9)).offset();
+      const editorOffset = $editor.offset();
+
+      expect(editorOffset.top).toBeCloseTo(cellOffset.top, 0);
+      expect(editorOffset.left).toBeCloseTo(cellOffset.left, 0);
+    });
+
+    it('should display the comment editor in the correct place when the viewport is not scrolled (the Window object is not a scrollable element)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(30, 20),
+        comments: true,
+        width: 200,
+        height: 200,
+      });
+
+      const plugin = getPlugin('comments');
+      const $editor = $(plugin.editor.getInputElement());
+
+      plugin.showAtCell(0, 1);
+
+      const cellOffset = $(getCell(0, 2)).offset();
+      const editorOffset = $editor.offset();
+
+      expect(editorOffset.top).toBeCloseTo(cellOffset.top, 0);
+      expect(editorOffset.left).toBeCloseTo(cellOffset.left, 0);
+    });
+
+    it('should display the comment editor in the correct place when the viewport is scrolled (the Window object is not a scrollable element)', async() => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(30, 20),
+        comments: true,
+        width: 200,
+        height: 200,
+      });
+
+      scrollViewportTo(countRows() - 1, countCols() - 1);
+
+      const plugin = getPlugin('comments');
+      const $editor = $(plugin.editor.getInputElement());
+
+      await sleep(10);
+
+      plugin.showAtCell(countRows() - 10, countCols() - 10);
+
+      const cellOffset = $(getCell(countRows() - 10, countCols() - 9)).offset();
       const editorOffset = $editor.offset();
 
       expect(editorOffset.top).toBeCloseTo(cellOffset.top, 0);

--- a/handsontable/src/plugins/comments/__tests__/rtl/comments.spec.js
+++ b/handsontable/src/plugins/comments/__tests__/rtl/comments.spec.js
@@ -38,7 +38,7 @@ describe('Comments (RTL mode)', () => {
       expect(getComputedStyle(getCell(2, 2), ':after').borderRightWidth).toBe('6px');
     });
 
-    it('should display the comment editor in the correct place', () => {
+    it('should display the comment editor in the correct place when the viewport is not scrolled (the Window object is a scrollable element)', () => {
       handsontable({
         data: Handsontable.helper.createSpreadsheetData(4, 4),
         comments: true,
@@ -50,6 +50,75 @@ describe('Comments (RTL mode)', () => {
       plugin.showAtCell(0, 1);
 
       const cellOffset = $(getCell(0, 1)).offset();
+      const editorOffset = $editor.offset();
+      const editorWidth = $editor.outerWidth();
+
+      expect(editorOffset.top).toBeCloseTo(cellOffset.top, 0);
+      expect(editorOffset.left).toBeCloseTo(cellOffset.left - editorWidth, 0);
+    });
+
+    it('should display the comment editor in the correct place when the viewport is scrolled (the Window object is a scrollable element)', async() => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(100, 100),
+        comments: true,
+      });
+
+      scrollViewportTo(countRows() - 1, countCols() - 1);
+
+      const plugin = getPlugin('comments');
+      const $editor = $(plugin.editor.getInputElement());
+
+      await sleep(10);
+
+      plugin.showAtCell(countRows() - 10, countCols() - 10);
+
+      const cellOffset = $(getCell(countRows() - 10, countCols() - 10)).offset();
+      const editorOffset = $editor.offset();
+      const editorWidth = $editor.outerWidth();
+
+      expect(editorOffset.top).toBeCloseTo(cellOffset.top, 0);
+      expect(editorOffset.left).toBeCloseTo(cellOffset.left - editorWidth, 0);
+    });
+
+    it('should display the comment editor in the correct place when the viewport is not scrolled (the Window object is not a scrollable element)', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(30, 20),
+        comments: true,
+        width: 200,
+        height: 200,
+      });
+
+      const plugin = getPlugin('comments');
+      const $editor = $(plugin.editor.getInputElement());
+
+      plugin.showAtCell(0, 1);
+
+      const cellOffset = $(getCell(0, 1)).offset();
+      const editorOffset = $editor.offset();
+      const editorWidth = $editor.outerWidth();
+
+      expect(editorOffset.top).toBeCloseTo(cellOffset.top, 0);
+      expect(editorOffset.left).toBeCloseTo(cellOffset.left - editorWidth, 0);
+    });
+
+    it('should display the comment editor in the correct place when the viewport is scrolled (the Window object is not a scrollable element)', async() => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(30, 20),
+        comments: true,
+        width: 200,
+        height: 200,
+      });
+
+      scrollViewportTo(countRows() - 1, countCols() - 1);
+
+      const plugin = getPlugin('comments');
+      const $editor = $(plugin.editor.getInputElement());
+
+      await sleep(10);
+
+      plugin.showAtCell(countRows() - 10, countCols() - 10);
+
+      const cellOffset = $(getCell(countRows() - 10, countCols() - 10)).offset();
       const editorOffset = $editor.offset();
       const editorWidth = $editor.outerWidth();
 

--- a/handsontable/src/plugins/comments/comments.js
+++ b/handsontable/src/plugins/comments/comments.js
@@ -451,7 +451,7 @@ export class Comments extends BasePlugin {
     }
 
     if (wtViewport.hasHorizontalScroll() && scrollableElement !== rootWindow) {
-      cellLeftOffset -= wtOverlays.inlineStartOverlay.getScrollPosition();
+      cellLeftOffset -= wtOverlays.inlineStartOverlay.getScrollPosition() * (this.hot.isRtl() ? -1 : 1);
     }
 
     const y = cellTopOffset + lastRowHeight;


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the comments editor misalignment that happens in RTL mode.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and covered the fix with new E2E tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes #9217 
2.
3.

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
