### PR TITLE
Docs: Adding Serbian langauge to the docs

### DIFF
--- a/docs/next/guides/internationalization/language.md
+++ b/docs/next/guides/internationalization/language.md
@@ -127,6 +127,7 @@ By default, Handsontable uses the **English - United States** language-country s
 * `pl-PL.js` for **Polish - Poland** (`pl-PL` code).
 * `pt-BR.js` for **Portuguese - Brazil** (`pt-BR` code).
 * `ru-RU.js` for **Russian - Russia** (`ru-RU` code).
+* `sr-SP.js` for **Serbian (Latin) - Serbia** (`sr-SP` code).
 * `zh-CN.js` for **Chinese - China** (`zh-CN` code).
 * `zh-TW.js` for **Chinese - Taiwan** (`zh-TW` code).
 

--- a/handsontable/src/dataMap/metaManager/metaSchema.js
+++ b/handsontable/src/dataMap/metaManager/metaSchema.js
@@ -2494,6 +2494,7 @@ export default () => {
      * | `'pl-PL'`           | Polish - Poland             |
      * | `'pt-BR'`           | Portuguese - Brazil         |
      * | `'ru-RU'`           | Russian - Russia            |
+     * | `'sr-SP'`           | Serbian (Latin) - Serbia    |
      * | `'zh-CN'`           | Chinese - China             |
      * | `'zh-TW'`           | Chinese - Taiwan            |
      *


### PR DESCRIPTION
This PR:
- Adds Serbian to the docs (due to #9469)

I'm mentioning **Serbia** (not **Republic of Serbia**), as we don't use official names for the other languages (e.g., we instead of **Federative Republic of Brazil** we say **Brazil**).

[skip changelog]