### PR TITLE
Docs: Hide the Demo page from the left-hand navigation

### DIFF
--- a/docs/12.0/guides/sidebar.js
+++ b/docs/12.0/guides/sidebar.js
@@ -1,6 +1,6 @@
 const gettingStartedItems = [
   'guides/getting-started/introduction',
-  'guides/getting-started/demo',
+  // 'guides/getting-started/demo', (temporarily hidden, till the demo is fixed)
   'guides/getting-started/installation',
   'guides/getting-started/binding-to-data',
   'guides/getting-started/saving-data',


### PR DESCRIPTION
This PR:
- Hides the Demo page from the left-hand navigation (it'll be brought back once the demo is fixed)

[skip changelog]