### PR TITLE
Get rid of the UNSAFE_ React lifecycle methods

### DIFF
--- a/wrappers/react/src/editorHolder.tsx
+++ b/wrappers/react/src/editorHolder.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import {
+  HotEditorElement
+} from './types';
+import {
+  DEFAULT_CLASSNAME,
+  getContainerAttributesProps
+} from './helpers';
+
+/**
+ * Component provides an editor container for custom editors.
+ */
+export function EditorHolder({ editorElement }: { editorElement: HotEditorElement }) {
+  if (editorElement === null) {
+    return null;
+  }
+
+  const containerProps = getContainerAttributesProps(editorElement.props, false);
+
+  containerProps.className = [DEFAULT_CLASSNAME, containerProps.className].join(' ');
+
+  return (
+    <div {...containerProps}>
+      {editorElement}
+    </div>
+  )
+}

--- a/wrappers/react/src/helpers.tsx
+++ b/wrappers/react/src/helpers.tsx
@@ -27,7 +27,7 @@ export const GLOBAL_EDITOR_SCOPE = 'global';
 /**
  * Default classname given to the wrapper container.
  */
-const DEFAULT_CLASSNAME = 'hot-wrapper-editor-container';
+export const DEFAULT_CLASSNAME = 'hot-wrapper-editor-container';
 
 /**
  * Logs warn to the console if the `console` object is exposed.
@@ -81,51 +81,6 @@ export function getOriginalEditorClass(editorElement: HotEditorElement) {
 }
 
 /**
- * Remove editor containers from DOM.
- *
- * @param {Document} [doc] Document to be used.
- * @param {Map} editorCache The editor cache reference.
- */
-export function removeEditorContainers(doc = document): void {
-  doc.querySelectorAll(`[class^="${DEFAULT_CLASSNAME}"]`).forEach((domNode) => {
-    if (domNode.parentNode) {
-      domNode.parentNode.removeChild(domNode);
-    }
-  });
-}
-
-/**
- * Create an editor portal.
- *
- * @param {Document} [doc] Document to be used.
- * @param {React.ReactElement} editorElement Editor's element.
- * @param {Map} editorCache The editor cache reference.
- * @returns {React.ReactPortal} The portal for the editor.
- */
-export function createEditorPortal(doc = document, editorElement: HotEditorElement, editorCache: HotEditorCache): React.ReactPortal {
-  if (editorElement === null) {
-    return;
-  }
-
-  const editorContainer = doc.createElement('DIV');
-  const {id, className, style} = getContainerAttributesProps(editorElement.props, false);
-
-  if (id) {
-    editorContainer.id = id;
-  }
-
-  editorContainer.className = [DEFAULT_CLASSNAME, className].join(' ');
-
-  if (style) {
-    Object.assign(editorContainer.style, style);
-  }
-
-  doc.body.appendChild(editorContainer);
-
-  return ReactDOM.createPortal(editorElement, editorContainer);
-}
-
-/**
  * Get an editor element extended with a instance-emitting method.
  *
  * @param {React.ReactNode} children Component children.
@@ -162,11 +117,10 @@ export function getExtendedEditorElement(children: React.ReactNode, editorCache:
  *
  * @param {React.ReactElement} rElement React element to be used as a base for the component.
  * @param {Object} props Props to be passed to the cloned element.
- * @param {Function} callback Callback to be called after the component has been mounted.
  * @param {Document} [ownerDocument] The owner document to set the portal up into.
  * @returns {{portal: React.ReactPortal, portalContainer: HTMLElement}} An object containing the portal and its container.
  */
