### PR TITLE
Fix wrong text alignment on RTL demos

### DIFF
--- a/docs/.vuepress/theme/styles/handsontable.styl
+++ b/docs/.vuepress/theme/styles/handsontable.styl
@@ -18,3 +18,15 @@
   font-size: 13px;
   color #222222;
 }
+
+// reset common TD, TH styles from the style.styl file (default styles from VuePress)
+[dir=rtl].handsontable {
+  table {
+    th {
+      text-align center
+    }
+    td {
+      text-align start
+    }
+  }
+}


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR resets the wrong text alignment (from common VuePress styling) for RTL demos.

_[skip changelog]_

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/handsontable/issues/9237

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
