### PR TITLE
Docs: Remove the Packages page for React

### DIFF
--- a/docs/content/guides/sidebar.js
+++ b/docs/content/guides/sidebar.js
@@ -137,7 +137,7 @@ const internationalizationItems = [
 ];
 
 const buildingAndToolingItems = [
-  { path: 'guides/tools-and-building/packages' },
+  { path: 'guides/tools-and-building/packages', onlyFor: ['javascript'] },
   { path: 'guides/tools-and-building/modules' },
   { path: 'guides/tools-and-building/custom-plugins' },
   { path: 'guides/tools-and-building/custom-builds' },

--- a/docs/content/guides/tools-and-building/custom-builds.md
+++ b/docs/content/guides/tools-and-building/custom-builds.md
@@ -291,5 +291,7 @@ From the `/wrappers/vue3` directory, you can also run individual Vue 3 `build` t
 
 ## Related guides
 
+::: only-for javascript
 - [Packages](@/guides/tools-and-building/packages.md)
+:::
 - [Testing](@/guides/tools-and-building/testing.md)

--- a/docs/content/guides/tools-and-building/modules.md
+++ b/docs/content/guides/tools-and-building/modules.md
@@ -46,7 +46,13 @@ No matter which of the optional modules you use, you always need to import the b
 
 ### Import the base module
 
+::: only-for javascript
 To get the base JavaScript module, import Handsontable from `handsontable/base` (not from `handsontable`, which would give you the [full distribution package](@/guides/tools-and-building/packages.md)):
+:::
+
+::: only-for react
+To get the base JavaScript module, import Handsontable from `handsontable/base` (not from `handsontable`, which would give you the full distribution package):
+:::
 
 ```js
 import Handsontable from 'handsontable/base';

--- a/docs/content/guides/tools-and-building/testing.md
+++ b/docs/content/guides/tools-and-building/testing.md
@@ -58,4 +58,6 @@ Keep in mind that running wrapper tests require building the Handsontable (`npm 
 ## Related guides
 
 - [Building](@/guides/tools-and-building/custom-builds.md)
+::: only-for javascript
 - [Packages](@/guides/tools-and-building/packages.md)
+:::


### PR DESCRIPTION
This PR:
- Removes the [Packages](https://handsontable.com/docs/packages/) page (and any links to it) for React (as per [this comment](https://github.com/handsontable/handsontable/pull/9786#issuecomment-1220681942))

[skip changelog]