### PR TITLE
Docs: Enable `bindRowsWithHeaders` in the Row parent-child demos

### DIFF
--- a/docs/content/guides/rows/row-parent-child.md
+++ b/docs/content/guides/rows/row-parent-child.md
@@ -195,6 +195,7 @@ const hot = new Handsontable(container, {
   colHeaders: ['Category', 'Artist', 'Title', 'Album', 'Label'],
   nestedRows: true,
   contextMenu: true,
+  bindRowsWithHeaders: true,
   licenseKey: 'non-commercial-and-evaluation'
 });
 ```
@@ -336,6 +337,7 @@ export const ExampleComponent = () => {
       colHeaders={['Category', 'Artist', 'Title', 'Album', 'Label']}
       nestedRows={true}
       contextMenu={true}
+      bindRowsWithHeaders={true}
       licenseKey="non-commercial-and-evaluation"
     />
   );


### PR DESCRIPTION
This PR:
- Enables `bindRowsWithHeaders` in the [Row parent-child demos](https://handsontable.com/docs/react-data-grid/row-parent-child/#prepare-the-data-source), as discussed with @adamu-handsontable

[skip changelog]