### PR TITLE
Work around a Chrome bug causing the freshly merged cells to not have right and bottom borders.

### DIFF
--- a/.changelogs/521.json
+++ b/.changelogs/521.json
@@ -1,0 +1,7 @@
+{
+  "title": "Fixed a Chrome issue, where the freshly-merged cells were missing right and bottom borders.",
+  "type": "fixed",
+  "issue": 521,
+  "breaking": false,
+  "framework": "none"
+}

--- a/docs/content/guides/cell-features/disabled-cells.md
+++ b/docs/content/guides/cell-features/disabled-cells.md
@@ -28,9 +28,9 @@ Make specified cells read-only to protect them from unwanted changes but still a
 Disabling a cell makes the cell read-only or non-editable. Both have similar outcomes, with the following differences:
 
 | Read-only cell<br>`readOnly: true`                                           | Non-editable cell<br>`editor: false`                                       |
-| ---------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+|------------------------------------------------------------------------------| -------------------------------------------------------------------------- |
 | Has an additional CSS class (`htDimmed`)                                     | Has no additional CSS class                                                |
-| Copy-paste doesn't work                                                      | Copy-paste works                                                           |
+| Copy works, paste doesn't work                                               | Copy-paste works                                                           |
 | Drag-to-fill doesn't work                                                    | Drag-to-fill works                                                         |
 | Can't be changed by [`populateFromArray()`](@/api/core.md#populatefromarray) | Can be changed by [`populateFromArray()`](@/api/core.md#populatefromarray) |
 

