### PR TITLE
Fix Search for other framework than React

### DIFF
--- a/docs/.vuepress/theme/components/FrameworksDropdown.vue
+++ b/docs/.vuepress/theme/components/FrameworksDropdown.vue
@@ -26,16 +26,19 @@ export default {
   },
   watch: {
     $route(to) {
-      this.detectFramework(to.fullPath);
+      this.detectLegacyFramework(to.fullPath);
     }
   },
+  data() {
+    return {
+      legacyFramework: null
+    };
+  },
   methods: {
-    detectFramework(path) {
+    detectLegacyFramework(path) {
       const frameworkMatch = path.match(/javascript-data-grid\/(vue3|vue|angular)?/);
 
-      if (frameworkMatch) {
-        this.$page.currentFramework = frameworkMatch[1] ?? 'javascript';
-      }
+      this.legacyFramework = frameworkMatch ? frameworkMatch[1] : null;
     },
     getLink(framework) {
       const {
@@ -64,19 +67,19 @@ export default {
   },
   computed: {
     imageUrl() {
-      const frameworkWithoutNumber = this.$page.currentFramework.replace(/\d+$/, '');
+      const frameworkWithoutNumber = (this.legacyFramework ?? this.$page.currentFramework).replace(/\d+$/, '');
 
       return this.$withBase(`/img/pages/introduction/${frameworkWithoutNumber}.svg`);
     },
     item() {
       return {
-        text: this.getFrameworkName(this.$page.currentFramework),
+        text: this.getFrameworkName(this.legacyFramework ?? this.$page.currentFramework),
         items: this.getFrameworkItems(),
       };
     }
   },
   created() {
-    this.detectFramework(this.$route.fullPath);
+    this.detectLegacyFramework(this.$route.fullPath);
   }
 };
 </script>


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the Docs Search that did not work for other frameworks than React and vanilla JS and fixes Guides and API pages that for Angular, Vue and Vue3 were incorrectly created with framework prefix (e.g `/docs/next/angular-data-grid/`).

_[skip changelog]_

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes #9818
2. fixes #9817

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
