### PR TITLE
Fix "no left space on the device" error on Windows GH action workflow

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # https://github.com/actions/setup-node/releases/tag/v3.5.1
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
+          # cache: 'npm'
 
       - name: Install the dependencies
         working-directory: C:/handsontable

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -38,10 +38,6 @@ jobs:
   build-on-windows:
     name: Build all packages in windows-latest
     runs-on: windows-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
     steps:
       - name: Checkout
         run: |

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -6,6 +6,7 @@ on:
       - 'master'
       - 'develop'
       - 'release/**'
+      - 'feature/dev-issue-1094'
   workflow_dispatch:
 
 env:
@@ -18,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ windows-latest ]
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # https://github.com/actions/checkout/releases/tag/v3.1.0
 

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -6,39 +6,39 @@ on:
       - 'master'
       - 'develop'
       - 'release/**'
-      - 'feature/dev-issue-1094'
   workflow_dispatch:
 
 env:
   NODE_VERSION: 16
 
 jobs:
-  # build-on-unix:
-  #   name: Build all packages in ${{ matrix.os }}
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       os: [ ubuntu-latest, macos-latest ]
-  #   steps:
-  #     - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # https://github.com/actions/checkout/releases/tag/v3.1.0
+  build-on-unix:
+    name: Build all packages in ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # https://github.com/actions/checkout/releases/tag/v3.1.0
 
-  #     - name: Use Node.js ${{ env.NODE_VERSION }}
-  #       uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # https://github.com/actions/setup-node/releases/tag/v3.5.1
-  #       with:
-  #         node-version: ${{ env.NODE_VERSION }}
-  #         cache: 'npm'
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # https://github.com/actions/setup-node/releases/tag/v3.5.1
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
 
-  #     - name: Install the dependencies
-  #       run: npm ci
+      - name: Install the dependencies
+        run: npm ci
 
-  #     - name: Build all packages
-  #       run: npm run all build
+      - name: Build all packages
+        run: npm run all build
 
   build-on-windows:
     name: Build all packages in windows-latest
     runs-on: windows-latest
     steps:
+      # on C drive there is more free space left to do this job (https://github.com/actions/runner-images/issues/1341#issuecomment-667478747)
       - name: Checkout
         run: |
           mkdir C:/handsontable
@@ -48,7 +48,6 @@ jobs:
         uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # https://github.com/actions/setup-node/releases/tag/v3.5.1
         with:
           node-version: ${{ env.NODE_VERSION }}
-          # cache: 'npm'
 
       - name: Install the dependencies
         working-directory: C:/handsontable

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -13,15 +13,40 @@ env:
   NODE_VERSION: 16
 
 jobs:
-  build-all:
-    name: Build all packages in ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+  # build-on-unix:
+  #   name: Build all packages in ${{ matrix.os }}
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os: [ ubuntu-latest, macos-latest ]
+  #   steps:
+  #     - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # https://github.com/actions/checkout/releases/tag/v3.1.0
+
+  #     - name: Use Node.js ${{ env.NODE_VERSION }}
+  #       uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # https://github.com/actions/setup-node/releases/tag/v3.5.1
+  #       with:
+  #         node-version: ${{ env.NODE_VERSION }}
+  #         cache: 'npm'
+
+  #     - name: Install the dependencies
+  #       run: npm ci
+
+  #     - name: Build all packages
+  #       run: npm run all build
+
+  build-on-windows:
+    name: Build all packages in windows-latest
+    runs-on: windows-latest
     strategy:
       fail-fast: false
       matrix:
-        os: [ windows-latest ]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # https://github.com/actions/checkout/releases/tag/v3.1.0
+      - name: Checkout
+        run: |
+          mkdir C:/handsontable
+          git clone https://github.com/handsontable/handsontable C:/handsontable --depth 1
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # https://github.com/actions/setup-node/releases/tag/v3.5.1
@@ -30,7 +55,9 @@ jobs:
           cache: 'npm'
 
       - name: Install the dependencies
+        working-directory: C:/handsontable
         run: npm ci
 
       - name: Build all packages
+        working-directory: C:/handsontable
         run: npm run all build


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the "no left space on the device" error in the GH flow that appears after merging the [Visual Tests PR](https://github.com/handsontable/handsontable/pull/10165). I reconfigured the "build-all.yml" workflow to use a disk drive that offers more space, as mentioned in [this comment](https://github.com/actions/runner-images/issues/1341#issuecomment-667478747) and [this example](https://github.com/actions/runner-images/issues/1341#issuecomment-1332779364).

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
The workflow passes on CI ([runs](https://github.com/handsontable/handsontable/actions/runs/4084037179)). 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1094

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)