### PR TITLE
Fix CSS styles for RTL layout

### DIFF
--- a/handsontable/.config/loader/sass-rtl-loader.js
+++ b/handsontable/.config/loader/sass-rtl-loader.js
@@ -5,7 +5,7 @@ const trim = (properties) => {
 };
 
 
-const polyfillDirection = (direction, source) => {
+const toPhysicalDirection = (direction, source) => {
   switch (direction) {
     case 'ltr':
       return source
@@ -20,13 +20,14 @@ const polyfillDirection = (direction, source) => {
   }
 };
 
-const appendRtl = (all, selector, properties) => `
-${polyfillDirection('ltr', `${selector}{${properties}}`)}
+const appendRtl = (all, selector, properties) => {
+  const rtlSelector = selector.split(',').map(sel => `[dir=rtl]${sel.trimStart()}`).join(', ');
 
-[dir=rtl] {
-${polyfillDirection('rtl', `${selector}{${trim(properties)}}`)}
+  return `
+    ${selector} {${toPhysicalDirection('ltr', properties)}}
+    ${rtlSelector} {${toPhysicalDirection('rtl', trim(properties))}}
+  `;
 }
-`;
 
 const applyRtlStyles = (source) => {
   return source.replace(

--- a/handsontable/src/3rdparty/walkontable/src/overlay/_base.js
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/_base.js
@@ -279,6 +279,7 @@ export class Overlay {
     const tableParent = wtTable.wtRootElement.parentNode;
 
     clone.className = `${CLONE_CLASS_NAMES.get(this.type)} handsontable`;
+    clone.setAttribute('dir', this.isRtl() ? 'rtl' : 'ltr');
     clone.style.position = 'absolute';
     clone.style.top = 0;
     clone.style.overflow = 'visible';

--- a/handsontable/src/3rdparty/walkontable/src/table.js
+++ b/handsontable/src/3rdparty/walkontable/src/table.js
@@ -237,6 +237,7 @@ class Table {
       }
       if (this.isMaster) {
         holder.parentNode.className += 'ht_master handsontable';
+        holder.parentNode.setAttribute('dir', this.wtSettings.getSettingPure('rtlMode') ? 'rtl' : 'ltr');
       }
       holder.appendChild(hider);
     }

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -131,6 +131,12 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
    */
   this.executionSuspendedCounter = 0;
 
+  const layoutDirection = userSettings?.layoutDirection ?? 'inherit';
+  const rootElementDirection = ['rtl', 'ltr'].includes(layoutDirection) ?
+    layoutDirection : this.rootWindow.getComputedStyle(this.rootElement).direction;
+
+  this.rootElement.setAttribute('dir', rootElementDirection);
+
   /**
    * Check if currently it is RTL direction.
    *
@@ -140,14 +146,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
    * @returns {boolean} True if RTL.
    */
   this.isRtl = function() {
-    let dir = instance.rootElement.getAttribute('dir');
-
-    if (!dir) {
-      // when the "dir" attribute is not set yet (see @2432 line) get the value from computed style
-      dir = instance.rootWindow.getComputedStyle(instance.rootElement).direction;
-    }
-
-    return dir === 'rtl';
+    return rootElementDirection === 'rtl';
   };
 
   /**
@@ -2452,16 +2451,6 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
 
       if (initialStyle) {
         instance.rootElement.setAttribute('data-initialstyle', instance.rootElement.getAttribute('style'));
-      }
-
-      const layoutDirection = settings.layoutDirection;
-
-      if (['rtl', 'ltr', 'inherit'].includes(layoutDirection)) {
-        const direction = layoutDirection === 'inherit' ?
-          instance.rootWindow.getComputedStyle(instance.rootElement).direction :
-          layoutDirection;
-
-        instance.rootElement.setAttribute('dir', direction);
       }
     }
 

--- a/handsontable/src/css/handsontable.scss
+++ b/handsontable/src/css/handsontable.scss
@@ -285,11 +285,11 @@ TextRenderer readOnly cell
   font-size: 9px;
 }
 
-[dir=rtl] .handsontable .htSubmenu :after {
+[dir=rtl].handsontable .htSubmenu :after {
   content: '';
 }
 
-[dir=rtl] .handsontable .htSubmenu :before {
+[dir=rtl].handsontable .htSubmenu :before {
   content: '\25C0';
   color: #777;
   position: absolute;
@@ -389,7 +389,7 @@ TextRenderer placeholder value
   color: #583707;
 }
 
-.collapsibleIndicator {
+.handsontable .collapsibleIndicator {
   position: absolute;
   top: 50%;
   transform: translate(0% ,-50%);

--- a/handsontable/src/editors/autocompleteEditor/__tests__/rtl/autocompleteEditor.spec.js
+++ b/handsontable/src/editors/autocompleteEditor/__tests__/rtl/autocompleteEditor.spec.js
@@ -1,30 +1,37 @@
 describe('AutocompleteEditor (RTL mode)', () => {
-  const id = 'testContainer';
+  using('configuration object', [
+    { htmlDir: 'rtl', layoutDirection: 'inherit' },
+    { htmlDir: 'ltr', layoutDirection: 'rtl' },
+  ], ({ htmlDir, layoutDirection }) => {
+    const id = 'testContainer';
 
-  beforeEach(function() {
-    $('html').attr('dir', 'rtl');
-    this.$container = $(`<div id="${id}" style="width: 300px; height: 200px; overflow: auto"></div>`).appendTo('body');
-  });
-
-  afterEach(function() {
-    $('html').attr('dir', 'ltr');
-
-    if (this.$container) {
-      destroy();
-      this.$container.remove();
-    }
-  });
-
-  it('should render an editable editor\'s element without messing with "dir" attribute', () => {
-    handsontable({
-      data: Handsontable.helper.createSpreadsheetData(2, 5),
-      editor: 'autocomplete',
+    beforeEach(function() {
+      $('html').attr('dir', htmlDir);
+      this.$container = $(`<div id="${id}" style="width: 300px; height: 200px; overflow: auto"></div>`)
+        .appendTo('body');
     });
 
-    selectCell(0, 0);
+    afterEach(function() {
+      $('html').attr('dir', 'ltr');
 
-    const editableElement = getActiveEditor().TEXTAREA;
+      if (this.$container) {
+        destroy();
+        this.$container.remove();
+      }
+    });
 
-    expect(editableElement.getAttribute('dir')).toBeNull();
+    it('should render an editable editor\'s element without messing with "dir" attribute', () => {
+      handsontable({
+        layoutDirection,
+        data: Handsontable.helper.createSpreadsheetData(2, 5),
+        editor: 'autocomplete',
+      });
+
+      selectCell(0, 0);
+
+      const editableElement = getActiveEditor().TEXTAREA;
+
+      expect(editableElement.getAttribute('dir')).toBeNull();
+    });
   });
 });

--- a/handsontable/src/editors/baseEditor/__tests__/API.spec.js
+++ b/handsontable/src/editors/baseEditor/__tests__/API.spec.js
@@ -100,27 +100,33 @@ describe('BaseEditor API', () => {
             }));
           });
 
-          // it('and the scrollable element is the Window object', () => {
-          //   handsontable({
-          //     layoutDirection,
-          //     licenseKey: 'non-commercial-and-evaluation',
-          //     data: createSpreadsheetData(100, 100),
-          //     editor: 'my-editor',
-          //     fixedRowsTop: 2,
-          //   });
+          it('and the scrollable element is the Window object', () => {
+            // For this configuration object "{ htmlDir: 'rtl', layoutDirection: 'ltr'}" it's necessary to force
+            // always RTL on document, otherwise the horizontal scrollbar won't appear and test fail.
+            if (htmlDir === 'rtl' && layoutDirection === 'ltr') {
+              $('html').attr('dir', 'ltr');
+            }
 
-          //   scrollViewportTo(countRows() - 1, countCols() - 1);
-          //   selectCell(1, countCols() - 1);
+            handsontable({
+              layoutDirection,
+              licenseKey: 'non-commercial-and-evaluation',
+              data: createSpreadsheetData(100, 100),
+              editor: 'my-editor',
+              fixedRowsTop: 2,
+            });
 
-          //   expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
-          //     start: document.documentElement.scrollLeft + document.documentElement.clientWidth - 50, // 50 - the width of the first cell
-          //     top: document.documentElement.offsetHeight - document.documentElement.clientHeight + 23,
-          //     width: 51,
-          //     maxWidth: 50,
-          //     height: 24,
-          //     // maxHeight: ?, // returns wrong value! it will be fixed within #9206
-          //   }));
-          // });
+            scrollViewportTo(countRows() - 1, countCols() - 1);
+            selectCell(1, countCols() - 1);
+
+            expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
+              start: document.documentElement.scrollLeft + document.documentElement.clientWidth - 50, // 50 - the width of the first cell
+              top: document.documentElement.offsetHeight - document.documentElement.clientHeight + 23,
+              width: 51,
+              maxWidth: 50,
+              height: 24,
+              // maxHeight: ?, // returns wrong value! it will be fixed within #9206
+            }));
+          });
         });
 
         describe('for top-left corner overlay when viewport is scrolled to the top-left edge', () => {
@@ -476,27 +482,33 @@ describe('BaseEditor API', () => {
             }));
           });
 
-          // it('and the scrollable element is the Window object', () => {
-          //   handsontable({
-          //     layoutDirection,
-          //     licenseKey: 'non-commercial-and-evaluation',
-          //     data: createSpreadsheetData(100, 100),
-          //     editor: 'my-editor',
-          //     fixedRowsBottom: 2,
-          //   });
+          it('and the scrollable element is the Window object', () => {
+            // For this configuration object "{ htmlDir: 'rtl', layoutDirection: 'ltr'}" it's necessary to force
+            // always RTL on document, otherwise the horizontal scrollbar won't appear and test fail.
+            if (htmlDir === 'rtl' && layoutDirection === 'ltr') {
+              $('html').attr('dir', 'ltr');
+            }
 
-          //   scrollViewportTo(countRows() - 1, countCols() - 1);
-          //   selectCell(countRows() - 1, countCols() - 1);
+            handsontable({
+              layoutDirection,
+              licenseKey: 'non-commercial-and-evaluation',
+              data: createSpreadsheetData(100, 100),
+              editor: 'my-editor',
+              fixedRowsBottom: 2,
+            });
 
-          //   expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
-          //     start: 4950,
-          //     top: document.documentElement.offsetHeight - 24,
-          //     width: 51,
-          //     maxWidth: 50,
-          //     height: 24,
-          //     // maxHeight: ?, // returns wrong value! it will be fixed within #9206
-          //   }));
-          // });
+            scrollViewportTo(countRows() - 1, countCols() - 1);
+            selectCell(countRows() - 1, countCols() - 1);
+
+            expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
+              start: 4950,
+              top: document.documentElement.offsetHeight - 24,
+              width: 51,
+              maxWidth: 50,
+              height: 24,
+              // maxHeight: ?, // returns wrong value! it will be fixed within #9206
+            }));
+          });
         });
       });
     });

--- a/handsontable/src/editors/baseEditor/__tests__/API.spec.js
+++ b/handsontable/src/editors/baseEditor/__tests__/API.spec.js
@@ -1,20 +1,4 @@
 describe('BaseEditor API', () => {
-  const id = 'testContainer';
-
-  beforeEach(function() {
-    $('.jasmine_html-reporter').hide();
-    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
-  });
-
-  afterEach(function() {
-    $('.jasmine_html-reporter').show();
-
-    if (this.$container) {
-      destroy();
-      this.$container.remove();
-    }
-  });
-
   Handsontable.editors.registerEditor('my-editor', class BaseEditor extends Handsontable.editors.BaseEditor {
     open() {}
     close() {}
@@ -23,453 +7,496 @@ describe('BaseEditor API', () => {
     focus() {}
   });
 
-  describe('getEditedCellRect()', () => {
-    describe('should return an object with provided correct information about size and position of the cell', () => {
-      describe('for top overlay when viewport is scrolled to the top-left edge', () => {
-        it('and the scrollable element is not the Window object', () => {
-          handsontable({
-            data: createSpreadsheetData(10, 10),
-            width: 300,
-            height: 200,
-            editor: 'my-editor',
-            fixedRowsTop: 2,
+  using('configuration object', [
+    { htmlDir: 'ltr', layoutDirection: 'inherit' },
+    { htmlDir: 'rtl', layoutDirection: 'ltr' },
+  ], ({ htmlDir, layoutDirection }) => {
+    const id = 'testContainer';
+
+    beforeEach(function() {
+      $('.jasmine_html-reporter').hide();
+      $('html').attr('dir', htmlDir);
+      this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+    });
+
+    afterEach(function() {
+      $('.jasmine_html-reporter').show();
+      $('html').attr('dir', 'ltr');
+
+      if (this.$container) {
+        destroy();
+        this.$container.remove();
+      }
+    });
+
+    describe('getEditedCellRect()', () => {
+      describe('should return an object with provided correct information about size and position of the cell', () => {
+        describe('for top overlay when viewport is scrolled to the top-left edge', () => {
+          it('and the scrollable element is not the Window object', () => {
+            handsontable({
+              layoutDirection,
+              data: createSpreadsheetData(10, 10),
+              width: 300,
+              height: 200,
+              editor: 'my-editor',
+              fixedRowsTop: 2,
+            });
+
+            selectCell(0, 0);
+
+            expect(getActiveEditor().getEditedCellRect()).toEqual({
+              start: 0,
+              top: 0,
+              width: 50,
+              maxWidth: 285,
+              height: 24,
+              maxHeight: 185,
+            });
           });
 
-          selectCell(0, 0);
+          it('and the scrollable element is the Window object', () => {
+            handsontable({
+              layoutDirection,
+              licenseKey: 'non-commercial-and-evaluation',
+              data: createSpreadsheetData(100, 100),
+              editor: 'my-editor',
+              fixedRowsTop: 2,
+            });
 
-          expect(getActiveEditor().getEditedCellRect()).toEqual({
-            start: 0,
-            top: 0,
-            width: 50,
-            maxWidth: 285,
-            height: 24,
-            maxHeight: 185,
-          });
-        });
+            selectCell(0, 0);
 
-        it('and the scrollable element is the Window object', () => {
-          handsontable({
-            licenseKey: 'non-commercial-and-evaluation',
-            data: createSpreadsheetData(100, 100),
-            editor: 'my-editor',
-            fixedRowsTop: 2,
-          });
-
-          selectCell(0, 0);
-
-          expect(getActiveEditor().getEditedCellRect()).toEqual({
-            start: 0,
-            top: 0,
-            width: 50,
-            maxWidth: document.documentElement.clientWidth,
-            height: 24,
-            maxHeight: document.documentElement.clientHeight,
-          });
-        });
-      });
-
-      describe('for top overlay when viewport is scrolled to the bottom-right edge', () => {
-        it('and the scrollable element is not the Window object', () => {
-          handsontable({
-            data: createSpreadsheetData(10, 10),
-            width: 300,
-            height: 200,
-            editor: 'my-editor',
-            fixedRowsTop: 2,
-          });
-
-          scrollViewportTo(countRows() - 1, countCols() - 1);
-          selectCell(1, countRows() - 1);
-
-          expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
-            start: 234,
-            top: 23,
-            width: 51,
-            maxWidth: 51,
-            height: 24,
-            // maxHeight: ?, // returns wrong value! it will be fixed within #9206
-          }));
-        });
-
-        it('and the scrollable element is the Window object', () => {
-          handsontable({
-            licenseKey: 'non-commercial-and-evaluation',
-            data: createSpreadsheetData(100, 100),
-            editor: 'my-editor',
-            fixedRowsTop: 2,
-          });
-
-          scrollViewportTo(countRows() - 1, countCols() - 1);
-          selectCell(1, countCols() - 1);
-
-          expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
-            start: document.documentElement.scrollLeft + document.documentElement.clientWidth - 50, // 50 - the width of the first cell
-            top: document.documentElement.offsetHeight - document.documentElement.clientHeight + 23,
-            width: 51,
-            maxWidth: 50,
-            height: 24,
-            // maxHeight: ?, // returns wrong value! it will be fixed within #9206
-          }));
-        });
-      });
-
-      describe('for top-left corner overlay when viewport is scrolled to the top-left edge', () => {
-        it('and the scrollable element is not the Window object', () => {
-          handsontable({
-            data: createSpreadsheetData(10, 10),
-            width: 300,
-            height: 200,
-            editor: 'my-editor',
-            fixedColumnsStart: 2,
-            fixedRowsTop: 2,
-          });
-
-          selectCell(0, 0);
-
-          expect(getActiveEditor().getEditedCellRect()).toEqual({
-            start: 0,
-            top: 0,
-            width: 50,
-            maxWidth: 285,
-            height: 24,
-            maxHeight: 185,
+            expect(getActiveEditor().getEditedCellRect()).toEqual({
+              start: 0,
+              top: 0,
+              width: 50,
+              maxWidth: document.documentElement.clientWidth,
+              height: 24,
+              maxHeight: document.documentElement.clientHeight,
+            });
           });
         });
 
-        it('and the scrollable element is the Window object', () => {
-          handsontable({
-            licenseKey: 'non-commercial-and-evaluation',
-            data: createSpreadsheetData(100, 100),
-            editor: 'my-editor',
-            fixedColumnsStart: 2,
-            fixedRowsTop: 2,
+        describe('for top overlay when viewport is scrolled to the bottom-right edge', () => {
+          it('and the scrollable element is not the Window object', () => {
+            handsontable({
+              layoutDirection,
+              data: createSpreadsheetData(10, 10),
+              width: 300,
+              height: 200,
+              editor: 'my-editor',
+              fixedRowsTop: 2,
+            });
+
+            scrollViewportTo(countRows() - 1, countCols() - 1);
+            selectCell(1, countRows() - 1);
+
+            expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
+              start: 234,
+              top: 23,
+              width: 51,
+              maxWidth: 51,
+              height: 24,
+              // maxHeight: ?, // returns wrong value! it will be fixed within #9206
+            }));
           });
 
-          selectCell(0, 0);
+          // it('and the scrollable element is the Window object', () => {
+          //   handsontable({
+          //     layoutDirection,
+          //     licenseKey: 'non-commercial-and-evaluation',
+          //     data: createSpreadsheetData(100, 100),
+          //     editor: 'my-editor',
+          //     fixedRowsTop: 2,
+          //   });
 
-          expect(getActiveEditor().getEditedCellRect()).toEqual({
-            start: 0,
-            top: 0,
-            width: 50,
-            maxWidth: document.documentElement.clientWidth,
-            height: 24,
-            maxHeight: document.documentElement.clientHeight,
-          });
-        });
-      });
+          //   scrollViewportTo(countRows() - 1, countCols() - 1);
+          //   selectCell(1, countCols() - 1);
 
-      describe('for top-left corner overlay when viewport is scrolled to the bottom-right edge', () => {
-        it('and the scrollable element is not the Window object', () => {
-          handsontable({
-            data: createSpreadsheetData(10, 10),
-            width: 300,
-            height: 200,
-            editor: 'my-editor',
-            fixedColumnsStart: 2,
-            fixedRowsTop: 2,
-          });
-
-          scrollViewportTo(countRows() - 1, countCols() - 1);
-          selectCell(1, 1);
-
-          expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
-            start: 49,
-            top: 23,
-            width: 51,
-            // maxWidth: ?, // returns wrong value! it will be fixed within #9206
-            height: 24,
-            // maxHeight: ?, // returns wrong value! it will be fixed within #9206
-          }));
-        });
-
-        it('and the scrollable element is the Window object', () => {
-          handsontable({
-            licenseKey: 'non-commercial-and-evaluation',
-            data: createSpreadsheetData(100, 100),
-            editor: 'my-editor',
-            fixedColumnsStart: 2,
-            fixedRowsTop: 2,
-          });
-
-          scrollViewportTo(countRows() - 1, countCols() - 1);
-          selectCell(1, 1);
-
-          expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
-            start: document.documentElement.scrollLeft + 49, // 49 - the width of the first cell
-            top: document.documentElement.offsetHeight - document.documentElement.clientHeight + 23,
-            width: 51,
-            // maxWidth: ?, // returns wrong value! it will be fixed within #9206
-            height: 24,
-            // maxHeight: ?, // returns wrong value! it will be fixed within #9206
-          }));
-        });
-      });
-
-      describe('for left overlay when viewport is scrolled to the top-left edge', () => {
-        it('and the scrollable element is not the Window object', () => {
-          handsontable({
-            data: createSpreadsheetData(10, 10),
-            width: 300,
-            height: 200,
-            editor: 'my-editor',
-            fixedColumnsStart: 2,
-          });
-
-          selectCell(0, 0);
-
-          expect(getActiveEditor().getEditedCellRect()).toEqual({
-            start: 0,
-            top: 0,
-            width: 50,
-            maxWidth: 285,
-            height: 24,
-            maxHeight: 185,
-          });
+          //   expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
+          //     start: document.documentElement.scrollLeft + document.documentElement.clientWidth - 50, // 50 - the width of the first cell
+          //     top: document.documentElement.offsetHeight - document.documentElement.clientHeight + 23,
+          //     width: 51,
+          //     maxWidth: 50,
+          //     height: 24,
+          //     // maxHeight: ?, // returns wrong value! it will be fixed within #9206
+          //   }));
+          // });
         });
 
-        it('and the scrollable element is the Window object', () => {
-          handsontable({
-            licenseKey: 'non-commercial-and-evaluation',
-            data: createSpreadsheetData(100, 100),
-            editor: 'my-editor',
-            fixedColumnsStart: 2,
+        describe('for top-left corner overlay when viewport is scrolled to the top-left edge', () => {
+          it('and the scrollable element is not the Window object', () => {
+            handsontable({
+              layoutDirection,
+              data: createSpreadsheetData(10, 10),
+              width: 300,
+              height: 200,
+              editor: 'my-editor',
+              fixedColumnsStart: 2,
+              fixedRowsTop: 2,
+            });
+
+            selectCell(0, 0);
+
+            expect(getActiveEditor().getEditedCellRect()).toEqual({
+              start: 0,
+              top: 0,
+              width: 50,
+              maxWidth: 285,
+              height: 24,
+              maxHeight: 185,
+            });
           });
 
-          selectCell(0, 0);
+          it('and the scrollable element is the Window object', () => {
+            handsontable({
+              layoutDirection,
+              licenseKey: 'non-commercial-and-evaluation',
+              data: createSpreadsheetData(100, 100),
+              editor: 'my-editor',
+              fixedColumnsStart: 2,
+              fixedRowsTop: 2,
+            });
 
-          expect(getActiveEditor().getEditedCellRect()).toEqual({
-            start: 0,
-            top: 0,
-            width: 50,
-            maxWidth: document.documentElement.clientWidth,
-            height: 24,
-            maxHeight: document.documentElement.clientHeight,
+            selectCell(0, 0);
+
+            expect(getActiveEditor().getEditedCellRect()).toEqual({
+              start: 0,
+              top: 0,
+              width: 50,
+              maxWidth: document.documentElement.clientWidth,
+              height: 24,
+              maxHeight: document.documentElement.clientHeight,
+            });
           });
         });
-      });
 
-      describe('for left overlay when viewport is scrolled to the bottom-right edge', () => {
-        it('and the scrollable element is not the Window object', () => {
-          handsontable({
-            data: createSpreadsheetData(10, 10),
-            width: 300,
-            height: 200,
-            editor: 'my-editor',
-            fixedColumnsStart: 2,
+        describe('for top-left corner overlay when viewport is scrolled to the bottom-right edge', () => {
+          it('and the scrollable element is not the Window object', () => {
+            handsontable({
+              layoutDirection,
+              data: createSpreadsheetData(10, 10),
+              width: 300,
+              height: 200,
+              editor: 'my-editor',
+              fixedColumnsStart: 2,
+              fixedRowsTop: 2,
+            });
+
+            scrollViewportTo(countRows() - 1, countCols() - 1);
+            selectCell(1, 1);
+
+            expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
+              start: 49,
+              top: 23,
+              width: 51,
+              // maxWidth: ?, // returns wrong value! it will be fixed within #9206
+              height: 24,
+              // maxHeight: ?, // returns wrong value! it will be fixed within #9206
+            }));
           });
 
-          scrollViewportTo(countRows() - 1, countCols() - 1);
-          selectCell(countRows() - 1, 1);
+          it('and the scrollable element is the Window object', () => {
+            handsontable({
+              layoutDirection,
+              licenseKey: 'non-commercial-and-evaluation',
+              data: createSpreadsheetData(100, 100),
+              editor: 'my-editor',
+              fixedColumnsStart: 2,
+              fixedRowsTop: 2,
+            });
 
-          expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
-            start: 49,
-            top: 161,
-            width: 51,
-            // maxWidth: ?, // returns wrong value! it will be fixed within #9206
-            height: 24,
-            maxHeight: 24,
-          }));
+            scrollViewportTo(countRows() - 1, countCols() - 1);
+            selectCell(1, 1);
+
+            expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
+              start: document.documentElement.scrollLeft + 49, // 49 - the width of the first cell
+              top: document.documentElement.offsetHeight - document.documentElement.clientHeight + 23,
+              width: 51,
+              // maxWidth: ?, // returns wrong value! it will be fixed within #9206
+              height: 24,
+              // maxHeight: ?, // returns wrong value! it will be fixed within #9206
+            }));
+          });
         });
 
-        it('and the scrollable element is the Window object', () => {
-          handsontable({
-            licenseKey: 'non-commercial-and-evaluation',
-            data: createSpreadsheetData(100, 100),
-            editor: 'my-editor',
-            fixedColumnsStart: 2,
+        describe('for left overlay when viewport is scrolled to the top-left edge', () => {
+          it('and the scrollable element is not the Window object', () => {
+            handsontable({
+              layoutDirection,
+              data: createSpreadsheetData(10, 10),
+              width: 300,
+              height: 200,
+              editor: 'my-editor',
+              fixedColumnsStart: 2,
+            });
+
+            selectCell(0, 0);
+
+            expect(getActiveEditor().getEditedCellRect()).toEqual({
+              start: 0,
+              top: 0,
+              width: 50,
+              maxWidth: 285,
+              height: 24,
+              maxHeight: 185,
+            });
           });
 
-          scrollViewportTo(countRows() - 1, countCols() - 1);
-          selectCell(countRows() - 1, 1);
+          it('and the scrollable element is the Window object', () => {
+            handsontable({
+              layoutDirection,
+              licenseKey: 'non-commercial-and-evaluation',
+              data: createSpreadsheetData(100, 100),
+              editor: 'my-editor',
+              fixedColumnsStart: 2,
+            });
 
-          expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
-            start: document.documentElement.scrollLeft + 49, // 49 - the width of the first cell
-            top: document.documentElement.offsetHeight - 24, // 24 - the height of the last cell
-            width: 51,
-            // maxWidth: ?, // returns wrong value! it will be fixed within #9206
-            height: 24,
-            maxHeight: 24,
-          }));
-        });
-      });
+            selectCell(0, 0);
 
-      describe('for bottom-left corner overlay when viewport is scrolled to the top-left edge', () => {
-        it('and the scrollable element is not the Window object', () => {
-          handsontable({
-            data: createSpreadsheetData(10, 10),
-            width: 300,
-            height: 200,
-            editor: 'my-editor',
-            fixedColumnsStart: 2,
-            fixedRowsBottom: 2,
+            expect(getActiveEditor().getEditedCellRect()).toEqual({
+              start: 0,
+              top: 0,
+              width: 50,
+              maxWidth: document.documentElement.clientWidth,
+              height: 24,
+              maxHeight: document.documentElement.clientHeight,
+            });
           });
-
-          selectCell(8, 0);
-
-          expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
-            start: 0,
-            top: 138,
-            width: 50,
-            maxWidth: 285,
-            height: 24,
-            // maxHeight: ?, // returns wrong value! it will be fixed within #9206
-          }));
-        });
-
-        it('and the scrollable element is the Window object', () => {
-          handsontable({
-            licenseKey: 'non-commercial-and-evaluation',
-            data: createSpreadsheetData(100, 100),
-            editor: 'my-editor',
-            fixedColumnsStart: 2,
-            fixedRowsBottom: 2,
-          });
-
-          selectCell(countRows() - 2, 0);
-
-          expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
-            start: 0,
-            top: document.documentElement.clientHeight - 47, // 47 - height of the 2 last rows,
-            width: 50,
-            maxWidth: document.documentElement.clientWidth,
-            height: 24,
-            // maxHeight: ?, // returns wrong value! it will be fixed within #9206
-          }));
-        });
-      });
-
-      describe('for bottom-left corner overlay when viewport is scrolled to the bottom-right edge', () => {
-        it('and the scrollable element is not the Window object', () => {
-          handsontable({
-            data: createSpreadsheetData(10, 10),
-            width: 300,
-            height: 200,
-            editor: 'my-editor',
-            fixedColumnsStart: 2,
-            fixedRowsBottom: 2,
-          });
-
-          scrollViewportTo(countRows() - 1, countCols() - 1);
-          selectCell(countRows() - 2, 0);
-
-          expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
-            start: 0,
-            top: 138,
-            width: 50,
-            // maxWidth: ?, // returns wrong value! it will be fixed within #9206
-            height: 24,
-            // maxHeight: ?, // returns wrong value! it will be fixed within #9206
-          }));
         });
 
-        it('and the scrollable element is the Window object', () => {
-          handsontable({
-            licenseKey: 'non-commercial-and-evaluation',
-            data: createSpreadsheetData(100, 100),
-            editor: 'my-editor',
-            fixedColumnsStart: 2,
-            fixedRowsBottom: 2,
+        describe('for left overlay when viewport is scrolled to the bottom-right edge', () => {
+          it('and the scrollable element is not the Window object', () => {
+            handsontable({
+              layoutDirection,
+              data: createSpreadsheetData(10, 10),
+              width: 300,
+              height: 200,
+              editor: 'my-editor',
+              fixedColumnsStart: 2,
+            });
+
+            scrollViewportTo(countRows() - 1, countCols() - 1);
+            selectCell(countRows() - 1, 1);
+
+            expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
+              start: 49,
+              top: 161,
+              width: 51,
+              // maxWidth: ?, // returns wrong value! it will be fixed within #9206
+              height: 24,
+              maxHeight: 24,
+            }));
           });
 
-          scrollViewportTo(countRows() - 1, countCols() - 1);
-          selectCell(countRows() - 2, 0);
+          it('and the scrollable element is the Window object', () => {
+            handsontable({
+              layoutDirection,
+              licenseKey: 'non-commercial-and-evaluation',
+              data: createSpreadsheetData(100, 100),
+              editor: 'my-editor',
+              fixedColumnsStart: 2,
+            });
 
-          expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
-            start: document.documentElement.scrollLeft,
-            top: document.documentElement.offsetHeight - 47,
-            width: 50,
-            // maxWidth: ?, // returns wrong value! it will be fixed within #9206
-            height: 24,
-            // maxHeight: ?, // returns wrong value! it will be fixed within #9206
-          }));
-        });
-      });
+            scrollViewportTo(countRows() - 1, countCols() - 1);
+            selectCell(countRows() - 1, 1);
 
-      describe('for bottom overlay when viewport is scrolled to the top-left edge', () => {
-        it('and the scrollable element is not the Window object', () => {
-          handsontable({
-            data: createSpreadsheetData(10, 10),
-            width: 300,
-            height: 200,
-            editor: 'my-editor',
-            fixedRowsBottom: 2,
+            expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
+              start: document.documentElement.scrollLeft + 49, // 49 - the width of the first cell
+              top: document.documentElement.offsetHeight - 24, // 24 - the height of the last cell
+              width: 51,
+              // maxWidth: ?, // returns wrong value! it will be fixed within #9206
+              height: 24,
+              maxHeight: 24,
+            }));
           });
-
-          selectCell(countRows() - 2, 0);
-
-          expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
-            start: 0,
-            top: 138,
-            width: 50, // 48px (the default cell width closest to the left side of the table) - 8px (padding)
-            maxWidth: 285,
-            height: 24,
-            // maxHeight: ?, // returns wrong value! it will be fixed within #9206
-          }));
-        });
-
-        it('and the scrollable element is the Window object', () => {
-          handsontable({
-            licenseKey: 'non-commercial-and-evaluation',
-            data: createSpreadsheetData(100, 100),
-            editor: 'my-editor',
-            fixedRowsBottom: 2,
-          });
-
-          selectCell(countRows() - 2, 0);
-
-          expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
-            start: 0,
-            top: document.documentElement.clientHeight - 47, // 47 - height of the 2 last rows
-            width: 50,
-            maxWidth: document.documentElement.clientWidth,
-            height: 24,
-            // maxHeight: ?, // returns wrong value! it will be fixed within #9206
-          }));
-        });
-      });
-
-      describe('for bottom overlay when viewport is scrolled to the bottom-right edge', () => {
-        it('and the scrollable element is not the Window object', () => {
-          handsontable({
-            data: createSpreadsheetData(10, 10),
-            width: 300,
-            height: 200,
-            editor: 'my-editor',
-            fixedRowsBottom: 2,
-          });
-
-          scrollViewportTo(countRows() - 1, countCols() - 1);
-          selectCell(countRows() - 1, countCols() - 1);
-
-          expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
-            start: 234,
-            top: 161,
-            width: 51,
-            maxWidth: 51,
-            height: 24,
-            // maxHeight: ?, // returns wrong value! it will be fixed within #9206
-          }));
         });
 
-        it('and the scrollable element is the Window object', () => {
-          handsontable({
-            licenseKey: 'non-commercial-and-evaluation',
-            data: createSpreadsheetData(100, 100),
-            editor: 'my-editor',
-            fixedRowsBottom: 2,
+        describe('for bottom-left corner overlay when viewport is scrolled to the top-left edge', () => {
+          it('and the scrollable element is not the Window object', () => {
+            handsontable({
+              layoutDirection,
+              data: createSpreadsheetData(10, 10),
+              width: 300,
+              height: 200,
+              editor: 'my-editor',
+              fixedColumnsStart: 2,
+              fixedRowsBottom: 2,
+            });
+
+            selectCell(8, 0);
+
+            expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
+              start: 0,
+              top: 138,
+              width: 50,
+              maxWidth: 285,
+              height: 24,
+              // maxHeight: ?, // returns wrong value! it will be fixed within #9206
+            }));
           });
 
-          scrollViewportTo(countRows() - 1, countCols() - 1);
-          selectCell(countRows() - 1, countCols() - 1);
+          it('and the scrollable element is the Window object', () => {
+            handsontable({
+              layoutDirection,
+              licenseKey: 'non-commercial-and-evaluation',
+              data: createSpreadsheetData(100, 100),
+              editor: 'my-editor',
+              fixedColumnsStart: 2,
+              fixedRowsBottom: 2,
+            });
 
-          expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
-            start: 4950,
-            top: document.documentElement.offsetHeight - 24,
-            width: 51,
-            maxWidth: 50,
-            height: 24,
-            // maxHeight: ?, // returns wrong value! it will be fixed within #9206
-          }));
+            selectCell(countRows() - 2, 0);
+
+            expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
+              start: 0,
+              top: document.documentElement.clientHeight - 47, // 47 - height of the 2 last rows,
+              width: 50,
+              maxWidth: document.documentElement.clientWidth,
+              height: 24,
+              // maxHeight: ?, // returns wrong value! it will be fixed within #9206
+            }));
+          });
+        });
+
+        describe('for bottom-left corner overlay when viewport is scrolled to the bottom-right edge', () => {
+          it('and the scrollable element is not the Window object', () => {
+            handsontable({
+              layoutDirection,
+              data: createSpreadsheetData(10, 10),
+              width: 300,
+              height: 200,
+              editor: 'my-editor',
+              fixedColumnsStart: 2,
+              fixedRowsBottom: 2,
+            });
+
+            scrollViewportTo(countRows() - 1, countCols() - 1);
+            selectCell(countRows() - 2, 0);
+
+            expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
+              start: 0,
+              top: 138,
+              width: 50,
+              // maxWidth: ?, // returns wrong value! it will be fixed within #9206
+              height: 24,
+              // maxHeight: ?, // returns wrong value! it will be fixed within #9206
+            }));
+          });
+
+          it('and the scrollable element is the Window object', () => {
+            handsontable({
+              layoutDirection,
+              licenseKey: 'non-commercial-and-evaluation',
+              data: createSpreadsheetData(100, 100),
+              editor: 'my-editor',
+              fixedColumnsStart: 2,
+              fixedRowsBottom: 2,
+            });
+
+            scrollViewportTo(countRows() - 1, countCols() - 1);
+            selectCell(countRows() - 2, 0);
+
+            expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
+              start: document.documentElement.scrollLeft,
+              top: document.documentElement.offsetHeight - 47,
+              width: 50,
+              // maxWidth: ?, // returns wrong value! it will be fixed within #9206
+              height: 24,
+              // maxHeight: ?, // returns wrong value! it will be fixed within #9206
+            }));
+          });
+        });
+
+        describe('for bottom overlay when viewport is scrolled to the top-left edge', () => {
+          it('and the scrollable element is not the Window object', () => {
+            handsontable({
+              layoutDirection,
+              data: createSpreadsheetData(10, 10),
+              width: 300,
+              height: 200,
+              editor: 'my-editor',
+              fixedRowsBottom: 2,
+            });
+
+            selectCell(countRows() - 2, 0);
+
+            expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
+              start: 0,
+              top: 138,
+              width: 50, // 48px (the default cell width closest to the left side of the table) - 8px (padding)
+              maxWidth: 285,
+              height: 24,
+              // maxHeight: ?, // returns wrong value! it will be fixed within #9206
+            }));
+          });
+
+          it('and the scrollable element is the Window object', () => {
+            handsontable({
+              layoutDirection,
+              licenseKey: 'non-commercial-and-evaluation',
+              data: createSpreadsheetData(100, 100),
+              editor: 'my-editor',
+              fixedRowsBottom: 2,
+            });
+
+            selectCell(countRows() - 2, 0);
+
+            expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
+              start: 0,
+              top: document.documentElement.clientHeight - 47, // 47 - height of the 2 last rows
+              width: 50,
+              maxWidth: document.documentElement.clientWidth,
+              height: 24,
+              // maxHeight: ?, // returns wrong value! it will be fixed within #9206
+            }));
+          });
+        });
+
+        describe('for bottom overlay when viewport is scrolled to the bottom-right edge', () => {
+          it('and the scrollable element is not the Window object', () => {
+            handsontable({
+              layoutDirection,
+              data: createSpreadsheetData(10, 10),
+              width: 300,
+              height: 200,
+              editor: 'my-editor',
+              fixedRowsBottom: 2,
+            });
+
+            scrollViewportTo(countRows() - 1, countCols() - 1);
+            selectCell(countRows() - 1, countCols() - 1);
+
+            expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
+              start: 234,
+              top: 161,
+              width: 51,
+              maxWidth: 51,
+              height: 24,
+              // maxHeight: ?, // returns wrong value! it will be fixed within #9206
+            }));
+          });
+
+          // it('and the scrollable element is the Window object', () => {
+          //   handsontable({
+          //     layoutDirection,
+          //     licenseKey: 'non-commercial-and-evaluation',
+          //     data: createSpreadsheetData(100, 100),
+          //     editor: 'my-editor',
+          //     fixedRowsBottom: 2,
+          //   });
+
+          //   scrollViewportTo(countRows() - 1, countCols() - 1);
+          //   selectCell(countRows() - 1, countCols() - 1);
+
+          //   expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
+          //     start: 4950,
+          //     top: document.documentElement.offsetHeight - 24,
+          //     width: 51,
+          //     maxWidth: 50,
+          //     height: 24,
+          //     // maxHeight: ?, // returns wrong value! it will be fixed within #9206
+          //   }));
+          // });
         });
       });
     });

--- a/handsontable/src/editors/baseEditor/__tests__/rtl/API.spec.js
+++ b/handsontable/src/editors/baseEditor/__tests__/rtl/API.spec.js
@@ -1,22 +1,4 @@
 describe('BaseEditor API (RTL mode)', () => {
-  const id = 'testContainer';
-
-  beforeEach(function() {
-    $('.jasmine_html-reporter').hide();
-    $('html').attr('dir', 'rtl');
-    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
-  });
-
-  afterEach(function() {
-    $('.jasmine_html-reporter').show();
-    $('html').attr('dir', 'ltr');
-
-    if (this.$container) {
-      destroy();
-      this.$container.remove();
-    }
-  });
-
   Handsontable.editors.registerEditor('my-editor', class BaseEditor extends Handsontable.editors.BaseEditor {
     open() {}
     close() {}
@@ -25,453 +7,498 @@ describe('BaseEditor API (RTL mode)', () => {
     focus() {}
   });
 
-  describe('getEditedCellRect()', () => {
-    describe('should return an object with provided correct information about size and position of the cell', () => {
-      describe('for top overlay when viewport is scrolled to the top-right edge', () => {
-        it('and the scrollable element is not the Window object', () => {
-          handsontable({
-            data: createSpreadsheetData(10, 10),
-            width: 300,
-            height: 200,
-            editor: 'my-editor',
-            fixedRowsTop: 2,
+  using('configuration object', [
+    { htmlDir: 'rtl', layoutDirection: 'inherit' },
+    { htmlDir: 'ltr', layoutDirection: 'rtl' },
+  ], ({ htmlDir, layoutDirection }) => {
+    const id = 'testContainer';
+
+    beforeEach(function() {
+      $('.jasmine_html-reporter').hide();
+      $('html').attr('dir', htmlDir);
+      this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+    });
+
+    afterEach(function() {
+      $('.jasmine_html-reporter').show();
+      $('html').attr('dir', 'ltr');
+
+      if (this.$container) {
+        destroy();
+        this.$container.remove();
+      }
+    });
+
+    describe('getEditedCellRect()', () => {
+      describe('should return an object with provided correct information about size and position of the cell', () => {
+        describe('for top overlay when viewport is scrolled to the top-right edge', () => {
+          it('and the scrollable element is not the Window object', () => {
+            handsontable({
+              layoutDirection,
+              data: createSpreadsheetData(10, 10),
+              width: 300,
+              height: 200,
+              editor: 'my-editor',
+              fixedRowsTop: 2,
+            });
+
+            selectCell(0, 0);
+
+            expect(getActiveEditor().getEditedCellRect()).toEqual({
+              start: 0,
+              top: 0,
+              width: 50,
+              maxWidth: 285,
+              height: 24,
+              maxHeight: 185,
+            });
           });
 
-          selectCell(0, 0);
+          it('and the scrollable element is the Window object', () => {
+            handsontable({
+              layoutDirection,
+              licenseKey: 'non-commercial-and-evaluation',
+              data: createSpreadsheetData(100, 100),
+              editor: 'my-editor',
+              fixedRowsTop: 2,
+            });
 
-          expect(getActiveEditor().getEditedCellRect()).toEqual({
-            start: 0,
-            top: 0,
-            width: 50,
-            maxWidth: 285,
-            height: 24,
-            maxHeight: 185,
-          });
-        });
+            selectCell(0, 0);
 
-        it('and the scrollable element is the Window object', () => {
-          handsontable({
-            licenseKey: 'non-commercial-and-evaluation',
-            data: createSpreadsheetData(100, 100),
-            editor: 'my-editor',
-            fixedRowsTop: 2,
-          });
-
-          selectCell(0, 0);
-
-          expect(getActiveEditor().getEditedCellRect()).toEqual({
-            start: 0,
-            top: 0,
-            width: 50,
-            maxWidth: document.documentElement.clientWidth,
-            height: 24,
-            maxHeight: document.documentElement.clientHeight,
-          });
-        });
-      });
-
-      describe('for top overlay when viewport is scrolled to the bottom-left edge', () => {
-        it('and the scrollable element is not the Window object', () => {
-          handsontable({
-            data: createSpreadsheetData(10, 10),
-            width: 300,
-            height: 200,
-            editor: 'my-editor',
-            fixedRowsTop: 2,
-          });
-
-          scrollViewportTo(countRows() - 1, countCols() - 1);
-          selectCell(1, countRows() - 1);
-
-          expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
-            start: 234,
-            top: 23,
-            width: 51,
-            maxWidth: 51,
-            height: 24,
-            // maxHeight: ?, // returns wrong value! it will be fixed within #9206
-          }));
-        });
-
-        it('and the scrollable element is the Window object', () => {
-          handsontable({
-            licenseKey: 'non-commercial-and-evaluation',
-            data: createSpreadsheetData(100, 100),
-            editor: 'my-editor',
-            fixedRowsTop: 2,
-          });
-
-          scrollViewportTo(countRows() - 1, countCols() - 1);
-          selectCell(1, countCols() - 1);
-
-          expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
-            start: Math.abs(document.documentElement.scrollLeft) + document.documentElement.clientWidth - 50, // 50 - the width of the first cell
-            top: document.documentElement.offsetHeight - document.documentElement.clientHeight + 23,
-            width: 51,
-            maxWidth: 50,
-            height: 24,
-            // maxHeight: ?, // returns wrong value! it will be fixed within #9206
-          }));
-        });
-      });
-
-      describe('for top-right corner overlay when viewport is scrolled to the top-right edge', () => {
-        it('and the scrollable element is not the Window object', () => {
-          handsontable({
-            data: createSpreadsheetData(10, 10),
-            width: 300,
-            height: 200,
-            editor: 'my-editor',
-            fixedColumnsStart: 2,
-            fixedRowsTop: 2,
-          });
-
-          selectCell(0, 0);
-
-          expect(getActiveEditor().getEditedCellRect()).toEqual({
-            start: 0,
-            top: 0,
-            width: 50,
-            maxWidth: 285,
-            height: 24,
-            maxHeight: 185,
+            expect(getActiveEditor().getEditedCellRect()).toEqual({
+              start: 0,
+              top: 0,
+              width: 50,
+              maxWidth: document.documentElement.clientWidth,
+              height: 24,
+              maxHeight: document.documentElement.clientHeight,
+            });
           });
         });
 
-        it('and the scrollable element is the Window object', () => {
-          handsontable({
-            licenseKey: 'non-commercial-and-evaluation',
-            data: createSpreadsheetData(100, 100),
-            editor: 'my-editor',
-            fixedColumnsStart: 2,
-            fixedRowsTop: 2,
+        describe('for top overlay when viewport is scrolled to the bottom-left edge', () => {
+          it('and the scrollable element is not the Window object', () => {
+            handsontable({
+              layoutDirection,
+              data: createSpreadsheetData(10, 10),
+              width: 300,
+              height: 200,
+              editor: 'my-editor',
+              fixedRowsTop: 2,
+            });
+
+            scrollViewportTo(countRows() - 1, countCols() - 1);
+            selectCell(1, countRows() - 1);
+
+            expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
+              start: 234,
+              top: 23,
+              width: 51,
+              maxWidth: 51,
+              height: 24,
+              // maxHeight: ?, // returns wrong value! it will be fixed within #9206
+            }));
           });
 
-          selectCell(0, 0);
+          // it('and the scrollable element is the Window object', async() => {
+          //   handsontable({
+          //     layoutDirection,
+          //     licenseKey: 'non-commercial-and-evaluation',
+          //     data: createSpreadsheetData(100, 100),
+          //     editor: 'my-editor',
+          //     fixedRowsTop: 2,
+          //   });
 
-          expect(getActiveEditor().getEditedCellRect()).toEqual({
-            start: 0,
-            top: 0,
-            width: 50,
-            maxWidth: document.documentElement.clientWidth,
-            height: 24,
-            maxHeight: document.documentElement.clientHeight,
-          });
-        });
-      });
+          //   scrollViewportTo(countRows() - 1, countCols() - 1);
+          //   selectCell(1, countCols() - 1);
 
-      describe('for top-right corner overlay when viewport is scrolled to the bottom-left edge', () => {
-        it('and the scrollable element is not the Window object', () => {
-          handsontable({
-            data: createSpreadsheetData(10, 10),
-            width: 300,
-            height: 200,
-            editor: 'my-editor',
-            fixedColumnsStart: 2,
-            fixedRowsTop: 2,
-          });
+          //   await sleep(100);
 
-          scrollViewportTo(countRows() - 1, countCols() - 1);
-          selectCell(1, 1);
-
-          expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
-            start: 49,
-            top: 23,
-            width: 51,
-            // maxWidth: ?, // returns wrong value! it will be fixed within #9206
-            height: 24,
-            // maxHeight: ?, // returns wrong value! it will be fixed within #9206
-          }));
-        });
-
-        it('and the scrollable element is the Window object', () => {
-          handsontable({
-            licenseKey: 'non-commercial-and-evaluation',
-            data: createSpreadsheetData(100, 100),
-            editor: 'my-editor',
-            fixedColumnsStart: 2,
-            fixedRowsTop: 2,
-          });
-
-          scrollViewportTo(countRows() - 1, countCols() - 1);
-          selectCell(1, 1);
-
-          expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
-            start: Math.abs(document.documentElement.scrollLeft) + 49, // 49 - the width of the first cell
-            top: document.documentElement.offsetHeight - document.documentElement.clientHeight + 23,
-            width: 51,
-            // maxWidth: ?, // returns wrong value! it will be fixed within #9206
-            height: 24,
-            // maxHeight: ?, // returns wrong value! it will be fixed within #9206
-          }));
-        });
-      });
-
-      describe('for right overlay when viewport is scrolled to the top-right edge', () => {
-        it('and the scrollable element is not the Window object', () => {
-          handsontable({
-            data: createSpreadsheetData(10, 10),
-            width: 300,
-            height: 200,
-            editor: 'my-editor',
-            fixedColumnsStart: 2,
-          });
-
-          selectCell(0, 0);
-
-          expect(getActiveEditor().getEditedCellRect()).toEqual({
-            start: 0,
-            top: 0,
-            width: 50,
-            maxWidth: 285,
-            height: 24,
-            maxHeight: 185,
-          });
+          //   expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
+          //     start: Math.abs(document.documentElement.scrollLeft) + document.documentElement.clientWidth - 50, // 50 - the width of the first cell
+          //     top: document.documentElement.offsetHeight - document.documentElement.clientHeight + 23,
+          //     width: 51,
+          //     maxWidth: 50,
+          //     height: 24,
+          //     // maxHeight: ?, // returns wrong value! it will be fixed within #9206
+          //   }));
+          // });
         });
 
-        it('and the scrollable element is the Window object', () => {
-          handsontable({
-            licenseKey: 'non-commercial-and-evaluation',
-            data: createSpreadsheetData(100, 100),
-            editor: 'my-editor',
-            fixedColumnsStart: 2,
+        describe('for top-right corner overlay when viewport is scrolled to the top-right edge', () => {
+          it('and the scrollable element is not the Window object', () => {
+            handsontable({
+              layoutDirection,
+              data: createSpreadsheetData(10, 10),
+              width: 300,
+              height: 200,
+              editor: 'my-editor',
+              fixedColumnsStart: 2,
+              fixedRowsTop: 2,
+            });
+
+            selectCell(0, 0);
+
+            expect(getActiveEditor().getEditedCellRect()).toEqual({
+              start: 0,
+              top: 0,
+              width: 50,
+              maxWidth: 285,
+              height: 24,
+              maxHeight: 185,
+            });
           });
 
-          selectCell(0, 0);
+          it('and the scrollable element is the Window object', () => {
+            handsontable({
+              layoutDirection,
+              licenseKey: 'non-commercial-and-evaluation',
+              data: createSpreadsheetData(100, 100),
+              editor: 'my-editor',
+              fixedColumnsStart: 2,
+              fixedRowsTop: 2,
+            });
 
-          expect(getActiveEditor().getEditedCellRect()).toEqual({
-            start: 0,
-            top: 0,
-            width: 50,
-            maxWidth: document.documentElement.clientWidth,
-            height: 24,
-            maxHeight: document.documentElement.clientHeight,
+            selectCell(0, 0);
+
+            expect(getActiveEditor().getEditedCellRect()).toEqual({
+              start: 0,
+              top: 0,
+              width: 50,
+              maxWidth: document.documentElement.clientWidth,
+              height: 24,
+              maxHeight: document.documentElement.clientHeight,
+            });
           });
         });
-      });
 
-      describe('for right overlay when viewport is scrolled to the bottom-left edge', () => {
-        it('and the scrollable element is not the Window object', () => {
-          handsontable({
-            data: createSpreadsheetData(10, 10),
-            width: 300,
-            height: 200,
-            editor: 'my-editor',
-            fixedColumnsStart: 2,
+        describe('for top-right corner overlay when viewport is scrolled to the bottom-left edge', () => {
+          it('and the scrollable element is not the Window object', () => {
+            handsontable({
+              layoutDirection,
+              data: createSpreadsheetData(10, 10),
+              width: 300,
+              height: 200,
+              editor: 'my-editor',
+              fixedColumnsStart: 2,
+              fixedRowsTop: 2,
+            });
+
+            scrollViewportTo(countRows() - 1, countCols() - 1);
+            selectCell(1, 1);
+
+            expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
+              start: 49,
+              top: 23,
+              width: 51,
+              // maxWidth: ?, // returns wrong value! it will be fixed within #9206
+              height: 24,
+              // maxHeight: ?, // returns wrong value! it will be fixed within #9206
+            }));
           });
 
-          scrollViewportTo(countRows() - 1, countCols() - 1);
-          selectCell(countRows() - 1, 1);
+          it('and the scrollable element is the Window object', () => {
+            handsontable({
+              layoutDirection,
+              licenseKey: 'non-commercial-and-evaluation',
+              data: createSpreadsheetData(100, 100),
+              editor: 'my-editor',
+              fixedColumnsStart: 2,
+              fixedRowsTop: 2,
+            });
 
-          expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
-            start: 49,
-            top: 161,
-            width: 51,
-            // maxWidth: ?, // returns wrong value! it will be fixed within #9206
-            height: 24,
-            maxHeight: 24,
-          }));
+            scrollViewportTo(countRows() - 1, countCols() - 1);
+            selectCell(1, 1);
+
+            expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
+              start: Math.abs(document.documentElement.scrollLeft) + 49, // 49 - the width of the first cell
+              top: document.documentElement.offsetHeight - document.documentElement.clientHeight + 23,
+              width: 51,
+              // maxWidth: ?, // returns wrong value! it will be fixed within #9206
+              height: 24,
+              // maxHeight: ?, // returns wrong value! it will be fixed within #9206
+            }));
+          });
         });
 
-        it('and the scrollable element is the Window object', () => {
-          handsontable({
-            licenseKey: 'non-commercial-and-evaluation',
-            data: createSpreadsheetData(100, 100),
-            editor: 'my-editor',
-            fixedColumnsStart: 2,
+        describe('for right overlay when viewport is scrolled to the top-right edge', () => {
+          it('and the scrollable element is not the Window object', () => {
+            handsontable({
+              layoutDirection,
+              data: createSpreadsheetData(10, 10),
+              width: 300,
+              height: 200,
+              editor: 'my-editor',
+              fixedColumnsStart: 2,
+            });
+
+            selectCell(0, 0);
+
+            expect(getActiveEditor().getEditedCellRect()).toEqual({
+              start: 0,
+              top: 0,
+              width: 50,
+              maxWidth: 285,
+              height: 24,
+              maxHeight: 185,
+            });
           });
 
-          scrollViewportTo(countRows() - 1, countCols() - 1);
-          selectCell(countRows() - 1, 1);
+          it('and the scrollable element is the Window object', () => {
+            handsontable({
+              layoutDirection,
+              licenseKey: 'non-commercial-and-evaluation',
+              data: createSpreadsheetData(100, 100),
+              editor: 'my-editor',
+              fixedColumnsStart: 2,
+            });
 
-          expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
-            start: Math.abs(document.documentElement.scrollLeft) + 49, // 49 - the width of the first cell
-            top: document.documentElement.offsetHeight - 24, // 24 - the height of the last cell
-            width: 51,
-            // maxWidth: ?, // returns wrong value! it will be fixed within #9206
-            height: 24,
-            maxHeight: 24,
-          }));
-        });
-      });
+            selectCell(0, 0);
 
-      describe('for bottom-right corner overlay when viewport is scrolled to the top-right edge', () => {
-        it('and the scrollable element is not the Window object', () => {
-          handsontable({
-            data: createSpreadsheetData(10, 10),
-            width: 300,
-            height: 200,
-            editor: 'my-editor',
-            fixedColumnsStart: 2,
-            fixedRowsBottom: 2,
+            expect(getActiveEditor().getEditedCellRect()).toEqual({
+              start: 0,
+              top: 0,
+              width: 50,
+              maxWidth: document.documentElement.clientWidth,
+              height: 24,
+              maxHeight: document.documentElement.clientHeight,
+            });
           });
-
-          selectCell(8, 0);
-
-          expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
-            start: 0,
-            top: 138,
-            width: 50,
-            maxWidth: 285,
-            height: 24,
-            // maxHeight: ?, // returns wrong value! it will be fixed within #9206
-          }));
-        });
-
-        it('and the scrollable element is the Window object', () => {
-          handsontable({
-            licenseKey: 'non-commercial-and-evaluation',
-            data: createSpreadsheetData(100, 100),
-            editor: 'my-editor',
-            fixedColumnsStart: 2,
-            fixedRowsBottom: 2,
-          });
-
-          selectCell(countRows() - 2, 0);
-
-          expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
-            start: 0,
-            top: document.documentElement.clientHeight - 47, // 47 - height of the 2 last rows,
-            width: 50,
-            maxWidth: document.documentElement.clientWidth,
-            height: 24,
-            // maxHeight: ?, // returns wrong value! it will be fixed within #9206
-          }));
-        });
-      });
-
-      describe('for bottom-right corner overlay when viewport is scrolled to the bottom-left edge', () => {
-        it('and the scrollable element is not the Window object', () => {
-          handsontable({
-            data: createSpreadsheetData(10, 10),
-            width: 300,
-            height: 200,
-            editor: 'my-editor',
-            fixedColumnsStart: 2,
-            fixedRowsBottom: 2,
-          });
-
-          scrollViewportTo(countRows() - 1, countCols() - 1);
-          selectCell(countRows() - 2, 0);
-
-          expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
-            start: 0,
-            top: 138,
-            width: 50,
-            // maxWidth: ?, // returns wrong value! it will be fixed within #9206
-            height: 24,
-            // maxHeight: ?, // returns wrong value! it will be fixed within #9206
-          }));
         });
 
-        it('and the scrollable element is the Window object', () => {
-          handsontable({
-            licenseKey: 'non-commercial-and-evaluation',
-            data: createSpreadsheetData(100, 100),
-            editor: 'my-editor',
-            fixedColumnsStart: 2,
-            fixedRowsBottom: 2,
+        describe('for right overlay when viewport is scrolled to the bottom-left edge', () => {
+          it('and the scrollable element is not the Window object', () => {
+            handsontable({
+              layoutDirection,
+              data: createSpreadsheetData(10, 10),
+              width: 300,
+              height: 200,
+              editor: 'my-editor',
+              fixedColumnsStart: 2,
+            });
+
+            scrollViewportTo(countRows() - 1, countCols() - 1);
+            selectCell(countRows() - 1, 1);
+
+            expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
+              start: 49,
+              top: 161,
+              width: 51,
+              // maxWidth: ?, // returns wrong value! it will be fixed within #9206
+              height: 24,
+              maxHeight: 24,
+            }));
           });
 
-          scrollViewportTo(countRows() - 1, countCols() - 1);
-          selectCell(countRows() - 2, 0);
+          it('and the scrollable element is the Window object', () => {
+            handsontable({
+              layoutDirection,
+              licenseKey: 'non-commercial-and-evaluation',
+              data: createSpreadsheetData(100, 100),
+              editor: 'my-editor',
+              fixedColumnsStart: 2,
+            });
 
-          expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
-            start: Math.abs(document.documentElement.scrollLeft),
-            top: document.documentElement.offsetHeight - 47,
-            width: 50,
-            // maxWidth: ?, // returns wrong value! it will be fixed within #9206
-            height: 24,
-            // maxHeight: ?, // returns wrong value! it will be fixed within #9206
-          }));
-        });
-      });
+            scrollViewportTo(countRows() - 1, countCols() - 1);
+            selectCell(countRows() - 1, 1);
 
-      describe('for bottom overlay when viewport is scrolled to the top-right edge', () => {
-        it('and the scrollable element is not the Window object', () => {
-          handsontable({
-            data: createSpreadsheetData(10, 10),
-            width: 300,
-            height: 200,
-            editor: 'my-editor',
-            fixedRowsBottom: 2,
+            expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
+              start: Math.abs(document.documentElement.scrollLeft) + 49, // 49 - the width of the first cell
+              top: document.documentElement.offsetHeight - 24, // 24 - the height of the last cell
+              width: 51,
+              // maxWidth: ?, // returns wrong value! it will be fixed within #9206
+              height: 24,
+              maxHeight: 24,
+            }));
           });
-
-          selectCell(countRows() - 2, 0);
-
-          expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
-            start: 0,
-            top: 138,
-            width: 50,
-            maxWidth: 285,
-            height: 24,
-            // maxHeight: ?, // returns wrong value! it will be fixed within #9206
-          }));
-        });
-
-        it('and the scrollable element is the Window object', () => {
-          handsontable({
-            licenseKey: 'non-commercial-and-evaluation',
-            data: createSpreadsheetData(100, 100),
-            editor: 'my-editor',
-            fixedRowsBottom: 2,
-          });
-
-          selectCell(countRows() - 2, 0);
-
-          expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
-            start: 0,
-            top: document.documentElement.clientHeight - 47, // 47 - height of the 2 last rows
-            width: 50,
-            maxWidth: document.documentElement.clientWidth,
-            height: 24,
-            // maxHeight: ?, // returns wrong value! it will be fixed within #9206
-          }));
-        });
-      });
-
-      describe('for bottom overlay when viewport is scrolled to the bottom-left edge', () => {
-        it('and the scrollable element is not the Window object', () => {
-          handsontable({
-            data: createSpreadsheetData(10, 10),
-            width: 300,
-            height: 200,
-            editor: 'my-editor',
-            fixedRowsBottom: 2,
-          });
-
-          scrollViewportTo(countRows() - 1, countCols() - 1);
-          selectCell(countRows() - 1, countCols() - 1);
-
-          expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
-            start: 234,
-            top: 161,
-            width: 51,
-            maxWidth: 51,
-            height: 24,
-            // maxHeight: ?, // returns wrong value! it will be fixed within #9206
-          }));
         });
 
-        it('and the scrollable element is the Window object', () => {
-          handsontable({
-            licenseKey: 'non-commercial-and-evaluation',
-            data: createSpreadsheetData(100, 100),
-            editor: 'my-editor',
-            fixedRowsBottom: 2,
+        describe('for bottom-right corner overlay when viewport is scrolled to the top-right edge', () => {
+          it('and the scrollable element is not the Window object', () => {
+            handsontable({
+              layoutDirection,
+              data: createSpreadsheetData(10, 10),
+              width: 300,
+              height: 200,
+              editor: 'my-editor',
+              fixedColumnsStart: 2,
+              fixedRowsBottom: 2,
+            });
+
+            selectCell(8, 0);
+
+            expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
+              start: 0,
+              top: 138,
+              width: 50,
+              maxWidth: 285,
+              height: 24,
+              // maxHeight: ?, // returns wrong value! it will be fixed within #9206
+            }));
           });
 
-          scrollViewportTo(countRows() - 1, countCols() - 1);
-          selectCell(countRows() - 1, countCols() - 1);
+          it('and the scrollable element is the Window object', () => {
+            handsontable({
+              layoutDirection,
+              licenseKey: 'non-commercial-and-evaluation',
+              data: createSpreadsheetData(100, 100),
+              editor: 'my-editor',
+              fixedColumnsStart: 2,
+              fixedRowsBottom: 2,
+            });
 
-          expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
-            start: 4950,
-            top: document.documentElement.offsetHeight - 24,
-            width: 51,
-            maxWidth: 50,
-            height: 24,
-            // maxHeight: ?, // returns wrong value! it will be fixed within #9206
-          }));
+            selectCell(countRows() - 2, 0);
+
+            expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
+              start: 0,
+              top: document.documentElement.clientHeight - 47, // 47 - height of the 2 last rows,
+              width: 50,
+              maxWidth: document.documentElement.clientWidth,
+              height: 24,
+              // maxHeight: ?, // returns wrong value! it will be fixed within #9206
+            }));
+          });
+        });
+
+        describe('for bottom-right corner overlay when viewport is scrolled to the bottom-left edge', () => {
+          it('and the scrollable element is not the Window object', () => {
+            handsontable({
+              layoutDirection,
+              data: createSpreadsheetData(10, 10),
+              width: 300,
+              height: 200,
+              editor: 'my-editor',
+              fixedColumnsStart: 2,
+              fixedRowsBottom: 2,
+            });
+
+            scrollViewportTo(countRows() - 1, countCols() - 1);
+            selectCell(countRows() - 2, 0);
+
+            expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
+              start: 0,
+              top: 138,
+              width: 50,
+              // maxWidth: ?, // returns wrong value! it will be fixed within #9206
+              height: 24,
+              // maxHeight: ?, // returns wrong value! it will be fixed within #9206
+            }));
+          });
+
+          it('and the scrollable element is the Window object', () => {
+            handsontable({
+              layoutDirection,
+              licenseKey: 'non-commercial-and-evaluation',
+              data: createSpreadsheetData(100, 100),
+              editor: 'my-editor',
+              fixedColumnsStart: 2,
+              fixedRowsBottom: 2,
+            });
+
+            scrollViewportTo(countRows() - 1, countCols() - 1);
+            selectCell(countRows() - 2, 0);
+
+            expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
+              start: Math.abs(document.documentElement.scrollLeft),
+              top: document.documentElement.offsetHeight - 47,
+              width: 50,
+              // maxWidth: ?, // returns wrong value! it will be fixed within #9206
+              height: 24,
+              // maxHeight: ?, // returns wrong value! it will be fixed within #9206
+            }));
+          });
+        });
+
+        describe('for bottom overlay when viewport is scrolled to the top-right edge', () => {
+          it('and the scrollable element is not the Window object', () => {
+            handsontable({
+              layoutDirection,
+              data: createSpreadsheetData(10, 10),
+              width: 300,
+              height: 200,
+              editor: 'my-editor',
+              fixedRowsBottom: 2,
+            });
+
+            selectCell(countRows() - 2, 0);
+
+            expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
+              start: 0,
+              top: 138,
+              width: 50,
+              maxWidth: 285,
+              height: 24,
+              // maxHeight: ?, // returns wrong value! it will be fixed within #9206
+            }));
+          });
+
+          it('and the scrollable element is the Window object', () => {
+            handsontable({
+              layoutDirection,
+              licenseKey: 'non-commercial-and-evaluation',
+              data: createSpreadsheetData(100, 100),
+              editor: 'my-editor',
+              fixedRowsBottom: 2,
+            });
+
+            selectCell(countRows() - 2, 0);
+
+            expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
+              start: 0,
+              top: document.documentElement.clientHeight - 47, // 47 - height of the 2 last rows
+              width: 50,
+              maxWidth: document.documentElement.clientWidth,
+              height: 24,
+              // maxHeight: ?, // returns wrong value! it will be fixed within #9206
+            }));
+          });
+        });
+
+        describe('for bottom overlay when viewport is scrolled to the bottom-left edge', () => {
+          it('and the scrollable element is not the Window object', () => {
+            handsontable({
+              layoutDirection,
+              data: createSpreadsheetData(10, 10),
+              width: 300,
+              height: 200,
+              editor: 'my-editor',
+              fixedRowsBottom: 2,
+            });
+
+            scrollViewportTo(countRows() - 1, countCols() - 1);
+            selectCell(countRows() - 1, countCols() - 1);
+
+            expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
+              start: 234,
+              top: 161,
+              width: 51,
+              maxWidth: 51,
+              height: 24,
+              // maxHeight: ?, // returns wrong value! it will be fixed within #9206
+            }));
+          });
+
+          // it('and the scrollable element is the Window object', () => {
+          //   handsontable({
+          //     layoutDirection,
+          //     licenseKey: 'non-commercial-and-evaluation',
+          //     data: createSpreadsheetData(100, 100),
+          //     editor: 'my-editor',
+          //     fixedRowsBottom: 2,
+          //   });
+
+          //   scrollViewportTo(countRows() - 1, countCols() - 1);
+          //   selectCell(countRows() - 1, countCols() - 1);
+
+          //   expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
+          //     start: 4950,
+          //     top: document.documentElement.offsetHeight - 24,
+          //     width: 51,
+          //     maxWidth: 50,
+          //     height: 24,
+          //     // maxHeight: ?, // returns wrong value! it will be fixed within #9206
+          //   }));
+          // });
         });
       });
     });

--- a/handsontable/src/editors/baseEditor/__tests__/rtl/API.spec.js
+++ b/handsontable/src/editors/baseEditor/__tests__/rtl/API.spec.js
@@ -100,29 +100,35 @@ describe('BaseEditor API (RTL mode)', () => {
             }));
           });
 
-          // it('and the scrollable element is the Window object', async() => {
-          //   handsontable({
-          //     layoutDirection,
-          //     licenseKey: 'non-commercial-and-evaluation',
-          //     data: createSpreadsheetData(100, 100),
-          //     editor: 'my-editor',
-          //     fixedRowsTop: 2,
-          //   });
+          it('and the scrollable element is the Window object', async() => {
+            // For this configuration object "{ htmlDir: 'ltr', layoutDirection: 'rtl' }" it's necessary to force
+            // always RTL on document, otherwise the horizontal scrollbar won't appear and test fail.
+            if (htmlDir === 'ltr' && layoutDirection === 'rtl') {
+              $('html').attr('dir', 'rtl');
+            }
 
-          //   scrollViewportTo(countRows() - 1, countCols() - 1);
-          //   selectCell(1, countCols() - 1);
+            handsontable({
+              layoutDirection,
+              licenseKey: 'non-commercial-and-evaluation',
+              data: createSpreadsheetData(100, 100),
+              editor: 'my-editor',
+              fixedRowsTop: 2,
+            });
 
-          //   await sleep(100);
+            scrollViewportTo(countRows() - 1, countCols() - 1);
+            selectCell(1, countCols() - 1);
 
-          //   expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
-          //     start: Math.abs(document.documentElement.scrollLeft) + document.documentElement.clientWidth - 50, // 50 - the width of the first cell
-          //     top: document.documentElement.offsetHeight - document.documentElement.clientHeight + 23,
-          //     width: 51,
-          //     maxWidth: 50,
-          //     height: 24,
-          //     // maxHeight: ?, // returns wrong value! it will be fixed within #9206
-          //   }));
-          // });
+            await sleep(100);
+
+            expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
+              start: Math.abs(document.documentElement.scrollLeft) + document.documentElement.clientWidth - 50, // 50 - the width of the first cell
+              top: document.documentElement.offsetHeight - document.documentElement.clientHeight + 23,
+              width: 51,
+              maxWidth: 50,
+              height: 24,
+              // maxHeight: ?, // returns wrong value! it will be fixed within #9206
+            }));
+          });
         });
 
         describe('for top-right corner overlay when viewport is scrolled to the top-right edge', () => {
@@ -478,27 +484,33 @@ describe('BaseEditor API (RTL mode)', () => {
             }));
           });
 
-          // it('and the scrollable element is the Window object', () => {
-          //   handsontable({
-          //     layoutDirection,
-          //     licenseKey: 'non-commercial-and-evaluation',
-          //     data: createSpreadsheetData(100, 100),
-          //     editor: 'my-editor',
-          //     fixedRowsBottom: 2,
-          //   });
+          it('and the scrollable element is the Window object', () => {
+            // For this configuration object "{ htmlDir: 'ltr', layoutDirection: 'rtl' }" it's necessary to force
+            // always RTL on document, otherwise the horizontal scrollbar won't appear and test fail.
+            if (htmlDir === 'ltr' && layoutDirection === 'rtl') {
+              $('html').attr('dir', 'rtl');
+            }
 
-          //   scrollViewportTo(countRows() - 1, countCols() - 1);
-          //   selectCell(countRows() - 1, countCols() - 1);
+            handsontable({
+              layoutDirection,
+              licenseKey: 'non-commercial-and-evaluation',
+              data: createSpreadsheetData(100, 100),
+              editor: 'my-editor',
+              fixedRowsBottom: 2,
+            });
 
-          //   expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
-          //     start: 4950,
-          //     top: document.documentElement.offsetHeight - 24,
-          //     width: 51,
-          //     maxWidth: 50,
-          //     height: 24,
-          //     // maxHeight: ?, // returns wrong value! it will be fixed within #9206
-          //   }));
-          // });
+            scrollViewportTo(countRows() - 1, countCols() - 1);
+            selectCell(countRows() - 1, countCols() - 1);
+
+            expect(getActiveEditor().getEditedCellRect()).toEqual(jasmine.objectContaining({
+              start: 4950,
+              top: document.documentElement.offsetHeight - 24,
+              width: 51,
+              maxWidth: 50,
+              height: 24,
+              // maxHeight: ?, // returns wrong value! it will be fixed within #9206
+            }));
+          });
         });
       });
     });

--- a/handsontable/src/editors/dateEditor/__tests__/rtl/dateEditor.spec.js
+++ b/handsontable/src/editors/dateEditor/__tests__/rtl/dateEditor.spec.js
@@ -1,109 +1,118 @@
 describe('DateEditor (RTL mode)', () => {
-  const id = 'testContainer';
+  using('configuration object', [
+    { htmlDir: 'rtl', layoutDirection: 'inherit' },
+    { htmlDir: 'ltr', layoutDirection: 'rtl' },
+  ], ({ htmlDir, layoutDirection }) => {
+    const id = 'testContainer';
 
-  beforeEach(function() {
-    $('html').attr('dir', 'rtl');
-    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
-  });
-
-  afterEach(function() {
-    $('html').attr('dir', 'ltr');
-
-    if (this.$container) {
-      destroy();
-      this.$container.remove();
-    }
-  });
-
-  it('should render an editable editor\'s element without messing with "dir" attribute', () => {
-    handsontable({
-      data: Handsontable.helper.createSpreadsheetData(2, 5),
-      editor: 'date',
+    beforeEach(function() {
+      $('html').attr('dir', htmlDir);
+      this.$container = $(`<div id="${id}"></div>`).appendTo('body');
     });
 
-    selectCell(0, 0);
+    afterEach(function() {
+      $('html').attr('dir', 'ltr');
 
-    const editableElement = getActiveEditor().TEXTAREA;
-
-    expect(editableElement.getAttribute('dir')).toBeNull();
-  });
-
-  it('should render Pikaday within element that contains correct "dir" attribute value', () => {
-    handsontable({
-      data: Handsontable.helper.createSpreadsheetData(5, 2),
-      columns: [
-        { type: 'date' },
-        { type: 'date' }
-      ]
+      if (this.$container) {
+        destroy();
+        this.$container.remove();
+      }
     });
 
-    selectCell(1, 1);
-    keyDown('enter');
+    it('should render an editable editor\'s element without messing with "dir" attribute', () => {
+      handsontable({
+        layoutDirection,
+        data: Handsontable.helper.createSpreadsheetData(2, 5),
+        editor: 'date',
+      });
 
-    const datePicker = getActiveEditor().datePicker;
-    const config = getActiveEditor().$datePicker.config();
+      selectCell(0, 0);
 
-    expect(datePicker.getAttribute('dir')).toBe('rtl');
-    // it's set as `false` in RTL due to https://github.com/Pikaday/Pikaday/issues/647 bug. The Pikaday layout
-    // direction mode is controlled by above "dir" attribute.
-    expect(config.isRTL).toBe(false);
-  });
+      const editableElement = getActiveEditor().TEXTAREA;
 
-  it('should display Pikaday Calendar left-bottom of the selected cell', () => {
-    handsontable({
-      data: Handsontable.helper.createSpreadsheetData(5, 2),
-      columns: [
-        { type: 'date' },
-        { type: 'date' }
-      ]
+      expect(editableElement.getAttribute('dir')).toBeNull();
     });
 
-    selectCell(1, 1);
-    keyDown('enter');
+    it('should render Pikaday within element that contains correct "dir" attribute value', () => {
+      handsontable({
+        layoutDirection,
+        data: Handsontable.helper.createSpreadsheetData(5, 2),
+        columns: [
+          { type: 'date' },
+          { type: 'date' }
+        ]
+      });
 
-    const cellOffset = $(getActiveEditor().TD).offset();
-    const cellWidth = $(getActiveEditor().TD).outerWidth();
-    const $datePicker = $('.htDatepickerHolder');
-    const datePickerOffset = $datePicker.offset();
-    const datePickerWidth = $datePicker.outerWidth();
+      selectCell(1, 1);
+      keyDown('enter');
 
-    // 23 is a height of the editor's cell
-    expect(cellOffset.top + 23).toBeCloseTo(datePickerOffset.top, 0);
-    expect(cellOffset.left).toBeCloseTo(datePickerOffset.left + datePickerWidth - cellWidth, 0);
-  });
+      const datePicker = getActiveEditor().datePicker;
+      const config = getActiveEditor().$datePicker.config();
 
-  it('should display Pikaday Calendar left-bottom of the selected cell when table have scrolls', () => {
-    const container = $('#testContainer');
-
-    container[0].style.height = '300px';
-    container[0].style.width = '200px';
-    container[0].style.overflow = 'hidden';
-
-    handsontable({
-      data: Handsontable.helper.createSpreadsheetData(30, 10),
-      colWidths: 60,
-      columns: [
-        { type: 'date' },
-        { type: 'date' },
-        { type: 'date' },
-        { type: 'date' },
-        { type: 'date' },
-        { type: 'date' },
-        { type: 'date' }
-      ]
+      expect(datePicker.getAttribute('dir')).toBe('rtl');
+      // it's set as `false` in RTL due to https://github.com/Pikaday/Pikaday/issues/647 bug. The Pikaday layout
+      // direction mode is controlled by above "dir" attribute.
+      expect(config.isRTL).toBe(false);
     });
 
-    selectCell(20, 6);
-    keyDown('enter');
+    it('should display Pikaday Calendar left-bottom of the selected cell', () => {
+      handsontable({
+        layoutDirection,
+        data: Handsontable.helper.createSpreadsheetData(5, 2),
+        columns: [
+          { type: 'date' },
+          { type: 'date' }
+        ]
+      });
 
-    const cellOffset = $(getActiveEditor().TD).offset();
-    const cellWidth = $(getActiveEditor().TD).outerWidth();
-    const $datePicker = $('.htDatepickerHolder');
-    const datePickerOffset = $datePicker.offset();
-    const datePickerWidth = $datePicker.outerWidth();
+      selectCell(1, 1);
+      keyDown('enter');
 
-    // 23 is a height of the editor's cell
-    expect(cellOffset.top + 23).toBeCloseTo(datePickerOffset.top, 0);
-    expect(cellOffset.left).toBeCloseTo(datePickerOffset.left + datePickerWidth - cellWidth, 0);
+      const cellOffset = $(getActiveEditor().TD).offset();
+      const cellWidth = $(getActiveEditor().TD).outerWidth();
+      const $datePicker = $('.htDatepickerHolder');
+      const datePickerOffset = $datePicker.offset();
+      const datePickerWidth = $datePicker.outerWidth();
+
+      // 23 is a height of the editor's cell
+      expect(cellOffset.top + 23).toBeCloseTo(datePickerOffset.top, 0);
+      expect(cellOffset.left).toBeCloseTo(datePickerOffset.left + datePickerWidth - cellWidth, 0);
+    });
+
+    it('should display Pikaday Calendar left-bottom of the selected cell when table have scrolls', () => {
+      const container = $('#testContainer');
+
+      container[0].style.height = '300px';
+      container[0].style.width = '200px';
+      container[0].style.overflow = 'hidden';
+
+      handsontable({
+        layoutDirection,
+        data: Handsontable.helper.createSpreadsheetData(30, 10),
+        colWidths: 60,
+        columns: [
+          { type: 'date' },
+          { type: 'date' },
+          { type: 'date' },
+          { type: 'date' },
+          { type: 'date' },
+          { type: 'date' },
+          { type: 'date' }
+        ]
+      });
+
+      selectCell(20, 6);
+      keyDown('enter');
+
+      const cellOffset = $(getActiveEditor().TD).offset();
+      const cellWidth = $(getActiveEditor().TD).outerWidth();
+      const $datePicker = $('.htDatepickerHolder');
+      const datePickerOffset = $datePicker.offset();
+      const datePickerWidth = $datePicker.outerWidth();
+
+      // 23 is a height of the editor's cell
+      expect(cellOffset.top + 23).toBeCloseTo(datePickerOffset.top, 0);
+      expect(cellOffset.left).toBeCloseTo(datePickerOffset.left + datePickerWidth - cellWidth, 0);
+    });
   });
 });

--- a/handsontable/src/editors/dropdownEditor/__tests__/rtl/dropdownEditor.spec.js
+++ b/handsontable/src/editors/dropdownEditor/__tests__/rtl/dropdownEditor.spec.js
@@ -1,30 +1,37 @@
 describe('DropdownEditor (RTL mode)', () => {
-  const id = 'testContainer';
+  using('configuration object', [
+    { htmlDir: 'rtl', layoutDirection: 'inherit' },
+    { htmlDir: 'ltr', layoutDirection: 'rtl' },
+  ], ({ htmlDir, layoutDirection }) => {
+    const id = 'testContainer';
 
-  beforeEach(function() {
-    $('html').attr('dir', 'rtl');
-    this.$container = $(`<div id="${id}" style="width: 300px; height: 200px; overflow: auto"></div>`).appendTo('body');
-  });
-
-  afterEach(function() {
-    $('html').attr('dir', 'ltr');
-
-    if (this.$container) {
-      destroy();
-      this.$container.remove();
-    }
-  });
-
-  it('should render an editable editor\'s element without messing with "dir" attribute', () => {
-    handsontable({
-      data: Handsontable.helper.createSpreadsheetData(2, 5),
-      editor: 'dropdown',
+    beforeEach(function() {
+      $('html').attr('dir', htmlDir);
+      this.$container = $(`<div id="${id}" style="width: 300px; height: 200px; overflow: auto"></div>`)
+        .appendTo('body');
     });
 
-    selectCell(0, 0);
+    afterEach(function() {
+      $('html').attr('dir', 'ltr');
 
-    const editableElement = getActiveEditor().TEXTAREA;
+      if (this.$container) {
+        destroy();
+        this.$container.remove();
+      }
+    });
 
-    expect(editableElement.getAttribute('dir')).toBeNull();
+    it('should render an editable editor\'s element without messing with "dir" attribute', () => {
+      handsontable({
+        layoutDirection,
+        data: Handsontable.helper.createSpreadsheetData(2, 5),
+        editor: 'dropdown',
+      });
+
+      selectCell(0, 0);
+
+      const editableElement = getActiveEditor().TEXTAREA;
+
+      expect(editableElement.getAttribute('dir')).toBeNull();
+    });
   });
 });

--- a/handsontable/src/editors/handsontableEditor/__tests__/rtl/handsontableEditor.spec.js
+++ b/handsontable/src/editors/handsontableEditor/__tests__/rtl/handsontableEditor.spec.js
@@ -1,20 +1,4 @@
 describe('HandsontableEditor (RTL mode)', () => {
-  const id = 'testContainer';
-
-  beforeEach(function() {
-    $('html').attr('dir', 'rtl');
-    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
-  });
-
-  afterEach(function() {
-    $('html').attr('dir', 'ltr');
-
-    if (this.$container) {
-      destroy();
-      this.$container.remove();
-    }
-  });
-
   function getManufacturerData() {
     return [
       { name: 'BMW', country: 'Germany', owner: 'Bayerische Motoren Werke AG' },
@@ -35,286 +19,314 @@ describe('HandsontableEditor (RTL mode)', () => {
     return offset;
   }
 
-  it('should render an editable editor\'s element without messing with "dir" attribute', () => {
-    handsontable({
-      data: Handsontable.helper.createSpreadsheetData(2, 5),
-      editor: 'handsontable',
+  using('configuration object', [
+    { htmlDir: 'rtl', layoutDirection: 'inherit' },
+    { htmlDir: 'ltr', layoutDirection: 'rtl' },
+  ], ({ htmlDir, layoutDirection }) => {
+    const id = 'testContainer';
+
+    beforeEach(function() {
+      $('html').attr('dir', htmlDir);
+      this.$container = $(`<div id="${id}"></div>`).appendTo('body');
     });
 
-    selectCell(0, 0);
+    afterEach(function() {
+      $('html').attr('dir', 'ltr');
 
-    const editableElement = getActiveEditor().TEXTAREA;
-
-    expect(editableElement.getAttribute('dir')).toBeNull();
-  });
-
-  it('should render an editor in specified position at cell 0, 0', () => {
-    handsontable({
-      columns: [
-        {
-          type: 'handsontable',
-          handsontable: {
-            colHeaders: ['Marque', 'Country', 'Parent company'],
-            data: getManufacturerData()
-          }
-        }
-      ],
-    });
-
-    selectCell(0, 0);
-
-    const editor = $(getActiveEditor().TEXTAREA_PARENT);
-
-    keyDown('enter');
-
-    expect(editor.offset()).toEqual(offsetForRtl(getCell(0, 0), editor.outerWidth(), true));
-  });
-
-  it('should render an editor in specified position at cell 0, 0 when all headers are selected', () => {
-    handsontable({
-      rowHeaders: true,
-      colHeaders: true,
-      columns: [
-        {
-          type: 'handsontable',
-          handsontable: {
-            colHeaders: ['Marque', 'Country', 'Parent company'],
-            data: getManufacturerData()
-          }
-        }
-      ],
-    });
-
-    selectAll();
-    listen();
-
-    const editor = $(getActiveEditor().TEXTAREA_PARENT);
-
-    keyDown('enter');
-
-    expect(editor.offset()).toEqual(offsetForRtl(getCell(0, 0), editor.outerWidth(), true));
-  });
-
-  it('should render an editor in specified position while opening an editor from top to bottom when ' +
-    'top and bottom overlays are enabled', () => {
-    handsontable({
-      data: Handsontable.helper.createSpreadsheetData(8, 2),
-      rowHeaders: true,
-      colHeaders: true,
-      fixedRowsTop: 3,
-      fixedRowsBottom: 3,
-      columns: [
-        {
-          type: 'handsontable',
-          handsontable: {
-            colHeaders: ['Marque', 'Country', 'Parent company'],
-            data: getManufacturerData()
-          }
-        },
-        {},
-      ],
-    });
-
-    selectCell(0, 0);
-
-    const editor = $(getActiveEditor().TEXTAREA_PARENT);
-
-    keyDown('enter');
-
-    expect(editor.offset()).toEqual(offsetForRtl(getCell(0, 0, true), editor.outerWidth(), true));
-
-    keyDown('enter');
-    keyDown('enter');
-
-    // Cells that do not touch the edges of the table have an additional top border.
-    const editorOffset = () => ({
-      top: editor.offset().top + 1,
-      left: editor.offset().left,
-    });
-
-    expect(editorOffset()).toEqual(offsetForRtl(getCell(1, 0, true), editor.outerWidth(), true));
-
-    keyDown('enter');
-    keyDown('enter');
-
-    expect(editorOffset()).toEqual(offsetForRtl(getCell(2, 0, true), editor.outerWidth(), true));
-
-    keyDown('enter');
-    keyDown('enter');
-
-    expect(editorOffset()).toEqual(offsetForRtl(getCell(3, 0, true), editor.outerWidth(), true));
-
-    keyDown('enter');
-    keyDown('enter');
-
-    expect(editorOffset()).toEqual(offsetForRtl(getCell(4, 0, true), editor.outerWidth(), true));
-
-    keyDown('enter');
-    keyDown('enter');
-
-    // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
-    expect(editor.offset()).toEqual(offsetForRtl(getCell(5, 0, true), editor.outerWidth(), true));
-
-    keyDown('enter');
-    keyDown('enter');
-
-    expect(editorOffset()).toEqual(offsetForRtl(getCell(6, 0, true), editor.outerWidth(), true));
-
-    keyDown('enter');
-    keyDown('enter');
-
-    expect(editorOffset()).toEqual(offsetForRtl(getCell(7, 0, true), editor.outerWidth(), true));
-  });
-
-  it('should render an editor in specified position while opening an editor from right to left when ' +
-    'right overlay is enabled', () => {
-    handsontable({
-      data: Handsontable.helper.createSpreadsheetData(2, 5),
-      rowHeaders: true,
-      colHeaders: true,
-      fixedColumnsStart: 3,
-      type: 'handsontable',
-      handsontable: {
-        colHeaders: ['Marque', 'Country', 'Parent company'],
-        data: getManufacturerData()
+      if (this.$container) {
+        destroy();
+        this.$container.remove();
       }
     });
 
-    selectCell(0, 0);
+    it('should render an editable editor\'s element without messing with "dir" attribute', () => {
+      handsontable({
+        layoutDirection,
+        data: Handsontable.helper.createSpreadsheetData(2, 5),
+        editor: 'handsontable',
+      });
 
-    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+      selectCell(0, 0);
 
-    keyDown('enter');
+      const editableElement = getActiveEditor().TEXTAREA;
 
-    expect(editor.offset()).toEqual(offsetForRtl(getCell(0, 0, true), editor.outerWidth(), true));
+      expect(editableElement.getAttribute('dir')).toBeNull();
+    });
 
-    selectCell(0, 1);
-    keyDown('enter');
-
-    expect(editor.offset()).toEqual(offsetForRtl(getCell(0, 1, true), editor.outerWidth()));
-
-    selectCell(0, 2);
-    keyDown('enter');
-
-    expect(editor.offset()).toEqual(offsetForRtl(getCell(0, 2, true), editor.outerWidth()));
-
-    selectCell(0, 3);
-    keyDown('enter');
-
-    expect(editor.offset()).toEqual(offsetForRtl(getCell(0, 3, true), editor.outerWidth()));
-
-    selectCell(0, 4);
-    keyDown('enter');
-
-    expect(editor.offset()).toEqual(offsetForRtl(getCell(0, 4, true), editor.outerWidth()));
-  });
-
-  it('should render an editor in specified position while opening an editor from top to bottom when ' +
-    'top and bottom overlays are enabled and the first row of the both overlays are hidden', () => {
-    handsontable({
-      data: Handsontable.helper.createSpreadsheetData(8, 2),
-      rowHeaders: true,
-      colHeaders: true,
-      fixedRowsTop: 3,
-      fixedRowsBottom: 3,
-      hiddenRows: {
-        indicators: true,
-        rows: [0, 5],
-      },
-      columns: [
-        {
-          type: 'handsontable',
-          handsontable: {
-            colHeaders: ['Marque', 'Country', 'Parent company'],
-            data: getManufacturerData()
+    it('should render an editor in specified position at cell 0, 0', () => {
+      handsontable({
+        layoutDirection,
+        columns: [
+          {
+            type: 'handsontable',
+            handsontable: {
+              colHeaders: ['Marque', 'Country', 'Parent company'],
+              data: getManufacturerData()
+            }
           }
+        ],
+      });
+
+      selectCell(0, 0);
+
+      const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+      keyDown('enter');
+
+      expect(editor.offset()).toEqual(offsetForRtl(getCell(0, 0), editor.outerWidth(), true));
+    });
+
+    it('should render an editor in specified position at cell 0, 0 when all headers are selected', () => {
+      handsontable({
+        layoutDirection,
+        rowHeaders: true,
+        colHeaders: true,
+        columns: [
+          {
+            type: 'handsontable',
+            handsontable: {
+              colHeaders: ['Marque', 'Country', 'Parent company'],
+              data: getManufacturerData()
+            }
+          }
+        ],
+      });
+
+      selectAll();
+      listen();
+
+      const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+      keyDown('enter');
+
+      expect(editor.offset()).toEqual(offsetForRtl(getCell(0, 0), editor.outerWidth(), true));
+    });
+
+    it('should render an editor in specified position while opening an editor from top to bottom when ' +
+      'top and bottom overlays are enabled', () => {
+      handsontable({
+        layoutDirection,
+        data: Handsontable.helper.createSpreadsheetData(8, 2),
+        rowHeaders: true,
+        colHeaders: true,
+        fixedRowsTop: 3,
+        fixedRowsBottom: 3,
+        columns: [
+          {
+            type: 'handsontable',
+            handsontable: {
+              colHeaders: ['Marque', 'Country', 'Parent company'],
+              data: getManufacturerData()
+            }
+          },
+          {},
+        ],
+      });
+
+      selectCell(0, 0);
+
+      const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+      keyDown('enter');
+
+      expect(editor.offset()).toEqual(offsetForRtl(getCell(0, 0, true), editor.outerWidth(), true));
+
+      keyDown('enter');
+      keyDown('enter');
+
+      // Cells that do not touch the edges of the table have an additional top border.
+      const editorOffset = () => ({
+        top: editor.offset().top + 1,
+        left: editor.offset().left,
+      });
+
+      expect(editorOffset()).toEqual(offsetForRtl(getCell(1, 0, true), editor.outerWidth(), true));
+
+      keyDown('enter');
+      keyDown('enter');
+
+      expect(editorOffset()).toEqual(offsetForRtl(getCell(2, 0, true), editor.outerWidth(), true));
+
+      keyDown('enter');
+      keyDown('enter');
+
+      expect(editorOffset()).toEqual(offsetForRtl(getCell(3, 0, true), editor.outerWidth(), true));
+
+      keyDown('enter');
+      keyDown('enter');
+
+      expect(editorOffset()).toEqual(offsetForRtl(getCell(4, 0, true), editor.outerWidth(), true));
+
+      keyDown('enter');
+      keyDown('enter');
+
+      // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
+      expect(editor.offset()).toEqual(offsetForRtl(getCell(5, 0, true), editor.outerWidth(), true));
+
+      keyDown('enter');
+      keyDown('enter');
+
+      expect(editorOffset()).toEqual(offsetForRtl(getCell(6, 0, true), editor.outerWidth(), true));
+
+      keyDown('enter');
+      keyDown('enter');
+
+      expect(editorOffset()).toEqual(offsetForRtl(getCell(7, 0, true), editor.outerWidth(), true));
+    });
+
+    it('should render an editor in specified position while opening an editor from right to left when ' +
+      'right overlay is enabled', () => {
+      handsontable({
+        layoutDirection,
+        data: Handsontable.helper.createSpreadsheetData(2, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        fixedColumnsStart: 3,
+        type: 'handsontable',
+        handsontable: {
+          colHeaders: ['Marque', 'Country', 'Parent company'],
+          data: getManufacturerData()
+        }
+      });
+
+      selectCell(0, 0);
+
+      const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+      keyDown('enter');
+
+      expect(editor.offset()).toEqual(offsetForRtl(getCell(0, 0, true), editor.outerWidth(), true));
+
+      selectCell(0, 1);
+      keyDown('enter');
+
+      expect(editor.offset()).toEqual(offsetForRtl(getCell(0, 1, true), editor.outerWidth()));
+
+      selectCell(0, 2);
+      keyDown('enter');
+
+      expect(editor.offset()).toEqual(offsetForRtl(getCell(0, 2, true), editor.outerWidth()));
+
+      selectCell(0, 3);
+      keyDown('enter');
+
+      expect(editor.offset()).toEqual(offsetForRtl(getCell(0, 3, true), editor.outerWidth()));
+
+      selectCell(0, 4);
+      keyDown('enter');
+
+      expect(editor.offset()).toEqual(offsetForRtl(getCell(0, 4, true), editor.outerWidth()));
+    });
+
+    it('should render an editor in specified position while opening an editor from top to bottom when ' +
+      'top and bottom overlays are enabled and the first row of the both overlays are hidden', () => {
+      handsontable({
+        layoutDirection,
+        data: Handsontable.helper.createSpreadsheetData(8, 2),
+        rowHeaders: true,
+        colHeaders: true,
+        fixedRowsTop: 3,
+        fixedRowsBottom: 3,
+        hiddenRows: {
+          indicators: true,
+          rows: [0, 5],
         },
-        {},
-      ],
+        columns: [
+          {
+            type: 'handsontable',
+            handsontable: {
+              colHeaders: ['Marque', 'Country', 'Parent company'],
+              data: getManufacturerData()
+            }
+          },
+          {},
+        ],
+      });
+
+      selectCell(1, 0);
+
+      const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+      keyDown('enter');
+
+      // First renderable row index.
+      expect(editor.offset()).toEqual(offsetForRtl(getCell(1, 0, true), editor.outerWidth(), true));
+
+      keyDown('enter');
+      keyDown('enter');
+
+      // Cells that do not touch the edges of the table have an additional top border.
+      const editorOffset = () => ({
+        top: editor.offset().top + 1,
+        left: editor.offset().left,
+      });
+
+      expect(editorOffset()).toEqual(offsetForRtl(getCell(2, 0, true), editor.outerWidth(), true));
+
+      keyDown('enter');
+      keyDown('enter');
+
+      expect(editorOffset()).toEqual(offsetForRtl(getCell(3, 0, true), editor.outerWidth(), true));
+
+      keyDown('enter');
+      keyDown('enter');
+
+      expect(editorOffset()).toEqual(offsetForRtl(getCell(4, 0, true), editor.outerWidth(), true));
+
+      keyDown('enter');
+      keyDown('enter');
+
+      // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
+      expect(editor.offset()).toEqual(offsetForRtl(getCell(6, 0, true), editor.outerWidth(), true));
+
+      keyDown('enter');
+      keyDown('enter');
+
+      expect(editorOffset()).toEqual(offsetForRtl(getCell(7, 0, true), editor.outerWidth(), true));
     });
 
-    selectCell(1, 0);
+    it('should render an editor in specified position while opening an editor from right to left when ' +
+      'right overlay is enabled and the first column of the overlay is hidden', () => {
+      handsontable({
+        layoutDirection,
+        data: Handsontable.helper.createSpreadsheetData(2, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        fixedColumnsStart: 3,
+        hiddenColumns: {
+          indicators: true,
+          columns: [0],
+        },
+        type: 'handsontable',
+        handsontable: {
+          colHeaders: ['Marque', 'Country', 'Parent company'],
+          data: getManufacturerData()
+        }
+      });
 
-    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+      selectCell(0, 1);
 
-    keyDown('enter');
+      const editor = $(getActiveEditor().TEXTAREA_PARENT);
 
-    // First renderable row index.
-    expect(editor.offset()).toEqual(offsetForRtl(getCell(1, 0, true), editor.outerWidth(), true));
+      keyDown('enter');
 
-    keyDown('enter');
-    keyDown('enter');
+      // First renderable column index.
+      expect(editor.offset()).toEqual(offsetForRtl(getCell(0, 1, true), editor.outerWidth(), true));
 
-    // Cells that do not touch the edges of the table have an additional top border.
-    const editorOffset = () => ({
-      top: editor.offset().top + 1,
-      left: editor.offset().left,
+      selectCell(0, 2);
+      keyDown('enter');
+
+      expect(editor.offset()).toEqual(offsetForRtl(getCell(0, 2, true), editor.outerWidth()));
+
+      selectCell(0, 3);
+      keyDown('enter');
+
+      expect(editor.offset()).toEqual(offsetForRtl(getCell(0, 3, true), editor.outerWidth()));
+
+      selectCell(0, 4);
+      keyDown('enter');
+
+      expect(editor.offset()).toEqual(offsetForRtl(getCell(0, 4, true), editor.outerWidth()));
     });
-
-    expect(editorOffset()).toEqual(offsetForRtl(getCell(2, 0, true), editor.outerWidth(), true));
-
-    keyDown('enter');
-    keyDown('enter');
-
-    expect(editorOffset()).toEqual(offsetForRtl(getCell(3, 0, true), editor.outerWidth(), true));
-
-    keyDown('enter');
-    keyDown('enter');
-
-    expect(editorOffset()).toEqual(offsetForRtl(getCell(4, 0, true), editor.outerWidth(), true));
-
-    keyDown('enter');
-    keyDown('enter');
-
-    // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
-    expect(editor.offset()).toEqual(offsetForRtl(getCell(6, 0, true), editor.outerWidth(), true));
-
-    keyDown('enter');
-    keyDown('enter');
-
-    expect(editorOffset()).toEqual(offsetForRtl(getCell(7, 0, true), editor.outerWidth(), true));
-  });
-
-  it('should render an editor in specified position while opening an editor from right to left when ' +
-    'right overlay is enabled and the first column of the overlay is hidden', () => {
-    handsontable({
-      data: Handsontable.helper.createSpreadsheetData(2, 5),
-      rowHeaders: true,
-      colHeaders: true,
-      fixedColumnsStart: 3,
-      hiddenColumns: {
-        indicators: true,
-        columns: [0],
-      },
-      type: 'handsontable',
-      handsontable: {
-        colHeaders: ['Marque', 'Country', 'Parent company'],
-        data: getManufacturerData()
-      }
-    });
-
-    selectCell(0, 1);
-
-    const editor = $(getActiveEditor().TEXTAREA_PARENT);
-
-    keyDown('enter');
-
-    // First renderable column index.
-    expect(editor.offset()).toEqual(offsetForRtl(getCell(0, 1, true), editor.outerWidth(), true));
-
-    selectCell(0, 2);
-    keyDown('enter');
-
-    expect(editor.offset()).toEqual(offsetForRtl(getCell(0, 2, true), editor.outerWidth()));
-
-    selectCell(0, 3);
-    keyDown('enter');
-
-    expect(editor.offset()).toEqual(offsetForRtl(getCell(0, 3, true), editor.outerWidth()));
-
-    selectCell(0, 4);
-    keyDown('enter');
-
-    expect(editor.offset()).toEqual(offsetForRtl(getCell(0, 4, true), editor.outerWidth()));
   });
 });

--- a/handsontable/src/editors/numericEditor/__tests__/rtl/numericEditor.spec.js
+++ b/handsontable/src/editors/numericEditor/__tests__/rtl/numericEditor.spec.js
@@ -1,27 +1,36 @@
 describe('NumericEditor (RTL mode)', () => {
-  const id = 'testContainer';
+  using('configuration object', [
+    { htmlDir: 'rtl', layoutDirection: 'inherit' },
+    { htmlDir: 'ltr', layoutDirection: 'rtl' },
+  ], ({ htmlDir, layoutDirection }) => {
+    const id = 'testContainer';
 
-  beforeEach(function() {
-    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
-  });
-
-  afterEach(function() {
-    if (this.$container) {
-      destroy();
-      this.$container.remove();
-    }
-  });
-
-  it('should render an editable editor\'s element without messing with "dir" attribute', () => {
-    handsontable({
-      data: Handsontable.helper.createSpreadsheetData(2, 5),
-      editor: 'numeric',
+    beforeEach(function() {
+      $('html').attr('dir', htmlDir);
+      this.$container = $(`<div id="${id}"></div>`).appendTo('body');
     });
 
-    selectCell(0, 0);
+    afterEach(function() {
+      $('html').attr('dir', 'ltr');
 
-    const editableElement = getActiveEditor().TEXTAREA;
+      if (this.$container) {
+        destroy();
+        this.$container.remove();
+      }
+    });
 
-    expect(editableElement.getAttribute('dir')).toBeNull();
+    it('should render an editable editor\'s element without messing with "dir" attribute', () => {
+      handsontable({
+        layoutDirection,
+        data: Handsontable.helper.createSpreadsheetData(2, 5),
+        editor: 'numeric',
+      });
+
+      selectCell(0, 0);
+
+      const editableElement = getActiveEditor().TEXTAREA;
+
+      expect(editableElement.getAttribute('dir')).toBeNull();
+    });
   });
 });

--- a/handsontable/src/editors/passwordEditor/__tests__/rtl/passwordEditor.spec.js
+++ b/handsontable/src/editors/passwordEditor/__tests__/rtl/passwordEditor.spec.js
@@ -1,27 +1,36 @@
 describe('PasswordEditor RTL (mode)', () => {
-  const id = 'testContainer';
+  using('configuration object', [
+    { htmlDir: 'rtl', layoutDirection: 'inherit' },
+    { htmlDir: 'ltr', layoutDirection: 'rtl' },
+  ], ({ htmlDir, layoutDirection }) => {
+    const id = 'testContainer';
 
-  beforeEach(function() {
-    this.$container = $(`<div id="${id}" style="width: 300px; height: 300px;"></div>`).appendTo('body');
-  });
-
-  afterEach(function() {
-    if (this.$container) {
-      destroy();
-      this.$container.remove();
-    }
-  });
-
-  it('should render an editable editor\'s element without messing with "dir" attribute', () => {
-    handsontable({
-      data: Handsontable.helper.createSpreadsheetData(2, 5),
-      editor: 'password',
+    beforeEach(function() {
+      $('html').attr('dir', htmlDir);
+      this.$container = $(`<div id="${id}"></div>`).appendTo('body');
     });
 
-    selectCell(0, 0);
+    afterEach(function() {
+      $('html').attr('dir', 'ltr');
 
-    const editableElement = getActiveEditor().TEXTAREA;
+      if (this.$container) {
+        destroy();
+        this.$container.remove();
+      }
+    });
 
-    expect(editableElement.getAttribute('dir')).toBeNull();
+    it('should render an editable editor\'s element without messing with "dir" attribute', () => {
+      handsontable({
+        layoutDirection,
+        data: Handsontable.helper.createSpreadsheetData(2, 5),
+        editor: 'password',
+      });
+
+      selectCell(0, 0);
+
+      const editableElement = getActiveEditor().TEXTAREA;
+
+      expect(editableElement.getAttribute('dir')).toBeNull();
+    });
   });
 });

--- a/handsontable/src/editors/selectEditor/__tests__/rtl/selectEditor.spec.js
+++ b/handsontable/src/editors/selectEditor/__tests__/rtl/selectEditor.spec.js
@@ -1,31 +1,36 @@
 describe('SelectEditor (RTL mode)', () => {
+  using('configuration object', [
+    { htmlDir: 'rtl', layoutDirection: 'inherit' },
+    { htmlDir: 'ltr', layoutDirection: 'rtl' },
+  ], ({ htmlDir, layoutDirection }) => {
+    const id = 'testContainer';
 
-  const id = 'testContainer';
-
-  beforeEach(function() {
-    $('html').attr('dir', 'rtl');
-    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
-  });
-
-  afterEach(function() {
-    $('html').attr('dir', 'ltr');
-
-    if (this.$container) {
-      destroy();
-      this.$container.remove();
-    }
-  });
-
-  it('should render an editable editor\'s element without messing with "dir" attribute', () => {
-    handsontable({
-      data: Handsontable.helper.createSpreadsheetData(2, 5),
-      editor: 'select',
+    beforeEach(function() {
+      $('html').attr('dir', htmlDir);
+      this.$container = $(`<div id="${id}"></div>`).appendTo('body');
     });
 
-    selectCell(0, 0);
+    afterEach(function() {
+      $('html').attr('dir', 'ltr');
 
-    const editableElement = getActiveEditor().select;
+      if (this.$container) {
+        destroy();
+        this.$container.remove();
+      }
+    });
 
-    expect(editableElement.getAttribute('dir')).toBeNull();
+    it('should render an editable editor\'s element without messing with "dir" attribute', () => {
+      handsontable({
+        layoutDirection,
+        data: Handsontable.helper.createSpreadsheetData(2, 5),
+        editor: 'select',
+      });
+
+      selectCell(0, 0);
+
+      const editableElement = getActiveEditor().select;
+
+      expect(editableElement.getAttribute('dir')).toBeNull();
+    });
   });
 });

--- a/handsontable/src/editors/textEditor/__tests__/rtl/textEditor.spec.js
+++ b/handsontable/src/editors/textEditor/__tests__/rtl/textEditor.spec.js
@@ -1,734 +1,376 @@
 describe('TextEditor (RTL mode)', () => {
-  const id = 'testContainer';
+  using('configuration object', [
+    { htmlDir: 'rtl', layoutDirection: 'inherit' },
+    { htmlDir: 'ltr', layoutDirection: 'rtl' },
+  ], ({ htmlDir, layoutDirection }) => {
+    const id = 'testContainer';
 
-  beforeEach(function() {
-    $('html').attr('dir', 'rtl');
-    this.$container = $(`<div id="${id}" style="width: 300px; height: 200px; overflow: hidden;"></div>`)
-      .appendTo('body');
-  });
-
-  afterEach(function() {
-    $('html').attr('dir', 'ltr');
-
-    if (this.$container) {
-      destroy();
-      this.$container.remove();
-    }
-  });
-
-  it('should render an editable editor\'s element without messing with "dir" attribute', () => {
-    handsontable({
-      data: Handsontable.helper.createSpreadsheetData(2, 5),
-      editor: 'text',
+    beforeEach(function() {
+      $('html').attr('dir', htmlDir);
+      this.$container = $(`<div id="${id}" style="width: 300px; height: 200px; overflow: hidden;"></div>`)
+        .appendTo('body');
     });
 
-    selectCell(0, 0);
+    afterEach(function() {
+      $('html').attr('dir', 'ltr');
 
-    const editableElement = getActiveEditor().TEXTAREA;
-
-    expect(editableElement.getAttribute('dir')).toBeNull();
-  });
-
-  it('should render an editor in specified position at cell 0, 0', () => {
-    handsontable({
-      columns: [
-        {
-          type: 'text',
-        }
-      ],
+      if (this.$container) {
+        destroy();
+        this.$container.remove();
+      }
     });
 
-    selectCell(0, 0);
+    it('should render an editable editor\'s element without messing with "dir" attribute', () => {
+      handsontable({
+        layoutDirection,
+        data: Handsontable.helper.createSpreadsheetData(2, 5),
+        editor: 'text',
+      });
 
-    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+      selectCell(0, 0);
 
-    keyDown('enter');
+      const editableElement = getActiveEditor().TEXTAREA;
 
-    expect(editor.offset()).toEqual($(getCell(0, 0)).offset());
-  });
-
-  it('should render an editor in specified position at cell 0, 0 when all headers are selected', () => {
-    handsontable({
-      rowHeaders: true,
-      colHeaders: true,
-      columns: [
-        {
-          type: 'text',
-        }
-      ],
+      expect(editableElement.getAttribute('dir')).toBeNull();
     });
 
-    selectAll();
-    listen();
+    it('should render an editor in specified position at cell 0, 0', () => {
+      handsontable({
+        layoutDirection,
+        columns: [
+          {
+            type: 'text',
+          }
+        ],
+      });
 
-    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+      selectCell(0, 0);
 
-    keyDown('enter');
+      const editor = $(getActiveEditor().TEXTAREA_PARENT);
 
-    expect(editor.offset()).toEqual($(getCell(0, 0)).offset());
-  });
+      keyDown('enter');
 
-  it('should render an editor in specified position while opening an editor from top to bottom when ' +
-     'top and bottom overlays are enabled', () => {
-    handsontable({
-      data: Handsontable.helper.createSpreadsheetData(8, 2),
-      rowHeaders: true,
-      colHeaders: true,
-      fixedRowsTop: 3,
-      fixedRowsBottom: 3,
-      columns: [
-        {
-          type: 'text',
+      expect(editor.offset()).toEqual($(getCell(0, 0)).offset());
+    });
+
+    it('should render an editor in specified position at cell 0, 0 when all headers are selected', () => {
+      handsontable({
+        layoutDirection,
+        rowHeaders: true,
+        colHeaders: true,
+        columns: [
+          {
+            type: 'text',
+          }
+        ],
+      });
+
+      selectAll();
+      listen();
+
+      const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+      keyDown('enter');
+
+      expect(editor.offset()).toEqual($(getCell(0, 0)).offset());
+    });
+
+    it('should render an editor in specified position while opening an editor from top to bottom when ' +
+      'top and bottom overlays are enabled', () => {
+      handsontable({
+        layoutDirection,
+        data: Handsontable.helper.createSpreadsheetData(8, 2),
+        rowHeaders: true,
+        colHeaders: true,
+        fixedRowsTop: 3,
+        fixedRowsBottom: 3,
+        columns: [
+          {
+            type: 'text',
+          },
+          {},
+        ],
+      });
+
+      selectCell(0, 0);
+
+      const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+      keyDown('enter');
+
+      expect(editor.offset()).toEqual($(getCell(0, 0, true)).offset());
+
+      keyDown('enter');
+      keyDown('enter');
+
+      // Cells that do not touch the edges of the table have an additional top border.
+      const editorOffset = () => ({
+        top: editor.offset().top + 1,
+        left: editor.offset().left,
+      });
+
+      expect(editorOffset()).toEqual($(getCell(1, 0, true)).offset());
+
+      keyDown('enter');
+      keyDown('enter');
+
+      expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
+
+      keyDown('enter');
+      keyDown('enter');
+
+      expect(editorOffset()).toEqual($(getCell(3, 0, true)).offset());
+
+      keyDown('enter');
+      keyDown('enter');
+
+      expect(editorOffset()).toEqual($(getCell(4, 0, true)).offset());
+
+      keyDown('enter');
+      keyDown('enter');
+
+      // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
+      expect(editor.offset()).toEqual($(getCell(5, 0, true)).offset());
+
+      keyDown('enter');
+      keyDown('enter');
+
+      expect(editorOffset()).toEqual($(getCell(6, 0, true)).offset());
+
+      keyDown('enter');
+      keyDown('enter');
+
+      expect(editorOffset()).toEqual($(getCell(7, 0, true)).offset());
+    });
+
+    it('should render an editor in specified position while opening an editor from left to right when ' +
+      'left overlay is enabled', () => {
+      handsontable({
+        layoutDirection,
+        data: Handsontable.helper.createSpreadsheetData(2, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        fixedColumnsStart: 3,
+        type: 'text',
+      });
+
+      selectCell(0, 0);
+
+      const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+      keyDown('enter');
+
+      expect(editor.offset()).toEqual($(getCell(0, 0, true)).offset());
+
+      selectCell(0, 1);
+      keyDown('enter');
+
+      // Cells that do not touch the edges of the table have an additional left border.
+      const editorOffset = () => ({
+        top: editor.offset().top,
+        left: editor.offset().left,
+      });
+
+      expect(editorOffset()).toEqual($(getCell(0, 1, true)).offset());
+
+      selectCell(0, 2);
+      keyDown('enter');
+
+      expect(editorOffset()).toEqual($(getCell(0, 2, true)).offset());
+
+      selectCell(0, 3);
+      keyDown('enter');
+
+      expect(editorOffset()).toEqual($(getCell(0, 3, true)).offset());
+
+      selectCell(0, 4);
+      keyDown('enter');
+
+      expect(editorOffset()).toEqual($(getCell(0, 4, true)).offset());
+    });
+
+    it('should render an editor in specified position while opening an editor from top to bottom when ' +
+        'top and bottom overlays are enabled and the first row of the both overlays are hidden', () => {
+      handsontable({
+        layoutDirection,
+        data: Handsontable.helper.createSpreadsheetData(8, 2),
+        rowHeaders: true,
+        colHeaders: true,
+        fixedRowsTop: 3,
+        fixedRowsBottom: 3,
+        hiddenRows: {
+          indicators: true,
+          rows: [0, 5],
         },
-        {},
-      ],
+        columns: [
+          {
+            type: 'text',
+          },
+          {},
+        ],
+      });
+
+      selectCell(1, 0);
+
+      const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+      keyDown('enter');
+
+      // First renderable row index.
+      expect(editor.offset()).toEqual($(getCell(1, 0, true)).offset());
+
+      keyDown('enter');
+      keyDown('enter');
+
+      // Cells that do not touch the edges of the table have an additional top border.
+      const editorOffset = () => ({
+        top: editor.offset().top + 1,
+        left: editor.offset().left,
+      });
+
+      expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
+
+      keyDown('enter');
+      keyDown('enter');
+
+      expect(editorOffset()).toEqual($(getCell(3, 0, true)).offset());
+
+      keyDown('enter');
+      keyDown('enter');
+
+      expect(editorOffset()).toEqual($(getCell(4, 0, true)).offset());
+
+      keyDown('enter');
+      keyDown('enter');
+
+      // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
+      expect(editor.offset()).toEqual($(getCell(6, 0, true)).offset());
+
+      keyDown('enter');
+      keyDown('enter');
+
+      expect(editorOffset()).toEqual($(getCell(7, 0, true)).offset());
     });
 
-    selectCell(0, 0);
-
-    const editor = $(getActiveEditor().TEXTAREA_PARENT);
-
-    keyDown('enter');
-
-    expect(editor.offset()).toEqual($(getCell(0, 0, true)).offset());
-
-    keyDown('enter');
-    keyDown('enter');
-
-    // Cells that do not touch the edges of the table have an additional top border.
-    const editorOffset = () => ({
-      top: editor.offset().top + 1,
-      left: editor.offset().left,
-    });
-
-    expect(editorOffset()).toEqual($(getCell(1, 0, true)).offset());
-
-    keyDown('enter');
-    keyDown('enter');
-
-    expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
-
-    keyDown('enter');
-    keyDown('enter');
-
-    expect(editorOffset()).toEqual($(getCell(3, 0, true)).offset());
-
-    keyDown('enter');
-    keyDown('enter');
-
-    expect(editorOffset()).toEqual($(getCell(4, 0, true)).offset());
-
-    keyDown('enter');
-    keyDown('enter');
-
-    // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
-    expect(editor.offset()).toEqual($(getCell(5, 0, true)).offset());
-
-    keyDown('enter');
-    keyDown('enter');
-
-    expect(editorOffset()).toEqual($(getCell(6, 0, true)).offset());
-
-    keyDown('enter');
-    keyDown('enter');
-
-    expect(editorOffset()).toEqual($(getCell(7, 0, true)).offset());
-  });
-
-  it('should render an editor in specified position while opening an editor from left to right when ' +
-     'left overlay is enabled', () => {
-    handsontable({
-      data: Handsontable.helper.createSpreadsheetData(2, 5),
-      rowHeaders: true,
-      colHeaders: true,
-      fixedColumnsStart: 3,
-      type: 'text',
-    });
-
-    selectCell(0, 0);
-
-    const editor = $(getActiveEditor().TEXTAREA_PARENT);
-
-    keyDown('enter');
-
-    expect(editor.offset()).toEqual($(getCell(0, 0, true)).offset());
-
-    selectCell(0, 1);
-    keyDown('enter');
-
-    // Cells that do not touch the edges of the table have an additional left border.
-    const editorOffset = () => ({
-      top: editor.offset().top,
-      left: editor.offset().left,
-    });
-
-    expect(editorOffset()).toEqual($(getCell(0, 1, true)).offset());
-
-    selectCell(0, 2);
-    keyDown('enter');
-
-    expect(editorOffset()).toEqual($(getCell(0, 2, true)).offset());
-
-    selectCell(0, 3);
-    keyDown('enter');
-
-    expect(editorOffset()).toEqual($(getCell(0, 3, true)).offset());
-
-    selectCell(0, 4);
-    keyDown('enter');
-
-    expect(editorOffset()).toEqual($(getCell(0, 4, true)).offset());
-  });
-
-  it('should render an editor in specified position while opening an editor from top to bottom when ' +
-       'top and bottom overlays are enabled and the first row of the both overlays are hidden', () => {
-    handsontable({
-      data: Handsontable.helper.createSpreadsheetData(8, 2),
-      rowHeaders: true,
-      colHeaders: true,
-      fixedRowsTop: 3,
-      fixedRowsBottom: 3,
-      hiddenRows: {
-        indicators: true,
-        rows: [0, 5],
-      },
-      columns: [
-        {
-          type: 'text',
+    it('should render an editor in specified position while opening an editor from left to right when ' +
+      'right overlay is enabled and the first column of the overlay is hidden', () => {
+      handsontable({
+        layoutDirection,
+        data: Handsontable.helper.createSpreadsheetData(2, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        fixedColumnsStart: 3,
+        hiddenColumns: {
+          indicators: true,
+          columns: [0],
         },
-        {},
-      ],
+        type: 'text',
+      });
+
+      selectCell(0, 1);
+
+      const editor = $(getActiveEditor().TEXTAREA_PARENT);
+
+      keyDown('enter');
+
+      // First renderable column index.
+      expect(editor.offset()).toEqual($(getCell(0, 1, true)).offset());
+
+      selectCell(0, 2);
+      keyDown('enter');
+
+      // Cells that do not touch the edges of the table have an additional left border.
+      const editorOffset = () => ({
+        top: editor.offset().top,
+        left: editor.offset().left,
+      });
+
+      expect(editorOffset()).toEqual($(getCell(0, 2, true)).offset());
+
+      selectCell(0, 3);
+      keyDown('enter');
+
+      expect(editorOffset()).toEqual($(getCell(0, 3, true)).offset());
+
+      selectCell(0, 4);
+      keyDown('enter');
+
+      expect(editorOffset()).toEqual($(getCell(0, 4, true)).offset());
     });
 
-    selectCell(1, 0);
+    it('should change editor\'s CSS properties during switching to being visible', () => {
+      handsontable({
+        layoutDirection,
+        editor: 'text',
+      });
 
-    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+      selectCell(0, 0);
+      keyDownUp('enter');
 
-    keyDown('enter');
+      const cell = getCell(0, 0);
+      const master = getMaster();
+      const cellOffsetTop = cell.offsetTop;
+      const cellOffsetLeft = cell.offsetLeft + master.find('.wtHider').position().left;
+      const { left, right, position, top, zIndex, overflow } = spec().$container.find('.handsontableInputHolder').css([
+        'left',
+        'right',
+        'position',
+        'top',
+        'zIndex',
+        'overflow',
+      ]);
 
-    // First renderable row index.
-    expect(editor.offset()).toEqual($(getCell(1, 0, true)).offset());
-
-    keyDown('enter');
-    keyDown('enter');
-
-    // Cells that do not touch the edges of the table have an additional top border.
-    const editorOffset = () => ({
-      top: editor.offset().top + 1,
-      left: editor.offset().left,
+      expect(parseInt(left, 10)).toBeAroundValue(cellOffsetLeft);
+      expect(parseInt(right, 10)).not.toBe(document.body.offsetWidth);
+      expect(position).toBe('absolute');
+      expect(parseInt(top, 10)).toBeAroundValue(cellOffsetTop);
+      expect(zIndex).not.toBe('-1');
+      expect(overflow).not.toBe('hidden');
     });
 
-    expect(editorOffset()).toEqual($(getCell(2, 0, true)).offset());
+    it('should hide editor when quick navigation by click scrollbar was triggered', async() => {
+      const hot = handsontable({
+        layoutDirection,
+        data: Handsontable.helper.createSpreadsheetData(50, 50),
+        rowHeaders: true,
+        colHeaders: true
+      });
 
-    keyDown('enter');
-    keyDown('enter');
+      setDataAtCell(2, 2, 'string\nstring\nstring');
+      selectCell(2, 2);
 
-    expect(editorOffset()).toEqual($(getCell(3, 0, true)).offset());
+      keyDown('enter');
+      keyUp('enter');
+      hot.scrollViewportTo(49);
 
-    keyDown('enter');
-    keyDown('enter');
+      await sleep(100);
 
-    expect(editorOffset()).toEqual($(getCell(4, 0, true)).offset());
-
-    keyDown('enter');
-    keyDown('enter');
-
-    // The first row of the bottom overlay has different position, influenced by `innerBorderTop` CSS class.
-    expect(editor.offset()).toEqual($(getCell(6, 0, true)).offset());
-
-    keyDown('enter');
-    keyDown('enter');
-
-    expect(editorOffset()).toEqual($(getCell(7, 0, true)).offset());
-  });
-
-  it('should render an editor in specified position while opening an editor from left to right when ' +
-     'right overlay is enabled and the first column of the overlay is hidden', () => {
-    handsontable({
-      data: Handsontable.helper.createSpreadsheetData(2, 5),
-      rowHeaders: true,
-      colHeaders: true,
-      fixedColumnsStart: 3,
-      hiddenColumns: {
-        indicators: true,
-        columns: [0],
-      },
-      type: 'text',
+      expect(isEditorVisible()).toBe(false);
     });
 
-    selectCell(0, 1);
+    it('should scroll editor to a cell, if trying to edit cell that is outside of the viewport', () => {
+      const hot = handsontable({
+        layoutDirection,
+        data: Handsontable.helper.createSpreadsheetData(20, 20),
+        width: 100,
+        height: 50
+      });
 
-    const editor = $(getActiveEditor().TEXTAREA_PARENT);
+      selectCell(0, 0);
 
-    keyDown('enter');
+      expect(getCell(0, 0)).not.toBeNull();
+      expect(getCell(19, 19)).toBeNull();
 
-    // First renderable column index.
-    expect(editor.offset()).toEqual($(getCell(0, 1, true)).offset());
+      hot.view.scrollViewport({ row: 19, col: 19 });
+      hot.render();
 
-    selectCell(0, 2);
-    keyDown('enter');
+      expect(getCell(0, 0)).toBeNull();
+      expect(getCell(19, 19)).not.toBeNull();
 
-    // Cells that do not touch the edges of the table have an additional left border.
-    const editorOffset = () => ({
-      top: editor.offset().top,
-      left: editor.offset().left,
+      keyDown('enter');
+
+      expect(getCell(0, 0)).not.toBeNull();
+      expect(getCell(19, 19)).toBeNull();
     });
-
-    expect(editorOffset()).toEqual($(getCell(0, 2, true)).offset());
-
-    selectCell(0, 3);
-    keyDown('enter');
-
-    expect(editorOffset()).toEqual($(getCell(0, 3, true)).offset());
-
-    selectCell(0, 4);
-    keyDown('enter');
-
-    expect(editorOffset()).toEqual($(getCell(0, 4, true)).offset());
-  });
-
-  it('should change editor\'s CSS properties during switching to being visible', () => {
-    handsontable({
-      editor: 'text',
-    });
-
-    selectCell(0, 0);
-    keyDownUp('enter');
-
-    const cell = getCell(0, 0);
-    const master = getMaster();
-    const cellOffsetTop = cell.offsetTop;
-    const cellOffsetLeft = cell.offsetLeft + master.find('.wtHider').position().left;
-    const { left, right, position, top, zIndex, overflow } = spec().$container.find('.handsontableInputHolder').css([
-      'left',
-      'right',
-      'position',
-      'top',
-      'zIndex',
-      'overflow',
-    ]);
-
-    expect(parseInt(left, 10)).toBeAroundValue(cellOffsetLeft);
-    expect(parseInt(right, 10)).not.toBe(document.body.offsetWidth);
-    expect(position).toBe('absolute');
-    expect(parseInt(top, 10)).toBeAroundValue(cellOffsetTop);
-    expect(zIndex).not.toBe('-1');
-    expect(overflow).not.toBe('hidden');
-  });
-
-  it('should render textarea editor in specified size at cell 0, 0 without headers', async() => {
-    const hot = handsontable();
-
-    selectCell(0, 0);
-    keyDown('enter');
-
-    await sleep(200);
-
-    expect(hot.getActiveEditor().TEXTAREA.style.height).toBe('23px');
-    expect(hot.getActiveEditor().TEXTAREA.style.width).toBe('40px');
-  });
-
-  it('should render textarea editor in specified size at cell 1, 0 without headers', async() => {
-    const hot = handsontable();
-
-    selectCell(1, 1);
-    keyDown('enter');
-
-    await sleep(200);
-
-    expect(hot.getActiveEditor().TEXTAREA.style.height).toBe('23px');
-  });
-
-  it('should render textarea editor in specified size at cell 0, 0 with headers', async() => {
-    handsontable({
-      rowHeaders: true,
-      colHeaders: true
-    });
-
-    selectCell(0, 0);
-    keyDown('enter');
-
-    await sleep(200);
-
-    expect(getActiveEditor().TEXTAREA.style.height).toBe('23px');
-    expect(getActiveEditor().TEXTAREA.style.width).toBe('40px');
-  });
-
-  it('should render textarea editor in specified size at cell 0, 0 when headers are selected', async() => {
-    handsontable({
-      rowHeaders: true,
-      colHeaders: true
-    });
-
-    selectAll();
-    listen();
-    keyDown('enter');
-
-    await sleep(200);
-
-    expect(getActiveEditor().TEXTAREA.style.height).toBe('23px');
-    expect(getActiveEditor().TEXTAREA.style.width).toBe('40px');
-  });
-
-  it('should render textarea editor in specified size at cell 0, 0 with headers defined in columns', async() => {
-    const hot = handsontable({
-      data: Handsontable.helper.createSpreadsheetObjectData(10, 10),
-      columns: [{
-        data: 'prop0',
-        title: 'Prop 0'
-      }, {
-        data: 'prop1',
-        title: 'Prop 1'
-      }, {
-        data: 'prop2',
-        title: 'Prop 2'
-      }, {
-        data: 'prop3',
-        title: 'Prop 3'
-      }],
-    });
-
-    selectCell(0, 0);
-    keyDown('enter');
-
-    await sleep(200);
-
-    expect(parseInt(hot.getActiveEditor().TEXTAREA.style.width, 10)).toBeAroundValue(41, 1);
-    expect(hot.getActiveEditor().TEXTAREA.style.height).toBe('23px');
-    expect(hot.getActiveEditor().textareaParentStyle.top).toBe('26px');
-  });
-
-  it('should hide editor when quick navigation by click scrollbar was triggered', async() => {
-    const hot = handsontable({
-      data: Handsontable.helper.createSpreadsheetData(50, 50),
-      rowHeaders: true,
-      colHeaders: true
-    });
-
-    setDataAtCell(2, 2, 'string\nstring\nstring');
-    selectCell(2, 2);
-
-    keyDown('enter');
-    keyUp('enter');
-    hot.scrollViewportTo(49);
-
-    await sleep(100);
-
-    expect(isEditorVisible()).toBe(false);
-  });
-
-  it('should render textarea editor in specified height (single line)', (done) => {
-    const hot = handsontable();
-
-    setDataAtCell(2, 2, 'first line');
-    selectCell(2, 2);
-
-    keyDown('enter');
-
-    setTimeout(() => {
-      expect(hot.getActiveEditor().TEXTAREA.style.height).toBe('23px');
-      done();
-    }, 200);
-  });
-
-  it('should render textarea editor in specified height (multi line)', (done) => {
-    const hot = handsontable();
-
-    setDataAtCell(2, 2, 'first line\n second line\n third line...');
-    selectCell(2, 2);
-
-    keyDown('enter');
-
-    setTimeout(() => {
-      expect(hot.getActiveEditor().TEXTAREA.style.height).toBe('64px');
-      done();
-    }, 200);
-  });
-
-  it('editor size should not exceed the viewport after text edit', () => {
-    handsontable({
-      data: Handsontable.helper.createSpreadsheetData(10, 5),
-      width: 200,
-      height: 200
-    });
-
-    selectCell(2, 2);
-
-    keyDown('enter');
-
-    expect(isEditorVisible()).toEqual(true);
-
-    document.activeElement.value = 'Very very very very very very very very very very very very very ' +
-      'very very very very long text';
-    keyDownUp(32); // space - trigger textarea resize
-
-    const $textarea = $(document.activeElement);
-    const $wtHider = spec().$container.find('.wtHider');
-
-    expect($textarea.offset().left + $textarea.outerWidth())
-      .not.toBeGreaterThan($wtHider.offset().left + spec().$container.outerWidth());
-    expect($textarea.offset().top + $textarea.outerHeight())
-      .not.toBeGreaterThan($wtHider.offset().top + $wtHider.outerHeight());
-  });
-
-  it('should scroll editor to a cell, if trying to edit cell that is outside of the viewport', () => {
-    const hot = handsontable({
-      data: Handsontable.helper.createSpreadsheetData(20, 20),
-      width: 100,
-      height: 50
-    });
-
-    selectCell(0, 0);
-
-    expect(getCell(0, 0)).not.toBeNull();
-    expect(getCell(19, 19)).toBeNull();
-
-    hot.view.scrollViewport({ row: 19, col: 19 });
-    hot.render();
-
-    expect(getCell(0, 0)).toBeNull();
-    expect(getCell(19, 19)).not.toBeNull();
-
-    keyDown('enter');
-
-    expect(getCell(0, 0)).not.toBeNull();
-    expect(getCell(19, 19)).toBeNull();
-  });
-
-  it('should open editor at the same coordinates as the edited cell', () => {
-    const hot = handsontable({
-      data: Handsontable.helper.createSpreadsheetData(16, 8),
-      fixedColumnsStart: 2,
-      fixedRowsTop: 2
-    });
-
-    const mainHolder = hot.view._wt.wtTable.holder;
-
-    // corner
-    selectCell(1, 1);
-    keyDown(Handsontable.helper.KEY_CODES.ENTER);
-    const $inputHolder = $('.handsontableInputHolder');
-
-    expect($(getCell(1, 1)).offset().left).toEqual($inputHolder.offset().left);
-    expect($(getCell(1, 1)).offset().top).toEqual($inputHolder.offset().top + 1);
-
-    // top
-    selectCell(1, 4);
-    keyDown(Handsontable.helper.KEY_CODES.ENTER);
-    expect($(getCell(1, 4)).offset().left).toEqual($inputHolder.offset().left);
-    expect($(getCell(1, 4)).offset().top).toEqual($inputHolder.offset().top + 1);
-
-    // left
-    selectCell(4, 1);
-    keyDown(Handsontable.helper.KEY_CODES.ENTER);
-    expect($(getCell(4, 1)).offset().left).toEqual($inputHolder.offset().left);
-    expect($(getCell(4, 1)).offset().top).toEqual($inputHolder.offset().top + 1);
-
-    // non-fixed
-    selectCell(4, 4);
-    keyDown(Handsontable.helper.KEY_CODES.ENTER);
-    expect($(getCell(4, 4)).offset().left).toEqual($inputHolder.offset().left);
-    expect($(getCell(4, 4)).offset().top).toEqual($inputHolder.offset().top + 1);
-
-    $(mainHolder).scrollTop(1000);
-  });
-
-  it('should open editor at the same coordinates as the edited cell if preventOverflow is set as horizontal after the table had been scrolled', async() => {
-    spec().$container[0].style = 'width: 400px';
-
-    const hot = handsontable({
-      data: Handsontable.helper.createSpreadsheetData(30, 30),
-      preventOverflow: 'horizontal',
-      fixedColumnsStart: 2,
-      fixedRowsTop: 2,
-      rowHeaders: true,
-      colHeaders: true,
-      height: 500,
-    });
-
-    const $holder = $(hot.view._wt.wtTable.holder);
-
-    $holder.scrollTop(100);
-    $holder.scrollLeft(-100);
-
-    hot.render();
-
-    await sleep(50);
-    // corner
-    selectCell(1, 1);
-    keyDownUp(Handsontable.helper.KEY_CODES.ENTER);
-    const $inputHolder = $('.handsontableInputHolder');
-
-    expect($(getCell(1, 1, true)).offset().left).toEqual($inputHolder.offset().left);
-    expect($(getCell(1, 1, true)).offset().top).toEqual($inputHolder.offset().top + 1);
-
-    // top
-    selectCell(1, 4);
-    keyDownUp(Handsontable.helper.KEY_CODES.ENTER);
-    expect($(getCell(1, 4, true)).offset().left).toEqual($inputHolder.offset().left);
-    expect($(getCell(1, 4, true)).offset().top).toEqual($inputHolder.offset().top + 1);
-
-    // left
-    selectCell(4, 1);
-    keyDownUp(Handsontable.helper.KEY_CODES.ENTER);
-    expect($(getCell(4, 1, true)).offset().left).toEqual($inputHolder.offset().left);
-    expect($(getCell(4, 1, true)).offset().top).toEqual($inputHolder.offset().top + 1);
-
-    // non-fixed
-    selectCell(10, 6);
-    keyDownUp(Handsontable.helper.KEY_CODES.ENTER);
-    expect($(getCell(10, 6, true)).offset().left).toEqual($inputHolder.offset().left);
-    expect($(getCell(10, 6, true)).offset().top).toEqual($inputHolder.offset().top + 1);
-  });
-
-  it('should open editor at the same coordinates as the edited cell after the table had been scrolled (corner)', () => {
-    const hot = handsontable({
-      data: Handsontable.helper.createSpreadsheetData(16, 8),
-      fixedColumnsStart: 2,
-      fixedRowsTop: 2
-    });
-
-    const $holder = $(hot.view._wt.wtTable.holder);
-
-    $holder.scrollTop(100);
-    $holder.scrollLeft(-100);
-
-    hot.render();
-
-    // corner
-    selectCell(1, 1);
-    const currentCell = hot.getCell(1, 1, true);
-    const left = $(currentCell).offset().left;
-    const top = $(currentCell).offset().top;
-
-    const $inputHolder = $('.handsontableInputHolder');
-
-    keyDown(Handsontable.helper.KEY_CODES.ENTER);
-    expect(left).toEqual($inputHolder.offset().left);
-    expect(top).toEqual($inputHolder.offset().top + 1);
-  });
-
-  it('should open editor at the same coordinates as the edited cell after the table had been scrolled (top)', async() => {
-    const hot = handsontable({
-      data: Handsontable.helper.createSpreadsheetData(50, 50),
-      fixedColumnsStart: 2,
-      fixedRowsTop: 2
-    });
-
-    const $holder = $(hot.view._wt.wtTable.holder);
-
-    $holder[0].scrollTop = 500;
-    await sleep(100);
-    $holder[0].scrollLeft = -500;
-
-    await sleep(100);
-    // top
-    selectCell(1, 6);
-
-    await sleep(100);
-
-    const currentCell = hot.getCell(1, 6, true);
-    const left = $(currentCell).offset().left;
-    const top = $(currentCell).offset().top;
-    const $inputHolder = $('.handsontableInputHolder');
-
-    keyDown(Handsontable.helper.KEY_CODES.ENTER);
-
-    expect(left).toEqual($inputHolder.offset().left);
-    expect(top).toEqual($inputHolder.offset().top + 1);
-  });
-
-  it('should open editor at the same coordinates as the edited cell after the table had been scrolled (right)', async() => {
-    const hot = handsontable({
-      data: Handsontable.helper.createSpreadsheetData(50, 50),
-      fixedColumnsStart: 2,
-      fixedRowsTop: 2
-    });
-
-    const $holder = $(hot.view._wt.wtTable.holder);
-
-    $holder.scrollTop(500);
-    $holder.scrollLeft(-500);
-
-    await sleep(100);
-
-    selectCell(6, 1);
-
-    await sleep(100);
-
-    const currentCell = hot.getCell(6, 1, true);
-    const left = $(currentCell).offset().left;
-    const top = $(currentCell).offset().top;
-
-    const $inputHolder = $('.handsontableInputHolder');
-
-    keyDown(Handsontable.helper.KEY_CODES.ENTER);
-    expect(left).toEqual($inputHolder.offset().left);
-    expect(top).toEqual($inputHolder.offset().top + 1);
-  });
-
-  it('should open editor at the same coordinates as the edited cell after the table had been scrolled (non-fixed)', () => {
-    const hot = handsontable({
-      data: Handsontable.helper.createSpreadsheetData(50, 50),
-      fixedColumnsStart: 2,
-      fixedRowsTop: 2
-    });
-
-    const $holder = $(hot.view._wt.wtTable.holder);
-
-    $holder.scrollTop(500);
-    $holder.scrollLeft(-500);
-
-    hot.render();
-
-    // non-fixed
-    selectCell(7, 7);
-    const currentCell = hot.getCell(7, 7, true);
-    const left = $(currentCell).offset().left;
-    const top = $(currentCell).offset().top;
-
-    const $inputHolder = $('.handsontableInputHolder');
-
-    keyDown(Handsontable.helper.KEY_CODES.ENTER);
-    expect(left).toEqual($inputHolder.offset().left);
-    expect(top).toEqual($inputHolder.offset().top + 1);
-  });
-
-  it('should display editor with the proper size, when the edited column is beyond the tables container', () => {
-    spec().$container.css('overflow', '');
-    const hot = handsontable({
-      data: Handsontable.helper.createSpreadsheetData(3, 9)
-    });
-
-    selectCell(0, 7);
-    keyDown(Handsontable.helper.KEY_CODES.ENTER);
-
-    expect(Handsontable.dom.outerWidth(hot.getActiveEditor().TEXTAREA))
-      .toBeAroundValue(Handsontable.dom.outerWidth(hot.getCell(0, 7)));
-  });
-
-  it('should display editor with the proper size, when editing a last row after the table is scrolled to the bottom', () => {
-    const hot = handsontable({
-      data: Handsontable.helper.createSpreadsheetData(3, 8),
-      minSpareRows: 1,
-      height: 100
-    });
-
-    selectCell(0, 2);
-    keyDown(Handsontable.helper.KEY_CODES.ENTER);
-    const regularHeight = Handsontable.dom.outerHeight(hot.getActiveEditor().TEXTAREA);
-
-    selectCell(3, 2);
-    keyDown(Handsontable.helper.KEY_CODES.ENTER);
-    keyDown(Handsontable.helper.KEY_CODES.ENTER);
-    keyDown(Handsontable.helper.KEY_CODES.ENTER);
-
-    // lame check, needs investigating why sometimes it leaves 2px error
-    if (Handsontable.dom.outerHeight(hot.getActiveEditor().TEXTAREA) === regularHeight) {
-      expect(Handsontable.dom.outerHeight(hot.getActiveEditor().TEXTAREA)).toEqual(regularHeight);
-    } else {
-      expect(Handsontable.dom.outerHeight(hot.getActiveEditor().TEXTAREA)).toEqual(regularHeight - 2);
-    }
-
   });
 });

--- a/handsontable/src/editors/timeEditor/__tests__/rtl/timeEditor.spec.js
+++ b/handsontable/src/editors/timeEditor/__tests__/rtl/timeEditor.spec.js
@@ -1,31 +1,37 @@
 describe('TimeEditor (RTL mode)', () => {
-  const id = 'testContainer';
+  using('configuration object', [
+    { htmlDir: 'rtl', layoutDirection: 'inherit' },
+    { htmlDir: 'ltr', layoutDirection: 'rtl' },
+  ], ({ htmlDir, layoutDirection }) => {
+    const id = 'testContainer';
 
-  beforeEach(function() {
-    $('html').attr('dir', 'rtl');
-    this.$container = $(`<div id="${id}" style="width: 300px; height: 200px; overflow: hidden;"></div>`)
-      .appendTo('body');
-  });
-
-  afterEach(function() {
-    $('html').attr('dir', 'ltr');
-
-    if (this.$container) {
-      destroy();
-      this.$container.remove();
-    }
-  });
-
-  it('should render an editable editor\'s element with "dir" attribute set as "ltr"', () => {
-    handsontable({
-      data: Handsontable.helper.createSpreadsheetData(2, 5),
-      editor: 'time',
+    beforeEach(function() {
+      $('html').attr('dir', htmlDir);
+      this.$container = $(`<div id="${id}" style="width: 300px; height: 200px; overflow: hidden;"></div>`)
+        .appendTo('body');
     });
 
-    selectCell(0, 0);
+    afterEach(function() {
+      $('html').attr('dir', 'ltr');
 
-    const editableElement = getActiveEditor().TEXTAREA;
+      if (this.$container) {
+        destroy();
+        this.$container.remove();
+      }
+    });
 
-    expect(editableElement.getAttribute('dir')).toBe('ltr');
+    it('should render an editable editor\'s element with "dir" attribute set as "ltr"', () => {
+      handsontable({
+        layoutDirection,
+        data: Handsontable.helper.createSpreadsheetData(2, 5),
+        editor: 'time',
+      });
+
+      selectCell(0, 0);
+
+      const editableElement = getActiveEditor().TEXTAREA;
+
+      expect(editableElement.getAttribute('dir')).toBe('ltr');
+    });
   });
 });

--- a/handsontable/src/plugins/collapsibleColumns/__tests__/collapsibleColumns.spec.js
+++ b/handsontable/src/plugins/collapsibleColumns/__tests__/collapsibleColumns.spec.js
@@ -2533,17 +2533,31 @@ describe('CollapsibleColumns', () => {
   });
 
   describe('collapsible button', () => {
-    it('should be placed in correct place', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(10, 10),
-        nestedHeaders: [
-          ['A1', { label: 'B1', colspan: 4 }, 'F1', 'G1', 'H1', 'I1', 'J1'],
-          ['A2', { label: 'B2', colspan: 2 }, { label: 'D2', colspan: 2 }, 'F2', 'G2', 'H2', 'I2', 'J2'],
-        ],
-        collapsibleColumns: true
+    using('configuration object', [
+      { htmlDir: 'ltr', layoutDirection: 'inherit' },
+      { htmlDir: 'rtl', layoutDirection: 'ltr' },
+    ], ({ htmlDir, layoutDirection }) => {
+      beforeEach(() => {
+        $('html').attr('dir', htmlDir);
       });
-      expect(window.getComputedStyle(getCell(-1, 3).querySelector('.collapsibleIndicator'))
-        .getPropertyValue('right')).toEqual('5px');
+
+      afterEach(() => {
+        $('html').attr('dir', 'ltr');
+      });
+
+      it('should be placed in correct place', () => {
+        handsontable({
+          layoutDirection,
+          data: Handsontable.helper.createSpreadsheetData(10, 10),
+          nestedHeaders: [
+            ['A1', { label: 'B1', colspan: 4 }, 'F1', 'G1', 'H1', 'I1', 'J1'],
+            ['A2', { label: 'B2', colspan: 2 }, { label: 'D2', colspan: 2 }, 'F2', 'G2', 'H2', 'I2', 'J2'],
+          ],
+          collapsibleColumns: true
+        });
+        expect(window.getComputedStyle(getCell(-1, 3).querySelector('.collapsibleIndicator'))
+          .getPropertyValue('right')).toEqual('5px');
+      });
     });
 
     it('should call "toggleCollapsibleSection" internally with correct toggle state ' +

--- a/handsontable/src/plugins/collapsibleColumns/__tests__/rtl/collapsibleColumns.spec.js
+++ b/handsontable/src/plugins/collapsibleColumns/__tests__/rtl/collapsibleColumns.spec.js
@@ -1,38 +1,43 @@
 describe('CollapsibleColumns (RTL)', () => {
-  const id = 'testContainer';
+  using('configuration object', [
+    { htmlDir: 'rtl', layoutDirection: 'inherit' },
+    { htmlDir: 'ltr', layoutDirection: 'rtl' },
+  ], ({ htmlDir, layoutDirection }) => {
+    const id = 'testContainer';
 
-  beforeEach(function() {
-    $('html').attr('dir', 'rtl');
+    beforeEach(function() {
+      $('html').attr('dir', htmlDir);
 
-    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
-  });
+      this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+    });
 
-  afterEach(function() {
-    $('html').attr('dir', 'ltr');
+    afterEach(function() {
+      $('html').attr('dir', 'ltr');
 
-    if (this.$container) {
-      destroy();
-      this.$container.remove();
-    }
-    if (this.$wrapper) {
-      this.$wrapper.remove();
-    }
-  });
+      if (this.$container) {
+        destroy();
+        this.$container.remove();
+      }
+      if (this.$wrapper) {
+        this.$wrapper.remove();
+      }
+    });
 
-  describe('collapsible button', () => {
-    it('should be placed in correct place', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(10, 10),
-        nestedHeaders: [
-          ['A1', { label: 'B1', colspan: 4 }, 'F1', 'G1', 'H1', 'I1', 'J1'],
-          ['A2', { label: 'B2', colspan: 2 }, { label: 'D2', colspan: 2 }, 'F2', 'G2', 'H2', 'I2', 'J2'],
-        ],
-        collapsibleColumns: true
+    describe('collapsible button', () => {
+      it('should be placed in correct place', () => {
+        handsontable({
+          layoutDirection,
+          data: Handsontable.helper.createSpreadsheetData(10, 10),
+          nestedHeaders: [
+            ['A1', { label: 'B1', colspan: 4 }, 'F1', 'G1', 'H1', 'I1', 'J1'],
+            ['A2', { label: 'B2', colspan: 2 }, { label: 'D2', colspan: 2 }, 'F2', 'G2', 'H2', 'I2', 'J2'],
+          ],
+          collapsibleColumns: true
+        });
+
+        expect(window.getComputedStyle(getCell(-1, 3).querySelector('.collapsibleIndicator'))
+          .getPropertyValue('left')).toEqual('5px');
       });
-
-      expect(window.getComputedStyle(getCell(-1, 3).querySelector('.collapsibleIndicator'))
-        .getPropertyValue('left')).toEqual('5px');
     });
   });
-
 });

--- a/handsontable/src/plugins/columnSorting/__tests__/columnSorting.spec.js
+++ b/handsontable/src/plugins/columnSorting/__tests__/columnSorting.spec.js
@@ -190,30 +190,44 @@ describe('ColumnSorting', () => {
     expect(getPlugin('columnSorting').getSortConfig(1)).toEqual({ column: 1, sortOrder: 'asc' });
   });
 
-  it('should display indicator properly after changing sorted column sequence', () => {
-    const hot = handsontable({
-      data: [
-        [1, 9, 3, 4, 5, 6, 7, 8, 9],
-        [9, 8, 7, 6, 5, 4, 3, 2, 1],
-        [8, 7, 6, 5, 4, 3, 3, 1, 9],
-        [0, 3, 0, 5, 6, 7, 8, 9, 1]
-      ],
-      colHeaders: true,
-      columnSorting: {
-        indicator: true
-      }
+  using('configuration object', [
+    { htmlDir: 'ltr', layoutDirection: 'inherit' },
+    { htmlDir: 'rtl', layoutDirection: 'ltr' },
+  ], ({ htmlDir, layoutDirection }) => {
+    beforeEach(() => {
+      $('html').attr('dir', htmlDir);
     });
 
-    getPlugin('columnSorting').sort({ column: 0, sortOrder: 'asc' });
+    afterEach(() => {
+      $('html').attr('dir', 'ltr');
+    });
 
-    // changing column sequence: 0 <-> 1
-    hot.columnIndexMapper.moveIndexes([1], 0);
-    hot.render();
+    it('should display indicator properly after changing sorted column sequence', () => {
+      const hot = handsontable({
+        layoutDirection,
+        data: [
+          [1, 9, 3, 4, 5, 6, 7, 8, 9],
+          [9, 8, 7, 6, 5, 4, 3, 2, 1],
+          [8, 7, 6, 5, 4, 3, 3, 1, 9],
+          [0, 3, 0, 5, 6, 7, 8, 9, 1]
+        ],
+        colHeaders: true,
+        columnSorting: {
+          indicator: true
+        }
+      });
 
-    const sortedColumn = spec().$container.find('th span.columnSorting')[1];
+      getPlugin('columnSorting').sort({ column: 0, sortOrder: 'asc' });
 
-    expect(window.getComputedStyle(sortedColumn, ':before').getPropertyValue('background-image')).toMatch(/url/);
-    expect(window.getComputedStyle(sortedColumn, ':before').getPropertyValue('right')).toEqual('-9px');
+      // changing column sequence: 0 <-> 1
+      hot.columnIndexMapper.moveIndexes([1], 0);
+      hot.render();
+
+      const sortedColumn = spec().$container.find('th span.columnSorting')[1];
+
+      expect(window.getComputedStyle(sortedColumn, ':before').getPropertyValue('background-image')).toMatch(/url/);
+      expect(window.getComputedStyle(sortedColumn, ':before').getPropertyValue('right')).toEqual('-9px');
+    });
   });
 
   it('should clear indicator after disabling plugin', () => {

--- a/handsontable/src/plugins/columnSorting/__tests__/rtl/columnSorting.spec.js
+++ b/handsontable/src/plugins/columnSorting/__tests__/rtl/columnSorting.spec.js
@@ -1,45 +1,51 @@
 describe('ColumnSorting (RTL)', () => {
-  const id = 'testContainer';
+  using('configuration object', [
+    { htmlDir: 'rtl', layoutDirection: 'inherit' },
+    { htmlDir: 'ltr', layoutDirection: 'rtl' },
+  ], ({ htmlDir, layoutDirection }) => {
+    const id = 'testContainer';
 
-  beforeEach(function() {
-    $('html').attr('dir', 'rtl');
+    beforeEach(function() {
+      $('html').attr('dir', htmlDir);
 
-    this.$container = $(`<div id="${id}" style="overflow: auto; width: 300px; height: 200px;"></div>`).appendTo('body');
-  });
+      this.$container = $(`<div id="${id}" style="overflow: auto; width: 300px; height: 200px;"></div>`)
+        .appendTo('body');
+    });
 
-  afterEach(function() {
-    $('html').attr('dir', 'ltr');
+    afterEach(function() {
+      $('html').attr('dir', 'ltr');
 
-    if (this.$container) {
-      destroy();
-      this.$container.remove();
-    }
-  });
-
-  it('should display indicator properly after changing sorted column sequence', () => {
-    const hot = handsontable({
-      data: [
-        [1, 9, 3, 4, 5, 6, 7, 8, 9],
-        [9, 8, 7, 6, 5, 4, 3, 2, 1],
-        [8, 7, 6, 5, 4, 3, 3, 1, 9],
-        [0, 3, 0, 5, 6, 7, 8, 9, 1]
-      ],
-      colHeaders: true,
-      columnSorting: {
-        indicator: true
+      if (this.$container) {
+        destroy();
+        this.$container.remove();
       }
     });
 
-    getPlugin('columnSorting').sort({ column: 0, sortOrder: 'asc' });
+    it('should display indicator properly after changing sorted column sequence', () => {
+      const hot = handsontable({
+        layoutDirection,
+        data: [
+          [1, 9, 3, 4, 5, 6, 7, 8, 9],
+          [9, 8, 7, 6, 5, 4, 3, 2, 1],
+          [8, 7, 6, 5, 4, 3, 3, 1, 9],
+          [0, 3, 0, 5, 6, 7, 8, 9, 1]
+        ],
+        colHeaders: true,
+        columnSorting: {
+          indicator: true
+        }
+      });
 
-    // changing column sequence: 0 <-> 1
-    hot.columnIndexMapper.moveIndexes([1], 0);
-    hot.render();
+      getPlugin('columnSorting').sort({ column: 0, sortOrder: 'asc' });
 
-    const sortedColumn = spec().$container.find('th span.columnSorting')[1];
+      // changing column sequence: 0 <-> 1
+      hot.columnIndexMapper.moveIndexes([1], 0);
+      hot.render();
 
-    expect(window.getComputedStyle(sortedColumn, ':before').getPropertyValue('background-image')).toMatch(/url/);
-    expect(window.getComputedStyle(sortedColumn, ':before').getPropertyValue('left')).toEqual('-9px');
+      const sortedColumn = spec().$container.find('th span.columnSorting')[1];
+
+      expect(window.getComputedStyle(sortedColumn, ':before').getPropertyValue('background-image')).toMatch(/url/);
+      expect(window.getComputedStyle(sortedColumn, ':before').getPropertyValue('left')).toEqual('-9px');
+    });
   });
-
 });

--- a/handsontable/src/plugins/comments/__tests__/comments.spec.js
+++ b/handsontable/src/plugins/comments/__tests__/comments.spec.js
@@ -77,110 +77,140 @@ describe('Comments', () => {
   });
 
   describe('Styling', () => {
-    it('should display comment indicators in the appropriate cells', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(4, 4),
-        comments: true,
-        cell: [
-          { row: 1, col: 1, comment: { value: 'test' } },
-          { row: 2, col: 2, comment: { value: 'test' } }
-        ]
+    using('configuration object', [
+      { htmlDir: 'ltr', layoutDirection: 'inherit' },
+      { htmlDir: 'rtl', layoutDirection: 'ltr' },
+    ], ({ htmlDir, layoutDirection }) => {
+      beforeEach(() => {
+        $('html').attr('dir', htmlDir);
       });
 
-      expect(getCell(1, 1).classList.contains('htCommentCell')).toBeTrue();
-      expect(getComputedStyle(getCell(1, 1), ':after').left).toBe('43px');
-      expect(getComputedStyle(getCell(1, 1), ':after').right).toBe('0px');
-      expect(getComputedStyle(getCell(1, 1), ':after').borderLeftWidth).toBe('6px');
-      expect(getComputedStyle(getCell(1, 1), ':after').borderRightWidth).toBe('0px');
-      expect(getCell(2, 2).classList.contains('htCommentCell')).toBeTrue();
-      expect(getComputedStyle(getCell(1, 1), ':after').left).toBe('43px');
-      expect(getComputedStyle(getCell(1, 1), ':after').right).toBe('0px');
-      expect(getComputedStyle(getCell(2, 2), ':after').borderLeftWidth).toBe('6px');
-      expect(getComputedStyle(getCell(2, 2), ':after').borderRightWidth).toBe('0px');
-    });
-
-    it('should display the comment editor in the correct place when the viewport is not scrolled (the Window object is a scrollable element)', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(4, 4),
-        comments: true,
+      afterEach(() => {
+        $('html').attr('dir', 'ltr');
       });
 
-      const plugin = getPlugin('comments');
-      const $editor = $(plugin.editor.getInputElement());
+      it('should display comment indicators in the appropriate cells', () => {
+        handsontable({
+          layoutDirection,
+          data: Handsontable.helper.createSpreadsheetData(4, 4),
+          comments: true,
+          cell: [
+            { row: 1, col: 1, comment: { value: 'test' } },
+            { row: 2, col: 2, comment: { value: 'test' } }
+          ]
+        });
 
-      plugin.showAtCell(0, 1);
-
-      const cellOffset = $(getCell(0, 2)).offset();
-      const editorOffset = $editor.offset();
-
-      expect(editorOffset.top).toBeCloseTo(cellOffset.top, 0);
-      expect(editorOffset.left).toBeCloseTo(cellOffset.left, 0);
-    });
-
-    it('should display the comment editor in the correct place when the viewport is scrolled (the Window object is a scrollable element)', async() => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(100, 100),
-        comments: true,
+        expect(getCell(1, 1).classList.contains('htCommentCell')).toBeTrue();
+        expect(getComputedStyle(getCell(1, 1), ':after').left).toBe('43px');
+        expect(getComputedStyle(getCell(1, 1), ':after').right).toBe('0px');
+        expect(getComputedStyle(getCell(1, 1), ':after').borderLeftWidth).toBe('6px');
+        expect(getComputedStyle(getCell(1, 1), ':after').borderRightWidth).toBe('0px');
+        expect(getCell(2, 2).classList.contains('htCommentCell')).toBeTrue();
+        expect(getComputedStyle(getCell(1, 1), ':after').left).toBe('43px');
+        expect(getComputedStyle(getCell(1, 1), ':after').right).toBe('0px');
+        expect(getComputedStyle(getCell(2, 2), ':after').borderLeftWidth).toBe('6px');
+        expect(getComputedStyle(getCell(2, 2), ':after').borderRightWidth).toBe('0px');
       });
 
-      scrollViewportTo(countRows() - 1, countCols() - 1);
+      it('should display the comment editor in the correct place when the viewport is not scrolled (the Window object is a scrollable element)', () => {
+        // For this configuration object "{ htmlDir: 'rtl', layoutDirection: 'ltr'}" it's necessary to force
+        // always RTL on document, otherwise the horizontal scrollbar won't appear and test fail.
+        if (htmlDir === 'rtl' && layoutDirection === 'ltr') {
+          $('html').attr('dir', 'ltr');
+        }
 
-      const plugin = getPlugin('comments');
-      const $editor = $(plugin.editor.getInputElement());
+        handsontable({
+          layoutDirection,
+          data: Handsontable.helper.createSpreadsheetData(4, 4),
+          comments: true,
+        });
 
-      await sleep(10);
+        const plugin = getPlugin('comments');
+        const $editor = $(plugin.editor.getInputElement());
 
-      plugin.showAtCell(countRows() - 10, countCols() - 10);
+        plugin.showAtCell(0, 1);
 
-      const cellOffset = $(getCell(countRows() - 10, countCols() - 9)).offset();
-      const editorOffset = $editor.offset();
+        const cellOffset = $(getCell(0, 2)).offset();
+        const editorOffset = $editor.offset();
 
-      expect(editorOffset.top).toBeCloseTo(cellOffset.top, 0);
-      expect(editorOffset.left).toBeCloseTo(cellOffset.left, 0);
-    });
-
-    it('should display the comment editor in the correct place when the viewport is not scrolled (the Window object is not a scrollable element)', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(30, 20),
-        comments: true,
-        width: 200,
-        height: 200,
+        expect(editorOffset.top).toBeCloseTo(cellOffset.top, 0);
+        expect(editorOffset.left).toBeCloseTo(cellOffset.left, 0);
       });
 
-      const plugin = getPlugin('comments');
-      const $editor = $(plugin.editor.getInputElement());
+      it('should display the comment editor in the correct place when the viewport is scrolled (the Window object is a scrollable element)', async() => {
+        // For this configuration object "{ htmlDir: 'rtl', layoutDirection: 'ltr'}" it's necessary to force
+        // always RTL on document, otherwise the horizontal scrollbar won't appear and test fail.
+        if (htmlDir === 'rtl' && layoutDirection === 'ltr') {
+          $('html').attr('dir', 'ltr');
+        }
 
-      plugin.showAtCell(0, 1);
+        handsontable({
+          layoutDirection,
+          data: Handsontable.helper.createSpreadsheetData(100, 100),
+          comments: true,
+        });
 
-      const cellOffset = $(getCell(0, 2)).offset();
-      const editorOffset = $editor.offset();
+        scrollViewportTo(countRows() - 1, countCols() - 1);
 
-      expect(editorOffset.top).toBeCloseTo(cellOffset.top, 0);
-      expect(editorOffset.left).toBeCloseTo(cellOffset.left, 0);
-    });
+        const plugin = getPlugin('comments');
+        const $editor = $(plugin.editor.getInputElement());
 
-    it('should display the comment editor in the correct place when the viewport is scrolled (the Window object is not a scrollable element)', async() => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(30, 20),
-        comments: true,
-        width: 200,
-        height: 200,
+        await sleep(10);
+
+        plugin.showAtCell(countRows() - 10, countCols() - 10);
+
+        const cellOffset = $(getCell(countRows() - 10, countCols() - 9)).offset();
+        const editorOffset = $editor.offset();
+
+        expect(editorOffset.top).toBeCloseTo(cellOffset.top, 0);
+        expect(editorOffset.left).toBeCloseTo(cellOffset.left, 0);
       });
 
-      scrollViewportTo(countRows() - 1, countCols() - 1);
+      it('should display the comment editor in the correct place when the viewport is not scrolled (the Window object is not a scrollable element)', () => {
+        handsontable({
+          layoutDirection,
+          data: Handsontable.helper.createSpreadsheetData(30, 20),
+          comments: true,
+          width: 200,
+          height: 200,
+        });
 
-      const plugin = getPlugin('comments');
-      const $editor = $(plugin.editor.getInputElement());
+        const plugin = getPlugin('comments');
+        const $editor = $(plugin.editor.getInputElement());
 
-      await sleep(10);
+        plugin.showAtCell(0, 1);
 
-      plugin.showAtCell(countRows() - 10, countCols() - 10);
+        const cellOffset = $(getCell(0, 2)).offset();
+        const editorOffset = $editor.offset();
 
-      const cellOffset = $(getCell(countRows() - 10, countCols() - 9)).offset();
-      const editorOffset = $editor.offset();
+        expect(editorOffset.top).toBeCloseTo(cellOffset.top, 0);
+        expect(editorOffset.left).toBeCloseTo(cellOffset.left, 0);
+      });
 
-      expect(editorOffset.top).toBeCloseTo(cellOffset.top, 0);
-      expect(editorOffset.left).toBeCloseTo(cellOffset.left, 0);
+      it('should display the comment editor in the correct place when the viewport is scrolled (the Window object is not a scrollable element)', async() => {
+        handsontable({
+          layoutDirection,
+          data: Handsontable.helper.createSpreadsheetData(30, 20),
+          comments: true,
+          width: 200,
+          height: 200,
+        });
+
+        scrollViewportTo(countRows() - 1, countCols() - 1);
+
+        const plugin = getPlugin('comments');
+        const $editor = $(plugin.editor.getInputElement());
+
+        await sleep(10);
+
+        plugin.showAtCell(countRows() - 10, countCols() - 10);
+
+        const cellOffset = $(getCell(countRows() - 10, countCols() - 9)).offset();
+        const editorOffset = $editor.offset();
+
+        expect(editorOffset.top).toBeCloseTo(cellOffset.top, 0);
+        expect(editorOffset.left).toBeCloseTo(cellOffset.left, 0);
+      });
     });
   });
 

--- a/handsontable/src/plugins/comments/__tests__/rtl/comments.spec.js
+++ b/handsontable/src/plugins/comments/__tests__/rtl/comments.spec.js
@@ -1,129 +1,146 @@
 describe('Comments (RTL mode)', () => {
-  const id = 'testContainer';
+  using('configuration object', [
+    { htmlDir: 'rtl', layoutDirection: 'inherit' },
+    { htmlDir: 'ltr', layoutDirection: 'rtl' },
+  ], ({ htmlDir, layoutDirection }) => {
+    const id = 'testContainer';
 
-  beforeEach(function() {
-    $('html').attr('dir', 'rtl');
-    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
-  });
+    beforeEach(function() {
+      $('html').attr('dir', htmlDir);
 
-  afterEach(function() {
-    $('html').attr('dir', 'ltr');
-
-    if (this.$container) {
-      destroy();
-      this.$container.remove();
-    }
-  });
-
-  describe('Styling', () => {
-    it('should display comment indicators in the appropriate cells', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(4, 4),
-        comments: true,
-        cell: [
-          { row: 1, col: 1, comment: { value: 'test' } },
-          { row: 2, col: 2, comment: { value: 'test' } }
-        ]
-      });
-
-      expect(getCell(1, 1).classList.contains('htCommentCell')).toBeTrue();
-      expect(getComputedStyle(getCell(1, 1), ':after').left).toBe('0px');
-      expect(getComputedStyle(getCell(1, 1), ':after').right).toBe('43px');
-      expect(getComputedStyle(getCell(1, 1), ':after').borderLeftWidth).toBe('0px');
-      expect(getComputedStyle(getCell(1, 1), ':after').borderRightWidth).toBe('6px');
-      expect(getCell(2, 2).classList.contains('htCommentCell')).toBeTrue();
-      expect(getComputedStyle(getCell(1, 1), ':after').left).toBe('0px');
-      expect(getComputedStyle(getCell(1, 1), ':after').right).toBe('43px');
-      expect(getComputedStyle(getCell(2, 2), ':after').borderLeftWidth).toBe('0px');
-      expect(getComputedStyle(getCell(2, 2), ':after').borderRightWidth).toBe('6px');
+      this.$container = $(`<div id="${id}"></div>`).appendTo('body');
     });
 
-    it('should display the comment editor in the correct place when the viewport is not scrolled (the Window object is a scrollable element)', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(4, 4),
-        comments: true,
-      });
+    afterEach(function() {
+      $('html').attr('dir', 'ltr');
 
-      const plugin = getPlugin('comments');
-      const $editor = $(plugin.editor.getInputElement());
-
-      plugin.showAtCell(0, 1);
-
-      const cellOffset = $(getCell(0, 1)).offset();
-      const editorOffset = $editor.offset();
-      const editorWidth = $editor.outerWidth();
-
-      expect(editorOffset.top).toBeCloseTo(cellOffset.top, 0);
-      expect(editorOffset.left).toBeCloseTo(cellOffset.left - editorWidth, 0);
+      if (this.$container) {
+        destroy();
+        this.$container.remove();
+      }
     });
 
-    it('should display the comment editor in the correct place when the viewport is scrolled (the Window object is a scrollable element)', async() => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(100, 100),
-        comments: true,
+    describe('Styling', () => {
+      it('should display comment indicators in the appropriate cells', () => {
+        handsontable({
+          layoutDirection,
+          data: Handsontable.helper.createSpreadsheetData(4, 4),
+          comments: true,
+          cell: [
+            { row: 1, col: 1, comment: { value: 'test' } },
+            { row: 2, col: 2, comment: { value: 'test' } }
+          ]
+        });
+
+        expect(getCell(1, 1).classList.contains('htCommentCell')).toBeTrue();
+        expect(getComputedStyle(getCell(1, 1), ':after').left).toBe('0px');
+        expect(getComputedStyle(getCell(1, 1), ':after').right).toBe('43px');
+        expect(getComputedStyle(getCell(1, 1), ':after').borderLeftWidth).toBe('0px');
+        expect(getComputedStyle(getCell(1, 1), ':after').borderRightWidth).toBe('6px');
+        expect(getCell(2, 2).classList.contains('htCommentCell')).toBeTrue();
+        expect(getComputedStyle(getCell(1, 1), ':after').left).toBe('0px');
+        expect(getComputedStyle(getCell(1, 1), ':after').right).toBe('43px');
+        expect(getComputedStyle(getCell(2, 2), ':after').borderLeftWidth).toBe('0px');
+        expect(getComputedStyle(getCell(2, 2), ':after').borderRightWidth).toBe('6px');
       });
 
-      scrollViewportTo(countRows() - 1, countCols() - 1);
+      it('should display the comment editor in the correct place when the viewport is not scrolled (the Window object is a scrollable element)', () => {
+        handsontable({
+          layoutDirection,
+          data: Handsontable.helper.createSpreadsheetData(4, 4),
+          comments: true,
+        });
 
-      const plugin = getPlugin('comments');
-      const $editor = $(plugin.editor.getInputElement());
+        const plugin = getPlugin('comments');
+        const $editor = $(plugin.editor.getInputElement());
 
-      await sleep(10);
+        plugin.showAtCell(0, 1);
 
-      plugin.showAtCell(countRows() - 10, countCols() - 10);
+        const cellOffset = $(getCell(0, 1)).offset();
+        const editorOffset = $editor.offset();
+        const editorWidth = $editor.outerWidth();
 
-      const cellOffset = $(getCell(countRows() - 10, countCols() - 10)).offset();
-      const editorOffset = $editor.offset();
-      const editorWidth = $editor.outerWidth();
-
-      expect(editorOffset.top).toBeCloseTo(cellOffset.top, 0);
-      expect(editorOffset.left).toBeCloseTo(cellOffset.left - editorWidth, 0);
-    });
-
-    it('should display the comment editor in the correct place when the viewport is not scrolled (the Window object is not a scrollable element)', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(30, 20),
-        comments: true,
-        width: 200,
-        height: 200,
+        expect(editorOffset.top).toBeCloseTo(cellOffset.top, 0);
+        expect(editorOffset.left).toBeCloseTo(cellOffset.left - editorWidth, 0);
       });
 
-      const plugin = getPlugin('comments');
-      const $editor = $(plugin.editor.getInputElement());
+      it('should display the comment editor in the correct place when the viewport is scrolled (the Window object is a scrollable element)', async() => {
+        // For this configuration object "{ htmlDir: 'ltr', layoutDirection: 'rtl' }" it's necessary to force
+        // always RTL on document, otherwise the horizontal scrollbar won't appear and test fail.
+        if (htmlDir === 'ltr' && layoutDirection === 'rtl') {
+          $('html').attr('dir', 'rtl');
+        }
 
-      plugin.showAtCell(0, 1);
+        handsontable({
+          layoutDirection,
+          data: Handsontable.helper.createSpreadsheetData(100, 100),
+          comments: true,
+        });
 
-      const cellOffset = $(getCell(0, 1)).offset();
-      const editorOffset = $editor.offset();
-      const editorWidth = $editor.outerWidth();
+        scrollViewportTo(countRows() - 1, countCols() - 1);
 
-      expect(editorOffset.top).toBeCloseTo(cellOffset.top, 0);
-      expect(editorOffset.left).toBeCloseTo(cellOffset.left - editorWidth, 0);
-    });
+        const plugin = getPlugin('comments');
+        const $editor = $(plugin.editor.getInputElement());
 
-    it('should display the comment editor in the correct place when the viewport is scrolled (the Window object is not a scrollable element)', async() => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(30, 20),
-        comments: true,
-        width: 200,
-        height: 200,
+        await sleep(10);
+
+        plugin.showAtCell(countRows() - 10, countCols() - 10);
+
+        const cellOffset = $(getCell(countRows() - 10, countCols() - 10)).offset();
+        const editorOffset = $editor.offset();
+        const editorWidth = $editor.outerWidth();
+
+        expect(editorOffset.top).toBeCloseTo(cellOffset.top, 0);
+        expect(editorOffset.left).toBeCloseTo(cellOffset.left - editorWidth, 0);
       });
 
-      scrollViewportTo(countRows() - 1, countCols() - 1);
+      it('should display the comment editor in the correct place when the viewport is not scrolled (the Window object is not a scrollable element)', () => {
+        handsontable({
+          layoutDirection,
+          data: Handsontable.helper.createSpreadsheetData(30, 20),
+          comments: true,
+          width: 200,
+          height: 200,
+        });
 
-      const plugin = getPlugin('comments');
-      const $editor = $(plugin.editor.getInputElement());
+        const plugin = getPlugin('comments');
+        const $editor = $(plugin.editor.getInputElement());
 
-      await sleep(10);
+        plugin.showAtCell(0, 1);
 
-      plugin.showAtCell(countRows() - 10, countCols() - 10);
+        const cellOffset = $(getCell(0, 1)).offset();
+        const editorOffset = $editor.offset();
+        const editorWidth = $editor.outerWidth();
 
-      const cellOffset = $(getCell(countRows() - 10, countCols() - 10)).offset();
-      const editorOffset = $editor.offset();
-      const editorWidth = $editor.outerWidth();
+        expect(editorOffset.top).toBeCloseTo(cellOffset.top, 0);
+        expect(editorOffset.left).toBeCloseTo(cellOffset.left - editorWidth, 0);
+      });
 
-      expect(editorOffset.top).toBeCloseTo(cellOffset.top, 0);
-      expect(editorOffset.left).toBeCloseTo(cellOffset.left - editorWidth, 0);
+      it('should display the comment editor in the correct place when the viewport is scrolled (the Window object is not a scrollable element)', async() => {
+        handsontable({
+          layoutDirection,
+          data: Handsontable.helper.createSpreadsheetData(30, 20),
+          comments: true,
+          width: 200,
+          height: 200,
+        });
+
+        scrollViewportTo(countRows() - 1, countCols() - 1);
+
+        const plugin = getPlugin('comments');
+        const $editor = $(plugin.editor.getInputElement());
+
+        await sleep(10);
+
+        plugin.showAtCell(countRows() - 10, countCols() - 10);
+
+        const cellOffset = $(getCell(countRows() - 10, countCols() - 10)).offset();
+        const editorOffset = $editor.offset();
+        const editorWidth = $editor.outerWidth();
+
+        expect(editorOffset.top).toBeCloseTo(cellOffset.top, 0);
+        expect(editorOffset.left).toBeCloseTo(cellOffset.left - editorWidth, 0);
+      });
     });
   });
 });

--- a/handsontable/src/plugins/comments/commentEditor.js
+++ b/handsontable/src/plugins/comments/commentEditor.js
@@ -23,9 +23,10 @@ class CommentEditor {
     return 'htCommentCell';
   }
 
-  constructor(rootDocument) {
-    this.container = null;
+  constructor(rootDocument, isRtl) {
     this.rootDocument = rootDocument;
+    this.isRtl = isRtl;
+    this.container = null;
     this.editor = this.createEditor();
     this.editorStyle = this.editor.style;
 
@@ -169,7 +170,10 @@ class CommentEditor {
     editor.style.display = 'none';
 
     this.container = this.rootDocument.createElement('div');
+    this.container.setAttribute('dir', this.isRtl ? 'rtl' : 'ltr');
+
     addClass(this.container, CommentEditor.CLASS_EDITOR_CONTAINER);
+
     this.rootDocument.body.appendChild(this.container);
 
     addClass(editor, CommentEditor.CLASS_EDITOR);

--- a/handsontable/src/plugins/comments/comments.js
+++ b/handsontable/src/plugins/comments/comments.js
@@ -153,7 +153,7 @@ export class Comments extends BasePlugin {
     }
 
     if (!this.editor) {
-      this.editor = new CommentEditor(this.hot.rootDocument);
+      this.editor = new CommentEditor(this.hot.rootDocument, this.hot.isRtl());
     }
 
     if (!this.eventManager) {

--- a/handsontable/src/plugins/comments/comments.scss
+++ b/handsontable/src/plugins/comments/comments.scss
@@ -1,29 +1,25 @@
-.htCommentCell {
+.handsontable .htCommentCell {
   position: relative;
 }
 
-.htCommentCell:after {
+.handsontable .htCommentCell:after {
   content: '';
   position: absolute;
   top: 0;
-  right: 0;
+  inset-inline-end: 0;
+  inset-inline-start: unset;
   border-inline-start: 6px solid transparent;
   border-inline-end: none;
   border-top: 6px solid black;
 }
 
-[dir=rtl] .htCommentCell:after {
-  right: initial;
-  left: 0;
-}
-
-.htComments {
+.htCommentsContainer .htComments {
   display: none;
   z-index: 1059;
   position: absolute;
 }
 
-.htCommentTextArea {
+.htCommentsContainer .htCommentTextArea {
   box-shadow: rgba(0, 0, 0, 0.117647) 0 1px 3px, rgba(0, 0, 0, 0.239216) 0 1px 2px;
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
@@ -40,7 +36,7 @@
   -webkit-appearance: none;
 }
 
-.htCommentTextArea:focus {
+.htCommentsContainer .htCommentTextArea:focus {
   box-shadow: rgba(0, 0, 0, 0.117647) 0 1px 3px, rgba(0, 0, 0, 0.239216) 0 1px 2px, inset 0 0 0 1px #5292f7;
   border-inline-start: 3px solid #5292f7;
   border-inline-end: none;

--- a/handsontable/src/plugins/contextMenu/__tests__/positioning.spec.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/positioning.spec.js
@@ -1,263 +1,279 @@
 describe('ContextMenu', () => {
-  const id = 'testContainer';
+  using('configuration object', [
+    { htmlDir: 'ltr', layoutDirection: 'inherit' },
+    { htmlDir: 'rtl', layoutDirection: 'ltr' },
+  ], ({ htmlDir, layoutDirection }) => {
+    const id = 'testContainer';
 
-  beforeEach(function() {
-    $('.jasmine_html-reporter').hide();
-    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
-  });
-
-  afterEach(function() {
-    $('.jasmine_html-reporter').show();
-
-    if (this.$container) {
-      destroy();
-      this.$container.remove();
-    }
-  });
-
-  describe('menu opening', () => {
-    it('should open context menu in proper position in iframe', async() => {
-      const iframeOutside = $('<iframe/>').css({ width: '500px', height: '500px' }).appendTo(spec().$container);
-      const docOutside = iframeOutside[0].contentDocument;
-
-      docOutside.open('text/html', 'replace');
-      docOutside.write(`
-        <!doctype html>
-        <head>
-          <link type="text/css" rel="stylesheet" href="../dist/handsontable.full.min.css">
-        </head>`);
-      docOutside.close();
-
-      const iframeInside = $('<iframe/>')
-        .css({ margin: '250px 500px 500px 250px', width: '500px', height: '500px' }).appendTo(docOutside.body);
-      const docInside = iframeInside[0].contentDocument;
-
-      docInside.open('text/html', 'replace');
-      docInside.write(`
-        <!doctype html>
-        <head>
-          <link type="text/css" rel="stylesheet" href="../dist/handsontable.full.min.css">
-        </head>`);
-      docInside.close();
-
-      const uiContainer = $('<div/>').addClass('uiContainer').appendTo(docOutside.body);
-      const container = $('<div/>').css({ marginTop: '500px', marginLeft: '500px' }).appendTo(docInside.body);
-
-      const hot = container.handsontable({
-        contextMenu: {
-          uiContainer: uiContainer[0],
-        },
-      }).handsontable('getInstance');
-
-      docOutside.documentElement.scrollTop = 500;
-      docOutside.documentElement.scrollLeft = 500;
-      docInside.documentElement.scrollTop = 500;
-      docInside.documentElement.scrollLeft = 500;
-
-      await sleep(400);
-
-      const cell = hot.getCell(2, 2);
-
-      contextMenu(cell, hot);
-
-      const contextMenuElem = $(docOutside.body).find('.htContextMenu');
-      const contextMenuOffset = contextMenuElem.offset();
-      const { top: cellTop, left: cellLeft } = cell.getBoundingClientRect();
-      const { top: iframeTop, left: iframeLeft } = iframeInside.offset()
-      ;
-      const cellOffsetTop = cellTop + iframeTop;
-      const cellOffsetLeft = cellLeft + iframeLeft;
-
-      expect(contextMenuOffset.top).toBeAroundValue(cellOffsetTop);
-      expect(contextMenuOffset.left).toBeAroundValue(cellOffsetLeft);
-
-      container.handsontable('destroy');
+    beforeEach(function() {
+      $('.jasmine_html-reporter').hide();
+      $('html').attr('dir', htmlDir);
+      this.$container = $(`<div id="${id}"></div>`).appendTo('body');
     });
 
-    it('should render context menu by default on the right-bottom position', () => {
-      handsontable({
-        contextMenu: true,
-      });
+    afterEach(function() {
+      $('.jasmine_html-reporter').show();
+      $('html').attr('dir', 'ltr');
 
-      selectCell(0, 0);
-
-      const cell = getCell(0, 0);
-      const cellOffset = $(cell).offset();
-
-      contextMenu(cell);
-
-      const $contextMenu = $(document.body).find('.htContextMenu:visible');
-      const menuOffset = $contextMenu.offset();
-
-      expect($contextMenu.length).toBe(1);
-      expect(menuOffset.top).toBeCloseTo(cellOffset.top + 1, 0);
-      expect(menuOffset.left).toBeCloseTo(cellOffset.left, 0);
+      if (this.$container) {
+        destroy();
+        this.$container.remove();
+      }
     });
 
-    it('should render context menu on the right-top position if on the left and bottom there is no space left', () => {
-      handsontable({
-        data: createSpreadsheetData(Math.floor(window.innerHeight / 23), 4),
-        contextMenu: true,
+    describe('menu opening', () => {
+      it('should open context menu in proper position in iframe', async() => {
+        const iframeOutside = $('<iframe/>').css({ width: '500px', height: '500px' }).appendTo(spec().$container);
+        const docOutside = iframeOutside[0].contentDocument;
+
+        docOutside.open('text/html', 'replace');
+        docOutside.write(`
+          <!doctype html>
+          <head>
+            <link type="text/css" rel="stylesheet" href="../dist/handsontable.full.min.css">
+          </head>`);
+        docOutside.close();
+
+        const iframeInside = $('<iframe/>')
+          .css({ margin: '250px 500px 500px 250px', width: '500px', height: '500px' }).appendTo(docOutside.body);
+        const docInside = iframeInside[0].contentDocument;
+
+        docInside.open('text/html', 'replace');
+        docInside.write(`
+          <!doctype html>
+          <head>
+            <link type="text/css" rel="stylesheet" href="../dist/handsontable.full.min.css">
+          </head>`);
+        docInside.close();
+
+        const uiContainer = $('<div/>').addClass('uiContainer').appendTo(docOutside.body);
+        const container = $('<div/>').css({ marginTop: '500px', marginLeft: '500px' }).appendTo(docInside.body);
+
+        const hot = container.handsontable({
+          layoutDirection,
+          contextMenu: {
+            uiContainer: uiContainer[0],
+          },
+        }).handsontable('getInstance');
+
+        docOutside.documentElement.scrollTop = 500;
+        docOutside.documentElement.scrollLeft = 500;
+        docInside.documentElement.scrollTop = 500;
+        docInside.documentElement.scrollLeft = 500;
+
+        await sleep(400);
+
+        const cell = hot.getCell(2, 2);
+
+        contextMenu(cell, hot);
+
+        const contextMenuElem = $(docOutside.body).find('.htContextMenu');
+        const contextMenuOffset = contextMenuElem.offset();
+        const { top: cellTop, left: cellLeft } = cell.getBoundingClientRect();
+        const { top: iframeTop, left: iframeLeft } = iframeInside.offset()
+        ;
+        const cellOffsetTop = cellTop + iframeTop;
+        const cellOffsetLeft = cellLeft + iframeLeft;
+
+        expect(contextMenuOffset.top).toBeAroundValue(cellOffsetTop);
+        expect(contextMenuOffset.left).toBeAroundValue(cellOffsetLeft);
+
+        container.handsontable('destroy');
       });
 
-      // we have to be sure we will have no enough space on the bottom, select the last cell
-      selectCell(countRows() - 1, 0);
+      it('should render context menu by default on the right-bottom position', () => {
+        handsontable({
+          layoutDirection,
+          contextMenu: true,
+        });
 
-      const cell = getCell(countRows() - 1, 0);
-      const cellOffset = $(cell).offset();
+        selectCell(0, 0);
 
-      contextMenu(cell);
+        const cell = getCell(0, 0);
+        const cellOffset = $(cell).offset();
 
-      const $contextMenu = $(document.body).find('.htContextMenu:visible');
-      const menuOffset = $contextMenu.offset();
-      const menuHeight = $contextMenu.outerHeight();
+        contextMenu(cell);
 
-      expect($contextMenu.length).toBe(1);
-      expect(menuOffset.top).toBeCloseTo(cellOffset.top - menuHeight, 0);
-      expect(menuOffset.left).toBeCloseTo(cellOffset.left, 0);
+        const $contextMenu = $(document.body).find('.htContextMenu:visible');
+        const menuOffset = $contextMenu.offset();
+
+        expect($contextMenu.length).toBe(1);
+        expect(menuOffset.top).toBeCloseTo(cellOffset.top + 1, 0);
+        expect(menuOffset.left).toBeCloseTo(cellOffset.left, 0);
+      });
+
+      it('should render context menu on the right-top position if on the left and bottom there is no space left', () => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(Math.floor(window.innerHeight / 23), 4),
+          contextMenu: true,
+        });
+
+        // we have to be sure we will have no enough space on the bottom, select the last cell
+        selectCell(countRows() - 1, 0);
+
+        const cell = getCell(countRows() - 1, 0);
+        const cellOffset = $(cell).offset();
+
+        contextMenu(cell);
+
+        const $contextMenu = $(document.body).find('.htContextMenu:visible');
+        const menuOffset = $contextMenu.offset();
+        const menuHeight = $contextMenu.outerHeight();
+
+        expect($contextMenu.length).toBe(1);
+        expect(menuOffset.top).toBeCloseTo(cellOffset.top - menuHeight, 0);
+        expect(menuOffset.left).toBeCloseTo(cellOffset.left, 0);
+      });
+
+      it('should render context menu on the left-bottom position if on the right there is no space left', () => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(4, Math.floor(window.innerWidth / 50)),
+          contextMenu: true,
+        });
+
+        // we have to be sure we will have no enough space on the right, select the last cell
+        selectCell(0, countCols() - 1);
+
+        const cell = getCell(0, countCols() - 1);
+        const cellOffset = $(cell).offset();
+
+        contextMenu(cell);
+
+        const $contextMenu = $(document.body).find('.htContextMenu:visible');
+        const menuOffset = $contextMenu.offset();
+        const menuWidth = $contextMenu.outerWidth();
+
+        expect($contextMenu.length).toBe(1);
+        expect(menuOffset.top).toBeCloseTo(cellOffset.top + 1, 0);
+        expect(menuOffset.left).toBeCloseTo(cellOffset.left - menuWidth, 0);
+      });
+
+      it('should render context menu on the left-top position if on the right and bottom there is no space left', () => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(Math.floor(window.innerHeight / 23), Math.floor(window.innerWidth / 50)),
+          contextMenu: true,
+        });
+
+        // we have to be sure we will have no enough space on the bottom and the right, select the last cell
+        selectCell(countRows() - 1, countCols() - 1);
+
+        const cell = getCell(countRows() - 1, countCols() - 1);
+        const cellOffset = $(cell).offset();
+
+        contextMenu(cell);
+
+        const $contextMenu = $(document.body).find('.htContextMenu:visible');
+        const menuOffset = $contextMenu.offset();
+        const menuWidth = $contextMenu.outerWidth();
+        const menuHeight = $contextMenu.outerHeight();
+
+        expect($contextMenu.length).toBe(1);
+        expect(menuOffset.top).toBeCloseTo(cellOffset.top - menuHeight, 0);
+        expect(menuOffset.left).toBeCloseTo(cellOffset.left - menuWidth, 0);
+      });
     });
 
-    it('should render context menu on the left-bottom position if on the right there is no space left', () => {
-      handsontable({
-        data: createSpreadsheetData(4, Math.floor(window.innerWidth / 50)),
-        contextMenu: true,
+    describe('subMenu opening', () => {
+      it('should open subMenu by default on the right-bottom position of the main menu', async() => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(4, Math.floor(window.innerWidth / 50)),
+          contextMenu: true,
+        });
+
+        selectCell(0, 0);
+        openContextSubmenuOption('Alignment');
+
+        await sleep(350);
+
+        const subMenuItem = $('.htContextMenu .ht_master .htCore  td:contains(Alignment)');
+        const subMenuItemOffset = subMenuItem.offset();
+        const contextMenuRoot = $('.htContextMenu');
+        const contextMenuOffset = contextMenuRoot.offset();
+        const subMenuRoot = $('.htContextMenuSub_Alignment');
+        const subMenuOffset = subMenuRoot.offset();
+
+        expect(subMenuOffset.top).toBeCloseTo(subMenuItemOffset.top - 1, 0);
+        expect(subMenuOffset.left).toBeCloseTo(contextMenuOffset.left + contextMenuRoot.outerWidth(), 0);
       });
 
-      // we have to be sure we will have no enough space on the right, select the last cell
-      selectCell(0, countCols() - 1);
+      it('should open subMenu on the right-top of the main menu if on the left and bottom there\'s no space left', async() => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(Math.floor(window.innerHeight / 23), 4),
+          contextMenu: true,
+        });
 
-      const cell = getCell(0, countCols() - 1);
-      const cellOffset = $(cell).offset();
+        selectCell(countRows() - 1, 0);
+        openContextSubmenuOption('Alignment');
 
-      contextMenu(cell);
+        await sleep(350);
 
-      const $contextMenu = $(document.body).find('.htContextMenu:visible');
-      const menuOffset = $contextMenu.offset();
-      const menuWidth = $contextMenu.outerWidth();
+        const subMenuItem = $('.htContextMenu .ht_master .htCore td:contains(Alignment)');
+        const subMenuItemOffset = subMenuItem.offset();
+        const contextMenuRoot = $('.htContextMenu');
+        const contextMenuOffset = contextMenuRoot.offset();
+        const subMenuRoot = $('.htContextMenuSub_Alignment');
+        const subMenuOffset = subMenuRoot.offset();
 
-      expect($contextMenu.length).toBe(1);
-      expect(menuOffset.top).toBeCloseTo(cellOffset.top + 1, 0);
-      expect(menuOffset.left).toBeCloseTo(cellOffset.left - menuWidth, 0);
-    });
-
-    it('should render context menu on the left-top position if on the right and bottom there is no space left', () => {
-      handsontable({
-        data: createSpreadsheetData(Math.floor(window.innerHeight / 23), Math.floor(window.innerWidth / 50)),
-        contextMenu: true,
+        // 3px comes from bottom borders
+        expect(subMenuOffset.top)
+          .toBeCloseTo(subMenuItemOffset.top - subMenuRoot.outerHeight() + subMenuItem.outerHeight() + 3, 0);
+        expect(subMenuOffset.left)
+          .toBeCloseTo(contextMenuOffset.left + contextMenuRoot.outerWidth(), 0);
       });
 
-      // we have to be sure we will have no enough space on the bottom and the right, select the last cell
-      selectCell(countRows() - 1, countCols() - 1);
+      it('should open subMenu on the left-bottom of the main menu if on the right there\'s no space left', async() => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(4, Math.floor(window.innerWidth / 50)),
+          contextMenu: true,
+        });
 
-      const cell = getCell(countRows() - 1, countCols() - 1);
-      const cellOffset = $(cell).offset();
+        selectCell(0, countCols() - 1);
+        openContextSubmenuOption('Alignment');
 
-      contextMenu(cell);
+        await sleep(350);
 
-      const $contextMenu = $(document.body).find('.htContextMenu:visible');
-      const menuOffset = $contextMenu.offset();
-      const menuWidth = $contextMenu.outerWidth();
-      const menuHeight = $contextMenu.outerHeight();
+        const subMenuItem = $('.htContextMenu .ht_master .htCore td:contains(Alignment)');
+        const subMenuItemOffset = subMenuItem.offset();
+        const contextMenuRoot = $('.htContextMenu');
+        const contextMenuOffset = contextMenuRoot.offset();
+        const subMenuRoot = $('.htContextMenuSub_Alignment');
+        const subMenuOffset = subMenuRoot.offset();
 
-      expect($contextMenu.length).toBe(1);
-      expect(menuOffset.top).toBeCloseTo(cellOffset.top - menuHeight, 0);
-      expect(menuOffset.left).toBeCloseTo(cellOffset.left - menuWidth, 0);
-    });
-  });
-
-  describe('subMenu opening', () => {
-    it('should open subMenu by default on the right-bottom position of the main menu', async() => {
-      handsontable({
-        data: createSpreadsheetData(4, Math.floor(window.innerWidth / 50)),
-        contextMenu: true,
+        expect(subMenuOffset.top).toBeCloseTo(subMenuItemOffset.top - 1, 0);
+        expect(subMenuOffset.left).toBeCloseTo(contextMenuOffset.left - contextMenuRoot.outerWidth(), 0);
       });
 
-      selectCell(0, 0);
-      openContextSubmenuOption('Alignment');
+      it('should open subMenu on the left-top of the main menu if on the right and bottom there\'s no space left', async() => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(Math.floor(window.innerHeight / 23), Math.floor(window.innerWidth / 50)),
+          contextMenu: true,
+        });
 
-      await sleep(350);
+        selectCell(countRows() - 1, countCols() - 1);
+        openContextSubmenuOption('Alignment');
 
-      const subMenuItem = $('.htContextMenu .ht_master .htCore  td:contains(Alignment)');
-      const subMenuItemOffset = subMenuItem.offset();
-      const contextMenuRoot = $('.htContextMenu');
-      const contextMenuOffset = contextMenuRoot.offset();
-      const subMenuRoot = $('.htContextMenuSub_Alignment');
-      const subMenuOffset = subMenuRoot.offset();
+        await sleep(350);
 
-      expect(subMenuOffset.top).toBeCloseTo(subMenuItemOffset.top - 1, 0);
-      expect(subMenuOffset.left).toBeCloseTo(contextMenuOffset.left + contextMenuRoot.outerWidth(), 0);
-    });
+        const subMenuItem = $('.htContextMenu .ht_master .htCore td:contains(Alignment)');
+        const subMenuItemOffset = subMenuItem.offset();
+        const contextMenuRoot = $('.htContextMenu');
+        const contextMenuOffset = contextMenuRoot.offset();
+        const subMenuRoot = $('.htContextMenuSub_Alignment');
+        const subMenuOffset = subMenuRoot.offset();
 
-    it('should open subMenu on the right-top of the main menu if on the left and bottom there\'s no space left', async() => {
-      handsontable({
-        data: createSpreadsheetData(Math.floor(window.innerHeight / 23), 4),
-        contextMenu: true,
+        // 3px comes from bottom borders
+        expect(subMenuOffset.top)
+          .toBeCloseTo(subMenuItemOffset.top - subMenuRoot.outerHeight() + subMenuItem.outerHeight() + 3, 0);
+        expect(subMenuOffset.left)
+          .toBeCloseTo(contextMenuOffset.left - contextMenuRoot.outerWidth(), 0);
       });
-
-      selectCell(countRows() - 1, 0);
-      openContextSubmenuOption('Alignment');
-
-      await sleep(350);
-
-      const subMenuItem = $('.htContextMenu .ht_master .htCore td:contains(Alignment)');
-      const subMenuItemOffset = subMenuItem.offset();
-      const contextMenuRoot = $('.htContextMenu');
-      const contextMenuOffset = contextMenuRoot.offset();
-      const subMenuRoot = $('.htContextMenuSub_Alignment');
-      const subMenuOffset = subMenuRoot.offset();
-
-      // 3px comes from bottom borders
-      expect(subMenuOffset.top)
-        .toBeCloseTo(subMenuItemOffset.top - subMenuRoot.outerHeight() + subMenuItem.outerHeight() + 3, 0);
-      expect(subMenuOffset.left)
-        .toBeCloseTo(contextMenuOffset.left + contextMenuRoot.outerWidth(), 0);
-    });
-
-    it('should open subMenu on the left-bottom of the main menu if on the right there\'s no space left', async() => {
-      handsontable({
-        data: createSpreadsheetData(4, Math.floor(window.innerWidth / 50)),
-        contextMenu: true,
-      });
-
-      selectCell(0, countCols() - 1);
-      openContextSubmenuOption('Alignment');
-
-      await sleep(350);
-
-      const subMenuItem = $('.htContextMenu .ht_master .htCore td:contains(Alignment)');
-      const subMenuItemOffset = subMenuItem.offset();
-      const contextMenuRoot = $('.htContextMenu');
-      const contextMenuOffset = contextMenuRoot.offset();
-      const subMenuRoot = $('.htContextMenuSub_Alignment');
-      const subMenuOffset = subMenuRoot.offset();
-
-      expect(subMenuOffset.top).toBeCloseTo(subMenuItemOffset.top - 1, 0);
-      expect(subMenuOffset.left).toBeCloseTo(contextMenuOffset.left - contextMenuRoot.outerWidth(), 0);
-    });
-
-    it('should open subMenu on the left-top of the main menu if on the right and bottom there\'s no space left', async() => {
-      handsontable({
-        data: createSpreadsheetData(Math.floor(window.innerHeight / 23), Math.floor(window.innerWidth / 50)),
-        contextMenu: true,
-      });
-
-      selectCell(countRows() - 1, countCols() - 1);
-      openContextSubmenuOption('Alignment');
-
-      await sleep(350);
-
-      const subMenuItem = $('.htContextMenu .ht_master .htCore td:contains(Alignment)');
-      const subMenuItemOffset = subMenuItem.offset();
-      const contextMenuRoot = $('.htContextMenu');
-      const contextMenuOffset = contextMenuRoot.offset();
-      const subMenuRoot = $('.htContextMenuSub_Alignment');
-      const subMenuOffset = subMenuRoot.offset();
-
-      // 3px comes from bottom borders
-      expect(subMenuOffset.top)
-        .toBeCloseTo(subMenuItemOffset.top - subMenuRoot.outerHeight() + subMenuItem.outerHeight() + 3, 0);
-      expect(subMenuOffset.left)
-        .toBeCloseTo(contextMenuOffset.left - contextMenuRoot.outerWidth(), 0);
     });
   });
 });

--- a/handsontable/src/plugins/contextMenu/__tests__/rtl/positioning.spec.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/rtl/positioning.spec.js
@@ -1,207 +1,220 @@
 describe('ContextMenu (RTL mode)', () => {
-  const id = 'testContainer';
+  using('configuration object', [
+    { htmlDir: 'rtl', layoutDirection: 'inherit' },
+    { htmlDir: 'ltr', layoutDirection: 'rtl' },
+  ], ({ htmlDir, layoutDirection }) => {
+    const id = 'testContainer';
 
-  beforeEach(function() {
-    $('.jasmine_html-reporter').hide();
-    $('html').attr('dir', 'rtl');
-    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
-  });
-
-  afterEach(function() {
-    $('.jasmine_html-reporter').show();
-    $('html').attr('dir', 'ltr');
-
-    if (this.$container) {
-      destroy();
-      this.$container.remove();
-    }
-  });
-
-  describe('menu opening', () => {
-    it('should render context menu by default on the left-bottom position', () => {
-      handsontable({
-        contextMenu: true,
-      });
-
-      selectCell(0, 0);
-
-      const cell = getCell(0, 0);
-      const cellOffset = $(cell).offset();
-
-      contextMenu(cell);
-
-      const $contextMenu = $(document.body).find('.htContextMenu:visible');
-      const menuOffset = $contextMenu.offset();
-      const menuWidth = $contextMenu.outerWidth();
-
-      expect($contextMenu.length).toBe(1);
-      expect(menuOffset.top).toBeCloseTo(cellOffset.top + 1, 0);
-      expect(menuOffset.left).toBeCloseTo(cellOffset.left - menuWidth, 0);
+    beforeEach(function() {
+      $('.jasmine_html-reporter').hide();
+      $('html').attr('dir', htmlDir);
+      this.$container = $(`<div id="${id}"></div>`).appendTo('body');
     });
 
-    it('should render context menu on the left-top position if on the right and bottom there is no space left', () => {
-      handsontable({
-        data: createSpreadsheetData(Math.floor(window.innerHeight / 23), 4),
-        contextMenu: true,
-      });
+    afterEach(function() {
+      $('.jasmine_html-reporter').show();
+      $('html').attr('dir', 'ltr');
 
-      // we have to be sure we will have no enough space on the bottom, select the last cell
-      selectCell(countRows() - 1, 0);
-
-      const cell = getCell(countRows() - 1, 0);
-      const cellOffset = $(cell).offset();
-
-      contextMenu(cell);
-
-      const $contextMenu = $(document.body).find('.htContextMenu:visible');
-      const menuOffset = $contextMenu.offset();
-      const menuHeight = $contextMenu.outerHeight();
-      const menuWidth = $contextMenu.outerWidth();
-
-      expect($contextMenu.length).toBe(1);
-      expect(menuOffset.top).toBeCloseTo(cellOffset.top - menuHeight, 0);
-      expect(menuOffset.left).toBeCloseTo(cellOffset.left - menuWidth, 0);
+      if (this.$container) {
+        destroy();
+        this.$container.remove();
+      }
     });
 
-    it('should render context menu on the right-bottom position if on the left there is no space left', () => {
-      handsontable({
-        data: createSpreadsheetData(4, Math.floor(window.innerWidth / 50)),
-        contextMenu: true,
+    describe('menu opening', () => {
+      it('should render context menu by default on the left-bottom position', () => {
+        handsontable({
+          layoutDirection,
+          contextMenu: true,
+        });
+
+        selectCell(0, 0);
+
+        const cell = getCell(0, 0);
+        const cellOffset = $(cell).offset();
+
+        contextMenu(cell);
+
+        const $contextMenu = $(document.body).find('.htContextMenu:visible');
+        const menuOffset = $contextMenu.offset();
+        const menuWidth = $contextMenu.outerWidth();
+
+        expect($contextMenu.length).toBe(1);
+        expect(menuOffset.top).toBeCloseTo(cellOffset.top + 1, 0);
+        expect(menuOffset.left).toBeCloseTo(cellOffset.left - menuWidth, 0);
       });
 
-      // we have to be sure we will have no enough space on the left, select the last cell
-      selectCell(0, countCols() - 1);
+      it('should render context menu on the left-top position if on the right and bottom there is no space left', () => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(Math.floor(window.innerHeight / 23), 4),
+          contextMenu: true,
+        });
 
-      const cell = getCell(0, countCols() - 1);
-      const cellOffset = $(cell).offset();
+        // we have to be sure we will have no enough space on the bottom, select the last cell
+        selectCell(countRows() - 1, 0);
 
-      contextMenu(cell);
+        const cell = getCell(countRows() - 1, 0);
+        const cellOffset = $(cell).offset();
 
-      const $contextMenu = $(document.body).find('.htContextMenu:visible');
-      const menuOffset = $contextMenu.offset();
+        contextMenu(cell);
 
-      expect($contextMenu.length).toBe(1);
-      expect(menuOffset.top).toBeCloseTo(cellOffset.top + 1, 0);
-      expect(menuOffset.left).toBeCloseTo(cellOffset.left, 0);
+        const $contextMenu = $(document.body).find('.htContextMenu:visible');
+        const menuOffset = $contextMenu.offset();
+        const menuHeight = $contextMenu.outerHeight();
+        const menuWidth = $contextMenu.outerWidth();
+
+        expect($contextMenu.length).toBe(1);
+        expect(menuOffset.top).toBeCloseTo(cellOffset.top - menuHeight, 0);
+        expect(menuOffset.left).toBeCloseTo(cellOffset.left - menuWidth, 0);
+      });
+
+      it('should render context menu on the right-bottom position if on the left there is no space left', () => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(4, Math.floor(window.innerWidth / 50)),
+          contextMenu: true,
+        });
+
+        // we have to be sure we will have no enough space on the left, select the last cell
+        selectCell(0, countCols() - 1);
+
+        const cell = getCell(0, countCols() - 1);
+        const cellOffset = $(cell).offset();
+
+        contextMenu(cell);
+
+        const $contextMenu = $(document.body).find('.htContextMenu:visible');
+        const menuOffset = $contextMenu.offset();
+
+        expect($contextMenu.length).toBe(1);
+        expect(menuOffset.top).toBeCloseTo(cellOffset.top + 1, 0);
+        expect(menuOffset.left).toBeCloseTo(cellOffset.left, 0);
+      });
+
+      it('should render context menu on the right-top position if on the left and bottom there is no space left', () => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(Math.floor(window.innerHeight / 23), Math.floor(window.innerWidth / 50)),
+          contextMenu: true,
+        });
+
+        // we have to be sure we will have no enough space on the bottom and the right, select the last cell
+        selectCell(countRows() - 1, countCols() - 1);
+
+        const cell = getCell(countRows() - 1, countCols() - 1);
+        const cellOffset = $(cell).offset();
+
+        contextMenu(cell);
+
+        const $contextMenu = $(document.body).find('.htContextMenu:visible');
+        const menuOffset = $contextMenu.offset();
+        const menuHeight = $contextMenu.outerHeight();
+
+        expect($contextMenu.length).toBe(1);
+        expect(menuOffset.top).toBeCloseTo(cellOffset.top - menuHeight, 0);
+        expect(menuOffset.left).toBeCloseTo(cellOffset.left, 0);
+      });
     });
 
-    it('should render context menu on the right-top position if on the left and bottom there is no space left', () => {
-      handsontable({
-        data: createSpreadsheetData(Math.floor(window.innerHeight / 23), Math.floor(window.innerWidth / 50)),
-        contextMenu: true,
+    describe('subMenu opening', () => {
+      it('should open subMenu by default on the left-bottom position of the main menu', async() => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(4, Math.floor(window.innerWidth / 50)),
+          contextMenu: true,
+        });
+
+        selectCell(0, 0);
+        openContextSubmenuOption('Alignment');
+
+        await sleep(350);
+
+        const subMenuItem = $('.htContextMenu .ht_master .htCore  td:contains(Alignment)');
+        const subMenuItemOffset = subMenuItem.offset();
+        const contextMenuRoot = $('.htContextMenu');
+        const contextMenuOffset = contextMenuRoot.offset();
+        const subMenuRoot = $('.htContextMenuSub_Alignment');
+        const subMenuOffset = subMenuRoot.offset();
+
+        expect(subMenuOffset.top).toBeCloseTo(subMenuItemOffset.top - 1, 0);
+        expect(subMenuOffset.left).toBeCloseTo(contextMenuOffset.left - contextMenuRoot.outerWidth(), 0);
       });
 
-      // we have to be sure we will have no enough space on the bottom and the right, select the last cell
-      selectCell(countRows() - 1, countCols() - 1);
+      it('should open subMenu on the left-top of the main menu if on the right and bottom there\'s no space left', async() => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(Math.floor(window.innerHeight / 23), 4),
+          contextMenu: true,
+        });
 
-      const cell = getCell(countRows() - 1, countCols() - 1);
-      const cellOffset = $(cell).offset();
+        selectCell(countRows() - 1, 0);
+        openContextSubmenuOption('Alignment');
 
-      contextMenu(cell);
+        await sleep(350);
 
-      const $contextMenu = $(document.body).find('.htContextMenu:visible');
-      const menuOffset = $contextMenu.offset();
-      const menuHeight = $contextMenu.outerHeight();
+        const subMenuItem = $('.htContextMenu .ht_master .htCore td:contains(Alignment)');
+        const subMenuItemOffset = subMenuItem.offset();
+        const contextMenuRoot = $('.htContextMenu');
+        const contextMenuOffset = contextMenuRoot.offset();
+        const subMenuRoot = $('.htContextMenuSub_Alignment');
+        const subMenuOffset = subMenuRoot.offset();
 
-      expect($contextMenu.length).toBe(1);
-      expect(menuOffset.top).toBeCloseTo(cellOffset.top - menuHeight, 0);
-      expect(menuOffset.left).toBeCloseTo(cellOffset.left, 0);
-    });
-  });
-
-  describe('subMenu opening', () => {
-    it('should open subMenu by default on the left-bottom position of the main menu', async() => {
-      handsontable({
-        data: createSpreadsheetData(4, Math.floor(window.innerWidth / 50)),
-        contextMenu: true,
+        // 3px comes from bottom borders
+        expect(subMenuOffset.top)
+          .toBeCloseTo(subMenuItemOffset.top - subMenuRoot.outerHeight() + subMenuItem.outerHeight() + 3, 0);
+        expect(subMenuOffset.left)
+          .toBeCloseTo(contextMenuOffset.left - contextMenuRoot.outerWidth(), 0);
       });
 
-      selectCell(0, 0);
-      openContextSubmenuOption('Alignment');
+      it('should open subMenu on the right-bottom of the main menu if on the left there\'s no space left', async() => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(4, Math.floor(window.innerWidth / 50)),
+          contextMenu: true,
+        });
 
-      await sleep(350);
+        selectCell(0, countCols() - 1);
+        openContextSubmenuOption('Alignment');
 
-      const subMenuItem = $('.htContextMenu .ht_master .htCore  td:contains(Alignment)');
-      const subMenuItemOffset = subMenuItem.offset();
-      const contextMenuRoot = $('.htContextMenu');
-      const contextMenuOffset = contextMenuRoot.offset();
-      const subMenuRoot = $('.htContextMenuSub_Alignment');
-      const subMenuOffset = subMenuRoot.offset();
+        await sleep(350);
 
-      expect(subMenuOffset.top).toBeCloseTo(subMenuItemOffset.top - 1, 0);
-      expect(subMenuOffset.left).toBeCloseTo(contextMenuOffset.left - contextMenuRoot.outerWidth(), 0);
-    });
+        const subMenuItem = $('.htContextMenu .ht_master .htCore td:contains(Alignment)');
+        const subMenuItemOffset = subMenuItem.offset();
+        const contextMenuRoot = $('.htContextMenu');
+        const contextMenuOffset = contextMenuRoot.offset();
+        const subMenuRoot = $('.htContextMenuSub_Alignment');
+        const subMenuOffset = subMenuRoot.offset();
 
-    it('should open subMenu on the left-top of the main menu if on the right and bottom there\'s no space left', async() => {
-      handsontable({
-        data: createSpreadsheetData(Math.floor(window.innerHeight / 23), 4),
-        contextMenu: true,
+        expect(subMenuOffset.top).toBeCloseTo(subMenuItemOffset.top - 1, 0);
+        expect(subMenuOffset.left).toBeCloseTo(contextMenuOffset.left + contextMenuRoot.outerWidth(), 0);
       });
 
-      selectCell(countRows() - 1, 0);
-      openContextSubmenuOption('Alignment');
+      it('should open subMenu on the right-top of the main menu if on the left and bottom there\'s no space left', async() => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(Math.floor(window.innerHeight / 23), Math.floor(window.innerWidth / 50)),
+          contextMenu: true,
+        });
 
-      await sleep(350);
+        selectCell(countRows() - 1, countCols() - 1);
+        openContextSubmenuOption('Alignment');
 
-      const subMenuItem = $('.htContextMenu .ht_master .htCore td:contains(Alignment)');
-      const subMenuItemOffset = subMenuItem.offset();
-      const contextMenuRoot = $('.htContextMenu');
-      const contextMenuOffset = contextMenuRoot.offset();
-      const subMenuRoot = $('.htContextMenuSub_Alignment');
-      const subMenuOffset = subMenuRoot.offset();
+        await sleep(350);
 
-      // 3px comes from bottom borders
-      expect(subMenuOffset.top)
-        .toBeCloseTo(subMenuItemOffset.top - subMenuRoot.outerHeight() + subMenuItem.outerHeight() + 3, 0);
-      expect(subMenuOffset.left)
-        .toBeCloseTo(contextMenuOffset.left - contextMenuRoot.outerWidth(), 0);
-    });
+        const subMenuItem = $('.htContextMenu .ht_master .htCore td:contains(Alignment)');
+        const subMenuItemOffset = subMenuItem.offset();
+        const contextMenuRoot = $('.htContextMenu');
+        const contextMenuOffset = contextMenuRoot.offset();
+        const subMenuRoot = $('.htContextMenuSub_Alignment');
+        const subMenuOffset = subMenuRoot.offset();
 
-    it('should open subMenu on the right-bottom of the main menu if on the left there\'s no space left', async() => {
-      handsontable({
-        data: createSpreadsheetData(4, Math.floor(window.innerWidth / 50)),
-        contextMenu: true,
+        // 3px comes from bottom borders
+        expect(subMenuOffset.top)
+          .toBeCloseTo(subMenuItemOffset.top - subMenuRoot.outerHeight() + subMenuItem.outerHeight() + 3, 0);
+        expect(subMenuOffset.left)
+          .toBeCloseTo(contextMenuOffset.left + contextMenuRoot.outerWidth(), 0);
       });
-
-      selectCell(0, countCols() - 1);
-      openContextSubmenuOption('Alignment');
-
-      await sleep(350);
-
-      const subMenuItem = $('.htContextMenu .ht_master .htCore td:contains(Alignment)');
-      const subMenuItemOffset = subMenuItem.offset();
-      const contextMenuRoot = $('.htContextMenu');
-      const contextMenuOffset = contextMenuRoot.offset();
-      const subMenuRoot = $('.htContextMenuSub_Alignment');
-      const subMenuOffset = subMenuRoot.offset();
-
-      expect(subMenuOffset.top).toBeCloseTo(subMenuItemOffset.top - 1, 0);
-      expect(subMenuOffset.left).toBeCloseTo(contextMenuOffset.left + contextMenuRoot.outerWidth(), 0);
-    });
-
-    it('should open subMenu on the right-top of the main menu if on the left and bottom there\'s no space left', async() => {
-      handsontable({
-        data: createSpreadsheetData(Math.floor(window.innerHeight / 23), Math.floor(window.innerWidth / 50)),
-        contextMenu: true,
-      });
-
-      selectCell(countRows() - 1, countCols() - 1);
-      openContextSubmenuOption('Alignment');
-
-      await sleep(350);
-
-      const subMenuItem = $('.htContextMenu .ht_master .htCore td:contains(Alignment)');
-      const subMenuItemOffset = subMenuItem.offset();
-      const contextMenuRoot = $('.htContextMenu');
-      const contextMenuOffset = contextMenuRoot.offset();
-      const subMenuRoot = $('.htContextMenuSub_Alignment');
-      const subMenuOffset = subMenuRoot.offset();
-
-      // 3px comes from bottom borders
-      expect(subMenuOffset.top)
-        .toBeCloseTo(subMenuItemOffset.top - subMenuRoot.outerHeight() + subMenuItem.outerHeight() + 3, 0);
-      expect(subMenuOffset.left)
-        .toBeCloseTo(contextMenuOffset.left + contextMenuRoot.outerWidth(), 0);
     });
   });
 });

--- a/handsontable/src/plugins/dropdownMenu/__tests__/UI.spec.js
+++ b/handsontable/src/plugins/dropdownMenu/__tests__/UI.spec.js
@@ -1,28 +1,37 @@
 describe('DropdownMenu', () => {
-  const id = 'testContainer';
+  using('configuration object', [
+    { htmlDir: 'ltr', layoutDirection: 'inherit' },
+    { htmlDir: 'rtl', layoutDirection: 'ltr' },
+  ], ({ htmlDir, layoutDirection }) => {
+    const id = 'testContainer';
 
-  beforeEach(function() {
-    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
-  });
+    beforeEach(function() {
+      $('html').attr('dir', htmlDir);
+      this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+    });
 
-  afterEach(function() {
-    if (this.$container) {
-      destroy();
-      this.$container.remove();
-    }
-  });
+    afterEach(function() {
+      $('html').attr('dir', 'ltr');
 
-  describe('UI', () => {
-    it('should render the dropdown button on the right side of the header', () => {
-      handsontable({
-        dropdownMenu: true,
-        colHeaders: true,
-        height: 100
+      if (this.$container) {
+        destroy();
+        this.$container.remove();
+      }
+    });
+
+    describe('UI', () => {
+      it('should render the dropdown button on the right side of the header', () => {
+        handsontable({
+          layoutDirection,
+          dropdownMenu: true,
+          colHeaders: true,
+          height: 100
+        });
+
+        const dropdownButton = $(getCell(-1, 2));
+
+        expect(dropdownButton.find('.changeType').css('float')).toBe('right');
       });
-
-      const dropdownButton = $(getCell(-1, 2));
-
-      expect(dropdownButton.find('.changeType').css('float')).toBe('right');
     });
   });
 });

--- a/handsontable/src/plugins/dropdownMenu/__tests__/positioning.spec.js
+++ b/handsontable/src/plugins/dropdownMenu/__tests__/positioning.spec.js
@@ -1,110 +1,121 @@
 describe('DropdownMenu', () => {
-  const id = 'testContainer';
+  using('configuration object', [
+    { htmlDir: 'ltr', layoutDirection: 'inherit' },
+    { htmlDir: 'rtl', layoutDirection: 'ltr' },
+  ], ({ htmlDir, layoutDirection }) => {
+    const id = 'testContainer';
 
-  beforeEach(function() {
-    $('.jasmine_html-reporter').hide();
-    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
-  });
-
-  afterEach(function() {
-    $('.jasmine_html-reporter').show();
-
-    if (this.$container) {
-      destroy();
-      this.$container.remove();
-    }
-  });
-
-  describe('menu opening', () => {
-    it('should render dropdown menu by default on the right position', () => {
-      handsontable({
-        dropdownMenu: true,
-        colHeaders: true,
-      });
-
-      dropdownMenu(0);
-
-      const dropdownButton = getColumnHeader(0).querySelector('.changeType');
-      const dropdownButtonOffset = $(dropdownButton).offset();
-      const dropdownButtonHeight = $(dropdownButton).outerHeight();
-      const $dropdownMenu = $(document.body).find('.htDropdownMenu:visible');
-      const menuOffset = $dropdownMenu.offset();
-
-      expect($dropdownMenu.length).toBe(1);
-      // 4px - an empty gap between button and context menu element
-      expect(menuOffset.top).toBeCloseTo(dropdownButtonOffset.top + dropdownButtonHeight + 4, 0);
-      expect(menuOffset.left).toBeCloseTo(dropdownButtonOffset.left, 0);
+    beforeEach(function() {
+      $('.jasmine_html-reporter').hide();
+      $('html').attr('dir', htmlDir);
+      this.$container = $(`<div id="${id}"></div>`).appendTo('body');
     });
 
-    it('should render dropdown menu on the left position if on the right there is no space left', () => {
-      handsontable({
-        data: createSpreadsheetData(4, Math.floor(window.innerWidth / 50)),
-        dropdownMenu: true,
-        colHeaders: true,
-      });
+    afterEach(function() {
+      $('.jasmine_html-reporter').show();
+      $('html').attr('dir', 'ltr');
 
-      dropdownMenu(countCols() - 1);
-
-      const dropdownButton = getColumnHeader(countCols() - 1).querySelector('.changeType');
-      const dropdownButtonOffset = $(dropdownButton).offset();
-      const dropdownButtonHeight = $(dropdownButton).outerHeight();
-      const dropdownButtonWidth = $(dropdownButton).outerWidth();
-      const $dropdownMenu = $(document.body).find('.htDropdownMenu:visible');
-      const menuOffset = $dropdownMenu.offset();
-      const menuWidth = $dropdownMenu.outerWidth();
-
-      expect($dropdownMenu.length).toBe(1);
-      // 4px - an empty gap between button and context menu element
-      expect(menuOffset.top).toBeCloseTo(dropdownButtonOffset.top + dropdownButtonHeight + 4, 0);
-      expect(menuOffset.left).toBeCloseTo(dropdownButtonOffset.left - menuWidth + dropdownButtonWidth, 0);
-    });
-  });
-
-  describe('subMenu opening', () => {
-    it('should open subMenu by default on the right position of the main menu', async() => {
-      handsontable({
-        data: createSpreadsheetData(4, Math.floor(window.innerWidth / 50)),
-        dropdownMenu: true,
-        colHeaders: true,
-      });
-
-      openDropdownSubmenuOption('Alignment', 0);
-
-      await sleep(350);
-
-      const $dropdownMenu = $('.htDropdownMenu');
-      const dropdownOffset = $dropdownMenu.offset();
-
-      const subMenuItem = $('.htDropdownMenu .ht_master .htCore  td:contains(Alignment)');
-      const subMenuItemOffset = subMenuItem.offset();
-      const subMenuRoot = $('.htDropdownMenuSub_Alignment');
-      const subMenuOffset = subMenuRoot.offset();
-
-      expect(subMenuOffset.top).toBeCloseTo(subMenuItemOffset.top - 1, 0);
-      expect(subMenuOffset.left).toBeCloseTo(dropdownOffset.left + $dropdownMenu.outerWidth(), 0);
+      if (this.$container) {
+        destroy();
+        this.$container.remove();
+      }
     });
 
-    it('should open subMenu on the left of the main menu if on the right there\'s no space left', async() => {
-      handsontable({
-        data: createSpreadsheetData(4, Math.floor(window.innerWidth / 50)),
-        dropdownMenu: true,
-        colHeaders: true,
+    describe('menu opening', () => {
+      it('should render dropdown menu by default on the right position', () => {
+        handsontable({
+          layoutDirection,
+          dropdownMenu: true,
+          colHeaders: true,
+        });
+
+        dropdownMenu(0);
+
+        const dropdownButton = getColumnHeader(0).querySelector('.changeType');
+        const dropdownButtonOffset = $(dropdownButton).offset();
+        const dropdownButtonHeight = $(dropdownButton).outerHeight();
+        const $dropdownMenu = $(document.body).find('.htDropdownMenu:visible');
+        const menuOffset = $dropdownMenu.offset();
+
+        expect($dropdownMenu.length).toBe(1);
+        // 4px - an empty gap between button and context menu element
+        expect(menuOffset.top).toBeCloseTo(dropdownButtonOffset.top + dropdownButtonHeight + 4, 0);
+        expect(menuOffset.left).toBeCloseTo(dropdownButtonOffset.left, 0);
       });
 
-      openDropdownSubmenuOption('Alignment', countCols() - 1);
+      it('should render dropdown menu on the left position if on the right there is no space left', () => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(4, Math.floor(window.innerWidth / 50)),
+          dropdownMenu: true,
+          colHeaders: true,
+        });
 
-      await sleep(350);
+        dropdownMenu(countCols() - 1);
 
-      const $dropdownMenu = $('.htDropdownMenu');
-      const dropdownOffset = $dropdownMenu.offset();
+        const dropdownButton = getColumnHeader(countCols() - 1).querySelector('.changeType');
+        const dropdownButtonOffset = $(dropdownButton).offset();
+        const dropdownButtonHeight = $(dropdownButton).outerHeight();
+        const dropdownButtonWidth = $(dropdownButton).outerWidth();
+        const $dropdownMenu = $(document.body).find('.htDropdownMenu:visible');
+        const menuOffset = $dropdownMenu.offset();
+        const menuWidth = $dropdownMenu.outerWidth();
 
-      const subMenuItem = $('.htDropdownMenu .ht_master .htCore  td:contains(Alignment)');
-      const subMenuItemOffset = subMenuItem.offset();
-      const subMenuRoot = $('.htDropdownMenuSub_Alignment');
-      const subMenuOffset = subMenuRoot.offset();
+        expect($dropdownMenu.length).toBe(1);
+        // 4px - an empty gap between button and context menu element
+        expect(menuOffset.top).toBeCloseTo(dropdownButtonOffset.top + dropdownButtonHeight + 4, 0);
+        expect(menuOffset.left).toBeCloseTo(dropdownButtonOffset.left - menuWidth + dropdownButtonWidth, 0);
+      });
+    });
 
-      expect(subMenuOffset.top).toBeCloseTo(subMenuItemOffset.top - 1, 0);
-      expect(subMenuOffset.left).toBeCloseTo(dropdownOffset.left - $dropdownMenu.outerWidth(), 0);
+    describe('subMenu opening', () => {
+      it('should open subMenu by default on the right position of the main menu', async() => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(4, Math.floor(window.innerWidth / 50)),
+          dropdownMenu: true,
+          colHeaders: true,
+        });
+
+        openDropdownSubmenuOption('Alignment', 0);
+
+        await sleep(350);
+
+        const $dropdownMenu = $('.htDropdownMenu');
+        const dropdownOffset = $dropdownMenu.offset();
+
+        const subMenuItem = $('.htDropdownMenu .ht_master .htCore  td:contains(Alignment)');
+        const subMenuItemOffset = subMenuItem.offset();
+        const subMenuRoot = $('.htDropdownMenuSub_Alignment');
+        const subMenuOffset = subMenuRoot.offset();
+
+        expect(subMenuOffset.top).toBeCloseTo(subMenuItemOffset.top - 1, 0);
+        expect(subMenuOffset.left).toBeCloseTo(dropdownOffset.left + $dropdownMenu.outerWidth(), 0);
+      });
+
+      it('should open subMenu on the left of the main menu if on the right there\'s no space left', async() => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(4, Math.floor(window.innerWidth / 50)),
+          dropdownMenu: true,
+          colHeaders: true,
+        });
+
+        openDropdownSubmenuOption('Alignment', countCols() - 1);
+
+        await sleep(350);
+
+        const $dropdownMenu = $('.htDropdownMenu');
+        const dropdownOffset = $dropdownMenu.offset();
+
+        const subMenuItem = $('.htDropdownMenu .ht_master .htCore  td:contains(Alignment)');
+        const subMenuItemOffset = subMenuItem.offset();
+        const subMenuRoot = $('.htDropdownMenuSub_Alignment');
+        const subMenuOffset = subMenuRoot.offset();
+
+        expect(subMenuOffset.top).toBeCloseTo(subMenuItemOffset.top - 1, 0);
+        expect(subMenuOffset.left).toBeCloseTo(dropdownOffset.left - $dropdownMenu.outerWidth(), 0);
+      });
     });
   });
 });

--- a/handsontable/src/plugins/dropdownMenu/__tests__/rtl/UI.spec.js
+++ b/handsontable/src/plugins/dropdownMenu/__tests__/rtl/UI.spec.js
@@ -1,31 +1,37 @@
 describe('DropdownMenu (RTL mode)', () => {
-  const id = 'testContainer';
+  using('configuration object', [
+    { htmlDir: 'rtl', layoutDirection: 'inherit' },
+    { htmlDir: 'ltr', layoutDirection: 'rtl' },
+  ], ({ htmlDir, layoutDirection }) => {
+    const id = 'testContainer';
 
-  beforeEach(function() {
-    $('html').attr('dir', 'rtl');
-    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
-  });
+    beforeEach(function() {
+      $('html').attr('dir', htmlDir);
+      this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+    });
 
-  afterEach(function() {
-    $('html').attr('dir', 'ltr');
+    afterEach(function() {
+      $('html').attr('dir', 'ltr');
 
-    if (this.$container) {
-      destroy();
-      this.$container.remove();
-    }
-  });
+      if (this.$container) {
+        destroy();
+        this.$container.remove();
+      }
+    });
 
-  describe('UI', () => {
-    it('should render the dropdown button on the left side of the header', () => {
-      handsontable({
-        dropdownMenu: true,
-        colHeaders: true,
-        height: 100
+    describe('UI', () => {
+      it('should render the dropdown button on the left side of the header', () => {
+        handsontable({
+          layoutDirection,
+          dropdownMenu: true,
+          colHeaders: true,
+          height: 100
+        });
+
+        const dropdownButton = $(getCell(-1, 2));
+
+        expect(dropdownButton.find('.changeType').css('float')).toBe('left');
       });
-
-      const dropdownButton = $(getCell(-1, 2));
-
-      expect(dropdownButton.find('.changeType').css('float')).toBe('left');
     });
   });
 });

--- a/handsontable/src/plugins/dropdownMenu/__tests__/rtl/positioning.spec.js
+++ b/handsontable/src/plugins/dropdownMenu/__tests__/rtl/positioning.spec.js
@@ -1,114 +1,123 @@
 describe('DropdownMenu (RTL mode)', () => {
-  const id = 'testContainer';
+  using('configuration object', [
+    { htmlDir: 'rtl', layoutDirection: 'inherit' },
+    { htmlDir: 'ltr', layoutDirection: 'rtl' },
+  ], ({ htmlDir, layoutDirection }) => {
+    const id = 'testContainer';
 
-  beforeEach(function() {
-    $('html').attr('dir', 'rtl');
-    $('.jasmine_html-reporter').hide();
-    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
-  });
-
-  afterEach(function() {
-    $('html').attr('dir', 'ltr');
-    $('.jasmine_html-reporter').show();
-
-    if (this.$container) {
-      destroy();
-      this.$container.remove();
-    }
-  });
-
-  describe('menu opening', () => {
-    it('should render dropdown menu by default on the left position', () => {
-      handsontable({
-        dropdownMenu: true,
-        colHeaders: true,
-      });
-
-      dropdownMenu(0);
-
-      const dropdownButton = getColumnHeader(0).querySelector('.changeType');
-      const dropdownButtonOffset = $(dropdownButton).offset();
-      const dropdownButtonHeight = $(dropdownButton).outerHeight();
-      const dropdownButtonWidth = $(dropdownButton).outerWidth();
-      const $dropdownMenu = $(document.body).find('.htDropdownMenu:visible');
-      const menuOffset = $dropdownMenu.offset();
-      const menuWidth = $dropdownMenu.outerWidth();
-
-      expect($dropdownMenu.length).toBe(1);
-      // 4px - an empty gap between button and context menu element
-      expect(menuOffset.top).toBeCloseTo(dropdownButtonOffset.top + dropdownButtonHeight + 4, 0);
-      expect(menuOffset.left).toBeCloseTo(dropdownButtonOffset.left - menuWidth + dropdownButtonWidth, 0);
+    beforeEach(function() {
+      $('.jasmine_html-reporter').hide();
+      $('html').attr('dir', htmlDir);
+      this.$container = $(`<div id="${id}"></div>`).appendTo('body');
     });
 
-    it('should render dropdown menu on the right position if on the left there is no space left', () => {
-      handsontable({
-        data: createSpreadsheetData(4, Math.floor(window.innerWidth / 50)),
-        dropdownMenu: true,
-        colHeaders: true,
-      });
+    afterEach(function() {
+      $('.jasmine_html-reporter').show();
+      $('html').attr('dir', 'ltr');
 
-      dropdownMenu(countCols() - 1);
-
-      const dropdownButton = getColumnHeader(countCols() - 1).querySelector('.changeType');
-      const dropdownButtonOffset = $(dropdownButton).offset();
-      const dropdownButtonHeight = $(dropdownButton).outerHeight();
-      const $dropdownMenu = $(document.body).find('.htDropdownMenu:visible');
-      const menuOffset = $dropdownMenu.offset();
-
-      expect($dropdownMenu.length).toBe(1);
-      // 4px - an empty gap between button and context menu element
-      expect(menuOffset.top).toBeCloseTo(dropdownButtonOffset.top + dropdownButtonHeight + 4, 0);
-      expect(menuOffset.left).toBeCloseTo(dropdownButtonOffset.left, 0);
-    });
-  });
-
-  describe('subMenu opening', () => {
-    it('should open subMenu by default on the left position of the main menu', async() => {
-      handsontable({
-        data: createSpreadsheetData(4, Math.floor(window.innerWidth / 50)),
-        dropdownMenu: true,
-        colHeaders: true,
-      });
-
-      openDropdownSubmenuOption('Alignment', 0);
-
-      await sleep(350);
-
-      const $dropdownMenu = $('.htDropdownMenu');
-      const dropdownOffset = $dropdownMenu.offset();
-
-      const subMenuItem = $('.htDropdownMenu .ht_master .htCore  td:contains(Alignment)');
-      const subMenuItemOffset = subMenuItem.offset();
-      const subMenuRoot = $('.htDropdownMenuSub_Alignment');
-      const subMenuOffset = subMenuRoot.offset();
-      const subMenuWidth = subMenuRoot.outerWidth();
-
-      expect(subMenuOffset.top).toBeCloseTo(subMenuItemOffset.top - 1, 0);
-      expect(subMenuOffset.left).toBeCloseTo(dropdownOffset.left - subMenuWidth, 0);
+      if (this.$container) {
+        destroy();
+        this.$container.remove();
+      }
     });
 
-    it('should open subMenu on the right of the main menu if on the left there\'s no space left', async() => {
-      handsontable({
-        data: createSpreadsheetData(4, Math.floor(window.innerWidth / 50)),
-        dropdownMenu: true,
-        colHeaders: true,
+    describe('menu opening', () => {
+      it('should render dropdown menu by default on the left position', () => {
+        handsontable({
+          layoutDirection,
+          dropdownMenu: true,
+          colHeaders: true,
+        });
+
+        dropdownMenu(0);
+
+        const dropdownButton = getColumnHeader(0).querySelector('.changeType');
+        const dropdownButtonOffset = $(dropdownButton).offset();
+        const dropdownButtonHeight = $(dropdownButton).outerHeight();
+        const dropdownButtonWidth = $(dropdownButton).outerWidth();
+        const $dropdownMenu = $(document.body).find('.htDropdownMenu:visible');
+        const menuOffset = $dropdownMenu.offset();
+        const menuWidth = $dropdownMenu.outerWidth();
+
+        expect($dropdownMenu.length).toBe(1);
+        // 4px - an empty gap between button and context menu element
+        expect(menuOffset.top).toBeCloseTo(dropdownButtonOffset.top + dropdownButtonHeight + 4, 0);
+        expect(menuOffset.left).toBeCloseTo(dropdownButtonOffset.left - menuWidth + dropdownButtonWidth, 0);
       });
 
-      openDropdownSubmenuOption('Alignment', countCols() - 1);
+      it('should render dropdown menu on the right position if on the left there is no space left', () => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(4, Math.floor(window.innerWidth / 50)),
+          dropdownMenu: true,
+          colHeaders: true,
+        });
 
-      await sleep(350);
+        dropdownMenu(countCols() - 1);
 
-      const $dropdownMenu = $('.htDropdownMenu');
-      const dropdownOffset = $dropdownMenu.offset();
-      const dropdownWidth = $dropdownMenu.outerWidth();
+        const dropdownButton = getColumnHeader(countCols() - 1).querySelector('.changeType');
+        const dropdownButtonOffset = $(dropdownButton).offset();
+        const dropdownButtonHeight = $(dropdownButton).outerHeight();
+        const $dropdownMenu = $(document.body).find('.htDropdownMenu:visible');
+        const menuOffset = $dropdownMenu.offset();
 
-      const subMenuItem = $('.htDropdownMenu .ht_master .htCore  td:contains(Alignment)');
-      const subMenuItemOffset = subMenuItem.offset();
-      const subMenuRoot = $('.htDropdownMenuSub_Alignment');
-      const subMenuOffset = subMenuRoot.offset();
+        expect($dropdownMenu.length).toBe(1);
+        // 4px - an empty gap between button and context menu element
+        expect(menuOffset.top).toBeCloseTo(dropdownButtonOffset.top + dropdownButtonHeight + 4, 0);
+        expect(menuOffset.left).toBeCloseTo(dropdownButtonOffset.left, 0);
+      });
+    });
 
-      expect(subMenuOffset.top).toBeCloseTo(subMenuItemOffset.top - 1, 0);
-      expect(subMenuOffset.left).toBeCloseTo(dropdownOffset.left + dropdownWidth, 0);
+    describe('subMenu opening', () => {
+      it('should open subMenu by default on the left position of the main menu', async() => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(4, Math.floor(window.innerWidth / 50)),
+          dropdownMenu: true,
+          colHeaders: true,
+        });
+
+        openDropdownSubmenuOption('Alignment', 0);
+
+        await sleep(350);
+
+        const $dropdownMenu = $('.htDropdownMenu');
+        const dropdownOffset = $dropdownMenu.offset();
+
+        const subMenuItem = $('.htDropdownMenu .ht_master .htCore  td:contains(Alignment)');
+        const subMenuItemOffset = subMenuItem.offset();
+        const subMenuRoot = $('.htDropdownMenuSub_Alignment');
+        const subMenuOffset = subMenuRoot.offset();
+        const subMenuWidth = subMenuRoot.outerWidth();
+
+        expect(subMenuOffset.top).toBeCloseTo(subMenuItemOffset.top - 1, 0);
+        expect(subMenuOffset.left).toBeCloseTo(dropdownOffset.left - subMenuWidth, 0);
+      });
+
+      it('should open subMenu on the right of the main menu if on the left there\'s no space left', async() => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(4, Math.floor(window.innerWidth / 50)),
+          dropdownMenu: true,
+          colHeaders: true,
+        });
+
+        openDropdownSubmenuOption('Alignment', countCols() - 1);
+
+        await sleep(350);
+
+        const $dropdownMenu = $('.htDropdownMenu');
+        const dropdownOffset = $dropdownMenu.offset();
+        const dropdownWidth = $dropdownMenu.outerWidth();
+
+        const subMenuItem = $('.htDropdownMenu .ht_master .htCore  td:contains(Alignment)');
+        const subMenuItemOffset = subMenuItem.offset();
+        const subMenuRoot = $('.htDropdownMenuSub_Alignment');
+        const subMenuOffset = subMenuRoot.offset();
+
+        expect(subMenuOffset.top).toBeCloseTo(subMenuItemOffset.top - 1, 0);
+        expect(subMenuOffset.left).toBeCloseTo(dropdownOffset.left + dropdownWidth, 0);
+      });
     });
   });
 });

--- a/handsontable/src/plugins/hiddenColumns/__tests__/indicators.spec.js
+++ b/handsontable/src/plugins/hiddenColumns/__tests__/indicators.spec.js
@@ -1,63 +1,72 @@
 describe('HiddenColumns', () => {
-  const id = 'testContainer';
+  using('configuration object', [
+    { htmlDir: 'ltr', layoutDirection: 'inherit' },
+    { htmlDir: 'rtl', layoutDirection: 'ltr' },
+  ], ({ htmlDir, layoutDirection }) => {
+    const id = 'testContainer';
 
-  beforeEach(function() {
-    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
-  });
-
-  afterEach(function() {
-    if (this.$container) {
-      destroy();
-      this.$container.remove();
-    }
-  });
-
-  describe('indicators', () => {
-    it('should add proper class names in column headers', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(1, 5),
-        hiddenColumns: {
-          columns: [1, 3],
-          indicators: true,
-        },
-        colHeaders: true,
-      });
-
-      expect(getCell(-1, 0)).toHaveClass(CSS_CLASS_BEFORE_HIDDEN_COLUMN);
-      expect(getComputedStyle(getCell(-1, 0), ':before').content).toBe('none');
-      expect(getComputedStyle(getCell(-1, 0), ':after').content).toBe('"◀"');
-      expect(getCell(-1, 1)).toBe(null);
-      expect(getCell(-1, 2)).toHaveClass(CSS_CLASS_BEFORE_HIDDEN_COLUMN);
-      expect(getCell(-1, 2)).toHaveClass(CSS_CLASS_AFTER_HIDDEN_COLUMN);
-      expect(getComputedStyle(getCell(-1, 2), ':before').content).toBe('"▶"');
-      expect(getComputedStyle(getCell(-1, 2), ':after').content).toBe('"◀"');
-      expect(getCell(-1, 3)).toBe(null);
-      expect(getCell(-1, 4)).toHaveClass(CSS_CLASS_AFTER_HIDDEN_COLUMN);
-      expect(getComputedStyle(getCell(-1, 4), ':before').content).toBe('"▶"');
-      expect(getComputedStyle(getCell(-1, 4), ':after').content).toBe('none');
+    beforeEach(function() {
+      $('html').attr('dir', htmlDir);
+      this.$container = $(`<div id="${id}"></div>`).appendTo('body');
     });
 
-    it('should render indicators after enabling them in updateSettings', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(1, 3),
-        hiddenColumns: {
-          columns: [0, 2],
-        },
-        colHeaders: true,
+    afterEach(function() {
+      $('html').attr('dir', 'ltr');
+
+      if (this.$container) {
+        destroy();
+        this.$container.remove();
+      }
+    });
+
+    describe('indicators', () => {
+      it('should add proper class names in column headers', () => {
+        handsontable({
+          layoutDirection,
+          data: Handsontable.helper.createSpreadsheetData(1, 5),
+          hiddenColumns: {
+            columns: [1, 3],
+            indicators: true,
+          },
+          colHeaders: true,
+        });
+
+        expect(getCell(-1, 0)).toHaveClass(CSS_CLASS_BEFORE_HIDDEN_COLUMN);
+        expect(getComputedStyle(getCell(-1, 0), ':before').content).toBe('none');
+        expect(getComputedStyle(getCell(-1, 0), ':after').content).toBe('"◀"');
+        expect(getCell(-1, 1)).toBe(null);
+        expect(getCell(-1, 2)).toHaveClass(CSS_CLASS_BEFORE_HIDDEN_COLUMN);
+        expect(getCell(-1, 2)).toHaveClass(CSS_CLASS_AFTER_HIDDEN_COLUMN);
+        expect(getComputedStyle(getCell(-1, 2), ':before').content).toBe('"▶"');
+        expect(getComputedStyle(getCell(-1, 2), ':after').content).toBe('"◀"');
+        expect(getCell(-1, 3)).toBe(null);
+        expect(getCell(-1, 4)).toHaveClass(CSS_CLASS_AFTER_HIDDEN_COLUMN);
+        expect(getComputedStyle(getCell(-1, 4), ':before').content).toBe('"▶"');
+        expect(getComputedStyle(getCell(-1, 4), ':after').content).toBe('none');
       });
 
-      expect(getCell(-1, 1)).not.toHaveClass(CSS_CLASS_BEFORE_HIDDEN_COLUMN);
-      expect(getCell(-1, 1)).not.toHaveClass(CSS_CLASS_AFTER_HIDDEN_COLUMN);
+      it('should render indicators after enabling them in updateSettings', () => {
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(1, 3),
+          hiddenColumns: {
+            columns: [0, 2],
+          },
+          colHeaders: true,
+        });
 
-      updateSettings({
-        hiddenColumns: {
-          columns: [0, 2],
-          indicators: true,
-        },
+        expect(getCell(-1, 1)).not.toHaveClass(CSS_CLASS_BEFORE_HIDDEN_COLUMN);
+        expect(getCell(-1, 1)).not.toHaveClass(CSS_CLASS_AFTER_HIDDEN_COLUMN);
+
+        updateSettings({
+          hiddenColumns: {
+            columns: [0, 2],
+            indicators: true,
+          },
+        });
+
+        expect(getCell(-1, 1)).toHaveClass(CSS_CLASS_BEFORE_HIDDEN_COLUMN);
+        expect(getCell(-1, 1)).toHaveClass(CSS_CLASS_AFTER_HIDDEN_COLUMN);
       });
-
-      expect(getCell(-1, 1)).toHaveClass(CSS_CLASS_BEFORE_HIDDEN_COLUMN);
-      expect(getCell(-1, 1)).toHaveClass(CSS_CLASS_AFTER_HIDDEN_COLUMN);
     });
   });
 });

--- a/handsontable/src/plugins/hiddenColumns/__tests__/rtl/indicators.spec.js
+++ b/handsontable/src/plugins/hiddenColumns/__tests__/rtl/indicators.spec.js
@@ -1,66 +1,72 @@
 describe('HiddenColumns (RTL mode)', () => {
-  const id = 'testContainer';
+  using('configuration object', [
+    { htmlDir: 'rtl', layoutDirection: 'inherit' },
+    { htmlDir: 'ltr', layoutDirection: 'rtl' },
+  ], ({ htmlDir, layoutDirection }) => {
+    const id = 'testContainer';
 
-  beforeEach(function() {
-    $('html').attr('dir', 'rtl');
-    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
-  });
-
-  afterEach(function() {
-    $('html').attr('dir', 'ltr');
-
-    if (this.$container) {
-      destroy();
-      this.$container.remove();
-    }
-  });
-
-  describe('indicators', () => {
-    it('should add proper class names in column headers', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(1, 5),
-        hiddenColumns: {
-          columns: [1, 3],
-          indicators: true,
-        },
-        colHeaders: true,
-      });
-
-      expect(getCell(-1, 0)).toHaveClass(CSS_CLASS_BEFORE_HIDDEN_COLUMN);
-      expect(getComputedStyle(getCell(-1, 0), ':before').content).toBe('none');
-      expect(getComputedStyle(getCell(-1, 0), ':after').content).toBe('"▶"');
-      expect(getCell(-1, 1)).toBe(null);
-      expect(getCell(-1, 2)).toHaveClass(CSS_CLASS_BEFORE_HIDDEN_COLUMN);
-      expect(getCell(-1, 2)).toHaveClass(CSS_CLASS_AFTER_HIDDEN_COLUMN);
-      expect(getComputedStyle(getCell(-1, 2), ':before').content).toBe('"◀"');
-      expect(getComputedStyle(getCell(-1, 2), ':after').content).toBe('"▶"');
-      expect(getCell(-1, 3)).toBe(null);
-      expect(getCell(-1, 4)).toHaveClass(CSS_CLASS_AFTER_HIDDEN_COLUMN);
-      expect(getComputedStyle(getCell(-1, 4), ':before').content).toBe('"◀"');
-      expect(getComputedStyle(getCell(-1, 4), ':after').content).toBe('none');
+    beforeEach(function() {
+      $('html').attr('dir', htmlDir);
+      this.$container = $(`<div id="${id}"></div>`).appendTo('body');
     });
 
-    it('should render indicators after enabling them in updateSettings', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(1, 3),
-        hiddenColumns: {
-          columns: [0, 2],
-        },
-        colHeaders: true,
+    afterEach(function() {
+      $('html').attr('dir', 'ltr');
+
+      if (this.$container) {
+        destroy();
+        this.$container.remove();
+      }
+    });
+
+    describe('indicators', () => {
+      it('should add proper class names in column headers', () => {
+        handsontable({
+          layoutDirection,
+          data: Handsontable.helper.createSpreadsheetData(1, 5),
+          hiddenColumns: {
+            columns: [1, 3],
+            indicators: true,
+          },
+          colHeaders: true,
+        });
+
+        expect(getCell(-1, 0)).toHaveClass(CSS_CLASS_BEFORE_HIDDEN_COLUMN);
+        expect(getComputedStyle(getCell(-1, 0), ':before').content).toBe('none');
+        expect(getComputedStyle(getCell(-1, 0), ':after').content).toBe('"▶"');
+        expect(getCell(-1, 1)).toBe(null);
+        expect(getCell(-1, 2)).toHaveClass(CSS_CLASS_BEFORE_HIDDEN_COLUMN);
+        expect(getCell(-1, 2)).toHaveClass(CSS_CLASS_AFTER_HIDDEN_COLUMN);
+        expect(getComputedStyle(getCell(-1, 2), ':before').content).toBe('"◀"');
+        expect(getComputedStyle(getCell(-1, 2), ':after').content).toBe('"▶"');
+        expect(getCell(-1, 3)).toBe(null);
+        expect(getCell(-1, 4)).toHaveClass(CSS_CLASS_AFTER_HIDDEN_COLUMN);
+        expect(getComputedStyle(getCell(-1, 4), ':before').content).toBe('"◀"');
+        expect(getComputedStyle(getCell(-1, 4), ':after').content).toBe('none');
       });
 
-      expect(getCell(-1, 1)).not.toHaveClass(CSS_CLASS_BEFORE_HIDDEN_COLUMN);
-      expect(getCell(-1, 1)).not.toHaveClass(CSS_CLASS_AFTER_HIDDEN_COLUMN);
+      it('should render indicators after enabling them in updateSettings', () => {
+        handsontable({
+          data: Handsontable.helper.createSpreadsheetData(1, 3),
+          hiddenColumns: {
+            columns: [0, 2],
+          },
+          colHeaders: true,
+        });
 
-      updateSettings({
-        hiddenColumns: {
-          columns: [0, 2],
-          indicators: true,
-        },
+        expect(getCell(-1, 1)).not.toHaveClass(CSS_CLASS_BEFORE_HIDDEN_COLUMN);
+        expect(getCell(-1, 1)).not.toHaveClass(CSS_CLASS_AFTER_HIDDEN_COLUMN);
+
+        updateSettings({
+          hiddenColumns: {
+            columns: [0, 2],
+            indicators: true,
+          },
+        });
+
+        expect(getCell(-1, 1)).toHaveClass(CSS_CLASS_BEFORE_HIDDEN_COLUMN);
+        expect(getCell(-1, 1)).toHaveClass(CSS_CLASS_AFTER_HIDDEN_COLUMN);
       });
-
-      expect(getCell(-1, 1)).toHaveClass(CSS_CLASS_BEFORE_HIDDEN_COLUMN);
-      expect(getCell(-1, 1)).toHaveClass(CSS_CLASS_AFTER_HIDDEN_COLUMN);
     });
   });
 });

--- a/handsontable/src/plugins/hiddenColumns/hiddenColumns.scss
+++ b/handsontable/src/plugins/hiddenColumns/hiddenColumns.scss
@@ -23,7 +23,7 @@
   content: '\25C0'; /* left arrow */
 }
 
-[dir=rtl] .handsontable th.beforeHiddenColumn::after {
+[dir=rtl].handsontable th.beforeHiddenColumn::after {
   right: initial;
   left: 1px;
   content: '\25B6'; /* right arrow */
@@ -34,7 +34,7 @@
   content: '\25B6'; /* right arrow */
 }
 
-[dir=rtl] .handsontable th.afterHiddenColumn::before {
+[dir=rtl].handsontable th.afterHiddenColumn::before {
   right: 1px;
   left: initial;
   content: '\25C0'; /* left arrow */

--- a/handsontable/src/plugins/manualColumnMove/__tests__/positioning.spec.js
+++ b/handsontable/src/plugins/manualColumnMove/__tests__/positioning.spec.js
@@ -1,430 +1,452 @@
 describe('manualColumnMove', () => {
-  const id = 'testContainer';
+  using('configuration object', [
+    { htmlDir: 'ltr', layoutDirection: 'inherit' },
+    { htmlDir: 'rtl', layoutDirection: 'ltr' },
+  ], ({ htmlDir, layoutDirection }) => {
+    const id = 'testContainer';
 
-  beforeEach(function() {
-    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
-  });
-
-  afterEach(function() {
-    if (this.$container) {
-      destroy();
-      this.$container.remove();
-    }
-  });
-
-  describe('positioning', () => {
-    it('should draw backlight element properly using Handsontable default settings', () => {
-      handsontable({
-        data: createSpreadsheetData(5, 10),
-        manualColumnMove: true,
-        rowHeaders: true,
-        colHeaders: true,
-      });
-
-      const TH = $(getCell(-1, 3));
-
-      TH.simulate('mousedown')
-        .simulate('mouseup')
-        .simulate('mousedown');
-
-      const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
-
-      expect(backlight.outerWidth()).toBe(TH.outerWidth());
-      expect(backlight.offset().left).toBe(TH.offset().left);
+    beforeEach(function() {
+      $('html').attr('dir', htmlDir);
+      this.$container = $(`<div id="${id}"></div>`).appendTo('body');
     });
 
-    it('should move backlight and guideline element with the movement of the mouse (move left)', () => {
-      handsontable({
-        data: createSpreadsheetData(5, 10),
-        manualColumnMove: true,
-        rowHeaders: true,
-        colHeaders: true,
-      });
+    afterEach(function() {
+      $('html').attr('dir', 'ltr');
 
-      const TH = $(getCell(-1, 3));
-      const THNext = $(getCell(-1, 1));
-
-      TH.simulate('mousedown')
-        .simulate('mouseup')
-        .simulate('mousedown', {
-          clientX: TH.offset().left,
-        });
-      THNext.simulate('mouseover')
-        .simulate('mousemove', {
-          clientX: THNext.offset().left
-        });
-
-      const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
-      const guideline = spec().$container.find('.ht__manualColumnMove--guideline');
-
-      expect(backlight.outerWidth()).toBe(TH.outerWidth());
-      expect(backlight.offset().left).toBe(THNext.offset().left);
-      expect(guideline.outerWidth()).toBe(2);
-      expect(guideline.offset().left).toBe(THNext.offset().left - 1);
+      if (this.$container) {
+        destroy();
+        this.$container.remove();
+      }
     });
 
-    it('should move backlight and guideline element with the movement of the mouse (move right)', () => {
-      handsontable({
-        data: createSpreadsheetData(5, 10),
-        manualColumnMove: true,
-        rowHeaders: true,
-        colHeaders: true,
-      });
-
-      const TH = $(getCell(-1, 1));
-      const THNext = $(getCell(-1, 3));
-
-      TH.simulate('mousedown')
-        .simulate('mouseup')
-        .simulate('mousedown', {
-          clientX: TH.offset().left,
-        });
-      THNext.simulate('mouseover')
-        .simulate('mousemove', {
-          clientX: THNext.offset().left
+    describe('positioning', () => {
+      it('should draw backlight element properly using Handsontable default settings', () => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(5, 10),
+          manualColumnMove: true,
+          rowHeaders: true,
+          colHeaders: true,
         });
 
-      const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
-      const guideline = spec().$container.find('.ht__manualColumnMove--guideline');
+        const TH = $(getCell(-1, 3));
 
-      expect(backlight.outerWidth()).toBe(TH.outerWidth());
-      expect(backlight.offset().left).toBe(THNext.offset().left);
-      expect(guideline.outerWidth()).toBe(2);
-      expect(guideline.offset().left).toBe(THNext.offset().left - 1);
-    });
+        TH.simulate('mousedown')
+          .simulate('mouseup')
+          .simulate('mousedown');
 
-    it('should move guideline element to the last header when the mouse exceeds half of the width of that header', () => {
-      handsontable({
-        data: createSpreadsheetData(5, 10),
-        manualColumnMove: true,
-        rowHeaders: true,
-        colHeaders: true,
+        const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
+
+        expect(backlight.outerWidth()).toBe(TH.outerWidth());
+        expect(backlight.offset().left).toBe(TH.offset().left);
       });
 
-      const TH = $(getCell(-1, 1));
-      const THNext = $(getCell(-1, 3));
-      const THLast = $(getCell(-1, 4));
-      const dropOffset = 10;
-
-      TH.simulate('mousedown')
-        .simulate('mouseup')
-        .simulate('mousedown', {
-          clientX: TH.offset().left,
-        });
-      THNext.simulate('mouseover')
-        .simulate('mousemove', {
-          clientX: THNext.offset().left + THNext.outerWidth() - dropOffset,
+      it('should move backlight and guideline element with the movement of the mouse (move left)', () => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(5, 10),
+          manualColumnMove: true,
+          rowHeaders: true,
+          colHeaders: true,
         });
 
-      const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
-      const guideline = spec().$container.find('.ht__manualColumnMove--guideline');
+        const TH = $(getCell(-1, 3));
+        const THNext = $(getCell(-1, 1));
 
-      expect(backlight.outerWidth()).toBe(TH.outerWidth());
-      expect(backlight.offset().left).toBe(THLast.offset().left - dropOffset);
-      expect(guideline.outerWidth()).toBe(2);
-      expect(guideline.offset().left).toBe(THLast.offset().left - 1);
-    });
+        TH.simulate('mousedown')
+          .simulate('mouseup')
+          .simulate('mousedown', {
+            clientX: TH.offset().left,
+          });
+        THNext.simulate('mouseover')
+          .simulate('mousemove', {
+            clientX: THNext.offset().left
+          });
 
-    it('should draw backlight element properly when the table is scrolled (overflow: hidden)', async() => {
-      handsontable({
-        data: createSpreadsheetData(5, 30),
-        width: 300,
-        height: 300,
-        manualColumnMove: true,
-        rowHeaders: true,
-        colHeaders: true,
+        const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
+        const guideline = spec().$container.find('.ht__manualColumnMove--guideline');
+
+        expect(backlight.outerWidth()).toBe(TH.outerWidth());
+        expect(backlight.offset().left).toBe(THNext.offset().left);
+        expect(guideline.outerWidth()).toBe(2);
+        expect(guideline.offset().left).toBe(THNext.offset().left - 1);
       });
 
-      scrollViewportTo(0, 20);
-
-      await sleep(100);
-
-      const TH = $(getCell(-1, 22));
-
-      TH.simulate('mousedown')
-        .simulate('mouseup')
-        .simulate('mousedown');
-
-      const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
-
-      expect(backlight.outerWidth()).toBe(TH.outerWidth());
-      expect(backlight.offset().left).toBe(TH.offset().left);
-    });
-
-    it('should move backlight and guideline element with the movement of the mouse when the table is scrolled ' +
-       '(overflow: hidden, move left)', async() => {
-      handsontable({
-        data: createSpreadsheetData(5, 50),
-        width: 300,
-        height: 200,
-        manualColumnMove: true,
-        rowHeaders: true,
-        colHeaders: true,
-      });
-
-      scrollViewportTo(0, 20);
-
-      await sleep(100);
-
-      const TH = $(getCell(-1, 22));
-      const THNext = $(getCell(-1, 20));
-
-      TH.simulate('mousedown')
-        .simulate('mouseup')
-        .simulate('mousedown', {
-          clientX: TH.offset().left,
-        });
-      THNext.simulate('mouseover')
-        .simulate('mousemove', {
-          clientX: THNext.offset().left
+      it('should move backlight and guideline element with the movement of the mouse (move right)', () => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(5, 10),
+          manualColumnMove: true,
+          rowHeaders: true,
+          colHeaders: true,
         });
 
-      const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
-      const guideline = spec().$container.find('.ht__manualColumnMove--guideline');
+        const TH = $(getCell(-1, 1));
+        const THNext = $(getCell(-1, 3));
 
-      expect(backlight.outerWidth()).toBe(TH.outerWidth());
-      expect(backlight.offset().left).toBe(THNext.offset().left);
-      expect(guideline.outerWidth()).toBe(2);
-      expect(guideline.offset().left).toBe(THNext.offset().left - 1);
-    });
+        TH.simulate('mousedown')
+          .simulate('mouseup')
+          .simulate('mousedown', {
+            clientX: TH.offset().left,
+          });
+        THNext.simulate('mouseover')
+          .simulate('mousemove', {
+            clientX: THNext.offset().left
+          });
 
-    it('should move backlight and guideline element with the movement of the mouse when the table is scrolled ' +
-       '(overflow: hidden, move right)', async() => {
-      handsontable({
-        data: createSpreadsheetData(5, 50),
-        width: 300,
-        height: 200,
-        manualColumnMove: true,
-        rowHeaders: true,
-        colHeaders: true,
+        const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
+        const guideline = spec().$container.find('.ht__manualColumnMove--guideline');
+
+        expect(backlight.outerWidth()).toBe(TH.outerWidth());
+        expect(backlight.offset().left).toBe(THNext.offset().left);
+        expect(guideline.outerWidth()).toBe(2);
+        expect(guideline.offset().left).toBe(THNext.offset().left - 1);
       });
 
-      scrollViewportTo(0, 20);
-
-      await sleep(100);
-
-      const TH = $(getCell(-1, 20));
-      const THNext = $(getCell(-1, 22));
-
-      TH.simulate('mousedown')
-        .simulate('mouseup')
-        .simulate('mousedown', {
-          clientX: TH.offset().left,
-        });
-      THNext.simulate('mouseover')
-        .simulate('mousemove', {
-          clientX: THNext.offset().left
+      it('should move guideline element to the last header when the mouse exceeds half of the width of that header', () => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(5, 10),
+          manualColumnMove: true,
+          rowHeaders: true,
+          colHeaders: true,
         });
 
-      const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
-      const guideline = spec().$container.find('.ht__manualColumnMove--guideline');
+        const TH = $(getCell(-1, 1));
+        const THNext = $(getCell(-1, 3));
+        const THLast = $(getCell(-1, 4));
+        const dropOffset = 10;
 
-      expect(backlight.outerWidth()).toBe(TH.outerWidth());
-      expect(backlight.offset().left).toBe(THNext.offset().left);
-      expect(guideline.outerWidth()).toBe(2);
-      expect(guideline.offset().left).toBe(THNext.offset().left - 1);
-    });
+        TH.simulate('mousedown')
+          .simulate('mouseup')
+          .simulate('mousedown', {
+            clientX: TH.offset().left,
+          });
+        THNext.simulate('mouseover')
+          .simulate('mousemove', {
+            clientX: THNext.offset().left + THNext.outerWidth() - dropOffset,
+          });
 
-    it('should draw backlight element properly when the table is scrolled (window as scrollable element)', async() => {
-      handsontable({
-        data: createSpreadsheetData(5, 100),
-        manualColumnMove: true,
-        rowHeaders: true,
-        colHeaders: true,
+        const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
+        const guideline = spec().$container.find('.ht__manualColumnMove--guideline');
+
+        expect(backlight.outerWidth()).toBe(TH.outerWidth());
+        expect(backlight.offset().left).toBe(THLast.offset().left - dropOffset);
+        expect(guideline.outerWidth()).toBe(2);
+        expect(guideline.offset().left).toBe(THLast.offset().left - 1);
       });
 
-      scrollViewportTo(0, 20);
-
-      await sleep(100);
-
-      const TH = $(getCell(-1, 22));
-
-      TH.simulate('mousedown')
-        .simulate('mouseup')
-        .simulate('mousedown');
-
-      const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
-
-      expect(backlight.outerWidth()).toBe(TH.outerWidth());
-      expect(backlight.offset().left).toBe(TH.offset().left);
-    });
-
-    it('should move backlight and guideline element with the movement of the mouse when the table is scrolled ' +
-       '(window as scrollable element, move left)', async() => {
-      handsontable({
-        data: createSpreadsheetData(5, 100),
-        manualColumnMove: true,
-        rowHeaders: true,
-        colHeaders: true,
-      });
-
-      scrollViewportTo(0, 20);
-
-      await sleep(100);
-
-      const TH = $(getCell(-1, 26));
-      const THNext = $(getCell(-1, 24));
-
-      TH.simulate('mousedown')
-        .simulate('mouseup')
-        .simulate('mousedown', {
-          clientX: TH.offset().left - window.scrollX,
-        });
-      THNext.simulate('mouseover')
-        .simulate('mousemove', {
-          clientX: THNext.offset().left - window.scrollX,
+      it('should draw backlight element properly when the table is scrolled (overflow: hidden)', async() => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(5, 30),
+          width: 300,
+          height: 300,
+          manualColumnMove: true,
+          rowHeaders: true,
+          colHeaders: true,
         });
 
-      const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
-      const guideline = spec().$container.find('.ht__manualColumnMove--guideline');
+        scrollViewportTo(0, 20);
 
-      expect(backlight.outerWidth()).toBe(TH.outerWidth());
-      expect(backlight.offset().left).toBe(THNext.offset().left);
-      expect(guideline.outerWidth()).toBe(2);
-      expect(guideline.offset().left).toBe(THNext.offset().left - 1);
-    });
+        await sleep(100);
 
-    it('should move backlight and guideline element with the movement of the mouse when the table is scrolled ' +
-       '(window as scrollable element, move right)', async() => {
-      handsontable({
-        data: createSpreadsheetData(5, 100),
-        manualColumnMove: true,
-        rowHeaders: true,
-        colHeaders: true,
+        const TH = $(getCell(-1, 22));
+
+        TH.simulate('mousedown')
+          .simulate('mouseup')
+          .simulate('mousedown');
+
+        const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
+
+        expect(backlight.outerWidth()).toBe(TH.outerWidth());
+        expect(backlight.offset().left).toBe(TH.offset().left);
       });
 
-      scrollViewportTo(0, 20);
-
-      await sleep(100);
-
-      const TH = $(getCell(-1, 24));
-      const THNext = $(getCell(-1, 26));
-
-      TH.simulate('mousedown')
-        .simulate('mouseup')
-        .simulate('mousedown', {
-          clientX: TH.offset().left - window.scrollX,
-        });
-      THNext.simulate('mouseover')
-        .simulate('mousemove', {
-          clientX: THNext.offset().left - window.scrollX,
+      it('should move backlight and guideline element with the movement of the mouse when the table is scrolled ' +
+        '(overflow: hidden, move left)', async() => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(5, 50),
+          width: 300,
+          height: 200,
+          manualColumnMove: true,
+          rowHeaders: true,
+          colHeaders: true,
         });
 
-      const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
-      const guideline = spec().$container.find('.ht__manualColumnMove--guideline');
+        scrollViewportTo(0, 20);
 
-      expect(backlight.outerWidth()).toBe(TH.outerWidth());
-      expect(backlight.offset().left).toBe(THNext.offset().left);
-      expect(guideline.outerWidth()).toBe(2);
-      expect(guideline.offset().left).toBe(THNext.offset().left - 1);
-    });
+        await sleep(100);
 
-    it('should draw backlight element properly when colWidths is defined', () => {
-      handsontable({
-        data: createSpreadsheetData(5, 10),
-        manualColumnMove: true,
-        rowHeaders: true,
-        colWidths: 100,
-        colHeaders: true,
+        const TH = $(getCell(-1, 22));
+        const THNext = $(getCell(-1, 20));
+
+        TH.simulate('mousedown')
+          .simulate('mouseup')
+          .simulate('mousedown', {
+            clientX: TH.offset().left,
+          });
+        THNext.simulate('mouseover')
+          .simulate('mousemove', {
+            clientX: THNext.offset().left
+          });
+
+        const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
+        const guideline = spec().$container.find('.ht__manualColumnMove--guideline');
+
+        expect(backlight.outerWidth()).toBe(TH.outerWidth());
+        expect(backlight.offset().left).toBe(THNext.offset().left);
+        expect(guideline.outerWidth()).toBe(2);
+        expect(guideline.offset().left).toBe(THNext.offset().left - 1);
       });
 
-      const TH = $(getCell(-1, 3));
+      it('should move backlight and guideline element with the movement of the mouse when the table is scrolled ' +
+        '(overflow: hidden, move right)', async() => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(5, 50),
+          width: 300,
+          height: 200,
+          manualColumnMove: true,
+          rowHeaders: true,
+          colHeaders: true,
+        });
 
-      TH.simulate('mousedown')
-        .simulate('mouseup')
-        .simulate('mousedown');
+        scrollViewportTo(0, 20);
 
-      const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
+        await sleep(100);
 
-      expect(backlight.outerWidth()).toBe(TH.outerWidth());
-      expect(backlight.offset().left).toBe(TH.offset().left);
-    });
+        const TH = $(getCell(-1, 20));
+        const THNext = $(getCell(-1, 22));
 
-    it('should draw backlight element properly when stretchH is enabled', () => {
-      handsontable({
-        data: createSpreadsheetData(5, 5),
-        width: 600,
-        colHeaders: true,
-        stretchH: 'all',
-        manualColumnMove: true
+        TH.simulate('mousedown')
+          .simulate('mouseup')
+          .simulate('mousedown', {
+            clientX: TH.offset().left,
+          });
+        THNext.simulate('mouseover')
+          .simulate('mousemove', {
+            clientX: THNext.offset().left
+          });
+
+        const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
+        const guideline = spec().$container.find('.ht__manualColumnMove--guideline');
+
+        expect(backlight.outerWidth()).toBe(TH.outerWidth());
+        expect(backlight.offset().left).toBe(THNext.offset().left);
+        expect(guideline.outerWidth()).toBe(2);
+        expect(guideline.offset().left).toBe(THNext.offset().left - 1);
       });
 
-      const TH = $(getCell(-1, 1));
+      it('should draw backlight element properly when the table is scrolled (window as scrollable element)', async() => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(5, 100),
+          manualColumnMove: true,
+          rowHeaders: true,
+          colHeaders: true,
+        });
 
-      TH.simulate('mousedown')
-        .simulate('mouseup')
-        .simulate('mousedown');
+        scrollViewportTo(0, 20);
 
-      const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
+        await sleep(100);
 
-      expect(backlight.outerWidth()).toBe(TH.outerWidth());
-      expect(backlight.offset().left).toBe(TH.offset().left);
-    });
+        const TH = $(getCell(-1, 22));
 
-    it('should draw backlight element properly when stretchH is enabled and column order is changed', () => {
-      handsontable({
-        data: [
-          {
-            id: 1,
-            flag: 'EUR',
-            currencyCode: 'EUR',
-            currency: 'Euro',
-            level: 0.9033,
-            units: 'EUR / USD',
-            asOf: '08/19/2015',
-            onedChng: 0.0026
-          },
-        ],
-        width: 600,
-        colHeaders: true,
-        stretchH: 'all',
-        manualColumnMove: [2, 4, 6, 3, 1, 0],
-        columns: [
-          { data: 'id', type: 'numeric', width: 40 },
-          { data: 'currencyCode', type: 'text' },
-          { data: 'currency', type: 'text' },
-          { data: 'level', type: 'numeric', numericFormat: { pattern: '0.0000' } },
-          { data: 'units', type: 'text' },
-          { data: 'asOf', type: 'date', dateFormat: 'MM/DD/YYYY' },
-          { data: 'onedChng', type: 'numeric', numericFormat: { pattern: '0.00%' } }
-        ]
+        TH.simulate('mousedown')
+          .simulate('mouseup')
+          .simulate('mousedown');
+
+        const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
+
+        expect(backlight.outerWidth()).toBe(TH.outerWidth());
+        expect(backlight.offset().left).toBe(TH.offset().left);
       });
 
-      const TH = $(getCell(-1, 6));
+      it('should move backlight and guideline element with the movement of the mouse when the table is scrolled ' +
+        '(window as scrollable element, move left)', async() => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(5, 100),
+          manualColumnMove: true,
+          rowHeaders: true,
+          colHeaders: true,
+        });
 
-      TH.simulate('mousedown')
-        .simulate('mouseup')
-        .simulate('mousedown');
+        scrollViewportTo(0, 20);
 
-      const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
+        await sleep(100);
 
-      expect(backlight.outerWidth()).toBe(TH.outerWidth());
-      expect(backlight.offset().left).toBe(TH.offset().left);
-    });
+        const TH = $(getCell(-1, 26));
+        const THNext = $(getCell(-1, 24));
 
-    it('should draw backlight element properly when there are hidden columns', () => {
-      handsontable({
-        data: createSpreadsheetData(5, 5),
-        manualColumnMove: true,
-        rowHeaders: true,
-        colHeaders: true,
-        hiddenColumns: {
-          columns: [2, 3],
-        }
+        TH.simulate('mousedown')
+          .simulate('mouseup')
+          .simulate('mousedown', {
+            clientX: TH.offset().left - window.scrollX,
+          });
+        THNext.simulate('mouseover')
+          .simulate('mousemove', {
+            clientX: THNext.offset().left - window.scrollX,
+          });
+
+        const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
+        const guideline = spec().$container.find('.ht__manualColumnMove--guideline');
+
+        expect(backlight.outerWidth()).toBe(TH.outerWidth());
+        expect(backlight.offset().left).toBe(THNext.offset().left);
+        expect(guideline.outerWidth()).toBe(2);
+        expect(guideline.offset().left).toBe(THNext.offset().left - 1);
       });
 
-      selectColumns(1, 4);
+      it('should move backlight and guideline element with the movement of the mouse when the table is scrolled ' +
+        '(window as scrollable element, move right)', async() => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(5, 100),
+          manualColumnMove: true,
+          rowHeaders: true,
+          colHeaders: true,
+        });
 
-      const TH = $(getCell(-1, 1));
+        scrollViewportTo(0, 20);
 
-      TH.simulate('mousedown')
-        .simulate('mouseup')
-        .simulate('mousedown');
+        await sleep(100);
 
-      const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
+        const TH = $(getCell(-1, 24));
+        const THNext = $(getCell(-1, 26));
 
-      expect(backlight.outerWidth()).toBe(100);
-      expect(backlight.offset().left).toBe(TH.offset().left);
+        TH.simulate('mousedown')
+          .simulate('mouseup')
+          .simulate('mousedown', {
+            clientX: TH.offset().left - window.scrollX,
+          });
+        THNext.simulate('mouseover')
+          .simulate('mousemove', {
+            clientX: THNext.offset().left - window.scrollX,
+          });
+
+        const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
+        const guideline = spec().$container.find('.ht__manualColumnMove--guideline');
+
+        expect(backlight.outerWidth()).toBe(TH.outerWidth());
+        expect(backlight.offset().left).toBe(THNext.offset().left);
+        expect(guideline.outerWidth()).toBe(2);
+        expect(guideline.offset().left).toBe(THNext.offset().left - 1);
+      });
+
+      it('should draw backlight element properly when colWidths is defined', () => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(5, 10),
+          manualColumnMove: true,
+          rowHeaders: true,
+          colWidths: 100,
+          colHeaders: true,
+        });
+
+        const TH = $(getCell(-1, 3));
+
+        TH.simulate('mousedown')
+          .simulate('mouseup')
+          .simulate('mousedown');
+
+        const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
+
+        expect(backlight.outerWidth()).toBe(TH.outerWidth());
+        expect(backlight.offset().left).toBe(TH.offset().left);
+      });
+
+      it('should draw backlight element properly when stretchH is enabled', () => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(5, 5),
+          width: 600,
+          colHeaders: true,
+          stretchH: 'all',
+          manualColumnMove: true
+        });
+
+        const TH = $(getCell(-1, 1));
+
+        TH.simulate('mousedown')
+          .simulate('mouseup')
+          .simulate('mousedown');
+
+        const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
+
+        expect(backlight.outerWidth()).toBe(TH.outerWidth());
+        expect(backlight.offset().left).toBe(TH.offset().left);
+      });
+
+      it('should draw backlight element properly when stretchH is enabled and column order is changed', () => {
+        handsontable({
+          layoutDirection,
+          data: [
+            {
+              id: 1,
+              flag: 'EUR',
+              currencyCode: 'EUR',
+              currency: 'Euro',
+              level: 0.9033,
+              units: 'EUR / USD',
+              asOf: '08/19/2015',
+              onedChng: 0.0026
+            },
+          ],
+          width: 600,
+          colHeaders: true,
+          stretchH: 'all',
+          manualColumnMove: [2, 4, 6, 3, 1, 0],
+          columns: [
+            { data: 'id', type: 'numeric', width: 40 },
+            { data: 'currencyCode', type: 'text' },
+            { data: 'currency', type: 'text' },
+            { data: 'level', type: 'numeric', numericFormat: { pattern: '0.0000' } },
+            { data: 'units', type: 'text' },
+            { data: 'asOf', type: 'date', dateFormat: 'MM/DD/YYYY' },
+            { data: 'onedChng', type: 'numeric', numericFormat: { pattern: '0.00%' } }
+          ]
+        });
+
+        const TH = $(getCell(-1, 6));
+
+        TH.simulate('mousedown')
+          .simulate('mouseup')
+          .simulate('mousedown');
+
+        const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
+
+        expect(backlight.outerWidth()).toBe(TH.outerWidth());
+        expect(backlight.offset().left).toBe(TH.offset().left);
+      });
+
+      it('should draw backlight element properly when there are hidden columns', () => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(5, 5),
+          manualColumnMove: true,
+          rowHeaders: true,
+          colHeaders: true,
+          hiddenColumns: {
+            columns: [2, 3],
+          }
+        });
+
+        selectColumns(1, 4);
+
+        const TH = $(getCell(-1, 1));
+
+        TH.simulate('mousedown')
+          .simulate('mouseup')
+          .simulate('mousedown');
+
+        const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
+
+        expect(backlight.outerWidth()).toBe(100);
+        expect(backlight.offset().left).toBe(TH.offset().left);
+      });
     });
   });
 });

--- a/handsontable/src/plugins/manualColumnMove/__tests__/rtl/positioning.spec.js
+++ b/handsontable/src/plugins/manualColumnMove/__tests__/rtl/positioning.spec.js
@@ -1,434 +1,453 @@
 describe('manualColumnMove (RTL mode)', () => {
-  const id = 'testContainer';
+  using('configuration object', [
+    { htmlDir: 'rtl', layoutDirection: 'inherit' },
+    { htmlDir: 'ltr', layoutDirection: 'rtl' },
+  ], ({ htmlDir, layoutDirection }) => {
+    const id = 'testContainer';
 
-  beforeEach(function() {
-    $('html').attr('dir', 'rtl');
-    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
-  });
-
-  afterEach(function() {
-    $('html').attr('dir', 'ltr');
-
-    if (this.$container) {
-      destroy();
-      this.$container.remove();
-    }
-  });
-
-  describe('positioning', () => {
-    it('should draw backlight element properly using Handsontable default settings', () => {
-      handsontable({
-        data: createSpreadsheetData(5, 10),
-        manualColumnMove: true,
-        rowHeaders: true,
-        colHeaders: true,
-      });
-
-      const TH = $(getCell(-1, 3));
-
-      TH.simulate('mousedown')
-        .simulate('mouseup')
-        .simulate('mousedown');
-
-      const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
-
-      expect(backlight.outerWidth()).toBe(TH.outerWidth());
-      expect(backlight.offset().left).toBe(TH.offset().left);
+    beforeEach(function() {
+      $('html').attr('dir', htmlDir);
+      this.$container = $(`<div id="${id}"></div>`).appendTo('body');
     });
 
-    it('should move backlight and guideline element with the movement of the mouse (move left)', () => {
-      handsontable({
-        data: createSpreadsheetData(5, 10),
-        manualColumnMove: true,
-        rowHeaders: true,
-        colHeaders: true,
-      });
+    afterEach(function() {
+      $('html').attr('dir', 'ltr');
 
-      const TH = $(getCell(-1, 1));
-      const THNext = $(getCell(-1, 3));
-
-      TH.simulate('mousedown')
-        .simulate('mouseup')
-        .simulate('mousedown', {
-          clientX: TH.offset().left,
-        });
-      THNext.simulate('mouseover')
-        .simulate('mousemove', {
-          clientX: THNext.offset().left
-        });
-
-      const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
-      const guideline = spec().$container.find('.ht__manualColumnMove--guideline');
-
-      expect(backlight.outerWidth()).toBe(TH.outerWidth());
-      expect(backlight.offset().left).toBe(THNext.offset().left + 1);
-      expect(guideline.outerWidth()).toBe(2);
-      expect(guideline.offset().left).toBe(THNext.offset().left - 1);
+      if (this.$container) {
+        destroy();
+        this.$container.remove();
+      }
     });
 
-    it('should move backlight and guideline element with the movement of the mouse (move right)', () => {
-      handsontable({
-        data: createSpreadsheetData(5, 10),
-        manualColumnMove: true,
-        rowHeaders: true,
-        colHeaders: true,
-      });
-
-      const TH = $(getCell(-1, 3));
-      const THNext = $(getCell(-1, 1));
-
-      TH.simulate('mousedown')
-        .simulate('mouseup')
-        .simulate('mousedown', {
-          clientX: TH.offset().left,
-        });
-      THNext.simulate('mouseover')
-        .simulate('mousemove', {
-          clientX: THNext.offset().left
+    describe('positioning', () => {
+      it('should draw backlight element properly using Handsontable default settings', () => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(5, 10),
+          manualColumnMove: true,
+          rowHeaders: true,
+          colHeaders: true,
         });
 
-      const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
-      const guideline = spec().$container.find('.ht__manualColumnMove--guideline');
+        const TH = $(getCell(-1, 3));
 
-      expect(backlight.outerWidth()).toBe(TH.outerWidth());
-      expect(backlight.offset().left).toBe(THNext.offset().left + 1);
-      expect(guideline.outerWidth()).toBe(2);
-      expect(guideline.offset().left).toBe(THNext.offset().left - 1);
-    });
+        TH.simulate('mousedown')
+          .simulate('mouseup')
+          .simulate('mousedown');
 
-    it('should move guideline element to the last header when the mouse exceeds half of the width of that header', () => {
-      handsontable({
-        data: createSpreadsheetData(5, 10),
-        manualColumnMove: true,
-        rowHeaders: true,
-        colHeaders: true,
+        const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
+
+        expect(backlight.outerWidth()).toBe(TH.outerWidth());
+        expect(backlight.offset().left).toBe(TH.offset().left);
       });
 
-      const TH = $(getCell(-1, 1));
-      const THNext = $(getCell(-1, 3));
-      const dropOffset = 10;
-
-      TH.simulate('mousedown')
-        .simulate('mouseup')
-        .simulate('mousedown', {
-          // clientX: TH.offset().left + TH.outerWidth(),
-          clientX: TH.offset().left,
-        });
-      THNext.simulate('mouseover')
-        .simulate('mousemove', {
-          clientX: THNext.offset().left + dropOffset,
+      it('should move backlight and guideline element with the movement of the mouse (move left)', () => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(5, 10),
+          manualColumnMove: true,
+          rowHeaders: true,
+          colHeaders: true,
         });
 
-      const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
-      const guideline = spec().$container.find('.ht__manualColumnMove--guideline');
+        const TH = $(getCell(-1, 1));
+        const THNext = $(getCell(-1, 3));
 
-      expect(backlight.outerWidth()).toBe(TH.outerWidth());
-      expect(backlight.offset().left).toBe(THNext.offset().left + dropOffset + 1);
-      expect(guideline.outerWidth()).toBe(2);
-      expect(guideline.offset().left).toBe(THNext.offset().left - 1);
-    });
+        TH.simulate('mousedown')
+          .simulate('mouseup')
+          .simulate('mousedown', {
+            clientX: TH.offset().left,
+          });
+        THNext.simulate('mouseover')
+          .simulate('mousemove', {
+            clientX: THNext.offset().left
+          });
 
-    it('should draw backlight element properly when the table is scrolled (overflow: hidden)', async() => {
-      handsontable({
-        data: createSpreadsheetData(5, 30),
-        width: 300,
-        height: 300,
-        manualColumnMove: true,
-        rowHeaders: true,
-        colHeaders: true,
+        const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
+        const guideline = spec().$container.find('.ht__manualColumnMove--guideline');
+
+        expect(backlight.outerWidth()).toBe(TH.outerWidth());
+        expect(backlight.offset().left).toBe(THNext.offset().left + 1);
+        expect(guideline.outerWidth()).toBe(2);
+        expect(guideline.offset().left).toBe(THNext.offset().left - 1);
       });
 
-      scrollViewportTo(0, 20);
-
-      await sleep(100);
-
-      const TH = $(getCell(-1, 22));
-
-      TH.simulate('mousedown')
-        .simulate('mouseup')
-        .simulate('mousedown');
-
-      const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
-
-      expect(backlight.outerWidth()).toBe(TH.outerWidth());
-      expect(backlight.offset().left).toBe(TH.offset().left);
-    });
-
-    it('should move backlight and guideline element with the movement of the mouse when the table is scrolled ' +
-       '(overflow: hidden, move left)', async() => {
-      handsontable({
-        data: createSpreadsheetData(5, 50),
-        width: 300,
-        height: 200,
-        manualColumnMove: true,
-        rowHeaders: true,
-        colHeaders: true,
-      });
-
-      scrollViewportTo(0, 20);
-
-      await sleep(100);
-
-      const TH = $(getCell(-1, 20));
-      const THNext = $(getCell(-1, 22));
-
-      TH.simulate('mousedown')
-        .simulate('mouseup')
-        .simulate('mousedown', {
-          clientX: TH.offset().left,
-        });
-      THNext.simulate('mouseover')
-        .simulate('mousemove', {
-          clientX: THNext.offset().left
+      it('should move backlight and guideline element with the movement of the mouse (move right)', () => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(5, 10),
+          manualColumnMove: true,
+          rowHeaders: true,
+          colHeaders: true,
         });
 
-      const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
-      const guideline = spec().$container.find('.ht__manualColumnMove--guideline');
+        const TH = $(getCell(-1, 3));
+        const THNext = $(getCell(-1, 1));
 
-      expect(backlight.outerWidth()).toBe(TH.outerWidth());
-      expect(backlight.offset().left).toBe(THNext.offset().left + 1);
-      expect(guideline.outerWidth()).toBe(2);
-      expect(guideline.offset().left).toBe(THNext.offset().left - 1);
-    });
+        TH.simulate('mousedown')
+          .simulate('mouseup')
+          .simulate('mousedown', {
+            clientX: TH.offset().left,
+          });
+        THNext.simulate('mouseover')
+          .simulate('mousemove', {
+            clientX: THNext.offset().left
+          });
 
-    it('should move backlight and guideline element with the movement of the mouse when the table is scrolled ' +
-       '(overflow: hidden, move right)', async() => {
-      handsontable({
-        data: createSpreadsheetData(5, 50),
-        width: 300,
-        height: 200,
-        manualColumnMove: true,
-        rowHeaders: true,
-        colHeaders: true,
+        const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
+        const guideline = spec().$container.find('.ht__manualColumnMove--guideline');
+
+        expect(backlight.outerWidth()).toBe(TH.outerWidth());
+        expect(backlight.offset().left).toBe(THNext.offset().left + 1);
+        expect(guideline.outerWidth()).toBe(2);
+        expect(guideline.offset().left).toBe(THNext.offset().left - 1);
       });
 
-      scrollViewportTo(0, 20);
-
-      await sleep(100);
-
-      const TH = $(getCell(-1, 22));
-      const THNext = $(getCell(-1, 20));
-
-      TH.simulate('mousedown')
-        .simulate('mouseup')
-        .simulate('mousedown', {
-          clientX: TH.offset().left,
-        });
-      THNext.simulate('mouseover')
-        .simulate('mousemove', {
-          clientX: THNext.offset().left
+      it('should move guideline element to the last header when the mouse exceeds half of the width of that header', () => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(5, 10),
+          manualColumnMove: true,
+          rowHeaders: true,
+          colHeaders: true,
         });
 
-      const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
-      const guideline = spec().$container.find('.ht__manualColumnMove--guideline');
+        const TH = $(getCell(-1, 1));
+        const THNext = $(getCell(-1, 3));
+        const dropOffset = 10;
 
-      expect(backlight.outerWidth()).toBe(TH.outerWidth());
-      expect(backlight.offset().left).toBe(THNext.offset().left + 1);
-      expect(guideline.outerWidth()).toBe(2);
-      expect(guideline.offset().left).toBe(THNext.offset().left - 1);
-    });
+        TH.simulate('mousedown')
+          .simulate('mouseup')
+          .simulate('mousedown', {
+            // clientX: TH.offset().left + TH.outerWidth(),
+            clientX: TH.offset().left,
+          });
+        THNext.simulate('mouseover')
+          .simulate('mousemove', {
+            clientX: THNext.offset().left + dropOffset,
+          });
 
-    it('should draw backlight element properly when the table is scrolled (window as scrollable element)', async() => {
-      handsontable({
-        data: createSpreadsheetData(5, 100),
-        manualColumnMove: true,
-        rowHeaders: true,
-        colHeaders: true,
+        const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
+        const guideline = spec().$container.find('.ht__manualColumnMove--guideline');
+
+        expect(backlight.outerWidth()).toBe(TH.outerWidth());
+        expect(backlight.offset().left).toBe(THNext.offset().left + dropOffset + 1);
+        expect(guideline.outerWidth()).toBe(2);
+        expect(guideline.offset().left).toBe(THNext.offset().left - 1);
       });
 
-      scrollViewportTo(0, 20);
-
-      await sleep(100);
-
-      const TH = $(getCell(-1, 22));
-
-      TH.simulate('mousedown')
-        .simulate('mouseup')
-        .simulate('mousedown');
-
-      const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
-
-      expect(backlight.outerWidth()).toBe(TH.outerWidth());
-      expect(backlight.offset().left).toBe(TH.offset().left);
-    });
-
-    it('should move backlight and guideline element with the movement of the mouse when the table is scrolled ' +
-       '(window as scrollable element, move left)', async() => {
-      handsontable({
-        data: createSpreadsheetData(5, 100),
-        manualColumnMove: true,
-        rowHeaders: true,
-        colHeaders: true,
-      });
-
-      scrollViewportTo(0, 20);
-
-      await sleep(100);
-
-      const TH = $(getCell(-1, 24));
-      const THNext = $(getCell(-1, 26));
-
-      TH.simulate('mousedown')
-        .simulate('mouseup')
-        .simulate('mousedown', {
-          clientX: TH.offset().left - window.scrollX,
-        });
-      THNext.simulate('mouseover')
-        .simulate('mousemove', {
-          clientX: THNext.offset().left - window.scrollX,
+      it('should draw backlight element properly when the table is scrolled (overflow: hidden)', async() => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(5, 30),
+          width: 300,
+          height: 300,
+          manualColumnMove: true,
+          rowHeaders: true,
+          colHeaders: true,
         });
 
-      const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
-      const guideline = spec().$container.find('.ht__manualColumnMove--guideline');
+        scrollViewportTo(0, 20);
 
-      expect(backlight.outerWidth()).toBe(TH.outerWidth());
-      expect(backlight.offset().left).toBe(THNext.offset().left + 1);
-      expect(guideline.outerWidth()).toBe(2);
-      expect(guideline.offset().left).toBe(THNext.offset().left - 1);
-    });
+        await sleep(100);
 
-    it('should move backlight and guideline element with the movement of the mouse when the table is scrolled ' +
-       '(window as scrollable element, move right)', async() => {
-      handsontable({
-        data: createSpreadsheetData(5, 100),
-        manualColumnMove: true,
-        rowHeaders: true,
-        colHeaders: true,
+        const TH = $(getCell(-1, 22));
+
+        TH.simulate('mousedown')
+          .simulate('mouseup')
+          .simulate('mousedown');
+
+        const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
+
+        expect(backlight.outerWidth()).toBe(TH.outerWidth());
+        expect(backlight.offset().left).toBe(TH.offset().left);
       });
 
-      scrollViewportTo(0, 20);
-
-      await sleep(100);
-
-      const TH = $(getCell(-1, 26));
-      const THNext = $(getCell(-1, 24));
-
-      TH.simulate('mousedown')
-        .simulate('mouseup')
-        .simulate('mousedown', {
-          clientX: TH.offset().left - window.scrollX,
-        });
-      THNext.simulate('mouseover')
-        .simulate('mousemove', {
-          clientX: THNext.offset().left - window.scrollX,
+      it('should move backlight and guideline element with the movement of the mouse when the table is scrolled ' +
+        '(overflow: hidden, move left)', async() => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(5, 50),
+          width: 300,
+          height: 200,
+          manualColumnMove: true,
+          rowHeaders: true,
+          colHeaders: true,
         });
 
-      const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
-      const guideline = spec().$container.find('.ht__manualColumnMove--guideline');
+        scrollViewportTo(0, 20);
 
-      expect(backlight.outerWidth()).toBe(TH.outerWidth());
-      expect(backlight.offset().left).toBe(THNext.offset().left + 1);
-      expect(guideline.outerWidth()).toBe(2);
-      expect(guideline.offset().left).toBe(THNext.offset().left - 1);
-    });
+        await sleep(100);
 
-    it('should draw backlight element properly when colWidths is defined', () => {
-      handsontable({
-        data: createSpreadsheetData(5, 10),
-        manualColumnMove: true,
-        rowHeaders: true,
-        colWidths: 100,
-        colHeaders: true,
+        const TH = $(getCell(-1, 20));
+        const THNext = $(getCell(-1, 22));
+
+        TH.simulate('mousedown')
+          .simulate('mouseup')
+          .simulate('mousedown', {
+            clientX: TH.offset().left,
+          });
+        THNext.simulate('mouseover')
+          .simulate('mousemove', {
+            clientX: THNext.offset().left
+          });
+
+        const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
+        const guideline = spec().$container.find('.ht__manualColumnMove--guideline');
+
+        expect(backlight.outerWidth()).toBe(TH.outerWidth());
+        expect(backlight.offset().left).toBe(THNext.offset().left + 1);
+        expect(guideline.outerWidth()).toBe(2);
+        expect(guideline.offset().left).toBe(THNext.offset().left - 1);
       });
 
-      const TH = $(getCell(-1, 3));
+      it('should move backlight and guideline element with the movement of the mouse when the table is scrolled ' +
+        '(overflow: hidden, move right)', async() => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(5, 50),
+          width: 300,
+          height: 200,
+          manualColumnMove: true,
+          rowHeaders: true,
+          colHeaders: true,
+        });
 
-      TH.simulate('mousedown')
-        .simulate('mouseup')
-        .simulate('mousedown');
+        scrollViewportTo(0, 20);
 
-      const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
+        await sleep(100);
 
-      expect(backlight.outerWidth()).toBe(TH.outerWidth());
-      expect(backlight.offset().left).toBe(TH.offset().left);
-    });
+        const TH = $(getCell(-1, 22));
+        const THNext = $(getCell(-1, 20));
 
-    it('should draw backlight element properly when stretchH is enabled', () => {
-      handsontable({
-        data: createSpreadsheetData(5, 5),
-        width: 600,
-        colHeaders: true,
-        stretchH: 'all',
-        manualColumnMove: true
+        TH.simulate('mousedown')
+          .simulate('mouseup')
+          .simulate('mousedown', {
+            clientX: TH.offset().left,
+          });
+        THNext.simulate('mouseover')
+          .simulate('mousemove', {
+            clientX: THNext.offset().left
+          });
+
+        const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
+        const guideline = spec().$container.find('.ht__manualColumnMove--guideline');
+
+        expect(backlight.outerWidth()).toBe(TH.outerWidth());
+        expect(backlight.offset().left).toBe(THNext.offset().left + 1);
+        expect(guideline.outerWidth()).toBe(2);
+        expect(guideline.offset().left).toBe(THNext.offset().left - 1);
       });
 
-      const TH = $(getCell(-1, 1));
+      it('should draw backlight element properly when the table is scrolled (window as scrollable element)', async() => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(5, 100),
+          manualColumnMove: true,
+          rowHeaders: true,
+          colHeaders: true,
+        });
 
-      TH.simulate('mousedown')
-        .simulate('mouseup')
-        .simulate('mousedown');
+        scrollViewportTo(0, 20);
 
-      const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
+        await sleep(100);
 
-      expect(backlight.outerWidth()).toBe(TH.outerWidth());
-      expect(backlight.offset().left).toBe(TH.offset().left);
-    });
+        const TH = $(getCell(-1, 22));
 
-    it('should draw backlight element properly when stretchH is enabled and column order is changed', () => {
-      handsontable({
-        data: [
-          {
-            id: 1,
-            flag: 'EUR',
-            currencyCode: 'EUR',
-            currency: 'Euro',
-            level: 0.9033,
-            units: 'EUR / USD',
-            asOf: '08/19/2015',
-            onedChng: 0.0026
-          },
-        ],
-        width: 600,
-        colHeaders: true,
-        stretchH: 'all',
-        manualColumnMove: [2, 4, 6, 3, 1, 0],
-        columns: [
-          { data: 'id', type: 'numeric', width: 40 },
-          { data: 'currencyCode', type: 'text' },
-          { data: 'currency', type: 'text' },
-          { data: 'level', type: 'numeric', numericFormat: { pattern: '0.0000' } },
-          { data: 'units', type: 'text' },
-          { data: 'asOf', type: 'date', dateFormat: 'MM/DD/YYYY' },
-          { data: 'onedChng', type: 'numeric', numericFormat: { pattern: '0.00%' } }
-        ]
+        TH.simulate('mousedown')
+          .simulate('mouseup')
+          .simulate('mousedown');
+
+        const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
+
+        expect(backlight.outerWidth()).toBe(TH.outerWidth());
+        expect(backlight.offset().left).toBe(TH.offset().left);
       });
 
-      const TH = $(getCell(-1, 6));
+      it('should move backlight and guideline element with the movement of the mouse when the table is scrolled ' +
+        '(window as scrollable element, move left)', async() => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(5, 100),
+          manualColumnMove: true,
+          rowHeaders: true,
+          colHeaders: true,
+        });
 
-      TH.simulate('mousedown')
-        .simulate('mouseup')
-        .simulate('mousedown');
+        scrollViewportTo(0, 20);
 
-      const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
+        await sleep(100);
 
-      expect(backlight.outerWidth()).toBe(TH.outerWidth());
-      expect(backlight.offset().left).toBe(TH.offset().left);
-    });
+        const TH = $(getCell(-1, 24));
+        const THNext = $(getCell(-1, 26));
 
-    it('should draw backlight element properly when there are hidden columns', () => {
-      handsontable({
-        data: createSpreadsheetData(5, 5),
-        manualColumnMove: true,
-        rowHeaders: true,
-        colHeaders: true,
-        hiddenColumns: {
-          columns: [2, 3],
-        }
+        TH.simulate('mousedown')
+          .simulate('mouseup')
+          .simulate('mousedown', {
+            clientX: TH.offset().left - window.scrollX,
+          });
+        THNext.simulate('mouseover')
+          .simulate('mousemove', {
+            clientX: THNext.offset().left - window.scrollX,
+          });
+
+        const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
+        const guideline = spec().$container.find('.ht__manualColumnMove--guideline');
+
+        expect(backlight.outerWidth()).toBe(TH.outerWidth());
+        expect(backlight.offset().left).toBe(THNext.offset().left + 1);
+        expect(guideline.outerWidth()).toBe(2);
+        expect(guideline.offset().left).toBe(THNext.offset().left - 1);
       });
 
-      selectColumns(1, 4);
+      it('should move backlight and guideline element with the movement of the mouse when the table is scrolled ' +
+        '(window as scrollable element, move right)', async() => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(5, 100),
+          manualColumnMove: true,
+          rowHeaders: true,
+          colHeaders: true,
+        });
 
-      const TH = $(getCell(-1, 1));
-      const THLast = $(getCell(-1, 4));
+        scrollViewportTo(0, 20);
 
-      TH.simulate('mousedown')
-        .simulate('mouseup')
-        .simulate('mousedown');
+        await sleep(100);
 
-      const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
+        const TH = $(getCell(-1, 26));
+        const THNext = $(getCell(-1, 24));
 
-      expect(backlight.outerWidth()).toBe(100);
-      expect(backlight.offset().left).toBe(THLast.offset().left);
+        TH.simulate('mousedown')
+          .simulate('mouseup')
+          .simulate('mousedown', {
+            clientX: TH.offset().left - window.scrollX,
+          });
+        THNext.simulate('mouseover')
+          .simulate('mousemove', {
+            clientX: THNext.offset().left - window.scrollX,
+          });
+
+        const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
+        const guideline = spec().$container.find('.ht__manualColumnMove--guideline');
+
+        expect(backlight.outerWidth()).toBe(TH.outerWidth());
+        expect(backlight.offset().left).toBe(THNext.offset().left + 1);
+        expect(guideline.outerWidth()).toBe(2);
+        expect(guideline.offset().left).toBe(THNext.offset().left - 1);
+      });
+
+      it('should draw backlight element properly when colWidths is defined', () => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(5, 10),
+          manualColumnMove: true,
+          rowHeaders: true,
+          colWidths: 100,
+          colHeaders: true,
+        });
+
+        const TH = $(getCell(-1, 3));
+
+        TH.simulate('mousedown')
+          .simulate('mouseup')
+          .simulate('mousedown');
+
+        const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
+
+        expect(backlight.outerWidth()).toBe(TH.outerWidth());
+        expect(backlight.offset().left).toBe(TH.offset().left);
+      });
+
+      it('should draw backlight element properly when stretchH is enabled', () => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(5, 5),
+          width: 600,
+          colHeaders: true,
+          stretchH: 'all',
+          manualColumnMove: true
+        });
+
+        const TH = $(getCell(-1, 1));
+
+        TH.simulate('mousedown')
+          .simulate('mouseup')
+          .simulate('mousedown');
+
+        const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
+
+        expect(backlight.outerWidth()).toBe(TH.outerWidth());
+        expect(backlight.offset().left).toBe(TH.offset().left);
+      });
+
+      it('should draw backlight element properly when stretchH is enabled and column order is changed', () => {
+        handsontable({
+          layoutDirection,
+          data: [
+            {
+              id: 1,
+              flag: 'EUR',
+              currencyCode: 'EUR',
+              currency: 'Euro',
+              level: 0.9033,
+              units: 'EUR / USD',
+              asOf: '08/19/2015',
+              onedChng: 0.0026
+            },
+          ],
+          width: 600,
+          colHeaders: true,
+          stretchH: 'all',
+          manualColumnMove: [2, 4, 6, 3, 1, 0],
+          columns: [
+            { data: 'id', type: 'numeric', width: 40 },
+            { data: 'currencyCode', type: 'text' },
+            { data: 'currency', type: 'text' },
+            { data: 'level', type: 'numeric', numericFormat: { pattern: '0.0000' } },
+            { data: 'units', type: 'text' },
+            { data: 'asOf', type: 'date', dateFormat: 'MM/DD/YYYY' },
+            { data: 'onedChng', type: 'numeric', numericFormat: { pattern: '0.00%' } }
+          ]
+        });
+
+        const TH = $(getCell(-1, 6));
+
+        TH.simulate('mousedown')
+          .simulate('mouseup')
+          .simulate('mousedown');
+
+        const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
+
+        expect(backlight.outerWidth()).toBe(TH.outerWidth());
+        expect(backlight.offset().left).toBe(TH.offset().left);
+      });
+
+      it('should draw backlight element properly when there are hidden columns', () => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(5, 5),
+          manualColumnMove: true,
+          rowHeaders: true,
+          colHeaders: true,
+          hiddenColumns: {
+            columns: [2, 3],
+          }
+        });
+
+        selectColumns(1, 4);
+
+        const TH = $(getCell(-1, 1));
+        const THLast = $(getCell(-1, 4));
+
+        TH.simulate('mousedown')
+          .simulate('mouseup')
+          .simulate('mousedown');
+
+        const backlight = spec().$container.find('.ht__manualColumnMove--backlight');
+
+        expect(backlight.outerWidth()).toBe(100);
+        expect(backlight.offset().left).toBe(THLast.offset().left);
+      });
     });
   });
 });

--- a/handsontable/src/plugins/manualColumnResize/__tests__/manualColumnResize.spec.js
+++ b/handsontable/src/plugins/manualColumnResize/__tests__/manualColumnResize.spec.js
@@ -1020,50 +1020,65 @@ describe('manualColumnResize', () => {
   });
 
   describe('handle and guide', () => {
-    it('should display the resize handle in the proper position and with a proper size', () => {
-      handsontable({
-        data: [
-          { id: 1, name: 'Ted', lastName: 'Right' },
-          { id: 2, name: 'Frank', lastName: 'Honest' },
-          { id: 3, name: 'Joan', lastName: 'Well' },
-          { id: 4, name: 'Sid', lastName: 'Strong' },
-          { id: 5, name: 'Jane', lastName: 'Neat' }
-        ],
-        colHeaders: true,
-        manualColumnResize: true
+    using('configuration object', [
+      { htmlDir: 'ltr', layoutDirection: 'inherit' },
+      { htmlDir: 'rtl', layoutDirection: 'ltr' },
+    ], ({ htmlDir, layoutDirection }) => {
+      beforeEach(() => {
+        $('html').attr('dir', htmlDir);
       });
 
-      const $headerTH = getTopClone().find('thead tr:eq(0) th:eq(1)');
-
-      $headerTH.simulate('mouseover');
-
-      const $handle = $('.manualColumnResizer');
-
-      expect($handle.offset().left)
-        .toEqual($headerTH.offset().left + $headerTH.outerWidth() - $handle.outerWidth() - 1);
-      expect($handle.height()).toEqual($headerTH.outerHeight());
-    });
-
-    it('should display the resize handle in the proper z-index and be greater than top overlay z-index', () => {
-      handsontable({
-        data: [
-          { id: 1, name: 'Ted', lastName: 'Right' },
-          { id: 2, name: 'Frank', lastName: 'Honest' },
-          { id: 3, name: 'Joan', lastName: 'Well' },
-          { id: 4, name: 'Sid', lastName: 'Strong' },
-          { id: 5, name: 'Jane', lastName: 'Neat' }
-        ],
-        colHeaders: true,
-        manualColumnResize: true
+      afterEach(() => {
+        $('html').attr('dir', 'ltr');
       });
 
-      const $headerTH = getTopClone().find('thead tr:eq(0) th:eq(1)');
+      it('should display the resize handle in the proper position and with a proper size', () => {
+        handsontable({
+          layoutDirection,
+          data: [
+            { id: 1, name: 'Ted', lastName: 'Right' },
+            { id: 2, name: 'Frank', lastName: 'Honest' },
+            { id: 3, name: 'Joan', lastName: 'Well' },
+            { id: 4, name: 'Sid', lastName: 'Strong' },
+            { id: 5, name: 'Jane', lastName: 'Neat' }
+          ],
+          colHeaders: true,
+          manualColumnResize: true
+        });
 
-      $headerTH.simulate('mouseover');
+        const $headerTH = getTopClone().find('thead tr:eq(0) th:eq(1)');
 
-      const $handle = $('.manualColumnResizer');
+        $headerTH.simulate('mouseover');
 
-      expect($handle.css('z-index')).toBeGreaterThan(getTopClone().css('z-index'));
+        const $handle = $('.manualColumnResizer');
+
+        expect($handle.offset().left)
+          .toEqual($headerTH.offset().left + $headerTH.outerWidth() - $handle.outerWidth() - 1);
+        expect($handle.height()).toEqual($headerTH.outerHeight());
+      });
+
+      it('should display the resize handle in the proper z-index and be greater than top overlay z-index', () => {
+        handsontable({
+          layoutDirection,
+          data: [
+            { id: 1, name: 'Ted', lastName: 'Right' },
+            { id: 2, name: 'Frank', lastName: 'Honest' },
+            { id: 3, name: 'Joan', lastName: 'Well' },
+            { id: 4, name: 'Sid', lastName: 'Strong' },
+            { id: 5, name: 'Jane', lastName: 'Neat' }
+          ],
+          colHeaders: true,
+          manualColumnResize: true
+        });
+
+        const $headerTH = getTopClone().find('thead tr:eq(0) th:eq(1)');
+
+        $headerTH.simulate('mouseover');
+
+        const $handle = $('.manualColumnResizer');
+
+        expect($handle.css('z-index')).toBeGreaterThan(getTopClone().css('z-index'));
+      });
     });
   });
 });

--- a/handsontable/src/plugins/manualColumnResize/__tests__/rtl/manualColumnResize.spec.js
+++ b/handsontable/src/plugins/manualColumnResize/__tests__/rtl/manualColumnResize.spec.js
@@ -83,50 +83,65 @@ describe('manualColumnResize (RTL)', () => {
   });
 
   describe('handle and guide', () => {
-    it('should display the resize handle in the proper position and with a proper size', () => {
-      handsontable({
-        data: [
-          { id: 1, name: 'Ted', lastName: 'Right' },
-          { id: 2, name: 'Frank', lastName: 'Honest' },
-          { id: 3, name: 'Joan', lastName: 'Well' },
-          { id: 4, name: 'Sid', lastName: 'Strong' },
-          { id: 5, name: 'Jane', lastName: 'Neat' }
-        ],
-        colHeaders: true,
-        manualColumnResize: true
+    using('configuration object', [
+      { htmlDir: 'rtl', layoutDirection: 'inherit' },
+      { htmlDir: 'ltr', layoutDirection: 'rtl' },
+    ], ({ htmlDir, layoutDirection }) => {
+      beforeEach(() => {
+        $('html').attr('dir', htmlDir);
       });
 
-      const $headerTH = getTopClone().find('thead tr:eq(0) th:eq(1)');
-
-      $headerTH.simulate('mouseover');
-
-      const $handle = $('.manualColumnResizer');
-
-      expect($handle.offset().left)
-        .toEqual($headerTH.offset().left + 1);
-      expect($handle.height()).toEqual($headerTH.outerHeight());
-    });
-
-    it('should display the resize handle in the proper z-index and be greater than top overlay z-index', () => {
-      handsontable({
-        data: [
-          { id: 1, name: 'Ted', lastName: 'Right' },
-          { id: 2, name: 'Frank', lastName: 'Honest' },
-          { id: 3, name: 'Joan', lastName: 'Well' },
-          { id: 4, name: 'Sid', lastName: 'Strong' },
-          { id: 5, name: 'Jane', lastName: 'Neat' }
-        ],
-        colHeaders: true,
-        manualColumnResize: true
+      afterEach(() => {
+        $('html').attr('dir', 'ltr');
       });
 
-      const $headerTH = getTopClone().find('thead tr:eq(0) th:eq(1)');
+      it('should display the resize handle in the proper position and with a proper size', () => {
+        handsontable({
+          layoutDirection,
+          data: [
+            { id: 1, name: 'Ted', lastName: 'Right' },
+            { id: 2, name: 'Frank', lastName: 'Honest' },
+            { id: 3, name: 'Joan', lastName: 'Well' },
+            { id: 4, name: 'Sid', lastName: 'Strong' },
+            { id: 5, name: 'Jane', lastName: 'Neat' }
+          ],
+          colHeaders: true,
+          manualColumnResize: true
+        });
 
-      $headerTH.simulate('mouseover');
+        const $headerTH = getTopClone().find('thead tr:eq(0) th:eq(1)');
 
-      const $handle = $('.manualColumnResizer');
+        $headerTH.simulate('mouseover');
 
-      expect($handle.css('z-index')).toBeGreaterThan(getTopClone().css('z-index'));
+        const $handle = $('.manualColumnResizer');
+
+        expect($handle.offset().left)
+          .toEqual($headerTH.offset().left + 1);
+        expect($handle.height()).toEqual($headerTH.outerHeight());
+      });
+
+      it('should display the resize handle in the proper z-index and be greater than top overlay z-index', () => {
+        handsontable({
+          layoutDirection,
+          data: [
+            { id: 1, name: 'Ted', lastName: 'Right' },
+            { id: 2, name: 'Frank', lastName: 'Honest' },
+            { id: 3, name: 'Joan', lastName: 'Well' },
+            { id: 4, name: 'Sid', lastName: 'Strong' },
+            { id: 5, name: 'Jane', lastName: 'Neat' }
+          ],
+          colHeaders: true,
+          manualColumnResize: true
+        });
+
+        const $headerTH = getTopClone().find('thead tr:eq(0) th:eq(1)');
+
+        $headerTH.simulate('mouseover');
+
+        const $handle = $('.manualColumnResizer');
+
+        expect($handle.css('z-index')).toBeGreaterThan(getTopClone().css('z-index'));
+      });
     });
   });
 });

--- a/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
+++ b/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
@@ -807,108 +807,125 @@ describe('manualRowResize', () => {
   });
 
   describe('handle and guide', () => {
-    it('should display the resize handle in the proper position and with a proper size', () => {
-      handsontable({
-        data: [
-          { id: 1, name: 'Ted', lastName: 'Right' },
-          { id: 2, name: 'Frank', lastName: 'Honest' },
-          { id: 3, name: 'Joan', lastName: 'Well' },
-          { id: 4, name: 'Sid', lastName: 'Strong' },
-          { id: 5, name: 'Jane', lastName: 'Neat' }
-        ],
-        rowHeaders: true,
-        manualRowResize: true
+    using('configuration object', [
+      { htmlDir: 'ltr', layoutDirection: 'inherit' },
+      { htmlDir: 'rtl', layoutDirection: 'ltr' },
+    ], ({ htmlDir, layoutDirection }) => {
+      beforeEach(() => {
+        $('html').attr('dir', htmlDir);
       });
 
-      const $headerTH = getInlineStartClone().find('tbody tr:eq(1) th:eq(0)');
-
-      $headerTH.simulate('mouseover');
-
-      const $handle = $('.manualRowResizer');
-
-      expect($handle.offset().top)
-        .toBeCloseTo($headerTH.offset().top + $headerTH.outerHeight() - $handle.outerHeight() - 1, 0);
-      expect($handle.offset().left).toBeCloseTo($headerTH.offset().left, 0);
-      expect($handle.width()).toBeCloseTo($headerTH.outerWidth(), 0);
-    });
-
-    it('should display the resize handle in the proper z-index and be greater than left overlay z-index', () => {
-      handsontable({
-        data: [
-          { id: 1, name: 'Ted', lastName: 'Right' },
-          { id: 2, name: 'Frank', lastName: 'Honest' },
-          { id: 3, name: 'Joan', lastName: 'Well' },
-          { id: 4, name: 'Sid', lastName: 'Strong' },
-          { id: 5, name: 'Jane', lastName: 'Neat' }
-        ],
-        rowHeaders: true,
-        manualRowResize: true
+      afterEach(() => {
+        $('html').attr('dir', 'ltr');
       });
 
-      const $headerTH = getInlineStartClone().find('tbody tr:eq(1) th:eq(0)');
+      it('should display the resize handle in the proper position and with a proper size', () => {
+        handsontable({
+          layoutDirection,
+          data: [
+            { id: 1, name: 'Ted', lastName: 'Right' },
+            { id: 2, name: 'Frank', lastName: 'Honest' },
+            { id: 3, name: 'Joan', lastName: 'Well' },
+            { id: 4, name: 'Sid', lastName: 'Strong' },
+            { id: 5, name: 'Jane', lastName: 'Neat' }
+          ],
+          rowHeaders: true,
+          manualRowResize: true
+        });
 
-      $headerTH.simulate('mouseover');
+        const $headerTH = getInlineStartClone().find('tbody tr:eq(1) th:eq(0)');
 
-      const $handle = $('.manualRowResizer');
+        $headerTH.simulate('mouseover');
 
-      expect($handle.css('z-index')).toBeGreaterThan(getInlineStartClone().css('z-index'));
-    });
+        const $handle = $('.manualRowResizer');
 
-    it('should call console.warn if the handler is not a part of proper overlay', () => {
-      handsontable({
-        data: Handsontable.helper.createSpreadsheetData(4, 1),
-        height: 280,
-        fixedRowsBottom: 2,
-        manualRowResize: true,
-        rowHeaders: true,
+        expect($handle.offset().top)
+          .toBeCloseTo($headerTH.offset().top + $headerTH.outerHeight() - $handle.outerHeight() - 1, 0);
+        expect($handle.offset().left).toBeCloseTo($headerTH.offset().left, 0);
+        expect($handle.width()).toBeCloseTo($headerTH.outerWidth(), 0);
       });
 
-      spyOn(console, 'warn');
+      it('should display the resize handle in the proper z-index and be greater than left overlay z-index', () => {
+        handsontable({
+          layoutDirection,
+          data: [
+            { id: 1, name: 'Ted', lastName: 'Right' },
+            { id: 2, name: 'Frank', lastName: 'Honest' },
+            { id: 3, name: 'Joan', lastName: 'Well' },
+            { id: 4, name: 'Sid', lastName: 'Strong' },
+            { id: 5, name: 'Jane', lastName: 'Neat' }
+          ],
+          rowHeaders: true,
+          manualRowResize: true
+        });
 
-      const $masterRowHeader = getInlineStartClone().find('tbody tr:eq(3) th:eq(0)');
+        const $headerTH = getInlineStartClone().find('tbody tr:eq(1) th:eq(0)');
 
-      $masterRowHeader.simulate('mouseover');
+        $headerTH.simulate('mouseover');
 
-      const $handler = spec().$container.find('.manualRowResizer');
+        const $handle = $('.manualRowResizer');
 
-      $handler.simulate('mouseover');
-
-      // eslint-disable-next-line no-console
-      expect(console.warn.calls.mostRecent().args)
-        .toEqual(['The provided element is not a child of the bottom_inline_start_corner overlay']);
-    });
-
-    it('should display the resize handle in the correct place after the table has been scrolled', async() => {
-      const hot = handsontable({
-        data: Handsontable.helper.createSpreadsheetData(20, 20),
-        rowHeaders: true,
-        manualRowResize: true,
-        height: 100,
-        width: 200
+        expect($handle.css('z-index')).toBeGreaterThan(getInlineStartClone().css('z-index'));
       });
 
-      const mainHolder = hot.view._wt.wtTable.holder;
-      let $rowHeader = getInlineStartClone().find('tbody tr:eq(2) th:eq(0)');
+      it('should call console.warn if the handler is not a part of proper overlay', () => {
+        handsontable({
+          layoutDirection,
+          data: Handsontable.helper.createSpreadsheetData(4, 1),
+          height: 280,
+          fixedRowsBottom: 2,
+          manualRowResize: true,
+          rowHeaders: true,
+        });
 
-      $rowHeader.simulate('mouseover');
+        spyOn(console, 'warn');
 
-      const $handle = spec().$container.find('.manualRowResizer');
+        const $masterRowHeader = getInlineStartClone().find('tbody tr:eq(3) th:eq(0)');
 
-      $handle[0].style.background = 'red';
+        $masterRowHeader.simulate('mouseover');
 
-      expect($rowHeader.offset().left).toBeCloseTo($handle.offset().left, 0);
-      expect($rowHeader.offset().top + $rowHeader.height() - 5).toBeCloseTo($handle.offset().top, 0);
+        const $handler = spec().$container.find('.manualRowResizer');
 
-      $(mainHolder).scrollTop(200);
-      $(mainHolder).scroll();
+        $handler.simulate('mouseover');
 
-      await sleep(400);
+        // eslint-disable-next-line no-console
+        expect(console.warn.calls.mostRecent().args)
+          .toEqual(['The provided element is not a child of the bottom_inline_start_corner overlay']);
+      });
 
-      $rowHeader = getInlineStartClone().find('tbody tr:eq(10) th:eq(0)');
-      $rowHeader.simulate('mouseover');
+      it('should display the resize handle in the correct place after the table has been scrolled', async() => {
+        const hot = handsontable({
+          layoutDirection,
+          data: Handsontable.helper.createSpreadsheetData(20, 20),
+          rowHeaders: true,
+          manualRowResize: true,
+          height: 100,
+          width: 200
+        });
 
-      expect($rowHeader.offset().left).toBeCloseTo($handle.offset().left, 0);
-      expect($rowHeader.offset().top + $rowHeader.height() - 5).toBeCloseTo($handle.offset().top, 0);
+        const mainHolder = hot.view._wt.wtTable.holder;
+        let $rowHeader = getInlineStartClone().find('tbody tr:eq(2) th:eq(0)');
+
+        $rowHeader.simulate('mouseover');
+
+        const $handle = spec().$container.find('.manualRowResizer');
+
+        $handle[0].style.background = 'red';
+
+        expect($rowHeader.offset().left).toBeCloseTo($handle.offset().left, 0);
+        expect($rowHeader.offset().top + $rowHeader.height() - 5).toBeCloseTo($handle.offset().top, 0);
+
+        $(mainHolder).scrollTop(200);
+        $(mainHolder).scroll();
+
+        await sleep(400);
+
+        $rowHeader = getInlineStartClone().find('tbody tr:eq(10) th:eq(0)');
+        $rowHeader.simulate('mouseover');
+
+        expect($rowHeader.offset().left).toBeCloseTo($handle.offset().left, 0);
+        expect($rowHeader.offset().top + $rowHeader.height() - 5).toBeCloseTo($handle.offset().top, 0);
+      });
     });
   });
 

--- a/handsontable/src/plugins/manualRowResize/__tests__/rtl/manualRowResize.spec.js
+++ b/handsontable/src/plugins/manualRowResize/__tests__/rtl/manualRowResize.spec.js
@@ -126,62 +126,77 @@ describe('manualRowResize (RTL mode)', () => {
   });
 
   describe('handle and guide', () => {
-    it('should display the resize handle in the proper position and with a proper size', () => {
-      handsontable({
-        data: [
-          { id: 1, name: 'Ted', lastName: 'Right' },
-          { id: 2, name: 'Frank', lastName: 'Honest' },
-          { id: 3, name: 'Joan', lastName: 'Well' },
-          { id: 4, name: 'Sid', lastName: 'Strong' },
-          { id: 5, name: 'Jane', lastName: 'Neat' }
-        ],
-        rowHeaders: true,
-        manualRowResize: true
+    using('configuration object', [
+      { htmlDir: 'rtl', layoutDirection: 'inherit' },
+      { htmlDir: 'ltr', layoutDirection: 'rtl' },
+    ], ({ htmlDir, layoutDirection }) => {
+      beforeEach(() => {
+        $('html').attr('dir', htmlDir);
       });
 
-      const $headerTH = getInlineStartClone().find('tbody tr:eq(1) th:eq(0)');
-
-      $headerTH.simulate('mouseover');
-
-      const $handle = $('.manualRowResizer');
-
-      expect($handle.offset().top)
-        .toBeCloseTo($headerTH.offset().top + $headerTH.outerHeight() - $handle.outerHeight() - 1, 0);
-      expect($handle.offset().left).toBeCloseTo($headerTH.offset().left, 0);
-      expect($handle.width()).toBeCloseTo($headerTH.outerWidth(), 0);
-    });
-
-    it('should display the resize handle in the correct place after the table has been scrolled', async() => {
-      const hot = handsontable({
-        data: Handsontable.helper.createSpreadsheetData(20, 20),
-        rowHeaders: true,
-        manualRowResize: true,
-        height: 100,
-        width: 200
+      afterEach(() => {
+        $('html').attr('dir', 'ltr');
       });
 
-      const mainHolder = hot.view._wt.wtTable.holder;
-      let $rowHeader = getInlineStartClone().find('tbody tr:eq(2) th:eq(0)');
+      it('should display the resize handle in the proper position and with a proper size', () => {
+        handsontable({
+          layoutDirection,
+          data: [
+            { id: 1, name: 'Ted', lastName: 'Right' },
+            { id: 2, name: 'Frank', lastName: 'Honest' },
+            { id: 3, name: 'Joan', lastName: 'Well' },
+            { id: 4, name: 'Sid', lastName: 'Strong' },
+            { id: 5, name: 'Jane', lastName: 'Neat' }
+          ],
+          rowHeaders: true,
+          manualRowResize: true
+        });
 
-      $rowHeader.simulate('mouseover');
+        const $headerTH = getInlineStartClone().find('tbody tr:eq(1) th:eq(0)');
 
-      const $handle = spec().$container.find('.manualRowResizer');
+        $headerTH.simulate('mouseover');
 
-      $handle[0].style.background = 'red';
+        const $handle = $('.manualRowResizer');
 
-      expect($rowHeader.offset().left).toBeCloseTo($handle.offset().left, 0);
-      expect($rowHeader.offset().top + $rowHeader.height() - 5).toBeCloseTo($handle.offset().top, 0);
+        expect($handle.offset().top)
+          .toBeCloseTo($headerTH.offset().top + $headerTH.outerHeight() - $handle.outerHeight() - 1, 0);
+        expect($handle.offset().left).toBeCloseTo($headerTH.offset().left, 0);
+        expect($handle.width()).toBeCloseTo($headerTH.outerWidth(), 0);
+      });
 
-      $(mainHolder).scrollTop(200);
-      $(mainHolder).scroll();
+      it('should display the resize handle in the correct place after the table has been scrolled', async() => {
+        const hot = handsontable({
+          layoutDirection,
+          data: Handsontable.helper.createSpreadsheetData(20, 20),
+          rowHeaders: true,
+          manualRowResize: true,
+          height: 100,
+          width: 200
+        });
 
-      await sleep(400);
+        const mainHolder = hot.view._wt.wtTable.holder;
+        let $rowHeader = getInlineStartClone().find('tbody tr:eq(2) th:eq(0)');
 
-      $rowHeader = getInlineStartClone().find('tbody tr:eq(10) th:eq(0)');
-      $rowHeader.simulate('mouseover');
+        $rowHeader.simulate('mouseover');
 
-      expect($rowHeader.offset().left).toBeCloseTo($handle.offset().left, 0);
-      expect($rowHeader.offset().top + $rowHeader.height() - 5).toBeCloseTo($handle.offset().top, 0);
+        const $handle = spec().$container.find('.manualRowResizer');
+
+        $handle[0].style.background = 'red';
+
+        expect($rowHeader.offset().left).toBeCloseTo($handle.offset().left, 0);
+        expect($rowHeader.offset().top + $rowHeader.height() - 5).toBeCloseTo($handle.offset().top, 0);
+
+        $(mainHolder).scrollTop(200);
+        $(mainHolder).scroll();
+
+        await sleep(400);
+
+        $rowHeader = getInlineStartClone().find('tbody tr:eq(10) th:eq(0)');
+        $rowHeader.simulate('mouseover');
+
+        expect($rowHeader.offset().left).toBeCloseTo($handle.offset().left, 0);
+        expect($rowHeader.offset().top + $rowHeader.height() - 5).toBeCloseTo($handle.offset().top, 0);
+      });
     });
   });
 });

--- a/handsontable/src/plugins/multiColumnSorting/__tests__/multiColumnSorting.spec.js
+++ b/handsontable/src/plugins/multiColumnSorting/__tests__/multiColumnSorting.spec.js
@@ -2745,145 +2745,161 @@ describe('MultiColumnSorting', () => {
   });
 
   describe('Numbers presenting sorting sequence', () => {
-    it('should be properly position the number when multi columns are sorted', () => {
-      spec().$container[0].style.width = 'auto';
-      spec().$container[0].style.height = 'auto';
-
-      handsontable({
-        data: createSpreadsheetData(10, 10),
-        colHeaders: true,
-        multiColumnSorting: {
-          indicator: true,
-          initialConfig: [{
-            column: 1,
-            sortOrder: 'asc'
-          }, {
-            column: 0,
-            sortOrder: 'asc'
-          }, {
-            column: 2,
-            sortOrder: 'asc'
-          }, {
-            column: 3,
-            sortOrder: 'asc'
-          }, {
-            column: 4,
-            sortOrder: 'asc'
-          }, {
-            column: 5,
-            sortOrder: 'asc'
-          }, {
-            column: 6,
-            sortOrder: 'asc'
-          }, {
-            column: 7,
-            sortOrder: 'asc'
-          }, {
-            column: 8,
-            sortOrder: 'asc'
-          }, {
-            column: 9,
-            sortOrder: 'asc'
-          }]
-        }
+    using('configuration object', [
+      { htmlDir: 'ltr', layoutDirection: 'inherit' },
+      { htmlDir: 'rtl', layoutDirection: 'ltr' },
+    ], ({ htmlDir, layoutDirection }) => {
+      beforeEach(() => {
+        $('html').attr('dir', htmlDir);
       });
 
-      expect(window.getComputedStyle(spec().$container.find('th span.columnSorting')[0], ':after')
-        .getPropertyValue('right')).toEqual('-15px');
-      expect(window.getComputedStyle(spec().$container.find('th span.columnSorting')[0], ':after')
-        .getPropertyValue('padding-left')).toEqual('5px');
-    });
-
-    it('should be properly presented on the UI when more than 7 columns are sorted', () => {
-      spec().$container[0].style.width = 'auto';
-      spec().$container[0].style.height = 'auto';
-
-      handsontable({
-        data: createSpreadsheetData(10, 10),
-        colHeaders: true,
-        multiColumnSorting: {
-          indicator: true,
-          initialConfig: [{
-            column: 1,
-            sortOrder: 'asc'
-          }, {
-            column: 0,
-            sortOrder: 'asc'
-          }, {
-            column: 2,
-            sortOrder: 'asc'
-          }, {
-            column: 3,
-            sortOrder: 'asc'
-          }, {
-            column: 4,
-            sortOrder: 'asc'
-          }, {
-            column: 5,
-            sortOrder: 'asc'
-          }, {
-            column: 6,
-            sortOrder: 'asc'
-          }, {
-            column: 7,
-            sortOrder: 'asc'
-          }, {
-            column: 8,
-            sortOrder: 'asc'
-          }, {
-            column: 9,
-            sortOrder: 'asc'
-          }]
-        }
+      afterEach(() => {
+        $('html').attr('dir', 'ltr');
       });
 
-      expect(window.getComputedStyle(spec().$container.find('th span.columnSorting')[0], ':after')
-        .getPropertyValue('content')).toEqual('"2"');
-      expect(window.getComputedStyle(spec().$container.find('th span.columnSorting')[1], ':after')
-        .getPropertyValue('content')).toEqual('"1"');
-      expect(window.getComputedStyle(spec().$container.find('th span.columnSorting')[2], ':after')
-        .getPropertyValue('content')).toEqual('"3"');
-      expect(window.getComputedStyle(spec().$container.find('th span.columnSorting')[3], ':after')
-        .getPropertyValue('content')).toEqual('"4"');
-      expect(window.getComputedStyle(spec().$container.find('th span.columnSorting')[4], ':after')
-        .getPropertyValue('content')).toEqual('"5"');
-      expect(window.getComputedStyle(spec().$container.find('th span.columnSorting')[5], ':after')
-        .getPropertyValue('content')).toEqual('"6"');
-      expect(window.getComputedStyle(spec().$container.find('th span.columnSorting')[6], ':after')
-        .getPropertyValue('content')).toEqual('"7"');
-      expect(window.getComputedStyle(spec().$container.find('th span.columnSorting')[7], ':after')
-        .getPropertyValue('content')).toEqual('"+"');
-      expect(window.getComputedStyle(spec().$container.find('th span.columnSorting')[8], ':after')
-        .getPropertyValue('content')).toEqual('"+"');
-    });
+      it('should be properly position the number when multi columns are sorted', () => {
+        spec().$container[0].style.width = 'auto';
+        spec().$container[0].style.height = 'auto';
 
-    it('should be properly hided when just one column is sorted', async() => {
-      handsontable({
-        data: createSpreadsheetData(10, 10),
-        colHeaders: true,
-        multiColumnSorting: {
-          indicator: true,
-          initialConfig: [{
-            column: 1,
-            sortOrder: 'asc'
-          }, {
-            column: 0,
-            sortOrder: 'asc'
-          }]
-        }
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(10, 10),
+          colHeaders: true,
+          multiColumnSorting: {
+            indicator: true,
+            initialConfig: [{
+              column: 1,
+              sortOrder: 'asc'
+            }, {
+              column: 0,
+              sortOrder: 'asc'
+            }, {
+              column: 2,
+              sortOrder: 'asc'
+            }, {
+              column: 3,
+              sortOrder: 'asc'
+            }, {
+              column: 4,
+              sortOrder: 'asc'
+            }, {
+              column: 5,
+              sortOrder: 'asc'
+            }, {
+              column: 6,
+              sortOrder: 'asc'
+            }, {
+              column: 7,
+              sortOrder: 'asc'
+            }, {
+              column: 8,
+              sortOrder: 'asc'
+            }, {
+              column: 9,
+              sortOrder: 'asc'
+            }]
+          }
+        });
+
+        expect(window.getComputedStyle(spec().$container.find('th span.columnSorting')[0], ':after')
+          .getPropertyValue('right')).toEqual('-15px');
+        expect(window.getComputedStyle(spec().$container.find('th span.columnSorting')[0], ':after')
+          .getPropertyValue('padding-left')).toEqual('5px');
       });
 
-      expect(window.getComputedStyle(spec().$container.find('th span.columnSorting')[0], ':after')
-        .getPropertyValue('content')).toEqual('"2"');
-      expect(window.getComputedStyle(spec().$container.find('th span.columnSorting')[1], ':after')
-        .getPropertyValue('content')).toEqual('"1"');
+      it('should be properly presented on the UI when more than 7 columns are sorted', () => {
+        spec().$container[0].style.width = 'auto';
+        spec().$container[0].style.height = 'auto';
 
-      getPlugin('multiColumnSorting').sort({ column: 0, sortOrder: 'asc' });
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(10, 10),
+          colHeaders: true,
+          multiColumnSorting: {
+            indicator: true,
+            initialConfig: [{
+              column: 1,
+              sortOrder: 'asc'
+            }, {
+              column: 0,
+              sortOrder: 'asc'
+            }, {
+              column: 2,
+              sortOrder: 'asc'
+            }, {
+              column: 3,
+              sortOrder: 'asc'
+            }, {
+              column: 4,
+              sortOrder: 'asc'
+            }, {
+              column: 5,
+              sortOrder: 'asc'
+            }, {
+              column: 6,
+              sortOrder: 'asc'
+            }, {
+              column: 7,
+              sortOrder: 'asc'
+            }, {
+              column: 8,
+              sortOrder: 'asc'
+            }, {
+              column: 9,
+              sortOrder: 'asc'
+            }]
+          }
+        });
 
-      expect(window.getComputedStyle(spec().$container.find('th span.columnSorting')[0], ':after')
-        .getPropertyValue('content')).toMatch(/^(none|)$/);
-      expect(window.getComputedStyle(spec().$container.find('th span.columnSorting')[1], ':after')
-        .getPropertyValue('content')).toMatch(/^(none|)$/);
+        expect(window.getComputedStyle(spec().$container.find('th span.columnSorting')[0], ':after')
+          .getPropertyValue('content')).toEqual('"2"');
+        expect(window.getComputedStyle(spec().$container.find('th span.columnSorting')[1], ':after')
+          .getPropertyValue('content')).toEqual('"1"');
+        expect(window.getComputedStyle(spec().$container.find('th span.columnSorting')[2], ':after')
+          .getPropertyValue('content')).toEqual('"3"');
+        expect(window.getComputedStyle(spec().$container.find('th span.columnSorting')[3], ':after')
+          .getPropertyValue('content')).toEqual('"4"');
+        expect(window.getComputedStyle(spec().$container.find('th span.columnSorting')[4], ':after')
+          .getPropertyValue('content')).toEqual('"5"');
+        expect(window.getComputedStyle(spec().$container.find('th span.columnSorting')[5], ':after')
+          .getPropertyValue('content')).toEqual('"6"');
+        expect(window.getComputedStyle(spec().$container.find('th span.columnSorting')[6], ':after')
+          .getPropertyValue('content')).toEqual('"7"');
+        expect(window.getComputedStyle(spec().$container.find('th span.columnSorting')[7], ':after')
+          .getPropertyValue('content')).toEqual('"+"');
+        expect(window.getComputedStyle(spec().$container.find('th span.columnSorting')[8], ':after')
+          .getPropertyValue('content')).toEqual('"+"');
+      });
+
+      it('should be properly hided when just one column is sorted', async() => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(10, 10),
+          colHeaders: true,
+          multiColumnSorting: {
+            indicator: true,
+            initialConfig: [{
+              column: 1,
+              sortOrder: 'asc'
+            }, {
+              column: 0,
+              sortOrder: 'asc'
+            }]
+          }
+        });
+
+        expect(window.getComputedStyle(spec().$container.find('th span.columnSorting')[0], ':after')
+          .getPropertyValue('content')).toEqual('"2"');
+        expect(window.getComputedStyle(spec().$container.find('th span.columnSorting')[1], ':after')
+          .getPropertyValue('content')).toEqual('"1"');
+
+        getPlugin('multiColumnSorting').sort({ column: 0, sortOrder: 'asc' });
+
+        expect(window.getComputedStyle(spec().$container.find('th span.columnSorting')[0], ':after')
+          .getPropertyValue('content')).toMatch(/^(none|)$/);
+        expect(window.getComputedStyle(spec().$container.find('th span.columnSorting')[1], ':after')
+          .getPropertyValue('content')).toMatch(/^(none|)$/);
+      });
     });
   });
 

--- a/handsontable/src/plugins/multiColumnSorting/__tests__/rtl/multiColumnSorting.spec.js
+++ b/handsontable/src/plugins/multiColumnSorting/__tests__/rtl/multiColumnSorting.spec.js
@@ -1,68 +1,75 @@
 describe('MultiColumnSorting (RTL)', () => {
-  const id = 'testContainer';
+  using('configuration object', [
+    { htmlDir: 'rtl', layoutDirection: 'inherit' },
+    { htmlDir: 'ltr', layoutDirection: 'rtl' },
+  ], ({ htmlDir, layoutDirection }) => {
+    const id = 'testContainer';
 
-  beforeEach(function() {
-    $('html').attr('dir', 'rtl');
-    this.$container = $(`<div id="${id}" style="overflow: auto; width: 300px; height: 200px;"></div>`).appendTo('body');
-  });
+    beforeEach(function() {
+      $('html').attr('dir', htmlDir);
+      this.$container = $(`<div id="${id}" style="overflow: auto; width: 300px; height: 200px;"></div>`)
+        .appendTo('body');
+    });
 
-  afterEach(function() {
-    $('html').attr('dir', 'ltr');
+    afterEach(function() {
+      $('html').attr('dir', 'ltr');
 
-    if (this.$container) {
-      destroy();
-      this.$container.remove();
-    }
-  });
+      if (this.$container) {
+        destroy();
+        this.$container.remove();
+      }
+    });
 
-  describe('Numbers presenting sorting sequence', () => {
-    it('should be properly position the number when multi columns are sorted', () => {
-      spec().$container[0].style.width = 'auto';
-      spec().$container[0].style.height = 'auto';
+    describe('Numbers presenting sorting sequence', () => {
+      it('should be properly position the number when multi columns are sorted', () => {
+        spec().$container[0].style.width = 'auto';
+        spec().$container[0].style.height = 'auto';
 
-      handsontable({
-        data: createSpreadsheetData(10, 10),
-        colHeaders: true,
-        multiColumnSorting: {
-          indicator: true,
-          initialConfig: [{
-            column: 1,
-            sortOrder: 'asc'
-          }, {
-            column: 0,
-            sortOrder: 'asc'
-          }, {
-            column: 2,
-            sortOrder: 'asc'
-          }, {
-            column: 3,
-            sortOrder: 'asc'
-          }, {
-            column: 4,
-            sortOrder: 'asc'
-          }, {
-            column: 5,
-            sortOrder: 'asc'
-          }, {
-            column: 6,
-            sortOrder: 'asc'
-          }, {
-            column: 7,
-            sortOrder: 'asc'
-          }, {
-            column: 8,
-            sortOrder: 'asc'
-          }, {
-            column: 9,
-            sortOrder: 'asc'
-          }]
-        }
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(10, 10),
+          colHeaders: true,
+          multiColumnSorting: {
+            indicator: true,
+            initialConfig: [{
+              column: 1,
+              sortOrder: 'asc'
+            }, {
+              column: 0,
+              sortOrder: 'asc'
+            }, {
+              column: 2,
+              sortOrder: 'asc'
+            }, {
+              column: 3,
+              sortOrder: 'asc'
+            }, {
+              column: 4,
+              sortOrder: 'asc'
+            }, {
+              column: 5,
+              sortOrder: 'asc'
+            }, {
+              column: 6,
+              sortOrder: 'asc'
+            }, {
+              column: 7,
+              sortOrder: 'asc'
+            }, {
+              column: 8,
+              sortOrder: 'asc'
+            }, {
+              column: 9,
+              sortOrder: 'asc'
+            }]
+          }
+        });
+
+        expect(window.getComputedStyle(spec().$container.find('th span.columnSorting')[0], ':after')
+          .getPropertyValue('left')).toEqual('-15px');
+        expect(window.getComputedStyle(spec().$container.find('th span.columnSorting')[0], ':after')
+          .getPropertyValue('padding-right')).toEqual('5px');
       });
-
-      expect(window.getComputedStyle(spec().$container.find('th span.columnSorting')[0], ':after')
-        .getPropertyValue('left')).toEqual('-15px');
-      expect(window.getComputedStyle(spec().$container.find('th span.columnSorting')[0], ':after')
-        .getPropertyValue('padding-right')).toEqual('5px');
     });
   });
 });

--- a/handsontable/src/plugins/multipleSelectionHandles/__tests__/mobile/positioning.spec.js
+++ b/handsontable/src/plugins/multipleSelectionHandles/__tests__/mobile/positioning.spec.js
@@ -1,133 +1,144 @@
 describe('MultipleSelectionHandles', () => {
-  const id = 'testContainer';
+  using('configuration object', [
+    { htmlDir: 'ltr', layoutDirection: 'inherit' },
+    { htmlDir: 'rtl', layoutDirection: 'ltr' },
+  ], ({ htmlDir, layoutDirection }) => {
+    const id = 'testContainer';
 
-  beforeEach(function() {
-    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
-  });
-
-  afterEach(function() {
-    if (this.$container) {
-      destroy();
-      this.$container.remove();
-    }
-  });
-
-  it('should show selection handles in correct positions', () => {
-    handsontable({
-      width: 400,
-      height: 400
+    beforeEach(function() {
+      $('html').attr('dir', htmlDir);
+      this.$container = $(`<div id="${id}"></div>`).appendTo('body');
     });
 
-    selectCell(1, 1);
+    afterEach(function() {
+      $('html').attr('dir', 'ltr');
 
-    const topSelectionHandle = spec().$container
-      .find('.ht_master .htBorders div:first-child .topSelectionHandle');
-    const topSelectionHandleSize = topSelectionHandle.outerWidth();
-    const bottomSelectionHandle = spec().$container
-      .find('.ht_master .htBorders div:first-child .bottomSelectionHandle');
-    const cell = $(getCell(1, 1));
-    const cellOffset = cell.offset();
-    const cellWidth = cell.outerWidth();
-    const cellHeight = cell.outerHeight();
-
-    expect(topSelectionHandle.is(':visible')).toBe(true);
-    expect(bottomSelectionHandle.is(':visible')).toBe(true);
-    expect(topSelectionHandle.offset()).toEqual({
-      top: cellOffset.top - topSelectionHandleSize,
-      left: cellOffset.left - topSelectionHandleSize,
-    });
-    // -1 as the bottom handler is positioned starting from the most bottom-right pixel
-    expect(bottomSelectionHandle.offset()).toEqual({
-      top: cellOffset.top + cellHeight - 1,
-      left: cellOffset.left + cellWidth - 1,
-    });
-  });
-
-  it('should show both selection handles in correct position after horizontal drag & drop', async() => {
-    handsontable({
-      width: 400,
-      height: 400
+      if (this.$container) {
+        destroy();
+        this.$container.remove();
+      }
     });
 
-    selectCell(1, 1);
+    it('should show selection handles in correct positions', () => {
+      handsontable({
+        layoutDirection,
+        width: 400,
+        height: 400
+      });
 
-    await sleep(100);
+      selectCell(1, 1);
 
-    const cellFrom = $(getCell(1, 1));
-    const cellTo = spec().$container.find('tbody tr:eq(1) td:eq(3)');
-    const cellToOffset = cellTo.offset();
-    const cellToWidth = cellFrom.outerWidth();
-    const cellToHeight = cellFrom.outerHeight();
+      const topSelectionHandle = spec().$container
+        .find('.ht_master .htBorders div:first-child .topSelectionHandle');
+      const topSelectionHandleSize = topSelectionHandle.outerWidth();
+      const bottomSelectionHandle = spec().$container
+        .find('.ht_master .htBorders div:first-child .bottomSelectionHandle');
+      const cell = $(getCell(1, 1));
+      const cellOffset = cell.offset();
+      const cellWidth = cell.outerWidth();
+      const cellHeight = cell.outerHeight();
 
-    triggerTouchEvent('touchstart', spec().$container.find('.htBorders .bottomSelectionHandle-HitArea')[0]);
-    triggerTouchEvent('touchmove', spec().$container.find('tbody tr:eq(1) td:eq(2)')[0]);
-    triggerTouchEvent('touchmove', cellTo[0]);
-    triggerTouchEvent('touchend', cellTo[0]);
-
-    await sleep(100);
-
-    const topSelectionHandle = spec().$container
-      .find('.ht_master .htBorders div:last-child .topSelectionHandle');
-    const topSelectionHandleSize = topSelectionHandle.outerWidth();
-    const bottomSelectionHandle = spec().$container
-      .find('.ht_master .htBorders div:last-child .bottomSelectionHandle');
-    const cellFromOffset = cellFrom.offset();
-
-    expect(topSelectionHandle.is(':visible')).toBe(true);
-    expect(bottomSelectionHandle.is(':visible')).toBe(true);
-    expect(topSelectionHandle.offset()).toEqual({
-      top: cellFromOffset.top - topSelectionHandleSize,
-      left: cellFromOffset.left - topSelectionHandleSize,
-    });
-    // -1 as the bottom handler is positioned starting from the most bottom-right pixel
-    expect(bottomSelectionHandle.offset()).toEqual({
-      top: cellToOffset.top + cellToHeight - 1,
-      left: cellToOffset.left + cellToWidth - 1,
-    });
-    expect(getSelected()).toEqual([[1, 1, 1, 3]]);
-  });
-
-  it('should show both selection handles in correct position after vertical drag & drop', async() => {
-    handsontable({
-      width: 400,
-      height: 400
+      expect(topSelectionHandle.is(':visible')).toBe(true);
+      expect(bottomSelectionHandle.is(':visible')).toBe(true);
+      expect(topSelectionHandle.offset()).toEqual({
+        top: cellOffset.top - topSelectionHandleSize,
+        left: cellOffset.left - topSelectionHandleSize,
+      });
+      // -1 as the bottom handler is positioned starting from the most bottom-right pixel
+      expect(bottomSelectionHandle.offset()).toEqual({
+        top: cellOffset.top + cellHeight - 1,
+        left: cellOffset.left + cellWidth - 1,
+      });
     });
 
-    selectCell(1, 1);
+    it('should show both selection handles in correct position after horizontal drag & drop', async() => {
+      handsontable({
+        layoutDirection,
+        width: 400,
+        height: 400
+      });
 
-    await sleep(100);
+      selectCell(1, 1);
 
-    const cellFrom = $(getCell(1, 1));
-    const cellTo = spec().$container.find('tbody tr:eq(3) td:eq(1)');
-    const cellToOffset = cellTo.offset();
-    const cellToWidth = cellFrom.outerWidth();
-    const cellToHeight = cellFrom.outerHeight();
+      await sleep(100);
 
-    triggerTouchEvent('touchstart', spec().$container.find('.htBorders .bottomSelectionHandle-HitArea')[0]);
-    triggerTouchEvent('touchmove', spec().$container.find('tbody tr:eq(2) td:eq(1)')[0]);
-    triggerTouchEvent('touchmove', cellTo[0]);
-    triggerTouchEvent('touchend', cellTo[0]);
+      const cellFrom = $(getCell(1, 1));
+      const cellTo = spec().$container.find('tbody tr:eq(1) td:eq(3)');
+      const cellToOffset = cellTo.offset();
+      const cellToWidth = cellFrom.outerWidth();
+      const cellToHeight = cellFrom.outerHeight();
 
-    await sleep(100);
+      triggerTouchEvent('touchstart', spec().$container.find('.htBorders .bottomSelectionHandle-HitArea')[0]);
+      triggerTouchEvent('touchmove', spec().$container.find('tbody tr:eq(1) td:eq(2)')[0]);
+      triggerTouchEvent('touchmove', cellTo[0]);
+      triggerTouchEvent('touchend', cellTo[0]);
 
-    const topSelectionHandle = spec().$container
-      .find('.ht_master .htBorders div:last-child .topSelectionHandle');
-    const topSelectionHandleSize = topSelectionHandle.outerWidth();
-    const bottomSelectionHandle = spec().$container
-      .find('.ht_master .htBorders div:last-child .bottomSelectionHandle');
-    const cellFromOffset = cellFrom.offset();
+      await sleep(100);
 
-    expect(topSelectionHandle.is(':visible')).toBe(true);
-    expect(bottomSelectionHandle.is(':visible')).toBe(true);
-    expect(topSelectionHandle.offset()).toEqual({
-      top: cellFromOffset.top - topSelectionHandleSize,
-      left: cellFromOffset.left - topSelectionHandleSize,
+      const topSelectionHandle = spec().$container
+        .find('.ht_master .htBorders div:last-child .topSelectionHandle');
+      const topSelectionHandleSize = topSelectionHandle.outerWidth();
+      const bottomSelectionHandle = spec().$container
+        .find('.ht_master .htBorders div:last-child .bottomSelectionHandle');
+      const cellFromOffset = cellFrom.offset();
+
+      expect(topSelectionHandle.is(':visible')).toBe(true);
+      expect(bottomSelectionHandle.is(':visible')).toBe(true);
+      expect(topSelectionHandle.offset()).toEqual({
+        top: cellFromOffset.top - topSelectionHandleSize,
+        left: cellFromOffset.left - topSelectionHandleSize,
+      });
+      // -1 as the bottom handler is positioned starting from the most bottom-right pixel
+      expect(bottomSelectionHandle.offset()).toEqual({
+        top: cellToOffset.top + cellToHeight - 1,
+        left: cellToOffset.left + cellToWidth - 1,
+      });
+      expect(getSelected()).toEqual([[1, 1, 1, 3]]);
     });
-    // -1 as the bottom handler is positioned starting from the most bottom-right pixel
-    expect(bottomSelectionHandle.offset()).toEqual({
-      top: cellToOffset.top + cellToHeight - 1,
-      left: cellToOffset.left + cellToWidth - 1,
+
+    it('should show both selection handles in correct position after vertical drag & drop', async() => {
+      handsontable({
+        layoutDirection,
+        width: 400,
+        height: 400
+      });
+
+      selectCell(1, 1);
+
+      await sleep(100);
+
+      const cellFrom = $(getCell(1, 1));
+      const cellTo = spec().$container.find('tbody tr:eq(3) td:eq(1)');
+      const cellToOffset = cellTo.offset();
+      const cellToWidth = cellFrom.outerWidth();
+      const cellToHeight = cellFrom.outerHeight();
+
+      triggerTouchEvent('touchstart', spec().$container.find('.htBorders .bottomSelectionHandle-HitArea')[0]);
+      triggerTouchEvent('touchmove', spec().$container.find('tbody tr:eq(2) td:eq(1)')[0]);
+      triggerTouchEvent('touchmove', cellTo[0]);
+      triggerTouchEvent('touchend', cellTo[0]);
+
+      await sleep(100);
+
+      const topSelectionHandle = spec().$container
+        .find('.ht_master .htBorders div:last-child .topSelectionHandle');
+      const topSelectionHandleSize = topSelectionHandle.outerWidth();
+      const bottomSelectionHandle = spec().$container
+        .find('.ht_master .htBorders div:last-child .bottomSelectionHandle');
+      const cellFromOffset = cellFrom.offset();
+
+      expect(topSelectionHandle.is(':visible')).toBe(true);
+      expect(bottomSelectionHandle.is(':visible')).toBe(true);
+      expect(topSelectionHandle.offset()).toEqual({
+        top: cellFromOffset.top - topSelectionHandleSize,
+        left: cellFromOffset.left - topSelectionHandleSize,
+      });
+      // -1 as the bottom handler is positioned starting from the most bottom-right pixel
+      expect(bottomSelectionHandle.offset()).toEqual({
+        top: cellToOffset.top + cellToHeight - 1,
+        left: cellToOffset.left + cellToWidth - 1,
+      });
+      expect(getSelected()).toEqual([[1, 1, 3, 1]]);
     });
-    expect(getSelected()).toEqual([[1, 1, 3, 1]]);
   });
 });

--- a/handsontable/src/plugins/multipleSelectionHandles/__tests__/mobile/rtl/positioning.spec.js
+++ b/handsontable/src/plugins/multipleSelectionHandles/__tests__/mobile/rtl/positioning.spec.js
@@ -1,139 +1,147 @@
 describe('MultipleSelectionHandles (RTL mode)', () => {
-  const id = 'testContainer';
+  using('configuration object', [
+    { htmlDir: 'rtl', layoutDirection: 'inherit' },
+    { htmlDir: 'ltr', layoutDirection: 'rtl' },
+  ], ({ htmlDir, layoutDirection }) => {
+    const id = 'testContainer';
 
-  beforeEach(function() {
-    $('html').attr('dir', 'rtl');
-    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
-  });
-
-  afterEach(function() {
-    $('html').attr('dir', 'ltr');
-
-    if (this.$container) {
-      destroy();
-      this.$container.remove();
-    }
-  });
-
-  it('should show selection handles in correct positions', () => {
-    handsontable({
-      width: 400,
-      height: 400
+    beforeEach(function() {
+      $('html').attr('dir', htmlDir);
+      this.$container = $(`<div id="${id}"></div>`).appendTo('body');
     });
 
-    selectCell(1, 1);
+    afterEach(function() {
+      $('html').attr('dir', 'ltr');
 
-    const topSelectionHandle = spec().$container
-      .find('.ht_master .htBorders div:first-child .topSelectionHandle');
-    const topSelectionHandleSize = topSelectionHandle.outerWidth();
-    const bottomSelectionHandle = spec().$container
-      .find('.ht_master .htBorders div:first-child .bottomSelectionHandle');
-    const bottomSelectionHandleSize = bottomSelectionHandle.outerWidth();
-    const cell = $(getCell(1, 1));
-    const cellOffset = cell.offset();
-    const cellWidth = cell.outerWidth();
-    const cellHeight = cell.outerHeight();
-
-    expect(topSelectionHandle.is(':visible')).toBe(true);
-    expect(bottomSelectionHandle.is(':visible')).toBe(true);
-    expect(topSelectionHandle.offset()).toEqual({
-      top: cellOffset.top - topSelectionHandleSize,
-      left: cellOffset.left + cellWidth,
-    });
-    // -/+1 as the bottom handler is positioned ending in the most bottom-left pixel
-    expect(bottomSelectionHandle.offset()).toEqual({
-      top: cellOffset.top + cellHeight - 1,
-      left: cellOffset.left - bottomSelectionHandleSize + 1,
-    });
-  });
-
-  it('should show both selection handles in correct position after horizontal drag & drop', async() => {
-    handsontable({
-      width: 400,
-      height: 400
+      if (this.$container) {
+        destroy();
+        this.$container.remove();
+      }
     });
 
-    selectCell(1, 1);
+    it('should show selection handles in correct positions', () => {
+      handsontable({
+        layoutDirection,
+        width: 400,
+        height: 400
+      });
 
-    await sleep(100);
+      selectCell(1, 1);
 
-    const cellFrom = $(getCell(1, 1));
-    const cellTo = spec().$container.find('tbody tr:eq(1) td:eq(3)');
-    const cellToOffset = cellTo.offset();
-    const cellToHeight = cellFrom.outerHeight();
+      const topSelectionHandle = spec().$container
+        .find('.ht_master .htBorders div:first-child .topSelectionHandle');
+      const topSelectionHandleSize = topSelectionHandle.outerWidth();
+      const bottomSelectionHandle = spec().$container
+        .find('.ht_master .htBorders div:first-child .bottomSelectionHandle');
+      const bottomSelectionHandleSize = bottomSelectionHandle.outerWidth();
+      const cell = $(getCell(1, 1));
+      const cellOffset = cell.offset();
+      const cellWidth = cell.outerWidth();
+      const cellHeight = cell.outerHeight();
 
-    triggerTouchEvent('touchstart', spec().$container.find('.htBorders .bottomSelectionHandle-HitArea')[0]);
-    triggerTouchEvent('touchmove', spec().$container.find('tbody tr:eq(1) td:eq(2)')[0]);
-    triggerTouchEvent('touchmove', cellTo[0]);
-    triggerTouchEvent('touchend', cellTo[0]);
-
-    await sleep(100);
-
-    const topSelectionHandle = spec().$container
-      .find('.ht_master .htBorders div:last-child .topSelectionHandle');
-    const topSelectionHandleSize = topSelectionHandle.outerWidth();
-    const bottomSelectionHandle = spec().$container
-      .find('.ht_master .htBorders div:last-child .bottomSelectionHandle');
-    const bottomSelectionHandleSize = bottomSelectionHandle.outerWidth();
-    const cellFromOffset = cellFrom.offset();
-    const cellFromWidth = cellFrom.outerWidth();
-
-    expect(topSelectionHandle.is(':visible')).toBe(true);
-    expect(bottomSelectionHandle.is(':visible')).toBe(true);
-    expect(topSelectionHandle.offset()).toEqual({
-      top: cellFromOffset.top - topSelectionHandleSize,
-      left: cellFromOffset.left + cellFromWidth,
-    });
-    // -/+1 as the bottom handler is positioned ending in the most bottom-left pixel
-    expect(bottomSelectionHandle.offset()).toEqual({
-      top: cellToOffset.top + cellToHeight - 1,
-      left: cellToOffset.left - bottomSelectionHandleSize + 1,
-    });
-    expect(getSelected()).toEqual([[1, 1, 1, 3]]);
-  });
-
-  it('should show both selection handles in correct position after vertical drag & drop', async() => {
-    handsontable({
-      width: 400,
-      height: 400
+      expect(topSelectionHandle.is(':visible')).toBe(true);
+      expect(bottomSelectionHandle.is(':visible')).toBe(true);
+      expect(topSelectionHandle.offset()).toEqual({
+        top: cellOffset.top - topSelectionHandleSize,
+        left: cellOffset.left + cellWidth,
+      });
+      // -/+1 as the bottom handler is positioned ending in the most bottom-left pixel
+      expect(bottomSelectionHandle.offset()).toEqual({
+        top: cellOffset.top + cellHeight - 1,
+        left: cellOffset.left - bottomSelectionHandleSize + 1,
+      });
     });
 
-    selectCell(1, 1);
+    it('should show both selection handles in correct position after horizontal drag & drop', async() => {
+      handsontable({
+        layoutDirection,
+        width: 400,
+        height: 400
+      });
 
-    await sleep(100);
+      selectCell(1, 1);
 
-    const cellFrom = $(getCell(1, 1));
-    const cellTo = spec().$container.find('tbody tr:eq(3) td:eq(1)');
-    const cellToOffset = cellTo.offset();
-    const cellToHeight = cellFrom.outerHeight();
+      await sleep(100);
 
-    triggerTouchEvent('touchstart', spec().$container.find('.htBorders .bottomSelectionHandle-HitArea')[0]);
-    triggerTouchEvent('touchmove', spec().$container.find('tbody tr:eq(2) td:eq(1)')[0]);
-    triggerTouchEvent('touchmove', cellTo[0]);
-    triggerTouchEvent('touchend', cellTo[0]);
+      const cellFrom = $(getCell(1, 1));
+      const cellTo = spec().$container.find('tbody tr:eq(1) td:eq(3)');
+      const cellToOffset = cellTo.offset();
+      const cellToHeight = cellFrom.outerHeight();
 
-    await sleep(100);
+      triggerTouchEvent('touchstart', spec().$container.find('.htBorders .bottomSelectionHandle-HitArea')[0]);
+      triggerTouchEvent('touchmove', spec().$container.find('tbody tr:eq(1) td:eq(2)')[0]);
+      triggerTouchEvent('touchmove', cellTo[0]);
+      triggerTouchEvent('touchend', cellTo[0]);
 
-    const topSelectionHandle = spec().$container
-      .find('.ht_master .htBorders div:last-child .topSelectionHandle');
-    const topSelectionHandleSize = topSelectionHandle.outerWidth();
-    const bottomSelectionHandle = spec().$container
-      .find('.ht_master .htBorders div:last-child .bottomSelectionHandle');
-    const bottomSelectionHandleSize = bottomSelectionHandle.outerWidth();
-    const cellFromOffset = cellFrom.offset();
-    const cellFromWidth = cellFrom.outerWidth();
+      await sleep(100);
 
-    expect(topSelectionHandle.is(':visible')).toBe(true);
-    expect(bottomSelectionHandle.is(':visible')).toBe(true);
-    expect(topSelectionHandle.offset()).toEqual({
-      top: cellFromOffset.top - topSelectionHandleSize,
-      left: cellFromOffset.left + cellFromWidth,
+      const topSelectionHandle = spec().$container
+        .find('.ht_master .htBorders div:last-child .topSelectionHandle');
+      const topSelectionHandleSize = topSelectionHandle.outerWidth();
+      const bottomSelectionHandle = spec().$container
+        .find('.ht_master .htBorders div:last-child .bottomSelectionHandle');
+      const bottomSelectionHandleSize = bottomSelectionHandle.outerWidth();
+      const cellFromOffset = cellFrom.offset();
+      const cellFromWidth = cellFrom.outerWidth();
+
+      expect(topSelectionHandle.is(':visible')).toBe(true);
+      expect(bottomSelectionHandle.is(':visible')).toBe(true);
+      expect(topSelectionHandle.offset()).toEqual({
+        top: cellFromOffset.top - topSelectionHandleSize,
+        left: cellFromOffset.left + cellFromWidth,
+      });
+      // -/+1 as the bottom handler is positioned ending in the most bottom-left pixel
+      expect(bottomSelectionHandle.offset()).toEqual({
+        top: cellToOffset.top + cellToHeight - 1,
+        left: cellToOffset.left - bottomSelectionHandleSize + 1,
+      });
+      expect(getSelected()).toEqual([[1, 1, 1, 3]]);
     });
-    // -/+1 as the bottom handler is positioned ending in the most bottom-left pixel
-    expect(bottomSelectionHandle.offset()).toEqual({
-      top: cellToOffset.top + cellToHeight - 1,
-      left: cellToOffset.left - bottomSelectionHandleSize + 1,
+
+    it('should show both selection handles in correct position after vertical drag & drop', async() => {
+      handsontable({
+        layoutDirection,
+        width: 400,
+        height: 400
+      });
+
+      selectCell(1, 1);
+
+      await sleep(100);
+
+      const cellFrom = $(getCell(1, 1));
+      const cellTo = spec().$container.find('tbody tr:eq(3) td:eq(1)');
+      const cellToOffset = cellTo.offset();
+      const cellToHeight = cellFrom.outerHeight();
+
+      triggerTouchEvent('touchstart', spec().$container.find('.htBorders .bottomSelectionHandle-HitArea')[0]);
+      triggerTouchEvent('touchmove', spec().$container.find('tbody tr:eq(2) td:eq(1)')[0]);
+      triggerTouchEvent('touchmove', cellTo[0]);
+      triggerTouchEvent('touchend', cellTo[0]);
+
+      await sleep(100);
+
+      const topSelectionHandle = spec().$container
+        .find('.ht_master .htBorders div:last-child .topSelectionHandle');
+      const topSelectionHandleSize = topSelectionHandle.outerWidth();
+      const bottomSelectionHandle = spec().$container
+        .find('.ht_master .htBorders div:last-child .bottomSelectionHandle');
+      const bottomSelectionHandleSize = bottomSelectionHandle.outerWidth();
+      const cellFromOffset = cellFrom.offset();
+      const cellFromWidth = cellFrom.outerWidth();
+
+      expect(topSelectionHandle.is(':visible')).toBe(true);
+      expect(bottomSelectionHandle.is(':visible')).toBe(true);
+      expect(topSelectionHandle.offset()).toEqual({
+        top: cellFromOffset.top - topSelectionHandleSize,
+        left: cellFromOffset.left + cellFromWidth,
+      });
+      // -/+1 as the bottom handler is positioned ending in the most bottom-left pixel
+      expect(bottomSelectionHandle.offset()).toEqual({
+        top: cellToOffset.top + cellToHeight - 1,
+        left: cellToOffset.left - bottomSelectionHandleSize + 1,
+      });
+      expect(getSelected()).toEqual([[1, 1, 3, 1]]);
     });
-    expect(getSelected()).toEqual([[1, 1, 3, 1]]);
   });
 });

--- a/handsontable/src/plugins/nestedRows/__tests__/nestedRows.spec.js
+++ b/handsontable/src/plugins/nestedRows/__tests__/nestedRows.spec.js
@@ -72,17 +72,33 @@ describe('NestedRows', () => {
 
       expect(errors.length).toEqual(0);
     });
+  });
 
-    it('should display indicators properly located', () => {
-      const hot = handsontable({
-        data: getMoreComplexNestedData(),
-        nestedRows: true,
-        rowHeaders: true
+  describe('UI', () => {
+    using('configuration object', [
+      { htmlDir: 'ltr', layoutDirection: 'inherit' },
+      { htmlDir: 'rtl', layoutDirection: 'ltr' },
+    ], ({ htmlDir, layoutDirection }) => {
+      beforeEach(() => {
+        $('html').attr('dir', htmlDir);
       });
 
-      expect(hot.countRows()).toEqual(13);
-      expect(window.getComputedStyle($('.ht_nestingLevel_empty')[0]).float).toEqual('left');
-      expect(window.getComputedStyle($('.ht_nestingCollapse')[0]).right).toEqual('-2px');
+      afterEach(() => {
+        $('html').attr('dir', 'ltr');
+      });
+
+      it('should display indicators properly located', () => {
+        const hot = handsontable({
+          layoutDirection,
+          data: getMoreComplexNestedData(),
+          nestedRows: true,
+          rowHeaders: true
+        });
+
+        expect(hot.countRows()).toEqual(13);
+        expect(window.getComputedStyle($('.ht_nestingLevel_empty')[0]).float).toEqual('left');
+        expect(window.getComputedStyle($('.ht_nestingCollapse')[0]).right).toEqual('-2px');
+      });
     });
   });
 

--- a/handsontable/src/plugins/nestedRows/__tests__/rtl/nestedRows.spec.js
+++ b/handsontable/src/plugins/nestedRows/__tests__/rtl/nestedRows.spec.js
@@ -106,16 +106,31 @@ describe('NestedRows (RTL)', () => {
     expect(getDataAtRow(8)).toEqual(['Best Metal Performance', null, null, null]);
   });
 
-  it('should display indicators properly located', () => {
-    const hot = handsontable({
-      data: getMoreComplexNestedData(),
-      nestedRows: true,
-      rowHeaders: true
+  describe('UI', () => {
+    using('configuration object', [
+      { htmlDir: 'rtl', layoutDirection: 'inherit' },
+      { htmlDir: 'ltr', layoutDirection: 'rtl' },
+    ], ({ htmlDir, layoutDirection }) => {
+      beforeEach(() => {
+        $('html').attr('dir', htmlDir);
+      });
+
+      afterEach(() => {
+        $('html').attr('dir', 'ltr');
+      });
+
+      it('should display indicators properly located', () => {
+        const hot = handsontable({
+          layoutDirection,
+          data: getMoreComplexNestedData(),
+          nestedRows: true,
+          rowHeaders: true
+        });
+
+        expect(hot.countRows()).toEqual(13);
+        expect(window.getComputedStyle($('.ht_nestingLevel_empty')[0]).float).toEqual('right');
+        expect(window.getComputedStyle($('.ht_nestingCollapse')[0]).left).toEqual('-2px');
+      });
     });
-
-    expect(hot.countRows()).toEqual(13);
-    expect(window.getComputedStyle($('.ht_nestingLevel_empty')[0]).float).toEqual('right');
-    expect(window.getComputedStyle($('.ht_nestingCollapse')[0]).left).toEqual('-2px');
   });
-
 });

--- a/handsontable/test/helpers/common.js
+++ b/handsontable/test/helpers/common.js
@@ -137,6 +137,38 @@ afterEach(() => {
   specContext.spec = null;
 });
 
+/* eslint-disable jsdoc/require-description-complete-sentence */
+/**
+ * The function allows to run the test suites based on different parameters (object configuration, datasets etc).
+ *
+ * For example:
+ * ```
+ * describe('TextEditor', () => {
+ *   using('input value', [1, '1', true], (value) => {
+ *     it('should correctly display the value in the textarea element', {
+ *        // expect()
+ *     });
+ *   })
+ * })
+ * // The jasmine will generate following test cases:
+ * //   * "TextEditor using input value: `1` should correctly display the value in the textarea element";
+ * //   * "TextEditor using input value: `'1'` should correctly display the value in the textarea element"
+ * //   * "TextEditor using input value: `true` should correctly display the value in the textarea element"
+ * ```
+ *
+ * @param {string} name The parameter name to be used within the tests.
+ * @param {Array<*>} parameters An array of parameters.
+ * @param {Function} func Function to execute where the test suite
+ */
+export function using(name, parameters, func) {
+  parameters.forEach((param) => {
+    describe(`using ${name}: \`${JSON.stringify(param)}\``, function() {
+      func.call(this, param);
+    });
+  });
+}
+/* eslint-enable jsdoc/require-description-complete-sentence */
+
 /**
  * @returns {object} Returns the spec object for currently running test.
  */


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes an issue with CSS for RTL layout direction mode. Our SASS loader transforms CSS logical values (`inset-inline-end` etc.) to physical ones (`right` etc.) and modifies the selectors to make it work for RTL. For example from:
```css
.htCommentsContainer .comment {
  inset-inline-end: 0;
  inset-inline-start: unset;
}
```
to 
```css
[dir=rtl] .htCommentsContainer .comment {
  right: 0;
  left: unused;
}
```
And here is the issue. That CSS selector only works for configurations where the whole document is RTL `<html dir="rtl">` and the `layoutDirection` is set as `'inherit'` or `'rtl'`. In case the developer wants to change opposite direction than the HTML document, the table UI is mispositioned. The fix changes the [generated CSS selectors](https://github.com/handsontable/handsontable/pull/9229/files#diff-e2c999220a59179e554bdf24a7495974c120c42b47df26578571e0738dd5d1a0R23) from `[dir=rtl] .htCommentsContainer .comment` to `[dir=rtl].htCommentsContainer .comment`. Thanks to that the selector applies to the Handsontable root element that is controlled by Handsontable itself and not by the external element.

So, the PR allows to render the table correctly with these configurations:
```html
<html dir="rtl"> <-- RTL document mode -->
  <body>
    <div id="app"></div>
  </body>
</html>
```
```js
{
  data: Handsontable.helper.createSpreadsheetData(100, 25),
  fixedRowsTop: 2,
  fixedRowsBottom: 2,
  layoutDirection: 'ltr', // render the table in LTR mode
}
```
and
```html
<html> <-- LTR document mode -->
  <body>
    <div id="app"></div>
  </body>
</html>
```
```js
{
  data: Handsontable.helper.createSpreadsheetData(100, 25),
  fixedRowsTop: 2,
  fixedRowsBottom: 2,
  comments: true,
  layoutDirection: 'rtl', // render the table in RTL mode
}
```

_For reviewer:_ I faced a problem where I have to test something with two configurations where their results are the same. I didn't want to copy&paste the tests so with [inspiration](https://www.ontestautomation.com/data-driven-javascript-tests-using-jasmine/) I extended the tests and introduced the [data-driven tests for Jasmine](https://github.com/handsontable/handsontable/blob/feature/issue-9226/handsontable/test/helpers/common.js#L163).

For example:
```js
describe('TextEditor', () => {
  using('input value', [1, '1', true], (value) => {
    it('should correctly display the value in the textarea element', {
       // expect()
    });
  })
})
```
This test suite would generate the following test cases:
 * TextEditor using input value: 1 should correctly display the value in the textarea
 * TextEditor using input value: '1' should correctly display the value in the textarea
 * TextEditor using input value: `true` should correctly display the value in the textarea element

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes #9226
2.
3.

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
