### PR TITLE
modifyRowSourceData type definition removed

### DIFF
--- a/handsontable/test/types/settings.types.ts
+++ b/handsontable/test/types/settings.types.ts
@@ -551,7 +551,6 @@ const allSettings: Required<Handsontable.GridSettings> = {
   modifyRowHeader: (row) => {},
   modifyRowHeaderWidth: (rowHeaderWidth) => {},
   modifyRowHeight: (height, row) => {},
-  modifyRowSourceData: (row) => {},
   modifyTransformEnd: (delta) => {},
   modifyTransformStart: (delta) => {},
   persistentStateLoad: () => {},

--- a/handsontable/types/pluginHooks.d.ts
+++ b/handsontable/types/pluginHooks.d.ts
@@ -231,7 +231,6 @@ export interface Events {
   modifyRowHeader?: (row: number) => void;
   modifyRowHeaderWidth?: (rowHeaderWidth: number) => void;
   modifyRowHeight?: (height: number, row: number) => void;
-  modifyRowSourceData?: (row: number) => void;
   modifySourceData?: (row: number, column: number, valueHolder: { value: CellValue }, ioMode: 'get' | 'set') => void;
   modifyTransformEnd?: (delta: CellCoords) => void;
   modifyTransformStart?: (delta: CellCoords) => void;


### PR DESCRIPTION
### Context
To remove type definition for no longer existing hook `modifyRowSourceData`.

### How has this been tested?
By running tests locally.

### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/7317
2.
3.

### Affected project(s):
- [X] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [X] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]
