### PR TITLE
Add logic to recognize the path of the "common" files.

### DIFF
--- a/docs/.vuepress/containers/examples/examples.js
+++ b/docs/.vuepress/containers/examples/examples.js
@@ -91,7 +91,6 @@ module.exports = {
     const m = token.info.trim().match(EXAMPLE_REGEX);
     const version = parseVersion(env.relativePath);
 
-
     if (token.nesting === 1 && m) { // open preview
       let [, , id, klass, preset, args] = m;
 

--- a/docs/.vuepress/containers/examples/examples.js
+++ b/docs/.vuepress/containers/examples/examples.js
@@ -9,7 +9,8 @@ const { buildCode } = require('./code-builder');
 const { jsfiddle } = require('./jsfiddle');
 const {
   getDefaultFramework,
-  isEnvDev
+  isEnvDev,
+  parseVersion
 } = require('../../helpers');
 const {
   getContainerFrontMatterLength,
@@ -88,7 +89,8 @@ module.exports = {
   render(tokens, index, opts, env) {
     const token = tokens[index];
     const m = token.info.trim().match(EXAMPLE_REGEX);
-    const version = env.relativePath.split('/')[0];
+    const version = parseVersion(env.relativePath);
+
 
     if (token.nesting === 1 && m) { // open preview
       let [, , id, klass, preset, args] = m;
@@ -181,7 +183,7 @@ module.exports = {
       tokens.splice(index + 1, 0, ...newTokens);
 
       return `
-          ${!noEdit ? jsfiddle(id, htmlContent, jsContent, cssContent, version, preset) : ''}
+          ${!noEdit ? jsfiddle(id, htmlContent, jsContent, cssContent, version, preset, framework) : ''}
           <tabs
             :options="{ useUrlFragment: false, defaultTabHash: '${activeTab}' }"
             cache-lifetime="0"

--- a/docs/.vuepress/containers/examples/jsfiddle.js
+++ b/docs/.vuepress/containers/examples/jsfiddle.js
@@ -2,10 +2,10 @@ const JSFIDDLE_ENDPOINT = 'https://jsfiddle.net/api/post/library/pure/';
 
 const { getDependencies } = require('../../handsontable-manager');
 
-const jsfiddle = (id, html, code, css, version, preset) => {
+const jsfiddle = (id, html, code, css, version, preset, framework) => {
   const isBabelPanel = preset.includes('react') || preset.includes('vue');
   const isAngularPanel = preset.includes('angular');
-  const imports = getDependencies(version, preset).reduce(
+  const imports = getDependencies(version, preset, framework).reduce(
     (p, c) =>
       p +
       (c[0] ? `<script src="${c[0]}"></script>\n` : '') +

--- a/docs/.vuepress/handsontable-manager/dependencies.js
+++ b/docs/.vuepress/handsontable-manager/dependencies.js
@@ -14,7 +14,7 @@ const generatePrefixes = (version, framework) => {
   );
 
   const versionPrefix = !isLatestVersion || version === 'next' ? `${version}/` : '';
-  const frameworkPrefix = `${framework}-data-grid/`;
+  const frameworkPrefix = framework ? `${framework}-data-grid/` : '';
 
   return {
     versionPrefix,

--- a/docs/.vuepress/handsontable-manager/dependencies.js
+++ b/docs/.vuepress/handsontable-manager/dependencies.js
@@ -1,13 +1,37 @@
+const semver = require('semver');
+const {
+  version: currentHandsontableVersion
+} = require('../../../handsontable/package.json');
+
 // eslint-disable-next-line no-restricted-globals
 const isBrowser = (typeof window !== 'undefined');
 
 const formatVersion = version => (/^\d+\.\d+$/.test(version) ? version : 'latest');
-const getHotUrls = (version) => {
+const generatePrefixes = (version, framework) => {
+  const isLatestVersion = semver.satisfies(
+    semver.coerce(version)?.version,
+    semver.coerce(currentHandsontableVersion)?.version.replace(/\.([a-z0-9]|-)+$/, '.x')
+  );
+
+  const versionPrefix = !isLatestVersion || version === 'next' ? `${version}/` : '';
+  const frameworkPrefix = `${framework}-data-grid/`;
+
+  return {
+    versionPrefix,
+    frameworkPrefix
+  };
+};
+const getHotUrls = (version, framework) => {
+  const {
+    versionPrefix,
+    frameworkPrefix
+  } = generatePrefixes(version, framework);
+
   if (version === 'next' && isBrowser) {
     return {
-      handsontableJs: '/docs/handsontable/handsontable.full.js',
-      handsontableCss: '/docs/handsontable/handsontable.full.css',
-      languagesJs: '/docs/handsontable/languages/all.js'
+      handsontableJs: `/docs/${versionPrefix}${frameworkPrefix}handsontable/handsontable.full.js`,
+      handsontableCss: `/docs/${versionPrefix}${frameworkPrefix}handsontable/handsontable.full.css`,
+      languagesJs: `/docs/${versionPrefix}${frameworkPrefix}handsontable/languages/all.js`
     };
   }
 
@@ -19,13 +43,26 @@ const getHotUrls = (version) => {
     languagesJs: `https://cdn.jsdelivr.net/npm/handsontable@${mappedVersion}/dist/languages/all.js`
   };
 };
-const getCommonScript = (scriptName) => {
+const getCommonScript = (scriptName, version, framework) => {
+  const {
+    versionPrefix,
+    frameworkPrefix
+  } = generatePrefixes(version, framework);
+
   if (isBrowser) {
     // eslint-disable-next-line no-restricted-globals
-    return [`${window.location.origin}/docs/scripts/${scriptName}.js`, ['require', 'exports']];
+    return [
+      `${window.location.origin}/docs/${versionPrefix}${frameworkPrefix}scripts/${scriptName}.js`,
+      ['require', 'exports']
+    ];
+
   }
 
-  return [`https://handsontable.com/docs/scripts/${scriptName}.js`, ['require', 'exports']];
+  return [
+    `https://handsontable.com/docs/${versionPrefix}${frameworkPrefix}scripts/${scriptName}.js`,
+    ['require', 'exports']
+  ];
+
 };
 
 /**
@@ -33,14 +70,15 @@ const getCommonScript = (scriptName) => {
  * The function `buildDependencyGetter` is the best place to care about that.
  *
  * @param {string} version The current selected documentation version.
+ * @param {string} framework The current selected documentation framework.
  * @returns {Function} Returns a function factory with the signature
  *                     `{function(dependency: string): [string,string[],string]} [jsUrl, dependentVars[]?, cssUrl?]`.
  */
-const buildDependencyGetter = (version) => {
-  const { handsontableJs, handsontableCss, languagesJs } = getHotUrls(version);
+const buildDependencyGetter = (version, framework) => {
+  const { handsontableJs, handsontableCss, languagesJs } = getHotUrls(version, framework);
   const mappedVersion = formatVersion(version);
-  const fixer = getCommonScript('fixer');
-  const helpers = getCommonScript('helpers');
+  const fixer = getCommonScript('fixer', version, framework);
+  const helpers = getCommonScript('helpers', version, framework);
 
   return (dependency) => {
     /* eslint-disable max-len */
@@ -109,8 +147,8 @@ const presetMap = {
   /* eslint-enable max-len */
 };
 
-const getDependencies = (version, preset) => {
-  const getter = buildDependencyGetter(version);
+const getDependencies = (version, preset, framework) => {
+  const getter = buildDependencyGetter(version, framework);
 
   if (!Array.isArray(presetMap[preset])) {
     throw new Error(`The preset "${preset}" was not found.`);
@@ -119,4 +157,9 @@ const getDependencies = (version, preset) => {
   return presetMap[preset].map(x => getter(x));
 };
 
-module.exports = { getDependencies, buildDependencyGetter, presetMap };
+module.exports = {
+  isBrowser,
+  getDependencies,
+  buildDependencyGetter,
+  presetMap
+};

--- a/docs/.vuepress/handsontable-manager/use-handsontable.js
+++ b/docs/.vuepress/handsontable-manager/use-handsontable.js
@@ -1,11 +1,15 @@
 const { register } = require('./register');
-const { buildDependencyGetter, presetMap } = require('./dependencies');
+const {
+  buildDependencyGetter,
+  presetMap,
+  isBrowser
+} = require('./dependencies');
 
 const ATTR_VERSION = 'data-hot-version';
 
 const useHandsontable = (version, callback = () => {}, preset = 'hot') => {
-
-  const getDependency = buildDependencyGetter(version);
+  const framework = isBrowser ? window.location.pathname.match(/([a-z]+)-data-grid/)?.[1] : null;
+  const getDependency = buildDependencyGetter(version, framework);
 
   const loadDependency = dep => new Promise((resolve) => {
     const id = `dependency-reloader_${dep}`;

--- a/docs/.vuepress/handsontable-manager/use-handsontable.js
+++ b/docs/.vuepress/handsontable-manager/use-handsontable.js
@@ -8,7 +8,7 @@ const {
 const ATTR_VERSION = 'data-hot-version';
 
 const useHandsontable = (version, callback = () => {}, preset = 'hot') => {
-  const framework = isBrowser ? window.location.pathname.match(/([a-z]+)-data-grid/)?.[1] : null;
+  const framework = isBrowser ? window.location.pathname.match(/([a-z]+)-data-grid/)?.[1] : void 0;
   const getDependency = buildDependencyGetter(version, framework);
 
   const loadDependency = dep => new Promise((resolve) => {

--- a/docs/.vuepress/helpers.js
+++ b/docs/.vuepress/helpers.js
@@ -186,6 +186,10 @@ function getNormalizedPath(normalizedPath) {
     return normalizedPath.replace(new RegExp(`^/?${TMP_DIR_FOR_WATCH}`), '');
   }
 
+  if (normalizedPath[0] !== '/') {
+    normalizedPath = `/${normalizedPath}`;
+  }
+
   return normalizedPath;
 }
 
@@ -296,9 +300,7 @@ function getIgnoredFilesPatterns(buildMode) {
  * @returns {string}
  */
 function parseVersion(url) {
-  const urlVersionSectionIndex = isEnvDev() ? 1 : 0;
-
-  return getNormalizedPath(url).split('/')[urlVersionSectionIndex] || getLatestVersion();
+  return getNormalizedPath(url).split('/')[1] || getLatestVersion();
 }
 
 /**

--- a/docs/.vuepress/helpers.js
+++ b/docs/.vuepress/helpers.js
@@ -261,7 +261,9 @@ function getNotSearchableLinks(buildMode) {
  * @returns {string}
  */
 function parseVersion(url) {
-  return getNormalizedPath(url).split('/')[1] || getLatestVersion();
+  const urlVersionSectionIndex = isEnvDev() ? 1 : 0;
+
+  return getNormalizedPath(url).split('/')[urlVersionSectionIndex] || getLatestVersion();
 }
 
 /**

--- a/docs/.vuepress/theme/components/SearchBox.vue
+++ b/docs/.vuepress/theme/components/SearchBox.vue
@@ -6,6 +6,7 @@
       :value="query"
       :class="{ 'focused': focused }"
       :placeholder="placeholder"
+      :style="inputCustomCssProps"
       autocomplete="off"
       spellcheck="false"
       @input="query = $event.target.value"
@@ -128,7 +129,10 @@ export default {
       query: '',
       focused: false,
       focusIndex: 0,
-      placeholder: undefined
+      placeholder: undefined,
+      inputCustomCssProps: {
+        '--search-icon-url': `url('${this.$router.options.base}/img/search.svg')`,
+      }
     };
   },
 
@@ -364,7 +368,9 @@ export default {
     line-height 2rem
     padding 0 0.5rem 0 2rem
     outline none
-    background #fff url('/docs/img/search.svg') 0.6rem 0.5rem no-repeat
+    /* Fallback for IE, should work in production */
+    background #fff url('/docs/javascript-data-grid/img/search.svg') 0.6rem 0.5rem no-repeat
+    background #fff var(--search-icon-url) 0.6rem 0.5rem no-repeat
     background-size 1rem
     &:focus
       color #104bcd

--- a/docs/.vuepress/theme/components/ThemeSwitcher.vue
+++ b/docs/.vuepress/theme/components/ThemeSwitcher.vue
@@ -2,7 +2,7 @@
   <label id="switch" class="switch">
     <div class="inner">
       <input type="checkbox" v-on:change="toggleTheme" id="slider" :checked="isDarkTheme">
-      <span class="slider round"></span>
+      <span :style="sliderCustomCssProps" class="slider round"></span>
     </div>
   </label>
 </template>
@@ -39,6 +39,10 @@ export default {
     return {
       isDarkTheme: null,
       htmlDomEl: null,
+      sliderCustomCssProps: {
+        '--light-icon-url': `url('${this.$router.options.base}/img/light-theme-icon.svg')`,
+        '--dark-icon-url': `url('${this.$router.options.base}/img/dark-theme-icon.svg')`
+      }
     };
   },
   beforeMount() {
@@ -136,14 +140,15 @@ export default {
   height: 26px;
   width: 26px;
   left: 0px;
-  bottom: 4px;
   top: 0;
   bottom: 0;
   margin: auto 0;
   -webkit-transition: 0.4s;
   transition: 0.4s;
   box-shadow: 0 0px 3px #2020203d;
-  background: #ffffff url('/docs/img/light-theme-icon.svg');
+  /* Fallback for IE, should work in production */
+  background: #ffffff url('/docs/javascript-data-grid/img/light-theme-icon.svg');
+  background: #ffffff var(--light-icon-url);
   background-size: 70%;
   background-repeat: no-repeat;
   background-position: center;
@@ -161,7 +166,9 @@ input:checked + .slider:before {
   -webkit-transform: translateX(16px);
   -ms-transform: translateX(16px);
   transform: translateX(16px);
-  background: #ffffff url('/docs/img/dark-theme-icon.svg');
+  /* Fallback for IE, should work in production */
+  background: #ffffff url('/docs/javascript-data-grid/img/dark-theme-icon.svg');
+  background: #ffffff var(--dark-icon-url);
   background-size: 70%;
   background-repeat: no-repeat;
   background-position: center;


### PR DESCRIPTION
### Context
This PR fixes the problem described in #9534.

As discussed, the logic targets only the "frameworked" docs versions.

### How has this been tested?
Run the docs using:
- `docs:start:no-cache`
- `docs:build:no-cache`

For setups:
- With just `next` as the framework version
- The latest version as frameworked
- Version before latest as frameworked

And running the examples both in the docs and JSFiddle. (In JSFiddle mostly checking the file URLs, as they're not present on production yet)

[skip changelog]

### Related issue(s):
1. #9534 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
