### PR TITLE
Docs: Add support for remembering the chosen framework

### DIFF
--- a/docs/.vuepress/helpers.js
+++ b/docs/.vuepress/helpers.js
@@ -258,8 +258,8 @@ function getDocsHostname(allowLocalhost = true) {
 }
 
 module.exports = {
-  MULTI_FRAMEWORKED_CONTENT_DIR,
   FRAMEWORK_SUFFIX,
+  MULTI_FRAMEWORKED_CONTENT_DIR,
   getNormalizedPath,
   getFrameworks,
   getPrettyFrameworkName,

--- a/docs/.vuepress/theme/components/DropdownLink.vue
+++ b/docs/.vuepress/theme/components/DropdownLink.vue
@@ -1,0 +1,261 @@
+<template>
+  <div
+    class="dropdown-wrapper"
+    :class="{ open }"
+  >
+    <button
+      class="dropdown-title"
+      type="button"
+      :aria-label="dropdownAriaLabel"
+      @click="handleDropdown"
+    >
+      <span class="title">{{ item.text }}</span>
+      <span
+        class="arrow down"
+      />
+    </button>
+    <button
+      class="mobile-dropdown-title"
+      type="button"
+      :aria-label="dropdownAriaLabel"
+      @click="setOpen(!open)"
+    >
+      <span class="title">{{ item.text }}</span>
+      <span
+        class="arrow"
+        :class="open ? 'down' : 'right'"
+      />
+    </button>
+
+    <DropdownTransition>
+      <ul
+        v-show="open"
+        class="nav-dropdown"
+      >
+        <li
+          v-for="(subItem, index) in item.items"
+          :key="subItem.link || index"
+          class="dropdown-item"
+        >
+          <h4 v-if="subItem.type === 'links'">
+            {{ subItem.text }}
+          </h4>
+
+          <ul
+            v-if="subItem.type === 'links'"
+            class="dropdown-subitem-wrapper"
+          >
+            <li
+              v-for="childSubItem in subItem.items"
+              :key="childSubItem.link"
+              class="dropdown-subitem"
+            >
+              <NavLink
+                :item="childSubItem"
+                @focusout="
+                  isLastItemOfArray(childSubItem, subItem.items) &&
+                    isLastItemOfArray(subItem, item.items) &&
+                    setOpen(false)
+                "
+              />
+            </li>
+          </ul>
+
+          <NavLink
+            v-else
+            :item="subItem"
+            @click.native="itemClick(subItem)"
+            @focusout="isLastItemOfArray(subItem, item.items) && setOpen(false)"
+          />
+        </li>
+      </ul>
+    </DropdownTransition>
+  </div>
+</template>
+
+<script>
+import NavLink from '@theme/components/NavLink.vue';
+import DropdownTransition from '@theme/components/DropdownTransition.vue';
+import last from 'lodash/last';
+
+export default {
+  name: 'DropdownLink',
+
+  components: {
+    NavLink,
+    DropdownTransition
+  },
+
+  props: {
+    item: {
+      required: true
+    },
+  },
+
+  data() {
+    return {
+      open: false
+    };
+  },
+
+  computed: {
+    dropdownAriaLabel() {
+      return this.item.ariaLabel || this.item.text;
+    }
+  },
+
+  watch: {
+    $route() {
+      this.open = false;
+    }
+  },
+
+  methods: {
+    itemClick(item) {
+      this.$emit('item-click', item);
+    },
+    setOpen(value) {
+      this.open = value;
+    },
+
+    isLastItemOfArray(item, array) {
+      return last(array) === item;
+    },
+
+    /**
+     * Open the dropdown when user tab and click from keyboard.
+     *
+     * Use event.detail to detect tab and click from keyboard. Ref: https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/detail
+     * The Tab + Click is UIEvent > KeyboardEvent, so the detail is 0.
+     *
+     * @param {Event} event The click event.
+     */
+    handleDropdown(event) {
+      const isTriggerByTab = event.detail === 0;
+
+      if (isTriggerByTab) {
+        this.setOpen(!this.open);
+      }
+    }
+  }
+};
+</script>
+
+<style lang="stylus">
+.dropdown-wrapper
+  cursor pointer
+  .dropdown-title
+    display block
+    font-size 0.9rem
+    font-family inherit
+    cursor inherit
+    padding inherit
+    line-height 1.4rem
+    background transparent
+    border none
+    font-weight 500
+    color $textColor
+    &:hover
+      border-color transparent
+    .arrow
+      vertical-align middle
+      margin-top -1px
+      margin-left 0.4rem
+  .mobile-dropdown-title
+    @extends .dropdown-title
+    display none
+    font-weight 600
+    font-size inherit
+      &:hover
+        color $accentColor
+  .nav-dropdown
+    .dropdown-item
+      color inherit
+      line-height 1.7rem
+      h4
+        margin 0.45rem 0 0
+        border-top 1px solid #eee
+        padding 1rem 1.5rem 0.45rem 1.25rem
+      .dropdown-subitem-wrapper
+        padding 0
+        list-style none
+        .dropdown-subitem
+          font-size 0.9em
+      a
+        display block
+        line-height 1.7rem
+        position relative
+        border-bottom none
+        font-weight 400
+        margin-bottom 0
+        padding 0 1.5rem 0 1.25rem
+        &:hover
+          color $accentColor
+        &.router-link-active
+          color $accentColor
+          &::after
+            content ""
+            width 0
+            height 0
+            border-left 5px solid $accentColor
+            border-top 3px solid transparent
+            border-bottom 3px solid transparent
+            position absolute
+            top calc(50% - 2px)
+            left 9px
+      &:first-child h4
+        margin-top 0
+        padding-top 0
+        border-top 0
+
+@media (max-width: $MQMobile)
+  .dropdown-wrapper
+    &.open .dropdown-title
+      margin-bottom 0.5rem
+    .dropdown-title
+      display: none
+    .mobile-dropdown-title
+      display: block
+    .nav-dropdown
+      transition height .1s ease-out
+      overflow hidden
+      .dropdown-item
+        h4
+          border-top 0
+          margin-top 0
+          padding-top 0
+        h4, & > a
+          font-size 15px
+          line-height 2rem
+        .dropdown-subitem
+          font-size 14px
+          padding-left 1rem
+
+@media (min-width: $MQMobile)
+  .dropdown-wrapper
+    height 1.8rem
+    &:hover .nav-dropdown,
+    &.open .nav-dropdown
+      // override the inline style.
+      display block !important
+    &.open:blur
+      display none
+    .nav-dropdown
+      display none
+      // Avoid height shaked by clicking
+      height auto !important
+      box-sizing border-box;
+      max-height calc(100vh - 2.7rem)
+      overflow-y auto
+      position absolute
+      top 100%
+      right 0
+      background-color #fff
+      padding 0.6rem 0
+      border 1px solid #ddd
+      border-bottom-color #ccc
+      text-align left
+      border-radius 0.25rem
+      white-space nowrap
+      margin 0
+</style>

--- a/docs/.vuepress/theme/components/FrameworksDropdown.vue
+++ b/docs/.vuepress/theme/components/FrameworksDropdown.vue
@@ -3,13 +3,29 @@
     <img :src="imageUrl"/>
     <!-- user links -->
     <nav class="nav-item" >
-      <DropdownLink :item="item"></DropdownLink>
+      <DropdownLink @item-click="onFrameworkClick" :item="item"></DropdownLink>
     </nav>
   </nav>
 </template>
 
 <script>
 import DropdownLink from '@theme/components/DropdownLink.vue';
+
+/**
+ * Sets cookie bound to the docs URL domain and path.
+ *
+ * @param {string} name Cookie name.
+ * @param {string} value Cookie value.
+ */
+function setCookie(name, value) {
+  let str = `${name}=${value}`;
+
+  str += `; Domain=${window.location.hostname}`;
+  str += '; Path=/docs';
+  str += `; Expires=${new Date(Date.now() + (365 * 24 * 60 * 60 * 1000)).toUTCString()}`; // 1 year
+
+  document.cookie = str;
+}
 
 const frameworkIdToFullName = new Map([
   ['javascript', { name: 'JavaScript' }],
@@ -35,6 +51,9 @@ export default {
     };
   },
   methods: {
+    onFrameworkClick(item) {
+      setCookie('docs_fw', item.id === 'react' ? 'react' : 'javascript');
+    },
     detectLegacyFramework(path) {
       const frameworkMatch = path.match(/javascript-data-grid\/(vue3|vue|angular)?/);
 
@@ -57,6 +76,7 @@ export default {
     getFrameworkItems() {
       return Array.from(frameworkIdToFullName.entries()).map(([id, { name }]) => {
         return {
+          id,
           text: name,
           link: this.getLink(id),
           target: '_self',

--- a/docs/docker/redirects.conf
+++ b/docs/docker/redirects.conf
@@ -22,12 +22,18 @@
 rewrite ^/docs/hyperformula$ https://hyperformula.handsontable.com permanent;
 rewrite ^/docs/hyperformula/(.*)$ https://hyperformula.handsontable.com/$1 permanent;
 
+set $framework "javascript-data-grid";
+
+if ($cookie_docs_fw = "react") {
+  set $framework "react-data-grid";
+}
+
 # --- redirect /docs/ to /docs/javascript-data-grid/ ---
-rewrite ^/docs/?$ /docs/javascript-data-grid/ permanent;
-rewrite ^/docs/(\d+\.\d+|next)/?$ /docs/$1/javascript-data-grid/ permanent;
+rewrite ^/docs/?$ /docs/$framework/ permanent;
+rewrite ^/docs/(\d+\.\d+|next)/?$ /docs/$1/$framework/ permanent;
 
 # --- documentation links that come up in Handsontable's console logs ---
-rewrite ^/docs/i18n/missing-language-code /docs/javascript-data-grid/language/#loading-the-prepared-language-files permanent;
+rewrite ^/docs/i18n/missing-language-code /docs/$framework/language/#loading-the-prepared-language-files permanent;
 
 # --- framework shortcuts ---
 rewrite ^/docs/react$ /docs/react-data-grid/installation/ permanent;
@@ -69,96 +75,96 @@ rewrite ^/docs/((\d+\.\d+|next)/)?frameworks-wrapper-for-react-redux-example/?$ 
 rewrite ^/docs/((\d+\.\d+|next)/)?frameworks-wrapper-for-react-hot-reference/?$ /docs/$1react-data-grid/methods/ permanent;
 
 # --- tutorials ---
-rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-introduction/?$ /docs/$1javascript-data-grid/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-compatibility/?$ /docs/$1javascript-data-grid/supported-browsers/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-licensing/?$ /docs/$1javascript-data-grid/software-license/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-license-key/?$ /docs/$1javascript-data-grid/license-key/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-quick-start/?$ /docs/$1javascript-data-grid/installation/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-data-binding/?$ /docs/$1javascript-data-grid/binding-to-data/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-data-sources/?$ /docs/$1javascript-data-grid/binding-to-data/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-load-and-save/?$ /docs/$1javascript-data-grid/saving-data/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-setting-options/?$ /docs/$1javascript-data-grid/setting-options/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-grid-sizing/?$ /docs/$1javascript-data-grid/grid-size/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-using-callbacks/?$ /docs/$1javascript-data-grid/events-and-hooks/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-keyboard-navigation/?$ /docs/$1javascript-data-grid/keyboard-navigation/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-internationalization/?$ /docs/$1javascript-data-grid/internationalization-i18n/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-modules/?$ /docs/$1javascript-data-grid/modules/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-custom-build/?$ /docs/$1javascript-data-grid/building/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-custom-plugin/?$ /docs/$1javascript-data-grid/plugins/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-cell-types/?$ /docs/$1javascript-data-grid/cell-type/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-cell-editor/?$ /docs/$1javascript-data-grid/cell-editor/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-cell-function/?$ /docs/$1javascript-data-grid/cell-function/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-suspend-rendering/?$ /docs/$1javascript-data-grid/batch-operations/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-testing/?$ /docs/$1javascript-data-grid/testing/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-performance-tips/?$ /docs/$1javascript-data-grid/performance/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-release-notes/?$ /docs/$1javascript-data-grid/release-notes/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-migration-guide/?$ /docs/$1javascript-data-grid/migration-from-7.4-to-8.0/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-known-limitations/?$ /docs/$1javascript-data-grid/third-party-licenses/ permanent;
-rewrite ^/docs/internationalization-i18n/?$ /docs/javascript-data-grid/language/ permanent;
-rewrite ^/docs/keyboard-navigation/?$ /docs/javascript-data-grid/keyboard-shortcuts/ permanent;
-rewrite ^/docs/hello-world/?$ /docs/javascript-data-grid/demo/ permanent;
-rewrite ^/docs/building/?$ /docs/javascript-data-grid/custom-builds/ permanent;
-rewrite ^/docs/plugins/?$ /docs/javascript-data-grid/custom-plugins/ permanent;
-rewrite ^/docs/file-structure/?$ /docs/javascript-data-grid/folder-structure/ permanent;
-rewrite ^/docs/examples/?$ /docs/javascript-data-grid/ permanent;
-rewrite ^/docs/setting-options/?$ /docs/javascript-data-grid/configuration-options/ permanent;
-rewrite ^/docs/angular-simple-example/?$ /docs/javascript-data-grid/angular-basic-example/ permanent;
-rewrite ^/docs/angular-setting-up-a-language/?$ /docs/javascript-data-grid/angular-setting-up-a-translation/ permanent;
-rewrite ^/docs/vue-simple-example/?$ /docs/javascript-data-grid/vue-basic-example/ permanent;
-rewrite ^/docs/vue-setting-up-a-language/?$ /docs/javascript-data-grid/vue-setting-up-a-translation/ permanent;
-rewrite ^/docs/vue3-simple-example/?$ /docs/javascript-data-grid/vue3-basic-example/ permanent;
-rewrite ^/docs/vue3-setting-up-a-language/?$ /docs/javascript-data-grid/vue3-setting-up-a-translation/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-introduction/?$ /docs/$1$framework/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-compatibility/?$ /docs/$1$framework/supported-browsers/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-licensing/?$ /docs/$1$framework/software-license/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-license-key/?$ /docs/$1$framework/license-key/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-quick-start/?$ /docs/$1$framework/installation/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-data-binding/?$ /docs/$1$framework/binding-to-data/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-data-sources/?$ /docs/$1$framework/binding-to-data/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-load-and-save/?$ /docs/$1$framework/saving-data/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-setting-options/?$ /docs/$1$framework/setting-options/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-grid-sizing/?$ /docs/$1$framework/grid-size/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-using-callbacks/?$ /docs/$1$framework/events-and-hooks/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-keyboard-navigation/?$ /docs/$1$framework/keyboard-navigation/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-internationalization/?$ /docs/$1$framework/internationalization-i18n/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-modules/?$ /docs/$1$framework/modules/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-custom-build/?$ /docs/$1$framework/building/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-custom-plugin/?$ /docs/$1$framework/plugins/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-cell-types/?$ /docs/$1$framework/cell-type/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-cell-editor/?$ /docs/$1$framework/cell-editor/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-cell-function/?$ /docs/$1$framework/cell-function/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-suspend-rendering/?$ /docs/$1$framework/batch-operations/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-testing/?$ /docs/$1$framework/testing/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-performance-tips/?$ /docs/$1$framework/performance/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-release-notes/?$ /docs/$1$framework/release-notes/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-migration-guide/?$ /docs/$1$framework/migration-from-7.4-to-8.0/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-known-limitations/?$ /docs/$1$framework/third-party-licenses/ permanent;
+rewrite ^/docs/internationalization-i18n/?$ /docs/$framework/language/ permanent;
+rewrite ^/docs/keyboard-navigation/?$ /docs/$framework/keyboard-shortcuts/ permanent;
+rewrite ^/docs/hello-world/?$ /docs/$framework/demo/ permanent;
+rewrite ^/docs/building/?$ /docs/$framework/custom-builds/ permanent;
+rewrite ^/docs/plugins/?$ /docs/$framework/custom-plugins/ permanent;
+rewrite ^/docs/file-structure/?$ /docs/$framework/folder-structure/ permanent;
+rewrite ^/docs/examples/?$ /docs/$framework/ permanent;
+rewrite ^/docs/setting-options/?$ /docs/$framework/configuration-options/ permanent;
+rewrite ^/docs/angular-simple-example/?$ /docs/$framework/angular-basic-example/ permanent;
+rewrite ^/docs/angular-setting-up-a-language/?$ /docs/$framework/angular-setting-up-a-translation/ permanent;
+rewrite ^/docs/vue-simple-example/?$ /docs/$framework/vue-basic-example/ permanent;
+rewrite ^/docs/vue-setting-up-a-language/?$ /docs/$framework/vue-setting-up-a-translation/ permanent;
+rewrite ^/docs/vue3-simple-example/?$ /docs/$framework/vue3-basic-example/ permanent;
+rewrite ^/docs/vue3-setting-up-a-language/?$ /docs/$framework/vue3-setting-up-a-translation/ permanent;
 
 # --- demos ---
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-scrolling/?$ /docs/$1javascript-data-grid/row-virtualization/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-fixing/?$ /docs/$1javascript-data-grid/column-freezing/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-resizing/?$ /docs/$1javascript-data-grid/column-width/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-moving/?$ /docs/$1javascript-data-grid/column-moving/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-pre-populating/?$ /docs/$1javascript-data-grid/row-prepopulating/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-stretching/?$ /docs/$1javascript-data-grid/column-width/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-freezing/?$ /docs/$1javascript-data-grid/column-freezing/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-fixing-bottom/?$ /docs/$1javascript-data-grid/row-freezing/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-hiding-rows/?$ /docs/$1javascript-data-grid/row-hiding/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-hiding-columns/?$ /docs/$1javascript-data-grid/column-hiding/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-trimming-rows/?$ /docs/$1javascript-data-grid/row-trimming/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-bind-rows-headers/?$ /docs/$1javascript-data-grid/row-header/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-collapsing-columns/?$ /docs/$1javascript-data-grid/column-groups/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-nested-headers/?$ /docs/$1javascript-data-grid/column-groups/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-nested-rows/?$ /docs/$1javascript-data-grid/row-parent-child/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-dropdown-menu/?$ /docs/$1javascript-data-grid/column-menu/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-sorting/?$ /docs/$1javascript-data-grid/row-sorting/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-multicolumn-sorting/?$ /docs/$1javascript-data-grid/row-sorting/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-searching/?$ /docs/$1javascript-data-grid/searching-values/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-filtering/?$ /docs/$1javascript-data-grid/column-filter/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-summary-calculations/?$ /docs/$1javascript-data-grid/column-summary/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-data-validation/?$ /docs/$1javascript-data-grid/cell-validator/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-auto-fill/?$ /docs/$1javascript-data-grid/autofill-values/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-merged-cells/?$ /docs/$1javascript-data-grid/merge-cells/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-alignment/?$ /docs/$1javascript-data-grid/text-alignment/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-read-only/?$ /docs/$1javascript-data-grid/disabled-cells/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-disabled-editing/?$ /docs/$1javascript-data-grid/disabled-cells/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-custom-renderers/?$ /docs/$1javascript-data-grid/cell-renderer/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-numeric/?$ /docs/$1javascript-data-grid/numeric-cell-type/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-date/?$ /docs/$1javascript-data-grid/date-cell-type/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-time/?$ /docs/$1javascript-data-grid/time-cell-type/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-checkbox/?$ /docs/$1javascript-data-grid/checkbox-cell-type/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-select/?$ /docs/$1javascript-data-grid/select-cell-type/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-dropdown/?$ /docs/$1javascript-data-grid/dropdown-cell-type/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-autocomplete/?$ /docs/$1javascript-data-grid/autocomplete-cell-type/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-password/?$ /docs/$1javascript-data-grid/password-cell-type/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-handsontable/?$ /docs/$1javascript-data-grid/handsontable-cell-type/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-context-menu/?$ /docs/$1javascript-data-grid/context-menu/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-spreadsheet-icons/?$ /docs/$1javascript-data-grid/icon-pack/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-comments_/?$ /docs/$1javascript-data-grid/comments/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-copy-paste/?$ /docs/$1javascript-data-grid/basic-clipboard/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-export-file/?$ /docs/$1javascript-data-grid/export-to-csv/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-conditional-formatting/?$ /docs/$1javascript-data-grid/conditional-formatting/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-customizing-borders/?$ /docs/$1javascript-data-grid/formatting-cells/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-custom-borders/?$ /docs/$1javascript-data-grid/formatting-cells/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-selecting-ranges/?$ /docs/$1javascript-data-grid/selection/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-formula-support/?$ /docs/$1javascript-data-grid/formula-calculation/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-using-callbacks/?$ /docs/$1javascript-data-grid/events-and-hooks/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?demo-react-simple-examples/?$ /docs/$1javascript-data-grid/react-simple-example/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-scrolling/?$ /docs/$1$framework/row-virtualization/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-fixing/?$ /docs/$1$framework/column-freezing/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-resizing/?$ /docs/$1$framework/column-width/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-moving/?$ /docs/$1$framework/column-moving/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-pre-populating/?$ /docs/$1$framework/row-prepopulating/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-stretching/?$ /docs/$1$framework/column-width/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-freezing/?$ /docs/$1$framework/column-freezing/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-fixing-bottom/?$ /docs/$1$framework/row-freezing/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-hiding-rows/?$ /docs/$1$framework/row-hiding/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-hiding-columns/?$ /docs/$1$framework/column-hiding/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-trimming-rows/?$ /docs/$1$framework/row-trimming/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-bind-rows-headers/?$ /docs/$1$framework/row-header/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-collapsing-columns/?$ /docs/$1$framework/column-groups/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-nested-headers/?$ /docs/$1$framework/column-groups/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-nested-rows/?$ /docs/$1$framework/row-parent-child/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-dropdown-menu/?$ /docs/$1$framework/column-menu/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-sorting/?$ /docs/$1$framework/row-sorting/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-multicolumn-sorting/?$ /docs/$1$framework/row-sorting/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-searching/?$ /docs/$1$framework/searching-values/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-filtering/?$ /docs/$1$framework/column-filter/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-summary-calculations/?$ /docs/$1$framework/column-summary/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-data-validation/?$ /docs/$1$framework/cell-validator/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-auto-fill/?$ /docs/$1$framework/autofill-values/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-merged-cells/?$ /docs/$1$framework/merge-cells/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-alignment/?$ /docs/$1$framework/text-alignment/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-read-only/?$ /docs/$1$framework/disabled-cells/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-disabled-editing/?$ /docs/$1$framework/disabled-cells/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-custom-renderers/?$ /docs/$1$framework/cell-renderer/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-numeric/?$ /docs/$1$framework/numeric-cell-type/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-date/?$ /docs/$1$framework/date-cell-type/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-time/?$ /docs/$1$framework/time-cell-type/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-checkbox/?$ /docs/$1$framework/checkbox-cell-type/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-select/?$ /docs/$1$framework/select-cell-type/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-dropdown/?$ /docs/$1$framework/dropdown-cell-type/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-autocomplete/?$ /docs/$1$framework/autocomplete-cell-type/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-password/?$ /docs/$1$framework/password-cell-type/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-handsontable/?$ /docs/$1$framework/handsontable-cell-type/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-context-menu/?$ /docs/$1$framework/context-menu/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-spreadsheet-icons/?$ /docs/$1$framework/icon-pack/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-comments_/?$ /docs/$1$framework/comments/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-copy-paste/?$ /docs/$1$framework/basic-clipboard/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-export-file/?$ /docs/$1$framework/export-to-csv/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-conditional-formatting/?$ /docs/$1$framework/conditional-formatting/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-customizing-borders/?$ /docs/$1$framework/formatting-cells/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-custom-borders/?$ /docs/$1$framework/formatting-cells/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-selecting-ranges/?$ /docs/$1$framework/selection/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-formula-support/?$ /docs/$1$framework/formula-calculation/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-using-callbacks/?$ /docs/$1$framework/events-and-hooks/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?demo-react-simple-examples/?$ /docs/$1$framework/react-simple-example/ permanent;
 
 # Redirect all urls without framework prefix e.g. from /docs/[path] to /docs/javascript-data-grid/[path].
 # Except those that already contain a name in the path:
@@ -173,5 +179,5 @@ rewrite ^/docs/((\d+\.\d+|next)/)?demo-react-simple-examples/?$ /docs/$1javascri
 #  * /sitemap.xml
 #  * /securitum-certificate.pdf
 #  * /seqred-certificate.pdf
-rewrite ^/docs/((?:\d+\.\d+|next)/)(?!(?:javascript|react)-data-grid/|assets/|data/|handsontable/|img/|scripts/|404\.html|sitemap\.xml|securitum-certificate\.pdf|seqred-certificate\.pdf)(.+)$ /docs/$1javascript-data-grid/$2 permanent;
-rewrite ^/docs/(?!\d+\.\d+|next\/)(?!(?:javascript|react)-data-grid/|assets/|data/|handsontable/|img/|scripts/|404\.html|sitemap\.xml|securitum-certificate\.pdf|seqred-certificate\.pdf)(.+)$ /docs/javascript-data-grid/$1 permanent;
+rewrite ^/docs/((?:\d+\.\d+|next)/)(?!(?:javascript|react)-data-grid/|assets/|data/|handsontable/|img/|scripts/|404\.html|sitemap\.xml|securitum-certificate\.pdf|seqred-certificate\.pdf)(.+)$ /docs/$1$framework/$2 permanent;
+rewrite ^/docs/(?!\d+\.\d+|next\/)(?!(?:javascript|react)-data-grid/|assets/|data/|handsontable/|img/|scripts/|404\.html|sitemap\.xml|securitum-certificate\.pdf|seqred-certificate\.pdf)(.+)$ /docs/$framework/$1 permanent;


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adds the feature to the Docs, which enables remembering the chosen framework. Once the framework is remembered, all Docs pages that do not have a defined framework within the name are redirected to the page with the remembered framework.

For example, when the "react" framework is saved, the following pages are permanently redirected:
 * `/docs/` -> `/docs/react-data-grid/`;
 * `/docs/12.1/` -> `/docs/12.1/react-data-grid/`;
 * `/docs/foo/bar` -> `/docs/react-data-grid/foo/bar`;
 * `/docs/12.1/foo/bar` -> `/docs/12.1/react-data-grid/foo/bar`;
 * The same happens for legacy URLs defined in [redirects.conf](https://github.com/handsontable/handsontable/blob/feature/issue-9907/docs/docker/redirects.conf#L1). For example:
   * `/docs/plugins/` -> `/docs/react-data-grid/plugins/`;
   * `/docs/demo-scrolling` -> `/docs/react-data-grid/row-virtualization/`;
   * ...

When the URL page already contains the framework, the page won't be redirected. For example:
 * `/docs/javascript-data-grid/`;
 * `/docs/12.1/javascript-data-grid/`;
 * `/docs/javascript-data-grid/foo/bar/`;
 * `/docs/12.1/javascript-data-grid/foo/bar/`;

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally using the Docker image. The redirect rules are applied to the server, so for `watch` mode, it won't work.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. fixes #9907

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
