### PR TITLE
Pages which have been excluded from showing in the sidebar won't be rendered anymore

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -17,7 +17,8 @@ const {
   isEnvDev,
   getDocsFrameworkedVersions,
   getLatestVersion,
-  FRAMEWORK_SUFFIX
+  getIgnoredFilesPatterns,
+  FRAMEWORK_SUFFIX,
 } = require('./helpers');
 
 const buildMode = process.env.BUILD_MODE;
@@ -86,7 +87,8 @@ module.exports = {
   patterns: [
     `${isEnvDev() ? `${TMP_DIR_FOR_WATCH}/` : ''}${versionPartialPath}${isEnvDev() && getEnvDocsFramework() ?
       `${frameworkPartialPath}` : ''}**/*.md`,
-    '!README.md', '!README-EDITING.md', '!README-DEPLOYMENT.md'
+    '!README.md', '!README-EDITING.md', '!README-DEPLOYMENT.md',
+    ...getIgnoredFilesPatterns(buildMode),
   ],
   description: 'Handsontable',
   base,

--- a/docs/.vuepress/helpers.js
+++ b/docs/.vuepress/helpers.js
@@ -229,26 +229,44 @@ function getNotSearchableLinks(buildMode) {
       // eslint-disable-next-line
       const sidebarConfig = require(path.join(__dirname, `../${version}/sidebars.js`));
 
-      notSearchableLinks[version] = filterLinks(sidebarConfig.guides);
+      if (Array.isArray(notSearchableLinks[version]) === false) {
+        notSearchableLinks[version] = [];
+      }
+
+      notSearchableLinks[version].push(...filterLinks(sidebarConfig.guides));
     });
 
     getDocsFrameworkedVersions(buildMode).forEach((version) => {
       frameworks.forEach((framework) => {
+        if (typeof notSearchableLinks[framework] !== 'object') {
+          notSearchableLinks[framework] = {};
+        }
+
+        if (Array.isArray(notSearchableLinks[framework][version]) === false) {
+          notSearchableLinks[framework][version] = [];
+        }
+
         // eslint-disable-next-line
         const sidebarConfig = require(path.join(__dirname, `../${version}/sidebars.js`));
 
-        notSearchableLinks[version] = filterLinks(sidebarConfig.guides, framework);
+        notSearchableLinks[framework][version].push(...filterLinks(sidebarConfig.guides, framework));
       });
     });
 
   } else {
-    getVersions(buildMode).forEach((version) => {
-      // eslint-disable-next-line
-      const sidebarConfig = require(path.join(__dirname, `../${version}/sidebars.js`));
-      const framework = getEnvDocsFramework();
+    const version = getEnvDocsVersion();
+    const framework = getEnvDocsFramework();
+    // eslint-disable-next-line
+    const sidebarConfig = require(path.join(__dirname, `../${version}/sidebars.js`));
 
-      notSearchableLinks[version] = filterLinks(sidebarConfig.guides, framework);
-    });
+    if (framework !== void 0) {
+      notSearchableLinks[framework] = {
+        [version]: filterLinks(sidebarConfig.guides, framework),
+      };
+
+    } else {
+      notSearchableLinks[version] = filterLinks(sidebarConfig.guides);
+    }
   }
 
   return notSearchableLinks;

--- a/docs/.vuepress/helpers.js
+++ b/docs/.vuepress/helpers.js
@@ -229,11 +229,7 @@ function getNotSearchableLinks(buildMode) {
       // eslint-disable-next-line
       const sidebarConfig = require(path.join(__dirname, `../${version}/sidebars.js`));
 
-      if (Array.isArray(notSearchableLinks[version]) === false) {
-        notSearchableLinks[version] = [];
-      }
-
-      notSearchableLinks[version].push(...filterLinks(sidebarConfig.guides));
+      notSearchableLinks[version] = filterLinks(sidebarConfig.guides);
     });
 
     getDocsFrameworkedVersions(buildMode).forEach((version) => {
@@ -242,14 +238,10 @@ function getNotSearchableLinks(buildMode) {
           notSearchableLinks[framework] = {};
         }
 
-        if (Array.isArray(notSearchableLinks[framework][version]) === false) {
-          notSearchableLinks[framework][version] = [];
-        }
-
         // eslint-disable-next-line
         const sidebarConfig = require(path.join(__dirname, `../${version}/sidebars.js`));
 
-        notSearchableLinks[framework][version].push(...filterLinks(sidebarConfig.guides, framework));
+        notSearchableLinks[framework][version] = filterLinks(sidebarConfig.guides, framework);
       });
     });
 

