### PR TITLE
Change the name of the theme switcher button

### DIFF
--- a/docs/.vuepress/theme/components/Sidebar.vue
+++ b/docs/.vuepress/theme/components/Sidebar.vue
@@ -1,7 +1,7 @@
 <template>
   <aside class="sidebar">
     <div class="theme-switcher-item">
-      Color theme: <ThemeSwitcher />
+      Choose a theme: <ThemeSwitcher />
     </div>
     <NavLinks />
 

--- a/docs/.vuepress/theme/components/ThemeSwitcher.vue
+++ b/docs/.vuepress/theme/components/ThemeSwitcher.vue
@@ -76,13 +76,13 @@ export default {
   @media (max-width: $MQNarrow) {
     & {
       display: inline-block;
-      left: 80px;
+      left: 50px;
     }
   }
 
   @media (max-width: $MQMobile) {
     & {
-      left: 90px;
+      left: 65px;
     }
   }
 }


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR changes the name of the switcher that allows changing a theme. 

Related issue https://github.com/handsontable/handsontable.com-v2/issues/135

_[skip changelog]_

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
