### PR TITLE
Fix the redirect links in dropdown menu

### DIFF
--- a/docs/.vuepress/theme/components/VersionsDropdown.vue
+++ b/docs/.vuepress/theme/components/VersionsDropdown.vue
@@ -46,8 +46,10 @@ export default {
       return version;
     },
     getLink(version) {
-      if (version === this.$page.latestVersion) {
-        return `/docs${this.$route.path}`;
+      if (version === this.$page.currentVersion) {
+        const isLatest = version === this.$page.latestVersion;
+
+        return `/docs${isLatest ? '' : `/${version}`}${this.$route.path}`;
       }
 
       // Using `location.origin` disables injecting `.html` postfix at the end of the URL


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The fix (cosmetic fix) applies the redirect links (`/redirect?....`) to all pages except the page that we are currently on. Currently, there is a bug that the link that points to the newest version doesn't have a redirect link which can cause 404s.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. hot fix for https://github.com/handsontable/handsontable/pull/10163

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
