### PR TITLE
[hot-fix] Remove unsupported v-show-else directive

### DIFF
--- a/docs/.vuepress/theme/layouts/Layout.vue
+++ b/docs/.vuepress/theme/layouts/Layout.vue
@@ -2,10 +2,10 @@
   <div class="layout-container">
     <ParentLayout>
       <template #page-top>
-        <div v-show="show" class="page-top">
+        <div v-if="show" class="page-top">
           <div class="version-alert">
-            <p v-show="isNext">This page covers a next version of Handsontable, and is not published yet.</p>
-            <p v-else-show="!isLatest">This page covers a non-latest version of Handsontable.</p>
+            <p v-if="isNext">This page covers a next version of Handsontable, and is not published yet.</p>
+            <p v-else-if="!isLatest">This page covers a non-latest version of Handsontable.</p>
           </div>
         </div>
       </template>
@@ -37,7 +37,7 @@ export default {
     },
 
     show() {
-      return !this.isLatest || this.isNext;
+      return this.$page.latestVersion && !this.isLatest || this.isNext;
     }
   }
 };


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR replaces the unsupported `v-show-else` Vue directive with `v-if-else`. The PR reverts https://github.com/handsontable/handsontable/commit/639a4e9b22adf30caa874a4ebb8742fb8b3b60dd.

_[skip changelog]_

fixes #9674

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
