### PR TITLE
[RTL] Fix scrolling on IE with RTL

### DIFF
--- a/handsontable/src/3rdparty/walkontable/src/overlay/inlineStart.js
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/inlineStart.js
@@ -9,6 +9,7 @@ import {
   setOverlayPosition,
   resetCssTransform,
 } from '../../../../helpers/dom/element';
+import { isIE } from '../../../../helpers/browser';
 import InlineStartOverlayTable from '../table/inlineStart';
 import { Overlay } from './_base';
 import {
@@ -93,7 +94,8 @@ export class InlineStartOverlay extends Overlay {
     const { rootWindow } = this.domBindings;
     let result = false;
 
-    if (this.isRtl()) {
+    // On all modern browsers the scroll position on RTL goes from 0 to -N. On IE the value is always positive.
+    if (this.isRtl() && !isIE()) {
       pos = -pos;
     }
 

--- a/handsontable/src/editors/baseEditor/baseEditor.js
+++ b/handsontable/src/editors/baseEditor/baseEditor.js
@@ -1,5 +1,6 @@
 import { stringify } from '../../helpers/mixed';
 import { mixin } from '../../helpers/object';
+import { isIE } from '../../helpers/browser';
 import hooksRefRegisterer from '../../mixins/hooksRefRegisterer';
 import {
   getScrollbarWidth,
@@ -443,7 +444,13 @@ export class BaseEditor {
     const overlayName = overlayTable.name;
 
     const scrollTop = ['master', 'inline_start'].includes(overlayName) ? containerScrollTop : 0;
-    const scrollLeft = ['master', 'top', 'bottom'].includes(overlayName) ? containerScrollLeft : 0;
+    let scrollLeft = ['master', 'top', 'bottom'].includes(overlayName) ? containerScrollLeft : 0;
+
+    // On all modern browsers the scroll position on RTL goes from 0 to -N. On IE the value is always positive.
+    // This "if" unifies the scrollLeft calculation.
+    if (this.hot.isRtl() && isIE()) {
+      scrollLeft = -Math.abs(scrollLeft);
+    }
 
     // If colHeaders is disabled, cells in the first row have border-top
     const editTopModifier = currentOffset.top === containerOffset.top ? 0 : 1;

--- a/handsontable/src/editors/baseEditor/baseEditor.js
+++ b/handsontable/src/editors/baseEditor/baseEditor.js
@@ -449,7 +449,7 @@ export class BaseEditor {
     // On all modern browsers the scroll position on RTL goes from 0 to -N. On IE the value is always positive.
     // This "if" unifies the scrollLeft calculation.
     if (this.hot.isRtl() && isIE()) {
-      scrollLeft = -Math.abs(scrollLeft);
+      scrollLeft = -scrollLeft;
     }
 
     // If colHeaders is disabled, cells in the first row have border-top


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the scrolling issue on IE with RTL. The `.scrollLeft` property on IE and in RTL mode returns always positive values where all modern browsers return negative values. The PR unifies the differences.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally on VM.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes #9244
2. fixes #9243

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
