### PR TITLE
Freeze the Vue dev dependency to ~2.6

### DIFF
--- a/wrappers/vue/package.json
+++ b/wrappers/vue/package.json
@@ -81,11 +81,11 @@
     "rollup-plugin-typescript2": "^0.21.1",
     "rollup-plugin-vue": "^5.0.0",
     "typescript": "3.8.2",
-    "vue": "^2.6.10",
+    "vue": "~2.6.10",
     "vue-class-component": "^7.1.0",
     "vue-jest": "^3.0.4",
     "vue-router": "^3.0.6",
-    "vue-template-compiler": "^2.6.10",
+    "vue-template-compiler": "~2.6.10",
     "vuex": "^3.1.1"
   },
   "scripts": {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The recently released Vue2 framework with version 2.7 introduced some changes in TypeScript typings that cause errors in our component compiling process. While preparing and testing [the fix for the component](https://github.com/handsontable/handsontable/pull/9625) I've noticed that the change is not backward-compatible, and does not work with Vue <=2.6. The fix needs more time to investigate.

The current version of the component works in both Vue versions (2.6 and 2.7). To fix the monorepo build workflow the PR proposes to freeze the dev dependencies of the `vue` and `vue-template-compiler` packages to `~2.6` (<2.7).

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/9624

### Affected project(s):
- [x] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
