### PR TITLE
Fixed an issue where some browser or system shortcuts left the CTRL/CMD key held down

### DIFF
--- a/.changelogs/6441.json
+++ b/.changelogs/6441.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fixed an issue where some browser or system shortcuts left the CTRL/CMD key held down",
+  "type": "fixed",
+  "issue": 6441,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -4712,6 +4712,13 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
     ownerWindow: this.rootWindow,
   });
 
+  this.addHook('beforeOnCellMouseDown', (event) => {
+    // Releasing keys as it seems that some browser/system shortcut hasn't triggered `keyup` event.
+    if (event.ctrlKey === false && event.metaKey === false) {
+      shortcutManager.releaseAll();
+    }
+  });
+
   /**
    * Returns instance of a manager responsible for handling shortcuts stored in some contexts. It run actions after
    * pressing key combination in active Handsontable instance.

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -4713,9 +4713,9 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
   });
 
   this.addHook('beforeOnCellMouseDown', (event) => {
-    // Releasing keys as it seems that some browser/system shortcut hasn't triggered `keyup` event.
+    // Releasing keys as some browser/system shortcuts break events sequence (thus the `keyup` event isn't triggered).
     if (event.ctrlKey === false && event.metaKey === false) {
-      shortcutManager.releaseAll();
+      shortcutManager.releasePressedKeys();
     }
   });
 

--- a/handsontable/src/plugins/collapsibleColumns/__tests__/selection.spec.js
+++ b/handsontable/src/plugins/collapsibleColumns/__tests__/selection.spec.js
@@ -329,31 +329,14 @@ describe('CollapsibleColumns', () => {
         collapsibleColumns: true
       });
 
-      $(getCell(-2, 7)) // Select header "H4"
-        .simulate('mousedown')
-        .simulate('mouseup')
-        .simulate('click');
-      $(getCell(-2, 7).querySelector('.collapsibleIndicator')) // Collapse header "H4"
-        .simulate('mousedown')
-        .simulate('mouseup')
-        .simulate('click');
+      simulateClick(getCell(-2, 7)); // Select header "H4"
+      simulateClick(getCell(-2, 7).querySelector('.collapsibleIndicator')); // Collapse header "H4"
 
       keyDown('control/meta');
 
-      $(getCell(-1, 5)) // Select header "F5"
-        .simulate('mousedown')
-        .simulate('mouseup')
-        .simulate('click');
-
-      $(getCell(-2, 1).querySelector('.collapsibleIndicator')) // Collapse header "B4"
-        .simulate('mousedown')
-        .simulate('mouseup')
-        .simulate('click');
-
-      $(getCell(-2, 3)) // Select header "D4"
-        .simulate('mousedown')
-        .simulate('mouseup')
-        .simulate('click');
+      simulateClick(getCell(-1, 5)); // Select header "F5"
+      simulateClick(getCell(-2, 1).querySelector('.collapsibleIndicator')); // Collapse header "B4"
+      simulateClick(getCell(-2, 3)); // Select header "D4"
 
       keyUp('control/meta');
 
@@ -413,10 +396,7 @@ describe('CollapsibleColumns', () => {
         `);
       expect(getSelected()).toEqual([[-2, 7, 4, 8], [-1, 5, 4, 5], [-2, 3, 4, 4]]);
 
-      $(getCell(-4, 1).querySelector('.collapsibleIndicator')) // Collapse header "B1"
-        .simulate('mousedown')
-        .simulate('mouseup')
-        .simulate('click');
+      simulateClick(getCell(-4, 1).querySelector('.collapsibleIndicator')); // Collapse header "B1"
 
       expect(extractDOMStructure(getTopClone())).toMatchHTML(`
         <thead>

--- a/handsontable/src/plugins/columnSorting/__tests__/columnSorting.spec.js
+++ b/handsontable/src/plugins/columnSorting/__tests__/columnSorting.spec.js
@@ -13,9 +13,7 @@ describe('ColumnSorting', () => {
         throw Error('Please check the test scenario. The header doesn\'t exist.');
       }
 
-      $spanInsideHeader.simulate('mousedown');
-      $spanInsideHeader.simulate('mouseup');
-      $spanInsideHeader.simulate('click');
+      simulateClick($spanInsideHeader[0]);
     };
   });
 

--- a/handsontable/src/plugins/columnSorting/__tests__/columnSorting.spec.js
+++ b/handsontable/src/plugins/columnSorting/__tests__/columnSorting.spec.js
@@ -13,7 +13,7 @@ describe('ColumnSorting', () => {
         throw Error('Please check the test scenario. The header doesn\'t exist.');
       }
 
-      simulateClick($spanInsideHeader[0]);
+      simulateClick($spanInsideHeader);
     };
   });
 

--- a/handsontable/src/plugins/contextMenu/__tests__/contextMenu.spec.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/contextMenu.spec.js
@@ -3164,19 +3164,19 @@ describe('ContextMenu', () => {
         height: 200
       });
 
-      $(getCell(0, 0)).simulate('mousedown');
-      $(getCell(2, 2)).simulate('mouseover');
-      $(getCell(2, 2)).simulate('mouseup');
+      mouseDown(getCell(0, 0));
+      mouseOver(getCell(2, 2));
+      mouseUp(getCell(2, 2));
 
       keyDown('control/meta');
 
-      $(getCell(2, 2)).simulate('mousedown');
-      $(getCell(7, 2)).simulate('mouseover');
-      $(getCell(7, 2)).simulate('mouseup');
+      mouseDown(getCell(2, 2));
+      mouseOver(getCell(7, 2));
+      mouseUp(getCell(7, 2));
 
-      $(getCell(2, 4)).simulate('mousedown');
-      $(getCell(2, 4)).simulate('mouseover');
-      $(getCell(2, 4)).simulate('mouseup');
+      mouseDown(getCell(2, 4));
+      mouseOver(getCell(2, 4));
+      mouseUp(getCell(2, 4));
 
       keyUp('control/meta');
       contextMenu(getCell(0, 0));
@@ -3192,19 +3192,19 @@ describe('ContextMenu', () => {
         height: 200
       });
 
-      $(getCell(0, 0)).simulate('mousedown');
-      $(getCell(2, 2)).simulate('mouseover');
-      $(getCell(2, 2)).simulate('mouseup');
+      mouseDown(getCell(0, 0));
+      mouseOver(getCell(2, 2));
+      mouseUp(getCell(2, 2));
 
       keyDown('control/meta');
 
-      $(getCell(2, 2)).simulate('mousedown');
-      $(getCell(7, 2)).simulate('mouseover');
-      $(getCell(7, 2)).simulate('mouseup');
+      mouseDown(getCell(2, 2));
+      mouseOver(getCell(7, 2));
+      mouseUp(getCell(7, 2));
 
-      $(getCell(2, 4)).simulate('mousedown');
-      $(getCell(2, 4)).simulate('mouseover');
-      $(getCell(2, 4)).simulate('mouseup');
+      mouseDown(getCell(2, 4));
+      mouseOver(getCell(2, 4));
+      mouseUp(getCell(2, 4));
 
       keyUp('control/meta');
       contextMenu(getCell(2, 2));
@@ -3220,19 +3220,19 @@ describe('ContextMenu', () => {
         height: 200
       });
 
-      $(getCell(0, 0)).simulate('mousedown');
-      $(getCell(2, 2)).simulate('mouseover');
-      $(getCell(2, 2)).simulate('mouseup');
+      mouseDown(getCell(0, 0));
+      mouseOver(getCell(2, 2));
+      mouseUp(getCell(2, 2));
 
       keyDown('control/meta');
 
-      $(getCell(2, 2)).simulate('mousedown');
-      $(getCell(7, 2)).simulate('mouseover');
-      $(getCell(7, 2)).simulate('mouseup');
+      mouseDown(getCell(2, 2));
+      mouseOver(getCell(7, 2));
+      mouseUp(getCell(7, 2));
 
-      $(getCell(2, 4)).simulate('mousedown');
-      $(getCell(2, 4)).simulate('mouseover');
-      $(getCell(2, 4)).simulate('mouseup');
+      mouseDown(getCell(2, 4));
+      mouseOver(getCell(2, 4));
+      mouseUp(getCell(2, 4));
 
       keyUp('control/meta');
       contextMenu(getCell(2, 4));

--- a/handsontable/src/plugins/contextMenu/__tests__/predefinedItems/removeColumn.spec.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/predefinedItems/removeColumn.spec.js
@@ -277,27 +277,27 @@ describe('ContextMenu', () => {
         contextMenu: true,
       });
 
-      $(getCell(0, 0)).simulate('mousedown');
-      $(getCell(1, 0)).simulate('mouseover');
-      $(getCell(1, 0)).simulate('mouseup');
+      mouseDown(getCell(0, 0));
+      mouseOver(getCell(1, 0));
+      mouseUp(getCell(1, 0));
 
       keyDown('control/meta');
 
-      $(getCell(2, 1)).simulate('mousedown');
-      $(getCell(2, 1)).simulate('mouseover');
-      $(getCell(2, 1)).simulate('mouseup');
+      mouseDown(getCell(2, 1));
+      mouseOver(getCell(2, 1));
+      mouseUp(getCell(2, 1));
 
-      $(getCell(0, 3)).simulate('mousedown');
-      $(getCell(5, 3)).simulate('mouseover');
-      $(getCell(5, 3)).simulate('mouseup');
+      mouseDown(getCell(0, 3));
+      mouseOver(getCell(5, 3));
+      mouseUp(getCell(5, 3));
 
-      $(getCell(5, 0)).simulate('mousedown');
-      $(getCell(5, 4)).simulate('mouseover');
-      $(getCell(5, 4)).simulate('mouseup');
+      mouseDown(getCell(5, 0));
+      mouseOver(getCell(5, 4));
+      mouseUp(getCell(5, 4));
 
-      $(getCell(7, 4)).simulate('mousedown');
-      $(getCell(7, 4)).simulate('mouseover');
-      $(getCell(7, 4)).simulate('mouseup');
+      mouseDown(getCell(7, 4));
+      mouseOver(getCell(7, 4));
+      mouseUp(getCell(7, 4));
 
       keyUp('control/meta');
 

--- a/handsontable/src/plugins/contextMenu/__tests__/predefinedItems/removeRow.spec.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/predefinedItems/removeRow.spec.js
@@ -227,27 +227,27 @@ describe('ContextMenu', () => {
         contextMenu: true,
       });
 
-      $(getCell(0, 0)).simulate('mousedown');
-      $(getCell(1, 0)).simulate('mouseover');
-      $(getCell(1, 0)).simulate('mouseup');
+      mouseDown(getCell(0, 0));
+      mouseOver(getCell(1, 0));
+      mouseUp(getCell(1, 0));
 
       keyDown('control/meta');
 
-      $(getCell(2, 1)).simulate('mousedown');
-      $(getCell(2, 1)).simulate('mouseover');
-      $(getCell(2, 1)).simulate('mouseup');
+      mouseDown(getCell(2, 1));
+      mouseOver(getCell(2, 1));
+      mouseUp(getCell(2, 1));
 
-      $(getCell(0, 3)).simulate('mousedown');
-      $(getCell(5, 3)).simulate('mouseover');
-      $(getCell(5, 3)).simulate('mouseup');
+      mouseDown(getCell(0, 3));
+      mouseOver(getCell(5, 3));
+      mouseUp(getCell(5, 3));
 
-      $(getCell(5, 0)).simulate('mousedown');
-      $(getCell(5, 4)).simulate('mouseover');
-      $(getCell(5, 4)).simulate('mouseup');
+      mouseDown(getCell(5, 0));
+      mouseOver(getCell(5, 4));
+      mouseUp(getCell(5, 4));
 
-      $(getCell(7, 4)).simulate('mousedown');
-      $(getCell(7, 4)).simulate('mouseover');
-      $(getCell(7, 4)).simulate('mouseup');
+      mouseDown(getCell(7, 4));
+      mouseOver(getCell(7, 4));
+      mouseUp(getCell(7, 4));
 
       keyUp('control/meta');
 

--- a/handsontable/src/plugins/hiddenColumns/__tests__/selection.spec.js
+++ b/handsontable/src/plugins/hiddenColumns/__tests__/selection.spec.js
@@ -234,9 +234,9 @@ describe('HiddenColumns', () => {
         },
       });
 
-      $(getCell(1, 3)).simulate('mousedown');
-      $(getCell(4, 6)).simulate('mouseover');
-      $(getCell(4, 6)).simulate('mouseup');
+      mouseDown(getCell(1, 3));
+      mouseOver(getCell(4, 6));
+      mouseUp(getCell(4, 6));
 
       expect(getSelected()).toEqual([[1, 3, 4, 6]]);
       expect(getSelectedRangeLast().highlight.row).toBe(1);
@@ -260,9 +260,9 @@ describe('HiddenColumns', () => {
 
       keyDown('control/meta');
 
-      $(getCell(3, 5)).simulate('mousedown');
-      $(getCell(5, 8)).simulate('mouseover');
-      $(getCell(5, 8)).simulate('mouseup');
+      mouseDown(getCell(3, 5));
+      mouseOver(getCell(5, 8));
+      mouseUp(getCell(5, 8));
 
       keyUp('control/meta');
 
@@ -1066,19 +1066,19 @@ describe('HiddenColumns', () => {
           },
         });
 
-        $(getCell(1, 3)).simulate('mousedown');
-        $(getCell(4, 6)).simulate('mouseover');
-        $(getCell(4, 6)).simulate('mouseup');
+        mouseDown(getCell(1, 3));
+        mouseOver(getCell(4, 6));
+        mouseUp(getCell(4, 6));
 
         keyDown('control/meta');
 
-        $(getCell(3, 5)).simulate('mousedown');
-        $(getCell(5, 8)).simulate('mouseover');
-        $(getCell(5, 8)).simulate('mouseup');
+        mouseDown(getCell(3, 5));
+        mouseOver(getCell(5, 8));
+        mouseUp(getCell(5, 8));
 
-        $(getCell(3, 6)).simulate('mousedown');
-        $(getCell(6, 9)).simulate('mouseover');
-        $(getCell(6, 9)).simulate('mouseup');
+        mouseDown(getCell(3, 6));
+        mouseOver(getCell(6, 9));
+        mouseUp(getCell(6, 9));
 
         keyUp('control/meta');
 
@@ -1212,19 +1212,19 @@ describe('HiddenColumns', () => {
           hiddenColumns: true,
         });
 
-        $(getCell(1, 3)).simulate('mousedown');
-        $(getCell(4, 6)).simulate('mouseover');
-        $(getCell(4, 6)).simulate('mouseup');
+        mouseDown(getCell(1, 3));
+        mouseOver(getCell(4, 6));
+        mouseUp(getCell(4, 6));
 
         keyDown('control/meta');
 
-        $(getCell(3, 5)).simulate('mousedown');
-        $(getCell(5, 8)).simulate('mouseover');
-        $(getCell(5, 8)).simulate('mouseup');
+        mouseDown(getCell(3, 5));
+        mouseOver(getCell(5, 8));
+        mouseUp(getCell(5, 8));
 
-        $(getCell(3, 6)).simulate('mousedown');
-        $(getCell(6, 9)).simulate('mouseover');
-        $(getCell(6, 9)).simulate('mouseup');
+        mouseDown(getCell(3, 6));
+        mouseOver(getCell(6, 9));
+        mouseUp(getCell(6, 9));
 
         keyUp('control/meta');
 

--- a/handsontable/src/plugins/hiddenRows/__tests__/selection.spec.js
+++ b/handsontable/src/plugins/hiddenRows/__tests__/selection.spec.js
@@ -219,7 +219,7 @@ describe('HiddenRows', () => {
         },
       });
 
-      $(getCell(3, 1)).simulate('mousedown');
+      mouseDown(getCell(3, 1));
       $(getCell(6, 4)).simulate('mouseover').simulate('mouseup');
 
       expect(getSelected()).toEqual([[3, 1, 6, 4]]);
@@ -246,7 +246,7 @@ describe('HiddenRows', () => {
 
       keyDown('control/meta');
 
-      $(getCell(5, 3)).simulate('mousedown');
+      mouseDown(getCell(5, 3));
       $(getCell(8, 5)).simulate('mouseover').simulate('mouseup');
 
       keyUp('control/meta');
@@ -956,15 +956,15 @@ describe('HiddenRows', () => {
           },
         });
 
-        $(getCell(3, 1)).simulate('mousedown');
+        mouseDown(getCell(3, 1));
         $(getCell(6, 4)).simulate('mouseover').simulate('mouseup');
 
         keyDown('control/meta');
 
-        $(getCell(5, 3)).simulate('mousedown');
+        mouseDown(getCell(5, 3));
         $(getCell(8, 5)).simulate('mouseover').simulate('mouseup');
 
-        $(getCell(6, 3)).simulate('mousedown');
+        mouseDown(getCell(6, 3));
         $(getCell(9, 6)).simulate('mouseover').simulate('mouseup');
 
         keyUp('control/meta');
@@ -1101,15 +1101,15 @@ describe('HiddenRows', () => {
           hiddenRows: true,
         });
 
-        $(getCell(3, 1)).simulate('mousedown');
+        mouseDown(getCell(3, 1));
         $(getCell(6, 4)).simulate('mouseover').simulate('mouseup');
 
         keyDown('control/meta');
 
-        $(getCell(5, 3)).simulate('mousedown');
+        mouseDown(getCell(5, 3));
         $(getCell(8, 5)).simulate('mouseover').simulate('mouseup');
 
-        $(getCell(6, 3)).simulate('mousedown');
+        mouseDown(getCell(6, 3));
         $(getCell(9, 6)).simulate('mouseover').simulate('mouseup');
 
         keyUp('control/meta');

--- a/handsontable/src/plugins/mergeCells/__tests__/selection.spec.js
+++ b/handsontable/src/plugins/mergeCells/__tests__/selection.spec.js
@@ -173,7 +173,6 @@ describe('MergeCells Selection', () => {
 
     keyDown('control/meta');
 
-
     mouseDown(firstRowHeader);
     mouseOver(thirdRowHeader);
     mouseUp(thirdRowHeader);

--- a/handsontable/src/plugins/mergeCells/__tests__/selection.spec.js
+++ b/handsontable/src/plugins/mergeCells/__tests__/selection.spec.js
@@ -53,8 +53,7 @@ describe('MergeCells Selection', () => {
 
     keyDown('control/meta');
 
-    $(firstRowHeader).simulate('mousedown');
-    $(firstRowHeader).simulate('mouseup');
+    simulateClick(firstRowHeader);
 
     keyUp('control/meta');
 
@@ -124,12 +123,12 @@ describe('MergeCells Selection', () => {
     deselectCell();
 
     keyDown('control/meta');
-    $(rowHeaders[0]).simulate('mousedown');
-    $(rowHeaders[1]).simulate('mouseover');
-    $(rowHeaders[1]).simulate('mouseup');
-    $(rowHeaders[2]).simulate('mousedown');
-    $(rowHeaders[2]).simulate('mouseover');
-    $(rowHeaders[2]).simulate('mouseup');
+    mouseDown(rowHeaders[0]);
+    mouseOver(rowHeaders[1]);
+    mouseUp(rowHeaders[1]);
+    mouseDown(rowHeaders[2]);
+    mouseOver(rowHeaders[2]);
+    mouseUp(rowHeaders[2]);
     keyUp('control/meta');
 
     expect(getComputedStyle(mergedCell, ':before').backgroundColor).toEqual(selectedCellBackground);
@@ -138,12 +137,12 @@ describe('MergeCells Selection', () => {
     deselectCell();
 
     keyDown('control/meta');
-    $(columnHeaders[0]).simulate('mousedown');
-    $(columnHeaders[1]).simulate('mouseover');
-    $(columnHeaders[1]).simulate('mouseup');
-    $(columnHeaders[2]).simulate('mousedown');
-    $(columnHeaders[3]).simulate('mouseover');
-    $(columnHeaders[3]).simulate('mouseup');
+    mouseDown(columnHeaders[0]);
+    mouseOver(columnHeaders[1]);
+    mouseUp(columnHeaders[1]);
+    mouseDown(columnHeaders[2]);
+    mouseOver(columnHeaders[3]);
+    mouseUp(columnHeaders[3]);
     keyUp('control/meta');
 
     expect(getComputedStyle(mergedCell, ':before').backgroundColor).toEqual(selectedCellBackground);
@@ -174,9 +173,10 @@ describe('MergeCells Selection', () => {
 
     keyDown('control/meta');
 
-    $(firstRowHeader).simulate('mousedown');
-    $(thirdRowHeader).simulate('mouseover');
-    $(thirdRowHeader).simulate('mouseup');
+
+    mouseDown(firstRowHeader);
+    mouseOver(thirdRowHeader);
+    mouseUp(thirdRowHeader);
 
     keyUp('control/meta');
 

--- a/handsontable/src/plugins/multiColumnSorting/__tests__/multiColumnSorting.spec.js
+++ b/handsontable/src/plugins/multiColumnSorting/__tests__/multiColumnSorting.spec.js
@@ -13,9 +13,7 @@ describe('MultiColumnSorting', () => {
         throw Error('Please check the test scenario. The header doesn\'t exist.');
       }
 
-      $spanInsideHeader.simulate('mousedown');
-      $spanInsideHeader.simulate('mouseup');
-      $spanInsideHeader.simulate('click');
+      simulateClick($spanInsideHeader[0]);
     };
   });
 

--- a/handsontable/src/plugins/multiColumnSorting/__tests__/multiColumnSorting.spec.js
+++ b/handsontable/src/plugins/multiColumnSorting/__tests__/multiColumnSorting.spec.js
@@ -13,7 +13,7 @@ describe('MultiColumnSorting', () => {
         throw Error('Please check the test scenario. The header doesn\'t exist.');
       }
 
-      simulateClick($spanInsideHeader[0]);
+      simulateClick($spanInsideHeader);
     };
   });
 

--- a/handsontable/src/plugins/nestedHeaders/__tests__/selection.spec.js
+++ b/handsontable/src/plugins/nestedHeaders/__tests__/selection.spec.js
@@ -712,9 +712,7 @@ describe('NestedHeaders', () => {
         ],
       });
 
-      $(getCell(-2, 1)) // Header "B3"
-        .simulate('mousedown')
-        .simulate('mouseup');
+      simulateClick(getCell(-2, 1)); // Header "B3"
 
       expect(extractDOMStructure(getTopClone())).toMatchHTML(`
         <thead>
@@ -773,9 +771,7 @@ describe('NestedHeaders', () => {
 
       keyDown('control/meta');
 
-      $(getCell(-3, 5)) // Header "F2"
-        .simulate('mousedown')
-        .simulate('mouseup');
+      simulateClick(getCell(-3, 5)); // Header "F2"
 
       keyUp('control/meta');
 
@@ -839,9 +835,7 @@ describe('NestedHeaders', () => {
 
       keyDown('control/meta');
 
-      $(getCell(-3, 1)) // Header "B2"
-        .simulate('mousedown')
-        .simulate('mouseup');
+      simulateClick(getCell(-3, 1)); // Header "B2"
 
       keyUp('control/meta');
 

--- a/handsontable/src/shortcuts/__tests__/shortcutManager.spec.js
+++ b/handsontable/src/shortcuts/__tests__/shortcutManager.spec.js
@@ -479,7 +479,7 @@ describe('shortcutManager', () => {
     document.body.removeChild(externalInputElement);
   });
 
-  it('should check if there is a need of releasing keys on click #32', () => {
+  it('should check if there is a need of releasing keys on click #dev-1025', () => {
     const hot = handsontable();
     const shortcutManager = hot.getShortcutManager();
     const releasePressedKeys = spyOn(shortcutManager, 'releasePressedKeys');

--- a/handsontable/src/shortcuts/__tests__/shortcutManager.spec.js
+++ b/handsontable/src/shortcuts/__tests__/shortcutManager.spec.js
@@ -478,4 +478,23 @@ describe('shortcutManager', () => {
 
     document.body.removeChild(externalInputElement);
   });
+
+  it('should check if there is a need of releasing keys on click #32', () => {
+    const hot = handsontable();
+    const shortcutManager = hot.getShortcutManager();
+    const releasePressedKeys = spyOn(shortcutManager, 'releasePressedKeys');
+
+    keyDown('control/meta');
+    simulateClick(getCell(0, 0));
+
+    expect(releasePressedKeys).not.toHaveBeenCalled();
+
+    keyUp('control/meta');
+    // Any key other than control/meta.
+    keyDown('f');
+
+    simulateClick(getCell(0, 0));
+
+    expect(releasePressedKeys).toHaveBeenCalled();
+  });
 });

--- a/handsontable/src/shortcuts/manager.js
+++ b/handsontable/src/shortcuts/manager.js
@@ -146,7 +146,13 @@ export const createShortcutManager = ({ ownerWindow, handleEvent, beforeKeyDown,
      * @returns {boolean}
      */
     isCtrlPressed: () => !isCtrlKeySilenced && (keyRecorder.isPressed('control') || keyRecorder.isPressed('meta')),
