### PR TITLE
Read only cell copy/paste description fix

### DIFF
--- a/docs/content/guides/cell-features/disabled-cells.md
+++ b/docs/content/guides/cell-features/disabled-cells.md
@@ -28,9 +28,9 @@ Make specified cells read-only to protect them from unwanted changes but still a
 Disabling a cell makes the cell read-only or non-editable. Both have similar outcomes, with the following differences:
 
 | Read-only cell<br>`readOnly: true`                                           | Non-editable cell<br>`editor: false`                                       |
-| ---------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+|------------------------------------------------------------------------------| -------------------------------------------------------------------------- |
 | Has an additional CSS class (`htDimmed`)                                     | Has no additional CSS class                                                |
-| Copy-paste doesn't work                                                      | Copy-paste works                                                           |
+| Copy works, paste doesn't work                                               | Copy-paste works                                                           |
 | Drag-to-fill doesn't work                                                    | Drag-to-fill works                                                         |
 | Can't be changed by [`populateFromArray()`](@/api/core.md#populatefromarray) | Can be changed by [`populateFromArray()`](@/api/core.md#populatefromarray) |
 


### PR DESCRIPTION
### Context

We had the wrong functionality description in the `ReadOnly` part of the table at the https://handsontable.com/docs/javascript-data-grid/disabled-cells/#overview page. This PR is fixing this issue by changing the description to:

> Copy works, paste doesn't work  

### How has this been tested?

By running the documentation locally.

### Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/996

### Affected project(s):
- [X] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:

- [X] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [X] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]