### PR TITLE
Fix an infinit loop in the CellRange's method

### DIFF
--- a/handsontable/src/3rdparty/walkontable/src/cell/range.js
+++ b/handsontable/src/3rdparty/walkontable/src/cell/range.js
@@ -272,17 +272,17 @@ class CellRange {
       return false;
     }
 
-    const topLeft = this.getOuterTopLeftCorner();
-    const bottomRight = this.getOuterBottomRightCorner();
+    const topStart = this.getOuterTopStartCorner();
+    const bottomEnd = this.getOuterBottomEndCorner();
     const initialDirection = this.getDirection();
 
-    const expandingTopLeft = expandingRange.getOuterTopLeftCorner();
-    const expandingBottomRight = expandingRange.getOuterBottomRightCorner();
+    const expandingTopStart = expandingRange.getOuterTopStartCorner();
+    const expandingBottomEnd = expandingRange.getOuterBottomEndCorner();
 
-    const resultTopRow = Math.min(topLeft.row, expandingTopLeft.row);
-    const resultTopCol = Math.min(topLeft.col, expandingTopLeft.col);
-    const resultBottomRow = Math.max(bottomRight.row, expandingBottomRight.row);
-    const resultBottomCol = Math.max(bottomRight.col, expandingBottomRight.col);
+    const resultTopRow = Math.min(topStart.row, expandingTopStart.row);
+    const resultTopCol = Math.min(topStart.col, expandingTopStart.col);
+    const resultBottomRow = Math.max(bottomEnd.row, expandingBottomEnd.row);
+    const resultBottomCol = Math.max(bottomEnd.col, expandingBottomEnd.col);
 
     const finalFrom = this._createCellCoords(resultTopRow, resultTopCol);
     const finalTo = this._createCellCoords(resultBottomRow, resultBottomCol);

--- a/handsontable/src/3rdparty/walkontable/test/unit/cell/range.unit.js
+++ b/handsontable/src/3rdparty/walkontable/test/unit/cell/range.unit.js
@@ -727,6 +727,68 @@ describe('CellRange', () => {
     });
   });
 
