### PR TITLE
IndexMapper interate indexes instead of recursion 

### DIFF
--- a/.changelogs/9064.json
+++ b/.changelogs/9064.json
@@ -1,0 +1,7 @@
+{
+  "title": "IndexMapper interate indexes instead of recursion (call stack exceeded)",
+  "type": "fixed",
+  "issue": 9064,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/translations/indexMapper.js
+++ b/handsontable/src/translations/indexMapper.js
@@ -386,22 +386,25 @@ export class IndexMapper {
    */
   getFirstNotHiddenIndex(fromVisualIndex, incrementBy, searchAlsoOtherWayAround = false,
                          indexForNextSearch = fromVisualIndex - incrementBy) {
-    const physicalIndex = this.getPhysicalFromVisualIndex(fromVisualIndex);
+    do {
+      const physicalIndex = this.getPhysicalFromVisualIndex(fromVisualIndex);
 
-    // First or next (it may be end of the table) index is beyond the table boundaries.
-    if (physicalIndex === null) {
-      // Looking for the next index in the opposite direction. This conditional won't be fulfilled when we STARTED
-      // the search from the index beyond the table boundaries.
-      if (searchAlsoOtherWayAround === true && indexForNextSearch !== fromVisualIndex - incrementBy) {
-        return this.getFirstNotHiddenIndex(indexForNextSearch, -incrementBy, false, indexForNextSearch);
+      // First or next (it may be end of the table) index is beyond the table boundaries.
+      if (physicalIndex === null) {
+        // Looking for the next index in the opposite direction. This conditional won't be fulfilled when we STARTED
+        // the search from the index beyond the table boundaries.
+        if (searchAlsoOtherWayAround === true && indexForNextSearch !== fromVisualIndex - incrementBy) {
+          return this.getFirstNotHiddenIndex(indexForNextSearch, -incrementBy, false, indexForNextSearch);
+        }
+
+        return null;
       }
 
-      return null;
-    }
-
-    if (this.isHidden(physicalIndex) === false) {
-      return fromVisualIndex;
-    }
+      if (this.isHidden(physicalIndex) === false) {
+        return fromVisualIndex;
+      }
+      fromVisualIndex += incrementBy;
+    } while (fromVisualIndex);
 
     // Looking for the next index, as the current isn't visible.
     return this.getFirstNotHiddenIndex(


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
`hiddenColumns` + `hiddenRows` were limited to ~5500 elements because of recursive method and exceeding call stack size for larger tables to be hidden. 

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/9064

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