-export function createPortal(rElement: React.ReactElement, props, callback: Function, ownerDocument: Document = document): {
+export function createPortal(rElement: React.ReactElement, props, ownerDocument: Document = document): {
   portal: React.ReactPortal,
   portalContainer: HTMLElement
 } {
@@ -206,28 +160,5 @@ export function getContainerAttributesProps(props, randomizeId: boolean = true):
     id: props.id || (randomizeId ? 'hot-' + Math.random().toString(36).substring(5) : void 0),
     className: props.className || '',
     style: props.style || {},
-  }
-}
-
-/**
- * Add the `UNSAFE_` prefixes to the deprecated lifecycle methods for React >= 16.3.
- *
- * @param {Object} instance Instance to have the methods renamed.
- */
-export function addUnsafePrefixes(instance: {
-  UNSAFE_componentWillUpdate?: Function,
-  componentWillUpdate: Function,
-  UNSAFE_componentWillMount?: Function,
-  componentWillMount: Function
-}): void {
-  const reactSemverArray = React.version.split('.').map((v) => parseInt(v));
-  const shouldPrefix = (reactSemverArray[0] >= 16 && reactSemverArray[1] >= 3) || reactSemverArray[0] >= 17;
-
-  if (shouldPrefix) {
-    instance.UNSAFE_componentWillUpdate = instance.componentWillUpdate;
-    instance.componentWillUpdate = void 0;
-
-    instance.UNSAFE_componentWillMount = instance.componentWillMount;
-    instance.componentWillMount = void 0;
   }
 }

--- a/wrappers/react/src/hotColumn.tsx
+++ b/wrappers/react/src/hotColumn.tsx
@@ -1,54 +1,15 @@
-import React, { ReactPortal } from 'react';
+import React from 'react';
 import { HotTableProps, HotColumnProps } from './types';
 import {
-  addUnsafePrefixes,
-  createEditorPortal,
   getExtendedEditorElement
 } from './helpers';
 import { SettingsMapper } from './settingsMapper';
