### PR TITLE
Docs: Update the documentation issue template to match the label change

### DIFF
--- a/.github/ISSUE_TEMPLATE/02-documentation.md
+++ b/.github/ISSUE_TEMPLATE/02-documentation.md
@@ -1,9 +1,9 @@
 ---
 name: "Handsontable Documentation"
 about: Issues regarding Handsontable documentation.
-title: ""
-labels: "Docs"
-assignees: ""
+title: "Docs: "
+labels: "Docs: Content"
+assignees: "kirszenbaum"
 ---
 
 ### Description


### PR DESCRIPTION
This PR:
- Updates the documentation issue template due to match the label changes (`Docs` -> `Docs: Content`)

[skip changelog]