### PR TITLE
Docs: Czech language fix

### DIFF
--- a/docs/12.0/guides/internationalization/language.md
+++ b/docs/12.0/guides/internationalization/language.md
@@ -113,7 +113,6 @@ Below you'll find a list of features which can be translated:
 By default, Handsontable uses the **English - United States** language-country set (`en-US` code) for creating the text of UI elements. However, it can be used like every extra, "non-standard" language file, thus the `en-US.js` file can be found in `/dist/languages`, `/languages` and `/src/languages` folders. Currently, we also distribute extra language-country files:
 
 * `ar-AR.js` for **Arabic - Global** (`ar-AR` code). To render this language as intended, set the [layout direction](@/guides/internationalization/language.md) to RTL.
-* `cs-CZ.js` for **Czech - Czech Republic** (`cs-CZ` code).
 * `de-CH.js` for **German - Switzerland** (`de-CH` code).
 * `de-DE.js` for **German - Germany** (`de-DE` code).
 * `es-MX.js` for **Spanish - Mexico** (`es-MX` code).

--- a/docs/next/guides/internationalization/language.md
+++ b/docs/next/guides/internationalization/language.md
@@ -113,7 +113,7 @@ Below you'll find a list of features which can be translated:
 By default, Handsontable uses the **English - United States** language-country set (`en-US` code) for creating the text of UI elements. However, it can be used like every extra, "non-standard" language file, thus the `en-US.js` file can be found in `/dist/languages`, `/languages` and `/src/languages` folders. Currently, we also distribute extra language-country files:
 
 * `ar-AR.js` for **Arabic - Global** (`ar-AR` code). To render this language as intended, set the [layout direction](@/guides/internationalization/language.md) to RTL.
-* `cs-CZ.js` for **Czech - Czech Republic** (`cs-CZ` code).
+* `cs-CZ.js` for **Czech - Czechia** (`cs-CZ` code).
 * `de-CH.js` for **German - Switzerland** (`de-CH` code).
 * `de-DE.js` for **German - Germany** (`de-DE` code).
 * `es-MX.js` for **Spanish - Mexico** (`es-MX` code).


### PR DESCRIPTION
This PR:
- Removes the Czech language from the `12.0` version of the docs (it was added by mistake)
- For the `12.1` version of the docs, changes **Czech Republic** to **Czechia** (as per [this comment](https://github.com/handsontable/handsontable/issues/9354#issuecomment-1092676598))

[skip changelog]