### PR TITLE
Add entry to the GH Action that triggers Docs image deployment

### DIFF
--- a/.github/workflows/docs-production.yml
+++ b/.github/workflows/docs-production.yml
@@ -48,3 +48,11 @@ jobs:
       - name: Docker push SHA tagged into GHCR
         run: |
           docker push $GHA_DOCKER_TAG":v${{steps.get-docs-version.outputs.result}}-${{ github.sha }}"
+      - name: Deploy the Docs image
+        uses: satak/webrequest-action@6127ff14e9269df0d49bcaec84f948dc8b50df1f # v1.2.4
+        with:
+          url: 'https://docs.handsontable.com/api/deploy'
+          method: POST
+          username: ${{secrets.DOCS_DEPLOYMENT_USER}}
+          password: ${{secrets.DOCS_DEPLOYMENT_PASSWORD}}
+          payload: '{"token": "${{secrets.DOCS_DEPLOYMENT_TOKEN}}","docsVersion": "${{steps.get-docs-version.outputs.result}}"}'


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR implements the mechanism that deploys the Docs image to production automatically for Major or Minor versions. Previously the new Docs version had to be deployed manually. Within that changes after the Docker image is built and published, the GH workflow triggers (by calling an internal Docs Deplyment API) the deployment on the server.

I've tested the changes by [deploying Docs v9.0](https://github.com/handsontable/handsontable/runs/7915317965?check_suite_focus=true#step:11:12) and comparing the logs on the server, it seems to work.

[skip changelog]

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
