### PR TITLE
Fixed an issue with not removing the resize handler when user clicks RMB

### DIFF
--- a/.changelogs/10416.json
+++ b/.changelogs/10416.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed an issue with not removing the resize handler when user clicks RMB ",
+  "type": "fixed",
+  "issueOrPR": 10416,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/manualColumnResize/__tests__/manualColumnResize.spec.js
+++ b/handsontable/src/plugins/manualColumnResize/__tests__/manualColumnResize.spec.js
@@ -1087,5 +1087,31 @@ describe('manualColumnResize', () => {
         expect($handle.css('z-index')).toBeGreaterThan(getTopClone().css('z-index'));
       });
     });
+
+    it('should remove resize handler when user clicks RMB', async() => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        colHeaders: true,
+        manualColumnResize: true
+      });
+
+      const $colHeader = getTopClone().find('thead tr:eq(0) th:eq(2)');
+
+      $colHeader.simulate('mouseover');
+
+      const $handle = spec().$container.find('.manualColumnResizer');
+      const resizerPosition = $handle.position();
+
+      $handle.simulate('mousedown', { clientX: resizerPosition.left });
+
+      // To watch whether color has changed.
+      expect(getComputedStyle($handle[0]).backgroundColor).toBe('rgb(52, 169, 219)');
+
+      $handle.simulate('contextmenu');
+
+      await sleep(0);
+
+      expect(getComputedStyle($handle[0]).backgroundColor).not.toBe('rgb(52, 169, 219)');
+    });
   });
 });

