### PR TITLE
Docs: Edit the Tools and building section

### DIFF
--- a/docs/content/guides/tools-and-building/custom-builds.md
+++ b/docs/content/guides/tools-and-building/custom-builds.md
@@ -23,13 +23,13 @@ Get an overview of Handsontable's building processes.
 
 The Handsontable repository is a monorepo that contains the following projects:
 
-| Project                 | Location            | Description                                                                |
-| ----------------------- | ------------------- | -------------------------------------------------------------------------- |
-| `handsontable`          | `/handsontable`     | Main Handsontable project                                                  |
-| `@handsontable/angular` | `/wrappers/angular` | [Angular wrapper](@/guides/integrate-with-angular/angular-installation.md) |
-| `@handsontable/react`   | `/wrappers/react`   | [React wrapper](../../react-data-grid)                                     |
-| `@handsontable/vue`     | `/wrappers/vue`     | [Vue 2 wrapper](@/guides/integrate-with-vue/vue-installation.md)           |
-| `@handsontable/vue3`    | `/wrappers/vue3`    | [Vue 3 wrapper](@/guides/integrate-with-vue3/vue3-installation.md)         |
+| Project                 | Location            | Description                                                        |
+| ----------------------- | ------------------- | ------------------------------------------------------------------ |
+| `handsontable`          | `/handsontable`     | Main Handsontable project                                          |
+| `@handsontable/react`   | `/wrappers/react`   | [React wrapper](../../react-data-grid)                             |
+| `@handsontable/angular` | `/wrappers/angular` | [Angular wrapper](../../javascript-data-grid/angular-installation) |
+| `@handsontable/vue`     | `/wrappers/vue`     | [Vue 2 wrapper](../../javascript-data-grid/vue-simple-example)     |
+| `@handsontable/vue3`    | `/wrappers/vue3`    | [Vue 3 wrapper](../../javascript-data-grid/vue3-installation)      |
 
 All the projects are released together, under the same version number.
 But each project has its own [building](#building-processes) and [testing](@/guides/tools-and-building/testing.md) processes.
@@ -67,8 +67,8 @@ Each Handsontable [project](#about-building) has its own building processes defi
 | -------------------------------- | --------------------------------------------------- |
 | `/package.json`                  | - All the packages at once<br>- Individual packages |
 | `/handsontable/package.json`     | The JavaScript package                              |
-| `/wrappers/angular/package.json` | The Angular package                                 |
 | `/wrappers/react/package.json`   | The React package                                   |
+| `/wrappers/angular/package.json` | The Angular package                                 |
 | `/wrappers/vue/package.json`     | The Vue 2 package                                   |
 | `/wrappers/vue3/package.json`    | The Vue 3 package                                   |
 
@@ -92,8 +92,8 @@ To build all the packages at once:
 2. Go to the root directory.
 3. Run `npm run build`.<br>The script builds the following packages:
      - The JavaScript package
-     - The Angular package
      - The React package
+     - The Angular package
      - The Vue 2 package
      - The Vue 3 package
      - A code examples package
@@ -153,28 +153,6 @@ From the `/handsontable` directory, you can also run individual JavaScript `buil
      - `/handsontable/dist/languages/all.min.js`
 :::
 
-### Building the Angular package
-
-To build the Angular package:
-1. Make sure you meet the [building requirements](#building-requirements).
-3. Go to `/wrappers/angular`.
-4. Run `npm run build`.<br>Only the Angular package builds.
-
-To build the Angular package from the root directory:
-1. Make sure you meet the [building requirements](#building-requirements).
-2. Go to the root directory.
-3. Run `npm run in angular build`.<br>Only the Angular package builds.
-
-#### Angular build tasks
-
-From the `/wrappers/angular` directory, You can also run individual Angular `build` tasks:
-
-::: details Angular build tasks
-`npm run build`
-  - Builds the `@handsontable/angular` package for multiple module systems.
-  - Places the output in the `/wrappers/angular/dist/hot-table/` directory.
-:::
-
 ### Building the React package
 
 To build the React package:
@@ -211,6 +189,31 @@ From the `/wrappers/react` directory, you can also run individual React `build` 
     - `/wrappers/react/dist/react-handsontable.min.js.map`
 :::
 
+::: only-for javascript
+### Building the Angular package
+
+To build the Angular package:
+1. Make sure you meet the [building requirements](#building-requirements).
+3. Go to `/wrappers/angular`.
+4. Run `npm run build`.<br>Only the Angular package builds.
+
+To build the Angular package from the root directory:
+1. Make sure you meet the [building requirements](#building-requirements).
+2. Go to the root directory.
+3. Run `npm run in angular build`.<br>Only the Angular package builds.
+
+#### Angular build tasks
+
+From the `/wrappers/angular` directory, You can also run individual Angular `build` tasks:
+
+::: details Angular build tasks
+`npm run build`
+  - Builds the `@handsontable/angular` package for multiple module systems.
+  - Places the output in the `/wrappers/angular/dist/hot-table/` directory.
+:::
+:::
+
+::: only-for javascript
 ### Building the Vue 2 package
 
 To build the Vue 2 package:
@@ -246,7 +249,9 @@ From the `/wrappers/vue` directory, you can also run individual Vue 2 `build` ta
     - `/wrappers/vue/dist/vue-handsontable.min.js`
     - `/wrappers/vue/dist/vue-handsontable.min.js.map`
 :::
+:::
 
+::: only-for javascript
 ### Building the Vue 3 package
 
 To build the Vue 3 package:
@@ -281,6 +286,7 @@ From the `/wrappers/vue3` directory, you can also run individual Vue 3 `build` t
   - Creates the minified bundles:
     - `/wrappers/vue3/dist/vue-handsontable.min.js`
     - `/wrappers/vue3/dist/vue-handsontable.min.js.map`
+:::
 :::
 
 ## Related guides

--- a/docs/content/guides/tools-and-building/custom-plugins.md
+++ b/docs/content/guides/tools-and-building/custom-plugins.md
@@ -13,11 +13,15 @@ tags:
 
 [[toc]]
 
+Create a custom plugin that extends Handsontable's built-in functionalities.
+
 ## Overview
 
 Plugins are a great way of extending Handsontable's capabilities. In fact, most Handsontable features are provided by plugins.
 
-This guide shows you how to create a custom plugin.
+::: only-for react
+You can create a custom plugin in JavaScript, and then reference it from within your React app.
+:::
 
 ### 1. Prerequisites
 

--- a/docs/content/guides/tools-and-building/custom-plugins.md
+++ b/docs/content/guides/tools-and-building/custom-plugins.md
@@ -38,7 +38,6 @@ The [`BasePlugin`](@/api/basePlugin.md) interface takes care of:
 * Memory leak prevention
 * Properly binding your plugin's instance to Handsontable
 
-
 ```js
 export class CustomPlugin extends BasePlugin {
  /**
@@ -252,6 +251,7 @@ There are two ways to register a plugin:
 ### 4. Use your plugin in Handsontable
 To control the plugin's options, pass a boolean or an object at the plugin's initialization:
 
+::: only-for javascript
 ```js
 import Handsontable from 'handsontable';
 import { CustomPlugin } from './customPlugin';
@@ -267,15 +267,50 @@ const hotInstance = new Handsontable(container, {
   [CustomPlugin.PLUGIN_KEY]: false,
 });
 ```
+:::
+
+::: only-for react
+```jsx
+import Handsontable from 'handsontable';
+import { CustomPlugin } from './customPlugin';
+
+<HotTable
+  // Pass `true` to enable the plugin with default options.
+  [CustomPlugin.PLUGIN_KEY]={true}
+  // You can also enable the plugin by passing an object with options.
+  [CustomPlugin.PLUGIN_KEY]={{
+    msg: 'user-defined message',
+  }}
+  // You can also initialize the plugin without enabling it at the beginning.
+  [CustomPlugin.PLUGIN_KEY]={false}
+/>
+```
+:::
 
 ### 5. Get a reference to the plugin's instance
 To use the plugin's API, call the [`getPlugin`](@/api/core.md#getplugin) method to get a reference to the plugin's instance.
 
+::: only-for javascript
 ```js
 const pluginInstance = hotInstance.getPlugin(CustomPlugin.PLUGIN_KEY);
 
 pluginInstance.externalMethodExample();
 ```
+:::
+
+::: only-for react
+::: tip
+To use the Handsontable API, create a reference to the `HotTable` component, and read its `hotInstance` property.
+
+For more information, see the [`Instance Methods`](@/guides/getting-started/react-methods.md) page.
+:::
+
+```jsx
+const hotTableComponent = useRef(null);
+
+const pluginInstance = hotTableComponent.current.hotInstance.getPlugin(CustomPlugin.PLUGIN_KEY);
+```
+:::
 
 ## Related API reference
 

--- a/docs/content/guides/tools-and-building/custom-plugins.md
+++ b/docs/content/guides/tools-and-building/custom-plugins.md
@@ -280,13 +280,13 @@ import { CustomPlugin } from './customPlugin';
 
 <HotTable
   // Pass `true` to enable the plugin with default options.
-  [CustomPlugin.PLUGIN_KEY]={true}
+  customPlugin={true}
   // You can also enable the plugin by passing an object with options.
-  [CustomPlugin.PLUGIN_KEY]={{
+  customPlugin={{
     msg: 'user-defined message',
   }}
   // You can also initialize the plugin without enabling it at the beginning.
-  [CustomPlugin.PLUGIN_KEY]={false}
+  customPlugin={false}
 />
 ```
 :::

--- a/docs/content/guides/tools-and-building/modules.md
+++ b/docs/content/guides/tools-and-building/modules.md
@@ -147,6 +147,7 @@ For the full list of those modules, see the [List of all modules](#list-of-all-m
 
 For example, you can import the `numeric` cell type as a whole:
 
+::: only-for javascript
 ```js
 import Handsontable from 'handsontable/base';
 import {
@@ -166,9 +167,33 @@ new Handsontable(container, {
   ]
 });
 ```
+:::
+
+::: only-for react
+```jsx
+import Handsontable from 'handsontable/base';
+import {
+  registerCellType,
+  NumericCellType,
+} from 'handsontable/cellTypes';
+
+registerCellType(NumericCellType);
+
+const container = document.querySelector('#example1');
+
+<HotTable
+  columns={[
+    {
+    type: 'numeric'
+    }
+  ]}
+/>
+```
+:::
 
 Or, you can import the `numeric` cell type's renderer, editor, and validator individually (the effect is the same as above):
 
+::: only-for javascript
 ```js
 import Handsontable from 'handsontable/base';
 import {
@@ -188,8 +213,6 @@ registerRenderer(numericRenderer);
 registerEditor(NumericEditor);
 registerValidator(numericValidator);
 
-const container = document.querySelector('#example1');
-
 new Handsontable(container, {
   columns: [
     {
@@ -197,10 +220,47 @@ new Handsontable(container, {
       editor: 'numeric',
       validator: 'numeric',
       dataType: 'number',
+      type: 'numeric',
     }
   ]
 });
 ```
+:::
+
+::: only-for react
+```jsx
+import Handsontable from 'handsontable/base';
+import {
+  registerRenderer,
+  numericRenderer,
+} from 'handsontable/renderers';
+import {
+  registerEditor,
+  NumericEditor,
+} from 'handsontable/editors';
+import {
+  registerValidator,
+  numericValidator,
+} from 'handsontable/validators';
+
+registerRenderer(numericRenderer);
+registerEditor(NumericEditor);
+registerValidator(numericValidator);
+
+<HotTable
+  columns={[
+    {
+      renderer: 'numeric',
+      editor: 'numeric',
+      validator: 'numeric',
+      dataType: 'number',
+      type: 'numeric',
+    }
+  ]}
+/>
+
+```
+:::
 
 ### Plugin modules
 

--- a/docs/content/guides/tools-and-building/modules.md
+++ b/docs/content/guides/tools-and-building/modules.md
@@ -184,7 +184,7 @@ const container = document.querySelector('#example1');
 <HotTable
   columns={[
     {
-    type: 'numeric'
+      type: 'numeric'
     }
   ]}
 />


### PR DESCRIPTION
This PR edits the **Tools and building** section in line with the #9737 guidelines.

Updated pages:
- http://localhost:8080/docs/next/react-data-grid/modules/
- http://localhost:8080/docs/next/react-data-grid/custom-plugins
- http://localhost:8080/docs/next/react-data-grid/custom-builds/

IMO the following pages don't require any updates (React-wise), it's worth double-checking, though:
- http://localhost:8080/docs/next/react-data-grid/packages
- http://localhost:8080/docs/next/react-data-grid/testing
- http://localhost:8080/docs/next/react-data-grid/folder-structure/

[skip changelog]