### PR TITLE
[RTL] Add missing `fixedColumnsStart` option

### DIFF
--- a/wrappers/angular/projects/hot-table/src/lib/hot-table.component.ts
+++ b/wrappers/angular/projects/hot-table/src/lib/hot-table.component.ts
@@ -81,6 +81,7 @@ export class HotTableComponent implements AfterViewInit, OnChanges, OnDestroy {
   @Input() filteringCaseSensitive: Handsontable.GridSettings['filteringCaseSensitive'];
   @Input() filters: Handsontable.GridSettings['filters'];
   @Input() fixedColumnsLeft: Handsontable.GridSettings['fixedColumnsLeft'];
+  @Input() fixedColumnsStart: Handsontable.GridSettings['fixedColumnsStart'];
   @Input() fixedRowsBottom: Handsontable.GridSettings['fixedRowsBottom'];
   @Input() fixedRowsTop: Handsontable.GridSettings['fixedRowsTop'];
   @Input() formulas: Handsontable.GridSettings['formulas'];


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adds the missing `fixedColumnsStart` option to the Angular wrapper.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
\-

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes #9235

### Affected project(s):
- [x] `@handsontable/angular`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
