### PR TITLE
Fix an issue with `0` initial dataset values in the Column Summary plugin.

### DIFF
--- a/.changelogs/6385.json
+++ b/.changelogs/6385.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fixed an issue with \"0\" values being unrecognized by the Column Summary plugin.",
+  "type": "fixed",
+  "issue": 6385,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/columnSummary/__tests__/columnSummary.spec.js
+++ b/handsontable/src/plugins/columnSummary/__tests__/columnSummary.spec.js
@@ -142,8 +142,13 @@ describe('ColumnSummarySpec', () => {
 
   describe('calculateMinMax', () => {
     it('should calculate the minimum from the provided range', () => {
+      const dataset = createNumericData(15, 15);
+
+      dataset[0][1] = 0;
+      dataset[0][2] = 0;
+
       handsontable({
-        data: createNumericData(15, 15),
+        data: dataset,
         height: 200,
         width: 200,
         columnSummary: [
@@ -155,16 +160,32 @@ describe('ColumnSummarySpec', () => {
               [5, 6], [8], [10, 13]
             ],
             type: 'min'
+          },
+          {
+            destinationColumn: 1,
+            reversedRowCoords: true,
+            destinationRow: 0,
+            ranges: [
+              [0, 13]
+            ],
+            type: 'min'
           }
         ]
       });
 
       expect(getDataAtCell(14, 0)).toEqual(6);
+      expect(getDataAtCell(14, 1)).toEqual(0);
     });
 
-    it('should calculate the minimum from the provided range', () => {
+    it('should calculate the maximum from the provided range', () => {
+      const dataset = createNumericData(15, 15);
+
+      dataset.forEach((rowArr) => {
+        rowArr[1] = 0;
+      });
+
       handsontable({
-        data: createNumericData(15, 15),
+        data: dataset,
         height: 200,
         width: 200,
         columnSummary: [
@@ -176,19 +197,34 @@ describe('ColumnSummarySpec', () => {
               [5, 6], [8], [10, 13]
             ],
             type: 'max'
+          },
+          {
+            destinationColumn: 1,
+            reversedRowCoords: true,
+            destinationRow: 0,
+            ranges: [
+              [0, 13]
+            ],
+            type: 'max'
           }
         ]
       });
 
       expect(getDataAtCell(14, 0)).toEqual(14);
+      expect(getDataAtCell(14, 1)).toEqual(0);
     });
-
   });
 
   describe('countEntries', () => {
     it('should count non-empty entries from the provided range', () => {
+      const dataset = createNumericData(15, 15);
+
+      dataset.forEach((rowArr) => {
+        rowArr[1] = 0;
+      });
+
       handsontable({
-        data: createNumericData(15, 15),
+        data: dataset,
         height: 200,
         width: 200,
         columnSummary: [
@@ -200,11 +236,21 @@ describe('ColumnSummarySpec', () => {
               [0, 3], [5, 6], [8], [10, 13]
             ],
             type: 'count'
+          },
+          {
+            destinationColumn: 1,
+            reversedRowCoords: true,
+            destinationRow: 0,
+            ranges: [
+              [0, 13]
+            ],
+            type: 'count'
           }
         ]
       });
 
       expect(getDataAtCell(14, 0)).toEqual(11);
+      expect(getDataAtCell(14, 1)).toEqual(14);
     });
   });
 

--- a/handsontable/src/plugins/columnSummary/columnSummary.js
+++ b/handsontable/src/plugins/columnSummary/columnSummary.js
@@ -193,7 +193,7 @@ export class ColumnSummary extends BasePlugin {
     let biggestDecimalPlacesCount = 0;
 
     do {
-      cellValue = this.getCellValue(i, col) || 0;
+      cellValue = this.getCellValue(i, col) ?? 0;
       const decimalPlaces = (((`${cellValue}`).split('.')[1] || []).length) || 1;
 
       if (decimalPlaces > biggestDecimalPlacesCount) {
@@ -250,7 +250,7 @@ export class ColumnSummary extends BasePlugin {
    * @param {Array} rowRange Range for the calculation.
    * @param {number} col Column index.
    * @param {string} type `'min'` or `'max'`.
-   * @returns {number} Min or max value.
+   * @returns {number|null} Min or max value.
    */
   getPartialMinMax(rowRange, col, type) {
     let result = null;
@@ -258,7 +258,7 @@ export class ColumnSummary extends BasePlugin {
     let cellValue;
 
     do {
-      cellValue = this.getCellValue(i, col) || null;
+      cellValue = this.getCellValue(i, col) ?? null;
 
       if (result === null) {
         result = cellValue;
@@ -296,9 +296,9 @@ export class ColumnSummary extends BasePlugin {
     let i = rowRange[1] || rowRange[0];
 
     do {
-      cellValue = this.getCellValue(i, col);
+      cellValue = this.getCellValue(i, col) ?? null;
 
-      if (!cellValue) {
+      if (cellValue === null) {
         counter += 1;
       }
 


### PR DESCRIPTION
### Context
This PR fixes an issue with `0` values being passed in the initial config not being taken into account when calculating the `min`, `max` and `count` functions in the Column Summary plugin.

### How has this been tested?
Modified the existing test cases checking these functions.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #6385 

### Affected project(s):
- [x] `handsontable`
- [x] `@handsontable/angular`
- [x] `@handsontable/react`
- [x] `@handsontable/vue`
- [x] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