+  describe('expandByRange()', () => {
+    it('should not expand a cell range when the passed range is not bigger than that expanded one', () => {
+      const range = createRange(0, 0, 0, 0, 2, 2);
+      const newRange = createRange(1, 1, 1, 1, 2, 2);
+
+      expect(range.expandByRange(newRange)).toBe(false);
+      expect(range.highlight).toEqual({ row: 0, col: 0 });
+      expect(range.from).toEqual({ row: 0, col: 0 });
+      expect(range.to).toEqual({ row: 2, col: 2 });
+    });
+
+    it('should not expand a cell range when the passed range does not overlap that range', () => {
+      const range = createRange(0, 0, 0, 0, 2, 2);
+      const newRange = createRange(3, 3, 3, 3, 4, 4);
+
+      expect(range.expandByRange(newRange)).toBe(false);
+      expect(range.highlight).toEqual({ row: 0, col: 0 });
+      expect(range.from).toEqual({ row: 0, col: 0 });
+      expect(range.to).toEqual({ row: 2, col: 2 });
+    });
+
+    it('should expand a cell range in top-left direction', () => {
+      const range = createRange(1, 1, 1, 1, 3, 3);
+      const newRange = createRange(0, 0, 0, 0, 1, 1);
+
+      expect(range.expandByRange(newRange)).toBe(true);
+      expect(range.highlight).toEqual({ row: 1, col: 1 });
+      expect(range.from).toEqual({ row: 0, col: 0 });
+      expect(range.to).toEqual({ row: 3, col: 3 });
+    });
+
+    it('should expand a cell range in top-right direction', () => {
+      const range = createRange(1, 1, 1, 1, 3, 3);
+      const newRange = createRange(0, 3, 0, 3, 1, 4);
+
+      expect(range.expandByRange(newRange)).toBe(true);
+      expect(range.highlight).toEqual({ row: 1, col: 1 });
+      expect(range.from).toEqual({ row: 0, col: 1 });
+      expect(range.to).toEqual({ row: 3, col: 4 });
+    });
+
+    it('should expand a cell range in bottom-left direction', () => {
+      const range = createRange(1, 1, 1, 1, 3, 3);
+      const newRange = createRange(3, 0, 3, 0, 4, 1);
+
+      expect(range.expandByRange(newRange)).toBe(true);
+      expect(range.highlight).toEqual({ row: 1, col: 1 });
+      expect(range.from).toEqual({ row: 1, col: 0 });
+      expect(range.to).toEqual({ row: 4, col: 3 });
+    });
+
+    it('should expand a cell range in bottom-right direction', () => {
+      const range = createRange(1, 1, 1, 1, 3, 3);
+      const newRange = createRange(0, 3, 0, 3, 1, 4);
+
+      expect(range.expandByRange(newRange)).toBe(true);
+      expect(range.highlight).toEqual({ row: 1, col: 1 });
+      expect(range.from).toEqual({ row: 0, col: 1 });
+      expect(range.to).toEqual({ row: 3, col: 4 });
+    });
+  });
+
   describe('isSingle()', () => {
     it('should return `true` when `from` and `to` are equals and there is no header selected', () => {
       {
@@ -1365,6 +1427,68 @@ describe('CellRange', () => {
 
         expect(bottomRight.row).toBe(5);
         expect(bottomRight.col).toBe(0);
+      });
+    });
+
+    describe('expandByRange()', () => {
+      it('should not expand a cell range when the passed range is not bigger than that expanded one', () => {
+        const range = createRangeRTL(0, 0, 0, 0, 2, 2);
+        const newRange = createRangeRTL(1, 1, 1, 1, 2, 2);
+
+        expect(range.expandByRange(newRange)).toBe(false);
+        expect(range.highlight).toEqual({ row: 0, col: 0 });
+        expect(range.from).toEqual({ row: 0, col: 0 });
+        expect(range.to).toEqual({ row: 2, col: 2 });
+      });
+
+      it('should not expand a cell range when the passed range does not overlap that range', () => {
+        const range = createRangeRTL(0, 0, 0, 0, 2, 2);
+        const newRange = createRangeRTL(3, 3, 3, 3, 4, 4);
+
+        expect(range.expandByRange(newRange)).toBe(false);
+        expect(range.highlight).toEqual({ row: 0, col: 0 });
+        expect(range.from).toEqual({ row: 0, col: 0 });
+        expect(range.to).toEqual({ row: 2, col: 2 });
+      });
+
+      it('should expand a cell range in top-right direction', () => {
+        const range = createRangeRTL(1, 1, 1, 1, 3, 3);
+        const newRange = createRangeRTL(0, 0, 0, 0, 1, 1);
+
+        expect(range.expandByRange(newRange)).toBe(true);
+        expect(range.highlight).toEqual({ row: 1, col: 1 });
+        expect(range.from).toEqual({ row: 0, col: 0 });
+        expect(range.to).toEqual({ row: 3, col: 3 });
+      });
+
+      it('should expand a cell range in top-left direction', () => {
+        const range = createRangeRTL(1, 1, 1, 1, 3, 3);
+        const newRange = createRangeRTL(0, 3, 0, 3, 1, 4);
+
+        expect(range.expandByRange(newRange)).toBe(true);
+        expect(range.highlight).toEqual({ row: 1, col: 1 });
+        expect(range.from).toEqual({ row: 0, col: 1 });
+        expect(range.to).toEqual({ row: 3, col: 4 });
+      });
+
+      it('should expand a cell range in bottom-right direction', () => {
+        const range = createRangeRTL(1, 1, 1, 1, 3, 3);
+        const newRange = createRangeRTL(3, 0, 3, 0, 4, 1);
+
+        expect(range.expandByRange(newRange)).toBe(true);
+        expect(range.highlight).toEqual({ row: 1, col: 1 });
+        expect(range.from).toEqual({ row: 1, col: 0 });
+        expect(range.to).toEqual({ row: 4, col: 3 });
+      });
+
+      it('should expand a cell range in bottom-left direction', () => {
+        const range = createRangeRTL(1, 1, 1, 1, 3, 3);
+        const newRange = createRangeRTL(0, 3, 0, 3, 1, 4);
+
+        expect(range.expandByRange(newRange)).toBe(true);
+        expect(range.highlight).toEqual({ row: 1, col: 1 });
+        expect(range.from).toEqual({ row: 0, col: 1 });
+        expect(range.to).toEqual({ row: 3, col: 4 });
       });
     });
   });


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the `expandByRange` method of the `CellRange` class. There was an implementation that goes into an infinity loop when Handsontable is initialized in RTL mode.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes #9288

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
