### PR TITLE
Change Docs frameworks order and code preview tabs order

### DIFF
--- a/docs/.vuepress/containers/examples/examples.js
+++ b/docs/.vuepress/containers/examples/examples.js
@@ -108,14 +108,7 @@ module.exports = function(docsVersion, base) {
 
         jsToken.content = jsToken.content.replaceAll('{{$basePath}}', base);
 
-        const activeTab = [args.match(/--tab (code|html|css|preview)/)?.[1]].map((entry) => {
-          if (!entry || entry === 'preview') {
-            return `preview-tab-${id}`;
-
-          } else {
-            return entry;
-          }
-        }).join('');
+        const activeTab = `${args.match(/--tab (code|html|css|preview)/)?.[1] ?? 'preview'}-tab-${id}`;
         const noEdit = !!args.match(/--no-edit/)?.[0];
 
         const code = buildCode(id + (preset.includes('angular') ? '.ts' : '.jsx'), jsToken.content, env.relativePath);

--- a/docs/.vuepress/containers/examples/examples.js
+++ b/docs/.vuepress/containers/examples/examples.js
@@ -126,10 +126,10 @@ module.exports = function(docsVersion, base) {
         });
 
         const newTokens = [
+          getPreviewTab(id, cssContent, htmlContentRoot, encodedCode),
           ...tab('Code', jsToken, id),
           ...tab('HTML', htmlToken, id),
           ...tab('CSS', cssToken, id),
-          getPreviewTab(id, cssContent, htmlContentRoot, encodedCode)
         ];
 
         tokens.splice(index + 1, 0, ...newTokens);

--- a/docs/.vuepress/theme/components/FrameworksDropdown.vue
+++ b/docs/.vuepress/theme/components/FrameworksDropdown.vue
@@ -13,8 +13,8 @@ import DropdownLink from '@theme/components/DropdownLink.vue';
 
 const frameworkIdToFullName = new Map([
   ['javascript', { name: 'JavaScript' }],
-  ['angular', { name: 'Angular', homepage: '/javascript-data-grid/angular-installation/' }],
   ['react', { name: 'React' }],
+  ['angular', { name: 'Angular', homepage: '/javascript-data-grid/angular-installation/' }],
   ['vue', { name: 'Vue 2', homepage: '/javascript-data-grid/vue-installation/' }],
   ['vue3', { name: 'Vue 3', homepage: '/javascript-data-grid/vue3-installation/' }],
 ]);

--- a/docs/content/guides/columns/column-summary.md
+++ b/docs/content/guides/columns/column-summary.md
@@ -116,7 +116,7 @@ const ExampleComponent = () => {
           destinationRow: 3,
           destinationColumn: 0
         },
-        { 
+        {
           sourceColumn: 1,
           type: 'min',
           destinationRow: 3,
@@ -333,7 +333,7 @@ columnSummary: [
     // set this column summary to return the sum all values in the summarized column
     type: 'sum',
   },
-  { 
+  {
     sourceColumn: 1,
     // set this column summary to return the lowest value in the summarized column
     type: 'min',
@@ -350,7 +350,7 @@ columnSummary={[
     // set this column summary to return the sum all values in the summarized column
     type: 'sum',
   },
-  { 
+  {
     sourceColumn: 1,
     // set this column summary to return the lowest value in the summarized column
     type: 'min',
@@ -767,7 +767,7 @@ const ExampleComponent = () => {
 
         if (nestedRowsPlugin.isEnabled()) {
           nestedRowsCache = this.hot.getPlugin('nestedRows').dataManager.cache;
-          
+
         } else {
           return;
         }
@@ -778,18 +778,18 @@ const ExampleComponent = () => {
           if (!nestedRowsCache.levels[0][i].__children || nestedRowsCache.levels[0][i].__children.length === 0) {
             continue;
           }
-          
+
           tempEndpoint.destinationColumn = resultColumn;
           tempEndpoint.destinationRow = getRowIndex(nestedRowsCache.levels[0][i]);
           tempEndpoint.type = 'sum';
           tempEndpoint.forceNumeric = true;
           tempEndpoint.ranges = [];
-          
+
           tempEndpoint.ranges.push([
             getRowIndex(nestedRowsCache.levels[0][i].__children[0]),
             getRowIndex(nestedRowsCache.levels[0][i].__children[nestedRowsCache.levels[0][i].__children.length - 1])
           ]);
-          
+
           endpoints.push(tempEndpoint);
           tempEndpoint = null;
         }
@@ -823,7 +823,7 @@ columnSummary: [{
   type: 'custom',
   destinationRow: 0,
   destinationColumn: 5,
-  reversedRowCoords: true 
+  reversedRowCoords: true
 }]
 ```
 :::
@@ -1207,7 +1207,7 @@ const ExampleComponent = () => {
       colHeaders={true}
       rowHeaders={true}
       columnSummary={
-        [{ 
+        [{
           type: 'sum',
           destinationRow: 0,
           destinationColumn: 0,

--- a/docs/content/guides/formulas/formula-calculation.md
+++ b/docs/content/guides/formulas/formula-calculation.md
@@ -900,13 +900,13 @@ const ExampleComponent = () => {
         licenseKey="non-commercial-and-evaluation"
       />
       <div className="controls">
-        <input 
-          id="named-expressions-input" 
-          type="text" 
-          defaultValue={namedExpressionValue} 
+        <input
+          id="named-expressions-input"
+          type="text"
+          defaultValue={namedExpressionValue}
           onChange={(...args) => inputChangeCallback(...args)}/>
-        <button 
-          id="named-expressions-button" 
+        <button
+          id="named-expressions-button"
           onClick={(...args) => buttonClickCallback(...args)}
         >
           Calculate price


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adds cosmetic changes such as:
 * Changes the order of the listed framework in the dropdown;
 * Changes the order of the tabs in the example containers. Now, the "Preview" tab is rendered as first.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally.

### Related issue(s):
1. fixes #9908

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
