### PR TITLE
improve example with manual resizing in React and make it easier to launch in local environment

### DIFF
--- a/docs/content/guides/getting-started/grid-size.md
+++ b/docs/content/guides/getting-started/grid-size.md
@@ -172,14 +172,9 @@ triggerBtn.addEventListener('click', () => {
 :::
 
 ::: only-for react
-::: example #example :react --css 1 --js 2
-```css
-#exampleParent {
-  height: 150px;
-}
-```
+::: example #example :react --js 1
 ```jsx
-import { useEffect, useRef } from 'react';
+import { useRef, useState } from 'react';
 import Handsontable from 'handsontable';
 import ReactDOM from 'react-dom';
 import { HotTable } from '@handsontable/react';
@@ -190,29 +185,20 @@ import 'handsontable/dist/handsontable.full.min.css';
 registerAllModules();
 
 const ExampleComponent = () => {
+  const [isContainerExpanded, setIsContainerExpanded] = useState(false);
   const hotRef = useRef(null);
-  
-  let triggerBtnClickCallback;
 
-  useEffect(() => {
-    const hot = hotRef.current.hotInstance;
-
-    triggerBtnClickCallback = () => {
-      if (triggerBtn.textContent === 'Collapse container') {
-        exampleParent.style.height = ''; // reset to initial 150px;
-        hot.refreshDimensions();
-        triggerBtn.textContent = 'Expand container';
-      } else {
-        exampleParent.style.height = '400px';
-        hot.refreshDimensions();
-        triggerBtn.textContent = 'Collapse container';
-      }
-    };
-  });
+  const triggerBtnClickCallback = () => {
+    setIsContainerExpanded(!isContainerExpanded);
+    hotRef.current.hotInstance.refreshDimensions();
+  };
 
   return (
     <>
-      <div id="exampleParent">
+      <div
+        id="exampleParent"
+        style={{ height: isContainerExpanded ? '400px' : '150px' }}
+      >
         <HotTable
           data={Handsontable.helper.createSpreadsheetData(100, 50)}
           rowHeaders={true}
@@ -221,13 +207,19 @@ const ExampleComponent = () => {
           height="100%"
           rowHeights={23}
           colWidths={100}
-          licenseKey="non-commercial-and-evaluation"  
+          licenseKey="non-commercial-and-evaluation"
           ref={hotRef}
         />
       </div>
-      
+
       <div className="controls">
-        <button id="triggerBtn" className="button button--primary" onClick={(...args) => triggerBtnClickCallback(...args)}>Expand container</button>
+        <button
+          id="triggerBtn"
+          className="button button--primary"
+          onClick={(...args) => triggerBtnClickCallback(...args)}
+        >
+          {isContainerExpanded ? 'Collapse container' : 'Expand container'}
+        </button>
       </div>
     </>
   );

--- a/docs/content/guides/getting-started/grid-size.md
+++ b/docs/content/guides/getting-started/grid-size.md
@@ -172,9 +172,14 @@ triggerBtn.addEventListener('click', () => {
 :::
 
 ::: only-for react
-::: example #example :react --js 1
+::: example #example :react --css 1 --js 2
+```css
+.exampleParent {
+  height: 150px;
+}
+```
 ```jsx
-import { useRef, useState } from 'react';
+import { useRef, useState, useEffect } from 'react';
 import Handsontable from 'handsontable';
 import ReactDOM from 'react-dom';
 import { HotTable } from '@handsontable/react';
@@ -190,15 +195,21 @@ const ExampleComponent = () => {
 
   const triggerBtnClickCallback = () => {
     setIsContainerExpanded(!isContainerExpanded);
-    hotRef.current.hotInstance.refreshDimensions();
   };
+
+  useEffect(() => {
+    if (isContainerExpanded) {
+      document.getElementById('exampleParent').style.height = '400px';
+    } else {
+      document.getElementById('exampleParent').style.height = ''; // reset to initial 150px;
+    }
+
+    hotRef.current.hotInstance.refreshDimensions();
+  });
 
   return (
     <>
-      <div
-        id="exampleParent"
-        style={{ height: isContainerExpanded ? '400px' : '150px' }}
-      >
+      <div id="exampleParent" className="exampleParent">
         <HotTable
           data={Handsontable.helper.createSpreadsheetData(100, 50)}
           rowHeaders={true}

--- a/docs/content/guides/getting-started/grid-size.md
+++ b/docs/content/guides/getting-started/grid-size.md
@@ -172,12 +172,7 @@ triggerBtn.addEventListener('click', () => {
 :::
 
 ::: only-for react
-::: example #example :react --css 1 --js 2
-```css
-.exampleParent {
-  height: 150px;
-}
-```
+::: example #example :react --js 1
 ```jsx
 import { useRef, useState, useEffect } from 'react';
 import Handsontable from 'handsontable';
@@ -198,12 +193,8 @@ const ExampleComponent = () => {
   };
 
   useEffect(() => {
-    if (isContainerExpanded) {
-      document.getElementById('exampleParent').style.height = '400px';
-    } else {
-      document.getElementById('exampleParent').style.height = ''; // reset to initial 150px;
-    }
-
+    // simulate layout change outside of React lifecycle
+    document.getElementById('exampleParent').style.height = isContainerExpanded ? '400px' : '150px';
     hotRef.current.hotInstance.refreshDimensions();
   });
 


### PR DESCRIPTION
### Context
- There was hard to launch `grid resizing` example without changes in the code - `triggerBtn` and `exampleParent` was not defined, cause calling DOM elements is not working in React in this way.
- `triggerBtnClickCallback` function is refactored a little bit.

### How has this been tested?
Copy-pasted improved example into local React enviroment and lauched in browser

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [x] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.


[skip changelog]
