### PR TITLE
Fix RTL demo overflowing

### DIFF
--- a/docs/12.0/guides/internationalization/layout-direction.md
+++ b/docs/12.0/guides/internationalization/layout-direction.md
@@ -59,7 +59,7 @@ function generateArabicData() {
   const randomNumber = (a = 0, b = 1000) => a + Math.floor(Math.random() * b);
   const randomPhrase = () =>
     `${randomCountry()} ${randomName()} ${randomNumber()}`;
-  
+
   const arr = Array.from({ length: 10 }, () => [
     randomBool(),
     randomName(),
@@ -81,6 +81,7 @@ const hot = new Handsontable(container, {
   data: generateArabicData(),
   colHeaders: true,
   rowHeaders: true,
+  height: 'auto',
   // render Handsontable from the right to the left
   layoutDirection: 'rtl',
   // load an RTL language (e.g., Arabic)
@@ -119,7 +120,7 @@ You can set the layout direction only at Handsontable's [initialization](@/guide
 
 ### Setting the layout direction automatically
 
-You can set Handsontable's layout direction automatically, 
+You can set Handsontable's layout direction automatically,
 based on on the value of your HTML document's [`dir`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir) attribute.
 This is the default setting.
 
@@ -149,6 +150,7 @@ const hot = new Handsontable(container, {
   ],
   colHeaders: true,
   rowHeaders: true,
+  height: 'auto',
   // inherit Handsontable's layout direction
   // from the value of your HTML document's `dir` attribute
   layoutDirection: 'inherit',
@@ -178,6 +180,7 @@ const hot = new Handsontable(container, {
   ],
   colHeaders: true,
   rowHeaders: true,
+  height: 'auto',
   // render Handsontable from the right to the left
   // regardless of your HTML document's `dir`
   layoutDirection: 'rtl',
@@ -207,6 +210,7 @@ const hot = new Handsontable(container, {
   ],
   colHeaders: true,
   rowHeaders: true,
+  height: 'auto',
   // render Handsontable from the left to the right
   // regardless of your HTML document's `dir`
   layoutDirection: 'ltr',
@@ -234,6 +238,7 @@ const hot = new Handsontable(container, {
   ],
   colHeaders: true,
   rowHeaders: true,
+  height: 'auto',
   // render Handsontable from the right to the left
   // regardless of your HTML document's `dir`
   layoutDirection: 'rtl',

--- a/docs/next/guides/internationalization/layout-direction.md
+++ b/docs/next/guides/internationalization/layout-direction.md
@@ -59,7 +59,7 @@ function generateArabicData() {
   const randomNumber = (a = 0, b = 1000) => a + Math.floor(Math.random() * b);
   const randomPhrase = () =>
     `${randomCountry()} ${randomName()} ${randomNumber()}`;
-  
+
   const arr = Array.from({ length: 10 }, () => [
     randomBool(),
     randomName(),
@@ -81,6 +81,7 @@ const hot = new Handsontable(container, {
   data: generateArabicData(),
   colHeaders: true,
   rowHeaders: true,
+  height: 'auto',
   // render Handsontable from the right to the left
   layoutDirection: 'rtl',
   // load an RTL language (e.g., Arabic)
@@ -119,7 +120,7 @@ You can set the layout direction only at Handsontable's [initialization](@/guide
 
 ### Setting the layout direction automatically
 
-You can set Handsontable's layout direction automatically, 
+You can set Handsontable's layout direction automatically,
 based on on the value of your HTML document's [`dir`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir) attribute.
 This is the default setting.
 
@@ -149,6 +150,7 @@ const hot = new Handsontable(container, {
   ],
   colHeaders: true,
   rowHeaders: true,
+  height: 'auto',
   // inherit Handsontable's layout direction
   // from the value of your HTML document's `dir` attribute
   layoutDirection: 'inherit',
@@ -178,6 +180,7 @@ const hot = new Handsontable(container, {
   ],
   colHeaders: true,
   rowHeaders: true,
+  height: 'auto',
   // render Handsontable from the right to the left
   // regardless of your HTML document's `dir`
   layoutDirection: 'rtl',
@@ -207,6 +210,7 @@ const hot = new Handsontable(container, {
   ],
   colHeaders: true,
   rowHeaders: true,
+  height: 'auto',
   // render Handsontable from the left to the right
   // regardless of your HTML document's `dir`
   layoutDirection: 'ltr',
@@ -234,6 +238,7 @@ const hot = new Handsontable(container, {
   ],
   colHeaders: true,
   rowHeaders: true,
+  height: 'auto',
   // render Handsontable from the right to the left
   // regardless of your HTML document's `dir`
   layoutDirection: 'rtl',


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR updates RTL demos in docs to prevent them to not overlapping the preview container element.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/handsontable/issues/9433

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
