### PR TITLE
Added `nestedRows` tag to the page

### DIFF
--- a/docs/content/guides/rows/row-parent-child.md
+++ b/docs/content/guides/rows/row-parent-child.md
@@ -5,6 +5,7 @@ permalink: /row-parent-child
 canonicalUrl: /row-parent-child
 tags:
   - nested rows
+  - nestedRows
   - parent child
   - tree grid
   - grouping rows


### PR DESCRIPTION
It's more probable that one would type `nestedRows` than `nested rows` as `nestedRows` is the option's name. I found myself also doing the same thing.

Page: https://handsontable.com/docs/row-parent-child/#overview

[skip changelog]
