### PR TITLE
[RTL] Move overlay's offset calculations to specific methods

### DIFF
--- a/handsontable/src/3rdparty/walkontable/src/overlay/bottom.js
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/bottom.js
@@ -321,8 +321,8 @@ export class BottomOverlay extends Overlay {
     let overlayOffset = 0;
 
     if (this.trimmingContainer === rootWindow && (!preventOverflow || preventOverflow !== 'vertical')) {
-      const rootHeight = this.wot.wtTable.getHeight();
-      const overlayRootHeight = this.clone.wtTable.getHeight();
+      const rootHeight = this.wot.wtTable.getTotalHeight();
+      const overlayRootHeight = this.clone.wtTable.getTotalHeight();
       const maxOffset = rootHeight - overlayRootHeight;
       const docClientHeight = this.domBindings.rootDocument.documentElement.clientHeight;
 

--- a/handsontable/src/3rdparty/walkontable/src/overlay/bottom.js
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/bottom.js
@@ -66,45 +66,24 @@ export class BottomOverlay extends Overlay {
       // removed from DOM
       return false;
     }
-    const { rootDocument, rootWindow } = this.domBindings;
+    const { rootWindow } = this.domBindings;
     const overlayRoot = this.clone.wtTable.holder.parentNode;
 
     overlayRoot.style.top = '';
 
-    let headerPosition = 0;
+    let overlayPosition = 0;
     const preventOverflow = this.wtSettings.getSetting('preventOverflow');
 
     if (this.trimmingContainer === rootWindow && (!preventOverflow || preventOverflow !== 'vertical')) {
-      const { wtTable } = this.wot;
-      const hiderRect = wtTable.hider.getBoundingClientRect();
-      const bottom = Math.ceil(hiderRect.bottom);
-      const bodyHeight = rootDocument.documentElement.clientHeight;
-      let finalLeft = 0;
-      let finalBottom = 0;
-
-      finalLeft = wtTable.hider.style.left;
-      finalLeft = finalLeft !== 0 ? `${finalLeft}px` : finalLeft;
-
-      if (bottom > bodyHeight) {
-        finalBottom = (bottom - bodyHeight);
-      }
-
-      headerPosition = finalBottom;
-
-      if (this.isRtl()) {
-        overlayRoot.style.right = `${finalLeft}px`;
-      } else {
-        overlayRoot.style.left = `${finalLeft}px`;
-      }
-
-      overlayRoot.style.bottom = `${finalBottom}px`;
+      overlayPosition = this.getOverlayOffset();
+      overlayRoot.style.bottom = `${overlayPosition}px`;
 
     } else {
-      headerPosition = this.getScrollPosition();
+      overlayPosition = this.getScrollPosition();
       this.repositionOverlay();
     }
 
-    const positionChanged = this.adjustHeaderBordersPosition(headerPosition);
+    const positionChanged = this.adjustHeaderBordersPosition(overlayPosition);
 
     this.adjustElementsSize();
 
@@ -329,6 +308,33 @@ export class BottomOverlay extends Overlay {
    */
   getScrollPosition() {
     return getScrollTop(this.mainTableScrollableElement, this.domBindings.rootWindow);
+  }
+
+  /**
+   * Gets the main overlay's vertical overlay offset.
+   *
+   * @returns {number} Main table's vertical overlay offset.
+   */
+  getOverlayOffset() {
+    const { rootWindow } = this.domBindings;
+    const preventOverflow = this.wtSettings.getSetting('preventOverflow');
+    let overlayOffset = 0;
+
+    if (this.trimmingContainer === rootWindow && (!preventOverflow || preventOverflow !== 'vertical')) {
+      const rootHeight = this.wot.wtTable.getHeight();
+      const overlayRootHeight = this.clone.wtTable.getHeight();
+      const maxOffset = rootHeight - overlayRootHeight;
+      const docClientHeight = this.domBindings.rootDocument.documentElement.clientHeight;
+
+      overlayOffset = Math.max(
+        this.getTableParentOffset() - this.getScrollPosition() - docClientHeight + rootHeight, 0);
+
+      if (overlayOffset > maxOffset) {
+        overlayOffset = 0;
+      }
+    }
+
+    return overlayOffset;
   }
 
   /**

--- a/handsontable/src/3rdparty/walkontable/src/overlay/bottomInlineStartCorner.js
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/bottomInlineStartCorner.js
@@ -69,7 +69,7 @@ export class BottomInlineStartCornerOverlay extends Overlay {
     overlayRoot.style.top = '';
 
     if (this.trimmingContainer === this.domBindings.rootWindow) {
-      const inlineStartOffset = Math.abs(this.inlineStartOverlay.getOverlayOffset());
+      const inlineStartOffset = this.inlineStartOverlay.getOverlayOffset();
       const bottom = this.bottomOverlay.getOverlayOffset();
 
       overlayRoot.style[this.isRtl() ? 'right' : 'left'] = `${inlineStartOffset}px`;

--- a/handsontable/src/3rdparty/walkontable/src/overlay/bottomInlineStartCorner.js
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/bottomInlineStartCorner.js
@@ -19,9 +19,13 @@ export class BottomInlineStartCornerOverlay extends Overlay {
    * @param {FacadeGetter} facadeGetter Function which return proper facade.
    * @param {Settings} wtSettings The Walkontable settings.
    * @param {DomBindings} domBindings Dom elements bound to the current instance.
+   * @param {BottomOverlay} bottomOverlay The instance of the Top overlay.
+   * @param {InlineStartOverlay} inlineStartOverlay The instance of the InlineStart overlay.
    */
-  constructor(wotInstance, facadeGetter, wtSettings, domBindings) {
+  constructor(wotInstance, facadeGetter, wtSettings, domBindings, bottomOverlay, inlineStartOverlay) {
     super(wotInstance, facadeGetter, CLONE_BOTTOM_INLINE_START_CORNER, wtSettings, domBindings);
+    this.bottomOverlay = bottomOverlay;
+    this.inlineStartOverlay = inlineStartOverlay;
   }
 
   /**
@@ -65,38 +69,11 @@ export class BottomInlineStartCornerOverlay extends Overlay {
     overlayRoot.style.top = '';
 
     if (this.trimmingContainer === this.domBindings.rootWindow) {
-      const { wtTable } = this.wot;
-      const { rootDocument } = this.domBindings;
-      const hiderRect = wtTable.hider.getBoundingClientRect();
-      const bottom = Math.ceil(hiderRect.bottom);
-      const left = Math.ceil(hiderRect.left);
-      const right = Math.ceil(hiderRect.right);
-      const bodyHeight = rootDocument.documentElement.clientHeight;
-      let finalLeft = 0;
-      let finalBottom = 0;
+      const inlineStartOffset = Math.abs(this.inlineStartOverlay.getOverlayOffset());
+      const bottom = this.bottomOverlay.getOverlayOffset();
 
-      if (this.isRtl()) {
-        const documentWidth = rootDocument.documentElement.clientWidth;
-
-        if (right >= documentWidth) {
-          finalLeft = Math.abs(documentWidth - right);
-        }
-
-      } else if (left < 0) {
-        finalLeft = -left;
-      }
-
-      if (bottom > bodyHeight) {
-        finalBottom = (bottom - bodyHeight);
-      }
-
-      if (this.isRtl()) {
-        overlayRoot.style.right = `${finalLeft}px`;
-      } else {
-        overlayRoot.style.left = `${finalLeft}px`;
-      }
-
-      overlayRoot.style.bottom = `${finalBottom}px`;
+      overlayRoot.style[this.isRtl() ? 'right' : 'left'] = `${inlineStartOffset}px`;
+      overlayRoot.style.bottom = `${bottom}px`;
 
     } else {
       resetCssTransform(overlayRoot);

--- a/handsontable/src/3rdparty/walkontable/src/overlay/inlineStart.js
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/inlineStart.js
@@ -310,8 +310,8 @@ export class InlineStartOverlay extends Overlay {
         overlayOffset = Math.max(this.getScrollPosition() - this.getTableParentOffset(), 0);
       }
 
-      const rootWidth = this.wot.wtTable.getWidth();
-      const overlayRootWidth = this.clone.wtTable.getWidth();
+      const rootWidth = this.wot.wtTable.getTotalWidth();
+      const overlayRootWidth = this.clone.wtTable.getTotalWidth();
       const maxOffset = rootWidth - overlayRootWidth;
 
       if (overlayOffset > maxOffset) {

--- a/handsontable/src/3rdparty/walkontable/src/overlay/inlineStart.js
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/inlineStart.js
@@ -68,7 +68,7 @@ export class InlineStartOverlay extends Overlay {
     let overlayPosition = 0;
 
     if (this.trimmingContainer === rootWindow && (!preventOverflow || preventOverflow !== 'horizontal')) {
-      overlayPosition = this.getOverlayOffset();
+      overlayPosition = this.getOverlayOffset() * (this.isRtl() ? -1 : 1);
       setOverlayPosition(overlayRoot, `${overlayPosition}px`, '0px');
 
     } else {
@@ -301,17 +301,25 @@ export class InlineStartOverlay extends Overlay {
   getOverlayOffset() {
     const { rootWindow } = this.domBindings;
     const preventOverflow = this.wtSettings.getSetting('preventOverflow');
-    let overlayPosition = 0;
+    let overlayOffset = 0;
 
     if (this.trimmingContainer === rootWindow && (!preventOverflow || preventOverflow !== 'horizontal')) {
       if (this.isRtl()) {
-        overlayPosition = Math.min(this.getTableParentOffset() - this.getScrollPosition(), 0);
+        overlayOffset = Math.abs(Math.min(this.getTableParentOffset() - this.getScrollPosition(), 0));
       } else {
-        overlayPosition = Math.max(this.getScrollPosition() - this.getTableParentOffset(), 0);
+        overlayOffset = Math.max(this.getScrollPosition() - this.getTableParentOffset(), 0);
+      }
+
+      const rootWidth = this.wot.wtTable.getWidth();
+      const overlayRootWidth = this.clone.wtTable.getWidth();
+      const maxOffset = rootWidth - overlayRootWidth;
+
+      if (overlayOffset > maxOffset) {
+        overlayOffset = 0;
       }
     }
 
-    return overlayPosition;
+    return overlayOffset;
   }
 
   /**

--- a/handsontable/src/3rdparty/walkontable/src/overlay/top.js
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/top.js
@@ -332,8 +332,8 @@ export class TopOverlay extends Overlay {
     let overlayOffset = 0;
 
     if (this.trimmingContainer === rootWindow && (!preventOverflow || preventOverflow !== 'vertical')) {
-      const rootHeight = this.wot.wtTable.getHeight();
-      const overlayRootHeight = this.clone.wtTable.getHeight();
+      const rootHeight = this.wot.wtTable.getTotalHeight();
+      const overlayRootHeight = this.clone.wtTable.getTotalHeight();
       const maxOffset = rootHeight - overlayRootHeight;
 
       overlayOffset = Math.max(this.getScrollPosition() - this.getTableParentOffset(), 0);

--- a/handsontable/src/3rdparty/walkontable/src/overlay/top.js
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/top.js
@@ -329,13 +329,21 @@ export class TopOverlay extends Overlay {
   getOverlayOffset() {
     const { rootWindow } = this.domBindings;
     const preventOverflow = this.wtSettings.getSetting('preventOverflow');
-    let overlayPosition = 0;
+    let overlayOffset = 0;
 
     if (this.trimmingContainer === rootWindow && (!preventOverflow || preventOverflow !== 'vertical')) {
-      overlayPosition = Math.max(this.getScrollPosition() - this.getTableParentOffset(), 0);
+      const rootHeight = this.wot.wtTable.getHeight();
+      const overlayRootHeight = this.clone.wtTable.getHeight();
+      const maxOffset = rootHeight - overlayRootHeight;
+
+      overlayOffset = Math.max(this.getScrollPosition() - this.getTableParentOffset(), 0);
+
+      if (Math.abs(overlayOffset) > maxOffset) {
+        overlayOffset = 0;
+      }
     }
 
-    return overlayPosition;
+    return overlayOffset;
   }
 
   /**

--- a/handsontable/src/3rdparty/walkontable/src/overlay/top.js
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/top.js
@@ -338,7 +338,7 @@ export class TopOverlay extends Overlay {
 
       overlayOffset = Math.max(this.getScrollPosition() - this.getTableParentOffset(), 0);
 
-      if (Math.abs(overlayOffset) > maxOffset) {
+      if (overlayOffset > maxOffset) {
         overlayOffset = 0;
       }
     }

--- a/handsontable/src/3rdparty/walkontable/src/overlay/topInlineStartCorner.js
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/topInlineStartCorner.js
@@ -78,7 +78,7 @@ export class TopInlineStartCornerOverlay extends Overlay {
     const overlayRoot = this.clone.wtTable.holder.parentNode;
 
     if (this.trimmingContainer === this.domBindings.rootWindow) {
-      const left = this.inlineStartOverlay.getOverlayOffset();
+      const left = this.inlineStartOverlay.getOverlayOffset() * (this.isRtl() ? -1 : 1);
       const top = this.topOverlay.getOverlayOffset();
 
       setOverlayPosition(overlayRoot, `${left}px`, `${top}px`);

--- a/handsontable/src/3rdparty/walkontable/src/table.js
+++ b/handsontable/src/3rdparty/walkontable/src/table.js
@@ -6,6 +6,7 @@ import {
   removeTextNodes,
   overlayContainsElement,
   closest,
+  outerHeight,
   outerWidth,
   innerHeight,
   isVisible,
@@ -1097,6 +1098,15 @@ class Table {
    */
   getWidth() {
     return outerWidth(this.TABLE);
+  }
+
+  /**
+   * Gets table's height.
+   *
+   * @returns {number}
+   */
+  getHeight() {
+    return outerHeight(this.TABLE);
   }
 
   /**

--- a/handsontable/src/3rdparty/walkontable/src/table.js
+++ b/handsontable/src/3rdparty/walkontable/src/table.js
@@ -1092,7 +1092,8 @@ class Table {
   }
 
   /**
-   * Gets table's width.
+   * Gets table's width. The returned width is the width of the rendered cells that fit in the
+   * current viewport. The value may change depends on the viewport position (scroll position).
    *
    * @returns {number}
    */
@@ -1101,12 +1102,39 @@ class Table {
   }
 
   /**
-   * Gets table's height.
+   * Gets table's height. The returned height is the height of the rendered cells that fit in the
+   * current viewport. The value may change depends on the viewport position (scroll position).
    *
    * @returns {number}
    */
   getHeight() {
     return outerHeight(this.TABLE);
+  }
+
+  /**
+   * Gets table's total width. The returned width is the width of all rendered cells (including headers)
+   * that can be displayed in the table.
+   *
+   * @returns {number}
+   */
+  getTotalWidth() {
+    const width = outerWidth(this.hider);
+
+    // when the overlay's table does not have any cells the hider returns 0, get then width from the table element
+    return width !== 0 ? width : this.getWidth();
+  }
+
+  /**
+   * Gets table's total height. The returned height is the height of all rendered cells (including headers)
+   * that can be displayed in the table.
+   *
+   * @returns {number}
+   */
+  getTotalHeight() {
+    const height = outerHeight(this.hider);
+
+    // when the overlay's table does not have any cells the hider returns 0, get then height from the table element
+    return height !== 0 ? height : this.getHeight();
   }
 
   /**

--- a/handsontable/src/3rdparty/walkontable/test/spec/overlay.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/overlay.spec.js
@@ -753,6 +753,94 @@ describe('WalkontableOverlay', () => {
     }));
   });
 
+  describe('overlay offset', () => {
+    beforeEach(function() {
+      spec().$wrapper
+        .css('overflow', '')
+        .css('width', '')
+        .css('height', '');
+
+      createDataArray(10, 10);
+
+      this.$wrapper.after($('<div class="space-filler" style="width: 4000px; height: 4000px">&nbsp;</div>'));
+      this.$wrapper.before($('<div class="space-filler" style="width: 4000px; height: 4000px">&nbsp;</div>'));
+    });
+
+    afterEach(() => {
+      jQuery('.space-filler').remove();
+    });
+
+    it('should reset top overlay\'s offset after the table is scroll out of the browser viewport (window object as scrollable element)', () => {
+      const wt = walkontable({
+        data: getData,
+        totalRows: getTotalRows,
+        totalColumns: getTotalColumns,
+        fixedRowsTop: 2,
+      });
+
+      wt.draw();
+      wt.scrollViewport({ row: getTotalRows() - 1, col: 0 }, true, false, false, true);
+      wt.draw();
+
+      // scroll the viewport precisely 1px before the top overlay disappears
+      window.scrollBy(0, 23);
+
+      expect(wt.wtOverlays.topOverlay.getOverlayOffset()).toBe(184);
+
+      // it causes the overlay to be reset to the initial position
+      window.scrollBy(0, 1);
+      wt.draw();
+
+      expect(wt.wtOverlays.topOverlay.getOverlayOffset()).toBe(0);
+    });
+
+    it('should reset left overlay\'s offset after the table is scroll out of the browser viewport (window object as scrollable element)', () => {
+      const wt = walkontable({
+        data: getData,
+        totalRows: getTotalRows,
+        totalColumns: getTotalColumns,
+        fixedColumnsStart: 2,
+      });
+
+      wt.draw();
+      wt.scrollViewport({ row: 0, col: getTotalColumns() - 1 }, true, false, false, true);
+      wt.draw();
+
+      // scroll the viewport precisely 1px before the left overlay disappears
+      window.scrollBy(50, 0);
+
+      expect(wt.wtOverlays.inlineStartOverlay.getOverlayOffset()).toBe(400);
+
+      // it causes the overlay to be reset to the initial position
+      window.scrollBy(1, 1);
+
+      expect(wt.wtOverlays.inlineStartOverlay.getOverlayOffset()).toBe(0);
+    });
+
+    it('should reset bottom overlay\'s offset after the table is scroll out of the browser viewport(window object as scrollable element)', () => {
+      const wt = walkontable({
+        data: getData,
+        totalRows: getTotalRows,
+        totalColumns: getTotalColumns,
+        fixedRowsBottom: 2,
+      });
+
+      wt.draw();
+      wt.scrollViewport({ row: getTotalRows() - 1, col: 0 }, false, true, true, false);
+      wt.draw();
+
+      // scroll the viewport precisely 1px before the bottom overlay disappears
+      window.scrollBy(0, -230);
+
+      expect(wt.wtOverlays.bottomOverlay.getOverlayOffset()).toBe(184);
+
+      // it causes the overlay to be reset to the initial position
+      window.scrollBy(0, -1);
+
+      expect(wt.wtOverlays.bottomOverlay.getOverlayOffset()).toBe(0);
+    });
+  });
+
   it('should adjust the header overlays sizes after table scroll (window object as scrollable element)', () => {
     spec().$wrapper
       .css('overflow', '')

--- a/handsontable/src/3rdparty/walkontable/test/spec/rtl/overlay.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/rtl/overlay.spec.js
@@ -774,6 +774,99 @@ describe('WalkontableOverlay (RTL mode)', () => {
     }));
   });
 
+  describe('overlay offset', () => {
+    beforeEach(function() {
+      spec().$wrapper
+        .css('overflow', '')
+        .css('width', '')
+        .css('height', '');
+
+      createDataArray(10, 10);
+
+      this.$wrapper.after($('<div class="space-filler" style="width: 4000px; height: 4000px">&nbsp;</div>'));
+      this.$wrapper.before($('<div class="space-filler" style="width: 4000px; height: 4000px">&nbsp;</div>'));
+    });
+
+    afterEach(() => {
+      jQuery('.space-filler').remove();
+    });
+
+    it('should reset top overlay\'s offset after the table is scroll out of the browser viewport (window object as scrollable element)', () => {
+      const wt = walkontable({
+        rtlMode: true,
+        data: getData,
+        totalRows: getTotalRows,
+        totalColumns: getTotalColumns,
+        fixedRowsTop: 2,
+      });
+
+      wt.draw();
+      wt.scrollViewport({ row: getTotalRows() - 1, col: 0 }, true, false, false, true);
+      wt.draw();
+
+      // scroll the viewport precisely 1px before the top overlay disappears
+      window.scrollBy(0, 23);
+
+      expect(wt.wtOverlays.topOverlay.getOverlayOffset()).toBe(184);
+
+      // it causes the overlay to be reset to the initial position
+      window.scrollBy(1, 1);
+      wt.draw();
+
+      expect(wt.wtOverlays.topOverlay.getOverlayOffset()).toBe(0);
+    });
+
+    it('should reset right overlay\'s offset after the table is scroll out of the browser viewport (window object as scrollable element)', () => {
+      const wt = walkontable({
+        rtlMode: true,
+        data: getData,
+        totalRows: getTotalRows,
+        totalColumns: getTotalColumns,
+        fixedColumnsStart: 2,
+      });
+
+      window.wt = wt;
+
+      wt.draw();
+      wt.scrollViewport({ row: 0, col: getTotalColumns() - 1 }, true, false, false, true);
+      wt.draw();
+
+      // scroll the viewport precisely 1px before the left overlay disappears
+      window.scrollBy(-50, 0);
+
+      expect(wt.wtOverlays.inlineStartOverlay.getOverlayOffset()).toBe(400);
+
+      // it causes the overlay to be reset to the initial position
+      window.scrollBy(-1, 0);
+
+      expect(wt.wtOverlays.inlineStartOverlay.getOverlayOffset()).toBe(0);
+    });
+
+    it('should reset bottom overlay\'s offset after the table is scroll out of the browser viewport(window object as scrollable element)', () => {
+      const wt = walkontable({
+        rtlMode: true,
+        data: getData,
+        totalRows: getTotalRows,
+        totalColumns: getTotalColumns,
+        fixedRowsBottom: 2,
+      });
+
+      wt.draw();
+      wt.scrollViewport({ row: getTotalRows() - 1, col: 0 }, false, true, true, false);
+      wt.draw();
+
+      // scroll the viewport precisely 1px before the bottom overlay disappears
+      window.scrollBy(0, -230);
+
+      expect(wt.wtOverlays.bottomOverlay.getOverlayOffset()).toBe(184);
+
+      // it causes the overlay to be reset to the initial position
+      window.scrollBy(0, -1);
+
+      expect(wt.wtOverlays.bottomOverlay.getOverlayOffset()).toBe(0);
+    });
+  });
+
   it('should adjust the header overlays sizes after table scroll (window object as scrollable element)', () => {
     spec().$wrapper
       .css('overflow', '')


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the overlays positioning bug introduces in https://github.com/handsontable/handsontable/pull/9201. The bug caused that the _Top_, _InlineStart_, and _Bottom_ overlays (including corners) do not hide when the table goes out of the browser viewport.

#### The bug:
![Kapture 2022-02-23 at 15 55 46](https://user-images.githubusercontent.com/571316/155344561-dd2c8578-71f3-4b46-9356-2feecc54993e.gif)
(the same happens for RTL)

#### The PRs fix:
![Kapture 2022-02-23 at 15 59 43](https://user-images.githubusercontent.com/571316/155345250-e2d2eb74-5a19-4bff-a5d9-93d5f29a39cd.gif)

#### Handsontable v11.1.0:
![Kapture 2022-02-23 at 16 01 35](https://user-images.githubusercontent.com/571316/155345636-932298ed-5b6b-4923-b570-2fe6b4719505.gif)

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and cover the fix with new E2E tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes #9233
2.
3.

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
