### PR TITLE
add lacking HotTable component imports in few snippets and examples

### DIFF
--- a/docs/content/guides/internationalization/language.md
+++ b/docs/content/guides/internationalization/language.md
@@ -75,6 +75,7 @@ To properly use the internationalization feature, you'll need to load the langua
 1. **ES modules (ESM)**
   ```js
   import Handsontable from 'handsontable/base';
+  import { HotTable } from '@handsontable/react';
   import { registerLanguageDictionary, deDE } from 'handsontable/i18n';
 
   registerLanguageDictionary(deDE);

--- a/docs/content/guides/optimization/bundle-size.md
+++ b/docs/content/guides/optimization/bundle-size.md
@@ -38,6 +38,7 @@ new Handsontable(container, {
 ::: only-for react
 ```js
 import Handsontable from 'handsontable/base';
+import { HotTable } from '@handsontable/react';
 import { registerPlugin, ContextMenu } from 'handsontable/plugins';
 
 registerPlugin(ContextMenu);
@@ -95,6 +96,7 @@ new Handsontable(container, {
 ::: only-for react
 ```js
 import Handsontable from 'handsontable/base';
+import { HotTable } from '@handsontable/react';
 import { registerCellType, DateCellType } from 'handsontable/cellTypes';
 
 // explicitly import Moment.js

--- a/docs/content/guides/tools-and-building/modules.md
+++ b/docs/content/guides/tools-and-building/modules.md
@@ -181,6 +181,7 @@ new Handsontable(container, {
 ::: only-for react
 ```jsx
 import Handsontable from 'handsontable/base';
+import { HotTable } from '@handsontable/react';
 import {
   registerCellType,
   NumericCellType,
@@ -239,6 +240,7 @@ new Handsontable(container, {
 ::: only-for react
 ```jsx
 import Handsontable from 'handsontable/base';
+import { HotTable } from '@handsontable/react';
 import {
   registerRenderer,
   numericRenderer,


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [x] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]