### PR TITLE
Add a new behavior for Cmd/Ctrl + Enter keyboard shortcut

### DIFF
--- a/.changelogs/9366.json
+++ b/.changelogs/9366.json
@@ -1,0 +1,7 @@
+{
+  "title": "Added Cmd/Ctrl + Enter keyboard shortcut that allows to fill the selected range of cells with the value of the active cell.",
+  "type": "added",
+  "issue": 9366,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/src/cell/range.js
+++ b/handsontable/src/3rdparty/walkontable/src/cell/range.js
@@ -139,6 +139,15 @@ class CellRange {
   }
 
   /**
+   * Returns the number of cells within the range (excluding the column and row headers, if selected).
+   *
+   * @returns {number}
+   */
+  getCellsCount() {
+    return this.getWidth() * this.getHeight();
+  }
+
+  /**
    * Checks if given cell coordinates are within `from` and `to` cell coordinates of this range.
    *
    * @param {CellCoords} cellCoords The cell coordinates to check.

--- a/handsontable/src/3rdparty/walkontable/test/unit/cell/range.unit.js
+++ b/handsontable/src/3rdparty/walkontable/test/unit/cell/range.unit.js
@@ -131,6 +131,26 @@ describe('CellRange', () => {
     });
   });
 
+  describe('getCellsCount()', () => {
+    it('should return correct cells count ignoring the negative values (headers)', () => {
+      const range = createRange(-1, -2, 1, -2, 5, 5);
+
+      expect(range.getCellsCount()).toBe(30);
+    });
+
+    it('should return correct cells count for selection in the middle of the coordinate space', () => {
+      const range = createRange(1, 1, 1, 1, 5, 5);
+
+      expect(range.getCellsCount()).toBe(25);
+    });
+
+    it('should return 1 for singular cell\'s selection', () => {
+      const range = createRange(0, 0, 0, 0, 0, 0);
+
+      expect(range.getCellsCount()).toBe(1);
+    });
+  });
+
   describe('getOuterHeight()', () => {
     it('should return range hight including headers - from top-left to bottom-right', () => {
       const range = createRange(-1, -2, -2, 1, 5, 5);

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -4644,10 +4644,9 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
     keys: [['Home']],
     captureCtrl: true,
     callback: () => {
-      const countColumns = instance.countCols();
-      const visualFixedColumns = Math.min(parseInt(instance.getSettings().fixedColumnsStart, 10), countColumns - 1);
+      const fixedColumns = parseInt(instance.getSettings().fixedColumnsStart, 10);
       const row = instance.getSelectedRangeLast().highlight.row;
-      const column = instance.columnIndexMapper.getFirstNotHiddenIndex(visualFixedColumns, 1);
+      const column = instance.columnIndexMapper.getFirstNotHiddenIndex(fixedColumns, 1);
 
       selection.setRangeStart(instance._createCellCoords(row, column));
     },
@@ -4664,12 +4663,10 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
     keys: [['Home', 'Control/Meta']],
     captureCtrl: true,
     callback: () => {
-      const countRows = instance.countRows();
-      const countColumns = instance.countCols();
-      const visualFixedRows = Math.min(parseInt(instance.getSettings().fixedRowsTop, 10), countRows - 1);
-      const visualFixedColumns = Math.min(parseInt(instance.getSettings().fixedColumnsStart, 10), countColumns - 1);
-      const row = instance.rowIndexMapper.getFirstNotHiddenIndex(visualFixedRows, 1);
-      const column = instance.columnIndexMapper.getFirstNotHiddenIndex(visualFixedColumns, 1);
+      const fixedRows = parseInt(instance.getSettings().fixedRowsTop, 10);
+      const fixedColumns = parseInt(instance.getSettings().fixedColumnsStart, 10);
+      const row = instance.rowIndexMapper.getFirstNotHiddenIndex(fixedRows, 1);
+      const column = instance.columnIndexMapper.getFirstNotHiddenIndex(fixedColumns, 1);
 
       selection.setRangeStart(instance._createCellCoords(row, column));
     },

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -4510,7 +4510,11 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
       for (let i = 0; i < selectedRange.length; i++) {
         selectedRange[i].forAll((row, column) => {
           if (row >= 0 && column >= 0 && (row !== highlightRow || column !== highlightColumn)) {
-            cellValues.set(`${row}x${column}`, [row, column, valueToPopulate]);
+            const { readOnly } = instance.getCellMeta(row, column);
+
+            if (!readOnly) {
+              cellValues.set(`${row}x${column}`, [row, column, valueToPopulate]);
+            }
           }
         });
       }

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -4644,9 +4644,10 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
     keys: [['Home']],
     captureCtrl: true,
     callback: () => {
-      const fixedColumns = parseInt(instance.getSettings().fixedColumnsStart, 10);
+      const countColumns = instance.countCols();
+      const visualFixedColumns = Math.min(parseInt(instance.getSettings().fixedColumnsStart, 10), countColumns - 1);
       const row = instance.getSelectedRangeLast().highlight.row;
-      const column = instance.columnIndexMapper.getFirstNotHiddenIndex(fixedColumns, 1);
+      const column = instance.columnIndexMapper.getFirstNotHiddenIndex(visualFixedColumns, 1);
 
       selection.setRangeStart(instance._createCellCoords(row, column));
     },
@@ -4663,10 +4664,12 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
     keys: [['Home', 'Control/Meta']],
     captureCtrl: true,
     callback: () => {
-      const fixedRows = parseInt(instance.getSettings().fixedRowsTop, 10);
-      const fixedColumns = parseInt(instance.getSettings().fixedColumnsStart, 10);
-      const row = instance.rowIndexMapper.getFirstNotHiddenIndex(fixedRows, 1);
-      const column = instance.columnIndexMapper.getFirstNotHiddenIndex(fixedColumns, 1);
+      const countRows = instance.countRows();
+      const countColumns = instance.countCols();
+      const visualFixedRows = Math.min(parseInt(instance.getSettings().fixedRowsTop, 10), countRows - 1);
+      const visualFixedColumns = Math.min(parseInt(instance.getSettings().fixedColumnsStart, 10), countColumns - 1);
+      const row = instance.rowIndexMapper.getFirstNotHiddenIndex(visualFixedRows, 1);
+      const column = instance.columnIndexMapper.getFirstNotHiddenIndex(visualFixedColumns, 1);
 
       selection.setRangeStart(instance._createCellCoords(row, column));
     },

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -4497,6 +4497,28 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
       instance.selectAll();
     },
   }, {
+    keys: [['Control/Meta', 'Enter']],
+    callback: () => {
+      const selectedRange = instance.getSelectedRange();
+      const {
+        row: highlightRow,
+        col: highlightColumn,
+      } = selectedRange[selectedRange.length - 1].highlight;
+      const valueToPopulate = instance.getDataAtCell(highlightRow, highlightColumn);
+      const cellValues = new Map();
+
+      for (let i = 0; i < selectedRange.length; i++) {
+        selectedRange[i].forAll((row, column) => {
+          if (row >= 0 && column >= 0 && (row !== highlightRow || column !== highlightColumn)) {
+            cellValues.set(`${row}x${column}`, [row, column, valueToPopulate]);
+          }
+        });
+      }
+
+      instance.setDataAtCell(Array.from(cellValues.values()));
+    },
+    runOnlyIf: () => instance.getSelectedRangeLast().getCellsCount() > 1,
+  }, {
     keys: [['ArrowUp']],
     callback: () => {
       selection.transformStart(-1, 0);

--- a/handsontable/src/shortcuts/recorder.js
+++ b/handsontable/src/shortcuts/recorder.js
@@ -97,11 +97,6 @@ export function useRecorder(ownerWindow, beforeKeyDown, afterKeyDown, callback) 
       callback(event, [pressedKey].concat(getPressedModifierKeys(event, true)));
     }
 
-    if (isMacOS() && extraModifierKeys.includes('meta') || !isMacOS() && extraModifierKeys.includes('control')) {
-      // Trigger the callback for the virtual OS-dependent "mod" key
-      callback(event, [pressedKey].concat(getPressedModifierKeys(event, true)));
-    }
-
     afterKeyDown(event);
   };
 

--- a/handsontable/src/shortcuts/recorder.js
+++ b/handsontable/src/shortcuts/recorder.js
@@ -97,6 +97,11 @@ export function useRecorder(ownerWindow, beforeKeyDown, afterKeyDown, callback) 
       callback(event, [pressedKey].concat(getPressedModifierKeys(event, true)));
     }
 
+    if (isMacOS() && extraModifierKeys.includes('meta') || !isMacOS() && extraModifierKeys.includes('control')) {
+      // Trigger the callback for the virtual OS-dependent "mod" key
+      callback(event, [pressedKey].concat(getPressedModifierKeys(event, true)));
+    }
+
     afterKeyDown(event);
   };
 

--- a/handsontable/test/e2e/keyboardShortcuts/selection.spec.js
+++ b/handsontable/test/e2e/keyboardShortcuts/selection.spec.js
@@ -99,6 +99,7 @@ describe('Core selection keyboard shortcut', () => {
       expect(getSelected()).toEqual([[-1, 1, 4, 4]]);
     });
 
+<<<<<<< HEAD
     it('should not change the selection when row header is selected', () => {
       handsontable({
         rowHeaders: true,
@@ -123,6 +124,8 @@ describe('Core selection keyboard shortcut', () => {
       expect(getSelected()).toEqual([[1, -1, 1, 4]]);
     });
 
+=======
+>>>>>>> c12bedb38 (Add a new behavior for Cmd/Ctrl + Shift + Arrow keys keybaord shortcuts)
     it('should not change the selection when all cells are selected (triggered by corner click)', () => {
       handsontable({
         rowHeaders: true,
@@ -136,6 +139,7 @@ describe('Core selection keyboard shortcut', () => {
       keyDownUp(['control/meta', 'shift', 'arrowright']);
 
       expect(`
+<<<<<<< HEAD
         |   ║ * : * : * : * : * |
         |===:===:===:===:===:===|
         | * ║ A : 0 : 0 : 0 : 0 |
@@ -144,6 +148,16 @@ describe('Core selection keyboard shortcut', () => {
         | * ║ 0 : 0 : 0 : 0 : 0 |
         | * ║ 0 : 0 : 0 : 0 : 0 |
       `).toBeMatchToSelectionPattern();
+=======
+      |   ║ * : * : * : * : * |
+      |===:===:===:===:===:===|
+      | * ║ A : 0 : 0 : 0 : 0 |
+      | * ║ 0 : 0 : 0 : 0 : 0 |
+      | * ║ 0 : 0 : 0 : 0 : 0 |
+      | * ║ 0 : 0 : 0 : 0 : 0 |
+      | * ║ 0 : 0 : 0 : 0 : 0 |
+    `).toBeMatchToSelectionPattern();
+>>>>>>> c12bedb38 (Add a new behavior for Cmd/Ctrl + Shift + Arrow keys keybaord shortcuts)
       expect(getSelected()).toEqual([[-1, -1, 4, 4]]);
     });
   });
@@ -235,6 +249,7 @@ describe('Core selection keyboard shortcut', () => {
       expect(getSelected()).toEqual([[-1, 3, 4, 0]]);
     });
 
+<<<<<<< HEAD
     it('should not change the selection when row header is selected', () => {
       handsontable({
         rowHeaders: true,
@@ -259,6 +274,8 @@ describe('Core selection keyboard shortcut', () => {
       expect(getSelected()).toEqual([[1, -1, 1, 4]]);
     });
 
+=======
+>>>>>>> c12bedb38 (Add a new behavior for Cmd/Ctrl + Shift + Arrow keys keybaord shortcuts)
     it('should not change the selection when all cells are selected (triggered by corner click)', () => {
       handsontable({
         rowHeaders: true,
@@ -371,6 +388,7 @@ describe('Core selection keyboard shortcut', () => {
       expect(getSelected()).toEqual([[3, -1, 0, 4]]);
     });
 
+<<<<<<< HEAD
     it('should not change the selection when column header is selected', () => {
       handsontable({
         rowHeaders: true,
@@ -395,6 +413,8 @@ describe('Core selection keyboard shortcut', () => {
       expect(getSelected()).toEqual([[-1, 1, 4, 1]]);
     });
 
+=======
+>>>>>>> c12bedb38 (Add a new behavior for Cmd/Ctrl + Shift + Arrow keys keybaord shortcuts)
     it('should not change the selection when all cells are selected (triggered by corner click)', () => {
       handsontable({
         rowHeaders: true,
@@ -507,6 +527,7 @@ describe('Core selection keyboard shortcut', () => {
       expect(getSelected()).toEqual([[1, -1, 4, 4]]);
     });
 
+<<<<<<< HEAD
     it('should not change the selection when column header is selected', () => {
       handsontable({
         rowHeaders: true,
@@ -531,6 +552,8 @@ describe('Core selection keyboard shortcut', () => {
       expect(getSelected()).toEqual([[-1, 1, 4, 1]]);
     });
 
+=======
+>>>>>>> c12bedb38 (Add a new behavior for Cmd/Ctrl + Shift + Arrow keys keybaord shortcuts)
     it('should not change the selection when all cells are selected (triggered by corner click)', () => {
       handsontable({
         rowHeaders: true,
@@ -555,6 +578,7 @@ describe('Core selection keyboard shortcut', () => {
       expect(getSelected()).toEqual([[-1, -1, 4, 4]]);
     });
   });
+<<<<<<< HEAD
 
   describe('"PageUp + Shift"', () => {
     it('should extend the cell selection up by the height of the table viewport', () => {
@@ -812,4 +836,6 @@ describe('Core selection keyboard shortcut', () => {
       expect(getSelectedRangeLast().to.row).toBe(hot.view.getFirstFullyVisibleRow() + 4);
     });
   });
+=======
+>>>>>>> c12bedb38 (Add a new behavior for Cmd/Ctrl + Shift + Arrow keys keybaord shortcuts)
 });

--- a/handsontable/test/e2e/keyboardShortcuts/selection.spec.js
+++ b/handsontable/test/e2e/keyboardShortcuts/selection.spec.js
@@ -99,7 +99,6 @@ describe('Core selection keyboard shortcut', () => {
       expect(getSelected()).toEqual([[-1, 1, 4, 4]]);
     });
 
-<<<<<<< HEAD
     it('should not change the selection when row header is selected', () => {
       handsontable({
         rowHeaders: true,
@@ -124,8 +123,6 @@ describe('Core selection keyboard shortcut', () => {
       expect(getSelected()).toEqual([[1, -1, 1, 4]]);
     });
 
-=======
->>>>>>> c12bedb38 (Add a new behavior for Cmd/Ctrl + Shift + Arrow keys keybaord shortcuts)
     it('should not change the selection when all cells are selected (triggered by corner click)', () => {
       handsontable({
         rowHeaders: true,
@@ -139,7 +136,6 @@ describe('Core selection keyboard shortcut', () => {
       keyDownUp(['control/meta', 'shift', 'arrowright']);
 
       expect(`
-<<<<<<< HEAD
         |   ║ * : * : * : * : * |
         |===:===:===:===:===:===|
         | * ║ A : 0 : 0 : 0 : 0 |
@@ -148,16 +144,6 @@ describe('Core selection keyboard shortcut', () => {
         | * ║ 0 : 0 : 0 : 0 : 0 |
         | * ║ 0 : 0 : 0 : 0 : 0 |
       `).toBeMatchToSelectionPattern();
-=======
-      |   ║ * : * : * : * : * |
-      |===:===:===:===:===:===|
-      | * ║ A : 0 : 0 : 0 : 0 |
-      | * ║ 0 : 0 : 0 : 0 : 0 |
-      | * ║ 0 : 0 : 0 : 0 : 0 |
-      | * ║ 0 : 0 : 0 : 0 : 0 |
-      | * ║ 0 : 0 : 0 : 0 : 0 |
-    `).toBeMatchToSelectionPattern();
->>>>>>> c12bedb38 (Add a new behavior for Cmd/Ctrl + Shift + Arrow keys keybaord shortcuts)
       expect(getSelected()).toEqual([[-1, -1, 4, 4]]);
     });
   });
@@ -249,7 +235,6 @@ describe('Core selection keyboard shortcut', () => {
       expect(getSelected()).toEqual([[-1, 3, 4, 0]]);
     });
 
-<<<<<<< HEAD
     it('should not change the selection when row header is selected', () => {
       handsontable({
         rowHeaders: true,
@@ -274,8 +259,6 @@ describe('Core selection keyboard shortcut', () => {
       expect(getSelected()).toEqual([[1, -1, 1, 4]]);
     });
 
-=======
->>>>>>> c12bedb38 (Add a new behavior for Cmd/Ctrl + Shift + Arrow keys keybaord shortcuts)
     it('should not change the selection when all cells are selected (triggered by corner click)', () => {
       handsontable({
         rowHeaders: true,
@@ -388,7 +371,6 @@ describe('Core selection keyboard shortcut', () => {
       expect(getSelected()).toEqual([[3, -1, 0, 4]]);
     });
 
-<<<<<<< HEAD
     it('should not change the selection when column header is selected', () => {
       handsontable({
         rowHeaders: true,
@@ -413,8 +395,6 @@ describe('Core selection keyboard shortcut', () => {
       expect(getSelected()).toEqual([[-1, 1, 4, 1]]);
     });
 
-=======
->>>>>>> c12bedb38 (Add a new behavior for Cmd/Ctrl + Shift + Arrow keys keybaord shortcuts)
     it('should not change the selection when all cells are selected (triggered by corner click)', () => {
       handsontable({
         rowHeaders: true,
@@ -527,7 +507,6 @@ describe('Core selection keyboard shortcut', () => {
       expect(getSelected()).toEqual([[1, -1, 4, 4]]);
     });
 
-<<<<<<< HEAD
     it('should not change the selection when column header is selected', () => {
       handsontable({
         rowHeaders: true,
@@ -552,8 +531,6 @@ describe('Core selection keyboard shortcut', () => {
       expect(getSelected()).toEqual([[-1, 1, 4, 1]]);
     });
 
-=======
->>>>>>> c12bedb38 (Add a new behavior for Cmd/Ctrl + Shift + Arrow keys keybaord shortcuts)
     it('should not change the selection when all cells are selected (triggered by corner click)', () => {
       handsontable({
         rowHeaders: true,
@@ -578,7 +555,6 @@ describe('Core selection keyboard shortcut', () => {
       expect(getSelected()).toEqual([[-1, -1, 4, 4]]);
     });
   });
-<<<<<<< HEAD
 
   describe('"PageUp + Shift"', () => {
     it('should extend the cell selection up by the height of the table viewport', () => {
@@ -836,6 +812,4 @@ describe('Core selection keyboard shortcut', () => {
       expect(getSelectedRangeLast().to.row).toBe(hot.view.getFirstFullyVisibleRow() + 4);
     });
   });
-=======
->>>>>>> c12bedb38 (Add a new behavior for Cmd/Ctrl + Shift + Arrow keys keybaord shortcuts)
 });

--- a/handsontable/test/e2e/keyboardShortcuts/selection.spec.js
+++ b/handsontable/test/e2e/keyboardShortcuts/selection.spec.js
@@ -1043,5 +1043,41 @@ describe('Core selection keyboard shortcut', () => {
         [1, 2, 'C2', 'A2'],
       ], 'edit');
     });
+
+    it('should populate the cell value omitting cells that are marked as read-only', () => {
+      const afterChange = jasmine.createSpy('afterChange');
+
+      handsontable({
+        data: createSpreadsheetData(8, 8),
+        rowHeaders: true,
+        colHeaders: true,
+        afterChange,
+        columns: [
+          {},
+          { readOnly: true },
+          {},
+          { readOnly: true },
+          {},
+          {},
+          {},
+          {},
+        ],
+        cell: [{ row: 1, col: 0, readOnly: true }],
+      });
+
+      afterChange.calls.reset(); // reset initial "afterChange" call after load data
+      selectCells([[1, 0, 4, 1], [4, 5, 4, 0]]);
+      keyDownUp(['control/meta', 'enter']);
+
+      expect(getSelected()).toEqual([[1, 0, 4, 1], [4, 5, 4, 0]]);
+      expect(afterChange).toHaveBeenCalledTimes(1);
+      expect(afterChange).toHaveBeenCalledWith([
+        [2, 0, 'A3', 'F5'],
+        [3, 0, 'A4', 'F5'],
+        [4, 0, 'A5', 'F5'],
+        [4, 2, 'C5', 'F5'],
+        [4, 4, 'E5', 'F5'],
+      ], 'edit');
+    });
   });
 });

--- a/handsontable/test/e2e/keyboardShortcuts/selection.spec.js
+++ b/handsontable/test/e2e/keyboardShortcuts/selection.spec.js
@@ -812,4 +812,236 @@ describe('Core selection keyboard shortcut', () => {
       expect(getSelectedRangeLast().to.row).toBe(hot.view.getFirstFullyVisibleRow() + 4);
     });
   });
+
+  describe('"Enter + Ctrl/Cmd"', () => {
+    it('should not populate the cell value when the selection range includes less than 2 cells', () => {
+      const afterChange = jasmine.createSpy('afterChange');
+
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        afterChange,
+      });
+
+      afterChange.calls.reset(); // reset initial "afterChange" call after load data
+      selectCell(1, 1);
+      keyDownUp(['control/meta', 'enter']);
+
+      expect(getData()).toEqual(createSpreadsheetData(5, 5));
+      expect(getSelected()).toEqual([[1, 1, 1, 1]]);
+      expect(afterChange).not.toHaveBeenCalled();
+    });
+
+    it('should not populate the cell value when the last non-contiguous selection layer includes less than 2 cells', () => {
+      const afterChange = jasmine.createSpy('afterChange');
+
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        afterChange,
+      });
+
+      afterChange.calls.reset(); // reset initial "afterChange" call after load data
+      selectCells([[1, 0, 3, 0], [2, 2, 2, 2]]);
+      keyDownUp(['control/meta', 'enter']);
+
+      expect(getData()).toEqual(createSpreadsheetData(5, 5));
+      expect(getSelected()).toEqual([[1, 0, 3, 0], [2, 2, 2, 2]]);
+      expect(afterChange).not.toHaveBeenCalled();
+    });
+
+    it('should not trigger the cells value change more than once for the same coords in "{after/before}Change" hooks ' +
+       'when selection layers overlap each self', () => {
+      const beforeChange = jasmine.createSpy('beforeChange');
+      const afterChange = jasmine.createSpy('afterChange');
+
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        beforeChange,
+        afterChange,
+      });
+
+      afterChange.calls.reset(); // reset initial "afterChange" call after load data
+      selectCells([[1, 1, 2, 2], [1, 2, 2, 2], [2, 1, 2, 2]]);
+      keyDownUp(['control/meta', 'enter']);
+
+      expect(getSelected()).toEqual([[1, 1, 2, 2], [1, 2, 2, 2], [2, 1, 2, 2]]);
+      expect(beforeChange).toHaveBeenCalledTimes(1);
+      expect(beforeChange).toHaveBeenCalledWith([
+        [1, 1, 'B2', 'B3'],
+        [1, 2, 'C2', 'B3'],
+        [2, 2, 'C3', 'B3'],
+      ], 'edit');
+      expect(afterChange).toHaveBeenCalledTimes(1);
+      expect(afterChange).toHaveBeenCalledWith([
+        [1, 1, 'B2', 'B3'],
+        [1, 2, 'C2', 'B3'],
+        [2, 2, 'C3', 'B3'],
+      ], 'edit');
+    });
+
+    it('should populate the cell value when the selection range includes at least 2 cells in a row', () => {
+      const afterChange = jasmine.createSpy('afterChange');
+
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        afterChange,
+      });
+
+      afterChange.calls.reset(); // reset initial "afterChange" call after load data
+      selectCells([[2, 1, 2, 2]]);
+      keyDownUp(['control/meta', 'enter']);
+
+      expect(getSelected()).toEqual([[2, 1, 2, 2]]);
+      expect(afterChange).toHaveBeenCalledTimes(1);
+      expect(afterChange).toHaveBeenCalledWith([
+        [2, 2, 'C3', 'B3'],
+      ], 'edit');
+    });
+
+    it('should populate the cell value when the selection range includes at least 2 cells in a column', () => {
+      const afterChange = jasmine.createSpy('afterChange');
+
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        afterChange,
+      });
+
+      afterChange.calls.reset(); // reset initial "afterChange" call after load data
+      selectCells([[1, 1, 2, 1]]);
+      keyDownUp(['control/meta', 'enter']);
+
+      expect(getSelected()).toEqual([[1, 1, 2, 1]]);
+      expect(afterChange).toHaveBeenCalledTimes(1);
+      expect(afterChange).toHaveBeenCalledWith([
+        [2, 1, 'B3', 'B2'],
+      ], 'edit');
+    });
+
+    it('should populate the cell value when the selection range goes from bottom-right to top-left direction', () => {
+      const afterChange = jasmine.createSpy('afterChange');
+
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        afterChange,
+      });
+
+      afterChange.calls.reset(); // reset initial "afterChange" call after load data
+      selectCells([[3, 3, 1, 1]]);
+      keyDownUp(['control/meta', 'enter']);
+
+      expect(getSelected()).toEqual([[3, 3, 1, 1]]);
+      expect(afterChange).toHaveBeenCalledTimes(1);
+      expect(afterChange).toHaveBeenCalledWith([
+        [1, 1, 'B2', 'D4'],
+        [1, 2, 'C2', 'D4'],
+        [1, 3, 'D2', 'D4'],
+        [2, 1, 'B3', 'D4'],
+        [2, 2, 'C3', 'D4'],
+        [2, 3, 'D3', 'D4'],
+        [3, 1, 'B4', 'D4'],
+        [3, 2, 'C4', 'D4'],
+      ], 'edit');
+    });
+
+    it('should populate the cell value to all selection layers', () => {
+      const afterChange = jasmine.createSpy('afterChange');
+
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        afterChange,
+      });
+
+      afterChange.calls.reset(); // reset initial "afterChange" call after load data
+      selectCells([[3, 4, 3, 4], [4, 3, 1, 3], [3, 2, 3, 2], [1, 1, 1, 2], [0, 0, 1, 0]]);
+      keyDownUp(['control/meta', 'enter']);
+
+      expect(getSelected()).toEqual([[3, 4, 3, 4], [4, 3, 1, 3], [3, 2, 3, 2], [1, 1, 1, 2], [0, 0, 1, 0]]);
+      expect(afterChange).toHaveBeenCalledTimes(1);
+      expect(afterChange).toHaveBeenCalledWith([
+        [3, 4, 'E4', 'A1'],
+        [1, 3, 'D2', 'A1'],
+        [2, 3, 'D3', 'A1'],
+        [3, 3, 'D4', 'A1'],
+        [4, 3, 'D5', 'A1'],
+        [3, 2, 'C4', 'A1'],
+        [1, 1, 'B2', 'A1'],
+        [1, 2, 'C2', 'A1'],
+        [1, 0, 'A2', 'A1'],
+      ], 'edit');
+    });
+
+    it('should populate the cell value to all cells when the selection is done by the corner click', () => {
+      const afterChange = jasmine.createSpy('afterChange');
+
+      handsontable({
+        data: createSpreadsheetData(3, 3),
+        rowHeaders: true,
+        colHeaders: true,
+        afterChange,
+      });
+
+      afterChange.calls.reset(); // reset initial "afterChange" call after load data
+      selectAll();
+      listen();
+      keyDownUp(['control/meta', 'enter']);
+
+      expect(getSelected()).toEqual([[-1, -1, 2, 2]]);
+      expect(afterChange).toHaveBeenCalledTimes(1);
+      expect(afterChange).toHaveBeenCalledWith([
+        [0, 1, 'B1', 'A1'],
+        [0, 2, 'C1', 'A1'],
+        [1, 0, 'A2', 'A1'],
+        [1, 1, 'B2', 'A1'],
+        [1, 2, 'C2', 'A1'],
+        [2, 0, 'A3', 'A1'],
+        [2, 1, 'B3', 'A1'],
+        [2, 2, 'C3', 'A1'],
+      ], 'edit');
+    });
+
+    it('should populate the cell value to all cells within selected column header', () => {
+      const afterChange = jasmine.createSpy('afterChange');
+
+      handsontable({
+        data: createSpreadsheetData(3, 3),
+        rowHeaders: true,
+        colHeaders: true,
+        afterChange,
+      });
+
+      afterChange.calls.reset(); // reset initial "afterChange" call after load data
+      selectColumns(1);
+      listen();
+      keyDownUp(['control/meta', 'enter']);
+
+      expect(getSelected()).toEqual([[-1, 1, 2, 1]]);
+      expect(afterChange).toHaveBeenCalledTimes(1);
+      expect(afterChange).toHaveBeenCalledWith([
+        [1, 1, 'B2', 'B1'],
+        [2, 1, 'B3', 'B1'],
+      ], 'edit');
+    });
+
+    it('should populate the cell value to all cells within selected row header', () => {
+      const afterChange = jasmine.createSpy('afterChange');
+
+      handsontable({
+        data: createSpreadsheetData(3, 3),
+        rowHeaders: true,
+        colHeaders: true,
+        afterChange,
+      });
+
+      afterChange.calls.reset(); // reset initial "afterChange" call after load data
+      selectRows(1);
+      listen();
+      keyDownUp(['control/meta', 'enter']);
+
+      expect(getSelected()).toEqual([[1, -1, 1, 2]]);
+      expect(afterChange).toHaveBeenCalledTimes(1);
+      expect(afterChange).toHaveBeenCalledWith([
+        [1, 1, 'B2', 'A2'],
+        [1, 2, 'C2', 'A2'],
+      ], 'edit');
+    });
+  });
 });


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adds the new Cmd/Ctrl + Enter keyboard shortcuts to Handsontable. Now it works as follows:

Shortcut | Expected behavior
-- | --
Cmd/Ctrl + Enter | Fill the selected range of cells with the value of the active cell 

The limitations and/or additional new behavior for the above keyboard shortcuts:
 * The filling works only when the last selection range (it matters for non-contiguous or multiple range selections) includes at least 2 cells. 
The example:
![Kapture 2022-04-12 at 14 00 17](https://user-images.githubusercontent.com/571316/162958077-dad97177-2e77-44fe-aee0-1e85427a8b7f.gif)
Here, the last selection is too small to trigger the filling (although the previous layers meet the requirements):
![Kapture 2022-04-12 at 14 02 05](https://user-images.githubusercontent.com/571316/162958332-10ee5d40-4d3f-42cb-ab62-4b0544ef51e7.gif)

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and covered the new behavior with new E2E tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. fixes #9366

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
