### PR TITLE
unify DOM of examples and search for table by ID

### DIFF
--- a/examples/next/visual-tests/angular-13/demo/src/data-grid/data-grid.component.html
+++ b/examples/next/visual-tests/angular-13/demo/src/data-grid/data-grid.component.html
@@ -1,6 +1,7 @@
 <div>
   <hot-table
     class="hot"
+    id="root"
     [data]="dataset"
     height="450"
     [colWidths]="[140, 192, 100, 90, 90, 110, 97, 100, 126]"

--- a/examples/next/visual-tests/js/demo/index.html
+++ b/examples/next/visual-tests/js/demo/index.html
@@ -8,7 +8,9 @@
 </head>
 
 <body>
-    <div id="example"></div>
+    <div id="root">
+        <div id="example"></div>
+    </div>
     <script src="./src/index.js"></script>
 </body>
 

--- a/examples/next/visual-tests/vue/demo/src/App.vue
+++ b/examples/next/visual-tests/vue/demo/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="app">
+  <div id="root">
     <DataGrid/>
   </div>
 </template>

--- a/examples/next/visual-tests/vue/demo/src/components/DataGrid.vue
+++ b/examples/next/visual-tests/vue/demo/src/components/DataGrid.vue
@@ -1,7 +1,5 @@
 <template>
-  <div id="example">
-    <hot-table ref="hotTableComponent" :data="data" :settings="hotSettings"></hot-table>
-  </div>
+  <hot-table ref="hotTableComponent" :data="data" :settings="hotSettings"></hot-table>
 </template>
 
 <script lang="ts">

--- a/visual-tests/imports/helpers.js
+++ b/visual-tests/imports/helpers.js
@@ -5,7 +5,7 @@ export const helpers = {
   screenshotsExtension: 'png',
 
   selectors: {
-    mainTable: 'div.handsontable.htRowHeaders.htColumnHeaders',
+    mainTable: '#root > .handsontable',
     mainTableBody: '> .ht_master.handsontable table tbody',
     mainTableHead: '> .ht_clone_top.handsontable table thead',
     mainTableFirstColumn: '> .ht_clone_inline_start.ht_clone_left.handsontable table tbody',


### PR DESCRIPTION
### Context
We need to unify DOM of examples to be sure that we are looking for correct element in visual testing

### How has this been tested?
Launched locally and in Github Action if fork built for visual testing

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]