### PR TITLE
React Docs: Remove the hash symbol from the permalink "a" element and move it to its ::before pseudoclass.

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -76,6 +76,7 @@ var DOCS_VERSION = '${getThisDocsVersion()}';
       containerHeaderHtml: '<div class="toc-container-header">Table of contents</div>'
     },
     anchor: {
+      permalinkSymbol: '',
       callback(token, slugInfo) {
         if (['h1', 'h2', 'h3'].includes(token.tag)) {
           // Remove the `-[number]` suffix from the slugs and header IDs

--- a/docs/.vuepress/theme/styles/index.styl
+++ b/docs/.vuepress/theme/styles/index.styl
@@ -186,6 +186,23 @@ h5 {
   font-size: 1em;
 }
 
+h1 a.header-anchor::before,
+h2 a.header-anchor::before,
+h3 a.header-anchor::before,
+h4 a.header-anchor::before,
+h5 a.header-anchor::before {
+  content: '#';
+  visibility: 'hidden';
+}
+
+h1:hover a.header-anchor::before,
+h2:hover a.header-anchor::before,
+h3:hover a.header-anchor::before,
+h4:hover a.header-anchor::before,
+h5:hover a.header-anchor::before {
+  visibility: 'visible';
+}
+
 .page {
   ul, ol {
       padding-left: 2.2em;

--- a/docs/.vuepress/theme/styles/index.styl
+++ b/docs/.vuepress/theme/styles/index.styl
@@ -186,21 +186,15 @@ h5 {
   font-size: 1em;
 }
 
-h1 a.header-anchor::before,
-h2 a.header-anchor::before,
-h3 a.header-anchor::before,
-h4 a.header-anchor::before,
-h5 a.header-anchor::before {
-  content: '#';
-  visibility: 'hidden';
-}
+h1, h2, h3, h4, h5 {
+  a.header-anchor::before {
+    content: '#';
+    visibility: 'hidden';
+  }
 
-h1:hover a.header-anchor::before,
-h2:hover a.header-anchor::before,
-h3:hover a.header-anchor::before,
-h4:hover a.header-anchor::before,
-h5:hover a.header-anchor::before {
-  visibility: 'visible';
+  &:hover {
+    visibility: 'visible';
+  }
 }
 
 .page {


### PR DESCRIPTION
### Context
This PR removes the `#` from the `<a>` element being the permalink handle for all headers and moves it to a CSS `::before` pseudoclass.

### How has this been tested?
Tested using `docs:start:no-cache`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #9803 

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]
