### PR TITLE
Fixed problem related to not working shortcut when using uppercase character in `addShortcut` method

### DIFF
--- a/handsontable/src/shortcuts/__tests__/context.unit.js
+++ b/handsontable/src/shortcuts/__tests__/context.unit.js
@@ -156,39 +156,75 @@ describe('context', () => {
       group: 'helloWorld'
     };
 
-    expect(context.hasShortcut(['control', 'a'])).toBe(false);
-    expect(context.hasShortcut(['Control', 'A'])).toBe(false);
-    expect(context.hasShortcut(['a', 'control'])).toBe(false);
-    expect(context.hasShortcut(['A', 'Control'])).toBe(false);
+    expect(context.hasShortcut(['meta', 'c'])).toBe(false);
+    expect(context.hasShortcut(['Meta', 'C'])).toBe(false);
+    expect(context.hasShortcut(['c', 'meta'])).toBe(false);
+    expect(context.hasShortcut(['C', 'Meta'])).toBe(false);
 
     context.addShortcut({
-      keys: [['control', 'a']],
+      keys: [['meta', 'C']],
       callback,
       ...options
     });
 
-    expect(context.hasShortcut(['control', 'a'])).toBe(true);
-    expect(context.hasShortcut(['Control', 'A'])).toBe(true);
-    expect(context.hasShortcut(['a', 'control'])).toBe(true);
-    expect(context.hasShortcut(['A', 'Control'])).toBe(true);
+    expect(context.hasShortcut(['meta', 'c'])).toBe(true);
+    expect(context.hasShortcut(['Meta', 'C'])).toBe(true);
+    expect(context.hasShortcut(['c', 'meta'])).toBe(true);
+    expect(context.hasShortcut(['C', 'Meta'])).toBe(true);
 
     context.addShortcut({
-      keys: [['control', 'a']],
+      keys: [['meta', 'c']],
       callback: callback2,
       ...options
     });
 
-    expect(context.hasShortcut(['control', 'a'])).toBe(true);
-    expect(context.hasShortcut(['Control', 'A'])).toBe(true);
-    expect(context.hasShortcut(['a', 'control'])).toBe(true);
-    expect(context.hasShortcut(['A', 'Control'])).toBe(true);
+    expect(context.hasShortcut(['meta', 'c'])).toBe(true);
+    expect(context.hasShortcut(['Meta', 'C'])).toBe(true);
+    expect(context.hasShortcut(['c', 'meta'])).toBe(true);
+    expect(context.hasShortcut(['C', 'Meta'])).toBe(true);
 
-    context.removeShortcutsByKeys(['control', 'a']);
+    context.removeShortcutsByKeys(['meta', 'c']);
 
-    expect(context.hasShortcut(['control', 'a'])).toBe(false);
-    expect(context.hasShortcut(['Control', 'A'])).toBe(false);
-    expect(context.hasShortcut(['a', 'control'])).toBe(false);
-    expect(context.hasShortcut(['A', 'Control'])).toBe(false);
+    expect(context.hasShortcut(['meta', 'c'])).toBe(false);
+    expect(context.hasShortcut(['Meta', 'C'])).toBe(false);
+    expect(context.hasShortcut(['c', 'meta'])).toBe(false);
+    expect(context.hasShortcut(['C', 'Meta'])).toBe(false);
+
+    context.addShortcut({
+      keys: [['Meta', 'c']],
+      callback,
+      ...options
+    });
+
+    expect(context.hasShortcut(['meta', 'c'])).toBe(true);
+    expect(context.hasShortcut(['Meta', 'C'])).toBe(true);
+    expect(context.hasShortcut(['c', 'meta'])).toBe(true);
+    expect(context.hasShortcut(['C', 'Meta'])).toBe(true);
+
+    context.removeShortcutsByKeys(['meta', 'c']);
+
+    expect(context.hasShortcut(['meta', 'c'])).toBe(false);
+    expect(context.hasShortcut(['Meta', 'C'])).toBe(false);
+    expect(context.hasShortcut(['c', 'meta'])).toBe(false);
+    expect(context.hasShortcut(['C', 'Meta'])).toBe(false);
+
+    context.addShortcut({
+      keys: [['Meta', 'C']],
+      callback,
+      ...options
+    });
+
+    expect(context.hasShortcut(['meta', 'c'])).toBe(true);
+    expect(context.hasShortcut(['Meta', 'C'])).toBe(true);
+    expect(context.hasShortcut(['c', 'meta'])).toBe(true);
+    expect(context.hasShortcut(['C', 'Meta'])).toBe(true);
+
+    context.removeShortcutsByKeys(['meta', 'c']);
+
+    expect(context.hasShortcut(['meta', 'c'])).toBe(false);
+    expect(context.hasShortcut(['Meta', 'C'])).toBe(false);
+    expect(context.hasShortcut(['c', 'meta'])).toBe(false);
+    expect(context.hasShortcut(['C', 'Meta'])).toBe(false);
   });
 
   it('should give a possibility to remove registered shortcuts by group', () => {

--- a/handsontable/src/shortcuts/utils.js
+++ b/handsontable/src/shortcuts/utils.js
@@ -28,7 +28,7 @@ const mappings = new Map([
  * @returns {string}
  */
 export const normalizeKeys = (keys) => {
-  return keys.sort().map((key) => {
+  return keys.map((key) => {
     const lowercaseKey = key.toLowerCase();
 
     if (mappings.has(lowercaseKey)) {
@@ -36,7 +36,7 @@ export const normalizeKeys = (keys) => {
     }
 
     return lowercaseKey;
-  }).join('+');
+  }).sort().join('+');
 };
 
 /**


### PR DESCRIPTION
### Context
Aa the title says.

Has been working:

`[['Control', 'c'], ['Meta', 'c']]`

Hasn't been working:

`[['Control', 'C'], ['Meta', 'C']]`

[skip changelog]

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Extra e2e test + manual tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #8955

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] My change requires a change to the documentation.
