### PR TITLE
Docs: Make "Code" the default tab for the error-testing example on the Column Summary page.

### DIFF
--- a/docs/content/guides/columns/column-summary.md
+++ b/docs/content/guides/columns/column-summary.md
@@ -1238,7 +1238,7 @@ You can throw a data type error whenever a non-numeric value is passed to your c
 To throw data type errors, set the [`suppressDataTypeErrors`](@/api/columnSummary.md) option to `false` (by default, [`suppressDataTypeErrors`](@/api/columnSummary.md) is set to `true`). For example:
 
 ::: only-for javascript
-::: example #example11
+::: example #example11 --tab code
 ```js
 const container = document.querySelector('#example11');
 
@@ -1275,7 +1275,7 @@ const hot = new Handsontable(container, {
 :::
 
 ::: only-for react
-::: example #example11 :react
+::: example #example11 :react --tab code
 ```jsx
 import ReactDOM from 'react-dom';
 import { HotTable } from '@handsontable/react';


### PR DESCRIPTION
### Context
This PR makes "Code" the default tab for the error-testing example on the Column Summary page.

More context: https://handsoncode.slack.com/archives/C034WPQUG9W/p1661248459667409

### How has this been tested?
Checked with `docs:start:no-cache`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]