--- a/handsontable/src/3rdparty/walkontable/src/overlays.js
+++ b/handsontable/src/3rdparty/walkontable/src/overlays.js
@@ -149,6 +149,29 @@ class Overlays {
   }
 
   /**
+   * Get the list of references to all overlays.
+   *
+   * @param {boolean} [includeMaster = false] If set to `true`, the list will contain the master table as the last
+   * element.
+   * @returns {(TopOverlay|TopInlineStartCornerOverlay|InlineStartOverlay|BottomOverlay|BottomInlineStartCornerOverlay)[]}
+   */
+  getOverlays(includeMaster = false) {
+    const overlays = [
+      this.topOverlay,
+      this.topInlineStartCornerOverlay,
+      this.inlineStartOverlay,
+      this.bottomOverlay,
+      this.bottomInlineStartCornerOverlay
+    ];
+
+    if (includeMaster) {
+      overlays.push(this.wtTable);
+    }
+
+    return overlays;
+  }
+
+  /**
    * Retrieve browser line height and apply its value to `browserLineHeight`.
    *
    * @private

--- a/handsontable/src/3rdparty/walkontable/src/table.js
+++ b/handsontable/src/3rdparty/walkontable/src/table.js
@@ -657,7 +657,7 @@ class Table {
       parentElement = this.TBODY;
     }
 
-    if (renderedRowIndex && parentElement) {
+    if (renderedRowIndex !== void 0 && parentElement !== void 0) {
       if (parentElement.childNodes.length < renderedRowIndex + 1) {
         return false;
 

--- a/handsontable/src/3rdparty/walkontable/src/table.js
+++ b/handsontable/src/3rdparty/walkontable/src/table.js
@@ -641,12 +641,33 @@ class Table {
    * Get the DOM element of the row with the provided index.
    *
    * @param {number} rowIndex Row index.
-   * @returns {HTMLTableRowElement}
+   * @returns {HTMLTableRowElement|boolean} Return the row's DOM element or `false` if the row with the provided
+   * index doesn't exist.
    */
   getRow(rowIndex) {
-    return rowIndex < 0 ?
-      this.THEAD.childNodes[this.rowFilter.sourceRowToVisibleColHeadedRow(rowIndex)] :
-      this.TBODY.childNodes[this.rowFilter.sourceToRendered(rowIndex)];
+    let renderedRowIndex = null;
+    let parentElement = null;
+
+    if (rowIndex < 0) {
+      renderedRowIndex = this.rowFilter?.sourceRowToVisibleColHeadedRow(rowIndex);
+      parentElement = this.THEAD;
+
+    } else {
+      renderedRowIndex = this.rowFilter?.sourceToRendered(rowIndex);
+      parentElement = this.TBODY;
+    }
+
+    if (renderedRowIndex && parentElement) {
+      if (parentElement.childNodes.length < renderedRowIndex + 1) {
+        return false;
+
+      } else {
+        return parentElement.childNodes[renderedRowIndex];
+      }
+
+    } else {
+      return false;
+    }
   }
 
   /**

--- a/handsontable/src/3rdparty/walkontable/src/table.js
+++ b/handsontable/src/3rdparty/walkontable/src/table.js
@@ -622,13 +622,7 @@ class Table {
       return -4;
     }
 
-    let TR;
-
-    if (row < 0) {
-      TR = this.THEAD.childNodes[this.rowFilter.sourceRowToVisibleColHeadedRow(row)];
-    } else {
-      TR = this.TBODY.childNodes[this.rowFilter.sourceToRendered(row)];
-    }
+    const TR = this.getRow(row);
 
     if (!TR && row >= 0) {
       throw new Error('TR was expected to be rendered but is not');
@@ -641,6 +635,18 @@ class Table {
     }
 
     return TD;
+  }
+
+  /**
+   * Get the DOM element of the row with the provided index.
+   *
+   * @param {number} rowIndex Row index.
+   * @returns {HTMLTableRowElement}
+   */
+  getRow(rowIndex) {
+    return rowIndex < 0 ?
+      this.THEAD.childNodes[this.rowFilter.sourceRowToVisibleColHeadedRow(rowIndex)] :
+      this.TBODY.childNodes[this.rowFilter.sourceToRendered(rowIndex)];
   }
 
   /**

--- a/handsontable/src/3rdparty/walkontable/test/spec/overlay.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/overlay.spec.js
@@ -899,4 +899,35 @@ describe('WalkontableOverlay', () => {
 
     expect(getTableTopClone().find('thead tr th').css('border-bottom-width')).toBe('1px');
   });
+
+  it('should return the list of all overlays when calling the `getOverlays` method', () => {
+    createDataArray(3, 3);
+
+    const wt = walkontable({
+      data: getData,
+      totalRows: getTotalRows,
+      totalColumns: getTotalColumns
+    });
+
+    const wtOverlaysRef = wt.wtOverlays;
+    const overlays = wtOverlaysRef.getOverlays();
+    const overlaysWithMaster = wtOverlaysRef.getOverlays(true);
+
+    expect(overlays).toEqual([
+      wtOverlaysRef.topOverlay,
+      wtOverlaysRef.topInlineStartCornerOverlay,
+      wtOverlaysRef.inlineStartOverlay,
+      wtOverlaysRef.bottomOverlay,
+      wtOverlaysRef.bottomInlineStartCornerOverlay
+    ]);
+
+    expect(overlaysWithMaster).toEqual([
+      wtOverlaysRef.topOverlay,
+      wtOverlaysRef.topInlineStartCornerOverlay,
+      wtOverlaysRef.inlineStartOverlay,
+      wtOverlaysRef.bottomOverlay,
+      wtOverlaysRef.bottomInlineStartCornerOverlay,
+      wtOverlaysRef.wtTable
+    ]);
+  });
 });

--- a/handsontable/src/plugins/mergeCells/mergeCells.js
+++ b/handsontable/src/plugins/mergeCells/mergeCells.js
@@ -227,7 +227,7 @@ export class MergeCells extends BasePlugin {
           rowToRefresh.style.background =
             getStyle(rowToRefresh, 'backgroundColor').replace(')', ', 0.99)');
 
-          rowsToRefresh.push();
+          rowsToRefresh.push(rowToRefresh);
         }
       });
     });

--- a/handsontable/src/plugins/mergeCells/mergeCells.js
+++ b/handsontable/src/plugins/mergeCells/mergeCells.js
@@ -214,7 +214,8 @@ export class MergeCells extends BasePlugin {
 
     rowIndexesToRefresh.forEach((rowIndex) => {
       const wtTableRef = this.hot.view._wt.wtTable;
-      const rowToRefresh = wtTableRef.getRow(rowIndex);
+      const renderableRowIndex = this.hot.rowIndexMapper.getRenderableFromVisualIndex(rowIndex);
+      const rowToRefresh = wtTableRef.getRow(renderableRowIndex);
 
       // Modify the TR's `background` property to later modify it asynchronously.
       // The background color is getting modified only with the alpha, so the change should not be visible (and is
@@ -450,7 +451,9 @@ export class MergeCells extends BasePlugin {
         this.hot.populateFromArray(mergeParent.row, mergeParent.col, clearedData, void 0, void 0, this.pluginName);
       }
 
-      this.#ifChromeForceRepaint();
+      if (!auto) {
+        this.#ifChromeForceRepaint();
+      }
 
       this.hot.runHooks('afterMergeCells', cellRange, mergeParent, auto);
 

--- a/handsontable/src/plugins/mergeCells/mergeCells.js
+++ b/handsontable/src/plugins/mergeCells/mergeCells.js
@@ -215,13 +215,9 @@ export class MergeCells extends BasePlugin {
     rowIndexesToRefresh.forEach((rowIndex) => {
       const renderableRowIndex = this.hot.rowIndexMapper.getRenderableFromVisualIndex(rowIndex);
 
-      [
-        'topOverlay',
-        'bottomOverlay',
-        'inlineStartOverlay',
-        'topInlineStartCornerOverlay',
-        'bottomInlineStartCornerOverlay'
-      ].map(overlay => this.hot.view._wt.wtOverlays[overlay].clone.wtTable).forEach((wtTableRef) => {
+      this.hot.view._wt.wtOverlays.getOverlays(true).map(
+        overlay => (overlay?.name === 'master' ? overlay : overlay.clone.wtTable)
+      ).forEach((wtTableRef) => {
         const rowToRefresh = wtTableRef.getRow(renderableRowIndex);
 
         if (rowToRefresh) {


### PR DESCRIPTION
### Context
This PR adds a logic to work around a Chrome bug, forcing a repaint after the merge action, only when triggered in Chrome.

I managed to reproduce the issue without Handsontable: https://jsfiddle.net/js_ziggle/qga74pyL/
And work around it similarly to as I did in this PR: https://jsfiddle.net/js_ziggle/L7b5pgzs/

### How has this been tested?
As it seems to be only a visual glitch, I don't know how to test it without visual tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#521

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
