### PR TITLE
Allow use `trimWhitespace` option in column and cell meta layers

### DIFF
--- a/.changelogs/7387.json
+++ b/.changelogs/7387.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fixed an issue where the `trimWhitespace` option can no be used in the columns and cells meta option layers.",
+  "type": "fixed",
+  "issue": 7387,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/dataMap/metaManager/metaSchema.js
+++ b/handsontable/src/dataMap/metaManager/metaSchema.js
@@ -4295,7 +4295,7 @@ export default () => {
      * | `true` (default) | Remove whitespace at the beginning and at the end of each cell |
      * | `false`          | Don't remove whitespace                                         |
      *
-     * @memberof Options#tr
+     * @memberof Options#
      * @type {boolean}
      * @default true
      * @category Core

--- a/handsontable/src/editors/baseEditor/baseEditor.js
+++ b/handsontable/src/editors/baseEditor/baseEditor.js
@@ -347,7 +347,7 @@ export class BaseEditor {
 
       const value = this.getValue();
 
-      if (this.hot.getSettings().trimWhitespace) {
+      if (this.cellProperties.trimWhitespace) {
         // We trim only string values
         val = [
           [typeof value === 'string' ? String.prototype.trim.call(value || '') : value]

--- a/handsontable/src/editors/textEditor/__tests__/textEditor.spec.js
+++ b/handsontable/src/editors/textEditor/__tests__/textEditor.spec.js
@@ -1603,21 +1603,6 @@ describe('TextEditor', () => {
 
   });
 
-  it('should render the text without trimming out the whitespace, if trimWhitespace is set to false', () => {
-    spec().$container.css('overflow', '');
-    const hot = handsontable({
-      data: createSpreadsheetData(3, 9),
-      trimWhitespace: false
-    });
-
-    selectCell(0, 2);
-    keyDownUp('enter');
-    hot.getActiveEditor().TEXTAREA.value = '       test    of    whitespace      ';
-    keyDownUp('enter');
-
-    expect(getDataAtCell(0, 2).length).toEqual(37);
-  });
-
   it('should insert new line on caret position when pressing ALT + ENTER, CTRL + ENTER or META + ENTER', () => {
     const data = [
       ['Maserati', 'Mazda'],

--- a/handsontable/src/renderers/textRenderer/__tests__/textRenderer.unit.js
+++ b/handsontable/src/renderers/textRenderer/__tests__/textRenderer.unit.js
@@ -59,9 +59,9 @@ describe('textRenderer', () => {
     it('should trim whitespaces if trimWhitespace is set as true', () => {
       const TD = document.createElement('td');
       const instance = getInstance({
-        trimWhitespace: true,
+        trimWhitespace: false,
       });
-      const cellMeta = {};
+      const cellMeta = { trimWhitespace: true }; // cell meta layer has priority
 
       textRenderer(instance, TD, void 0, void 0, void 0, 'Long   text ', cellMeta);
 
@@ -72,9 +72,9 @@ describe('textRenderer', () => {
       const TD = document.createElement('td');
       const instance = getInstance({
         wordWrap: true,
-        trimWhitespace: true
+        trimWhitespace: false
       });
-      const cellMeta = {};
+      const cellMeta = { trimWhitespace: true }; // cell meta layer has priority
 
       textRenderer(instance, TD, void 0, void 0, void 0, 'Long   text ', cellMeta);
 

--- a/handsontable/src/renderers/textRenderer/textRenderer.js
+++ b/handsontable/src/renderers/textRenderer/textRenderer.js
@@ -26,7 +26,7 @@ export function textRenderer(instance, TD, row, col, prop, value, cellProperties
 
   escaped = stringify(escaped);
 
-  if (instance.getSettings().trimWhitespace) {
+  if (cellProperties.trimWhitespace) {
     escaped = escaped.trim();
   }
 

--- a/handsontable/src/renderers/timeRenderer/__tests__/timeRenderer.unit.js
+++ b/handsontable/src/renderers/timeRenderer/__tests__/timeRenderer.unit.js
@@ -59,9 +59,9 @@ describe('timeRenderer', () => {
     it('should trim whitespaces if trimWhitespace is set as true', () => {
       const TD = document.createElement('td');
       const instance = getInstance({
-        trimWhitespace: true,
+        trimWhitespace: false,
       });
-      const cellMeta = {};
+      const cellMeta = { trimWhitespace: true }; // cell meta layer has priority
 
       timeRenderer(instance, TD, void 0, void 0, void 0, 'Long   text ', cellMeta);
 
@@ -72,9 +72,9 @@ describe('timeRenderer', () => {
       const TD = document.createElement('td');
       const instance = getInstance({
         wordWrap: true,
-        trimWhitespace: true
+        trimWhitespace: false
       });
-      const cellMeta = {};
+      const cellMeta = { trimWhitespace: true }; // cell meta layer has priority
 
       timeRenderer(instance, TD, void 0, void 0, void 0, 'Long   text ', cellMeta);
 

--- a/handsontable/test/e2e/settings/trimWhitespace.spec.js
+++ b/handsontable/test/e2e/settings/trimWhitespace.spec.js
@@ -13,30 +13,196 @@ describe('settings', () => {
       }
     });
 
-    it('should trim whitespaces from the beginning and the end of the cell when trimWhitespace options is true', () => {
-      handsontable({
-        trimWhitespace: true,
-        data: [
-          ['    text    with    spaces  ']
-        ],
+    describe('in table settings layer', () => {
+      it('should trimmed out the whitespace after cell edit, if trimWhitespace is set to `true`', () => {
+        handsontable({
+          data: createSpreadsheetData(3, 9),
+          trimWhitespace: true
+        });
+
+        selectCell(0, 2);
+        keyDownUp('enter');
+        getActiveEditor().TEXTAREA.value = '       test    of    whitespace      ';
+        keyDownUp('enter');
+
+        expect(getDataAtCell(0, 2)).toBe('test    of    whitespace');
       });
 
-      const innerTextOfCell = getCell(0, 0).innerText;
+      it('should not trimmed out the whitespace after cell edit, if trimWhitespace is set to `false`', () => {
+        handsontable({
+          data: createSpreadsheetData(3, 9),
+          trimWhitespace: false
+        });
 
-      expect(innerTextOfCell).toEqual('text    with    spaces');
+        selectCell(0, 2);
+        keyDownUp('enter');
+        getActiveEditor().TEXTAREA.value = '       test    of    whitespace      ';
+        keyDownUp('enter');
+
+        expect(getDataAtCell(0, 2)).toBe('       test    of    whitespace      ');
+      });
+
+      it('should trimmed out the whitespace through cell renderers, if trimWhitespace is set to `true`', () => {
+        handsontable({
+          data: [
+            ['       test    of    whitespace      ', '       test    of    whitespace      ']
+          ],
+          trimWhitespace: true
+        });
+
+        expect(getCell(0, 0).innerText).toBe('test    of    whitespace');
+      });
+
+      it('should not trimmed out the whitespace through cell renderers, if trimWhitespace is set to `false`', () => {
+        handsontable({
+          data: [
+            ['       test    of    whitespace      ', '       test    of    whitespace      ']
+          ],
+          trimWhitespace: false
+        });
+
+        expect(getCell(0, 0).innerText).toBe('       test    of    whitespace      ');
+      });
     });
 
-    it('should preserve whitespaces when trimWhitespace options is false', () => {
-      handsontable({
-        trimWhitespace: false,
-        data: [
-          ['    text    with    spaces  ']
-        ],
+    describe('in column settings layer', () => {
+      it('should trimmed out the whitespace after cell edit, if trimWhitespace is set to `true`', () => {
+        handsontable({
+          data: createSpreadsheetData(3, 9),
+          trimWhitespace: false,
+          columns: [
+            {},
+            { trimWhitespace: true }
+          ]
+        });
+
+        selectCell(0, 1);
+        keyDownUp('enter');
+        getActiveEditor().TEXTAREA.value = '       test    of    whitespace      ';
+        keyDownUp('enter');
+
+        expect(getDataAtCell(0, 1)).toBe('test    of    whitespace');
       });
 
-      const innerTextOfCell = getCell(0, 0).innerText;
+      it('should not trimmed out the whitespace after cell edit, if trimWhitespace is set to `false`', () => {
+        handsontable({
+          data: createSpreadsheetData(3, 9),
+          trimWhitespace: true,
+          columns: [
+            {},
+            { trimWhitespace: false }
+          ]
+        });
 
-      expect(innerTextOfCell).toEqual('    text    with    spaces  ');
+        selectCell(0, 1);
+        keyDownUp('enter');
+        getActiveEditor().TEXTAREA.value = '       test    of    whitespace      ';
+        keyDownUp('enter');
+
+        expect(getDataAtCell(0, 1)).toBe('       test    of    whitespace      ');
+      });
+
+      it('should trimmed out the whitespace through cell renderers, if trimWhitespace is set to `true`', () => {
+        handsontable({
+          data: [
+            ['       test    of    whitespace      ', '       test    of    whitespace      ']
+          ],
+          trimWhitespace: false,
+          columns: [
+            {},
+            { trimWhitespace: true }
+          ]
+        });
+
+        expect(getCell(0, 1).innerText).toBe('test    of    whitespace');
+      });
+
+      it('should not trimmed out the whitespace through cell renderers, if trimWhitespace is set to `false`', () => {
+        handsontable({
+          data: [
+            ['       test    of    whitespace      ', '       test    of    whitespace      ']
+          ],
+          trimWhitespace: true,
+          columns: [
+            {},
+            { trimWhitespace: false }
+          ]
+        });
+
+        expect(getCell(0, 1).innerText).toBe('       test    of    whitespace      ');
+      });
+    });
+
+    describe('in cell settings layer', () => {
+      it('should trimmed out the whitespace after cell edit, if trimWhitespace is set to `true`', () => {
+        handsontable({
+          data: createSpreadsheetData(3, 9),
+          trimWhitespace: false,
+          cells(row, col) {
+            if (col === 1) {
+              return { trimWhitespace: true };
+            }
+          }
+        });
+
+        selectCell(0, 1);
+        keyDownUp('enter');
+        getActiveEditor().TEXTAREA.value = '       test    of    whitespace      ';
+        keyDownUp('enter');
+
+        expect(getDataAtCell(0, 1)).toBe('test    of    whitespace');
+      });
+
+      it('should not trimmed out the whitespace after cell edit, if trimWhitespace is set to `false`', () => {
+        handsontable({
+          data: createSpreadsheetData(3, 9),
+          trimWhitespace: true,
+          cells(row, col) {
+            if (col === 1) {
+              return { trimWhitespace: false };
+            }
+          }
+        });
+
+        selectCell(0, 1);
+        keyDownUp('enter');
+        getActiveEditor().TEXTAREA.value = '       test    of    whitespace      ';
+        keyDownUp('enter');
+
+        expect(getDataAtCell(0, 1)).toBe('       test    of    whitespace      ');
+      });
+
+      it('should trimmed out the whitespace through cell renderers, if trimWhitespace is set to `true`', () => {
+        handsontable({
+          data: [
+            ['       test    of    whitespace      ', '       test    of    whitespace      ']
+          ],
+          trimWhitespace: false,
+          cells(row, col) {
+            if (col === 1) {
+              return { trimWhitespace: true };
+            }
+          }
+        });
+
+        expect(getCell(0, 1).innerText).toBe('test    of    whitespace');
+      });
+
+      it('should not trimmed out the whitespace through cell renderers, if trimWhitespace is set to `false`', () => {
+        handsontable({
+          data: [
+            ['       test    of    whitespace      ', '       test    of    whitespace      ']
+          ],
+          trimWhitespace: true,
+          cells(row, col) {
+            if (col === 1) {
+              return { trimWhitespace: false };
+            }
+          }
+        });
+
+        expect(getCell(0, 1).innerText).toBe('       test    of    whitespace      ');
+      });
     });
   });
 });


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes a bug that disallows defining the `trimWhitespace` option in the column or cell meta layers (cascading configuration).

#### Before
Before the changes, only in the table settings level, the option could be used:
```js
new Handsontable(element, {
  data: [[...]],
  trimWhitespace: true
});
```

#### After
After PR's changes, the option can be defined in columns and/or cells setting levels as well.
```js
new Handsontable(element, {
  data: [[...]],
  trimWhitespace: true,
  columns: [
    { data: '0' },
    { data: '1', trimWhitespace: false }
  ]
});
```
or
```js
new Handsontable(element, {
  data: [[...]],
  trimWhitespace: true,
  cells(row, col) {
    if (col === 1) {
      return { trimWhitespace: false };
    }
  }
});
```

Moreover, the PR fixes the JSDoc typo that prevents the `trimWhitespace` option from not being searched in the Docs.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally, and I covered the fix with new E2E tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes #7387

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)