### PR TITLE
Docs: Add a `readOnly` search tag

### DIFF
--- a/docs/content/guides/cell-features/disabled-cells.md
+++ b/docs/content/guides/cell-features/disabled-cells.md
@@ -5,6 +5,7 @@ permalink: /disabled-cells
 canonicalUrl: /disabled-cells
 tags:
   - read-only
+  - readonly
   - noneditable
 ---
 


### PR DESCRIPTION
This PR:
- Adds a `readOnly` search tag to the **Disabled cells** page

[skip changelog]