### PR TITLE
Remove an unnecessary character from the `AutoColumnSize` snippet

### DIFF
--- a/handsontable/src/plugins/autoColumnSize/autoColumnSize.js
+++ b/handsontable/src/plugins/autoColumnSize/autoColumnSize.js
@@ -39,7 +39,7 @@ const COLUMN_SIZE_MAP_NAME = 'autoColumnSize';
  *
  * ```js
  * // as a number (300 columns in sync, rest async)
- * autoColumnSize: {syncLimit: 300},.
+ * autoColumnSize: {syncLimit: 300},
  *
  * // as a string (percent)
  * autoColumnSize: {syncLimit: '40%'},


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
I checked the `AutoColumnSize` tutorial. There's a dot that shouldn't be there.

![Zrzut ekranu 2023-01-10 o 08 59 56](https://user-images.githubusercontent.com/10757813/211494154-812a8e5a-a98e-4fab-8915-f7cc14023b57.png)


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s): - no

### Affected project(s): - no
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]
