### PR TITLE
Docs: Add a release note about Walkontable not being part of public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ For more information on this release, see:
 - Changed two scripts of the main Handsontable workspace (`./`), to speed up the build process: now, the `npm run build` and `npm run test` scripts don't build or test the Handsontable examples (`./examples`). [#9412](https://github.com/handsontable/handsontable/issues/9412)
 - Changed the version of the Moment.js dependency from 2.24.0 to 2.29.3, in reaction to a recently-found Moment.js security vulnerability that did not directly affect Handsontable. [#9381](https://github.com/handsontable/handsontable/issues/9381)
 - Changed the version of the HyperFormula optional dependency from ^1.2.0 to ^2.0.0. [#9411](https://github.com/handsontable/handsontable/issues/9411)
+- Changed an internal property name, from `hot.view.wt` to `hot.view._wt`, to make it clear that Walkontable (Handsontable's rendering engine) is not a part of Handsontable's public API. [#8760](https://github.com/handsontable/handsontable/issues/8760)
 
 ### Fixed
 - *React, Angular, Vue 2, Vue 3:* Fixed an issue where using `updateSettings()` caused problems for state managers. [#8372](https://github.com/handsontable/handsontable/issues/8372)

--- a/docs/12.0/guides/upgrade-and-migration/migrating-from-11.1-to-12.0.md
+++ b/docs/12.0/guides/upgrade-and-migration/migrating-from-11.1-to-12.0.md
@@ -220,3 +220,17 @@ To keep the previous (pre-12.0) behavior of a default keyboard shortcut, use the
 - [Remove a default keyboard shortcut](@/guides/accessories-and-menus/keyboard-shortcuts.md#removing-a-keyboard-shortcut)
 - [Replace a default keyboard shortcut](@/guides/accessories-and-menus/keyboard-shortcuts.md#replacing-a-keyboard-shortcut)
 - [Block a default keyboard shortcut's action](@/guides/accessories-and-menus/keyboard-shortcuts.md#blocking-a-keyboard-shortcut-s-actions)
+
+## Step 5: Don't refer to Walkontable
+
+Handsontable 12.0.0 makes it clear that Handsontable's rendering engine (internally referred to as "Walkontable") is not a part of Handsontable's public API.
+
+To emphasize this, we changed the following property name:
+
+| Before        | After          |
+| ------------- | -------------- |
+| `hot.view.wt` | `hot.view._wt` |
+
+#### Migrating to Handsontable 12.0
+
+Referring to Walkontable has never been a supported customization method. Use Handsontable's public APIs instead.

--- a/docs/12.0/guides/upgrade-and-migration/release-notes.md
+++ b/docs/12.0/guides/upgrade-and-migration/release-notes.md
@@ -49,6 +49,7 @@ Released on 28th of April, 2022
 - Changed two scripts of the main Handsontable workspace (`./`), to speed up the build process: now, the `npm run build` and `npm run test` scripts don't build or test the Handsontable examples (`./examples`). [#9412](https://github.com/handsontable/handsontable/issues/9412)
 - Changed the version of the Moment.js dependency from 2.24.0 to 2.29.3, in reaction to a recently-found Moment.js security vulnerability that did not directly affect Handsontable. [#9381](https://github.com/handsontable/handsontable/issues/9381)
 - Changed the version of the HyperFormula optional dependency from ^1.2.0 to ^2.0.0. [#9411](https://github.com/handsontable/handsontable/issues/9411)
+- Changed an internal property name, from `hot.view.wt` to `hot.view._wt`, to make it clear that Walkontable (Handsontable's rendering engine) is not a part of Handsontable's public API. [#8760](https://github.com/handsontable/handsontable/issues/8760)
 
 **Fixed**
 - *React, Angular, Vue 2, Vue 3:* Fixed an issue where using [`updateSettings()`](@/api/core.md#updatesettings) caused problems for state managers. [#8372](https://github.com/handsontable/handsontable/issues/8372)

--- a/docs/next/guides/upgrade-and-migration/migrating-from-11.1-to-12.0.md
+++ b/docs/next/guides/upgrade-and-migration/migrating-from-11.1-to-12.0.md
@@ -23,7 +23,7 @@ Each [`updateSettings()`](@/api/core.md#updatesettings) call with the [`data`](@
 | Replaces [`data`](@/api/options.md#data)                          | Replaces [`data`](@/api/options.md#data)                              |
 | Triggers the same hooks as [`loadData()`](@/api/core.md#loaddata) | Triggers the same hooks as [`updateData()`](@/api/core.md#updatedata) |
 | Resets configuration options to the initial state                 | Doesn't reset configuration options to the initial state              |
-| Resets index mapper information                                             | Doesn't reset index mapper information                                          |
+| Resets index mapper information                                   | Doesn't reset index mapper information                                |
 
 #### Migrating to Handsontable 12.0
 
@@ -145,8 +145,8 @@ Now, the <kbd>**Cmd**</kbd> key triggers actions on macOS where the <kbd>**Ctrl*
 
 For example, the table below shows how this change affects the <kbd>**Ctrl**</kbd>/<kbd>**Cmd**</kbd> + <kbd>**A**</kbd> shortcut:
 
-|         | Before                                                                      | After                                     |
-| ------- | --------------------------------------------------------------------------- | ----------------------------------------- |
+|         | Before                                                                                      | After                                             |
+| ------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------- |
 | Windows | <kbd>**Ctrl**</kbd> + <kbd>**A**</kbd> works<br><kbd>**Cmd**</kbd> + <kbd>**A**</kbd> works | Only <kbd>**Ctrl**</kbd> + <kbd>**A**</kbd> works |
 | macOS   | <kbd>**Ctrl**</kbd> + <kbd>**A**</kbd> works<br><kbd>**Cmd**</kbd> + <kbd>**A**</kbd> works | Only <kbd>**Cmd**</kbd> + <kbd>**A**</kbd> works  |
 
@@ -208,9 +208,9 @@ The table below summarizes default keyboard shortcuts changes related to edition
 
 The table below summarizes default keyboard shortcuts changes related to cell merging:
 
-|         | Before                                                                   | After                                                                                                                               |
-| ------- | ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
-| Windows | <kbd>**Ctrl**</kbd> + <kbd>**M**</kbd> works <kbd>**Cmd**</kbd> + <kbd>**M**</kbd> works | Only <kbd>**Ctrl**</kbd> + <kbd>**M**</kbd> works                                                                                           |
+|         | Before                                                                                   | After                                                                                                                                               |
+| ------- | ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Windows | <kbd>**Ctrl**</kbd> + <kbd>**M**</kbd> works <kbd>**Cmd**</kbd> + <kbd>**M**</kbd> works | Only <kbd>**Ctrl**</kbd> + <kbd>**M**</kbd> works                                                                                                   |
 | macOS   | <kbd>**Ctrl**</kbd> + <kbd>**M**</kbd> works <kbd>**Cmd**</kbd> + <kbd>**M**</kbd> works | Only <kbd>**Ctrl**</kbd> + <kbd>**M**</kbd> works<br>(<kbd>**Cmd**</kbd> + <kbd>**M**</kbd> conflicted with macOS's shortcut for window minimizing) |
 
 #### Migrating to Handsontable 12.0
@@ -220,3 +220,17 @@ To keep the previous (pre-12.0) behavior of a default keyboard shortcut, use the
 - [Remove a default keyboard shortcut](@/guides/accessories-and-menus/keyboard-shortcuts.md#removing-a-keyboard-shortcut)
 - [Replace a default keyboard shortcut](@/guides/accessories-and-menus/keyboard-shortcuts.md#replacing-a-keyboard-shortcut)
 - [Block a default keyboard shortcut's action](@/guides/accessories-and-menus/keyboard-shortcuts.md#blocking-a-keyboard-shortcut-s-actions)
+
+## Step 5: Don't refer to Walkontable
+
+Handsontable 12.0.0 makes it clear that Handsontable's rendering engine (internally referred to as "Walkontable") is not a part of Handsontable's public API.
+
+To emphasize this, we changed the following property name:
+
+| Before        | After          |
+| ------------- | -------------- |
+| `hot.view.wt` | `hot.view._wt` |
+
+#### Migrating to Handsontable 12.0
+
+Referring to Walkontable has never been a supported customization method. Use Handsontable's public APIs instead.

--- a/docs/next/guides/upgrade-and-migration/release-notes.md
+++ b/docs/next/guides/upgrade-and-migration/release-notes.md
@@ -49,6 +49,7 @@ Released on 28th of April, 2022
 - Changed two scripts of the main Handsontable workspace (`./`), to speed up the build process: now, the `npm run build` and `npm run test` scripts don't build or test the Handsontable examples (`./examples`). [#9412](https://github.com/handsontable/handsontable/issues/9412)
 - Changed the version of the Moment.js dependency from 2.24.0 to 2.29.3, in reaction to a recently-found Moment.js security vulnerability that did not directly affect Handsontable. [#9381](https://github.com/handsontable/handsontable/issues/9381)
 - Changed the version of the HyperFormula optional dependency from ^1.2.0 to ^2.0.0. [#9411](https://github.com/handsontable/handsontable/issues/9411)
+- Changed an internal property name, from `hot.view.wt` to `hot.view._wt`, to make it clear that Walkontable (Handsontable's rendering engine) is not a part of Handsontable's public API. [#8760](https://github.com/handsontable/handsontable/issues/8760)
 
 **Fixed**
 - *React, Angular, Vue 2, Vue 3:* Fixed an issue where using [`updateSettings()`](@/api/core.md#updatesettings) caused problems for state managers. [#8372](https://github.com/handsontable/handsontable/issues/8372)


### PR DESCRIPTION
This PR:
- Adds the information about Walkontable not being part of public API to:
  - Handsontable 12.0.0 release notes (docs versions `next` and `12.0`)
  - The **Migrating from 11.1 to 12.0** guide (docs versions `next` and `12.0`)
  - Changelog