### PR TITLE
Docs: Clear up the "Merge cells" description

### DIFF
--- a/docs/content/guides/cell-features/merge-cells.md
+++ b/docs/content/guides/cell-features/merge-cells.md
@@ -17,9 +17,11 @@ Merge adjacent cells, using the <kbd>**Ctrl**</kbd> + <kbd>**M**</kbd> shortcut 
 
 ## Overview
 
-With merging, you can combine two or more adjacent cells into a single cell that spans several rows or columns.
+By merging, you can combine two or more adjacent cells into a single cell that spans several rows or columns.
 
-Handsontable merges cells like Microsoft Excel: keeps only the upper-left value of the selected range and clears other values.
+Handsontable merges cells in the same way as Microsoft Excel: keeps only the upper-left value of the selected range and clears other values.
+
+Cell merging happens on Handsontable's visual layer and doesn't affect your source data structure.
 
 ## How to merge cells
 

--- a/docs/content/guides/cell-features/merge-cells.md
+++ b/docs/content/guides/cell-features/merge-cells.md
@@ -1,7 +1,7 @@
 ---
 title: Merge cells
 metaTitle: Merge cells - JavaScript Data Grid | Handsontable
-description: Merge adjacent cells, using the "Ctrl + M" shortcut or the right-click context menu. Control merged cells, using Handsontable's API.
+description: Merge adjacent cells, using the "Ctrl + M" shortcut or the context menu. Control merged cells, using Handsontable's API.
 permalink: /merge-cells
 canonicalUrl: /merge-cells
 react:
@@ -11,13 +11,15 @@ searchCategory: Guides
 
 # Merge cells
 
-Merge adjacent cells, using the <kbd>**Ctrl**</kbd> + <kbd>**M**</kbd> shortcut or the right-click context menu. Control merged cells, using Handsontable's API.
+Merge adjacent cells, using the <kbd>**Ctrl**</kbd> + <kbd>**M**</kbd> shortcut or the context menu. Control merged cells, using Handsontable's API.
 
 [[toc]]
 
 ## Overview
 
-The merging cells feature enables you to combine the contents of two or more cells to create a new larger cell that spans several columns. Particularly useful when you have data that's length is greater than the width of the column. For example, a license id that's length is so long that it needs more than one column width to view it in its entirety.
+With merging, you can combine two or more adjacent cells into a single cell that spans several rows or columns.
+
+Handsontable merges cells like Microsoft Excel: keeps only the upper-left value of the selected range and clears other values.
 
 ## How to merge cells
 


### PR DESCRIPTION
This PR:
- Changes the "Overview" section of the [Merge cells](https://handsontable.com/docs/react-data-grid/merge-cells/) page, to focus on how the feature actually works (in line with [this](https://handsoncode.slack.com/archives/C5QL4R65R/p1642502316008800) discussion)

[skip changelog]