### PR TITLE
[hotfix] Fix failing Comments test (after code conflict)

### DIFF
--- a/handsontable/src/plugins/comments/__tests__/rtl/comments.spec.js
+++ b/handsontable/src/plugins/comments/__tests__/rtl/comments.spec.js
@@ -231,58 +231,7 @@ describe('Comments (RTL mode)', () => {
         });
 
         testContainer
-          .scrollLeft(-10)
-          .scrollTop(10);
-
-        const cell = $(hot.getCell(1, 1));
-
-        cell.simulate('mouseover', {
-          clientX: cell.offset().left + 5,
-          clientY: cell.offset().top + 5,
-        });
-
-        await sleep(10);
-
-        const commentEditor = $(hot.getPlugin('comments').editor.getInputElement());
-        const commentEditorOffset = commentEditor.offset();
-        const commentEditorWidth = commentEditor.outerWidth();
-
-        expect({
-          top: commentEditorOffset.top,
-          left: commentEditorOffset.left + commentEditorWidth,
-        }).toEqual(cell.offset());
-
-        hot.destroy();
-      });
-    });
-
-    describe('Displaying comment after `mouseover` event', () => {
-      it('should display in the left position when the table is initialized within the scrollable parent element', async() => {
-        const testContainer = $(`
-          <div style="width: 250px; height: 200px; overflow: scroll;">
-            <div style="width: 2000px; height: 2000px;">
-              <div id="hot-container"></div>
-            </div>
-          </div>
-        `).appendTo(spec().$container);
-
-        const hot = new Handsontable(testContainer.find('#hot-container')[0], {
-          layoutDirection,
-          data: createSpreadsheetData(10, 10),
-          width: 200,
-          height: 150,
-          rowHeaders: true,
-          colHeaders: true,
-          comments: {
-            displayDelay: 1
-          },
-          cell: [
-            { row: 1, col: 1, comment: { value: 'Some comment' } },
-          ]
-        });
-
-        testContainer
-          .scrollLeft(-10)
+          .scrollLeft(htmlDir === 'rtl' ? -10 : 10)
           .scrollTop(10);
 
         const cell = $(hot.getCell(1, 1));


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the failing _Comments_ E2E test that was wrongly merged after resolving the conflict between two similar PRs (https://github.com/handsontable/handsontable/pull/9424, https://github.com/handsontable/handsontable/pull/9439).

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
