### PR TITLE
Add support for creating links only for specific Docs framework

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -10,12 +10,13 @@ const firstHeaderInjection = require('./plugins/markdown-it-header-injection');
 const conditionalContainer = require('./plugins/markdown-it-conditional-container');
 const activeHeaderLinksPlugin = require('./plugins/active-header-links');
 const {
-  getDocsBaseFullUrl,
+  createSymlinks,
   getDocsBase,
+  getDocsBaseFullUrl,
   getDocsHostname,
+  getIgnorePagesPatternList,
   getThisDocsVersion,
   MULTI_FRAMEWORKED_CONTENT_DIR,
-  createSymlinks,
 } = require('./helpers');
 const dumpDocsDataPlugin = require('./plugins/dump-docs-data');
 
@@ -44,6 +45,7 @@ module.exports = {
   },
   patterns: [
     `${MULTI_FRAMEWORKED_CONTENT_DIR}/**/*.md`,
+    ...getIgnorePagesPatternList(),
   ],
   description: 'Handsontable',
   base: `${getDocsBase()}/`,

--- a/docs/.vuepress/docs-links.js
+++ b/docs/.vuepress/docs-links.js
@@ -1,21 +1,40 @@
 const { fs, path, parseFrontmatter } = require('@vuepress/shared-utils');
