### PR TITLE
Fix header anchoring

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -8,6 +8,7 @@ const nginxVariablesPlugin = require('./plugins/generate-nginx-variables');
 const extendPageDataPlugin = require('./plugins/extend-page-data');
 const firstHeaderInjection = require('./plugins/markdown-it-header-injection');
 const conditionalContainer = require('./plugins/markdown-it-conditional-container');
+const activeHeaderLinksPlugin = require('./plugins/active-header-links');
 const {
   getDocsBaseUrl,
   getThisDocsVersion,
@@ -118,9 +119,10 @@ module.exports = {
       hostname: getDocsBaseUrl(),
       exclude: ['/404.html']
     }],
-    ['@vuepress/active-header-links', {
+    [activeHeaderLinksPlugin, {
       sidebarLinkSelector: '.table-of-contents a',
-      headerAnchorSelector: '.header-anchor'
+      headerAnchorSelector: '.header-anchor',
+      anchorTopOffset: 75,
     }],
     ['container', examples(getThisDocsVersion(), base)],
     ['container', sourceCodeLink],

--- a/docs/.vuepress/enhanceApp.js
+++ b/docs/.vuepress/enhanceApp.js
@@ -40,60 +40,104 @@ const buildActiveHeaderLinkHandler = () => {
  * For the first page load, the GA automatically registers pageview. For other
  * route changes, the event is triggered manually.
  */
-let isFirstPageLoaded = true;
+let isFirstPageGALoaded = true;
+let isPageLoaded = false;
 
 export default async({ router, siteData, isServer }) => {
-  if (!isServer) {
-    const currentVersion = siteData.pages[0].currentVersion;
-    const buildMode = siteData.pages[0].buildMode;
-    let pathVersion = '';
+  if (isServer) {
+    return;
+  }
 
-    if (buildMode !== 'production') {
-      pathVersion = `${currentVersion}/`;
+  const currentVersion = siteData.pages[0].currentVersion;
+  const buildMode = siteData.pages[0].buildMode;
+  let pathVersion = '';
+
+  if (buildMode !== 'production') {
+    pathVersion = `${currentVersion}/`;
+  }
+
+  const response = await fetch(`${window.location.origin}/docs/${pathVersion}data/common.json`);
+  const docsData = await response.json();
+  const canonicalURLs = new Map(docsData.urls);
+
+  siteData.pages.forEach((page) => {
+    const frontmatter = page.frontmatter;
+    const canonicalUrl = frontmatter.canonicalUrl;
+    const canonicalUrlNorm = canonicalUrl.replace(/^\/docs\//, '').replace(/\/$/, '');
+
+    if (canonicalURLs.has(canonicalUrlNorm) && canonicalURLs.get(canonicalUrlNorm) !== '') {
+      const docsVersion = canonicalURLs.get(canonicalUrlNorm);
+
+      frontmatter.canonicalUrl = canonicalUrl.replace(/^\/docs\//, `/docs/${docsVersion}/`);
     }
 
-    const response = await fetch(`${window.location.origin}/docs/${pathVersion}data/common.json`);
-    const docsData = await response.json();
-    const canonicalURLs = new Map(docsData.urls);
+    page.versions = docsData.versions;
+    page.latestVersion = docsData.latestVersion;
+  });
 
-    siteData.pages.forEach((page) => {
-      const frontmatter = page.frontmatter;
-      const canonicalUrl = frontmatter.canonicalUrl;
-      const canonicalUrlNorm = canonicalUrl.replace(/^\/docs\//, '').replace(/\/$/, '');
+  router.options.scrollBehavior = function(to, from, savedPosition) {
+    if (this.app.$vuepress.$get('disableScrollBehavior')) {
+      return false;
+    }
 
-      if (canonicalURLs.has(canonicalUrlNorm) && canonicalURLs.get(canonicalUrlNorm) !== '') {
-        const docsVersion = canonicalURLs.get(canonicalUrlNorm);
+    let scrollPosition = { x: 0, y: 0 }; // page without hash
 
-        frontmatter.canonicalUrl = canonicalUrl.replace(/^\/docs\//, `/docs/${docsVersion}/`);
-      }
+    if (savedPosition) {
+      scrollPosition = savedPosition; // page from the browser navigation (back/forward)
 
-      page.versions = docsData.versions;
-      page.latestVersion = docsData.latestVersion;
+    } else if (to.hash) {
+      scrollPosition = {
+        selector: to.hash,
+        // top offset that matches to the "scroll-padding-top" (.vuepress/theme/styles/index.styl@34)
+        // mostly it's the height of the top header plus some margin
+        offset: { x: 0, y: 75 }
+      };
+    }
+
+    let scrollResolver;
+
+    const scrollPromise = new Promise((resolve) => {
+      scrollResolver = resolve;
     });
 
-    themeLoader();
-
-    if (typeof window.ga === 'function') {
-      router.afterEach((to) => {
-        if (!isFirstPageLoaded) {
-          ga.getAll().forEach((tracker) => {
-            if (tracker.get('trackingId') === GA_ID) {
-              // Collect the page view in the next browser event loop cycle to make sure
-              // that the VuePress finished render new page completely (change the URL address
-              // and document title).
-              setTimeout(() => {
-                tracker.set('page', router.app.$withBase(to.fullPath));
-                tracker.send('pageview');
-              });
-            }
-          });
-        }
-
-        isFirstPageLoaded = false;
-      });
+    if (isPageLoaded) {
+      if (to.path === from.path) {
+        scrollResolver(scrollPosition);
+      } else {
+        setTimeout(() => scrollResolver(scrollPosition));
+      }
+    } else {
+      window.onload = () => {
+        isPageLoaded = true;
+        scrollResolver(scrollPosition);
+      };
     }
 
-    router.afterEach(buildRegisterCleaner(instanceRegister));
-    router.afterEach(buildActiveHeaderLinkHandler());
+    return scrollPromise;
+  };
+
+  themeLoader();
+
+  if (typeof window.ga === 'function') {
+    router.afterEach((to) => {
+      if (!isFirstPageGALoaded) {
+        ga.getAll().forEach((tracker) => {
+          if (tracker.get('trackingId') === GA_ID) {
+            // Collect the page view in the next browser event loop cycle to make sure
+            // that the VuePress finished render new page completely (change the URL address
+            // and document title).
+            setTimeout(() => {
+              tracker.set('page', router.app.$withBase(to.fullPath));
+              tracker.send('pageview');
+            });
+          }
+        });
+      }
+
+      isFirstPageGALoaded = false;
+    });
   }
+
+  router.afterEach(buildRegisterCleaner(instanceRegister));
+  router.afterEach(buildActiveHeaderLinkHandler());
 };

--- a/docs/.vuepress/plugins/active-header-links/LICENSE
+++ b/docs/.vuepress/plugins/active-header-links/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2018-present, Yuxi (Evan) You
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/docs/.vuepress/plugins/active-header-links/README.md
+++ b/docs/.vuepress/plugins/active-header-links/README.md
@@ -1,0 +1,5 @@
+# @vuepress/plugin-active-header-links
+
+> active-header-links plugin for VuePress
+
+See [documentation](https://vuepress.vuejs.org/plugin/official/plugin-active-header-links.html).

--- a/docs/.vuepress/plugins/active-header-links/clientRootMixin.js
+++ b/docs/.vuepress/plugins/active-header-links/clientRootMixin.js
@@ -1,0 +1,68 @@
+/* global AHL_SIDEBAR_LINK_SELECTOR, AHL_HEADER_ANCHOR_SELECTOR, AHL_ANCHOR_TOP_OFFSET */
+
+import debounce from 'lodash.debounce';
+
+export default {
+  mounted() {
+    window.addEventListener('scroll', this.onScroll);
+  },
+
+  methods: {
+    onScroll: debounce(function() {
+      this.setActiveHash();
+    }, 300),
+
+    setActiveHash() {
+      const sidebarLinks = [].slice.call(document.querySelectorAll(AHL_SIDEBAR_LINK_SELECTOR));
+      const anchors = [].slice.call(document.querySelectorAll(AHL_HEADER_ANCHOR_SELECTOR))
+        .filter(anchor => sidebarLinks.some(sidebarLink => sidebarLink.hash === anchor.hash));
+
+      const scrollTop = Math.max(
+        window.pageYOffset,
+        document.documentElement.scrollTop,
+        document.body.scrollTop
+      ) + AHL_ANCHOR_TOP_OFFSET;
+      const scrollHeight = Math.max(
+        document.documentElement.scrollHeight,
+        document.body.scrollHeight
+      );
+      const bottomY = window.innerHeight + scrollTop;
+
+      for (let i = 0; i < anchors.length; i++) {
+        const anchor = anchors[i];
+        const nextAnchor = anchors[i + 1];
+        const isActive = i === 0 && scrollTop === 0
+          || (scrollTop >= anchor.parentElement.offsetTop + 10
+            && (!nextAnchor || scrollTop < nextAnchor.parentElement.offsetTop - 10));
+        const routeHash = decodeURIComponent(this.$route.hash);
+
+        if (isActive && routeHash !== decodeURIComponent(anchor.hash)) {
+          const activeAnchor = anchor;
+
+          // check if anchor is at the bottom of the page to keep $route.hash consistent
+          if (bottomY === scrollHeight) {
+            for (let j = i + 1; j < anchors.length; j++) {
+              if (routeHash === decodeURIComponent(anchors[j].hash)) {
+                return;
+              }
+            }
+          }
+
+          this.$vuepress.$set('disableScrollBehavior', true);
+          this.$router.replace(decodeURIComponent(activeAnchor.hash), () => {
+            // execute after scrollBehavior handler.
+            this.$nextTick(() => {
+              this.$vuepress.$set('disableScrollBehavior', false);
+            });
+          });
+
+          return;
+        }
+      }
+    }
+  },
+
+  beforeDestroy() {
+    window.removeEventListener('scroll', this.onScroll);
+  }
+};

--- a/docs/.vuepress/plugins/active-header-links/index.js
+++ b/docs/.vuepress/plugins/active-header-links/index.js
@@ -1,0 +1,15 @@
+/**
+ * The plugin is copy/paste of the official @vuepress/plugin-active-header-links plugin.
+ * For the plugin added support for anchor top offset (anchorTopOffset). The option is useful in cases
+ * when the CSS property "scroll-padding-top" is used.
+ */
+const { path } = require('@vuepress/shared-utils');
+
+module.exports = options => ({
+  clientRootMixin: path.resolve(__dirname, 'clientRootMixin.js'),
+  define: {
+    AHL_SIDEBAR_LINK_SELECTOR: options.sidebarLinkSelector || '.sidebar-link',
+    AHL_HEADER_ANCHOR_SELECTOR: options.headerAnchorSelector || '.header-anchor',
+    AHL_ANCHOR_TOP_OFFSET: options.anchorTopOffset || 0,
+  }
+});

--- a/docs/.vuepress/theme/components/Page.vue
+++ b/docs/.vuepress/theme/components/Page.vue
@@ -63,7 +63,7 @@ export default {
 
     .header-framework {
       position: absolute;
-      top: 48px;
+      top: -24px;
       font-size: 16px;
       opacity: .8;
     }

--- a/docs/.vuepress/theme/styles/index.styl
+++ b/docs/.vuepress/theme/styles/index.styl
@@ -30,18 +30,20 @@
 
 html {
   color-scheme light
+  /* Fix for anchor correct scroll positioning */
+  scroll-padding-top ($navbarHeight + 1.1rem)
 }
 
 body {
-  font-size: 15px;
+  font-size 15px
 }
 
 body, html, #app {
-  min-height 100vh;
+  min-height 100vh
 }
 
 body div {
-  user-select: initial;
+  user-select initial
 }
 
 .hidden {
@@ -155,9 +157,8 @@ a.source-code-link {
 h1 {
   font-size: 2rem;
   margin-bottom: 2rem !important;
-  /* Fix for anchor correct scroll positioning */
-  padding-top: 4.6rem !important;
-  margin-top: -3.8rem !important;
+  padding-top: 0 !important;
+  margin-top: 0.7rem !important;
 }
 
 h2 {
@@ -165,17 +166,16 @@ h2 {
   padding-bottom: 6px;
   font-size: 1.55rem;
   border-color: #e9eef2;
-  /* Fix for anchor correct scroll positioning */
-  padding-top: 5rem !important;
-  margin-top: -4.1rem !important;
+  padding-top: 0.5rem !important;
+  margin-top: 1.3rem !important;
 }
 
 h3 {
   margin-bottom: 1rem !important;
   font-size: 1.25rem;
-  /* Fix for anchor correct scroll positioning */
-  padding-top: 5.1rem !important;
-  margin-top: -4.6rem !important;
+  padding-top: 0.1rem !important;
+  padding-bottom: 0.1rem !important;
+  margin-top: 1.1rem !important;
 }
 
 h4 {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
To support the headers' anchors with Docs that have a top bar in its layout Vuepress uses a trick with expanding the headers using `margin` and `padding` (https://github.com/vuejs/vuepress/blob/master/packages/%40vuepress/theme-default/styles/index.styl#L112) CSS props. The solution has side effects which are manifested by the fact that the anchor shows up before hitting the header.

![Kapture 2022-08-23 at 15 53 53](https://user-images.githubusercontent.com/571316/186176595-45171a30-559e-4b56-9865-93ce86fa623e.gif)

The PRs solution abandons the native Vuepress solution and uses the CSS approach - the `scroll-padding-top` property. Thanks to that, I can get rid of the hack, and the anchors show at the right moment.

#### Before
![Kapture 2022-08-23 at 15 30 28](https://user-images.githubusercontent.com/571316/186170897-aa8b19f6-bddb-4f16-bd74-7b14495d47f5.gif)

#### After
![Kapture 2022-08-23 at 15 22 28](https://user-images.githubusercontent.com/571316/186170704-ca8225ac-9ac4-4b2f-9622-4df1ab365348.gif)


_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes #9803

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
