### PR TITLE
Disable date parsing and formatting for the HyperFormula instances connected/generated by the formula plugin.

### DIFF
--- a/.changelogs/10220.json
+++ b/.changelogs/10220.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed a problem where the formula plugin did not display accurate values when referencing date-typed cells.",
+  "type": "fixed",
+  "issueOrPR": 10220,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/formulas/__tests__/formulas.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/formulas.spec.js
@@ -2792,4 +2792,33 @@ describe('Formulas general', () => {
 
     expect(getDataAtCell(1, 4)).toEqual(3);
   });
+
+  it('should not make the engine parse and format the date-typed cells and work on their string representation' +
+    ' passed by Handsontable', () => {
+    const hfInstance1 = HyperFormula.buildEmpty({ licenseKey: 'internal-use-in-handsontable' });
+    const hot1 = handsontable({
+      data: [
+        ['12/05/2023'],
+        ['=A1'],
+      ],
+      formulas: {
+        engine: HyperFormula,
+      }
+    });
+    const hot2 = handsontable({
+      data: [
+        ['12/05/2023'],
+        ['=A1'],
+      ],
+      formulas: {
+        engine: hfInstance1,
+      }
+    });
+
+    expect(hot1.getPlugin('formulas').engine.getConfig().dateFormats).toEqual([]);
+    expect(hot2.getPlugin('formulas').engine.getConfig().dateFormats).toEqual([]);
+
+    expect(hot1.getDataAtCell(1, 0)).toEqual(hot1.getDataAtCell(0, 0));
+    expect(hot2.getDataAtCell(1, 0)).toEqual(hot2.getDataAtCell(0, 0));
+  });
 });

--- a/handsontable/src/plugins/formulas/engine/register.js
+++ b/handsontable/src/plugins/formulas/engine/register.js
@@ -52,7 +52,6 @@ export function setupEngine(hotInstance) {
     dateFormats: []
   };
 
-
   if (pluginSettings === true) {
     return null;
   }


### PR DESCRIPTION
### Context
In some instances, the Formulas plugin did not display accurate values when referencing date-typed cells. 

This was caused by HyperFormula's date parsing and/or formatting - in some cases, it recognized the references string as a date and parsed it to its internal numeric format; in other cases, it didn't. 
However, when it _did_, the HOT instance would receive its numeric format instead of a string-based date format used by Handsontable.

This PR disables HF's date parsing and formatting, as I don't think it's usable in Handsontable's context.

This change _might_ require some mentioning in the documentation, as it overwrites HyperFormula's `dateFormat` configuration.

### How has this been tested?
Added a test case.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#442

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
