### PR TITLE
Fixed problems with Safari - there were thrown an error for transpilled destructing operator

### DIFF
--- a/handsontable/src/dataMap/dataMap.js
+++ b/handsontable/src/dataMap/dataMap.js
@@ -597,7 +597,7 @@ class DataMap {
    *
    * @param {number} index Physical index of the element to add/remove.
    * @param {number} deleteCount Number of rows to remove.
-   * @param {...object} elements Row elements to be added.
+   * @param {Array<object>} elements Row elements to be added.
    */
   spliceData(index, deleteCount, elements) {
     const continueSplicing = this.instance.runHooks('beforeDataSplice', index, deleteCount, elements);

--- a/handsontable/src/dataMap/dataMap.js
+++ b/handsontable/src/dataMap/dataMap.js
@@ -341,7 +341,7 @@ class DataMap {
 
     this.instance.rowIndexMapper.insertIndexes(rowIndex, numberOfCreatedRows);
 
-    this.spliceData(physicalRowIndex, 0, ...rowsToAdd);
+    this.spliceData(physicalRowIndex, 0, rowsToAdd);
 
     this.instance.runHooks('afterCreateRow', rowIndex, numberOfCreatedRows, source);
     this.instance.forceFullRender = true; // used when data was changed
@@ -599,7 +599,7 @@ class DataMap {
    * @param {number} deleteCount Number of rows to remove.
    * @param {...object} elements Row elements to be added.
    */
-  spliceData(index, deleteCount, ...elements) {
+  spliceData(index, deleteCount, elements) {
     const continueSplicing = this.instance.runHooks('beforeDataSplice', index, deleteCount, elements);
 
     if (continueSplicing !== false) {

--- a/handsontable/src/dataMap/metaManager/lazyFactoryMap.js
+++ b/handsontable/src/dataMap/metaManager/lazyFactoryMap.js
@@ -207,9 +207,9 @@ export default class LazyFactoryMap {
       this.data.push(void 0);
     }
 
-    const sliceIndex = isNullish(key) ? this.index.length : key;
+    const insertionIndex = isNullish(key) ? this.index.length : key;
 
-    this.index = [...this.index.slice(0, sliceIndex), ...newIndexes, ...this.index.slice(sliceIndex)];
+    this.index = [...this.index.slice(0, insertionIndex), ...newIndexes, ...this.index.slice(insertionIndex)];
   }
 
   /**

--- a/handsontable/src/dataMap/metaManager/lazyFactoryMap.js
+++ b/handsontable/src/dataMap/metaManager/lazyFactoryMap.js
@@ -207,7 +207,9 @@ export default class LazyFactoryMap {
       this.data.push(void 0);
     }
 
-    this.index.splice(isNullish(key) ? this.index.length : key, 0, ...newIndexes);
+    const sliceIndex = isNullish(key) ? this.index.length : key;
+
+    this.index = [...this.index.slice(0, sliceIndex), ...newIndexes, ...this.index.slice(sliceIndex)];
   }
 
   /**


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
PR #9855 introduced changes in a way how row are inserted. The fix has been working for Chrome browser. However, it seems that problem resolved in the PR hasn't been resolved in another part of code. For the unknown reason it has worked for other browsers.

[skip changelog]

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I measured the performance for past and present solution on Safari and it seems that there is no significant difference in performance (the measured deviation was equal to `3,7%`). The same for Firefox (deviation is equal to `3,5%`).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7840

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] My change requires a change to the documentation.
