### PR TITLE
Fixed problem related to copying and pasting from Hansontable to Excel

### DIFF
--- a/.changelogs/10017.json
+++ b/.changelogs/10017.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed problem related to copying and pasting from Hansontable to Excel",
+  "type": "fixed",
+  "issueOrPR": 10017,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/copyPaste/__tests__/copy.spec.js
+++ b/handsontable/src/plugins/copyPaste/__tests__/copy.spec.js
@@ -99,10 +99,10 @@ describe('CopyPaste', () => {
         '<meta name="generator" content="Handsontable"/>' +
           '<style type="text/css">td{white-space:normal}br{mso-data-placement:same-cell}</style>',
         '<table><tbody>',
-        '<tr><td>{"test":&nbsp;"value"}</td></tr>',
-        '<tr><td>{"test":&nbsp;"value"}</td></tr>',
-        '<tr><td>{"test2":&nbsp;{"testtest":&nbsp;""}}</td></tr>',
-        '<tr><td>{"test3":&nbsp;""}</td></tr>',
+        '<tr><td>{"test": "value"}</td></tr>',
+        '<tr><td>{"test": "value"}</td></tr>',
+        '<tr><td>{"test2": {"testtest": ""}}</td></tr>',
+        '<tr><td>{"test3": ""}</td></tr>',
         '</tbody></table>',
       ].join(''));
     });

--- a/handsontable/src/plugins/copyPaste/__tests__/copy.spec.js
+++ b/handsontable/src/plugins/copyPaste/__tests__/copy.spec.js
@@ -132,5 +132,37 @@ describe('CopyPaste', () => {
         '</tbody></table>',
       ].join(''));
     });
+
+    it('should handle spaces properly (creates Excel compatible HTML)', () => {
+      handsontable({
+        colHeaders: ['a   b'],
+        data: [
+          ['c d'],
+          ['e  f'],
+          ['g      h'],
+        ],
+      });
+
+      const copyEvent = getClipboardEvent();
+      const plugin = getPlugin('CopyPaste');
+
+      selectAll();
+
+      plugin.copyWithColumnHeaders();
+      plugin.onCopy(copyEvent); // emulate native "copy" event
+
+      expect(copyEvent.clipboardData.getData('text/plain'))
+        .toBe('a   b\nc d\ne  f\ng      h');
+      expect(copyEvent.clipboardData.getData('text/html')).toBe([
+        '<meta name="generator" content="Handsontable"/>' +
+        '<style type="text/css">td{white-space:normal}br{mso-data-placement:same-cell}</style>',
+        '<table><tbody>',
+        '<tr><td>a<span style="mso-spacerun: yes">&nbsp;&nbsp; </span>b</td></tr>',
+        '<tr><td>c d</td></tr>',
+        '<tr><td>e<span style="mso-spacerun: yes">&nbsp; </span>f</td></tr>',
+        '<tr><td>g<span style="mso-spacerun: yes">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span>h</td></tr>',
+        '</tbody></table>',
+      ].join(''));
+    });
   });
 });

--- a/handsontable/src/utils/__tests__/parseTable.unit.js
+++ b/handsontable/src/utils/__tests__/parseTable.unit.js
@@ -137,7 +137,7 @@ describe('_dataToHTML', () => {
 
     expect(_dataToHTML(data)).toBe([
       '<table><tbody>',
-      '<tr><td>&lt;div&nbsp;class="test"&gt;A1&lt;/div&gt;</td></tr>',
+      '<tr><td>&lt;div class="test"&gt;A1&lt;/div&gt;</td></tr>',
       '</tbody></table>',
     ].join(''));
   });

--- a/handsontable/src/utils/parseTable.js
+++ b/handsontable/src/utils/parseTable.js
@@ -130,7 +130,7 @@ export function _dataToHTML(input) {
           .replace(/>/g, '&gt;')
           .replace(/(<br(\s*|\/)>(\r\n|\n)?|\r\n|\n)/g, '<br>\r\n')
           .replace(/\x20{2,}/gi, (substring) => {
-            // The way how Excel serializes data with at least two spaces
+            // The way how Excel serializes data with at least two spaces.
             return `<span style="mso-spacerun: yes">${'&nbsp;'.repeat(substring.length - 1)} </span>`;
           })
           .replace(/\t/gi, '&#9;');

--- a/handsontable/src/utils/parseTable.js
+++ b/handsontable/src/utils/parseTable.js
@@ -129,7 +129,10 @@ export function _dataToHTML(input) {
           .replace(/</g, '&lt;')
           .replace(/>/g, '&gt;')
           .replace(/(<br(\s*|\/)>(\r\n|\n)?|\r\n|\n)/g, '<br>\r\n')
-          .replace(/\x20/gi, '&nbsp;')
+          .replace(/\x20{2,}/gi, (substring) => {
+            // The way how Excel serializes data with at least two spaces
+            return `<span style="mso-spacerun: yes">${'&nbsp;'.repeat(substring.length - 1)} </span>`;
+          })
           .replace(/\t/gi, '&#9;');
 
       columnsResult.push(`<td>${parsedCellData}</td>`);


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
There has been problem related to converting every space to `&nbsp;` character while storing copied data to clipboard in `text/html` mode. This PR fixed the problem and introduced way of copying table using extra `<span>` elements with `mso-spacerun` style attribute. After that, a copied data is properly pasted to Excel product. 

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Copying single and multiple spaces and pasting them on Excel on office.com site.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #10017

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] My change requires a change to the documentation.
