### PR TITLE
Fix canonicals for old docs

### DIFF
--- a/docs/.vuepress/public/scripts/canonicals-for-legacy-docs.js
+++ b/docs/.vuepress/public/scripts/canonicals-for-legacy-docs.js
@@ -31,6 +31,7 @@
     [/\/docs\/\d+\.\d+\.\d+\/tutorial-testing.html$/, '/docs/testing/'],
     [/\/docs\/\d+\.\d+\.\d+\/tutorial-migration-guide.html$/, '/docs/migration-from-7.4-to-8.0/'],
     [/\/docs\/\d+\.\d+\.\d+\/tutorial-principles.html$/, '/docs/6.2.2/tutorial-principles.html'],
+    [/\/docs\/\d+\.\d+\.\d+\/tutorial-performance-tips.html$/, '/docs/performance/'],
     // frameworks React
     [/\/docs\/\d+\.\d+\.\d+\/frameworks-wrapper-for-react-installation.html$/, '/docs/react-installation/'],
     [/\/docs\/\d+\.\d+\.\d+\/frameworks-wrapper-for-react-simple-examples.html$/, '/docs/react-simple-example/'],

--- a/docs/.vuepress/public/scripts/canonicals-for-legacy-docs.js
+++ b/docs/.vuepress/public/scripts/canonicals-for-legacy-docs.js
@@ -31,6 +31,7 @@
     [/\/docs\/\d+\.\d+\.\d+\/tutorial-testing.html$/, '/docs/testing/'],
     [/\/docs\/\d+\.\d+\.\d+\/tutorial-migration-guide.html$/, '/docs/migration-from-7.4-to-8.0/'],
     [/\/docs\/\d+\.\d+\.\d+\/tutorial-principles.html$/, '/docs/6.2.2/tutorial-principles.html'],
+    [/\/docs\/\d+\.\d+\.\d+\/tutorial-good-practices.html$/, '/docs/6.2.2/tutorial-good-practices.html'],
     [/\/docs\/\d+\.\d+\.\d+\/tutorial-performance-tips.html$/, '/docs/performance/'],
     // frameworks React
     [/\/docs\/\d+\.\d+\.\d+\/frameworks-wrapper-for-react-installation.html$/, '/docs/react-installation/'],

--- a/docs/.vuepress/public/scripts/canonicals-for-legacy-docs.js
+++ b/docs/.vuepress/public/scripts/canonicals-for-legacy-docs.js
@@ -30,9 +30,10 @@
     [/\/docs\/\d+\.\d+\.\d+\/tutorial-suspend-rendering.html$/, '/docs/batch-operations/'],
     [/\/docs\/\d+\.\d+\.\d+\/tutorial-testing.html$/, '/docs/testing/'],
     [/\/docs\/\d+\.\d+\.\d+\/tutorial-migration-guide.html$/, '/docs/migration-from-7.4-to-8.0/'],
+    [/\/docs\/\d+\.\d+\.\d+\/tutorial-performance-tips.html$/, '/docs/performance/'],
+    [/\/docs\/\d+\.\d+\.\d+\/tutorial-release-notes.html$/, '/docs/release-notes/'],
     [/\/docs\/\d+\.\d+\.\d+\/tutorial-principles.html$/, '/docs/6.2.2/tutorial-principles.html'],
     [/\/docs\/\d+\.\d+\.\d+\/tutorial-good-practices.html$/, '/docs/6.2.2/tutorial-good-practices.html'],
-    [/\/docs\/\d+\.\d+\.\d+\/tutorial-performance-tips.html$/, '/docs/performance/'],
     // frameworks React
     [/\/docs\/\d+\.\d+\.\d+\/frameworks-wrapper-for-react-installation.html$/, '/docs/react-installation/'],
     [/\/docs\/\d+\.\d+\.\d+\/frameworks-wrapper-for-react-simple-examples.html$/, '/docs/react-simple-example/'],

--- a/docs/.vuepress/public/scripts/canonicals-for-legacy-docs.js
+++ b/docs/.vuepress/public/scripts/canonicals-for-legacy-docs.js
@@ -30,6 +30,7 @@
     [/\/docs\/\d+\.\d+\.\d+\/tutorial-suspend-rendering.html$/, '/docs/batch-operations/'],
     [/\/docs\/\d+\.\d+\.\d+\/tutorial-testing.html$/, '/docs/testing/'],
     [/\/docs\/\d+\.\d+\.\d+\/tutorial-migration-guide.html$/, '/docs/migration-from-7.4-to-8.0/'],
+    [/\/docs\/\d+\.\d+\.\d+\/tutorial-principles.html$/, '/docs/6.2.2/tutorial-principles.html'],
     // frameworks React
     [/\/docs\/\d+\.\d+\.\d+\/frameworks-wrapper-for-react-installation.html$/, '/docs/react-installation/'],
     [/\/docs\/\d+\.\d+\.\d+\/frameworks-wrapper-for-react-simple-examples.html$/, '/docs/react-simple-example/'],
@@ -85,7 +86,7 @@
     [/\/docs\/\d+\.\d+\.\d+\/demo-multicolumn-sorting.html$/, '/docs/row-sorting/'],
     [/\/docs\/\d+\.\d+\.\d+\/demo-searching.html$/, '/docs/searching-values/'],
     [/\/docs\/\d+\.\d+\.\d+\/demo-filtering.html$/, '/docs/column-filter/'],
-    [/\/docs\/\d+\.\d+\.\d+\/demo-summary-calculations.html$/, '/docs/column-summary//'],
+    [/\/docs\/\d+\.\d+\.\d+\/demo-summary-calculations.html$/, '/docs/column-summary/'],
     [/\/docs\/\d+\.\d+\.\d+\/demo-data-validation.html$/, '/docs/cell-validator/'],
     [/\/docs\/\d+\.\d+\.\d+\/demo-auto-fill.html$/, '/docs/autofill-values/'],
     [/\/docs\/\d+\.\d+\.\d+\/demo-merged-cells.html$/, '/docs/merge-cells/'],

--- a/docs/.vuepress/public/scripts/canonicals-for-legacy-docs.js
+++ b/docs/.vuepress/public/scripts/canonicals-for-legacy-docs.js
@@ -34,6 +34,7 @@
     [/\/docs\/\d+\.\d+\.\d+\/tutorial-release-notes.html$/, '/docs/release-notes/'],
     [/\/docs\/\d+\.\d+\.\d+\/tutorial-principles.html$/, '/docs/6.2.2/tutorial-principles.html'],
     [/\/docs\/\d+\.\d+\.\d+\/tutorial-good-practices.html$/, '/docs/6.2.2/tutorial-good-practices.html'],
+    [/\/docs\/\d+\.\d+\.\d+\/tutorial-known-limitations.html$/, '/docs/7.2.2/tutorial-known-limitations.html'],
     // frameworks React
     [/\/docs\/\d+\.\d+\.\d+\/frameworks-wrapper-for-react-installation.html$/, '/docs/react-installation/'],
     [/\/docs\/\d+\.\d+\.\d+\/frameworks-wrapper-for-react-simple-examples.html$/, '/docs/react-simple-example/'],


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the canonical URL for old docs (4.0.0-8.4.0).

_[skip changelog]_

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
