### PR TITLE
Revert the "getSelectedColumn" API signature

### DIFF
--- a/handsontable/src/plugins/filters/__tests__/filters.types.ts
+++ b/handsontable/src/plugins/filters/__tests__/filters.types.ts
@@ -14,6 +14,12 @@ filters.addCondition(1, 'eq', [2], 'conjunction');
 filters.removeConditions(1);
 filters.clearConditions(1);
 filters.filter();
-filters.getSelectedColumn();
 filters.getDataMapAtColumn(1);
 filters.destroy();
+
+const selectedColumn = filters.getSelectedColumn();
+
+if (selectedColumn !== null) {
+  const selectedColumnPhysicalIndex: number = selectedColumn.physicalIndex;
+  const selectedColumnVisualIndex: number = selectedColumn.visualIndex;
+}

--- a/handsontable/src/plugins/filters/component/condition.js
+++ b/handsontable/src/plugins/filters/component/condition.js
@@ -189,10 +189,12 @@ class ConditionComponent extends BaseComponent {
    * Reset elements to their initial state.
    */
   reset() {
-    const { visualIndex } = this.hot.getPlugin('filters').getSelectedColumn();
+    const selectedColumn = this.hot.getPlugin('filters').getSelectedColumn();
     let items = [getConditionDescriptor(CONDITION_NONE)];
 
-    if (visualIndex !== null) {
+    if (selectedColumn !== null) {
+      const { visualIndex } = selectedColumn;
+
       items = getOptionsList(this.hot.getDataType(0, visualIndex, this.hot.countRows(), visualIndex));
     }
 

--- a/handsontable/src/plugins/filters/component/value.js
+++ b/handsontable/src/plugins/filters/component/value.js
@@ -197,10 +197,10 @@ class ValueComponent extends BaseComponent {
     super.reset();
     this.getMultipleSelectElement().setValue(values);
 
-    const { visualIndex } = this.hot.getPlugin('filters').getSelectedColumn();
+    const selectedColumn = this.hot.getPlugin('filters').getSelectedColumn();
 
-    if (visualIndex !== null) {
-      this.getMultipleSelectElement().setLocale(this.hot.getCellMeta(0, visualIndex).locale);
+    if (selectedColumn !== null) {
+      this.getMultipleSelectElement().setLocale(this.hot.getCellMeta(0, selectedColumn.visualIndex).locale);
     }
   }
 
@@ -224,13 +224,13 @@ class ValueComponent extends BaseComponent {
    * @private
    */
   _getColumnVisibleValues() {
-    const { visualIndex } = this.hot.getPlugin('filters').getSelectedColumn();
+    const selectedColumn = this.hot.getPlugin('filters').getSelectedColumn();
 
-    if (visualIndex === null) {
+    if (selectedColumn === null) {
       return [];
     }
 
-    return arrayMap(this.hot.getDataAtCol(visualIndex), v => toEmptyString(v));
+    return arrayMap(this.hot.getDataAtCol(selectedColumn.visualIndex), v => toEmptyString(v));
   }
 }
 

--- a/handsontable/src/plugins/filters/filters.js
+++ b/handsontable/src/plugins/filters/filters.js
@@ -422,22 +422,21 @@ export class Filters extends BasePlugin {
   /**
    * Gets last selected column index.
    *
-   * @returns {{visualIndex: number | null, physicalIndex: number | null}} Return `null` when column isn't selected
-   * otherwise object containing information about selected column with keys `visualIndex` and `physicalIndex`.
+   * @returns {{visualIndex: number, physicalIndex: number} | null} Returns `null` when a column is
+   * not selected. Otherwise, returns an object with `visualIndex` and `physicalIndex` properties containing
+   * the index of the column.
    */
   getSelectedColumn() {
     const highlight = this.hot.getSelectedRangeLast()?.highlight;
-    const selectedColumn = {
-      visualIndex: null,
-      physicalIndex: null,
-    };
 
-    if (highlight) {
-      selectedColumn.visualIndex = highlight.col;
-      selectedColumn.physicalIndex = this.hot.toPhysicalColumn(selectedColumn.visualIndex);
+    if (!highlight) {
+      return null;
     }
 
-    return selectedColumn;
+    return {
+      visualIndex: highlight.col,
+      physicalIndex: this.hot.toPhysicalColumn(highlight.col),
+    };
   }
 
   /**
@@ -446,10 +445,10 @@ export class Filters extends BasePlugin {
    * @private
    */
   clearColumnSelection() {
-    const { visualIndex } = this.getSelectedColumn();
+    const selectedColumn = this.getSelectedColumn();
 
-    if (visualIndex !== null) {
-      this.hot.selectCell(0, visualIndex);
+    if (selectedColumn !== null) {
+      this.hot.selectCell(0, selectedColumn.visualIndex);
     }
   }
 
@@ -609,14 +608,15 @@ export class Filters extends BasePlugin {
    */
   onActionBarSubmit(submitType) {
     if (submitType === 'accept') {
-      const physicalIndex = this.getSelectedColumn()?.physicalIndex;
+      const selectedColumn = this.getSelectedColumn();
 
-      if (physicalIndex === null) {
+      if (selectedColumn === null) {
         this.dropdownMenuPlugin?.close();
 
         return;
       }
 
+      const { physicalIndex } = selectedColumn;
       const byConditionState1 = this.components.get('filter_by_condition').getState();
       const byConditionState2 = this.components.get('filter_by_condition2').getState();
       const byValueState = this.components.get('filter_by_value').getState();

--- a/handsontable/types/plugins/filters/filters.d.ts
+++ b/handsontable/types/plugins/filters/filters.d.ts
@@ -51,6 +51,6 @@ export declare class Filters extends BasePlugin {
   removeConditions(column: number): void;
   clearConditions(column?: number): void;
   filter(): void;
-  getSelectedColumn(): number;
+  getSelectedColumn(): { physicalIndex: number, visualIndex: number } | null;
   getDataMapAtColumn(column?: number): CellLikeData[];
 }


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR reverts the "getSelectedColumn" API signature change of the _Filters_ plugin from v12.1.2. The API change was introduced by mistake within #9829, and to make sure that the fix added in #9829 still works, the API usage within the plugin has to be adjusted.

The PR does not add any new tests as tests added in #9829 already covers the change.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/9561

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
