### PR TITLE
Fix tip box styling about viewing non-latest Docs version

### DIFF
--- a/docs/.vuepress/theme/styles/index.styl
+++ b/docs/.vuepress/theme/styles/index.styl
@@ -117,7 +117,7 @@ a.source-code-link {
   margin-top: 60px !important;
 }
 
-.theme-default-content:not(.custom) {
+.theme-default-content:not(.custom), .page-top {
   width: 100%;
   min-width: 200px;
   max-width: $contentWidth;


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the tib box styling that holds information about viewing the non-latest Docs version.

##### Before
![Kapture 2023-02-23 at 13 26 14](https://user-images.githubusercontent.com/571316/220905281-410031ec-a96e-4e2d-a86b-a45126ecf0aa.gif)

##### After
![Kapture 2023-02-23 at 13 27 07](https://user-images.githubusercontent.com/571316/220905437-a56f3811-a7f1-489d-9f18-fb4396f45646.gif)

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/856

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
