### PR TITLE
Add Japanese translation for Copy with Headers feature

### DIFF
--- a/.changelogs/950.json
+++ b/.changelogs/950.json
@@ -1,0 +1,7 @@
+{
+  "title": "Added Japanese translation for Copy with Headers feature.",
+  "type": "added",
+  "issue": 950,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/i18n/languages/ja-JP.js
+++ b/handsontable/src/i18n/languages/ja-JP.js
@@ -1,7 +1,7 @@
 /**
  * @preserve
  * Authors: hand-dot
- * Last updated: Jan 28, 2018
+ * Last updated: Jan 9, 2023
  *
  * Description: Definition file for Japanese - Japan language-country.
  */
@@ -48,6 +48,12 @@ const dictionary = {
   [C.CONTEXTMENU_ITEMS_UNMERGE_CELLS]: 'セルの結合を解除',
 
   [C.CONTEXTMENU_ITEMS_COPY]: 'コピー',
+  [C.CONTEXTMENU_ITEMS_COPY_WITH_COLUMN_HEADERS]: ['ヘッダ付きでコピー', 'ヘッダ付きでコピー'],
+  [C.CONTEXTMENU_ITEMS_COPY_WITH_COLUMN_GROUP_HEADERS]: [
+    'グループヘッダ付きでコピー',
+    'グループヘッダ付きでコピー'
+  ],
+  [C.CONTEXTMENU_ITEMS_COPY_COLUMN_HEADERS_ONLY]: ['ヘッダのみコピー', 'ヘッダのみコピー'],
   [C.CONTEXTMENU_ITEMS_CUT]: '切り取り',
 
   [C.CONTEXTMENU_ITEMS_NESTED_ROWS_INSERT_CHILD]: '子の行を挿入',


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adds Japanese translation for Copy with Headers feature.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Additional language file or change to the existing one (translations)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/950
2. https://github.com/handsontable/handsontable/issues/10112#issuecomment-1359216213

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
