### PR TITLE
Temporary disable "active" class for TOC

### DIFF
--- a/docs/.vuepress/enhanceApp.js
+++ b/docs/.vuepress/enhanceApp.js
@@ -17,23 +17,23 @@ const buildRegisterCleaner = register => (to, from) => {
   register.destroyAll();
 };
 
-const buildActiveHeaderLinkHandler = () => {
-  let activeLink = null;
+// const buildActiveHeaderLinkHandler = () => {
+//   let activeLink = null;
 
-  return (to, from) => {
-    if (to.hash !== from.hash) {
-      if (activeLink) {
-        activeLink.classList.remove('active');
-      }
-      // eslint-disable-next-line
-      activeLink = document.querySelector(`.table-of-contents a[href="${to.hash}"]`);
+//   return (to, from) => {
+//     if (to.hash !== from.hash) {
+//       if (activeLink) {
+//         activeLink.classList.remove('active');
+//       }
+//       // eslint-disable-next-line
+//       activeLink = document.querySelector(`.table-of-contents a[href="${to.hash}"]`);
 
-      if (activeLink) {
-        activeLink.classList.add('active');
-      }
-    }
-  };
-};
+//       if (activeLink) {
+//         activeLink.classList.add('active');
+//       }
+//     }
+//   };
+// };
 
 /**
  * The variable prevents collect double page views for the initial page load.

--- a/docs/.vuepress/enhanceApp.js
+++ b/docs/.vuepress/enhanceApp.js
@@ -14,10 +14,10 @@ const buildRegisterCleaner = register => (to, from) => {
 
     return;
   }
-  register.destroyAll();
+  register.destroyAll();``
 };
 
-// temporary disabled September 29 (#9963)
+// TODO: temporary disabled on September 29 (#9963)
 // const buildActiveHeaderLinkHandler = () => {
 //   let activeLink = null;
 
@@ -153,6 +153,6 @@ export default async({ router, siteData, isServer }) => {
   }
 
   router.afterEach(buildRegisterCleaner(instanceRegister));
-  // temporary disabled September 29 (#9963)
+  // TODO: temporary disabled on September 29 (#9963)
   // router.afterEach(buildActiveHeaderLinkHandler());
 };

--- a/docs/.vuepress/enhanceApp.js
+++ b/docs/.vuepress/enhanceApp.js
@@ -17,6 +17,7 @@ const buildRegisterCleaner = register => (to, from) => {
   register.destroyAll();
 };
 
+// temporary disabled September 29 (#9963)
 // const buildActiveHeaderLinkHandler = () => {
 //   let activeLink = null;
 

--- a/docs/.vuepress/enhanceApp.js
+++ b/docs/.vuepress/enhanceApp.js
@@ -152,5 +152,6 @@ export default async({ router, siteData, isServer }) => {
   }
 
   router.afterEach(buildRegisterCleaner(instanceRegister));
-  router.afterEach(buildActiveHeaderLinkHandler());
+  // temporary disabled September 29 (#9963)
+  // router.afterEach(buildActiveHeaderLinkHandler());
 };

--- a/docs/.vuepress/enhanceApp.js
+++ b/docs/.vuepress/enhanceApp.js
@@ -14,7 +14,7 @@ const buildRegisterCleaner = register => (to, from) => {
 
     return;
   }
-  register.destroyAll();``
+  register.destroyAll();
 };
 
 // TODO: temporary disabled on September 29 (#9963)


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR removes the "active" class from the table of contents. The change is temporary and will be fixed more broadly within #9963.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the change locally.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
