### PR TITLE
Some clarifications for the React docs

### DIFF
--- a/docs/README-EDITING.md
+++ b/docs/README-EDITING.md
@@ -313,3 +313,14 @@ For matters not covered here, follow the conventions of https://beta.reactjs.org
       </div>
     </>
   ```
+- Always define `data` as a const, outside of JSX.
+  ```jsx
+  const data = [
+    ['', 'Tesla', 'Volvo', 'Toyota', 'Ford'],
+    ['2019', 10, 11, 12, 13],
+    ['2020', 20, 11, 14, 13],
+    ['2021', 30, 15, 12, 13]
+  ];
+
+  return <HotTable data={data} />
+  ```

--- a/docs/content/api/introduction.md
+++ b/docs/content/api/introduction.md
@@ -19,8 +19,8 @@ However, data grids are rather complex libraries, so we assume that you possess 
 The API enables you to control the data grid programmatically. With this API, you can:
 
 -   Configure options
--   Use methods to integrate it with your app
--   Use hooks to interact with what's happening in the grid
+-   Use methods to programmatically control the grid
+-   Use Handsontable hooks to react to what's happening with the grid or change built-in behavior
 -   Introduce new integrations
 -   and more
 
@@ -32,7 +32,7 @@ The `Handsontable` class controls the essential aspects of the data grid.
 
 ### [Hooks](@/api/hooks.md)
 
-Hooks are two-directional events that fire whenever a specific action occurs within the instance of Handsontable.
+Handsontable hooks are events that fire whenever a specific action occurs within the instance of Handsontable.
 
 ### [Options](@/api/options.md)
 

--- a/docs/content/guides/cell-features/formatting-cells.md
+++ b/docs/content/guides/cell-features/formatting-cells.md
@@ -105,7 +105,7 @@ ReactDOM.render(<ExampleComponent />, document.getElementById('example1'));
 
 ## Apply inline styles
 
-You can apply inline styles directly to the DOM element using its `style` attribute. You can use the [`renderer`](@/api/options.md#renderer) option to do that.
+You can apply inline styles directly to the DOM element using its `style` property. You can use the [`renderer`](@/api/options.md#renderer) option to do that.
 
 ::: only-for javascript
 ::: example #example2

--- a/docs/content/guides/columns/react-hot-column.md
+++ b/docs/content/guides/columns/react-hot-column.md
@@ -12,11 +12,11 @@ canonicalUrl: /hot-column
 
 ## Overview
 
-You can configure the column-related settings using the `HotColumn` component's attributes. You can also create custom renderers and editors using React components.
+You can configure the column-related settings using the `HotColumn` component's props. You can also create custom renderers and editors using React components.
 
 ## Declaring column settings
 
-To declare column-specific settings, pass the settings as `HotColumn` properties, either separately or wrapped as a `settings` property, exactly as you would with `HotTable`.
+To declare column-specific settings, pass the settings as `HotColumn` props, either separately or wrapped as a `settings` prop, exactly as you would with `HotTable`.
 
 ::: example #example1 :react --tab preview
 ```jsx


### PR DESCRIPTION
### Context

While reviewing the React docs, I've noticed a few things I wanted to clarify in the content:

1. added the recommendation to use `data={data}` to the coding style in `README-EDITING.md`
2. replace incorrectly used word `attribute` on the "Cell renderer" page
3. clarify about the "Handsontable hooks" in the API reference introduction
4. Use the word `prop` more often in the HotColumn component guide.

### How has this been tested?

Locally with `npm run docs:start`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
5.
6.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]
