### PR TITLE
Remove hardcoded "htLeft" alignment from demos

### DIFF
--- a/.changelogs/9419.json
+++ b/.changelogs/9419.json
@@ -1,5 +1,5 @@
 {
-  "title": "Expose `isRtl`, `isLtr`, and `getDirectionFactor` methods to the public API.",
+  "title": "Exposed the `isRtl()`, `isLtr()`, and `getDirectionFactor()` methods to the public API.",
   "type": "added",
   "issue": 9419,
   "breaking": false,

--- a/.changelogs/9419.json
+++ b/.changelogs/9419.json
@@ -1,0 +1,7 @@
+{
+  "title": "Expose `isRtl`, `isLtr`, and `getDirectionFactor` methods to the public API.",
+  "type": "added",
+  "issue": 9419,
+  "breaking": false,
+  "framework": "none"
+}

--- a/examples/next/docs/angular/demo/src/data-grid/data-grid.scss
+++ b/examples/next/docs/angular/demo/src/data-grid/data-grid.scss
@@ -31,10 +31,6 @@ table.htCore {
   'Ubuntu', 'Helvetica Neue', Arial, sans-serif;
   font-weight: 400;
 
-  .htRight .changeType {
-    margin: 3px 1px 0 13px;
-  }
-
   .collapsibleIndicator {
     text-align: center;
   }

--- a/examples/next/docs/angular/demo/src/data-grid/utils/constants.ts
+++ b/examples/next/docs/angular/demo/src/data-grid/utils/constants.ts
@@ -1202,7 +1202,6 @@ export const data = [
 ];
 
 export const SELECTED_CLASS = "selected";
-export const DEFAULT_ALIGNMENT_CLASS = "htLeft";
 export const ODD_ROW_CLASS = "odd";
 
 export function getData() {

--- a/examples/next/docs/angular/demo/src/data-grid/utils/hooks-callbacks.ts
+++ b/examples/next/docs/angular/demo/src/data-grid/utils/hooks-callbacks.ts
@@ -1,7 +1,6 @@
 import Handsontable from "handsontable";
 import {
   SELECTED_CLASS,
-  DEFAULT_ALIGNMENT_CLASS,
   ODD_ROW_CLASS
 } from "./constants";
 
@@ -77,32 +76,19 @@ export const drawCheckboxInRowHeaders: DrawCheckboxInRowHeaders = function drawC
   TH.appendChild(input);
 };
 
-type AlignHeaders = (
-  row: number,
-  TH: HTMLTableCellElement
-) => void;
-
-export const alignHeaders: AlignHeaders = (column, TH) => {
+export function alignHeaders(this: Handsontable, column: number, TH: HTMLTableCellElement) {
   if (column < 0) {
     return;
   }
 
+  const alignmentClass = this.isRtl() ? "htRight" : "htLeft";
+
   if (TH.firstChild) {
     if (headerAlignments.has(column.toString())) {
-      Handsontable.dom.removeClass(
-        TH.firstChild as HTMLElement,
-        DEFAULT_ALIGNMENT_CLASS
-      );
-      Handsontable.dom.addClass(
-        TH.firstChild as HTMLElement,
-        // @ts-ignore Above if checks whether there is an element in the Map.
-        headerAlignments.get(column.toString())
-      );
+      Handsontable.dom.removeClass(TH.firstChild as HTMLElement, alignmentClass);
+      Handsontable.dom.addClass(TH.firstChild as HTMLElement, headerAlignments.get(column.toString()) as string);
     } else {
-      Handsontable.dom.addClass(
-        TH.firstChild as HTMLElement,
-        DEFAULT_ALIGNMENT_CLASS
-      );
+      Handsontable.dom.addClass(TH.firstChild as HTMLElement, alignmentClass);
     }
   }
 };

--- a/examples/next/docs/js/demo/src/constants.js
+++ b/examples/next/docs/js/demo/src/constants.js
@@ -1202,5 +1202,4 @@ export const data = [
 ];
 
 export const SELECTED_CLASS = "selected";
-export const DEFAULT_ALIGNMENT_CLASS = "htLeft";
 export const ODD_ROW_CLASS = "odd";

--- a/examples/next/docs/js/demo/src/hooksCallbacks.js
+++ b/examples/next/docs/js/demo/src/hooksCallbacks.js
@@ -1,7 +1,6 @@
 import Handsontable from "handsontable";
 import {
   SELECTED_CLASS,
-  DEFAULT_ALIGNMENT_CLASS,
   ODD_ROW_CLASS
 } from "./constants";
 
@@ -57,12 +56,14 @@ export function alignHeaders(column, TH) {
     return;
   }
 
+  const alignmentClass = this.isRtl() ? "htRight" : "htLeft";
+
   if (TH.firstChild) {
     if (headerAlignments.has(column.toString())) {
-      Handsontable.dom.removeClass(TH.firstChild, DEFAULT_ALIGNMENT_CLASS);
+      Handsontable.dom.removeClass(TH.firstChild, alignmentClass);
       Handsontable.dom.addClass(TH.firstChild, headerAlignments.get(column.toString()));
     } else {
-      Handsontable.dom.addClass(TH.firstChild, DEFAULT_ALIGNMENT_CLASS);
+      Handsontable.dom.addClass(TH.firstChild, alignmentClass);
     }
   }
 }

--- a/examples/next/docs/js/demo/src/styles.css
+++ b/examples/next/docs/js/demo/src/styles.css
@@ -27,9 +27,6 @@ table.htCore tr.selected td {
   text-align: center;
 }
 
-.handsontable .htRight .changeType {
-  margin: 3px 1px 0 13px;
-}
 .handsontable .green {
   background: #37bc6c;
   font-weight: bold;

--- a/examples/next/docs/react/demo/src/constants.ts
+++ b/examples/next/docs/react/demo/src/constants.ts
@@ -1202,5 +1202,4 @@ export const data = [
 ];
 
 export const SELECTED_CLASS = "selected";
-export const DEFAULT_ALIGNMENT_CLASS = "htLeft";
 export const ODD_ROW_CLASS = "odd";

--- a/examples/next/docs/react/demo/src/hooksCallbacks.ts
+++ b/examples/next/docs/react/demo/src/hooksCallbacks.ts
@@ -1,7 +1,6 @@
 import Handsontable from "handsontable";
 import {
   SELECTED_CLASS,
-  DEFAULT_ALIGNMENT_CLASS,
   ODD_ROW_CLASS
 } from "./constants";
 
@@ -77,35 +76,22 @@ export const drawCheckboxInRowHeaders: DrawCheckboxInRowHeaders = function drawC
   TH.appendChild(input);
 };
 
-type AlignHeaders = (
-  row: number,
-  TH: HTMLTableCellElement
-) => void;
-
-export const alignHeaders: AlignHeaders = (column, TH) => {
+export function alignHeaders(this: Handsontable, column: number, TH: HTMLTableCellElement) {
   if (column < 0) {
     return;
   }
 
+  const alignmentClass = this.isRtl() ? "htRight" : "htLeft";
+
   if (TH.firstChild) {
     if (headerAlignments.has(column.toString())) {
-      Handsontable.dom.removeClass(
-        TH.firstChild as HTMLElement,
-        DEFAULT_ALIGNMENT_CLASS
-      );
-      Handsontable.dom.addClass(
-        TH.firstChild as HTMLElement,
-        // @ts-ignore Above if checks whether there is an element in the Map.
-        headerAlignments.get(column.toString())
-      );
+      Handsontable.dom.removeClass(TH.firstChild as HTMLElement, alignmentClass);
+      Handsontable.dom.addClass(TH.firstChild as HTMLElement, headerAlignments.get(column.toString()) as string);
     } else {
-      Handsontable.dom.addClass(
-        TH.firstChild as HTMLElement,
-        DEFAULT_ALIGNMENT_CLASS
-      );
+      Handsontable.dom.addClass(TH.firstChild as HTMLElement, alignmentClass);
     }
   }
-};
+}
 
 type ChangeCheckboxCell = (
   this: Handsontable,

--- a/examples/next/docs/react/demo/src/styles.css
+++ b/examples/next/docs/react/demo/src/styles.css
@@ -33,7 +33,3 @@ table.htCore tr.selected td {
 .collapsibleIndicator {
   text-align: center;
 }
-
-.handsontable .htRight .changeType {
-  margin: 3px 1px 0 13px;
-}

--- a/examples/next/docs/ts/demo/src/constants.ts
+++ b/examples/next/docs/ts/demo/src/constants.ts
@@ -102,5 +102,4 @@ export const data = [
 ];
 
 export const SELECTED_CLASS = 'selected';
-export const DEFAULT_ALIGNMENT_CLASS = 'htLeft';
 export const ODD_ROW_CLASS = 'odd';

--- a/examples/next/docs/ts/demo/src/hooksCallbacks.ts
+++ b/examples/next/docs/ts/demo/src/hooksCallbacks.ts
@@ -1,7 +1,6 @@
 import Handsontable from "handsontable";
 import {
   SELECTED_CLASS,
-  DEFAULT_ALIGNMENT_CLASS,
   ODD_ROW_CLASS
 } from "./constants";
 
@@ -77,32 +76,19 @@ export const drawCheckboxInRowHeaders: DrawCheckboxInRowHeaders = function drawC
   TH.appendChild(input);
 };
 
-type AlignHeaders = (
-  row: number,
-  TH: HTMLTableCellElement
-) => void;
-
-export const alignHeaders: AlignHeaders = (column, TH) => {
+export function alignHeaders(this: Handsontable, column: number, TH: HTMLTableCellElement) {
   if (column < 0) {
     return;
   }
 
+  const alignmentClass = this.isRtl() ? "htRight" : "htLeft";
+
   if (TH.firstChild) {
     if (headerAlignments.has(column.toString())) {
-      Handsontable.dom.removeClass(
-        TH.firstChild as HTMLElement,
-        DEFAULT_ALIGNMENT_CLASS
-      );
-      Handsontable.dom.addClass(
-        TH.firstChild as HTMLElement,
-        // @ts-ignore Above if checks whether there is an element in the Map.
-        headerAlignments.get(column.toString())
-      );
+      Handsontable.dom.removeClass(TH.firstChild as HTMLElement, alignmentClass);
+      Handsontable.dom.addClass(TH.firstChild as HTMLElement, headerAlignments.get(column.toString()) as string);
     } else {
-      Handsontable.dom.addClass(
-        TH.firstChild as HTMLElement,
-        DEFAULT_ALIGNMENT_CLASS
-      );
+      Handsontable.dom.addClass(TH.firstChild as HTMLElement, alignmentClass);
     }
   }
 };

--- a/examples/next/docs/ts/demo/src/styles.css
+++ b/examples/next/docs/ts/demo/src/styles.css
@@ -33,7 +33,3 @@ table.htCore tr.selected td {
 .collapsibleIndicator {
   text-align: center;
 }
-
-.handsontable .htRight .changeType {
-  margin: 3px 1px 0 13px;
-}

--- a/examples/next/docs/vue/demo/src/components/DataGrid.vue
+++ b/examples/next/docs/vue/demo/src/components/DataGrid.vue
@@ -126,10 +126,6 @@ table.htCore {
   'Ubuntu', 'Helvetica Neue', Arial, sans-serif;
   font-weight: 400;
 
-  .htRight .changeType {
-    margin: 3px 1px 0 13px;
-  }
-
   .collapsibleIndicator {
     text-align: center;
   }

--- a/examples/next/docs/vue/demo/src/utils/constants.ts
+++ b/examples/next/docs/vue/demo/src/utils/constants.ts
@@ -1202,7 +1202,6 @@ const data = [
 ];
 
 export const SELECTED_CLASS = "selected";
-export const DEFAULT_ALIGNMENT_CLASS = "htLeft";
 export const ODD_ROW_CLASS = "odd";
 
 export function getData() {

--- a/examples/next/docs/vue/demo/src/utils/hooks-callbacks.ts
+++ b/examples/next/docs/vue/demo/src/utils/hooks-callbacks.ts
@@ -1,7 +1,6 @@
 import Handsontable from "handsontable";
 import {
   SELECTED_CLASS,
-  DEFAULT_ALIGNMENT_CLASS,
   ODD_ROW_CLASS
 } from "./constants";
 
@@ -77,32 +76,19 @@ export const drawCheckboxInRowHeaders: DrawCheckboxInRowHeaders = function drawC
   TH.appendChild(input);
 };
 
-type AlignHeaders = (
-  row: number,
-  TH: HTMLTableCellElement
-) => void;
-
-export const alignHeaders: AlignHeaders = (column, TH) => {
+export function alignHeaders(this: Handsontable, column: number, TH: HTMLTableCellElement) {
   if (column < 0) {
     return;
   }
 
+  const alignmentClass = this.isRtl() ? "htRight" : "htLeft";
+
   if (TH.firstChild) {
     if (headerAlignments.has(column.toString())) {
-      Handsontable.dom.removeClass(
-        TH.firstChild as HTMLElement,
-        DEFAULT_ALIGNMENT_CLASS
-      );
-      Handsontable.dom.addClass(
-        TH.firstChild as HTMLElement,
-        // @ts-ignore Above if checks whether there is an element in the Map.
-        headerAlignments.get(column.toString())
-      );
+      Handsontable.dom.removeClass(TH.firstChild as HTMLElement, alignmentClass);
+      Handsontable.dom.addClass(TH.firstChild as HTMLElement, headerAlignments.get(column.toString()) as string);
     } else {
-      Handsontable.dom.addClass(
-        TH.firstChild as HTMLElement,
-        DEFAULT_ALIGNMENT_CLASS
-      );
+      Handsontable.dom.addClass(TH.firstChild as HTMLElement, alignmentClass);
     }
   }
 };

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -136,7 +136,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
   this.rootElement.setAttribute('dir', rootElementDirection);
 
   /**
-   * Checks if the table is rendered using right-to-left layout direction.
+   * Checks if the grid is rendered using the right-to-left layout direction.
    *
    * @since 12.0.0
    * @memberof Core#
@@ -148,7 +148,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
   };
 
   /**
-   * Checks if the table is rendered using left-to-right layout direction.
+   * Checks if the grid is rendered using the left-to-right layout direction.
    *
    * @since 12.0.0
    * @memberof Core#

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -136,9 +136,8 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
   this.rootElement.setAttribute('dir', rootElementDirection);
 
   /**
-   * Check if currently it is RTL direction.
+   * Checks if the table is rendered using right-to-left layout direction.
    *
-   * @private
    * @memberof Core#
    * @function isRtl
    * @returns {boolean} True if RTL.
@@ -148,9 +147,8 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
   };
 
   /**
-   * Check if currently it is LTR direction.
+   * Checks if the table is rendered using left-to-right layout direction.
    *
-   * @private
    * @memberof Core#
    * @function isLtr
    * @returns {boolean} True if LTR.
@@ -162,7 +160,6 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
   /**
    * Returns 1 for LTR; -1 for RTL. Useful for calculations.
    *
-   * @private
    * @memberof Core#
    * @function getDirectionFactor
    * @returns {number} Returns 1 for LTR; -1 for RTL.

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -138,6 +138,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
   /**
    * Checks if the table is rendered using right-to-left layout direction.
    *
+   * @since 12.0.0
    * @memberof Core#
    * @function isRtl
    * @returns {boolean} True if RTL.
@@ -149,6 +150,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
   /**
    * Checks if the table is rendered using left-to-right layout direction.
    *
+   * @since 12.0.0
    * @memberof Core#
    * @function isLtr
    * @returns {boolean} True if LTR.
@@ -160,6 +162,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
   /**
    * Returns 1 for LTR; -1 for RTL. Useful for calculations.
    *
+   * @since 12.0.0
    * @memberof Core#
    * @function getDirectionFactor
    * @returns {number} Returns 1 for LTR; -1 for RTL.

--- a/handsontable/test/types/methods.types.ts
+++ b/handsontable/test/types/methods.types.ts
@@ -65,6 +65,7 @@ hot.getDataAtProp(123).forEach(v => v === '');
 hot.getDataAtRow(123).forEach(v => v === '');
 hot.getDataAtRowProp(123, 'foo') === '';
 hot.getDataType(123, 123, 123, 123) === 'text';
+hot.getDirectionFactor() === 1;
 
 const _hot: Handsontable = hot.getInstance();
 
@@ -97,8 +98,10 @@ const isEmptyCol: boolean = hot.isEmptyCol(123);
 const isEmptyRow: boolean = hot.isEmptyRow(123);
 const isExecutionSuspended: boolean = hot.isExecutionSuspended();
 const isListening: boolean = hot.isListening();
+const isLtr: boolean = hot.isLtr();
 const isRedoAvailable: boolean = hot.isRedoAvailable();
 const isRenderSuspended: boolean = hot.isRenderSuspended();
+const isRtl: boolean = hot.isRtl();
 const isUndoAvailable: boolean = hot.isUndoAvailable();
 
 hot.listen();

--- a/handsontable/types/core.d.ts
+++ b/handsontable/types/core.d.ts
@@ -71,6 +71,7 @@ export default class Core {
   getDataAtRow(row: number): CellValue[];
   getDataAtRowProp(row: number, prop: string): CellValue;
   getDataType(rowFrom: number, columnFrom: number, rowTo: number, columnTo: number): CellType | 'mixed';
+  getDirectionFactor(): 1 | -1;
   getInstance(): Core;
   getPlugin<T extends keyof Plugins>(pluginName: T): Plugins[T];
   getPlugin(pluginName: string): Plugins['basePlugin'];
@@ -85,7 +86,7 @@ export default class Core {
   getSettings(): GridSettings;
   getShortcutManager(): ShortcutManager;
   getSourceData(row?: number, column?: number, row2?: number, column2?: number): CellValue[][] | RowObject[];
-  getSourceDataArray(row?: number, column?: number, row2?: number, ccolumn2?: number): CellValue[][];
+  getSourceDataArray(row?: number, column?: number, row2?: number, column2?: number): CellValue[][];
   getSourceDataAtCell(row: number, column: number): CellValue;
   getSourceDataAtCol(column: number): CellValue[];
   getSourceDataAtRow(row: number): CellValue[] | RowObject;
@@ -101,8 +102,10 @@ export default class Core {
   isEmptyRow(row: number): boolean;
   isExecutionSuspended(): boolean;
   isListening(): boolean;
+  isLtr(): boolean;
   isRedoAvailable(): boolean;
   isRenderSuspended(): boolean;
+  isRtl(): boolean;
   isUndoAvailable(): boolean;
   listen(): void;
   loadData(data: CellValue[][] | RowObject[], source?: string): void;


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR updates all demos (from the examples package) to add support for different settings for the layout direction option. From now on, all demos should look just as good as with left-to-right direction and right-to-left.

The PR shows that there is a need to expose a private API to the public. The methods `isRtl`, `isLtr`, and `getDirectionFactor` in the context of demos (and probably in the context of the user's apps) turned out to be very useful.

@kirszenbaum that three methods will land in docs so now is a chance to update their description.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. fixes #9419
2. https://github.com/handsontable/handsontable.com-v2/pull/150

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
