### PR TITLE
Handle `licenseKey` for using HF inside HOT with no action required from the user

### DIFF
--- a/handsontable/src/plugins/formulas/__tests__/initialization.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/initialization.spec.js
@@ -821,7 +821,7 @@ describe('Formulas general', () => {
     });
   });
 
-  describe('Updating HF settings', () => {
+  describe('HF settings', () => {
     it('should initialize HyperFormula with the default set of settings', () => {
       handsontable({
         formulas: {
@@ -884,8 +884,8 @@ describe('Formulas general', () => {
       expect(hfConfig.useStats).toEqual(true);
     });
 
-    it('should update the external HyperFormula instance config with the Handsontable/HF licenseKey, if none was' +
-      ' provided', () => {
+    it('should initialize the HF licenseKey with the internal-use-in-handsontable string, if none was provided (HF' +
+      ' instance created manually)', () => {
       const hfInstance1 = HyperFormula.buildEmpty();
 
       handsontable({
@@ -897,8 +897,18 @@ describe('Formulas general', () => {
       expect(hfInstance1.getConfig().licenseKey).toEqual('internal-use-in-handsontable');
     });
 
-    it('should NOT update the external HyperFormula instance config with the Handsontable/HF licenseKey, if it was' +
-      ' provided beforehand', () => {
+    it('should initialize the HF licenseKey with the internal-use-in-handsontable string, if none was provided (HF' +
+      ' instance created automatically by HOT)', () => {
+      const hot = handsontable({
+        formulas: {
+          engine: HyperFormula
+        }
+      });
+
+      expect(hot.getPlugin('formulas').engine.getConfig().licenseKey).toEqual('internal-use-in-handsontable');
+    });
+
+    it('should overwrite the provided HF licenseKey with the internal-use-in-handsontable string', () => {
       const hfInstance1 = HyperFormula.buildEmpty({ licenseKey: 'dummy-license-key' });
 
       handsontable({
@@ -907,7 +917,7 @@ describe('Formulas general', () => {
         },
       });
 
-      expect(hfInstance1.getConfig().licenseKey).toEqual('dummy-license-key');
+      expect(hfInstance1.getConfig().licenseKey).toEqual('internal-use-in-handsontable');
     });
 
     it('should not update HyperFormula settings when Handsontable#updateSettings was called without the `formulas` key', () => {

--- a/handsontable/src/plugins/formulas/engine/register.js
+++ b/handsontable/src/plugins/formulas/engine/register.js
@@ -78,11 +78,9 @@ export function setupEngine(hotInstance) {
       sharedEngineUsage.push(hotInstance.guid);
     }
 
-    if (!engineConfigItem.getConfig().licenseKey) {
-      engineConfigItem.updateConfig({
-        licenseKey: DEFAULT_LICENSE_KEY
-      });
-    }
+    engineConfigItem.updateConfig({
+      licenseKey: DEFAULT_LICENSE_KEY
+    });
 
     return engineConfigItem;
   }


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->

- [ ] Make formulas plugin overwrite the HF licenseKey provided by user
- [ ] Update Formulas plugin documentation
- [ ] Chengelog entry

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

TBP

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
https://github.com/handsontable/dev-handsontable/issues/587

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
