### PR TITLE
Update the example checker to allow waiting on the examples to get rendered.

### DIFF
--- a/docs/.vuepress/tools/example-checker/index.js
+++ b/docs/.vuepress/tools/example-checker/index.js
@@ -98,7 +98,7 @@ const CHECK_TRIES = 15;
         while (
           (!pageEvaluation.result && tryCount < CHECK_TRIES) &&
           !pageEvaluation.elementsNotYetRendered
-          ) {
+        ) {
           tryCount += 1;
 
           // Wait for the HOT instances to initialize.

--- a/docs/.vuepress/tools/example-checker/index.js
+++ b/docs/.vuepress/tools/example-checker/index.js
@@ -54,7 +54,7 @@ const EXAMPLE_INIT_TIMEOUT = 500;
  *
  * @type {number}
  */
-const CHECK_TRIES = 7;
+const CHECK_TRIES = 10;
 
 (async() => {
   const FRAMEWORKS_TO_CHECK = getFrameworks();
@@ -95,13 +95,16 @@ const CHECK_TRIES = 7;
         let tryCount = 0;
 
         // If the test fails, do another try after a timeout (some instances might have not been initialized yet).
-        while (!pageEvaluation.result && tryCount < CHECK_TRIES) {
+        while (
+          (!pageEvaluation.result && tryCount < CHECK_TRIES) &&
+          !pageEvaluation.elementsNotYetRendered
+          ) {
           tryCount += 1;
 
           // Wait for the HOT instances to initialize.
           await sleep(EXAMPLE_INIT_TIMEOUT);
 
-          pageEvaluation = await page.evaluate(testCases[testIndex], permalink);
+          pageEvaluation = await page.evaluate(testCases[testIndex]);
         }
 
         if (pageEvaluation.error) {

--- a/docs/.vuepress/tools/example-checker/index.js
+++ b/docs/.vuepress/tools/example-checker/index.js
@@ -54,7 +54,7 @@ const EXAMPLE_INIT_TIMEOUT = 500;
  *
  * @type {number}
  */
-const CHECK_TRIES = 15;
+const CHECK_TRIES = 20;
 
 (async() => {
   const FRAMEWORKS_TO_CHECK = getFrameworks();

--- a/docs/.vuepress/tools/example-checker/index.js
+++ b/docs/.vuepress/tools/example-checker/index.js
@@ -54,7 +54,7 @@ const EXAMPLE_INIT_TIMEOUT = 500;
  *
  * @type {number}
  */
-const CHECK_TRIES = 10;
+const CHECK_TRIES = 15;
 
 (async() => {
   const FRAMEWORKS_TO_CHECK = getFrameworks();

--- a/docs/.vuepress/tools/example-checker/testCases.js
+++ b/docs/.vuepress/tools/example-checker/testCases.js
@@ -20,13 +20,7 @@
  */
 /* eslint-enable jsdoc/require-description-complete-sentence */
 const testCases = [
-  (permalink) => {
-    const INSTANCE_NUMBER_EXCEPTIONS = {
-      // The column-summary example on the page of the each framework shows an error being thrown - the Handsontable instance is never rendered.
-      '/next/react-data-grid/column-summary': -1,
-      '/next/javascript-data-grid/column-summary': -1,
-    };
-
+  () => {
     /**
      * Fetch the framework defined as a preset type in the container configuration.
      *
@@ -34,8 +28,14 @@ const testCases = [
      * @returns {string}
      */
     function fetchContainerFramework(parentNode) {
-      let containerFramework = parentNode
-        .querySelector('[data-preset-type]')
+      const presetHoldingElement = parentNode
+        .querySelector('[data-preset-type]');
+
+      if (!presetHoldingElement) {
+        return false;
+      }
+
+      let containerFramework = presetHoldingElement
         .getAttribute('data-preset-type')
         // Replace any digits with an empty string (vue3 -> vue)
         .replace(/\d/g, '')
@@ -86,12 +86,20 @@ const testCases = [
       angular: '<hot-table'
     };
     const emptyExampleContainers = [];
+    let elementsNotYetRendered = false;
     let hotInstancesCount = 0;
 
     codeTabs.forEach((codeTab) => {
       const exampleId = codeTab.id.split('-').at(-1);
       const codeTabParentElement = codeTab.parentElement;
       const containerFramework = fetchContainerFramework(codeTabParentElement);
+
+      if (containerFramework === false) {
+        elementsNotYetRendered = true;
+
+        return;
+      }
+
       const tabContent = fetchTabContent(codeTabParentElement, containerFramework);
       const prefixRegex = new RegExp(hotInitPrefixes[containerFramework], 'g');
       const foundInits = tabContent.match(prefixRegex)?.length;
@@ -104,14 +112,12 @@ const testCases = [
       }
     });
 
-    // Modify the number of expected instances, if there are any exceptions to the given page.
-    hotInstancesCount += (INSTANCE_NUMBER_EXCEPTIONS[permalink] || 0);
-
     return {
       result: (hotInstancesCount === htMasterElements.length) && emptyExampleContainers.length === 0,
       emptyExampleContainers,
       expected: hotInstancesCount,
       received: htMasterElements.length,
+      elementsNotYetRendered,
       error: (!document.body.innerHTML ? 'Page not accessible.' : null),
     };
   }


### PR DESCRIPTION
### Context
This PR:
- Removes the `INSTANCE_NUMBER_EXCEPTIONS` workaround, as it's no longer needed (the problematic example is not previewed by default)
- Adds a check for situations where not only Handsontable, but the entire example preview  is not loaded
- Doubles the possible retries number.

Note: after the changes in #9827 it takes significantly more time to load the example previews. I had to _double_ the retries number to compensate for the false-positive results.

### How has this been tested?
Tested by running the `docs:test:example-checker` script.

### Related issue(s):
1. #9827 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]