### PR TITLE
Fix wrong viewport width calculation for Viewport

### DIFF
--- a/handsontable/src/3rdparty/walkontable/src/viewport.js
+++ b/handsontable/src/3rdparty/walkontable/src/viewport.js
@@ -75,6 +75,10 @@ class Viewport {
     const docOffsetWidth = rootDocument.documentElement.offsetWidth;
     const totalColumns = wtSettings.getSetting('totalColumns');
     const preventOverflow = wtSettings.getSetting('preventOverflow');
+    const isRtl = wtSettings.getSetting('rtlMode');
+    const tableRect = this.wtTable.TABLE.getBoundingClientRect();
+    const inlineStart = isRtl ? tableRect.right - docOffsetWidth : tableRect.left;
+    const tableOffset = docOffsetWidth - inlineStart;
     let width;
     let overflow;
 
@@ -83,9 +87,9 @@ class Viewport {
     }
 
     if (wtSettings.getSetting('freezeOverlays')) {
-      width = Math.min(docOffsetWidth - this.getWorkspaceOffset().left, docOffsetWidth);
+      width = Math.min(tableOffset, docOffsetWidth);
     } else {
-      width = Math.min(this.getContainerFillWidth(), docOffsetWidth - this.getWorkspaceOffset().left, docOffsetWidth);
+      width = Math.min(this.getContainerFillWidth(), tableOffset, docOffsetWidth);
     }
 
     if (trimmingContainer === rootWindow && totalColumns > 0 && this.sumColumnWidths(0, totalColumns - 1) > width) {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the bug that causes returning the wrong viewport width value through the `getWorkspaceWidth` method of the `Viewport` class when Handsontable is initialized in RTL mode.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes #9289

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
