### PR TITLE
Changed structure for version's drop-down menu & styled the element properly #10088

### DIFF
--- a/docs/.vuepress/theme/components/DropdownLink.vue
+++ b/docs/.vuepress/theme/components/DropdownLink.vue
@@ -177,6 +177,7 @@ export default {
       &:hover
         color $accentColor
   .nav-dropdown
+    list-style none
     .dropdown-item
       color inherit
       line-height 1.7rem

--- a/docs/.vuepress/theme/components/DropdownLink.vue
+++ b/docs/.vuepress/theme/components/DropdownLink.vue
@@ -180,9 +180,10 @@ export default {
         color $accentColor
   .nav-dropdown
     list-style none
-    .dropdown-item
-      color inherit
+    li.dropdown-item, li.dropdown-subitem
       line-height 1.7rem
+      color inherit
+    .dropdown-item
       h4
         margin 0.45rem 0 0
         border-top 1px solid #eee
@@ -200,7 +201,6 @@ export default {
             opacity: .6
       a
         display block
-        line-height 1.7rem
         position relative
         border-bottom none
         font-weight 400

--- a/docs/.vuepress/theme/components/DropdownLink.vue
+++ b/docs/.vuepress/theme/components/DropdownLink.vue
@@ -61,23 +61,12 @@
             </li>
           </ul>
 
-          <a
-            class="nav-link"
-            :href="subItem.link"
-            @click="itemClick(subItem)"
+          <NavLink
+            v-else
+            :item="subItem"
+            @click.native="itemClick(subItem)"
             @focusout="isLastItemOfArray(subItem, item.items) && setOpen(false)"
-          >
-            <ul
-              class="dropdown-subitem-wrapper font-normal"
-            >
-              <li class="dropdown-subitem">{{ subItem.text }}</li>
-              <li v-for="childSubItem in subItem.subitems"
-                  class="dropdown-subitem intend"
-              >
-                {{ childSubItem}}
-              </li>
-            </ul>
-          </a>
+          />
         </li>
       </ul>
     </DropdownTransition>
@@ -180,10 +169,9 @@ export default {
         color $accentColor
   .nav-dropdown
     list-style none
-    li.dropdown-item, li.dropdown-subitem
-      line-height 1.7rem
-      color inherit
     .dropdown-item
+      color inherit
+      line-height 1.7rem
       h4
         margin 0.45rem 0 0
         border-top 1px solid #eee
@@ -191,16 +179,11 @@ export default {
       .dropdown-subitem-wrapper
         padding 0
         list-style none
-        &.font-normal .dropdown-subitem
-          font-size: inherit;
         .dropdown-subitem
           font-size 0.9em
-          &.intend
-            position: relative;
-            left: 1.5rem;
-            opacity: .6
       a
         display block
+        line-height 1.7rem
         position relative
         border-bottom none
         font-weight 400

--- a/docs/.vuepress/theme/components/NavLink.vue
+++ b/docs/.vuepress/theme/components/NavLink.vue
@@ -16,7 +16,22 @@
     :rel="rel"
     @focusout="focusoutAction"
   >
-    {{ item.text }}
+    <section v-if="item.subTexts?.length">
+      <p>{{ item.text }}</p>
+      <ul>
+        <li
+          v-for="(subText, i) in item.subTexts"
+          :key="i"
+          class="subtext"
+        >
+          {{ subText  }}
+        </li>
+      </ul>
+    </section>
+
+    <template v-else>
+      {{ item.text }}
+    </template>
     <OutboundLink v-if="isBlankTarget" />
   </a>
 </template>
@@ -95,3 +110,16 @@ export default {
   }
 };
 </script>
+
+<style lang="stylus">
+  section
+    p
+      margin 0
+    ul
+      list-style none
+      padding 0
+      li.subtext
+        position: relative;
+        left: 1.5rem;
+        opacity: .6
+</style>

--- a/docs/.vuepress/theme/components/NavLink.vue
+++ b/docs/.vuepress/theme/components/NavLink.vue
@@ -16,7 +16,7 @@
     :rel="rel"
     @focusout="focusoutAction"
   >
-    <section v-if="item.subTexts?.length">
+    <section v-if="item.subTexts && item.subTexts.length">
       <p>{{ item.text }}</p>
       <ul>
         <li

--- a/docs/.vuepress/theme/components/VersionsDropdown.vue
+++ b/docs/.vuepress/theme/components/VersionsDropdown.vue
@@ -50,11 +50,11 @@ export default {
       items:
         [
           ...Array.from(this.$page.versionsWithPatches.keys()).map(v => ({
-            text: `${this.addLatest(v, false)}`,
+            text: v,
+            subTexts: this.$page.versionsWithPatches.get(v),
             link: this.getLink(v),
             target: '_self',
             isHtmlLink: true,
-            subitems: this.$page.versionsWithPatches.get(v),
           })),
         ]
     };


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
PR #10079 introduced some changes which add an extra `ul` element. So far existing `li.dropdown-item` has been a simple `<li>` with text. After the changes, it became `<li>` containing an extra `<ul>` which shows nested versions. It also has added some spacing for nested `<li>` elements.

This PR put the newly created `<ul>` element into `<section>` and achieved nesting elements by extending `NavLink` component. It seems to be much more clear approach.

[skip changelog]

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Tested locally, using cases from the issue.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #10014
2. #10088
