### PR TITLE
Disable rule '@typescript-eslint/no-explicit-any' in Vue3 wrapper

### DIFF
--- a/wrappers/vue3/.eslintrc.js
+++ b/wrappers/vue3/.eslintrc.js
@@ -4,6 +4,7 @@ module.exports = {
     'no-restricted-globals': 'off',
     'import/no-unresolved': 'off',
     'import/extensions': 'off',
+    '@typescript-eslint/no-explicit-any': 'off',
   },
   overrides: [
     {

--- a/wrappers/vue3/.eslintrc.js
+++ b/wrappers/vue3/.eslintrc.js
@@ -4,7 +4,6 @@ module.exports = {
     'no-restricted-globals': 'off',
     'import/no-unresolved': 'off',
     'import/extensions': 'off',
-    '@typescript-eslint/no-explicit-any': 'off',
   },
   overrides: [
     {
@@ -14,6 +13,9 @@ module.exports = {
       files: ['*.ts'],
       parser: '@typescript-eslint/parser',
       plugins: ['@typescript-eslint'],
+      rules: {
+        '@typescript-eslint/no-explicit-any': 'off',
+      },
     },
     {
       files: ['*.vue'],
@@ -25,7 +27,7 @@ module.exports = {
       parserOptions: {
         parser: '@typescript-eslint/parser',
         sourceType: 'module',
-      },
+      }
     },
   ],
 };

--- a/wrappers/vue3/.eslintrc.js
+++ b/wrappers/vue3/.eslintrc.js
@@ -27,7 +27,7 @@ module.exports = {
       parserOptions: {
         parser: '@typescript-eslint/parser',
         sourceType: 'module',
-      }
+      },
     },
   ],
 };


### PR DESCRIPTION
This PR disables the rule `@typescript-eslint/no-explicit-any` in the Vue3 wrapper, because we will not change the type definitions any time soon, and the linter pollutes every PR with 4 warnings

Example polluted PR: https://github.com/handsontable/handsontable/pull/9519

These annotations are coming from this CI step: https://github.com/handsontable/handsontable/runs/6573168076?check_suite_focus=true

Screenshot: <img width="1771" alt="Screen Shot 2022-05-24 at 3 12 24 PM" src="https://user-images.githubusercontent.com/566463/170043150-61359127-11b6-4187-a2c3-edfbaaae66b0.png">

### Context
<!--- Why is this change required? What problem does it solve? -->

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Test run in the CI

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [x] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]