### PR TITLE
Docs: Document visual testing

### DIFF
--- a/.github/workflows/docs-staging.yml
+++ b/.github/workflows/docs-staging.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches-ignore:
       - 'prod-docs/**'
+      - 'master'
     paths:
       - 'docs/**'
   workflow_dispatch:

--- a/docs/content/guides/tools-and-building/testing.md
+++ b/docs/content/guides/tools-and-building/testing.md
@@ -62,6 +62,10 @@ Keep in mind that running wrapper tests require building the Handsontable (`npm 
 * The browser window running the test should be on top. Some tests will not pass while running in the background.
 * Focus should be on the browser window and the mouse should be still. Moving the mouse or losing focus on the window can interfere with the tests, causing them not to pass.
 
+## Visual testing
+
+
+
 ## Related guides
 
 - [Building](@/guides/tools-and-building/custom-builds.md)

--- a/docs/content/guides/tools-and-building/testing.md
+++ b/docs/content/guides/tools-and-building/testing.md
@@ -64,7 +64,9 @@ Keep in mind that running wrapper tests require building the Handsontable (`npm 
 
 ## Visual testing
 
+To avoid unintended changes to Handsontable's UI, we use automated visual regression testing.
 
+Learn more on our [GitHub](https://github.com/handsontable/handsontable/blob/develop/visual-tests/README.md).
 
 ## Related guides
 

--- a/visual-tests/README.md
+++ b/visual-tests/README.md
@@ -26,7 +26,7 @@ If Argos spots differences between two corresponding screenshots,
 the **Visual tests** check on on your pull request fails, and you can't merge your changes to `develop`. In that case:
 1. Open the log of the **Visual tests** job:<br>
    At the bottom of your pull request, find the **Visual tests** check. Select **Details**.
-2. Open the Argos URL and [review the differences](https://argos-ci.com/docs/visual-testing#reviewing-visual-changes).<br>
+2. Open the Argos URL and [review the differences](https://argos-ci.com/docs/visual-testing#reviewing-visual-changes).
    You can:
       - [Reject the modified screenshots](https://argos-ci.com/docs/visual-testing#-reject-a-build-workflow), update your code,
         and [re-run the visual tests](#run-visual-tests-through-github-actions).

--- a/visual-tests/README.md
+++ b/visual-tests/README.md
@@ -12,7 +12,7 @@ We run visual tests automatically by using the following tools:
 | [Argos](https://argos-ci.com/docs/visual-testing)                      | An external visual testing service. We use it to compare screenshots.                                                                                   |
 | [GitHub Actions](https://github.com/handsontable/handsontable/actions) | GitHub's CI platform. We use it to automate our [test workflows](https://github.com/handsontable/handsontable/blob/develop/.github/workflows/test.yml). |
 
-When you push changes to a GitHub pull request, you trigger the following:
+When you push changes to a GitHub pull request:
 1. The [Visual tests linter](https://github.com/handsontable/handsontable/actions/workflows/visual-tests-linter.yml)
    workflow checks the code of each visual test.
 2. The [Tests](https://github.com/handsontable/handsontable/blob/develop/.github/workflows/test.yml) workflow runs all
@@ -23,15 +23,16 @@ When you push changes to a GitHub pull request, you trigger the following:
    (so-called "baseline" or "golden" screenshots).
 
 If Argos spots differences between two corresponding screenshots,
-the **Visual tests** check on on your pull request fails, and you can't merge it. In that case:
-1. Open the log of the visual tests workflow:
+the **Visual tests** check on on your pull request fails, and you can't merge your changes to `develop`. In that case:
+1. Open the log of the visual tests job:<br>
    At the bottom of your pull request, find the **Visual tests** check. Select **Details**.
 2. Open the Argos URL and [review the differences](https://argos-ci.com/docs/visual-testing#reviewing-visual-changes).<br>
    You can:
-      - [Reject the changes](https://argos-ci.com/docs/visual-testing#-reject-a-build-workflow), update your code,
+      - [Reject the changes in Argos](https://argos-ci.com/docs/visual-testing#-reject-a-build-workflow), update your code,
         and [re-run the visual tests](#run-visual-tests-through-github-actions).
-      - [Accept the changes](https://argos-ci.com/docs/visual-testing#-approving-a-build).<br>
-        As a result, after you merge your changes to `develop`, the modified screenshots become the new baseline.
+      - [Accept the changes in Argos](https://argos-ci.com/docs/visual-testing#-approving-a-build).
+        You can now merge your changes to `develop`.
+        As a result, the new, modified screenshots become the new baseline.
 
 ## Run visual tests through GitHub Actions
 

--- a/visual-tests/README.md
+++ b/visual-tests/README.md
@@ -6,28 +6,38 @@ To avoid unintended changes to Handsontable's UI, we use visual regression testi
 
 We run visual tests automatically by using the following tools:
 
-| Tool                                                                   | Description                                                                                                                                     |
-| ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Playwright](https://playwright.dev/docs/intro)                        | An open-source testing framework backed by Microsoft. We use it to write and run visual tests.                                                  |
-| [Argos](https://argos-ci.com/docs/visual-testing)                      | An external visual testing service. We use it to compare screenshots.                                                                           |
-| [GitHub Actions](https://github.com/handsontable/handsontable/actions) | A CI platform. We use it to automate our [test workflow](https://github.com/handsontable/handsontable/blob/develop/.github/workflows/test.yml). |
+| Tool                                                                   | Description                                                                                                                                             |
+| ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Playwright](https://playwright.dev/docs/intro)                        | An open-source testing framework backed by Microsoft. We use it to write and run visual tests.                                                          |
+| [Argos](https://argos-ci.com/docs/visual-testing)                      | An external visual testing service. We use it to compare screenshots.                                                                                   |
+| [GitHub Actions](https://github.com/handsontable/handsontable/actions) | GitHub's CI platform. We use it to automate our [test workflows](https://github.com/handsontable/handsontable/blob/develop/.github/workflows/test.yml). |
 
-On pushing a commit to a pull request's feature branch:
-1. The [Visual tests Linter](https://github.com/handsontable/handsontable/actions/workflows/visual-tests-linter.yml)
+When you push changes to a GitHub pull request, you trigger the following:
+1. The [Visual tests linter](https://github.com/handsontable/handsontable/actions/workflows/visual-tests-linter.yml)
    workflow checks the code of each visual test.
 2. The [Tests](https://github.com/handsontable/handsontable/blob/develop/.github/workflows/test.yml) workflow runs all
    of Handsontable's tests.
-3. If all the tests pass successfully, the [Visual tests](https://github.com/handsontable/handsontable/blob/develop/.github/workflows/test.yml#L432-L502) job runs the visual tests and uploads the resulting screenshots to Argos.<br>
-   You can find the Argos URL in the logs of the [Tests](https://github.com/handsontable/handsontable/blob/develop/.github/workflows/test.yml) workflow.
-4. Argos compares the feature branch screenshots against the `develop` branch screenshots (so-called "golden screenshots").
-5. If Argos detects differences between the screenshots, the **Visual tests** check in GitHub prevents you from merging the PR.
-   You can either fix the issue, or accept the changes in Argos.
+3. After all tests pass successfully, the [Visual tests](https://github.com/handsontable/handsontable/blob/develop/.github/workflows/test.yml#L432-L502)
+   job runs the visual tests and uploads the resulting screenshots to Argos.
+4. Argos compares your feature branch screenshots against the `develop` screenshots
+   (so-called "baseline" or "golden" screenshots).
+
+If Argos spots differences between two corresponding screenshots,
+the **Visual tests** check on on your pull request fails, and you can't merge it. In that case:
+1. Open the log of the visual tests workflow:
+   At the bottom of your pull request, find the **Visual tests** check. Select **Details**.
+2. Open the Argos URL and [review the differences](https://argos-ci.com/docs/visual-testing#reviewing-visual-changes).<br>
+   You can:
+      - [Reject the changes](https://argos-ci.com/docs/visual-testing#-reject-a-build-workflow), update your code,
+        and [re-run the visual tests](#run-visual-tests-through-github-actions).
+      - [Accept the changes](https://argos-ci.com/docs/visual-testing#-approving-a-build).<br>
+        As a result, after you merge your changes to `develop`, the modified screenshots become the new baseline.
 
 ## Run visual tests through GitHub Actions
 
 Our GitHub Actions configuration runs the visual tests automatically, but you can run them manually as well:
 
-1. On GitHub, at the bottom of your PR, find the **Visual tests** check. Select **Details**.
+1. On GitHub, at the bottom of your pull request, find the **Visual tests** check. Select **Details**.
 2. On the left, next to the **Visual tests** job, select 🔄.
 3. Select **Re-run jobs**.
 
@@ -35,7 +45,7 @@ Our GitHub Actions configuration runs the visual tests automatically, but you ca
 
 You can manually run visual tests on your machine and then upload the resulting screenshots to Argos.
 
-First, prepare your visual testing environment:
+First, prepare your local visual testing environment:
 
 1. Make sure your [Docker Desktop](https://www.docker.com/products/docker-desktop/) app is running.
 2. Make sure you're using the Node and npm versions mentioned [here](https://handsontable.com/docs/react-data-grid/custom-builds/#build-requirements).
@@ -58,7 +68,7 @@ To run the visual tests locally:
 2. From the `./visual-tests/` directory, run `npm run upload`.
 3. Open the Argos URL displayed in the terminal.
 
-## Add visual tests
+## Write a new visual test
 
 To add a new visual test:
 
@@ -71,7 +81,9 @@ To add a new visual test:
       - [Playwright's docs](https://playwright.dev/docs/writing-tests)
       - [Helpers](#helpers)
       - [Take screenshots](#take-screenshots)
-4. Keep your file in the `./visual-tests/tests/` directory.
+4. Push your changes to a pull request.<br>
+   The [Visual tests linter](https://github.com/handsontable/handsontable/actions/workflows/visual-tests-linter.yml)
+   workflow checks the code of your test.
 
 ### Take screenshots
 

--- a/visual-tests/README.md
+++ b/visual-tests/README.md
@@ -24,15 +24,15 @@ When you push changes to a GitHub pull request:
 
 If Argos spots differences between two corresponding screenshots,
 the **Visual tests** check on on your pull request fails, and you can't merge your changes to `develop`. In that case:
-1. Open the log of the visual tests job:<br>
+1. Open the log of the **Visual tests** job:<br>
    At the bottom of your pull request, find the **Visual tests** check. Select **Details**.
 2. Open the Argos URL and [review the differences](https://argos-ci.com/docs/visual-testing#reviewing-visual-changes).<br>
    You can:
-      - [Reject the changes in Argos](https://argos-ci.com/docs/visual-testing#-reject-a-build-workflow), update your code,
+      - [Reject the modified screenshots in Argos](https://argos-ci.com/docs/visual-testing#-reject-a-build-workflow), update your code,
         and [re-run the visual tests](#run-visual-tests-through-github-actions).
-      - [Accept the changes in Argos](https://argos-ci.com/docs/visual-testing#-approving-a-build).
+      - [Accept the modified screenshots in Argos](https://argos-ci.com/docs/visual-testing#-approving-a-build).
         You can now merge your changes to `develop`.
-        As a result, the new, modified screenshots become the new baseline.
+        As a result, the modified screenshots become the new baseline.
 
 ## Run visual tests through GitHub Actions
 

--- a/visual-tests/README.md
+++ b/visual-tests/README.md
@@ -6,18 +6,18 @@ To avoid unintended changes to Handsontable's UI, we use visual regression testi
 
 We run visual tests automatically by using the following tools:
 
-| Tool                                                                                                   | Description                                                                                    |
-| ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------- |
-| [Playwright](https://playwright.dev/docs/intro)                                                        | An open-source testing framework backed by Microsoft. We use it to write and run visual tests. |
-| [Argos](https://argos-ci.com/docs/visual-testing)                                                      | An external visual testing service. We use it to compare screenshots.                          |
-| [GitHub Actions](https://github.com/handsontable/handsontable/blob/develop/.github/workflows/test.yml) | A CI platform. We use it to automate our testing workflows.                                    |
+| Tool                                                                   | Description                                                                                                                                     |
+| ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Playwright](https://playwright.dev/docs/intro)                        | An open-source testing framework backed by Microsoft. We use it to write and run visual tests.                                                  |
+| [Argos](https://argos-ci.com/docs/visual-testing)                      | An external visual testing service. We use it to compare screenshots.                                                                           |
+| [GitHub Actions](https://github.com/handsontable/handsontable/actions) | A CI platform. We use it to automate our [test workflow](https://github.com/handsontable/handsontable/blob/develop/.github/workflows/test.yml). |
 
 On pushing a commit to a pull request's feature branch:
 1. The [Visual tests Linter](https://github.com/handsontable/handsontable/actions/workflows/visual-tests-linter.yml)
    workflow checks the code of each visual test.
 2. The [Tests](https://github.com/handsontable/handsontable/blob/develop/.github/workflows/test.yml) workflow runs all
    of Handsontable's tests.
-3. If all the tests pass successfully, the [Visual tests](https://github.com/handsontable/handsontable/blob/develop/.github/workflows/test.yml#L432-L502) job runs the visual tests and uploads the resulting screenshots to Argos.
+3. If all the tests pass successfully, the [Visual tests](https://github.com/handsontable/handsontable/blob/develop/.github/workflows/test.yml#L432-L502) job runs the visual tests and uploads the resulting screenshots to Argos.<br>
    You can find the Argos URL in the logs of the [Tests](https://github.com/handsontable/handsontable/blob/develop/.github/workflows/test.yml) workflow.
 4. Argos compares the feature branch screenshots against the `develop` branch screenshots (so-called "golden screenshots").
 5. If Argos detects differences between the screenshots, the **Visual tests** check in GitHub prevents you from merging the PR.
@@ -92,8 +92,7 @@ await page.screenshot({ path: helpers.screenshotPath() });
 ```
 
 To take a screenshot of a specific element of Handsontable,
-use Playwright's [`locator`](https://playwright.dev/docs/locators#locate-by-css-or-xpath),
-and the [helper](#helpers). For example:
+use Playwright's [`locator()`](https://playwright.dev/docs/locators#locate-by-css-or-xpath) method. For example:
 
 ```js
 const dropdownMenu = page.locator(helpers.selectors.dropdownMenu);

--- a/visual-tests/README.md
+++ b/visual-tests/README.md
@@ -1,6 +1,6 @@
 # Handsontable visual testing
 
-To avoid unintended changes to Handsontable's UI, we perform automated visual regression tests.
+To avoid unintended changes to Handsontable's UI, we use automated visual regression testing.
 
 ## Overview
 
@@ -9,22 +9,42 @@ We use the following tools:
 | Tool                                                                                                   | Description                                                                                    |
 | ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------- |
 | [Playwright](https://playwright.dev/docs/intro)                                                        | An open-source testing framework backed by Microsoft. We use it to write and run visual tests. |
-| [Argos](https://argos-ci.com/docs/visual-testing)                                                      | A visual testing platform. We use it to compare screenshots.                                   |
+| [Argos](https://argos-ci.com/docs/visual-testing)                                                      | An external visual testing service. We use it to compare screenshots.                          |
 | [GitHub Actions](https://github.com/handsontable/handsontable/blob/develop/.github/workflows/test.yml) | A CI platform. We use it to automate our testing workflows.                                    |
 
-Here's an overview of the visual testing workflow:
+Developers add Playwright visual tests to the `/visual-tests/tests` directory.
+Then, on pushing a commit to a pull request's feature branch:
+1. The [Visual tests Linter](https://github.com/handsontable/handsontable/actions/workflows/visual-tests-linter.yml)
+   workflow checks the code of all the visual tests.
+2. As part of the [Tests](https://github.com/handsontable/handsontable/blob/develop/.github/workflows/test.yml) workflow,
+   the [Visual tests](https://github.com/handsontable/handsontable/blob/develop/.github/workflows/test.yml#L432-L502)
+   job runs all the visual tests and uploads the resulting screenshots to Argos.
+3. Argos compares the feature branch screenshots against the `develop` branch screenshots (so-called "golden screenshots").
+   It adds a URL with the results to the GitHub Actions log.
+4. If Argos detects differences between the screenshots, the **Visual tests** check in GitHub prevents you from merging the PR.
+   You can either fix the issue, or accept the changes in Argos.
 
-1. Developers add Playwright tests (as `*.spec.ts` files) to the `/visual-tests/tests` directory.
-2. On pushing a commit to a feature branch, the
-   [Visual tests Linter](https://github.com/handsontable/handsontable/actions/workflows/visual-tests-linter.yml) workflow
-   checks the code of all the visual tests.
-3. The [Tests](https://github.com/handsontable/handsontable/actions/workflows/test.yml) workflow runs all the visual tests
-   and uploads the resulting screenshots to Argos.
-4. Argos compares the feature branch screenshots against the base branch (`develop`) screenshots
-   (so-called "golden screenshots").
-5. 
+## Write a visual test
 
-- which browsers? (I think only Chromium)
+To add a new visual test:
+1. On your machine, in the `/visual-tests/tests/` folder, create a `.spec.ts` file.
+2. Give your file a descriptive name. This name is used in test logs and screenshot names.
+   - ✅ Good: `open-dropdown-menu.spec.ts`.
+   - ❌ Bad: `my-test-1.spec.ts`.
+3. Copy the template from `/visual-tests/tests/.empty-test-template.ts` into your file.
+4. Write your test, following the [Playwright docs](https://playwright.dev/docs/writing-tests).
+5. Keep your file in the `/visual-tests/tests/` folder.
+
+## Manually run visual tests through GitHub Actions
+
+1. On GitHub, at the bottom of your PR, find the **Visual tests** check. Select **Details**.
+2. On the left, next to **Visual tests**, select 🔄.
+3. Select **Re-run jobs**.
+
+## Manually run visual tests locally
+
+
+
 
 ## Installation
 
@@ -55,14 +75,6 @@ After that launch `npm run in visual-tests upload` in main directory or `npm run
 After upload you can find URL to your set of images in console or Github Actions logs as a result of `Visual testing - upload` job (NOTE: add example link when first build from official repo will be ready).
 
 If you open Pull Request and try to merge to the base branch, you will be informed in Github `checks` section if there are detected some differences between images and merge will be not possible until fix or decision that differences were expected (in Argos there is option `Accept this build`).
-
-## Writing tests
-
-In `tests` folder there is file `.empty-test-template.ts` - copy-paste it if you want to add new test, it will make some configuration things faster. There is marked place for your code also.
-
-Test file must have `.spec.ts` in the name of file.
-Test files must be stored in `tests` folder.
-Test filename should describe as much as possible what test is doing - it will be used as a title in logs and in screenshots names, you do not have to define them manually anymore. Example: `./tests/open-dropdown-menu.spec.ts`.
 
 ## Making screenshots
 
@@ -126,7 +138,3 @@ Example:
 const cell = helpers.tbody.locator(helpers.findCell({ row: 2, cell: 2, cellType: 'td' }));
 await cell.click();
 ```
-
-## External docs:
-As a testing tool we decided to use Playwright: https://playwright.dev/docs/intro
-As a service comparing screenshots we have chosen Argos: https://argos-ci.com/docs/visual-testing

--- a/visual-tests/README.md
+++ b/visual-tests/README.md
@@ -28,10 +28,10 @@ the **Visual tests** check on on your pull request fails, and you can't merge yo
    At the bottom of your pull request, find the **Visual tests** check. Select **Details**.
 2. Open the Argos URL and [review the differences](https://argos-ci.com/docs/visual-testing#reviewing-visual-changes).<br>
    You can:
-      - [Reject the modified screenshots in Argos](https://argos-ci.com/docs/visual-testing#-reject-a-build-workflow), update your code,
+      - [Reject the modified screenshots](https://argos-ci.com/docs/visual-testing#-reject-a-build-workflow), update your code,
         and [re-run the visual tests](#run-visual-tests-through-github-actions).
-      - [Accept the modified screenshots in Argos](https://argos-ci.com/docs/visual-testing#-approving-a-build).
-        You can now merge your changes to `develop`.
+      - [Accept the modified screenshots](https://argos-ci.com/docs/visual-testing#-approving-a-build).
+        You can then merge your changes to `develop`.
         As a result, the modified screenshots become the new baseline.
 
 ## Run visual tests through GitHub Actions

--- a/visual-tests/README.md
+++ b/visual-tests/README.md
@@ -1,3 +1,31 @@
+# Handsontable visual testing
+
+To avoid unintended changes to Handsontable's UI, we perform automated visual regression tests.
+
+## Overview
+
+We use the following tools:
+
+| Tool                                                                                                   | Description                                                                                    |
+| ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------- |
+| [Playwright](https://playwright.dev/docs/intro)                                                        | An open-source testing framework backed by Microsoft. We use it to write and run visual tests. |
+| [Argos](https://argos-ci.com/docs/visual-testing)                                                      | A visual testing platform. We use it to compare screenshots.                                   |
+| [GitHub Actions](https://github.com/handsontable/handsontable/blob/develop/.github/workflows/test.yml) | A CI platform. We use it to automate our testing workflows.                                    |
+
+Here's an overview of the visual testing workflow:
+
+1. Developers add Playwright tests (as `*.spec.ts` files) to the `/visual-tests/tests` directory.
+2. On pushing a commit to a feature branch, the
+   [Visual tests Linter](https://github.com/handsontable/handsontable/actions/workflows/visual-tests-linter.yml) workflow
+   checks the code of all the visual tests.
+3. The [Tests](https://github.com/handsontable/handsontable/actions/workflows/test.yml) workflow runs all the visual tests
+   and uploads the resulting screenshots to Argos.
+4. Argos compares the feature branch screenshots against the base branch (`develop`) screenshots
+   (so-called "golden screenshots").
+5. 
+
+- which browsers? (I think only Chromium)
+
 ## Installation
 
 Install by command `npm install` in the root directory and make sure that before testing you've installed and executed the [Docker Desktop](https://www.docker.com/products/docker-desktop/) application.

--- a/visual-tests/README.md
+++ b/visual-tests/README.md
@@ -19,8 +19,8 @@ When you push changes to a GitHub pull request:
    of Handsontable's tests.
 3. After all tests pass successfully, the [Visual tests](https://github.com/handsontable/handsontable/blob/develop/.github/workflows/test.yml#L432-L502)
    job runs the visual tests and uploads the resulting screenshots to Argos.
-4. Argos compares your feature branch screenshots against the `develop` screenshots
-   (so-called "baseline" or "golden" screenshots).
+4. Argos compares your feature branch screenshots against the reference branch (`develop`) screenshots
+   (so-called "reference", "baseline" or "golden" screenshots).
 
 If Argos spots differences between two corresponding screenshots,
 the **Visual tests** check on on your pull request fails, and you can't merge your changes to `develop`. In that case:

--- a/visual-tests/README.md
+++ b/visual-tests/README.md
@@ -1,10 +1,10 @@
 # Handsontable visual testing
 
-To avoid unintended changes to Handsontable's UI, we use automated visual regression testing.
+To avoid unintended changes to Handsontable's UI, we use visual regression testing.
 
 ## Overview
 
-We use the following tools:
+We run our visual tests automatically, using the following tools:
 
 | Tool                                                                                                   | Description                                                                                    |
 | ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------- |
@@ -12,129 +12,135 @@ We use the following tools:
 | [Argos](https://argos-ci.com/docs/visual-testing)                                                      | An external visual testing service. We use it to compare screenshots.                          |
 | [GitHub Actions](https://github.com/handsontable/handsontable/blob/develop/.github/workflows/test.yml) | A CI platform. We use it to automate our testing workflows.                                    |
 
-Developers add Playwright visual tests to the `/visual-tests/tests` directory.
-Then, on pushing a commit to a pull request's feature branch:
+On pushing a commit to a pull request's feature branch:
 1. The [Visual tests Linter](https://github.com/handsontable/handsontable/actions/workflows/visual-tests-linter.yml)
-   workflow checks the code of all the visual tests.
-2. As part of the [Tests](https://github.com/handsontable/handsontable/blob/develop/.github/workflows/test.yml) workflow,
-   the [Visual tests](https://github.com/handsontable/handsontable/blob/develop/.github/workflows/test.yml#L432-L502)
-   job runs all the visual tests and uploads the resulting screenshots to Argos.
-3. Argos compares the feature branch screenshots against the `develop` branch screenshots (so-called "golden screenshots").
+   workflow checks the code of each visual test.
+2. The [Tests](https://github.com/handsontable/handsontable/blob/develop/.github/workflows/test.yml) workflow runs all
+   of Handsontable's tests.
+3. After all the tests pass successfully, the [Visual tests](https://github.com/handsontable/handsontable/blob/develop/.github/workflows/test.yml#L432-L502) job runs the visual tests and uploads the resulting screenshots to Argos.
+4. Argos compares the feature branch screenshots against the `develop` branch screenshots (so-called "golden screenshots").
    It adds a URL with the results to the GitHub Actions log.
-4. If Argos detects differences between the screenshots, the **Visual tests** check in GitHub prevents you from merging the PR.
+5. If Argos detects differences between the screenshots, the **Visual tests** check in GitHub prevents you from merging the PR.
    You can either fix the issue, or accept the changes in Argos.
 
-## Write a visual test
+## Run visual tests through GitHub Actions
 
-To add a new visual test:
-1. On your machine, in the `/visual-tests/tests/` folder, create a `.spec.ts` file.
-2. Give your file a descriptive name. This name is used in test logs and screenshot names.
-   - ✅ Good: `open-dropdown-menu.spec.ts`.
-   - ❌ Bad: `my-test-1.spec.ts`.
-3. Copy the template from `/visual-tests/tests/.empty-test-template.ts` into your file.
-4. Write your test, following the [Playwright docs](https://playwright.dev/docs/writing-tests).
-5. Keep your file in the `/visual-tests/tests/` folder.
-
-## Manually run visual tests through GitHub Actions
+GitHub Actions runs the visual tests automatically, but you can run them manually as well:
 
 1. On GitHub, at the bottom of your PR, find the **Visual tests** check. Select **Details**.
-2. On the left, next to **Visual tests**, select 🔄.
+2. On the left, next to the **Visual tests** job, select 🔄.
 3. Select **Re-run jobs**.
 
-## Manually run visual tests locally
+## Run visual tests locally
 
+You can manually run visual tests on your machine and then upload the resulting screenshots to Argos for comparison.
 
+First, prepare your visual testing environment:
 
+1. Make sure your [Docker Desktop](https://www.docker.com/products/docker-desktop/) app is running.
+2. Make sure you're using the Node and npm versions mentioned [here](https://handsontable.com/docs/react-data-grid/custom-builds/#build-requirements).
+3. From the `./visual-tests/` directory, run `npm install`.
+4. In the `./visual-tests/` directory, create a file called `.env`. In the file, add the Argos token:
+   ```bash
+   ARGOS_TOKEN=xxx
+   ```
+   Ask your supervisor for the token's value.
 
-## Installation
+To run the visual tests locally:
 
-Install by command `npm install` in the root directory and make sure that before testing you've installed and executed the [Docker Desktop](https://www.docker.com/products/docker-desktop/) application.
+1. From the `./visual-tests/` directory, run one of the following commands:
+   | Command                               | Action                                                                                             |
+   | ------------------------------------- | -------------------------------------------------------------------------------------------------- |
+   | `npm run test`                        | Run all the visual tests,<br>for all the configured frameworks,<br>for all the supported browsers. |
+   | `npx playwright test {{ file name }}` | Run a specific test.<br><br>For example: `npx playwright test mouse-wheel`                         |
+   The resulting screenshots are saved in `./visual-tests/screenshots/`.
+2. From the `./visual-tests/` directory, run `npm run upload`.
+3. Open the Argos URL displayed in the terminal.
 
-## Usage
+## Add visual tests
 
-In Github `Visual tests` workflow is launched automatically after `Tests` workflow passed successfully. In local environment you have to launch it manually.
+To add a new visual test:
 
-## Testing
+1. On your machine, in the `./visual-tests/tests/` directory, create a new `.spec.ts` file.<br>
+   Give your file a descriptive name. This name is later used in test logs and screenshot names.
+      - ✅ Good: `open-dropdown-menu.spec.ts`.
+      - ❌ Bad: `my-test-1.spec.ts`.
+2. Copy the template code from `./visual-tests/tests/.empty-test-template.ts` into your file.
+3. Write your test. For more information, see:
+      - [Take screenshots](#take-screenshots)
+      - [Helpers](#helpers)
+      - [Playwright's docs](https://playwright.dev/docs/writing-tests)
+4. Keep your file in the `./visual-tests/tests/` directory.
 
-Launch `npm run in visual-tests test` in main directory or `npm run test` in `./visual-tests` directory to run all of tests with all of frameworks in all of browsers. After tests screenshots will appear in `./visual-tests/screenshots`.
-Launch by command `npx playwright test {{ name of file }}` in `./visual-tests` directory to run specific test, e.g. `npx playwright test mouse-wheel`.
+### Take screenshots
 
-## Upload and compare screenshots
+To capture a [screenshot](https://playwright.dev/docs/screenshots) and save it to a file,
+add this line anywhere in your test:
 
-For the screen comparison we use external service (currently it's Argos CI). Argos CI compares screenshots from your branch with the base branch (which currently is `develop`).
-
-In Github screenshots are uploaded automatically after every test.
-In local environment upload won't work until you create `.env` file in `./visual-tests/` directory and set variable `ARGOS_TOKEN` there - ask your teammates or supervisor for its value.
-
+```js
+await page.screenshot({ path: helpers.screenshotPath() });
 ```
-ARGOS_TOKEN=xxx
-```
 
-After that launch `npm run in visual-tests upload` in main directory or `npm run upload` in `./visual-tests` directory to upload all of screenshots. Do not worry, you will not overwrite anything - uploading golden screenshots from base branch (if nothing changed in a meanwhile it's `develop`) is not possible on local environment.
+In each test, you can take as many screenshots as you want. For example:
 
-After upload you can find URL to your set of images in console or Github Actions logs as a result of `Visual testing - upload` job (NOTE: add example link when first build from official repo will be ready).
-
-If you open Pull Request and try to merge to the base branch, you will be informed in Github `checks` section if there are detected some differences between images and merge will be not possible until fix or decision that differences were expected (in Argos there is option `Accept this build`).
-
-## Making screenshots
-
-If you want to make screenshot, just copy-paste this line anywhere:
-`await page.screenshot({ path: helpers.screenshotPath() });`
-From now it will take care about names, browsers, frameworks and paths automatically.
-
-You can make as much screenshots per test as needed (it can be 0 also - we still can test anything without screenshots too), for example:
-
-```
+```js
 await cell.click();
 await page.screenshot({ path: helpers.screenshotPath() });
 await anotherCell.click();
 await page.screenshot({ path: helpers.screenshotPath() });
 ```
 
-If you want to make screenshot of specific element, just use given locator instead of `page`, e.g.:
+To take a screenshot of a specific element of Handsontable,
+use Playwright's [`locator`](https://playwright.dev/docs/locators#locate-by-css-or-xpath),
+and the `selectors` [helper](#helpers). For example:
 
-```
+```js
 const dropdownMenu = page.locator(helpers.selectors.dropdownMenu);
+
 await dropdownMenu.screenshot({ path: helpers.screenshotPath() });
 ```
 
-## Helpers
+### Helpers
 
-There are prepared few helpers, you can find them in `/src/helpers`. Helpers are loaded automatically (if you use `.empty-test-template` file). Not all of them will be necessary for you in writing tests, but for sure few of them would make work easier:
+To write tests faster, use the helper variables and functions stored in the `./visual-tests/src/helpers.ts` file.
 
-### modifier
-Returns modifier key - CTRL / Meta depending on system. It can be useful e.g. if you want to copy-paste something.
+#### `modifier`
 
-Example:
-```
-// copy cell content
+Returns the current modifier key: `Ctrl` for Windows or `Meta` for Mac.
+
+```js
+// copy the contents of the currently-selected cell
 await page.keyboard.press(`${helpers.modifier}+c`);
 ```
 
-### isMac
-Returns information if test is launched on Mac or not.
+#### `isMac`
 
-Example:
-```
+Returns `true` if the test is run on Mac.
+
+```js
 if (helpers.isMac) {
   // do something
 }
 ```
 
-### findDropdownMenuExpander({ col: number })
+#### `findDropdownMenuExpander()`
+
+findDropdownMenuExpander({ col: number })
+
 Returns button to expand dropdown menu in column specified by number.
 
-Example:
-```
+```js
 const changeTypeButton = table.locator(helpers.findDropdownMenuExpander({ col: 2 }));
 await changeTypeButton.click();
 ```
 
-### findCell(options = { row: number, cell: number, cellType: 'td / th' }) {
+#### `findCell()`
+
+findCell(options = { row: number, cell: number, cellType: 'td / th' }) {
+
 Returns given cell in main table. You can specify row, column and type of cell `td` or `th`.
 
-Example:
-```
+```js
 const cell = helpers.tbody.locator(helpers.findCell({ row: 2, cell: 2, cellType: 'td' }));
 await cell.click();
 ```

--- a/visual-tests/README.md
+++ b/visual-tests/README.md
@@ -25,7 +25,7 @@ On pushing a commit to a pull request's feature branch:
 
 ## Run visual tests through GitHub Actions
 
-GitHub Actions runs the visual tests automatically, but you can run them manually as well:
+Our GitHub Actions configuration runs the visual tests automatically, but you can run them manually as well:
 
 1. On GitHub, at the bottom of your PR, find the **Visual tests** check. Select **Details**.
 2. On the left, next to the **Visual tests** job, select 🔄.
@@ -53,6 +53,7 @@ To run the visual tests locally:
    | ------------------------------------- | -------------------------------------------------------------------------------------------------- |
    | `npm run test`                        | Run all the visual tests,<br>for all the configured frameworks,<br>for all the supported browsers. |
    | `npx playwright test {{ file name }}` | Run a specific test.<br><br>For example: `npx playwright test mouse-wheel`                         |
+
    The resulting screenshots are saved in `./visual-tests/screenshots/`.
 2. From the `./visual-tests/` directory, run `npm run upload`.
 3. Open the Argos URL displayed in the terminal.
@@ -115,7 +116,7 @@ await page.keyboard.press(`${helpers.modifier}+c`);
 
 #### `isMac`
 
-Returns `true` if the test is run on Mac.
+Returns `true` if the test runs on Mac.
 
 ```js
 if (helpers.isMac) {

--- a/visual-tests/README.md
+++ b/visual-tests/README.md
@@ -4,7 +4,7 @@ To avoid unintended changes to Handsontable's UI, we use visual regression testi
 
 ## Overview
 
-We run our visual tests automatically, using the following tools:
+We run visual tests automatically by using the following tools:
 
 | Tool                                                                                                   | Description                                                                                    |
 | ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------- |
@@ -17,9 +17,9 @@ On pushing a commit to a pull request's feature branch:
    workflow checks the code of each visual test.
 2. The [Tests](https://github.com/handsontable/handsontable/blob/develop/.github/workflows/test.yml) workflow runs all
    of Handsontable's tests.
-3. After all the tests pass successfully, the [Visual tests](https://github.com/handsontable/handsontable/blob/develop/.github/workflows/test.yml#L432-L502) job runs the visual tests and uploads the resulting screenshots to Argos.
+3. If all the tests pass successfully, the [Visual tests](https://github.com/handsontable/handsontable/blob/develop/.github/workflows/test.yml#L432-L502) job runs the visual tests and uploads the resulting screenshots to Argos.
+   You can find the Argos URL in the logs of the [Tests](https://github.com/handsontable/handsontable/blob/develop/.github/workflows/test.yml) workflow.
 4. Argos compares the feature branch screenshots against the `develop` branch screenshots (so-called "golden screenshots").
-   It adds a URL with the results to the GitHub Actions log.
 5. If Argos detects differences between the screenshots, the **Visual tests** check in GitHub prevents you from merging the PR.
    You can either fix the issue, or accept the changes in Argos.
 
@@ -33,7 +33,7 @@ Our GitHub Actions configuration runs the visual tests automatically, but you ca
 
 ## Run visual tests locally
 
-You can manually run visual tests on your machine and then upload the resulting screenshots to Argos for comparison.
+You can manually run visual tests on your machine and then upload the resulting screenshots to Argos.
 
 First, prepare your visual testing environment:
 
@@ -44,7 +44,7 @@ First, prepare your visual testing environment:
    ```bash
    ARGOS_TOKEN=xxx
    ```
-   Ask your supervisor for the token's value.
+   Ask your supervisor about the token's value.
 
 To run the visual tests locally:
 
@@ -68,9 +68,9 @@ To add a new visual test:
       - ❌ Bad: `my-test-1.spec.ts`.
 2. Copy the template code from `./visual-tests/tests/.empty-test-template.ts` into your file.
 3. Write your test. For more information, see:
-      - [Take screenshots](#take-screenshots)
-      - [Helpers](#helpers)
       - [Playwright's docs](https://playwright.dev/docs/writing-tests)
+      - [Helpers](#helpers)
+      - [Take screenshots](#take-screenshots)
 4. Keep your file in the `./visual-tests/tests/` directory.
 
 ### Take screenshots
@@ -93,7 +93,7 @@ await page.screenshot({ path: helpers.screenshotPath() });
 
 To take a screenshot of a specific element of Handsontable,
 use Playwright's [`locator`](https://playwright.dev/docs/locators#locate-by-css-or-xpath),
-and the `selectors` [helper](#helpers). For example:
+and the [helper](#helpers). For example:
 
 ```js
 const dropdownMenu = page.locator(helpers.selectors.dropdownMenu);
@@ -103,14 +103,14 @@ await dropdownMenu.screenshot({ path: helpers.screenshotPath() });
 
 ### Helpers
 
-To write tests faster, use the helper variables and functions stored in the `./visual-tests/src/helpers.ts` file.
+To write tests faster, use the custom helper functions and variables stored in the `./visual-tests/src/helpers.ts` file.
 
 #### `modifier`
 
 Returns the current modifier key: `Ctrl` for Windows or `Meta` for Mac.
 
 ```js
-// copy the contents of the currently-selected cell
+// copy the contents of the selected cell
 await page.keyboard.press(`${helpers.modifier}+c`);
 ```
 
@@ -124,24 +124,28 @@ if (helpers.isMac) {
 }
 ```
 
-#### `findDropdownMenuExpander()`
-
-findDropdownMenuExpander({ col: number })
-
-Returns button to expand dropdown menu in column specified by number.
-
-```js
-const changeTypeButton = table.locator(helpers.findDropdownMenuExpander({ col: 2 }));
-await changeTypeButton.click();
-```
-
 #### `findCell()`
 
-findCell(options = { row: number, cell: number, cellType: 'td / th' }) {
+Returns the specified cell.
 
-Returns given cell in main table. You can specify row, column and type of cell `td` or `th`.
+Syntax: `findCell({ row: number, cell: number, cellType: 'td / th' })`.
 
 ```js
 const cell = helpers.tbody.locator(helpers.findCell({ row: 2, cell: 2, cellType: 'td' }));
+
 await cell.click();
+```
+
+#### `findDropdownMenuExpander()`
+
+Returns the button that expands the dropdown menu
+(also known as [column menu](https://handsontable.com/docs/react-data-grid/column-menu/)) of the specified column.
+
+Syntax: `findDropdownMenuExpander({ col: number })`.
+
+```js
+// select the column menu button of the second column
+const changeTypeButton = table.locator(helpers.findDropdownMenuExpander({ col: 2 }));
+
+await changeTypeButton.click();
 ```

--- a/visual-tests/scripts/build.mjs
+++ b/visual-tests/scripts/build.mjs
@@ -1,7 +1,7 @@
 /**
- * Visual testing build script that is responsible for following steps:
- * - Installs all necessary dependencies for examples;
- * - Builds all of examples for all of frameworks to test.
+ * This script:
+ * - Installs the examples' dependencies.
+ * - Builds all the examples, for each framework that is going to be tested.
  */
 import execa from 'execa';
 import chalk from 'chalk';

--- a/visual-tests/scripts/upload.mjs
+++ b/visual-tests/scripts/upload.mjs
@@ -1,5 +1,5 @@
 /**
- * This script is responsible for uploading package of screenshots to external comparing services.
+ * This script uploads the screenshots package to an external service (Argos).
  */
 import execa from 'execa';
 import { isReferenceBranch } from './utils/utils.mjs';

--- a/visual-tests/scripts/utils/utils.mjs
+++ b/visual-tests/scripts/utils/utils.mjs
@@ -6,9 +6,9 @@ import { BASE_BRANCH, REFERENCE_FRAMEWORK, WRAPPERS } from '../../src/config.mjs
 const psTreePromisified = promisify(psTree);
 
 /**
- * Returns a Promise which is resolved after some milliseconds.
+ * Returns a Promise that's resolved after the specified number of milliseconds.
  *
- * @param {number} [delay=100] The delay in ms after which the Promise is resolved.
+ * @param {number} [delay=100] The delay after which the Promise is resolved (in milliseconds).
  * @returns {Promise}
  */
 export function sleep(delay = 100) {
@@ -20,7 +20,7 @@ export function sleep(delay = 100) {
 }
 
 /**
- * Gets the current branch name.
+ * Returns the name of the current branch.
  *
  * @returns {string}
  */
@@ -30,7 +30,7 @@ export function getCurrentBranchName() {
 }
 
 /**
- * Checks if tests are run on the base/reference branch.
+ * Returns `true` if tests are run on the reference branch (`develop`).
  *
  * @returns {boolean}
  */
@@ -39,8 +39,8 @@ export function isReferenceBranch() {
 }
 
 /**
- * Returns list of the frameworks that should be tested. The list differs depends on that branch the
- * scripts are currently run.
+ * Returns a list of frameworks to be tested,
+ * depending on which branch the scripts are run on.
  *
  * @returns {string[]}
  */
@@ -55,8 +55,8 @@ export function getFrameworkList() {
 /**
  * Kills the main process and all its children.
  *
- * @param {number} pid The process id to kill.
- * @param {string} [signal='SIGKILL'] The signal type to send.
+ * @param {number} pid The ID of the process to kill.
+ * @param {string} [signal='SIGKILL'] The type of the signal to send.
  */
 export async function killProcess(pid, signal = 'SIGKILL') {
   const pids = await psTreePromisified(pid);

--- a/visual-tests/src/config.mjs
+++ b/visual-tests/src/config.mjs
@@ -3,14 +3,14 @@
  */
 export const BASE_BRANCH = 'develop';
 /**
- * The list of the wrappers that are considered to test.
+ * The list of wrappers that are to be tested.
  */
 export const WRAPPERS = ['angular', 'react', 'vue'];
 /**
- * The framework that provides reference screenshots to compare with other frameworks.
+ * The framework that provides reference screenshots to compare against other frameworks.
  */
 export const REFERENCE_FRAMEWORK = 'js';
 /**
- * The port for the static server that servers the example.
+ * The port for the static server that serves the examples.
  */
 export const EXAMPLES_SERVER_PORT = '8080';

--- a/visual-tests/src/test-runner.ts
+++ b/visual-tests/src/test-runner.ts
@@ -8,9 +8,9 @@ const stylesToAdd = [
 ];
 
 /**
- * Exports "test" function from playwright but covered with some predefined initial setup.
+ * Exports the `test` function from Playwright, and configures its initial settings.
  *
- * @param {string} filename The test name.
+ * @param {string} filename The name of the test.
  * @param {Function} callback The function to call for the test case.
  */
 export async function test(filename: string, callback: (pageInfo: { page: Page }) => Promise<void>) {

--- a/visual-tests/tests/.empty-test-template.ts
+++ b/visual-tests/tests/.empty-test-template.ts
@@ -9,5 +9,7 @@ test(__filename, async({ page }) => {
   // const tbody = table.locator(helpers.selectors.mainTableBody);
   // const thead = table.locator(helpers.selectors.mainTableHead);
 
-  /* your test here */
+  /*
+  write your test here
+  */
 });

--- a/visual-tests/tests/change-rows-order.spec.ts
+++ b/visual-tests/tests/change-rows-order.spec.ts
@@ -9,11 +9,9 @@ test(__filename, async({ page }) => {
   const cloneInlineStartTable = table.locator(helpers.selectors.cloneInlineStartTable);
   const cell = cloneInlineStartTable.locator(helpers.findCell({ row: 4, cell: 1, cellType: 'th' }));
 
-  // Without coordinates `click` works on the middle of element,
-  // what means that in this case it will deselect checkbox.
-  // We do not want it, so we should define coordinates out of checkbox, but still in cell
-  // - here it can be { 1, 1 }.
-
+  // without coordinates, `click()` works in the middle of the element,
+  // so in this case, it would deselect the checkbox
+  // to avoid it, let's define coordinates inside of the cell, but outside of the checkbox
   await cell.click({ position: { x: 1, y: 1 } });
   await page.screenshot({ path: helpers.screenshotPath() });
 


### PR DESCRIPTION
This PR solves [#970](https://github.com/handsontable/dev-handsontable/issues/970), [#971](https://github.com/handsontable/dev-handsontable/issues/971), and [#973](https://github.com/handsontable/dev-handsontable/issues/973):
- Edits and expands the visual testing [README file](https://github.com/handsontable/handsontable/blob/docs/dev-970/visual-tests/README.md).
- Adds a mention about visual testing in the Knowledge Base: https://kb.handsontable.com/display/BOOK/Visual+testing
- Adds a mention about visual testing in the docs: http://localhost:8080/docs/javascript-data-grid/testing/#visual-testing

[skip changelog]