### PR TITLE
Add more frameworks to dropdown list

### DIFF
--- a/docs/.vuepress/theme/components/FrameworksDropdown.vue
+++ b/docs/.vuepress/theme/components/FrameworksDropdown.vue
@@ -10,11 +10,13 @@
 
 <script>
 import DropdownLink from '@theme/components/DropdownLink.vue';
-import { getLinkTransformed } from '../../components/utils';
 
 const frameworkIdToFullName = new Map([
-  ['javascript', 'JavaScript'],
-  ['react', 'React'],
+  ['javascript', { name: 'JavaScript' }],
+  ['angular', { name: 'Angular', homepage: '/javascript-data-grid/angular-installation/' }],
+  ['react', { name: 'React' }],
+  ['vue', { name: 'Vue 2', homepage: '/javascript-data-grid/vue-installation/' }],
+  ['vue3', { name: 'Vue 3', homepage: '/javascript-data-grid/vue3-installation/' }],
 ]);
 
 export default {
@@ -22,21 +24,37 @@ export default {
   components: {
     DropdownLink
   },
+  watch: {
+    $route(to) {
+      this.detectFramework(to.fullPath);
+    }
+  },
   methods: {
+    detectFramework(path) {
+      const frameworkMatch = path.match(/javascript-data-grid\/(vue3|vue|angular)?/);
+
+      if (frameworkMatch) {
+        this.$page.currentFramework = frameworkMatch[1] ?? 'javascript';
+      }
+    },
     getLink(framework) {
+      const {
+        homepage = `/${framework}${this.$page.frameworkSuffix}/`
+      } = frameworkIdToFullName.get(framework);
+
       if (this.$page.currentVersion === this.$page.latestVersion) {
-        return `/docs/${framework}${this.$page.frameworkSuffix}/`;
+        return `/docs${homepage}`;
       }
 
-      return `/docs/${this.$page.currentVersion}/${framework}${this.$page.frameworkSuffix}/`;
+      return `/docs/${this.$page.currentVersion}${homepage}`;
     },
     getFrameworkName(id) {
-      return frameworkIdToFullName.get(id);
+      return frameworkIdToFullName.get(id).name;
     },
     getFrameworkItems() {
-      return Array.from(frameworkIdToFullName.entries()).map(([id, fullName]) => {
+      return Array.from(frameworkIdToFullName.entries()).map(([id, { name }]) => {
         return {
-          text: fullName,
+          text: name,
           link: this.getLink(id),
           target: '_self',
           isHtmlLink: true
@@ -46,11 +64,9 @@ export default {
   },
   computed: {
     imageUrl() {
-      const currentVersion = this.$page.currentVersion;
       const frameworkWithoutNumber = this.$page.currentFramework.replace(/\d+$/, '');
-      const src = this.$withBase(`/img/pages/introduction/${frameworkWithoutNumber}.svg`);
 
-      return getLinkTransformed(src, currentVersion, this.$page.latestVersion);
+      return this.$withBase(`/img/pages/introduction/${frameworkWithoutNumber}.svg`);
     },
     item() {
       return {
@@ -58,6 +74,9 @@ export default {
         items: this.getFrameworkItems(),
       };
     }
+  },
+  created() {
+    this.detectFramework(this.$route.fullPath);
   }
 };
 </script>
@@ -98,7 +117,7 @@ export default {
     overflow-y auto
     position absolute
     top 100%
-    left 0
+    left -19px
     background-color #fff
     padding 0.6rem 0
     border 1px solid #ddd


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adds all supported frameworks to the framework dropdown list. Those frameworks that do not have a dedicated "frameworked" Docs content point to the not-yet rewritten section in the Docs. Moreover, as the issue says, the list is shifted slightly. It's placed right under the chosen framework with image and not the framework text. 

![image](https://user-images.githubusercontent.com/571316/185926894-36272f19-4408-4352-90ed-5a5e35fe1f7d.png)

The PR additionally adds a feature that switches the chosen framework to the framework currently read. For example, for pages "Integrate with Vue 2 ->" the Vue 2 framework is selected. The same works for other frameworks. 

![Kapture 2022-08-22 at 15 08 46](https://user-images.githubusercontent.com/571316/185928843-f17dafdd-11ca-40f7-8f40-2b94c7e5737b.gif)

_[skip changelog]_

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. fixes #9796

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
