### PR TITLE
Docs: Adding the `dateFormat` description to the 12.0 docs version

### DIFF
--- a/docs/12.0/api/options.md
+++ b/docs/12.0/api/options.md
@@ -1263,14 +1263,12 @@ copyPaste: {
 
 _options.correctFormat : boolean_
 
-The `correctFormat` option configures [`date`](@/guides/cell-types/date-cell-type.md) cells' date format correction.
+The `correctFormat` option configures what happens when the format of a date entered into a [`date`](@/guides/cell-types/date-cell-type.md) cell doesn't match the format specified by the [`dateFormat`](#dateformat) option:
 
-You can set the `correctFormat` option to one of the following
-
-| Setting           | Description                                                           |
-| ----------------- | --------------------------------------------------------------------- |
-| `false` (default) | Don't correct dates                                                   |
-| `true`            | Enforce the date format set by the [`dateFormat`](#dateformat) option |
+| Setting           | Description                                                                        |
+| ----------------- | ---------------------------------------------------------------------------------- |
+| `false` (default) | Don't correct the entered date's format (treat the entered date as invalid)        |
+| `true`            | Correct the entered date's format to match the [`dateFormat`](#dateformat) setting |
 
 Read more:
 - [Date cell type &#8594;](@/guides/cell-types/date-cell-type.md)

--- a/docs/12.0/guides/cell-types/date-cell-type.md
+++ b/docs/12.0/guides/cell-types/date-cell-type.md
@@ -24,7 +24,38 @@ Note that date cell requires additional modules :
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/pikaday@1.8.0/css/pikaday.css">
 ```
 
-All data entered into the date-type cells are validated against the default date format `DD/MM/YYYY` unless another format is provided. If you enable the `correctFormat` config item, the dates will be automatically formatted to match the desired format.
+## Date format
+
+`date` cells accept strings that are formatted in line with the [`dateFormat`](@/api/options.md#dateformat) setting.
+
+The default date format is `'DD/MM/YYYY'`.
+
+Handsontable doesn't support JavaScript's `Date` object.
+
+### Changing the date format
+
+To change the date format accepted by `date` cells, set the [`dateFormat`](@/api/options.md#dateformat) configuration option to a string with your preferred format. For example:
+
+```js
+dateFormat: 'YYYY-MM-DD',
+```
+
+### Autocorrecting invalid dates
+
+By default, when the user enters a date in a format that doesn't match the [`dateFormat`](@/api/options.md#dateformat) setting, the date is treated as invalid.
+
+You can let Handsontable correct such dates automatically, so they match the required format. To do this, set the [`correctFormat`](@/api/options.md#correctformat) option to `true`. For example:
+
+```js
+dateFormat: 'YYYY-MM-DD',
+
+// default behavior
+// date entered as `30/12/2022` will be invalid
+correctFormat: false,
+
+// date entered as `30/12/2022` will be corrected to `2022/12/30`
+correctFormat: true,
+```
 
 ## Basic example
 


### PR DESCRIPTION
This PR:
- Adds the same information that was added in #9465, but for the current docs version (`12.0`), so it's published immediately

[skip changelog]