### PR TITLE
Docs: Various fixes

### DIFF
--- a/docs/content/guides/accessories-and-menus/export-to-csv.md
+++ b/docs/content/guides/accessories-and-menus/export-to-csv.md
@@ -2,7 +2,7 @@
 id: 51aacis1
 title: Export to CSV
 metaTitle: Export to CSV - JavaScript Data Grid | Handsontable
-description: Export your grid's data to the CSV format, as a downloadable file, a blob, or a string. Customize your export using Handsontable's configuration options.
+description: Export your grid's raw data to the CSV format, as a downloadable file, a blob, or a string. Customize your export using Handsontable's configuration options.
 permalink: /export-to-csv
 canonicalUrl: /export-to-csv
 tags:
@@ -16,11 +16,13 @@ searchCategory: Guides
 
 # Export to CSV
 
-Export your grid's data to the CSV format, as a downloadable file, a blob, or a string. Customize your export using Handsontable's configuration options.
+Export your grid's raw data to the CSV format, as a downloadable file, a blob, or a string. Customize your export using Handsontable's configuration options.
 
 [[toc]]
 
 ## Examples
+
+Mind that CSV exports contain only raw data, and don't include formulas, styling, or formatting information.
 
 ### Export to file
 

--- a/docs/content/guides/integrate-with-angular/angular-installation.md
+++ b/docs/content/guides/integrate-with-angular/angular-installation.md
@@ -56,6 +56,13 @@ registerAllModules();
 export class AppModule { }
 ```
 
+::: tip
+
+You can reduce the size of your bundle by importing and registering only the
+[modules](@/guides/tools-and-building/modules.md) that you need.
+
+:::
+
 Now, you can use the Handsontable component in your HTML files.
 
 ```html

--- a/docs/content/guides/integrate-with-angular/angular-installation.md
+++ b/docs/content/guides/integrate-with-angular/angular-installation.md
@@ -59,7 +59,7 @@ export class AppModule { }
 ::: tip
 
 You can reduce the size of your bundle by importing and registering only the
-[modules](@/guides/tools-and-building/modules.md) that you need.
+[modules](@/guides/integrate-with-angular/angular-modules.md) that you need.
 
 :::
 

--- a/docs/content/guides/integrate-with-vue/vue-installation.md
+++ b/docs/content/guides/integrate-with-vue/vue-installation.md
@@ -55,6 +55,13 @@ npm install handsontable @handsontable/vue
 </script>
 ```
 
+::: tip
+
+You can reduce the size of your bundle by importing and registering only the
+[modules](@/guides/tools-and-building/modules.md) that you need.
+
+:::
+
 ## Related API reference
 
 - Configuration options:

--- a/docs/content/guides/integrate-with-vue/vue-installation.md
+++ b/docs/content/guides/integrate-with-vue/vue-installation.md
@@ -58,7 +58,7 @@ npm install handsontable @handsontable/vue
 ::: tip
 
 You can reduce the size of your bundle by importing and registering only the
-[modules](@/guides/tools-and-building/modules.md) that you need.
+[modules](@/guides/integrate-with-vue/vue-modules.md) that you need.
 
 :::
 

--- a/docs/content/guides/integrate-with-vue3/vue3-installation.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-installation.md
@@ -65,6 +65,13 @@ npm install handsontable @handsontable/vue3
 </script>
 ```
 
+::: tip
+
+You can reduce the size of your bundle by importing and registering only the
+[modules](@/guides/tools-and-building/modules.md) that you need.
+
+:::
+
 ## Related API reference
 
 - Configuration options:

--- a/docs/content/guides/integrate-with-vue3/vue3-installation.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-installation.md
@@ -68,7 +68,7 @@ npm install handsontable @handsontable/vue3
 ::: tip
 
 You can reduce the size of your bundle by importing and registering only the
-[modules](@/guides/tools-and-building/modules.md) that you need.
+[modules](@/guides/integrate-with-vue3/vue3-modules.md) that you need.
 
 :::
 

--- a/docs/content/guides/tools-and-building/folder-structure.md
+++ b/docs/content/guides/tools-and-building/folder-structure.md
@@ -37,6 +37,7 @@ Handsontable's source files are stored on GitHub, in a monorepo.
     └── types                               # Handsontable TypeScript definitions files
 ├── resources                               # Static files for README.md
 ├── scripts                                 # Monorepo scripts
+├── visual-tests                            # Automated visual regression tests
 └── wrappers                                # Wrapper files
     ├── angular                             # Wrapper for Angular
     ├── react                               # Wrapper for React

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -71,7 +71,7 @@ const deprecationWarns = new Set();
  * :::
  *
  * ::: only-for react
- * ```jsx{3,7,13}
+ * ```jsx
  * import { useRef } from 'react';
  *
  * const hotTableComponent = useRef(null);

--- a/handsontable/src/plugins/autoRowSize/autoRowSize.js
+++ b/handsontable/src/plugins/autoRowSize/autoRowSize.js
@@ -36,10 +36,10 @@ const ROW_WIDTHS_MAP_NAME = 'autoRowSize';
  * To configure the sync/async distribution, you can pass an absolute value (number of rows) or a percentage value to a config object:
  * ```js
  * // as a number (300 rows in sync, rest async)
- * autoRowSize: {syncLimit: 300},.
+ * autoRowSize: {syncLimit: 300},
  *
  * // as a string (percent)
- * autoRowSize: {syncLimit: '40%'},.
+ * autoRowSize: {syncLimit: '40%'},
  *
  * // allow sample duplication
  * autoRowSize: {syncLimit: '40%', allowSampleDuplicates: true},


### PR DESCRIPTION
This PR:
- Removes code higlights from the [How to call a method section](https://handsontable.com/docs/react-data-grid/api/core/#how-to-call-a-method) of React's Core API ([#1282](https://github.com/handsontable/dev-handsontable/issues/1282))
- In Angular, Vue 2 and Vue 3 installation guides, adds links to their respective "Modules" pages ([#1264](https://github.com/handsontable/dev-handsontable/issues/1264))
- Removes redundant dots from the [`AutoRowSize`](https://handsontable.com/docs/javascript-data-grid/api/auto-row-size/) API ref ([#1263](https://github.com/handsontable/dev-handsontable/issues/1263))
- In the [Export to CSV](https://handsontable.com/docs/javascript-data-grid/export-to-csv/) guide adds a note that only raw data is exported ([#1244](https://handsontable.com/docs/javascript-data-grid/export-to-csv/))
- Updates the [Folder structure](https://handsontable.com/docs/javascript-data-grid/folder-structure/) page to include the `visual-tests` folder ([#1243](https://github.com/handsontable/dev-handsontable/issues/1243))

[skip changelog]
