### PR TITLE
Remove URL path from docs version dropdown list

### DIFF
--- a/docs/.vuepress/theme/components/Versions.vue
+++ b/docs/.vuepress/theme/components/Versions.vue
@@ -24,13 +24,11 @@ export default {
       return version;
     },
     getLink(version) {
-      const pathWithoutVersion = this.$route.path.replace(/^\/(\d+\.\d+|next)/, '');
-
       if (version === this.$page.latestVersion) {
-        return `/docs${pathWithoutVersion}`;
+        return `/docs/`;
       }
 
-      return `/docs/${version}${pathWithoutVersion}`;
+      return `/docs/${version}/`;
     },
     getLegacyVersions() {
       return [

--- a/docs/.vuepress/theme/components/Versions.vue
+++ b/docs/.vuepress/theme/components/Versions.vue
@@ -25,7 +25,7 @@ export default {
     },
     getLink(version) {
       if (version === this.$page.latestVersion) {
-        return `/docs/`;
+        return '/docs/';
       }
 
       return `/docs/${version}/`;


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR removes the URL's path from the docs version dropdown list. From now on all links points to the main page (Introduction) of the docs instead of the same page where the user navigates from but with a different version.

The change allows decreasing the 404 pages that happen when the new docs page does not exist in previous docs versions.

![Kapture 2022-03-08 at 13 32 33](https://user-images.githubusercontent.com/571316/157238839-a0104fa3-0f26-47f5-8c44-c3a41d9497c1.gif)

_[skip changelog]_

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
