### PR TITLE
improve React exampless using `React.createRef()` to make them copy-pastable

### DIFF
--- a/docs/content/guides/columns/column-filter.md
+++ b/docs/content/guides/columns/column-filter.md
@@ -266,7 +266,7 @@ const hot = new Handsontable(container, {
 ::: only-for react
 ::: example #example3 :react
 ```jsx
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import Handsontable from 'handsontable';
 import ReactDOM from 'react-dom';
 import { HotTable } from '@handsontable/react';
@@ -277,7 +277,7 @@ import 'handsontable/dist/handsontable.full.min.css';
 registerAllModules();
 
 const ExampleComponent = () => {
-  const hotRef = React.createRef();
+  const hotRef = useRef(null);
   let debounceFn = null;
 
   const addEventListeners = (input, colIndex) => {
@@ -664,7 +664,7 @@ const hot = new Handsontable(container, {
 ::: only-for react
 ::: example #example4 :react
 ```jsx
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import Handsontable from 'handsontable';
 import ReactDOM from 'react-dom';
 import { HotTable } from '@handsontable/react';
@@ -675,7 +675,7 @@ import 'handsontable/dist/handsontable.full.min.css';
 registerAllModules();
 
 const ExampleComponent = () => {
-  const hotRef = React.createRef();
+  const hotRef = useRef(null);
   const [colHeaders, setColHeaders] = React.useState([]);
   const [selectedColumnIndex, setSelectedColumnIndex] = React.useState(0);
   const [rowEntries, setRowEntries] = React.useState([]);

--- a/docs/content/guides/columns/column-filter.md
+++ b/docs/content/guides/columns/column-filter.md
@@ -266,7 +266,7 @@ const hot = new Handsontable(container, {
 ::: only-for react
 ::: example #example3 :react
 ```jsx
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import Handsontable from 'handsontable';
 import ReactDOM from 'react-dom';
 import { HotTable } from '@handsontable/react';

--- a/docs/content/guides/columns/react-hot-column.md
+++ b/docs/content/guides/columns/react-hot-column.md
@@ -144,7 +144,7 @@ In this example, the custom editor component is created with an external depende
 
 ::: example #example6 :react-advanced --tab preview
 ```jsx
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import ReactDOM from 'react-dom';
 import { HexColorPicker } from 'react-colorful';
 import StarRatingComponent from 'react-star-rating-component';
@@ -158,7 +158,7 @@ class UnconnectedColorPicker extends BaseEditorComponent {
   constructor(props) {
     super(props);
 
-    this.editorRef = React.createRef();
+    this.editorRef = useRef(null);
 
     this.editorContainerStyle = {
       display: 'none',

--- a/docs/content/guides/columns/react-hot-column.md
+++ b/docs/content/guides/columns/react-hot-column.md
@@ -144,7 +144,7 @@ In this example, the custom editor component is created with an external depende
 
 ::: example #example6 :react-advanced --tab preview
 ```jsx
-import { useEffect, useRef } from 'react';
+import React, { useEffect } from 'react';
 import ReactDOM from 'react-dom';
 import { HexColorPicker } from 'react-colorful';
 import StarRatingComponent from 'react-star-rating-component';
@@ -158,7 +158,7 @@ class UnconnectedColorPicker extends BaseEditorComponent {
   constructor(props) {
     super(props);
 
-    this.editorRef = useRef(null);
+    this.editorRef = React.createRef(null);
 
     this.editorContainerStyle = {
       display: 'none',

--- a/docs/content/guides/getting-started/binding-to-data.md
+++ b/docs/content/guides/getting-started/binding-to-data.md
@@ -740,7 +740,7 @@ hot.setDataAtCell(0, 1, 'Ford');
 ::: example #example10 :react
 
 ```jsx
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import ReactDOM from 'react-dom';
 import { HotTable } from '@handsontable/react';
 import { registerAllModules } from 'handsontable/registry';
@@ -750,7 +750,7 @@ import 'handsontable/dist/handsontable.full.min.css';
 registerAllModules();
 
 const ExampleComponent = () => {
-  const hotRef = React.createRef();
+  const hotRef = useRef(null);
 
   useEffect(() => {
     const hot = hotRef.current.hotInstance;

--- a/docs/content/guides/getting-started/events-and-hooks.md
+++ b/docs/content/guides/getting-started/events-and-hooks.md
@@ -454,7 +454,7 @@ hot.updateSettings({
 ::: only-for react
 ::: example #example2 :react
 ```jsx
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import ReactDOM from 'react-dom';
 import { HotTable } from '@handsontable/react';
 import { registerAllModules } from 'handsontable/registry';
@@ -464,7 +464,7 @@ import 'handsontable/dist/handsontable.full.min.css';
 registerAllModules();
 
 const ExampleComponent = () => {
-  const hotRef = React.createRef();
+  const hotRef = useRef(null);
   let lastChange = null;
 
   useEffect(() => {

--- a/docs/content/guides/getting-started/grid-size.md
+++ b/docs/content/guides/getting-started/grid-size.md
@@ -179,7 +179,7 @@ triggerBtn.addEventListener('click', () => {
 }
 ```
 ```jsx
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import Handsontable from 'handsontable';
 import ReactDOM from 'react-dom';
 import { HotTable } from '@handsontable/react';
@@ -190,7 +190,7 @@ import 'handsontable/dist/handsontable.full.min.css';
 registerAllModules();
 
 const ExampleComponent = () => {
-  const hotRef = React.createRef();
+  const hotRef = useRef(null);
   
   let triggerBtnClickCallback;
 


### PR DESCRIPTION

### Context
<!--- Why is this change required? What problem does it solve? -->

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [x] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [] My change requires a change to the documentation.

[skip changelog]