### PR TITLE
Change behavior of the Cmd/Ctrl + Arrow keyboard shortcuts

### DIFF
--- a/.changelogs/9363.json
+++ b/.changelogs/9363.json
@@ -1,0 +1,7 @@
+{
+  "title": "Changed behavior of the Cmd/Ctrl + Arrow keyboard shortcuts.",
+  "type": "changed",
+  "issue": 9363,
+  "breaking": true,
+  "framework": "none"
+}

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -4543,10 +4543,12 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
     keys: [['ArrowLeft', 'Control/Meta']],
     captureCtrl: true,
     callback: () => {
-      selection.setRangeStart(instance._createCellCoords(
-        instance.getSelectedRangeLast().highlight.row,
-        instance.columnIndexMapper.getFirstNotHiddenIndex(0, 1),
-      ));
+      const row = instance.getSelectedRangeLast().highlight.row;
+      const column = instance.columnIndexMapper.getFirstNotHiddenIndex(
+        ...(instance.isRtl() ? [instance.countCols() - 1, -1] : [0, 1])
+      );
+
+      selection.setRangeStart(instance._createCellCoords(row, column));
     },
   }, {
     keys: [
@@ -4566,10 +4568,12 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
     keys: [['ArrowRight', 'Control/Meta']],
     captureCtrl: true,
     callback: () => {
-      selection.setRangeStart(instance._createCellCoords(
-        instance.getSelectedRangeLast().highlight.row,
-        instance.columnIndexMapper.getFirstNotHiddenIndex(instance.countCols() - 1, -1),
-      ));
+      const row = instance.getSelectedRangeLast().highlight.row;
+      const column = instance.columnIndexMapper.getFirstNotHiddenIndex(
+        ...(instance.isRtl() ? [0, 1] : [instance.countCols() - 1, -1])
+      );
+
+      selection.setRangeStart(instance._createCellCoords(row, column));
     },
   }, {
     keys: [

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -4489,9 +4489,18 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
       instance.selectAll();
     },
   }, {
-    keys: [['ArrowUp'], ['Control/Meta', 'ArrowUp']],
+    keys: [['ArrowUp']],
     callback: () => {
       selection.transformStart(-1, 0);
+    },
+  }, {
+    keys: [['ArrowUp', 'Control/Meta']],
+    captureCtrl: true,
+    callback: () => {
+      selection.setRangeStart(instance._createCellCoords(
+        instance.rowIndexMapper.getFirstNotHiddenIndex(0, 1),
+        instance.getSelectedRangeLast().highlight.col,
+      ));
     },
   }, {
     keys: [
@@ -4503,9 +4512,18 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
       selection.transformEnd(-1, 0);
     },
   }, {
-    keys: [['ArrowDown'], ['Control/Meta', 'ArrowDown']],
+    keys: [['ArrowDown']],
     callback: () => {
       selection.transformStart(1, 0);
+    },
+  }, {
+    keys: [['ArrowDown', 'Control/Meta']],
+    captureCtrl: true,
+    callback: () => {
+      selection.setRangeStart(instance._createCellCoords(
+        instance.rowIndexMapper.getFirstNotHiddenIndex(instance.countRows() - 1, -1),
+        instance.getSelectedRangeLast().highlight.col,
+      ));
     },
   }, {
     keys: [
@@ -4517,9 +4535,18 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
       selection.transformEnd(1, 0);
     },
   }, {
-    keys: [['ArrowLeft'], ['Control/Meta', 'ArrowLeft']],
+    keys: [['ArrowLeft']],
     callback: () => {
       selection.transformStart(0, -1 * instance.getDirectionFactor());
+    },
+  }, {
+    keys: [['ArrowLeft', 'Control/Meta']],
+    captureCtrl: true,
+    callback: () => {
+      selection.setRangeStart(instance._createCellCoords(
+        instance.getSelectedRangeLast().highlight.row,
+        instance.columnIndexMapper.getFirstNotHiddenIndex(0, 1),
+      ));
     },
   }, {
     keys: [
@@ -4531,9 +4558,18 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
       selection.transformEnd(0, -1 * instance.getDirectionFactor());
     },
   }, {
-    keys: [['ArrowRight'], ['Control/Meta', 'ArrowRight']],
+    keys: [['ArrowRight']],
     callback: () => {
       selection.transformStart(0, instance.getDirectionFactor());
+    },
+  }, {
+    keys: [['ArrowRight', 'Control/Meta']],
+    captureCtrl: true,
+    callback: () => {
+      selection.setRangeStart(instance._createCellCoords(
+        instance.getSelectedRangeLast().highlight.row,
+        instance.columnIndexMapper.getFirstNotHiddenIndex(instance.countCols() - 1, -1),
+      ));
     },
   }, {
     keys: [

--- a/handsontable/src/shortcuts/__tests__/context.unit.js
+++ b/handsontable/src/shortcuts/__tests__/context.unit.js
@@ -339,22 +339,26 @@ describe('context', () => {
     };
     const config = {
       group: 'namespace1',
+      captureCtrl: false,
       runOnlyIf: () => true,
     };
     const config2 = {
       group: 'namespace2',
       relativeToGroup: 'namespace1',
       position: 'before',
+      captureCtrl: false,
       runOnlyIf: () => true,
     };
     const config3 = {
       group: 'namespace3',
+      captureCtrl: false,
       runOnlyIf: () => true,
     };
     const config4 = {
       group: 'namespace4',
       relativeToGroup: 'namespace2',
       position: 'after',
+      captureCtrl: false,
       runOnlyIf: () => true,
     };
 

--- a/handsontable/src/shortcuts/__tests__/shortcutManager.spec.js
+++ b/handsontable/src/shortcuts/__tests__/shortcutManager.spec.js
@@ -51,7 +51,7 @@ describe('shortcutManager', () => {
 
       keyDown('control');
 
-      expect(shortcutManager.isCtrlPressed()).toBe(true);
+      expect(shortcutManager.isCtrlPressed()).toBeTrue();
 
       keyUp('control');
 
@@ -82,7 +82,7 @@ describe('shortcutManager', () => {
 
       keyDown('meta');
 
-      expect(shortcutManager.isCtrlPressed()).toBe(true);
+      expect(shortcutManager.isCtrlPressed()).toBeTrue();
 
       keyUp('meta');
 
@@ -272,6 +272,40 @@ describe('shortcutManager', () => {
     keyDownUp(['control', 'b']);
 
     expect(text).toBe('12');
+  });
+
+  it('should be possible to capture the Ctrl/Meta pressed keys state using the "captureCtrl" option', () => {
+    const hot = handsontable({});
+    const shortcutManager = hot.getShortcutManager();
+    const gridContext = shortcutManager.getContext('grid');
+    const isCtrlPressedSpy = jasmine.createSpy();
+
+    gridContext.addShortcut({
+      keys: [['control', 'b']],
+      callback: () => {
+        isCtrlPressedSpy(shortcutManager.isCtrlPressed());
+      },
+      group: 'spy',
+    });
+
+    gridContext.addShortcut({
+      keys: [['control', 'k']],
+      captureCtrl: true,
+      callback: () => {
+        isCtrlPressedSpy(shortcutManager.isCtrlPressed());
+      },
+      group: 'spy',
+    });
+
+    selectCell(0, 0);
+    keyDownUp(['control', 'b']);
+
+    expect(isCtrlPressedSpy).toHaveBeenCalledWith(true);
+
+    isCtrlPressedSpy.calls.reset();
+    keyDownUp(['control', 'k']);
+
+    expect(isCtrlPressedSpy).toHaveBeenCalledWith(false);
   });
 
   it('should handle action properly when something is removed from actions stack dynamically (executing "old" list of actions)', () => {

--- a/handsontable/src/shortcuts/context.js
+++ b/handsontable/src/shortcuts/context.js
@@ -26,12 +26,14 @@ export const createContext = (name) => {
    * @param {Array<Array<string>>} options.keys Shortcut's keys being KeyboardEvent's key properties. Full list of values
    * is [available here](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key).
    * @param {Function} options.callback The callback.
-   * @param {object} options.group Group for shortcut.
-   * @param {object} [options.runOnlyIf]  Option determine whether assigned callback should be performed.
-   * @param {object} [options.stopPropagation=true] Option determine whether to stop event's propagation.
-   * @param {object} [options.preventDefault=true] Option determine whether to prevent default behavior.
-   * @param {object} [options.relativeToGroup] Group name, relative which the shortcut is placed.
-   * @param {object} [options.position='after'] Position where shortcut is placed. It may be added before or after
+   * @param {string} options.group Group for shortcut.
+   * @param {Function} [options.runOnlyIf] Option determines whether assigned callback should be performed.
+   * @param {boolean} [options.captureCtrl=false] Option determines whether the Ctrl/Meta modifier keys will be
+   *                                              blocked for other listeners while executing this shortcut action.
+   * @param {boolean} [options.stopPropagation=true] Option determines whether to stop event's propagation.
+   * @param {boolean} [options.preventDefault=true] Option determines whether to prevent default behavior.
+   * @param {string} [options.relativeToGroup] Group name, relative which the shortcut is placed.
+   * @param {string} [options.position='after'] Position where shortcut is placed. It may be added before or after
    * another group.
    *
    */
@@ -41,6 +43,7 @@ export const createContext = (name) => {
       callback,
       group,
       runOnlyIf = () => true,
+      captureCtrl = false,
       preventDefault = true,
       stopPropagation = false,
       relativeToGroup,
@@ -65,6 +68,7 @@ export const createContext = (name) => {
       callback,
       group,
       runOnlyIf,
+      captureCtrl,
       preventDefault,
       stopPropagation,
     };

--- a/handsontable/src/shortcuts/manager.js
+++ b/handsontable/src/shortcuts/manager.js
@@ -76,6 +76,15 @@ export const createShortcutManager = ({ ownerWindow, beforeKeyDown, afterKeyDown
   };
 
   /**
+   * The variable, in combination with the `captureCtrl` shortcut option, allows capturing the state
+   * of the pressed Control/Meta keys. Some keyboard shortcuts related to the selection to work
+   * correctly need to use that feature.
+   *
+   * @type {boolean}
+   */
+  let isCtrlKeySilenced = false;
+
+  /**
    * Internal key recorder.
    *
    * @private
@@ -84,28 +93,32 @@ export const createShortcutManager = ({ ownerWindow, beforeKeyDown, afterKeyDown
     const activeContext = getContext(getActiveContextName());
     let isExecutionCancelled = false;
 
-    if (activeContext.hasShortcut(keys)) {
-      // Processing just actions being in stack at the moment of shortcut pressing (without respecting additions/removals performed dynamically).
-      const shortcuts = activeContext.getShortcuts(keys);
+    if (!activeContext.hasShortcut(keys)) {
+      return isExecutionCancelled;
+    }
 
-      for (let index = 0; index < shortcuts.length; index++) {
-        const { callback, runOnlyIf, preventDefault, stopPropagation } = shortcuts[index];
+    // Processing just actions being in stack at the moment of shortcut pressing (without respecting additions/removals performed dynamically).
+    const shortcuts = activeContext.getShortcuts(keys);
 
-        if (runOnlyIf(event) !== false) {
-          // eslint-disable-next-line no-unneeded-ternary
-          isExecutionCancelled = callback(event, keys) === false ? true : false;
+    for (let index = 0; index < shortcuts.length; index++) {
+      const { callback, runOnlyIf, preventDefault, stopPropagation, captureCtrl } = shortcuts[index];
 
-          if (preventDefault) {
-            event.preventDefault();
-          }
+      if (runOnlyIf(event) !== false) {
+        isCtrlKeySilenced = captureCtrl;
+        // eslint-disable-next-line no-unneeded-ternary
+        isExecutionCancelled = callback(event, keys) === false ? true : false;
+        isCtrlKeySilenced = false;
 
-          if (stopPropagation) {
-            event.stopPropagation();
-          }
+        if (preventDefault) {
+          event.preventDefault();
+        }
 
-          if (isExecutionCancelled) {
-            break;
-          }
+        if (stopPropagation) {
+          event.stopPropagation();
+        }
+
+        if (isExecutionCancelled) {
+          break;
         }
       }
     }
@@ -121,13 +134,13 @@ export const createShortcutManager = ({ ownerWindow, beforeKeyDown, afterKeyDown
     getContext,
     setActiveContextName,
     /**
-     * Returns whether `control` key is pressed.
+     * Returns whether `control` or `meta` keys are pressed.
      *
      * @memberof ShortcutManager#
      * @type {Function}
      * @returns {boolean}
      */
-    isCtrlPressed: () => keyRecorder.isPressed('control') || keyRecorder.isPressed('meta'),
+    isCtrlPressed: () => !isCtrlKeySilenced && (keyRecorder.isPressed('control') || keyRecorder.isPressed('meta')),
     /**
      * Destroys instance of the manager.
      *

--- a/handsontable/test/e2e/Core_selection.spec.js
+++ b/handsontable/test/e2e/Core_selection.spec.js
@@ -3243,7 +3243,7 @@ describe('Core_selection', () => {
       expect(hooks.afterSelectionEnd.calls.argsFor(0)).toEqual([10, 'prop10', 10, 'prop25', 10]);
     });
 
-    describe('should select multiple cells while using ctrl/meta + arrow keys', () => {
+    describe('should move the selection highlight to a proper position while using ctrl/meta + arrow keys', () => {
       it('arrow down', () => {
         handsontable({
           rowHeaders: true,
@@ -3252,23 +3252,50 @@ describe('Core_selection', () => {
           startCols: 5,
         });
 
-        selectCell(0, 0);
+        selectCell(1, 1);
         keyDownUp(['control/meta', 'arrowdown']);
 
-        expect(getSelected()).toEqual([[0, 0, 0, 0], [1, 0, 1, 0]]);
+        expect(getSelected()).toEqual([[4, 1, 4, 1]]);
         expect(`
-          |   ║ - :   :   :   :   |
+          |   ║   : - :   :   :   |
           |===:===:===:===:===:===|
-          | - ║ 0 :   :   :   :   |
-          | - ║ A :   :   :   :   |
           |   ║   :   :   :   :   |
           |   ║   :   :   :   :   |
           |   ║   :   :   :   :   |
+          |   ║   :   :   :   :   |
+          | - ║   : # :   :   :   |
+        `).toBeMatchToSelectionPattern();
+
+        selectCells([[3, 3, 1, 1]]);
+        keyDownUp(['control/meta', 'arrowdown']);
+
+        expect(getSelected()).toEqual([[4, 3, 4, 3]]);
+        expect(`
+          |   ║   :   :   : - :   |
+          |===:===:===:===:===:===|
+          |   ║   :   :   :   :   |
+          |   ║   :   :   :   :   |
+          |   ║   :   :   :   :   |
+          |   ║   :   :   :   :   |
+          | - ║   :   :   : # :   |
+        `).toBeMatchToSelectionPattern();
+
+        selectColumns(2);
+        keyDownUp(['control/meta', 'arrowdown']);
+
+        expect(getSelected()).toEqual([[4, 2, 4, 2]]);
+        expect(`
+          |   ║   :   : - :   :   |
+          |===:===:===:===:===:===|
+          |   ║   :   :   :   :   |
+          |   ║   :   :   :   :   |
+          |   ║   :   :   :   :   |
+          |   ║   :   :   :   :   |
+          | - ║   :   : # :   :   |
         `).toBeMatchToSelectionPattern();
       });
 
       it('arrow up', () => {
-
         handsontable({
           rowHeaders: true,
           colHeaders: true,
@@ -3276,18 +3303,46 @@ describe('Core_selection', () => {
           startCols: 5,
         });
 
-        selectCell(4, 0);
+        selectCell(3, 3);
         keyDownUp(['control/meta', 'arrowup']);
 
-        expect(getSelected()).toEqual([[4, 0, 4, 0], [3, 0, 3, 0]]);
+        expect(getSelected()).toEqual([[0, 3, 0, 3]]);
         expect(`
-          |   ║ - :   :   :   :   |
+          |   ║   :   :   : - :   |
           |===:===:===:===:===:===|
+          | - ║   :   :   : # :   |
           |   ║   :   :   :   :   |
           |   ║   :   :   :   :   |
           |   ║   :   :   :   :   |
-          | - ║ A :   :   :   :   |
-          | - ║ 0 :   :   :   :   |
+          |   ║   :   :   :   :   |
+        `).toBeMatchToSelectionPattern();
+
+        selectCells([[3, 1, 1, 3]]);
+        keyDownUp(['control/meta', 'arrowup']);
+
+        expect(getSelected()).toEqual([[0, 1, 0, 1]]);
+        expect(`
+          |   ║   : - :   :   :   |
+          |===:===:===:===:===:===|
+          | - ║   : # :   :   :   |
+          |   ║   :   :   :   :   |
+          |   ║   :   :   :   :   |
+          |   ║   :   :   :   :   |
+          |   ║   :   :   :   :   |
+        `).toBeMatchToSelectionPattern();
+
+        selectColumns(2);
+        keyDownUp(['control/meta', 'arrowup']);
+
+        expect(getSelected()).toEqual([[0, 2, 0, 2]]);
+        expect(`
+          |   ║   :   : - :   :   |
+          |===:===:===:===:===:===|
+          | - ║   :   : # :   :   |
+          |   ║   :   :   :   :   |
+          |   ║   :   :   :   :   |
+          |   ║   :   :   :   :   |
+          |   ║   :   :   :   :   |
         `).toBeMatchToSelectionPattern();
       });
 
@@ -3299,16 +3354,44 @@ describe('Core_selection', () => {
           startCols: 5,
         });
 
-        selectCell(0, 4);
+        selectCell(1, 3);
         keyDownUp(['control/meta', 'arrowleft']);
 
-        expect(getSelected()).toEqual([[0, 4, 0, 4], [0, 3, 0, 3]]);
+        expect(getSelected()).toEqual([[1, 0, 1, 0]]);
         expect(`
-          |   ║   :   :   : - : - |
+          |   ║ - :   :   :   :   |
           |===:===:===:===:===:===|
-          | - ║   :   :   : A : 0 |
+          |   ║   :   :   :   :   |
+          | - ║ # :   :   :   :   |
           |   ║   :   :   :   :   |
           |   ║   :   :   :   :   |
+          |   ║   :   :   :   :   |
+        `).toBeMatchToSelectionPattern();
+
+        selectCells([[3, 3, 1, 1]]);
+        keyDownUp(['control/meta', 'arrowleft']);
+
+        expect(getSelected()).toEqual([[3, 0, 3, 0]]);
+        expect(`
+          |   ║ - :   :   :   :   |
+          |===:===:===:===:===:===|
+          |   ║   :   :   :   :   |
+          |   ║   :   :   :   :   |
+          |   ║   :   :   :   :   |
+          | - ║ # :   :   :   :   |
+          |   ║   :   :   :   :   |
+        `).toBeMatchToSelectionPattern();
+
+        selectRows(2);
+        keyDownUp(['control/meta', 'arrowleft']);
+
+        expect(getSelected()).toEqual([[2, 0, 2, 0]]);
+        expect(`
+          |   ║ - :   :   :   :   |
+          |===:===:===:===:===:===|
+          |   ║   :   :   :   :   |
+          |   ║   :   :   :   :   |
+          | - ║ # :   :   :   :   |
           |   ║   :   :   :   :   |
           |   ║   :   :   :   :   |
         `).toBeMatchToSelectionPattern();
@@ -3322,16 +3405,44 @@ describe('Core_selection', () => {
           startCols: 5,
         });
 
-        selectCell(0, 0);
+        selectCell(1, 3);
         keyDownUp(['control/meta', 'arrowright']);
 
-        expect(getSelected()).toEqual([[0, 0, 0, 0], [0, 1, 0, 1]]);
+        expect(getSelected()).toEqual([[1, 4, 1, 4]]);
         expect(`
-          |   ║ - : - :   :   :   |
+          |   ║   :   :   :   : - |
           |===:===:===:===:===:===|
-          | - ║ 0 : A :   :   :   |
+          |   ║   :   :   :   :   |
+          | - ║   :   :   :   : # |
           |   ║   :   :   :   :   |
           |   ║   :   :   :   :   |
+          |   ║   :   :   :   :   |
+        `).toBeMatchToSelectionPattern();
+
+        selectCells([[3, 1, 1, 3]]);
+        keyDownUp(['control/meta', 'arrowright']);
+
+        expect(getSelected()).toEqual([[3, 4, 3, 4]]);
+        expect(`
+          |   ║   :   :   :   : - |
+          |===:===:===:===:===:===|
+          |   ║   :   :   :   :   |
+          |   ║   :   :   :   :   |
+          |   ║   :   :   :   :   |
+          | - ║   :   :   :   : # |
+          |   ║   :   :   :   :   |
+        `).toBeMatchToSelectionPattern();
+
+        selectRows(2);
+        keyDownUp(['control/meta', 'arrowright']);
+
+        expect(getSelected()).toEqual([[2, 4, 2, 4]]);
+        expect(`
+          |   ║   :   :   :   : - |
+          |===:===:===:===:===:===|
+          |   ║   :   :   :   :   |
+          |   ║   :   :   :   :   |
+          | - ║   :   :   :   : # |
           |   ║   :   :   :   :   |
           |   ║   :   :   :   :   |
         `).toBeMatchToSelectionPattern();

--- a/handsontable/test/e2e/rtl/Core_selection.spec.js
+++ b/handsontable/test/e2e/rtl/Core_selection.spec.js
@@ -1,0 +1,234 @@
+describe('ContextMenu (RTL mode)', () => {
+  using('configuration object', [
+    { htmlDir: 'rtl', layoutDirection: 'inherit' },
+    { htmlDir: 'ltr', layoutDirection: 'rtl' },
+  ], ({ htmlDir, layoutDirection }) => {
+    const id = 'testContainer';
+
+    beforeEach(function() {
+      $('html').attr('dir', htmlDir);
+      this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+    });
+
+    afterEach(function() {
+      $('html').attr('dir', 'ltr');
+
+      if (this.$container) {
+        destroy();
+        this.$container.remove();
+      }
+    });
+
+    describe('multiple selection mode', () => {
+      describe('should move the selection highlight to a proper position while using ctrl/meta + arrow keys', () => {
+        it('arrow down', () => {
+          handsontable({
+            layoutDirection,
+            rowHeaders: true,
+            colHeaders: true,
+            startRows: 5,
+            startCols: 5,
+          });
+
+          selectCell(1, 1);
+          keyDownUp(['control/meta', 'arrowdown']);
+
+          expect(getSelected()).toEqual([[4, 1, 4, 1]]);
+          expect(`
+            |   ║   : - :   :   :   |
+            |===:===:===:===:===:===|
+            |   ║   :   :   :   :   |
+            |   ║   :   :   :   :   |
+            |   ║   :   :   :   :   |
+            |   ║   :   :   :   :   |
+            | - ║   : # :   :   :   |
+          `).toBeMatchToSelectionPattern();
+
+          selectCells([[3, 3, 1, 1]]);
+          keyDownUp(['control/meta', 'arrowdown']);
+
+          expect(getSelected()).toEqual([[4, 3, 4, 3]]);
+          expect(`
+            |   ║   :   :   : - :   |
+            |===:===:===:===:===:===|
+            |   ║   :   :   :   :   |
+            |   ║   :   :   :   :   |
+            |   ║   :   :   :   :   |
+            |   ║   :   :   :   :   |
+            | - ║   :   :   : # :   |
+          `).toBeMatchToSelectionPattern();
+
+          selectColumns(2);
+          keyDownUp(['control/meta', 'arrowdown']);
+
+          expect(getSelected()).toEqual([[4, 2, 4, 2]]);
+          expect(`
+            |   ║   :   : - :   :   |
+            |===:===:===:===:===:===|
+            |   ║   :   :   :   :   |
+            |   ║   :   :   :   :   |
+            |   ║   :   :   :   :   |
+            |   ║   :   :   :   :   |
+            | - ║   :   : # :   :   |
+          `).toBeMatchToSelectionPattern();
+        });
+
+        it('arrow up', () => {
+          handsontable({
+            layoutDirection,
+            rowHeaders: true,
+            colHeaders: true,
+            startRows: 5,
+            startCols: 5,
+          });
+
+          selectCell(3, 3);
+          keyDownUp(['control/meta', 'arrowup']);
+
+          expect(getSelected()).toEqual([[0, 3, 0, 3]]);
+          expect(`
+            |   ║   :   :   : - :   |
+            |===:===:===:===:===:===|
+            | - ║   :   :   : # :   |
+            |   ║   :   :   :   :   |
+            |   ║   :   :   :   :   |
+            |   ║   :   :   :   :   |
+            |   ║   :   :   :   :   |
+          `).toBeMatchToSelectionPattern();
+
+          selectCells([[3, 1, 1, 3]]);
+          keyDownUp(['control/meta', 'arrowup']);
+
+          expect(getSelected()).toEqual([[0, 1, 0, 1]]);
+          expect(`
+            |   ║   : - :   :   :   |
+            |===:===:===:===:===:===|
+            | - ║   : # :   :   :   |
+            |   ║   :   :   :   :   |
+            |   ║   :   :   :   :   |
+            |   ║   :   :   :   :   |
+            |   ║   :   :   :   :   |
+          `).toBeMatchToSelectionPattern();
+
+          selectColumns(2);
+          keyDownUp(['control/meta', 'arrowup']);
+
+          expect(getSelected()).toEqual([[0, 2, 0, 2]]);
+          expect(`
+            |   ║   :   : - :   :   |
+            |===:===:===:===:===:===|
+            | - ║   :   : # :   :   |
+            |   ║   :   :   :   :   |
+            |   ║   :   :   :   :   |
+            |   ║   :   :   :   :   |
+            |   ║   :   :   :   :   |
+          `).toBeMatchToSelectionPattern();
+        });
+
+        it('arrow left', () => {
+          handsontable({
+            layoutDirection,
+            rowHeaders: true,
+            colHeaders: true,
+            startRows: 5,
+            startCols: 5,
+          });
+
+          selectCell(1, 3);
+          keyDownUp(['control/meta', 'arrowleft']);
+
+          expect(getSelected()).toEqual([[1, 4, 1, 4]]);
+          expect(`
+            |   ║   :   :   :   : - |
+            |===:===:===:===:===:===|
+            |   ║   :   :   :   :   |
+            | - ║   :   :   :   : # |
+            |   ║   :   :   :   :   |
+            |   ║   :   :   :   :   |
+            |   ║   :   :   :   :   |
+          `).toBeMatchToSelectionPattern();
+
+          selectCells([[3, 1, 1, 3]]);
+          keyDownUp(['control/meta', 'arrowleft']);
+
+          expect(getSelected()).toEqual([[3, 4, 3, 4]]);
+          expect(`
+            |   ║   :   :   :   : - |
+            |===:===:===:===:===:===|
+            |   ║   :   :   :   :   |
+            |   ║   :   :   :   :   |
+            |   ║   :   :   :   :   |
+            | - ║   :   :   :   : # |
+            |   ║   :   :   :   :   |
+          `).toBeMatchToSelectionPattern();
+
+          selectRows(2);
+          keyDownUp(['control/meta', 'arrowleft']);
+
+          expect(getSelected()).toEqual([[2, 4, 2, 4]]);
+          expect(`
+            |   ║   :   :   :   : - |
+            |===:===:===:===:===:===|
+            |   ║   :   :   :   :   |
+            |   ║   :   :   :   :   |
+            | - ║   :   :   :   : # |
+            |   ║   :   :   :   :   |
+            |   ║   :   :   :   :   |
+          `).toBeMatchToSelectionPattern();
+        });
+
+        it('arrow right', () => {
+          handsontable({
+            layoutDirection,
+            rowHeaders: true,
+            colHeaders: true,
+            startRows: 5,
+            startCols: 5,
+          });
+
+          selectCell(1, 3);
+          keyDownUp(['control/meta', 'arrowright']);
+
+          expect(getSelected()).toEqual([[1, 0, 1, 0]]);
+          expect(`
+            |   ║ - :   :   :   :   |
+            |===:===:===:===:===:===|
+            |   ║   :   :   :   :   |
+            | - ║ # :   :   :   :   |
+            |   ║   :   :   :   :   |
+            |   ║   :   :   :   :   |
+            |   ║   :   :   :   :   |
+          `).toBeMatchToSelectionPattern();
+
+          selectCells([[3, 3, 1, 1]]);
+          keyDownUp(['control/meta', 'arrowright']);
+
+          expect(getSelected()).toEqual([[3, 0, 3, 0]]);
+          expect(`
+            |   ║ - :   :   :   :   |
+            |===:===:===:===:===:===|
+            |   ║   :   :   :   :   |
+            |   ║   :   :   :   :   |
+            |   ║   :   :   :   :   |
+            | - ║ # :   :   :   :   |
+            |   ║   :   :   :   :   |
+          `).toBeMatchToSelectionPattern();
+
+          selectRows(2);
+          keyDownUp(['control/meta', 'arrowright']);
+
+          expect(getSelected()).toEqual([[2, 0, 2, 0]]);
+          expect(`
+            |   ║ - :   :   :   :   |
+            |===:===:===:===:===:===|
+            |   ║   :   :   :   :   |
+            |   ║   :   :   :   :   |
+            | - ║ # :   :   :   :   |
+            |   ║   :   :   :   :   |
+            |   ║   :   :   :   :   |
+          `).toBeMatchToSelectionPattern();
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR changes the behavior of the Cmd/Ctrl + Arrow keyboard shortcuts.

macOS | Windows, Linux | Expected behavior
-- | -- | --
Cmd ⌘ + Arrow up | Ctrl + Arrow up | Move to the first cell (first row) in a column 
Cmd ⌘ + Arrow down | Ctrl + Arrow down | Move to the last cell (last row) in a column 
Cmd ⌘ + Arrow left | Ctrl + Arrow left | Move to the left-most cell in a row 
Cmd ⌘ + Arrow right | Ctrl + Arrow right | Move to the right-most cell in a row 

To implement a new behavior there is a need to implement a new mechanism that disables capturing and returning the state of the pressed Command/Meta keys. 

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally using LTR and RTL layout direction and I covered the code with the new unit and E2E tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):
1.
2.
3.

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
