### PR TITLE
Update Pikaday to 1.8.2

### DIFF
--- a/.changelogs/9410.json
+++ b/.changelogs/9410.json
@@ -1,0 +1,7 @@
+{
+  "title": "Updated the Pikaday dependency to 1.8.2.",
+  "type": "changed",
+  "issue": 9410,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/package.json
+++ b/handsontable/package.json
@@ -81,7 +81,7 @@
     "dompurify": "^2.1.1",
     "moment": "2.29.3",
     "numbro": "2.1.2",
-    "pikaday": "1.8.0"
+    "pikaday": "1.8.2"
   },
   "optionalDependencies": {
     "hyperformula": "^2.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,13 +51,10 @@
     },
     "examples": {
       "name": "handsontable-examples",
-      "version": "11.1.0",
-      "workspaces": [
-        "@(next|@(+([0-9]).+([0-9]).+([0-9])*))/@(!(node_modules))/+(js|ts|angular|react|vue)"
-      ]
+      "version": "12.0.1"
     },
     "handsontable": {
-      "version": "11.1.0",
+      "version": "12.0.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@types/pikaday": "1.7.4",
@@ -65,7 +62,7 @@
         "dompurify": "^2.1.1",
         "moment": "2.29.3",
         "numbro": "2.1.2",
-        "pikaday": "1.8.0"
+        "pikaday": "1.8.2"
       },
       "devDependencies": {
         "@babel/cli": "^7.8.3",
@@ -138,6 +135,7 @@
       }
     },
     "handsontable/.config/plugin/eslint": {
+      "name": "eslint-plugin-handsontable",
       "version": "1.0.0",
       "dev": true
     },
@@ -23201,9 +23199,9 @@
       }
     },
     "node_modules/pikaday": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/pikaday/-/pikaday-1.8.0.tgz",
-      "integrity": "sha512-SgGxMYX0NHj9oQnMaSyAipr2gOrbB4Lfs/TJTb6H6hRHs39/5c5VZi73Q8hr53+vWjdn6HzkWcj8Vtl3c9ziaA=="
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/pikaday/-/pikaday-1.8.2.tgz",
+      "integrity": "sha512-TNtsE+34BIax3WtkB/qqu5uepV1McKYEgvL3kWzU7aqPCpMEN6rBF3AOwu4WCwAealWlBGobXny/9kJb49C1ew=="
     },
     "node_modules/pinkie": {
       "version": "2.0.4",
@@ -34731,7 +34729,7 @@
     },
     "wrappers/angular": {
       "name": "@handsontable/angular",
-      "version": "11.1.0",
+      "version": "12.0.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@angular/animations": "^9.0.0",
@@ -34743,7 +34741,7 @@
         "@angular/platform-browser-dynamic": "^9.0.0",
         "@angular/router": "^9.0.0",
         "core-js": "^2.5.4",
-        "handsontable": "^11.0.0",
+        "handsontable": "^12.0.0",
         "rxjs": "~6.5.2",
         "zone.js": "~0.10.3"
       },
@@ -34774,7 +34772,7 @@
         "typescript": "3.8.2"
       },
       "peerDependencies": {
-        "handsontable": "^11.0.0"
+        "handsontable": "^12.0.0"
       }
     },
     "wrappers/angular/node_modules/core-js": {
@@ -34792,7 +34790,7 @@
     },
     "wrappers/react": {
       "name": "@handsontable/react",
-      "version": "11.1.0",
+      "version": "12.0.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "@babel/cli": "^7.8.4",
@@ -34811,7 +34809,7 @@
         "cpy-cli": "^3.1.1",
         "cross-env": "^5.2.0",
         "del-cli": "^3.0.1",
-        "handsontable": "^11.0.0",
+        "handsontable": "^12.0.0",
         "jest": "^25.1.0",
         "prop-types": "^15.7.2",
         "react": "^16.10.2",
@@ -34831,7 +34829,7 @@
         "uglify-js": "^3.4.9"
       },
       "peerDependencies": {
-        "handsontable": ">=11.0.0"
+        "handsontable": ">=12.0.0"
       }
     },
     "wrappers/react/node_modules/@jest/console": {
@@ -36105,7 +36103,7 @@
     },
     "wrappers/vue": {
       "name": "@handsontable/vue",
-      "version": "11.1.0",
+      "version": "12.0.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "@babel/cli": "^7.4.4",
@@ -36121,7 +36119,7 @@
         "cross-env": "^5.2.0",
         "css-loader": "^3.0.0",
         "del-cli": "^3.0.1",
-        "handsontable": "^11.0.0",
+        "handsontable": "^12.0.0",
         "jest": "^26.6.3",
         "rollup": "^2.0.0",
         "rollup-plugin-babel": "^4.3.2",
@@ -36143,7 +36141,7 @@
         "vuex": "^3.1.1"
       },
       "peerDependencies": {
-        "handsontable": ">=11.0.0",
+        "handsontable": ">=12.0.0",
         "vue": "^2.5.0"
       }
     },
