### PR TITLE
Make the keyboard docs table more responsible for mobile screens

### DIFF
--- a/docs/.vuepress/theme/styles/index.styl
+++ b/docs/.vuepress/theme/styles/index.styl
@@ -219,10 +219,6 @@ table {
   .page {
     padding-left: 0;
   }
-
-  table {
-    word-break: break-word;
-  }
 }
 
 @media (min-width: 1080px) {
@@ -348,6 +344,14 @@ kbd {
   border-bottom-width: 2px;
   background: #fafbff;
 }
+
+@media (max-width: $MQMobileNarrow) {
+  kbd {
+    white-space: pre-wrap;
+    display: inline-block;
+  }
+}
+
 
 /* Styles for the icon-pack page */
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adjusts the markdown table to be more readable for mobile screens.

#### Before (http://localhost:8080/docs/keyboard-navigation/):
![image](https://user-images.githubusercontent.com/571316/159669688-373c9f6f-d1b1-4566-9b41-109072c66f65.png)

#### After:
![image](https://user-images.githubusercontent.com/571316/159669755-86a5c717-c454-4d4d-be21-37076f931c31.png)

Related issue https://github.com/handsontable/handsontable.com-v2/issues/135

_[skip changelog]_

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
