### PR TITLE
Docs: Fixing a note

### DIFF
--- a/docs/content/guides/optimization/batch-operations.md
+++ b/docs/content/guides/optimization/batch-operations.md
@@ -61,7 +61,8 @@ Suspending the render results in better performance, which is especially noticea
 
 ![batch_operations_comparison](/docs/{{$page.currentVersion}}/img/batch_operations_comparison.png)
 
-:::tip Note that other methods can be used to batch operations, but they are slightly more advanced and should be used with caution. Flickering, glitches or other visual distortion may happen when you forget to `resume` render after suspending it several times. Mixing methods of a render type with those focused on operations can also result in some unexpected behavior. Above all, [`batch()`](@/api/core.md#batch) should be sufficient in most use cases, and it is safe to work with.
+:::tip
+Note that other methods can be used to batch operations, but they are slightly more advanced and should be used with caution. Flickering, glitches or other visual distortion may happen when you forget to `resume` render after suspending it several times. Mixing methods of a render type with those focused on operations can also result in some unexpected behavior. Above all, [`batch()`](@/api/core.md#batch) should be sufficient in most use cases, and it is safe to work with.
 :::
 
 ## API methods


### PR DESCRIPTION
This PR:
- Unhides a note hidden by mistake (fixing #8389)

[skip changelog]