### PR TITLE
Add support for title and description for multi-frameworked content

### DIFF
--- a/docs/.vuepress/plugins/extend-page-data/index.js
+++ b/docs/.vuepress/plugins/extend-page-data/index.js
@@ -46,10 +46,13 @@ module.exports = (options, context) => {
      * @param {object} $page The $page value of the page you’re currently reading.
      */
     extendPageData($page) {
-      $page.normalizedPath = getNormalizedPath($page.path);
+      const normalizedPath = getNormalizedPath($page.path);
+      const currentFramework = parseFramework(normalizedPath);
+
+      $page.normalizedPath = normalizedPath;
       $page.baseUrl = getDocsBaseUrl();
       $page.currentVersion = getThisDocsVersion();
-      $page.currentFramework = parseFramework($page.normalizedPath);
+      $page.currentFramework = currentFramework;
       $page.frameworkName = getPrettyFrameworkName($page.currentFramework);
       $page.defaultFramework = getDefaultFramework();
       $page.frameworkSuffix = FRAMEWORK_SUFFIX;
@@ -57,6 +60,14 @@ module.exports = (options, context) => {
       $page.buildMode = buildMode;
       $page.isSearchable = notSearchableLinks[$page.currentFramework]?.every(
         notSearchableLink => $page.normalizedPath.includes(notSearchableLink) === false);
+
+      const frontmatter = $page.frontmatter;
+
+      if (frontmatter[currentFramework]) {
+        for (const prop in frontmatter[currentFramework]) {
+          frontmatter[prop] = frontmatter[currentFramework][prop] ?? frontmatter[prop];
+        }
+      }
 
       const frameworkPath = $page.currentFramework + FRAMEWORK_SUFFIX;
 

--- a/docs/.vuepress/plugins/extend-page-data/index.js
+++ b/docs/.vuepress/plugins/extend-page-data/index.js
@@ -64,9 +64,9 @@ module.exports = (options, context) => {
       const frontmatter = $page.frontmatter;
 
       if (frontmatter[currentFramework]) {
-        for (const prop in frontmatter[currentFramework]) {
-          frontmatter[prop] = frontmatter[currentFramework][prop] ?? frontmatter[prop];
-        }
+        Object.keys(frontmatter[currentFramework]).forEach((key) => {
+          frontmatter[key] = frontmatter[currentFramework][key] ?? frontmatter[key];
+        });
       }
 
       const frameworkPath = $page.currentFramework + FRAMEWORK_SUFFIX;

--- a/docs/README-EDITING.md
+++ b/docs/README-EDITING.md
@@ -23,9 +23,22 @@ Each Markdown file can start with the following frontmatter tags:
 | `canonicalUrl` | A canonical URL of the page's latest version. | None (not required)                                        |
 | `metaTitle`    | The page's SEO meta title.                    | None (not required)                                        |
 | `description`  | The page's SEO meta description.              | None (not required)                                        |
-| `tags`         | Tags used by the documentation search engine. | None (not required)                                        |
+| `tags`         | Search tags used by the documentation search engine. | None (not required)                                        |
+| `react`        | Holds an alternative set of frontmatter tags (applied only to the React version of the page) | None (not required)                                        |
 
-Each tag value can be overwritten. For multi-frameworked pages, there can be a case when the page title, description, or search tags should be different. To overwrite the values for specific framework, use the same tag names and define them under the framework key. The list of supported framework keys: `react`.
+You can set different frontmatter tags for different framework versions of the page. For example, you can set `metaTitle` to say either `JS data grid` or `React data table`, depending on the framework:
+
+\```yaml
+// applies to the JS version of the page
+metaTitle: JS data grid
+
+// applies to the React version of the page
+react:
+  metaTitle: React data table
+\```
+
+You can use the following framework keys:
+- `react`
 
 Frontmatter example:
 

--- a/docs/README-EDITING.md
+++ b/docs/README-EDITING.md
@@ -22,15 +22,24 @@ Each Markdown file can start with the following frontmatter tags:
 | `permalink`    | The page's **unique** URL.                    | If not set, gets generated from the Markdown file name.    |
 | `canonicalUrl` | A canonical URL of the page's latest version. | None (not required)                                        |
 | `metaTitle`    | The page's SEO meta title.                    | None (not required)                                        |
+| `description`  | The page's SEO meta description.              | None (not required)                                        |
 | `tags`         | Tags used by the documentation search engine. | None (not required)                                        |
+
+Each tag value can be overwritten. For multi-frameworked pages, there can be a case when the page title, description, or search tags should be different. To overwrite the values for specific framework, use the same tag names and define them under the framework key. The list of supported framework keys: `react`.
 
 Frontmatter example:
 
-```
+```yaml
 ---
 title: Introduction
+metaTitle: Installation - Guide - Handsontable Documentation for Javascript
+description: Easily install the data grid using your preferred package manager or import Handsontable assets directly from the CDN.
 permalink: /api/
 canonicalUrl: /api/
+react:
+  metaTitle: Installation - Guide - Handsontable Documentation for React
+  description: Install the wrapper for React via npm, import stylesheets, and use it to get up and running your application.
+  customValue: Custom # Custom value that can be used within template and will be available only for React framework
 ---
 ```
 

--- a/docs/content/guides/getting-started/installation.md
+++ b/docs/content/guides/getting-started/installation.md
@@ -1,6 +1,10 @@
 ---
 title: Installation
 metaTitle: Installation - Guide - Handsontable Documentation
+description: Easily install the data grid using your preferred package manager or import Handsontable assets directly from the CDN.
+react:
+  metaTitle: Installation - Guide - Handsontable Documentation for React
+  description: Install the wrapper for React via npm, import stylesheets, and use it to get up and running your application.
 permalink: /installation
 canonicalUrl: /installation
 tags:


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adds support for dynamically selecting page titles and description contents based on the chosen framework. The PR adds an example to the Installation page.

The usage example:
```yaml
title: Installation
metaTitle: Javascript - Installation - Guide - Handsontable Documentation
description: This is how you can install Handsontable for JavaScript
react:
  metaTitle: React - Installation - Guide - Handsontable Documentation
  description: This is how you can install Handsontable for React
angular:
  metaTitle: Angular - Installation - Guide - Handsontable Documentation
  description: This is how you can install Handsontable for Angular
vue:
  metaTitle: Vue - Installation - Guide - Handsontable Documentation
  description: This is how you can install Handsontable for Vue
vue3:
  metaTitle: Vue3 - Installation - Guide - Handsontable Documentation
  description: This is how you can install Handsontable for Vue3
```

The PR implements only the logic to the engine. The page titles and descriptions will be applied in the separate issue/es.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the Docs using the `npm run docs:start` command.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. fixes #9780

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