+import { EditorHolder } from './editorHolder';
 import Handsontable from 'handsontable/base';
 
 class HotColumn extends React.Component<HotColumnProps, {}> {
   internalProps: string[];
   columnSettings: Handsontable.ColumnSettings;
-
-  /**
-   * Local editor portal cache.
-   *
-   * @private
-   * @type {ReactPortal}
-   */
-  private localEditorPortal: ReactPortal = null;
-
-  /**
-   * HotColumn class constructor.
-   *
-   * @param {HotColumnProps} props Component props.
-   * @param {*} [context] Component context.
-   */
-  constructor(props: HotColumnProps, context?: any) {
-    super(props, context);
-
-    addUnsafePrefixes(this);
-  }
-
-  /**
-   * Get the local editor portal cache property.
-   *
-   * @return {ReactPortal} Local editor portal.
-   */
-  getLocalEditorPortal(): ReactPortal {
-    return this.localEditorPortal;
-  }
-
-  /**
-   * Set the local editor portal cache property.
-   *
-   * @param {ReactPortal} portal Local editor portal.
-   */
-  setLocalEditorPortal(portal): void {
-    this.localEditorPortal = portal;
-  }
 
   /**
    * Filter out all the internal properties and return an object with just the Handsontable-related props.
@@ -99,20 +60,6 @@ class HotColumn extends React.Component<HotColumnProps, {}> {
   }
 
   /**
-   * Create the local editor portal and its destination HTML element if needed.
-   *
-   * @param {React.ReactNode} [children] Children of the HotTable instance. Defaults to `this.props.children`.
-   */
-  createLocalEditorPortal(children = this.props.children): void {
-    const editorCache = this.props._getEditorCache();
-    const localEditorElement: React.ReactElement = getExtendedEditorElement(children, editorCache, this.props._columnIndex);
-
-    if (localEditorElement) {
-      this.setLocalEditorPortal(createEditorPortal(this.props._getOwnerDocument(), localEditorElement, editorCache));
-    }
-  }
-
-  /**
    * Emit the column settings to the parent using a prop passed from the parent.
    */
   emitColumnSettings(): void {
@@ -124,27 +71,12 @@ class HotColumn extends React.Component<HotColumnProps, {}> {
   ------- React lifecycle methods -------
   ---------------------------------------
   */
-
-  /**
-   * Logic performed before the mounting of the HotColumn component.
-   */
-  componentWillMount(): void {
-    this.createLocalEditorPortal();
-  }
-
   /**
    * Logic performed after the mounting of the HotColumn component.
    */
   componentDidMount(): void {
     this.createColumnSettings();
     this.emitColumnSettings();
-  }
-
-  /**
-   * Logic performed before the updating of the HotColumn component.
-   */
-  componentWillUpdate(nextProps: Readonly<HotColumnProps>, nextState: Readonly<{}>, nextContext: any): void {
-    this.createLocalEditorPortal(nextProps.children);
   }
 
   /**
@@ -163,7 +95,7 @@ class HotColumn extends React.Component<HotColumnProps, {}> {
   render(): React.ReactElement {
     return (
       <React.Fragment>
-        {this.getLocalEditorPortal()}
+        <EditorHolder editorElement={this.getLocalEditorElement()}></EditorHolder>
       </React.Fragment>
     )
   }

--- a/wrappers/react/src/portalManager.tsx
+++ b/wrappers/react/src/portalManager.tsx
@@ -4,13 +4,9 @@ import React from 'react';
  * Component class used to manage the renderer component portals.
  */
 export class PortalManager extends React.Component<{}, {portals?: React.ReactPortal[]}> {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      portals: []
-    };
-  }
+  state = {
+    portals: []
+  };
 
   render(): React.ReactNode {
     return (

--- a/wrappers/react/test/_helpers.tsx
+++ b/wrappers/react/test/_helpers.tsx
@@ -2,7 +2,6 @@ import React, { useRef } from 'react';
 import { render } from 'react-dom';
 import { act } from 'react-dom/test-utils';
 import { HotTable } from '../src/hotTable';
-import { addUnsafePrefixes } from '../src/helpers';
 import { BaseEditorComponent } from '../src/baseEditorComponent';
 
 const SPEC = {
@@ -169,16 +168,7 @@ export function simulateMouseEvent(element, type) {
 
 class IndividualPropsWrapper extends React.Component<{ref?: string, id?: string}, {hotSettings?: object}> {
   hotTable: typeof HotTable;
-
-  constructor(props) {
-    super(props);
-
-    addUnsafePrefixes(this);
-  }
-
-  componentWillMount() {
-    this.setState({});
-  }
+  state = {};
 
   private setHotElementRef(component: typeof HotTable): void {
     this.hotTable = component;
@@ -203,19 +193,10 @@ export { IndividualPropsWrapper };
 
 class SingleObjectWrapper extends React.Component<{ref?: string, id?: string}, {hotSettings?: object}> {
   hotTable: typeof HotTable;
-
-  constructor(props) {
-    super(props);
-
-    addUnsafePrefixes(this);
-  }
+  state = {};
 
   private setHotElementRef(component: typeof HotTable): void {
     this.hotTable = component;
-  }
-
-  componentWillMount() {
-    this.setState({});
   }
 
   render(): React.ReactElement {

--- a/wrappers/react/test/_helpers.tsx
+++ b/wrappers/react/test/_helpers.tsx
@@ -41,7 +41,11 @@ export function mountComponent(Component, container = SPEC.container) {
   }
 
   act(() => {
-    render(<App/>, container);
+    render(
+      <React.StrictMode>
+        <App/>
+      </React.StrictMode>
+      , container);
   });
 
   return hotTableComponent?.current;

--- a/wrappers/react/test/componentInternals.spec.tsx
+++ b/wrappers/react/test/componentInternals.spec.tsx
@@ -145,15 +145,9 @@ describe('Component lifecyle', () => {
         super(props);
 
         rendererCounters.set(`${this.props.row}-${this.props.col}`, {
-          willMount: 0,
           didMount: 0,
           willUnmount: 0
         });
-      }
-
-      UNSAFE_componentWillMount(): void {
-        const counters = rendererCounters.get(`${this.props.row}-${this.props.col}`);
-        counters.willMount++;
       }
 
       componentDidMount(): void {
@@ -209,7 +203,6 @@ describe('Component lifecyle', () => {
     )).hotInstance;
 
     rendererCounters.forEach((counters) => {
-      expect(counters.willMount).toEqual(1);
       expect(counters.didMount).toEqual(1);
       expect(counters.willUnmount).toEqual(0);
     });
@@ -220,7 +213,6 @@ describe('Component lifecyle', () => {
     await sleep(300);
 
     rendererCounters.forEach((counters) => {
-      expect(counters.willMount).toEqual(1);
       expect(counters.didMount).toEqual(1);
       expect(counters.willUnmount).toEqual(1);
     });
@@ -232,16 +224,11 @@ describe('Component lifecyle', () => {
         super(props);
 
         editorCounters.set(`${this.props.row}-${this.props.col}`, {
-          willMount: 0,
           didMount: 0,
           willUnmount: 0
         });
       }
 
-      UNSAFE_componentWillMount(): void {
-        const counters = editorCounters.get(`${this.props.row}-${this.props.col}`);
-        counters.willMount++;
-      }
 
       componentDidMount(): void {
         const counters = editorCounters.get(`${this.props.row}-${this.props.col}`);
@@ -289,7 +276,6 @@ describe('Component lifecyle', () => {
     ));
 
     editorCounters.forEach((counters) => {
-      expect(counters.willMount).toEqual(1);
       expect(counters.didMount).toEqual(1);
       expect(counters.willUnmount).toEqual(0);
     });
@@ -301,7 +287,6 @@ describe('Component lifecyle', () => {
     await sleep(100);
 
     editorCounters.forEach((counters) => {
-      expect(counters.willMount).toEqual(1);
       expect(counters.didMount).toEqual(1);
       expect(counters.willUnmount).toEqual(1);
     });

--- a/wrappers/react/test/hotTable.spec.tsx
+++ b/wrappers/react/test/hotTable.spec.tsx
@@ -182,19 +182,92 @@ describe('Editor configuration using React components', () => {
 
     expect((document.querySelector('#editorComponentContainer') as any).style.display).toEqual('none');
 
-    hotInstance.selectCell(0,0);
+    hotInstance.selectCell(0, 0);
     simulateKeyboardEvent('keydown', 13);
 
     expect((document.querySelector('#editorComponentContainer') as any).style.display).toEqual('block');
 
-    expect(hotInstance.getDataAtCell(0,0)).toEqual('A1');
+    expect(hotInstance.getDataAtCell(0, 0)).toEqual('A1');
 
     simulateMouseEvent(document.querySelector('#editorComponentContainer button'), 'click');
 
-    expect(hotInstance.getDataAtCell(0,0)).toEqual('new-value');
+    expect(hotInstance.getDataAtCell(0, 0)).toEqual('new-value');
 
     hotInstance.getActiveEditor().close();
 
     expect((document.querySelector('#editorComponentContainer') as any).style.display).toEqual('none');
+  });
+
+  it('should use the correct editor inside HotTable component depends on its mount state', async () => {
+    let hotTableInstanceRef = React.createRef();
+
+    class WrapperComponent extends React.Component<any, any> {
+      state = {
+        editor: false,
+      }
+
+      render() {
+        return (
+          <HotTable licenseKey="non-commercial-and-evaluation"
+                    id="test-hot"
+                    data={createSpreadsheetData(3, 3)}
+                    width={300}
+                    height={300}
+                    rowHeights={23}
+                    colWidths={50}
+                    init={function () {
+                      mockElementDimensions(this.rootElement, 300, 300);
+                    }}
+                    ref={hotTableInstanceRef}>
+            {this.state.editor ? <EditorComponent hot-editor></EditorComponent> : null}
+          </HotTable>
+        );
+      };
+    }
+
+    const wrapperComponentInstance = mountComponent((
+      <WrapperComponent/>
+    ));
+
+    let hotInstance = (hotTableInstanceRef.current as any).hotInstance;
+
+    hotInstance.selectCell(0, 0);
+
+    {
+      const activeEditor = hotInstance.getActiveEditor();
+
+      expect(activeEditor.constructor.name).toBe('TextEditor');
+
+      activeEditor.close();
+    }
+
+    wrapperComponentInstance.setState({ editor: true });
+
+    await sleep(100);
+
+    hotInstance.selectCell(0, 0);
+
+    {
+      const activeEditor = hotInstance.getActiveEditor();
+
+      expect(activeEditor.constructor.name).toBe('CustomEditor');
+      expect(activeEditor.editorComponent.__proto__.constructor.name).toBe('EditorComponent');
+
+      activeEditor.close();
+    }
+
+    wrapperComponentInstance.setState({ editor: false });
+
+    await sleep(100);
+
+    hotInstance.selectCell(0, 0);
+
+    {
+      const activeEditor = hotInstance.getActiveEditor();
+
+      expect(activeEditor.constructor.name).toBe('TextEditor');
+
+      activeEditor.close();
+    }
   });
 });


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR removes all UNSAFE_ React lifecycle methods used within the Handsontable wrapper for React. 

### Tasks to be done
- [ ] Remove unsafe methods from the `HotTable` component, test it, and cover it with new tests;
- [ ] Remove unsafe methods from the `HotColumn` component, test it, and cover it with new tests;

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
\-

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/465

### Affected project(s):
- [x] `@handsontable/react`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
