### PR TITLE
Implement ResizeObserver to the table's root element

### DIFF
--- a/handsontable/src/3rdparty/walkontable/src/overlays.js
+++ b/handsontable/src/3rdparty/walkontable/src/overlays.js
@@ -82,6 +82,15 @@ class Overlays {
   wtSettings = null;
 
   /**
+   * The instance of the ResizeObserver that observes the size of the Walkontable wrapper element.
+   * In case of the size change detection the `onContainerElementResize` is fired.
+   *
+   * @private
+   * @type {ResizeObserver}
+   */
+  resizeObserver = new ResizeObserver(() => this.wtSettings.getSetting('onContainerElementResize'));
+
+  /**
    * @param {Walkontable} wotInstance The Walkontable instance. @todo refactoring remove.
    * @param {FacadeGetter} facadeGetter Function which return proper facade.
    * @param {DomBindings} domBindings Bindings into DOM.
@@ -293,6 +302,10 @@ class Overlays {
         this.wtSettings.getSetting('onWindowResize');
       }, 200);
     });
+
+    if (!isScrollOnWindow) {
+      this.resizeObserver.observe(this.wtTable.wtRootElement.parentElement);
+    }
   }
 
   /**
@@ -511,6 +524,7 @@ class Overlays {
    *
    */
   destroy() {
+    this.resizeObserver.disconnect();
     this.eventManager.destroy();
     // todo, probably all below `destory` calls has no sense. To analyze
     this.topOverlay.destroy();

--- a/handsontable/src/3rdparty/walkontable/src/settings.js
+++ b/handsontable/src/3rdparty/walkontable/src/settings.js
@@ -216,6 +216,7 @@ export default class Settings {
       onBeforeHighlightingColumnHeader: sourceCol => sourceCol,
 
       onWindowResize: null,
+      onContainerElementResize: null,
 
       renderAllRows: false,
       groups: false,

--- a/handsontable/src/tableView.js
+++ b/handsontable/src/tableView.js
@@ -695,11 +695,14 @@ class TableView {
       selections: this.instance.selection.highlight,
       hideBorderOnMouseDownOver: () => this.settings.fragmentSelection,
       onWindowResize: () => {
-        if (!this.instance || this.instance.isDestroyed) {
-          return;
+        if (this.instance && !this.instance.isDestroyed) {
+          this.instance.refreshDimensions();
         }
-
-        this.instance.refreshDimensions();
+      },
+      onContainerElementResize: () => {
+        if (this.instance && !this.instance.isDestroyed) {
+          this.instance.refreshDimensions();
+        }
       },
       onCellMouseDown: (event, coords, TD, wt) => {
         const visualCoords = this.translateFromRenderableToVisualCoords(coords);


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the issue related to the UI glitches that happened while expanding Handsontable's root element from the outside. Or expanding the window size that is caused by the context menu or dropdown menu within the iframe.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. fixes #9580

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
