### PR TITLE
Docs: Apply the Technical Support Team name

### DIFF
--- a/docs/content/guides/getting-started/introduction.md
+++ b/docs/content/guides/getting-started/introduction.md
@@ -110,7 +110,7 @@ Handsontable's built-in features and customizability keep it present across diff
 
 ## Technical support
 
-Implementing Handsontable requires a certain level of front-end development skills. In case you need help, and can't find a solution in the documentation, reach out to us. If you have a commercial Handsontable license, and your support plan is active, contact our Support Team at [support@handsontable.com](mailto:support@handsontable.com).
+Implementing Handsontable requires a certain level of front-end development skills. In case you need help, and can't find a solution in the documentation, reach out to us. If you have a commercial Handsontable license, and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
 
 ## Feedback
 

--- a/docs/content/guides/security/security.md
+++ b/docs/content/guides/security/security.md
@@ -76,7 +76,7 @@ The security audits were carried out in accordance with industry-standard method
 - OWASP Top 10
 - OWASP Application Security Verification Standard (ASVS)
 
-For detailed security reports, contact our [Support Team](https://handsontable.com/contact).
+For detailed security reports, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
 
 ## Code auditing
 

--- a/docs/content/guides/upgrade-and-migration/migrating-from-7.4-to-8.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-7.4-to-8.0.md
@@ -29,7 +29,7 @@ Handsontable 8.0.0 introduces [`IndexMapper`](@/api/indexMapper.md), a new API t
 ## General guidelines
 
 * Check if you use any of the features listed in the [Keywords](#keywords-alphabetically) section. You need to address them first after installing Handsontable 8.0.0.
-* To keep backward compatibility, test solutions proposed in this guide. If you experience any problems, contact us.
+* To keep backward compatibility, test solutions proposed in this guide. If you experience any problems, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
 * You can also check the release notes for a complete list of all changes.
 
 ## Keywords (alphabetically)
@@ -813,4 +813,4 @@ Public methods `colOffset()` and `rowOffset()` were removed and their functional
 
 Also, an experimental feature called `ganttChart` was removed and is no longer supported.
 
-If you use these features in your project and need backward compatibility, please contact our Support Team ([support@handsontable.com](mailto:support@handsontable.com)).
+If you use these features in your project and need backward compatibility, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).

--- a/examples/10.0.0/docs/angular/basic-example/README.md
+++ b/examples/10.0.0/docs/angular/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/10.0.0/docs/js/basic-example/README.md
+++ b/examples/10.0.0/docs/js/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/10.0.0/docs/react/basic-example/README.md
+++ b/examples/10.0.0/docs/react/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/10.0.0/docs/vue/basic-example/README.md
+++ b/examples/10.0.0/docs/vue/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/11.0.0/docs/angular/basic-example/README.md
+++ b/examples/11.0.0/docs/angular/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/11.0.0/docs/js/basic-example/README.md
+++ b/examples/11.0.0/docs/js/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/11.0.0/docs/react/basic-example/README.md
+++ b/examples/11.0.0/docs/react/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).t).

