### PR TITLE
Warn that DOCS_VERSION or DOCS_FRAMEWORK environment variable should be used will be thrown #9463

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -45,11 +45,13 @@ if (getEnvDocsVersion()) {
 
 } else if (isEnvDev()) {
   // eslint-disable-next-line no-console
-  console.error(chalk.red(
-    'Stopping `docs:start` script execution. Any from `DOCS_FRAMEWORK` or `DOCS_FRAMEWORK` environment variables ' +
-    'should be defined for performance reason, ie. by using `DOCS_FRAMEWORK=javascript npm run docs:start:no-cache` ' +
-    'command.'
-  ));
+  console.error(
+    `${chalk.red(`\
+Stopping the ${chalk.italic('docs:start')} script execution. For performance reasons, the \
+${chalk.italic('DOCS_VERSION')} and/or ${chalk.italic('DOCS_FRAMEWORK')} environment variables need to be defined. \
+For example, try calling:
+${chalk.italic.bold('DOCS_VERSION=next DOCS_FRAMEWORK=javascript npm run docs:start:no-cache')}.
+`)}`);
   process.exit(1);
 }
 

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const chalk = require('chalk');
 const highlight = require('./highlight');
 const examples = require('./containers/examples');
 const sourceCodeLink = require('./containers/sourceCodeLink');
@@ -6,7 +7,6 @@ const conditionalBlock = require('./containers/conditionalBlock');
 const nginxRedirectsPlugin = require('./plugins/generate-nginx-redirects');
 const assetsVersioningPlugin = require('./plugins/assets-versioning');
 const extendPageDataPlugin = require('./plugins/extend-page-data');
-const chalk = require('chalk');
 const {
   getEnvDocsVersion,
   getEnvDocsFramework,

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -6,6 +6,7 @@ const conditionalBlock = require('./containers/conditionalBlock');
 const nginxRedirectsPlugin = require('./plugins/generate-nginx-redirects');
 const assetsVersioningPlugin = require('./plugins/assets-versioning');
 const extendPageDataPlugin = require('./plugins/extend-page-data');
+const chalk = require('chalk');
 const {
   getEnvDocsVersion,
   getEnvDocsFramework,
@@ -41,6 +42,15 @@ if (getEnvDocsVersion()) {
 } else if (getEnvDocsFramework()) {
   versionPartialPath = '**/';
   frameworkPartialPath = `${getEnvDocsFramework()}${FRAMEWORK_SUFFIX}/`;
+
+} else if (isEnvDev()) {
+  // eslint-disable-next-line no-console
+  console.error(chalk.red(
+    'Stopping `docs:start` script execution. Any from `DOCS_FRAMEWORK` or `DOCS_FRAMEWORK` environment variables ' +
+    'should be defined for performance reason, ie. by using `DOCS_FRAMEWORK=javascript npm run docs:start:no-cache` ' +
+    'command.'
+  ));
+  process.exit(1);
 }
 
 const redirectsPlugin = isLatest ?

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,6 +60,7 @@ From the `docs` directory, you can run the following npm scripts:
 * `npm run docs:review [COMMIT_HASH]` – Deploys the documentation locally at a `[COMMIT_HASH]` commit.
 * `DOCS_VERSION=<semver.version> npm run docs:start:no-cache` – Starts a local documentation server, just for the <semver.version> documentation version.
 * `DOCS_VERSION=next npm run docs:start:no-cache` – Starts a local documentation server, just for the `next` documentation version.
+* `DOCS_FRAMEWORK=<javascript|react|angular|vue2|vue3> npm run docs:start:no-cache` – Starts a local documentation server, just for the framework documentation version.
 
 ## Handsontable documentation directory structure
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
We need an extra error for performance reasons. Process should be killed when there is no environment variable `docs:start` script.

[skip changelog]

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
By running `docs:start` script with/without  `DOCS_VERSION`/`DOCS_FRAMEWORK` environment variables and `docs:build` script.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #9463 

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] My change requires a change to the documentation.