### PR TITLE
Docs: Expand the API ref descriptions of the `beforeFilter` and `afterFilter` hooks

### DIFF
--- a/handsontable/src/pluginHooks.js
+++ b/handsontable/src/pluginHooks.js
@@ -1800,59 +1800,156 @@ const REGISTERED_HOOKS = [
   'beforeStretchingColumnWidth',
 
   /**
-   * Fired by {@link Filters} plugin before applying [filtering](@/guides/columns/column-filter.md).
-   * This hook is fired when {@link Options#filters} option is enabled.
+   * Fired by the [`Filters`](@/api/filters.md) plugin,
+   * before a [column filter](@/guides/columns/column-filter.md) gets applied.
+   *
+   * [`beforeFilter`](#beforefilter) takes one argument (`conditionsStack`), which is an array of objects.
+   * Each object represents one of your [column filters](@/api/filters.md#addcondition),
+   * and consists of the following properties:
+   *
+   * | Property     | Possible values                                                         | Description                                                                                                              |
+   * | ------------ | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+   * | `column`     | Number                                                                  | A visual index of the column to which the filter will be applied.                                                        |
+   * | `conditions` | Array of objects                                                        | Each object represents one condition. For details, see [`addCondition()`](@/api/filters.md#addcondition).                |
+   * | `operation`  | `'conjunction'` \| `'disjunction'` \| `'disjunctionWithExtraCondition'` | An operation to perform on your set of `conditions`. For details, see [`addCondition()`](@/api/filters.md#addcondition). |
+   *
+   * ```js
+   * new Handsontable(document.getElementById('example'), {
+   *
+   *   // enable the `Filters` plugin
+   *   filters: true,
+   *
+   *   // make the `beforeFilter` hook react to your selected column filters
+   *   // (you'll set the filters further below, by using Handsontable's API)
+   *   beforeFilter: (
+   *     [
+   *       {
+   *         column: 1,
+   *         conditions: [
+   *           {name: 'begins_with', args: [['de']]}
+   *         ],
+   *         operation: 'conjunction'
+   *       },
+   *       {
+   *         column: 1,
+   *         conditions: [
+   *           {name: 'not_contains', args: [['ing']]}
+   *         ],
+   *         operation: 'conjunction'
+   *       },
+   *     ]
+   *   ) => {
+   *     console.log(`Column 1 is going to get filtered.`);
+   *   }
+   * });
+   *
+   * // configure your column filters by using Handsontable's API:
+   *
+   * // access the instance of the `Filters` plugin
+   * const filtersPlugin = hot.getPlugin('filters');
+   *
+   * // in column 1, add two mutually compatible conditions:
+   * // "Begins with" with value "de", and
+   * // "Not contains" with value "ing"
+   * filtersPlugin.addCondition(1, 'begins_with', ['de'], 'conjunction');
+   * filtersPlugin.addCondition(1, 'not_contains', ['ing'], 'conjunction');
+   *
+   * // apply the filters (the `beforeFilter` hook gets fired just before the `filter()` method runs)
+   * filtersPlugin.filter();
+   * ```
+   *
+   * To perform server-side filtering (i.e., to not apply filtering to Handsontable's UI),
+   * set [`beforeFilter`](#beforefilter) to return `false`:
+   *
+   * ```js
+   * new Handsontable(document.getElementById('example'), {
+   *   beforeFilter: (conditionsStack) => {
+   *     return false;
+   *   }
+   * });
+   * ```
+   *
+   * Read more:
+   * - [Guides: Column filter](@/guides/columns/column-filter.md)
+   * - [Hooks: `afterFilter`](#afterfilter)
+   * - [Options: `filters`](@/api/options.md#filters)
+   * - [Plugins: `Filters`](@/api/filters.md)
+   * – [Plugin methods: `addCondition()`](@/api/filters.md#addcondition)
    *
    * @event Hooks#beforeFilter
-   * @param {object[]} conditionsStack An array of objects with added formulas.
-   * ```js
-   * // Example format of the conditionsStack argument:
-   * [
-   *   {
-   *     column: 2,
-   *     conditions: [
-   *       {name: 'begins_with', args: [['S']]}
-   *     ],
-   *     operation: 'conjunction'
-   *   },
-   *   {
-   *     column: 4,
-   *     conditions: [
-   *       {name: 'not_empty', args: []}
-   *     ],
-   *     operation: 'conjunction'
-   *   },
-   * ]
-   * ```
-   * @returns {boolean} If hook returns `false` value then filtering won't be applied on the UI side (server-side filtering).
+   * @param {object[]} conditionsStack An array of objects with your [column filters](@/api/filters.md#addcondition).
+   * @returns {boolean} To perform server-side filtering (i.e., to not apply filtering to Handsontable's UI), return `false`.
    */
   'beforeFilter',
 
   /**
-   * Fired by {@link Filters} plugin after applying [filtering](@/guides/columns/column-filter.md).
-   * This hook is fired when {@link Options#filters} option is enabled.
+   * Fired by the [`Filters`](@/api/filters.md) plugin,
+   * after a [column filter](@/guides/columns/column-filter.md) gets applied.
+   *
+   * [`afterFilter`](#afterfilter) takes one argument (`conditionsStack`), which is an array of objects.
+   * Each object represents one of your [column filters](@/api/filters.md#addcondition),
+   * and consists of the following properties:
+   *
+   * | Property     | Possible values                                                         | Description                                                                                                              |
+   * | ------------ | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+   * | `column`     | Number                                                                  | A visual index of the column to which the filter was applied.                                                            |
+   * | `conditions` | Array of objects                                                        | Each object represents one condition. For details, see [`addCondition()`](@/api/filters.md#addcondition).                |
+   * | `operation`  | `'conjunction'` \| `'disjunction'` \| `'disjunctionWithExtraCondition'` | An operation to perform on your set of `conditions`. For details, see [`addCondition()`](@/api/filters.md#addcondition). |
+   *
+   * ```js
+   * new Handsontable(document.getElementById('example'), {
+   *
+   *   // enable the `Filters` plugin
+   *   filters: true,
+   *
+   *   // make the `afterFilter` hook react to your selected column filters
+   *   // (you'll set the filters further below, by using Handsontable's API)
+   *   afterFilter: (
+   *     [
+   *       {
+   *         column: 1,
+   *         conditions: [
+   *           {name: 'begins_with', args: [['de']]}
+   *         ],
+   *         operation: 'conjunction'
+   *       },
+   *       {
+   *         column: 1,
+   *         conditions: [
+   *           {name: 'not_contains', args: [['ing']]}
+   *         ],
+   *         operation: 'conjunction'
+   *       },
+   *     ]
+   *   ) => {
+   *     console.log(`Column 1 has just got filtered.`);
+   *   }
+   * });
+   *
+   * // configure your column filters by using Handsontable's API:
+   *
+   * // access the instance of the `Filters` plugin
+   * const filtersPlugin = hot.getPlugin('filters');
+   *
+   * // in column 1, add two mutually compatible conditions:
+   * // "Begins with" with value "de", and
+   * // "Not contains" with value "ing"
+   * filtersPlugin.addCondition(1, 'begins_with', ['de'], 'conjunction');
+   * filtersPlugin.addCondition(1, 'not_contains', ['ing'], 'conjunction');
+   *
+   * // apply the filters (the `afterFilter` hook gets fired just after the `filter()` method runs)
+   * filtersPlugin.filter();
+   * ```
+   *
+   * Read more:
+   * - [Guides: Column filter](@/guides/columns/column-filter.md)
+   * - [Hooks: `beforeFilter`](#beforefilter)
+   * - [Options: `filters`](@/api/options.md#filters)
+   * - [Plugins: `Filters`](@/api/filters.md)
+   * – [Plugin methods: `addCondition()`](@/api/filters.md#addcondition)
    *
    * @event Hooks#afterFilter
-   * @param {object[]} conditionsStack An array of objects with added conditions.
-   * ```js
-   * // Example format of the conditionsStack argument:
-   * [
-   *   {
-   *     column: 2,
-   *     conditions: [
-   *       {name: 'begins_with', args: [['S']]}
-   *     ],
-   *     operation: 'conjunction'
-   *   },
-   *   {
-   *     column: 4,
-   *     conditions: [
-   *       {name: 'not_empty', args: []}
-   *     ],
-   *     operation: 'conjunction'
-   *   },
-   * ]
-   * ```
+   * @param {object[]} conditionsStack An array of objects with your [column filters](@/api/filters.md#addcondition).
    */
   'afterFilter',
 


### PR DESCRIPTION
This PR:
- Expand the API ref descriptions of the `beforeFilter` and `afterFilter` hooks.

[skip changelog]