### PR TITLE
React docs: Modify the example checker to wait for all the network calls to be finished.

### DIFF
--- a/.github/workflows/docs-staging.yml
+++ b/.github/workflows/docs-staging.yml
@@ -42,6 +42,35 @@ jobs:
       - name: Test examples
         run: |
           npm run docs:test:example-checker
+          npm run docs:test:example-checker
+          npm run docs:test:example-checker
+          npm run docs:test:example-checker
+          npm run docs:test:example-checker
+          npm run docs:test:example-checker
+          npm run docs:test:example-checker
+          npm run docs:test:example-checker
+          npm run docs:test:example-checker
+          npm run docs:test:example-checker
+          npm run docs:test:example-checker
+          npm run docs:test:example-checker
+          npm run docs:test:example-checker
+          npm run docs:test:example-checker
+          npm run docs:test:example-checker
+          npm run docs:test:example-checker
+          npm run docs:test:example-checker
+          npm run docs:test:example-checker
+          npm run docs:test:example-checker
+          npm run docs:test:example-checker
+          npm run docs:test:example-checker
+          npm run docs:test:example-checker
+          npm run docs:test:example-checker
+          npm run docs:test:example-checker
+          npm run docs:test:example-checker
+          npm run docs:test:example-checker
+          npm run docs:test:example-checker
+          npm run docs:test:example-checker
+          npm run docs:test:example-checker
+          npm run docs:test:example-checker
 
       - name: Docker tags
         run: |

--- a/.github/workflows/docs-staging.yml
+++ b/.github/workflows/docs-staging.yml
@@ -39,10 +39,9 @@ jobs:
         run: |
           npm run docs:docker:build
 
-      # Temporary disabled on September 2
-      # - name: Test examples
-      #   run: |
-      #     npm run docs:test:example-checker
+      - name: Test examples
+        run: |
+          npm run docs:test:example-checker
 
       - name: Docker tags
         run: |

--- a/.github/workflows/docs-staging.yml
+++ b/.github/workflows/docs-staging.yml
@@ -42,35 +42,6 @@ jobs:
       - name: Test examples
         run: |
           npm run docs:test:example-checker
-          npm run docs:test:example-checker
-          npm run docs:test:example-checker
-          npm run docs:test:example-checker
-          npm run docs:test:example-checker
-          npm run docs:test:example-checker
-          npm run docs:test:example-checker
-          npm run docs:test:example-checker
-          npm run docs:test:example-checker
-          npm run docs:test:example-checker
-          npm run docs:test:example-checker
-          npm run docs:test:example-checker
-          npm run docs:test:example-checker
-          npm run docs:test:example-checker
-          npm run docs:test:example-checker
-          npm run docs:test:example-checker
-          npm run docs:test:example-checker
-          npm run docs:test:example-checker
-          npm run docs:test:example-checker
-          npm run docs:test:example-checker
-          npm run docs:test:example-checker
-          npm run docs:test:example-checker
-          npm run docs:test:example-checker
-          npm run docs:test:example-checker
-          npm run docs:test:example-checker
-          npm run docs:test:example-checker
-          npm run docs:test:example-checker
-          npm run docs:test:example-checker
-          npm run docs:test:example-checker
-          npm run docs:test:example-checker
 
       - name: Docker tags
         run: |

--- a/docs/.vuepress/tools/example-checker/index.js
+++ b/docs/.vuepress/tools/example-checker/index.js
@@ -54,7 +54,7 @@ const EXAMPLE_INIT_TIMEOUT = 100;
  *
  * @type {number}
  */
