### PR TITLE
Fix a problem with the dropdown-typed cells validation when using `HotColumn`.

### DIFF
--- a/.changelogs/10065.json
+++ b/.changelogs/10065.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fixed a problem with the dropdown-typed cells validation when using `HotColumn`.",
+  "type": "fixed",
+  "issue": 10065,
+  "breaking": false,
+  "framework": "react"
+}

--- a/wrappers/react/src/hotColumn.tsx
+++ b/wrappers/react/src/hotColumn.tsx
@@ -71,16 +71,6 @@ class HotColumn extends React.Component<HotColumnProps, {}> {
   }
 
   /**
-   * Check whether the HotColumn component contains a provided prop.
-   *
-   * @param {String} propName Property name.
-   * @returns {Boolean}
-   */
-  hasProp(propName: string): boolean {
-    return !!this.props[propName];
-  }
-
-  /**
    * Get the editor element for the current column.
    *
    * @returns {React.ReactElement} React editor component element.
@@ -101,22 +91,10 @@ class HotColumn extends React.Component<HotColumnProps, {}> {
     if (rendererElement !== null) {
       this.columnSettings.renderer = this.props._getRendererWrapper(rendererElement);
       this.props._componentRendererColumns.set(this.props._columnIndex, true);
-
-    } else if (this.hasProp('renderer')) {
-      this.columnSettings.renderer = this.props.renderer;
-
-    } else {
-      this.columnSettings.renderer = void 0;
     }
 
     if (editorElement !== null) {
       this.columnSettings.editor = this.props._getEditorClass(editorElement, this.props._columnIndex);
-
-    } else if (this.hasProp('editor')) {
-      this.columnSettings.editor = this.props.editor;
-
-    } else {
-      this.columnSettings.editor = void 0;
     }
   }
 

--- a/wrappers/react/test/hotColumn.spec.tsx
+++ b/wrappers/react/test/hotColumn.spec.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { HotTable } from '../src/hotTable';
 import { HotColumn } from '../src/hotColumn';
+import { registerAllModules } from 'handsontable/registry';
 import {
   createSpreadsheetData,
   RendererComponent,
@@ -11,6 +12,9 @@ import {
   simulateMouseEvent,
   mountComponent
 } from './_helpers';
+
+// register Handsontable's modules
+registerAllModules();
 
 describe('Passing column settings using HotColumn', () => {
   it('should apply the Handsontable settings passed as HotColumn arguments to the Handsontable instance', async () => {
@@ -306,5 +310,28 @@ describe('Dynamic HotColumn configuration changes', () => {
     hotInstance.getActiveEditor().close();
 
     expect(hotInstance.getSettings().licenseKey).toEqual('non-commercial-and-evaluation');
+  });
+});
+
+describe('Miscellaneous scenarios with `HotColumn` config', () => {
+  it('should validate all cells correctly in a `dropdown`-typed column after populating data through it', async () => {
+    const onAfterValidate = jasmine.createSpy('warn');
+    const hotInstance = mountComponent((
+      <HotTable licenseKey="non-commercial-and-evaluation"
+                data={[['yellow'], ['white'], ['orange']]}
+                afterValidate={onAfterValidate}
+      >
+        <HotColumn type="dropdown" source={['yellow', 'red', 'orange']}/>
+      </HotTable>
+    )).hotInstance;
+
+    hotInstance.populateFromArray(0, 0, [['test'], ['test2'], ['test3']]);
+
+    await sleep(300);
+
+    expect(onAfterValidate).toHaveBeenCalledTimes(3);
+    expect(onAfterValidate).toHaveBeenCalledWith(false, 'test3', 2, 0, 'populateFromArray');
+    expect(onAfterValidate).toHaveBeenCalledWith(false, 'test2', 1, 0, 'populateFromArray');
+    expect(onAfterValidate).toHaveBeenCalledWith(false, 'test', 0, 0, 'populateFromArray');
   });
 });


### PR DESCRIPTION
### Context
The `HotColumn` component contained some redundant logic that broke the validation of the `dropdown`-typed cells. This PR removes the problematic part and adds a test case recreating a scenario described in #10065.

### How has this been tested?
Added a test case recreating a scenario described in #10065.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #10065 

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [x] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
