### PR TITLE
Restored `puppeteer`'s timeout to default

### DIFF
--- a/handsontable/test/scripts/run-puppeteer.mjs
+++ b/handsontable/test/scripts/run-puppeteer.mjs
@@ -5,7 +5,6 @@ import { createServer } from 'http-server';
 import JasmineReporter from 'jasmine-terminal-reporter';
 
 const PORT = 8086;
-const DEFAULT_INACTIVITY_TIMEOUT = 10000;
 const IS_CI = process.env.CI;
 const CI_DOTS_PER_LINE = 120;
 
@@ -44,7 +43,6 @@ const cleanupFactory = (browser, server) => async(exitCode) => {
 
 (async() => {
   const browser = await puppeteer.launch({
-    timeout: DEFAULT_INACTIVITY_TIMEOUT,
     // devtools: true, // Turn it on to debug the tests.
     headless: false,
     // Puppeteer by default hide the scrollbars in headless mode (https://github.com/GoogleChrome/puppeteer/blob/master/lib/Launcher.js#L86).


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
After discussion with @warpech a suggestion was made to restore `puppeteer`'s timeout to default.

[skip changelog]

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Run `npm run test` script few times.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] My change requires a change to the documentation.
