### PR TITLE
Docs: Replace `from './helpers'` import so that React examples work locally

### DIFF
--- a/docs/content/guides/accessories-and-menus/context-menu.md
+++ b/docs/content/guides/accessories-and-menus/context-menu.md
@@ -188,11 +188,11 @@ In addition to built-in options, you can equip your context menu with custom opt
 
 ::: example #example4 :react
 ```jsx
+import Handsontable from 'handsontable';
 import ReactDOM from 'react-dom';
 import { HotTable } from '@handsontable/react';
 import { ContextMenu } from 'handsontable/plugins/contextMenu';
 import { registerAllModules } from 'handsontable/registry';
-import { createSpreadsheetData } from './helpers';
 import 'handsontable/dist/handsontable.full.min.css';
 
 // register Handsontable's modules
@@ -203,7 +203,7 @@ const ExampleComponent = () => {
     <div>
       <HotTable
         id="hot"
-        data={createSpreadsheetData(5, 5)}
+        data={Handsontable.helper.createSpreadsheetData(5, 5)}
         colHeaders={true}
         height="auto"
         contextMenu={{

--- a/docs/content/guides/getting-started/events-and-hooks.md
+++ b/docs/content/guides/getting-started/events-and-hooks.md
@@ -111,11 +111,11 @@ The first argument may be modified and passed on through the Handsontable hooks 
 
 ::: example #example3 :react
 ```jsx
+import Handsontable from 'handsontable';
 import { useState } from 'react';
 import ReactDOM from 'react-dom';
 import { HotTable } from '@handsontable/react';
 import { registerAllModules } from 'handsontable/registry';
-import { createSpreadsheetData } from './helpers';
 import 'handsontable/dist/handsontable.full.min.css';
 
 // register Handsontable's modules
@@ -124,7 +124,7 @@ registerAllModules();
 const ExampleComponent = () => {
   const [settings, setSettings] = useState(() => {
     const initialState = {
-      data: createSpreadsheetData(15, 20),
+      data: Handsontable.helper.createSpreadsheetData(15, 20),
       height: 220,
       licenseKey: 'non-commercial-and-evaluation'
     }

--- a/docs/content/guides/getting-started/react-methods.md
+++ b/docs/content/guides/getting-started/react-methods.md
@@ -23,11 +23,11 @@ The following example implements the `HotTable` component showing how to referen
 
 ::: example #example1 :react
 ```jsx
+import Handsontable from 'handsontable';
 import { useRef } from 'react';
 import ReactDOM from 'react-dom';
 import { HotTable } from '@handsontable/react';
 import { registerAllModules } from 'handsontable/registry';
-import { createSpreadsheetData } from './helpers';
 import 'handsontable/dist/handsontable.full.min.css';
 
 // register Handsontable's modules
@@ -45,13 +45,13 @@ const ExampleComponent = () => {
     <>
       <HotTable
         ref={hotTableComponent}
-        data={createSpreadsheetData(4, 4)}
+        data={Handsontable.helper.createSpreadsheetData(4, 4)}
         colHeaders={true}
         height="auto"
         licenseKey="non-commercial-and-evaluation"
       />
       <div className="controls">
-        <button onClick={selectCell}>Select B2 cell!</button>
+        <button onClick={selectCell}>Select cell B2</button>
       </div>
     </>
   );

--- a/docs/content/guides/getting-started/react-redux.md
+++ b/docs/content/guides/getting-started/react-redux.md
@@ -25,13 +25,13 @@ The following example implements the `@handsontable/react` component with a [`re
 
 ::: example #example1 :react-redux
 ```jsx
+import Handsontable from 'handsontable';
 import { useRef } from 'react';
 import ReactDOM from 'react-dom';
 import { createStore } from 'redux';
 import { Provider, useSelector, useDispatch } from 'react-redux';
 import { HotTable } from '@handsontable/react';
 import { registerAllModules } from 'handsontable/registry';
-import { createSpreadsheetData } from './helpers';
 import 'handsontable/dist/handsontable.full.min.css';
 
 // register Handsontable's modules
@@ -116,7 +116,7 @@ const ExampleComponent = () => {
 };
 
 const initialReduxStoreState = {
-  data: createSpreadsheetData(5, 3),
+  data: Handsontable.helper.createSpreadsheetData(5, 3),
   colHeaders: true,
   rowHeaders: true,
   readOnly: false,

--- a/docs/content/guides/internationalization/language.md
+++ b/docs/content/guides/internationalization/language.md
@@ -176,12 +176,12 @@ Note that the `language` property is bound to the component separately using `la
 
 ::: example #example2 :react-languages
 ```jsx
+import Handsontable from 'handsontable';
 import { useState, useEffect } from 'react';
 import ReactDOM from 'react-dom';
 import { HotTable } from '@handsontable/react';
 import { getLanguagesDictionaries } from 'handsontable/i18n';
 import { registerAllModules } from 'handsontable/registry';
-import { createSpreadsheetData } from './helpers';
 import 'handsontable/dist/handsontable.full.min.css';
 
 // register Handsontable's modules
@@ -213,7 +213,7 @@ const ExampleComponent = () => {
       </label></div>
 
       <HotTable
-        data={createSpreadsheetData(5, 10)}
+        data={Handsontable.helper.createSpreadsheetData(5, 10)}
         colHeaders={true}
         rowHeaders={true}
         contextMenu={true}


### PR DESCRIPTION
This PR:
- Replaces `import { createSpreadsheetData } from './helpers'` so that React examples work locally

### Related issues:
- #9954