### PR TITLE
Docs: Update `Formulas` plugin's dependencies

### DIFF
--- a/docs/content/guides/technical-specification/third-party-licenses.md
+++ b/docs/content/guides/technical-specification/third-party-licenses.md
@@ -56,25 +56,10 @@ The dependencies below apply only if you use the [`Formulas`](@/api/formulas.md)
     License: Apache v2.0<br>
     [https://github.com/SAP/chevrotain](https://github.com/SAP/chevrotain)
 
-- **core-js**<br>
-    Author: Denis Pushkarev<br>
-    License: Open source (MIT)<br>
-    [https://github.com/zloirock/core-js](https://github.com/zloirock/core-js)
-
-- **GPU.js (optional)**<br>
-    Author: GPU.js team<br>
-    License: Open source (MIT)<br>
-    [https://github.com/gpujs/gpu.js](https://github.com/gpujs/gpu.js/)
-
 - **jStat**<br>
     Author: jStat<br>
     License: Open source (MIT)<br>
     [https://github.com/jstat/jstat](https://github.com/jstat/jstat)
-
-- **regenerator-runtime**<br>
-    Author: Facebook, Inc.<br>
-    License: Open source (MIT)<br>
-    [https://github.com/facebook/regenerator/tree/master/packages/regenerator-runtime](https://github.com/facebook/regenerator/tree/master/packages/regenerator-runtime)
 
 - **tiny-emitter**<br>
     Author: Scott Corgan<br>

--- a/docs/content/guides/technical-specification/third-party-licenses.md
+++ b/docs/content/guides/technical-specification/third-party-licenses.md
@@ -56,6 +56,11 @@ The dependencies below apply only if you use the [`Formulas`](@/api/formulas.md)
     License: Apache v2.0<br>
     [https://github.com/SAP/chevrotain](https://github.com/SAP/chevrotain)
 
+- **core-js**<br>
+    Author: Denis Pushkarev<br>
+    License: Open source (MIT)<br>
+    [https://github.com/zloirock/core-js](https://github.com/zloirock/core-js)
+
 - **jStat**<br>
     Author: jStat<br>
     License: Open source (MIT)<br>


### PR DESCRIPTION
This PR:
- Updates the `Formulas` plugin's dependencies, to match the state of HyperFormula 2.1.0 (to be released on Sep 9)

[skip changelog]