### PR TITLE
Docs: Fixing a docs regression

### DIFF
--- a/docs/11.1/guides/cell-features/autofill-values.md
+++ b/docs/11.1/guides/cell-features/autofill-values.md
@@ -44,8 +44,8 @@ const hot = new Handsontable(container, {
   licenseKey: 'non-commercial-and-evaluation'
 });
 
-hot.loadData(data);
 // or, use `updateData()` to replace `data` without resetting states
+hot.loadData(data);
 ```
 :::
 

--- a/docs/11.1/guides/rows/row-prepopulating.md
+++ b/docs/11.1/guides/rows/row-prepopulating.md
@@ -101,7 +101,7 @@ const hot = new Handsontable(container, {
   }
 });
 
-hot.loadData(data);
 // or, use `updateData()` to replace `data` without resetting states
+hot.loadData(data);
 ```
 :::

--- a/docs/next/guides/cell-features/autofill-values.md
+++ b/docs/next/guides/cell-features/autofill-values.md
@@ -44,8 +44,8 @@ const hot = new Handsontable(container, {
   licenseKey: 'non-commercial-and-evaluation'
 });
 
-hot.loadData(data);
 // or, use `updateData()` to replace `data` without resetting states
+hot.loadData(data);
 ```
 :::
 

--- a/docs/next/guides/rows/row-prepopulating.md
+++ b/docs/next/guides/rows/row-prepopulating.md
@@ -101,7 +101,7 @@ const hot = new Handsontable(container, {
   }
 });
 
-hot.loadData(data);
 // or, use `updateData()` to replace `data` without resetting states
+hot.loadData(data);
 ```
 :::


### PR DESCRIPTION
This PR:
- Moves an inline comment that caused a few demos to fail (fixing #9214)

Affected pages:
- http://localhost:8080/docs/next/autofill-values/#autofill-in-all-directions
- http://localhost:8080/docs/autofill-values/#autofill-in-all-directions
- http://localhost:8080/docs/row-prepopulating/#example
- http://localhost:8080/docs/next/row-prepopulating/#example

[skip changelog]