### PR TITLE
Docs: Adding Czech to the 11.1 docs

### DIFF
--- a/docs/11.1/api/options.md
+++ b/docs/11.1/api/options.md
@@ -2526,6 +2526,7 @@ You can set the `language` option to one of the following:
 | Setting             | Description                 |
 | ------------------- | --------------------------- |
 | `'en-US'` (default) | English - United States     |
+| `'cs-CZ'`           | Czech - Czech Republic      |
 | `'de-DE'`           | German - Germany            |
 | `'es-MX'`           | Spanish - Mexico            |
 | `'fr-FR'`           | French - France             |

--- a/docs/11.1/guides/internationalization/internationalization-i18n.md
+++ b/docs/11.1/guides/internationalization/internationalization-i18n.md
@@ -107,8 +107,8 @@ Below you'll find a list of features which can be translated with the internatio
 By default, Handsontable uses the **English - United States** language-country set (`en-US` code) for creating the text of UI elements. However, it can be used like every extra, "non-standard" language file, thus the `en-US.js` file can be found in `/dist/languages`, `/languages` and `/src/languages` folders. Currently, we also distribute extra language-country files:
 
 * `cs-CZ.js` for **Czech - Czech Republic** (`cs-CZ` code).
-* `de-DE.js` for **German - Germany** (`de-DE` code).
 * `de-CH.js` for **German - Switzerland** (`de-CH` code).
+* `de-DE.js` for **German - Germany** (`de-DE` code).
 * `es-MX.js` for **Spanish - Mexico** (`es-MX` code).
 * `fr-FR.js` for **French - France** (`fr-FR` code).
 * `it-IT.js` for **Italian - Italy** (`it-IT` code).

--- a/docs/11.1/guides/internationalization/internationalization-i18n.md
+++ b/docs/11.1/guides/internationalization/internationalization-i18n.md
@@ -106,6 +106,7 @@ Below you'll find a list of features which can be translated with the internatio
 
 By default, Handsontable uses the **English - United States** language-country set (`en-US` code) for creating the text of UI elements. However, it can be used like every extra, "non-standard" language file, thus the `en-US.js` file can be found in `/dist/languages`, `/languages` and `/src/languages` folders. Currently, we also distribute extra language-country files:
 
+* `cs-CZ.js` for **Czech - Czech Republic** (`cs-CZ` code).
 * `de-DE.js` for **German - Germany** (`de-DE` code).
 * `de-CH.js` for **German - Switzerland** (`de-CH` code).
 * `es-MX.js` for **Spanish - Mexico** (`es-MX` code).


### PR DESCRIPTION
This PR:
- Adds info about the Czech translation, for the docs version `11.1` (for `12.0` and `next`, I'll add it to #9271)

[skip changelog]