### PR TITLE
Add `master` branch to ignore about Docs staging

### DIFF
--- a/.github/workflows/docs-staging.yml
+++ b/.github/workflows/docs-staging.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches-ignore:
       - 'prod-docs/**'
+      - 'master'
     paths:
       - 'docs/**'
   workflow_dispatch:


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adds the `master` branch to ignore for the _Docs staging deployment_ GH workflow. It's redundant to create docker images for the `master` branch moreover, it can create false-positive [fails status](https://github.com/handsontable/handsontable/commit/3f2492270df434299c86a620083f1b83efd24b74).

_[skip changelog]_

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)