### PR TITLE
Fix an issue where typing in editors causes the IME editor to disappear

### DIFF
--- a/.changelogs/9672.json
+++ b/.changelogs/9672.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fixed `dropdown`-type editor that prevents typing values using IME.",
+  "type": "fixed",
+  "issue": 9672,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/editorManager.js
+++ b/handsontable/src/editorManager.js
@@ -1,5 +1,6 @@
 import { isFunctionKey, isCtrlMetaKey } from './helpers/unicode';
 import { stopImmediatePropagation } from './helpers/dom/event';
+import { isOutsideInput } from './helpers/dom/element';
 import { getEditorInstance } from './editors/registry';
 import EventManager from './eventManager';
 import { isDefined } from './helpers/mixed';
@@ -213,10 +214,11 @@ class EditorManager {
 
     const { activeElement } = this.instance.rootDocument;
 
-    if (activeElement) {
-      // Blurring the activeElement removes unwanted border around the focusable element
-      // (and resets activeElement prop). Without blurring the activeElement points to the
-      // previously focusable element after clicking onto the cell (#6877).
+    // Blurring the `activeElement` removes the unwanted border around the focusable element (#6877)
+    // and resets the `document.activeElement` property. The blurring should happen only when the
+    // previously selected input element has not belonged to the Handsontable editor. If blurring is
+    // triggered for all elements, there is a problem with the disappearing IME editor (#9672).
+    if (activeElement && isOutsideInput(activeElement)) {
       activeElement.blur();
     }
 

--- a/handsontable/src/editors/__tests__/noEditor.spec.js
+++ b/handsontable/src/editors/__tests__/noEditor.spec.js
@@ -156,10 +156,11 @@ describe('noEditor', () => {
     expect(isEditorVisible()).toBe(false);
   });
 
-  it('should blur activeElement while preparing the editor to open', () => {
+  it('should blur `activeElement` while preparing the editor to open', () => {
     const externalInputElement = document.createElement('input');
 
     document.body.appendChild(externalInputElement);
+    spyOn(externalInputElement, 'blur').and.callThrough();
 
     handsontable({
       editor: false,
@@ -168,6 +169,7 @@ describe('noEditor', () => {
     externalInputElement.select();
     selectCell(2, 2);
 
+    expect(externalInputElement.blur).toHaveBeenCalled();
     expect(document.activeElement).not.toBe(externalInputElement);
 
     document.body.removeChild(externalInputElement);

--- a/handsontable/src/editors/baseEditor/__tests__/baseEditor.spec.js
+++ b/handsontable/src/editors/baseEditor/__tests__/baseEditor.spec.js
@@ -25,25 +25,45 @@ describe('BaseEditor', () => {
     expect(Handsontable.editors.TextEditor).toBeDefined();
   });
 
-  it('should blur activeElement while preparing the editor to open', () => {
+  it('should blur `activeElement` while preparing the editor to open', () => {
     const externalInputElement = document.createElement('input');
 
     document.body.appendChild(externalInputElement);
+    spyOn(externalInputElement, 'blur').and.callThrough();
 
     handsontable();
 
     externalInputElement.select();
     selectCell(2, 2);
 
+    expect(externalInputElement.blur).toHaveBeenCalled();
     expect(document.activeElement).not.toBe(externalInputElement);
 
     document.body.removeChild(externalInputElement);
   });
 
-  it('should blur activeElement while preparing the editor to open even when readOnly is enabled', () => {
+  it('should not blur `activeElement` when previously active element is HoT component', () => {
+    const hotInputElement = document.createElement('input');
+
+    hotInputElement.setAttribute('data-hot-input', true);
+    document.body.appendChild(hotInputElement);
+    spyOn(hotInputElement, 'blur').and.callThrough();
+
+    handsontable();
+
+    hotInputElement.select();
+    selectCell(2, 2);
+
+    expect(hotInputElement.blur).not.toHaveBeenCalled();
+
+    document.body.removeChild(hotInputElement);
+  });
+
+  it('should blur `activeElement` while preparing the editor to open even when readOnly is enabled', () => {
     const externalInputElement = document.createElement('input');
 
     document.body.appendChild(externalInputElement);
+    spyOn(externalInputElement, 'blur').and.callThrough();
 
     handsontable({
       readOnly: true,
@@ -52,6 +72,7 @@ describe('BaseEditor', () => {
     externalInputElement.select();
     selectCell(2, 2);
 
+    expect(externalInputElement.blur).toHaveBeenCalled();
     expect(document.activeElement).not.toBe(externalInputElement);
 
     document.body.removeChild(externalInputElement);


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes an issue where typing in some editors like `dropdown` causes the IME to disappear, resulting in typing the wrong letter. The fix is caused by #6916, where the `blur()` is called every time the cell is selected. The solution to the problem is adding logic that blurs the active element only when the previously active element was not an element that belongs to the Handsontable. Thanks to that, the fix for #6916 is still valid, and the IME does not disappear.

### Demo
The issue is replicable on Win11 + Chrome (latest) using the Japanese IME. The combination of the letters `p` and `a` should produce `ぱ`.

#### ✅ The PR changes 
![Kapture 2022-12-06 at 11 51 26](https://user-images.githubusercontent.com/571316/205891856-893ecfc9-2eff-43f2-a973-0046e852ea4d.gif)

#### 🔴 v12.2.0
![Kapture 2022-12-06 at 11 50 18](https://user-images.githubusercontent.com/571316/205891649-51fe4f87-875c-4d5c-a689-2df50abd6343.gif)

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally on Win11 + Chrome using the Japanese language. I covered the changes with changes new E2E test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes #9672

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
