### PR TITLE
Change the Demo to use a DIV, not an IFRAME

### DIFF
--- a/docs/README-EDITING.md
+++ b/docs/README-EDITING.md
@@ -176,6 +176,24 @@ To check for broken links:
    ```
 4. Open the broken links report: `/docs/report-check-links.xlsx`.
 
+
+## Markdown variables
+
+It is possible to include metadata from VuePress or frontmatter in the content using the `$page` object and the following syntax:
+
+```
+Welcome the users of {{ $page.frameworkName }}!
+```
+
+The above code prints the following text in the React variant of the docs:
+
+> Welcome the users of React!
+
+The full list of available variables is available at:
+
+- https://vuepress.vuejs.org/guide/frontmatter.html (official)
+- https://github.com/handsontable/handsontable/blob/develop/docs/.vuepress/plugins/extend-page-data/index.js#L53-L60 (our modifications)
+
 ## Markdown containers
 
 To render content in different ways, the documentation uses Markdown containers, for example:

--- a/docs/content/guides/getting-started/demo.md
+++ b/docs/content/guides/getting-started/demo.md
@@ -12,7 +12,13 @@ tags:
 
 [[toc]]
 
+::: only-for javascript
 Play around with a demo of Handsontable, in your favorite framework.
+:::
+
+::: only-for react
+Play around with a demo of Handsontable, in React.
+:::
 
 <div class="example-container">
   <div id="example"></div>

--- a/docs/content/guides/getting-started/demo.md
+++ b/docs/content/guides/getting-started/demo.md
@@ -14,12 +14,14 @@ tags:
 
 Play around with a demo of Handsontable, in your favorite framework.
 
-<div class="example-container"><iframe
-    src="https://handsontable.github.io/handsontable/examples/next/docs/js/demo/"
-    allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone;
-      midi; payment; usb; vr; xr-spatial-tracking"
-    sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
-  ></iframe></div>
+<div class="example-container">
+  <div id="example"></div>
+  <script src="https://examples.handsontable.com/examples/12.1.1/docs/js/demo/src.3f3ef8b8.js"></script>
+  <style>
+    @import 'https://examples.handsontable.com/examples/12.1.1/docs/js/demo/src.4d67a99b.css';
+  </style>
+</div>
+
 ## Find the code on GitHub
 
 - [JavaScript demo app](https://github.com/handsontable/handsontable/tree/develop/examples/next/docs/js/demo/)

--- a/docs/content/guides/getting-started/demo.md
+++ b/docs/content/guides/getting-started/demo.md
@@ -24,11 +24,18 @@ Play around with a demo of Handsontable, in your favorite framework.
 
 ## Find the code on GitHub
 
+::: only-for javascript
 - [JavaScript demo app](https://github.com/handsontable/handsontable/tree/develop/examples/next/docs/js/demo/)
 - [TypeScript demo app](https://github.com/handsontable/handsontable/tree/develop/examples/next/docs/ts/demo/)
-- [Angular demo app](https://github.com/handsontable/handsontable/tree/develop/examples/next/docs/angular/demo/)
 - [React demo app](https://github.com/handsontable/handsontable/tree/develop/examples/next/docs/react/demo/)
+- [Angular demo app](https://github.com/handsontable/handsontable/tree/develop/examples/next/docs/angular/demo/)
 - [Vue demo app](https://github.com/handsontable/handsontable/tree/develop/examples/next/docs/vue/demo/)
+:::
+
+::: only-for react
+- [TypeScript demo app](https://github.com/handsontable/handsontable/tree/develop/examples/next/docs/ts/demo/)
+- [React demo app](https://github.com/handsontable/handsontable/tree/develop/examples/next/docs/react/demo/)
+:::
 
 ## Try out the demo's features
 

--- a/docs/content/guides/sidebar.js
+++ b/docs/content/guides/sidebar.js
@@ -1,6 +1,6 @@
 const gettingStartedItems = [
   { path: 'guides/getting-started/introduction' },
-  // { path: 'guides/getting-started/demo' }, (temporarily hidden, till the demo is fixed)
+  { path: 'guides/getting-started/demo' },
   { path: 'guides/getting-started/installation' },
   { path: 'guides/getting-started/binding-to-data' },
   { path: 'guides/getting-started/react-redux', onlyFor: ['react'] },


### PR DESCRIPTION
### Context

This PR changes the demo from using an `<iframe>` to inserting the demo directly to the page using `<div>`, `<script>`, `<style>`. 

The demo remains built from the `examples/` and served from `examples.handsontable.com`.

All framework variants of the page will still render the vanilla JavaScript version, as previously.

### How has this been tested?

Tested the JavaScript and React variants locally using `npm run docs:dev`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #9644
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
