### PR TITLE
Remove hardcoded React version in Docs

### DIFF
--- a/docs/.vuepress/handsontable-manager/dependencies.js
+++ b/docs/.vuepress/handsontable-manager/dependencies.js
@@ -48,13 +48,6 @@ const buildDependencyGetter = (version) => {
   const fixer = getCommonScript('fixer', version);
   const helpers = getCommonScript('helpers', version);
 
-  let reactLink = `https://cdn.jsdelivr.net/npm/@handsontable/react@${mappedVersion}/dist/react-handsontable.js`;
-
-  // hotfix after release 12.3.2
-  if (mappedVersion === '12.3' || mappedVersion === 'latest') {
-    reactLink = 'https://cdn.jsdelivr.net/npm/@handsontable/react@12.3.1/dist/react-handsontable.js';
-  }
-
   return (dependency) => {
     /* eslint-disable max-len */
     const dependencies = {
@@ -63,7 +56,7 @@ const buildDependencyGetter = (version) => {
       hot: [handsontableJs, ['Handsontable'], handsontableCss],
       react: ['https://cdn.jsdelivr.net/npm/react@17/umd/react.production.min.js', ['React']],
       'react-dom': ['https://cdn.jsdelivr.net/npm/react-dom@17/umd/react-dom.production.min.js', ['ReactDOM']],
-      'hot-react': [reactLink, ['Handsontable.react']],
+      'hot-react': [`https://cdn.jsdelivr.net/npm/@handsontable/react@${mappedVersion}/dist/react-handsontable.js`, ['Handsontable.react']],
       'react-redux': ['https://cdnjs.cloudflare.com/ajax/libs/react-redux/7.2.4/react-redux.min.js'],
       'react-colorful': ['https://cdn.jsdelivr.net/npm/react-colorful@5.5.1/dist/index.min.js'],
       'react-star-rating-component': ['https://cdn.jsdelivr.net/npm/react-star-rating-component@1.4.1/dist/react-star-rating-component.min.js'],


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR removes hardcoded React version in Docs.

_[skip changelog]_

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
