### PR TITLE
Add redirect to the default framework and up README files

### DIFF
--- a/docs/.vuepress/enhanceApp.js
+++ b/docs/.vuepress/enhanceApp.js
@@ -48,8 +48,20 @@ export default async({ router, siteData, isServer }) => {
     return;
   }
 
-  const currentVersion = siteData.pages[0].currentVersion;
-  const buildMode = siteData.pages[0].buildMode;
+  const {
+    currentVersion,
+    buildMode,
+    defaultFramework,
+    frameworkSuffix,
+  } = siteData.pages[0];
+
+  // in watch mode redirect to page with default framework
+  if (location.pathname === '/docs/next/' && !buildMode) {
+    location.replace(`${location.href}${defaultFramework}${frameworkSuffix}`);
+
+    return;
+  }
+
   let pathVersion = '';
 
   if (buildMode !== 'production') {

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,13 +38,13 @@ To start a local Handsontable documentation server:
    ```bash
    npm run docs:start
    ```
-4. In your browser, go to: http://localhost:8080/docs/.
+4. In your browser, go to: http://localhost:8080/docs/next/.
 
 ## Documentation npm scripts:
 
 From the `docs` directory, you can run the following npm scripts:
 
-* `npm run docs:start` – Starts a local documentation server at `localhost:8080/docs/`.
+* `npm run docs:start` – Starts a local documentation server at `localhost:8080/docs/next/`.
 * `npm run docs:start:no-cache` – Starts a local documentation server without cache.
 * `npm run docs:api` – Generates the Handsontable API reference into `/content/api`.
 * `npm run docs:build` – Builds the documentation output into `/.vuepress/dist`.
@@ -56,6 +56,7 @@ From the `docs` directory, you can run the following npm scripts:
 * `npm run docs:lint:fix` – Runs ESLint on the `/next/` directory's content and auto-fixes problems.
 * `npm run docs:scripts:link-assets` – Prepares the `next` documentation version's CSS and JavaScript.
 * `npm run docs:review [COMMIT_HASH]` – Deploys the documentation locally at a `[COMMIT_HASH]` commit.
+* `npm run docs:test:example-checker` – Runs the tests that checks if all Docs examples work.
 
 ## Handsontable documentation directory structure
 
@@ -68,18 +69,20 @@ docs                            # All documentation files
 │   │   └── sourceCodeLink.js   # `source-code-link` container.
 │   ├── handsontable-manager    # A module that runs Handsontable examples in different Handsontable versions and frameworks
 │   ├── plugins                 # VuePress plugins
-|   |   ├── assets-versioning                  # Plugin responsible for copying from `docs/<semver.version>/public` to `dist/docs/<semver.version>/public` directory
+|   |   ├── active-header-links                # Plugin responsible for updating the URL with hash after scrolling the page to the nearest anchor
+|   |   ├── dump-docs-data                     # Plugin responsible for generating the all available Docs version and canonical URLs to the JSON file. Then, the file is consumed by other Docs Docker images as source of true about Docs versions and canonicals.
 |   |   ├── extend-page-data                   # Plugin responsible for extending `$page` object and rewriting some properties to add framework ID/name
 |   |   ├── generate-nginx-redirects           # Plugin responsible for generating nginx redirects
+|   |   ├── generate-nginx-variables           # Plugin responsible for generating nginx variables
 |   |   ├── markdown-it-header-injection       # Plugin responsible for injecting `<FRAMEWORK NAME> Data Grid` string before the first header
 |   |   ├── markdown-it-conditional-container  # Plugin responsible for creating conditional containers used for displaying/hiding blocks of content relevant to specific frameworks
 │   ├── public                  # The documentation's public (static) assets
 │   ├── theme                   # Theme overwrites and customizations
 │   ├── tools                   # Our custom documentation tools
+│   │   ├── build.mjs           # Builds the documentation for staging or production
 │   │   ├── check-links.js      # The documentation's link checker
 │   │   ├── jsdoc-convert       # JSDoc-to-Markdown converter
 │   │   ├── utils.js            # Tools utilities
-│   │   └── version             # A tool that creates new documentation versions
 │   ├── config.js               # VuePress configuration
 │   ├── docs-links.js           # Lets us link within the currently-selected docs version and framework with `@` (e.g. [link](@/guides/path/file.md).)
 │   ├── enhanceApp.js           # VuePress app-level enhancements


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adds a redirect to the default framework. The rule applies only to Docs that run in `watch` mode. Moreover, the PR updates the documentation of the README files. 

_[skip changelog]_

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. fixes #9834

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
