### PR TITLE
Change the redirection rule for "/react-setting-up-a-locale/"

### DIFF
--- a/docs/docker/redirects.conf
+++ b/docs/docker/redirects.conf
@@ -48,7 +48,7 @@ rewrite ^/docs/((\d+\.\d+|next)/)?react-simple-examples?/?$ /docs/$1react-data-g
 rewrite ^/docs/((\d+\.\d+|next)/)?react-modules/?$ /docs/$1react-data-grid/modules/ permanent;
 rewrite ^/docs/((\d+\.\d+|next)/)?react-hot-column/?$ /docs/$1react-data-grid/hot-column/ permanent;
 rewrite ^/docs/((\d+\.\d+|next)/)?react-setting-up-a-language/?$ /docs/$1react-data-grid/language/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?react-setting-up-a-locale/?$ /docs/$1react-data-grid/language/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?react-setting-up-a-locale/?$ /docs/$1react-data-grid/numeric-cell-type/ permanent;
 rewrite ^/docs/((\d+\.\d+|next)/)?react-custom-context-menu-example/?$ /docs/$1react-data-grid/context-menu/ permanent;
 rewrite ^/docs/((\d+\.\d+|next)/)?react-custom-editor-example/?$ /docs/$1react-data-grid/cell-editor/ permanent;
 rewrite ^/docs/((\d+\.\d+|next)/)?react-custom-renderer-example/?$ /docs/$1react-data-grid/cell-renderer/ permanent;
@@ -60,7 +60,7 @@ rewrite ^/docs/((\d+\.\d+|next)/)?react-hot-reference/?$ /docs/$1react-data-grid
 rewrite ^/docs/((\d+\.\d+|next)/)?frameworks-wrapper-for-react-installation/?$ /docs/$1react-data-grid/installation/ permanent;
 rewrite ^/docs/((\d+\.\d+|next)/)?frameworks-wrapper-for-react-simple-examples/?$ /docs/$1react-data-grid/binding-to-data/ permanent;
 rewrite ^/docs/((\d+\.\d+|next)/)?frameworks-wrapper-for-react-hot-column/?$ /docs/$1react-data-grid/hot-column/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?frameworks-wrapper-for-react-setting-up-a-locale/?$ /docs/$1react-data-grid/language/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?frameworks-wrapper-for-react-setting-up-a-locale/?$ /docs/$1react-data-grid/numeric-cell-type/ permanent;
 rewrite ^/docs/((\d+\.\d+|next)/)?frameworks-wrapper-for-react-custom-context-menu-example/?$ /docs/$1react-data-grid/context-menu/ permanent;
 rewrite ^/docs/((\d+\.\d+|next)/)?frameworks-wrapper-for-react-custom-editor-example/?$ /docs/$1react-data-grid/cell-editor/ permanent;
 rewrite ^/docs/((\d+\.\d+|next)/)?frameworks-wrapper-for-react-custom-renderer-example/?$ /docs/$1react-data-grid/cell-renderer/ permanent;


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR changes the redirection rule for `/docs/react-setting-up-a-locale/` and redirects to `/docs/numeric-cell-type/`.

_[skip changelog]_

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes #9794
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
