### PR TITLE
Reverts part of code incorrectly deleted #10087

### DIFF
--- a/docs/.vuepress/theme/components/DropdownLink.vue
+++ b/docs/.vuepress/theme/components/DropdownLink.vue
@@ -64,6 +64,8 @@
           <a
             class="nav-link"
             :href="subItem.link"
+            @click="itemClick(subItem)"
+            @focusout="isLastItemOfArray(subItem, item.items) && setOpen(false)"
           >
             <ul
               class="dropdown-subitem-wrapper font-normal"


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Reverted part of code not intentionally removed by [the commit](https://github.com/handsontable/handsontable/pull/10079/files#diff-a7e72ce51c0baa2e9ebd04dcaa3bdad9b3cf9a93f820f29461fe321847589e78L67-L68). The only change is using `@click` instead of `@click.native` as introduced `a` tag is native element, not a component.

[skip changelog]

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Tested locally, checking cookies.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #10014
2. #10087