### PR TITLE
Docs: Edit 12.3.3 docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ For more information on Handsontable 12.3.3, see:
 - [Documentation (12.3)](https://handsontable.com/docs/12.3)
 - [Release notes (12.3.3)](https://handsontable.com/docs/release-notes/#_12-3-3)
 
+## [12.3.2] - 2023-03-23
+
+Handsontable 12.3.2 may not work properly with React's functional components. If you're using React, you should upgrade to [12.3.3](#_12-3-3).
+
 ## [12.3.1] - 2023-02-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ For more information on Handsontable 12.3.3, see:
 
 ## [12.3.2] - 2023-03-23
 
-Handsontable 12.3.2 may not work properly with React's functional components. If you're using React, you should upgrade to [12.3.3](#_12-3-3).
+Handsontable 12.3.2 may not work properly with React's functional components. If you're using React, you should upgrade to 12.3.3.
 
 ## [12.3.1] - 2023-02-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,35 +11,25 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [12.3.3] - 2023-03-28
 
-### Fixed
-
-- React: Fixed React 18 warnings about deprecated lifecycle methods. We removed
-  `componentWillMount()` and `componentWillUpdate()` from Handsontable's codebase and recreated
-  their functionality by using React's portals.
-  [#10263](https://github.com/handsontable/handsontable/pull/10263)
-
-## [12.3.2] - 2023-03-23
-
 ### Added
-- Added a Chinese (zh-CN) translation of the "Copy with headers" feature.
-  [#10273](https://github.com/handsontable/handsontable/pull/10273)
+
+- Added a Chinese (zh-CN) translation of the "Copy with headers" feature. [#10273](https://github.com/handsontable/handsontable/pull/10273)
 - Added a new "Rows sorting" guide. [#10183](https://github.com/handsontable/handsontable/pull/10183)
 
 ### Fixed
 
-- Fixed an issue where column-filter checkboxes were resetting when the table was scrolled out
-  of view. We solved this by preventing the table from triggering a complete render each time it
-  leaves the viewport. [#10206](https://github.com/handsontable/handsontable/pull/10206)
-- Fixed an issue where clicking on a cell scrolled the table sideways in certain RTL configurations.
-  [#10206](https://github.com/handsontable/handsontable/pull/10206)
-- Fixed an issue where calling
-  [`getDataAtCol()`](https://handsontable.com/docs/javascript-data-grid/api/core/#getdataatcol) or
-  [`getDataAtProp()`](https://handsontable.com/docs/javascript-data-grid/api/core/#getdataatprop) caused an error when the data set had more than 125 000 rows.
-  [#10226](https://github.com/handsontable/handsontable/pull/10226)
-- React: Fixed React 18 warnings about deprecated lifecycle methods. We removed
-  `componentWillMount()` and `componentWillUpdate()` from Handsontable's codebase and recreated
-  their functionality by using React's portals.
-  [#10263](https://github.com/handsontable/handsontable/pull/10263)
+- Fixed an issue where column-filter checkboxes got reset when the table was scrolled out of view. We solved this by preventing the table from triggering a complete render each time it leaves the viewport. [#10206](https://github.com/handsontable/handsontable/pull/10206)
+- Fixed an issue where clicking on a cell scrolled the table sideways in certain RTL configurations. [#10206](https://github.com/handsontable/handsontable/pull/10206)
+- Fixed an issue where calling [`getDataAtCol()`](https://handsontable.com/docs/javascript-data-grid/api/core/#getdataatcol) or [`getDataAtProp()`](https://handsontable.com/docs/javascript-data-grid/api/core/#getdataatprop) caused an error in case of data sets with more than 125 000 rows. [#10226](https://github.com/handsontable/handsontable/pull/10226)
+- React: Fixed React 18 warnings about deprecated lifecycle methods. We removed `componentWillMount()` and `componentWillUpdate()` from Handsontable's codebase and recreated their functionality by using React's portals. [#10263](https://github.com/handsontable/handsontable/pull/10263)
+
+For more information on Handsontable 12.3.3, see:
+
+- [Blog post (12.3.3)](https://handsontable.com/blog/handsontable-12-3-2-better-support-for-react-18-and-large-data-sets)
+- [Documentation (12.3)](https://handsontable.com/docs/12.3)
+- [Release notes (12.3.3)](https://handsontable.com/docs/release-notes/#_12-3-3)
+
+## [12.3.2] - 2023-03-23
 
 ## [12.3.1] - 2023-02-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Added a Chinese (zh-CN) translation of the "Copy with headers" feature. [#10273](https://github.com/handsontable/handsontable/pull/10273)
-- Added a new "Rows sorting" guide. [#10183](https://github.com/handsontable/handsontable/pull/10183)
+- Added a new guide: Rows sorting. [#10183](https://github.com/handsontable/handsontable/pull/10183)
 
 ### Fixed
 
@@ -25,11 +25,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 For more information on Handsontable 12.3.3, see:
 
-- [Blog post (12.3.3)](https://handsontable.com/blog/handsontable-12-3-2-better-support-for-react-18-and-large-data-sets)
+- [Blog post (12.3.3)](https://handsontable.com/blog/handsontable-12-3-3-better-support-for-react-18-and-large-data-sets)
 - [Documentation (12.3)](https://handsontable.com/docs/12.3)
 - [Release notes (12.3.3)](https://handsontable.com/docs/release-notes/#_12-3-3)
-
-## [12.3.2] - 2023-03-23
 
 ## [12.3.1] - 2023-02-06
 

--- a/docs/content/guides/getting-started/demo.md
+++ b/docs/content/guides/getting-started/demo.md
@@ -2964,11 +2964,11 @@ console.log(`Handsontable: v${Handsontable.version} (${Handsontable.buildDate}) 
 
 ## Find the code on GitHub
 
-- [JavaScript demo app](https://github.com/handsontable/handsontable/tree/develop/examples/12.3.2/docs/js/demo/)
-- [TypeScript demo app](https://github.com/handsontable/handsontable/tree/develop/examples/12.3.2/docs/ts/demo/)
-- [Angular demo app](https://github.com/handsontable/handsontable/tree/develop/examples/12.3.2/docs/angular/demo/)
-- [React demo app](https://github.com/handsontable/handsontable/tree/develop/examples/12.3.2/docs/react/demo/)
-- [Vue demo app](https://github.com/handsontable/handsontable/tree/develop/examples/12.3.2/docs/vue/demo/)
+- [JavaScript demo app](https://github.com/handsontable/handsontable/tree/develop/examples/12.3.3/docs/js/demo/)
+- [TypeScript demo app](https://github.com/handsontable/handsontable/tree/develop/examples/12.3.3/docs/ts/demo/)
+- [Angular demo app](https://github.com/handsontable/handsontable/tree/develop/examples/12.3.3/docs/angular/demo/)
+- [React demo app](https://github.com/handsontable/handsontable/tree/develop/examples/12.3.3/docs/react/demo/)
+- [Vue demo app](https://github.com/handsontable/handsontable/tree/develop/examples/12.3.3/docs/vue/demo/)
 
 ## Try out the demo's features
 

--- a/docs/content/guides/getting-started/introduction.md
+++ b/docs/content/guides/getting-started/introduction.md
@@ -41,15 +41,15 @@ Thousands of business apps depend on Handsontable for entering, editing, validat
 ::: only-for javascript
 To jump straight into the sample code, open the demo app at CodeSandbox:
 
-- [JavaScript demo](https://codesandbox.io/s/handsontable-javascript-data-grid-hello-world-app-12-3-2-updhi7)
-- [React demo](https://codesandbox.io/s/handsontable-react-data-grid-hello-world-app-12-3-2-hqy9xi)
-- [Angular demo](https://codesandbox.io/s/handsontable-angular-data-grid-hello-world-app-12-3-2-hvzrx0)
-- [Vue 2 demo](https://codesandbox.io/s/handsontable-vue-data-grid-hello-world-app-12-3-2-eexqzj)
-- [TypeScript demo](https://codesandbox.io/s/handsontable-typescript-data-grid-hello-world-app-12-3-2-be9p99)
+- [JavaScript demo](https://codesandbox.io/s/handsontable-javascript-data-grid-hello-world-app-12-3-3-6rf1pz)
+- [React demo](https://codesandbox.io/s/handsontable-react-data-grid-hello-world-app-12-3-3-z9bmr6)
+- [Angular demo](https://codesandbox.io/s/handsontable-angular-data-grid-hello-world-app-12-3-3-9r6ve9)
+- [Vue 2 demo](https://codesandbox.io/s/handsontable-vue-data-grid-hello-world-app-12-3-3-p71oki)
+- [TypeScript demo](https://codesandbox.io/s/handsontable-typescript-data-grid-hello-world-app-12-3-3-be9p99)
 :::
 
 ::: only-for react
-To jump straight into the sample code, [open the demo app at CodeSandbox](https://codesandbox.io/s/handsontable-react-data-grid-hello-world-app-12-3-2-hqy9xi).
+To jump straight into the sample code, [open the demo app at CodeSandbox](https://codesandbox.io/s/handsontable-react-data-grid-hello-world-app-12-3-3-z9bmr6).
 :::
 
 Then, move on to [connecting](@/guides/getting-started/binding-to-data.md) your data and [configuring](@/guides/getting-started/configuration-options.md) Handsontable's built-in features. For more advanced implementations, use Handsontable's [API](@/api/introduction.md).

--- a/docs/content/guides/upgrade-and-migration/release-notes.md
+++ b/docs/content/guides/upgrade-and-migration/release-notes.md
@@ -24,27 +24,27 @@ See the full history of changes made to Handsontable in each major, minor, and p
 
 [[toc]]
 
-## 12.3.2
+## 12.3.3
 
-Released on March 23, 2023.
+Released on March 28, 2023.
 
 For more information on this release, see:
 
-- [Blog post (12.3.2)](https://handsontable.com/blog/handsontable-12-3-2-better-support-for-react-18-and-large-data-sets)
+- [Blog post (12.3.3)](https://handsontable.com/blog/handsontable-12-3-3-better-support-for-react-18-and-large-data-sets)
 - [Documentation (12.3)](https://handsontable.com/docs/12.3)
 
 #### Added
 
 - Added a Chinese (zh-CN) translation of the "Copy with headers" feature.
   [#10273](https://github.com/handsontable/handsontable/pull/10273)
-- Added a new "[Rows sorting](https://handsontable.com/docs/rows-sorting)" guide.
+- Added a new guide: [Rows sorting](@/guides/rows/rows-sorting.md).
   [#10183](https://github.com/handsontable/handsontable/pull/10183)
 
 #### Fixed
 
-- Fixed an issue where column-filter checkboxes were resetting when the table was scrolled out of
-  view. We solved this by preventing the table from triggering a complete render each time it leaves
-  the viewport. [#10206](https://github.com/handsontable/handsontable/pull/10206)
+- Fixed an issue where column-filter checkboxes got reset when the table was scrolled out of view.
+  We solved this by preventing the table from triggering a complete render each time it leaves the
+  viewport. [#10206](https://github.com/handsontable/handsontable/pull/10206)
 - Fixed an issue where clicking on a cell scrolled the table sideways in certain RTL configurations.
   [#10206](https://github.com/handsontable/handsontable/pull/10206)
 - Fixed an issue where calling
@@ -56,6 +56,13 @@ For more information on this release, see:
   `componentWillMount()` and `componentWillUpdate()` from Handsontable's codebase and recreated
   their functionality by using React's portals.
   [#10263](https://github.com/handsontable/handsontable/pull/10263)
+
+## 12.3.2
+
+Released on March 23, 2023.
+
+Handsontable 12.3.2 may not work properly with React's functional components. If you're using React,
+you should upgrade to [12.3.3](#_12-3-3).
 
 ## 12.3.1
 


### PR DESCRIPTION
This PR:
- Edits 12.3.3 changelog entries (similarly we did for [7.4.1](https://github.com/handsontable/handsontable/releases?q=7.4.0&expanded=true))
- Edits 12.3.3 release notes
- Updates CodeSandbox demo links to demos with Handsontable 12.3.3

[skip changelog]