### PR TITLE
Improve the main Column hiding demo

### DIFF
--- a/docs/content/guides/columns/column-hiding.md
+++ b/docs/content/guides/columns/column-hiding.md
@@ -2,7 +2,9 @@
 id: 6elqkmhr
 title: Column hiding
 metaTitle: Column hiding - JavaScript Data Grid | Handsontable
-description: Hide individual columns to avoid rendering them as DOM elements. It helps you reduce screen clutter and improve the grid's performance.
+description:
+  Hide individual columns to avoid rendering them as DOM elements. It helps you reduce screen
+  clutter and improve the grid's performance.
 permalink: /column-hiding
 canonicalUrl: /column-hiding
 react:
@@ -13,7 +15,8 @@ searchCategory: Guides
 
 # Column hiding
 
-Hide individual columns to avoid rendering them as DOM elements. It helps you reduce screen clutter and improve the grid's performance.
+Hide individual columns to avoid rendering them as DOM elements. It helps you reduce screen clutter
+and improve the grid's performance.
 
 [[toc]]
 
@@ -22,15 +25,20 @@ Hide individual columns to avoid rendering them as DOM elements. It helps you re
 "Hiding a column" means that the hidden column doesn't get rendered as a DOM element.
 
 When you're hiding a column:
+
 - The source data doesn't get modified.