--- a/docs/.vuepress/helpers.js
+++ b/docs/.vuepress/helpers.js
@@ -265,6 +265,34 @@ function getNotSearchableLinks(buildMode) {
 }
 
 /**
+ * Get ignored files for particular build.
+ *
+ * Note: Please keep in mind that this method is useful only for full build.
+ *
+ * @param {string} buildMode The env name.
+ * @returns {Array<string>}
+ */
+function getIgnoredFilesPatterns(buildMode) {
+  if (isEnvDev() === false) {
+    const notSearchableLinks = getNotSearchableLinks(buildMode);
+    const version = getEnvDocsVersion();
+    const framework = getEnvDocsFramework();
+    let ignoredFiles;
+
+    if (framework !== void 0) {
+      ignoredFiles = notSearchableLinks[framework][version];
+
+    } else {
+      ignoredFiles = notSearchableLinks[version];
+    }
+
+    return ignoredFiles.map(excludedPath => `!${version}/${excludedPath}.md`);
+  }
+
+  return [];
+}
+
+/**
  * Parses the docs version from the URL.
  *
  * @param {string} url The URL to parse.
@@ -356,4 +384,5 @@ module.exports = {
   isEnvDev,
   createSymlinks,
   getDocsBaseUrl,
+  getIgnoredFilesPatterns,
 };

--- a/docs/.vuepress/plugins/extend-page-data/index.js
+++ b/docs/.vuepress/plugins/extend-page-data/index.js
@@ -26,6 +26,9 @@ const DOCS_FRAMEWORK = getEnvDocsFramework();
 collectAllUrls();
 
 const notSearchableLinks = getNotSearchableLinks(buildMode);
+
+console.log(notSearchableLinks);
+
 const formatDate = (dateString) => {
   const date = new Date(dateString);
   const twoDigitDay = date.getDate();
@@ -64,9 +67,17 @@ module.exports = (options, context) => {
       $page.isFrameworked = getDocsFrameworkedVersions(buildMode).includes($page.currentVersion);
       $page.lastUpdatedFormat = formatDate($page.lastUpdated);
       $page.frontmatter.canonicalUrl = getCanonicalUrl($page.frontmatter.canonicalUrl);
-      $page.isSearchable = notSearchableLinks[$page.currentVersion]?.every((notSearchableLink) => {
-        return $page.normalizedPath.includes(notSearchableLink) === false;
-      });
+
+      if ($page.currentFramework !== void 0) {
+        $page.isSearchable =
+          notSearchableLinks[$page.currentFramework][$page.currentVersion]?.every(
+            notSearchableLink => $page.normalizedPath.includes(notSearchableLink) === false);
+
+      } else {
+        $page.isSearchable =
+          notSearchableLinks[$page.currentVersion]?.every(
+            notSearchableLink => $page.normalizedPath.includes(notSearchableLink) === false);
+      }
 
       const isFrameworked = $page.isFrameworked;
       const buildingSingleVersion = DOCS_VERSION !== void 0 && (DOCS_FRAMEWORK !== void 0 || DOCS_FRAMEWORK === void 0

--- a/docs/.vuepress/plugins/extend-page-data/index.js
+++ b/docs/.vuepress/plugins/extend-page-data/index.js
@@ -64,6 +64,7 @@ module.exports = (options, context) => {
       $page.isFrameworked = getDocsFrameworkedVersions(buildMode).includes($page.currentVersion);
       $page.lastUpdatedFormat = formatDate($page.lastUpdated);
       $page.frontmatter.canonicalUrl = getCanonicalUrl($page.frontmatter.canonicalUrl);
+      $page.isEnvDev = isEnvDev();
 
       if ($page.currentFramework !== void 0) {
         $page.isSearchable =

--- a/docs/.vuepress/plugins/extend-page-data/index.js
+++ b/docs/.vuepress/plugins/extend-page-data/index.js
@@ -26,9 +26,6 @@ const DOCS_FRAMEWORK = getEnvDocsFramework();
 collectAllUrls();
 
 const notSearchableLinks = getNotSearchableLinks(buildMode);
-
-console.log(notSearchableLinks);
-
 const formatDate = (dateString) => {
   const date = new Date(dateString);
   const twoDigitDay = date.getDate();

--- a/docs/.vuepress/theme/components/SearchBox.vue
+++ b/docs/.vuepress/theme/components/SearchBox.vue
@@ -289,7 +289,8 @@ export default {
     isSearchable(page) {
       let framework = '';
 
-      if (this.$page.currentFramework) {
+      // Only dev environment contain framework element as a part of the `normalizedPath` key's value.
+      if (this.$page.isEnvDev === true && this.$page.currentFramework) {
         framework = `${this.$page.currentFramework}${this.$page.frameworkSuffix}/`;
       }
 

--- a/docs/.vuepress/theme/components/SearchBox.vue
+++ b/docs/.vuepress/theme/components/SearchBox.vue
@@ -287,7 +287,13 @@ export default {
     },
 
     isSearchable(page) {
-      return page.isSearchable === true && page.normalizedPath.startsWith(`/${this.$page.currentVersion}/`);
+      let framework = '';
+
+      if (this.$page.currentFramework) {
+        framework = `${this.$page.currentFramework}${this.$page.frameworkSuffix}/`;
+      }
+
+      return page.isSearchable === true && page.normalizedPath.startsWith(`/${this.$page.currentVersion}/${framework}`);
     },
 
     onHotkey(event) {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
This PR allow to exclude some files from rendering. Please keep in mind that it works only for `npm run docs:build` script. I assumed that this solution is only needed for production. I also fixed found bugs related to showing search results for not currently selected framework.

[skip changelog]

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Used `npm run docs:build` command and checked some URLs such as:

- http://localhost:8080/docs/next/javascript-data-grid/react-installation/
- http://localhost:8080/docs/next/react-data-grid/angular-installation

They shouldn't exist (error 404 is thrown).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #9543 

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] My change requires a change to the documentation.
