### PR TITLE
Fix PageUp/PageDown keyboard shortcuts for context menu

### DIFF
--- a/.changelogs/9394.json
+++ b/.changelogs/9394.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fixed PageUp/PageDown keyboard shortcuts for context menu",
+  "type": "fixed",
+  "issue": 9394,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/contextMenu/__tests__/contextMenu.spec.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/contextMenu.spec.js
@@ -2865,25 +2865,6 @@ describe('ContextMenu', () => {
         expect(itemAction).toHaveBeenCalled();
         expect($(hot.getPlugin('contextMenu').menu).is(':visible')).toBe(false);
       });
-
-      it('should navigate using `PageDown` and `PageUp` after selecting some item', () => {
-        const hot = handsontable({
-          contextMenu: ['row_above', 'row_below', 'remove_row', 'col_left', 'col_right'],
-        });
-
-        contextMenu();
-
-        const menuHot = hot.getPlugin('contextMenu').menu.hotMenu;
-
-        keyDownUp('arrowdown');
-        keyDownUp('pagedown');
-
-        expect(menuHot.getSelected()).toEqual([[4, 0, 4, 0]]);
-
-        keyDownUp('pageup');
-
-        expect(menuHot.getSelected()).toEqual([[0, 0, 0, 0]]);
-      });
     });
 
     it('should close menu when user hits ESC', () => {

--- a/handsontable/src/plugins/contextMenu/__tests__/keyboardShortcuts.spec.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/keyboardShortcuts.spec.js
@@ -5,7 +5,7 @@ describe('ContextMenu keyboard shortcut', () => {
     return Array.from(new Array(itemsCount)).map((_, i) => {
       return {
         name: `Test item ${i + 1}`
-      }
+      };
     });
   }
 
@@ -181,7 +181,6 @@ describe('ContextMenu keyboard shortcut', () => {
           startRow,
           endRow,
         } = getPlugin('contextMenu').menu.hotMenu.view._wt.wtViewport.createRowsCalculator(-2);
-
 
         expect(endRow).toBe(lastVisibleRow);
         expect(getPlugin('contextMenu').menu.getSelectedItem().name).toBe(`Test item ${startRow + 1}`);

--- a/handsontable/src/plugins/contextMenu/__tests__/keyboardShortcuts.spec.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/keyboardShortcuts.spec.js
@@ -1,0 +1,233 @@
+describe('ContextMenu keyboard shortcut', () => {
+  const id = 'testContainer';
+
+  function generateRandomMenuItems(itemsCount = 200) {
+    return Array.from(new Array(itemsCount)).map((_, i) => {
+      return {
+        name: `Test item ${i + 1}`
+      }
+    });
+  }
+
+  beforeEach(function() {
+    $('.jasmine_html-reporter').hide();
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    $('.jasmine_html-reporter').show();
+
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  describe('"PageDown"', () => {
+    it('should move the menu item selection to the last item that is visible in the browser viewport' +
+       'when there is no initial selection', () => {
+      handsontable({
+        contextMenu: generateRandomMenuItems(200),
+      });
+
+      contextMenu();
+      keyDownUp('pagedown');
+
+      expect(getPlugin('contextMenu').menu.getSelectedItem().name).toBe('Test item 200');
+      // check if the viewport is scrolled to the bottom
+      expect(document.documentElement.scrollHeight)
+        .toBe(window.scrollY + document.documentElement.clientHeight + 2); // 2px as menu bottom border
+    });
+
+    it('should move the menu item selection to the last item when the menu fits within the browser viewport' +
+       'and there is initial selection', () => {
+      handsontable({
+        contextMenu: generateRandomMenuItems(10),
+      });
+
+      contextMenu();
+      getPlugin('contextMenu').menu.selectFirstCell();
+      keyDownUp('pagedown');
+
+      const hotMenu = getPlugin('contextMenu').menu.hotMenu;
+
+      expect(hotMenu.getSelected()).toEqual([[9, 0, 9, 0]]);
+      expect(getPlugin('contextMenu').menu.getSelectedItem().name).toBe('Test item 10');
+    });
+
+    it('should move the menu item selection down by the count of visible items in the browser viewport', () => {
+      handsontable({
+        contextMenu: generateRandomMenuItems(200),
+      });
+
+      contextMenu();
+      getPlugin('contextMenu').menu.selectFirstCell();
+      keyDownUp('pagedown');
+
+      let firstVisibleRow = 0;
+
+      {
+        // create rows calculator that allows gather information about what rows are already
+        // visible in the browser viewport. The -2 argument means that the calculator takes into
+        // account rows that are partially visible.
+        const {
+          startRow,
+          endRow,
+        } = getPlugin('contextMenu').menu.hotMenu.view._wt.wtViewport.createRowsCalculator(-2);
+
+        expect(startRow).toBe(firstVisibleRow);
+        expect(getPlugin('contextMenu').menu.getSelectedItem().name).toBe(`Test item ${endRow}`);
+
+        firstVisibleRow = (endRow - 1);
+      }
+
+      keyDownUp('pagedown');
+
+      {
+        const {
+          startRow,
+          endRow,
+        } = getPlugin('contextMenu').menu.hotMenu.view._wt.wtViewport.createRowsCalculator(-2);
+
+        expect(startRow).toBe(firstVisibleRow);
+        expect(getPlugin('contextMenu').menu.getSelectedItem().name).toBe(`Test item ${endRow}`);
+
+        firstVisibleRow = (endRow - 1);
+      }
+
+      keyDownUp('pagedown');
+
+      {
+        const {
+          startRow,
+          endRow,
+        } = getPlugin('contextMenu').menu.hotMenu.view._wt.wtViewport.createRowsCalculator(-2);
+
+        expect(startRow).toBe(firstVisibleRow);
+        expect(getPlugin('contextMenu').menu.getSelectedItem().name).toBe(`Test item ${endRow}`);
+
+        firstVisibleRow = (endRow - 1);
+      }
+
+      keyDownUp('pagedown');
+
+      {
+        const {
+          startRow,
+          endRow,
+        } = getPlugin('contextMenu').menu.hotMenu.view._wt.wtViewport.createRowsCalculator(-2);
+
+        expect(startRow).toBe(firstVisibleRow);
+        expect(getPlugin('contextMenu').menu.getSelectedItem().name).toBe(`Test item ${endRow}`);
+      }
+    });
+  });
+
+  describe('"PageUp"', () => {
+    it('should move the menu item selection to the first item that is visible in the browser viewport' +
+       'when there is no initial selection', async() => {
+      handsontable({
+        contextMenu: generateRandomMenuItems(200),
+      });
+
+      contextMenu();
+      window.scrollTo(0, 1000);
+
+      await sleep(100);
+
+      keyDownUp('pageup');
+
+      expect(getPlugin('contextMenu').menu.getSelectedItem().name).toBe('Test item 1');
+      expect(window.scrollY).toBe(1);
+    });
+
+    it('should move the menu item selection to the first item when the menu fits within the browser viewport' +
+       'and there is initial selection', () => {
+      handsontable({
+        contextMenu: generateRandomMenuItems(10),
+      });
+
+      contextMenu();
+      getPlugin('contextMenu').menu.selectLastCell();
+      keyDownUp('pageup');
+
+      const hotMenu = getPlugin('contextMenu').menu.hotMenu;
+
+      expect(hotMenu.getSelected()).toEqual([[0, 0, 0, 0]]);
+      expect(getPlugin('contextMenu').menu.getSelectedItem().name).toBe('Test item 1');
+    });
+
+    it('should move the menu item selection up by the count of visible items in the browser viewport', async() => {
+      handsontable({
+        contextMenu: generateRandomMenuItems(200),
+      });
+
+      contextMenu();
+      getPlugin('contextMenu').menu.selectLastCell();
+
+      window.scrollTo(0, document.documentElement.scrollHeight);
+
+      await sleep(100);
+
+      keyDownUp('pageup');
+
+      let lastVisibleRow = 199;
+
+      {
+        // create rows calculator that allows gather information about what rows are already
+        // visible in the browser viewport. The -2 argument means that the calculator takes into
+        // account rows that are partially visible.
+        const {
+          startRow,
+          endRow,
+        } = getPlugin('contextMenu').menu.hotMenu.view._wt.wtViewport.createRowsCalculator(-2);
+
+
+        expect(endRow).toBe(lastVisibleRow);
+        expect(getPlugin('contextMenu').menu.getSelectedItem().name).toBe(`Test item ${startRow + 1}`);
+
+        lastVisibleRow = startRow;
+      }
+
+      keyDownUp('pageup');
+
+      {
+        const {
+          startRow,
+          endRow,
+        } = getPlugin('contextMenu').menu.hotMenu.view._wt.wtViewport.createRowsCalculator(-2);
+
+        expect(endRow).toBe(lastVisibleRow);
+        expect(getPlugin('contextMenu').menu.getSelectedItem().name).toBe(`Test item ${startRow + 1}`);
+
+        lastVisibleRow = startRow;
+      }
+
+      keyDownUp('pageup');
+
+      {
+        const {
+          startRow,
+          endRow,
+        } = getPlugin('contextMenu').menu.hotMenu.view._wt.wtViewport.createRowsCalculator(-2);
+
+        expect(endRow).toBe(lastVisibleRow);
+        expect(getPlugin('contextMenu').menu.getSelectedItem().name).toBe(`Test item ${startRow + 1}`);
+
+        lastVisibleRow = startRow;
+      }
+
+      keyDownUp('pageup');
+
+      {
+        const {
+          startRow,
+          endRow,
+        } = getPlugin('contextMenu').menu.hotMenu.view._wt.wtViewport.createRowsCalculator(-2);
+
+        expect(endRow).toBe(lastVisibleRow);
+        expect(getPlugin('contextMenu').menu.getSelectedItem().name).toBe(`Test item ${startRow + 1}`);
+      }
+    });
+  });
+});

--- a/handsontable/src/plugins/contextMenu/menu.js
+++ b/handsontable/src/plugins/contextMenu/menu.js
@@ -365,14 +365,32 @@ class Menu {
     }, {
       keys: [['PageUp']],
       callback: () => {
-        this.hotMenu.selection.transformStart(-this.hotMenu.countVisibleRows(), 0);
+        const selection = this.hotMenu.getSelectedLast();
+
+        this.keyEvent = true;
+
+        if (selection) {
+          this.hotMenu.selection.transformStart(-this.hotMenu.countVisibleRows(), 0);
+
+        } else {
+          this.selectFirstCell();
+        }
 
         this.keyEvent = false;
       },
     }, {
       keys: [['PageDown']],
       callback: () => {
-        this.hotMenu.selection.transformStart(this.hotMenu.countVisibleRows(), 0);
+        const selection = this.hotMenu.getSelectedLast();
+
+        this.keyEvent = true;
+
+        if (selection) {
+          this.hotMenu.selection.transformStart(this.hotMenu.countVisibleRows(), 0);
+
+        } else {
+          this.selectLastCell();
+        }
 
         this.keyEvent = false;
       },
@@ -688,7 +706,10 @@ class Menu {
     if (isSeparator(cell) || isDisabled(cell) || isSelectionDisabled(cell)) {
       this.selectPrevCell(lastRow, 0);
     } else {
-      this.hotMenu.selectCell(lastRow, 0);
+      // disable default "scroll-to-cell" option and instead of that...
+      this.hotMenu.selectCell(lastRow, 0, undefined, undefined, false);
+      // ...scroll to the cell with "snap to the bottom" option
+      this.hotMenu.scrollViewportTo(lastRow, 0, true, false);
     }
   }
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the bug that causes throwing an exception when the `PageUp` or `PageDown` keyboard keys was used within the context menu. Besides fixing the error the PR improves the UI by adding viewport scrolling for selected items that are out of the browser's viewport. The same works for navigation by arrow keys.

#### Before (11.1)
![Kapture 2022-04-15 at 16 56 14](https://user-images.githubusercontent.com/571316/163586122-6f806217-67a7-4b62-a286-b72a926328a0.gif)

#### After (this PR)
![Kapture 2022-04-15 at 16 57 47](https://user-images.githubusercontent.com/571316/163586294-e7f08cf6-1a0e-41a6-a3f8-45d0157da702.gif)

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally, and I covered the fix with new E2E tests. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes #9394

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
