### PR TITLE
Add a link from custom editor and renderer pages to the hot-column page 

### DIFF
--- a/docs/12.1/guides/integrate-with-react/react-custom-editor-example.md
+++ b/docs/12.1/guides/integrate-with-react/react-custom-editor-example.md
@@ -9,6 +9,10 @@ canonicalUrl: /react-custom-editor-example
 
 [[toc]]
 
+::: tip Using React components
+This page shows how to integrate a plain JavaScript custom editor with the React component. Information how to [declare a custom editor using React components](@/guides/integrate-with-react/react-hot-column.md#declaring-a-custom-editor-as-a-component) is presented on another page.
+:::
+
 ## Overview
 
 You can declare a custom editor for the `HotTable` component by declaring it as a class and passing it to the Handsontable options or creating an editor component.

--- a/docs/12.1/guides/integrate-with-react/react-custom-renderer-example.md
+++ b/docs/12.1/guides/integrate-with-react/react-custom-renderer-example.md
@@ -9,6 +9,10 @@ canonicalUrl: /react-custom-renderer-example
 
 [[toc]]
 
+::: tip Using React components
+This page shows how to integrate a plain JavaScript custom renderer with the React component. Information how to [declare a custom renderer using React components](@/guides/integrate-with-react/react-hot-column.md#declaring-a-custom-renderer-as-a-component) is presented on another page.
+:::
+
 ## Overview
 
 You can declare a custom renderer for the `HotTable` component by declaring it as a function in the Handsontable options or creating a rendering component.

--- a/docs/next/guides/integrate-with-react/react-custom-editor-example.md
+++ b/docs/next/guides/integrate-with-react/react-custom-editor-example.md
@@ -9,6 +9,10 @@ canonicalUrl: /react-custom-editor-example
 
 [[toc]]
 
+::: tip Using React components
+This page shows how to integrate a plain JavaScript custom editor with the React component. Information how to [declare a custom editor using React components](@/guides/integrate-with-react/react-hot-column.md#declaring-a-custom-editor-as-a-component) is presented on another page.
+:::
+
 ## Overview
 
 You can declare a custom editor for the `HotTable` component by declaring it as a class and passing it to the Handsontable options or creating an editor component.

--- a/docs/next/guides/integrate-with-react/react-custom-renderer-example.md
+++ b/docs/next/guides/integrate-with-react/react-custom-renderer-example.md
@@ -9,6 +9,10 @@ canonicalUrl: /react-custom-renderer-example
 
 [[toc]]
 
+::: tip Using React components
+This page shows how to integrate a plain JavaScript custom renderer with the React component. Information how to [declare a custom renderer using React components](@/guides/integrate-with-react/react-hot-column.md#declaring-a-custom-renderer-as-a-component) is presented on another page.
+:::
+
 ## Overview
 
 You can declare a custom renderer for the `HotTable` component by declaring it as a function in the Handsontable options or creating a rendering component.


### PR DESCRIPTION
This PR adds a link from custom editor and renderer pages to the hot-column page to solve a problem that users did not find information that they can use React components in custom renderers and editors.

### Context

Allows to better find information in the docs

### How has this been tested?

- Not tested yet. Can be tested using the Docker image

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/9633
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [x] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]
