### PR TITLE
Make the staging/"watch" version of the documentation use the local `handsontable` and wrapper builds.

### DIFF
--- a/.github/workflows/docs-staging.yml
+++ b/.github/workflows/docs-staging.yml
@@ -35,7 +35,13 @@ jobs:
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login -u ${GITHUB_ACTOR} --password-stdin https://docker.pkg.github.com
 
-      - name: Dependencies
+      - name: Install the monorepo dependencies and build the packages
+        run: |
+          cd ..
+          npm ci
+          npm run all build -- --e examples visual-tests
+
+      - name: Install the documentation dependencies
         run: |
           npm ci
 

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -15,6 +15,7 @@ report-check-links.xlsx
 ~$*.xlsx
 
 /.vuepress/public/handsontable
+/.vuepress/public/@handsontable
 /.vuepress/public/data/
 /.build-tmp/
 

--- a/docs/.vuepress/handsontable-manager/dependencies.js
+++ b/docs/.vuepress/handsontable-manager/dependencies.js
@@ -72,7 +72,6 @@ const getCommonScript = (scriptName, version) => {
  *                     `{function(dependency: string): [string,string[],string]} [jsUrl, dependentVars[]?, cssUrl?]`.
  */
 const buildDependencyGetter = (version) => {
-  const mappedVersion = formatVersion(version);
   const fixer = getCommonScript('fixer', version);
   const helpers = getCommonScript('helpers', version);
 

--- a/docs/.vuepress/handsontable-manager/dependencies.js
+++ b/docs/.vuepress/handsontable-manager/dependencies.js
@@ -1,8 +1,6 @@
 // eslint-disable-next-line no-restricted-globals
 const isBrowser = (typeof window !== 'undefined');
 
-// TODO: remove this line.
-
 const formatVersion = version => (/^\d+\.\d+$/.test(version) ? version : 'latest');
 
 /**

--- a/docs/.vuepress/handsontable-manager/dependencies.js
+++ b/docs/.vuepress/handsontable-manager/dependencies.js
@@ -19,7 +19,7 @@ const getPackageUrls = (packageName, version, fileSelection) => {
       css: 'handsontable.full.min.css'
     },
     '@handsontable/react': {
-      js: 'react-handsontable.js'
+      js: 'react-handsontable.min.js'
     },
     '@handsontable/angular': {
       js: 'handsontable-angular.umd.min.js',

--- a/docs/.vuepress/handsontable-manager/dependencies.js
+++ b/docs/.vuepress/handsontable-manager/dependencies.js
@@ -2,23 +2,52 @@
 const isBrowser = (typeof window !== 'undefined');
 
 const formatVersion = version => (/^\d+\.\d+$/.test(version) ? version : 'latest');
-const getHotUrls = (version) => {
+
+/**
+ * Gets the local/remote package url for the required file type.
+ *
+ * @param {string} packageName The package name.
+ * @param {string} version The package version. If specified as 'next', the local urls will be returned.
+ * @param {'js'|'css'|string} fileSelection If set to `js` or `css`, it will return the urls of the default js/css
+ * files. If any other value is provided, it will be treated as a path the required file.
+ * @returns {string} Url to the required file.
+ */
+const getPackageUrls = (packageName, version, fileSelection) => {
+  const subDirs = {
+    handsontable: {
+      js: 'handsontable.full.min.js',
+      css: 'handsontable.full.min.css'
+    },
+    '@handsontable/react': {
+      js: 'react-handsontable.js'
+    },
+    '@handsontable/angular': {
+      js: 'handsontable-angular.umd.min.js',
+      subDir: 'bundles/'
+    },
+    '@handsontable/vue': {
+      js: 'vue-handsontable.min.js'
+    },
+    '@handsontable/vue3': {
+      js: 'vue-handsontable.min.js'
+    }
+  };
+
+  const urlSet = subDirs[packageName];
+
   if (version === 'next' && isBrowser) {
-    return {
-      handsontableJs: '/docs/handsontable/handsontable.full.js',
-      handsontableCss: '/docs/handsontable/handsontable.full.css',
-      languagesJs: '/docs/handsontable/languages/all.js'
-    };
+    return urlSet[fileSelection] ?
+      `/docs/${packageName}/${urlSet[fileSelection]}` :
+      `/docs/${packageName}/${fileSelection}`;
   }
 
   const mappedVersion = formatVersion(version);
 
-  return {
-    handsontableJs: `https://cdn.jsdelivr.net/npm/handsontable@${mappedVersion}/dist/handsontable.full.min.js`,
-    handsontableCss: `https://cdn.jsdelivr.net/npm/handsontable@${mappedVersion}/dist/handsontable.full.min.css`,
-    languagesJs: `https://cdn.jsdelivr.net/npm/handsontable@${mappedVersion}/dist/languages/all.js`
-  };
+  return urlSet[fileSelection] ?
+    `https://cdn.jsdelivr.net/npm/${packageName}@${mappedVersion}/${urlSet.subDir || 'dist/'}${urlSet[fileSelection]}` :
+    `https://cdn.jsdelivr.net/npm/${packageName}@${mappedVersion}/${fileSelection}`;
 };
+
 const getCommonScript = (scriptName, version) => {
   if (isBrowser) {
     // eslint-disable-next-line no-restricted-globals
@@ -43,7 +72,6 @@ const getCommonScript = (scriptName, version) => {
  *                     `{function(dependency: string): [string,string[],string]} [jsUrl, dependentVars[]?, cssUrl?]`.
  */
 const buildDependencyGetter = (version) => {
-  const { handsontableJs, handsontableCss, languagesJs } = getHotUrls(version);
   const mappedVersion = formatVersion(version);
   const fixer = getCommonScript('fixer', version);
   const helpers = getCommonScript('helpers', version);
@@ -53,10 +81,10 @@ const buildDependencyGetter = (version) => {
     const dependencies = {
       fixer,
       helpers,
-      hot: [handsontableJs, ['Handsontable'], handsontableCss],
+      hot: [getPackageUrls('handsontable', version, 'js'), ['Handsontable'], getPackageUrls('handsontable', version, 'css')],
       react: ['https://cdn.jsdelivr.net/npm/react@17/umd/react.production.min.js', ['React']],
       'react-dom': ['https://cdn.jsdelivr.net/npm/react-dom@17/umd/react-dom.production.min.js', ['ReactDOM']],
-      'hot-react': [`https://cdn.jsdelivr.net/npm/@handsontable/react@${mappedVersion}/dist/react-handsontable.js`, ['Handsontable.react']],
+      'hot-react': [getPackageUrls('@handsontable/react', version, 'js'), ['Handsontable.react']],
       'react-redux': ['https://cdnjs.cloudflare.com/ajax/libs/react-redux/7.2.4/react-redux.min.js'],
       'react-colorful': ['https://cdn.jsdelivr.net/npm/react-colorful@5.5.1/dist/index.min.js'],
       'react-star-rating-component': ['https://cdn.jsdelivr.net/npm/react-star-rating-component@1.4.1/dist/react-star-rating-component.min.js'],
@@ -71,9 +99,9 @@ const buildDependencyGetter = (version) => {
       'angular-forms': ['https://cdn.jsdelivr.net/npm/@angular/forms@7/bundles/forms.umd.min.js', [/* todo */]],
       'angular-platform-browser': ['https://cdn.jsdelivr.net/npm/@angular/platform-browser@8/bundles/platform-browser.umd.min.js', [/* todo */]],
       'angular-platform-browser-dynamic': ['https://cdn.jsdelivr.net/npm/@angular/platform-browser-dynamic@8/bundles/platform-browser-dynamic.umd.min.js', [/* todo */]],
-      'hot-angular': [`https://cdn.jsdelivr.net/npm/@handsontable/angular@${mappedVersion}/bundles/handsontable-angular.umd.min.js`, [/* todo */]],
-      'hot-vue': [`https://cdn.jsdelivr.net/npm/@handsontable/vue@${mappedVersion}/dist/vue-handsontable.min.js`, [/* todo */], null, 'hot-vue3'],
-      'hot-vue3': [`https://cdn.jsdelivr.net/npm/@handsontable/vue3@${mappedVersion}/dist/vue-handsontable.min.js`, [/* todo */], null, 'hot-vue'],
+      'hot-angular': [getPackageUrls('@handsontable/angular', version, 'js'), [/* todo */]],
+      'hot-vue': [getPackageUrls('@handsontable/vue', version, 'js'), [/* todo */], null, 'hot-vue3'],
+      'hot-vue3': [getPackageUrls('@handsontable/vue3', version, 'js'), [/* todo */], null, 'hot-vue'],
       vue: ['https://cdn.jsdelivr.net/npm/vue@2/dist/vue.min.js', [/* todo */], null, 'vue3'],
       vuex: ['https://cdn.jsdelivr.net/npm/vuex@3/dist/vuex.min.js', [/* todo */], null, 'vuex4'],
       'vue-color': ['https://cdn.jsdelivr.net/npm/vue-color@2/dist/vue-color.min.js', [/* todo */]],
@@ -81,7 +109,7 @@ const buildDependencyGetter = (version) => {
       'vue-star-rating': ['https://cdn.jsdelivr.net/npm/vue-star-rating@1/dist/VueStarRating.umd.min.js', [/* todo */]],
       vue3: ['https://cdn.jsdelivr.net/npm/vue@3/dist/vue.global.prod.js', [/* todo */], null, 'vue'],
       vuex4: ['https://cdn.jsdelivr.net/npm/vuex@4/dist/vuex.global.min.js', [/* todo */], null, 'vuex'],
-      languages: [languagesJs, [/* todo */]],
+      languages: [getPackageUrls('handsontable', version, 'languages/all.js'), [/* todo */]],
     };
     /* eslint-enable max-len */
 

--- a/docs/.vuepress/handsontable-manager/dependencies.js
+++ b/docs/.vuepress/handsontable-manager/dependencies.js
@@ -1,6 +1,8 @@
 // eslint-disable-next-line no-restricted-globals
 const isBrowser = (typeof window !== 'undefined');
 
+// TODO: remove this line.
+
 const formatVersion = version => (/^\d+\.\d+$/.test(version) ? version : 'latest');
 
 /**

--- a/docs/.vuepress/tools/link-assets.mjs
+++ b/docs/.vuepress/tools/link-assets.mjs
@@ -7,25 +7,41 @@ const { logger } = utils;
 
 const docsBasePath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 
-const SOURCE_PATH = path.resolve('../handsontable/dist/');
-const TARGET_PATH = path.resolve('./.vuepress/public/handsontable/');
+const SYMLINK_PATHS = [
+  { source: '../handsontable/dist/', target: './.vuepress/public/handsontable/' },
+  { source: '../wrappers/react/dist/', target: './.vuepress/public/@handsontable/react/' },
+  { source: '../wrappers/angular/dist/hot-table/bundles/', target: './.vuepress/public/@handsontable/angular/' },
+  { source: '../wrappers/vue/dist/', target: './.vuepress/public/@handsontable/vue/' },
+  { source: '../wrappers/vue3/dist/', target: './.vuepress/public/@handsontable/vue3/' },
+];
 
-const relativeFrom = path.relative(docsBasePath, SOURCE_PATH);
-const relativeTo = path.relative(docsBasePath, TARGET_PATH);
-
-if (fs.existsSync(SOURCE_PATH)) {
-  if (fs.existsSync(TARGET_PATH)) {
-    fs.unlinkSync(TARGET_PATH);
-  }
-
-  fs.symlinkSync(
-    SOURCE_PATH,
-    TARGET_PATH,
-    'junction',
-  );
-
-  logger.success(`Symlink created ${relativeFrom} -> ${relativeTo}.`);
-
-} else {
-  logger.error(`Cannot create symlink from ${relativeFrom} - the path doesn't exist.`);
+if (!fs.existsSync(path.resolve('./.vuepress/public/@handsontable'))) {
+  fs.mkdirSync(path.resolve('./.vuepress/public/@handsontable'));
 }
+
+SYMLINK_PATHS.forEach((paths) => {
+  let { source, target } = paths;
+
+  source = path.resolve(source);
+  target = path.resolve(target);
+
+  const relativeFrom = path.relative(docsBasePath, source);
+  const relativeTo = path.relative(docsBasePath, target);
+
+  if (fs.existsSync(source)) {
+    if (fs.existsSync(target)) {
+      fs.unlinkSync(target);
+    }
+
+    fs.symlinkSync(
+      source,
+      target,
+      'junction',
+    );
+
+    logger.success(`Symlink created ${relativeFrom} -> ${relativeTo}.`);
+
+  } else {
+    logger.error(`Cannot create symlink from ${relativeFrom} - the path doesn't exist.`);
+  }
+});

--- a/docs/docker/redirects.conf
+++ b/docs/docker/redirects.conf
@@ -185,5 +185,5 @@ rewrite ^/docs/((\d+\.\d+|next)/)?demo-react-simple-examples/?$ /docs/$1$framewo
 #  * /sitemap.xml
 #  * /securitum-certificate.pdf
 #  * /seqred-certificate.pdf
-rewrite ^/docs/((?:\d+\.\d+|next)/)(?!(?:javascript|react)-data-grid|redirect|assets/|data/|handsontable|\@handsontable/|img/|scripts/|404\.html|sitemap\.xml|securitum-certificate\.pdf|seqred-certificate\.pdf)(.+)$ /docs/$1$framework/$2 permanent;
-rewrite ^/docs/(?!\d+\.\d+|next\/)(?!(?:javascript|react)-data-grid|redirect|assets/|data/|handsontable/|\@handsontable/|img/|scripts/|404\.html|sitemap\.xml|securitum-certificate\.pdf|seqred-certificate\.pdf)(.+)$ /docs/$framework/$1 permanent;
+rewrite ^/docs/((?:\d+\.\d+|next)/)(?!(?:javascript|react)-data-grid|redirect|assets/|data/|handsontable|@handsontable/|img/|scripts/|404\.html|sitemap\.xml|securitum-certificate\.pdf|seqred-certificate\.pdf)(.+)$ /docs/$1$framework/$2 permanent;
+rewrite ^/docs/(?!\d+\.\d+|next\/)(?!(?:javascript|react)-data-grid|redirect|assets/|data/|handsontable/|@handsontable/|img/|scripts/|404\.html|sitemap\.xml|securitum-certificate\.pdf|seqred-certificate\.pdf)(.+)$ /docs/$framework/$1 permanent;

--- a/docs/docker/redirects.conf
+++ b/docs/docker/redirects.conf
@@ -178,11 +178,12 @@ rewrite ^/docs/((\d+\.\d+|next)/)?demo-react-simple-examples/?$ /docs/$1$framewo
 #  * /assets/
 #  * /data/
 #  * /handsontable/
+#  * /@handsontable/
 #  * /scripts/
 #  * /img/
 #  * /404.html
 #  * /sitemap.xml
 #  * /securitum-certificate.pdf
 #  * /seqred-certificate.pdf
-rewrite ^/docs/((?:\d+\.\d+|next)/)(?!(?:javascript|react)-data-grid|redirect|assets/|data/|handsontable/|img/|scripts/|404\.html|sitemap\.xml|securitum-certificate\.pdf|seqred-certificate\.pdf)(.+)$ /docs/$1$framework/$2 permanent;
-rewrite ^/docs/(?!\d+\.\d+|next\/)(?!(?:javascript|react)-data-grid|redirect|assets/|data/|handsontable/|img/|scripts/|404\.html|sitemap\.xml|securitum-certificate\.pdf|seqred-certificate\.pdf)(.+)$ /docs/$framework/$1 permanent;
+rewrite ^/docs/((?:\d+\.\d+|next)/)(?!(?:javascript|react)-data-grid|redirect|assets/|data/|handsontable|\@handsontable/|img/|scripts/|404\.html|sitemap\.xml|securitum-certificate\.pdf|seqred-certificate\.pdf)(.+)$ /docs/$1$framework/$2 permanent;
+rewrite ^/docs/(?!\d+\.\d+|next\/)(?!(?:javascript|react)-data-grid|redirect|assets/|data/|handsontable/|\@handsontable/|img/|scripts/|404\.html|sitemap\.xml|securitum-certificate\.pdf|seqred-certificate\.pdf)(.+)$ /docs/$framework/$1 permanent;

--- a/wrappers/react/src/hotTable.tsx
+++ b/wrappers/react/src/hotTable.tsx
@@ -136,16 +136,17 @@ class HotTable extends React.Component<HotTableProps, {}> {
    * Getter for the property storing the Handsontable instance.
    */
   get hotInstance(): Handsontable | null {
-    if (!this.__hotInstance || (this.__hotInstance && !this.__hotInstance.isDestroyed)) {
-
-      // Will return the Handsontable instance or `null` if it's not yet been created.
-      return this.__hotInstance;
-
-    } else {
-      console.warn(HOT_DESTROYED_WARNING);
-
+    // TODO: COMMENTED OUT TEMPORARILY
+    // if (!this.__hotInstance || (this.__hotInstance && !this.__hotInstance.isDestroyed)) {
+    //
+    //   // Will return the Handsontable instance or `null` if it's not yet been created.
+    //   return this.__hotInstance;
+    //
+    // } else {
+    //   console.warn(HOT_DESTROYED_WARNING);
+    //
       return null;
-    }
+    // }
   }
 
   /**

--- a/wrappers/react/src/hotTable.tsx
+++ b/wrappers/react/src/hotTable.tsx
@@ -136,17 +136,16 @@ class HotTable extends React.Component<HotTableProps, {}> {
    * Getter for the property storing the Handsontable instance.
    */
   get hotInstance(): Handsontable | null {
-    // TODO: COMMENTED OUT TEMPORARILY
-    // if (!this.__hotInstance || (this.__hotInstance && !this.__hotInstance.isDestroyed)) {
-    //
-    //   // Will return the Handsontable instance or `null` if it's not yet been created.
-    //   return this.__hotInstance;
-    //
-    // } else {
-    //   console.warn(HOT_DESTROYED_WARNING);
-    //
+    if (!this.__hotInstance || (this.__hotInstance && !this.__hotInstance.isDestroyed)) {
+
+      // Will return the Handsontable instance or `null` if it's not yet been created.
+      return this.__hotInstance;
+
+    } else {
+      console.warn(HOT_DESTROYED_WARNING);
+
       return null;
-    // }
+    }
   }
 
   /**


### PR DESCRIPTION
### Context
This PR:
- Makes the docs symlink the wrappers alongside `handsontable`
- Make the `next`-based docs use the locally symlinked versions of the wrappers
- Make the staging workflow build `handsontable` + the wrappers before building the docs to use the current state of the repo

_[skip changelog]_

### How has this been tested?
- Manually by running `npm run start:no-cache`
- [By committing a broken react wrapper and checking if staging environment fails](https://github.com/handsontable/handsontable/actions/runs/4617671232/jobs/8164194825)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#1232


### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
