### PR TITLE
Fix Comments widget in dark mode of the docs

### DIFF
--- a/docs/.vuepress/theme/styles/handsontable.styl
+++ b/docs/.vuepress/theme/styles/handsontable.styl
@@ -14,7 +14,8 @@
   width: 100%;
 }
 
-.handsontable {
+.handsontable,
+.htComments {
   font-size: 13px;
   color #222222;
 }

--- a/docs/.vuepress/theme/styles/handsontable.styl
+++ b/docs/.vuepress/theme/styles/handsontable.styl
@@ -14,9 +14,12 @@
   width: 100%;
 }
 
-.handsontable,
-.htComments {
+.handsontable {
   font-size: 13px;
+  color #222222;
+}
+
+.htCommentsContainer .htCommentTextArea {
   color #222222;
 }
 


### PR DESCRIPTION
This PR applies the same color customization to `.htComments` as to `.handsontable`.

### Context

Because in the dark mode, the Comments widget inherited white text from the page, resulting with white text on white background

After this change, the comment widget in the light and dark theme will have the color `#222222`

### How has this been tested?

Locally, in the Docker container

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #9595
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]