### PR TITLE
Docs: Remove information about incompatibility with nested rows

### DIFF
--- a/docs/content/guides/rows/rows-sorting.md
+++ b/docs/content/guides/rows/rows-sorting.md
@@ -56,9 +56,6 @@ Handsontable sorts data only visually, so your source data remains in the origin
 your sorting changes in the data source, see this guide:
 [Saving data](@/guides/getting-started/saving-data.md).
 
-You can't use sorting with [nested data structures](@/guides/rows/row-parent-child.md)
-([`NestedRows`](@/api/nestedRows.md)).
-
 ## Sorting demo
 
 Click on one of the column names to sort the values in ascending (↑) or descending (↓) order, or to


### PR DESCRIPTION
This PR:
- From the [Rows sorting](https://handsontable.com/docs/react-data-grid/rows-sorting/#overview) page, removes the paragraph about incompatibility with nested rows, as requested [here](https://handsoncode.slack.com/archives/C01KNSJ4M08/p1681372214830719).

[skip changelog]