### PR TITLE
React Docs: Bypass the Vuepress' ID-duplication prevention mechanism.

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -75,6 +75,19 @@ module.exports = {
       includeLevel: [2, 3],
       containerHeaderHtml: '<div class="toc-container-header">Table of contents</div>'
     },
+    anchor: {
+      callback: function(token, slugInfo) {
+        if (['h1', 'h2', 'h3'].includes(token.tag)) {
+          // Remove the `-[number]` suffix from the slugs and header IDs
+          const duplicatedSlugsMatch = /(.*)-(\d)+$/.exec(token.attrs[0][1]);
+
+          if (duplicatedSlugsMatch) {
+            token.attrs[0][1] = duplicatedSlugsMatch[1];
+            slugInfo.slug = duplicatedSlugsMatch[1];
+          }
+        }
+      }
+    },
     externalLinks: {
       target: '_blank',
       rel: 'nofollow noopener noreferrer'

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -76,7 +76,7 @@ module.exports = {
       containerHeaderHtml: '<div class="toc-container-header">Table of contents</div>'
     },
     anchor: {
-      callback: function(token, slugInfo) {
+      callback(token, slugInfo) {
         if (['h1', 'h2', 'h3'].includes(token.tag)) {
           // Remove the `-[number]` suffix from the slugs and header IDs
           const duplicatedSlugsMatch = /(.*)-(\d)+$/.exec(token.attrs[0][1]);


### PR DESCRIPTION
### Context
This PR bypasses the Vuepress' mechanism preventing the creation of DOM elements with duplicated `id`-s.

### How has this been tested?
Tested mostly on `javascript` and `react` versions of `/docs/next/react-data-grid/cell-renderer/`, where the `::: only-for` containers make the problem visible.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #9750 

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]