### PR TITLE
Reinitialization of the example after the user changes from the `Code` to the `Preview` tab

### DIFF
--- a/docs/.vuepress/handsontable-manager/register.js
+++ b/docs/.vuepress/handsontable-manager/register.js
@@ -77,11 +77,22 @@ function createRegister() {
 
           if (rootExampleElement) {
             const examplePresetType = rootExampleElement.getAttribute('data-preset-type');
-
-            register.add(createDestroyableResource(examplePresetType, {
+            const tabsComponent = closest(this.rootElement, '.tabs-component');
+            const allTabs = tabsComponent.querySelectorAll('a');
+            const codeTab = Array.from(allTabs).find(tab => tab.innerText === 'Code'); // Usually first tab
+            const destroyableResource = createDestroyableResource(examplePresetType, {
               rootExampleElement,
               hotInstance: this,
-            }));
+            });
+
+            codeTab?.addEventListener('click', () => {
+              if (register.has(destroyableResource)) {
+                register.delete(destroyableResource);
+                destroyableResource();
+              }
+            });
+
+            register.add(destroyableResource);
           }
         });
       }

--- a/docs/.vuepress/theme/components/Page.vue
+++ b/docs/.vuepress/theme/components/Page.vue
@@ -47,6 +47,9 @@ export default {
       if (selectedTab.tab.computedId.startsWith('preview-tab')) {
         this.activatedExamples.push(exampleId);
         parentContainer.className += ` ${changedClass}`; // Adding class by method compatible with IE
+
+      } else {
+        this.activatedExamples = this.activatedExamples.filter(activatedExample => activatedExample !== exampleId);
       }
     },
     isScriptLoaderActivated(exampleId) {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
We have some problem related to opening the context-menu and changing the `example's` tab. It has been changed. Every click on the `Code` tab destroys an existing instance while every change to `Preview` tab loads scripts which initiate new Handsontable. 

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested using `npm run docs:start:no-cache` examples which have enabled the `ContextMenu` plugin.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #9239