### PR TITLE
Docs: Revert back to gerunds in topic titles and frontmatter

### DIFF
--- a/docs/content/guides/accessories-and-menus/searching-values.md
+++ b/docs/content/guides/accessories-and-menus/searching-values.md
@@ -1,6 +1,6 @@
 ---
-title: Search values
-metaTitle: Search values - JavaScript Data Grid | Handsontable
+title: Searching values
+metaTitle: Searching values - JavaScript Data Grid | Handsontable
 description: Type the text you are looking for in the search bar to highlight the desired values. Use API methods to implement the search bar outside of the data grid.
 permalink: /searching-values
 canonicalUrl: /searching-values
@@ -9,11 +9,11 @@ tags:
   - highlight values
   - search values
 react:
-  metaTitle: Search values - React Data Grid | Handsontable
+  metaTitle: Searching values - React Data Grid | Handsontable
 searchCategory: Guides
 ---
 
-# Search values
+# Searching values
 
 Type the text you are looking for in the search bar to highlight the desired values. Use API methods to implement the search bar outside of the data grid.
 

--- a/docs/content/guides/getting-started/binding-to-data.md
+++ b/docs/content/guides/getting-started/binding-to-data.md
@@ -1,6 +1,6 @@
 ---
-title: Bind to data
-metaTitle: Bind to data - JavaScript Data Grid | Handsontable
+title: Binding to data
+metaTitle: Binding to data - JavaScript Data Grid | Handsontable
 description: Use Handsontable's configuration options or API methods to fill your data grid with various data structures, including an array of arrays or an array of objects.
 permalink: /binding-to-data
 canonicalUrl: /binding-to-data
@@ -9,11 +9,11 @@ tags:
   - data connect
   - data sources
 react:
-  metaTitle: Bind to data - React Data Grid | Handsontable
+  metaTitle: Binding to data - React Data Grid | Handsontable
 searchCategory: Guides
 ---
 
-# Bind to data
+# Binding to data
 
 Fill your data grid with various data structures, including an array of arrays or an array of objects.
 

--- a/docs/content/guides/getting-started/saving-data.md
+++ b/docs/content/guides/getting-started/saving-data.md
@@ -1,7 +1,7 @@
 ---
-title: Save data
-metaTitle: Save data - JavaScript Data Grid | Handsontable
-description: Save data after each change to the data set, using Handsontable's API hooks. Preserve the table's state by saving data to the local storage.
+title: Saving data
+metaTitle: Saving data - JavaScript Data Grid | Handsontable
+description: Saving data after each change to the data set, using Handsontable's API hooks. Preserve the table's state by saving data to the local storage.
 permalink: /saving-data
 canonicalUrl: /saving-data
 tags:
@@ -9,11 +9,11 @@ tags:
   - server
   - ajax
 react:
-  metaTitle: Save data - React Data Grid | Handsontable
+  metaTitle: Saving data - React Data Grid | Handsontable
 searchCategory: Guides
 ---
 
-# Save data
+# Saving data
 
 Save data after each change to the data set, using Handsontable's API hooks. Preserve the table's state by saving data to the local storage.
 

--- a/docs/content/guides/integrate-with-angular/angular-hot-reference.md
+++ b/docs/content/guides/integrate-with-angular/angular-hot-reference.md
@@ -1,13 +1,13 @@
 ---
-title: Reference a Handsontable instance in Angular
-metaTitle: Reference Handsontable - Angular Data Grid | Handsontable
-description: Reference a Handsontable instance from an Angular component to programmatically perform actions such as reloading the data in your data grid.
+title: Referencing a Handsontable instance in Angular
+metaTitle: Referencing Handsontable - Angular Data Grid | Handsontable
+description: Referencing a Handsontable instance from an Angular component to programmatically perform actions such as reloading the data in your data grid.
 permalink: /angular-hot-reference
 canonicalUrl: /angular-hot-reference
 searchCategory: Guides
 ---
 
-# Reference a Handsontable instance in Angular
+# Referencing a Handsontable instance in Angular
 
 Reference a Handsontable instance from an Angular component to programmatically perform actions such as reloading the data in your data grid.
 

--- a/docs/content/guides/integrate-with-angular/angular-setting-up-a-translation.md
+++ b/docs/content/guides/integrate-with-angular/angular-setting-up-a-translation.md
@@ -1,13 +1,13 @@
 ---
-title: Set up a translation in Angular
-metaTitle: Set up a translation - Angular Data Grid | Handsontable
+title: Setting up a translation in Angular
+metaTitle: Setting up a translation - Angular Data Grid | Handsontable
 description: Configure your Angular data grid with different number formats, depending on the specified language and culture.
 permalink: /angular-setting-up-a-translation
 canonicalUrl: /angular-setting-up-a-translation
 searchCategory: Guides
 ---
 
-# Set up a translation in Angular
+# Setting up a translation in Angular
 
 Configure your Angular data grid with different number formats, depending on the specified language and culture.
 

--- a/docs/content/guides/integrate-with-vue/vue-hot-column.md
+++ b/docs/content/guides/integrate-with-vue/vue-hot-column.md
@@ -1,5 +1,5 @@
 ---
