### PR TITLE
Add support for jsfiddle examples for staging

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -10,6 +10,7 @@ const firstHeaderInjection = require('./plugins/markdown-it-header-injection');
 const conditionalContainer = require('./plugins/markdown-it-conditional-container');
 const {
   getDocsBaseUrl,
+  getDocsHostname,
   getThisDocsVersion,
   MULTI_FRAMEWORKED_CONTENT_DIR,
   createSymlinks,
@@ -58,7 +59,7 @@ module.exports = {
     }],
     ['link', {
       rel: 'preload',
-      href: isProduction ? `${getDocsBaseUrl()}/docs/data/common.json` : '/data/common.json',
+      href: `${getDocsBaseUrl()}/data/common.json`,
       as: 'fetch',
       crossorigin: ''
     }],
@@ -115,7 +116,7 @@ module.exports = {
     extendPageDataPlugin,
     'tabs',
     ['sitemap', {
-      hostname: getDocsBaseUrl(),
+      hostname: getDocsHostname(),
       exclude: ['/404.html']
     }],
     ['@vuepress/active-header-links', {

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -49,7 +49,7 @@ module.exports = {
   head: [
     ['link', {
       rel: 'icon',
-      href: `${getDocsBaseFullUrl()}/static/images/template/ModCommon/favicon-32x32.png`
+      href: 'https://handsontable.com/static/images/template/ModCommon/favicon-32x32.png'
     }],
     ['link', {
       rel: 'preload',

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -9,7 +9,8 @@ const extendPageDataPlugin = require('./plugins/extend-page-data');
 const firstHeaderInjection = require('./plugins/markdown-it-header-injection');
 const conditionalContainer = require('./plugins/markdown-it-conditional-container');
 const {
-  getDocsBaseUrl,
+  getDocsBaseFullUrl,
+  getDocsBase,
   getDocsHostname,
   getThisDocsVersion,
   MULTI_FRAMEWORKED_CONTENT_DIR,
@@ -17,7 +18,6 @@ const {
 } = require('./helpers');
 const dumpDocsDataPlugin = require('./plugins/dump-docs-data');
 
-const docsBase = process.env.DOCS_BASE ? process.env.DOCS_BASE : getThisDocsVersion();
 const buildMode = process.env.BUILD_MODE;
 const isProduction = buildMode === 'production';
 const environmentHead = isProduction ?
@@ -37,12 +37,6 @@ const environmentHead = isProduction ?
 // which are watched by the script. It's done before a compilation is starting.
 createSymlinks();
 
-let base = '/docs/';
-
-if (docsBase !== 'latest') {
-  base += `${docsBase}/`;
-}
-
 module.exports = {
   define: {
     GA_ID: 'UA-33932793-7',
@@ -51,15 +45,15 @@ module.exports = {
     `${MULTI_FRAMEWORKED_CONTENT_DIR}/**/*.md`,
   ],
   description: 'Handsontable',
-  base,
+  base: `${getDocsBase()}/`,
   head: [
     ['link', {
       rel: 'icon',
-      href: `${getDocsBaseUrl()}/static/images/template/ModCommon/favicon-32x32.png`
+      href: `${getDocsBaseFullUrl()}/static/images/template/ModCommon/favicon-32x32.png`
     }],
     ['link', {
       rel: 'preload',
-      href: `${getDocsBaseUrl()}/data/common.json`,
+      href: `${getDocsBaseFullUrl()}/data/common.json`,
       as: 'fetch',
       crossorigin: ''
     }],
@@ -108,7 +102,7 @@ module.exports = {
     define: {
       url: (expression) => {
         return new stylusNodes
-          .Literal(`url("${expression.string.replace('{{$basePath}}', base.replace(/\/$/, ''))}")`);
+          .Literal(`url("${expression.string.replace('{{$basePath}}', getDocsBase())}")`);
       },
     }
   },
@@ -123,7 +117,7 @@ module.exports = {
       sidebarLinkSelector: '.table-of-contents a',
       headerAnchorSelector: '.header-anchor'
     }],
-    ['container', examples(getThisDocsVersion(), base)],
+    ['container', examples(getThisDocsVersion(), getDocsBase())],
     ['container', sourceCodeLink],
     {
       extendMarkdown(md) {
@@ -136,7 +130,7 @@ module.exports = {
             token.attrs.forEach(([name, value], index) => {
               if (name === 'src') {
                 token.attrs[index][1] = (
-                  decodeURIComponent(value).replace('{{$basePath}}', base.replace(/\/$/, ''))
+                  decodeURIComponent(value).replace('{{$basePath}}', getDocsBase())
                 );
               }
             });
@@ -156,7 +150,7 @@ module.exports = {
             token.attrs.forEach(([name, value], index) => {
               if (name === 'href') {
                 token.attrs[index][1] = (
-                  decodeURIComponent(value).replace('{{$basePath}}', base.replace(/\/$/, ''))
+                  decodeURIComponent(value).replace('{{$basePath}}', getDocsBase())
                 );
               }
             });

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -102,7 +102,7 @@ module.exports = {
     define: {
       url: (expression) => {
         return new stylusNodes
-          .Literal(`url("${expression.string.replace('{{$basePath}}', getDocsBase())}")`);
+          .Literal(`url("${expression.string.replace('{{$basePath}}', getDocsBaseFullUrl())}")`);
       },
     }
   },
@@ -117,7 +117,7 @@ module.exports = {
       sidebarLinkSelector: '.table-of-contents a',
       headerAnchorSelector: '.header-anchor'
     }],
-    ['container', examples(getThisDocsVersion(), getDocsBase())],
+    ['container', examples(getThisDocsVersion(), getDocsBaseFullUrl())],
     ['container', sourceCodeLink],
     {
       extendMarkdown(md) {
@@ -130,7 +130,7 @@ module.exports = {
             token.attrs.forEach(([name, value], index) => {
               if (name === 'src') {
                 token.attrs[index][1] = (
-                  decodeURIComponent(value).replace('{{$basePath}}', getDocsBase())
+                  decodeURIComponent(value).replace('{{$basePath}}', getDocsBaseFullUrl())
                 );
               }
             });
@@ -150,7 +150,7 @@ module.exports = {
             token.attrs.forEach(([name, value], index) => {
               if (name === 'href') {
                 token.attrs[index][1] = (
-                  decodeURIComponent(value).replace('{{$basePath}}', getDocsBase())
+                  decodeURIComponent(value).replace('{{$basePath}}', getDocsBaseFullUrl())
                 );
               }
             });

--- a/docs/.vuepress/containers/examples/examples.js
+++ b/docs/.vuepress/containers/examples/examples.js
@@ -102,7 +102,7 @@ module.exports = function(docsVersion, base) {
         const jsIndex = index + Number.parseInt(jsPos, 10);
         const jsToken = tokens[jsIndex];
 
-        jsToken.content = jsToken.content.replaceAll('{{$basePath}}', base.replace(/\/$/, ''));
+        jsToken.content = jsToken.content.replaceAll('{{$basePath}}', base);
 
         const activeTab = args.match(/--tab (code|html|css|preview)/)?.[1] || 'code';
         const noEdit = !!args.match(/--no-edit/)?.[0];

--- a/docs/.vuepress/handsontable-manager/dependencies.js
+++ b/docs/.vuepress/handsontable-manager/dependencies.js
@@ -29,9 +29,9 @@ const getCommonScript = (scriptName, version) => {
   }
 
   // eslint-disable-next-line global-require
-  const { getDocsBaseUrl } = require('../helpers');
+  const { getDocsBaseFullUrl } = require('../helpers');
 
-  return [`${getDocsBaseUrl()}/${version}/scripts/${scriptName}.js`, ['require', 'exports']];
+  return [`${getDocsBaseFullUrl()}/scripts/${scriptName}.js`, ['require', 'exports']];
 };
 
 /**

--- a/docs/.vuepress/handsontable-manager/dependencies.js
+++ b/docs/.vuepress/handsontable-manager/dependencies.js
@@ -28,7 +28,10 @@ const getCommonScript = (scriptName, version) => {
     ];
   }
 
-  return [`https://handsontable.com/docs/${version}/scripts/${scriptName}.js`, ['require', 'exports']];
+  // eslint-disable-next-line global-require
+  const { getDocsBaseUrl } = require('../helpers');
+
+  return [`${getDocsBaseUrl()}/${version}/scripts/${scriptName}.js`, ['require', 'exports']];
 };
 
 /**

--- a/docs/.vuepress/helpers.js
+++ b/docs/.vuepress/helpers.js
@@ -185,11 +185,24 @@ function createSymlinks() {
 }
 
 /**
- * Gets docs base url (eq: https://handsontable.com).
+ * Gets docs base url (eq: https://handsontable.com/docs).
  *
  * @returns {string}
  */
 function getDocsBaseUrl() {
+  if (process.env.BUILD_MODE) {
+    return `${getDocsHostname()}/docs`;
+  }
+
+  return ''; // use relative URLs for local builds
+}
+
+/**
+ * Gets docs hostname (eq: https://handsontable.com).
+ *
+ * @returns {string}
+ */
+function getDocsHostname() {
   return `https://${process.env.BUILD_MODE === 'staging' ? 'dev.' : ''}handsontable.com`;
 }
 
@@ -206,4 +219,5 @@ module.exports = {
   createSymlinks,
   getThisDocsVersion,
   getDocsBaseUrl,
+  getDocsHostname,
 };

--- a/docs/.vuepress/helpers.js
+++ b/docs/.vuepress/helpers.js
@@ -185,16 +185,28 @@ function createSymlinks() {
 }
 
 /**
- * Gets docs base url (eq: https://handsontable.com/docs).
+ * Gets docs base path (eq: /docs/12.1).
  *
  * @returns {string}
  */
-function getDocsBaseUrl() {
-  if (process.env.BUILD_MODE) {
-    return `${getDocsHostname()}/docs`;
+function getDocsBase() {
+  const docsBase = process.env.DOCS_BASE ?? getThisDocsVersion();
+  let base = '/docs/';
+
+  if (docsBase !== 'latest') {
+    base += `${docsBase}/`;
   }
 
-  return ''; // use relative URLs for local builds
+  return base.replace(/\/$/, '');
+}
+
+/**
+ * Gets docs base full url with hostname (eq: https://handsontable.com/docs/12.1).
+ *
+ * @returns {string}
+ */
+function getDocsBaseFullUrl() {
+  return `${getDocsHostname()}${getDocsBase()}`;
 }
 
 /**
@@ -203,7 +215,13 @@ function getDocsBaseUrl() {
  * @returns {string}
  */
 function getDocsHostname() {
-  return `https://${process.env.BUILD_MODE === 'staging' ? 'dev.' : ''}handsontable.com`;
+  const buildMode = process.env.BUILD_MODE;
+
+  if (!buildMode) {
+    return 'http://localhost:8080'
+  }
+
+  return `https://${buildMode === 'staging' ? 'dev.' : ''}handsontable.com`;
 }
 
 module.exports = {
@@ -218,6 +236,7 @@ module.exports = {
   getDefaultFramework,
   createSymlinks,
   getThisDocsVersion,
-  getDocsBaseUrl,
+  getDocsBase,
+  getDocsBaseFullUrl,
   getDocsHostname,
 };

--- a/docs/.vuepress/helpers.js
+++ b/docs/.vuepress/helpers.js
@@ -218,7 +218,7 @@ function getDocsHostname() {
   const buildMode = process.env.BUILD_MODE;
 
   if (!buildMode) {
-    return 'http://localhost:8080'
+    return 'http://localhost:8080';
   }
 
   return `https://${buildMode === 'staging' ? 'dev.' : ''}handsontable.com`;

--- a/docs/.vuepress/plugins/extend-page-data/index.js
+++ b/docs/.vuepress/plugins/extend-page-data/index.js
@@ -3,7 +3,6 @@ const {
   getNormalizedPath,
   parseFramework,
   getThisDocsVersion,
-  getDocsBaseUrl,
   getPrettyFrameworkName,
   getDefaultFramework,
   FRAMEWORK_SUFFIX,
@@ -50,7 +49,6 @@ module.exports = (options, context) => {
       const currentFramework = parseFramework(normalizedPath);
 
       $page.normalizedPath = normalizedPath;
-      $page.baseUrl = getDocsBaseUrl();
       $page.currentVersion = getThisDocsVersion();
       $page.currentFramework = currentFramework;
       $page.frameworkName = getPrettyFrameworkName($page.currentFramework);

--- a/docs/.vuepress/theme/components/VersionsDropdown.vue
+++ b/docs/.vuepress/theme/components/VersionsDropdown.vue
@@ -62,7 +62,9 @@ export default {
         '4.0.0',
       ].map(version => ({
         text: version.replace(/\.\d+$/, ''),
-        link: `${this.$page.baseUrl}/${version}/`
+        link: `/docs/${version}/`,
+        target: '_blank',
+        isHtmlLink: true,
       }));
     }
   },

--- a/docs/.vuepress/theme/components/VersionsDropdown.vue
+++ b/docs/.vuepress/theme/components/VersionsDropdown.vue
@@ -62,7 +62,7 @@ export default {
         '4.0.0',
       ].map(version => ({
         text: version.replace(/\.\d+$/, ''),
-        link: `${this.$page.baseUrl}/docs/${version}/`
+        link: `${this.$page.baseUrl}/${version}/`
       }));
     }
   },


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adds support for jsFiddle examples for the staging environment. To do that, URL assets have to be changed from relative to absolute paths. Depending on the environment, the assets points for `https://handsontable.com` (production), `https://dev.handsontable,.com` (staging), and `http://localhost:8080` for local development.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes #9795

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
