### PR TITLE
Fix Docs build on non-next versions

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -10,7 +10,6 @@ const conditionalContainer = require('./plugins/markdown-it-conditional-containe
 const {
   getDocsBaseUrl,
   getThisDocsVersion,
-  getEnvDocsFramework,
   TMP_DIR_FOR_WATCH,
   createSymlinks,
   isEnvDev,
@@ -20,7 +19,6 @@ const dumpDocsDataPlugin = require('./plugins/dump-docs-data');
 
 const docsBase = process.env.DOCS_BASE ? process.env.DOCS_BASE : getThisDocsVersion();
 const buildMode = process.env.BUILD_MODE;
-const frameworkFromEnv = getEnvDocsFramework();
 const isProduction = buildMode === 'production';
 const environmentHead = isProduction ?
   [

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -15,7 +15,6 @@ const {
   createSymlinks,
   isEnvDev,
   getIgnoredFilesPatterns,
-  FRAMEWORK_SUFFIX,
 } = require('./helpers');
 const dumpDocsDataPlugin = require('./plugins/dump-docs-data');
 
@@ -46,17 +45,12 @@ if (docsBase !== 'latest') {
   base += `${docsBase}/`;
 }
 
-if (frameworkFromEnv !== void 0) {
-  base += `${frameworkFromEnv}${FRAMEWORK_SUFFIX}/`;
-}
-
 module.exports = {
   define: {
     GA_ID: 'UA-33932793-7',
   },
   patterns: [
     isEnvDev() ? `${TMP_DIR_FOR_WATCH}/**/*.md` : 'content/**/*.md',
-    '!README.md', '!README-EDITING.md', '!README-DEPLOYMENT.md',
     ...getIgnoredFilesPatterns(),
   ],
   description: 'Handsontable',

--- a/docs/.vuepress/containers/examples/examples.js
+++ b/docs/.vuepress/containers/examples/examples.js
@@ -7,8 +7,6 @@ const EXAMPLE_REGEX = /^(example)\s*(#\S*|)\s*(\.\S*|)\s*(:\S*|)\s*([\S|\s]*)$/;
 
 const { buildCode } = require('./code-builder');
 const { jsfiddle } = require('./jsfiddle');
-const { isEnvDev } = require('../../helpers');
-const { getContainerFramework } = require('../helpers');
 
 const tab = (tabName, token) => {
   if (!token) return [];
@@ -103,8 +101,6 @@ module.exports = function(docsVersion, base) {
         const jsPos = args.match(/--js (\d*)/)?.[1] || 1;
         const jsIndex = index + Number.parseInt(jsPos, 10);
         const jsToken = tokens[jsIndex];
-        const filePath = env.relativePath;
-        const framework = getContainerFramework(filePath);
 
         jsToken.content = jsToken.content.replaceAll('{{$basePath}}', base.replace(/\/$/, ''));
 
@@ -112,10 +108,7 @@ module.exports = function(docsVersion, base) {
         const noEdit = !!args.match(/--no-edit/)?.[0];
 
         const code = buildCode(id + (preset.includes('angular') ? '.ts' : '.jsx'), jsToken.content, env.relativePath);
-        const encodedCode = encodeURI(
-          `useHandsontable('${docsVersion}', function(){${code}}, '${preset}', ${
-            isEnvDev() ? '\'development\'' : '\'production\''
-          })`);
+        const encodedCode = encodeURI(`useHandsontable('${docsVersion}', function(){${code}}, '${preset}')`);
 
         [htmlIndex, jsIndex, cssIndex].filter(x => !!x).sort().reverse().forEach((x) => {
           tokens.splice(x, 1);
@@ -131,7 +124,7 @@ module.exports = function(docsVersion, base) {
         tokens.splice(index + 1, 0, ...newTokens);
 
         return `
-            ${!noEdit ? jsfiddle(id, htmlContent, jsToken.content, cssContent, docsVersion, preset, framework) : ''}
+            ${!noEdit ? jsfiddle(id, htmlContent, jsToken.content, cssContent, docsVersion, preset) : ''}
             <tabs
               :options="{ useUrlFragment: false, defaultTabHash: '${activeTab}' }"
               cache-lifetime="0"

--- a/docs/.vuepress/containers/examples/jsfiddle.js
+++ b/docs/.vuepress/containers/examples/jsfiddle.js
@@ -2,10 +2,10 @@ const JSFIDDLE_ENDPOINT = 'https://jsfiddle.net/api/post/library/pure/';
 
 const { getDependencies } = require('../../handsontable-manager');
 
-const jsfiddle = (id, html, code, css, version, preset, framework) => {
+const jsfiddle = (id, html, code, css, version, preset) => {
   const isBabelPanel = preset.includes('react') || preset.includes('vue');
   const isAngularPanel = preset.includes('angular');
-  const imports = getDependencies(version, preset, framework).reduce(
+  const imports = getDependencies(version, preset).reduce(
     (p, c) =>
       p +
       (c[0] ? `<script src="${c[0]}"></script>\n` : '') +

--- a/docs/.vuepress/docs-links.js
+++ b/docs/.vuepress/docs-links.js
@@ -13,16 +13,10 @@ module.exports = function(src) {
       const fm = parseFrontmatter(fs.readFileSync(path.resolve(basePath, 'content', file)));
 
       if (fm.data.permalink) {
-        permalink = fm.data.permalink;
+        const framework = `${helpers.getEnvDocsFramework() ||
+          helpers.parseFramework(pathForServingDocs)}${helpers.FRAMEWORK_SUFFIX}`;
 
-        // Docs base for full build already has framework part.
-        if (helpers.isEnvDev() === true) {
-          const framework = `${helpers.getEnvDocsFramework() ||
-            helpers.parseFramework(pathForServingDocs)}${helpers.FRAMEWORK_SUFFIX}`;
-
-          permalink = `/${framework}${permalink}`;
-        }
-
+        permalink = `/${framework}${fm.data.permalink}`;
         permalink = permalink.endsWith('/') ? permalink : `${permalink}/`;
         permalink = hash ? permalink + hash : permalink;
       }

--- a/docs/.vuepress/enhanceApp.js
+++ b/docs/.vuepress/enhanceApp.js
@@ -45,12 +45,11 @@ let isFirstPageLoaded = true;
 export default async({ router, siteData, isServer }) => {
   if (!isServer) {
     const currentVersion = siteData.pages[0].currentVersion;
-    const framework = `${siteData.pages[0].currentFramework}${siteData.pages[0].frameworkSuffix}`;
-    const devBuildMode = siteData.pages[0].isEnvDev;
-    let pathVersion = `${currentVersion}/`;
+    const buildMode = siteData.pages[0].buildMode;
+    let pathVersion = '';
 
-    if (!devBuildMode) {
-      pathVersion += `${framework}/`;
+    if (buildMode !== 'production') {
+      pathVersion = `${currentVersion}/`;
     }
 
     const response = await fetch(`${window.location.origin}/docs/${pathVersion}data/common.json`);
@@ -70,7 +69,6 @@ export default async({ router, siteData, isServer }) => {
 
       page.versions = docsData.versions;
       page.latestVersion = docsData.latestVersion;
-      page.frameworkedVersions = docsData.frameworkedVersions;
     });
 
     themeLoader();

--- a/docs/.vuepress/handsontable-manager/dependencies.js
+++ b/docs/.vuepress/handsontable-manager/dependencies.js
@@ -1,38 +1,13 @@
-const semver = require('semver');
-const {
-  version: currentHandsontableVersion
-} = require('../../../handsontable/package.json');
-
 // eslint-disable-next-line no-restricted-globals
 const isBrowser = (typeof window !== 'undefined');
 
 const formatVersion = version => (/^\d+\.\d+$/.test(version) ? version : 'latest');
-const generatePrefixes = (version, framework, buildMode) => {
-  const isLatestVersion = semver.satisfies(
-    semver.coerce(version)?.version,
-    semver.coerce(currentHandsontableVersion)?.version.replace(/\.([a-z0-9]|-)+$/, '.x')
-  );
-
-  const versionPrefix = !isLatestVersion || version === 'next' ? `${version}/` : '';
-  const frameworkPrefix = framework ? `${framework}-data-grid/` : '';
-  const urlPrefix = buildMode === 'production' ? `${versionPrefix}${frameworkPrefix}` : `${versionPrefix}`;
-
-  return {
-    versionPrefix,
-    frameworkPrefix,
-    urlPrefix
-  };
-};
-const getHotUrls = (version, framework, buildMode) => {
-  const {
-    urlPrefix
-  } = generatePrefixes(version, framework, buildMode);
-
+const getHotUrls = (version) => {
   if (version === 'next' && isBrowser) {
     return {
-      handsontableJs: `/docs/${urlPrefix}handsontable/handsontable.full.js`,
-      handsontableCss: `/docs/${urlPrefix}handsontable/handsontable.full.css`,
-      languagesJs: `/docs/${urlPrefix}handsontable/languages/all.js`
+      handsontableJs: '/docs/next/handsontable/handsontable.full.js',
+      handsontableCss: '/docs/next/handsontable/handsontable.full.css',
+      languagesJs: '/docs/next/handsontable/languages/all.js'
     };
   }
 
@@ -44,25 +19,16 @@ const getHotUrls = (version, framework, buildMode) => {
     languagesJs: `https://cdn.jsdelivr.net/npm/handsontable@${mappedVersion}/dist/languages/all.js`
   };
 };
-const getCommonScript = (scriptName, version, framework, buildMode) => {
-  const {
-    versionPrefix,
-    frameworkPrefix,
-    urlPrefix
-  } = generatePrefixes(version, framework, buildMode);
-
+const getCommonScript = (scriptName, version) => {
   if (isBrowser) {
     // eslint-disable-next-line no-restricted-globals
     return [
-      `${window.location.origin}/docs/${urlPrefix}scripts/${scriptName}.js`,
+      `${window.location.origin}/docs/${version}/scripts/${scriptName}.js`,
       ['require', 'exports']
     ];
   }
 
-  return [
-    `https://handsontable.com/docs/${versionPrefix}${frameworkPrefix}scripts/${scriptName}.js`,
-    ['require', 'exports']
-  ];
+  return [`https://handsontable.com/docs/${version}/scripts/${scriptName}.js`, ['require', 'exports']];
 };
 
 /**
@@ -70,16 +36,14 @@ const getCommonScript = (scriptName, version, framework, buildMode) => {
  * The function `buildDependencyGetter` is the best place to care about that.
  *
  * @param {string} version The current selected documentation version.
- * @param {string} framework The current selected documentation framework.
- * @param {'development'|'production'} buildMode The documentation build mode.
  * @returns {Function} Returns a function factory with the signature
  *                     `{function(dependency: string): [string,string[],string]} [jsUrl, dependentVars[]?, cssUrl?]`.
  */
-const buildDependencyGetter = (version, framework, buildMode) => {
-  const { handsontableJs, handsontableCss, languagesJs } = getHotUrls(version, framework, buildMode);
+const buildDependencyGetter = (version) => {
+  const { handsontableJs, handsontableCss, languagesJs } = getHotUrls(version);
   const mappedVersion = formatVersion(version);
-  const fixer = getCommonScript('fixer', version, framework, buildMode);
-  const helpers = getCommonScript('helpers', version, framework, buildMode);
+  const fixer = getCommonScript('fixer', version);
+  const helpers = getCommonScript('helpers', version);
 
   return (dependency) => {
     /* eslint-disable max-len */
@@ -148,8 +112,8 @@ const presetMap = {
   /* eslint-enable max-len */
 };
 
-const getDependencies = (version, preset, framework) => {
-  const getter = buildDependencyGetter(version, framework);
+const getDependencies = (version, preset) => {
+  const getter = buildDependencyGetter(version);
 
   if (!Array.isArray(presetMap[preset])) {
     throw new Error(`The preset "${preset}" was not found.`);

--- a/docs/.vuepress/handsontable-manager/use-handsontable.js
+++ b/docs/.vuepress/handsontable-manager/use-handsontable.js
@@ -2,14 +2,12 @@ const { register } = require('./register');
 const {
   buildDependencyGetter,
   presetMap,
-  isBrowser
 } = require('./dependencies');
 
 const ATTR_VERSION = 'data-hot-version';
 
 const useHandsontable = (version, callback = () => {}, preset = 'hot', buildMode = 'production') => {
-  const framework = isBrowser ? window.location.pathname.match(/([a-z]+)-data-grid/)?.[1] : void 0;
-  const getDependency = buildDependencyGetter(version, framework, buildMode);
+  const getDependency = buildDependencyGetter(version, buildMode);
 
   const loadDependency = dep => new Promise((resolve) => {
     const id = `dependency-reloader_${dep}`;

--- a/docs/.vuepress/plugins/dump-docs-data/docs-versions.js
+++ b/docs/.vuepress/plugins/dump-docs-data/docs-versions.js
@@ -7,9 +7,6 @@
 const semver = require('semver');
 const { Octokit } = require('@octokit/rest');
 const { logger } = require('@vuepress/shared-utils');
-const {
-  getFrameworkedVersions,
-} = require('../../helpers');
 
 /**
  * Min Docs version that is listed in the Docs version dropdown menu.
@@ -69,7 +66,6 @@ async function readFromGitHub() {
   return {
     versions,
     latestVersion: versions[0],
-    frameworkedVersions: getFrameworkedVersions(versions),
   };
 }
 

--- a/docs/.vuepress/plugins/dump-docs-data/index.js
+++ b/docs/.vuepress/plugins/dump-docs-data/index.js
@@ -5,7 +5,6 @@ const { generateCommonCanonicalURLs } = require('./canonicals');
 const { fetchDocsVersions } = require('./docs-versions');
 const {
   getThisDocsVersion,
-  getFrameworkedVersions,
 } = require('../../helpers');
 
 const pluginName = 'hot/dump-canonicals';
@@ -57,7 +56,6 @@ module.exports = (options, context) => {
       docsDataCommon.urls = Array.from(canonicalURLs);
       docsDataCommon.versions = docsVersions.versions;
       docsDataCommon.latestVersion = docsVersions.latestVersion;
-      docsDataCommon.frameworkedVersions = getFrameworkedVersions(docsVersions.versions);
 
       try {
         await fsp.writeFile(`${outputDir}/common.json`, JSON.stringify(docsDataCommon));

--- a/docs/.vuepress/plugins/extend-page-data/index.js
+++ b/docs/.vuepress/plugins/extend-page-data/index.js
@@ -61,20 +61,17 @@ module.exports = (options, context) => {
       $page.lastUpdatedFormat = formatDate($page.lastUpdated);
       $page.isEnvDev = isEnvDev();
       $page.buildMode = buildMode;
-      $page.frontmatter.canonicalUrl = dedupeSlashes(`/docs${$page.frontmatter.canonicalUrl}/`);
-      $page.isSearchable =
-        notSearchableLinks[$page.currentFramework]?.every(
-          notSearchableLink => $page.normalizedPath.includes(notSearchableLink) === false);
+      $page.isSearchable = notSearchableLinks[$page.currentFramework]?.every(
+        notSearchableLink => $page.normalizedPath.includes(notSearchableLink) === false);
+
+      const frameworkPath = $page.currentFramework + FRAMEWORK_SUFFIX;
+
+      if ($page.frontmatter.canonicalUrl) {
+        $page.frontmatter.canonicalUrl = dedupeSlashes(`/docs/${frameworkPath}${$page.frontmatter.canonicalUrl}/`);
+      }
 
       if ($page.frontmatter.permalink) {
-        if ($page.currentVersion !== 'next') {
-          $page.frontmatter.permalink = $page.frontmatter.permalink.replace(/^\/[^/]*\//, '/');
-        }
-
-        // Only dev script need to perform build to specific place. Full build script perform moving directory separately.
-        if (isEnvDev()) {
-          $page.frontmatter.permalink = `/${$page.currentFramework}${FRAMEWORK_SUFFIX}${$page.frontmatter.permalink}`;
-        }
+        $page.frontmatter.permalink = `/${frameworkPath}${$page.frontmatter.permalink}`;
       }
     },
   };

--- a/docs/.vuepress/theme/components/NavLinks.vue
+++ b/docs/.vuepress/theme/components/NavLinks.vue
@@ -45,9 +45,7 @@ export default {
   },
   computed: {
     frameworkUrlPrefix() {
-      return this.$page.isEnvDev ?
-        `/${this.$page.currentFramework}${this.$page.frameworkSuffix}` :
-        '';
+      return `/${this.$page.currentFramework}${this.$page.frameworkSuffix}`;
     },
     guideLink() {
       return {

--- a/docs/.vuepress/theme/components/Navbar.vue
+++ b/docs/.vuepress/theme/components/Navbar.vue
@@ -61,9 +61,7 @@ export default {
   },
   computed: {
     frameworkUrlPrefix() {
-      return this.$page.isEnvDev ?
-        `/${this.$page.currentFramework}${this.$page.frameworkSuffix}` :
-        '';
+      return `/${this.$page.currentFramework}${this.$page.frameworkSuffix}`;
     },
     algolia() {
       return this.$themeLocaleConfig.algolia || this.$site.themeConfig.algolia || {};

--- a/docs/.vuepress/theme/components/VersionsDropdown.vue
+++ b/docs/.vuepress/theme/components/VersionsDropdown.vue
@@ -10,6 +10,8 @@
 <script>
 import DropdownLink from '@theme/components/DropdownLink.vue';
 
+const MIN_FRAMEWORKED_DOCS_VERSION = 12.1;
+
 export default {
   name: 'VersionsDropdown',
   components: {
@@ -31,7 +33,7 @@ export default {
     getLink(version) {
       let framework = '';
 
-      if (this.$page.frameworkedVersions.includes(version)) {
+      if (parseFloat(version) >= MIN_FRAMEWORKED_DOCS_VERSION || version === 'next') {
         framework = `${this.$page.currentFramework}${this.$page.frameworkSuffix}/`;
       }
 

--- a/docs/.vuepress/tools/build.mjs
+++ b/docs/.vuepress/tools/build.mjs
@@ -3,7 +3,7 @@ import { fileURLToPath } from 'url';
 import fse from 'fs-extra';
 import fs from 'fs/promises';
 import utils from './utils.js';
-import { getThisDocsVersion, getFrameworks, FRAMEWORK_SUFFIX, getPrettyFrameworkName } from '../helpers.js';
+import { getThisDocsVersion, getFrameworks, getPrettyFrameworkName } from '../helpers.js';
 
 const { logger, spawnProcess } = utils;
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -36,20 +36,20 @@ async function buildVersion(version, framework) {
   await spawnProcess(
     'node --experimental-fetch node_modules/.bin/vuepress build -d .vuepress/dist/pre-' +
       `${versionEscaped}/${NO_CACHE ? ' --no-cache' : ''}`,
-      { cwd, env: { DOCS_BASE: version, DOCS_FRAMEWORK: framework }, }
-    );
+    { cwd, env: { DOCS_BASE: version, DOCS_FRAMEWORK: framework }, }
+  );
 
   if (version !== 'next') {
     await spawnProcess(
       'node --experimental-fetch node_modules/.bin/vuepress build -d .vuepress/dist/pre-latest-' +
-      `${versionEscaped}/${NO_CACHE ? ' --no-cache' : ''}`,
+        `${versionEscaped}/${NO_CACHE ? ' --no-cache' : ''}`,
       { cwd, env: { DOCS_BASE: 'latest', DOCS_FRAMEWORK: framework }, }
     );
   }
 
   logger.success(`Version "${version}" with framework "${getPrettyFrameworkName(framework)}" build ` +
     'finished at', new Date().toString());
-};
+}
 
 /**
  * Concatenates the dist's.

--- a/docs/.vuepress/tools/build.mjs
+++ b/docs/.vuepress/tools/build.mjs
@@ -1,6 +1,7 @@
 import path from 'path';
 import { fileURLToPath } from 'url';
 import fse from 'fs-extra';
+import fs from 'fs/promises';
 import utils from './utils.js';
 import { getThisDocsVersion, getFrameworks, FRAMEWORK_SUFFIX, getPrettyFrameworkName } from '../helpers.js';
 
@@ -25,34 +26,29 @@ async function cleanUp() {
  * @param {string} version The docs version to build.
  * @param {string} framework The docs framework to build.
  */
-const buildVersion = (version, framework) => {
-  // eslint-disable-next-line no-async-promise-executor
-  return new Promise(async(resolve) => {
-    logger.info(`Version "${version}" with framework "${getPrettyFrameworkName(framework)}" build started at`,
-      new Date().toString());
+async function buildVersion(version, framework) {
+  logger.info(`Version "${version}" with framework "${getPrettyFrameworkName(framework)}" build started at`,
+    new Date().toString());
 
-    const cwd = path.resolve(__dirname, '../../');
-    const versionEscaped = version.replace('.', '-');
+  const cwd = path.resolve(__dirname, '../../');
+  const versionEscaped = version.replace('.', '-');
 
-    await spawnProcess(
-      'node --experimental-fetch node_modules/.bin/vuepress build -d .vuepress/dist/pre-' +
-      `${versionEscaped}/${framework}${FRAMEWORK_SUFFIX}${NO_CACHE ? ' --no-cache' : ''}`,
+  await spawnProcess(
+    'node --experimental-fetch node_modules/.bin/vuepress build -d .vuepress/dist/pre-' +
+      `${versionEscaped}/${NO_CACHE ? ' --no-cache' : ''}`,
       { cwd, env: { DOCS_BASE: version, DOCS_FRAMEWORK: framework }, }
     );
 
-    if (version !== 'next') {
-      await spawnProcess(
-        'node --experimental-fetch node_modules/.bin/vuepress build -d .vuepress/dist/pre-latest-' +
-        `${versionEscaped}/${framework}${FRAMEWORK_SUFFIX}${NO_CACHE ? ' --no-cache' : ''}`,
-        { cwd, env: { DOCS_BASE: 'latest', DOCS_FRAMEWORK: framework }, }
-      );
-    }
+  if (version !== 'next') {
+    await spawnProcess(
+      'node --experimental-fetch node_modules/.bin/vuepress build -d .vuepress/dist/pre-latest-' +
+      `${versionEscaped}/${NO_CACHE ? ' --no-cache' : ''}`,
+      { cwd, env: { DOCS_BASE: 'latest', DOCS_FRAMEWORK: framework }, }
+    );
+  }
 
-    logger.success(`Version "${version}" with framework "${getPrettyFrameworkName(framework)}" build ` +
-      'finished at', new Date().toString());
-
-    resolve();
-  });
+  logger.success(`Version "${version}" with framework "${getPrettyFrameworkName(framework)}" build ` +
+    'finished at', new Date().toString());
 };
 
 /**
@@ -62,56 +58,50 @@ const buildVersion = (version, framework) => {
  * @param {string} framework The docs framework to build.
  */
 async function concatenate(version, framework) {
-  // eslint-disable-next-line no-async-promise-executor
-  return new Promise(async(resolve) => {
-    if (version !== 'next') {
-      const prebuildLatest = path.resolve(__dirname, '../../', '.vuepress/dist/pre-latest-' +
-        `${version.replace('.', '-')}/${framework}-${FRAMEWORK_SUFFIX}`);
-      const distLatest = path.resolve(__dirname, '../../', `.vuepress/dist/docs/${framework}${FRAMEWORK_SUFFIX}`);
+  const versionEscaped = version.replace('.', '-');
 
-      await fse.move(prebuildLatest, distLatest);
-    }
+  if (version !== 'next') {
+    const prebuildLatest = path.resolve(__dirname, '../../', `.vuepress/dist/pre-latest-${versionEscaped}`);
+    const distLatest = path.resolve(__dirname, '../../', '.vuepress/dist/docs');
 
-    const prebuildVersioned = path.resolve(
-      __dirname,
-      '../../', `.vuepress/dist/pre-${version.replace('.', '-')}/${framework}${FRAMEWORK_SUFFIX}`
-    );
-    const distVersioned = path.resolve(
-      __dirname,
-      '../../', `.vuepress/dist/docs/${version}/${framework}${FRAMEWORK_SUFFIX}`
-    );
+    await fs.cp(prebuildLatest, distLatest, { force: true, recursive: true });
+    await fs.rmdir(prebuildLatest, { recursive: true });
+  }
 
-    logger.info(`Apply built version "${version}" with framework "${getPrettyFrameworkName(framework)}" ` +
-      'to the `docs/`');
+  const prebuildVersioned = path.resolve(
+    __dirname,
+    '../../', `.vuepress/dist/pre-${versionEscaped}`
+  );
+  const distVersioned = path.resolve(
+    __dirname,
+    '../../', `.vuepress/dist/docs/${version}`
+  );
 
-    await fse.move(prebuildVersioned, distVersioned);
+  logger.info(`Apply built version "${version}" with framework "${getPrettyFrameworkName(framework)}" ` +
+    'to the `docs/`');
 
-    resolve();
-  });
+  await fs.cp(prebuildVersioned, distVersioned, { force: true, recursive: true });
+  await fs.rmdir(prebuildVersioned, { recursive: true });
 }
 
-const buildApp = async() => {
-  const startedAt = new Date().toString();
+const startedAt = new Date().toString();
 
-  logger.info('Build started at', startedAt);
+logger.info('Build started at', startedAt);
 
-  if (buildMode) {
-    logger.info('buildMode: ', buildMode);
-  }
+if (buildMode) {
+  logger.info('buildMode: ', buildMode);
+}
 
-  const frameworks = getFrameworks();
+const frameworks = getFrameworks();
 
-  await cleanUp();
+await cleanUp();
 
-  // eslint-disable-next-line no-restricted-syntax
-  for (const framework of frameworks) {
-    // eslint-disable-next-line no-await-in-loop
-    await buildVersion(getThisDocsVersion(), framework);
-    // eslint-disable-next-line no-await-in-loop
-    await concatenate(getThisDocsVersion(), framework);
-  }
+// eslint-disable-next-line no-restricted-syntax
+for (const framework of frameworks) {
+  // eslint-disable-next-line no-await-in-loop
+  await buildVersion(getThisDocsVersion(), framework);
+  // eslint-disable-next-line no-await-in-loop
+  await concatenate(getThisDocsVersion(), framework);
+}
 
-  logger.success('Build finished at', new Date().toString());
-};
-
-buildApp();
+logger.success('Build finished at', new Date().toString());


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR simplifies and unifies the Docs build process for the watch, staging and production build. From now on, all the permalinks and URLs for static assets are generated in all environments in the same way.

Previously the assets depends on the env were generated as `/docs/[docs-version]/react-data-grid/img/foo.jpg` or `/docs/[docs-version]/img/foo.jpg`. After the changes the assets are always fetched from the root directory of the specific Docs version. So for "latest" (no matter what framework is choose) it will be `/docs/img/foo.jpg` and for older Docs versions `/docs/[docs-version]/img/foo.jpg`.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested most of the links in the main menu, sidemenu. I checked how the URL assets are generated using the watch env `npm run docs:start` and build mode `npm run docs:build` (with `http-server -c-1 .vuepress/dist`). 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. fixes #9756

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
