### PR TITLE
Error thrown after deselecting the table and triggering some keys won't occur anymore

### DIFF
--- a/.changelogs/10272.json
+++ b/.changelogs/10272.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Error thrown after deselecting the table and triggering some keys won't occur anymore",
+  "type": "fixed",
+  "issueOrPR": 10272,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/__tests__/editorManager.spec.js
+++ b/handsontable/src/__tests__/editorManager.spec.js
@@ -94,24 +94,22 @@ describe('editorManager', () => {
       });
     });
 
-    describe('should not throw an error', () => {
-      [
-        ['f2'],
-        ['backspace'],
-        ['delete'],
-        ['enter'],
-        ['enter', 'shift']
-      ].forEach((key) => {
-        it(`if ${key.join(', ')} was pressed`, () => {
-          handsontable();
+    using('shortcut key', [
+      ['f2'],
+      ['backspace'],
+      ['delete'],
+      ['enter'],
+      ['enter', 'shift']
+    ], (shortcutKey) => {
+      it('should not throw an error when pressed in case when the table is not selected', () => {
+        handsontable();
 
-          selectCell(0, 0);
-          deselectCell(0, 0);
+        selectCell(0, 0);
+        deselectCell(0, 0);
 
-          expect(() => {
-            keyDownUp(key);
-          }).not.toThrowError();
-        });
+        expect(() => {
+          keyDownUp(shortcutKey);
+        }).not.toThrowError();
       });
     });
   });

--- a/handsontable/src/__tests__/editorManager.spec.js
+++ b/handsontable/src/__tests__/editorManager.spec.js
@@ -93,5 +93,26 @@ describe('editorManager', () => {
         });
       });
     });
+
+    describe('should not throw an error', () => {
+      [
+        ['f2'],
+        ['backspace'],
+        ['delete'],
+        ['enter'],
+        ['enter', 'shift']
+      ].forEach((key) => {
+        it(`if ${key.join(', ')} was pressed`, () => {
+          handsontable();
+
+          selectCell(0, 0);
+          deselectCell(0, 0);
+
+          expect(() => {
+            keyDownUp(key);
+          }).not.toThrowError();
+        });
+      });
+    });
   });
 });

--- a/handsontable/src/editorManager.js
+++ b/handsontable/src/editorManager.js
@@ -142,7 +142,10 @@ class EditorManager {
 
         stopImmediatePropagation(event); // required by HandsontableEditor
       },
-    }], config);
+    }], {
+      ...config,
+      runOnlyIf: () => isDefined(this.instance.getSelected()),
+    });
   }
 
   /**


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
We have a problem with throwing an error described within https://github.com/handsontable/dev-handsontable/issues/1177 when HOT is listening, but no cell is selected.

This PR adds an extra conditional for shortcut.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I manually tested the fix for `f2`, `backspace`, `delete`, `enter`, `shift+enter` shortcuts using case described in the issue.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/1177

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] My change requires a change to the documentation.
