### PR TITLE
Docs: Add JavaScript version of the Format numbers demo

### DIFF
--- a/docs/content/guides/cell-types/numeric-cell-type.md
+++ b/docs/content/guides/cell-types/numeric-cell-type.md
@@ -19,17 +19,24 @@ Use the numeric cell type to correctly display, format, sort, and filter numbers
 
 ## Overview
 
-The default cell type in Handsontable is text. The data of a text cell is processed as a `string` type that corresponds to the value of the text editor's internal `<textarea>` element. However, there are many cases where you need cell values to be treated as a `number` type. The numeric cell type allows you to format displayed numbers nicely and sort them correctly.
+The default cell type in Handsontable is text. The data of a text cell is processed as a `string`
+type that corresponds to the value of the text editor's internal `<textarea>` element. However,
+there are many cases where you need cell values to be treated as a `number` type. The numeric cell
+type allows you to format displayed numbers nicely and sort them correctly.
 
 ## Usage
 
 ::: tip
-Ensure your numeric cell values are stored as numbers and not strings in the data source, as Handsontable doesn't parse strings to numbers.
+
+Ensure your numeric cell values are stored as numbers and not strings in the data source, as
+Handsontable doesn't parse strings to numbers.
+
 :::
 
 To use the `numeric` cell type, set the [`type`](@/api/options.md#type) option to `'numeric'`:
 
 ::: only-for javascript
+
 ```js
 // set the `numeric` cell type for each cell of the entire grid
 type: 'numeric',
@@ -50,9 +57,11 @@ cell: [
   }
 ],
 ```
+
 :::
 
 ::: only-for react
+
 ```jsx
 // set the `numeric` cell type for each cell of the entire grid
 type={'numeric'},
@@ -69,29 +78,40 @@ cell={[{
   type: 'numeric',
 }]}
 ```
+
 :::
 
 ### Numeric values in the editor
 
 In the cell editor of a `numeric` cell:
-- The number is initially presented with a dot (`50.5`) as the decimal separator and without the thousands separator.
+
+- The number is initially presented with a dot (`50.5`) as the decimal separator and without the
+  thousands separator.
 - A dot (`50.5`) or a comma (`50,5`) can be entered as the decimal separator.
 - No character can be used as the thousands separator.
 
 ::: tip
-All the positive and negative integers whose magnitude is no greater than 253 (+/- 9007199254740991) are representable in the `Number` type, i.e., safe integer. Any calculations that are performed on bigger numbers won't be calculated precisely due to JavaScript limitations.
+
+All the positive and negative integers whose magnitude is no greater than 253 (+/- 9007199254740991)
+are representable in the `Number` type, i.e., safe integer. Any calculations that are performed on
+bigger numbers won't be calculated precisely due to JavaScript limitations.
+
 :::
 
 ### Numeric values in the renderer
 
-To format the look of numeric values in cell renderers, use the [`numericFormat`](@/api/options.md#numericformat) option.
+To format the look of numeric values in cell renderers, use the
+[`numericFormat`](@/api/options.md#numericformat) option.
 
-Note that the [`numericFormat`](@/api/options.md#numericformat) option doesn't change the way numbers are presented or parsed by the [cell editor](#numeric-values-in-the-editor).
+Note that the [`numericFormat`](@/api/options.md#numericformat) option doesn't change the way
+numbers are presented or parsed by the [cell editor](#numeric-values-in-the-editor).
 
 ## Basic example
 
 ::: only-for javascript
+
 ::: example #example1 :hot-numbro
+
 ```js
 import Handsontable from 'handsontable';
 import numbro from 'numbro';
@@ -108,47 +128,51 @@ const hot = new Handsontable(container, {
     { car: 'Citroen C4 Coupe', year: 2018, price_usd: 8330, price_eur: 8330 },
     { car: 'Audi A4 Avant', year: 2019, price_usd: 33900, price_eur: 33900 },
     { car: 'Opel Astra', year: 2020, price_usd: 5000, price_eur: 5000 },
-    { car: 'BMW 320i Coupe', year: 2021, price_usd: 30500, price_eur: 30500 }
+    { car: 'BMW 320i Coupe', year: 2021, price_usd: 30500, price_eur: 30500 },
   ],
   colHeaders: ['Car', 'Year', 'Price ($)', 'Price (€)'],
-  columnSorting : true,
+  columnSorting: true,
   height: 'auto',
   licenseKey: 'non-commercial-and-evaluation',
   columns: [
     {
-      data: 'car'
+      data: 'car',
       // 1st column is simple text, no special options here
     },
     {
       data: 'year',
-      type: 'numeric'
+      type: 'numeric',
     },
     {
       data: 'price_usd',
       type: 'numeric',
       numericFormat: {
         pattern: '$0,0.00',
-        culture: 'en-US' // this is the default culture, set up for USD
+        culture: 'en-US', // this is the default culture, set up for USD
       },
-      allowEmpty: false
+      allowEmpty: false,
     },
     {
       data: 'price_eur',
       type: 'numeric',
       numericFormat: {
         pattern: '0,0.00 $',
-        culture: 'de-DE' // use this for EUR (German),
+        culture: 'de-DE', // use this for EUR (German),
         // more cultures available on http://numbrojs.com/languages.html
-      }
-    }
-  ]
+      },
+    },
+  ],
 });
 ```
+
 :::
+
 :::
 
 ::: only-for react
+
 ::: example #example1 :react-numbro
+
 ```jsx
 import { HotTable } from '@handsontable/react';
 import numbro from 'numbro';
@@ -170,38 +194,39 @@ export const ExampleComponent = () => {
         { car: 'Citroen C4 Coupe', year: 2018, price_usd: 8330, price_eur: 8330 },
         { car: 'Audi A4 Avant', year: 2019, price_usd: 33900, price_eur: 33900 },
         { car: 'Opel Astra', year: 2020, price_usd: 5000, price_eur: 5000 },
-        { car: 'BMW 320i Coupe', year: 2021, price_usd: 30500, price_eur: 30500 }
+        { car: 'BMW 320i Coupe', year: 2021, price_usd: 30500, price_eur: 30500 },
       ]}
       colHeaders={['Car', 'Year', 'Price ($)', 'Price (€)']}
       columnSorting={true}
       height="auto"
       licenseKey="non-commercial-and-evaluation"
-      columns={[{
-          data: 'car'
+      columns={[
+        {
+          data: 'car',
           // 1st column is simple text, no special options here
         },
         {
           data: 'year',
-          type: 'numeric'
+          type: 'numeric',
         },
         {
           data: 'price_usd',
           type: 'numeric',
           numericFormat: {
             pattern: '$0,0.00',
-            culture: 'en-US' // this is the default culture, set up for USD
+            culture: 'en-US', // this is the default culture, set up for USD
           },
-          allowEmpty: false
+          allowEmpty: false,
         },
         {
           data: 'price_eur',
           type: 'numeric',
           numericFormat: {
             pattern: '0,0.00 $',
-            culture: 'de-DE' // use this for EUR (German),
+            culture: 'de-DE', // use this for EUR (German),
             // more cultures available on http://numbrojs.com/languages.html
-          }
-        }
+          },
+        },
       ]}
     />
   );
@@ -211,14 +236,93 @@ export const ExampleComponent = () => {
 ReactDOM.render(<ExampleComponent />, document.getElementById('example1'));
 /* end:skip-in-preview */
 ```
-:::
+
 :::
 
+:::
 
-::: only-for react
 ## Format numbers
 
+::: only-for javascript
+
+::: example #example3 :hot-numbro
+
+```js
+import Handsontable from 'handsontable';
+import numbro from 'numbro';
+import jaJP from 'numbro/languages/ja-JP';
+import trTR from 'numbro/languages/tr-TR';
+import 'handsontable/dist/handsontable.full.min.css';
+
+// register the languages you need
+numbro.registerLanguage(jaJP);
+numbro.registerLanguage(trTR);
+
+// define formats
+const formatJP = {
+  pattern: '0,0.00 $',
+  culture: 'ja-JP',
+};
+
+const formatTR = {
+  pattern: '0,0.00 $',
+  culture: 'tr-TR',
+};
+
+const container = document.querySelector('#example3');
+const hot = new Handsontable(container, {
+  data: [
+    {
+      productName: 'Product A',
+      JP_price: 1.32,
+      TR_price: 100.56,
+    },
+    {
+      productName: 'Product B',
+      JP_price: 2.22,
+      TR_price: 453.5,
+    },
+    {
+      productName: 'Product C',
+      JP_price: 3.1,
+      TR_price: 678.1,
+    },
+  ],
+  columns: [
+    {
+      data: 'productName',
+      type: 'text',
+      width: '120',
+    },
+    {
+      data: 'JP_price',
+      type: 'numeric',
+      width: '120',
+      numericFormat: formatJP,
+    },
+    {
+      data: 'TR_price',
+      type: 'numeric',
+      width: '120',
+      numericFormat: formatTR,
+    },
+  ],
+  autoRowSize: false,
+  autoColumnSize: false,
+  colHeaders: ['Product name', 'Price in Japan', 'Price in Turkey'],
+  height: 'auto',
+  licenseKey: 'non-commercial-and-evaluation',
+});
+```
+
+:::
+
+:::
+
+::: only-for react
+
 ::: example #example3 :react-numbro
+
 ```jsx
 import { HotTable, HotColumn } from '@handsontable/react';
 import { registerAllModules } from 'handsontable/registry';
@@ -237,12 +341,12 @@ numbro.registerLanguage(trTR);
 // define formats
 const formatJP = {
   pattern: '0,0.00 $',
-  culture: 'ja-JP'
+  culture: 'ja-JP',
 };
 
 const formatTR = {
   pattern: '0,0.00 $',
-  culture: 'tr-TR'
+  culture: 'tr-TR',
 };
 
 export const ExampleComponent = () => {
@@ -252,47 +356,39 @@ export const ExampleComponent = () => {
         {
           productName: 'Product A',
           JP_price: 1.32,
-          TR_price: 100.56
+          TR_price: 100.56,
         },
         {
           productName: 'Product B',
           JP_price: 2.22,
-          TR_price: 453.5
+          TR_price: 453.5,
         },
         {
           productName: 'Product C',
           JP_price: 3.1,
-          TR_price: 678.1
-        }
+          TR_price: 678.1,
+        },
       ]}
       autoRowSize={false}
       autoColumnSize={false}
       colHeaders={['Product name', 'Price in Japan', 'Price in Turkey']}
       height="auto"
       licenseKey="non-commercial-and-evaluation"
-      >
+    >
       <HotColumn data="productName" type="text" width="120" />
-      <HotColumn
-        data="JP_price"
-        type="numeric"
-        numericFormat={formatJP}
-        width="120"
-      />
-      <HotColumn
-        data="TR_price"
-        type="numeric"
-        numericFormat={formatTR}
-        width="120"
-      />
+      <HotColumn data="JP_price" type="numeric" numericFormat={formatJP} width="120" />
+      <HotColumn data="TR_price" type="numeric" numericFormat={formatTR} width="120" />
     </HotTable>
-  )
-}
+  );
+};
 
 /* start:skip-in-preview */
 ReactDOM.render(<ExampleComponent />, document.getElementById('example3'));
 /* end:skip-in-preview */
 ```
+
 :::
+
 :::
 
 ## Related articles


### PR DESCRIPTION
This PR:
- On the [Numeric cell type](https://handsontable.com/docs/react-data-grid/numeric-cell-type) page, adds a JavaScript version of the [Format numbers](https://handsontable.com/docs/react-data-grid/numeric-cell-type/#format-numbers) demo
- Applies minor formatting changes, to unify Markdown and JS formatting across the docs

Affected content:
- http://localhost:8082/docs/javascript-data-grid/numeric-cell-type/#format-numbers

[skip changelog]