### PR TITLE
Allow for more customisable manualColumnResize

### DIFF
--- a/.changelogs/10266.json
+++ b/.changelogs/10266.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Make manualColumnResize.js more customizable",
+  "type": "changed",
+  "issueOrPR": 10266,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/manualColumnResize/manualColumnResize.js
+++ b/handsontable/src/plugins/manualColumnResize/manualColumnResize.js
@@ -225,6 +225,20 @@ export class ManualColumnResize extends BasePlugin {
   }
 
   /**
+   * Returns the bounding client rect of an element
+   *
+   * @param {HTMLElement} element HTML element.
+   * @returns {DOMRect} Bounding client rect of the given element
+   */
+  getBoundingClientRect(element) {
+    if (!element) {
+      return;
+    }
+
+    return element.getBoundingClientRect();
+  }
+
+  /**
    * Set the resize handle position.
    *
    * @private
@@ -247,7 +261,7 @@ export class ManualColumnResize extends BasePlugin {
     }
 
     const headerHeight = outerHeight(this.currentTH);
-    const box = this.currentTH.getBoundingClientRect();
+    const box = this.getBoundingClientRect(this.currentTH);
     // Read "fixedColumnsStart" through the Walkontable as in that context, the fixed columns
     // are modified (reduced by the number of hidden columns) by TableView module.
     const fixedColumn = col < wt.getSetting('fixedColumnsStart');


### PR DESCRIPTION
### Context

I'm implementing Handsontable for the our company's application. And we're having an issue where the manual column resizer handle is not correctly positioned in the header in some situations.

![CleanShot 2023-03-06 at 14 03 07](https://user-images.githubusercontent.com/83485085/223009961-77c9ff40-40dc-4346-b6bd-8ada22861b54.png)

The reason why this is happening is that we are rendering the table on a "digital whiteboard", which can be zoomed in and out. The way we are zooming in and out is by applying a CSS transformation to the canvas. We are finding that when the whiteboard is not at 100%, the manual column resizer handle is not correctly positioned.

I've taken a look at the Handsontable codebase and we can very easily solve this issue by pulling [getBoundingClientRect()](https://github.com/handsontable/handsontable/blob/develop/handsontable/src/plugins/manualColumnResize/manualColumnResize.js#L250) out into its own function (in manualColumnResize.js), and for us to essentially override this function. Hope that this is an acceptable change on your end, which will make our lives much easier!

Great library btw!

### How has this been tested?

- Ran npm run test
- I pulled the repository locally, made our application depend on my local handsontable version, and tested the changes on our app


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

N/A

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
