### PR TITLE
Docs: Various improvements

### DIFF
--- a/docs/content/guides/cell-types/date-cell-type.md
+++ b/docs/content/guides/cell-types/date-cell-type.md
@@ -87,6 +87,8 @@ correctFormat={true}
 
 ## Basic example
 
+Click on one of the ▼ icons to open an interactive date editor.
+
 ::: only-for javascript
 ::: example #example1
 ```js
@@ -123,7 +125,6 @@ const hot = new Handsontable(container, {
         // First day of the week (0: Sunday, 1: Monday, etc)
         firstDay: 0,
         showWeekNumber: true,
-        numberOfMonths: 3,
         disableDayFn(date) {
           // Disable Sunday and Saturday
           return date.getDay() === 0 || date.getDay() === 6;
@@ -182,7 +183,6 @@ export const ExampleComponent = () => {
             // First day of the week (0: Sunday, 1: Monday, etc)
             firstDay: 0,
             showWeekNumber: true,
-            numberOfMonths: 3,
             licenseKey: 'non-commercial-and-evaluation',
             disableDayFn(date) {
               // Disable Sunday and Saturday
@@ -207,7 +207,6 @@ ReactDOM.render(<ExampleComponent />, document.getElementById('example1'));
 ```
 :::
 :::
-
 
 ## Related articles
 

--- a/docs/content/guides/columns/column-summary.md
+++ b/docs/content/guides/columns/column-summary.md
@@ -10,6 +10,10 @@ tags:
   - calculations
   - formulas
   - functions
+  - suppressDataTypeErrors
+  - destinationRow
+  - destinationColumn
+  - reversedRowCoords
 react:
   id: r3x4l0gp
   metaTitle: Column summary - React Data Grid | Handsontable

--- a/docs/content/guides/columns/column-summary.md
+++ b/docs/content/guides/columns/column-summary.md
@@ -191,9 +191,7 @@ To set up a column summary, follow the steps below.
 
 ### Step 1: Enable the [`ColumnSummary`](@/api/columnSummary.md) plugin
 
-To enable the [`ColumnSummary`](@/api/columnSummary.md) plugin, set the [`columnSummary`](@/api/options.md#columnsummary) configuration option to an array of objects.
-
-Each object represents a single column summary.
+To enable the [`ColumnSummary`](@/api/columnSummary.md) plugin, set the [`columnSummary`](@/api/options.md#columnsummary) configuration option to an array of objects. Each object represents a single column summary.
 
 ::: only-for javascript
 ```js
@@ -248,9 +246,7 @@ export const ExampleComponent = () => {
 ```
 :::
 
-::: tip
-You can also set the [`columnSummary`](@/api/options.md#columnsummary) option to a function.
-:::
+You can also set the [`columnSummary`](@/api/options.md#columnsummary) option [to a function](#set-up-column-summaries-using-a-function).
 
 ### Step 2: Select cells that you want to summarize
 

--- a/docs/content/guides/getting-started/configuration-options.md
+++ b/docs/content/guides/getting-started/configuration-options.md
@@ -425,8 +425,8 @@ const hot = new Handsontable(container, {
   cells(row, col, prop) {
     if (row === 1 || row === 4) {
       return {
-        // row options, apply to each cell of the first row
-        // and to each cell of the fourth row
+        // row options, which apply to each cell of the second row
+        // and to each cell of the fifth row
         readOnly: true,
       };
     }
@@ -450,8 +450,8 @@ The function can take three arguments:<br>
 <HotTable cells={(row, col, prop) => {
   if (row === 1 || row === 4) {
     return {
-      // row options, apply to each cell of the first row
-      // and to each cell of the fourth row
+      // row options, which apply to each cell of the second row
+      // and to each cell of the fifth row
       readOnly: true,
     };
   }

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -2612,11 +2612,13 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
   };
 
   /**
-   * Get value from the selected cell.
+   * Gets the value of the currently focused cell.
+   *
+   * For column headers and row headers, returns `null`.
    *
    * @memberof Core#
    * @function getValue
-   * @returns {*} Value of selected cell.
+   * @returns {*} The value of the focused cell.
    */
   this.getValue = function() {
     const sel = instance.getSelectedLast();

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -3347,7 +3347,13 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
   };
 
   /**
-   * Checks if the data format and config allows user to modify the column structure.
+   * Checks if your [data format](@/guides/getting-started/binding-to-data.md#compatible-data-types)
+   * and [configuration options](@/guides/getting-started/configuration-options.md)
+   * allow for changing the number of columns.
+   *
+   * Returns `false` when your data is an array of objects,
+   * or when you use the [`columns`](@/api/options.md#columns) option.
+   * Otherwise, returns `true`.
    *
    * @memberof Core#
    * @function isColumnModificationAllowed

--- a/handsontable/src/dataMap/metaManager/metaSchema.js
+++ b/handsontable/src/dataMap/metaManager/metaSchema.js
@@ -10,7 +10,7 @@ import { isObjectEqual } from '../../helpers/object';
  * [Configuration options](@/guides/getting-started/configuration-options.md) let you heavily customize your Handsontable instance. For example, you can:
  *
  * - Enable and disable built-in features
- * - Enable and configure additional [plugins](@/guides/tools-and-building/custom-plugins.md)
+ * - Enable and configure additional [plugins](@/api/plugins.md)
  * - Personalize Handsontable's look
  * - Adjust Handsontable's behavior
  * - Implement your own custom features


### PR DESCRIPTION
This PR:
- In the [Basic example](https://handsontable.com/docs/javascript-data-grid/date-cell-type/#basic-example) section of the [Date cell type](https://handsontable.com/docs/javascript-data-grid/date-cell-type/) page, adds a description and changes the demo to show only 1 month in the date picker. ([#1237](https://github.com/handsontable/dev-handsontable/issues/1237))
- Improves the searchability of the [Column summary](https://handsontable.com/docs/javascript-data-grid/column-summary/) guide [(#1221](https://github.com/handsontable/dev-handsontable/issues/1221))
- Fixes wrong code comments on the [Configuration options](https://handsontable.com/docs/javascript-data-grid/configuration-options/) page ([#1210](https://github.com/handsontable/dev-handsontable/issues/1210))
- Changes the **plugins** link on the [Configuration options API ref](https://handsontable.com/docs/javascript-data-grid/api/options/) page ([#1206](https://github.com/handsontable/dev-handsontable/issues/1206))
- On the [Column summary](https://handsontable.com/docs/javascript-data-grid/column-summary/#step-1-enable-the-columnsummary-plugin) page, in the note about setting `columnSummary` to a function, adds a link to section [Set up column summaries, using a function](https://handsontable.com/docs/javascript-data-grid/column-summary/#set-up-column-summaries-using-a-function) ([#1200](https://github.com/handsontable/dev-handsontable/issues/1200))
- Changes the descripition of [`isColumnModificationAllowed`](https://handsontable.com/docs/javascript-data-grid/api/core/#iscolumnmodificationallowed) [(#1180](https://handsontable.com/docs/javascript-data-grid/api/core/#iscolumnmodificationallowed))
- Changes the description of [`getValue()`](https://handsontable.com/docs/javascript-data-grid/api/core/#getvalue) [(#1178](https://github.com/handsontable/dev-handsontable/issues/1178))

[skip changelog]