### PR TITLE
Docs: Add a note about setting the type option

### DIFF
--- a/docs/content/guides/cell-functions/cell-editor.md
+++ b/docs/content/guides/cell-functions/cell-editor.md
@@ -15,6 +15,17 @@ Handsontable separates the process of displaying the cell value from the process
 
 This tutorial will give you a comprehensive understanding of how the whole process of cell editing works, how Handsontable Core manages editors, how editor life cycle looks like and finally - how to create your own editors.
 
+::: tip
+You can set a cell's [`renderer`](@/api/options.md#renderer), [`editor`](@/api/options.md#editor) or [`validator`](@/api/options.md#validator) individually, but you still need to set that cell's [`type`](@/api/options.md#type). For example:
+
+```js
+renderer: Handsontable.NumericRenderer,
+editor: Handsontable.editors.NumericEditor,
+validator: Handsontable.NumericValidator,
+type: 'numeric'
+```
+:::
+
 ## EditorManager
 
 [`EditorManager`](@/api/baseEditor.md) is a class responsible for handling all editors available in Handsontable. If `Handsontable` needs to interact with editors it uses [`EditorManager`](@/api/baseEditor.md) object. [`EditorManager`](@/api/baseEditor.md) object is instantiated in [`init()`](@/api/baseEditor.md#init) method which is run, after you invoke `Handsontable()` constructor for the first time. The reference for [`EditorManager`](@/api/baseEditor.md) object is kept private in Handsontable instance and you cannot access it. However, there are ways to alter the default behaviour of [`EditorManager`](@/api/baseEditor.md), more on that later.

--- a/docs/content/guides/cell-functions/cell-function.md
+++ b/docs/content/guides/cell-functions/cell-function.md
@@ -19,6 +19,17 @@ With every cell in the Handsontable there are 3 associated functions:
 
 Each of those functions are responsible for a different cell behavior. You can define them separately or use a [cell type](#cell-type) to define all three at once.
 
+::: tip
+You can set a cell's [`renderer`](@/api/options.md#renderer), [`editor`](@/api/options.md#editor) or [`validator`](@/api/options.md#validator) individually, but you still need to set that cell's [`type`](@/api/options.md#type). For example:
+
+```js
+renderer: Handsontable.NumericRenderer,
+editor: Handsontable.editors.NumericEditor,
+validator: Handsontable.NumericValidator,
+type: 'numeric'
+```
+:::
+
 ## Renderer
 
 Handsontable does not display the values stored in the data source directly. Instead, every time a value from data source needs to be displayed in a table cell, it is passed to the cell `renderer` function, together with the table cell object of type `HTMLTableCellElement` (DOM node), along with other useful information.

--- a/docs/content/guides/cell-functions/cell-renderer.md
+++ b/docs/content/guides/cell-functions/cell-renderer.md
@@ -24,6 +24,17 @@ When you create a renderer, a good idea is to assign it as an alias that will re
 
 It gives users a convenient way for defining which renderer should be used when table rendering was triggered. User doesn't need to know which renderer function is responsible for displaying the cell value, he does not even need to know that there is any function at all. What is more, you can change the render function associated with an alias without a need to change code that defines a table.
 
+::: tip
+You can set a cell's [`renderer`](@/api/options.md#renderer), [`editor`](@/api/options.md#editor) or [`validator`](@/api/options.md#validator) individually, but you still need to set that cell's [`type`](@/api/options.md#type). For example:
+
+```js
+renderer: Handsontable.NumericRenderer,
+editor: Handsontable.editors.NumericEditor,
+validator: Handsontable.NumericValidator,
+type: 'numeric'
+```
+:::
+
 ## Using a cell renderer
 
 Use the renderer name of your choice when configuring the column:

--- a/docs/content/guides/cell-functions/cell-validator.md
+++ b/docs/content/guides/cell-functions/cell-validator.md
@@ -19,6 +19,17 @@ When you create a validator, a good idea is to assign it as an alias that will r
 
 It gives users a convenient way for defining which validator should be used when table validation was triggered. User doesn't need to know which validator function is responsible for checking the cell value, he does not even need to know that there is any function at all. What is more, you can change the validator function associated with an alias without a need to change code that defines a table.
 
+::: tip
+You can set a cell's [`renderer`](@/api/options.md#renderer), [`editor`](@/api/options.md#editor) or [`validator`](@/api/options.md#validator) individually, but you still need to set that cell's [`type`](@/api/options.md#type). For example:
+
+```js
+renderer: Handsontable.NumericRenderer,
+editor: Handsontable.editors.NumericEditor,
+validator: Handsontable.NumericValidator,
+type: 'numeric'
+```
+:::
+
 ## Registering custom cell validator
 
 To register your own alias use `Handsontable.validators.registerValidator()` function. It takes two arguments:

--- a/docs/content/guides/cell-types/cell-type.md
+++ b/docs/content/guides/cell-types/cell-type.md
@@ -10,11 +10,23 @@ canonicalUrl: /cell-type
 [[toc]]
 
 ## Overview
+
 The cell type functionality enables you to customize the appearance and validate the cell(s) when applied.
 
 ## Usage
 
 There are three functions associated with every table cell: [`renderer`](@/api/options.md#renderer), [`editor`](@/api/options.md#editor), and optionally [`validator`](@/api/options.md#validator). These functions are mostly used all together as they are strongly connected.
+
+::: tip
+You can set a cell's [`renderer`](@/api/options.md#renderer), [`editor`](@/api/options.md#editor) or [`validator`](@/api/options.md#validator) individually, but you still need to set that cell's [`type`](@/api/options.md#type). For example:
+
+```js
+renderer: Handsontable.NumericRenderer,
+editor: Handsontable.editors.NumericEditor,
+validator: Handsontable.NumericValidator,
+type: 'numeric'
+```
+:::
 
 Example scenario - To store a date in a cell, you would:
 * Use a [`renderer`](@/api/options.md#renderer) to display the date using appropriate formatting `dd/mm/yyyy`, `yyyy-mm-dd`, etc.
@@ -24,9 +36,8 @@ Example scenario - To store a date in a cell, you would:
 Cell type is represented by a string i.e. `"text"`, `"numeric"`, `"date"`. Each string is internally mapped to functions associated with this type e.g., `"numeric"` type is associated with the following functions:
 
 * `Handsontable.renderers.NumericRenderer`
-* `Handsontable.editors.TextEditor`
 * `Handsontable.validators.NumericValidator`
-
+* `Handsontable.editors.NumericEditor` (same as `Handsontable.editors.TextEditor`)
 
 When Handsontable encounters a cell with the [`type`](@/api/options.md#type) option defined, it checks which cell functions this type refers to and uses them. For example, when setting the column type to `'password'`:
 

--- a/handsontable/src/dataMap/metaManager/metaSchema.js
+++ b/handsontable/src/dataMap/metaManager/metaSchema.js
@@ -1729,6 +1729,17 @@ export default () => {
      * To set the [`editor`](#editor), [`renderer`](#renderer), and [`validator`](#validator)
      * options all at once, use the [`type`](#type) option.
      *
+     * ::: tip
+     * You can set a cell's [`renderer`](#renderer), [`editor`](#editor) or [`validator`](#validator) individually, but you still need to set that cell's [`type`](#type). For example:
+     *
+     * ```js
+     * renderer: Handsontable.NumericRenderer,
+     * editor: Handsontable.editors.NumericEditor,
+     * validator: Handsontable.NumericValidator,
+     * type: 'numeric'
+     * ```
+     * :::
+     *
      * Read more:
      * - [Cell editor](@/guides/cell-functions/cell-editor.md)
      * - [Cell type](@/guides/cell-types/cell-type.md)
@@ -3505,6 +3516,17 @@ export default () => {
      * To set the [`renderer`](#renderer), [`editor`](#editor), and [`validator`](#validator)
      * options all at once, use the [`type`](#type) option.
      *
+     * ::: tip
+     * You can set a cell's [`renderer`](#renderer), [`editor`](#editor) or [`validator`](#validator) individually, but you still need to set that cell's [`type`](#type). For example:
+     *
+     * ```js
+     * renderer: Handsontable.NumericRenderer,
+     * editor: Handsontable.editors.NumericEditor,
+     * validator: Handsontable.NumericValidator,
+     * type: 'numeric'
+     * ```
+     * :::
+     *
      * Read more:
      * - [Cell renderer](@/guides/cell-functions/cell-renderer.md)
      * - [Cell type](@/guides/cell-types/cell-type.md)
@@ -4268,15 +4290,26 @@ export default () => {
      * | Cell type                                                         | Renderer, editor & validator                                                                                                                                                                                                                       |
      * | ----------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
      * | A [custom cell type](@/guides/cell-types/cell-type.md)            | Renderer: your [custom cell renderer](@/guides/cell-functions/cell-renderer.md)<br>Editor: your [custom cell editor](@/guides/cell-functions/cell-editor.md)<br>Validator: your [custom cell validator](@/guides/cell-functions/cell-validator.md) |
-     * | [`'autocomplete'`](@/guides/cell-types/autocomplete-cell-type.md) | Renderer: `AutocompleteRenderer`<br>Editor: `AutocompleteEditor`<br>Validator: `AutocompleteValidator`                                                                         |
-     * | [`'checkbox'`](@/guides/cell-types/checkbox-cell-type.md)         | Renderer: `CheckboxRenderer`<br>Editor: `CheckboxEditor`<br>Validator: -                                                                                                                               |
-     * | [`'date'`](@/guides/cell-types/date-cell-type.md)                 | Renderer: `DateRenderer`<br>Editor: `DateEditor`<br>Validator: `DateValidator`                                                                                                 |
-     * | [`'dropdown'`](@/guides/cell-types/dropdown-cell-type.md)         | Renderer: `DropdownRenderer`<br>Editor: `DropdownEditor`<br>Validator: `DropdownValidator`                                                                                     |
-     * | [`'handsontable'`](@/guides/cell-types/handsontable-cell-type.md) | Renderer: `AutocompleteRenderer`<br>Editor: `HandsontableEditor`<br>Validator: -                                                                                                                       |
-     * | [`'numeric'`](@/guides/cell-types/numeric-cell-type.md)           | Renderer: `NumericRenderer`<br>Editor: `NumericEditor`<br>Validator: `NumericValidator`                                                                                        |
-     * | [`'password'`](@/guides/cell-types/password-cell-type.md)         | Renderer: `PasswordRenderer`<br>Editor: `PasswordEditor`<br>Validator: -                                                                                                                               |
-     * | `'text'`                                                          | Renderer: `TextRenderer`<br>Editor: `TextEditor`<br>Validator: -                                                                                                                                       |
-     * | [`'time`'](@/guides/cell-types/time-cell-type.md)                 | Renderer: `TimeRenderer`<br>Editor: `TimeEditor`<br>Validator: `TimeValidator`                                                                                                 |
+     * | [`'autocomplete'`](@/guides/cell-types/autocomplete-cell-type.md) | Renderer: `AutocompleteRenderer`<br>Editor: `AutocompleteEditor`<br>Validator: `AutocompleteValidator`                                                                                                                                             |
+     * | [`'checkbox'`](@/guides/cell-types/checkbox-cell-type.md)         | Renderer: `CheckboxRenderer`<br>Editor: `CheckboxEditor`<br>Validator: -                                                                                                                                                                           |
+     * | [`'date'`](@/guides/cell-types/date-cell-type.md)                 | Renderer: `DateRenderer`<br>Editor: `DateEditor`<br>Validator: `DateValidator`                                                                                                                                                                     |
+     * | [`'dropdown'`](@/guides/cell-types/dropdown-cell-type.md)         | Renderer: `DropdownRenderer`<br>Editor: `DropdownEditor`<br>Validator: `DropdownValidator`                                                                                                                                                         |
+     * | [`'handsontable'`](@/guides/cell-types/handsontable-cell-type.md) | Renderer: `AutocompleteRenderer`<br>Editor: `HandsontableEditor`<br>Validator: -                                                                                                                                                                   |
+     * | [`'numeric'`](@/guides/cell-types/numeric-cell-type.md)           | Renderer: `NumericRenderer`<br>Editor: `NumericEditor` (same as `TextEditor`)<br>Validator: `NumericValidator`                                                                                                                                     |
+     * | [`'password'`](@/guides/cell-types/password-cell-type.md)         | Renderer: `PasswordRenderer`<br>Editor: `PasswordEditor`<br>Validator: -                                                                                                                                                                           |
+     * | `'text'`                                                          | Renderer: `TextRenderer`<br>Editor: `TextEditor`<br>Validator: -                                                                                                                                                                                   |
+     * | [`'time`'](@/guides/cell-types/time-cell-type.md)                 | Renderer: `TimeRenderer`<br>Editor: `TimeEditor`<br>Validator: `TimeValidator`                                                                                                                                                                     |
+     *
+     * ::: tip
+     * You can set a cell's [`renderer`](#renderer), [`editor`](#editor) or [`validator`](#validator) individually, but you still need to set that cell's [`type`](#type). For example:
+     *
+     * ```js
+     * renderer: Handsontable.NumericRenderer,
+     * editor: Handsontable.editors.NumericEditor,
+     * validator: Handsontable.NumericValidator,
+     * type: 'numeric'
+     * ```
+     * :::
      *
      * Read more:
      * - [Cell type](@/guides/cell-types/cell-type.md)
@@ -4413,6 +4446,17 @@ export default () => {
      *
      * To set the [`editor`](#editor), [`renderer`](#renderer), and [`validator`](#validator)
      * options all at once, use the [`type`](#type) option.
+     *
+     * ::: tip
+     * You can set a cell's [`renderer`](#renderer), [`editor`](#editor) or [`validator`](#validator) individually, but you still need to set that cell's [`type`](#type). For example:
+     *
+     * ```js
+     * renderer: Handsontable.NumericRenderer,
+     * editor: Handsontable.editors.NumericEditor,
+     * validator: Handsontable.NumericValidator,
+     * type: 'numeric'
+     * ```
+     * :::
      *
      * Read more:
      * - [Cell validator](@/guides/cell-functions/cell-validator.md)


### PR DESCRIPTION
This PR:
- Adds info that `NumericEditor` is basically the same as `TextEditor`
- Adds a note saying that even if you set a cell's `renderer`, `editor` or `validator` separately, you still need to set the cell's `type`.

Modified pages:
- http://localhost:8080/docs/next/api/options/#editor
- http://localhost:8080/docs/next/api/options/#renderer
- http://localhost:8080/docs/next/api/options/#type
- http://localhost:8080/docs/next/api/options/#validator
- http://localhost:8080/docs/next/cell-function/
- http://localhost:8080/docs/next/cell-renderer/
- http://localhost:8080/docs/next/cell-editor/
- http://localhost:8080/docs/next/cell-validator/
- http://localhost:8080/docs/next/cell-type/

[skip changelog]