### PR TITLE
Add support for keyboard shortcut that allows opening context menu

### DIFF
--- a/handsontable/src/shortcuts/recorder.js
+++ b/handsontable/src/shortcuts/recorder.js
@@ -89,7 +89,7 @@ export function useRecorder(ownerWindow, handleEvent, beforeKeyDown, afterKeyDow
       return;
     }
 
-    const pressedKey = normalizeEventKey(event.key);
+    const pressedKey = normalizeEventKey(event);
     let extraModifierKeys = [];
 
     if (isModifierKey(pressedKey)) {
@@ -122,7 +122,7 @@ export function useRecorder(ownerWindow, handleEvent, beforeKeyDown, afterKeyDow
       return;
     }
 
-    const pressedKey = normalizeEventKey(event.key);
+    const pressedKey = normalizeEventKey(event);
 
     if (isModifierKey(pressedKey) === false) {
       return;

--- a/handsontable/src/shortcuts/utils.js
+++ b/handsontable/src/shortcuts/utils.js
@@ -52,11 +52,21 @@ export const getKeysList = (normalizedKeys) => {
 };
 
 /**
- * Normalize a `KeyboardEvent.key` property, to use it for keyboard shortcuts.
+ * The regex tests if the event.code matches to the patter and it's used to extract letters and digits from
+ * the string.
+ */
+const codeToKeyRegExp = new RegExp('^(?:Key|Digit)([A-Z0-9])$');
+
+/**
+ * Normalizes a keyboard event key value to a key before its modification. When the keyboard event
+ * is triggered with Alt, Control or Shift keys the `key` property contains modified key e.g. for Alt+L
+ * it will be `ł`. But that value is only valid for polish keyboard layout. To fix that limitations, for
+ * letters and digits the value is taken from the `code` property which holds original value before
+ * transformation.
  *
- * @param {string} key KeyboardEvent's key property.
+ * @param {Event} event The KeyboardEvent object.
  * @returns {string}
  */
-export const normalizeEventKey = (key) => {
-  return key.toLowerCase();
+export const normalizeEventKey = ({ key, code }) => {
+  return (codeToKeyRegExp.test(code) ? code.replace(codeToKeyRegExp, '$1') : key).toLowerCase();
 };


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adds support for a new keyboard shortcut that allows opening the context menu (from _ContextMenu_ plugin). The keyboard shortcut is active for cells and for headers as well.

### Expected working new keyboard shortcuts
 - <kbd>Cmd/Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>\\</kbd> or <kbd>Shift</kbd>+<kbd>F10</kbd> Opens the context menu.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1357

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
