### PR TITLE
Docs: Changing `lazy` to `flexible`

### DIFF
--- a/docs/next/guides/cell-types/autocomplete-cell-type.md
+++ b/docs/next/guides/cell-types/autocomplete-cell-type.md
@@ -10,11 +10,11 @@ canonicalUrl: /autocomplete-cell-type
 [[toc]]
 
 ## Overview
-The `autocomplete` cell type enables the user to choose a suggested option while typing. Autocomplete can be configured in three different ways, lazy mode, strict mode, and strict mode using Ajax.
+The `autocomplete` cell type enables the user to choose a suggested option while typing. Autocomplete can be configured in three different ways, flexible mode, strict mode, and strict mode using Ajax.
 
-## Autocomplete lazy mode
+## Autocomplete flexible mode
 
-This example uses the `autocomplete` feature in the default **lazy mode**. In this mode, the user can choose one of the suggested options while typing or enter a custom value that is not included in the suggestions.
+This example uses the `autocomplete` feature in the default **flexible mode**. In this mode, the user can choose one of the suggested options while typing or enter a custom value that is not included in the suggestions.
 
 In this mode, the mouse and keyboard bindings are identical to the [Handsontable cell type](@/guides/cell-types/handsontable-cell-type.md). The options are rendered from the `source` property, either an array or a function that returns an array.
 

--- a/handsontable/src/dataMap/metaManager/metaSchema.js
+++ b/handsontable/src/dataMap/metaManager/metaSchema.js
@@ -4019,15 +4019,14 @@ export default () => {
     stretchH: 'none',
 
     /**
-     * The `strict` option configures [`autocomplete`](@/guides/cell-types/autocomplete-cell-type.md)
-     * cells' strict/lazy mode.
+     * The `strict` option configures the behavior of [`autocomplete`](@/guides/cell-types/autocomplete-cell-type.md) cells.
      *
      * You can set the `strict` option to one of the following:
      *
-     * | Setting | Mode                                                                                  | Description                                                                                                                                       |
-     * | ------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-     * | `true`  | [Strict mode](@/guides/cell-types/autocomplete-cell-type.md#autocomplete-strict-mode) | The value entered must match an autocomplete option (case-sensitive)                                                                              |
-     * | `false` | [Lazy mode](@/guides/cell-types/autocomplete-cell-type.md#autocomplete-lazy-mode)     | The value entered doesn't have to match an autocomplete option.<br>The end user can:<br>- Choose from suggested options<br>- Enter a custom value |
+     * | Setting | Mode                                                                                          | Description                                                                                |
+     * | ------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+     * | `true`  | [Strict mode](@/guides/cell-types/autocomplete-cell-type.md#autocomplete-strict-mode)         | The end user:<br>- Can only choose one of suggested values<br>- Can't enter a custom value |
+     * | `false` | [Flexible mode](@/guides/cell-types/autocomplete-cell-type.md#autocomplete-flexible-mode)     | The end user:<br>- Can choose one of suggested values<br>- Can enter a custom value        |
      *
      * Read more:
      * - [Autocomplete cell type &#8594;](@/guides/cell-types/autocomplete-cell-type.md)


### PR DESCRIPTION
This PR:
- Changes the term used to describe the `strict: false` setting, from `lazy` to `flexible`

[skip changelog]