### PR TITLE
Change styling of the framework dropdown list on mobiles

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,5 +1,4 @@
 const path = require('path');
-const stylusNodes = require('stylus/lib/nodes');
 const highlight = require('./highlight');
 const examples = require('./containers/examples');
 const sourceCodeLink = require('./containers/sourceCodeLink');
@@ -98,15 +97,6 @@ module.exports = {
   configureWebpack: {
     resolve: {
       symlinks: false,
-    }
-  },
-  stylus: {
-    preferPathResolver: 'webpack',
-    define: {
-      versionedUrl: (expression) => {
-        return new stylusNodes
-          .Literal(`url("${expression.string.replace('{docsVersion}', getThisDocsVersion())}")`);
-      },
     }
   },
   plugins: [

--- a/docs/.vuepress/theme/components/FrameworksDropdown.vue
+++ b/docs/.vuepress/theme/components/FrameworksDropdown.vue
@@ -81,6 +81,9 @@ export default {
     text-transform capitalize
   }
 
+  .nav-dropdown
+    z-index 100
+
   .icon.outbound
     display none
 

--- a/docs/.vuepress/theme/components/Navbar.vue
+++ b/docs/.vuepress/theme/components/Navbar.vue
@@ -148,5 +148,8 @@ $navbar-horizontal-padding = 1.5rem
     padding-left 4rem
     .can-hide
       display none
+@media (max-width: $MQNarrow)
+  .navbar .nav-frameworks
+    display none
 
 </style>

--- a/docs/.vuepress/theme/components/SearchBox.vue
+++ b/docs/.vuepress/theme/components/SearchBox.vue
@@ -378,7 +378,6 @@ export default {
     padding 0 0.5rem 0 2rem
     outline none
     /* Fallback for IE, should work in production */
-    background #fff url('/docs/javascript-data-grid/img/search.svg') 0.6rem 0.5rem no-repeat
     background #fff var(--search-icon-url) 0.6rem 0.5rem no-repeat
     background-size 1rem
     &:focus

--- a/docs/.vuepress/theme/components/Sidebar.vue
+++ b/docs/.vuepress/theme/components/Sidebar.vue
@@ -1,9 +1,11 @@
 <template>
   <aside class="sidebar">
+    <div class="framework-switcher-item">
+      Framework: <FrameworksDropdown class="sidebar-mode"/>
+    </div>
     <div class="theme-switcher-item">
       Choose a theme: <ThemeSwitcher />
     </div>
-    <NavLinks />
 
     <slot name="top" />
 
@@ -19,11 +21,12 @@
 import SidebarLinks from '@theme/components/SidebarLinks.vue';
 import NavLinks from '@theme/components/NavLinks.vue';
 import ThemeSwitcher from '@theme/components/ThemeSwitcher.vue';
+import FrameworksDropdown from '@theme/components/FrameworksDropdown.vue';
 
 export default {
   name: 'Sidebar',
 
-  components: { SidebarLinks, NavLinks, ThemeSwitcher },
+  components: { SidebarLinks, NavLinks, ThemeSwitcher, FrameworksDropdown },
 
   props: ['items']
 };
@@ -43,6 +46,29 @@ export default {
     }
 }
 
+.framework-switcher-item
+  width 235px
+  position relative
+  display inline-block
+  margin-left 1.5rem
+  line-height 2rem
+  font-weight 600
+  margin-top 10px
+
+  .nav-frameworks
+    float right
+    margin-left 0
+
+    .nav-dropdown
+      left unset
+
+      @media (max-width: $MQMobile) {
+        right -35px
+      }
+
+  @media (min-width: $MQNarrow)
+    display none
+
 .sidebar
   width 17rem
   z-index 1000
@@ -59,20 +85,6 @@ export default {
     list-style-type none
   a
     display inline-block
-  .nav-links
-    display none
-    border-bottom 1px solid $borderColor
-    padding 8px 0 0.75rem 0
-    a
-      font-weight 600
-      @media (max-width: $MQMobile) {
-        font-size 15px
-      }
-    .nav-item, .repo-link
-      display block
-      line-height 1.25rem
-      font-size 1.1em
-      padding 0.5rem 0 0.5rem 1.5rem
   & > .sidebar-links
     padding 1.5rem 0
     @media (max-width: $MQNarrow) {

--- a/docs/.vuepress/theme/components/ThemeSwitcher.vue
+++ b/docs/.vuepress/theme/components/ThemeSwitcher.vue
@@ -147,7 +147,6 @@ export default {
   transition: 0.4s;
   box-shadow: 0 0px 3px #2020203d;
   /* Fallback for IE, should work in production */
-  background: #ffffff url('/docs/javascript-data-grid/img/light-theme-icon.svg');
   background: #ffffff var(--light-icon-url);
   background-size: 70%;
   background-repeat: no-repeat;
@@ -167,7 +166,6 @@ input:checked + .slider:before {
   -ms-transform: translateX(16px);
   transform: translateX(16px);
   /* Fallback for IE, should work in production */
-  background: #ffffff url('/docs/javascript-data-grid/img/dark-theme-icon.svg');
   background: #ffffff var(--dark-icon-url);
   background-size: 70%;
   background-repeat: no-repeat;


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR changes the styles of the framework dropdown list component. Now, on narrow viewports, the component is moved to the sidebar.

Moreover, the PR removes the unused leftovers from the merging `develop` branch. 

_[skip changelog]_

#### Before
![Zrzut ekranu 2022-08-9 o 10 22 37](https://user-images.githubusercontent.com/571316/183601172-9d932cdb-d7b1-4a28-b6b8-01bed9a9b04c.png)

#### After
![Zrzut ekranu 2022-08-9 o 10 24 17](https://user-images.githubusercontent.com/571316/183601315-94b41cbf-79e3-487f-b779-8f1a374e722a.png)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes #9739

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
