### PR TITLE
Fix IME

### DIFF
--- a/.changelogs/9586.json
+++ b/.changelogs/9586.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fix an issue that breaks the IME.",
+  "type": "fixed",
+  "issue": 9586,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/editorManager.js
+++ b/handsontable/src/editorManager.js
@@ -349,12 +349,6 @@ class EditorManager {
 
     const { keyCode } = event;
 
-    // keyCode 229 aka 'uninitialized' doesn't take into account with editors. This key code is produced when unfinished
-    // character is entering (using IME editor). It is fired mainly on linux (ubuntu) with installed ibus-pinyin package.
-    if (keyCode === 229) {
-      return;
-    }
-
     if (!this.selection.isSelected()) {
       return;
     }

--- a/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
@@ -2252,8 +2252,8 @@ describe('Filters UI', () => {
 
       inputs[0].value = '1';
       inputs[1].value = '15';
-      keyUp('1', {}, inputs[0]);
-      keyUp('5', {}, inputs[1]);
+      keyUp('1', { target: inputs[0] });
+      keyUp('5', { target: inputs[1] });
       simulateClick(dropdownMenuRootElement().querySelector('.htUIButton.htUIButtonOK input'));
 
       await sleep(10);

--- a/handsontable/src/shortcuts/__tests__/shortcutManager.spec.js
+++ b/handsontable/src/shortcuts/__tests__/shortcutManager.spec.js
@@ -136,6 +136,39 @@ describe('shortcutManager', () => {
     expect(spy.calls.count()).toBe(1);
   });
 
+  it('should not trigger a callback when IME event is triggered (keyCode 229)', () => {
+    const hot = handsontable();
+    const shortcutManager = hot.getShortcutManager();
+    const gridContext = shortcutManager.getContext('grid');
+    const callback = jasmine.createSpy();
+
+    gridContext.removeShortcutsByKeys(['a']);
+    gridContext.addShortcut({
+      keys: [['a']],
+      callback,
+      group: 'spy',
+    });
+    gridContext.removeShortcutsByKeys(['Enter']);
+    gridContext.addShortcut({
+      keys: [['Enter']],
+      callback,
+      group: 'spy',
+    });
+    hot.listen();
+
+    keyDownUp(['a'], { ime: true });
+
+    expect(callback.calls.count()).toBe(0);
+
+    keyDownUp(['Enter'], { ime: true });
+
+    expect(callback.calls.count()).toBe(0);
+
+    keyDownUp(['Enter'], { ime: false });
+
+    expect(callback.calls.count()).toBe(1);
+  });
+
   it('should run action for specified Command/Control modifier key depending on the operating system the table runs on', () => {
     const hot = handsontable();
     const shortcutManager = hot.getShortcutManager();

--- a/handsontable/src/shortcuts/recorder.js
+++ b/handsontable/src/shortcuts/recorder.js
@@ -81,7 +81,10 @@ export function useRecorder(ownerWindow, handleEvent, beforeKeyDown, afterKeyDow
 
     const result = beforeKeyDown(event);
 
-    if (result === false || isImmediatePropagationStopped(event)) {
+    // keyCode 229 aka 'uninitialized' doesn't take into account with editors. This key code is
+    // produced when unfinished character is entering using the IME editor. It is fired on macOS,
+    // Windows and linux (ubuntu) with installed ibus-pinyin package.
+    if (event.keyCode === 229 || result === false || isImmediatePropagationStopped(event)) {
       return;
     }
 

--- a/handsontable/test/helpers/keyboardEvents.js
+++ b/handsontable/test/helpers/keyboardEvents.js
@@ -71,14 +71,14 @@ const KEY_CODES_MAP = new Map([
  * @param {HTMLElement} options.target The DOM element that the event is dispatched from.
  * @param {boolean} options.ime Indicates whether the event needs to be dispatched as it would by IME.
  */
-export function handsontableKeyTriggerFactory(type, key, { extend, target, ime }) {
+export function keyTriggerFactory(type, key, { extend, target, ime }) {
   const ev = {};
 
   if (ime) {
     // emulates the event that happens while using IME
     ev.keyCode = 229;
   } else {
-    ev.keyCode = KEY_CODES_MAP.has(key) ?? key.codePointAt(0);
+    ev.keyCode = KEY_CODES_MAP.has(key) ? KEY_CODES_MAP.get(key) : key.codePointAt(0);
   }
 
   ev.key = key;
@@ -120,7 +120,7 @@ function triggerKeys(type) {
       extend.shiftKey = isKeyUp && key === 'shift' ? false : keys.includes('shift');
       extend.altKey = isKeyUp && key === 'alt' ? false : keys.includes('alt');
 
-      handsontableKeyTriggerFactory(type, key, { extend, target, ime });
+      keyTriggerFactory(type, key, { extend, target, ime });
     });
   };
 }

--- a/handsontable/test/helpers/keyboardEvents.js
+++ b/handsontable/test/helpers/keyboardEvents.js
@@ -1,5 +1,5 @@
 const { KEY_CODES } = Handsontable.helper;
-const KEYCODES_MAP = new Map([
+const KEY_CODES_MAP = new Map([
   ['A', KEY_CODES.A],
   ['a', 97],
   ['alt', KEY_CODES.ALT],
@@ -65,19 +65,26 @@ const KEYCODES_MAP = new Map([
  * Returns a function that triggers a key event.
  *
  * @param {string} type Event type.
- * @param {string|Element} target Event target.
- * @returns {Function}
+ * @param {string} key The event key name.
+ * @param {object} options Additional options which extends the event or change its behavior.
+ * @param {object} options.extend Additional options which extends the event object.
+ * @param {HTMLElement} options.target The DOM element that the event is dispatched from.
+ * @param {boolean} options.ime Indicates whether the event needs to be dispatched as it would by IME.
  */
-export function handsontableKeyTriggerFactory(type, target) {
-  return function(key, extend) {
-    const ev = {};
+export function handsontableKeyTriggerFactory(type, key, { extend, target, ime }) {
+  const ev = {};
 
-    ev.keyCode = KEYCODES_MAP.has(key) ? KEYCODES_MAP.get(key) : key.codePointAt(0);
-    ev.key = key;
+  if (ime) {
+    // emulates the event that happens while using IME
+    ev.keyCode = 229;
+  } else {
+    ev.keyCode = KEY_CODES_MAP.has(key) ?? key.codePointAt(0);
+  }
 
-    $.extend(ev, extend);
-    $(target).simulate(type, ev);
-  };
+  ev.key = key;
+
+  $.extend(ev, extend);
+  $(target).simulate(type, ev);
 }
 
 export const keyDown = triggerKeys('keydown');
@@ -88,7 +95,7 @@ export const keyUp = triggerKeys('keyup');
  * @returns {Function}
  */
 function triggerKeys(type) {
-  return function(keys, extend = {}, target = document.activeElement) {
+  return function(keys, { extend = {}, target = document.activeElement, ime = false } = {}) {
     // Adds support for a single key as a string and as an array of strings.
     keys = typeof keys === 'string' ? [keys] : keys;
     const isKeyUp = type === 'keyup';
@@ -113,7 +120,7 @@ function triggerKeys(type) {
       extend.shiftKey = isKeyUp && key === 'shift' ? false : keys.includes('shift');
       extend.altKey = isKeyUp && key === 'alt' ? false : keys.includes('alt');
 
-      handsontableKeyTriggerFactory(type, target)(key, extend);
+      handsontableKeyTriggerFactory(type, key, { extend, target, ime });
     });
   };
 }
@@ -122,12 +129,11 @@ function triggerKeys(type) {
  * Presses keyDown, then keyUp.
  *
  * @param {Array} keys The keys `key` which will be associated with the event.
- * @param {object} extend Additional options which extends the event.
- * @param {string|Element} target Event target.
+ * @param {object} options Additional options which extends the event or change its behavior.
  */
-export function keyDownUp(keys, extend, target) {
-  keyDown(keys, extend, target);
-  keyUp(keys, extend, target);
+export function keyDownUp(keys, options) {
+  keyDown(keys, options);
+  keyUp(keys, options);
 }
 
 /**


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the bug where the IME (Input Method Editor) was not usable. An input method editor is a program that provides a specialized user interface for text input. Input method editors are used in situations like entering Chinese, Japanese, or Korean text using a Latin keyboard. The regression was introduced within v12+.

#### Before
![Kapture 2022-08-25 at 15 51 05](https://user-images.githubusercontent.com/571316/186682975-954b861e-e981-4f36-b9cd-c221394ae5eb.gif)

(<kbd>Enter</kbd> causes move to the next row instead of selecting the word)

#### After
![Kapture 2022-08-25 at 15 50 33](https://user-images.githubusercontent.com/571316/186682832-ec8e1621-5ef1-4436-8b1d-31bfea430ac0.gif)

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the fix using the Chinese Pinyin (simplified) keyboard layout. I covered the changes with a new E2E test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes #9586

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
