### PR TITLE
Docs: Add info that you can't change class of the column summary destination row

### DIFF
--- a/docs/content/guides/columns/column-summary.md
+++ b/docs/content/guides/columns/column-summary.md
@@ -415,7 +415,7 @@ columnSummary={[
 :::
 
 ::: tip
-Don't change the CSS class of a column summary's destination row. Otherwise, the summary may not work properly.
+We don't recommend changing the CSS styling of the summary's destination row (the summary may not work properly).
 :::
 
 ### Step 5: Make room for the destination cell

--- a/docs/content/guides/columns/column-summary.md
+++ b/docs/content/guides/columns/column-summary.md
@@ -33,7 +33,7 @@ To customize your column summaries, you can:
 
 ### Column summary example
 
-The example below calculates and displays five different column summaries:
+This example calculates and displays five different column summaries:
 
 ::: only-for javascript
 ::: example #example1
@@ -56,7 +56,9 @@ const hot = new Handsontable(container, {
       sourceColumn: 0,
       type: 'sum',
       destinationRow: 3,
-      destinationColumn: 0
+      destinationColumn: 0,
+      // force this column summary to treat non-numeric values as numeric values
+      forceNumeric: true
     },
     {
       sourceColumn: 1,
@@ -116,7 +118,9 @@ const ExampleComponent = () => {
           sourceColumn: 0,
           type: 'sum',
           destinationRow: 3,
-          destinationColumn: 0
+          destinationColumn: 0,
+          // force this column summary to treat non-numeric values as numeric values
+          forceNumeric: true
         },
         {
           sourceColumn: 1,
@@ -879,7 +883,7 @@ columnSummary={[{
 ```
 :::
 
-The example below implements a function that counts the number of even values in a column:
+This example implements a function that counts the number of even values in a column:
 
 ::: only-for javascript
 ::: example #example9

--- a/docs/content/guides/columns/column-summary.md
+++ b/docs/content/guides/columns/column-summary.md
@@ -414,6 +414,10 @@ columnSummary={[
 ```
 :::
 
+::: tip
+Don't change the CSS class of a column summary's destination row. Otherwise, the summary may not work properly.
+:::
+
 ### Step 5: Make room for the destination cell
 
 The [`ColumnSummary`](@/api/columnSummary.md) plugin doesn't automatically add new rows to display its summary results.

--- a/handsontable/src/dataMap/metaManager/metaSchema.js
+++ b/handsontable/src/dataMap/metaManager/metaSchema.js
@@ -584,7 +584,7 @@ export default () => {
      * | An array of strings | Add multiple CSS class names to every currently-selected element |
      *
      * ::: tip
-     * Don't change the CSS class of a [column summary](@/guides/columns/column-summary.md)'s destination row. Otherwise, the summary may not work properly.
+     * We don't recommend changing the CSS styling of the [column summary](@/guides/columns/column-summary.md)'s destination row (the summary may not work properly).
      * :::
      *
      * To apply different CSS class names on different levels, use Handsontable's [cascading configuration](@/guides/getting-started/configuration-options.md#cascading-configuration).

--- a/handsontable/src/dataMap/metaManager/metaSchema.js
+++ b/handsontable/src/dataMap/metaManager/metaSchema.js
@@ -583,6 +583,10 @@ export default () => {
      * | A string            | Add a single CSS class name to every currently-selected element  |
      * | An array of strings | Add multiple CSS class names to every currently-selected element |
      *
+     * ::: tip
+     * Don't change the CSS class of a [column summary](@/guides/columns/column-summary.md)'s destination row. Otherwise, the summary may not work properly.
+     * :::
+     *
      * To apply different CSS class names on different levels, use Handsontable's [cascading configuration](@/guides/getting-started/configuration-options.md#cascading-configuration).
      *
      * Read more:


### PR DESCRIPTION
This PR
- Adds info that you can't change class of the column summary destination row

[skip changelog]

### Links:
- http://localhost:8080/docs/react-data-grid/column-summary/#step-4-provide-the-destination-cell-s-coordinates
- http://localhost:8080/docs/react-data-grid/api/options/#classname

### Related issues:
1. https://github.com/handsontable/handsontable/issues/10025