### PR TITLE
Fix tip flickering about the latest version

### DIFF
--- a/docs/.vuepress/theme/layouts/Layout.vue
+++ b/docs/.vuepress/theme/layouts/Layout.vue
@@ -29,7 +29,8 @@ export default {
   },
   computed: {
     show() {
-      return this.$page.currentVersion !== this.$page.latestVersion && this.$page.currentVersion !== 'next';
+      return this.$page.latestVersion && this.$page.currentVersion !== this.$page.latestVersion &&
+        this.$page.currentVersion !== 'next';
     }
   },
   created() {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the tip about the latest version flickering. There is an added additional check for the `this.$page.latestVersion` property that is [assigned asynchronously](https://github.com/handsontable/handsontable/blob/feature/issue-10058/docs/.vuepress/enhanceApp.js#L86) after the Docs is loaded. This asynchronicity causes flickering.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the bug using the `npm run docs:build` command. On watch mode the issue does not exist.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes #10058

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
