### PR TITLE
Disable automatic Docs deployment for staging

### DIFF
--- a/.github/ISSUE_TEMPLATE/02-documentation.md
+++ b/.github/ISSUE_TEMPLATE/02-documentation.md
@@ -2,7 +2,7 @@
 name: "Handsontable Documentation"
 about: Issues regarding Handsontable documentation.
 title: ""
-labels: "documentation"
+labels: "Docs"
 assignees: ""
 ---
 

--- a/.github/workflows/docs-staging-build.yml
+++ b/.github/workflows/docs-staging-build.yml
@@ -1,7 +1,7 @@
-name: Docs Staging Deployment
+name: Docs Staging Build
 
 env:
-  GHA_DOCKER_TAG: docker.pkg.github.com/${{ github.repository }}/handsontable-documentation:latest
+  GHA_DOCKER_TAG: docker.pkg.github.com/${{ github.repository }}/handsontable-documentation:staging
   GHA_DOCKER_TAG_SHA: docker.pkg.github.com/${{ github.repository }}/handsontable-documentation:${{ github.sha }}
 
 on:
@@ -56,15 +56,14 @@ jobs:
         id: pr-finder
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-  
+
       - name: Publish sticky comment in PR
         uses: marocchino/sticky-pull-request-comment@6804b5ad49d19c10c9ae7cf5057352f7ff333f31 # https://github.com/marocchino/sticky-pull-request-comment/tree/v1.6.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           number: ${{ steps.pr-finder.outputs.pr }}
           message: |
-            Launch the local version of documentation by running: 
+            Launch the local version of documentation by running:
             ```bash
             npm run docs:review ${{ github.sha }}
             ```
-            

--- a/.github/workflows/docs-staging-deploy.yml
+++ b/.github/workflows/docs-staging-deploy.yml
@@ -1,0 +1,31 @@
+name: Docs Staging Deployment
+
+env:
+  GHA_DOCKER_LATEST_TAG: docker.pkg.github.com/${{ github.repository }}/handsontable-documentation:latest
+  GHA_DOCKER_STAGING_TAG: docker.pkg.github.com/${{ github.repository }}/handsontable-documentation:staging
+
+on:
+  workflow_dispatch:
+
+defaults:
+  run:
+    working-directory: ./docs/
+
+jobs:
+  docker:
+    name: Deploy image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2
+
+      - name: Docker login into GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login -u ${GITHUB_ACTOR} --password-stdin https://docker.pkg.github.com
+
+      - name: Docker tags
+        run: |
+          docker tag $GHA_DOCKER_STAGING_TAG $GHA_DOCKER_LATEST_TAG
+
+      - name: Docker push latest into GHCR
+        run: |
+          docker push ${GHA_DOCKER_LATEST_TAG}


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR disables automatic deployment of the Docs for the staging environment. To push the image to the staging use the manual workflow dispatcher at https://github.com/handsontable/handsontable/actions/workflows/docs-staging-deploy.yml.

Additionally, I fixed the label name for the Documentation issue template https://github.com/handsontable/handsontable/pull/9461/files#diff-15605cb0d2a1a33ba7cca1756c594422d4acc5cdff51719612a95fa39a3b8fd7R5.

_[skip changelog]_

### Related issue(s):
1. fixes https://github.com/handsontable/handsontable/issues/9460

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
