### PR TITLE
Add "exports" field to wrappers

### DIFF
--- a/.changelogs/9140.json
+++ b/.changelogs/9140.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fixed an issue with registering modules for React wrapper",
+  "type": "fixed",
+  "issue": 9140,
+  "breaking": false,
+  "framework": "react"
+}

--- a/wrappers/react/package.json
+++ b/wrappers/react/package.json
@@ -10,6 +10,12 @@
   "jsdelivr": "./dist/react-handsontable.min.js",
   "unpkg": "./dist/react-handsontable.min.js",
   "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./es/react-handsontable.js",
+      "require": "./commonjs/react-handsontable.js"
+    }
+  },
   "keywords": [
     "handsontable",
     "component",

--- a/wrappers/vue/package.json
+++ b/wrappers/vue/package.json
@@ -10,6 +10,12 @@
   "jsdelivr": "./dist/vue-handsontable.min.js",
   "unpkg": "./dist/vue-handsontable.min.js",
   "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./es/vue-handsontable.js",
+      "require": "./commonjs/vue-handsontable.js"
+    }
+  },
   "keywords": [
     "handsontable",
     "component",

--- a/wrappers/vue3/package.json
+++ b/wrappers/vue3/package.json
@@ -10,6 +10,12 @@
   "jsdelivr": "./dist/vue-handsontable.min.js",
   "unpkg": "./dist/vue-handsontable.min.js",
   "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./es/vue-handsontable.js",
+      "require": "./commonjs/vue-handsontable.js"
+    }
+  },
   "keywords": [
     "handsontable",
     "component",


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adds the `"exports"` field to the `package.json` file of the wrappers. This resolves an issue with Webpack5 that in some cases grabs the ES files even when the code was written (or transpiled to) the CommonJS format.

The changes are applied to the React, Vue 2, and Vue 3 wrappers. The Angular wrapper has its own environment so I guess the change there is not necessary.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Based on [this comment](https://github.com/handsontable/handsontable/issues/9140#issuecomment-1029193443) I was able to reproduce the issue. Applying the fix that PR shows resolved the problem.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes #9140

### Affected project(s):
- [x] `@handsontable/react`
- [x] `@handsontable/vue`
- [x] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
