### PR TITLE
Add missing redirect for /demo-custom-borders.html page

### DIFF
--- a/docs/docker/redirects.conf
+++ b/docs/docker/redirects.conf
@@ -113,6 +113,7 @@ rewrite ^/((\d+\.\d+|next)/)?demo-copy-paste/?$ /docs/$1basic-clipboard/ permane
 rewrite ^/((\d+\.\d+|next)/)?demo-export-file/?$ /docs/$1export-to-csv/ permanent;
 rewrite ^/((\d+\.\d+|next)/)?demo-conditional-formatting/?$ /docs/$1conditional-formatting/ permanent;
 rewrite ^/((\d+\.\d+|next)/)?demo-customizing-borders/?$ /docs/$1formatting-cells/ permanent;
+rewrite ^/((\d+\.\d+|next)/)?demo-custom-borders/?$ /docs/$1formatting-cells/ permanent;
 rewrite ^/((\d+\.\d+|next)/)?demo-selecting-ranges/?$ /docs/$1selection/ permanent;
 rewrite ^/((\d+\.\d+|next)/)?demo-formula-support/?$ /docs/$1formula-calculation/ permanent;
 rewrite ^/((\d+\.\d+|next)/)?demo-using-callbacks/?$ /docs/$1events-and-hooks/ permanent;


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adds a missing redirect for [/docs/demo-custom-borders.html](https://handsontable.com/docs/demo-custom-borders.html) page. The page has some incoming traffic (reported by Ahrefs).

_[skip changelog]_

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
