### PR TITLE
Docs: Minor changes

### DIFF
--- a/docs/content/guides/rows/row-hiding.md
+++ b/docs/content/guides/rows/row-hiding.md
@@ -27,7 +27,7 @@ When you're hiding a row:
 
 ## Enable row hiding
 
-To simply enable row hiding (without further configuration), set the [`hiddenRows`](@/api/options.md#hiddenrows) configuration option to `true`:
+To enable row hiding, use the [`hiddenRows`](@/api/options.md#hiddenrows) option.
 
 ::: only-for javascript
 ::: example #example1
@@ -56,7 +56,11 @@ const hot = new Handsontable(container, {
   colHeaders: true,
   rowHeaders: true,
   // enable the `HiddenRows` plugin
-  hiddenRows: true
+  hiddenRows: {
+    rows: [3, 5, 9],
+    // show UI indicators to mark hidden rows
+    indicators: true
+  }
 });
 ```
 :::
@@ -93,7 +97,11 @@ export const ExampleComponent = () => {
       height="auto"
       colHeaders={true}
       rowHeaders={true}
-      hiddenRows={true}
+      hiddenRows={{
+        rows: [3, 5, 9],
+        // show UI indicators to mark hidden rows
+        indicators: true
+      }}
     />
   );
 };

--- a/docs/content/guides/rows/rows-sorting.md
+++ b/docs/content/guides/rows/rows-sorting.md
@@ -382,7 +382,7 @@ const handsontableInstance = new Handsontable(container, {
   columnSorting: true,
   columns: [
     {
-      title: 'Brand<br>(non-sortable)',
+      title: 'Brand',
       type: 'text',
       data: 'brand',
       // disable sorting for the 'Brand' column
@@ -391,12 +391,12 @@ const handsontableInstance = new Handsontable(container, {
       },
     },
     {
-      title: 'Model<br>(sortable)',
+      title: 'Model',
       type: 'text',
       data: 'model',
     },
     {
-      title: 'Price<br>(non-sortable)',
+      title: 'Price',
       type: 'numeric',
       data: 'price',
       numericFormat: {
@@ -409,7 +409,7 @@ const handsontableInstance = new Handsontable(container, {
       },
     },
     {
-      title: 'Date<br>(sortable)',
+      title: 'Date',
       type: 'date',
       data: 'sellDate',
       dateFormat: 'MMM D, YYYY',
@@ -417,7 +417,7 @@ const handsontableInstance = new Handsontable(container, {
       className: 'htRight',
     },
     {
-      title: 'Time<br>(non-sortable)',
+      title: 'Time',
       type: 'time',
       data: 'sellTime',
       timeFormat: 'hh:mm A',
@@ -429,13 +429,13 @@ const handsontableInstance = new Handsontable(container, {
       },
     },
     {
-      title: 'In stock<br>(sortable)',
+      title: 'In stock',
       type: 'checkbox',
       data: 'inStock',
       className: 'htCenter',
     },
   ],
-  height: 168,
+  height: 'auto',
   stretchH: 'all',
   licenseKey: 'non-commercial-and-evaluation',
 });
@@ -506,7 +506,7 @@ export const App = () => {
       columnSorting={true}
       columns={[
         {
-          title: 'Brand<br>(non-sortable)',
+          title: 'Brand',
           type: 'text',
           data: 'brand',
           // disable sorting for the 'Brand' column
@@ -515,12 +515,12 @@ export const App = () => {
           },
         },
         {
-          title: 'Model<br>(sortable)',
+          title: 'Model',
           type: 'text',
           data: 'model',
         },
         {
-          title: 'Price<br>(non-sortable)',
+          title: 'Price',
           type: 'numeric',
           data: 'price',
           numericFormat: {
@@ -533,7 +533,7 @@ export const App = () => {
           },
         },
         {
-          title: 'Date<br>(sortable)',
+          title: 'Date',
           type: 'date',
           data: 'sellDate',
           dateFormat: 'MMM D, YYYY',
@@ -541,7 +541,7 @@ export const App = () => {
           className: 'htRight',
         },
         {
-          title: 'Time<br>(non-sortable)',
+          title: 'Time',
           type: 'time',
           data: 'sellTime',
           timeFormat: 'hh:mm A',
@@ -553,13 +553,13 @@ export const App = () => {
           },
         },
         {
-          title: 'In stock<br>(sortable)',
+          title: 'In stock',
           type: 'checkbox',
           data: 'inStock',
           className: 'htCenter',
         },
       ]}
-      height={168}
+      height="auto"
       stretchH="all"
       licenseKey="non-commercial-and-evaluation"
     />

--- a/docs/content/guides/rows/rows-sorting.md
+++ b/docs/content/guides/rows/rows-sorting.md
@@ -320,7 +320,7 @@ const configurationOptions = {
 :::
 
 To enable sorting only for specific columns, set [`headerAction`](@/api/options.md#columnsorting) to
-`false` for those columns that you don't want to sort.
+`false` for those columns that you don't want to sort. In the following example, only columns **Model**, **Date** and **In stock** are sortable.
 
 ::: only-for javascript
 


### PR DESCRIPTION
This PR makes minor changes requested by Krzysiek:
- In the first demo on the [Row hiding](https://handsontable.com/docs/javascript-data-grid/row-hiding/#enable-row-hiding) page, adds hidden-row indicators
- In the [Enable sorting](https://handsontable.com/docs/javascript-data-grid/rows-sorting/#enable-sorting) demo,  removes the bottom scrollbar and the "sortable/non-sortable" text

Affected sections:
- https://handsontable.com/docs/javascript-data-grid/rows-sorting/#enable-sorting
- https://handsontable.com/docs/react-data-grid/rows-sorting/#enable-sorting
- https://handsontable.com/docs/javascript-data-grid/row-hiding/#enable-row-hiding
- https://handsontable.com/docs/react-data-grid/row-hiding/#enable-row-hiding

[skip changelog]