### PR TITLE
Fix the react tests for #8942

### DIFF
--- a/wrappers/react/test/_helpers.tsx
+++ b/wrappers/react/test/_helpers.tsx
@@ -145,7 +145,7 @@ export function simulateKeyboardEvent(type, keyCode) {
   });
   Object.defineProperty(newEvent, 'key', {
     get : function() {
-      return KEY_CODES[this.keyCodeVal] ?? String.fromCharCode(keyCode).toLowerCase();
+      return KEY_CODES[this.keyCodeVal] ?? String.fromCharCode(this.keyCodeVal).toLowerCase();
     }
   });
 

--- a/wrappers/react/test/_helpers.tsx
+++ b/wrappers/react/test/_helpers.tsx
@@ -122,7 +122,15 @@ export function mockElementDimensions(element, width, height) {
 
 export function simulateKeyboardEvent(type, keyCode) {
   const newEvent = document.createEvent('KeyboardEvent');
-  // const init = (event as any).initKeyboardEvent !== void 0 ? 'initKeyboardEvent' : 'initKeyEvent';
+  const KEY_CODES = {
+    8: 'backspace',
+    9: 'tab',
+    13: 'enter',
+    16: 'shift',
+    17: 'control',
+    18: 'alt',
+    27: 'escape'
+  };
 
   // Chromium Hack
   Object.defineProperty(newEvent, 'keyCode', {
@@ -134,6 +142,11 @@ export function simulateKeyboardEvent(type, keyCode) {
       get : function() {
           return this.keyCodeVal;
       }
+  });
+  Object.defineProperty(newEvent, 'key', {
+    get : function() {
+      return KEY_CODES[this.keyCodeVal] ?? String.fromCharCode(keyCode).toLowerCase();
+    }
   });
 
   if ((newEvent as any).initKeyboardEvent !== void 0) {


### PR DESCRIPTION
### Context
This PR fixes the failed tests for the React wrapper for #8942.

The problem was caused by the wrapper's helper script - it simulated the keyboard events using only the key codes, while the new logic inside Handsontable utilizes the events' `key` property as well.

I don't think it's a breaking change (as in the real-world usage all the event props are filled properly), but it might cause some problems in testing environments, where the events are mocked, sometimes not very precisely (as were in this case).

[skip changelog]

### How has this been tested?
Run the existing tests for the React wrapper.

### Related issue(s):
1. #8942 
2. #8955 

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [x] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
