### PR TITLE
Comment editor will be shown properly, when comment had been added on fixed column and some scrolling was performed

### DIFF
--- a/.changelogs/9645.json
+++ b/.changelogs/9645.json
@@ -1,0 +1,7 @@
+{
+  "title": "Comment editor will be shown properly, when comment had been added on fixed column and some scrolling was performed",
+  "type": "fixed",
+  "issue": 9645,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/comments/__tests__/comments.spec.js
+++ b/handsontable/src/plugins/comments/__tests__/comments.spec.js
@@ -389,6 +389,32 @@ describe('Comments', () => {
     });
   });
 
+  it('should display the comment editor properly, when comment had been added on fixed column and some scrolling was performed', async() => {
+    const hot = handsontable({
+      data: Handsontable.helper.createSpreadsheetData(5, 20),
+      comments: true,
+      cell: [
+        { row: 0, col: 0, comment: { value: 'test' } },
+      ],
+      width: 300,
+      height: 200,
+      fixedColumnsStart: 5,
+    });
+
+    hot.scrollViewportTo(0, 19);
+
+    await sleep(10);
+
+    const plugin = hot.getPlugin('comments');
+    const editor = plugin.editor.getInputElement();
+
+    expect(plugin.getCommentAtCell(0, 0)).toEqual('test');
+
+    plugin.showAtCell(0, 0);
+
+    expect(editor.parentNode.style.display).toEqual('block');
+  });
+
   describe('API', () => {
     it('should return the comment from a proper cell, when using the getCommentAtCell method', () => {
       const hot = handsontable({

--- a/handsontable/src/plugins/comments/comments.js
+++ b/handsontable/src/plugins/comments/comments.js
@@ -468,6 +468,8 @@ export class Comments extends BasePlugin {
 
     const { rootWindow, view: { _wt: wt } } = this.hot;
     const { wtTable } = wt;
+    // TODO: Probably using `hot.getCell` would be the best. However, case for showing comment editor for hidden cell
+    // potentially should be removed with that change (currently a test for it is passing).
     const TD = wt.getCell({ row: renderableRow, col: renderableColumn }, true);
     const commentStyle = this.getCommentMeta(visualRow, visualColumn, META_STYLE);
 

--- a/handsontable/src/plugins/comments/comments.js
+++ b/handsontable/src/plugins/comments/comments.js
@@ -468,12 +468,7 @@ export class Comments extends BasePlugin {
 
     const { rootWindow, view: { _wt: wt } } = this.hot;
     const { wtTable } = wt;
-
-    const TD = wtTable.getCell({
-      row: renderableRow,
-      col: renderableColumn,
-    });
-
+    const TD = wt.getCell({ row: renderableRow, col: renderableColumn }, true);
     const commentStyle = this.getCommentMeta(visualRow, visualColumn, META_STYLE);
 
     if (commentStyle) {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
I investigated that we have some problems with showing a comment editor for the cell which is placed [on other overlays than the main](https://github.com/handsontable/handsontable/issues/9645#issuecomment-1307430838). Probably the best solution would be using `hot.getCell` method instead of `hot.view._wt`. Although, the current code is connected with a feature that allows showing a comment editor for hidden cells. Thus, I'm still using the Walkontable method and I've decided to not extend the task scope.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Tested case described in the issue

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #9645

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] My change requires a change to the documentation.
