### PR TITLE
Disable Docs examples checker

### DIFF
--- a/.github/workflows/docs-staging.yml
+++ b/.github/workflows/docs-staging.yml
@@ -39,9 +39,10 @@ jobs:
         run: |
           npm run docs:docker:build
 
-      - name: Test examples
-        run: |
-          npm run docs:test:example-checker
+      # Temporary disabled on September 2
+      # - name: Test examples
+      #   run: |
+      #     npm run docs:test:example-checker
 
       - name: Docker tags
         run: |


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR disables the Docs examples checker from GitHub Docs Staging Deployment workflow. The checker reports random false-positive errors that break the flow.

_[skip changelog]_

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
