### PR TITLE
Docs: Adjust the docs to the 12.3.2 rollout changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   [`getDataAtCol()`](https://handsontable.com/docs/javascript-data-grid/api/core/#getdataatcol) or
   [`getDataAtProp()`](https://handsontable.com/docs/javascript-data-grid/api/core/#getdataatprop) caused an error when the data set had more than 125 000 rows.
   [#10226](https://github.com/handsontable/handsontable/pull/10226)
-- React: Fixed React 18 warnings about deprecated lifecycle methods. We removed
-  `componentWillMount()` and `componentWillUpdate()` from Handsontable's codebase and recreated
-  their functionality by using React's portals.
-  [#10263](https://github.com/handsontable/handsontable/pull/10263)
 
 ## [12.3.1] - 2023-02-06
 

--- a/docs/content/guides/getting-started/demo.md
+++ b/docs/content/guides/getting-started/demo.md
@@ -2967,7 +2967,7 @@ console.log(`Handsontable: v${Handsontable.version} (${Handsontable.buildDate}) 
 - [JavaScript demo app](https://github.com/handsontable/handsontable/tree/develop/examples/12.3.2/docs/js/demo/)
 - [TypeScript demo app](https://github.com/handsontable/handsontable/tree/develop/examples/12.3.2/docs/ts/demo/)
 - [Angular demo app](https://github.com/handsontable/handsontable/tree/develop/examples/12.3.2/docs/angular/demo/)
-- [React demo app](https://github.com/handsontable/handsontable/tree/develop/examples/12.3.2/docs/react/demo/)
+- [React demo app](https://github.com/handsontable/handsontable/tree/develop/examples/12.3.1/docs/react/demo/)
 - [Vue demo app](https://github.com/handsontable/handsontable/tree/develop/examples/12.3.2/docs/vue/demo/)
 
 ## Try out the demo's features


### PR DESCRIPTION
This PR:
- Removes the React 18 entry from the changelog
- Changes the React examples link back to 12.3.1
- In the CodeSandbox demo, changes the version of the React wrapper to 12.3.1: https://codesandbox.io/s/handsontable-react-data-grid-hello-world-app-12-3-2-hqy9xi

[skip changelog]