### PR TITLE
Fix area selection flickering

### DIFF
--- a/.changelogs/8317.json
+++ b/.changelogs/8317.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fixed selection flickering of the edge of the table.",
+  "type": "fixed",
+  "issue": 8317,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/src/table.js
+++ b/handsontable/src/3rdparty/walkontable/src/table.js
@@ -372,8 +372,10 @@ class Table {
       }
     }
 
+    let positionChanged = false;
+
     if (this.isMaster) {
-      let positionChanged = wtOverlays.topOverlay.resetFixedPosition();
+      positionChanged = wtOverlays.topOverlay.resetFixedPosition();
 
       if (wtOverlays.bottomOverlay.clone) {
         positionChanged = wtOverlays.bottomOverlay.resetFixedPosition() || positionChanged;
@@ -388,17 +390,17 @@ class Table {
       if (wtOverlays.bottomInlineStartCornerOverlay && wtOverlays.bottomInlineStartCornerOverlay.clone) {
         wtOverlays.bottomInlineStartCornerOverlay.resetFixedPosition();
       }
-
-      if (positionChanged) {
-        // It refreshes the cells borders caused by a 1px shift (introduced by overlays which add or
-        // remove `innerBorderTop` and `innerBorderInlineStart` CSS classes to the DOM element. This happens
-        // when there is a switch between rendering from 0 to N rows/columns and vice versa).
-        wtOverlays.refreshAll();
-        wtOverlays.adjustElementsSize();
-      }
     }
 
-    this.refreshSelections(runFastDraw);
+    if (positionChanged) {
+      // It refreshes the cells borders caused by a 1px shift (introduced by overlays which add or
+      // remove `innerBorderTop` and `innerBorderInlineStart` CSS classes to the DOM element. This happens
+      // when there is a switch between rendering from 0 to N rows/columns and vice versa).
+      wtOverlays.refreshAll(); // `refreshAll()` internally already calls `refreshSelections()` method
+      wtOverlays.adjustElementsSize();
+    } else {
+      this.refreshSelections(runFastDraw);
+    }
 
     if (syncScroll) {
       wtOverlays.syncScrollWithMaster();

--- a/handsontable/src/3rdparty/walkontable/test/helpers/common.js
+++ b/handsontable/src/3rdparty/walkontable/test/helpers/common.js
@@ -284,20 +284,30 @@ export function range(start, end) {
 export function createSelectionController({ current, area, fill, custom, activeHeader, header } = {}) {
   const currentCtrl = current || createSelection({
     className: 'current',
+    selectionType: 'cell',
     border: {
       width: 2,
       color: '#4b89ff',
     },
   });
   const areaCtrl = area || createSelection({
+    markIntersections: true,
+    layerLevel: 1,
     className: 'area',
+    selectionType: 'area',
     border: {
       width: 1,
       color: '#4b89ff',
     },
   });
+
+  const areaControllers = new Map([
+    [areaCtrl.layerLevel || 1, areaCtrl]
+  ]);
+
   const fillCtrl = fill || createSelection({
     className: 'fill',
+    selectionType: 'fill',
     border: {
       width: 1,
       color: '#ff0000',
@@ -305,9 +315,11 @@ export function createSelectionController({ current, area, fill, custom, activeH
   });
   const activeHeaderCtrl = activeHeader || createSelection({
     highlightHeaderClassName: 'active_highlight',
+    selectionType: 'active-header',
   });
   const headerCtrl = header || createSelection({
     highlightHeaderClassName: 'highlight',
+    selectionType: 'header',
   });
   const customCtrl = custom || [];
 
@@ -321,11 +333,31 @@ export function createSelectionController({ current, area, fill, custom, activeH
     getActiveHeader() {
       return activeHeaderCtrl;
     },
-    createOrGetArea() {
-      return areaCtrl;
+    createOrGetArea(options = {}) {
+      const optionsWithDefaults = {
+        markIntersections: true,
+        layerLevel: 1,
+        border: {
+          width: 1,
+          color: '#4b89ff',
+        },
+        ...options,
+        className: 'area',
+        selectionType: 'area',
+      };
+
+      if (areaControllers.has(optionsWithDefaults.layerLevel)) {
+        return areaControllers.get(optionsWithDefaults.layerLevel);
+      }
+
+      const newArea = createSelection(optionsWithDefaults);
+
+      areaControllers.set(optionsWithDefaults.layerLevel, newArea);
+
+      return newArea;
     },
     getAreas() {
-      return [areaCtrl];
+      return Array.from(areaControllers.values());
     },
     getFill() {
       return fillCtrl;
@@ -334,7 +366,7 @@ export function createSelectionController({ current, area, fill, custom, activeH
       return [
         currentCtrl,
         fillCtrl,
-        areaCtrl,
+        ...this.getAreas(),
         headerCtrl,
         activeHeaderCtrl,
         ...customCtrl,


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the bug that causes the area selection to flicker. The bug occurs only when the row headers are enabled, and the table is horizontally scrolled by ~2 pixels back and forth near the table's left edge. The main problem was the double selection refresh call that was caused by [the overlays](https://github.com/handsontable/handsontable/blob/develop/handsontable/src/3rdparty/walkontable/src/table.js#L396). The area selection depends on the current `class` added to the DOM elements so with double selection refresh calls the logic behind the selection adds wrong area classes (`area-1`, `area-2` etc.) to the element. The fix adjusts the code to call selection refresh only once.

#### Before
![Kapture 2022-09-06 at 13 04 04](https://user-images.githubusercontent.com/571316/188619411-5573bfc3-a950-46c7-b8b8-77f5a4641e5f.gif)

#### After
![Kapture 2022-09-06 at 13 04 35](https://user-images.githubusercontent.com/571316/188619494-3c016da9-c991-43df-b96b-d6a37bf00c12.gif)

Moreover, the PR updates the [selection controller mock](https://github.com/handsontable/handsontable/pull/9871/files#diff-58d9769609cf0cbb2900cbd22a3b953d6f646daa1d576af7059202704876d8f3R336) to be matched to a more real object used by the Handsontable Selection class.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally, and I covered the fix with a new E2E test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes #8317

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