--- a/handsontable/src/plugins/manualColumnResize/manualColumnResize.js
+++ b/handsontable/src/plugins/manualColumnResize/manualColumnResize.js
@@ -579,7 +579,7 @@ export class ManualColumnResize extends BasePlugin {
 
     // There is thrown "mouseover" event right after opening a context menu. This flag inform that handle
     // shouldn't be drawn just after removing it.
-    setImmediate(() => {
+    this.hot._registerImmediate(() => {
       this.skipMouseOverAction = false;
     });
   }

--- a/handsontable/src/plugins/manualColumnResize/manualColumnResize.js
+++ b/handsontable/src/plugins/manualColumnResize/manualColumnResize.js
@@ -52,7 +52,7 @@ export class ManualColumnResize extends BasePlugin {
     this.guide = rootDocument.createElement('DIV');
     this.eventManager = new EventManager(this);
     this.pressed = null;
-    this.isTriggeredbyRMB = false;
+    this.isTriggeredByRMB = false;
     this.dblclick = 0;
     this.autoresizeTimeout = null;
 
@@ -398,7 +398,7 @@ export class ManualColumnResize extends BasePlugin {
     }
 
     // A "mouseover" action is triggered right after executing "contextmenu" event. It should be ignored.
-    if (this.isTriggeredbyRMB === true) {
+    if (this.isTriggeredByRMB === true) {
       return;
     }
 
@@ -577,12 +577,12 @@ export class ManualColumnResize extends BasePlugin {
     this.hot.rootElement.removeChild(this.guide);
 
     this.pressed = false;
-    this.isTriggeredbyRMB = true;
+    this.isTriggeredByRMB = true;
 
     // There is thrown "mouseover" event right after opening a context menu. This flag inform that handle
     // shouldn't be drawn just after removing it.
     this.hot._registerImmediate(() => {
-      this.isTriggeredbyRMB = false;
+      this.isTriggeredByRMB = false;
     });
   }
 

--- a/handsontable/src/plugins/manualColumnResize/manualColumnResize.js
+++ b/handsontable/src/plugins/manualColumnResize/manualColumnResize.js
@@ -52,6 +52,7 @@ export class ManualColumnResize extends BasePlugin {
     this.guide = rootDocument.createElement('DIV');
     this.eventManager = new EventManager(this);
     this.pressed = null;
+    this.skipMouseOverAction = false;
     this.dblclick = 0;
     this.autoresizeTimeout = null;
 
@@ -396,6 +397,11 @@ export class ManualColumnResize extends BasePlugin {
       return;
     }
 
+    // A "mouseover" action is triggered right after executing "contextmenu" event. It should be ignored.
+    if (this.skipMouseOverAction === true) {
+      return;
+    }
+
     if (this.checkIfColumnHeader(event.target)) {
       const th = this.getClosestTHParent(event.target);
 
@@ -561,6 +567,24 @@ export class ManualColumnResize extends BasePlugin {
   }
 
   /**
+   * Callback for "contextmenu" event triggered on element showing move handle. It removes handle and guide elements.
+   */
+  onContextMenu() {
+    this.hideHandleAndGuide();
+    this.hot.rootElement.removeChild(this.handle);
+    this.hot.rootElement.removeChild(this.guide);
+
+    this.pressed = false;
+    this.skipMouseOverAction = true;
+
+    // There is thrown "mouseover" event right after opening a context menu. This flag inform that handle
+    // shouldn't be drawn just after removing it.
+    setImmediate(() => {
+      this.skipMouseOverAction = false;
+    });
+  }
+
+  /**
    * Binds the mouse events.
    *
    * @private
@@ -572,6 +596,7 @@ export class ManualColumnResize extends BasePlugin {
     this.eventManager.addEventListener(rootElement, 'mousedown', e => this.onMouseDown(e));
     this.eventManager.addEventListener(rootWindow, 'mousemove', e => this.onMouseMove(e));
     this.eventManager.addEventListener(rootWindow, 'mouseup', () => this.onMouseUp());
+    this.eventManager.addEventListener(this.handle, 'contextmenu', () => this.onContextMenu());
   }
 
   /**

--- a/handsontable/src/plugins/manualColumnResize/manualColumnResize.js
+++ b/handsontable/src/plugins/manualColumnResize/manualColumnResize.js
@@ -52,7 +52,7 @@ export class ManualColumnResize extends BasePlugin {
     this.guide = rootDocument.createElement('DIV');
     this.eventManager = new EventManager(this);
     this.pressed = null;
-    this.skipMouseOverAction = false;
+    this.isTriggeredbyRMB = false;
     this.dblclick = 0;
     this.autoresizeTimeout = null;
 
@@ -398,7 +398,7 @@ export class ManualColumnResize extends BasePlugin {
     }
 
     // A "mouseover" action is triggered right after executing "contextmenu" event. It should be ignored.
-    if (this.skipMouseOverAction === true) {
+    if (this.isTriggeredbyRMB === true) {
       return;
     }
 
@@ -568,6 +568,8 @@ export class ManualColumnResize extends BasePlugin {
 
   /**
    * Callback for "contextmenu" event triggered on element showing move handle. It removes handle and guide elements.
+   *
+   * @private
    */
   onContextMenu() {
     this.hideHandleAndGuide();
@@ -575,12 +577,12 @@ export class ManualColumnResize extends BasePlugin {
     this.hot.rootElement.removeChild(this.guide);
 
     this.pressed = false;
-    this.skipMouseOverAction = true;
+    this.isTriggeredbyRMB = true;
 
     // There is thrown "mouseover" event right after opening a context menu. This flag inform that handle
     // shouldn't be drawn just after removing it.
     this.hot._registerImmediate(() => {
-      this.skipMouseOverAction = false;
+      this.isTriggeredbyRMB = false;
     });
   }
 

--- a/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
+++ b/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
@@ -943,8 +943,6 @@ describe('manualRowResize', () => {
 
       const $rowHeader = getInlineStartClone().find('tbody tr:eq(2) th:eq(0)');
 
-      debugger;
-
       $rowHeader.simulate('mouseover');
 
       const $handle = spec().$container.find('.manualRowResizer');

--- a/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
+++ b/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
@@ -933,6 +933,34 @@ describe('manualRowResize', () => {
         expect($rowHeader.offset().top + $rowHeader.height() - 5).toBeCloseTo($handle.offset().top, 0);
       });
     });
+
+    it('should remove resize handler when user clicks RMB', async() => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        manualRowResize: true
+      });
+
+      const $rowHeader = getInlineStartClone().find('tbody tr:eq(2) th:eq(0)');
+
+      debugger;
+
+      $rowHeader.simulate('mouseover');
+
+      const $handle = spec().$container.find('.manualRowResizer');
+      const resizerPosition = $handle.position();
+
+      $handle.simulate('mousedown', { clientY: resizerPosition.top });
+
+      // To watch whether color has changed.
+      expect(getComputedStyle($handle[0]).backgroundColor).toBe('rgb(52, 169, 219)');
+
+      $handle.simulate('contextmenu');
+
+      await sleep(0);
+
+      expect(getComputedStyle($handle[0]).backgroundColor).not.toBe('rgb(52, 169, 219)');
+    });
   });
 
   describe('hooks', () => {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
This PR adds callback for right click on resize handler. It fixes problem described within https://github.com/handsontable/dev-handsontable/issues/1312.

> The resize handler should be deactivated upon right mouse button (RMB) click by the user. Although it does not result in any technical problems, its presence primarily affects the overall user experience of the component. Currently, when the RMB is clicked and the menu is closed, the resizing handle remains visible and follows the movement of the mouse cursor.

See below a video showing the problem, mentioned in the issue.

https://github.com/handsontable/handsontable/assets/141330/65744d9d-dc7e-4066-9869-58e6149c1296

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Tested case described in the issue.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/1312

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] My change requires a change to the documentation.
