### PR TITLE
Docs: Improve Docs on mobile devices

### DIFF
--- a/docs/.vuepress/theme/components/FrameworksDropdown.vue
+++ b/docs/.vuepress/theme/components/FrameworksDropdown.vue
@@ -103,9 +103,6 @@ export default {
     text-transform capitalize
   }
 
-  .nav-dropdown
-    z-index 100
-
   .icon.outbound
     display none
 
@@ -129,6 +126,7 @@ export default {
     border-radius 0.25rem
     white-space nowrap
     margin 0
+    z-index 100
 .dropdown-wrapper .dropdown-title .arrow, .dropdown-wrapper .mobile-dropdown-title .arrow
   margin-left 0.1rem
 

--- a/docs/.vuepress/theme/components/Navbar.vue
+++ b/docs/.vuepress/theme/components/Navbar.vue
@@ -149,5 +149,8 @@ $navbar-horizontal-padding = 1.5rem
 @media (max-width: $MQNarrow)
   .navbar .nav-frameworks
     display none
+@media (max-width: $MQMobileNarrow)
+  .navbar .nav-versions
+    display none
 
 </style>

--- a/docs/.vuepress/theme/components/SearchBox.vue
+++ b/docs/.vuepress/theme/components/SearchBox.vue
@@ -434,7 +434,6 @@ export default {
       border-color transparent
       position relative
       font-size 16px
-      z-index 200
       &:focus
         cursor text
         left 0

--- a/docs/.vuepress/theme/components/SearchBox.vue
+++ b/docs/.vuepress/theme/components/SearchBox.vue
@@ -430,7 +430,7 @@ export default {
     input
       cursor pointer
       width 0
-      background-color #fff
+      background-color transparent
       border-color transparent
       position relative
       font-size 16px

--- a/docs/.vuepress/theme/components/SearchBox.vue
+++ b/docs/.vuepress/theme/components/SearchBox.vue
@@ -430,10 +430,11 @@ export default {
     input
       cursor pointer
       width 0
-      background-color transparent
+      background-color #fff
       border-color transparent
       position relative
       font-size 16px
+      z-index 200
       &:focus
         cursor text
         left 0

--- a/docs/.vuepress/theme/components/Sidebar.vue
+++ b/docs/.vuepress/theme/components/Sidebar.vue
@@ -1,5 +1,8 @@
 <template>
   <aside class="sidebar">
+    <div class="version-switcher-item">
+      Version: <VersionsDropdown class="sidebar-mode"/>
+    </div>
     <div class="framework-switcher-item">
       Framework: <FrameworksDropdown class="sidebar-mode"/>
     </div>
@@ -22,11 +25,18 @@ import SidebarLinks from '@theme/components/SidebarLinks.vue';
 import NavLinks from '@theme/components/NavLinks.vue';
 import ThemeSwitcher from '@theme/components/ThemeSwitcher.vue';
 import FrameworksDropdown from '@theme/components/FrameworksDropdown.vue';
+import VersionsDropdown from '@theme/components/VersionsDropdown.vue';
 
 export default {
   name: 'Sidebar',
 
-  components: { SidebarLinks, NavLinks, ThemeSwitcher, FrameworksDropdown },
+  components: {
+    SidebarLinks,
+    NavLinks,
+    ThemeSwitcher,
+    FrameworksDropdown,
+    VersionsDropdown,
+  },
 
   props: ['items']
 };
@@ -45,6 +55,29 @@ export default {
       display none
     }
 }
+
+.version-switcher-item
+  width 235px
+  position relative
+  display inline-block
+  margin-left 1.5rem
+  line-height 2rem
+  font-weight 600
+  margin-top 10px
+
+  .nav-versions
+    float right
+    margin-left 0
+
+    .nav-dropdown
+      left unset
+
+      @media (max-width: $MQMobile) {
+        right -35px
+      }
+
+  @media (min-width: $MQMobileNarrow)
+    display none
 
 .framework-switcher-item
   width 235px
@@ -133,16 +166,5 @@ export default {
 
 .sidebar > .sidebar-links > li:not(:first-child)
   margin-top 0
-
-@media (max-width: $MQMobile)
-  .sidebar
-    .nav-links
-      .mobile-dropdown-title
-        font-size 15px
-      display block
-      .dropdown-wrapper .nav-dropdown .dropdown-item a.router-link-active::after
-        top calc(1rem - 2px)
-    & > .sidebar-links
-      padding 1rem 0
 
 </style>

--- a/docs/.vuepress/theme/components/VersionsDropdown.vue
+++ b/docs/.vuepress/theme/components/VersionsDropdown.vue
@@ -84,7 +84,6 @@ export default {
   position relative
   top -1px
   text-transform capitalize
-  z-index 100
 
   .dropdown-title, .mobile-dropdown-title
     text-transform capitalize
@@ -112,6 +111,7 @@ export default {
     border-radius 0.25rem
     white-space nowrap
     margin 0
+    z-index 100
 .dropdown-wrapper .dropdown-title .arrow, .dropdown-wrapper .mobile-dropdown-title .arrow
   margin-left 0.1rem
 

--- a/docs/.vuepress/theme/components/VersionsDropdown.vue
+++ b/docs/.vuepress/theme/components/VersionsDropdown.vue
@@ -1,6 +1,5 @@
 <template>
     <nav class="nav-versions nav-links" >
-      <!-- user links -->
       <nav class="nav-item" >
         <DropdownLink :item="item"></DropdownLink>
       </nav>
@@ -85,10 +84,10 @@ export default {
   position relative
   top -1px
   text-transform capitalize
+  z-index 100
 
-  .dropdown-title {
+  .dropdown-title, .mobile-dropdown-title
     text-transform capitalize
-  }
 
   .icon.outbound
     display none

--- a/docs/.vuepress/theme/styles/index.styl
+++ b/docs/.vuepress/theme/styles/index.styl
@@ -224,22 +224,22 @@ table {
   width: 100%;
 
   tr {
-      border-top: none;
+    border-top: none;
   }
 
   td {
-      white-space: normal;
+    white-space: normal;
 
-      @media (max-width: $MQNarrow) {
-        white-space: nowrap;
-      }
+    @media (max-width: $MQNarrow) {
+      white-space: nowrap;
+    }
   }
 
   th, td {
-      border: none;
-      border-bottom: 1px solid #e9eef2;
-      line-height: 1.7;
-      text-align: left;
+    border: none;
+    border-bottom: 1px solid #e9eef2;
+    line-height: 1.7;
+    text-align: left;
   }
 }
 

--- a/docs/.vuepress/theme/styles/index.styl
+++ b/docs/.vuepress/theme/styles/index.styl
@@ -216,13 +216,23 @@ a {
   overflow-x: scroll;
 }
 
+table.htCore {
+  display: table;
+}
+
 table {
   width: 100%;
-  display: table;
-  overflow: scroll;
 
   tr {
       border-top: none;
+  }
+
+  td {
+      white-space: normal;
+
+      @media (max-width: $MQNarrow) {
+        white-space: nowrap;
+      }
   }
 
   th, td {
@@ -231,11 +241,6 @@ table {
       line-height: 1.7;
       text-align: left;
   }
-}
-
-/* fix for very wide tables in the migration guides */
-.migration-guide table {
-  word-break: break-word;
 }
 
 // floating sidebar should be inline on mobile, and float on wider screens

--- a/docs/content/guides/cell-features/disabled-cells.md
+++ b/docs/content/guides/cell-features/disabled-cells.md
@@ -47,6 +47,7 @@ const hot = new Handsontable(container, {
     {car: 'Chrysler', year: 2019, chassis: 'yellow', bumper: 'black'},
     {car: 'Volvo', year: 2020, chassis: 'white', bumper: 'gray'}
   ],
+  height: 'auto',
   colHeaders: ['Car', 'Year', 'Chassis color', 'Bumper color'],
   licenseKey: 'non-commercial-and-evaluation',
   columns: [
@@ -88,6 +89,7 @@ const ExampleComponent = () => {
         { car: 'Chrysler', year: 2019, chassis: 'yellow', bumper: 'black' },
         { car: 'Volvo', year: 2020, chassis: 'white', bumper: 'gray' }
       ]}
+      height="auto"
       colHeaders={['Car', 'Year', 'Chassis color', 'Bumper color']}
       licenseKey="non-commercial-and-evaluation"
       columns={[
@@ -223,6 +225,7 @@ const hot = new Handsontable(container, {
     {car: 'Chrysler', year: 2019, chassis: 'yellow', bumper: 'black'},
     {car: 'Volvo', year: 2020, chassis: 'white', bumper: 'gray'}
   ],
+  height: 'auto',
   colHeaders: ['Car', 'Year', 'Chassis color', 'Bumper color'],
   licenseKey: 'non-commercial-and-evaluation',
   columns: [
@@ -267,6 +270,7 @@ const ExampleComponent = () => {
         { car: 'Chrysler', year: 2019, chassis: 'yellow', bumper: 'black' },
         { car: 'Volvo', year: 2020, chassis: 'white', bumper: 'gray' }
       ]}
+      height="auto"
       colHeaders={['Car', 'Year', 'Chassis color', 'Bumper color']}
       licenseKey="non-commercial-and-evaluation"
       columns={[

--- a/docs/content/guides/columns/column-hiding.md
+++ b/docs/content/guides/columns/column-hiding.md
@@ -34,6 +34,7 @@ const container = document.querySelector('#example1');
 const hot = new Handsontable(container, {
   licenseKey: 'non-commercial-and-evaluation',
   data: Handsontable.helper.createSpreadsheetData(5, 12),
+  height: 'auto',
   colHeaders: true,
   rowHeaders: true,
   // enable the `HiddenColumns` plugin
@@ -57,8 +58,9 @@ registerAllModules();
 const ExampleComponent = () => {
   return (
     <HotTable
-      licenseKey='non-commercial-and-evaluation'
+      licenseKey="non-commercial-and-evaluation"
       data={Handsontable.helper.createSpreadsheetData(5, 12)}
+      height="auto"
       colHeaders={true}
       rowHeaders={true}
       // enable the `HiddenColumns` plugin
@@ -93,6 +95,7 @@ const container = document.querySelector('#example2');
 const hot = new Handsontable(container, {
   licenseKey: 'non-commercial-and-evaluation',
   data: Handsontable.helper.createSpreadsheetData(5, 12),
+  height: 'auto',
   colHeaders: true,
   rowHeaders: true,
   // enable the `HiddenColumns` plugin
@@ -121,6 +124,7 @@ const ExampleComponent = () => {
     <HotTable
       licenseKey="non-commercial-and-evaluation"
       data={Handsontable.helper.createSpreadsheetData(5, 12)}
+      height="auto"
       colHeaders={true}
       rowHeaders={true}
       // enable the `HiddenColumns` plugin
@@ -156,6 +160,7 @@ const container = document.querySelector('#example3');
 const hot = new Handsontable(container, {
   licenseKey: 'non-commercial-and-evaluation',
   data: Handsontable.helper.createSpreadsheetData(5, 12),
+  height: 'auto',
   colHeaders: true,
   rowHeaders: true,
   hiddenColumns: {
@@ -184,6 +189,7 @@ const ExampleComponent = () => {
     <HotTable
       licenseKey="non-commercial-and-evaluation"
       data={Handsontable.helper.createSpreadsheetData(5, 12)}
+      height="auto"
       colHeaders={true}
       rowHeaders={true}
       hiddenColumns={{
@@ -215,6 +221,7 @@ const container = document.querySelector('#example4');
 const hot = new Handsontable(container, {
   licenseKey: 'non-commercial-and-evaluation',
   data: Handsontable.helper.createSpreadsheetData(5, 12),
+  height: 'auto',
   colHeaders: true,
   rowHeaders: true,
   // enable the context menu
@@ -246,6 +253,7 @@ const ExampleComponent = () => {
     <HotTable
       licenseKey={"non-commercial-and-evaluation"}
       data={Handsontable.helper.createSpreadsheetData(5, 12)}
+      height="auto"
       colHeaders={true}
       rowHeaders={true}
       // enable the context menu
@@ -276,6 +284,7 @@ const container = document.querySelector('#example5');
 const hot = new Handsontable(container, {
   licenseKey: 'non-commercial-and-evaluation',
   data: Handsontable.helper.createSpreadsheetData(5, 12),
+  height: 'auto',
   colHeaders: true,
   rowHeaders: true,
   // individually add column hiding context menu items
@@ -305,6 +314,7 @@ const ExampleComponent = () => {
     <HotTable
       licenseKey="non-commercial-and-evaluation"
       data={Handsontable.helper.createSpreadsheetData(5, 12)}
+      height="auto"
       colHeaders={true}
       rowHeaders={true}
       contextMenu={['hidden_columns_show', 'hidden_columns_hide']}
@@ -336,6 +346,7 @@ const container = document.querySelector('#example6');
 const hot = new Handsontable(container, {
   licenseKey: 'non-commercial-and-evaluation',
   data: Handsontable.helper.createSpreadsheetData(5, 12),
+  height: 'auto',
   colHeaders: true,
   rowHeaders: true,
   contextMenu: [`hidden_columns_show`, `hidden_columns_hide`],
@@ -366,6 +377,7 @@ const ExampleComponent = () => {
     <HotTable
       licenseKey="non-commercial-and-evaluation"
       data={Handsontable.helper.createSpreadsheetData(5, 12)}
+      height="auto"
       colHeaders={true}
       rowHeaders={true}
       contextMenu={[`hidden_columns_show`, `hidden_columns_hide`]}
@@ -393,7 +405,7 @@ For the most popular column hiding tasks, use the API methods below.
 ::: tip
 To use the Handsontable API, you'll need access to the Handsontable instance. You can do that by utilizing a reference to the `HotTable` component, and reading its `hotInstance` property.
 
-For more information, see the [`Instance Methods`](@/guides/getting-started/react-methods.md) page. 
+For more information, see the [`Instance Methods`](@/guides/getting-started/react-methods.md) page.
 :::
 :::
 

--- a/docs/content/guides/rows/row-hiding.md
+++ b/docs/content/guides/rows/row-hiding.md
@@ -34,6 +34,7 @@ const container = document.querySelector('#example1');
 const hot = new Handsontable(container, {
   licenseKey: 'non-commercial-and-evaluation',
   data: Handsontable.helper.createSpreadsheetData(12, 5),
+  height: 'auto',
   colHeaders: true,
   rowHeaders: true,
   // enable the `HiddenRows` plugin
@@ -59,6 +60,7 @@ const ExampleComponent = () => {
     <HotTable
       licenseKey="non-commercial-and-evaluation"
       data={Handsontable.helper.createSpreadsheetData(12, 5)}
+      height="auto"
       colHeaders={true}
       rowHeaders={true}
       hiddenRows={true}
@@ -92,6 +94,7 @@ const container = document.querySelector('#example2');
 const hot = new Handsontable(container, {
   licenseKey: 'non-commercial-and-evaluation',
   data: Handsontable.helper.createSpreadsheetData(12, 5),
+  height: 'auto',
   colHeaders: true,
   rowHeaders: true,
   // enable the `HiddenRows` plugin
@@ -120,6 +123,7 @@ const ExampleComponent = () => {
     <HotTable
       licenseKey="non-commercial-and-evaluation"
       data={Handsontable.helper.createSpreadsheetData(12, 5)}
+      height="auto"
       colHeaders={true}
       rowHeaders={true}
       hiddenRows={{
@@ -154,6 +158,7 @@ const container = document.querySelector('#example3');
 const hot = new Handsontable(container, {
   licenseKey: 'non-commercial-and-evaluation',
   data: Handsontable.helper.createSpreadsheetData(12, 5),
+  height: 'auto',
   colHeaders: true,
   rowHeaders: true,
   hiddenRows: {
@@ -182,6 +187,7 @@ const ExampleComponent = () => {
     <HotTable
       licenseKey="non-commercial-and-evaluation"
       data={Handsontable.helper.createSpreadsheetData(12, 5)}
+      height="auto"
       colHeaders={true}
       rowHeaders={true}
       hiddenRows={{
@@ -213,6 +219,7 @@ const container = document.querySelector('#example4');
 const hot = new Handsontable(container, {
   licenseKey: 'non-commercial-and-evaluation',
   data: Handsontable.helper.createSpreadsheetData(12, 5),
+  height: 'auto',
   colHeaders: true,
   rowHeaders: true,
   // enable the context menu
@@ -244,6 +251,7 @@ const ExampleComponent = () => {
     <HotTable
       licenseKey="non-commercial-and-evaluation"
       data={Handsontable.helper.createSpreadsheetData(12, 5)}
+      height="auto"
       colHeaders={true}
       rowHeaders={true}
       contextMenu={true}
@@ -271,6 +279,7 @@ const container = document.querySelector('#example5');
 const hot = new Handsontable(container, {
   licenseKey: 'non-commercial-and-evaluation',
   data: Handsontable.helper.createSpreadsheetData(12, 5),
+  height: 'auto',
   colHeaders: true,
   rowHeaders: true,
   // individually add row hiding context menu items
@@ -300,6 +309,7 @@ const ExampleComponent = () => {
     <HotTable
       licenseKey="non-commercial-and-evaluation"
       data={Handsontable.helper.createSpreadsheetData(12, 5)}
+      height="auto"
       colHeaders={true}
       rowHeaders={true}
       contextMenu={[`hidden_rows_show`, `hidden_rows_hide`]}
@@ -331,6 +341,7 @@ const container = document.querySelector('#example6');
 const hot = new Handsontable(container, {
   licenseKey: 'non-commercial-and-evaluation',
   data: Handsontable.helper.createSpreadsheetData(12, 5),
+  height: 'auto',
   colHeaders: true,
   rowHeaders: true,
   contextMenu: [`hidden_rows_show`, `hidden_rows_hide`],
@@ -361,6 +372,7 @@ const ExampleComponent = () => {
     <HotTable
       licenseKey="non-commercial-and-evaluation"
       data={Handsontable.helper.createSpreadsheetData(12, 5)}
+      height="auto"
       colHeaders={true}
       rowHeaders={true}
       contextMenu={[`hidden_rows_show`, `hidden_rows_hide`]}


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR improves the UI styling, content styling, and demos for mobile devices (narrow viewports). The PRs changes:

#### 1. Docs versions dropdown component 
Fix the Docs versions dropdown component by moving the component to the sidebar for narrow viewports (width < 340). 

##### Before
![Kapture 2022-09-20 at 09 29 59](https://user-images.githubusercontent.com/571316/191194715-3bc845b7-67df-49df-8fab-fdf4dc903126.gif)

##### After
![Kapture 2022-09-20 at 09 30 27](https://user-images.githubusercontent.com/571316/191194859-b54ee331-7024-46c8-b9dd-7be5ef932aad.gif)

#### 2. Search component
Fix the Search component that overlaps the Docs versions component. The PR sets the background color to fix components blending. 

##### Before
![image](https://user-images.githubusercontent.com/571316/191195899-80328441-55d2-48c0-9fe4-bf73aaf404f2.png)

##### After
![image](https://user-images.githubusercontent.com/571316/191195831-dc1bf48b-6f0d-44c0-a94d-675acc355ba8.png)

#### 3. Improve styling for tables within the Docs content
The styles are changed as the [issue](https://github.com/handsontable/handsontable/issues/9831) suggested ([_diff_](https://github.com/handsontable/handsontable/pull/9926/files#diff-64d3e686e1f494fff70ff8aadbaafe1f7c7e7fdcbbbdf476a28321c6d0cb4f7dR231)). 

##### Before
![Kapture 2022-09-20 at 09 41 39](https://user-images.githubusercontent.com/571316/191197214-ea51cd30-6d95-425b-89f3-10c502e806c9.gif)

##### After
![Kapture 2022-09-20 at 09 40 43](https://user-images.githubusercontent.com/571316/191196947-60aefe96-6e8e-4f07-a8fc-4c56327028f2.gif)

#### 4. Fix jumping-out demos
Add missing `height: 'auto'` options to all demos except that which uses the dropdown, autocomplete, or handsontable type editors. That demos can not be changed due to [the bug](https://github.com/handsontable/handsontable/issues/8688).

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes using the Chrome Toggle device toolbar.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes #9831

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
