### PR TITLE
Fix column-groups linking

### DIFF
--- a/docs/10.0/guides/columns/column-groups.md
+++ b/docs/10.0/guides/columns/column-groups.md
@@ -20,7 +20,7 @@ Columns in Handsontable may be grouped using multiple levels of headers. We refe
 
 The **Nested Headers** plugin allows creating a nested header structure using the `colspan` attribute. The header cannot be wider than its parent element, i.e., headers cannot overlap each other.
 
-To make a header that spans across multiple columnns, its corresponding configuration array element should be provided as an object with `label` and `colspan` properties. The `label` property defines the header's label, while the `colspan` property defines the number of columns that the header should cover.
+To make a header that spans across multiple columns, its corresponding configuration array element should be provided as an object with `label` and `colspan` properties. The `label` property defines the header's label, while the `colspan` property defines the number of columns that the header should cover.
 
 The maximum value for `colspan` for nested headers is 1000, meaning that the maximum number of columns that a header can span is 1000.  This constraint is based on [_HTML table specification_](https://html.spec.whatwg.org/multipage/tables.html#dom-tdth-colspan), which sets the limit of `colspan` to 1000.
 

--- a/docs/11.0/guides/columns/column-groups.md
+++ b/docs/11.0/guides/columns/column-groups.md
@@ -20,7 +20,7 @@ Columns in Handsontable may be grouped using multiple levels of headers. We refe
 
 The **Nested Headers** plugin allows creating a nested header structure using the `colspan` attribute. The header cannot be wider than its parent element, i.e., headers cannot overlap each other.
 
-To make a header that spans across multiple columnns, its corresponding configuration array element should be provided as an object with `label` and `colspan` properties. The `label` property defines the header's label, while the `colspan` property defines the number of columns that the header should cover.
+To make a header that spans across multiple columns, its corresponding configuration array element should be provided as an object with `label` and `colspan` properties. The `label` property defines the header's label, while the `colspan` property defines the number of columns that the header should cover.
 
 The maximum value for `colspan` for nested headers is 1000, meaning that the maximum number of columns that a header can span is 1000.  This constraint is based on [_HTML table specification_](https://html.spec.whatwg.org/multipage/tables.html#dom-tdth-colspan), which sets the limit of `colspan` to 1000.
 

--- a/docs/11.1/guides/columns/column-groups.md
+++ b/docs/11.1/guides/columns/column-groups.md
@@ -20,7 +20,7 @@ Columns in Handsontable may be grouped using multiple levels of headers. We refe
 
 The **Nested Headers** plugin allows creating a nested header structure using the `colspan` attribute. The header cannot be wider than its parent element, i.e., headers cannot overlap each other.
 
-To make a header that spans across multiple columnns, its corresponding configuration array element should be provided as an object with `label` and `colspan` properties. The `label` property defines the header's label, while the `colspan` property defines the number of columns that the header should cover.
+To make a header that spans across multiple columns, its corresponding configuration array element should be provided as an object with `label` and `colspan` properties. The `label` property defines the header's label, while the `colspan` property defines the number of columns that the header should cover.
 
 The maximum value for `colspan` for nested headers is 1000, meaning that the maximum number of columns that a header can span is 1000.  This constraint is based on [_HTML table specification_](https://html.spec.whatwg.org/multipage/tables.html#dom-tdth-colspan), which sets the limit of `colspan` to 1000.
 

--- a/docs/12.0/guides/columns/column-groups.md
+++ b/docs/12.0/guides/columns/column-groups.md
@@ -20,7 +20,7 @@ Columns in Handsontable may be grouped using multiple levels of headers. We refe
 
 The **Nested Headers** plugin allows creating a nested header structure using the `colspan` attribute. The header cannot be wider than its parent element, i.e., headers cannot overlap each other.
 
-To make a header that spans across multiple columnns, its corresponding configuration array element should be provided as an object with `label` and `colspan` properties. The `label` property defines the header's label, while the `colspan` property defines the number of columns that the header should cover.
+To make a header that spans across multiple columns, its corresponding configuration array element should be provided as an object with `label` and `colspan` properties. The `label` property defines the header's label, while the `colspan` property defines the number of columns that the header should cover.
 
 The maximum value for `colspan` for nested headers is 1000, meaning that the maximum number of columns that a header can span is 1000.  This constraint is based on [_HTML table specification_](https://html.spec.whatwg.org/multipage/tables.html#dom-tdth-colspan), which sets the limit of `colspan` to 1000.
 
@@ -63,7 +63,7 @@ The **Collapsible Columns** plugin enables columns and their headers to be colla
 
 This plugin adds multi-column headers which have buttons. Clicking these buttons will collapse or expand all "child" headers, leaving the first one visible.
 
-The [Nested Headers](#nested-headers.md) plugin needs to be enabled for this to work properly.
+The [Nested Headers](#nested-headers) plugin needs to be enabled for this to work properly.
 
 ### Configuration
 

--- a/docs/12.0/guides/columns/column-groups.md
+++ b/docs/12.0/guides/columns/column-groups.md
@@ -63,7 +63,7 @@ The **Collapsible Columns** plugin enables columns and their headers to be colla
 
 This plugin adds multi-column headers which have buttons. Clicking these buttons will collapse or expand all "child" headers, leaving the first one visible.
 
-The [Nested Headers](#nested-headers) plugin needs to be enabled for this to work properly.
+The [`NestedHeaders`](@/api/nestedHeaders.md) plugin needs to be enabled for this to work properly.
 
 ### Configuration
 

--- a/docs/9.0/guides/columns/column-groups.md
+++ b/docs/9.0/guides/columns/column-groups.md
@@ -20,7 +20,7 @@ Columns in Handsontable may be grouped using multiple levels of headers. We refe
 
 The **Nested Headers** plugin allows creating a nested header structure using the `colspan` attribute. The header cannot be wider than its parent element, i.e., headers cannot overlap each other.
 
-To make a header that spans across multiple columnns, its corresponding configuration array element should be provided as an object with `label` and `colspan` properties. The `label` property defines the header's label, while the `colspan` property defines the number of columns that the header should cover.
+To make a header that spans across multiple columns, its corresponding configuration array element should be provided as an object with `label` and `colspan` properties. The `label` property defines the header's label, while the `colspan` property defines the number of columns that the header should cover.
 
 The maximum value for `colspan` for nested headers is 1000, meaning that the maximum number of columns that a header can span is 1000.  This constraint is based on [_HTML table specification_](https://html.spec.whatwg.org/multipage/tables.html#dom-tdth-colspan), which sets the limit of `colspan` to 1000.
 

--- a/docs/next/guides/columns/column-groups.md
+++ b/docs/next/guides/columns/column-groups.md
@@ -20,7 +20,7 @@ Columns in Handsontable may be grouped using multiple levels of headers. We refe
 
 The **Nested Headers** plugin allows creating a nested header structure using the `colspan` attribute. The header cannot be wider than its parent element, i.e., headers cannot overlap each other.
 
-To make a header that spans across multiple columnns, its corresponding configuration array element should be provided as an object with `label` and `colspan` properties. The `label` property defines the header's label, while the `colspan` property defines the number of columns that the header should cover.
+To make a header that spans across multiple columns, its corresponding configuration array element should be provided as an object with `label` and `colspan` properties. The `label` property defines the header's label, while the `colspan` property defines the number of columns that the header should cover.
 
 The maximum value for `colspan` for nested headers is 1000, meaning that the maximum number of columns that a header can span is 1000.  This constraint is based on [_HTML table specification_](https://html.spec.whatwg.org/multipage/tables.html#dom-tdth-colspan), which sets the limit of `colspan` to 1000.
 
@@ -63,7 +63,7 @@ The **Collapsible Columns** plugin enables columns and their headers to be colla
 
 This plugin adds multi-column headers which have buttons. Clicking these buttons will collapse or expand all "child" headers, leaving the first one visible.
 
-The [Nested Headers](#nested-headers.md) plugin needs to be enabled for this to work properly.
+The [Nested Headers](#nested-headers) plugin needs to be enabled for this to work properly.
 
 ### Configuration
 

--- a/docs/next/guides/columns/column-groups.md
+++ b/docs/next/guides/columns/column-groups.md
@@ -63,7 +63,7 @@ The **Collapsible Columns** plugin enables columns and their headers to be colla
 
 This plugin adds multi-column headers which have buttons. Clicking these buttons will collapse or expand all "child" headers, leaving the first one visible.
 
-The [Nested Headers](#nested-headers) plugin needs to be enabled for this to work properly.
+The [`NestedHeaders`](@/api/nestedHeaders.md) plugin needs to be enabled for this to work properly.
 
 ### Configuration
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the **Nested Headers** link (https://handsontable.com/docs/column-groups/) for docs plus some typos.

The link (anchor) generally works but the full URL is wrong. It points to the `https://handsontable.com/docs/12.0/guides/columns/column-groups.html#nested-headers.html`
 
![Zrzut ekranu 2022-05-9 o 09 33 35](https://user-images.githubusercontent.com/571316/167361898-ef612d5d-aa2d-444e-bec9-f4315dc13a26.png)

_[skip changelog]_

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
