### PR TITLE
Fix all "Suggest edits" links

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -231,7 +231,7 @@ var DOCS_VERSION = '${getThisDocsVersion()}';
     prevLinks: true,
     repo: 'handsontable/handsontable',
     docsRepo: 'handsontable/handsontable',
-    docsDir: 'docs',
+    docsDir: 'docs/content',
     docsBranch: 'develop',
     editLinks: true,
     editLinkText: 'Suggest edits',

--- a/docs/.vuepress/plugins/dump-docs-data/canonicals.js
+++ b/docs/.vuepress/plugins/dump-docs-data/canonicals.js
@@ -10,7 +10,7 @@ const fetchCommonHeaders = new Headers({
   'User-Agent': 'HandsontableDocsBuilder'
 });
 
-logger.info(`Using "${BASE_URL}/docs/data/common.json" URL for fetching and building Docs data` +
+logger.info(`Using "${BASE_URL}/docs/data/common.json" URL for fetching and building Docs data ` +
   '(fetch docs versions and build canonical URLs).');
 
 /**

--- a/docs/.vuepress/plugins/extend-page-data/index.js
+++ b/docs/.vuepress/plugins/extend-page-data/index.js
@@ -29,11 +29,11 @@ function dedupeSlashes(string) {
  * Returns the original (not symlinked) relative path of the MD file, which the page
  * are created from.
  *
- * @param {object} $page The $page value of the page you’re currently reading.
+ * @param {string} relativePath The relative path of the processed file (symlinked path).
  * @returns {string}
  */
-function getOriginPath($page) {
-  return $page.relativePath
+function getOriginRelativePath(relativePath) {
+  return relativePath
     .replace(new RegExp(`^/?${MULTI_FRAMEWORKED_CONTENT_DIR}`), '')
     .replace(new RegExp(`/(${getFrameworks().join('|')})${FRAMEWORK_SUFFIX}/`), '');
 }
@@ -68,7 +68,10 @@ module.exports = (options, context) => {
       $page.defaultFramework = getDefaultFramework();
       $page.frameworkSuffix = FRAMEWORK_SUFFIX;
       $page.buildMode = buildMode;
-      $page.originRelativePath = getOriginPath($page);
+
+      if ($page.relativePath) {
+        $page.originRelativePath = getOriginRelativePath($page.relativePath);
+      }
 
       if ($page.currentVersion === 'next') {
         $page.docsGenStamp = `<!--

--- a/docs/.vuepress/plugins/extend-page-data/index.js
+++ b/docs/.vuepress/plugins/extend-page-data/index.js
@@ -1,5 +1,6 @@
 const {
   FRAMEWORK_SUFFIX,
+  MULTI_FRAMEWORKED_CONTENT_DIR,
   getDefaultFramework,
   getDocsBase,
   getDocsRepoSHA,
@@ -7,6 +8,7 @@ const {
   getSidebars,
   getThisDocsVersion,
   parseFramework,
+  getFrameworks,
 } = require('../../helpers');
 
 const buildMode = process.env.BUILD_MODE;
@@ -21,6 +23,19 @@ const now = new Date();
  */
 function dedupeSlashes(string) {
   return string.replace(/(\/)+/g, '$1');
+}
+
+/**
+ * Returns the original (not symlinked) relative path of the MD file, which the page
+ * are created from.
+ *
+ * @param {object} $page The $page value of the page you’re currently reading.
+ * @returns {string}
+ */
+function getOriginPath($page) {
+  return $page.relativePath
+    .replace(new RegExp(`^/?${MULTI_FRAMEWORKED_CONTENT_DIR}`), '')
+    .replace(new RegExp(`/(${getFrameworks().join('|')})${FRAMEWORK_SUFFIX}/`), '');
 }
 
 const formatDate = (dateString) => {
@@ -53,6 +68,7 @@ module.exports = (options, context) => {
       $page.defaultFramework = getDefaultFramework();
       $page.frameworkSuffix = FRAMEWORK_SUFFIX;
       $page.buildMode = buildMode;
+      $page.originRelativePath = getOriginPath($page);
 
       if ($page.currentVersion === 'next') {
         $page.docsGenStamp = `<!--

--- a/docs/.vuepress/theme/components/PageEdit.vue
+++ b/docs/.vuepress/theme/components/PageEdit.vue
@@ -57,13 +57,13 @@ export default {
         docsRepo = repo
       } = this.$site.themeConfig;
 
-      if (showEditLink && docsRepo && this.$page.relativePath) {
+      if (showEditLink && docsRepo && this.$page.originRelativePath) {
         return this.createEditLink(
           repo,
           docsRepo,
           docsDir,
           docsBranch,
-          this.$page.relativePath
+          this.$page.originRelativePath
         );
       }
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes all "Suggest edits" links in the Docs. Now, they point to the correct file within this repo.

_[skip changelog]_

### Related issue(s):
1. fixes #9972

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
