### PR TITLE
Fix 404 page that redirects to the wrong home page

### DIFF
--- a/docs/.vuepress/theme/components/Navbar.vue
+++ b/docs/.vuepress/theme/components/Navbar.vue
@@ -3,7 +3,7 @@
     <SidebarButton @toggle-sidebar="$emit('toggle-sidebar')" />
 
     <RouterLink
-        :to="`${this.frameworkUrlPrefix}/`"
+        :to="frameworkUrlPrefix"
         class="home-link"
     >
 
@@ -61,7 +61,7 @@ export default {
   },
   computed: {
     frameworkUrlPrefix() {
-      return `/${this.$page.currentFramework}${this.$page.frameworkSuffix}`;
+      return `/${this.$page.currentFramework}${this.$page.frameworkSuffix}/`;
     },
     algolia() {
       return this.$themeLocaleConfig.algolia || this.$site.themeConfig.algolia || {};

--- a/docs/.vuepress/theme/layouts/404.vue
+++ b/docs/.vuepress/theme/layouts/404.vue
@@ -5,7 +5,7 @@
 
       <blockquote>{{ getMsg() }}</blockquote>
 
-      <RouterLink to="/">
+      <RouterLink :to="homeUrl">
         Take me home.
       </RouterLink>
     </div>
@@ -21,14 +21,32 @@ const msgs = [
 ];
 
 export default {
+  data() {
+    return {
+      homeUrl: '/'
+    };
+  },
   methods: {
+    /**
+     * Returns the new homepage URL of the previously selected framework. For example for
+     * `/docs/10.1/javascript-data-grid/ble-ble` it's `/docs/10.1/javascript-data-grid/`.
+     *
+     * The $page object is not available within the component so read the state from
+     * the "window.location".
+     */
+    getFrameworkHomePage() {
+      return '/' + window.location.pathname.replace(/^\/docs\/(?:next|\d+\.\d\/)?(.+\-data-grid\/).*/, '$1');
+    },
     getMsg() {
       return msgs[Math.floor(Math.random() * msgs.length)];
     }
   },
+  mounted() {
+    this.homeUrl = this.getFrameworkHomePage();
+  },
   created() {
     if (this.$ssrContext) {
-      this.$ssrContext.docsGenStamp = this.$page.docsGenStamp ?? '';
+      this.$ssrContext.docsGenStamp = '';
     }
   }
 };

--- a/docs/.vuepress/theme/layouts/404.vue
+++ b/docs/.vuepress/theme/layouts/404.vue
@@ -2,12 +2,8 @@
   <div class="theme-container">
     <div class="theme-default-content">
       <h1>404</h1>
-
       <blockquote>{{ getMsg() }}</blockquote>
-
-      <RouterLink :to="homeUrl">
-        Take me home.
-      </RouterLink>
+      <a :href="homeUrl">Take me home.</a>
     </div>
   </div>
 </template>
@@ -29,13 +25,15 @@ export default {
   methods: {
     /**
      * Returns the new homepage URL of the previously selected framework. For example for
-     * `/docs/10.1/javascript-data-grid/ble-ble` it's `/docs/10.1/javascript-data-grid/`.
+     * `/docs/10.1/react-data-grid/foo/bar` it's `/docs/10.1/react-data-grid/`.
      *
      * The $page object is not available within the component so read the state from
      * the "window.location".
+     *
+     * @returns {string}
      */
     getFrameworkHomePage() {
-      return '/' + window.location.pathname.replace(/^\/docs\/(?:next|\d+\.\d\/)?(.+\-data-grid\/).*/, '$1');
+      return window.location.pathname.replace(/^(\/docs\/(?:(?:next|\d+\.\d)\/)?.+-data-grid\/).*/, '$1');
     },
     getMsg() {
       return msgs[Math.floor(Math.random() * msgs.length)];


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the 404 page that redirects the user to the wrong home page (another 404 page).

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes using `npm run docs:start` and `npm run docs:docker:build` build modes.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes #9857

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
