### PR TITLE
Docs: Add missing `README-EDITING` entries.

### DIFF
--- a/docs/README-EDITING.md
+++ b/docs/README-EDITING.md
@@ -248,7 +248,7 @@ To use the `example-checker` script: (all the commands need to be run from the `
   npm run docs:test:example-checker
   ```
 
-The script is also automatically deployed by the `Docs Staging Deployment` Github Actions workflow.
+The script is also automatically executed by the `Docs Staging Deployment` Github Actions workflow.
 
 ## React style guide
 

--- a/docs/README-EDITING.md
+++ b/docs/README-EDITING.md
@@ -232,6 +232,24 @@ The `example` Markdown container offers the following options:
 | `--no-edit`    | No       | `--no-edit`     | `--no-edit`                                                                                                                                                                                                                                                 | Removes the **Edit** button.                                                                          |
 | `--tab <tab>`  | No       | `--tab preview` | `code` \| `html` \| `css` \| `preview`                                                                                                                                                                                                                      | Sets a tab as open by default.                                                                        |
 
+### Finding the broken examples
+
+The `example-checker` script checks if:
+- Every example container's code initializes at least one Handsontable instance.
+- The number of Handsontable instances implemented in the example containers corresponds to the number of Handsontable instance DOM containers being rendered on the page.
+
+To use the `example-checker` script: (all the commands need to be run from the `docs` directory)
+1. Build the documentation. 
+  ```bash
+  npm run docs:build
+  ```
+2. Run the script:
+  ```bash
+  npm run docs:test:example-checker
+  ```
+
+The script is also automatically deployed by the `Docs Staging Deployment` Github Actions workflow.
+
 ## React style guide
 
 When you edit React examples and code samples, follow the guidelines below.
@@ -270,3 +288,12 @@ For matters not covered here, follow the conventions of https://beta.reactjs.org
   const hotTableComponentRef = useRef(null);
   ```
 - In functional React components, use `useRef` instead of `React.createRef`.
+- For the React Fragments, use the `<>` shorthand instead of the explicit syntax (`<React.Fragment>`).
+  ```jsx
+    <>
+      <HotTable/>
+      <div className="controls">
+      // (...)
+      </div>
+    </>
+  ```

--- a/docs/content/guides/cell-functions/cell-renderer.md
+++ b/docs/content/guides/cell-functions/cell-renderer.md
@@ -75,12 +75,12 @@ const RendererComponent = (props) => {
   // - `TD` (the HTML cell element)
   // - `cellProperties` (the `cellProperties` object for the edited cell)
   return (
-    <React.Fragment>
+    <>
       <i style={{ color: "#a9a9a9" }}>
         Row: {props.row}, column: {props.col},
       </i>{" "}
       value: {props.value}
-    </React.Fragment>
+    </>
   );
 }
 
@@ -88,14 +88,12 @@ const hotData = Handsontable.helper.createSpreadsheetData(10, 5);
 
 const ExampleComponent = () => {
   return (
-    <div>
     <HotTable data={hotData} licenseKey="non-commercial-and-evaluation">
       <HotColumn width={250}>
         {/* add the `hot-renderer` attribute to mark the component as a Handsontable renderer */}
         <RendererComponent hot-renderer />
       </HotColumn>
     </HotTable>
-    </div>
   );
 };
 


### PR DESCRIPTION
### Context
This PR:

- Adds the information about the `React.Fragment` to the docs` examples style guide
- Adds the information about the example checker to the docs editing readme
- Corrects the usage of `React.Fragment` in the cell renderers page

[skip changelog]