### PR TITLE
Docs: Add info on incompatibility between formulas and `getSourceData()`

### DIFF
--- a/docs/content/guides/formulas/formula-calculation.md
+++ b/docs/content/guides/formulas/formula-calculation.md
@@ -82,6 +82,7 @@ To use HyperFormula outside of a Handsontable instance (e.g., on a server), you 
 *   Doesn't work with [nested rows](@/guides/rows/row-parent-child.md)
 *   Doesn't work with [undo/redo](@/guides/accessories-and-menus/undo-redo.md)
 *   Doesn't work with nested data (when Handsontable's [`data`](@/api/options.md#data) is set to an [array of nested objects](@/guides/getting-started/binding-to-data.md#array-of-objects))
+*   Doesn't work with the [`getSourceData()`](@/api/core.md#getsourcedata) method.
 
 ## Available options and methods
 

--- a/docs/content/guides/formulas/formula-calculation.md
+++ b/docs/content/guides/formulas/formula-calculation.md
@@ -79,10 +79,10 @@ To use HyperFormula outside of a Handsontable instance (e.g., on a server), you 
 
 **Known limitations:**
 
-*   Doesn't work with [nested rows](@/guides/rows/row-parent-child.md)
-*   Doesn't work with [undo/redo](@/guides/accessories-and-menus/undo-redo.md)
-*   Doesn't work with nested data (when Handsontable's [`data`](@/api/options.md#data) is set to an [array of nested objects](@/guides/getting-started/binding-to-data.md#array-of-objects))
-*   Doesn't work with the [`getSourceData()`](@/api/core.md#getsourcedata) method.
+*   Doesn't support [nested rows](@/guides/rows/row-parent-child.md).
+*   Doesn't support [undo/redo](@/guides/accessories-and-menus/undo-redo.md).
+*   Doesn't support nested data, i.e., when Handsontable's [`data`](@/api/options.md#data) is set to an [array of nested objects](@/guides/getting-started/binding-to-data.md#array-of-objects).
+*   Doesn't support [`getSourceData()`](@/api/core.md#getsourcedata), as this method operates on source data (using [physical indexes](@/api/indexMapper.md)), whereas formulas operate on visual data (using visual indexes).
 
 ## Available options and methods
 

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -2975,8 +2975,9 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
    * __Note__: This method does not participate in data transformation. If the visual data of the table is reordered,
    * sorted or trimmed only physical indexes are correct.
    *
-   * __Note__: By design, this method doesn't support [formulas](@/guides/formulas/formula-calculation.md).
-   * `getSourceData()` operates on source data ([physical indexes](@/api/indexMapper.md)),
+   * __Note__: This method may return incorrect values for cells that contain
+   * [formulas](@/guides/formulas/formula-calculation.md). This is because `getSourceData()`
+   * operates on source data ([physical indexes](@/api/indexMapper.md)),
    * whereas formulas operate on visual data (visual indexes).
    *
    * @memberof Core#

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -2976,7 +2976,8 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
    * sorted or trimmed only physical indexes are correct.
    *
    * __Note__: By design, this method doesn't support [formulas](@/guides/formulas/formula-calculation.md).
-   * `getSourceData()` operates on physical data, whereas formulas operate on visual data.
+   * `getSourceData()` operates on source data ([physical indexes](@/api/indexMapper.md)),
+   * whereas formulas operate on visual data (visual indexes).
    *
    * @memberof Core#
    * @function getSourceData

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -2975,6 +2975,9 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
    * __Note__: This method does not participate in data transformation. If the visual data of the table is reordered,
    * sorted or trimmed only physical indexes are correct.
    *
+   * __Note__: By design, this method doesn't support [formulas](@/guides/formulas/formula-calculation.md).
+   * `getSourceData()` operates on physical data, whereas formulas operate on visual data.
+   *
    * @memberof Core#
    * @function getSourceData
    * @param {number} [row] From physical row index.


### PR DESCRIPTION
This PR stems from a long discussion held by the dev team regarding [#1235](https://github.com/handsontable/dev-handsontable/issues/1235). We concluded that formulas are inherently incapable of working with the `getSourceData()` method, and we need to document that.

This PR:
- Adds a note to the [`getSourceData()`](https://handsontable.com/docs/javascript-data-grid/api/core/#getsourcedata) API ref.
- Adds a bullet point to the [Known limitations](https://handsontable.com/docs/javascript-data-grid/formula-calculation/#features) section of the [Formula calculation](https://handsontable.com/docs/javascript-data-grid/formula-calculation/) guide.

[skip changelog]