-    releaseAll: () => keyRecorder.releaseAll(),
+    /**
+     * Release every previously pressed key.
+     *
+     * @type {Function}
+     * @memberof ShortcutManager#
+     */
+    releasePressedKeys: () => keyRecorder.releasePressedKeys(),
     /**
      * Destroy a context manager instance.
      *

--- a/handsontable/src/shortcuts/manager.js
+++ b/handsontable/src/shortcuts/manager.js
@@ -146,6 +146,7 @@ export const createShortcutManager = ({ ownerWindow, handleEvent, beforeKeyDown,
      * @returns {boolean}
      */
     isCtrlPressed: () => !isCtrlKeySilenced && (keyRecorder.isPressed('control') || keyRecorder.isPressed('meta')),
+    releaseAll: () => keyRecorder.releaseAll(),
     /**
      * Destroy a context manager instance.
      *

--- a/handsontable/src/shortcuts/recorder.js
+++ b/handsontable/src/shortcuts/recorder.js
@@ -174,6 +174,6 @@ export function useRecorder(ownerWindow, handleEvent, beforeKeyDown, afterKeyDow
     mount,
     unmount,
     isPressed: key => modifierKeysObserver.isPressed(key),
-    releaseAll: () => modifierKeysObserver.releaseAll(),
+    releasePressedKeys: () => modifierKeysObserver.releaseAll(),
   };
 }

--- a/handsontable/src/shortcuts/recorder.js
+++ b/handsontable/src/shortcuts/recorder.js
@@ -173,6 +173,7 @@ export function useRecorder(ownerWindow, handleEvent, beforeKeyDown, afterKeyDow
   return {
     mount,
     unmount,
-    isPressed: key => modifierKeysObserver.isPressed(key)
+    isPressed: key => modifierKeysObserver.isPressed(key),
+    releaseAll: () => modifierKeysObserver.releaseAll(),
   };
 }

--- a/handsontable/test/e2e/Core_selection.spec.js
+++ b/handsontable/test/e2e/Core_selection.spec.js
@@ -20,23 +20,23 @@ describe('Core_selection', () => {
       rowHeaders: true,
     });
 
-    $(getCell(5, 4)).simulate('mousedown');
-    $(getCell(1, 1)).simulate('mouseover');
-    $(getCell(1, 1)).simulate('mouseup');
+    mouseDown(getCell(5, 4));
+    mouseOver(getCell(1, 1));
+    mouseUp(getCell(1, 1));
 
     keyDown('control/meta');
 
-    $(getCell(0, 2)).simulate('mousedown');
-    $(getCell(8, 2)).simulate('mouseover');
-    $(getCell(7, 2)).simulate('mouseup');
+    mouseDown(getCell(0, 2));
+    mouseOver(getCell(8, 2));
+    mouseUp(getCell(7, 2));
 
-    $(getCell(2, 4)).simulate('mousedown');
-    $(getCell(2, 4)).simulate('mouseover');
-    $(getCell(2, 4)).simulate('mouseup');
+    mouseDown(getCell(2, 4));
+    mouseOver(getCell(2, 4));
+    mouseUp(getCell(2, 4));
 
-    $(getCell(7, 6)).simulate('mousedown');
-    $(getCell(8, 7)).simulate('mouseover');
-    $(getCell(8, 7)).simulate('mouseup');
+    mouseDown(getCell(7, 6));
+    mouseOver(getCell(8, 7));
+    mouseUp(getCell(8, 7));
 
     keyUp('control/meta');
 
@@ -816,7 +816,7 @@ describe('Core_selection', () => {
 
     keyDown('control/meta');
 
-    spec().$container.find('tr:eq(2) th:eq(0)').simulate('mousedown');
+    mouseDown(spec().$container.find('tr:eq(2) th:eq(0)')[0]);
 
     keyUp('control/meta');
 
@@ -853,8 +853,8 @@ describe('Core_selection', () => {
 
     keyDown('control/meta');
 
-    spec().$container.find('thead th:eq(3)').simulate('mousedown');
-    spec().$container.find('tr:eq(3) th:eq(0)').simulate('mousedown');
+    mouseDown(spec().$container.find('thead th:eq(3)')[0]);
+    mouseDown(spec().$container.find('tr:eq(3) th:eq(0)')[0]);
 
     keyUp('control/meta');
 
@@ -878,9 +878,9 @@ describe('Core_selection', () => {
       cells: (row, col) => (row === 1 && col === 1 ? { className: 'red-background' } : void 0)
     });
 
-    $(getCell(0, 0)).simulate('mousedown');
-    $(getCell(4, 4)).simulate('mouseover');
-    $(getCell(4, 4)).simulate('mouseup');
+    mouseDown(getCell(0, 0));
+    mouseOver(getCell(4, 4));
+    mouseUp(getCell(4, 4));
 
     expect(window.getComputedStyle(getCell(1, 1))['background-color']).toBe('rgb(255, 0, 0)');
   });
@@ -986,7 +986,7 @@ describe('Core_selection', () => {
 
     await sleep(30);
 
-    $(getCell(12, 11)).simulate('mousedown');
+    mouseDown(getCell(12, 11));
     spec().$container.find('.ht_clone_top thead th:eq(6)').simulate('mouseover'); // Header `L`
 
     await sleep(30);
@@ -1051,7 +1051,7 @@ describe('Core_selection', () => {
 
     await sleep(30);
 
-    $(getCell(12, 11)).simulate('mousedown');
+    mouseDown(getCell(12, 11));
     spec().$container.find('.ht_clone_inline_start tbody th:eq(12)').simulate('mouseover');
 
     await sleep(30);
@@ -1781,9 +1781,9 @@ describe('Core_selection', () => {
         `).toBeMatchToSelectionPattern();
 
         // Area selection (headers aren't selected).
-        $(getCell(1, 1)).simulate('mousedown');
-        $(getCell(4, 4)).simulate('mouseover');
-        $(getCell(4, 4)).simulate('mouseup');
+        mouseDown(getCell(1, 1));
+        mouseOver(getCell(4, 4));
+        mouseUp(getCell(4, 4));
 
         expect(getSelected()).toEqual([[1, 1, 4, 4]]);
         expect(getSelectedRangeLast().highlight.row).toBe(1);
@@ -1873,9 +1873,9 @@ describe('Core_selection', () => {
         `).toBeMatchToSelectionPattern();
 
         // Area selection (headers and area is selected).
-        $(getCell(1, 1)).simulate('mousedown');
-        $(getCell(4, 4)).simulate('mouseover');
-        $(getCell(4, 4)).simulate('mouseup');
+        mouseDown(getCell(1, 1));
+        mouseOver(getCell(4, 4));
+        mouseUp(getCell(4, 4));
 
         expect(getSelected()).toEqual([[1, 1, 4, 4]]);
         expect(getSelectedRangeLast().highlight.row).toBe(1);
@@ -1965,9 +1965,9 @@ describe('Core_selection', () => {
         `).toBeMatchToSelectionPattern();
 
         // Area selection (headers are selected).
-        $(getCell(1, 1)).simulate('mousedown');
-        $(getCell(4, 4)).simulate('mouseover');
-        $(getCell(4, 4)).simulate('mouseup');
+        mouseDown(getCell(1, 1));
+        mouseOver(getCell(4, 4));
+        mouseUp(getCell(4, 4));
 
         expect(getSelected()).toEqual([[1, 1, 4, 4]]);
         expect(getSelectedRangeLast().highlight.row).toBe(1);
@@ -2057,9 +2057,9 @@ describe('Core_selection', () => {
         `).toBeMatchToSelectionPattern();
 
         // Area selection
-        $(getCell(1, 1)).simulate('mousedown');
-        $(getCell(4, 4)).simulate('mouseover');
-        $(getCell(4, 4)).simulate('mouseup');
+        mouseDown(getCell(1, 1));
+        mouseOver(getCell(4, 4));
+        mouseUp(getCell(4, 4));
 
         expect(getSelected()).toEqual([[1, 1, 4, 4]]);
         expect(getSelectedRangeLast().highlight.row).toBe(1);
@@ -2165,9 +2165,9 @@ describe('Core_selection', () => {
         `).toBeMatchToSelectionPattern();
 
         // Area selection (headers aren't selected).
-        $(getCell(1, 1)).simulate('mousedown');
-        $(getCell(4, 4)).simulate('mouseover');
-        $(getCell(4, 4)).simulate('mouseup');
+        mouseDown(getCell(1, 1));
+        mouseOver(getCell(4, 4));
+        mouseUp(getCell(4, 4));
 
         expect(getSelected()).toEqual([[1, 1, 4, 4]]);
         expect(getSelectedRangeLast().highlight.row).toBe(1);
@@ -2271,9 +2271,9 @@ describe('Core_selection', () => {
         `).toBeMatchToSelectionPattern();
 
         // Area selection (headers aren't selected).
-        $(getCell(1, 1)).simulate('mousedown');
-        $(getCell(4, 4)).simulate('mouseover');
-        $(getCell(4, 4)).simulate('mouseup');
+        mouseDown(getCell(1, 1));
+        mouseOver(getCell(4, 4));
+        mouseUp(getCell(4, 4));
 
         expect(getSelected()).toEqual([[1, 1, 4, 4]]);
         expect(getSelectedRangeLast().highlight.row).toBe(1);
@@ -2376,9 +2376,9 @@ describe('Core_selection', () => {
         `).toBeMatchToSelectionPattern();
 
         // Area selection (headers and area is selected).
-        $(getCell(1, 1)).simulate('mousedown');
-        $(getCell(4, 4)).simulate('mouseover');
-        $(getCell(4, 4)).simulate('mouseup');
+        mouseDown(getCell(1, 1));
+        mouseOver(getCell(4, 4));
+        mouseUp(getCell(4, 4));
 
         expect(getSelected()).toEqual([[1, 1, 4, 4]]);
         expect(getSelectedRangeLast().highlight.row).toBe(1);
@@ -2481,9 +2481,9 @@ describe('Core_selection', () => {
         `).toBeMatchToSelectionPattern();
 
         // Area selection (headers are selected).
-        $(getCell(1, 1)).simulate('mousedown');
-        $(getCell(4, 4)).simulate('mouseover');
-        $(getCell(4, 4)).simulate('mouseup');
+        mouseDown(getCell(1, 1));
+        mouseOver(getCell(4, 4));
+        mouseUp(getCell(4, 4));
 
         expect(getSelected()).toEqual([[1, 1, 4, 4]]);
         expect(getSelectedRangeLast().highlight.row).toBe(1);
@@ -2586,9 +2586,9 @@ describe('Core_selection', () => {
         `).toBeMatchToSelectionPattern();
 
         // Area selection
-        $(getCell(1, 1)).simulate('mousedown');
-        $(getCell(4, 4)).simulate('mouseover');
-        $(getCell(4, 4)).simulate('mouseup');
+        mouseDown(getCell(1, 1));
+        mouseOver(getCell(4, 4));
+        mouseUp(getCell(4, 4));
 
         expect(getSelected()).toEqual([[1, 1, 4, 4]]);
         expect(getSelectedRangeLast().highlight.row).toBe(1);
@@ -2661,9 +2661,9 @@ describe('Core_selection', () => {
         startCols: 10
       });
 
-      $(getCell(1, 1)).simulate('mousedown');
-      $(getCell(4, 4)).simulate('mouseover');
-      $(getCell(4, 4)).simulate('mouseup');
+      mouseDown(getCell(1, 1));
+      mouseOver(getCell(4, 4));
+      mouseUp(getCell(4, 4));
 
       expect(getSelected()).toEqual([[1, 1, 4, 4]]);
       expect(`
@@ -2681,9 +2681,9 @@ describe('Core_selection', () => {
 
       keyDown('control/meta');
 
-      $(getCell(3, 3)).simulate('mousedown');
-      $(getCell(5, 6)).simulate('mouseover');
-      $(getCell(5, 6)).simulate('mouseup');
+      mouseDown(getCell(3, 3));
+      mouseOver(getCell(5, 6));
+      mouseUp(getCell(5, 6));
 
       keyUp('control/meta');
 
@@ -2711,9 +2711,9 @@ describe('Core_selection', () => {
         selectionMode: 'single',
       });
 
-      $(getCell(1, 1)).simulate('mousedown');
-      $(getCell(4, 4)).simulate('mouseover');
-      $(getCell(4, 4)).simulate('mouseup');
+      mouseDown(getCell(1, 1));
+      mouseOver(getCell(4, 4));
+      mouseUp(getCell(4, 4));
 
       expect(getSelected()).toEqual([[1, 1, 1, 1]]);
       expect(`
@@ -2731,9 +2731,9 @@ describe('Core_selection', () => {
 
       keyDown('control/meta');
 
-      $(getCell(3, 3)).simulate('mousedown');
-      $(getCell(5, 6)).simulate('mouseover');
-      $(getCell(5, 6)).simulate('mouseup');
+      mouseDown(getCell(3, 3));
+      mouseOver(getCell(5, 6));
+      mouseUp(getCell(5, 6));
 
       keyUp('control/meta');
 
@@ -2761,9 +2761,9 @@ describe('Core_selection', () => {
         selectionMode: 'range',
       });
 
-      $(getCell(1, 1)).simulate('mousedown');
-      $(getCell(4, 4)).simulate('mouseover');
-      $(getCell(4, 4)).simulate('mouseup');
+      mouseDown(getCell(1, 1));
+      mouseOver(getCell(4, 4));
+      mouseUp(getCell(4, 4));
 
       expect(getSelected()).toEqual([[1, 1, 4, 4]]);
       expect(`
@@ -2779,9 +2779,9 @@ describe('Core_selection', () => {
       |   ║   :   :   :   :   :   :   :   :   :   |
       `).toBeMatchToSelectionPattern();
 
-      $(getCell(3, 3)).simulate('mousedown');
-      $(getCell(5, 6)).simulate('mouseover');
-      $(getCell(5, 6)).simulate('mouseup');
+      mouseDown(getCell(3, 3));
+      mouseOver(getCell(5, 6));
+      mouseUp(getCell(5, 6));
 
       expect(getSelected()).toEqual([[3, 3, 5, 6]]);
       expect(`
@@ -2807,9 +2807,9 @@ describe('Core_selection', () => {
         selectionMode: 'range',
       });
 
-      $(getCell(1, 1)).simulate('mousedown');
-      $(getCell(4, 4)).simulate('mouseover');
-      $(getCell(4, 4)).simulate('mouseup');
+      mouseDown(getCell(1, 1));
+      mouseOver(getCell(4, 4));
+      mouseUp(getCell(4, 4));
 
       expect(getSelected()).toEqual([[1, 1, 4, 4]]);
       expect(`
@@ -2827,9 +2827,9 @@ describe('Core_selection', () => {
 
       keyDown('control/meta');
 
-      $(getCell(3, 3)).simulate('mousedown');
-      $(getCell(5, 6)).simulate('mouseover');
-      $(getCell(5, 6)).simulate('mouseup');
+      mouseDown(getCell(3, 3));
+      mouseOver(getCell(5, 6));
+      mouseUp(getCell(5, 6));
 
       keyUp('control/meta');
 
@@ -2857,51 +2857,51 @@ describe('Core_selection', () => {
         rowHeaders: true,
       });
 
-      $(getCell(0, 0)).simulate('mousedown');
-      $(getCell(20, 15)).simulate('mouseover');
-      $(getCell(20, 15)).simulate('mouseup');
+      mouseDown(getCell(0, 0));
+      mouseOver(getCell(20, 15));
+      mouseUp(getCell(20, 15));
 
       keyDown('control/meta');
 
-      $(getCell(1, 1)).simulate('mousedown');
-      $(getCell(19, 16)).simulate('mouseover');
-      $(getCell(19, 16)).simulate('mouseup');
+      mouseDown(getCell(1, 1));
+      mouseOver(getCell(19, 16));
+      mouseUp(getCell(19, 16));
 
-      $(getCell(2, 2)).simulate('mousedown');
-      $(getCell(18, 17)).simulate('mouseover');
-      $(getCell(18, 17)).simulate('mouseup');
+      mouseDown(getCell(2, 2));
+      mouseOver(getCell(18, 17));
+      mouseUp(getCell(18, 17));
 
-      $(getCell(3, 3)).simulate('mousedown');
-      $(getCell(17, 18)).simulate('mouseover');
-      $(getCell(17, 18)).simulate('mouseup');
+      mouseDown(getCell(3, 3));
+      mouseOver(getCell(17, 18));
+      mouseUp(getCell(17, 18));
 
-      $(getCell(4, 4)).simulate('mousedown');
-      $(getCell(16, 19)).simulate('mouseover');
-      $(getCell(16, 19)).simulate('mouseup');
+      mouseDown(getCell(4, 4));
+      mouseOver(getCell(16, 19));
+      mouseUp(getCell(16, 19));
 
-      $(getCell(5, 5)).simulate('mousedown');
-      $(getCell(15, 20)).simulate('mouseover');
-      $(getCell(15, 20)).simulate('mouseup');
+      mouseDown(getCell(5, 5));
+      mouseOver(getCell(15, 20));
+      mouseUp(getCell(15, 20));
 
-      $(getCell(6, 6)).simulate('mousedown');
-      $(getCell(14, 21)).simulate('mouseover');
-      $(getCell(14, 21)).simulate('mouseup');
+      mouseDown(getCell(6, 6));
+      mouseOver(getCell(14, 21));
+      mouseUp(getCell(14, 21));
 
-      $(getCell(7, 7)).simulate('mousedown');
-      $(getCell(13, 22)).simulate('mouseover');
-      $(getCell(13, 22)).simulate('mouseup');
+      mouseDown(getCell(7, 7));
+      mouseOver(getCell(13, 22));
+      mouseUp(getCell(13, 22));
 
-      $(getCell(8, 8)).simulate('mousedown');
-      $(getCell(12, 23)).simulate('mouseover');
-      $(getCell(12, 23)).simulate('mouseup');
+      mouseDown(getCell(8, 8));
+      mouseOver(getCell(12, 23));
+      mouseUp(getCell(12, 23));
 
-      $(getCell(9, 9)).simulate('mousedown');
-      $(getCell(11, 24)).simulate('mouseover');
-      $(getCell(11, 24)).simulate('mouseup');
+      mouseDown(getCell(9, 9));
+      mouseOver(getCell(11, 24));
+      mouseUp(getCell(11, 24));
 
-      $(getCell(10, 10)).simulate('mousedown');
-      $(getCell(10, 25)).simulate('mouseover');
-      $(getCell(10, 25)).simulate('mouseup');
+      mouseDown(getCell(10, 10));
+      mouseOver(getCell(10, 25));
+      mouseUp(getCell(10, 25));
 
       keyUp('control/meta');
 
@@ -2945,9 +2945,9 @@ describe('Core_selection', () => {
         afterSelectionEnd: hooks.afterSelectionEnd,
       });
 
-      $(getCell(0, 0)).simulate('mousedown');
-      $(getCell(20, 15)).simulate('mouseover');
-      $(getCell(20, 15)).simulate('mouseup');
+      mouseDown(getCell(0, 0));
+      mouseOver(getCell(20, 15));
+      mouseUp(getCell(20, 15));
 
       expect(hooks.afterSelection.calls.count()).toBe(2);
       expect(hooks.afterSelection.calls.argsFor(0)).toEqual([0, 0, 0, 0, jasmine.any(Object), 0]);
@@ -2959,9 +2959,9 @@ describe('Core_selection', () => {
       hooks.afterSelection.calls.reset();
       hooks.afterSelectionEnd.calls.reset();
 
-      $(getCell(1, 1)).simulate('mousedown');
-      $(getCell(19, 16)).simulate('mouseover');
-      $(getCell(19, 16)).simulate('mouseup');
+      mouseDown(getCell(1, 1));
+      mouseOver(getCell(19, 16));
+      mouseUp(getCell(19, 16));
 
       expect(hooks.afterSelection.calls.count()).toBe(2);
       expect(hooks.afterSelection.calls.argsFor(0)).toEqual([1, 1, 1, 1, jasmine.any(Object), 1]);
@@ -2972,9 +2972,9 @@ describe('Core_selection', () => {
       hooks.afterSelection.calls.reset();
       hooks.afterSelectionEnd.calls.reset();
 
-      $(getCell(2, 2)).simulate('mousedown');
-      $(getCell(18, 17)).simulate('mouseover');
-      $(getCell(18, 17)).simulate('mouseup');
+      mouseDown(getCell(2, 2));
+      mouseOver(getCell(18, 17));
+      mouseUp(getCell(18, 17));
 
       expect(hooks.afterSelection.calls.count()).toBe(2);
       expect(hooks.afterSelection.calls.argsFor(0)).toEqual([2, 2, 2, 2, jasmine.any(Object), 2]);
@@ -2985,9 +2985,9 @@ describe('Core_selection', () => {
       hooks.afterSelection.calls.reset();
       hooks.afterSelectionEnd.calls.reset();
 
-      $(getCell(3, 3)).simulate('mousedown');
-      $(getCell(17, 18)).simulate('mouseover');
-      $(getCell(17, 18)).simulate('mouseup');
+      mouseDown(getCell(3, 3));
+      mouseOver(getCell(17, 18));
+      mouseUp(getCell(17, 18));
 
       expect(hooks.afterSelection.calls.count()).toBe(2);
       expect(hooks.afterSelection.calls.argsFor(0)).toEqual([3, 3, 3, 3, jasmine.any(Object), 3]);
@@ -2998,9 +2998,9 @@ describe('Core_selection', () => {
       hooks.afterSelection.calls.reset();
       hooks.afterSelectionEnd.calls.reset();
 
-      $(getCell(4, 4)).simulate('mousedown');
-      $(getCell(16, 19)).simulate('mouseover');
-      $(getCell(16, 19)).simulate('mouseup');
+      mouseDown(getCell(4, 4));
+      mouseOver(getCell(16, 19));
+      mouseUp(getCell(16, 19));
 
       expect(hooks.afterSelection.calls.count()).toBe(2);
       expect(hooks.afterSelection.calls.argsFor(0)).toEqual([4, 4, 4, 4, jasmine.any(Object), 4]);
@@ -3011,9 +3011,9 @@ describe('Core_selection', () => {
       hooks.afterSelection.calls.reset();
       hooks.afterSelectionEnd.calls.reset();
 
-      $(getCell(5, 5)).simulate('mousedown');
-      $(getCell(15, 20)).simulate('mouseover');
-      $(getCell(15, 20)).simulate('mouseup');
+      mouseDown(getCell(5, 5));
+      mouseOver(getCell(15, 20));
+      mouseUp(getCell(15, 20));
 
       expect(hooks.afterSelection.calls.count()).toBe(2);
       expect(hooks.afterSelection.calls.argsFor(0)).toEqual([5, 5, 5, 5, jasmine.any(Object), 5]);
@@ -3024,9 +3024,9 @@ describe('Core_selection', () => {
       hooks.afterSelection.calls.reset();
       hooks.afterSelectionEnd.calls.reset();
 
-      $(getCell(6, 6)).simulate('mousedown');
-      $(getCell(14, 21)).simulate('mouseover');
-      $(getCell(14, 21)).simulate('mouseup');
+      mouseDown(getCell(6, 6));
+      mouseOver(getCell(14, 21));
+      mouseUp(getCell(14, 21));
 
       expect(hooks.afterSelection.calls.count()).toBe(2);
       expect(hooks.afterSelection.calls.argsFor(0)).toEqual([6, 6, 6, 6, jasmine.any(Object), 6]);
@@ -3037,9 +3037,9 @@ describe('Core_selection', () => {
       hooks.afterSelection.calls.reset();
       hooks.afterSelectionEnd.calls.reset();
 
-      $(getCell(7, 7)).simulate('mousedown');
-      $(getCell(13, 22)).simulate('mouseover');
-      $(getCell(13, 22)).simulate('mouseup');
+      mouseDown(getCell(7, 7));
+      mouseOver(getCell(13, 22));
+      mouseUp(getCell(13, 22));
 
       expect(hooks.afterSelection.calls.count()).toBe(2);
       expect(hooks.afterSelection.calls.argsFor(0)).toEqual([7, 7, 7, 7, jasmine.any(Object), 7]);
@@ -3050,9 +3050,9 @@ describe('Core_selection', () => {
       hooks.afterSelection.calls.reset();
       hooks.afterSelectionEnd.calls.reset();
 
-      $(getCell(8, 8)).simulate('mousedown');
-      $(getCell(12, 23)).simulate('mouseover');
-      $(getCell(12, 23)).simulate('mouseup');
+      mouseDown(getCell(8, 8));
+      mouseOver(getCell(12, 23));
+      mouseUp(getCell(12, 23));
 
       expect(hooks.afterSelection.calls.count()).toBe(2);
       expect(hooks.afterSelection.calls.argsFor(0)).toEqual([8, 8, 8, 8, jasmine.any(Object), 8]);
@@ -3063,9 +3063,9 @@ describe('Core_selection', () => {
       hooks.afterSelection.calls.reset();
       hooks.afterSelectionEnd.calls.reset();
 
-      $(getCell(9, 9)).simulate('mousedown');
-      $(getCell(11, 24)).simulate('mouseover');
-      $(getCell(11, 24)).simulate('mouseup');
+      mouseDown(getCell(9, 9));
+      mouseOver(getCell(11, 24));
+      mouseUp(getCell(11, 24));
 
       expect(hooks.afterSelection.calls.count()).toBe(2);
       expect(hooks.afterSelection.calls.argsFor(0)).toEqual([9, 9, 9, 9, jasmine.any(Object), 9]);
@@ -3076,9 +3076,9 @@ describe('Core_selection', () => {
       hooks.afterSelection.calls.reset();
       hooks.afterSelectionEnd.calls.reset();
 
-      $(getCell(10, 10)).simulate('mousedown');
-      $(getCell(10, 25)).simulate('mouseover');
-      $(getCell(10, 25)).simulate('mouseup');
+      mouseDown(getCell(10, 10));
+      mouseOver(getCell(10, 25));
+      mouseUp(getCell(10, 25));
 
       keyUp('control/meta');
 
@@ -3099,9 +3099,9 @@ describe('Core_selection', () => {
         afterSelectionEndByProp: hooks.afterSelectionEnd,
       });
 
-      $(getCell(0, 0)).simulate('mousedown');
-      $(getCell(20, 15)).simulate('mouseover');
-      $(getCell(20, 15)).simulate('mouseup');
+      mouseDown(getCell(0, 0));
+      mouseOver(getCell(20, 15));
+      mouseUp(getCell(20, 15));
 
       expect(hooks.afterSelection.calls.count()).toBe(2);
       expect(hooks.afterSelection.calls.argsFor(0)).toEqual([0, 'prop0', 0, 'prop0', jasmine.any(Object), 0]);
@@ -3113,9 +3113,9 @@ describe('Core_selection', () => {
       hooks.afterSelection.calls.reset();
       hooks.afterSelectionEnd.calls.reset();
 
-      $(getCell(1, 1)).simulate('mousedown');
-      $(getCell(19, 16)).simulate('mouseover');
-      $(getCell(19, 16)).simulate('mouseup');
+      mouseDown(getCell(1, 1));
+      mouseOver(getCell(19, 16));
+      mouseUp(getCell(19, 16));
 
       expect(hooks.afterSelection.calls.count()).toBe(2);
       expect(hooks.afterSelection.calls.argsFor(0)).toEqual([1, 'prop1', 1, 'prop1', jasmine.any(Object), 1]);
@@ -3126,9 +3126,9 @@ describe('Core_selection', () => {
       hooks.afterSelection.calls.reset();
       hooks.afterSelectionEnd.calls.reset();
 
-      $(getCell(2, 2)).simulate('mousedown');
-      $(getCell(18, 17)).simulate('mouseover');
-      $(getCell(18, 17)).simulate('mouseup');
+      mouseDown(getCell(2, 2));
+      mouseOver(getCell(18, 17));
+      mouseUp(getCell(18, 17));
 
       expect(hooks.afterSelection.calls.count()).toBe(2);
       expect(hooks.afterSelection.calls.argsFor(0)).toEqual([2, 'prop2', 2, 'prop2', jasmine.any(Object), 2]);
@@ -3139,9 +3139,9 @@ describe('Core_selection', () => {
       hooks.afterSelection.calls.reset();
       hooks.afterSelectionEnd.calls.reset();
 
-      $(getCell(3, 3)).simulate('mousedown');
-      $(getCell(17, 18)).simulate('mouseover');
-      $(getCell(17, 18)).simulate('mouseup');
+      mouseDown(getCell(3, 3));
+      mouseOver(getCell(17, 18));
+      mouseUp(getCell(17, 18));
 
       expect(hooks.afterSelection.calls.count()).toBe(2);
       expect(hooks.afterSelection.calls.argsFor(0)).toEqual([3, 'prop3', 3, 'prop3', jasmine.any(Object), 3]);
@@ -3152,9 +3152,9 @@ describe('Core_selection', () => {
       hooks.afterSelection.calls.reset();
       hooks.afterSelectionEnd.calls.reset();
 
-      $(getCell(4, 4)).simulate('mousedown');
-      $(getCell(16, 19)).simulate('mouseover');
-      $(getCell(16, 19)).simulate('mouseup');
+      mouseDown(getCell(4, 4));
+      mouseOver(getCell(16, 19));
+      mouseUp(getCell(16, 19));
 
       expect(hooks.afterSelection.calls.count()).toBe(2);
       expect(hooks.afterSelection.calls.argsFor(0)).toEqual([4, 'prop4', 4, 'prop4', jasmine.any(Object), 4]);
@@ -3165,9 +3165,9 @@ describe('Core_selection', () => {
       hooks.afterSelection.calls.reset();
       hooks.afterSelectionEnd.calls.reset();
 
-      $(getCell(5, 5)).simulate('mousedown');
-      $(getCell(15, 20)).simulate('mouseover');
-      $(getCell(15, 20)).simulate('mouseup');
+      mouseDown(getCell(5, 5));
+      mouseOver(getCell(15, 20));
+      mouseUp(getCell(15, 20));
 
       expect(hooks.afterSelection.calls.count()).toBe(2);
       expect(hooks.afterSelection.calls.argsFor(0)).toEqual([5, 'prop5', 5, 'prop5', jasmine.any(Object), 5]);
@@ -3178,9 +3178,9 @@ describe('Core_selection', () => {
       hooks.afterSelection.calls.reset();
       hooks.afterSelectionEnd.calls.reset();
 
-      $(getCell(6, 6)).simulate('mousedown');
-      $(getCell(14, 21)).simulate('mouseover');
-      $(getCell(14, 21)).simulate('mouseup');
+      mouseDown(getCell(6, 6));
+      mouseOver(getCell(14, 21));
+      mouseUp(getCell(14, 21));
 
       expect(hooks.afterSelection.calls.count()).toBe(2);
       expect(hooks.afterSelection.calls.argsFor(0)).toEqual([6, 'prop6', 6, 'prop6', jasmine.any(Object), 6]);
@@ -3191,9 +3191,9 @@ describe('Core_selection', () => {
       hooks.afterSelection.calls.reset();
       hooks.afterSelectionEnd.calls.reset();
 
-      $(getCell(7, 7)).simulate('mousedown');
-      $(getCell(13, 22)).simulate('mouseover');
-      $(getCell(13, 22)).simulate('mouseup');
+      mouseDown(getCell(7, 7));
+      mouseOver(getCell(13, 22));
+      mouseUp(getCell(13, 22));
 
       expect(hooks.afterSelection.calls.count()).toBe(2);
       expect(hooks.afterSelection.calls.argsFor(0)).toEqual([7, 'prop7', 7, 'prop7', jasmine.any(Object), 7]);
@@ -3204,9 +3204,9 @@ describe('Core_selection', () => {
       hooks.afterSelection.calls.reset();
       hooks.afterSelectionEnd.calls.reset();
 
-      $(getCell(8, 8)).simulate('mousedown');
-      $(getCell(12, 23)).simulate('mouseover');
-      $(getCell(12, 23)).simulate('mouseup');
+      mouseDown(getCell(8, 8));
+      mouseOver(getCell(12, 23));
+      mouseUp(getCell(12, 23));
 
       expect(hooks.afterSelection.calls.count()).toBe(2);
       expect(hooks.afterSelection.calls.argsFor(0)).toEqual([8, 'prop8', 8, 'prop8', jasmine.any(Object), 8]);
@@ -3217,9 +3217,9 @@ describe('Core_selection', () => {
       hooks.afterSelection.calls.reset();
       hooks.afterSelectionEnd.calls.reset();
 
-      $(getCell(9, 9)).simulate('mousedown');
-      $(getCell(11, 24)).simulate('mouseover');
-      $(getCell(11, 24)).simulate('mouseup');
+      mouseDown(getCell(9, 9));
+      mouseOver(getCell(11, 24));
+      mouseUp(getCell(11, 24));
 
       expect(hooks.afterSelection.calls.count()).toBe(2);
       expect(hooks.afterSelection.calls.argsFor(0)).toEqual([9, 'prop9', 9, 'prop9', jasmine.any(Object), 9]);
@@ -3230,9 +3230,9 @@ describe('Core_selection', () => {
       hooks.afterSelection.calls.reset();
       hooks.afterSelectionEnd.calls.reset();
 
-      $(getCell(10, 10)).simulate('mousedown');
-      $(getCell(10, 25)).simulate('mouseover');
-      $(getCell(10, 25)).simulate('mouseup');
+      mouseDown(getCell(10, 10));
+      mouseOver(getCell(10, 25));
+      mouseUp(getCell(10, 25));
 
       keyUp('control/meta');
 
@@ -3494,21 +3494,21 @@ describe('Core_selection', () => {
 
     keyDown('control/meta');
 
-    $(hot1.getCell(0, 1)).simulate('mousedown');
-    $(hot1.getCell(0, 1)).simulate('mouseover');
-    $(hot1.getCell(0, 1)).simulate('mouseup');
+    mouseDown(hot1.getCell(0, 1));
+    mouseOver(hot1.getCell(0, 1));
+    mouseUp(hot1.getCell(0, 1));
 
-    $(hot1.getCell(0, 2)).simulate('mousedown');
-    $(hot1.getCell(0, 2)).simulate('mouseover');
-    $(hot1.getCell(0, 2)).simulate('mouseup');
+    mouseDown(hot1.getCell(0, 2));
+    mouseOver(hot1.getCell(0, 2));
+    mouseUp(hot1.getCell(0, 2));
 
-    $(hot2.getCell(0, 0)).simulate('mousedown');
-    $(hot2.getCell(0, 0)).simulate('mouseover');
-    $(hot2.getCell(0, 0)).simulate('mouseup');
+    mouseDown(hot2.getCell(0, 0));
+    mouseOver(hot2.getCell(0, 0));
+    mouseUp(hot2.getCell(0, 0));
 
-    $(hot2.getCell(0, 1)).simulate('mousedown');
-    $(hot2.getCell(0, 1)).simulate('mouseover');
-    $(hot2.getCell(0, 1)).simulate('mouseup');
+    mouseDown(hot2.getCell(0, 1));
+    mouseOver(hot2.getCell(0, 1));
+    mouseUp(hot2.getCell(0, 1));
 
     keyUp('control/meta');
 
@@ -3517,13 +3517,13 @@ describe('Core_selection', () => {
 
     keyDown('control/meta');
 
-    $(hot1.getCell(0, 0)).simulate('mousedown');
-    $(hot1.getCell(0, 0)).simulate('mouseover');
-    $(hot1.getCell(0, 0)).simulate('mouseup');
+    mouseDown(hot1.getCell(0, 0));
+    mouseOver(hot1.getCell(0, 0));
+    mouseUp(hot1.getCell(0, 0));
 
-    $(hot1.getCell(0, 1)).simulate('mousedown');
-    $(hot1.getCell(0, 1)).simulate('mouseover');
-    $(hot1.getCell(0, 1)).simulate('mouseup');
+    mouseDown(hot1.getCell(0, 1));
+    mouseOver(hot1.getCell(0, 1));
+    mouseUp(hot1.getCell(0, 1));
 
     expect(hot1.getSelected()).toEqual([[0, 0, 0, 0], [0, 1, 0, 1]]);
     expect(hot2.getSelected()).toBe(undefined);

--- a/handsontable/test/e2e/core/emptySelectedCells.spec.js
+++ b/handsontable/test/e2e/core/emptySelectedCells.spec.js
@@ -16,23 +16,23 @@ describe('Core.emptySelectedCells', () => {
       selectionMode: 'multiple',
     });
 
-    $(getCell(5, 4)).simulate('mousedown');
-    $(getCell(1, 1)).simulate('mouseover');
-    $(getCell(1, 1)).simulate('mouseup');
+    mouseDown(getCell(5, 4));
+    mouseOver(getCell(1, 1));
+    mouseUp(getCell(1, 1));
 
     keyDown('control/meta');
 
-    $(getCell(2, 2)).simulate('mousedown');
-    $(getCell(7, 2)).simulate('mouseover');
-    $(getCell(7, 2)).simulate('mouseup');
+    mouseDown(getCell(2, 2));
+    mouseOver(getCell(7, 2));
+    mouseUp(getCell(7, 2));
 
-    $(getCell(2, 4)).simulate('mousedown');
-    $(getCell(2, 4)).simulate('mouseover');
-    $(getCell(2, 4)).simulate('mouseup');
+    mouseDown(getCell(2, 4));
+    mouseOver(getCell(2, 4));
+    mouseUp(getCell(2, 4));
 
-    $(getCell(7, 6)).simulate('mousedown');
-    $(getCell(8, 7)).simulate('mouseover');
-    $(getCell(8, 7)).simulate('mouseup');
+    mouseDown(getCell(7, 6));
+    mouseOver(getCell(8, 7));
+    mouseUp(getCell(8, 7));
 
     keyUp('control/meta');
 

--- a/handsontable/test/e2e/core/getSelected.spec.js
+++ b/handsontable/test/e2e/core/getSelected.spec.js
@@ -23,29 +23,29 @@ describe('Core.getSelected', () => {
       [7, 6, 8, 7],
     ];
 
-    $(getCell(5, 4)).simulate('mousedown');
-    $(getCell(1, 1)).simulate('mouseover');
-    $(getCell(1, 1)).simulate('mouseup');
+    mouseDown(getCell(5, 4));
+    mouseOver(getCell(1, 1));
+    mouseUp(getCell(1, 1));
 
     expect(getSelected()).toEqual([snapshot[0]]);
 
     keyDown('control/meta');
 
-    $(getCell(2, 2)).simulate('mousedown');
-    $(getCell(7, 2)).simulate('mouseover');
-    $(getCell(7, 2)).simulate('mouseup');
+    mouseDown(getCell(2, 2));
+    mouseOver(getCell(7, 2));
+    mouseUp(getCell(7, 2));
 
     expect(getSelected()).toEqual([snapshot[0], snapshot[1]]);
 
-    $(getCell(2, 4)).simulate('mousedown');
-    $(getCell(2, 4)).simulate('mouseover');
-    $(getCell(2, 4)).simulate('mouseup');
+    mouseDown(getCell(2, 4));
+    mouseOver(getCell(2, 4));
+    mouseUp(getCell(2, 4));
 
     expect(getSelected()).toEqual([snapshot[0], snapshot[1], snapshot[2]]);
 
-    $(getCell(7, 6)).simulate('mousedown');
-    $(getCell(8, 7)).simulate('mouseover');
-    $(getCell(8, 7)).simulate('mouseup');
+    mouseDown(getCell(7, 6));
+    mouseOver(getCell(8, 7));
+    mouseUp(getCell(8, 7));
 
     keyUp('control/meta');
 

--- a/handsontable/test/e2e/core/getSelectedLast.spec.js
+++ b/handsontable/test/e2e/core/getSelectedLast.spec.js
@@ -23,29 +23,29 @@ describe('Core.getSelectedLast', () => {
       [7, 6, 8, 7],
     ];
 
-    $(getCell(5, 4)).simulate('mousedown');
-    $(getCell(1, 1)).simulate('mouseover');
-    $(getCell(1, 1)).simulate('mouseup');
+    mouseDown(getCell(5, 4));
+    mouseOver(getCell(1, 1));
+    mouseUp(getCell(1, 1));
 
     expect(getSelectedLast()).toEqual(snapshot[0]);
 
     keyDown('control/meta');
 
-    $(getCell(2, 2)).simulate('mousedown');
-    $(getCell(7, 2)).simulate('mouseover');
-    $(getCell(7, 2)).simulate('mouseup');
+    mouseDown(getCell(2, 2));
+    mouseOver(getCell(7, 2));
+    mouseUp(getCell(7, 2));
 
     expect(getSelectedLast()).toEqual(snapshot[1]);
 
-    $(getCell(2, 4)).simulate('mousedown');
-    $(getCell(2, 4)).simulate('mouseover');
-    $(getCell(2, 4)).simulate('mouseup');
+    mouseDown(getCell(2, 4));
+    mouseOver(getCell(2, 4));
+    mouseUp(getCell(2, 4));
 
     expect(getSelectedLast()).toEqual(snapshot[2]);
 
-    $(getCell(7, 6)).simulate('mousedown');
-    $(getCell(8, 7)).simulate('mouseover');
-    $(getCell(8, 7)).simulate('mouseup');
+    mouseDown(getCell(7, 6));
+    mouseOver(getCell(8, 7));
+    mouseUp(getCell(8, 7));
 
     keyUp('control/meta');
 
@@ -65,32 +65,32 @@ describe('Core.getSelectedLast', () => {
       { from: { row: 7, col: 6 }, to: { row: 8, col: 7 } },
     ];
 
-    $(getCell(5, 4)).simulate('mousedown');
-    $(getCell(1, 1)).simulate('mouseover');
-    $(getCell(1, 1)).simulate('mouseup');
+    mouseDown(getCell(5, 4));
+    mouseOver(getCell(1, 1));
+    mouseUp(getCell(1, 1));
 
     expect(getSelectedRangeLast().toObject()).toEqual(snapshot[0]);
     expect(getSelectedRange().map(cellRange => cellRange.toObject())).toEqual([snapshot[0]]);
 
     keyDown('control/meta');
 
-    $(getCell(2, 2)).simulate('mousedown');
-    $(getCell(7, 2)).simulate('mouseover');
-    $(getCell(7, 2)).simulate('mouseup');
+    mouseDown(getCell(2, 2));
+    mouseOver(getCell(7, 2));
+    mouseUp(getCell(7, 2));
 
     expect(getSelectedRangeLast().toObject()).toEqual(snapshot[1]);
     expect(getSelectedRange().map(cellRange => cellRange.toObject())).toEqual([snapshot[0], snapshot[1]]);
 
-    $(getCell(2, 4)).simulate('mousedown');
-    $(getCell(2, 4)).simulate('mouseover');
-    $(getCell(2, 4)).simulate('mouseup');
+    mouseDown(getCell(2, 4));
+    mouseOver(getCell(2, 4));
+    mouseUp(getCell(2, 4));
 
     expect(getSelectedRangeLast().toObject()).toEqual(snapshot[2]);
     expect(getSelectedRange().map(cellRange => cellRange.toObject())).toEqual([snapshot[0], snapshot[1], snapshot[2]]);
 
-    $(getCell(7, 6)).simulate('mousedown');
-    $(getCell(8, 7)).simulate('mouseover');
-    $(getCell(8, 7)).simulate('mouseup');
+    mouseDown(getCell(7, 6));
+    mouseOver(getCell(8, 7));
+    mouseUp(getCell(8, 7));
 
     keyUp('control/meta');
 

--- a/handsontable/test/e2e/core/getSelectedRange.spec.js
+++ b/handsontable/test/e2e/core/getSelectedRange.spec.js
@@ -23,29 +23,29 @@ describe('Core.getSelectedRange', () => {
       { from: { row: 7, col: 6 }, to: { row: 8, col: 7 } },
     ];
 
-    $(getCell(5, 4)).simulate('mousedown');
-    $(getCell(1, 1)).simulate('mouseover');
-    $(getCell(1, 1)).simulate('mouseup');
+    mouseDown(getCell(5, 4));
+    mouseOver(getCell(1, 1));
+    mouseUp(getCell(1, 1));
 
     expect(getSelectedRange().map(cellRange => cellRange.toObject())).toEqual([snapshot[0]]);
 
     keyDown('control/meta');
 
-    $(getCell(2, 2)).simulate('mousedown');
-    $(getCell(7, 2)).simulate('mouseover');
-    $(getCell(7, 2)).simulate('mouseup');
+    mouseDown(getCell(2, 2));
+    mouseOver(getCell(7, 2));
+    mouseUp(getCell(7, 2));
 
     expect(getSelectedRange().map(cellRange => cellRange.toObject())).toEqual([snapshot[0], snapshot[1]]);
 
-    $(getCell(2, 4)).simulate('mousedown');
-    $(getCell(2, 4)).simulate('mouseover');
-    $(getCell(2, 4)).simulate('mouseup');
+    mouseDown(getCell(2, 4));
+    mouseOver(getCell(2, 4));
+    mouseUp(getCell(2, 4));
 
     expect(getSelectedRange().map(cellRange => cellRange.toObject())).toEqual([snapshot[0], snapshot[1], snapshot[2]]);
 
-    $(getCell(7, 6)).simulate('mousedown');
-    $(getCell(8, 7)).simulate('mouseover');
-    $(getCell(8, 7)).simulate('mouseup');
+    mouseDown(getCell(7, 6));
+    mouseOver(getCell(8, 7));
+    mouseUp(getCell(8, 7));
 
     keyUp('control/meta');
 

--- a/handsontable/test/e2e/core/getSelectedRangeLast.spec.js
+++ b/handsontable/test/e2e/core/getSelectedRangeLast.spec.js
@@ -23,29 +23,29 @@ describe('Core.getSelectedRangeLast', () => {
       { from: { row: 7, col: 6 }, to: { row: 8, col: 7 } },
     ];
 
-    $(getCell(5, 4)).simulate('mousedown');
-    $(getCell(1, 1)).simulate('mouseover');
-    $(getCell(1, 1)).simulate('mouseup');
+    mouseDown(getCell(5, 4));
+    mouseOver(getCell(1, 1));
+    mouseUp(getCell(1, 1));
 
     expect(getSelectedRangeLast().toObject()).toEqual(snapshot[0]);
 
     keyDown('control/meta');
 
-    $(getCell(2, 2)).simulate('mousedown');
-    $(getCell(7, 2)).simulate('mouseover');
-    $(getCell(7, 2)).simulate('mouseup');
+    mouseDown(getCell(2, 2));
+    mouseOver(getCell(7, 2));
+    mouseUp(getCell(7, 2));
 
     expect(getSelectedRangeLast().toObject()).toEqual(snapshot[1]);
 
-    $(getCell(2, 4)).simulate('mousedown');
-    $(getCell(2, 4)).simulate('mouseover');
-    $(getCell(2, 4)).simulate('mouseup');
+    mouseDown(getCell(2, 4));
+    mouseOver(getCell(2, 4));
+    mouseUp(getCell(2, 4));
 
     expect(getSelectedRangeLast().toObject()).toEqual(snapshot[2]);
 
-    $(getCell(7, 6)).simulate('mousedown');
-    $(getCell(8, 7)).simulate('mouseover');
-    $(getCell(8, 7)).simulate('mouseup');
+    mouseDown(getCell(7, 6));
+    mouseOver(getCell(8, 7));
+    mouseUp(getCell(8, 7));
 
     keyUp('control/meta');
 

--- a/handsontable/test/helpers/keyboardEvents.js
+++ b/handsontable/test/helpers/keyboardEvents.js
@@ -61,6 +61,23 @@ const KEY_CODES_MAP = new Map([
   ['z', KEY_CODES.Z],
 ]);
 
+export const pressedModifierKeys = {
+  ctrlKey: false,
+  metaKey: false,
+  shiftKey: false,
+  altKey: false,
+};
+
+/**
+ * @param {object} options Object for storing information about pressed modifier key.
+ * @param {string} modifiedKey Name of the modifier key.
+ * @param {boolean} isPressed Information whether the modifier kay was pressed.
+ */
+function saveStateAndExtendEvent(options, modifiedKey, isPressed) {
+  pressedModifierKeys[modifiedKey] = isPressed;
+  options[modifiedKey] = isPressed;
+}
+
 /**
  * Returns a function that triggers a key event.
  *
@@ -115,11 +132,14 @@ function triggerKeys(type) {
     });
 
     keys.forEach((key) => {
-      extend.ctrlKey = isKeyUp && key === 'control' ? false : keys.includes('control');
-      extend.metaKey = isKeyUp && key === 'meta' ? false : keys.includes('meta');
-      extend.shiftKey = isKeyUp && key === 'shift' ? false : keys.includes('shift');
-      extend.altKey = isKeyUp && key === 'alt' ? false : keys.includes('alt');
-
+      saveStateAndExtendEvent(extend, 'ctrlKey',
+        isKeyUp === true && key === 'control' ? false : keys.includes('control'));
+      saveStateAndExtendEvent(extend, 'metaKey',
+        isKeyUp === true && key === 'meta' ? false : keys.includes('meta'));
+      saveStateAndExtendEvent(extend, 'shiftKey',
+        isKeyUp === true && key === 'shift' ? false : keys.includes('shift'));
+      saveStateAndExtendEvent(extend, 'altKey',
+        isKeyUp === true && key === 'alt' ? false : keys.includes('alt'));
       keyTriggerFactory(type, key, { extend, target, ime });
     });
   };

--- a/handsontable/test/helpers/keyboardEvents.js
+++ b/handsontable/test/helpers/keyboardEvents.js
@@ -71,7 +71,7 @@ export const pressedModifierKeys = {
 /**
  * @param {object} options Object for storing information about pressed modifier key.
  * @param {string} modifiedKey Name of the modifier key.
- * @param {boolean} isPressed Information whether the modifier kay was pressed.
+ * @param {boolean} isPressed Information whether the modifier kay has been pressed.
  */
 function saveStateAndExtendEvent(options, modifiedKey, isPressed) {
   pressedModifierKeys[modifiedKey] = isPressed;

--- a/handsontable/test/helpers/mouseEvents.js
+++ b/handsontable/test/helpers/mouseEvents.js
@@ -1,3 +1,4 @@
+import { pressedModifierKeys } from './keyboardEvents';
 
 const MOUSE_BUTTONS = new Map();
 
@@ -24,7 +25,7 @@ function getMouseButton(buttonKey) {
  * @returns {Function}
  */
 export function handsontableMouseTriggerFactory(type, defaultButtonKey = getMouseButton('LMB')) {
-  return function(element, buttonKey = defaultButtonKey, eventProps = {}) {
+  return function(element, buttonKey = defaultButtonKey, eventProps = pressedModifierKeys) {
     let handsontableElement = element;
 
     if (!(handsontableElement instanceof jQuery)) {
@@ -56,7 +57,7 @@ export const contextMenuEvent = handsontableMouseTriggerFactory('contextmenu');
  * @param {number} [buttonKey] Number representing mouse button key.
  * @param {object} [eventProps] Addional object with props to merge with the event.
  */
-export function simulateClick(element, buttonKey = 'LMB', eventProps = {}) {
+export function simulateClick(element, buttonKey = 'LMB', eventProps = pressedModifierKeys) {
   const mouseButton = getMouseButton(buttonKey);
 
   mouseDown(element, mouseButton, eventProps);
@@ -79,7 +80,7 @@ export function simulateClick(element, buttonKey = 'LMB', eventProps = {}) {
  * @param {Element} element An element on which there will be performed mouse events.
  * @param {object} [eventProps] Addional object with props to merge with the event.
  */
-export function mouseDoubleClick(element, eventProps) {
+export function mouseDoubleClick(element, eventProps = pressedModifierKeys) {
   mouseDown(element, eventProps);
   mouseUp(element, eventProps);
   mouseDown(element, eventProps);


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Currently, most of the keyboard events is handled by the `ShortcutManager`. Internal recorder is responsible for catching `keydown` and `keyup` events. Unfortunately, using browser or system shortcut breaks a flow which releasing list of pressed keys. After triggering such a shortcut, a `keyup` event isn't emitted.

I'm afraid that there is no alternative way of fixing the **source of the problem**. This solution fixes just found side effects by adding extra callback to some hook. It also changing helpers for tests. Separately used jQuery simulate events don't transfer information about pressed meta keys to each other. I decided not to pass extra options to every method call, but use modified helper.

**Note**: I haven't added extra e2e test as is seems to be impossible to trigger system/browser events using simulated events.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I was testing cases from the issue and other system/browser shortcuts.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. [#31](https://github.com/handsontable/dev-handsontable/issues/31)

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] My change requires a change to the documentation.
