### PR TITLE
React Docs: Fix search engine

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -270,7 +270,7 @@ var DOCS_VERSION = '${getThisDocsVersion()}';
           maxSuggestions: 10,
         },
       ],
-      fuzzySearchDomains: ['Core', 'Hooks', 'Options'],
+      fuzzySearchDomains: ['Core', 'Hooks', 'Configuration options'],
     }
   }
 };

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -255,14 +255,22 @@ var DOCS_VERSION = '${getThisDocsVersion()}';
     search: true,
     searchOptions: {
       placeholder: 'Search...',
-      guidesMaxSuggestions: 5,
-      apiMaxSuggestions: 10,
+      categoryPriorityList: [
+        {
+          name: 'Guides',
+          domainPriority: [],
+          maxSuggestions: 5,
+        },
+        {
+          name: 'API Reference',
+          // The "domainPriority" list modifies the search results position. When the search phrase matches
+          // the page titles, the search suggestions are placed before the rest results. The pages declared
+          // in the array at the beginning have the highest display priority.
+          domainPriority: ['Configuration options', 'Core'],
+          maxSuggestions: 10,
+        },
+      ],
       fuzzySearchDomains: ['Core', 'Hooks', 'Options'],
-      // The list modifies the search results position. When the search phrase matches the pages
-      // below, the search suggestions are placed before the rest results. The pages declared in
-      // the array at the beginning have the highest display priority.
-      apiSearchDomainPriorityList: ['Options'],
-      guidesSearchDomainPriorityList: [],
     }
   }
 };

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -266,7 +266,7 @@ var DOCS_VERSION = '${getThisDocsVersion()}';
           // The "domainPriority" list modifies the search results position. When the search phrase matches
           // the page titles, the search suggestions are placed before the rest results. The pages declared
           // in the array at the beginning have the highest display priority.
-          domainPriority: ['Configuration options', 'Core'],
+          domainPriority: ['Configuration options', 'Core', 'Hooks'],
           maxSuggestions: 10,
         },
       ],

--- a/docs/.vuepress/theme/components/SearchBox.vue
+++ b/docs/.vuepress/theme/components/SearchBox.vue
@@ -163,6 +163,10 @@ export default {
         return this.isSearchable(page);
       };
 
