### PR TITLE
Fixed problem with not showing the latest patch version

### DIFF
--- a/docs/.vuepress/theme/components/VersionsDropdown.vue
+++ b/docs/.vuepress/theme/components/VersionsDropdown.vue
@@ -25,7 +25,7 @@ export default {
 
       if (version === latestMinor) {
         if (version !== 'next') {
-          version = this.$page.versionsWithPatches.get(latestMinor)[0]; // Latest patch.
+          version = this.$page.versionsWithPatches.get(latestMinor)[0]; // Latest version in a format major.minor.patch
         }
 
         return `${version} (Latest)`;

--- a/docs/.vuepress/theme/components/VersionsDropdown.vue
+++ b/docs/.vuepress/theme/components/VersionsDropdown.vue
@@ -20,15 +20,12 @@ export default {
     };
   },
   methods: {
-    addLatest(version, showPatch) {
+    addLatest(version) {
       const latestMinor = this.$page.latestVersion;
 
       if (version === latestMinor) {
-        const patches = this.$page.versionsWithPatches.get(latestMinor);
-
-        // It will show patches only when we have at least two versions for certain minor.
-        if (showPatch === true && patches?.length > 1) {
-          version = patches[0];
+        if (version !== 'next') {
+          version = this.$page.versionsWithPatches.get(latestMinor)[0]; // Latest patch.
         }
 
         return `${version} (Latest)`;
@@ -46,7 +43,7 @@ export default {
   },
   mounted() {
     this.item = {
-      text: this.addLatest(this.$page.currentVersion, true),
+      text: this.addLatest(this.$page.currentVersion),
       items:
         [
           ...Array.from(this.$page.versionsWithPatches.keys()).map(v => ({


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
@krzysztofspilka found that one requirement isn't met.

`We want to show the full version number in the nav bar - instead of 12.1 (Latest), it should be 12.1.3 (Latest).`

<table>
<tr>
	<td>Is (handsontable.com)
	<td>Should be
<tr>
	<td><img src="https://user-images.githubusercontent.com/141330/200790912-d1a53aec-d901-40f0-9e3c-fe0b5d7f06be.png">
	<td><img src="https://user-images.githubusercontent.com/141330/200790907-b8642b12-4626-4dfc-837e-7de53f3a0d4c.png">
</table>

It's effect of bug. Already created conditional has been used for excluding getting patches for `next` version. Current code, do the same simply.

For tests I've changed two places in config.

From

https://github.com/handsontable/handsontable/blob/66ae9dbd78d83e72cc14775a7c5c9377e012f5ae/docs/.vuepress/enhanceApp.js#L85

To

```js
page.latestVersion = '12.2';
 ```

From

https://github.com/handsontable/handsontable/blob/a4cb5f96e2f15e48051379739ca52a0dd7eb0366/docs/.vuepress/helpers.js#L58-L70

To

```js
function getThisDocsVersion() {
  return `12.2`;

  if (docsVersion === null) {
    const branchName = execa.sync('git rev-parse --abbrev-ref HEAD', { shell: true }).stdout;

    if (versionFromBranchRegExp.test(branchName)) {
      docsVersion = branchName.match(versionFromBranchRegExp)[1];
    } else {
      docsVersion = 'next';
    }
  }

  return docsVersion;
}
```

[skip changelog]