### PR TITLE
Correct the wrappers' `es` build paths in their `package.json` files.

### DIFF
--- a/docs/content/guides/tools-and-building/custom-builds.md
+++ b/docs/content/guides/tools-and-building/custom-builds.md
@@ -183,7 +183,7 @@ From the `/wrappers/react` directory, you can also run individual React `build` 
 
 `npm run build:es`
   - Transpiles the files into the ESM format.
-  - Places the output in `/wrappers/react/es/react-handsontable.js`
+  - Places the output in `/wrappers/react/es/react-handsontable.mjs`
 
 `npm run build:min`
   - Creates the minified bundles:
@@ -244,7 +244,7 @@ From the `/wrappers/vue` directory, you can also run individual Vue 2 `build` ta
 
 `npm run build:es`
   - Transpiles the files into the ESM format.
-  - Places the output in `/wrappers/vue/es/vue-handsontable.js`
+  - Places the output in `/wrappers/vue/es/vue-handsontable.mjs`
 
 `npm run build:min`
   - Creates the minified bundles:
@@ -282,7 +282,7 @@ From the `/wrappers/vue3` directory, you can also run individual Vue 3 `build` t
 
 `npm run build:es`
   - Transpiles the files into the ESM format.
-  - Places the output in `/wrappers/vue3/es/vue-handsontable.js`
+  - Places the output in `/wrappers/vue3/es/vue-handsontable.mjs`
 
 `npm run build:min`
   - Creates the minified bundles:

--- a/wrappers/react/package.json
+++ b/wrappers/react/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://handsontable.com",
   "license": "SEE LICENSE IN LICENSE.txt",
   "main": "./commonjs/react-handsontable.js",
-  "module": "./es/react-handsontable.js",
+  "module": "./es/react-handsontable.mjs",
   "jsdelivr": "./dist/react-handsontable.min.js",
   "unpkg": "./dist/react-handsontable.min.js",
   "types": "./index.d.ts",

--- a/wrappers/vue/package.json
+++ b/wrappers/vue/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://handsontable.com",
   "license": "SEE LICENSE IN LICENSE.txt",
   "main": "./commonjs/vue-handsontable.js",
-  "module": "./es/vue-handsontable.js",
+  "module": "./es/vue-handsontable.mjs",
   "jsdelivr": "./dist/vue-handsontable.min.js",
   "unpkg": "./dist/vue-handsontable.min.js",
   "types": "./index.d.ts",

--- a/wrappers/vue3/package.json
+++ b/wrappers/vue3/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://handsontable.com",
   "license": "SEE LICENSE IN LICENSE.txt",
   "main": "./commonjs/vue-handsontable.js",
-  "module": "./es/vue-handsontable.js",
+  "module": "./es/vue-handsontable.mjs",
   "jsdelivr": "./dist/vue-handsontable.min.js",
   "unpkg": "./dist/vue-handsontable.min.js",
   "types": "./index.d.ts",


### PR DESCRIPTION
### Context
This PR corrects the `react`, `vue` and `vue3` wrappers' `es` build paths that were mistakenly ommited in #9891.
This resulted in projects using those wrappers falling back to the `commonjs` build.

Additionally, it corrects those paths in the docs as well.

[skip changelog]

### How has this been tested?
Checked the `react` package in a react-based project.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #9891 

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [x] `@handsontable/react`
- [x] `@handsontable/vue`
- [x] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
