### PR TITLE
Changed margins for context-menu in RTL mode and fixed problem with wrong position for check inside `Read only` entry 

### DIFF
--- a/.changelogs/10375.json
+++ b/.changelogs/10375.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Changed margins for context-menu in RTL mode and fixed problem with wrong position for check inside Read only entry",
+  "type": "fixed",
+  "issueOrPR": 10375,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/contextMenu/__tests__/positioning.spec.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/positioning.spec.js
@@ -273,5 +273,29 @@ describe('ContextMenu', () => {
           .toBeCloseTo(contextMenuOffset.left - contextMenuRoot.outerWidth(), 0);
       });
     });
+
+    it('should show tick from "Read only" element at proper place', () => {
+      handsontable({
+        layoutDirection,
+        data: createSpreadsheetData(10, 10),
+        contextMenu: true,
+        readOnly: true,
+      });
+
+      selectCell(0, 0);
+
+      const cell = getCell(0, 0);
+
+      contextMenu(cell);
+
+      const $readOnlyItem = $('.htContextMenu .ht_master .htCore td:contains(Read only)');
+      const $tickItem = $readOnlyItem.find('span.selected');
+      const tickItemOffset = $tickItem.offset();
+      const $contextMenuRoot = $('.htContextMenu');
+      const contextMenuOffset = $contextMenuRoot.offset();
+
+      expect(tickItemOffset.top).toBe(216);
+      expect(tickItemOffset.left).toBe(contextMenuOffset.left + 4);
+    });
   });
 });

--- a/handsontable/src/plugins/contextMenu/__tests__/rtl/positioning.spec.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/rtl/positioning.spec.js
@@ -214,5 +214,29 @@ describe('ContextMenu (RTL mode)', () => {
           .toBeCloseTo(contextMenuOffset.left + contextMenuRoot.outerWidth(), 0);
       });
     });
+
+    it('should show tick from "Read only" element at proper place', () => {
+      handsontable({
+        layoutDirection,
+        data: createSpreadsheetData(10, 10),
+        contextMenu: true,
+        readOnly: true,
+      });
+
+      selectCell(0, 0);
+
+      const cell = getCell(0, 0);
+
+      contextMenu(cell);
+
+      const $readOnlyItem = $('.htContextMenu .ht_master .htCore td:contains(Read only)');
+      const $tickItem = $readOnlyItem.find('span.selected');
+      const tickItemOffset = $tickItem.offset();
+      const $contextMenuRoot = $('.htContextMenu');
+      const contextMenuOffset = $contextMenuRoot.offset();
+
+      expect(tickItemOffset.top).toBe(216);
+      expect(tickItemOffset.left).toBe(contextMenuOffset.left + $contextMenuRoot.outerWidth() - 4);
+    });
   });
 });

--- a/handsontable/src/plugins/contextMenu/contextMenu.scss
+++ b/handsontable/src/plugins/contextMenu/contextMenu.scss
@@ -80,14 +80,19 @@
 }
 
 .htContextMenu table tbody tr td .htItemWrapper {
-  margin-left: 10px;
-  margin-right: 6px;
+  margin-inline-start: 10px;
+  margin-inline-end: 6px;
 }
 
 .htContextMenu table tbody tr td div span.selected {
   margin-top: -2px;
   position: absolute;
-  left: 4px;
+  inset-inline-start: 4px;
+}
+
+[dir=rtl].handsontable .htContextMenu table tbody tr td div span.selected {
+  inset-inline-start: unset;
+  inset-inline-end: 4px;
 }
 
 .htContextMenu .ht_master .wtHolder {

--- a/handsontable/src/plugins/contextMenu/contextMenu.scss
+++ b/handsontable/src/plugins/contextMenu/contextMenu.scss
@@ -88,11 +88,8 @@
   margin-top: -2px;
   position: absolute;
   inset-inline-start: 4px;
+  inset-inline-start: 0px;
 }
-
-[dir=rtl].handsontable .htContextMenu table tbody tr td div span.selected {
-  inset-inline-start: unset;
-  inset-inline-end: 4px;
 }
 
 .htContextMenu .ht_master .wtHolder {

--- a/handsontable/src/plugins/contextMenu/contextMenu.scss
+++ b/handsontable/src/plugins/contextMenu/contextMenu.scss
@@ -90,7 +90,6 @@
   inset-inline-start: 4px;
   inset-inline-start: 0px;
 }
-}
 
 .htContextMenu .ht_master .wtHolder {
   overflow: hidden;

--- a/handsontable/src/plugins/contextMenu/contextMenu.scss
+++ b/handsontable/src/plugins/contextMenu/contextMenu.scss
@@ -88,7 +88,7 @@
   margin-top: -2px;
   position: absolute;
   inset-inline-start: 4px;
-  inset-inline-start: 0px;
+  inset-inline-end: 0;
 }
 
 .htContextMenu .ht_master .wtHolder {

--- a/handsontable/src/plugins/dropdownMenu/__tests__/positioning.spec.js
+++ b/handsontable/src/plugins/dropdownMenu/__tests__/positioning.spec.js
@@ -115,5 +115,26 @@ describe('DropdownMenu', () => {
         expect(subMenuOffset.left).toBeCloseTo(dropdownOffset.left - $dropdownMenu.outerWidth(), 0);
       });
     });
