### PR TITLE
Docs: Edit 12.4.0 docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Updated TypeScript definition files related to the `CustomBorders` plugin [#10360](https://github.com/handsontable/handsontable/pull/10360)
 - Fixed an issue where moving rows manually to the bottom was difficult due the misalignment between the backlight and guideline elements. [#9556](https://github.com/handsontable/handsontable/issues/9556)
 
+For more information on Handsontable 12.4.3, see:
+
+- [Blog post (12.4.0)](PLACEHOLDER)
+- [Documentation (12.4)](https://handsontable.com/docs/12.4)
+- [Release notes (12.4.0)](https://handsontable.com/docs/release-notes/#_12-4-0)
+
 ## [12.3.3] - 2023-03-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,15 +20,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Fixed numerous issues related to syncing Handsontable with HyperFormula. Now, formulas work properly with all the Handsontable features. [#10215](https://github.com/handsontable/handsontable/pull/10215)
 - Fixed na issue where formulas didn't recalculate after rows or columns were moved. [#4668](https://github.com/handsontable/handsontable/issues/4668)
 - Fixed an issue where Handsontable's dates didn't sync correctly with HyperFormula's dates. [#10085](https://github.com/handsontable/handsontable/issues/10085)
-- Fixed an issue where calling `updateSettings()` would reset HyperFormula's undo/redo actions stack [#10326](https://github.com/handsontable/handsontable/pull/10326)
+- Fixed an issue where calling `updateSettings()` would reset HyperFormula's undo/redo actions stack. [#10326](https://github.com/handsontable/handsontable/pull/10326)
 - Fixed an issue where the `Autofill`, `TrimRows` and `Formulas` plugins didn't work properly together. [#10200](https://github.com/handsontable/handsontable/issues/10200)
 - Fixed an issue where the `modifySourceData` hook used the wrong type of indexes. [#10215](https://github.com/handsontable/handsontable/pull/10215)
 - Fixed an issue where text copied from Handsontable to Excel included wrong types of spaces. [#10017](https://github.com/handsontable/handsontable/issues/10017)
 - Fixed an issue where mousing over the same cell twice didn't trigger the `beforeOnCellMouseOver` and `afterOnCellMouseOver` hooks. [#10321](https://github.com/handsontable/handsontable/pull/10321)
-- Updated TypeScript definition files related to the `CustomBorders` plugin [#10360](https://github.com/handsontable/handsontable/pull/10360)
+- Updated TypeScript definition files related to the `CustomBorders` plugin. [#10360](https://github.com/handsontable/handsontable/pull/10360)
 - Fixed an issue where moving rows manually to the bottom was difficult due the misalignment between the backlight and guideline elements. [#9556](https://github.com/handsontable/handsontable/issues/9556)
 
-For more information on Handsontable 12.4.3, see:
+For more information on Handsontable 12.4.0, see:
 
 - [Blog post (12.4.0)](PLACEHOLDER)
 - [Documentation (12.4)](https://handsontable.com/docs/12.4)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,17 +13,20 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- Added new `afterColumnSequenceChange` and `afterRowSequenceChange` hooks and synchronization of actions done on HOT with HF's engine [#10215](https://github.com/handsontable/handsontable/pull/10215)
+- Added two new Handsontable hooks, `afterColumnSequenceChange` and `afterRowSequenceChange`, which are fired after changing the order of columns or rows, respectively. [#10215](https://github.com/handsontable/handsontable/pull/10215)
 
 ### Fixed
 
-- Fixed problem related to copying and pasting from Hansontable to Excel [#10017](https://github.com/handsontable/handsontable/issues/10017)
+- Fixed numerous issues related to syncing Handsontable with HyperFormula. Now, formulas work properly with all the Handsontable features. [#10215](https://github.com/handsontable/handsontable/pull/10215)
+- Fixed na issue where formulas didn't recalculate after rows or columns were moved. [#4668](https://github.com/handsontable/handsontable/issues/4668)
 - Fixed an issue where Handsontable's dates didn't sync correctly with HyperFormula's dates. [#10085](https://github.com/handsontable/handsontable/issues/10085)
-- Fixed problem related to Autofill, TrimRows and Formulas plugins cooperation. [#10200](https://github.com/handsontable/handsontable/issues/10200)
-- Fixed a problem where re-entering the same cells/headers with the mouse cursor would not trigger the `beforeOnCellMouseOver` and `afterOnCellMouseOver` hooks. [#10321](https://github.com/handsontable/handsontable/pull/10321)
-- Fixed a problem where Handsontable's `updateSettings` method would reset the HyperFormula's Undo/Redo actions stack in the connected instance. [#10326](https://github.com/handsontable/handsontable/pull/10326)
-- Updated TypeScript definition files related to CustomBorders plugin [#1240](https://github.com/handsontable/handsontable/pull/1240)
-- Fixed problems with backlight and guideline elements misalignment and moving row after the last position [#9556](https://github.com/handsontable/handsontable/issues/9556)
+- Fixed an issue where calling `updateSettings()` would reset HyperFormula's undo/redo actions stack [#10326](https://github.com/handsontable/handsontable/pull/10326)
+- Fixed an issue where the `Autofill`, `TrimRows` and `Formulas` plugins didn't work properly together. [#10200](https://github.com/handsontable/handsontable/issues/10200)
+- Fixed an issue where the `modifySourceData` hook used the wrong type of indexes. [#10215](https://github.com/handsontable/handsontable/pull/10215)
+- Fixed an issue where text copied from Handsontable to Excel included wrong types of spaces. [#10017](https://github.com/handsontable/handsontable/issues/10017)
+- Fixed an issue where mousing over the same cell twice didn't trigger the `beforeOnCellMouseOver` and `afterOnCellMouseOver` hooks. [#10321](https://github.com/handsontable/handsontable/pull/10321)
+- Updated TypeScript definition files related to the `CustomBorders` plugin [#10360](https://github.com/handsontable/handsontable/pull/10360)
+- Fixed an issue where moving rows manually to the bottom was difficult due the misalignment between the backlight and guideline elements. [#9556](https://github.com/handsontable/handsontable/issues/9556)
 
 ## [12.3.3] - 2023-03-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [12.4.0] - 2023-05-23
 
 ### Added
-- Added new afterColumnSequenceChange and afterRowSequenceChange hooks and synchronization of actions done on HOT with HF's engine [#10215](https://github.com/handsontable/handsontable/pull/10215)
+
+- Added new `afterColumnSequenceChange` and `afterRowSequenceChange` hooks and synchronization of actions done on HOT with HF's engine [#10215](https://github.com/handsontable/handsontable/pull/10215)
 
 ### Fixed
+
 - Fixed problem related to copying and pasting from Hansontable to Excel [#10017](https://github.com/handsontable/handsontable/issues/10017)
 - Fixed an issue where Handsontable's dates didn't sync correctly with HyperFormula's dates. [#10085](https://github.com/handsontable/handsontable/issues/10085)
 - Fixed problem related to Autofill, TrimRows and Formulas plugins cooperation. [#10200](https://github.com/handsontable/handsontable/issues/10200)

--- a/docs/content/guides/formulas/formula-calculation.md
+++ b/docs/content/guides/formulas/formula-calculation.md
@@ -6,10 +6,10 @@ description: Perform calculations on cells' values, using a powerful calculation
 permalink: /formula-calculation
 canonicalUrl: /formula-calculation
 tags:
+  - formulas
   - formula
   - excel
   - spreadsheet
-  - gpu
   - worksheet
   - workbook
   - sheet
@@ -26,11 +26,6 @@ searchCategory: Guides
 Perform calculations on cells' values, using a powerful calculation engine that handles 380+ functions, custom functions, named expressions, and more.
 
 [[toc]]
-
-::: warning
-Moving using low-level functionality such as [index mapper's API](@/api/indexMapper.md) doesn't update dataset properly.
-Please consider using [ManualRowMove](@/api/manualRowMove.md) and [ManualColumnMove](@/api/manualColumnMove.md) plugins.
-:::
 
 ## Overview
 
@@ -949,12 +944,15 @@ ReactDOM.render(<ExampleComponent />, document.getElementById('example-named-exp
 :::
 :::
 
-
-For more information about named expressions, please refer to the [HyperFormula docs](https://handsontable.github.io/hyperformula/guide/named-ranges.html).
+For more information about named expressions, refer to the [HyperFormula docs](https://handsontable.github.io/hyperformula/guide/named-ranges.html).
 
 ## View the explainer video
 
 <iframe width="100%" height="425px" src="https://www.youtube.com/embed/JJXUmACTDdk"></iframe>
+
+## Known limitations
+
+- Using the [`IndexMapper`](@/api/indexMapper.md) API to programmatically [move rows](@/guides/rows/row-moving.md) or [columns](@/guides/columns/column-moving.md) that contain formulas is not supported. Instead, use the [`ManualRowMove`](@/api/manualRowMove.md) or [`ManualColumnMove`](@/api/manualColumnMove.md) APIs.
 
 ## Related articles
 

--- a/docs/content/guides/formulas/formula-calculation.md
+++ b/docs/content/guides/formulas/formula-calculation.md
@@ -33,13 +33,13 @@ The _Formulas_ plugin provides you an extensive calculation capabilities based o
 
 This plugin comes with a library of 386 functions grouped into categories, such as Math and trigonometry, Engineering, Statistical, Financial, and Logical. Using these, you can create complex data entry rules in business apps and much more. Below are some ideas on what you can do with it:
 
-*   Fully-featured spreadsheet apps
-*   Smart documents
-*   Educational apps
-*   Business logic builders
-*   Forms and form builders
-*   Online calculators
-*   Low connectivity apps
+- Fully-featured spreadsheet apps
+- Smart documents
+- Educational apps
+- Business logic builders
+- Forms and form builders
+- Online calculators
+- Low connectivity apps
 
 ### HyperFormula version support
 
@@ -63,21 +63,14 @@ To use HyperFormula outside of a Handsontable instance (e.g., on a server), you 
 
 ## Features
 
-*   High-speed formula calculations
-*   Function syntax compatible with Excel and Google Sheets
-*   A library of built-in functions available in 16 languages
-*   Support for wildcard characters
-*   Support for CRUD operations
-*   Support for cross-sheet references
-*   Support for multiple Handsontable instances
-*   Uses GPU acceleration for better performance
-
-**Known limitations:**
-
-*   Doesn't support [nested rows](@/guides/rows/row-parent-child.md).
-*   Doesn't support [undo/redo](@/guides/accessories-and-menus/undo-redo.md).
-*   Doesn't support nested data, i.e., when Handsontable's [`data`](@/api/options.md#data) is set to an [array of nested objects](@/guides/getting-started/binding-to-data.md#array-of-objects).
-*   Doesn't support [`getSourceData()`](@/api/core.md#getsourcedata), as this method operates on source data (using [physical indexes](@/api/indexMapper.md)), whereas formulas operate on visual data (using visual indexes).
+- High-speed formula calculations
+- Function syntax compatible with Excel and Google Sheets
+- A library of built-in functions available in 16 languages
+- Support for wildcard characters
+- Support for CRUD operations
+- Support for cross-sheet references
+- Support for multiple Handsontable instances
+- Uses GPU acceleration for better performance
 
 ## Available options and methods
 
@@ -953,6 +946,8 @@ For more information about named expressions, refer to the [HyperFormula docs](h
 ## Known limitations
 
 - Using the [`IndexMapper`](@/api/indexMapper.md) API to programmatically [move rows](@/guides/rows/row-moving.md) or [columns](@/guides/columns/column-moving.md) that contain formulas is not supported. Instead, use the [`ManualRowMove`](@/api/manualRowMove.md) or [`ManualColumnMove`](@/api/manualColumnMove.md) APIs.
+- Formulas don't support [`getSourceData()`](@/api/core.md#getsourcedata), as this method operates on source data (using [physical indexes](@/api/indexMapper.md)), whereas formulas operate on visual data (using visual indexes).
+- Formulas don't support nested data, i.e., when Handsontable's [`data`](@/api/options.md#data) is set to an [array of nested objects](@/guides/getting-started/binding-to-data.md#array-of-objects).
 
 ## Related articles
 

--- a/docs/content/guides/getting-started/demo.md
+++ b/docs/content/guides/getting-started/demo.md
@@ -2964,11 +2964,11 @@ console.log(`Handsontable: v${Handsontable.version} (${Handsontable.buildDate}) 
 
 ## Find the code on GitHub
 
-- [JavaScript demo app](https://github.com/handsontable/handsontable/tree/develop/examples/12.3.3/docs/js/demo/)
-- [TypeScript demo app](https://github.com/handsontable/handsontable/tree/develop/examples/12.3.3/docs/ts/demo/)
-- [Angular demo app](https://github.com/handsontable/handsontable/tree/develop/examples/12.3.3/docs/angular/demo/)
-- [React demo app](https://github.com/handsontable/handsontable/tree/develop/examples/12.3.3/docs/react/demo/)
-- [Vue demo app](https://github.com/handsontable/handsontable/tree/develop/examples/12.3.3/docs/vue/demo/)
+- [JavaScript demo app](https://github.com/handsontable/handsontable/tree/develop/examples/12.4.0/docs/js/demo/)
+- [TypeScript demo app](https://github.com/handsontable/handsontable/tree/develop/examples/12.4.0/docs/ts/demo/)
+- [Angular demo app](https://github.com/handsontable/handsontable/tree/develop/examples/12.4.0/docs/angular/demo/)
+- [React demo app](https://github.com/handsontable/handsontable/tree/develop/examples/12.4.0/docs/react/demo/)
+- [Vue demo app](https://github.com/handsontable/handsontable/tree/develop/examples/12.4.0/docs/vue/demo/)
 
 ## Try out the demo's features
 

--- a/docs/content/guides/getting-started/events-and-hooks.md
+++ b/docs/content/guides/getting-started/events-and-hooks.md
@@ -396,7 +396,6 @@ It's worth mentioning that some Handsontable hooks are triggered from the Handso
 List of callbacks that operate on the `source` parameter:
 
 * [`afterChange`](@/api/hooks.md#afterchange)
-* [`afterColumnSequenceChange`](@/api/hooks.md#aftercolumnsequencechange)
 * [`afterCreateCol`](@/api/hooks.md#aftercreatecol)
 * [`afterCreateRow`](@/api/hooks.md#aftercreaterow)
 * [`afterLoadData`](@/api/hooks.md#afterloaddata)
@@ -405,7 +404,6 @@ List of callbacks that operate on the `source` parameter:
 * [`afterSetSourceDataAtCell`](@/api/hooks.md#aftersetsourcedataatcell)
 * [`afterRemoveCol`](@/api/hooks.md#afterremovecol)
 * [`afterRemoveRow`](@/api/hooks.md#aftermoverow)
-* [`afterRowSequenceChange`](@/api/hooks.md#afterrowsequencechange)
 * [`afterValidate`](@/api/hooks.md#aftervalidate)
 * [`beforeChange`](@/api/hooks.md#beforechange)
 * [`beforeChangeRender`](@/api/hooks.md#beforechangerender)

--- a/docs/content/guides/getting-started/events-and-hooks.md
+++ b/docs/content/guides/getting-started/events-and-hooks.md
@@ -396,6 +396,7 @@ It's worth mentioning that some Handsontable hooks are triggered from the Handso
 List of callbacks that operate on the `source` parameter:
 
 * [`afterChange`](@/api/hooks.md#afterchange)
+* [`afterColumnSequenceChange`](@/api/hooks.md#aftercolumnsequencechange)
 * [`afterCreateCol`](@/api/hooks.md#aftercreatecol)
 * [`afterCreateRow`](@/api/hooks.md#aftercreaterow)
 * [`afterLoadData`](@/api/hooks.md#afterloaddata)
@@ -404,6 +405,7 @@ List of callbacks that operate on the `source` parameter:
 * [`afterSetSourceDataAtCell`](@/api/hooks.md#aftersetsourcedataatcell)
 * [`afterRemoveCol`](@/api/hooks.md#afterremovecol)
 * [`afterRemoveRow`](@/api/hooks.md#aftermoverow)
+* [`afterRowSequenceChange`](@/api/hooks.md#afterrowsequencechange)
 * [`afterValidate`](@/api/hooks.md#aftervalidate)
 * [`beforeChange`](@/api/hooks.md#beforechange)
 * [`beforeChangeRender`](@/api/hooks.md#beforechangerender)

--- a/docs/content/guides/getting-started/introduction.md
+++ b/docs/content/guides/getting-started/introduction.md
@@ -38,18 +38,19 @@ Thousands of business apps depend on Handsontable for entering, editing, validat
 </div>
 
 ## Get started with Handsontable
+
 ::: only-for javascript
 To jump straight into the sample code, open the demo app at CodeSandbox:
 
-- [JavaScript demo](https://codesandbox.io/s/handsontable-javascript-data-grid-hello-world-app-12-3-3-6rf1pz)
-- [React demo](https://codesandbox.io/s/handsontable-react-data-grid-hello-world-app-12-3-3-z9bmr6)
-- [Angular demo](https://codesandbox.io/s/handsontable-angular-data-grid-hello-world-app-12-3-3-9r6ve9)
-- [Vue 2 demo](https://codesandbox.io/s/handsontable-vue-data-grid-hello-world-app-12-3-3-p71oki)
-- [TypeScript demo](https://codesandbox.io/s/handsontable-typescript-data-grid-hello-world-app-12-3-3-be9p99)
+- [JavaScript demo](https://codesandbox.io/s/handsontable-javascript-data-grid-hello-world-app-12-4-0-qy4fks)
+- [React demo](https://codesandbox.io/s/handsontable-react-data-grid-hello-world-app-12-4-0-esczegs)
+- [Angular demo](https://codesandbox.io/s/handsontable-angular-data-grid-hello-world-app-12-4-0-5vgmo3)
+- [Vue 2 demo](https://codesandbox.io/s/handsontable-vue-data-grid-hello-world-app-12-4-0-0sqeye)
+- [TypeScript demo](https://codesandbox.io/s/handsontable-typescript-data-grid-hello-world-app-12-4-0-h4wjmd)
 :::
 
 ::: only-for react
-To jump straight into the sample code, [open the demo app at CodeSandbox](https://codesandbox.io/s/handsontable-react-data-grid-hello-world-app-12-3-3-z9bmr6).
+To jump straight into the sample code, [open the demo app at CodeSandbox](https://codesandbox.io/s/handsontable-react-data-grid-hello-world-app-12-4-0-esczegs).
 :::
 
 Then, move on to [connecting](@/guides/getting-started/binding-to-data.md) your data and [configuring](@/guides/getting-started/configuration-options.md) Handsontable's built-in features. For more advanced implementations, use Handsontable's [API](@/api/introduction.md).

--- a/docs/content/guides/tools-and-building/packages.md
+++ b/docs/content/guides/tools-and-building/packages.md
@@ -38,7 +38,7 @@ If you are a "Bob the Builder" kind of hacker, you will need to load Handsontabl
 <script src="https://cdn.jsdelivr.net/npm/moment@2.29.4/moment.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/pikaday@1.8.2/pikaday.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/numbro@2.1.2/dist/numbro.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/dompurify@2.4.0/dist/purify.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/dompurify@2.4.5/dist/purify.js"></script>
 
 <!-- Handsontable bare files -->
 <script src="dist/handsontable.js"></script>

--- a/docs/content/guides/upgrade-and-migration/release-notes.md
+++ b/docs/content/guides/upgrade-and-migration/release-notes.md
@@ -24,6 +24,32 @@ See the full history of changes made to Handsontable in each major, minor, and p
 
 [[toc]]
 
+## 12.4.0
+
+Released on May 23, 2023.
+
+For more information on this release, see:
+
+- [Blog post (12.4.0)](PLACEHOLDER)
+- [Documentation (12.4)](https://handsontable.com/docs/12.4)
+
+#### Added
+
+- Added two new Handsontable hooks, [`afterColumnSequenceChange`](@/api/hooks.md#aftercolumnsequencechange) and [`afterRowSequenceChange`](@/api/hooks.md#afterrowsequencechange), which are fired after changing the order of columns or rows, respectively. [#10215](https://github.com/handsontable/handsontable/pull/10215)
+
+#### Fixed
+
+- Fixed numerous issues related to syncing Handsontable with HyperFormula. Now, formulas work properly with all the Handsontable features. [#10215](https://github.com/handsontable/handsontable/pull/10215)
+- Fixed na issue where formulas didn't recalculate after rows or columns were moved. [#4668](https://github.com/handsontable/handsontable/issues/4668)
+- Fixed an issue where Handsontable's dates didn't sync correctly with HyperFormula's dates. [#10085](https://github.com/handsontable/handsontable/issues/10085)
+- Fixed an issue where calling [`updateSettings()`](@/api/core.md#updatesettings) would reset HyperFormula's undo/redo actions stack [#10326](https://github.com/handsontable/handsontable/pull/10326)
+- Fixed an issue where the [`Autofill`](@/api/autofill.md), [`TrimRows`](@/api/trimRows.md) and [`Formulas`](@/api/formulas.md) plugins didn't work properly together. [#10200](https://github.com/handsontable/handsontable/issues/10200)
+- Fixed an issue where the [`modifySourceData`](@/api/hooks.md#modifysourcedata) hook used the wrong type of indexes. [#10215](https://github.com/handsontable/handsontable/pull/10215)
+- Fixed an issue where text copied from Handsontable to Excel included wrong types of spaces. [#10017](https://github.com/handsontable/handsontable/issues/10017)
+- Fixed an issue where mousing over the same cell twice didn't trigger the [`beforeOnCellMouseOver`](@/api/hooks.md#beforeoncellmouseover) and [`afterOnCellMouseOver`](@/api/hooks.md#afteroncellmouseover) hooks. [#10321](https://github.com/handsontable/handsontable/pull/10321)
+- Updated TypeScript definition files related to the [`CustomBorders`](@/api/customBorders.md) plugin [#10360](https://github.com/handsontable/handsontable/pull/10360)
+- Fixed an issue where moving rows manually to the bottom was difficult due the misalignment between the backlight and guideline elements. [#9556](https://github.com/handsontable/handsontable/issues/9556)
+
 ## 12.3.3
 
 Released on March 28, 2023.

--- a/docs/content/guides/upgrade-and-migration/release-notes.md
+++ b/docs/content/guides/upgrade-and-migration/release-notes.md
@@ -42,12 +42,12 @@ For more information on this release, see:
 - Fixed numerous issues related to syncing Handsontable with HyperFormula. Now, formulas work properly with all the Handsontable features. [#10215](https://github.com/handsontable/handsontable/pull/10215)
 - Fixed na issue where formulas didn't recalculate after rows or columns were moved. [#4668](https://github.com/handsontable/handsontable/issues/4668)
 - Fixed an issue where Handsontable's dates didn't sync correctly with HyperFormula's dates. [#10085](https://github.com/handsontable/handsontable/issues/10085)
-- Fixed an issue where calling [`updateSettings()`](@/api/core.md#updatesettings) would reset HyperFormula's undo/redo actions stack [#10326](https://github.com/handsontable/handsontable/pull/10326)
+- Fixed an issue where calling [`updateSettings()`](@/api/core.md#updatesettings) would reset HyperFormula's undo/redo actions stack. [#10326](https://github.com/handsontable/handsontable/pull/10326)
 - Fixed an issue where the [`Autofill`](@/api/autofill.md), [`TrimRows`](@/api/trimRows.md) and [`Formulas`](@/api/formulas.md) plugins didn't work properly together. [#10200](https://github.com/handsontable/handsontable/issues/10200)
 - Fixed an issue where the [`modifySourceData`](@/api/hooks.md#modifysourcedata) hook used the wrong type of indexes. [#10215](https://github.com/handsontable/handsontable/pull/10215)
 - Fixed an issue where text copied from Handsontable to Excel included wrong types of spaces. [#10017](https://github.com/handsontable/handsontable/issues/10017)
 - Fixed an issue where mousing over the same cell twice didn't trigger the [`beforeOnCellMouseOver`](@/api/hooks.md#beforeoncellmouseover) and [`afterOnCellMouseOver`](@/api/hooks.md#afteroncellmouseover) hooks. [#10321](https://github.com/handsontable/handsontable/pull/10321)
-- Updated TypeScript definition files related to the [`CustomBorders`](@/api/customBorders.md) plugin [#10360](https://github.com/handsontable/handsontable/pull/10360)
+- Updated TypeScript definition files related to the [`CustomBorders`](@/api/customBorders.md) plugin. [#10360](https://github.com/handsontable/handsontable/pull/10360)
 - Fixed an issue where moving rows manually to the bottom was difficult due the misalignment between the backlight and guideline elements. [#9556](https://github.com/handsontable/handsontable/issues/9556)
 
 ## 12.3.3

--- a/handsontable/src/pluginHooks.js
+++ b/handsontable/src/pluginHooks.js
@@ -280,7 +280,7 @@ const REGISTERED_HOOKS = [
    * This hook is fired by changing column indexes of any type supported by the {@link IndexMapper}.
    *
    * @event Hooks#afterColumnSequenceChange
-   * @param {string} [source] A string that indicates what caused the change to the order of columns: `'init'`, `'remove'`, `'insert'`, `'move'`, or `'update'`.
+   * @param {'init'|'remove'|'insert'|'move'|'update'} [source] A string that indicates what caused the change to the order of columns.
    */
   'afterColumnSequenceChange',
 
@@ -577,7 +577,7 @@ const REGISTERED_HOOKS = [
    * This hook is fired by changing row indexes of any type supported by the {@link IndexMapper}.
    *
    * @event Hooks#afterRowSequenceChange
-   * @param {string} [source] A string that indicates what caused the change to the order of rows: `'init'`, `'remove'`, `'insert'`, `'move'`, or `'update'`.
+   * @param {'init'|'remove'|'insert'|'move'|'update'} [source] A string that indicates what caused the change to the order of rows.
    */
   'afterRowSequenceChange',
 

--- a/handsontable/src/pluginHooks.js
+++ b/handsontable/src/pluginHooks.js
@@ -276,9 +276,11 @@ const REGISTERED_HOOKS = [
   'beforeCreateCol',
 
   /**
-   * Fired after changing a column sequence. It populates every change on indexes captured by {@link IndexMapper}.
+   * Fired after the order of columns has changed.
+   * This hook is fired by changing column indexes of any type supported by the {@link IndexMapper}.
    *
-   * @param {'init'|'remove'|'insert'|'move'|'update'} [source] String that identifies source of row sequence change.
+   * @event Hooks#afterColumnSequenceChange
+   * @param {string} [source] A string that indicates what caused the change to the order of columns: `'init'`, `'remove'`, `'insert'`, `'move'`, or `'update'`.
    */
   'afterColumnSequenceChange',
 
@@ -571,9 +573,11 @@ const REGISTERED_HOOKS = [
   'afterRenderer',
 
   /**
-   * Fired after changing a row sequence. It populates every change on indexes captured by {@link IndexMapper}.
+   * Fired after the order of rows has changed.
+   * This hook is fired by changing row indexes of any type supported by the {@link IndexMapper}.
    *
-   * @param {'init'|'remove'|'insert'|'move'|'update'} [source] String that identifies source of row sequence change.
+   * @event Hooks#afterRowSequenceChange
+   * @param {string} [source] A string that indicates what caused the change to the order of rows: `'init'`, `'remove'`, `'insert'`, `'move'`, or `'update'`.
    */
   'afterRowSequenceChange',
 


### PR DESCRIPTION
This PR:
- Edits the 12.4.0 changelog entries
- Adds 12.4.0 release notes
- Updates the docs' CodeSandbox demos to forked ones with updated HoT dependencies
- In the [Bare distribution](https://handsontable.com/docs/javascript-data-grid/packages/#bare-distribution) section of the [Packages](https://handsontable.com/docs/javascript-data-grid/packages) page, updates the `dompurify` version to `2.4.5`
- Updates links in the [Find the code on GitHub](https://handsontable.com/docs/javascript-data-grid/demo/#find-the-code-on-github) section
- Applies further changes listed below

### New hooks: `afterColumnSequenceChange` and `afterRowSequenceChange`
- Fixed the API refs of the newly-added hooks (they didn't show up in the docs)
- Rewrote the hooks' API descriptions

### [Formula calculation](https://handsontable.com/docs/react-data-grid/formula-calculation) page
- Rewrote and moved the top-of-the-page warning about `IndexMapper` into a new **Known limitations** section
- Removed nested rows and undo/redo from the list of features unsupported by formulas (as per #10215)
- Cleaned up formulas' known limitations

[skip changelog]