### PR TITLE
[RTL] Overwrite CSS selector specificity

### DIFF
--- a/handsontable/src/css/handsontable.scss
+++ b/handsontable/src/css/handsontable.scss
@@ -352,7 +352,7 @@ TextRenderer placeholder value
 .handsontable.listbox tr:last-child th,
 .handsontable.listbox tr:first-child td,
 .handsontable.listbox td {
-  border-color: transparent;
+  border-color: transparent !important;
 }
 
 .handsontable.listbox th,


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR overwrites the CSS selector specificity to fix the unwanted right border in the dropdown editor's list.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes #9258

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
