### PR TITLE
Add "Test examples" action to the Docs Prod Deployment workflow

### DIFF
--- a/.github/workflows/docs-production.yml
+++ b/.github/workflows/docs-production.yml
@@ -32,22 +32,32 @@ jobs:
       - name: Docker login into GHCR
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login -u ${GITHUB_ACTOR} --password-stdin https://docker.pkg.github.com
+
       - name: Dependencies
         run: |
           npm ci
+
       - name: Docker build
         run: |
           npm run docs:docker:build:production
+
+      - name: Test examples
+        run: |
+          npm run docs:test:example-checker
+
       - name: Docker tags
         run: |
           docker tag docs-md:production $GHA_DOCKER_TAG":v${{steps.get-docs-version.outputs.result}}"
           docker tag docs-md:production $GHA_DOCKER_TAG":v${{steps.get-docs-version.outputs.result}}-${{ github.sha }}"
+
       - name: Docker push production into GHCR
         run: |
           docker push $GHA_DOCKER_TAG":v${{steps.get-docs-version.outputs.result}}"
+
       - name: Docker push SHA tagged into GHCR
         run: |
           docker push $GHA_DOCKER_TAG":v${{steps.get-docs-version.outputs.result}}-${{ github.sha }}"
+
       - name: Deploy the Docs image
         uses: satak/webrequest-action@6127ff14e9269df0d49bcaec84f948dc8b50df1f # v1.2.4
         with:

--- a/docs/content/guides/upgrade-and-migration/migrating-from-7.4-to-8.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-7.4-to-8.0.md
@@ -811,4 +811,4 @@ Public methods `colOffset()` and `rowOffset()` were removed and their functional
 
 Also, an experimental feature called `ganttChart` was removed and is no longer supported.
 
-If you use these features in your project and need backward compatibility, please contact our Suppport Team ([support@handsontable.com](mailto:support@handsontable.com)).
+If you use these features in your project and need backward compatibility, please contact our Support Team ([support@handsontable.com](mailto:support@handsontable.com)).


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adds "Test examples" action to the Docs Prod Deployment workflow. The same is already added to the Staging env. https://github.com/handsontable/handsontable/blob/develop/.github/workflows/docs-staging.yml#L48.

_[skip changelog]_

### Related issue(s):
1. fixes #9978

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