-const CHECK_TRIES = 40;
+const CHECK_TRIES = 15;
 
 (async() => {
   const FRAMEWORKS_TO_CHECK = getFrameworks();
@@ -88,7 +88,9 @@ const CHECK_TRIES = 40;
 
       const permalink = extendPermalink(permalinks[i].permalink, framework);
 
-      await page.goto(`http://localhost:${PORT}/docs${permalink}`, {});
+      await page.goto(`http://localhost:${PORT}/docs${permalink}`, {
+        waitUntil: 'networkidle0'
+      });
 
       for (let testIndex = 0; testIndex < testCases.length; testIndex++) {
         let pageEvaluation = await page.evaluate(testCases[testIndex], permalink);

--- a/docs/.vuepress/tools/example-checker/index.js
+++ b/docs/.vuepress/tools/example-checker/index.js
@@ -163,5 +163,3 @@ ${brokenExamplePaths.map(
     process.exit(0);
   }
 })();
-
-// TODO: remove this comment

--- a/docs/.vuepress/tools/example-checker/index.js
+++ b/docs/.vuepress/tools/example-checker/index.js
@@ -164,4 +164,4 @@ ${brokenExamplePaths.map(
   }
 })();
 
-
+//

--- a/docs/.vuepress/tools/example-checker/index.js
+++ b/docs/.vuepress/tools/example-checker/index.js
@@ -164,4 +164,4 @@ ${brokenExamplePaths.map(
   }
 })();
 
-//
+

--- a/docs/.vuepress/tools/example-checker/index.js
+++ b/docs/.vuepress/tools/example-checker/index.js
@@ -165,3 +165,5 @@ ${brokenExamplePaths.map(
     process.exit(0);
   }
 })();
+
+// TODO: Testing, remove this.

--- a/docs/.vuepress/tools/example-checker/index.js
+++ b/docs/.vuepress/tools/example-checker/index.js
@@ -163,5 +163,3 @@ ${brokenExamplePaths.map(
     process.exit(0);
   }
 })();
-
-//

--- a/docs/.vuepress/tools/example-checker/index.js
+++ b/docs/.vuepress/tools/example-checker/index.js
@@ -163,3 +163,5 @@ ${brokenExamplePaths.map(
     process.exit(0);
   }
 })();
+
+//

--- a/docs/.vuepress/tools/example-checker/index.js
+++ b/docs/.vuepress/tools/example-checker/index.js
@@ -54,7 +54,7 @@ const EXAMPLE_INIT_TIMEOUT = 100;
  *
  * @type {number}
  */
-const CHECK_TRIES = 10;
+const CHECK_TRIES = 40;
 
 (async() => {
   const FRAMEWORKS_TO_CHECK = getFrameworks();

--- a/docs/.vuepress/tools/example-checker/index.js
+++ b/docs/.vuepress/tools/example-checker/index.js
@@ -163,3 +163,5 @@ ${brokenExamplePaths.map(
     process.exit(0);
   }
 })();
+
+// TODO: remove this comment

--- a/docs/.vuepress/tools/example-checker/index.js
+++ b/docs/.vuepress/tools/example-checker/index.js
@@ -155,7 +155,9 @@ ${brokenExamplePaths.map(
     })
     .join('\n')}`
     );
-    process.exit(1);
+    // process.exit(1);
+    // Temporarily don't end with an error
+    process.exit(0);
   }
 
   if (brokenExamplePaths.length === 0) {

--- a/docs/.vuepress/tools/example-checker/index.js
+++ b/docs/.vuepress/tools/example-checker/index.js
@@ -165,5 +165,3 @@ ${brokenExamplePaths.map(
     process.exit(0);
   }
 })();
-
-// TODO: Testing, remove this.

--- a/docs/.vuepress/tools/example-checker/index.js
+++ b/docs/.vuepress/tools/example-checker/index.js
@@ -155,9 +155,7 @@ ${brokenExamplePaths.map(
     })
     .join('\n')}`
     );
-    // process.exit(1);
-    // Temporarily don't end with an error
-    process.exit(0);
+    process.exit(1);
   }
 
   if (brokenExamplePaths.length === 0) {


### PR DESCRIPTION
### Context
Seems like @budnix's suggestion that the example checker might be failing because of the cdn files not being loaded on time was (at least partially) correct.

This PR:
- Utilizes the Puppeteer's `waitUntil` option to wait for all the network calls to be done before running the test script
- Extends the re-check try count to 15 to be double safe

### How has this been tested?
Triggered the CI 13 times in a row to see if the checker is not failing.

[skip changelog]
