### PR TITLE
Fixed an error thrown while building docs version 12.0.0

### DIFF
--- a/docs/.vuepress/helpers.js
+++ b/docs/.vuepress/helpers.js
@@ -8,7 +8,7 @@ const unsortedVersions = fs.readdirSync(path.join(__dirname, '..'))
 
 const availableVersions = unsortedVersions.sort((a, b) => semver.rcompare(semver.coerce(a), semver.coerce((b))));
 const TMP_DIR_FOR_WATCH = '.watch-tmp';
-const MIN_FRAMEWORKED_DOCS_VERSION = '12.1.0';
+const MIN_FRAMEWORKED_DOCS_VERSION = '12.1.1';
 const FRAMEWORK_SUFFIX = '-data-grid';
 
 // Please keep in mind that the first element is default framework.

--- a/docs/12.0/api/sidebar.js
+++ b/docs/12.0/api/sidebar.js
@@ -1,6 +1,9 @@
 const fs = require('fs');
 const path = require('path');
-const { getBuildDocsVersion, getLatestVersion } = require('../../.vuepress/helpers');
+const {
+  getEnvDocsVersion,
+  getLatestVersion,
+} = require('../../.vuepress/helpers');
 
 const apiHighLevelPages = [
   'introduction',
@@ -19,7 +22,7 @@ const plugins = fs.readdirSync(path.join(__dirname, './'))
 const getUrlVersionPart = () => {
   const version = path.resolve(__dirname, '../').split('/').pop();
 
-  return getLatestVersion() === version || getBuildDocsVersion() ? '' : `/${version}`;
+  return getLatestVersion() === version || getEnvDocsVersion() ? '' : `/${version}`;
 };
 
 module.exports = {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
It seem that `sidebar.js` file hasn't been updated for `feature/react-docs` branch. I also updated `MIN_FRAMEWORKED_DOCS_VERSION` constant within the PR as docs isn't ready for `12.1.0` yet.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I run `DOCS_VERSION=12.1 npm run docs:start:no-cache` command.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #9650

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] My change requires a change to the documentation.