-const helpers = require('./helpers');
+const {
+  MULTI_FRAMEWORKED_CONTENT_DIR,
+  FRAMEWORK_SUFFIX,
+  parseFramework,
+  getFrameworks,
+} = require('./helpers');
+
+const frameworkFromLink = new RegExp(`^(${getFrameworks().join('|')})/`);
 
 module.exports = function(src) {
   const resourcePathNormalized = path.sep === '\\' ? this.resourcePath.replace(/\\/g, '/') : this.resourcePath;
   const pathForServingDocs = resourcePathNormalized.replace(/.*?docs\//, '/');
+  const defaultFrameworkForThisFile = parseFramework(pathForServingDocs);
   const basePath = this.rootContext;
 
   return src.replace(/\((@\/([^)]*\.md))(#[^)]*)?\)/g, (m, full, file, hash) => {
+    let frameworkPrefix = defaultFrameworkForThisFile;
+
+    // If the link contains the framework e.g `@/react/foo/bar.md` than create the permalink for
+    // that framework
+    if (frameworkFromLink.test(file)) {
+      frameworkPrefix = file.match(frameworkFromLink)[1];
+      file = file.replace(frameworkFromLink, `$1${FRAMEWORK_SUFFIX}/`);
+
+    } else { // otherwise, use default framework for this MD file
+      file = `${defaultFrameworkForThisFile}${FRAMEWORK_SUFFIX}/${file}`;
+    }
+
+    const filePathWithBase = path.resolve(basePath, MULTI_FRAMEWORKED_CONTENT_DIR, file);
     let permalink = full;
 
     try {
-      const fm = parseFrontmatter(fs.readFileSync(path.resolve(basePath, 'content', file)));
+      const fm = parseFrontmatter(fs.readFileSync(filePathWithBase));
 
       if (fm.data.permalink) {
-        const framework = `${helpers.parseFramework(pathForServingDocs)}${helpers.FRAMEWORK_SUFFIX}`;
-
-        permalink = `/${framework}${fm.data.permalink}`;
+        permalink = `/${frameworkPrefix}${FRAMEWORK_SUFFIX}${fm.data.permalink}`;
         permalink = permalink.endsWith('/') ? permalink : `${permalink}/`;
         permalink = hash ? permalink + hash : permalink;
       }

--- a/docs/.vuepress/helpers.js
+++ b/docs/.vuepress/helpers.js
@@ -93,7 +93,7 @@ function getSidebars() {
   const sidebars = {};
 
   getFrameworks().forEach((framework) => {
-    for (const [parentPath, subjectChildren] of Object.entries(sidebarConfig)) {
+    Object.entries(sidebarConfig).forEach(([parentPath, subjectChildren]) => {
       const childrenClone = JSON.parse(JSON.stringify(subjectChildren));
       const isGuidesPage = parentPath === 'guides';
       const sidebarChildren = isGuidesPage ? filterByFramework(childrenClone, framework) : childrenClone;
@@ -106,7 +106,7 @@ function getSidebars() {
 
         return child;
       });
-    }
+    });
   });
 
   return sidebars;

--- a/docs/.vuepress/helpers.js
+++ b/docs/.vuepress/helpers.js
@@ -216,7 +216,15 @@ function getDocsBase() {
   const docsBase = process.env.DOCS_BASE ?? getThisDocsVersion();
   let base = '/docs/';
 
-  if ((docsBase !== 'latest' && docsBase !== 'next') || buildMode === 'staging') {
+  // For staging:
+  //   * `docsBase` === 'next' generate docs with Docs base set as `/docs/next`;
+  //   * `docsBase` === 'latest' generate docs with Docs base set as `/docs`;
+  // For other environments (prod, local build, local watch):
+  //   * `docsBase` === 'next' (happens locally) generate docs with Docs base set as `/docs`;
+  //   * `docsBase` === 'latest' generate docs with Docs base set as `/docs`;
+  //   * `docsBase` === '12.1' (happens while testing production branch) generate docs with Docs base set as `/docs/12.1`;
+  if ((buildMode === 'staging' && docsBase !== 'latest') ||
+      (buildMode !== 'staging' && docsBase !== 'next' && docsBase !== 'latest')) {
     base += `${docsBase}/`;
   }
 

--- a/docs/.vuepress/helpers.js
+++ b/docs/.vuepress/helpers.js
@@ -212,10 +212,11 @@ function getDocsRepoSHA() {
  * @returns {string}
  */
 function getDocsBase() {
+  const buildMode = process.env.BUILD_MODE;
   const docsBase = process.env.DOCS_BASE ?? getThisDocsVersion();
   let base = '/docs/';
 
-  if (docsBase !== 'latest' && docsBase !== 'next') {
+  if ((docsBase !== 'latest' && docsBase !== 'next') || buildMode === 'staging') {
     base += `${docsBase}/`;
   }
 

--- a/docs/.vuepress/helpers.js
+++ b/docs/.vuepress/helpers.js
@@ -116,7 +116,9 @@ function getSidebars() {
  * @returns {string}
  */
 function getNormalizedPath(normalizedPath) {
-  return normalizedPath.replace(new RegExp(`^/?${MULTI_FRAMEWORKED_CONTENT_DIR}`), '');
+  return normalizedPath
+    .replace(new RegExp(`^/?${MULTI_FRAMEWORKED_CONTENT_DIR}`), '')
+    .replace(/\.(html|md)$/, '');
 }
 
 /**
@@ -124,9 +126,8 @@ function getNormalizedPath(normalizedPath) {
  *
  * @returns {object}
  */
-function getNotSearchableLinks() {
+function getIgnorePagesPatternList() {
   const frameworks = getFrameworks();
-  const notSearchableLinks = {};
 
   const filterLinks = (guides, framework) => {
     const links = [];
@@ -152,12 +153,16 @@ function getNotSearchableLinks() {
 
   // eslint-disable-next-line
   const sidebarConfig = require(path.join(__dirname, `../content/sidebars.js`));
+  const pages = [];
 
   frameworks.forEach((framework) => {
-    notSearchableLinks[framework] = filterLinks(sidebarConfig.guides, framework);
+    const linksWithFramework = filterLinks(sidebarConfig.guides, framework)
+      .map(link => `!${MULTI_FRAMEWORKED_CONTENT_DIR}/${framework}${FRAMEWORK_SUFFIX}/${link}.md`);
+
+    pages.push(...linksWithFramework);
   });
 
-  return notSearchableLinks;
+  return pages;
 }
 
 /**
@@ -247,7 +252,7 @@ module.exports = {
   getFrameworks,
   getPrettyFrameworkName,
   getSidebars,
-  getNotSearchableLinks,
+  getIgnorePagesPatternList,
   parseFramework,
   getDefaultFramework,
   createSymlinks,

--- a/docs/.vuepress/plugins/extend-page-data/index.js
+++ b/docs/.vuepress/plugins/extend-page-data/index.js
@@ -1,13 +1,11 @@
 const {
-  getSidebars,
-  getNormalizedPath,
-  parseFramework,
-  getThisDocsVersion,
-  getPrettyFrameworkName,
-  getDefaultFramework,
   FRAMEWORK_SUFFIX,
-  getNotSearchableLinks,
+  getDefaultFramework,
   getDocsRepoSHA,
+  getPrettyFrameworkName,
+  getSidebars,
+  getThisDocsVersion,
+  parseFramework,
 } = require('../../helpers');
 
 const buildMode = process.env.BUILD_MODE;
@@ -24,7 +22,6 @@ function dedupeSlashes(string) {
   return string.replace(/(\/)+/g, '$1');
 }
 
-const notSearchableLinks = getNotSearchableLinks();
 const formatDate = (dateString) => {
   const date = new Date(dateString);
   const twoDigitDay = date.getDate();
@@ -47,18 +44,14 @@ module.exports = (options, context) => {
      * @param {object} $page The $page value of the page you’re currently reading.
      */
     extendPageData($page) {
-      const normalizedPath = getNormalizedPath($page.path);
-      const currentFramework = parseFramework(normalizedPath);
+      const currentFramework = parseFramework($page.path);
 
-      $page.normalizedPath = normalizedPath;
       $page.currentVersion = getThisDocsVersion();
       $page.currentFramework = currentFramework;
-      $page.frameworkName = getPrettyFrameworkName($page.currentFramework);
+      $page.frameworkName = getPrettyFrameworkName(currentFramework);
       $page.defaultFramework = getDefaultFramework();
       $page.frameworkSuffix = FRAMEWORK_SUFFIX;
       $page.buildMode = buildMode;
-      $page.isSearchable = notSearchableLinks[$page.currentFramework]?.every(
-        notSearchableLink => $page.normalizedPath.includes(notSearchableLink) === false);
 
       if ($page.currentVersion === 'next') {
         $page.docsGenStamp = `<!--
@@ -80,7 +73,7 @@ SHA: ${getDocsRepoSHA()}
         });
       }
 
-      const frameworkPath = $page.currentFramework + FRAMEWORK_SUFFIX;
+      const frameworkPath = currentFramework + FRAMEWORK_SUFFIX;
 
       if ($page.frontmatter.canonicalUrl) {
         $page.frontmatter.canonicalUrl = dedupeSlashes(`/docs/${frameworkPath}${$page.frontmatter.canonicalUrl}/`);

--- a/docs/.vuepress/plugins/extend-page-data/index.js
+++ b/docs/.vuepress/plugins/extend-page-data/index.js
@@ -1,6 +1,7 @@
 const {
   FRAMEWORK_SUFFIX,
   getDefaultFramework,
+  getDocsBase,
   getDocsRepoSHA,
   getPrettyFrameworkName,
   getSidebars,
@@ -76,7 +77,8 @@ SHA: ${getDocsRepoSHA()}
       const frameworkPath = currentFramework + FRAMEWORK_SUFFIX;
 
       if ($page.frontmatter.canonicalUrl) {
-        $page.frontmatter.canonicalUrl = dedupeSlashes(`/docs/${frameworkPath}${$page.frontmatter.canonicalUrl}/`);
+        $page.frontmatter
+          .canonicalUrl = dedupeSlashes(`${getDocsBase()}/${frameworkPath}${$page.frontmatter.canonicalUrl}/`);
       }
 
       if ($page.frontmatter.permalink) {

--- a/docs/.vuepress/theme/components/NavLink.vue
+++ b/docs/.vuepress/theme/components/NavLink.vue
@@ -42,7 +42,7 @@ export default {
     },
     exact() {
       if (this.link === `/${this.$page.currentFramework}${this.$page.frameworkSuffix}/`) {
-        return /\/api\//.test(this.$route.fullPath) || /\/examples\//.test(this.$route.fullPath);
+        return /\/api\//.test(this.$route.fullPath);
       }
 
       return false;

--- a/docs/.vuepress/theme/components/NavVersionedLink.vue
+++ b/docs/.vuepress/theme/components/NavVersionedLink.vue
@@ -37,7 +37,7 @@ export default {
       }
     },
     exact() {
-      if (this.link === '/' && this.$route.fullPath.match(/([^/]*\/)?(api|examples)\//)) {
+      if (this.link === '/' && this.$route.fullPath.match(/([^/]*\/)?(api)\//)) {
         return true;
       }
 

--- a/docs/.vuepress/theme/components/SearchBox.vue
+++ b/docs/.vuepress/theme/components/SearchBox.vue
@@ -287,10 +287,7 @@ export default {
     },
 
     isSearchable(page) {
-      const isSelectedFramework = page.normalizedPath
-        .startsWith(`/${this.$page.currentFramework}${this.$page.frameworkSuffix}/`);
-
-      return page.isSearchable === true && isSelectedFramework;
+      return this.$page.currentFramework === page.currentFramework;
     },
 
     onHotkey(event) {

--- a/docs/.vuepress/theme/layouts/404.vue
+++ b/docs/.vuepress/theme/layouts/404.vue
@@ -41,7 +41,7 @@ export default {
         framework: 'javascript'
       };
 
-      return `/docs/${framework}-data-grid`;
+      return `/docs/${framework}-data-grid/`;
     },
     getMsg() {
       return msgs[Math.floor(Math.random() * msgs.length)];

--- a/docs/.vuepress/theme/layouts/404.vue
+++ b/docs/.vuepress/theme/layouts/404.vue
@@ -16,6 +16,8 @@ const msgs = [
   'Looks like we\'ve got some broken links.'
 ];
 
+const frameworkRegExp = new RegExp('^/docs/((next|\\d+.\\d+)/)?(?<framework>react|javascript)-data-grid/.*');
+
 export default {
   data() {
     return {
@@ -25,7 +27,7 @@ export default {
   methods: {
     /**
      * Returns the new homepage URL of the previously selected framework. For example for
-     * `/docs/10.1/react-data-grid/foo/bar` it's `/docs/10.1/react-data-grid/`.
+     * `/docs/10.1/react-data-grid/foo/bar` it's `/docs/react-data-grid/`.
      *
      * The $page object is not available within the component so read the state from
      * the "window.location".
@@ -33,7 +35,13 @@ export default {
      * @returns {string}
      */
     getFrameworkHomePage() {
-      return window.location.pathname.replace(/^(\/docs\/(?:(?:next|\d+\.\d)\/)?.+-data-grid\/).*/, '$1');
+      const {
+        framework,
+      } = window.location.pathname.match(frameworkRegExp)?.groups ?? {
+        framework: 'javascript'
+      };
+
+      return `/docs/${framework}-data-grid`;
     },
     getMsg() {
       return msgs[Math.floor(Math.random() * msgs.length)];

--- a/docs/.vuepress/tools/build.mjs
+++ b/docs/.vuepress/tools/build.mjs
@@ -31,7 +31,7 @@ async function buildVersion(version) {
   const cwd = path.resolve(__dirname, '../../');
   const versionEscaped = version.replace('.', '-');
 
-  if (version !== 'next') {
+  if (version !== 'next' || buildMode === 'staging') {
     await spawnProcess(
       'node --experimental-fetch node_modules/.bin/vuepress build -d .vuepress/dist/pre-' +
         `${versionEscaped}/${NO_CACHE ? ' --no-cache' : ''}`,
@@ -56,7 +56,7 @@ async function buildVersion(version) {
 async function concatenate(version) {
   const versionEscaped = version.replace('.', '-');
 
-  if (version !== 'next') {
+  if (version !== 'next' || buildMode === 'staging') {
     const prebuildVersioned = path.resolve(
       __dirname,
       '../../', `.vuepress/dist/pre-${versionEscaped}`

--- a/docs/README-EDITING.md
+++ b/docs/README-EDITING.md
@@ -131,7 +131,7 @@ takes care to create a Documentation production branch, generate API content fro
 
 ## Markdown links
 
-When linking to other documentation pages, avoid using absolute links or relative URLs.
+When linking to other documentation pages, *avoid using absolute links or relative URLs*.
 
 To link to another page in the same documentation version, use the following syntax:
 
@@ -142,8 +142,24 @@ To link to another page in the same documentation version, use the following syn
 For example, to link to a file called `core.md`, from anywhere in the same documentation version:
 
 ```markdown
-[Core](@/api/core.md)
+[Core](@/api/core.md#updatesettings)
 ```
+
+To link to another page but for other framework (and still for the same documentation version), use the following syntax:
+
+```markdown
+[link_text](@/{FRAMEWORK}/relative_file_path_from_this_version's_root/file_name.md#some-anchor)
+```
+
+For example, to link to a file called `./content/guides/getting-started/react-methods.md` that should be accessible only for React framework, use:
+
+```markdown
+[React methods](@/react/guides/getting-started/react-methods.md)
+```
+
+When there is no framework defined in the link URL, the generated link will be pointed to the currently viewed framework. For example, link `[Core](@/api/core.md)` for Javascript will point to `/docs/javascript-data-grid/api/core` and for chosen React framework to `/docs/react-data-grid/api/core`.
+
+List of available frameworks: `javascript`, `react`.
 
 Follow these rules:
 * After the `@` character, provide the target's relative file path (from the current version's root directory).<br>

--- a/docs/README-EDITING.md
+++ b/docs/README-EDITING.md
@@ -131,7 +131,7 @@ takes care to create a Documentation production branch, generate API content fro
 
 ## Markdown links
 
-When linking to other documentation pages, *avoid using absolute links or relative URLs*.
+When linking to other documentation pages, **avoid using absolute links or relative URLs**.
 
 To link to another page in the same documentation version, use the following syntax:
 

--- a/docs/content/api/sidebar.js
+++ b/docs/content/api/sidebar.js
@@ -20,7 +20,7 @@ module.exports = {
     ...apiHighLevelPages,
     {
       title: 'Plugins',
-      path: '/api/plugins',
+      path: 'plugins',
       collapsable: false,
       children: plugins
     },

--- a/docs/content/guides/accessories-and-menus/context-menu.md
+++ b/docs/content/guides/accessories-and-menus/context-menu.md
@@ -217,7 +217,7 @@ const ExampleComponent = () => {
             }
           }
         }}
-        licenseKey="non-commercial-and-evaluation" 
+        licenseKey="non-commercial-and-evaluation"
       />
     </div>
   )
@@ -448,7 +448,7 @@ ReactDOM.render(<ExampleComponent />, document.getElementById('example3'));
 - [Clipboard: Context menu](@/guides/cell-features/clipboard.md#context-menu)
 - [Icon pack](@/guides/accessories-and-menus/icon-pack.md)
 ::: only-for javascript
-- [Custom context menu in React](../../react-data-grid)
+- [Custom context menu in React](@/react/guides/getting-started/introduction.md)
 - [Custom context menu in Angular](@/guides/integrate-with-angular/angular-custom-context-menu-example.md)
 - [Custom context menu in Vue 2](@/guides/integrate-with-vue/vue-custom-context-menu-example.md)
 - [Custom context menu in Vue 3](@/guides/integrate-with-vue3/vue3-custom-context-menu-example.md)

--- a/docs/content/guides/cell-functions/cell-editor.md
+++ b/docs/content/guides/cell-functions/cell-editor.md
@@ -163,7 +163,7 @@ const data = [
 
 const ExampleComponent = () => {
   return (
-    <HotTable 
+    <HotTable
       data={data}
       rowHeaders={true}
       licenseKey="non-commercial-and-evaluation"
@@ -1252,7 +1252,7 @@ const hot = new Handsontable(container, {
 ## Related articles
 
 ### Related guides
-- [Custom editor in React](../../react-data-grid/cell-editor)
+- [Custom editor in React](@/react/guides/cell-functions/cell-editor.md)
 - [Custom editor in Angular](@/guides/integrate-with-angular/angular-custom-editor-example.md)
 - [Custom editor in Vue 2](@/guides/integrate-with-vue/vue-custom-editor-example.md)
 - [Custom editor in Vue 3](@/guides/integrate-with-vue3/vue3-custom-editor-example.md)

--- a/docs/content/guides/cell-functions/cell-renderer.md
+++ b/docs/content/guides/cell-functions/cell-renderer.md
@@ -660,7 +660,7 @@ const ExampleComponent = () => {
             switch (col) {
             case 0:
             return '<b>Bold</b> and <em>Beautiful</em>';
-  
+
             case 1:
             return `Some <input type="checkbox" class="checker" ${isChecked ? `checked="checked"` : ''}> checkbox`;
           }
@@ -703,7 +703,7 @@ Cell renderers are called separately for every displayed cell, during every tabl
 
 ### Related guides
 
-- [Custom renderer in React](../../react-data-grid/cell-renderer)
+- [Custom renderer in React](@/react/guides/cell-functions/cell-renderer.md)
 - [Custom renderer in Angular](@/guides/integrate-with-angular/angular-custom-renderer-example.md)
 - [Custom renderer in Vue 2](@/guides/integrate-with-vue/vue-custom-renderer-example.md)
 - [Custom renderer in Vue 3](@/guides/integrate-with-vue3/vue3-custom-renderer-example.md)

--- a/docs/content/guides/getting-started/installation.md
+++ b/docs/content/guides/getting-started/installation.md
@@ -41,7 +41,7 @@ To install Handsontable locally using a package manager, run one of these comman
 ::: tip
 To install Handsontable using a framework, see:
 
- - [Installation in React](../../react-data-grid/installation)
+ - [Installation in React](@/react/guides/getting-started/installation.md)
  - [Installation in Angular](@/guides/integrate-with-angular/angular-installation.md)
  - [Installation in Vue 2](@/guides/integrate-with-vue/vue-installation.md)
  - [Installation in Vue 3](@/guides/integrate-with-vue3/vue3-installation.md)

--- a/docs/content/guides/getting-started/introduction.md
+++ b/docs/content/guides/getting-started/introduction.md
@@ -14,7 +14,7 @@ react:
 
 ::: only-for javascript
 ::: tip
-Using React? [Switch to the React version of this documentation](../../react-data-grid).
+Using React? [Switch to the React version of this documentation](@/react/guides/getting-started/introduction.md).
 :::
 :::
 
@@ -73,7 +73,7 @@ Then, move on to [connecting](@/guides/getting-started/binding-to-data.md) your 
 
 Handsontable supports popular JavaScript frameworks through wrappers. It also features a TypeScript declaration file that standardizes the API [methods](@/api/core.md), [hooks](@/api/hooks.md), and [options](@/api/options.md).
 
-Explore Handsontable's documentation for [React](../../react-data-grid), [Angular](@/guides/integrate-with-angular/angular-installation.md), [Vue 2](@/guides/integrate-with-vue/vue-installation.md), and [Vue 3](@/guides/integrate-with-vue3/vue3-installation.md).
+Explore Handsontable's documentation for [React](@/react/guides/getting-started/introduction.md), [Angular](@/guides/integrate-with-angular/angular-installation.md), [Vue 2](@/guides/integrate-with-vue/vue-installation.md), and [Vue 3](@/guides/integrate-with-vue3/vue3-installation.md).
 :::
 
 ## What can I use Handsontable for?

--- a/docs/content/guides/tools-and-building/custom-builds.md
+++ b/docs/content/guides/tools-and-building/custom-builds.md
@@ -26,13 +26,13 @@ Get an overview of Handsontable's building processes.
 
 The Handsontable repository is a monorepo that contains the following projects:
 
-| Project                 | Location            | Description                                                        |
-| ----------------------- | ------------------- | ------------------------------------------------------------------ |
-| `handsontable`          | `/handsontable`     | Main Handsontable project                                          |
-| `@handsontable/react`   | `/wrappers/react`   | [React wrapper](../../react-data-grid)                             |
-| `@handsontable/angular` | `/wrappers/angular` | [Angular wrapper](../../javascript-data-grid/angular-installation) |
-| `@handsontable/vue`     | `/wrappers/vue`     | [Vue 2 wrapper](../../javascript-data-grid/vue-simple-example)     |
-| `@handsontable/vue3`    | `/wrappers/vue3`    | [Vue 3 wrapper](../../javascript-data-grid/vue3-installation)      |
+| Project                 | Location            | Description                                                                           |
+| ----------------------- | ------------------- | ------------------------------------------------------------------------------------- |
+| `handsontable`          | `/handsontable`     | Main Handsontable project                                                             |
+| `@handsontable/react`   | `/wrappers/react`   | [React wrapper](@/react/guides/getting-started/introduction.md)                       |
+| `@handsontable/angular` | `/wrappers/angular` | [Angular wrapper](@/javascript/guides/integrate-with-angular/angular-installation.md) |
+| `@handsontable/vue`     | `/wrappers/vue`     | [Vue 2 wrapper](@/javascript/guides/integrate-with-vue/vue-installation.md)           |
+| `@handsontable/vue3`    | `/wrappers/vue3`    | [Vue 3 wrapper](@/javascript/guides/integrate-with-vue3/vue3-installation.md)         |
 
 All the projects are released together, under the same version number.
 But each project has its own [building](#building-processes) and [testing](@/guides/tools-and-building/testing.md) processes.

--- a/docs/content/guides/tools-and-building/modules.md
+++ b/docs/content/guides/tools-and-building/modules.md
@@ -952,7 +952,7 @@ import { registerLanguageDictionary } from 'handsontable/i18n/registry';
 ## Using modules with frameworks
 
 You can also use modules with Handsontable's framework wrappers:
-- [Using modules with React](../../react-data-grid/modules)
+- [Using modules with React](@/react/guides/tools-and-building/modules.md)
 - [Using modules with Angular](@/guides/integrate-with-angular/angular-modules.md)
 - [Using modules with Vue 2](@/guides/integrate-with-vue/vue-modules.md)
 - [Using modules with Vue 3](@/guides/integrate-with-vue3/vue3-modules.md)
@@ -965,7 +965,7 @@ You can also use modules with Handsontable's framework wrappers:
 - [Bundle size](@/guides/optimization/bundle-size.md)
 - [Installation](@/guides/getting-started/installation.md)
 ::: only-for javascript
-- [Modules in React](../../react-data-grid/modules)
+- [Modules in React](@/react/guides/tools-and-building/modules.md)
 - [Modules in Angular](@/guides/integrate-with-angular/angular-modules.md)
 - [Modules in Vue 2](@/guides/integrate-with-vue/vue-modules.md)
 - [Modules in Vue 3](@/guides/integrate-with-vue3/vue3-modules.md)

--- a/docs/content/guides/upgrade-and-migration/migrating-from-10.0-to-11.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-10.0-to-11.0.md
@@ -18,7 +18,7 @@ To upgrade your Handsontable version from 10.x.x to 11.x.x, follow this guide.
 ::: only-for javascript
 ## Step 1: React, Angular, Vue – register your modules
 
-Starting with Handsontable 11.0.0, the [React wrapper](../../react-data-grid), the [Angular wrapper](@/guides/integrate-with-angular/angular-installation.md), and the [Vue wrapper](@/guides/integrate-with-vue/vue-installation.md) support [modularization](@/guides/tools-and-building/modules.md).
+Starting with Handsontable 11.0.0, the [React wrapper](@/react/guides/getting-started/introduction.md), the [Angular wrapper](@/guides/integrate-with-angular/angular-installation.md), and the [Vue wrapper](@/guides/integrate-with-vue/vue-installation.md) support [modularization](@/guides/tools-and-building/modules.md).
 
 If you don't use any of the wrappers, you don't need to change anything.
 
@@ -38,7 +38,7 @@ registerAllModules();
 ### Using individual modules
 
 To start using individual Handsontable modules with your wrapper, see the following guides:
-- [Using modules with React](../../react-data-grid/modules)
+- [Using modules with React](@/react/guides/tools-and-building/modules.md)
 - [Using modules with Angular](@/guides/integrate-with-angular/angular-modules.md)
 - [Using modules with Vue](@/guides/integrate-with-vue/vue-modules.md)
 :::

--- a/docs/content/guides/upgrade-and-migration/migrating-from-11.1-to-12.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-11.1-to-12.0.md
@@ -77,7 +77,7 @@ To replace [`data`](@/api/options.md#data) and reset the states, call the [`load
 
 Read more on referencing the Handsontable instance:
 - [Referencing the Handsontable instance in Angular](@/guides/integrate-with-angular/angular-hot-reference.md)
-- [Referencing the Handsontable instance in React](../../react-data-grid/methods)
+- [Referencing the Handsontable instance in React](@/guides/getting-started/react-methods.md)
 - [Referencing the Handsontable instance in Vue 2](@/guides/integrate-with-vue/vue-hot-reference.md)
 - [Referencing the Handsontable instance in Vue 3](@/guides/integrate-with-vue3/vue3-hot-reference.md)
 :::

--- a/docs/content/guides/upgrade-and-migration/migrating-from-11.1-to-12.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-11.1-to-12.0.md
@@ -77,7 +77,7 @@ To replace [`data`](@/api/options.md#data) and reset the states, call the [`load
 
 Read more on referencing the Handsontable instance:
 - [Referencing the Handsontable instance in Angular](@/guides/integrate-with-angular/angular-hot-reference.md)
-- [Referencing the Handsontable instance in React](@/guides/getting-started/react-methods.md)
+- [Referencing the Handsontable instance in React](@/react/guides/getting-started/react-methods.md)
 - [Referencing the Handsontable instance in Vue 2](@/guides/integrate-with-vue/vue-hot-reference.md)
 - [Referencing the Handsontable instance in Vue 3](@/guides/integrate-with-vue3/vue3-hot-reference.md)
 :::

--- a/docs/content/guides/upgrade-and-migration/release-notes.md
+++ b/docs/content/guides/upgrade-and-migration/release-notes.md
@@ -125,7 +125,7 @@ Released on 13th of January, 2022
 
 **Added**
 - Added [`updateData()`](@/api/core.md#updatedata), a new method that lets you replace Handsontable's [`data`](@/api/options.md#data) without resetting the states of cells, rows and columns. [#7263](https://github.com/handsontable/handsontable/issues/7263)
-- *Vue:* Added [Vue 3](https://v3.vuejs.org/guide/migration/introduction.html#overview) support, by introducing a [new wrapper](@/guides/integrate-with-vue3/vue3-simple-example.md). [#7545](https://github.com/handsontable/handsontable/issues/7545)
+- *Vue:* Added [Vue 3](https://v3.vuejs.org/guide/migration/introduction.html#overview) support, by introducing a [new wrapper](@/javascript/guides/integrate-with-vue3/vue3-simple-example.md). [#7545](https://github.com/handsontable/handsontable/issues/7545)
 
 **Changed**
 - Updated the TypeScript definition of the [`setDataAtCell()`](@/api/core.md#setdataatcell) method. [#8601](https://github.com/handsontable/handsontable/issues/8601)

--- a/docs/content/guides/upgrade-and-migration/versioning-policy.md
+++ b/docs/content/guides/upgrade-and-migration/versioning-policy.md
@@ -29,7 +29,7 @@ The following table outlines which number would change when a Major, Minor, or P
 
 Up to Handsontable 8.3.2, each framework variant of Handsontable was versioned separately:
 - [Vanilla JavaScript](@/guides/getting-started/introduction.md)
-- [React wrapper](../../react-data-grid)
+- [React wrapper](@/react/guides/getting-started/introduction.md)
 - [Angular wrapper](@/guides/integrate-with-angular/angular-installation.md)
 - [Vue 2 wrapper](@/guides/integrate-with-vue/vue-installation.md)
 - [Vue 3 wrapper](@/guides/integrate-with-vue3/vue3-installation.md)
@@ -41,7 +41,7 @@ Starting with version 8.4.0 (released in May 2021), all framework variants of Ha
 ## Versioning of framework variants
 
 Up to Handsontable 8.3.2, the JavaScript variant and the React variant of Handsontable were versioned separately:
-- [Vanilla JavaScript](../../javascript-data-grid)
+- [Vanilla JavaScript](@/javascript/guides/getting-started/introduction.md)
 - [React wrapper](@/guides/getting-started/introduction.md)
 
 Starting with version 8.4.0 (released in May 2021), both the JavaScript variant and the React variant of Handsontable have the same version number.

--- a/docs/docker/default.conf
+++ b/docs/docker/default.conf
@@ -22,6 +22,6 @@ server {
         try_files $uri/index.html $uri $uri.html =404;
     }
 
-    error_page 404 =404 /docs/$docs_version/404.html;
-    error_page 403 =403 /docs/$docs_version/403.html;
+    error_page 404 =404 /docs/404.html;
+    error_page 403 =403 /docs/403.html;
 }

--- a/docs/docker/redirects.conf
+++ b/docs/docker/redirects.conf
@@ -173,5 +173,5 @@ rewrite ^/docs/((\d+\.\d+|next)/)?demo-react-simple-examples/?$ /docs/$1javascri
 #  * /sitemap.xml
 #  * /securitum-certificate.pdf
 #  * /seqred-certificate.pdf
-rewrite ^/docs/((?:\d+\.\d+|next)/)(?!(?:javascript|react)-data-grid/|assets/|data/|handsontable/|img/|scripts/|404\.html|sitemap\.xml|securitum-certificate\.pdf|seqred-certificate\.pdf)(.+)$ /docs/$1javascript-data-grid/$2 permanent;
-rewrite ^/docs/(?!\d+\.\d+|next\/)(?!(?:javascript|react)-data-grid/|assets/|data/|handsontable/|img/|scripts/|404\.html|sitemap\.xml|securitum-certificate\.pdf|seqred-certificate\.pdf)(.+)$ /docs/javascript-data-grid/$1 permanent;
+rewrite ^/docs/((?:\d+\.\d+|next)/)(?!(?:javascript|react)-data-grid|assets/|data/|handsontable/|img/|scripts/|404\.html|sitemap\.xml|securitum-certificate\.pdf|seqred-certificate\.pdf)(.+)$ /docs/$1javascript-data-grid/$2 permanent;
+rewrite ^/docs/(?!\d+\.\d+|next\/)(?!(?:javascript|react)-data-grid|assets/|data/|handsontable/|img/|scripts/|404\.html|sitemap\.xml|securitum-certificate\.pdf|seqred-certificate\.pdf)(.+)$ /docs/javascript-data-grid/$1 permanent;


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR extends the feature that transforms the markdown links for the ability to define the framework to which a given link points.

For example, when I want to create a link that always points to the React modules page. No matter if I chose the React or Javascript framework, the link should always point to the React Docs version. Within the PR changes, it's possible to do that by writing `[React wrapper](@/react/guides/getting-started/introduction.md)`. 

This also works the other way around. When I want to create a link that always points to the Javascript page, I will do `[JS modules](@/javascript/guides/tools-and-building/modules.md)`. 

Moreover, the PR changes the following things:
 * Improves the redirect rules (#9893). So there will be no more redirects for `/docs/react-data-grid` pages (without ending slash);
 * Fixes 404 pages that won't work (the VuePress layout was not loaded);
 * Improves the staging environment by adding the ability to test the "next" Docs version under the URL with the version in the name (`/docs/next/`).

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. fixes #9903 
2. fixes #9893

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
