### PR TITLE
Docs: Revert Stylus "versionedUrl" helper function

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -92,7 +92,7 @@ module.exports = {
   stylus: {
     preferPathResolver: 'webpack',
     define: {
-      versionedUrl: (expression) => {
+      url: (expression) => {
         return new stylusNodes
           .Literal(`url("${expression.string.replace('{{$basePath}}', base.replace(/\/$/, ''))}")`);
       },

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const stylusNodes = require('stylus/lib/nodes');
 const highlight = require('./highlight');
 const examples = require('./containers/examples');
 const sourceCodeLink = require('./containers/sourceCodeLink');
@@ -86,6 +87,15 @@ module.exports = {
   configureWebpack: {
     resolve: {
       symlinks: false,
+    }
+  },
+  stylus: {
+    preferPathResolver: 'webpack',
+    define: {
+      versionedUrl: (expression) => {
+        return new stylusNodes
+          .Literal(`url("${expression.string.replace('{{$basePath}}', base.replace(/\/$/, ''))}")`);
+      },
     }
   },
   plugins: [

--- a/docs/.vuepress/theme/components/SearchBox.vue
+++ b/docs/.vuepress/theme/components/SearchBox.vue
@@ -368,7 +368,7 @@ export default {
     padding 0 0.5rem 0 2rem
     outline none
     /* Fallback for IE, should work in production */
-    background #fff var(--search-icon-url) 0.6rem 0.5rem no-repeat
+    background #fff versionedUrl('{{$basePath}}/img/search.svg') 0.6rem 0.5rem no-repeat
     background-size 1rem
     &:focus
       color #104bcd

--- a/docs/.vuepress/theme/components/SearchBox.vue
+++ b/docs/.vuepress/theme/components/SearchBox.vue
@@ -368,7 +368,7 @@ export default {
     padding 0 0.5rem 0 2rem
     outline none
     /* Fallback for IE, should work in production */
-    background #fff versionedUrl('{{$basePath}}/img/search.svg') 0.6rem 0.5rem no-repeat
+    background #fff url('{{$basePath}}/img/search.svg') 0.6rem 0.5rem no-repeat
     background-size 1rem
     &:focus
       color #104bcd

--- a/docs/.vuepress/theme/components/SearchBox.vue
+++ b/docs/.vuepress/theme/components/SearchBox.vue
@@ -6,7 +6,6 @@
       :value="query"
       :class="{ 'focused': focused }"
       :placeholder="placeholder"
-      :style="inputCustomCssProps"
       autocomplete="off"
       spellcheck="false"
       @input="query = $event.target.value"
@@ -130,9 +129,6 @@ export default {
       focused: false,
       focusIndex: 0,
       placeholder: undefined,
-      inputCustomCssProps: {
-        '--search-icon-url': `url('${this.$router.options.base}/img/search.svg')`,
-      }
     };
   },
 

--- a/docs/.vuepress/theme/components/ThemeSwitcher.vue
+++ b/docs/.vuepress/theme/components/ThemeSwitcher.vue
@@ -2,7 +2,7 @@
   <label id="switch" class="switch">
     <div class="inner">
       <input type="checkbox" v-on:change="toggleTheme" id="slider" :checked="isDarkTheme">
-      <span :style="sliderCustomCssProps" class="slider round"></span>
+      <span class="slider round"></span>
     </div>
   </label>
 </template>
@@ -39,10 +39,6 @@ export default {
     return {
       isDarkTheme: null,
       htmlDomEl: null,
-      sliderCustomCssProps: {
-        '--light-icon-url': `url('${this.$router.options.base}/img/light-theme-icon.svg')`,
-        '--dark-icon-url': `url('${this.$router.options.base}/img/dark-theme-icon.svg')`
-      }
     };
   },
   beforeMount() {
@@ -147,7 +143,7 @@ export default {
   transition: 0.4s;
   box-shadow: 0 0px 3px #2020203d;
   /* Fallback for IE, should work in production */
-  background: #ffffff var(--light-icon-url);
+  background: #ffffff versionedUrl('{{$basePath}}/img/light-theme-icon.svg');
   background-size: 70%;
   background-repeat: no-repeat;
   background-position: center;
@@ -166,7 +162,7 @@ input:checked + .slider:before {
   -ms-transform: translateX(16px);
   transform: translateX(16px);
   /* Fallback for IE, should work in production */
-  background: #ffffff var(--dark-icon-url);
+  background: #ffffff versionedUrl('{{$basePath}}/img/dark-theme-icon.svg');
   background-size: 70%;
   background-repeat: no-repeat;
   background-position: center;

--- a/docs/.vuepress/theme/components/ThemeSwitcher.vue
+++ b/docs/.vuepress/theme/components/ThemeSwitcher.vue
@@ -143,7 +143,7 @@ export default {
   transition: 0.4s;
   box-shadow: 0 0px 3px #2020203d;
   /* Fallback for IE, should work in production */
-  background: #ffffff versionedUrl('{{$basePath}}/img/light-theme-icon.svg');
+  background: #ffffff url('{{$basePath}}/img/light-theme-icon.svg');
   background-size: 70%;
   background-repeat: no-repeat;
   background-position: center;
@@ -162,7 +162,7 @@ input:checked + .slider:before {
   -ms-transform: translateX(16px);
   transform: translateX(16px);
   /* Fallback for IE, should work in production */
-  background: #ffffff versionedUrl('{{$basePath}}/img/dark-theme-icon.svg');
+  background: #ffffff url('{{$basePath}}/img/dark-theme-icon.svg');
   background-size: 70%;
   background-repeat: no-repeat;
   background-position: center;

--- a/docs/.vuepress/theme/styles/theme-dark.styl
+++ b/docs/.vuepress/theme/styles/theme-dark.styl
@@ -50,7 +50,7 @@ html.theme-dark {
   /* Searchbox */
   .search-box.search-box {
     input {
-      background $searchBoxBackground versionedUrl('/docs/{docsVersion}/img/search.svg') 0.6rem 0.5rem no-repeat
+      background $searchBoxBackground versionedUrl('{{$basePath}}/img/search.svg') 0.6rem 0.5rem no-repeat
       background-size 1rem
       border-color $searchBoxInputBorderColor
       color $fontColor

--- a/docs/.vuepress/theme/styles/theme-dark.styl
+++ b/docs/.vuepress/theme/styles/theme-dark.styl
@@ -50,7 +50,7 @@ html.theme-dark {
   /* Searchbox */
   .search-box.search-box {
     input {
-      background $searchBoxBackground versionedUrl('{{$basePath}}/img/search.svg') 0.6rem 0.5rem no-repeat
+      background $searchBoxBackground url('{{$basePath}}/img/search.svg') 0.6rem 0.5rem no-repeat
       background-size 1rem
       border-color $searchBoxInputBorderColor
       color $fontColor


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR reverts Stylus "versionedUrl" background helper function and renames it to "url". The function ensures that uses assets always point to the static directory for the currently viewed Docs version. 

For example, the expression `background: url('{{$basePath}}/img/search.svg')` for Docs 11.0 will be transformed to `background: url('/docs/11.0/img/search.svg')` and for the latest Docs version `background: url('/docs/img/search.svg')`.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes #9781

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
