### PR TITLE
Adds support for describing API docs individually

### DIFF
--- a/docs/.vuepress/tools/jsdoc-convert/configuration.mjs
+++ b/docs/.vuepress/tools/jsdoc-convert/configuration.mjs
@@ -3,25 +3,21 @@ export default {
   pathToDist: '../../../content/api',
   urlPrefix: '/api/',
   seo: {
-    'dataMap/metaManager/metaSchema.js': {
+    'Options.md': {
       title: 'Options',
-      metaTitle: 'Options - API Reference - Handsontable Documentation',
-      permalink: '/api/options'
+      metaTitle: 'Options - API Reference - Handsontable Documentation for Javascript',
+      description: 'Configure your Handsontable instance using the "Configuration Options" object. You can also use it to implement custom functions.',
+      react: {
+        metaTitle: 'Options - API Reference - Handsontable Documentation for React',
+      },
     },
-    'pluginHooks.js': {
+    'Hooks.md': {
       title: 'Hooks',
       metaTitle: 'Hooks - API Reference - Handsontable Documentation',
-      permalink: '/api/hooks'
     },
-    'core.js': {
+    'Core.md': {
       title: 'Core',
       metaTitle: 'Core - API Reference - Handsontable Documentation',
-      permalink: '/api/core'
     },
-    '3rdparty/walkontable/src/cell/coords.js': {
-      title: 'CellCoords',
-      metaTitle: 'CellCoords - API Reference - Handsontable Documentation',
-      permalink: '/api/coords'
-    }
   }
 };

--- a/docs/.vuepress/tools/jsdoc-convert/renderer/seo.mjs
+++ b/docs/.vuepress/tools/jsdoc-convert/renderer/seo.mjs
@@ -4,35 +4,43 @@ export const buildHeaderWriter = ({ seo, urlPrefix }) => {
   const genSeoTitle = file => escape(
     file.replace(/(^.*\/)?(.*?)\.[.a-zA-Z]*$/, '$2') // Get first filename segment (to the first dot) without full path
   ).replace(/(^[a-z])/, m => m.toUpperCase()); // To upper first letter
-  const seoTitle = file => seo[file] && seo[file].title || genSeoTitle(file);
 
   const genSeoMetaTitle = (file, isPlugin) => {
-    return `${seoTitle(file)} - ${isPlugin ? 'Plugin' : 'API Reference'} - Handsontable Documentation`;
+    return `${genSeoTitle(file)} - ${isPlugin ? 'Plugin' : 'API Reference'} - Handsontable Documentation`;
   };
-  const seoMetaTitle = (file, isPlugin) => seo[file] && seo[file].metaTitle || genSeoMetaTitle(file, isPlugin);
 
-  const genSeoPermalink = file => escape(file
+  const genSeoPermalink = file => urlPrefix + escape(file
     .replace(/(^.*\/)?(.*)\.[a-zA-Z]*$/, '$2') // Get filename without full path and extension
   )
     .replace(/([a-z])([A-Z]+)/g, '$1-$2') // Separate words
     .toLowerCase();
-  const seoPermalink = file => seo[file] && seo[file].permalink || urlPrefix + genSeoPermalink(file);
 
-  const seoCanonicalUrl = file => seoPermalink(file).replace('/next', '');
+  // Simple converter from JS object to YAML
+  const toYaml = (meta, indent = 0) => {
+    return Object.keys(meta).map((key) => {
+      if (typeof meta[key] === 'object') {
+        return `${key}:\n${toYaml(meta[key], indent + 2)}`;
+      }
+
+      return `${' '.repeat(indent)}${key}: ${meta[key]}`;
+    }).join('\n');
+  };
 
   return (file, isPlugin) => {
-    const title = seoTitle(file, isPlugin);
+    const pageMeta = Object.assign({
+      title: genSeoTitle(file),
+      metaTitle: genSeoMetaTitle(file, isPlugin),
+      permalink: genSeoPermalink(file),
+      canonicalUrl: genSeoPermalink(file),
+      hotPlugin: isPlugin,
+      editLink: false,
+    }, seo[file] || {});
 
     return `---
-title: ${title}
-metaTitle: ${seoMetaTitle(file, isPlugin)}
-permalink: ${seoPermalink(file)}
-canonicalUrl: ${seoCanonicalUrl(file)}
-hotPlugin: ${isPlugin ? 'true' : 'false'}
-editLink: false
+${toYaml(pageMeta)}
 ---
 
-# ${title}
+# ${pageMeta.title}
 
 [[toc]]
 `;


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR is a continuation of #9782 and adds support for describing generated API references individually for each framework.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. fixes #9780 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
