### PR TITLE
Docs: Feature/react docs nestedheaders

### DIFF
--- a/docs/content/guides/columns/column-groups.md
+++ b/docs/content/guides/columns/column-groups.md
@@ -5,6 +5,7 @@ permalink: /column-groups
 canonicalUrl: /column-groups
 tags:
   - nested headers
+  - nestedHeaders
   - collapsing columns
 ---
 

--- a/handsontable/src/dataMap/metaManager/metaSchema.js
+++ b/handsontable/src/dataMap/metaManager/metaSchema.js
@@ -3101,9 +3101,17 @@ export default () => {
      * @description
      * The `nestedHeaders` option configures the [`NestedHeaders`](@/api/nestedHeaders.md) plugin.
      *
-     * You can set the `nestedHeaders` option to an array of arrays:
-     * - Each array configures one set of nested headers.
-     * - Each array element configures one header, and can be one of the following:
+     * You can set the `nestedHeaders` option to one of the following:
+     *
+     * | Setting           | Description                                                                                                                           |
+     * | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+     * | `false` (default) | Disable the [`NestedHeaders`](@/api/nestedHeaders.md) plugin                                                                          |
+     * | `true`            | - Enable the [`NestedHeaders`](@/api/nestedHeaders.md) plugin<br>- Don't configure any nested headers                                 |
+     * | Array of arrays   | - Enable the [`NestedHeaders`](@/api/nestedHeaders.md) plugin<br>- Configure headers that are nested on Handsontable's initialization |
+     *
+     * If you set the `nestedHeaders` option to an array of arrays, each array configures one set of nested headers.
+     *
+     * Each array element configures one header, and can be one of the following:
      *
      * | Array element | Description                                                                                  |
      * | ------------- | -------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
This PR:
- Expands the `nestedHeaders` API ref
- Adds `nestedHeaders` search tag to the Column groups page (like it was done for `nestedRows` in #9790)

[skip changelog]