### PR TITLE
Update SonarSource actions to the latest versions

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -19,13 +19,13 @@ jobs:
           fetch-depth: 0
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@5392662532e48780d7e796d79e55351fcb7ee3c9 # Commits on Sep 16, 2021
+        uses: SonarSource/sonarcloud-github-action@cb201f3b2d7a38231a8c042dfea4539c8bea180b # Commits on Nov 21, 2022
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
       - name: SonarQube Quality Gate check
-        uses: sonarsource/sonarqube-quality-gate-action@6a7dcc22310cef7cb83b0dfcf37c225113fb37cf # Commits on Jun 25, 2021
+        uses: SonarSource/sonarqube-quality-gate-action@d304d050d930b02a896b0f85935344f023928496 # https://github.com/SonarSource/sonarqube-quality-gate-action/releases/tag/v1.1.0
         # Force to fail step after specific time
         timeout-minutes: 1
         env:


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR updates the SonarSource action to the latest versions. The updates fix the warning notification about using old Node (14) for code analysis.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I checked the action dependencies, and previously there was used `sonarsource/sonar-scanner-cli:4.6` image shipped with Node 14. After updating, [it can be seen](https://github.com/handsontable/handsontable/actions/runs/4162486983/jobs/7201719528#step:2:20) that the action uses the same image but with the newer version (4.7) that contains Node 18.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1079

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)