### PR TITLE
Search engine will work while starting documentation using the `docs:start` script

### DIFF
--- a/docs/.vuepress/helpers.js
+++ b/docs/.vuepress/helpers.js
@@ -145,10 +145,6 @@ function getSidebars(buildMode) {
  * @returns {string}
  */
 function parseVersion(url) {
-  if (isEnvDev()) {
-    url = url.replace(`/${TMP_DIR_FOR_WATCH}`, '');
-  }
-
   return url.split('/')[1] || getLatestVersion();
 }
 
@@ -159,10 +155,6 @@ function parseVersion(url) {
  * @returns {string}
  */
 function parseFramework(url) {
-  if (isEnvDev()) {
-    url = url.replace(`/${TMP_DIR_FOR_WATCH}`, '');
-  }
-
   const potentialFramework = url.split('/')[2]?.replace(FRAMEWORK_SUFFIX, '');
 
   if (getFrameworks().includes(potentialFramework)) {

--- a/docs/.vuepress/plugins/extend-page-data/index.js
+++ b/docs/.vuepress/plugins/extend-page-data/index.js
@@ -10,6 +10,7 @@ const {
   isEnvDev,
   getDefaultFramework,
   FRAMEWORK_SUFFIX,
+  TMP_DIR_FOR_WATCH,
 } = require('../../helpers');
 const { collectAllUrls, getCanonicalUrl } = require('./canonicals');
 
@@ -45,12 +46,14 @@ module.exports = (options, context) => {
     extendPageData($page) {
       $page.DOCS_VERSION = DOCS_VERSION;
       $page.DOCS_FRAMEWORK = DOCS_FRAMEWORK;
+      $page.normalizedPath = isEnvDev() ?
+        $page.path.replace(new RegExp(`^/?${TMP_DIR_FOR_WATCH}`), '') : $page.path;
       $page.frameworkedVersions = getDocsFrameworkedVersions(buildMode);
       $page.nonFrameworkedVersions = getDocsNonFrameworkedVersions(buildMode);
       $page.latestVersion = getLatestVersion();
-      $page.currentVersion = parseVersion($page.path);
+      $page.currentVersion = parseVersion($page.normalizedPath);
       // Framework isn't stored in PATH for full build. However, it's defined in ENV variable.
-      $page.currentFramework = DOCS_FRAMEWORK || parseFramework($page.path);
+      $page.currentFramework = DOCS_FRAMEWORK || parseFramework($page.normalizedPath);
       $page.defaultFramework = getDefaultFramework();
       $page.frameworkSuffix = FRAMEWORK_SUFFIX;
       $page.lastUpdatedFormat = formatDate($page.lastUpdated);

--- a/docs/.vuepress/theme/components/SearchBox.vue
+++ b/docs/.vuepress/theme/components/SearchBox.vue
@@ -287,7 +287,7 @@ export default {
     },
 
     isSearchable(page) {
-      return page.regularPath.startsWith(`/${this.$page.currentVersion}/`);
+      return page.normalizedPath.startsWith(`/${this.$page.currentVersion}/`);
     },
 
     onHotkey(event) {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The search bar hasn't worked. This PR fix the problem by introducing an extra key for the Front Matter's `page` object.

[skip changelog]

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I've checked whether `docs:start` and `docs:build` script works.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #9451

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] My change requires a change to the documentation.