### PR TITLE
Enable ManualColumnMove plugin for visual tests Vue example

### DIFF
--- a/examples/next/visual-tests/vue/demo/src/components/DataGrid.vue
+++ b/examples/next/visual-tests/vue/demo/src/components/DataGrid.vue
@@ -24,6 +24,7 @@ export default {
       hotSettings: {
         height: 450,
         dropdownMenu: true,
+        manualRowMove: true,
         hiddenColumns: {
           indicators: true,
         },


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR enabled the _ManualColumnMove_ plugin for Visual Tests. The PR is a hot fix for #10165.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
