### PR TITLE
Docs: Add missing 8.4.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -327,6 +327,10 @@ For more information on this release, see:
 - Introduced the `modifyAutoColumnSizeSeed` hook to let developers overwrite the default behaviour of the AutoColumnSize sampling. [#3339](https://github.com/handsontable/handsontable/issues/3339)
 - Added support for hiding columns for the _NestedHeaders_ plugin. [#6879](https://github.com/handsontable/handsontable/issues/6879)
 - Added ability to skip stacking actions by the `UndoRedo` plugin and introduced new hooks. [#6948](https://github.com/handsontable/handsontable/issues/6948)
+-   Added 2 new hooks, `beforeHighlightingColumnHeader` and `beforeHighlightingRowHeader`. Use them to retrieve a header element (`<th>`) before it gets highlighted. ([#7528](https://github.com/handsontable/handsontable/pull/7528))
+-   Added a new method, `indexMapper.unregisterAll()`. Use it to unregister all collected index maps from all map collections types. ([#7528](https://github.com/handsontable/handsontable/pull/7528))
+-   Added a new method, `indexMapper.createChangesObserver()`. Use it to listen to any changes made to indexes while Handsontable is running. ([#7528](https://github.com/handsontable/handsontable/pull/7528))
+-   Added a new method, `indexMapper.createAndRegisterIndexMap()`. Use it to create and register a new index map. ([#7528](https://github.com/handsontable/handsontable/pull/7528))
 
 ### Fixed
 - Fixed a problem with sorting the `checkbox`-typed cells and an issue with empty cells not being displayed properly. [#4047](https://github.com/handsontable/handsontable/issues/4047)

--- a/docs/content/guides/upgrade-and-migration/release-notes.md
+++ b/docs/content/guides/upgrade-and-migration/release-notes.md
@@ -378,6 +378,10 @@ For more information on this release, see:
 *   Introduced the `modifyAutoColumnSizeSeed` hook to let developers overwrite the default behaviour of the AutoColumnSize sampling. ([#3339](https://github.com/handsontable/handsontable/issues/3339))
 *   Added support for hiding columns for the `NestedHeaders` plugin. ([#6879](https://github.com/handsontable/handsontable/issues/6879))
 *   Added ability to skip stacking actions by the `UndoRedo` plugin and introduced new hooks. ([#6948](https://github.com/handsontable/handsontable/issues/6948))
+*   Added 2 new hooks, [`beforeHighlightingColumnHeader`](@/api/hooks.md#beforehighlightingcolumnheader) and [`beforeHighlightingRowHeader`](@/api/hooks.md#beforehighlightingrowheader). Use them to retrieve a header element (`<th>`) before it gets highlighted. ([#7528](https://github.com/handsontable/handsontable/pull/7528))
+*   Added a new method, [`indexMapper.unregisterAll()`](@/api/indexMapper.md#unregisterall). Use it to unregister all collected index maps from all map collections types. ([#7528](https://github.com/handsontable/handsontable/pull/7528))
+*   Added a new method, [`indexMapper.createChangesObserver()`](@/api/indexMapper.md#createchangesobserver). Use it to listen to any changes made to indexes while Handsontable is running. ([#7528](https://github.com/handsontable/handsontable/pull/7528))
+*   Added a new method, [`indexMapper.createAndRegisterIndexMap()`](@/api/indexMapper.md#createandregisterindexmap). Use it to create and register a new index map. ([#7528](https://github.com/handsontable/handsontable/pull/7528))
 
 **Fixed**
 

--- a/handsontable/src/translations/indexMapper.js
+++ b/handsontable/src/translations/indexMapper.js
@@ -222,10 +222,10 @@ export class IndexMapper {
   }
 
   /**
-   * Creates and register the new IndexMap for specified IndexMapper instance.
+   * Creates and register a new `IndexMap` for a specified `IndexMapper` instance.
    *
-   * @param {string} indexName The uniq index name.
-   * @param {string} mapType The index map type (e.q. "hiding, "trimming", "physicalIndexToValue").
+   * @param {string} indexName A unique index name.
+   * @param {string} mapType The index map type (e.g., "hiding", "trimming", "physicalIndexToValue").
    * @param {*} [initValueOrFn] The initial value for the index map.
    * @returns {IndexMap}
    */


### PR DESCRIPTION
This PR:
- Adds missing 8.4.0 release notes and changelog entries
- Fixes a few typos