### PR TITLE
Prevent browser navigation on horizontal scroll

### DIFF
--- a/.changelogs/9272.json
+++ b/.changelogs/9272.json
@@ -1,0 +1,7 @@
+{
+  "title": "Added browser navigation prevention on horizontal scroll.",
+  "type": "added",
+  "issue": 9272,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/css/walkontable.scss
+++ b/handsontable/src/3rdparty/walkontable/css/walkontable.scss
@@ -227,6 +227,7 @@ innerBorderBottom - Property controlled by bottom overlay
 
 .ht_master .wtHolder {
   overflow: auto;
+  overscroll-behavior-x: none;
 }
 
 .handsontable .ht_master thead,

--- a/handsontable/src/tableView.js
+++ b/handsontable/src/tableView.js
@@ -377,6 +377,19 @@ class TableView {
       // Prevent text from being selected when performing drag down.
       event.preventDefault();
     });
+
+    let origOverscrollBehaviorX = '';
+
+    // Prevents triggering browsers "go to back/forward" navigation while scrolling the table.
+    // The code below works for Chrome. For FF it is enough to add CSS "overscroll-behavior-x"
+    // property to "wtHolder" CSS class within the walkontable.css file.
+    this.eventManager.addEventListener(rootElement, 'mouseenter', () => {
+      origOverscrollBehaviorX = rootDocument.body.style.overscrollBehaviorX;
+      rootDocument.body.style.overscrollBehaviorX = 'none';
+    });
+    this.eventManager.addEventListener(rootElement, 'mouseleave', () => {
+      rootDocument.body.style.overscrollBehaviorX = origOverscrollBehaviorX ?? 'unset';
+    });
   }
 
   /**

--- a/handsontable/test/e2e/Core_view.spec.js
+++ b/handsontable/test/e2e/Core_view.spec.js
@@ -33,6 +33,29 @@ describe('Core_view', () => {
     expect(isEditorVisible()).toEqual(true);
   });
 
+  it('should add/remove "overscroll-behavior-x: none" CSS property once the cursor moves over or out the table', () => {
+    const hot = handsontable({
+      data: createSpreadsheetData(5, 5),
+    });
+
+    $(hot.rootElement).simulate('mouseenter');
+
+    expect(document.body.style.overscrollBehaviorX).toBe('none');
+
+    $(hot.rootElement).simulate('mouseleave');
+
+    expect(document.body.style.overscrollBehaviorX).toBe('');
+
+    document.body.style.overscrollBehaviorX = 'contain';
+    $(hot.rootElement).simulate('mouseenter');
+
+    expect(document.body.style.overscrollBehaviorX).toBe('none');
+
+    $(hot.rootElement).simulate('mouseleave');
+
+    expect(document.body.style.overscrollBehaviorX).toBe('contain');
+  });
+
   it('should scroll viewport if selected cell is out of the viewport and renderAllRows is enabled', () => {
     spec().$container[0].style.width = '400px';
     spec().$container[0].style.height = '50px';


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adds a feature that prevents the browser navigation that happened while the table horizontal scroll. The navigation back or forth was triggered when the scrollbar was on the far left or right side of the table viewport.

The PR changes work for Chrome and FF. For Safari, I was not able to find a fix.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. fixes #9272

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
