### PR TITLE
Fixed linter error - wrong type definition

### DIFF
--- a/handsontable/test/types/settings.types.ts
+++ b/handsontable/test/types/settings.types.ts
@@ -474,7 +474,7 @@ const allSettings: Required<Handsontable.GridSettings> = {
   beforeAutofill: (start, end, data) => {},
   beforeAutofillInsidePopulate: (index, direction, input, deltas) => {},
   beforeCellAlignment: (stateBefore, range, type, alignmentClass) => {},
-  beforeChange: (changes, source) => { changes[0][3] = 10; return false; },
+  beforeChange: (changes, source) => { if (changes?.[0] !== null) { changes[0][3] = 10; } return false; },
   beforeChangeRender: (changes, source) => {},
   beforeColumnCollapse: (currentCollapsedColumn, destinationCollapsedColumns, collapsePossible) => {},
   beforeColumnExpand: (currentCollapsedColumn, destinationCollapsedColumns, expandPossible) => {},

--- a/handsontable/types/pluginHooks.d.ts
+++ b/handsontable/types/pluginHooks.d.ts
@@ -154,7 +154,7 @@ export interface Events {
   beforeAutofillInsidePopulate?: (index: CellCoords, direction: 'up' | 'down' | 'left' | 'right', input: CellValue[][], deltas: any[]) => void;
   beforeCellAlignment?: (stateBefore: { [row: number]: string[] }, range: CellRange[], type: 'horizontal' | 'vertical',
     alignmentClass: 'htLeft' | 'htCenter' | 'htRight' | 'htJustify' | 'htTop' | 'htMiddle' | 'htBottom') => void;
-  beforeChange?: (changes: CellChange[] | null, source: ChangeSource) => void | boolean;
+  beforeChange?: (changes: Array<CellChange | null>, source: ChangeSource) => void | boolean;
   beforeChangeRender?: (changes: CellChange[], source: ChangeSource) => void;
   beforeColumnCollapse?: (currentCollapsedColumn: number[], destinationCollapsedColumns: number[], collapsePossible: boolean) => void | boolean;
   beforeColumnExpand?: (currentCollapsedColumn: number[], destinationCollapsedColumns: number[], expandPossible: boolean) => void | boolean;


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
PR https://github.com/handsontable/handsontable/pull/9791 has introduced change in type definition. However, tests have shown a problem not caught by me. This PR change the definition properly for case of overriding array element. Tests also pass.

[skip changelog]