### PR TITLE
Hide unwanted overlays from the Filters conditional menu

### DIFF
--- a/.changelogs/83.json
+++ b/.changelogs/83.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fixed unwanted rendered overlay that was visible in the Filters conditional component.",
+  "type": "fixed",
+  "issue": 83,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
@@ -68,6 +68,28 @@ describe('Filters UI', () => {
       expect(document.querySelector('.htFiltersConditionsMenu.handsontable table')).not.toBeNull();
     });
 
+    it('should have no rendered overlays visible', () => {
+      handsontable({
+        data: getDataForFilters(),
+        columns: getColumnsForFilters(),
+        filters: true,
+        dropdownMenu: true,
+        width: 500,
+        height: 300
+      });
+
+      dropdownMenu(1);
+      $(dropdownMenuRootElement().querySelector('.htUISelect')).simulate('click');
+
+      const conditionalMenu = $(conditionMenuRootElements().first);
+
+      expect(conditionalMenu.find('.ht_clone_top:visible').length).toBe(0);
+      expect(conditionalMenu.find('.ht_clone_bottom:visible').length).toBe(0);
+      expect(conditionalMenu.find('.ht_clone_inline_start:visible').length).toBe(0);
+      expect(conditionalMenu.find('.ht_clone_top_inline_start_corner:visible').length).toBe(0);
+      expect(conditionalMenu.find('.ht_clone_bottom_inline_start_corner:visible').length).toBe(0);
+    });
+
     it('should appear conditional options menu in the proper place after UISelect element click', () => {
       const hot = handsontable({
         data: getDataForFilters(),

--- a/handsontable/src/plugins/filters/filters.scss
+++ b/handsontable/src/plugins/filters/filters.scss
@@ -10,8 +10,10 @@
 }
 
 .htFiltersConditionsMenu .ht_clone_top,
+.htFiltersConditionsMenu .ht_clone_bottom,
 .htFiltersConditionsMenu .ht_clone_inline_start,
-.htFiltersConditionsMenu .ht_clone_corner {
+.htFiltersConditionsMenu .ht_clone_top_inline_start_corner,
+.htFiltersConditionsMenu .ht_clone_bottom_inline_start_corner {
   display: none;
 }
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR hides the unwanted rendered overlays from the _Filters_ conditional menu.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and covered the fix with a new E2E test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/83

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