-- The [`HiddenColumns`](@/api/hiddenColumns.md) plugin doesn't participate in data transformation<br>(the shape of the data returned by the [`getData*()` methods](@/api/core.md#getdata) stays intact).
+- The [`HiddenColumns`](@/api/hiddenColumns.md) plugin doesn't participate in data
+  transformation<br>(the shape of the data returned by the
+  [`getData*()` methods](@/api/core.md#getdata) stays intact).
 
 ## Enable column hiding
 
-To simply enable column hiding (without further configuration), set the [`hiddenColumns`](@/api/options.md#hiddencolumns) configuration option to `true`:
+To enable column hiding, use the [`hiddenColumns`](@/api/options.md#hiddencolumns) option.
 
 ::: only-for javascript
+
 ::: example #example1
+
 ```js
 import Handsontable from 'handsontable';
 import 'handsontable/dist/handsontable.full.min.css';
@@ -48,15 +56,23 @@ const hot = new Handsontable(container, {
   height: 'auto',
   colHeaders: true,
   rowHeaders: true,
+  contextMenu: true,
   // enable the `HiddenColumns` plugin
-  hiddenColumns: true,
+  hiddenColumns: {
+    columns: [2, 4, 6],
+    indicators: true,
+  },
 });
 ```
+
 :::
+
 :::
 
 ::: only-for react
+
 ::: example #example1 :react
+
 ```jsx
 import { HotTable } from '@handsontable/react';
 import { registerAllModules } from 'handsontable/registry';
@@ -79,8 +95,12 @@ export const ExampleComponent = () => {
       height="auto"
       colHeaders={true}
       rowHeaders={true}
+      contextMenu={true}
       // enable the `HiddenColumns` plugin
-      hiddenColumns={true}
+      hiddenColumns={{
+        columns: [2, 4, 6],
+        indicators: true,
+      }}
     />
   );
 };
@@ -89,9 +109,10 @@ export const ExampleComponent = () => {
 ReactDOM.render(<ExampleComponent />, document.getElementById('example1'));
 /* end:skip-in-preview */
 ```
-:::
+
 :::
 
+:::
 
 ## Set up column hiding
 
@@ -99,14 +120,18 @@ To set up your column hiding configuration, follow the steps below.
 
 ### Step 1: Specify columns hidden by default
 
-To both enable column hiding and specify columns hidden by default, set the [`hiddenColumns`](@/api/options.md#hiddencolumns) configuration option to an object.
+To both enable column hiding and specify columns hidden by default, set the
+[`hiddenColumns`](@/api/options.md#hiddencolumns) configuration option to an object.
 
-In the object, add a [`columns`](@/api/options.md#columns) configuration option, and set it to an array of column indexes.
+In the object, add a [`columns`](@/api/options.md#columns) configuration option, and set it to an
+array of column indexes.
 
 Now, those columns are hidden by default:
 
 ::: only-for javascript
+
 ::: example #example2
+
 ```js
 import Handsontable from 'handsontable';
 import 'handsontable/dist/handsontable.full.min.css';
@@ -127,15 +152,19 @@ const hot = new Handsontable(container, {
   // enable the `HiddenColumns` plugin
   hiddenColumns: {
     // specify columns hidden by default
-    columns: [3, 5, 9]
-  }
+    columns: [3, 5, 9],
+  },
 });
 ```
+
 :::
+
 :::
 
 ::: only-for react
+
 ::: example #example2 :react
+
 ```jsx
 import { HotTable } from '@handsontable/react';
 import { registerAllModules } from 'handsontable/registry';
@@ -161,7 +190,7 @@ export const ExampleComponent = () => {
       // enable the `HiddenColumns` plugin
       hiddenColumns={{
         // specify columns hidden by default
-        columns: [3, 5, 9]
+        columns: [3, 5, 9],
       }}
     />
   );
@@ -171,22 +200,31 @@ export const ExampleComponent = () => {
 ReactDOM.render(<ExampleComponent />, document.getElementById('example2'));
 /* end:skip-in-preview */
 ```
-:::
+
 :::
 
+:::
 
 ### Step 2: Show UI indicators
 
 To easily see which columns are currently hidden, display UI indicators.
 
-To enable the UI indicators, in the [`hiddenColumns`](@/api/options.md#hiddencolumns) object, set the [`indicators`](@/api/hiddenColumns.md) property to `true`:
+To enable the UI indicators, in the [`hiddenColumns`](@/api/options.md#hiddencolumns) object, set
+the [`indicators`](@/api/hiddenColumns.md) property to `true`:
 
 ::: tip
-If you use both the [`NestedHeaders`](@/api/nestedHeaders.md) plugin and the [`HiddenColumns`](@/api/hiddenColumns.md) plugin, you also need to set the [`colHeaders`](@/api/options.md#colheaders) property to `true`. Otherwise, [`indicators`](@/api/hiddenColumns.md) won't work.
+
+If you use both the [`NestedHeaders`](@/api/nestedHeaders.md) plugin and the
+[`HiddenColumns`](@/api/hiddenColumns.md) plugin, you also need to set the
+[`colHeaders`](@/api/options.md#colheaders) property to `true`. Otherwise,
+[`indicators`](@/api/hiddenColumns.md) won't work.
+
 :::
 
 ::: only-for javascript
+
 ::: example #example3
+
 ```js
 import Handsontable from 'handsontable';
 import 'handsontable/dist/handsontable.full.min.css';
@@ -207,15 +245,19 @@ const hot = new Handsontable(container, {
   hiddenColumns: {
     columns: [3, 5, 9],
     // show UI indicators to mark hidden columns
-    indicators: true
-  }
+    indicators: true,
+  },
 });
 ```
+
 :::
+
 :::
 
 ::: only-for react
+
 ::: example #example3 :react
+
 ```jsx
 import { HotTable } from '@handsontable/react';
 import { registerAllModules } from 'handsontable/registry';
@@ -241,7 +283,7 @@ export const ExampleComponent = () => {
       hiddenColumns={{
         columns: [3, 5, 9],
         // show UI indicators to mark hidden columns
-        indicators: true
+        indicators: true,
       }}
     />
   );
@@ -251,18 +293,24 @@ export const ExampleComponent = () => {
 ReactDOM.render(<ExampleComponent />, document.getElementById('example3'));
 /* end:skip-in-preview */
 ```
-:::
+
 :::
 
+:::
 
 ### Step 3: Set up context menu items
 
-To easily hide and unhide columns, add column hiding items to Handsontable's [context menu](@/guides/accessories-and-menus/context-menu.md).
+To easily hide and unhide columns, add column hiding items to Handsontable's
+[context menu](@/guides/accessories-and-menus/context-menu.md).
 
-Enable both the [`ContextMenu`](@/api/contextMenu.md) plugin and the [`HiddenColumns`](@/api/hiddenColumns.md) plugin. Now, the context menu automatically displays additional items for hiding and unhiding columns.
+Enable both the [`ContextMenu`](@/api/contextMenu.md) plugin and the
+[`HiddenColumns`](@/api/hiddenColumns.md) plugin. Now, the context menu automatically displays
+additional items for hiding and unhiding columns.
 
 ::: only-for javascript
+
 ::: example #example4
+
 ```js
 import Handsontable from 'handsontable';
 import 'handsontable/dist/handsontable.full.min.css';
@@ -286,15 +334,19 @@ const hot = new Handsontable(container, {
   // automatically adds the context menu's column hiding items
   hiddenColumns: {
     columns: [3, 5, 9],
-    indicators: true
-  }
+    indicators: true,
+  },
 });
 ```
+
 :::
+
 :::
 
 ::: only-for react
+
 ::: example #example4 :react
+
 ```jsx
 import { HotTable } from '@handsontable/react';
 import { registerAllModules } from 'handsontable/registry';
@@ -323,7 +375,7 @@ export const ExampleComponent = () => {
       // automatically adds the context menu's column hiding items
       hiddenColumns={{
         columns: [3, 5, 9],
-        indicators: true
+        indicators: true,
       }}
     />
   );
@@ -333,14 +385,21 @@ export const ExampleComponent = () => {
 ReactDOM.render(<ExampleComponent />, document.getElementById('example4'));
 /* end:skip-in-preview */
 ```
-:::
+
 :::
 
+:::
 
-You can also add the column hiding menu items individually, by adding the [`hidden_columns_show`](@/guides/accessories-and-menus/context-menu.md#context-menu-with-specific-options) and [`hidden_columns_hide`](@/guides/accessories-and-menus/context-menu.md#context-menu-with-specific-options) strings to the[ `contextMenu`](@/api/contextMenu.md) parameter:
+You can also add the column hiding menu items individually, by adding the
+[`hidden_columns_show`](@/guides/accessories-and-menus/context-menu.md#context-menu-with-specific-options)
+and
+[`hidden_columns_hide`](@/guides/accessories-and-menus/context-menu.md#context-menu-with-specific-options)
+strings to the[ `contextMenu`](@/api/contextMenu.md) parameter:
 
 ::: only-for javascript
+
 ::: example #example5
+
 ```js
 import Handsontable from 'handsontable';
 import 'handsontable/dist/handsontable.full.min.css';
@@ -362,15 +421,19 @@ const hot = new Handsontable(container, {
   contextMenu: [`hidden_columns_show`, `hidden_columns_hide`],
   hiddenColumns: {
     columns: [3, 5, 9],
-    indicators: true
-  }
+    indicators: true,
+  },
 });
 ```
+
 :::
+
 :::
 
 ::: only-for react
+
 ::: example #example5 :react
+
 ```jsx
 import { HotTable } from '@handsontable/react';
 import { registerAllModules } from 'handsontable/registry';
@@ -396,7 +459,7 @@ export const ExampleComponent = () => {
       contextMenu={['hidden_columns_show', 'hidden_columns_hide']}
       hiddenColumns={{
         columns: [3, 5, 9],
-        indicators: true
+        indicators: true,
       }}
     />
   );
@@ -406,18 +469,22 @@ export const ExampleComponent = () => {
 ReactDOM.render(<ExampleComponent />, document.getElementById('example5'));
 /* end:skip-in-preview */
 ```
-:::
+
 :::
 
+:::
 
 ### Step 4: Set up copy and paste behavior
 
 By default, hidden columns are included in copying and pasting.
 
-To exclude hidden columns from copying and pasting, in the [`hiddenColumns`](@/api/hiddenColumns.md) object, set the [`copyPasteEnabled`](@/api/hiddenColumns.md) property to `false`:
+To exclude hidden columns from copying and pasting, in the [`hiddenColumns`](@/api/hiddenColumns.md)
+object, set the [`copyPasteEnabled`](@/api/hiddenColumns.md) property to `false`:
 
 ::: only-for javascript
+
 ::: example #example6
+
 ```js
 import Handsontable from 'handsontable';
 import 'handsontable/dist/handsontable.full.min.css';
@@ -440,15 +507,19 @@ const hot = new Handsontable(container, {
     columns: [3, 5, 9],
     indicators: true,
     // exclude hidden columns from copying and pasting
-    copyPasteEnabled: false
-  }
+    copyPasteEnabled: false,
+  },
 });
 ```
+
 :::
+
 :::
 
 ::: only-for react
+
 ::: example #example6 :react
+
 ```jsx
 import { HotTable } from '@handsontable/react';
 import { registerAllModules } from 'handsontable/registry';
@@ -476,7 +547,7 @@ export const ExampleComponent = () => {
         columns: [3, 5, 9],
         indicators: true,
         // exclude hidden columns from copying and pasting
-        copyPasteEnabled: false
+        copyPasteEnabled: false,
       }}
     />
   );
@@ -486,27 +557,35 @@ export const ExampleComponent = () => {
 ReactDOM.render(<ExampleComponent />, document.getElementById('example6'));
 /* end:skip-in-preview */
 ```
-:::
+
 :::
 
+:::
 
 ## Column hiding API methods
 
 For the most popular column hiding tasks, use the API methods below.
 
 ::: only-for react
+
 ::: tip
-To use the Handsontable API, you'll need access to the Handsontable instance. You can do that by utilizing a reference to the `HotTable` component, and reading its `hotInstance` property.
+
+To use the Handsontable API, you'll need access to the Handsontable instance. You can do that by
+utilizing a reference to the `HotTable` component, and reading its `hotInstance` property.
 
 For more information, see the [`Instance Methods`](@/guides/getting-started/react-methods.md) page.
-:::
+
 :::
 
-To see your changes, re-render your Handsontable instance with the [`render()`](@/api/core.md#render) method.
+:::
+
+To see your changes, re-render your Handsontable instance with the
+[`render()`](@/api/core.md#render) method.
 
 ### Access the [`HiddenColumns`](@/api/hiddenColumns.md) plugin instance
 
-To access the [`HiddenColumns`](@/api/hiddenColumns.md) plugin instance, use the [`getPlugin()`](@/api/core.md#getplugin) method:
+To access the [`HiddenColumns`](@/api/hiddenColumns.md) plugin instance, use the
+[`getPlugin()`](@/api/core.md#getplugin) method:
 
 ```js
 const plugin = hot.getPlugin('hiddenColumns');
@@ -522,14 +601,17 @@ const plugin = hot.getPlugin('hiddenColumns');
 plugin.hideColumn(4);
 
 // re-render your Handsontable instance
-hot.render()
+hot.render();
 ```
 
 ### Hide multiple columns
 
 To hide multiple columns:
-- Either pass column indexes as arguments to the [`hideColumn()`](@/api/hiddenColumns.md#hidecolumn) method
-- Or pass an array of column indexes to the [`hideColumns()`](@/api/hiddenColumns.md#hidecolumn) method
+
+- Either pass column indexes as arguments to the [`hideColumn()`](@/api/hiddenColumns.md#hidecolumn)
+  method
+- Or pass an array of column indexes to the [`hideColumns()`](@/api/hiddenColumns.md#hidecolumn)
+  method
 
 ```js
 const plugin = hot.getPlugin('hiddenColumns');
@@ -539,7 +621,7 @@ plugin.hideColumn(0, 4, 6);
 plugin.hideColumns([0, 4, 6]);
 
 // re-render your Handsontable instance
-hot.render()
+hot.render();
 ```
 
 ### Unhide a single column
@@ -552,14 +634,17 @@ const plugin = hot.getPlugin('hiddenColumns');
 plugin.showColumn(4);
 
 // re-render your Handsontable instance
-hot.render()
+hot.render();
 ```
 
 ### Unhide multiple columns
 
 To unhide multiple columns:
-- Either pass column indexes as arguments to the [`showColumn()`](@/api/hiddenColumns.md#showcolumn) method
-- Or pass an array of column indexes to the [`showColumns()`](@/api/hiddenColumns.md#showcolumns) method
+
+- Either pass column indexes as arguments to the [`showColumn()`](@/api/hiddenColumns.md#showcolumn)
+  method
+- Or pass an array of column indexes to the [`showColumns()`](@/api/hiddenColumns.md#showcolumns)
+  method
 
 ```js
 const plugin = hot.getPlugin('hiddenColumns');
@@ -569,7 +654,7 @@ plugin.showColumn(0, 4, 6);
 plugin.showColumns([0, 4, 6]);
 
 // re-render your Handsontable instance
-hot.render()
+hot.render();
 ```
 
 ## Related API reference


### PR DESCRIPTION
This PR:
- In the first demo of the [Column hiding](https://handsontable.com/docs/react-data-grid/numeric-cell-type) page, changes the configuration so that hidden columns are immediately visible
- Applies minor formatting changes, to unify Markdown and JS formatting across the docs

Affected content:
- http://localhost:8083/docs/javascript-data-grid/column-hiding/#enable-column-hiding
- http://localhost:8083/docs/react-data-grid/column-hiding/#enable-column-hiding

[skip changelog]