### PR TITLE
Docs: Fix the error being thrown when building the docs.

### DIFF
--- a/docs/content/guides/cell-features/text-alignment.md
+++ b/docs/content/guides/cell-features/text-alignment.md
@@ -1,7 +1,7 @@
 ---
 title: Text alignment
 metaTitle: Text alignment - JavaScript Data Grid | Handsontable
-description: Align values within cells: horizontally (to the right, left, center, or by justifying them), and vertically (to the top, middle, or bottom of the cell).
+description: "Align values within cells: horizontally (to the right, left, center, or by justifying them), and vertically (to the top, middle, or bottom of the cell)."
 permalink: /text-alignment
 canonicalUrl: /text-alignment
 react:


### PR DESCRIPTION
### Context
After merging https://github.com/handsontable/handsontable/pull/9968 to `develop`, the docs building workflow started throwing errors.
It was caused by using ":" in the frontmatter section of one of the pages (when ':' is part of the syntax of the YAML (ish?) based frontmatter section). I resolved it by wrapping the entire text entry in quotes.

CC: @kirszenbaum, this information might be useful when making similar content changes in the future.

### How has this been tested?
Built locally using `docs:start:no-cache`.

### Related issue(s):
1. #9968 

[skip changelog]