--- a/examples/11.0.0/docs/vue/basic-example/README.md
+++ b/examples/11.0.0/docs/vue/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/11.0.1/docs/angular/basic-example/README.md
+++ b/examples/11.0.1/docs/angular/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/11.0.1/docs/js/basic-example/README.md
+++ b/examples/11.0.1/docs/js/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/11.0.1/docs/react/basic-example/README.md
+++ b/examples/11.0.1/docs/react/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/11.0.1/docs/vue/basic-example/README.md
+++ b/examples/11.0.1/docs/vue/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/11.1.0/docs/angular/basic-example/README.md
+++ b/examples/11.1.0/docs/angular/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/11.1.0/docs/angular/demo/README.md
+++ b/examples/11.1.0/docs/angular/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/11.1.0/docs/js/basic-example/README.md
+++ b/examples/11.1.0/docs/js/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/11.1.0/docs/js/demo/README.md
+++ b/examples/11.1.0/docs/js/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/11.1.0/docs/react/basic-example/README.md
+++ b/examples/11.1.0/docs/react/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/11.1.0/docs/react/demo/README.md
+++ b/examples/11.1.0/docs/react/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/11.1.0/docs/ts/demo/README.md
+++ b/examples/11.1.0/docs/ts/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/11.1.0/docs/vue/basic-example/README.md
+++ b/examples/11.1.0/docs/vue/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/11.1.0/docs/vue/demo/README.md
+++ b/examples/11.1.0/docs/vue/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.0.0/docs/angular/basic-example/README.md
+++ b/examples/12.0.0/docs/angular/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.0.0/docs/angular/demo/README.md
+++ b/examples/12.0.0/docs/angular/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.0.0/docs/js/basic-example/README.md
+++ b/examples/12.0.0/docs/js/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.0.0/docs/js/demo/README.md
+++ b/examples/12.0.0/docs/js/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.0.0/docs/react/basic-example/README.md
+++ b/examples/12.0.0/docs/react/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.0.0/docs/react/demo/README.md
+++ b/examples/12.0.0/docs/react/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.0.0/docs/ts/demo/README.md
+++ b/examples/12.0.0/docs/ts/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.0.0/docs/vue/basic-example/README.md
+++ b/examples/12.0.0/docs/vue/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.0.0/docs/vue/demo/README.md
+++ b/examples/12.0.0/docs/vue/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.0.1/docs/angular/basic-example/README.md
+++ b/examples/12.0.1/docs/angular/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.0.1/docs/angular/demo/README.md
+++ b/examples/12.0.1/docs/angular/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.0.1/docs/js/basic-example/README.md
+++ b/examples/12.0.1/docs/js/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.0.1/docs/js/demo/README.md
+++ b/examples/12.0.1/docs/js/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.0.1/docs/react/basic-example/README.md
+++ b/examples/12.0.1/docs/react/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.0.1/docs/react/demo/README.md
+++ b/examples/12.0.1/docs/react/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.0.1/docs/ts/demo/README.md
+++ b/examples/12.0.1/docs/ts/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.0.1/docs/vue/basic-example/README.md
+++ b/examples/12.0.1/docs/vue/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.0.1/docs/vue/demo/README.md
+++ b/examples/12.0.1/docs/vue/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.0/docs/angular-9/basic-example/README.md
+++ b/examples/12.1.0/docs/angular-9/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.0/docs/angular-9/demo/README.md
+++ b/examples/12.1.0/docs/angular-9/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.0/docs/js/basic-example/README.md
+++ b/examples/12.1.0/docs/js/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.0/docs/js/demo/README.md
+++ b/examples/12.1.0/docs/js/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.0/docs/react/basic-example/README.md
+++ b/examples/12.1.0/docs/react/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.0/docs/react/demo/README.md
+++ b/examples/12.1.0/docs/react/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.0/docs/ts/demo/README.md
+++ b/examples/12.1.0/docs/ts/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.0/docs/vue/basic-example/README.md
+++ b/examples/12.1.0/docs/vue/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.0/docs/vue/demo/README.md
+++ b/examples/12.1.0/docs/vue/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.1/docs/angular-10/basic-example/README.md
+++ b/examples/12.1.1/docs/angular-10/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.1/docs/angular-10/demo/README.md
+++ b/examples/12.1.1/docs/angular-10/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.1/docs/angular-11/basic-example/README.md
+++ b/examples/12.1.1/docs/angular-11/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.1/docs/angular-11/demo/README.md
+++ b/examples/12.1.1/docs/angular-11/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.1/docs/angular-12/basic-example/README.md
+++ b/examples/12.1.1/docs/angular-12/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.1/docs/angular-12/demo/README.md
+++ b/examples/12.1.1/docs/angular-12/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.1/docs/angular-13/basic-example/README.md
+++ b/examples/12.1.1/docs/angular-13/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.1/docs/angular-13/demo/README.md
+++ b/examples/12.1.1/docs/angular-13/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.1/docs/angular-9/basic-example/README.md
+++ b/examples/12.1.1/docs/angular-9/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.1/docs/angular-9/demo/README.md
+++ b/examples/12.1.1/docs/angular-9/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.1/docs/angular/basic-example/README.md
+++ b/examples/12.1.1/docs/angular/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.1/docs/angular/demo/README.md
+++ b/examples/12.1.1/docs/angular/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.1/docs/js/basic-example/README.md
+++ b/examples/12.1.1/docs/js/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.1/docs/js/demo/README.md
+++ b/examples/12.1.1/docs/js/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.1/docs/react/basic-example/README.md
+++ b/examples/12.1.1/docs/react/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.1/docs/react/demo/README.md
+++ b/examples/12.1.1/docs/react/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.1/docs/ts/demo/README.md
+++ b/examples/12.1.1/docs/ts/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.1/docs/vue/basic-example/README.md
+++ b/examples/12.1.1/docs/vue/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.1/docs/vue/demo/README.md
+++ b/examples/12.1.1/docs/vue/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.2/docs/angular-10/basic-example/README.md
+++ b/examples/12.1.2/docs/angular-10/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.2/docs/angular-10/demo/README.md
+++ b/examples/12.1.2/docs/angular-10/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.2/docs/angular-11/basic-example/README.md
+++ b/examples/12.1.2/docs/angular-11/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.2/docs/angular-11/demo/README.md
+++ b/examples/12.1.2/docs/angular-11/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.2/docs/angular-12/basic-example/README.md
+++ b/examples/12.1.2/docs/angular-12/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.2/docs/angular-12/demo/README.md
+++ b/examples/12.1.2/docs/angular-12/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.2/docs/angular-13/basic-example/README.md
+++ b/examples/12.1.2/docs/angular-13/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.2/docs/angular-13/demo/README.md
+++ b/examples/12.1.2/docs/angular-13/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.2/docs/angular-9/basic-example/README.md
+++ b/examples/12.1.2/docs/angular-9/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.2/docs/angular-9/demo/README.md
+++ b/examples/12.1.2/docs/angular-9/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.2/docs/angular/basic-example/README.md
+++ b/examples/12.1.2/docs/angular/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.2/docs/angular/demo/README.md
+++ b/examples/12.1.2/docs/angular/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.2/docs/js/basic-example/README.md
+++ b/examples/12.1.2/docs/js/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.2/docs/js/demo/README.md
+++ b/examples/12.1.2/docs/js/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.2/docs/react/basic-example/README.md
+++ b/examples/12.1.2/docs/react/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.2/docs/react/demo/README.md
+++ b/examples/12.1.2/docs/react/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.2/docs/ts/demo/README.md
+++ b/examples/12.1.2/docs/ts/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.2/docs/vue/basic-example/README.md
+++ b/examples/12.1.2/docs/vue/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.2/docs/vue/demo/README.md
+++ b/examples/12.1.2/docs/vue/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.3/docs/angular-10/basic-example/README.md
+++ b/examples/12.1.3/docs/angular-10/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.3/docs/angular-10/demo/README.md
+++ b/examples/12.1.3/docs/angular-10/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.3/docs/angular-11/basic-example/README.md
+++ b/examples/12.1.3/docs/angular-11/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.3/docs/angular-11/demo/README.md
+++ b/examples/12.1.3/docs/angular-11/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.3/docs/angular-12/basic-example/README.md
+++ b/examples/12.1.3/docs/angular-12/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.3/docs/angular-12/demo/README.md
+++ b/examples/12.1.3/docs/angular-12/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.3/docs/angular-13/basic-example/README.md
+++ b/examples/12.1.3/docs/angular-13/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.3/docs/angular-13/demo/README.md
+++ b/examples/12.1.3/docs/angular-13/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.3/docs/angular-9/basic-example/README.md
+++ b/examples/12.1.3/docs/angular-9/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.3/docs/angular-9/demo/README.md
+++ b/examples/12.1.3/docs/angular-9/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.3/docs/angular/basic-example/README.md
+++ b/examples/12.1.3/docs/angular/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.3/docs/angular/demo/README.md
+++ b/examples/12.1.3/docs/angular/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.3/docs/js/basic-example/README.md
+++ b/examples/12.1.3/docs/js/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.3/docs/js/demo/README.md
+++ b/examples/12.1.3/docs/js/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.3/docs/react/basic-example/README.md
+++ b/examples/12.1.3/docs/react/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.3/docs/react/demo/README.md
+++ b/examples/12.1.3/docs/react/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.3/docs/ts/demo/README.md
+++ b/examples/12.1.3/docs/ts/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.3/docs/vue/basic-example/README.md
+++ b/examples/12.1.3/docs/vue/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/12.1.3/docs/vue/demo/README.md
+++ b/examples/12.1.3/docs/vue/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/8.4.0/docs/angular/basic-example/README.md
+++ b/examples/8.4.0/docs/angular/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/8.4.0/docs/js/basic-example/README.md
+++ b/examples/8.4.0/docs/js/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/8.4.0/docs/react/basic-example/README.md
+++ b/examples/8.4.0/docs/react/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/8.4.0/docs/vue/basic-example/README.md
+++ b/examples/8.4.0/docs/vue/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/9.0.0/docs/angular/basic-example/README.md
+++ b/examples/9.0.0/docs/angular/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/9.0.0/docs/js/basic-example/README.md
+++ b/examples/9.0.0/docs/js/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/9.0.0/docs/react/basic-example/README.md
+++ b/examples/9.0.0/docs/react/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/9.0.0/docs/vue/basic-example/README.md
+++ b/examples/9.0.0/docs/vue/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/9.0.1/docs/angular/basic-example/README.md
+++ b/examples/9.0.1/docs/angular/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/9.0.1/docs/js/basic-example/README.md
+++ b/examples/9.0.1/docs/js/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/9.0.1/docs/react/basic-example/README.md
+++ b/examples/9.0.1/docs/react/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/9.0.1/docs/vue/basic-example/README.md
+++ b/examples/9.0.1/docs/vue/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/9.0.2/docs/angular/basic-example/README.md
+++ b/examples/9.0.2/docs/angular/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/9.0.2/docs/js/basic-example/README.md
+++ b/examples/9.0.2/docs/js/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/9.0.2/docs/react/basic-example/README.md
+++ b/examples/9.0.2/docs/react/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/9.0.2/docs/vue/basic-example/README.md
+++ b/examples/9.0.2/docs/vue/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/next/docs/angular-10/basic-example/README.md
+++ b/examples/next/docs/angular-10/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/next/docs/angular-10/demo/README.md
+++ b/examples/next/docs/angular-10/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/next/docs/angular-11/basic-example/README.md
+++ b/examples/next/docs/angular-11/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/next/docs/angular-11/demo/README.md
+++ b/examples/next/docs/angular-11/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/next/docs/angular-12/basic-example/README.md
+++ b/examples/next/docs/angular-12/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/next/docs/angular-12/demo/README.md
+++ b/examples/next/docs/angular-12/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/next/docs/angular-13/basic-example/README.md
+++ b/examples/next/docs/angular-13/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/next/docs/angular-13/demo/README.md
+++ b/examples/next/docs/angular-13/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/next/docs/angular-9/basic-example/README.md
+++ b/examples/next/docs/angular-9/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/next/docs/angular-9/demo/README.md
+++ b/examples/next/docs/angular-9/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/next/docs/angular/basic-example/README.md
+++ b/examples/next/docs/angular/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/next/docs/angular/demo/README.md
+++ b/examples/next/docs/angular/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/next/docs/js/basic-example/README.md
+++ b/examples/next/docs/js/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/next/docs/js/demo/README.md
+++ b/examples/next/docs/js/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/next/docs/react/basic-example/README.md
+++ b/examples/next/docs/react/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/next/docs/react/demo/README.md
+++ b/examples/next/docs/react/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/next/docs/ts/demo/README.md
+++ b/examples/next/docs/ts/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/next/docs/vue/basic-example/README.md
+++ b/examples/next/docs/vue/basic-example/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/next/docs/vue/demo/README.md
+++ b/examples/next/docs/vue/demo/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/templates/angular/README.md
+++ b/examples/templates/angular/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/templates/js/README.md
+++ b/examples/templates/js/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/templates/react/README.md
+++ b/examples/templates/react/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).

--- a/examples/templates/vue/README.md
+++ b/examples/templates/vue/README.md
@@ -32,6 +32,8 @@ Handsontable is a commercial software with two licenses available:
 - Free for non-commercial purposes such as teaching, academic research, and evaluation. [Read it here](https://github.com/handsontable/handsontable/blob/master/handsontable-non-commercial-license.pdf).
 - Commercial license with support and maintenance included. See [pricing plans](https://handsontable.com/pricing).
 
-## Contact support
+## Technical support
 
-We provide support for all users through [GitHub issues](https://github.com/handsontable/handsontable/issues). If you have a commercial license then you can add a new ticket through the [contact form](https://handsontable.com/contact?category=technical_support).
+If you have a commercial license and your support plan is active, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+We also support free-tier users through [GitHub issues](https://github.com/handsontable/handsontable/issues).


### PR DESCRIPTION
This PR:
- Adds the **Technical Support Team** name across the project

[skip changelog]