### PR TITLE
Prevent clearing portal cache array in StrictMode second render (#9723)

### DIFF
--- a/.changelogs/9723.json
+++ b/.changelogs/9723.json
@@ -1,0 +1,7 @@
+{
+  "title": "Prevent clearing portal cache array in StrictMode second render.",
+  "type": "fixed",
+  "issue": 9723,
+  "breaking": false,
+  "framework": "react"
+}

--- a/wrappers/react/src/hotTable.tsx
+++ b/wrappers/react/src/hotTable.tsx
@@ -526,7 +526,10 @@ class HotTable extends React.Component<HotTableProps, {}> {
     });
 
     this.hotInstance.addHook('afterViewRender', function () {
-      hotTableComponent.handsontableAfterViewRender();
+      // Prevent clearing portal cache array in StrictMode second render.
+      if (hotTableComponent.renderedCellCache.size === hotTableComponent.portalCacheArray.length) {
+        hotTableComponent.handsontableAfterViewRender();
+      }
     });
 
     // `init` missing in Handsontable's type definitions.


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
This PR prevents the issue when custom rendered components are not visible after second render caused by react StrictMode in development mode. I have noticed that if render is forced by StrictMode renderedCellCache and portalCacheArray sizes are not equal and thats how i detect it.
Actual problem is caused by line
```this.portalCacheArray.length = 0;```
Length of the array is modified directly, outside of react's lifecycle and doesnt trigger methods necessary to render components properly.
Unfortunately, i'm not able to write unit test for this, because wrapper uses older version of react, which does not behave in same way as the newest.
 
### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
In demo application from components-comparison repository using reacts StrictMode component in 'all grids' section. Development mode only.
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #9723 
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [x] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
