### PR TITLE
Fix "Last Updated" labels for API pages

### DIFF
--- a/docs/.vuepress/plugins/extend-page-data/index.js
+++ b/docs/.vuepress/plugins/extend-page-data/index.js
@@ -66,7 +66,7 @@ Generated at ${now}
 SHA: ${getDocsRepoSHA()}
 -->`;
         // The `$page.lastUpdated` date is taken from `git log`. For Docs "next" it's impossible to take
-        // the last change date for API files (for "next" they are added to gitignore).
+        // the last change date for API files as they are added to gitignore.
         $page.lastUpdatedFormat = formatDate(new Date());
       } else {
         $page.lastUpdatedFormat = formatDate($page.lastUpdated);

--- a/docs/.vuepress/plugins/extend-page-data/index.js
+++ b/docs/.vuepress/plugins/extend-page-data/index.js
@@ -56,7 +56,6 @@ module.exports = (options, context) => {
       $page.frameworkName = getPrettyFrameworkName($page.currentFramework);
       $page.defaultFramework = getDefaultFramework();
       $page.frameworkSuffix = FRAMEWORK_SUFFIX;
-      $page.lastUpdatedFormat = formatDate($page.lastUpdated);
       $page.buildMode = buildMode;
       $page.isSearchable = notSearchableLinks[$page.currentFramework]?.every(
         notSearchableLink => $page.normalizedPath.includes(notSearchableLink) === false);
@@ -66,6 +65,11 @@ module.exports = (options, context) => {
 Generated at ${now}
 SHA: ${getDocsRepoSHA()}
 -->`;
+        // The `$page.lastUpdated` date is taken from `git log`. For Docs "next" it's impossible to take
+        // the last change date for API files (for "next" they are added to gitignore).
+        $page.lastUpdatedFormat = formatDate(new Date());
+      } else {
+        $page.lastUpdatedFormat = formatDate($page.lastUpdated);
       }
 
       const frontmatter = $page.frontmatter;


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the `$page.lastUpdated` property for Docs "next" version. 

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes using npm run docs:start and npm run docs:docker:build build modes.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes #9816

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