+      const getShortPageTitle = ({ title }) => {
+        return title === 'Configuration options' ? 'Options' : title;
+      }
+
       const duplicatePagesGuard = [];
       const searchResults = new Map(categoryPriorityList.map(({ name, domainPriority }) => {
         const priorityList = [...domainPriority].reverse();
@@ -181,6 +185,7 @@ export default {
           if (matchQuery(query, p, null, fuzzySearchDomains)) {
             categorySearchResults.push({
               ...p,
+              title: getShortPageTitle(p),
               category: name,
               priority,
             });
@@ -196,6 +201,7 @@ export default {
                 duplicatePagesGuard.push(path);
                 categorySearchResults.push({
                   ...p,
+                  title: getShortPageTitle(p),
                   path,
                   header: h,
                   category: name,

--- a/docs/.vuepress/theme/components/SearchBox.vue
+++ b/docs/.vuepress/theme/components/SearchBox.vue
@@ -165,7 +165,7 @@ export default {
 
       const getShortPageTitle = ({ title }) => {
         return title === 'Configuration options' ? 'Options' : title;
-      }
+      };
 
       const duplicatePagesGuard = [];
       const searchResults = new Map(categoryPriorityList.map(({ name, domainPriority }) => {

--- a/docs/.vuepress/theme/components/SearchBox.vue
+++ b/docs/.vuepress/theme/components/SearchBox.vue
@@ -179,7 +179,6 @@ export default {
           const priority = priorityList.indexOf(get(p, 'title', ''));
 
           if (matchQuery(query, p, null, fuzzySearchDomains)) {
-            duplicatePagesGuard.push(p.key);
             categorySearchResults.push({
               ...p,
               category: name,
@@ -190,13 +189,14 @@ export default {
           if (p.headers) {
             for (let j = 0; j < p.headers.length; j++) {
               const h = p.headers[j];
+              const path = `${p.path}#${h.slug}`;
 
               if (h.title && matchQuery(query, p, h.title, fuzzySearchDomains) &&
-                  !duplicatePagesGuard.includes(p.key)) {
-                duplicatePagesGuard.push(p.key);
+                  !duplicatePagesGuard.includes(path)) {
+                duplicatePagesGuard.push(path);
                 categorySearchResults.push({
                   ...p,
-                  path: `${p.path}#${h.slug}`,
+                  path,
                   header: h,
                   category: name,
                   priority,

--- a/docs/.vuepress/theme/components/SearchBox.vue
+++ b/docs/.vuepress/theme/components/SearchBox.vue
@@ -170,8 +170,9 @@ export default {
 
         for (let i = 0; i < pages.length; i++) {
           const p = pages[i];
+          const searchCategory = p.frontmatter.searchCategory;
 
-          if (!isSearchable(p) || p.frontmatter.searchCategory !== name) {
+          if (!isSearchable(p) || searchCategory && searchCategory !== name) {
             continue; // eslint-disable-line
           }
 

--- a/docs/.vuepress/theme/components/SearchBox.vue
+++ b/docs/.vuepress/theme/components/SearchBox.vue
@@ -51,7 +51,7 @@
 </template>
 
 <script>
-/* global SEARCH_MAX_SUGGESTIONS, SEARCH_HOTKEYS */
+/* global SEARCH_HOTKEYS */
 import get from 'lodash/get';
 
 const ALLOWED_TAGS = ['BODY', 'A', 'BUTTON'];
@@ -71,7 +71,7 @@ const matchTest = (query, domain, isFuzzySearch = false) => {
   const escapeRegExp = str => str.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
 
   // eslint-disable-next-line no-control-regex
-  const nonASCIIRegExp = new RegExp('[^\x00-\x7F]');
+  const nonASCIIRegExp = /[^\x00-\x7F]/;
 
   const words = query
     .split(/\s+/g)

--- a/docs/.vuepress/theme/components/SearchBox.vue
+++ b/docs/.vuepress/theme/components/SearchBox.vue
@@ -113,7 +113,7 @@ const matchQuery = (query, page, additionalStr = null, fuzzySearchDomains = []) 
     domain += ` ${additionalStr}`;
   }
 
-  const isFuzzySearch = fuzzySearchDomains.includes(get(page, 'frontmatter.searchCategory'));
+  const isFuzzySearch = fuzzySearchDomains.includes(get(page, 'title', ''));
 
   return matchTest(query, domain, isFuzzySearch);
 };

--- a/docs/.vuepress/theme/layouts/404.vue
+++ b/docs/.vuepress/theme/layouts/404.vue
@@ -16,7 +16,7 @@ const msgs = [
   'Looks like we\'ve got some broken links.'
 ];
 
-const frameworkRegExp = new RegExp('^/docs/((next|\\d+.\\d+)/)?(?<framework>react|javascript)-data-grid/.*');
+const frameworkRegExp = /^\/docs\/((next|\d+.\d+)\/)?(?<framework>react|javascript)-data-grid\/.*/;
 
 export default {
   data() {

--- a/docs/.vuepress/tools/build.mjs
+++ b/docs/.vuepress/tools/build.mjs
@@ -57,14 +57,8 @@ async function concatenate(version) {
   const versionEscaped = version.replace('.', '-');
 
   if (version !== 'next' || buildMode === 'staging') {
-    const prebuildVersioned = path.resolve(
-      __dirname,
-      '../../', `.vuepress/dist/pre-${versionEscaped}`
-    );
-    const distVersioned = path.resolve(
-      __dirname,
-      '../../', `.vuepress/dist/docs/${version}`
-    );
+    const prebuildVersioned = path.resolve(__dirname, '../../', `.vuepress/dist/pre-${versionEscaped}`);
+    const distVersioned = path.resolve(__dirname, '../../', `.vuepress/dist/docs/${version}`);
 
     await fs.cp(prebuildVersioned, distVersioned, { force: true, recursive: true });
     await fs.rm(prebuildVersioned, { recursive: true });

--- a/docs/.vuepress/tools/jsdoc-convert/renderer/seo.mjs
+++ b/docs/.vuepress/tools/jsdoc-convert/renderer/seo.mjs
@@ -32,6 +32,7 @@ export const buildHeaderWriter = ({ seo, urlPrefix }) => {
       metaTitle: genSeoMetaTitle(file, isPlugin),
       permalink: genSeoPermalink(file),
       canonicalUrl: genSeoPermalink(file),
+      searchCategory: 'API Reference',
       hotPlugin: isPlugin,
       editLink: false,
       ...seo[file],

--- a/docs/README-EDITING.md
+++ b/docs/README-EDITING.md
@@ -16,15 +16,16 @@ When adding new documentation files, check the documentation [directory structur
 
 Each Markdown file can start with the following frontmatter tags:
 
-| Tag            | Meaning                                       | Default value                                              |
-| -------------- | --------------------------------------------- | ---------------------------------------------------------- |
-| `title`        | The page's header.                            | If not set, gets generated from the page's parent's title. |
-| `permalink`    | The page's **unique** URL.                    | If not set, gets generated from the Markdown file name.    |
-| `canonicalUrl` | A canonical URL of the page's latest version. | None (not required)                                        |
-| `metaTitle`    | The page's SEO meta title.                    | None (not required)                                        |
-| `description`  | The page's SEO meta description.              | None (not required)                                        |
-| `tags`         | Search tags used by the documentation search engine. | None (not required)                                        |
-| `react`        | Holds an alternative set of frontmatter tags (applied only to the React version of the page) | None (not required)                                        |
+| Tag              | Meaning                                              | Default value                                              |
+| ---------------- | ---------------------------------------------------- | ---------------------------------------------------------- |
+| `title`          | The page's header.                                   | If not set, gets generated from the page's parent's title. |
+| `permalink`      | The page's **unique** URL.                           | If not set, gets generated from the Markdown file name.    |
+| `canonicalUrl`   | A canonical URL of the page's latest version.        | None (not required)                                        |
+| `metaTitle`      | The page's SEO meta title.                           | None (not required)                                        |
+| `description`    | The page's SEO meta description.                     | None (not required)                                        |
+| `tags`           | Search tags used by the documentation search engine. | None (not required)                                 |
+| `react`          | Holds an alternative set of frontmatter tags (applied only to the React version of the page) | None (not required)                                             |
+| `searchCategory` | Search category used by the search engine to categorize the search results. | If not set, the search result will be listed under the default "Guides" section. |
 
 You can set different frontmatter tags for different framework versions of the page. For example, you can set `metaTitle` to say either `JS data grid` or `React data table`, depending on the framework:
 
@@ -53,6 +54,10 @@ react:
   metaTitle: Installation - Guide - Handsontable Documentation for React
   description: Install the wrapper for React via npm, import stylesheets, and use it to get up and running your application.
   customValue: Custom # Custom value that can be used within template and will be available only for React framework
+tags:
+  - api
+  - api ref
+searchCategory: API Reference # The list of categories can be found here ./docs/.vuepress/config.js#L258
 ---
 ```
 

--- a/docs/content/api/introduction.md
+++ b/docs/content/api/introduction.md
@@ -4,6 +4,7 @@ metaTitle: API reference - JavaScript Data Grid | Handsontable
 description: Control the data grid programmatically, using Handsontable's API options and methods.
 permalink: /api/
 canonicalUrl: /api/
+searchCategory: API Reference
 react:
   metaTitle: API reference - React Data Grid | Handsontable
 ---

--- a/docs/content/api/plugins.md
+++ b/docs/content/api/plugins.md
@@ -4,6 +4,7 @@ metaTitle: 'API reference: Plugins - JavaScript Data Grid | Handsontable'
 description: A complete list of Handsontable's plugins that can extend your data grid's capabilities.
 permalink: /api/plugins
 canonicalUrl: /api/plugins
+searchCategory: API Reference
 react:
   metaTitle: 'API reference: Plugins - React Data Grid | Handsontable'
 ---

--- a/docs/content/guides/accessories-and-menus/context-menu.md
+++ b/docs/content/guides/accessories-and-menus/context-menu.md
@@ -11,6 +11,7 @@ tags:
   - right-click menu
 react:
   metaTitle: Context menu - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Context menu

--- a/docs/content/guides/accessories-and-menus/export-to-csv.md
+++ b/docs/content/guides/accessories-and-menus/export-to-csv.md
@@ -9,6 +9,7 @@ tags:
   - save file
 react:
   metaTitle: Export to CSV - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Export to CSV
@@ -197,7 +198,7 @@ const ExampleComponent = () => {
   useEffect(() => {
     const hot = hotRef.current.hotInstance;
     const exportPlugin = hot.getPlugin('exportFile');
-    
+
     buttonClickCallback = () => {
       const exportedBlob = exportPlugin.exportAsBlob('csv', {
         bom: false,
@@ -300,7 +301,7 @@ registerAllModules();
 
 const ExampleComponent = () => {
   const hotRef = useRef(null);
-  
+
   let buttonClickCallback;
 
   useEffect(() => {

--- a/docs/content/guides/accessories-and-menus/icon-pack.md
+++ b/docs/content/guides/accessories-and-menus/icon-pack.md
@@ -9,6 +9,7 @@ tags:
   - toolbar icons
 react:
   metaTitle: Icon pack - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Icon pack

--- a/docs/content/guides/accessories-and-menus/keyboard-shortcuts.md
+++ b/docs/content/guides/accessories-and-menus/keyboard-shortcuts.md
@@ -16,6 +16,7 @@ tags:
 - commands
 react:
   metaTitle: Keyboard shortcuts - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Keyboard shortcuts
@@ -212,7 +213,7 @@ For more information, see the [`Instance Methods`](@/guides/getting-started/reac
     ```js
     const gridContext = hot.getShortcutManager().getContext('grid');
     ```
-3. Use the selected context's [methods](@/api/shortcutContext.md). 
+3. Use the selected context's [methods](@/api/shortcutContext.md).
     For example, to use the [`addShortcut()`](@/api/shortcutContext.md#addshortcut) method in the `grid` context:
     ```js
     const gridContext = hot.getShortcutManager().getContext('grid');
@@ -248,7 +249,7 @@ Using the [`ShortcutManager`](@/api/shortcutManager.md) API methods, you can:
 - Get an already-registered context: [`getContext()`](@/api/shortcutManager.md#getcontext)
 - Create and register a new context: [`addContext()`](@/api/shortcutManager.md#addcontext)
 
-For example: if you're using a complex [custom editor](@/guides/cell-functions/cell-editor.md#how-to-create-a-custom-editor), 
+For example: if you're using a complex [custom editor](@/guides/cell-functions/cell-editor.md#how-to-create-a-custom-editor),
 you can create a new shortcut context to navigate your editor's UI with the arrow keys (normally, the arrow keys would navigate the grid instead).
 
 ### Adding a custom keyboard shortcut

--- a/docs/content/guides/accessories-and-menus/searching-values.md
+++ b/docs/content/guides/accessories-and-menus/searching-values.md
@@ -9,6 +9,7 @@ tags:
   - highlight values
 react:
   metaTitle: Searching values - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Searching values
@@ -529,7 +530,7 @@ registerAllModules();
 const ExampleComponent = () => {
   const hot4Ref = useRef(null);
   const [output, setOutput] = useState('');
-  
+
   const data = [
     ['Tesla', 2017, 'black', 'black'],
     ['Nissan', 2018, 'blue', 'blue'],

--- a/docs/content/guides/accessories-and-menus/undo-redo.md
+++ b/docs/content/guides/accessories-and-menus/undo-redo.md
@@ -14,6 +14,7 @@ tags:
   - roll back changes
 react:
   metaTitle: Undo and redo - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Undo and redo

--- a/docs/content/guides/cell-features/autofill-values.md
+++ b/docs/content/guides/cell-features/autofill-values.md
@@ -14,6 +14,7 @@ tags:
   - auto fill
 react:
   metaTitle: Autofill values - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Autofill values

--- a/docs/content/guides/cell-features/clipboard.md
+++ b/docs/content/guides/cell-features/clipboard.md
@@ -10,6 +10,7 @@ tags:
   - paste
 react:
   metaTitle: Clipboard - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Clipboard
@@ -176,7 +177,7 @@ registerAllModules();
 
 const ExampleComponent = () => {
   const hotRef = useRef(null);
-  
+
   const copyBtnClickCallback = function() {
     document.execCommand('copy');
   };
@@ -209,16 +210,16 @@ const ExampleComponent = () => {
         licenseKey="non-commercial-and-evaluation"
       />
       <div className="controls">
-        <button 
-          id="copy" 
-          onMouseDown={(...args) => copyBtnMousedownCallback(...args)} 
+        <button
+          id="copy"
+          onMouseDown={(...args) => copyBtnMousedownCallback(...args)}
           onClick={(...args) => copyBtnClickCallback(...args)}
         >
           Select and copy cell B2
         </button>
-        <button 
-          id="cut" 
-          onMouseDown={(...args) => cutBtnMousedownCallback(...args)} 
+        <button
+          id="cut"
+          onMouseDown={(...args) => cutBtnMousedownCallback(...args)}
           onClick={(...args) => cutBtnClickCallback(...args)}
         >
           Select and cut cell B2

--- a/docs/content/guides/cell-features/comments.md
+++ b/docs/content/guides/cell-features/comments.md
@@ -8,6 +8,7 @@ tags:
   - notes
 react:
   metaTitle: Comments - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Comments

--- a/docs/content/guides/cell-features/conditional-formatting.md
+++ b/docs/content/guides/cell-features/conditional-formatting.md
@@ -6,6 +6,7 @@ permalink: /conditional-formatting
 canonicalUrl: /conditional-formatting
 react:
   metaTitle: Conditional formatting - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Conditional formatting
@@ -181,10 +182,10 @@ const ExampleComponent = () => {
         if (row === 0 || data[row] && data[row][col] === 'readOnly') {
         cellProperties.readOnly = true; // make cell read-only if it is first row or the text reads 'readOnly'
         }
-    
+
         if (row === 0) {
           cellProperties.renderer = firstRowRenderer; // uses function directly
-    
+
         } else {
           cellProperties.renderer = 'negativeValueRenderer'; // uses lookup map
         }

--- a/docs/content/guides/cell-features/disabled-cells.md
+++ b/docs/content/guides/cell-features/disabled-cells.md
@@ -12,6 +12,7 @@ tags:
   - locked
 react:
   metaTitle: Disabled cells - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Disabled cells

--- a/docs/content/guides/cell-features/formatting-cells.md
+++ b/docs/content/guides/cell-features/formatting-cells.md
@@ -6,6 +6,7 @@ permalink: /formatting-cells
 canonicalUrl: /formatting-cells
 react:
   metaTitle: Formatting cells - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Formatting cells
@@ -159,7 +160,7 @@ const ExampleComponent = () => {
     .renderers
     .registerRenderer('customStylesRenderer', (hotInstance, TD, ...rest) => {
       Handsontable.renderers.getRenderer('text')(hotInstance, TD, ...rest);
-  
+
       TD.style.fontWeight = 'bold';
       TD.style.color = 'green';
       TD.style.background = '#d7f1e1';

--- a/docs/content/guides/cell-features/merge-cells.md
+++ b/docs/content/guides/cell-features/merge-cells.md
@@ -6,6 +6,7 @@ permalink: /merge-cells
 canonicalUrl: /merge-cells
 react:
   metaTitle: Merge cells - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Merge cells
@@ -20,7 +21,7 @@ The merging cells feature enables you to combine the contents of two or more cel
 
 To enable the merge cells feature, set the [`mergeCells`](@/api/options.md#mergecells) option to  `true` or to an array.
 
-To initialize Handsontable with predefined merged cells, provide merged cells details in form of an array: 
+To initialize Handsontable with predefined merged cells, provide merged cells details in form of an array:
 
 ::: only-for javascript
 `mergeCells: [{ row: 1, col: 1, rowspan: 2, colspan: 2 }]`

--- a/docs/content/guides/cell-features/selection.md
+++ b/docs/content/guides/cell-features/selection.md
@@ -9,6 +9,7 @@ tags:
   - cell selection
 react:
   metaTitle: Selection - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Selection
@@ -90,7 +91,7 @@ registerAllModules();
 
 const ExampleComponent = () => {
   const hotRef = useRef(null);
-  
+
   let selectOptionChangeCallback;
 
   useEffect(() => {
@@ -108,7 +109,7 @@ const ExampleComponent = () => {
 
   return (
     <>
-      <HotTable 
+      <HotTable
         ref={hotRef}
         data={Handsontable.helper.createSpreadsheetData(10, 10)}
         width="auto"
@@ -121,10 +122,10 @@ const ExampleComponent = () => {
         licenseKey="non-commercial-and-evaluation"
       />
       <div className="controls">
-        <select 
-          id="selectOption" 
-          style={{width: 'auto', marginTop: 16}} 
-          onChange={(...args) => selectOptionChangeCallback(...args)} 
+        <select
+          id="selectOption"
+          style={{width: 'auto', marginTop: 16}}
+          onChange={(...args) => selectOptionChangeCallback(...args)}
           defaultValue="multiple"
         >
           <option value="single">Single selection</option>
@@ -205,7 +206,7 @@ registerAllModules();
 const ExampleComponent = () => {
   const hotRef = useRef(null);
   const [output, setOutput] = useState('');
-  
+
   let getButtonClickCallback;
 
   useEffect(() => {
@@ -242,8 +243,8 @@ const ExampleComponent = () => {
       />
       <output className="console" id="output">{output}</output>
       <div className="controls">
-        <button 
-          id="getButton" 
+        <button
+          id="getButton"
           onClick={(...args) => getButtonClickCallback(...args)}
         >
           Get data
@@ -342,7 +343,7 @@ registerAllModules();
 
 const ExampleComponent = () => {
   const hotRef = useRef(null);
-  
+
   let buttonClickCallback;
 
   useEffect(() => {

--- a/docs/content/guides/cell-features/text-alignment.md
+++ b/docs/content/guides/cell-features/text-alignment.md
@@ -6,6 +6,7 @@ permalink: /text-alignment
 canonicalUrl: /text-alignment
 react:
   metaTitle: Text alignment - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Text alignment

--- a/docs/content/guides/cell-functions/cell-editor.md
+++ b/docs/content/guides/cell-functions/cell-editor.md
@@ -6,6 +6,7 @@ permalink: /cell-editor
 canonicalUrl: /cell-editor
 react:
   metaTitle: Cell editor - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Cell editor

--- a/docs/content/guides/cell-functions/cell-function.md
+++ b/docs/content/guides/cell-functions/cell-function.md
@@ -6,6 +6,7 @@ permalink: /cell-function
 canonicalUrl: /cell-function
 react:
   metaTitle: Cell functions - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Cell function

--- a/docs/content/guides/cell-functions/cell-renderer.md
+++ b/docs/content/guides/cell-functions/cell-renderer.md
@@ -6,6 +6,7 @@ permalink: /cell-renderer
 canonicalUrl: /cell-renderer
 react:
   metaTitle: Cell renderer - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Cell renderer

--- a/docs/content/guides/cell-functions/cell-validator.md
+++ b/docs/content/guides/cell-functions/cell-validator.md
@@ -6,6 +6,7 @@ permalink: /cell-validator
 canonicalUrl: /cell-validator
 react:
   metaTitle: Cell validator - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Cell validator

--- a/docs/content/guides/cell-types/autocomplete-cell-type.md
+++ b/docs/content/guides/cell-types/autocomplete-cell-type.md
@@ -6,6 +6,7 @@ permalink: /autocomplete-cell-type
 canonicalUrl: /autocomplete-cell-type
 react:
   metaTitle: Autocomplete cell type - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Autocomplete cell type

--- a/docs/content/guides/cell-types/cell-type.md
+++ b/docs/content/guides/cell-types/cell-type.md
@@ -6,6 +6,7 @@ permalink: /cell-type
 canonicalUrl: /cell-type
 react:
   metaTitle: Cell type - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Cell type

--- a/docs/content/guides/cell-types/checkbox-cell-type.md
+++ b/docs/content/guides/cell-types/checkbox-cell-type.md
@@ -6,6 +6,7 @@ permalink: /checkbox-cell-type
 canonicalUrl: /checkbox-cell-type
 react:
   metaTitle: Checkbox cell type - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Checkbox cell type

--- a/docs/content/guides/cell-types/date-cell-type.md
+++ b/docs/content/guides/cell-types/date-cell-type.md
@@ -6,6 +6,7 @@ permalink: /date-cell-type
 canonicalUrl: /date-cell-type
 react:
   metaTitle: Date cell type - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Date cell type

--- a/docs/content/guides/cell-types/dropdown-cell-type.md
+++ b/docs/content/guides/cell-types/dropdown-cell-type.md
@@ -6,6 +6,7 @@ permalink: /dropdown-cell-type
 canonicalUrl: /dropdown-cell-type
 react:
   metaTitle: Dropdown cell type - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Dropdown cell type

--- a/docs/content/guides/cell-types/handsontable-cell-type.md
+++ b/docs/content/guides/cell-types/handsontable-cell-type.md
@@ -6,6 +6,7 @@ permalink: /handsontable-cell-type
 canonicalUrl: /handsontable-cell-type
 react:
   metaTitle: Handsontable cell type - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Handsontable cell type

--- a/docs/content/guides/cell-types/numeric-cell-type.md
+++ b/docs/content/guides/cell-types/numeric-cell-type.md
@@ -6,6 +6,7 @@ permalink: /numeric-cell-type
 canonicalUrl: /numeric-cell-type
 react:
   metaTitle: Numeric cell type - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Numeric cell type

--- a/docs/content/guides/cell-types/password-cell-type.md
+++ b/docs/content/guides/cell-types/password-cell-type.md
@@ -6,6 +6,7 @@ permalink: /password-cell-type
 canonicalUrl: /password-cell-type
 react:
   metaTitle: Password cell type - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Password cell type

--- a/docs/content/guides/cell-types/select-cell-type.md
+++ b/docs/content/guides/cell-types/select-cell-type.md
@@ -6,6 +6,7 @@ permalink: /select-cell-type
 canonicalUrl: /select-cell-type
 react:
   metaTitle: Select cell type - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Select cell type

--- a/docs/content/guides/cell-types/time-cell-type.md
+++ b/docs/content/guides/cell-types/time-cell-type.md
@@ -6,6 +6,7 @@ permalink: /time-cell-type
 canonicalUrl: /time-cell-type
 react:
   metaTitle: Time cell type - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Time cell type

--- a/docs/content/guides/columns/column-filter.md
+++ b/docs/content/guides/columns/column-filter.md
@@ -8,6 +8,7 @@ tags:
   - filtering data
 react:
   metaTitle: Column filter - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Column filter
@@ -285,7 +286,7 @@ const ExampleComponent = () => {
       debounceFn(colIndex, event);
     });
   };
-  
+
   //  Build elements which will be displayed in header.
   const getInitializedElements = colIndex => {
     const div = document.createElement('div');
@@ -299,7 +300,7 @@ const ExampleComponent = () => {
 
     return div;
   };
-  
+
   //  Add elements to header on `afterGetColHeader` hook.
   const addInput = (col, TH) => {
     // Hooks can return a value other than number (for example `columnSorting` plugin uses this).
@@ -324,7 +325,7 @@ const ExampleComponent = () => {
       filtersPlugin.filter();
     }, 100);
   });
-  
+
   return (
     <HotTable
       ref={hotRef}
@@ -776,7 +777,7 @@ const ExampleComponent = () => {
             )}
           </select>
         </div>
-    
+
         <div id="filterSelect">
           <div className="controllers">
             <div>
@@ -787,19 +788,19 @@ const ExampleComponent = () => {
           <div className="items">
             {rowEntries.map(
               (rowEntry, index) => <React.Fragment key={`${rowEntry}-${index}`}>
-                <label><input type="checkbox" onChange={() => selectEntry(rowEntry)} 
+                <label><input type="checkbox" onChange={() => selectEntry(rowEntry)}
                   checked={selectedRowEntries.includes(rowEntry)}/>{rowEntry}</label><br/>
               </React.Fragment>
             )}
           </div>
         </div>
-    
+
         <div className="buttons controls">
           <button onClick={() => applyFilter()} className="apply">Apply filter</button>
           <button onClick={() => clearFilter()} className="clear">Clear filter</button>
         </div>
       </div>
-    
+
     </>
   );
 };

--- a/docs/content/guides/columns/column-freezing.md
+++ b/docs/content/guides/columns/column-freezing.md
@@ -10,6 +10,7 @@ tags:
   - pinning columns
 react:
   metaTitle: Column freezing - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Column freezing

--- a/docs/content/guides/columns/column-groups.md
+++ b/docs/content/guides/columns/column-groups.md
@@ -10,6 +10,7 @@ tags:
   - collapsing columns
 react:
   metaTitle: Column groups - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Column groups
@@ -209,7 +210,7 @@ const ExampleComponent = () => {
         { row: -2, col: 1, collapsible: true },
         { row: -2, col: 3, collapsible: true }
       ]}
-      licenseKey="non-commercial-and-evaluation"        
+      licenseKey="non-commercial-and-evaluation"
     >
     </HotTable>
   );

--- a/docs/content/guides/columns/column-header.md
+++ b/docs/content/guides/columns/column-header.md
@@ -6,6 +6,7 @@ permalink: /column-header
 canonicalUrl: /column-header
 react:
   metaTitle: Column headers - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Column header
@@ -52,7 +53,7 @@ registerAllModules();
 
 const ExampleComponent = () => {
   return (
-    <HotTable 
+    <HotTable
       data={Handsontable.helper.createSpreadsheetData(3, 11)}
       colHeaders={true}
       rowHeaders={true}

--- a/docs/content/guides/columns/column-hiding.md
+++ b/docs/content/guides/columns/column-hiding.md
@@ -6,6 +6,7 @@ permalink: /column-hiding
 canonicalUrl: /column-hiding
 react:
   metaTitle: Column hiding - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Column hiding

--- a/docs/content/guides/columns/column-menu.md
+++ b/docs/content/guides/columns/column-menu.md
@@ -8,6 +8,7 @@ tags:
   - dropdown menu
 react:
   metaTitle: Column menu - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Column menu

--- a/docs/content/guides/columns/column-moving.md
+++ b/docs/content/guides/columns/column-moving.md
@@ -6,6 +6,7 @@ permalink: /column-moving
 canonicalUrl: /column-moving
 react:
   metaTitle: Column moving - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Column moving

--- a/docs/content/guides/columns/column-sorting.md
+++ b/docs/content/guides/columns/column-sorting.md
@@ -6,6 +6,7 @@ permalink: /column-sorting
 canonicalUrl: /column-sorting
 react:
   metaTitle: Column sorting - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Column sorting

--- a/docs/content/guides/columns/column-summary.md
+++ b/docs/content/guides/columns/column-summary.md
@@ -11,6 +11,7 @@ tags:
   - functions
 react:
   metaTitle: Column summary - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Column summary

--- a/docs/content/guides/columns/column-virtualization.md
+++ b/docs/content/guides/columns/column-virtualization.md
@@ -10,6 +10,7 @@ tags:
   - offset
 react:
   metaTitle: Column virtualization - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Column virtualization

--- a/docs/content/guides/columns/column-width.md
+++ b/docs/content/guides/columns/column-width.md
@@ -15,6 +15,7 @@ tags:
   - manual resize
 react:
   metaTitle: Column width - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Column width

--- a/docs/content/guides/columns/react-hot-column.md
+++ b/docs/content/guides/columns/react-hot-column.md
@@ -4,8 +4,9 @@ metaTitle: Column component - React Data Grid | Handsontable
 description: Configure the React data grid's columns, using the props of the "HotColumn" component. Pass your component as a custom cell editor or a custom cell renderer.
 permalink: /hot-column
 canonicalUrl: /hot-column
-tags: 
-- hotcolumn
+tags:
+  - hotcolumn
+searchCategory: Guides
 ---
 
 # Column component
@@ -45,7 +46,7 @@ const ExampleComponent = () => {
 ReactDOM.render(<ExampleComponent />, document.getElementById('example1'));
 ```
 :::
- 
+
 ## Object data source
 
 When you use object data binding for `<HotColumn/>`, you need to provide precise information about the data structure for columns. To do so, refer to your object-based data property in `HotColumn`'s `data` prop, for example, `<HotColumn data='id' />`:
@@ -115,7 +116,7 @@ const data = [
 
 const ExampleComponent = () => {
   return (
-    <HotTable 
+    <HotTable
         data={data}
         licenseKey="non-commercial-and-evaluation"
         autoRowSize={false}

--- a/docs/content/guides/formulas/formula-calculation.md
+++ b/docs/content/guides/formulas/formula-calculation.md
@@ -15,6 +15,7 @@ tags:
   - function
 react:
   metaTitle: Formula calculation - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Formula calculation

--- a/docs/content/guides/getting-started/binding-to-data.md
+++ b/docs/content/guides/getting-started/binding-to-data.md
@@ -10,6 +10,7 @@ tags:
   - data sources
 react:
   metaTitle: Binding to data - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Binding to data
@@ -85,7 +86,7 @@ const ExampleComponent = () => {
       colHeaders={true}
       minSpareRows={1}
       licenseKey="non-commercial-and-evaluation"
-    />  
+    />
   );
 };
 
@@ -154,7 +155,7 @@ const ExampleComponent = () => {
     ['2020', 10, 11, 12, 13, 15, 16],
     ['2021', 10, 11, 12, 13, 15, 16]
   ];
-  
+
   return (
     <HotTable
       data={data}
@@ -230,7 +231,7 @@ const ExampleComponent = () => {
     { id: 4, name: 'Gail Polite', address: '' },
     { id: 5, name: 'Michael Fair', address: '' }
   ];
-  
+
   return (
     <HotTable
       data={data}
@@ -310,7 +311,7 @@ const ExampleComponent = () => {
     { id: 2, address: '' }, // Handsontable will create missing properties on demand
     { id: 3, name: { first: 'Joan', last: 'Well' }, address: '' }
   ];
-      
+
   return (
     <HotTable
       data={data}
@@ -396,7 +397,7 @@ const ExampleComponent = () => {
     { id: 2, address: '' }, // Handsontable will create missing properties on demand
     { id: 3, name: { first: 'Joan', last: 'Well' }, address: '' }
   ];
-  
+
   return (
     <HotTable
       data={data}
@@ -468,7 +469,7 @@ const ExampleComponent = () => {
   return (
     <HotTable
       data={[]}
-      dataSchema={{ 
+      dataSchema={{
         id: null,
         name: {
           first: null,
@@ -768,7 +769,7 @@ const ExampleComponent = () => {
   ];
 
   return (
-      <HotTable 
+      <HotTable
         ref={hotRef}
         data={data}
         height="auto"

--- a/docs/content/guides/getting-started/configuration-options.md
+++ b/docs/content/guides/getting-started/configuration-options.md
@@ -9,6 +9,7 @@ tags:
   - config
 react:
   metaTitle: Configuration options - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Configuration options
@@ -253,7 +254,7 @@ To apply configuration options to an individual column (or a range of columns), 
 
 ::: only-for react
 ```jsx
-<HotTable 
+<HotTable
   columns={[
     {width: 100}, // column options for the first (by physical index) column
     {width: 100}, // column options for the second (by physical index) column

--- a/docs/content/guides/getting-started/demo.md
+++ b/docs/content/guides/getting-started/demo.md
@@ -10,6 +10,7 @@ tags:
 react:
   metaTitle: Demo - React Data Grid | Handsontable
   description: Play around with a demo of Handsontable in React.
+searchCategory: Guides
 ---
 
 # Demo
@@ -41,7 +42,7 @@ Explore the demo and discover Handsontable's most popular features:
 - [Dropdown cell type](@/guides/cell-types/dropdown-cell-type.md)
 - [Column groups](@/guides/columns/column-groups.md)
 - [Column menu](@/guides/columns/column-menu.md)
-- [Column filter](@/guides/columns/column-filter.md)- 
+- [Column filter](@/guides/columns/column-filter.md)-
 - [Column hiding](@/guides/columns/column-hiding.md)
 - [Row sorting](@/guides/rows/row-sorting.md)
 - And more!

--- a/docs/content/guides/getting-started/events-and-hooks.md
+++ b/docs/content/guides/getting-started/events-and-hooks.md
@@ -16,6 +16,7 @@ tags:
 - hooks
 react:
   metaTitle: Events and hooks - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Events and hooks
@@ -513,7 +514,7 @@ const ExampleComponent = () => {
       beforeChange={(changes, source) => {
         lastChange = changes;
       }}
-      licenseKey="non-commercial-and-evaluation"  
+      licenseKey="non-commercial-and-evaluation"
       ref={hotRef}
     />
   );

--- a/docs/content/guides/getting-started/grid-size.md
+++ b/docs/content/guides/getting-started/grid-size.md
@@ -11,6 +11,7 @@ tags:
   - dimensions
 react:
   metaTitle: Grid size - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Grid size
@@ -52,7 +53,7 @@ or
 }
 ```
 or
-```js 
+```js
 {
   width: 100,
   height: 100,
@@ -70,7 +71,7 @@ or
 ```
 or
 ```jsx
-  <HotTable height="100px" width="100px" /> 
+  <HotTable height="100px" width="100px" />
 ```
 :::
 
@@ -102,7 +103,7 @@ You can easily overwrite this behaviour by returning `false` in the [`beforeRefr
 
 ::: only-for react
 ```jsx
-  <HotTable beforeRefreshDimensions={() => false} /> 
+  <HotTable beforeRefreshDimensions={() => false} />
 ```
 :::
 

--- a/docs/content/guides/getting-started/installation.md
+++ b/docs/content/guides/getting-started/installation.md
@@ -8,6 +8,7 @@ tags:
   - quick start
 react:
   metaTitle: Installation - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Installation

--- a/docs/content/guides/getting-started/introduction.md
+++ b/docs/content/guides/getting-started/introduction.md
@@ -6,6 +6,7 @@ permalink: /
 canonicalUrl: /
 react:
   metaTitle: Introduction - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Handsontable documentation

--- a/docs/content/guides/getting-started/license-key.md
+++ b/docs/content/guides/getting-started/license-key.md
@@ -6,6 +6,7 @@ permalink: /license-key
 canonicalUrl: /license-key
 react:
   metaTitle: License key - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # License key

--- a/docs/content/guides/getting-started/react-methods.md
+++ b/docs/content/guides/getting-started/react-methods.md
@@ -12,13 +12,14 @@ tags:
   - methods
 react:
   metaTitle: Instance methods - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Instance methods
 
 You can programmatically change the internal state of Handsontable beyond what's possible with props. To do that, you will need to call API methods of the relevant Handsontable instance associated with your instance of the `HotTable` component.
 
-The following example implements the `HotTable` component showing how to reference the Handsontable instance from the wrapper component. 
+The following example implements the `HotTable` component showing how to reference the Handsontable instance from the wrapper component.
 
 ::: example #example1 :react
 ```jsx

--- a/docs/content/guides/getting-started/react-redux.md
+++ b/docs/content/guides/getting-started/react-redux.md
@@ -6,6 +6,7 @@ permalink: /redux
 canonicalUrl: /redux
 react:
   metaTitle: Integration with Redux - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Integration with Redux

--- a/docs/content/guides/getting-started/saving-data.md
+++ b/docs/content/guides/getting-started/saving-data.md
@@ -10,6 +10,7 @@ tags:
   - ajax
 react:
   metaTitle: Saving data - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Saving data
@@ -136,7 +137,7 @@ const ExampleComponent = () => {
 
   let loadClickCallback;
   let saveClickCallback;
-  
+
   const autosaveClickCallback = (event) => {
     setIsAutosave(event.target.checked);
     if (event.target.checked) {

--- a/docs/content/guides/integrate-with-angular/angular-custom-context-menu-example.md
+++ b/docs/content/guides/integrate-with-angular/angular-custom-context-menu-example.md
@@ -4,6 +4,7 @@ metaTitle: Custom context menu - Angular Data Grid | Handsontable
 description: Customize the right-click context menu of your Angular data grid, by a creating a custom function for each menu item.
 permalink: /angular-custom-context-menu-example
 canonicalUrl: /angular-custom-context-menu-example
+searchCategory: Guides
 ---
 
 # Custom context menu in Angular

--- a/docs/content/guides/integrate-with-angular/angular-custom-editor-example.md
+++ b/docs/content/guides/integrate-with-angular/angular-custom-editor-example.md
@@ -4,6 +4,7 @@ metaTitle: Custom cell editor - Angular Data Grid | Handsontable
 description: Create a custom cell editor, and use it in your Angular data grid by declaring it as a class.
 permalink: /angular-custom-editor-example
 canonicalUrl: /angular-custom-editor-example
+searchCategory: Guides
 ---
 
 # Custom editor example in Angular

--- a/docs/content/guides/integrate-with-angular/angular-custom-id.md
+++ b/docs/content/guides/integrate-with-angular/angular-custom-id.md
@@ -4,6 +4,7 @@ metaTitle: Custom ID - Angular Data Grid | Handsontable
 description: Pass a custom ID to the "HotTable" component to further customize your Angular data grid.
 permalink: /angular-custom-id
 canonicalUrl: /angular-custom-id
+searchCategory: Guides
 ---
 
 # Custom ID in Angular
@@ -70,4 +71,3 @@ import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 platformBrowserDynamic().bootstrapModule(AppModule).catch(err => { console.error(err) });
 ```
 :::
-

--- a/docs/content/guides/integrate-with-angular/angular-custom-renderer-example.md
+++ b/docs/content/guides/integrate-with-angular/angular-custom-renderer-example.md
@@ -4,6 +4,7 @@ metaTitle: Custom cell renderer - Angular Data Grid | Handsontable
 description: Create a custom cell renderer, and use it in your Angular data grid by declaring it as a function.
 permalink: /angular-custom-renderer-example
 canonicalUrl: /angular-custom-renderer-example
+searchCategory: Guides
 ---
 
 # Custom renderer in Angular

--- a/docs/content/guides/integrate-with-angular/angular-hot-reference.md
+++ b/docs/content/guides/integrate-with-angular/angular-hot-reference.md
@@ -4,6 +4,7 @@ metaTitle: Referencing Handsontable - Angular Data Grid | Handsontable
 description: Reference the Handsontable instance from an Angular component to programmatically perform actions such as reloading the data in your data grid.
 permalink: /angular-hot-reference
 canonicalUrl: /angular-hot-reference
+searchCategory: Guides
 ---
 
 # Referencing the Handsontable instance in Angular

--- a/docs/content/guides/integrate-with-angular/angular-installation.md
+++ b/docs/content/guides/integrate-with-angular/angular-installation.md
@@ -4,6 +4,7 @@ metaTitle: Installation - Angular Data Grid | Handsontable
 description: Install Handsontable's Angular wrapper via npm, import the stylesheets, and get your application up and running.
 permalink: /angular-installation
 canonicalUrl: /angular-installation
+searchCategory: Guides
 ---
 
 # Installation in Angular

--- a/docs/content/guides/integrate-with-angular/angular-language-change-example.md
+++ b/docs/content/guides/integrate-with-angular/angular-language-change-example.md
@@ -4,6 +4,7 @@ metaTitle: Language change - Angular Data Grid | Handsontable
 description: Change the default language of the right-click context menu from English to any of the built-in translations, using the "language" property.
 permalink: /angular-language-change-example
 canonicalUrl: /angular-language-change-example
+searchCategory: Guides
 ---
 
 # Language change in Angular

--- a/docs/content/guides/integrate-with-angular/angular-modules.md
+++ b/docs/content/guides/integrate-with-angular/angular-modules.md
@@ -4,6 +4,7 @@ metaTitle: Modules - Angular Data Grid | Handsontable
 description: Reduce the size of your Angular app by importing only the modules that you need and use.
 permalink: /angular-modules
 canonicalUrl: /angular-modules
+searchCategory: Guides
 ---
 
 # Modules in Angular

--- a/docs/content/guides/integrate-with-angular/angular-setting-up-a-translation.md
+++ b/docs/content/guides/integrate-with-angular/angular-setting-up-a-translation.md
@@ -4,6 +4,7 @@ metaTitle: Setting up a translation - Angular Data Grid | Handsontable
 description: Configure your Angular data grid with different number formats, depending on the specified language and culture.
 permalink: /angular-setting-up-a-translation
 canonicalUrl: /angular-setting-up-a-translation
+searchCategory: Guides
 ---
 
 # Setting up a translation in Angular

--- a/docs/content/guides/integrate-with-angular/angular-simple-example.md
+++ b/docs/content/guides/integrate-with-angular/angular-simple-example.md
@@ -4,6 +4,7 @@ metaTitle: Basic example - Angular Data Grid | Handsontable
 description: Start with the Angular data grid basic configuration examples, using component properties for configuration and external control.
 permalink: /angular-basic-example
 canonicalUrl: /angular-basic-example
+searchCategory: Guides
 ---
 
 # Basic example in Angular

--- a/docs/content/guides/integrate-with-vue/vue-custom-context-menu-example.md
+++ b/docs/content/guides/integrate-with-vue/vue-custom-context-menu-example.md
@@ -4,6 +4,7 @@ metaTitle: Custom context menu - Vue 2 Data Grid | Handsontable
 description: Customize the right-click context menu of your Vue 2 data grid, by a creating a custom function for each menu item.
 permalink: /vue-custom-context-menu-example
 canonicalUrl: /vue-custom-context-menu-example
+searchCategory: Guides
 ---
 
 # Custom context menu in Vue 2

--- a/docs/content/guides/integrate-with-vue/vue-custom-editor-example.md
+++ b/docs/content/guides/integrate-with-vue/vue-custom-editor-example.md
@@ -4,6 +4,7 @@ metaTitle: Custom cell editor - Vue 2 Data Grid | Handsontable
 description: Create a custom cell editor, and use it in your Vue 2 data grid by declaring it as a class.
 permalink: /vue-custom-editor-example
 canonicalUrl: /vue-custom-editor-example
+searchCategory: Guides
 ---
 
 # Custom editor in Vue 2

--- a/docs/content/guides/integrate-with-vue/vue-custom-id-class-style.md
+++ b/docs/content/guides/integrate-with-vue/vue-custom-id-class-style.md
@@ -4,6 +4,7 @@ metaTitle: Custom ID, class, and style - Vue 2 Data Grid | Handsontable
 description: Pass a custom ID, class, and style to the "HotTable" component, to further customize your Vue 2 data grid.
 permalink: /vue-custom-id-class-style
 canonicalUrl: /vue-custom-id-class-style
+searchCategory: Guides
 ---
 
 # Custom ID, Class, Style, and other attributes in Vue 2

--- a/docs/content/guides/integrate-with-vue/vue-custom-renderer-example.md
+++ b/docs/content/guides/integrate-with-vue/vue-custom-renderer-example.md
@@ -4,6 +4,7 @@ metaTitle: Custom cell renderer - Vue 2 Data Grid | Handsontable
 description: Create a custom cell renderer, and use it in your Vue 2 data grid by declaring it as a function.
 permalink: /vue-custom-renderer-example
 canonicalUrl: /vue-custom-renderer-example
+searchCategory: Guides
 ---
 
 # Custom renderer in Vue 2

--- a/docs/content/guides/integrate-with-vue/vue-hot-column.md
+++ b/docs/content/guides/integrate-with-vue/vue-hot-column.md
@@ -4,6 +4,7 @@ metaTitle: HotColumn component - Vue 2 Data Grid | Handsontable
 description: Configure the Vue 2 data grid's columns, using the props of the "HotColumn" component. Define a custom cell editor or a custom cell renderer.
 permalink: /vue-hot-column
 canonicalUrl: /vue-hot-column
+searchCategory: Guides
 ---
 
 # Using the `HotColumn` component in Vue 2

--- a/docs/content/guides/integrate-with-vue/vue-hot-reference.md
+++ b/docs/content/guides/integrate-with-vue/vue-hot-reference.md
@@ -4,6 +4,7 @@ metaTitle: Referencing Handsontable - Vue 2 Data Grid | Handsontable
 description: Reference the Handsontable instance from a Vue 2 component to programmatically perform actions such as reloading the data in your data grid.
 permalink: /vue-hot-reference
 canonicalUrl: /vue-hot-reference
+searchCategory: Guides
 ---
 
 # Referencing the Handsontable instance in Vue 2

--- a/docs/content/guides/integrate-with-vue/vue-installation.md
+++ b/docs/content/guides/integrate-with-vue/vue-installation.md
@@ -4,6 +4,7 @@ metaTitle: Installation - Vue 2 Data Grid | Handsontable
 description: Install Handsontable's Vue 2 wrapper via npm, import the stylesheets, and get your application up and running.
 permalink: /vue-installation
 canonicalUrl: /vue-installation
+searchCategory: Guides
 ---
 
 # Installation in Vue 2

--- a/docs/content/guides/integrate-with-vue/vue-language-change-example.md
+++ b/docs/content/guides/integrate-with-vue/vue-language-change-example.md
@@ -4,6 +4,7 @@ metaTitle: Language change - Vue 2 Data Grid | Handsontable
 description: Change the default language of the right-click context menu from English to any of the built-in translations, using the "language" property.
 permalink: /vue-language-change-example
 canonicalUrl: /vue-language-change-example
+searchCategory: Guides
 ---
 
 # Language change in Vue 2

--- a/docs/content/guides/integrate-with-vue/vue-modules.md
+++ b/docs/content/guides/integrate-with-vue/vue-modules.md
@@ -4,6 +4,7 @@ metaTitle: Modules - Vue 2 Data Grid | Handsontable
 description: Reduce the size of your Vue 2 app by importing only the modules that you need and use.
 permalink: /vue-modules
 canonicalUrl: /vue-modules
+searchCategory: Guides
 ---
 
 # Modules in Vue 2

--- a/docs/content/guides/integrate-with-vue/vue-setting-up-a-language.md
+++ b/docs/content/guides/integrate-with-vue/vue-setting-up-a-language.md
@@ -4,6 +4,7 @@ metaTitle: Setting up a translation - Vue 2 Data Grid | Handsontable
 description: Configure your Vue 2 data grid with different number formats, depending on the specified language and culture.
 permalink: /vue-setting-up-a-translation
 canonicalUrl: /vue-setting-up-a-translation
+searchCategory: Guides
 ---
 
 # Setting up a translation in Vue 2

--- a/docs/content/guides/integrate-with-vue/vue-simple-example.md
+++ b/docs/content/guides/integrate-with-vue/vue-simple-example.md
@@ -4,6 +4,7 @@ metaTitle: Basic example - Vue 2 Data Grid | Handsontable
 description: Start with a basic example of the Vue 2 data grid, using component props for configuration and external control.
 permalink: /vue-basic-example
 canonicalUrl: /vue-basic-example
+searchCategory: Guides
 ---
 
 # Basic example in Vue 2

--- a/docs/content/guides/integrate-with-vue/vue-vuex-example.md
+++ b/docs/content/guides/integrate-with-vue/vue-vuex-example.md
@@ -4,6 +4,7 @@ metaTitle: Integration with Vuex - Vue 2 Data Grid - Handsontable
 description: Use the Vuex state management pattern to maintain the data and configuration options of your Vue 2 data grid.
 permalink: /vue-vuex-example
 canonicalUrl: /vue-vuex-example
+searchCategory: Guides
 ---
 
 # Vuex example in Vue 2

--- a/docs/content/guides/integrate-with-vue3/vue3-custom-context-menu-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-custom-context-menu-example.md
@@ -4,6 +4,7 @@ metaTitle: Custom context menu - Vue 3 Data Grid | Handsontable
 description: Customize the right-click context menu of your Vue 3 data grid, by a creating a custom function for each menu item.
 permalink: /vue3-custom-context-menu-example
 canonicalUrl: /vue3-custom-context-menu-example
+searchCategory: Guides
 ---
 
 # Custom context menu example in Vue 3

--- a/docs/content/guides/integrate-with-vue3/vue3-custom-editor-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-custom-editor-example.md
@@ -4,6 +4,7 @@ metaTitle: Custom cell editor - Vue 3 Data Grid | Handsontable
 description: Create a custom cell editor, and use it in your Vue 3 data grid by declaring it as a class.
 permalink: /vue3-custom-editor-example
 canonicalUrl: /vue3-custom-editor-example
+searchCategory: Guides
 ---
 
 # Custom editor  in Vue 3

--- a/docs/content/guides/integrate-with-vue3/vue3-custom-id-class-style.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-custom-id-class-style.md
@@ -4,6 +4,7 @@ metaTitle: Custom ID, class, and style - Vue 3 Data Grid | Handsontable
 description: Pass a custom ID, class, and style to the "HotTable" component, to further customize your Vue 3 data grid.
 permalink: /vue3-custom-id-class-style
 canonicalUrl: /vue3-custom-id-class-style
+searchCategory: Guides
 ---
 
 # Custom ID, Class, Style, and other attributes in Vue 3

--- a/docs/content/guides/integrate-with-vue3/vue3-custom-renderer-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-custom-renderer-example.md
@@ -4,6 +4,7 @@ metaTitle: Custom cell renderer - Vue 3 Data Grid | Handsontable
 description: Create a custom cell renderer, and use it in your Vue 3 data grid by declaring it as a function.
 permalink: /vue3-custom-renderer-example
 canonicalUrl: /vue3-custom-renderer-example
+searchCategory: Guides
 ---
 
 # Custom renderer in Vue 3

--- a/docs/content/guides/integrate-with-vue3/vue3-hot-column.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-hot-column.md
@@ -4,6 +4,7 @@ metaTitle: HotColumn component - Vue 3 Data Grid | Handsontable
 description: Configure the Vue 3 data grid's columns, using the props of the "HotColumn" component. Define a custom cell editor or a custom cell renderer.
 permalink: /vue3-hot-column
 canonicalUrl: /vue3-hot-column
+searchCategory: Guides
 ---
 
 # Using the `HotColumn` component in Vue 3

--- a/docs/content/guides/integrate-with-vue3/vue3-hot-reference.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-hot-reference.md
@@ -4,6 +4,7 @@ metaTitle: Referencing Handsontable - Vue 3 Data Grid | Handsontable
 description: Reference the Handsontable instance from a Vue 3 component to programmatically perform actions such as reloading the data in your data grid.
 permalink: /vue3-hot-reference
 canonicalUrl: /vue3-hot-reference
+searchCategory: Guides
 ---
 
 # Referencing the Handsontable instance in Vue 3

--- a/docs/content/guides/integrate-with-vue3/vue3-installation.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-installation.md
@@ -4,6 +4,7 @@ metaTitle: Installation - Vue 3 Data Grid | Handsontable
 description: Install Handsontable's Vue 3 wrapper via npm, import the stylesheets, and get your application up and running.
 permalink: /vue3-installation
 canonicalUrl: /vue3-installation
+searchCategory: Guides
 ---
 
 # Installation in Vue 3

--- a/docs/content/guides/integrate-with-vue3/vue3-language-change-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-language-change-example.md
@@ -4,6 +4,7 @@ metaTitle: Language change - Vue 3 Data Grid | Handsontable
 description: Change the default language of the right-click context menu from English to any of the built-in translations, using the "language" property.
 permalink: /vue3-language-change-example
 canonicalUrl: /vue3-language-change-example
+searchCategory: Guides
 ---
 
 # Language change in Vue 3

--- a/docs/content/guides/integrate-with-vue3/vue3-modules.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-modules.md
@@ -4,6 +4,7 @@ metaTitle: Modules - Vue 3 Data Grid | Handsontable
 description: Reduce the size of your Vue 3 app by importing only the modules that you need and use.
 permalink: /vue3-modules
 canonicalUrl: /vue3-modules
+searchCategory: Guides
 ---
 
 # Modules in Vue 3

--- a/docs/content/guides/integrate-with-vue3/vue3-setting-up-a-language.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-setting-up-a-language.md
@@ -4,6 +4,7 @@ metaTitle: Setting up a translation - Vue 3 Data Grid | Handsontable
 description: Configure your Vue 3 data grid with different number formats, depending on the specified language and culture.
 permalink: /vue3-setting-up-a-translation
 canonicalUrl: /vue3-setting-up-a-translation
+searchCategory: Guides
 ---
 
 # Setting up a translation in Vue 3

--- a/docs/content/guides/integrate-with-vue3/vue3-simple-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-simple-example.md
@@ -4,6 +4,7 @@ metaTitle: Basic example - Vue 3 Data Grid | Handsontable
 description: Start with a basic example of the Vue 3 data grid, using component props for configuration and external control.
 permalink: /vue3-basic-example
 canonicalUrl: /vue3-basic-example
+searchCategory: Guides
 ---
 
 # Basic example in Vue 3

--- a/docs/content/guides/integrate-with-vue3/vue3-vuex-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-vuex-example.md
@@ -4,6 +4,7 @@ metaTitle: Integration with Vuex - Vue 3 Data Grid - Handsontable
 description: Use the Vuex state management pattern to maintain the data and configuration options of your Vue 3 data grid.
 permalink: /vue3-vuex-example
 canonicalUrl: /vue3-vuex-example
+searchCategory: Guides
 ---
 
 # Vuex in Vue 3

--- a/docs/content/guides/internationalization/ime-support.md
+++ b/docs/content/guides/internationalization/ime-support.md
@@ -12,6 +12,7 @@ tags:
   - latin
 react:
   metaTitle: IME support - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # IME support

--- a/docs/content/guides/internationalization/language.md
+++ b/docs/content/guides/internationalization/language.md
@@ -12,6 +12,7 @@ tags:
   - i18n
 react:
   metaTitle: Language - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Language

--- a/docs/content/guides/internationalization/layout-direction.md
+++ b/docs/content/guides/internationalization/layout-direction.md
@@ -17,6 +17,7 @@ tags:
   - i18n
 react:
   metaTitle: Layout direction - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Layout direction

--- a/docs/content/guides/internationalization/locale.md
+++ b/docs/content/guides/internationalization/locale.md
@@ -11,6 +11,7 @@ tags:
   - i18n
 react:
   metaTitle: Locale - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Locale

--- a/docs/content/guides/optimization/batch-operations.md
+++ b/docs/content/guides/optimization/batch-operations.md
@@ -8,6 +8,7 @@ tags:
   - suspend rendering
 react:
   metaTitle: Batch operations - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Batch operations

--- a/docs/content/guides/optimization/bundle-size.md
+++ b/docs/content/guides/optimization/bundle-size.md
@@ -8,6 +8,7 @@ tags:
   - size
 react:
   metaTitle: Bundle size - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Bundle size

--- a/docs/content/guides/optimization/performance.md
+++ b/docs/content/guides/optimization/performance.md
@@ -8,6 +8,7 @@ tags:
   - speed
 react:
   metaTitle: Performance - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Performance

--- a/docs/content/guides/rows/row-freezing.md
+++ b/docs/content/guides/rows/row-freezing.md
@@ -9,6 +9,7 @@ tags:
   - pinning rows
 react:
   metaTitle: Row freezing - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Row freezing

--- a/docs/content/guides/rows/row-header.md
+++ b/docs/content/guides/rows/row-header.md
@@ -10,6 +10,7 @@ tags:
   - row id
 react:
   metaTitle: Row headers - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Row header

--- a/docs/content/guides/rows/row-height.md
+++ b/docs/content/guides/rows/row-height.md
@@ -17,6 +17,7 @@ tags:
   - manual resize
 react:
   metaTitle: Row height - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Row height

--- a/docs/content/guides/rows/row-hiding.md
+++ b/docs/content/guides/rows/row-hiding.md
@@ -6,6 +6,7 @@ permalink: /row-hiding
 canonicalUrl: /row-hiding
 react:
   metaTitle: Row hiding - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Row hiding

--- a/docs/content/guides/rows/row-moving.md
+++ b/docs/content/guides/rows/row-moving.md
@@ -6,6 +6,7 @@ permalink: /row-moving
 canonicalUrl: /row-moving
 react:
   metaTitle: Row moving - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Row moving

--- a/docs/content/guides/rows/row-parent-child.md
+++ b/docs/content/guides/rows/row-parent-child.md
@@ -13,6 +13,7 @@ tags:
   - master detail
 react:
   metaTitle: Row parent-child - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Row parent-child
@@ -393,4 +394,4 @@ The “Insert row above” and “Insert row below” options were modified to w
 - Plugins:
   - [`BindRowsWithHeaders`](@/api/bindRowsWithHeaders.md)
   - [`ContextMenu`](@/api/contextMenu.md)
-  - [`NestedRows`](@/api/nestedRows.md) 
+  - [`NestedRows`](@/api/nestedRows.md)

--- a/docs/content/guides/rows/row-prepopulating.md
+++ b/docs/content/guides/rows/row-prepopulating.md
@@ -11,6 +11,7 @@ tags:
   - placeholder
 react:
   metaTitle: Row pre-populating - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Row pre-populating

--- a/docs/content/guides/rows/row-sorting.md
+++ b/docs/content/guides/rows/row-sorting.md
@@ -6,6 +6,7 @@ permalink: /row-sorting
 canonicalUrl: /row-sorting
 react:
   metaTitle: Row sorting - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Row sorting

--- a/docs/content/guides/rows/row-trimming.md
+++ b/docs/content/guides/rows/row-trimming.md
@@ -6,6 +6,7 @@ permalink: /row-trimming
 canonicalUrl: /row-trimming
 react:
   metaTitle: Row trimming - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Row trimming

--- a/docs/content/guides/rows/row-virtualization.md
+++ b/docs/content/guides/rows/row-virtualization.md
@@ -10,6 +10,7 @@ tags:
   - offset
 react:
   metaTitle: Row virtualization - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Row virtualization

--- a/docs/content/guides/security/security.md
+++ b/docs/content/guides/security/security.md
@@ -6,6 +6,7 @@ permalink: /security
 canonicalUrl: /security
 react:
   metaTitle: Security - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Security

--- a/docs/content/guides/technical-specification/documentation-license.md
+++ b/docs/content/guides/technical-specification/documentation-license.md
@@ -6,6 +6,7 @@ permalink: /documentation-license
 canonicalUrl: /documentation-license
 react:
   metaTitle: Documentation license - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Documentation license

--- a/docs/content/guides/technical-specification/software-license.md
+++ b/docs/content/guides/technical-specification/software-license.md
@@ -6,6 +6,7 @@ permalink: /software-license
 canonicalUrl: /software-license
 react:
   metaTitle: Software license - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Software license

--- a/docs/content/guides/technical-specification/supported-browsers.md
+++ b/docs/content/guides/technical-specification/supported-browsers.md
@@ -8,6 +8,7 @@ tags:
   - compatibility
 react:
   metaTitle: Supported browsers - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Supported browsers

--- a/docs/content/guides/technical-specification/third-party-licenses.md
+++ b/docs/content/guides/technical-specification/third-party-licenses.md
@@ -6,6 +6,7 @@ permalink: /third-party-licenses
 canonicalUrl: /third-party-licenses
 react:
   metaTitle: Third-party licenses - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Third-party licenses

--- a/docs/content/guides/tools-and-building/custom-builds.md
+++ b/docs/content/guides/tools-and-building/custom-builds.md
@@ -10,6 +10,7 @@ tags:
   - contributing
 react:
   metaTitle: Custom builds - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Custom builds

--- a/docs/content/guides/tools-and-building/custom-plugins.md
+++ b/docs/content/guides/tools-and-building/custom-plugins.md
@@ -10,6 +10,7 @@ tags:
   - extend
 react:
   metaTitle: Custom plugins - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Custom plugins

--- a/docs/content/guides/tools-and-building/folder-structure.md
+++ b/docs/content/guides/tools-and-building/folder-structure.md
@@ -13,6 +13,7 @@ tags:
   - files
 react:
   metaTitle: Folder structure - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Folder structure

--- a/docs/content/guides/tools-and-building/modules.md
+++ b/docs/content/guides/tools-and-building/modules.md
@@ -8,6 +8,7 @@ tags:
   - tree shaking
 react:
   metaTitle: Modules - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Modules

--- a/docs/content/guides/tools-and-building/packages.md
+++ b/docs/content/guides/tools-and-building/packages.md
@@ -4,6 +4,7 @@ metaTitle: Packages - JavaScript Data Grid | Handsontable
 description: Instantly add Handsontable to your web app, using pre-built UMD packages of JavaScript and CSS.
 permalink: /packages
 canonicalUrl: /packages
+searchCategory: Guides
 ---
 
 # Packages

--- a/docs/content/guides/tools-and-building/testing.md
+++ b/docs/content/guides/tools-and-building/testing.md
@@ -13,6 +13,7 @@ tags:
   - spec
 react:
   metaTitle: Testing - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Testing

--- a/docs/content/guides/upgrade-and-migration/migrating-from-10.0-to-11.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-10.0-to-11.0.md
@@ -7,6 +7,7 @@ canonicalUrl: /migration-from-10.0-to-11.0
 pageClass: migration-guide
 react:
   metaTitle: Migrate from 10.0 to 11.0 - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Migrating from 10.0 to 11.0

--- a/docs/content/guides/upgrade-and-migration/migrating-from-11.1-to-12.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-11.1-to-12.0.md
@@ -7,6 +7,7 @@ canonicalUrl: /migration-from-11.1-to-12.0
 pageClass: migration-guide
 react:
   metaTitle: Migrate from 11.1 to 12.0 - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Migrate from 11.1 to 12.0

--- a/docs/content/guides/upgrade-and-migration/migrating-from-7.4-to-8.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-7.4-to-8.0.md
@@ -7,6 +7,7 @@ canonicalUrl: /migration-from-7.4-to-8.0
 pageClass: migration-guide
 react:
   metaTitle: Migrate from 7.4 to 8.0 - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Migrate from 7.4 to 8.0
@@ -468,7 +469,7 @@ const hot = new Handsontable(container, {
 });
 
 hot.setDataAtRowProp(0, 'available', true) // in 8.0.0, this throws an error
-hot.setSourceDataAtCell(0, 'available', true) // in 8.0.0, this sets a new property 
+hot.setSourceDataAtCell(0, 'available', true) // in 8.0.0, this sets a new property
 ```
 :::
 
@@ -482,7 +483,7 @@ hot.setSourceDataAtCell(0, 'available', true) // in 8.0.0, this sets a new prope
 />
 
 hotTableComponentRef.current.hotInstance.setDataAtRowProp(0, 'available', true) // in 8.0.0, this throws an error
-hotTableComponentRef.current.hotInstance.setSourceDataAtCell(0, 'available', true) // in 8.0.0, this sets a new property 
+hotTableComponentRef.current.hotInstance.setSourceDataAtCell(0, 'available', true) // in 8.0.0, this sets a new property
 ```
 :::
 

--- a/docs/content/guides/upgrade-and-migration/migrating-from-8.4-to-9.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-8.4-to-9.0.md
@@ -7,6 +7,7 @@ canonicalUrl: /migration-from-8.4-to-9.0
 pageClass: migration-guide
 react:
   metaTitle: Migrate from 8.4 to 9.0 - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Migrate from 8.4 to 9.0

--- a/docs/content/guides/upgrade-and-migration/migrating-from-9.0-to-10.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-9.0-to-10.0.md
@@ -7,6 +7,7 @@ canonicalUrl: /migration-from-9.0-to-10.0
 pageClass: migration-guide
 react:
   metaTitle: Migrate from 9.0 to 10.0 - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Migrate from 9.0 to 10.0

--- a/docs/content/guides/upgrade-and-migration/release-notes.md
+++ b/docs/content/guides/upgrade-and-migration/release-notes.md
@@ -12,6 +12,7 @@ tags:
   - breaking change
 react:
   metaTitle: Release notes - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Release notes

--- a/docs/content/guides/upgrade-and-migration/versioning-policy.md
+++ b/docs/content/guides/upgrade-and-migration/versioning-policy.md
@@ -6,6 +6,7 @@ permalink: /versioning-policy
 canonicalUrl: /versioning-policy
 react:
   metaTitle: Versioning policy - React Data Grid | Handsontable
+searchCategory: Guides
 ---
 
 # Versioning policy


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the search engine of Docs. Previously the search results were filtered by the page title. That solution tends to be unstable as the page titles are not stable - they can be changed.

The PR implements the stable solution based on the frontmatter header, where each page defines the search category to which it belongs. Moreover, I improved the search results by prioritizing not only "Configuration options" in the API reference section by "Core" and "Hooks" results as well ([52eb86](https://github.com/handsontable/handsontable/pull/9964/files#diff-52eb86351480925d61947a58caca1ea76d10950ec26533f16f37cb12a3519dffR269)). Thus, the search results are different comparing https://handsontable.com and https://dev.handsontable.com.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally using the `npm run docs:start` command. **It's important to regenerate API reference files before testing (`npm run docs:api`).**

### Related issue(s):
1. fixes #9962

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
