### PR TITLE
Fix canonical URLs for Docs served as non-latest

### DIFF
--- a/docs/.vuepress/plugins/dump-docs-data/index.js
+++ b/docs/.vuepress/plugins/dump-docs-data/index.js
@@ -5,6 +5,7 @@ const { generateCommonCanonicalURLs } = require('./canonicals');
 const { fetchDocsVersions } = require('./docs-versions');
 const {
   getThisDocsVersion,
+  getDocsBase,
 } = require('../../helpers');
 
 const pluginName = 'hot/dump-canonicals';
@@ -31,10 +32,14 @@ module.exports = (options, context) => {
      */
     async extendPageData($page) {
       if ($page.frontmatter.permalink) {
-        // Remove the slash ('/') from the beginning and ending of the URL path to reduce
+        // Remove the slash ('/') from the beginning and ending of the URL path and Docs base to reduce
         // the resulting file size
-        rawCanonicalURLs.urls
-          .push($page.frontmatter.canonicalUrl.replace(/^\/docs\//, '').replace(/\/$/, ''));
+        rawCanonicalURLs.urls.push(
+          $page.frontmatter.canonicalUrl
+            .replace(getDocsBase(), '')
+            .replace(/^\//, '')
+            .replace(/\/$/, '')
+        );
       }
     },
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the canonical URLs which are incorrectly generated for the latest Docs version (12.1).

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
To test the fix go through the following steps:
 * Emulate Docs 12.1 build by hardcoding the `getThisDocsVersion` function:
```
function getThisDocsVersion() {
  return '12.1';
}
```
 * Generate production build by executing `npm run docs:docker:build:production`;
 * As a result, the `./docs/.vuepress/public/data/common.json` file will contain the correct URLs without the version of the current docs in the name.
   * Correct values `"urls":[["javascript-data-grid/api/auto-column-size",""],["javascript-data-grid/api/auto-row-size",""]...`;
   * Incorect values `"urls":[["12.1/javascript-data-grid/api/auto-column-size",""],["12.1/javascript-data-grid/api/auto-row-size",""]...`;

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes #9973

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
