### PR TITLE
Improve Docs building time by ~200%!!!

### DIFF
--- a/docs/.vuepress/helpers.js
+++ b/docs/.vuepress/helpers.js
@@ -2,7 +2,7 @@ const path = require('path');
 const execa = require('execa');
 
 const versionFromBranchRegExp = /^prod-docs\/(\d+\.\d+)$/;
-let thisDocsVersion = null;
+let docsVersion = null;
 
 /**
  * Gets the current (this) version of docs.
@@ -10,17 +10,17 @@ let thisDocsVersion = null;
  * @returns {string}
  */
 function getThisDocsVersion() {
-  if (thisDocsVersion === null) {
+  if (docsVersion === null) {
     const branchName = execa.sync('git rev-parse --abbrev-ref HEAD', { shell: true }).stdout;
 
     if (versionFromBranchRegExp.test(branchName)) {
-      thisDocsVersion = branchName.match(versionFromBranchRegExp)[1];
+      docsVersion = branchName.match(versionFromBranchRegExp)[1];
     } else {
-      thisDocsVersion = 'next';
+      docsVersion = 'next';
     }
   }
 
-  return thisDocsVersion;
+  return docsVersion;
 }
 
 /**

--- a/docs/.vuepress/helpers.js
+++ b/docs/.vuepress/helpers.js
@@ -2,6 +2,7 @@ const path = require('path');
 const execa = require('execa');
 
 const versionFromBranchRegExp = /^prod-docs\/(\d+\.\d+)$/;
+let thisDocsVersion = null;
 
 /**
  * Gets the current (this) version of docs.
@@ -9,13 +10,17 @@ const versionFromBranchRegExp = /^prod-docs\/(\d+\.\d+)$/;
  * @returns {string}
  */
 function getThisDocsVersion() {
-  const branchName = execa.sync('git rev-parse --abbrev-ref HEAD', { shell: true }).stdout;
+  if (thisDocsVersion === null) {
+    const branchName = execa.sync('git rev-parse --abbrev-ref HEAD', { shell: true }).stdout;
 
-  if (versionFromBranchRegExp.test(branchName)) {
-    return branchName.match(versionFromBranchRegExp)[1];
+    if (versionFromBranchRegExp.test(branchName)) {
+      thisDocsVersion = branchName.match(versionFromBranchRegExp)[1];
+    } else {
+      thisDocsVersion = 'next';
+    }
   }
 
-  return 'next';
+  return thisDocsVersion;
 }
 
 /**


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR improves Docs building time by more than 200% by caching the results of the `getThisDocsVersion()` helper function.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
