### PR TITLE
Fix ColumnSummary miscalculations for non-numeric values

### DIFF
--- a/handsontable/src/plugins/columnSummary/__tests__/columnSummary.spec.js
+++ b/handsontable/src/plugins/columnSummary/__tests__/columnSummary.spec.js
@@ -118,7 +118,7 @@ describe('ColumnSummarySpec', () => {
   });
 
   describe('calculateSum', () => {
-    it('should calculate sum  of values from the provided range', () => {
+    it('should calculate sum of values from the provided range', () => {
       handsontable({
         data: createNumericData(15, 15),
         height: 200,
@@ -177,6 +177,29 @@ describe('ColumnSummarySpec', () => {
       expect(getDataAtCell(14, 1)).toEqual(0);
     });
 
+    it('should calculate the minimum from the column when the destination row is empty and `forceNumeric` is enabled', () => {
+      handsontable({
+        data: [
+          [0],
+          [1],
+          [5],
+          [],
+        ],
+        columnSummary: [
+          {
+            sourceColumn: 0,
+            destinationColumn: 0,
+            reversedRowCoords: true,
+            destinationRow: 0,
+            forceNumeric: true,
+            type: 'min'
+          },
+        ]
+      });
+
+      expect(getDataAtCell(3, 0)).toBe(0);
+    });
+
     it('should calculate the maximum from the provided range', () => {
       const dataset = createNumericData(15, 15);
 
@@ -212,6 +235,29 @@ describe('ColumnSummarySpec', () => {
 
       expect(getDataAtCell(14, 0)).toEqual(14);
       expect(getDataAtCell(14, 1)).toEqual(0);
+    });
+
+    it('should calculate the maximum from the column when the destination row is empty and `forceNumeric` is enabled', () => {
+      handsontable({
+        data: [
+          [0],
+          [1],
+          [5],
+          [],
+        ],
+        columnSummary: [
+          {
+            sourceColumn: 0,
+            destinationColumn: 0,
+            reversedRowCoords: true,
+            destinationRow: 0,
+            forceNumeric: true,
+            type: 'max'
+          },
+        ]
+      });
+
+      expect(getDataAtCell(3, 0)).toBe(5);
     });
   });
 
@@ -252,6 +298,29 @@ describe('ColumnSummarySpec', () => {
       expect(getDataAtCell(14, 0)).toEqual(11);
       expect(getDataAtCell(14, 1)).toEqual(14);
     });
+
+    it('should count non-empty entries from the column when the destination row is empty and `forceNumeric` is enabled', () => {
+      handsontable({
+        data: [
+          [4],
+          [1],
+          [5],
+          [],
+        ],
+        columnSummary: [
+          {
+            sourceColumn: 0,
+            destinationColumn: 0,
+            reversedRowCoords: true,
+            destinationRow: 0,
+            forceNumeric: true,
+            type: 'count'
+          },
+        ]
+      });
+
+      expect(getDataAtCell(3, 0)).toBe(3);
+    });
   });
 
   describe('calculateAverage', () => {
@@ -274,6 +343,29 @@ describe('ColumnSummarySpec', () => {
       });
 
       expect(getDataAtCell(14, 0).toFixed(4)).toEqual((7.45454545454545).toFixed(4));
+    });
+
+    it('should count average value from the column when the destination row is empty and `forceNumeric` is enabled', () => {
+      handsontable({
+        data: [
+          [4],
+          [2],
+          [5],
+          [],
+        ],
+        columnSummary: [
+          {
+            sourceColumn: 0,
+            destinationColumn: 0,
+            reversedRowCoords: true,
+            destinationRow: 0,
+            forceNumeric: true,
+            type: 'average'
+          },
+        ]
+      });
+
+      expect(getDataAtCell(3, 0)).toBe(3.6666666666666665);
     });
   });
 

--- a/handsontable/src/plugins/columnSummary/columnSummary.js
+++ b/handsontable/src/plugins/columnSummary/columnSummary.js
@@ -2,6 +2,7 @@ import { BasePlugin } from '../base';
 import { objectEach } from '../../helpers/object';
 import Endpoints from './endpoints';
 import { toSingleLine } from '../../helpers/templateLiteralTag';
+import { isNullishOrNaN } from './utils';
 
 export const PLUGIN_KEY = 'columnSummary';
 export const PLUGIN_PRIORITY = 220;
@@ -193,11 +194,15 @@ export class ColumnSummary extends BasePlugin {
     let biggestDecimalPlacesCount = 0;
 
     do {
-      cellValue = this.getCellValue(i, col) ?? 0;
-      const decimalPlaces = (((`${cellValue}`).split('.')[1] || []).length) || 1;
+      cellValue = this.getCellValue(i, col);
+      cellValue = isNullishOrNaN(cellValue) ? null : cellValue;
 
-      if (decimalPlaces > biggestDecimalPlacesCount) {
-        biggestDecimalPlacesCount = decimalPlaces;
+      if (cellValue !== null) {
+        const decimalPlaces = (((`${cellValue}`).split('.')[1] || []).length) || 1;
+
+        if (decimalPlaces > biggestDecimalPlacesCount) {
+          biggestDecimalPlacesCount = decimalPlaces;
+        }
       }
 
       sum += cellValue || 0;
@@ -258,7 +263,8 @@ export class ColumnSummary extends BasePlugin {
     let cellValue;
 
     do {
-      cellValue = this.getCellValue(i, col) ?? null;
+      cellValue = this.getCellValue(i, col);
+      cellValue = isNullishOrNaN(cellValue) ? null : cellValue;
 
       if (result === null) {
         result = cellValue;
@@ -296,7 +302,8 @@ export class ColumnSummary extends BasePlugin {
     let i = rowRange[1] || rowRange[0];
 
     do {
-      cellValue = this.getCellValue(i, col) ?? null;
+      cellValue = this.getCellValue(i, col);
+      cellValue = isNullishOrNaN(cellValue) ? null : cellValue;
 
       if (cellValue === null) {
         counter += 1;

--- a/handsontable/src/plugins/columnSummary/utils.js
+++ b/handsontable/src/plugins/columnSummary/utils.js
@@ -1,0 +1,9 @@
+/**
+ * Returns `true` if the value is one of the type: `null`, `undefined` or `NaN`.
+ *
+ * @param {*} value The value to check.
+ * @returns {boolean}
+ */
+export function isNullishOrNaN(value) {
+  return value === null || value === undefined || isNaN(value);
+}


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR is a hot-fix for #9825. The origin PR introduced a bug that occurs in the wrong `min`, `max`, `count`, and `avarage` calculations when one of the cell data is a non-numeric value. When the `forceNumeric` option is enabled that non-numeric values were converted to `NaN` and here the additional check was missing in the calculator's logic.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and I cover the fix with new E2E tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/handsontable/issues/6385

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
