### PR TITLE
New meta tags added for the guides docs

### DIFF
--- a/docs/content/guides/accessories-and-menus/searching-values.md
+++ b/docs/content/guides/accessories-and-menus/searching-values.md
@@ -7,6 +7,7 @@ canonicalUrl: /searching-values
 tags:
   - find values
   - highlight values
+  - search values
 react:
   metaTitle: Searching values - React Data Grid | Handsontable
 searchCategory: Guides

--- a/docs/content/guides/columns/column-freezing.md
+++ b/docs/content/guides/columns/column-freezing.md
@@ -8,6 +8,7 @@ tags:
   - fixing columns
   - snapping columns
   - pinning columns
+  - fixedColumns
 react:
   metaTitle: Column freezing - React Data Grid | Handsontable
 searchCategory: Guides

--- a/docs/content/guides/formulas/formula-calculation.md
+++ b/docs/content/guides/formulas/formula-calculation.md
@@ -13,6 +13,7 @@ tags:
   - workbook
   - sheet
   - function
+  - hyperformula
 react:
   metaTitle: Formula calculation - React Data Grid | Handsontable
 searchCategory: Guides

--- a/docs/content/guides/optimization/batch-operations.md
+++ b/docs/content/guides/optimization/batch-operations.md
@@ -6,6 +6,8 @@ permalink: /batch-operations
 canonicalUrl: /batch-operations
 tags:
   - suspend rendering
+  - batching
+  - performance
 react:
   metaTitle: Batch operations - React Data Grid | Handsontable
 searchCategory: Guides

--- a/docs/content/guides/rows/row-freezing.md
+++ b/docs/content/guides/rows/row-freezing.md
@@ -7,6 +7,7 @@ canonicalUrl: /row-freezing
 tags:
   - fixing rows
   - pinning rows
+  - fixedRows
 react:
   metaTitle: Row freezing - React Data Grid | Handsontable
 searchCategory: Guides


### PR DESCRIPTION
### Context

I added new meta tags for guides to improve the search experience for the users. List of tags added:

- Searching values (search values)
- Column freezing (fixedColumns)
- Formula calculation (hyperformula)
- Batch operations (batching, performance)
- Row freezing (fixedRows)

### How has this been tested?

By running tests locally and building the documentation.

### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/9882

### Affected project(s):
- [X] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [X] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [X] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]
