### PR TITLE
Add an placeholder of the migration guide for 12.0

### DIFF
--- a/docs/next/guides/sidebar.js
+++ b/docs/next/guides/sidebar.js
@@ -183,6 +183,7 @@ const upgradeAndMigrationItems = [
   'guides/upgrade-and-migration/migrating-from-8.4-to-9.0',
   'guides/upgrade-and-migration/migrating-from-9.0-to-10.0',
   'guides/upgrade-and-migration/migrating-from-10.0-to-11.0',
+  'guides/upgrade-and-migration/migrating-from-11.1-to-12.0',
 ];
 
 module.exports = {

--- a/docs/next/guides/upgrade-and-migration/migrating-from-11.1-to-12.0.md
+++ b/docs/next/guides/upgrade-and-migration/migrating-from-11.1-to-12.0.md
@@ -1,0 +1,14 @@
+---
+title: Migrating from 11.1 to 12.0
+metaTitle: Migrating from 11.1 to 12.0 - Guide - Handsontable Documentation
+permalink: /next/migration-from-11.1-to-12.0
+canonicalUrl: /migration-from-11.1-to-12.0
+pageClass: migration-guide
+---
+
+# Migrating from 11.1 to 12.0
+
+[[toc]]
+
+To upgrade your Handsontable version from 11.x.x to 12.x.x, follow this guide.
+


### PR DESCRIPTION
### Context

Since 12.0 is a breaking release, a migration guide will be needed across various changes. This change adds an empty migration guide to avoid merge conflicts.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Tested locally by running the docs.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]