### PR TITLE
Fixed problem with not adding `selected-preview` class on page start

### DIFF
--- a/docs/.vuepress/containers/examples/examples.js
+++ b/docs/.vuepress/containers/examples/examples.js
@@ -137,6 +137,7 @@ module.exports = function(docsVersion, base) {
         return `
             ${!noEdit ? jsfiddle(id, htmlContent, jsToken.content, cssContent, docsVersion, preset) : ''}
             <tabs
+              :class="$parent.$parent.addClassIfPreviewTabIsSelected('${id}', 'selected-preview')"
               :options="{ useUrlFragment: false, defaultTabHash: '${activeTab}' }"
               cache-lifetime="0"
               @changed="$parent.$parent.codePreviewTabChanged(...arguments, '${id}')"

--- a/docs/.vuepress/theme/components/Page.vue
+++ b/docs/.vuepress/theme/components/Page.vue
@@ -32,13 +32,6 @@ export default {
       activatedExamples: [],
     };
   },
-  mounted() {
-    // console.log(document.querySelector('.tabs-component-panels'));
-    // setTimeout(() => {
-    //   document.querySelector('.tabs-component-panels').classList.add('selected-preview');
-    // }, 0);
-    // console.log(document.querySelector('.tabs-component-panels').classList);
-  },
   computed: {
     isApi() {
       return this.$route.fullPath.match(/([^/]*\/)?api\//);
@@ -55,6 +48,7 @@ export default {
       if (selectedTab.tab.computedId.startsWith('preview-tab')) {
         this.activatedExamples.push(exampleId);
 
+        // Extra timeout as there is some problem related to not adding class properly (#9856).
         setTimeout(() => {
           parentContainer.className += ` ${changedClass}`; // Adding class by method compatible with IE
         }, 0);

--- a/docs/.vuepress/theme/components/Page.vue
+++ b/docs/.vuepress/theme/components/Page.vue
@@ -32,6 +32,13 @@ export default {
       activatedExamples: [],
     };
   },
+  mounted() {
+    // console.log(document.querySelector('.tabs-component-panels'));
+    // setTimeout(() => {
+    //   document.querySelector('.tabs-component-panels').classList.add('selected-preview');
+    // }, 0);
+    // console.log(document.querySelector('.tabs-component-panels').classList);
+  },
   computed: {
     isApi() {
       return this.$route.fullPath.match(/([^/]*\/)?api\//);
@@ -47,7 +54,10 @@ export default {
 
       if (selectedTab.tab.computedId.startsWith('preview-tab')) {
         this.activatedExamples.push(exampleId);
-        parentContainer.className += ` ${changedClass}`; // Adding class by method compatible with IE
+
+        setTimeout(() => {
+          parentContainer.className += ` ${changedClass}`; // Adding class by method compatible with IE
+        }, 0);
 
       } else {
         instanceRegister.destroyExample(exampleId);

--- a/docs/.vuepress/theme/components/Page.vue
+++ b/docs/.vuepress/theme/components/Page.vue
@@ -39,24 +39,15 @@ export default {
   },
   methods: {
     codePreviewTabChanged(selectedTab, exampleId) {
-      const changedClass = 'selected-preview';
-      const parentContainer = selectedTab.tab.$el.parentElement;
-
-      // Removing class by method compatible with IE
-      parentContainer.className = parentContainer.className.replace(new RegExp(` ?${changedClass}`), '');
-
       if (selectedTab.tab.computedId.startsWith('preview-tab')) {
         this.activatedExamples.push(exampleId);
-
-        // Extra timeout as there is some problem related to not adding class properly (#9856).
-        setTimeout(() => {
-          parentContainer.className += ` ${changedClass}`; // Adding class by method compatible with IE
-        }, 0);
-
       } else {
         instanceRegister.destroyExample(exampleId);
         this.activatedExamples = this.activatedExamples.filter(activatedExample => activatedExample !== exampleId);
       }
+    },
+    addClassIfPreviewTabIsSelected(exampleId, className) {
+      return this.activatedExamples.includes(exampleId) ? className : '';
     },
     isScriptLoaderActivated(exampleId) {
       return this.activatedExamples.includes(exampleId);

--- a/docs/.vuepress/theme/styles/theme-dark.styl
+++ b/docs/.vuepress/theme/styles/theme-dark.styl
@@ -171,6 +171,14 @@ html.theme-dark {
   .tabs-component {
     border-color $tabsComponentBorderColor
 
+    &.selected-preview {
+      .tabs-component-panels {
+        color-scheme light
+        color $tabsComponentBackgroundColor /* Related to issue #8355 */
+        background-color white; /* Related to issue #8355 */
+      }
+    }
+
     ul.tabs-component-tabs {
       border-bottom-color $tabsComponentBorderColor
       background $tabsComponentBackgroundColor
@@ -193,12 +201,6 @@ html.theme-dark {
     .tabs-component-panels {
       background-color $tabsComponentPanels
       border-radius 0
-
-      &.selected-preview {
-        color-scheme light
-        color $tabsComponentBackgroundColor /* Related to issue #8355 */
-        background-color white; /* Related to issue #8355 */
-      }
 
       section {
         &[id*="preview-"] {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
I discovered that documentation build using `npm run docs:start` script looks properly, while those build using `npm run docs:build` script not. I can't find the source of the problem. The `MutationObserver` has shown that `class` attribute doesn't change on first `codePreviewTabChanged` method execution (on start). There should be added `selected-preview` to class list. It's worth to mention that every click on the [`tabs` element](https://github.com/spatie/vue-tabs-component) already call the method properly. It seems that extra timeout fixes the problem.

edit: Thanks to @budnix changes the code changing DOM by adding/removing classes has been refactored and suggested workaround removed.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested http://localhost:8080/docs/next/react-data-grid/redux/#example page multiple times. I was checking whether DOM element with `tabs-component-panels` class is changed on the start.

[skip changelog]

### Related issue(s):
1. #9856 