-title: Use the `HotColumn` component in Vue 2
+title: Using the `HotColumn` component in Vue 2
 metaTitle: HotColumn component - Vue 2 Data Grid | Handsontable
 description: Configure the Vue 2 data grid's columns, using the props of the "HotColumn" component. Define a custom cell editor or a custom cell renderer.
 permalink: /vue-hot-column
@@ -7,7 +7,7 @@ canonicalUrl: /vue-hot-column
 searchCategory: Guides
 ---
 
-# Use the `HotColumn` component in Vue 2
+# Using the `HotColumn` component in Vue 2
 
 Configure the Vue 2 data grid's columns, using the props of the `HotColumn` component. Define a custom cell editor or a custom cell renderer.
 

--- a/docs/content/guides/integrate-with-vue/vue-setting-up-a-language.md
+++ b/docs/content/guides/integrate-with-vue/vue-setting-up-a-language.md
@@ -1,13 +1,13 @@
 ---
-title: Set up a translation in Vue 2
-metaTitle: Set up a translation - Vue 2 Data Grid | Handsontable
+title: Setting up a translation in Vue 2
+metaTitle: Setting up a translation - Vue 2 Data Grid | Handsontable
 description: Configure your Vue 2 data grid with different number formats, depending on the specified language and culture.
 permalink: /vue-setting-up-a-translation
 canonicalUrl: /vue-setting-up-a-translation
 searchCategory: Guides
 ---
 
-# Set up a translation in Vue 2
+# Setting up a translation in Vue 2
 
 Configure your Vue 2 data grid with different number formats, depending on the specified language and culture.
 

--- a/docs/content/guides/integrate-with-vue3/vue3-hot-column.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-hot-column.md
@@ -1,5 +1,5 @@
 ---
-title: Use the `HotColumn` component in Vue 3
+title: Using the `HotColumn` component in Vue 3
 metaTitle: HotColumn component - Vue 3 Data Grid | Handsontable
 description: Configure the Vue 3 data grid's columns, using the props of the "HotColumn" component. Define a custom cell editor or a custom cell renderer.
 permalink: /vue3-hot-column
@@ -7,7 +7,7 @@ canonicalUrl: /vue3-hot-column
 searchCategory: Guides
 ---
 
-# Use the `HotColumn` component in Vue 3
+# Using the `HotColumn` component in Vue 3
 
 Configure the Vue 3 data grid's columns, using the props of the `HotColumn` component. Define a custom cell editor or a custom cell renderer.
 

--- a/docs/content/guides/integrate-with-vue3/vue3-hot-reference.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-hot-reference.md
@@ -1,13 +1,13 @@
 ---
-title: Reference the Handsontable instance in Vue 3
-metaTitle: Reference Handsontable - Vue 3 Data Grid | Handsontable
-description: Reference the Handsontable instance from a Vue 3 component to programmatically perform actions such as reloading the data in your data grid.
+title: Referencing the Handsontable instance in Vue 3
+metaTitle: Referencing Handsontable - Vue 3 Data Grid | Handsontable
+description: Referencing the Handsontable instance from a Vue 3 component to programmatically perform actions such as reloading the data in your data grid.
 permalink: /vue3-hot-reference
 canonicalUrl: /vue3-hot-reference
 searchCategory: Guides
 ---
 
-# Reference the Handsontable instance in Vue 3
+# Referencing the Handsontable instance in Vue 3
 
 Reference the Handsontable instance from a Vue 3 component to programmatically perform actions such as reloading the data in your data grid.
 

--- a/docs/content/guides/integrate-with-vue3/vue3-setting-up-a-language.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-setting-up-a-language.md
@@ -1,13 +1,13 @@
 ---
-title: Set up a translation in Vue 3
-metaTitle: Set up a translation - Vue 3 Data Grid | Handsontable
+title: Setting up a translation in Vue 3
+metaTitle: Setting up a translation - Vue 3 Data Grid | Handsontable
 description: Configure your Vue 3 data grid with different number formats, depending on the specified language and culture.
 permalink: /vue3-setting-up-a-translation
 canonicalUrl: /vue3-setting-up-a-translation
 searchCategory: Guides
 ---
 
-# Set up a translation in Vue 3
+# Setting up a translation in Vue 3
 
 Configure your Vue 3 data grid with different number formats, depending on the specified language and culture.
 

--- a/docs/content/guides/sidebar.js
+++ b/docs/content/guides/sidebar.js
@@ -178,7 +178,7 @@ const upgradeAndMigrationItems = [
 
 module.exports = {
   sidebar: [
-    { title: 'Get started', children: gettingStartedItems },
+    { title: 'Getting started', children: gettingStartedItems },
     { title: 'Integrate with Angular', children: integrateWithAngularItems, onlyFor: ['javascript'] },
     { title: 'Integrate with Vue 2', children: integrateWithVueItems, onlyFor: ['javascript'] },
     { title: 'Integrate with Vue 3', children: integrateWithVue3Items, onlyFor: ['javascript'], },


### PR DESCRIPTION
This PR:
- Reverts back to gerunds in topic titles and frontmatter

[skip changelog]