### PR TITLE
Docs: Rewrite the introduction page

### DIFF
--- a/docs/content/guides/getting-started/installation.md
+++ b/docs/content/guides/getting-started/installation.md
@@ -249,7 +249,7 @@ The main Handsontable component is called `HotTable`.
 import { HotTable } from '@handsontable/react';
 ```
 
-To set Handsontable's [configuration options](@/guides/getting-started/setting-options.md), use `HotTable`'s props. For example:
+To set Handsontable's [configuration options](@/guides/getting-started/configuration-options.md), use `HotTable`'s props. For example:
 
 ```jsx
 <HotTable

--- a/docs/content/guides/getting-started/introduction.md
+++ b/docs/content/guides/getting-started/introduction.md
@@ -10,6 +10,8 @@ react:
 
 # Handsontable documentation
 
+[[toc]]
+
 ::: only-for javascript
 ::: tip
 Using React? [Switch to the React version of this documentation](../react-data-grid).
@@ -25,11 +27,18 @@ Thousands of business apps depend on Handsontable for entering, editing, validat
 ## Get started with Handsontable
 
 To jump straight into the sample code, open Handsontable's demo app at CodeSandbox. Get your data grid up and running in just a few minutes:
-- [JavaScript](https://codesandbox.io/s/handsontable-javascript-data-grid-hello-world-app-forked-zee1jw)
-- [React](https://codesandbox.io/s/handsontable-react-data-grid-hello-world-app-forked-16c9gw)
-- [Angular](https://codesandbox.io/s/handsontable-angular-data-grid-hello-world-app-forked-fz9zrz)
-- [Vue 2](https://codesandbox.io/s/handsontable-vue-data-grid-hello-world-app-forked-6z4395)
-- [TypeScript](https://codesandbox.io/s/handsontable-typescript-data-grid-hello-world-app-forked-xd6xek)
+
+::: only-for javascript
+- [JavaScript demo](https://codesandbox.io/s/handsontable-javascript-data-grid-hello-world-app-forked-zee1jw)
+- [React demo](https://codesandbox.io/s/handsontable-react-data-grid-hello-world-app-forked-16c9gw)
+- [Angular demo](https://codesandbox.io/s/handsontable-angular-data-grid-hello-world-app-forked-fz9zrz)
+- [Vue 2 demo](https://codesandbox.io/s/handsontable-vue-data-grid-hello-world-app-forked-6z4395)
+- [TypeScript demo](https://codesandbox.io/s/handsontable-typescript-data-grid-hello-world-app-forked-xd6xek)
+:::
+
+::: only-for react
+- [React demo](https://codesandbox.io/s/handsontable-react-data-grid-hello-world-app-forked-16c9gw)
+:::
 
 Then, move on to [connecting](@/guides/getting-started/binding-to-data.md) your data and [configuring](@/guides/getting-started/configuration-options.md) Handsontable's built-in features. For more complex implementations, use Handsontable's [API](@/api/introduction.md).
 
@@ -59,11 +68,13 @@ Then, move on to [connecting](@/guides/getting-started/binding-to-data.md) your 
 - [Create a custom plugin](@/guides/tools-and-building/custom-plugins.md)
 - [Translate the UI](@/guides/internationalization/language.md)
 
+::: only-for javascript
 ## Supported frameworks
 
 Handsontable supports popular JavaScript frameworks through wrappers. It also features a TypeScript declaration file that standardizes the API [methods](@/api/core.md), [hooks](@/api/hooks.md), and [options](@/api/options.md).
 
 Explore Handsontable's documentation for [React](../react-data-grid), [Angular](@/guides/integrate-with-angular/angular-installation.md), [Vue 2](@/guides/integrate-with-vue/vue-installation.md), and [Vue 3](@/guides/integrate-with-vue3/vue3-installation.md).
+:::
 
 ## What can I use Handsontable for?
 

--- a/docs/content/guides/getting-started/introduction.md
+++ b/docs/content/guides/getting-started/introduction.md
@@ -8,62 +8,107 @@ react:
   metaTitle: Introduction - React Data Grid | Handsontable
 ---
 
-# Handsontable guides
-
-[[toc]]
-
-Welcome to the Handsontable guides. 👋
-
-Learn how Handsontable works and what you can do with it, through:
-- Code samples
-- Live examples
-- Step-by-step instructions
-- Real-life use cases
-- And much more
-
-## Demo
-
-Explore Handsontable's features and source code:
-
-- [Demo](@/guides/getting-started/demo.md)
+# Handsontable documentation
 
 ::: only-for javascript
-
-## Guides for your framework
-
-<div class="row-items-container">
-  <Link href="../javascript-data-grid/" hide-latest-version class="row-item">
-    <Img class="integration-framework-logo" src="/img/pages/introduction/javascript.svg" alt="JavaScript logo" />
-      <h3>JavaScript</h3>
-  </Link>
-  <Link href="../react-data-grid/" hide-latest-version class="row-item">
-    <Img class="integration-framework-logo" src="/img/pages/introduction/react.svg" alt="React logo" />
-      <h3>React</h3>
-  </Link>
-  <Link href="../javascript-data-grid/angular-simple-example" hide-latest-version class="row-item">
-    <Img class="integration-framework-logo" src="/img/pages/introduction/angular.svg" alt="Angular logo" />
-      <h3>Angular</h3>
-  </Link>
-  <Link href="../javascript-data-grid/vue-simple-example/" hide-latest-version class="row-item">
-    <Img class="integration-framework-logo" src="/img/pages/introduction/vue.svg" alt="Vue logo" />
-      <h3>Vue</h3>
-  </Link>
-  <Link href="../javascript-data-grid/vue3-simple-example/" hide-latest-version class="row-item">
-    <Img class="integration-framework-logo" src="/img/pages/introduction/vue.svg" alt="Vue 3 logo" />
-      <h3>Vue 3</h3>
-  </Link>
-</div>
+::: tip
+Using React? [Switch to the React version of this documentation](../react-data-grid).
+:::
 :::
 
-## What's new
+## What is Handsontable?
+
+Handsontable (pronounced "hands-on-table") is a JavaScript data grid component that provides the well-known look and feel of spreadsheet applications.
+
+Thousands of business apps depend on Handsontable for entering, editing, validating, and cleansing data that comes from remote sources such as databases and APIs, or from HTML documents, Excel files, Google Sheets, and manual input.
+
+## Get started with Handsontable
+
+To jump straight into the sample code, open Handsontable's demo app at CodeSandbox. Get your data grid up and running in just a few minutes:
+- [JavaScript](https://codesandbox.io/s/handsontable-javascript-data-grid-hello-world-app-forked-zee1jw)
+- [React](https://codesandbox.io/s/handsontable-react-data-grid-hello-world-app-forked-16c9gw)
+- [Angular](https://codesandbox.io/s/handsontable-angular-data-grid-hello-world-app-forked-fz9zrz)
+- [Vue 2](https://codesandbox.io/s/handsontable-vue-data-grid-hello-world-app-forked-6z4395)
+- [TypeScript](https://codesandbox.io/s/handsontable-typescript-data-grid-hello-world-app-forked-xd6xek)
+
+Then, move on to [connecting](@/guides/getting-started/binding-to-data.md) your data and [configuring](@/guides/getting-started/configuration-options.md) Handsontable's built-in features. For more complex implementations, use Handsontable's [API](@/api/introduction.md).
+
+### Quickstart
+
+- [Install Handsontable](@/guides/getting-started/installation.md)
+- [Load data](@/guides/getting-started/binding-to-data.md)
+- [Save data](@/guides/getting-started/saving-data.md)
+- [Configure options](@/guides/getting-started/configuration-options.md)
+- [Define the size](@/guides/getting-started/grid-size.md)
+
+### Use popular features
+
+- [Cell types](@/guides/cell-types/cell-type.md)
+- [Formula calculations](@/guides/formulas/formula-calculation.md)
+- [Column filter](@/guides/columns/column-filter.md)
+- [Column groups](@/guides/columns/column-groups.md)
+- [Column summary](@/guides/columns/column-summary.md)
+- [Row parent-child](@/guides/rows/row-parent-child.md)
+- [Context menu](@/guides/accessories-and-menus/context-menu.md)
+
+### Customize the grid
+
+- [Create a custom renderer](@/guides/cell-functions/cell-renderer.md)
+- [Create a custom editor](@/guides/cell-functions/cell-editor.md)
+- [Create a custom validator](@/guides/cell-functions/cell-validator.md)
+- [Create a custom plugin](@/guides/tools-and-building/custom-plugins.md)
+- [Translate the UI](@/guides/internationalization/language.md)
+
+## Supported frameworks
+
+Handsontable supports popular JavaScript frameworks through wrappers. It also features a TypeScript declaration file that standardizes the API [methods](@/api/core.md), [hooks](@/api/hooks.md), and [options](@/api/options.md).
+
+Explore Handsontable's documentation for [React](../react-data-grid), [Angular](@/guides/integrate-with-angular/angular-installation.md), [Vue 2](@/guides/integrate-with-vue/vue-installation.md), and [Vue 3](@/guides/integrate-with-vue3/vue3-installation.md).
+
+## What can I use Handsontable for?
+
+Think of Handsontable as an extensible framework that lets you quickly build tabular, data-oriented user interfaces.
+
+Choose those of the built-in features that you need, and customize the rest through your own [cell types](@/guides/cell-types/cell-type.md), [plugins](@/guides/tools-and-building/custom-plugins.md), and the comprehensive [API](@/api/introduction.md). Provide your users with a highly personalized experience, tailor-made for your business case and unmatched by off-the-shelf software.
+
+### Real-life use cases
+
+Handsontable helps developers solve real-life problems. A few examples:
+
+- In an internal financial application, an editable, Handsontable-based grid simplifies the process of importing hand-picked data from Excel and Google Sheets.
+- In a construction company's software, an interactive data table built with Handsontable helps users modify codes and standards tables.
+- At a hospital, Handsontable helps with tracking and managing supplies.
+- A mobile game company uses Handsontable to streamline certain aspects of the development.
+- In project management software, Handsontable allows managers to collect weekly feedback from the team and customers.
+
+### Types of software
+
+Handsontable's vast set of built-in features and its near-infinite customizability keep it present across different industries and types of software, for example:
+
+- Data modeling applications
+- Resource planning software
+- ERP software
+- Construction digital platforms
+- Commission automation tools
+- Knowledge management systems
+- Reporting platforms for citizens
+- Data management systems
+
+## Technical support
+
+Implementing Handsontable requires a certain level of front-end development skills. In case you need help, and can't find a solution in the documentation, reach out to us. If you have a commercial Handsontable license, and your support plan is active, contact our Support Team at [support@handsontable.com](mailto:support@handsontable.com).
+
+## Feedback
+
+Contribute to the development of Handsontable:
+
+- [Report a GitHub issue](https://github.com/handsontable/handsontable/issues/new/choose)
+- [Ask a question on Stack Overflow](https://stackoverflow.com/questions/tagged/handsontable)
+- [Make a GitHub pull request](https://github.com/handsontable/handsontable/pulls)
+- [Report a documentation issue](https://github.com/handsontable/handsontable/issues/new?assignees=&labels=Docs%3A+Content&template=02-documentation.md&title=Docs%3A+)
+
+## Stay in the loop
 
 - [Release notes](@/guides/upgrade-and-migration/release-notes.md)
 - [Blog](https://handsontable.com/blog)
 - [Twitter](https://twitter.com/handsontable)
-
-## Technical support
-
-- [Contact technical support](https://handsontable.com/contact?category=technical_support)
-- [Ask a question on the Handsontable forum](https://forum.handsontable.com)
-- [Report an issue on GitHub](https://github.com/handsontable/handsontable/issues)
-- [Take part in GitHub Discussions](https://github.com/handsontable/handsontable/discussions)

--- a/docs/content/guides/getting-started/introduction.md
+++ b/docs/content/guides/getting-started/introduction.md
@@ -14,7 +14,7 @@ react:
 
 ::: only-for javascript
 ::: tip
-Using React? [Switch to the React version of this documentation](../react-data-grid).
+Using React? [Switch to the React version of this documentation](../../react-data-grid).
 :::
 :::
 
@@ -73,7 +73,7 @@ Then, move on to [connecting](@/guides/getting-started/binding-to-data.md) your 
 
 Handsontable supports popular JavaScript frameworks through wrappers. It also features a TypeScript declaration file that standardizes the API [methods](@/api/core.md), [hooks](@/api/hooks.md), and [options](@/api/options.md).
 
-Explore Handsontable's documentation for [React](../react-data-grid), [Angular](@/guides/integrate-with-angular/angular-installation.md), [Vue 2](@/guides/integrate-with-vue/vue-installation.md), and [Vue 3](@/guides/integrate-with-vue3/vue3-installation.md).
+Explore Handsontable's documentation for [React](../../react-data-grid), [Angular](@/guides/integrate-with-angular/angular-installation.md), [Vue 2](@/guides/integrate-with-vue/vue-installation.md), and [Vue 3](@/guides/integrate-with-vue3/vue3-installation.md).
 :::
 
 ## What can I use Handsontable for?


### PR DESCRIPTION
This PR:
- Rewrites the introduction page (for JavaScript and React)
- Fixes a broken link

[skip changelog]