### PR TITLE
Make re-entering the same cell/header with the mouse cursor trigger the `-OnCellMouseOver` hooks.

### DIFF
--- a/.changelogs/645.json
+++ b/.changelogs/645.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed a problem where re-entering the same cells/headers with the mouse cursor would not trigger the `beforeOnCellMouseOver` and `afterOnCellMouseOver` hooks.",
+  "type": "fixed",
+  "issueOrPR": 645,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/src/event.js
+++ b/handsontable/src/3rdparty/walkontable/src/event.js
@@ -255,9 +255,14 @@ class Event {
     const table = this.wtTable.TABLE;
     const lastTD = closestDown(event.target, ['TD', 'TH'], table);
     const nextTD = closestDown(event.relatedTarget, ['TD', 'TH'], table);
+    const parent = this.parent || this;
 
     if (lastTD && lastTD !== nextTD && isChildOf(lastTD, table)) {
       this.callListener('onCellMouseOut', event, this.wtTable.getCoords(lastTD), lastTD);
+
+      if (nextTD === null) {
+        parent.lastMouseOver = null;
+      }
     }
   }
 

--- a/handsontable/test/e2e/hooks/afterOnCellMouseOver.spec.js
+++ b/handsontable/test/e2e/hooks/afterOnCellMouseOver.spec.js
@@ -1,0 +1,90 @@
+describe('The afterOnCellMouseOver hook', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should be triggered every time the cursor starts hovering over a cell or a header', async() => {
+    const spy = jasmine.createSpy('afterOnCellMouseOver');
+
+    handsontable({
+      data: createSpreadsheetData(10, 10),
+      rowHeaders: true,
+      colHeaders: true,
+      afterOnCellMouseOver: spy,
+    });
+
+    const $colHeader = getTopClone().find('thead tr:eq(0) th:eq(1)');
+
+    $('body').simulate('mouseover');
+    await sleep(50);
+
+    $colHeader.simulate('mouseover');
+    await sleep(50);
+
+    $colHeader.simulate('mouseout');
+    await sleep(50);
+
+    $('body').simulate('mouseover');
+    await sleep(100);
+
+    $('body').simulate('mouseout');
+    await sleep(50);
+
+    $colHeader.simulate('mouseover');
+    await sleep(100);
+
+    $colHeader.simulate('mouseout');
+    await sleep(50);
+
+    getMaster().find('tbody tr:eq(0) td:eq(1)').simulate('mouseover');
+    await sleep(100);
+
+    getMaster().find('tbody tr:eq(0) td:eq(1)').simulate('mouseout');
+    await sleep(50);
+
+    getMaster().find('tbody tr:eq(0) td:eq(2)').simulate('mouseover');
+    await sleep(100);
+
+    getMaster().find('tbody tr:eq(0) td:eq(2)').simulate('mouseout');
+    await sleep(50);
+
+    expect(spy).toHaveBeenCalledTimes(4);
+  });
+
+  it('should NOT be triggered if the preceding `beforeOnCellMouseOver` hook\'s event stopped i\'s propagation', async() => {
+    const spy = jasmine.createSpy('afterOnCellMouseOver');
+
+    handsontable({
+      data: createSpreadsheetData(10, 10),
+      rowHeaders: true,
+      colHeaders: true,
+      beforeOnCellMouseOver: (event) => {
+        Handsontable.dom.stopImmediatePropagation(event);
+      },
+      afterOnCellMouseOver: spy,
+    });
+
+    getMaster().find('tbody tr:eq(0) td:eq(1)').simulate('mouseover');
+    await sleep(100);
+
+    getMaster().find('tbody tr:eq(0) td:eq(1)').simulate('mouseout');
+    await sleep(50);
+
+    getMaster().find('tbody tr:eq(0) td:eq(2)').simulate('mouseover');
+    await sleep(100);
+
+    getMaster().find('tbody tr:eq(0) td:eq(2)').simulate('mouseout');
+    await sleep(50);
+
+    expect(spy).toHaveBeenCalledTimes(0);
+  });
+});

--- a/handsontable/test/e2e/hooks/afterOnCellMouseOver.spec.js
+++ b/handsontable/test/e2e/hooks/afterOnCellMouseOver.spec.js
@@ -60,7 +60,7 @@ describe('The afterOnCellMouseOver hook', () => {
     expect(spy).toHaveBeenCalledTimes(4);
   });
 
-  it('should NOT be triggered if the preceding `beforeOnCellMouseOver` hook\'s event stopped i\'s propagation', async() => {
+  it('should NOT be triggered if the preceding `beforeOnCellMouseOver` hook\'s event stopped its propagation', async() => {
     const spy = jasmine.createSpy('afterOnCellMouseOver');
 
     handsontable({

--- a/handsontable/test/e2e/hooks/beforeOnCellMouseOver.spec.js
+++ b/handsontable/test/e2e/hooks/beforeOnCellMouseOver.spec.js
@@ -1,0 +1,62 @@
+describe('The beforeOnCellMouseOver hook', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should be triggered every time the cursor starts hovering over a cell or a header', async() => {
+    const spy = jasmine.createSpy('beforeOnCellMouseOver');
+
+    handsontable({
+      data: createSpreadsheetData(10, 10),
+      rowHeaders: true,
+      colHeaders: true,
+      beforeOnCellMouseOver: spy,
+    });
+
+    const $colHeader = getTopClone().find('thead tr:eq(0) th:eq(1)');
+
+    $('body').simulate('mouseover');
+    await sleep(50);
+
+    $colHeader.simulate('mouseover');
+    await sleep(50);
+
+    $colHeader.simulate('mouseout');
+    await sleep(50);
+
+    $('body').simulate('mouseover');
+    await sleep(100);
+
+    $('body').simulate('mouseout');
+    await sleep(50);
+
+    $colHeader.simulate('mouseover');
+    await sleep(100);
+
+    $colHeader.simulate('mouseout');
+    await sleep(50);
+
+    getMaster().find('tbody tr:eq(0) td:eq(1)').simulate('mouseover');
+    await sleep(100);
+
+    getMaster().find('tbody tr:eq(0) td:eq(1)').simulate('mouseout');
+    await sleep(50);
+
+    getMaster().find('tbody tr:eq(0) td:eq(2)').simulate('mouseover');
+    await sleep(100);
+
+    getMaster().find('tbody tr:eq(0) td:eq(2)').simulate('mouseout');
+    await sleep(50);
+
+    expect(spy).toHaveBeenCalledTimes(4);
+  });
+});


### PR DESCRIPTION
### Context
This PR makes 
- `beforeOnCellMouseOver`
- `afterOnCellMouseOver`
hooks get triggered when re-entering the same cells/headers with the mouse cursor (for example, hovering over a header -> leaving the table -> hovering over the same header)

### How has this been tested?
Added the test cases.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#645

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
