### PR TITLE
Fix exception while updating custom borders

### DIFF
--- a/.changelogs/9455.json
+++ b/.changelogs/9455.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fixed a bug where updating custom borders could lead to uncaught error exceptions",
+  "type": "fixed",
+  "issue": 9455,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/customBorders/__tests__/backward-compatibility.spec.js
+++ b/handsontable/src/plugins/customBorders/__tests__/backward-compatibility.spec.js
@@ -96,6 +96,30 @@ describe('CustomBorders (using backward compatible "left"/"right" options)', () 
       expect(countVisibleCustomBorders()).toBe(0); // TODO this assertion checks current behavior that looks like a bug. I would expect 3
       expect(countCustomBorders()).toBe(0);
     });
+
+    it('should not throw an error when the same borders object is passed by reference', () => {
+      const customBorders = [{
+        row: 2,
+        col: 2,
+        left: RED_BORDER,
+        right: GREEN_BORDER,
+      }];
+
+      handsontable({
+        customBorders,
+      });
+
+      expect(() => {
+        customBorders.push({
+          row: 2,
+          col: 2,
+          left: RED_BORDER,
+          right: GREEN_BORDER,
+        });
+
+        updateSettings({ customBorders });
+      }).not.toThrow();
+    });
   });
 
   it('should translate borders declared using new "start"/"end" API to backward compatible format', () => {

--- a/handsontable/src/plugins/customBorders/__tests__/customBorders.spec.js
+++ b/handsontable/src/plugins/customBorders/__tests__/customBorders.spec.js
@@ -211,6 +211,41 @@ describe('CustomBorders', () => {
                       'Please use only the option "start"/"end".');
     });
 
+    it('should create a deep clone of the borders object configuration', () => {
+      const customBorders = [{
+        row: 2,
+        col: 2,
+        left: RED_BORDER,
+        right: GREEN_BORDER,
+      }];
+
+      handsontable({
+        customBorders,
+      });
+
+      expect(customBorders).toEqual([
+        {
+          row: 2,
+          col: 2,
+          left: RED_BORDER,
+          right: GREEN_BORDER,
+        }
+      ]);
+      expect(getPlugin('customBorders').savedBorders).not.toBe(customBorders);
+
+      updateSettings({ customBorders });
+
+      expect(customBorders).toEqual([
+        {
+          row: 2,
+          col: 2,
+          left: RED_BORDER,
+          right: GREEN_BORDER,
+        }
+      ]);
+      expect(getPlugin('customBorders').savedBorders).not.toBe(customBorders);
+    });
+
     it('should be possible to update borders using backward compatible API ("left"/"right") even when Handsontable was initialized using new API ("start"/"end")', () => {
       handsontable({
         customBorders: [{

--- a/handsontable/src/plugins/customBorders/customBorders.js
+++ b/handsontable/src/plugins/customBorders/customBorders.js
@@ -1,5 +1,5 @@
 import { BasePlugin } from '../base';
-import { hasOwnProperty, objectEach } from '../../helpers/object';
+import { hasOwnProperty, objectEach, deepClone } from '../../helpers/object';
 import { rangeEach } from '../../helpers/number';
 import { arrayEach, arrayReduce, arrayMap } from '../../helpers/array';
 import * as C from '../../i18n/constants';
@@ -736,13 +736,15 @@ export class CustomBorders extends BasePlugin {
     const customBorders = this.hot.getSettings()[PLUGIN_KEY];
 
     if (Array.isArray(customBorders)) {
-      this.checkSettingsCohesion(customBorders);
+      const bordersClone = deepClone(customBorders);
 
-      if (!customBorders.length) {
-        this.savedBorders = customBorders;
+      this.checkSettingsCohesion(bordersClone);
+
+      if (!bordersClone.length) {
+        this.savedBorders = bordersClone;
       }
 
-      this.createCustomBorders(customBorders);
+      this.createCustomBorders(bordersClone);
 
     } else if (customBorders !== void 0) {
       this.createCustomBorders(this.savedBorders);


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes a regression bug that causes the throwing of an error. The bug occurs only when the border configuration object is passed to the Handsontable by reference. The change fixes the bug by cloning the configuration object before the plugin processes it.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and I cover the fix with E2E tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes #9455 

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
