### PR TITLE
Update jwalton/gh-find-current-pr and

### DIFF
--- a/.github/workflows/code-examples.yml
+++ b/.github/workflows/code-examples.yml
@@ -54,7 +54,7 @@ env:
 jobs:
   prepare-matrix:
     name: Prepare the version Matrix and cache dependencies.
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     outputs:
       versions: ${{ steps.get-dispatch-value.outputs.matrix || steps.prepare-version-matrix.outputs.matrix }}
@@ -330,7 +330,7 @@ jobs:
       needs.build-vue.result != 'failure' &&
       needs.build-vue3.result != 'failure' &&
       needs.prepare-matrix.outputs.versions != '[]'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
@@ -508,7 +508,7 @@ jobs:
       always() &&
       (github.ref == 'refs/heads/develop' || github.event_name == 'workflow_dispatch') &&
       needs.install-and-build.result == 'success'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout gh-pages branch to "./examples/tmp".

--- a/.github/workflows/docs-staging.yml
+++ b/.github/workflows/docs-staging.yml
@@ -64,15 +64,12 @@ jobs:
           docker push ${GHA_DOCKER_TAG_SHA}
 
       - name: Find PR
-        uses: jwalton/gh-find-current-pr@b6f8d7342efe4913388d5d1ac7f4b956caa5db52 # https://github.com/jwalton/gh-find-current-pr/tree/v1
+        uses: jwalton/gh-find-current-pr@7ada613939e2a233c83a1320679446fa1c6bdcb9 # https://github.com/jwalton/gh-find-current-pr/tree/v1.3.2
         id: pr-finder
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish sticky comment in PR
-        uses: marocchino/sticky-pull-request-comment@6804b5ad49d19c10c9ae7cf5057352f7ff333f31 # https://github.com/marocchino/sticky-pull-request-comment/tree/v1.6.0
+        uses: marocchino/sticky-pull-request-comment@adca94abcaf73c10466a71cc83ae561fd66d1a56 # https://github.com/marocchino/sticky-pull-request-comment/tree/v2.3.0
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           number: ${{ steps.pr-finder.outputs.pr }}
           message: |
             Launch the local version of documentation by running:

--- a/docs/content/guides/accessories-and-menus/context-menu.md
+++ b/docs/content/guides/accessories-and-menus/context-menu.md
@@ -18,6 +18,8 @@ searchCategory: Guides
 
 Open a right-click context menu to access contextual actions such as removing rows, inserting columns, or copying data to the clipboard.
 
+test
+
 [[toc]]
 
 ## Context menu with default options

--- a/docs/content/guides/accessories-and-menus/context-menu.md
+++ b/docs/content/guides/accessories-and-menus/context-menu.md
@@ -18,8 +18,6 @@ searchCategory: Guides
 
 Open a right-click context menu to access contextual actions such as removing rows, inserting columns, or copying data to the clipboard.
 
-test
-
 [[toc]]
 
 ## Context menu with default options


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR updates the following GH workflow actions:
 * [jwalton/gh-find-current-pr](https://github.com/jwalton/gh-find-current-pr);
 * [marocchino/sticky-pull-request-commen](https://github.com/marocchino/sticky-pull-request-comment);

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
The workflow [added the comment](https://github.com/handsontable/handsontable/pull/10077#issuecomment-1294857927) below so I guess it works.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. related to #10037
2. continuation of #10040

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
