### PR TITLE
Hide all overlays for the menus

### DIFF
--- a/handsontable/src/plugins/contextMenu/contextMenu.scss
+++ b/handsontable/src/plugins/contextMenu/contextMenu.scss
@@ -10,8 +10,10 @@
 }
 
 .htContextMenu .ht_clone_top,
+.htContextMenu .ht_clone_bottom,
 .htContextMenu .ht_clone_inline_start,
-.htContextMenu .ht_clone_corner {
+.htContextMenu .ht_clone_top_inline_start_corner,
+.htContextMenu .ht_clone_bottom_inline_start_corner {
   display: none;
 }
 

--- a/handsontable/src/plugins/dropdownMenu/dropdownMenu.scss
+++ b/handsontable/src/plugins/dropdownMenu/dropdownMenu.scss
@@ -30,8 +30,10 @@
 }
 
 .htDropdownMenu .ht_clone_top,
+.htDropdownMenu .ht_clone_bottom,
 .htDropdownMenu .ht_clone_inline_start,
-.htDropdownMenu .ht_clone_corner {
+.htDropdownMenu .ht_clone_top_inline_start_corner,
+.htDropdownMenu .ht_clone_bottom_inline_start_corner {
   display: none;
 }
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR hides all unwanted overlays for context and dropdown menus.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations).
I tested the changes locally.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. resolves #9240

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
