### PR TITLE
Add ar-AR language in a few places where it was missing

### DIFF
--- a/docs/next/guides/building-and-testing/modules.md
+++ b/docs/next/guides/building-and-testing/modules.md
@@ -343,6 +343,7 @@ import {
 // import translations
 import {
   registerLanguageDictionary,
+  arAR,
   deCH,
   deDE,
   enUS,
@@ -373,6 +374,7 @@ import {
 } from 'handsontable/registry'
 
 // register individual translations
+registerLanguageDictionary(arAR);
 registerLanguageDictionary(deCH);
 registerLanguageDictionary(deDE);
 registerLanguageDictionary(enUS);

--- a/handsontable/src/dataMap/metaManager/metaSchema.js
+++ b/handsontable/src/dataMap/metaManager/metaSchema.js
@@ -2457,6 +2457,7 @@ export default () => {
      * | Setting             | Description                 |
      * | ------------------- | --------------------------- |
      * | `'en-US'` (default) | English - United States     |
+     * | `'de-CH'`           | German - Switzerland        |
      * | `'de-DE'`           | German - Germany            |
      * | `'es-MX'`           | Spanish - Mexico            |
      * | `'fr-FR'`           | French - France             |

--- a/handsontable/src/dataMap/metaManager/metaSchema.js
+++ b/handsontable/src/dataMap/metaManager/metaSchema.js
@@ -2457,6 +2457,7 @@ export default () => {
      * | Setting             | Description                 |
      * | ------------------- | --------------------------- |
      * | `'en-US'` (default) | English - United States     |
+     * | `'ar-AR'`           | Arabic - Global             |
      * | `'de-CH'`           | German - Switzerland        |
      * | `'de-DE'`           | German - Germany            |
      * | `'es-MX'`           | Spanish - Mexico            |

--- a/handsontable/src/i18n/__tests__/moduleInterface.unit.js
+++ b/handsontable/src/i18n/__tests__/moduleInterface.unit.js
@@ -7,6 +7,7 @@ import {
   hasLanguageDictionary,
   registerLanguageDictionary,
   dictionaryKeys,
+  arAR,
   deCH,
   deDE,
   enUS,
@@ -42,6 +43,7 @@ describe('i18n', () => {
   });
 
   it('should be possible to import all languages from the module entrypoint', () => {
+    expect(arAR.languageCode).toBe('ar-AR');
     expect(deCH.languageCode).toBe('de-CH');
     expect(deDE.languageCode).toBe('de-DE');
     expect(enUS.languageCode).toBe('en-US');


### PR DESCRIPTION
### Context

I searched for `esMX` and `es-MX` and expected to also see `arAR` and `ar-AR` in all the search results. But in some results it was missing. This PR adds it.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]