### PR TITLE
Fix redirects for old Angular, Vue 2, and Vue 3 URLs

### DIFF
--- a/docs/docker/redirects.conf
+++ b/docs/docker/redirects.conf
@@ -108,12 +108,12 @@ rewrite ^/docs/plugins/?$ /docs/$framework/custom-plugins/ permanent;
 rewrite ^/docs/file-structure/?$ /docs/$framework/folder-structure/ permanent;
 rewrite ^/docs/examples/?$ /docs/$framework/ permanent;
 rewrite ^/docs/setting-options/?$ /docs/$framework/configuration-options/ permanent;
-rewrite ^/docs/angular-simple-example/?$ /docs/$framework/angular-basic-example/ permanent;
-rewrite ^/docs/angular-setting-up-a-language/?$ /docs/$framework/angular-setting-up-a-translation/ permanent;
-rewrite ^/docs/vue-simple-example/?$ /docs/$framework/vue-basic-example/ permanent;
-rewrite ^/docs/vue-setting-up-a-language/?$ /docs/$framework/vue-setting-up-a-translation/ permanent;
-rewrite ^/docs/vue3-simple-example/?$ /docs/$framework/vue3-basic-example/ permanent;
-rewrite ^/docs/vue3-setting-up-a-language/?$ /docs/$framework/vue3-setting-up-a-translation/ permanent;
+rewrite ^/docs/angular-simple-example/?$ /docs/javascript-data-grid/angular-basic-example/ permanent;
+rewrite ^/docs/angular-setting-up-a-language/?$ /docs/javascript-data-grid/angular-setting-up-a-translation/ permanent;
+rewrite ^/docs/vue-simple-example/?$ /docs/javascript-data-grid/vue-basic-example/ permanent;
+rewrite ^/docs/vue-setting-up-a-language/?$ /docs/javascript-data-grid/vue-setting-up-a-translation/ permanent;
+rewrite ^/docs/vue3-simple-example/?$ /docs/javascript-data-grid/vue3-basic-example/ permanent;
+rewrite ^/docs/vue3-setting-up-a-language/?$ /docs/javascript-data-grid/vue3-setting-up-a-translation/ permanent;
 
 # --- demos ---
 rewrite ^/docs/((\d+\.\d+|next)/)?demo-scrolling/?$ /docs/$1$framework/row-virtualization/ permanent;


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the redirects for old Angular, Vue 2, and Vue 3 URLs

To reproduce the bug, go to https://handsontable.com/docs, choose the _React_ framework from the dropdown list, then visit one of the following links:
 * https://handsontable.com/docs/angular-simple-example
 * https://handsontable.com/docs/angular-setting-up-a-language
 * https://handsontable.com/docs/vue-simple-example
 * https://handsontable.com/docs/vue-setting-up-a-language
 * https://handsontable.com/docs/vue3-simple-example
 * https://handsontable.com/docs/vue3-setting-up-a-language

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
The fix can be tested only after building the Docs docker image:
 * `npm run docs:docker:build`;
 * `docker run --rm -p 8080:80 --name handsontable-docs docs-md`

or basically using the `npm run review:...` script.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes #9982

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
