### PR TITLE
Update GH Actions dependencies

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -20,9 +20,9 @@ jobs:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
     steps:
-      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # https://github.com/actions/checkout/releases/tag/v2.3.4
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # https://github.com/actions/checkout/releases/tag/v3.0.2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@25316bbc1f10ac9d8798711f44914b1cf3c4e954 # https://github.com/actions/setup-node/releases/tag/v2.4.0
+        uses: actions/setup-node@eeb10cff27034e7acf239c5d29f62154018672fd # https://github.com/actions/setup-node/releases/tag/v3.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'

--- a/examples/next/docs/angular-12/basic-example/angular.json
+++ b/examples/next/docs/angular-12/basic-example/angular.json
@@ -31,7 +31,7 @@
               "node_modules/handsontable/dist/handsontable.full.css"
             ],
             "scripts": [],
-            "preserveSymlinks": false,
+            "preserveSymlinks": true,
             "allowedCommonJsDependencies": [
               "core-js",
               "pikaday"

--- a/examples/next/docs/angular-12/demo/angular.json
+++ b/examples/next/docs/angular-12/demo/angular.json
@@ -31,7 +31,7 @@
               "node_modules/handsontable/dist/handsontable.full.css"
             ],
             "scripts": [],
-            "preserveSymlinks": false,
+            "preserveSymlinks": true,
             "allowedCommonJsDependencies": [
               "core-js",
               "pikaday"

--- a/examples/next/docs/angular-13/basic-example/angular.json
+++ b/examples/next/docs/angular-13/basic-example/angular.json
@@ -31,7 +31,7 @@
               "node_modules/handsontable/dist/handsontable.full.css"
             ],
             "scripts": [],
-            "preserveSymlinks": false,
+            "preserveSymlinks": true,
             "allowedCommonJsDependencies": [
               "core-js",
               "pikaday"

--- a/examples/next/docs/angular-13/demo/angular.json
+++ b/examples/next/docs/angular-13/demo/angular.json
@@ -31,7 +31,7 @@
               "node_modules/handsontable/dist/handsontable.full.css"
             ],
             "scripts": [],
-            "preserveSymlinks": false,
+            "preserveSymlinks": true,
             "allowedCommonJsDependencies": [
               "core-js",
               "pikaday"


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR updates GH Actions dependencies. This should fix an error with `npm` that throws [an error in one of our workflows](https://github.com/handsontable/handsontable/runs/6967264564?check_suite_focus=true#step:3:15) and fixes Angular 10+ examples by enabling symlink preserving. 

[Here is a workflow test](https://github.com/handsontable/handsontable/actions/runs/2535076664) with PR's changes where it passes on each environment. 

_[skip changelog] (hotfix)_

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
