### PR TITLE
Avoid serializing Date objects to strings in populateFromArray()

### DIFF
--- a/.changelogs/9405.json
+++ b/.changelogs/9405.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fixed an issue with Date objects being serialized to strings.",
+  "type": "fixed",
+  "issue": 9405,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -992,7 +992,9 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
 
                   /* eslint-disable max-depth */
                   if (isObjectEqual(orgValueSchema, valueSchema)) {
-                    value = deepClone(value);
+                    value = typeof value === "object" && value instanceof Date
+                      ? new Date(value.getTime())
+                      : deepClone(value);
                   } else {
                     pushData = false;
                   }

--- a/handsontable/test/e2e/Core_populateFromArray.spec.js
+++ b/handsontable/test/e2e/Core_populateFromArray.spec.js
@@ -35,6 +35,24 @@ describe('Core_populateFromArray', () => {
     expect(output).toEqual([[0, 0, '', 'test'], [0, 1, 'Kia', 'test'], [1, 0, '2008', 'test'], [1, 1, 10, 'test']]);
   });
 
+  it('should not serialize Date object cell values to strings', () => {
+    let output = null;
+
+    const today = new Date();
+    const tomorrow = new Date(today);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+
+    handsontable({
+      data: [[today]],
+      afterChange(changes) {
+        output = changes;
+      }
+    });
+    populateFromArray(0, 0, [[tomorrow]], 0, 0);
+
+    expect(output).toEqual([[0, 0, today, tomorrow]]);
+  });
+
   it('should populate single value for whole selection', () => {
     let output = null;
 


### PR DESCRIPTION
### Context
> When using a `Date` object for the data at a given cell w/custom editor and renderer, Handsontable changes the underlying type of the data to a `string` after making changes. This is because `cloneDeep()` is used when setting a new value and it isn't supported on dates due to use of `JSON.stringify()`. In practice, this means that a custom editor expecting date types can only work on a given cell once, since changing from a string to an object or an object to a string is prevented by Handsontable.

### How has this been tested?
Custom date editor implementation relying on date types internally where this bug was fixed initially. Also, added a failing unit test that was fixed by this patch.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/9405

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.