### PR TITLE
Fix links header section highlighting

### DIFF
--- a/docs/.vuepress/theme/components/NavLink.vue
+++ b/docs/.vuepress/theme/components/NavLink.vue
@@ -41,11 +41,11 @@ export default {
       return !!this.item.isHtmlLink;
     },
     exact() {
-      if (this.$site.locales) {
-        return Object.keys(this.$site.locales).some(rootLink => rootLink === this.link);
+      if (this.link === `/${this.$page.currentFramework}${this.$page.frameworkSuffix}/`) {
+        return /\/api\//.test(this.$route.fullPath) || /\/examples\//.test(this.$route.fullPath);
       }
 
-      return this.link === `/${this.$page.currentFramework}${this.$page.frameworkSuffix}/`;
+      return false;
     },
 
     isNonHttpURI() {

--- a/docs/.vuepress/theme/components/NavLink.vue
+++ b/docs/.vuepress/theme/components/NavLink.vue
@@ -45,7 +45,7 @@ export default {
         return Object.keys(this.$site.locales).some(rootLink => rootLink === this.link);
       }
 
-      return this.link === '/';
+      return this.link === `/${this.$page.currentFramework}${this.$page.frameworkSuffix}/`;
     },
 
     isNonHttpURI() {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes an issue where the "Guides" link is incorrectly marked as active.

_[skip changelog]_

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes #9715

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
