### PR TITLE
API reference for `beforeChange` hook has been made more precise + added changelog for changes improving the documentation and the types

### DIFF
--- a/.changelogs/9901.json
+++ b/.changelogs/9901.json
@@ -1,5 +1,5 @@
 {
-  "title": "API reference and type definitions for `beforeChange` hook has been made more precise",
+  "title": "API reference and type definitions for hooks and methods has been made more precise",
   "type": "changed",
   "issue": 9901,
   "breaking": false,

--- a/.changelogs/9901.json
+++ b/.changelogs/9901.json
@@ -1,0 +1,7 @@
+{
+  "title": "API reference and type definitions for `beforeChange` hook has been made more precise",
+  "type": "changed",
+  "issue": 9901,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/pluginHooks.js
+++ b/handsontable/src/pluginHooks.js
@@ -824,7 +824,7 @@ const REGISTERED_HOOKS = [
    *
    * `row` is a visual row index.
    *
-   * Note: Nullified array items or `false` return value can be used to disregard changes, as presented in the code snippet below
+   * __Note:__: Nullified array items or `false` return value can be used to disregard changes, as presented in the code snippet below.
    *
    * @event Hooks#beforeChange
    * @param {Array[]} changes 2D array containing information about each of the edited cells.

--- a/handsontable/src/pluginHooks.js
+++ b/handsontable/src/pluginHooks.js
@@ -824,6 +824,8 @@ const REGISTERED_HOOKS = [
    *
    * `row` is a visual row index.
    *
+   * Note: Nullified array items or `false` return value can be used to disregard changes, as presented in the code snippet below
+   *
    * @event Hooks#beforeChange
    * @param {Array[]} changes 2D array containing information about each of the edited cells.
    * @param {string} [source] String that identifies source of hook call

--- a/handsontable/src/plugins/filters/filters.js
+++ b/handsontable/src/plugins/filters/filters.js
@@ -39,7 +39,6 @@ export const PLUGIN_PRIORITY = 250;
  * See [the filtering demo](@/guides/columns/column-filter.md) for examples.
  *
  * @example
- * ::: only-for javascript
  * ```js
  * const container = document.getElementById('example');
  * const hot = new Handsontable(container, {
@@ -50,19 +49,6 @@ export const PLUGIN_PRIORITY = 250;
  *   filters: true
  * });
  * ```
- * :::
- *
- * ::: only-for react
- * ```jsx
- * <HotTable
- *   data={getData()}
- *   colHeaders={true}
- *   rowHeaders={true}
- *   dropdownMenu={true}
- *   filters={true}
- * />
- * ```
- * :::
  */
 export class Filters extends BasePlugin {
   static get PLUGIN_KEY() {
@@ -140,23 +126,18 @@ export class Filters extends BasePlugin {
      */
     this.filtersRowsMap = null;
 
-    console.log('aaa')
-    
-    return;
-
     // One listener for the enable/disable functionality
     this.hot.addHook('afterGetColHeader', (col, TH) => this.onAfterGetColHeader(col, TH));
   }
 
   /**
    * Checks if the plugin is enabled in the handsontable settings. This method is executed in {@link Hooks#beforeInit}
-   * hook and if it returns `true` then the {@link Filters#enablePlugin} method is called.
+   * hook and if it returns `true` than the {@link Filters#enablePlugin} method is called.
    *
    * @returns {boolean}
    */
   isEnabled() {
     /* eslint-disable no-unneeded-ternary */
-    return false;
     return this.hot.getSettings()[PLUGIN_KEY] ? true : false;
   }
 
@@ -168,98 +149,98 @@ export class Filters extends BasePlugin {
       return;
     }
 
-    // this.filtersRowsMap = this.hot.rowIndexMapper.registerMap(this.pluginName, new TrimmingMap());
-    // this.dropdownMenuPlugin = this.hot.getPlugin('dropdownMenu');
+    this.filtersRowsMap = this.hot.rowIndexMapper.registerMap(this.pluginName, new TrimmingMap());
+    this.dropdownMenuPlugin = this.hot.getPlugin('dropdownMenu');
 
-    // const dropdownSettings = this.hot.getSettings().dropdownMenu;
-    // const menuContainer = (dropdownSettings && dropdownSettings.uiContainer) || this.hot.rootDocument.body;
-    // const addConfirmationHooks = (component) => {
-    //   component.addLocalHook('accept', () => this.onActionBarSubmit('accept'));
-    //   component.addLocalHook('cancel', () => this.onActionBarSubmit('cancel'));
-    //   component.addLocalHook('change', command => this.onComponentChange(component, command));
-    //
-    //   return component;
-    // };
-    //
-    // const filterByConditionLabel = () => `${this.hot.getTranslatedPhrase(constants.FILTERS_DIVS_FILTER_BY_CONDITION)}:`;
-    // const filterValueLabel = () => `${this.hot.getTranslatedPhrase(constants.FILTERS_DIVS_FILTER_BY_VALUE)}:`;
-    //
-    // if (!this.components.get('filter_by_condition')) {
-    //   const conditionComponent = new ConditionComponent(this.hot, {
-    //     id: 'filter_by_condition',
-    //     name: filterByConditionLabel,
-    //     addSeparator: false,
-    //     menuContainer
-    //   });
-    //
-    //   conditionComponent.addLocalHook('afterClose', () => this.onSelectUIClosed());
-    //
-    //   this.components.set('filter_by_condition', addConfirmationHooks(conditionComponent));
-    // }
-    //
-    // if (!this.components.get('filter_operators')) {
-    //   this.components.set('filter_operators', new OperatorsComponent(this.hot, {
-    //     id: 'filter_operators',
-    //     name: 'Operators'
-    //   }));
-    // }
-    //
-    // if (!this.components.get('filter_by_condition2')) {
-    //   const conditionComponent = new ConditionComponent(this.hot, {
-    //     id: 'filter_by_condition2',
-    //     name: '',
-    //     addSeparator: true,
-    //     menuContainer
-    //   });
-    //
-    //   conditionComponent.addLocalHook('afterClose', () => this.onSelectUIClosed());
-    //
-    //   this.components.set('filter_by_condition2', addConfirmationHooks(conditionComponent));
-    // }
-    //
-    // if (!this.components.get('filter_by_value')) {
-    //   this.components.set('filter_by_value', addConfirmationHooks(new ValueComponent(this.hot, {
-    //     id: 'filter_by_value',
-    //     name: filterValueLabel
-    //   })));
-    // }
-    //
-    // if (!this.components.get('filter_action_bar')) {
-    //   this.components.set('filter_action_bar', addConfirmationHooks(new ActionBarComponent(this.hot, {
-    //     id: 'filter_action_bar',
-    //     name: 'Action bar'
-    //   })));
-    // }
-    //
-    // if (!this.conditionCollection) {
-    //   this.conditionCollection = new ConditionCollection(this.hot);
-    // }
-    //
-    // if (!this.conditionUpdateObserver) {
-    //   this.conditionUpdateObserver = new ConditionUpdateObserver(
-    //     this.hot,
-    //     this.conditionCollection,
-    //     physicalColumn => this.getDataMapAtColumn(physicalColumn),
-    //   );
-    //   this.conditionUpdateObserver.addLocalHook('update', conditionState => this.updateComponents(conditionState));
-    // }
-    //
-    // this.components.forEach(component => component.show());
+    const dropdownSettings = this.hot.getSettings().dropdownMenu;
+    const menuContainer = (dropdownSettings && dropdownSettings.uiContainer) || this.hot.rootDocument.body;
+    const addConfirmationHooks = (component) => {
+      component.addLocalHook('accept', () => this.onActionBarSubmit('accept'));
+      component.addLocalHook('cancel', () => this.onActionBarSubmit('cancel'));
+      component.addLocalHook('change', command => this.onComponentChange(component, command));
 
-    // this.addHook('beforeDropdownMenuSetItems', items => this.onBeforeDropdownMenuSetItems(items));
-    // this.addHook('afterDropdownMenuDefaultOptions',
-    //   defaultOptions => this.onAfterDropdownMenuDefaultOptions(defaultOptions));
-    // this.addHook('afterDropdownMenuShow', () => this.onAfterDropdownMenuShow());
-    // this.addHook('afterDropdownMenuHide', () => this.onAfterDropdownMenuHide());
-    // this.addHook('afterChange', changes => this.onAfterChange(changes));
+      return component;
+    };
+
+    const filterByConditionLabel = () => `${this.hot.getTranslatedPhrase(constants.FILTERS_DIVS_FILTER_BY_CONDITION)}:`;
+    const filterValueLabel = () => `${this.hot.getTranslatedPhrase(constants.FILTERS_DIVS_FILTER_BY_VALUE)}:`;
+
+    if (!this.components.get('filter_by_condition')) {
+      const conditionComponent = new ConditionComponent(this.hot, {
+        id: 'filter_by_condition',
+        name: filterByConditionLabel,
+        addSeparator: false,
+        menuContainer
+      });
+
+      conditionComponent.addLocalHook('afterClose', () => this.onSelectUIClosed());
+
+      this.components.set('filter_by_condition', addConfirmationHooks(conditionComponent));
+    }
+
+    if (!this.components.get('filter_operators')) {
+      this.components.set('filter_operators', new OperatorsComponent(this.hot, {
+        id: 'filter_operators',
+        name: 'Operators'
+      }));
+    }
+
+    if (!this.components.get('filter_by_condition2')) {
+      const conditionComponent = new ConditionComponent(this.hot, {
+        id: 'filter_by_condition2',
+        name: '',
+        addSeparator: true,
+        menuContainer
+      });
+
+      conditionComponent.addLocalHook('afterClose', () => this.onSelectUIClosed());
+
+      this.components.set('filter_by_condition2', addConfirmationHooks(conditionComponent));
+    }
+
+    if (!this.components.get('filter_by_value')) {
+      this.components.set('filter_by_value', addConfirmationHooks(new ValueComponent(this.hot, {
+        id: 'filter_by_value',
+        name: filterValueLabel
+      })));
+    }
+
+    if (!this.components.get('filter_action_bar')) {
+      this.components.set('filter_action_bar', addConfirmationHooks(new ActionBarComponent(this.hot, {
+        id: 'filter_action_bar',
+        name: 'Action bar'
+      })));
+    }
+
+    if (!this.conditionCollection) {
+      this.conditionCollection = new ConditionCollection(this.hot);
+    }
+
+    if (!this.conditionUpdateObserver) {
+      this.conditionUpdateObserver = new ConditionUpdateObserver(
+        this.hot,
+        this.conditionCollection,
+        physicalColumn => this.getDataMapAtColumn(physicalColumn),
+      );
+      this.conditionUpdateObserver.addLocalHook('update', conditionState => this.updateComponents(conditionState));
+    }
+
+    this.components.forEach(component => component.show());
+
+    this.addHook('beforeDropdownMenuSetItems', items => this.onBeforeDropdownMenuSetItems(items));
+    this.addHook('afterDropdownMenuDefaultOptions',
+      defaultOptions => this.onAfterDropdownMenuDefaultOptions(defaultOptions));
+    this.addHook('afterDropdownMenuShow', () => this.onAfterDropdownMenuShow());
+    this.addHook('afterDropdownMenuHide', () => this.onAfterDropdownMenuHide());
+    this.addHook('afterChange', changes => this.onAfterChange(changes));
 
     // Temp. solution (extending menu items bug in contextMenu/dropdownMenu)
-    // if (this.hot.getSettings().dropdownMenu && this.dropdownMenuPlugin) {
-    //   this.dropdownMenuPlugin.disablePlugin();
-    //   this.dropdownMenuPlugin.enablePlugin();
-    // }
+    if (this.hot.getSettings().dropdownMenu && this.dropdownMenuPlugin) {
+      this.dropdownMenuPlugin.disablePlugin();
+      this.dropdownMenuPlugin.enablePlugin();
+    }
 
-    // super.enablePlugin();
+    super.enablePlugin();
   }
 
   /**
@@ -318,7 +299,6 @@ export class Filters extends BasePlugin {
    * **Note**: Mind that you cannot mix different types of operations (for instance, if you use `conjunction`, use it consequently for a particular column).
    *
    * @example
-   * ::: only-for javascript
    * ```js
    * const container = document.getElementById('example');
    * const hot = new Handsontable(container, {
@@ -348,45 +328,6 @@ export class Filters extends BasePlugin {
    * filtersPlugin.addCondition(1, 'not_contains', ['ing'], 'disjunction');
    * filtersPlugin.filter();
    * ```
-   * :::
-   *
-   * ::: only-for react
-   * ```jsx
-   * const hotRef = useRef();
-   *
-   * ...
-   *
-   * <HotTable
-   *   ref={hotRef}
-   *   data={getData()}
-   *   filters={true}
-   * />
-   *
-   * // access to filters plugin instance
-   * const hot = hotRef.current.hotInstance;
-   * const filtersPlugin = hot.getPlugin('filters');
-   *
-   * // add filter "Greater than" 95 to column at index 1
-   * filtersPlugin.addCondition(1, 'gt', [95]);
-   * filtersPlugin.filter();
-   *
-   * // add filter "By value" to column at index 1
-   * // in this case all value's that don't match will be filtered.
-   * filtersPlugin.addCondition(1, 'by_value', [['ing', 'ed', 'as', 'on']]);
-   * filtersPlugin.filter();
-   *
-   * // add filter "Begins with" with value "de" AND "Not contains" with value "ing"
-   * filtersPlugin.addCondition(1, 'begins_with', ['de'], 'conjunction');
-   * filtersPlugin.addCondition(1, 'not_contains', ['ing'], 'conjunction');
-   * filtersPlugin.filter();
-   *
-   * // add filter "Begins with" with value "de" OR "Not contains" with value "ing"
-   * filtersPlugin.addCondition(1, 'begins_with', ['de'], 'disjunction');
-   * filtersPlugin.addCondition(1, 'not_contains', ['ing'], 'disjunction');
-   * filtersPlugin.filter();
-   * ```
-   * :::
-   *
    * @param {number} column Visual column index.
    * @param {string} name Condition short name.
    * @param {Array} args Condition arguments.

--- a/handsontable/src/plugins/filters/filters.js
+++ b/handsontable/src/plugins/filters/filters.js
@@ -140,6 +140,10 @@ export class Filters extends BasePlugin {
      */
     this.filtersRowsMap = null;
 
+    console.log('aaa')
+    
+    return;
+
     // One listener for the enable/disable functionality
     this.hot.addHook('afterGetColHeader', (col, TH) => this.onAfterGetColHeader(col, TH));
   }
@@ -152,6 +156,7 @@ export class Filters extends BasePlugin {
    */
   isEnabled() {
     /* eslint-disable no-unneeded-ternary */
+    return false;
     return this.hot.getSettings()[PLUGIN_KEY] ? true : false;
   }
 
@@ -163,98 +168,98 @@ export class Filters extends BasePlugin {
       return;
     }
 
-    this.filtersRowsMap = this.hot.rowIndexMapper.registerMap(this.pluginName, new TrimmingMap());
-    this.dropdownMenuPlugin = this.hot.getPlugin('dropdownMenu');
+    // this.filtersRowsMap = this.hot.rowIndexMapper.registerMap(this.pluginName, new TrimmingMap());
+    // this.dropdownMenuPlugin = this.hot.getPlugin('dropdownMenu');
 
-    const dropdownSettings = this.hot.getSettings().dropdownMenu;
-    const menuContainer = (dropdownSettings && dropdownSettings.uiContainer) || this.hot.rootDocument.body;
-    const addConfirmationHooks = (component) => {
-      component.addLocalHook('accept', () => this.onActionBarSubmit('accept'));
-      component.addLocalHook('cancel', () => this.onActionBarSubmit('cancel'));
-      component.addLocalHook('change', command => this.onComponentChange(component, command));
+    // const dropdownSettings = this.hot.getSettings().dropdownMenu;
+    // const menuContainer = (dropdownSettings && dropdownSettings.uiContainer) || this.hot.rootDocument.body;
+    // const addConfirmationHooks = (component) => {
+    //   component.addLocalHook('accept', () => this.onActionBarSubmit('accept'));
+    //   component.addLocalHook('cancel', () => this.onActionBarSubmit('cancel'));
+    //   component.addLocalHook('change', command => this.onComponentChange(component, command));
+    //
+    //   return component;
+    // };
+    //
+    // const filterByConditionLabel = () => `${this.hot.getTranslatedPhrase(constants.FILTERS_DIVS_FILTER_BY_CONDITION)}:`;
+    // const filterValueLabel = () => `${this.hot.getTranslatedPhrase(constants.FILTERS_DIVS_FILTER_BY_VALUE)}:`;
+    //
+    // if (!this.components.get('filter_by_condition')) {
+    //   const conditionComponent = new ConditionComponent(this.hot, {
+    //     id: 'filter_by_condition',
+    //     name: filterByConditionLabel,
+    //     addSeparator: false,
+    //     menuContainer
+    //   });
+    //
+    //   conditionComponent.addLocalHook('afterClose', () => this.onSelectUIClosed());
+    //
+    //   this.components.set('filter_by_condition', addConfirmationHooks(conditionComponent));
+    // }
+    //
+    // if (!this.components.get('filter_operators')) {
+    //   this.components.set('filter_operators', new OperatorsComponent(this.hot, {
+    //     id: 'filter_operators',
+    //     name: 'Operators'
+    //   }));
+    // }
+    //
+    // if (!this.components.get('filter_by_condition2')) {
+    //   const conditionComponent = new ConditionComponent(this.hot, {
+    //     id: 'filter_by_condition2',
+    //     name: '',
+    //     addSeparator: true,
+    //     menuContainer
+    //   });
+    //
+    //   conditionComponent.addLocalHook('afterClose', () => this.onSelectUIClosed());
+    //
+    //   this.components.set('filter_by_condition2', addConfirmationHooks(conditionComponent));
+    // }
+    //
+    // if (!this.components.get('filter_by_value')) {
+    //   this.components.set('filter_by_value', addConfirmationHooks(new ValueComponent(this.hot, {
+    //     id: 'filter_by_value',
+    //     name: filterValueLabel
+    //   })));
+    // }
+    //
+    // if (!this.components.get('filter_action_bar')) {
+    //   this.components.set('filter_action_bar', addConfirmationHooks(new ActionBarComponent(this.hot, {
+    //     id: 'filter_action_bar',
+    //     name: 'Action bar'
+    //   })));
+    // }
+    //
+    // if (!this.conditionCollection) {
+    //   this.conditionCollection = new ConditionCollection(this.hot);
+    // }
+    //
+    // if (!this.conditionUpdateObserver) {
+    //   this.conditionUpdateObserver = new ConditionUpdateObserver(
+    //     this.hot,
+    //     this.conditionCollection,
+    //     physicalColumn => this.getDataMapAtColumn(physicalColumn),
+    //   );
+    //   this.conditionUpdateObserver.addLocalHook('update', conditionState => this.updateComponents(conditionState));
+    // }
+    //
+    // this.components.forEach(component => component.show());
 
-      return component;
-    };
-
-    const filterByConditionLabel = () => `${this.hot.getTranslatedPhrase(constants.FILTERS_DIVS_FILTER_BY_CONDITION)}:`;
-    const filterValueLabel = () => `${this.hot.getTranslatedPhrase(constants.FILTERS_DIVS_FILTER_BY_VALUE)}:`;
-
-    if (!this.components.get('filter_by_condition')) {
-      const conditionComponent = new ConditionComponent(this.hot, {
-        id: 'filter_by_condition',
-        name: filterByConditionLabel,
-        addSeparator: false,
-        menuContainer
-      });
-
-      conditionComponent.addLocalHook('afterClose', () => this.onSelectUIClosed());
-
-      this.components.set('filter_by_condition', addConfirmationHooks(conditionComponent));
-    }
-
-    if (!this.components.get('filter_operators')) {
-      this.components.set('filter_operators', new OperatorsComponent(this.hot, {
-        id: 'filter_operators',
-        name: 'Operators'
-      }));
-    }
-
-    if (!this.components.get('filter_by_condition2')) {
-      const conditionComponent = new ConditionComponent(this.hot, {
-        id: 'filter_by_condition2',
-        name: '',
-        addSeparator: true,
-        menuContainer
-      });
-
-      conditionComponent.addLocalHook('afterClose', () => this.onSelectUIClosed());
-
-      this.components.set('filter_by_condition2', addConfirmationHooks(conditionComponent));
-    }
-
-    if (!this.components.get('filter_by_value')) {
-      this.components.set('filter_by_value', addConfirmationHooks(new ValueComponent(this.hot, {
-        id: 'filter_by_value',
-        name: filterValueLabel
-      })));
-    }
-
-    if (!this.components.get('filter_action_bar')) {
-      this.components.set('filter_action_bar', addConfirmationHooks(new ActionBarComponent(this.hot, {
-        id: 'filter_action_bar',
-        name: 'Action bar'
-      })));
-    }
-
-    if (!this.conditionCollection) {
-      this.conditionCollection = new ConditionCollection(this.hot);
-    }
-
-    if (!this.conditionUpdateObserver) {
-      this.conditionUpdateObserver = new ConditionUpdateObserver(
-        this.hot,
-        this.conditionCollection,
-        physicalColumn => this.getDataMapAtColumn(physicalColumn),
-      );
-      this.conditionUpdateObserver.addLocalHook('update', conditionState => this.updateComponents(conditionState));
-    }
-
-    this.components.forEach(component => component.show());
-
-    this.addHook('beforeDropdownMenuSetItems', items => this.onBeforeDropdownMenuSetItems(items));
-    this.addHook('afterDropdownMenuDefaultOptions',
-      defaultOptions => this.onAfterDropdownMenuDefaultOptions(defaultOptions));
-    this.addHook('afterDropdownMenuShow', () => this.onAfterDropdownMenuShow());
-    this.addHook('afterDropdownMenuHide', () => this.onAfterDropdownMenuHide());
-    this.addHook('afterChange', changes => this.onAfterChange(changes));
+    // this.addHook('beforeDropdownMenuSetItems', items => this.onBeforeDropdownMenuSetItems(items));
+    // this.addHook('afterDropdownMenuDefaultOptions',
+    //   defaultOptions => this.onAfterDropdownMenuDefaultOptions(defaultOptions));
+    // this.addHook('afterDropdownMenuShow', () => this.onAfterDropdownMenuShow());
+    // this.addHook('afterDropdownMenuHide', () => this.onAfterDropdownMenuHide());
+    // this.addHook('afterChange', changes => this.onAfterChange(changes));
 
     // Temp. solution (extending menu items bug in contextMenu/dropdownMenu)
-    if (this.hot.getSettings().dropdownMenu && this.dropdownMenuPlugin) {
-      this.dropdownMenuPlugin.disablePlugin();
-      this.dropdownMenuPlugin.enablePlugin();
-    }
+    // if (this.hot.getSettings().dropdownMenu && this.dropdownMenuPlugin) {
+    //   this.dropdownMenuPlugin.disablePlugin();
+    //   this.dropdownMenuPlugin.enablePlugin();
+    // }
 
-    super.enablePlugin();
+    // super.enablePlugin();
   }
 
   /**

--- a/handsontable/src/plugins/filters/filters.js
+++ b/handsontable/src/plugins/filters/filters.js
@@ -39,6 +39,7 @@ export const PLUGIN_PRIORITY = 250;
  * See [the filtering demo](@/guides/columns/column-filter.md) for examples.
  *
  * @example
+ * ::: only-for javascript
  * ```js
  * const container = document.getElementById('example');
  * const hot = new Handsontable(container, {
@@ -49,6 +50,19 @@ export const PLUGIN_PRIORITY = 250;
  *   filters: true
  * });
  * ```
+ * :::
+ *
+ * ::: only-for react
+ * ```jsx
+ * <HotTable
+ *   data={getData()}
+ *   colHeaders={true}
+ *   rowHeaders={true}
+ *   dropdownMenu={true}
+ *   filters={true}
+ * />
+ * ```
+ * :::
  */
 export class Filters extends BasePlugin {
   static get PLUGIN_KEY() {
@@ -132,7 +146,7 @@ export class Filters extends BasePlugin {
 
   /**
    * Checks if the plugin is enabled in the handsontable settings. This method is executed in {@link Hooks#beforeInit}
-   * hook and if it returns `true` than the {@link Filters#enablePlugin} method is called.
+   * hook and if it returns `true` then the {@link Filters#enablePlugin} method is called.
    *
    * @returns {boolean}
    */
@@ -299,6 +313,7 @@ export class Filters extends BasePlugin {
    * **Note**: Mind that you cannot mix different types of operations (for instance, if you use `conjunction`, use it consequently for a particular column).
    *
    * @example
+   * ::: only-for javascript
    * ```js
    * const container = document.getElementById('example');
    * const hot = new Handsontable(container, {
@@ -328,6 +343,45 @@ export class Filters extends BasePlugin {
    * filtersPlugin.addCondition(1, 'not_contains', ['ing'], 'disjunction');
    * filtersPlugin.filter();
    * ```
+   * :::
+   *
+   * ::: only-for react
+   * ```jsx
+   * const hotRef = useRef();
+   *
+   * ...
+   *
+   * <HotTable
+   *   ref={hotRef}
+   *   data={getData()}
+   *   filters={true}
+   * />
+   *
+   * // access to filters plugin instance
+   * const hot = hotRef.current.hotInstance;
+   * const filtersPlugin = hot.getPlugin('filters');
+   *
+   * // add filter "Greater than" 95 to column at index 1
+   * filtersPlugin.addCondition(1, 'gt', [95]);
+   * filtersPlugin.filter();
+   *
+   * // add filter "By value" to column at index 1
+   * // in this case all value's that don't match will be filtered.
+   * filtersPlugin.addCondition(1, 'by_value', [['ing', 'ed', 'as', 'on']]);
+   * filtersPlugin.filter();
+   *
+   * // add filter "Begins with" with value "de" AND "Not contains" with value "ing"
+   * filtersPlugin.addCondition(1, 'begins_with', ['de'], 'conjunction');
+   * filtersPlugin.addCondition(1, 'not_contains', ['ing'], 'conjunction');
+   * filtersPlugin.filter();
+   *
+   * // add filter "Begins with" with value "de" OR "Not contains" with value "ing"
+   * filtersPlugin.addCondition(1, 'begins_with', ['de'], 'disjunction');
+   * filtersPlugin.addCondition(1, 'not_contains', ['ing'], 'disjunction');
+   * filtersPlugin.filter();
+   * ```
+   * :::
+   *
    * @param {number} column Visual column index.
    * @param {string} name Condition short name.
    * @param {Array} args Condition arguments.


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
This PR adds missing parts of changes for the `beforeChange` hook (see image below).

<img width="1638" alt="Screenshot 2022-09-13 at 18 12 41" src="https://user-images.githubusercontent.com/141330/189952951-d801a2e2-786c-48f7-854d-a44fbb93afee.png">

This PR along with #9791 and #9815 PRs improved the documentation (the API reference - created from JSDoc comments) and types (the TS definition file and tests for it). 


### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I run documentation locally.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #9791
2. #9815

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] My change requires a change to the documentation.
