### PR TITLE
Revert the changes from #9415

### DIFF
--- a/.changelogs/8688.json
+++ b/.changelogs/8688.json
@@ -1,7 +1,0 @@
-{
-  "title": "Fixed table DOM element's size update after changing `height`/`width` options.",
-  "type": "fixed",
-  "issue": 8688,
-  "breaking": false,
-  "framework": "none"
-}

--- a/handsontable/src/3rdparty/walkontable/src/table/master.js
+++ b/handsontable/src/3rdparty/walkontable/src/table/master.js
@@ -35,11 +35,7 @@ class MasterTable extends Table {
 
       if (!preventOverflow) {
         this.holder.style.overflow = 'visible';
-        this.holder.style.width = '';
-        this.holder.style.height = '';
         this.wtRootElement.style.overflow = 'visible';
-        this.wtRootElement.style.width = '';
-        this.wtRootElement.style.height = '';
       }
     } else {
       const trimmingElementParent = trimmingElement.parentElement;

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -2469,7 +2469,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
 
     } else if (height !== void 0) {
       instance.rootElement.style.height = isNaN(height) ? `${height}` : `${height}px`;
-      instance.rootElement.style.overflow = height === 'auto' ? '' : 'hidden';
+      instance.rootElement.style.overflow = 'hidden';
     }
 
     if (typeof settings.width !== 'undefined') {
@@ -2479,12 +2479,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
         width = width();
       }
 
-      if (width === null) {
-        instance.rootElement.style.width = '';
-
-      } else {
-        instance.rootElement.style.width = isNaN(width) ? `${width}` : `${width}px`;
-      }
+      instance.rootElement.style.width = isNaN(width) ? `${width}` : `${width}px`;
     }
 
     if (!init) {

--- a/handsontable/src/editors/dropdownEditor/__tests__/dropdownEditor.spec.js
+++ b/handsontable/src/editors/dropdownEditor/__tests__/dropdownEditor.spec.js
@@ -516,26 +516,4 @@ describe('DropdownEditor', () => {
       expect(document.activeElement).toBe(getActiveEditor().TEXTAREA);
     });
   });
-
-  it('should display the dropdown list below the editor, when table\'s height is set as "auto"', async() => {
-    handsontable({
-      data: createSpreadsheetData(5, 1),
-      height: 'auto',
-      columns: [
-        {
-          type: 'dropdown',
-          source: choices,
-        }
-      ]
-    });
-    selectCell(4, 0);
-    keyDownUp('enter');
-
-    const autocompleteEditor = $('.autocompleteEditor');
-
-    await sleep(10);
-
-    expect(autocompleteEditor.height()).toBe(230);
-    expect(autocompleteEditor.css('top')).toBe('0px');
-  });
 });

--- a/handsontable/test/e2e/settings/height.spec.js
+++ b/handsontable/test/e2e/settings/height.spec.js
@@ -29,21 +29,6 @@ describe('settings', () => {
       expect($(hot.rootElement).height()).not.toBe(initialHeight);
     });
 
-    // temporarily disabled due to reverting PR https://github.com/handsontable/handsontable/pull/9415
-    xit('should reset the table height', () => {
-      const hot = handsontable({
-        startRows: 20,
-        startCols: 5,
-        height: 100,
-      });
-
-      updateSettings({
-        height: null
-      });
-
-      expect($(hot.rootElement).height()).toBe((20 * 23) + 1); // rows * default cell height + border top
-    });
-
     it('should allow height to be a number', () => {
       handsontable({
         startRows: 10,
@@ -64,26 +49,6 @@ describe('settings', () => {
       });
 
       expect(spec().$container.height()).toBe(107);
-    });
-
-    // temporarily disabled due to reverting PR https://github.com/handsontable/handsontable/pull/9415
-    xit('should update the table height after setting the new value as "auto"', () => {
-      const hot = handsontable({
-        startRows: 20,
-        startCols: 5,
-        height: 100,
-      });
-
-      const initialHeight = $(hot.rootElement).height();
-
-      updateSettings({
-        height: 'auto'
-      });
-
-      expect(hot.rootElement.style.height).toBe('auto');
-      expect(hot.rootElement.style.overflow).toBe('');
-      expect($(hot.rootElement).height()).toBe((20 * 23) + 1); // rows * default cell height + border top
-      expect($(hot.rootElement).height()).not.toBe(initialHeight);
     });
 
     it('should not reset the table height, when the updateSettings config object doesn\'t have any height specified', () => {

--- a/handsontable/test/e2e/settings/height.spec.js
+++ b/handsontable/test/e2e/settings/height.spec.js
@@ -29,7 +29,8 @@ describe('settings', () => {
       expect($(hot.rootElement).height()).not.toBe(initialHeight);
     });
 
-    it('should reset the table height', () => {
+    // temporarily disabled due to reverting PR https://github.com/handsontable/handsontable/pull/9415
+    xit('should reset the table height', () => {
       const hot = handsontable({
         startRows: 20,
         startCols: 5,
@@ -65,7 +66,8 @@ describe('settings', () => {
       expect(spec().$container.height()).toBe(107);
     });
 
-    it('should update the table height after setting the new value as "auto"', () => {
+    // temporarily disabled due to reverting PR https://github.com/handsontable/handsontable/pull/9415
+    xit('should update the table height after setting the new value as "auto"', () => {
       const hot = handsontable({
         startRows: 20,
         startCols: 5,

--- a/handsontable/test/e2e/settings/width.spec.js
+++ b/handsontable/test/e2e/settings/width.spec.js
@@ -29,22 +29,6 @@ describe('settings', () => {
       expect($(hot.rootElement).width()).not.toBe(initialWidth);
     });
 
-    // temporarily disabled due to reverting PR https://github.com/handsontable/handsontable/pull/9415
-    xit('should reset the table width', () => {
-      const hot = handsontable({
-        startRows: 5,
-        startCols: 15,
-        width: 200,
-        height: 100,
-      });
-
-      updateSettings({
-        width: null
-      });
-
-      expect(hot.rootElement.style.width).toBe('');
-    });
-
     it('should update the table width after setting the new value as "auto"', () => {
       const hot = handsontable({
         startRows: 5,

--- a/handsontable/test/e2e/settings/width.spec.js
+++ b/handsontable/test/e2e/settings/width.spec.js
@@ -29,7 +29,8 @@ describe('settings', () => {
       expect($(hot.rootElement).width()).not.toBe(initialWidth);
     });
 
-    it('should reset the table width', () => {
+    // temporarily disabled due to reverting PR https://github.com/handsontable/handsontable/pull/9415
+    xit('should reset the table width', () => {
       const hot = handsontable({
         startRows: 5,
         startCols: 15,


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR reverts the changes from the #9415. The origin PR includes potentially breaking change in `height: "auto"` option.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. #9415

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
