### PR TITLE
Docs: Expand `getRowHeight()` API ref

### DIFF
--- a/docs/content/guides/getting-started/grid-size.md
+++ b/docs/content/guides/getting-started/grid-size.md
@@ -256,7 +256,12 @@ ReactDOM.render(<ExampleComponent />, document.getElementById('example'));
 :::
 
 
-## Related API reference
+## Related articles
+
+- [Column widths](@/guides/columns/column-width.md)
+- [Row heights](@/guides/rows/row-height.md)
+
+**Related API reference**
 
 - Configuration options:
   - [`height`](@/api/options.md#height)

--- a/docs/content/guides/rows/row-height.md
+++ b/docs/content/guides/rows/row-height.md
@@ -28,9 +28,9 @@ Configure row heights, using a number, an array or a function. Let your users ma
 
 ## Overview
 
-The default (and minimum) row height is 23 px (22 px + 1 px of the row's bottom border). Unless configured otherwise, Handsontable assumes that the contents of your cells fit in this default row height.
+The default (and minimum) row height is 23 px (22 px + 1 px of the row's bottom border). Unless configured otherwise, Handsontable assumes that your cell contents fit in this default row height.
 
-If the contents of your cells require heights greater than the default 23 px (because you use multiline text, or [custom renderers](@/guides/cell-functions/cell-renderer.md#), or custom styles), use one of the following configurations to avoid potential layout problems:
+If your cell contents require heights greater than the default 23 px (because you use multiline text, or [custom renderers](@/guides/cell-functions/cell-renderer.md#), or custom styles), use one of the following configurations to avoid potential layout problems:
   - Configure your row heights in advance: set the [`rowHeights`](@/api/options.md#rowheights) option to a [number](#set-row-heights-to-a-number), or an [array](#set-row-heights-with-an-array), or a [function](#set-row-heights-with-a-function). This requires you to know the heights beforehand, but results in the best runtime performance.
   - Set the [`manualRowResize`](@/api/options.md#manualrowresize) option to an array, to configure initial row heights and let your users [adjust the row heights manually](#adjust-row-heights-manually).
   - Enable the [`AutoRowSize`](@/api/autoRowSize.md) plugin, by setting `autoRowSize: true`. This tells Handsontable to measure the actual row heights in the DOM. It impacts runtime performance but is accurate.

--- a/docs/content/guides/rows/row-height.md
+++ b/docs/content/guides/rows/row-height.md
@@ -30,7 +30,7 @@ Configure row heights, using a number, an array or a function. Let your users ma
 
 By default, the height of a row adjusts to the height of the content. The content gets wrapped if it doesn't fit the cell's size. The default (and minimum) row height is 23 px (22 px + 1 px of the row's bottom border).
 
-If your rows will different heights than the default (because you use multiline text, or [custom renderers](@/guides/cell-functions/cell-renderer.md#), or custom styles), do one of the following:
+If your rows will have different heights than the default (because you use multiline text, or [custom renderers](@/guides/cell-functions/cell-renderer.md#), or custom styles), do one of the following:
   - Configure your row heights in advance:  set the [`rowHeights`](@/api/options.md#rowheights) option to a [number](#set-row-heights-to-a-number), or an [array](#set-row-heights-with-an-array), or a [function](#set-row-heights-with-a-function). This requires you to know the heights beforehand, but results in the best runtime performance.
   - Set the [`manualRowResize`](@/api/options.md#manualrowresize) option to an array, to configure initial row heights and let your users [adjust the row heights manually](#adjust-row-heights-manually).
   - Enable the [`AutoRowSize`](@/api/autoRowSize.md) plugin, by setting `autoRowSize: true`. This tells Handsontable to measure the actual row heights in the DOM. It impacts runtime performance but is accurate.

--- a/docs/content/guides/rows/row-height.md
+++ b/docs/content/guides/rows/row-height.md
@@ -28,11 +28,14 @@ Configure row heights, using a number, an array or a function. Let your users ma
 
 ## Overview
 
-By default, the height of a row adjusts to the height of the content. The minimum height is `23px`. The row height can be passed as a `constant`, an `array`, or a `function`.
+By default, the height of a row adjusts to the height of the content. The content gets wrapped if it doesn't fit the cell's size. The default (and minimum) row height is 23 px (22 px + 1 px of the row's bottom border).
 
-The content inside a cell gets wrapped if it doesn't fit the cell's size.
+If your rows will different heights than the default (because you use multiline text, or [custom renderers](@/guides/cell-functions/cell-renderer.md#), or custom styles), do one of the following:
+  - Configure your row heights in advance:  set the [`rowHeights`](@/api/options.md#rowheights) option to a [number](#set-row-heights-to-a-number), or an [array](#set-row-heights-with-an-array), or a [function](#set-row-heights-with-a-function). This requires you to know the heights beforehand, but results in the best runtime performance.
+  - Set the [`manualRowResize`](@/api/options.md#manualrowresize) option to an array, to configure initial row heights and let your users [adjust the row heights manually](#adjust-row-heights-manually).
+  - Enable the [`AutoRowSize`](@/api/autoRowSize.md) plugin, by setting `autoRowSize: true`. This tells Handsontable to measure the actual row heights in the DOM. It impacts runtime performance but is accurate.
 
-## Set the row height as a constant
+## Set row heights to a number
 
 We set the same height of `40px` for all rows across the entire grid in this example.
 
@@ -98,7 +101,7 @@ ReactDOM.render(<ExampleComponent />, document.getElementById('example1'));
 :::
 
 
-## Set the row height in an array
+## Set row heights with an array
 
 In this example, the height is only set for the first rows. Each additional row would be automatically adjusted to the content.
 
@@ -166,7 +169,7 @@ ReactDOM.render(<ExampleComponent />, document.getElementById('example2'));
 :::
 
 
-## Set the row height using a function
+## Set row heights with a function
 
 The row height can be set using a function. In this example, the size of all rows is set using a function that takes a row `index` (1, 2 ...) and multiplies it by `20px` for each consecutive row.
 
@@ -235,8 +238,7 @@ ReactDOM.render(<ExampleComponent />, document.getElementById('example3'));
 :::
 :::
 
-
-## Adjust the row height manually
+## Adjust row heights manually
 
 Set the option [`manualRowResize`](@/api/options.md#manualrowresize) to `true` to allow users to manually resize the row height by dragging the handle between the adjacent row headers. Don't forget to enable row headers by setting [`rowHeaders`](@/api/options.md#rowheaders) to `true`.
 
@@ -305,11 +307,11 @@ ReactDOM.render(<ExampleComponent />, document.getElementById('example4'));
 :::
 :::
 
-
 ## Related API reference
 
 - Configuration options:
   - [`autoRowSize`](@/api/options.md#autorowsize)
+  - [`manualRowResize`](@/api/options.md#manualrowresize)
   - [`rowHeights`](@/api/options.md#rowheights)
 - Core methods:
   - [`getRowHeight()`](@/api/core.md#getrowheight)

--- a/docs/content/guides/rows/row-height.md
+++ b/docs/content/guides/rows/row-height.md
@@ -30,7 +30,7 @@ Configure row heights, using a number, an array or a function. Let your users ma
 
 By default, the height of a row adjusts to the height of the content. The content gets wrapped if it doesn't fit the cell's size. The default (and minimum) row height is 23 px (22 px + 1 px of the row's bottom border).
 
-If your rows will have different heights than the default (because you use multiline text, or [custom renderers](@/guides/cell-functions/cell-renderer.md#), or custom styles), do one of the following:
+If your rows have different heights than the default 23 px (because you use multiline text, or [custom renderers](@/guides/cell-functions/cell-renderer.md#), or custom styles), do one of the following:
   - Configure your row heights in advance:  set the [`rowHeights`](@/api/options.md#rowheights) option to a [number](#set-row-heights-to-a-number), or an [array](#set-row-heights-with-an-array), or a [function](#set-row-heights-with-a-function). This requires you to know the heights beforehand, but results in the best runtime performance.
   - Set the [`manualRowResize`](@/api/options.md#manualrowresize) option to an array, to configure initial row heights and let your users [adjust the row heights manually](#adjust-row-heights-manually).
   - Enable the [`AutoRowSize`](@/api/autoRowSize.md) plugin, by setting `autoRowSize: true`. This tells Handsontable to measure the actual row heights in the DOM. It impacts runtime performance but is accurate.

--- a/docs/content/guides/rows/row-height.md
+++ b/docs/content/guides/rows/row-height.md
@@ -28,10 +28,10 @@ Configure row heights, using a number, an array or a function. Let your users ma
 
 ## Overview
 
-By default, the height of a row adjusts to the height of the content. The content gets wrapped if it doesn't fit the cell's size. The default (and minimum) row height is 23 px (22 px + 1 px of the row's bottom border).
+The default (and minimum) row height is 23 px (22 px + 1 px of the row's bottom border). Unless configured otherwise, Handsontable assumes that the contents of your cells fit in this default row height.
 
-If your rows have different heights than the default 23 px (because you use multiline text, or [custom renderers](@/guides/cell-functions/cell-renderer.md#), or custom styles), do one of the following:
-  - Configure your row heights in advance:  set the [`rowHeights`](@/api/options.md#rowheights) option to a [number](#set-row-heights-to-a-number), or an [array](#set-row-heights-with-an-array), or a [function](#set-row-heights-with-a-function). This requires you to know the heights beforehand, but results in the best runtime performance.
+If the contents of your cells require heights greater than the default 23 px (because you use multiline text, or [custom renderers](@/guides/cell-functions/cell-renderer.md#), or custom styles), use one of the following configurations to avoid potential layout problems:
+  - Configure your row heights in advance: set the [`rowHeights`](@/api/options.md#rowheights) option to a [number](#set-row-heights-to-a-number), or an [array](#set-row-heights-with-an-array), or a [function](#set-row-heights-with-a-function). This requires you to know the heights beforehand, but results in the best runtime performance.
   - Set the [`manualRowResize`](@/api/options.md#manualrowresize) option to an array, to configure initial row heights and let your users [adjust the row heights manually](#adjust-row-heights-manually).
   - Enable the [`AutoRowSize`](@/api/autoRowSize.md) plugin, by setting `autoRowSize: true`. This tells Handsontable to measure the actual row heights in the DOM. It impacts runtime performance but is accurate.
 

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -3762,21 +3762,16 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
   /**
    * Returns a row's height, as recognized by Handsontable.
    *
-   * Depending on your configuration, the method may return:
-   *   - The row height set by the [`ManualRowResize`](@/api/manualRowResize.md) plugin
+   * Depending on your configuration, the method returns (in order of priority):
+   *   1. The row height set by the [`ManualRowResize`](@/api/manualRowResize.md) plugin
    *     (if the plugin is enabled).
-   *   - The row height set by the [`rowHeights`](@/api/options.md#rowheights) configuration option
+   *   2. The row height set by the [`rowHeights`](@/api/options.md#rowheights) configuration option
    *     (if the option is set).
-   *   - The row height as measured in the DOM by the [`AutoRowSize`](@/api/autoRowSize.md) plugin
+   *   3. The row height as measured in the DOM by the [`AutoRowSize`](@/api/autoRowSize.md) plugin
    *     (if the plugin is enabled).
-   *   - `undefined`, if neither [`ManualRowResize`](@/api/manualRowResize.md),
+   *   4. `undefined`, if neither [`ManualRowResize`](@/api/manualRowResize.md),
    *     nor [`rowHeights`](@/api/options.md#rowheights),
    *     nor [`AutoRowSize`](@/api/autoRowSize.md) is used.
-   *
-   * The order of priority:
-   *   1. [`ManualRowResize`](@/api/manualRowResize.md)
-   *   2. [`rowHeights`](@/api/options.md#rowheights)
-   *   3. [`AutoRowSize`](@/api/autoRowSize.md)
    *
    * The height returned includes 1 px of the row's bottom border.
    *

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -3760,14 +3760,34 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
   };
 
   /**
-   * Returns the row height.
+   * Returns a row's height, as recognized by Handsontable.
    *
-   * Mind that this method is different from the [AutoRowSize](@/api/autoRowSize.md) plugin's [`getRowHeight()`](@/api/autoRowSize.md#getrowheight) method.
+   * Depending on your configuration, the method may return:
+   *   - The row height set by the [`ManualRowResize`](@/api/manualRowResize.md) plugin
+   *     (if the plugin is enabled).
+   *   - The row height set by the [`rowHeights`](@/api/options.md#rowheights) configuration option
+   *     (if the option is set).
+   *   - The row height as measured in the DOM by the [`AutoRowSize`](@/api/autoRowSize.md) plugin
+   *     (if the plugin is enabled).
+   *   - `undefined`, if neither [`ManualRowResize`](@/api/manualRowResize.md),
+   *     nor [`rowHeights`](@/api/options.md#rowheights),
+   *     nor [`AutoRowSize`](@/api/autoRowSize.md) is used.
+   *
+   * The order of priority:
+   *   1. [`ManualRowResize`](@/api/manualRowResize.md)
+   *   2. [`rowHeights`](@/api/options.md#rowheights)
+   *   3. [`AutoRowSize`](@/api/autoRowSize.md)
+   *
+   * The height returned includes 1 px of the row's bottom border.
+   *
+   * Mind that this method is different from the
+   * [`getRowHeight()`](@/api/autoRowSize.md#getrowheight) method
+   * of the [`AutoRowSize`](@/api/autoRowSize.md) plugin.
    *
    * @memberof Core#
    * @function getRowHeight
-   * @param {number} row Visual row index.
-   * @returns {number} The given row's height.
+   * @param {number} row A visual row index.
+   * @returns {number|undefined} The height of the specified row, in pixels.
    * @fires Hooks#modifyRowHeight
    */
   this.getRowHeight = function(row) {

--- a/handsontable/src/dataMap/metaManager/metaSchema.js
+++ b/handsontable/src/dataMap/metaManager/metaSchema.js
@@ -3713,7 +3713,7 @@ export default () => {
     /**
      * The `rowHeights` option sets rows' heights, in pixels.
      *
-     * In the rendering process, the default row height is 23px.
+     * In the rendering process, the default row height is 23 px (22 px + 1 px of the row's bottom border).
      * You can change it to equal or greater than 23px, by setting the `rowHeights` option to one of the following:
      *
      * | Setting     | Description                                                                                         | Example                                                      |

--- a/handsontable/src/plugins/autoRowSize/autoRowSize.js
+++ b/handsontable/src/plugins/autoRowSize/autoRowSize.js
@@ -399,13 +399,17 @@ export class AutoRowSize extends BasePlugin {
   }
 
   /**
-   * Gets the calculated row height.
+   * Get a row's height, as measured in the DOM.
    *
-   * Mind that this method is different from the [Core](@/api/core.md)'s [`getRowHeight()`](@/api/core.md#getrowheight) method.
+   * The height returned includes 1 px of the row's bottom border.
    *
-   * @param {number} row Visual row index.
-   * @param {number} [defaultHeight] Default row height. It will be picked up if no calculated height found.
-   * @returns {number}
+   * Mind that this method is different from the
+   * [`getRowHeight()`](@/api/core.md#getrowheight) method
+   * of Handsontable's [Core](@/api/core.md).
+   *
+   * @param {number} row A visual row index.
+   * @param {number} [defaultHeight] If no height is found, `defaultHeight` is returned instead.
+   * @returns {number} The height of the specified row, in pixels.
    */
   getRowHeight(row, defaultHeight = void 0) {
     const cachedHeight = row < 0 ? this.headerHeight : this.rowHeightsMap.getValueAtIndex(this.hot.toPhysicalRow(row));


### PR DESCRIPTION
This PR rewrites the API ref descriptions of the following methods:
- `getRowHeight()` (from the Core)
- `getRowHeight()` (from the `AutoRowSize` plugin)

### Affected content:
- https://handsontable.com/docs/javascript-data-grid/api/core/#getrowheight
- https://handsontable.com/docs/javascript-data-grid/api/auto-row-size/#getrowheight

### Input
- [Slack](https://handsoncode.slack.com/archives/C039R5SAB0U/p1666080099528589)
- https://github.com/handsontable/handsontable/issues/2822#issuecomment-1304655263

[skip changelog]