### PR TITLE
Docs: Remove a duplicate `licenseKey`

### DIFF
--- a/docs/content/guides/cell-types/date-cell-type.md
+++ b/docs/content/guides/cell-types/date-cell-type.md
@@ -92,7 +92,6 @@ const hot = new Handsontable(container, {
         firstDay: 0,
         showWeekNumber: true,
         numberOfMonths: 3,
-        licenseKey: 'non-commercial-and-evaluation',
         disableDayFn(date) {
           // Disable Sunday and Saturday
           return date.getDay() === 0 || date.getDay() === 6;


### PR DESCRIPTION
This PR:
- Removes a duplicate `licenseKey`

Affected pages:
- http://localhost:8080/docs/next/date-cell-type/#basic-example