### PR TITLE
React docs: Correct the permalink `href` attributes on headers duplicated between vanilla/react versions.

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -77,9 +77,19 @@ var DOCS_VERSION = '${getThisDocsVersion()}';
     },
     anchor: {
       permalinkSymbol: '',
+      permalinkHref(slug) {
+        // Remove the `-[number]` suffix from the permalink href attribute.
+        const duplicatedSlugsMatch = /(.*)-(\d)+$/.exec(slug);
+
+        if (duplicatedSlugsMatch) {
+          slug = duplicatedSlugsMatch[1];
+        }
+
+        return `#${slug}`;
+      },
       callback(token, slugInfo) {
         if (['h1', 'h2', 'h3'].includes(token.tag)) {
-          // Remove the `-[number]` suffix from the slugs and header IDs
+          // Remove the `-[number]` suffix from the slugs and header IDs.
           const duplicatedSlugsMatch = /(.*)-(\d)+$/.exec(token.attrs[0][1]);
 
           if (duplicatedSlugsMatch) {


### PR DESCRIPTION
### Context
This PR should correct the `-2`, suffixes in the `href` attributes on the permalinks of the headers duplicated between vanilla/react docs versions - it's a continuation of #9783.

### How has this been tested?
Tested using `docs:start:no-cache`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #9892 
2. #9783

[skip changelog]