@@ -36447,7 +36445,7 @@
     },
     "wrappers/vue3": {
       "name": "@handsontable/vue3",
-      "version": "11.1.0",
+      "version": "12.0.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "@babel/cli": "^7.11.0",
@@ -36466,7 +36464,7 @@
         "cross-env": "^7.0.0",
         "del-cli": "^4.0.1",
         "eslint-plugin-vue": "^8.0.3",
-        "handsontable": "^11.0.0",
+        "handsontable": "^12.0.0",
         "jest": "^26.6.3",
         "rollup": "^2.0.0",
         "rollup-plugin-babel": "^4.3.2",
@@ -36485,7 +36483,7 @@
         "vue-jest": "5.0.0-alpha.10"
       },
       "peerDependencies": {
-        "handsontable": ">=11.0.0",
+        "handsontable": ">=12.0.0",
         "vue": "next"
       }
     },
@@ -40626,7 +40624,7 @@
         "@types/node": "^11.9.6",
         "codelyzer": "^5.0.1",
         "core-js": "^2.5.4",
-        "handsontable": "^11.0.0",
+        "handsontable": "^12.0.0",
         "jasmine-core": "~3.5.0",
         "jasmine-spec-reporter": "~4.2.1",
         "karma": "^6.3.2",
@@ -40678,7 +40676,7 @@
         "cpy-cli": "^3.1.1",
         "cross-env": "^5.2.0",
         "del-cli": "^3.0.1",
-        "handsontable": "^11.0.0",
+        "handsontable": "^12.0.0",
         "jest": "^25.1.0",
         "prop-types": "^15.7.2",
         "react": "^16.10.2",
@@ -41732,7 +41730,7 @@
         "cross-env": "^5.2.0",
         "css-loader": "^3.0.0",
         "del-cli": "^3.0.1",
-        "handsontable": "^11.0.0",
+        "handsontable": "^12.0.0",
         "jest": "^26.6.3",
         "rollup": "^2.0.0",
         "rollup-plugin-babel": "^4.3.2",
@@ -42017,7 +42015,7 @@
         "cross-env": "^7.0.0",
         "del-cli": "^4.0.1",
         "eslint-plugin-vue": "^8.0.3",
-        "handsontable": "^11.0.0",
+        "handsontable": "^12.0.0",
         "jest": "^26.6.3",
         "rollup": "^2.0.0",
         "rollup-plugin-babel": "^4.3.2",
@@ -51243,7 +51241,7 @@
         "numbro": "2.1.2",
         "on-build-webpack": "^0.1.0",
         "optimize-css-assets-webpack-plugin": "^5.0.1",
-        "pikaday": "1.8.0",
+        "pikaday": "1.8.2",
         "progress-bar-webpack-plugin": "^1.10.0",
         "puppeteer": "^10.2.0",
         "replace-in-file": "^6.1.0",
@@ -57577,9 +57575,9 @@
       "dev": true
     },
     "pikaday": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/pikaday/-/pikaday-1.8.0.tgz",
-      "integrity": "sha512-SgGxMYX0NHj9oQnMaSyAipr2gOrbB4Lfs/TJTb6H6hRHs39/5c5VZi73Q8hr53+vWjdn6HzkWcj8Vtl3c9ziaA=="
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/pikaday/-/pikaday-1.8.2.tgz",
+      "integrity": "sha512-TNtsE+34BIax3WtkB/qqu5uepV1McKYEgvL3kWzU7aqPCpMEN6rBF3AOwu4WCwAealWlBGobXny/9kJb49C1ew=="
     },
     "pinkie": {
       "version": "2.0.4",


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR updates Pikday to the newest 1.8.2 version. The newest version removes support for IE7. The CSS crafted for that browser causes warnings while bundling with Parcel bundler.

I compared the introduced changes between [1.8.0..1.8.2](https://github.com/Pikaday/Pikaday/compare/1.8.0...1.8.2) and I checked with the implementation on the Handsontable side and I didn't find any issues or places where the API needs to be changed. 

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally including the Right-to-Left layout direction.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. fixes #9410

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
