### PR TITLE
Introduced `frameworkName` key in the `$page` variable which contain a framework name

### DIFF
--- a/docs/.vuepress/helpers.js
+++ b/docs/.vuepress/helpers.js
@@ -11,6 +11,15 @@ const TMP_DIR_FOR_WATCH = '.watch-tmp';
 const MIN_FRAMEWORKED_DOCS_VERSION = '12.1.0';
 const FRAMEWORK_SUFFIX = '-data-grid';
 
+// Please keep in mind that the first element is default framework.
+const frameworkToPrettyName = new Map([
+  ['javascript', 'JavaScript'],
+  ['react', 'React'],
+  ['angular', 'Angular'],
+  ['vue2', 'Vue 2'],
+  ['vue3', 'Vue 3'],
+]);
+
 /**
  * Get whether we work in dev mode (watch script).
  *
@@ -64,7 +73,7 @@ function getVersions(buildMode) {
  * @returns {string[]}
  */
 function getFrameworks() {
-  return ['javascript', 'react', 'angular', 'vue2', 'vue3'];
+  return Array.from(frameworkToPrettyName.keys());
 }
 
 /**
@@ -73,7 +82,17 @@ function getFrameworks() {
  * @returns {string}
  */
 function getDefaultFramework() {
-  return 'javascript';
+  return getFrameworks()[0];
+}
+
+/**
+ * Get pretty framework name.
+ *
+ * @param {string} framework Framework ID.
+ * @returns {string}
+ */
+function getPrettyFrameworkName(framework) {
+  return frameworkToPrettyName.get(framework);
 }
 
 /**
@@ -304,6 +323,7 @@ module.exports = {
   getNormalizedPath,
   getVersions,
   getFrameworks,
+  getPrettyFrameworkName,
   getDocsFrameworkedVersions,
   getDocsNonFrameworkedVersions,
   getLatestVersion,

--- a/docs/.vuepress/plugins/extend-page-data/index.js
+++ b/docs/.vuepress/plugins/extend-page-data/index.js
@@ -4,6 +4,7 @@ const {
   getNormalizedPath,
   parseVersion,
   parseFramework,
+  getPrettyFrameworkName,
   getEnvDocsFramework,
   getEnvDocsVersion,
   getDocsFrameworkedVersions,
@@ -55,6 +56,7 @@ module.exports = (options, context) => {
       $page.currentVersion = parseVersion($page.normalizedPath);
       // Framework isn't stored in PATH for full build. However, it's defined in ENV variable.
       $page.currentFramework = DOCS_FRAMEWORK || parseFramework($page.normalizedPath);
+      $page.frameworkName = getPrettyFrameworkName($page.currentFramework);
       $page.defaultFramework = getDefaultFramework();
       $page.frameworkSuffix = FRAMEWORK_SUFFIX;
       $page.isFrameworked = getDocsFrameworkedVersions(buildMode).includes($page.currentVersion);


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
We can use [Vue in `.md` files ](https://vuepress.vuejs.org/guide/using-vue.html#browser-api-access-restrictions). Thus, I've exposed extra `frameworkName` key within the `$page` variable. It will return `undefined`, `JavaScript`, `React` etc.

For example:

`# Handsontable {{ $page.frameworkName ? $page.frameworkName + " Data Grid": "" }} API Reference`

will be parsed to:

`# Handsontable JavaScript Data Grid API Reference`

However, please keep in mind that slugs for headers aren't created properly. For the above example ID attribute equals to `#handsontable-page-frameworkname-page-frameworkname-data-grid-api-reference`.

[skip changelog]

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I did changes in `.md` file and used variable.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #9537 

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] My change requires a change to the documentation.* WIP: Built script create subdirectories with docs for particular framework #9307