### PR TITLE
Docs: Fix typo

### DIFF
--- a/handsontable/src/dataMap/metaManager/metaSchema.js
+++ b/handsontable/src/dataMap/metaManager/metaSchema.js
@@ -2904,13 +2904,13 @@ export default () => {
      * @example
      * ```js
      * // enable the `ManualRowResize` plugin
-     * manualColumnResize: true,
+     * manualRowResize: true,
      *
      * // enable the `ManualRowResize` plugin
      * // set the initial height of row 0 to 40 pixels
      * // set the initial height of row 1 to 50 pixels
      * // set the initial height of row 2 to 60 pixels
-     * manualColumnResize: [40, 50, 60],
+     * manualRowResize: [40, 50, 60],
      * ```
      */
     manualRowResize: void 0,


### PR DESCRIPTION
This PR:
- Fixes a typo (`manualColumnResize` -> `manualRowResize`)

Affected pages:
- https://handsontable.com/docs/react-data-grid/api/options/#manualrowresize

[skip changelog]