+
+    it('should show tick from "Read only" element at proper place', () => {
+      handsontable({
+        layoutDirection,
+        data: createSpreadsheetData(10, 10),
+        dropdownMenu: true,
+        colHeaders: true,
+        readOnly: true,
+      });
+
+      dropdownMenu(0);
+
+      const $readOnlyItem = $('.htDropdownMenu .ht_master .htCore td:contains(Read only)');
+      const $tickItem = $readOnlyItem.find('span.selected');
+      const tickItemOffset = $tickItem.offset();
+      const $dropdownMenuRoot = $('.htDropdownMenu');
+      const dropdownMenuOffset = $dropdownMenuRoot.offset();
+
+      expect(tickItemOffset.top).toBe(135);
+      expect(tickItemOffset.left).toBe(dropdownMenuOffset.left + 4);
+    });
   });
 });

--- a/handsontable/src/plugins/dropdownMenu/__tests__/rtl/positioning.spec.js
+++ b/handsontable/src/plugins/dropdownMenu/__tests__/rtl/positioning.spec.js
@@ -117,5 +117,26 @@ describe('DropdownMenu (RTL mode)', () => {
         expect(subMenuOffset.left).toBeCloseTo(dropdownOffset.left + dropdownWidth, 0);
       });
     });
+
+    it('should show tick from "Read only" element at proper place', () => {
+      handsontable({
+        layoutDirection,
+        data: createSpreadsheetData(10, 10),
+        dropdownMenu: true,
+        colHeaders: true,
+        readOnly: true,
+      });
+
+      dropdownMenu(0);
+
+      const $readOnlyItem = $('.htDropdownMenu .ht_master .htCore td:contains(Read only)');
+      const $tickItem = $readOnlyItem.find('span.selected');
+      const tickItemOffset = $tickItem.offset();
+      const $dropdownMenuRoot = $('.htDropdownMenu');
+      const dropdownMenuOffset = $dropdownMenuRoot.offset();
+
+      expect(tickItemOffset.top).toBe(135);
+      expect(tickItemOffset.left).toBe(dropdownMenuOffset.left + $dropdownMenuRoot.outerWidth() - 4);
+    });
   });
 });

--- a/handsontable/src/plugins/dropdownMenu/dropdownMenu.scss
+++ b/handsontable/src/plugins/dropdownMenu/dropdownMenu.scss
@@ -107,11 +107,8 @@
   margin-top: -2px;
   position: absolute;
   inset-inline-start: 4px;
+  inset-inline-start: 0px;
 }
-
-[dir=rtl].handsontable .htDropdownMenu table tbody tr td div span.selected {
-  inset-inline-start: unset;
-  inset-inline-end: 4px;
 }
 
 .htDropdownMenu .ht_master .wtHolder {

--- a/handsontable/src/plugins/dropdownMenu/dropdownMenu.scss
+++ b/handsontable/src/plugins/dropdownMenu/dropdownMenu.scss
@@ -99,14 +99,19 @@
 }
 
 .htDropdownMenu table tbody tr td .htItemWrapper {
-  margin-left: 10px;
-  margin-right: 10px;
+  margin-inline-start: 10px;
+  margin-inline-end: 10px;
 }
 
 .htDropdownMenu table tbody tr td div span.selected {
   margin-top: -2px;
   position: absolute;
-  left: 4px;
+  inset-inline-start: 4px;
+}
+
+[dir=rtl].handsontable .htDropdownMenu table tbody tr td div span.selected {
+  inset-inline-start: unset;
+  inset-inline-end: 4px;
 }
 
 .htDropdownMenu .ht_master .wtHolder {

--- a/handsontable/src/plugins/dropdownMenu/dropdownMenu.scss
+++ b/handsontable/src/plugins/dropdownMenu/dropdownMenu.scss
@@ -109,7 +109,6 @@
   inset-inline-start: 4px;
   inset-inline-start: 0px;
 }
-}
 
 .htDropdownMenu .ht_master .wtHolder {
   overflow: hidden;

--- a/handsontable/src/plugins/dropdownMenu/dropdownMenu.scss
+++ b/handsontable/src/plugins/dropdownMenu/dropdownMenu.scss
@@ -107,7 +107,7 @@
   margin-top: -2px;
   position: absolute;
   inset-inline-start: 4px;
-  inset-inline-start: 0px;
+  inset-inline-end: 0;
 }
 
 .htDropdownMenu .ht_master .wtHolder {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
This PR changed a way how context-menu looks like in RTL mode (margins). It also did changes to place check inside `Read only` entry at proper position. It fixes problem described in #752 issue. 

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I checked how `layoutDirection` works.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. [#752](https://github.com/handsontable/dev-handsontable/issues/752)

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] My change requires a change to the documentation.
