### PR TITLE
Restore the default redirect behavior for Docs 9.0

### DIFF
--- a/docs/docker/Dockerfile
+++ b/docs/docker/Dockerfile
@@ -4,8 +4,10 @@ FROM nginx:alpine
 # set up static content
 WORKDIR /usr/share/nginx
 
+COPY ./docker/nginx.conf /etc/nginx/nginx.conf
 COPY ./docker/default.conf /etc/nginx/conf.d/default.conf
 COPY ./docker/variables.conf /etc/nginx/variables.conf
+COPY ./docker/redirect.js /etc/nginx/njs/redirect.js
 COPY ./docker/redirects.conf /etc/nginx/redirects.conf
 COPY ./.vuepress/dist ./html
 

--- a/docs/docker/default.conf
+++ b/docs/docker/default.conf
@@ -6,10 +6,17 @@ server {
 
     include variables.conf;
 
+    js_path "/etc/nginx/njs/";
+    js_import redirect from redirect.js;
+
     absolute_redirect off;
 
     # disable http://example.org/index as a duplicate content
     location = /index      { return 404; }
+
+    location ~ ^/docs/((\d+\.\d+|next)/)?redirect$ {
+      js_content redirect.redirectToPageId;
+    }
 
     include redirects.conf;
 

--- a/docs/docker/nginx.conf
+++ b/docs/docker/nginx.conf
@@ -1,0 +1,27 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /var/run/nginx.pid;
+
+load_module modules/ngx_http_js_module.so;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    keepalive_timeout  65;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/docs/docker/redirect.js
+++ b/docs/docker/redirect.js
@@ -1,0 +1,9 @@
+const HTTP_REDIRECT_CODE = 301;
+
+async function redirectToPageId(r) {
+  const docsVersion = r.variables.docs_version;
+
+  r.return(HTTP_REDIRECT_CODE, `/docs/${docsVersion}/`);
+}
+
+export default { redirectToPageId };


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR restores the default redirect behavior for Docs 9.0 - which means switching for/to Docs 9.0 always redirect the user to the main (Introduction) page. The change is connected with https://github.com/handsontable/handsontable/pull/10163.

_[skip changelog]_

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. connected with https://github.com/handsontable/handsontable/pull/10163

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
