### PR TITLE
Remove non-spec keyboard shortcuts

### DIFF
--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -4698,14 +4698,6 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
     },
     runOnlyIf: () => instance.view.isMainTableNotFullyCoveredByOverlays(),
   }, {
-    keys: [['Home', 'Control/Meta', 'Shift']],
-    callback: () => {
-      selection.setRangeEnd(instance._createCellCoords(
-        instance.rowIndexMapper.getFirstNotHiddenIndex(0, 1),
-        selection.selectedRange.current().from.col,
-      ));
-    },
-  }, {
     keys: [['End']],
     captureCtrl: true,
     callback: () => {
@@ -4734,14 +4726,6 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
       selection.setRangeStart(instance._createCellCoords(row, column));
     },
     runOnlyIf: () => instance.view.isMainTableNotFullyCoveredByOverlays(),
-  }, {
-    keys: [['End', 'Control/Meta', 'Shift']],
-    callback: () => {
-      selection.setRangeEnd(instance._createCellCoords(
-        instance.rowIndexMapper.getFirstNotHiddenIndex(instance.countRows() - 1, -1),
-        selection.selectedRange.current().from.col,
-      ));
-    },
   }, {
     keys: [
       ['PageUp'],


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR removes non-spec keyboard shortcuts. Following keyboard shortcuts are removed:
 * `Cmd/Ctrl + Shift + Home`
 * `Cmd/Ctrl + Shift + End`

This is a hotfix for unreleased change so the changelog is not necessary _[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/handsontable/issues/9428

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
