### PR TITLE
Remove the Cmd+M keyboard shortcut

### DIFF
--- a/handsontable/src/plugins/mergeCells/__tests__/keyboardShortcuts.spec.js
+++ b/handsontable/src/plugins/mergeCells/__tests__/keyboardShortcuts.spec.js
@@ -1,0 +1,73 @@
+describe('MergeCells keyboard shortcut', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  describe('"Control" + "M"', () => {
+    it('should merge selected cells', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        mergeCells: true,
+      });
+
+      selectCells([[1, 1, 3, 3]]);
+      keyDownUp(['control', 'm']);
+
+      const cell = getCell(1, 1);
+
+      expect(cell.rowSpan).toBe(3);
+      expect(cell.colSpan).toBe(3);
+    });
+
+    it('should toggle the selected cells to merged/unmerged/merged state', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        mergeCells: true,
+      });
+
+      selectCells([[1, 1, 3, 3]]);
+      keyDownUp(['control', 'm']);
+
+      const cell = getCell(1, 1);
+
+      expect(cell.rowSpan).toBe(3);
+      expect(cell.colSpan).toBe(3);
+
+      keyDownUp(['control', 'm']);
+
+      expect(cell.rowSpan).toBe(1);
+      expect(cell.colSpan).toBe(1);
+
+      keyDownUp(['control', 'm']);
+
+      expect(cell.rowSpan).toBe(3);
+      expect(cell.colSpan).toBe(3);
+    });
+  });
+
+  describe('"Command" + "M"', () => {
+    it('should not merge selected cells', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        mergeCells: true,
+      });
+
+      selectCells([[1, 1, 3, 3]]);
+      keyDownUp(['command', 'm']);
+
+      const cell = getCell(1, 1);
+
+      expect(cell.rowSpan).toBe(1);
+      expect(cell.colSpan).toBe(1);
+    });
+  });
+});

--- a/handsontable/src/plugins/mergeCells/mergeCells.js
+++ b/handsontable/src/plugins/mergeCells/mergeCells.js
@@ -537,7 +537,7 @@ export class MergeCells extends BasePlugin {
     const gridContext = shortcutManager.getContext('grid');
 
     gridContext.addShortcut({
-      keys: [['Control/Meta', 'm']],
+      keys: [['Control', 'm']],
       callback: () => {
         this.toggleMerge(this.hot.getSelectedRangeLast());
         this.hot.render();


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR removes the Command+M keyboard shortcut. To merge the cells, only the Control+M keyboard shortcut will work. This removes the conflict with native macOS behavior, which minimizes the application windows.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the change locally, and I covered the fix with E2E tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):
1. fixes #9368

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
