### PR TITLE
Docs: Edit 13.0.0 docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- **Breaking change**: Changed the order in which hooks are executed: now, the `beforeChange` hook is fired before the `afterSetDataAtCell` and `afterSetDataAtRowProp` hooks. [#10231](https://github.com/handsontable/handsontable/pull/10231)
-- React, Angular, Vue 2, Vue 3: Changed Handsontable's policy toward supporting frameworks versions. From now on, Handsontable supports only those versions of Angular, React, and Vue that are officially supported by their respective teams. Dropping Handsontable's support for any older versions of the frameworks won't be treated as a breaking change. [#10396](https://github.com/handsontable/handsontable/pull/10396)
+- **Breaking change**: React, Angular, Vue 2, Vue 3: Changed Handsontable's policy toward older versions of supported frameworks. From now on, Handsontable supports only those versions of any supported frameworks that are officially supported by their respective teams. Dropping Handsontable's support for any older framework versions won't be treated as a breaking change. [#10396](https://github.com/handsontable/handsontable/pull/10396)
+- **Breaking change**: Changed the order in which three hooks are executed: now, the `beforeChange` hook is fired before the `afterSetDataAtCell` and `afterSetDataAtRowProp` hooks. [#10231](https://github.com/handsontable/handsontable/pull/10231)
 - Changed the margins of the context menu in the RTL layout direction. [#10375](https://github.com/handsontable/handsontable/pull/10375)
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **Breaking change**: Angular: Rewritten the Angular wrapper to be based on Angular@12 and to support Angular versions 12 and above. [#10396](https://github.com/handsontable/handsontable/pull/10396)
 
 ### Changed
-- **Breaking change**: Swapping `beforeChange` and `afterSetDataAtCell`/`afterSetDataAtRowProp` hooks order [#677](https://github.com/handsontable/handsontable/pull/677)
+- **Breaking change**: Swapping `beforeChange` and `afterSetDataAtCell`/`afterSetDataAtRowProp` hooks order [#10231](https://github.com/handsontable/handsontable/pull/10231)
 
 ### Removed
 - **Breaking change**: Removed the the deprecated hooks, methods and options for 13.0.0. [#10407](https://github.com/handsontable/handsontable/issues/10407)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 For more information on Handsontable 13.0.0, see:
 
-- [Blog post (13.4.0)](PLACEHOLDER)
+- [Blog post (13.0.0)](PLACEHOLDER)
 - [Documentation (13.0)](https://handsontable.com/docs/13.0)
 - [Migration guide (12.4 → 13.0)](https://handsontable.com/docs/migration-from-12.4-to-13.0)
 - [Release notes (13.0.0)](https://handsontable.com/docs/release-notes/#_13-0-0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,19 +9,36 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- UNVERSIONED -->
 
-## [13.0.0] - 2023-06-20
+## [13.0.0] - 2023-06-22
 
 ### Added
-- **Breaking change**: Angular: Rewritten the Angular wrapper to be based on Angular@12 and to support Angular versions 12 and above. [#10396](https://github.com/handsontable/handsontable/pull/10396)
+
+- Angular: Added support for Angular 16. [#10396](https://github.com/handsontable/handsontable/pull/10396)
 
 ### Changed
-- **Breaking change**: Swapping `beforeChange` and `afterSetDataAtCell`/`afterSetDataAtRowProp` hooks order [#10231](https://github.com/handsontable/handsontable/pull/10231)
+
+- **Breaking change**: Changed the order in which hooks are executed: now, the `beforeChange` hook is fired before the `afterSetDataAtCell` and `afterSetDataAtRowProp` hooks. [#10231](https://github.com/handsontable/handsontable/pull/10231)
+- React, Angular, Vue 2, Vue 3: Changed Handsontable's policy toward supporting frameworks versions. From now on, Handsontable supports only those versions of Angular, React, and Vue that are officially supported by their respective teams. Dropping Handsontable's support for any older versions of the frameworks won't be treated as a breaking change. [#10396](https://github.com/handsontable/handsontable/pull/10396)
+- Changed the margins of the context menu in the RTL layout direction. [#10375](https://github.com/handsontable/handsontable/pull/10375)
 
 ### Removed
-- **Breaking change**: Removed the the deprecated hooks, methods and options for 13.0.0. [#10407](https://github.com/handsontable/handsontable/issues/10407)
+
+- **Breaking change (Angular)**: Dropped support for Angular 13 and lower. From now on, Handsontable supports only those versions of Angular that are officially supported by the Angular team. Dropping Handsontable's support for any older Angular versions won't be treated as a breaking change. [#10396](https://github.com/handsontable/handsontable/pull/10396)
+- **Breaking change**: Removed the deprecated `beforeAutofillInsidePopulate` hook. [#10407](https://github.com/handsontable/handsontable/pull/10407)
+- **Breaking change**: Removed the deprecated `getFirstNotHiddenIndex` method. Instead, use the `getNearestNotHiddenIndex()` method. [#10407](https://github.com/handsontable/handsontable/pull/10407)
+- **Breaking change**: Removed the deprecated parameters of the `alter()` method: `insert_row` and `insert_col`. Instead, use the following parameters: `insert_row_above`, `insert_row_below`, `insert_col_start`, and `insert_col_end`. [#10407](https://github.com/handsontable/handsontable/pull/10407)
+- **Breaking change**: Removed the deprecated parameters of the `populateFromArray()` method: `direction` and `deltas`. [#10407](https://github.com/handsontable/handsontable/pull/10407)
 
 ### Fixed
-- Changed margins for context-menu in RTL mode and fixed problem with wrong position for check inside Read only entry [#10375](https://github.com/handsontable/handsontable/pull/10375)
+
+- Fixed an issue where the "Read only" icon of the context menu displayed incorrectly in the RTL layout direction. [#10375](https://github.com/handsontable/handsontable/pull/10375)
+
+For more information on Handsontable 13.0.0, see:
+
+- [Blog post (13.4.0)](PLACEHOLDER)
+- [Documentation (13.0)](https://handsontable.com/docs/13.0)
+- [Migration guide (12.4 → 13.0)](https://handsontable.com/docs/migration-from-12.4-to-13.0)
+- [Release notes (13.0.0)](https://handsontable.com/docs/release-notes/#_13-0-0)
 
 ## [12.4.0] - 2023-05-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Removed
 
-- **Breaking change (Angular)**: Dropped support for Angular 13 and lower. From now on, Handsontable supports only those versions of Angular that are officially supported by the Angular team. Dropping Handsontable's support for any older Angular versions won't be treated as a breaking change. [#10396](https://github.com/handsontable/handsontable/pull/10396)
+- **Breaking change (Angular)**: Dropped support for Angular 13 and lower. From now on, Handsontable supports only those versions of Angular that are officially supported by the Angular team: currently, it's 14-16. However, Handsontable 13.0.0 was thoroughly tested and, to the best of our knowledge, works correctly with versions down to Angular 12. [#10396](https://github.com/handsontable/handsontable/pull/10396)
 - **Breaking change**: Removed the deprecated `beforeAutofillInsidePopulate` hook. [#10407](https://github.com/handsontable/handsontable/pull/10407)
 - **Breaking change**: Removed the deprecated `getFirstNotHiddenIndex` method. Instead, use the `getNearestNotHiddenIndex()` method. [#10407](https://github.com/handsontable/handsontable/pull/10407)
 - **Breaking change**: Removed the deprecated parameters of the `alter()` method: `insert_row` and `insert_col`. Instead, use the following parameters: `insert_row_above`, `insert_row_below`, `insert_col_start`, and `insert_col_end`. [#10407](https://github.com/handsontable/handsontable/pull/10407)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- **Breaking change**: React, Angular, Vue 2, Vue 3: Changed Handsontable's policy toward older versions of supported frameworks. From now on, Handsontable supports only those versions of any supported frameworks that are officially supported by their respective teams. Dropping Handsontable's support for any older framework versions won't be treated as a breaking change. [#10396](https://github.com/handsontable/handsontable/pull/10396)
+- **Breaking change (React, Angular, Vue 2, Vue 3)**: Changed Handsontable's policy toward older versions of supported frameworks. From now on, Handsontable supports only those versions of any supported frameworks that are officially supported by their respective teams. Dropping Handsontable's support for any older framework versions won't be treated as a breaking change. [#10396](https://github.com/handsontable/handsontable/pull/10396)
 - **Breaking change**: Changed the order in which three hooks are executed: now, the `beforeChange` hook is fired before the `afterSetDataAtCell` and `afterSetDataAtRowProp` hooks. [#10231](https://github.com/handsontable/handsontable/pull/10231)
 - Changed the margins of the context menu in the RTL layout direction. [#10375](https://github.com/handsontable/handsontable/pull/10375)
 

--- a/docs/content/guides/formulas/formula-calculation.md
+++ b/docs/content/guides/formulas/formula-calculation.md
@@ -975,12 +975,18 @@ ReactDOM.render(<ExampleComponent />, document.getElementById('example-named-exp
 
 :::
 
-For more information about named expressions, please refer to the
+For more information about named expressions, refer to the
 [HyperFormula docs](https://handsontable.github.io/hyperformula/guide/named-ranges.html).
 
 ## View the explainer video
 
 <iframe width="100%" height="425px" src="https://www.youtube.com/embed/JJXUmACTDdk"></iframe>
+
+## Known limitations
+
+- Using the [`IndexMapper`](@/api/indexMapper.md) API to programmatically [move rows](@/guides/rows/row-moving.md) or [columns](@/guides/columns/column-moving.md) that contain formulas is not supported. Instead, use the [`ManualRowMove`](@/api/manualRowMove.md) or [`ManualColumnMove`](@/api/manualColumnMove.md) APIs.
+- Formulas don't support [`getSourceData()`](@/api/core.md#getsourcedata), as this method operates on source data (using [physical indexes](@/api/indexMapper.md)), whereas formulas operate on visual data (using visual indexes).
+- Formulas don't support nested data, i.e., when Handsontable's [`data`](@/api/options.md#data) is set to an [array of nested objects](@/guides/getting-started/binding-to-data.md#array-of-objects).
 
 ### HyperFormula version support
 

--- a/docs/content/guides/getting-started/demo.md
+++ b/docs/content/guides/getting-started/demo.md
@@ -2972,11 +2972,11 @@ console.log(`Handsontable: v${Handsontable.version} (${Handsontable.buildDate}) 
 
 ## Find the code on GitHub
 
-- [JavaScript demo app](https://github.com/handsontable/handsontable/tree/develop/examples/12.4.0/docs/js/demo/)
-- [TypeScript demo app](https://github.com/handsontable/handsontable/tree/develop/examples/12.4.0/docs/ts/demo/)
-- [Angular demo app](https://github.com/handsontable/handsontable/tree/develop/examples/12.4.0/docs/angular/demo/)
-- [React demo app](https://github.com/handsontable/handsontable/tree/develop/examples/12.4.0/docs/react/demo/)
-- [Vue demo app](https://github.com/handsontable/handsontable/tree/develop/examples/12.4.0/docs/vue/demo/)
+- [JavaScript demo app](https://github.com/handsontable/handsontable/tree/develop/examples/13.0.0/docs/js/demo/)
+- [TypeScript demo app](https://github.com/handsontable/handsontable/tree/develop/examples/13.0.0/docs/ts/demo/)
+- [Angular demo app](https://github.com/handsontable/handsontable/tree/develop/examples/13.0.0/docs/angular/demo/)
+- [React demo app](https://github.com/handsontable/handsontable/tree/develop/examples/13.0.0/docs/react/demo/)
+- [Vue demo app](https://github.com/handsontable/handsontable/tree/develop/examples/13.0.0/docs/vue/demo/)
 
 ## Try out the demo's features
 

--- a/docs/content/guides/getting-started/introduction.md
+++ b/docs/content/guides/getting-started/introduction.md
@@ -47,18 +47,15 @@ Thousands of business apps depend on Handsontable for entering, editing, validat
 
 To jump straight into the sample code, open the demo app at CodeSandbox:
 
-- [JavaScript demo](https://codesandbox.io/s/handsontable-javascript-data-grid-hello-world-app-12-4-0-qy4fks)
-- [React demo](https://codesandbox.io/s/handsontable-react-data-grid-hello-world-app-12-4-0-esczegs)
-- [Angular demo](https://codesandbox.io/s/handsontable-angular-data-grid-hello-world-app-12-4-0-5vgmo3)
-- [Vue 2 demo](https://codesandbox.io/s/handsontable-vue-data-grid-hello-world-app-12-4-0-0sqeye)
-- [TypeScript demo](https://codesandbox.io/s/handsontable-typescript-data-grid-hello-world-app-12-4-0-h4wjmd)
-
+- [JavaScript demo](https://codesandbox.io/s/handsontable-javascript-data-grid-hello-world-app-13-0-0-4skskh)
+- [React demo](https://codesandbox.io/s/handsontable-react-data-grid-hello-world-app-13-0-0-965nm6)
+- [Angular demo](https://codesandbox.io/s/handsontable-angular-data-grid-hello-world-app-13-0-0-49m644)
+- [Vue 2 demo](https://codesandbox.io/s/handsontable-vue-data-grid-hello-world-app-13-0-0-6czkyj)
+- [TypeScript demo](https://codesandbox.io/s/handsontable-typescript-data-grid-hello-world-app-13-0-0-tmvhv8)
 :::
 
 ::: only-for react
-
-To jump straight into the sample code, [open the demo app at CodeSandbox](https://codesandbox.io/s/handsontable-react-data-grid-hello-world-app-12-4-0-esczegs).
-
+To jump straight into the sample code, [open the demo app at CodeSandbox](https://codesandbox.io/s/handsontable-react-data-grid-hello-world-app-13-0-0-965nm6).
 :::
 
 Then, move on to [connecting](@/guides/getting-started/binding-to-data.md) your data and [configuring](@/guides/getting-started/configuration-options.md) Handsontable's built-in features. For more advanced implementations, use Handsontable's [API](@/api/introduction.md).

--- a/docs/content/guides/sidebar.js
+++ b/docs/content/guides/sidebar.js
@@ -173,6 +173,7 @@ const upgradeAndMigrationItems = [
   { path: 'guides/upgrade-and-migration/migrating-from-9.0-to-10.0' },
   { path: 'guides/upgrade-and-migration/migrating-from-10.0-to-11.0' },
   { path: 'guides/upgrade-and-migration/migrating-from-11.1-to-12.0' },
+  { path: 'guides/upgrade-and-migration/migrating-from-12.4-to-13.0' },
 ];
 
 module.exports = {

--- a/docs/content/guides/upgrade-and-migration/migrating-from-12.4-to-13.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-12.4-to-13.0.md
@@ -71,14 +71,8 @@ You can read more about this change on [our blog](https://handsontable.com/blog/
 #### Before
 
 ```js
-// insert a row below the last row
-handsontableInstance.alter('insert_row');
-
 // insert a row above row number 10
 handsontableInstance.alter('insert_row', 10);
-
-// insert a column after the last column
-handsontableInstance.alter('insert_col');
 
 // insert a column before column number 10
 handsontableInstance.alter('insert_col', 10);

--- a/docs/content/guides/upgrade-and-migration/migrating-from-12.4-to-13.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-12.4-to-13.0.md
@@ -27,7 +27,7 @@ If you're having any issues with Handsontable's [Angular wrapper](@/guides/integ
 
 ## Step 2: Stop using the `beforeAutofillInsidePopulate` hook
 
-Handsontable 13.0 removes the [`beforeAutofillInsidePopulate`](https://handsontable.com/docs/javascript-data-grid/api/hooks/#beforeautofillinsidepopulate) hook,
+Handsontable 13.0 removes the [`beforeAutofillInsidePopulate`](https://handsontable.com/docs/12.4/javascript-data-grid/api/hooks/#beforeautofillinsidepopulate) hook,
 which has been marked as deprecated since Handsontable [9.0.0](@/guides/upgrade-and-migration/release-notes.md#deprecated-3).
 
 Make sure you're not using this hook.
@@ -35,18 +35,18 @@ Make sure you're not using this hook.
 ## Step 3: Remove `direction` and `deltas` from your `populateFromArray()` calls
 
 The [`populateFromArray()`](@/api/core.md#populatefromarray) method no longer accepts `direction` and `deltas` arguments, as they were used only by the
-deprecated [`beforeAutofillInsidePopulate`](https://handsontable.com/docs/javascript-data-grid/api/hooks/#beforeautofillinsidepopulate) hook. Make sure that you
+deprecated [`beforeAutofillInsidePopulate`](https://handsontable.com/docs/12.4/javascript-data-grid/api/hooks/#beforeautofillinsidepopulate) hook. Make sure that you
 don't pass these arguments to [`populateFromArray()`](@/api/core.md#populatefromarray).
 
 ## Step 4: Change from `getFirstNotHiddenIndex()` to `getNearestNotHiddenIndex()`
 
-Handsontable 13.0 removes the [`getFirstNotHiddenIndex()`](https://handsontable.com/docs/javascript-data-grid/api/index-mapper/#getfirstnothiddenindex) method,
+Handsontable 13.0 removes the [`getFirstNotHiddenIndex()`](https://handsontable.com/docs/12.4/javascript-data-grid/api/index-mapper/#getfirstnothiddenindex) method,
 which has been marked as deprecated since Handsontable [12.1.0](@/guides/upgrade-and-migration/release-notes.md#deprecated-2). Instead , use the new
 [`getNearestNotHiddenIndex()`](@/api/indexMapper.md#getnearestnothiddenindex) method.
 
 For more details, see the API reference:
 
-- [`getFirstNotHiddenIndex()`](https://handsontable.com/docs/javascript-data-grid/api/index-mapper/#getfirstnothiddenindex)
+- [`getFirstNotHiddenIndex()`](https://handsontable.com/docs/12.4/javascript-data-grid/api/index-mapper/#getfirstnothiddenindex)
 - [`getNearestNotHiddenIndex()`](@/api/indexMapper.md#getnearestnothiddenindex)
 
 #### Before

--- a/docs/content/guides/upgrade-and-migration/migrating-from-12.4-to-13.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-12.4-to-13.0.md
@@ -18,4 +18,108 @@ Migrate from Handsontable 12.4 to Handsontable 13.0, released on June 22, 2023.
 
 [[toc]]
 
-## Step 1:
+## Step 1: Update to Angular 12 or higher
+
+Handsontable 13.0 requires Angular 12 or higher. If you're using an older version of Angular, you need to upgrade it.
+
+If you're having any issues with Handsontable's [Angular wrapper](@/guides/integrate-with-angular/angular-installation.md), contact our
+[technical support](https://handsontable.com/contact?category=technical_support) for help.
+
+## Step 2: Stop using `beforeAutofillInsidePopulate`
+
+Handsontable 13.0 removes the [`beforeAutofillInsidePopulate`](https://handsontable.com/docs/javascript-data-grid/api/hooks/#beforeautofillinsidepopulate) hook,
+which has been marked as deprecated ever since Handsontable [9.0.0](@/guides/upgrade-and-migration/release-notes.md#deprecated-3).
+
+Make sure you're not using this hook.
+
+## Step 3: Remove `direction` and `deltas` from your `populateFromArray()` calls
+
+The [`populateFromArray()`](@/api/core.md#populatefromarray) method no longer accepts `direction` and `deltas` arguments, as they were used only by the
+deprecated [`beforeAutofillInsidePopulate`](https://handsontable.com/docs/javascript-data-grid/api/hooks/#beforeautofillinsidepopulate) hook. Make sure that you
+don't pass these arguments to [`populateFromArray()`](@/api/core.md#populatefromarray).
+
+## Step 4: Instead of `getFirstNotHiddenIndex()`, use `getNearestNotHiddenIndex()`
+
+Handsontable 13.0 removes the [`getFirstNotHiddenIndex()`](https://handsontable.com/docs/javascript-data-grid/api/index-mapper/#getfirstnothiddenindex) method,
+which has been marked as deprecated since Handsontable [12.1.0](@/guides/upgrade-and-migration/release-notes.md#deprecated-2). Instead , use the new
+[`getNearestNotHiddenIndex()`](@/api/indexMapper.md#getnearestnothiddenindex) method.
+
+For more details, see the API reference:
+
+- [`getFirstNotHiddenIndex()`](https://handsontable.com/docs/javascript-data-grid/api/index-mapper/#getfirstnothiddenindex)
+- [`getNearestNotHiddenIndex()`](@/api/indexMapper.md#getnearestnothiddenindex)
+
+#### Before
+
+```js
+handsontableInstance.getFirstNotHiddenIndex(0, 1, true, 1);
+```
+
+#### After
+
+```js
+handsontableInstance.getNearestNotHiddenIndex(0, 1, true);
+```
+
+## Step 5: Replace `'insert_row'` and `'insert_col'` in your `alter()` calls
+
+The [`alter()`](@/api/core.md#alter) method no longer accepts `'insert_row'` and `'insert_col'` arguments, which have been marked as deprecated since
+Handsontable [12.2.0](@/guides/upgrade-and-migration/release-notes.md#deprecated).
+
+You can read more about this change on [our blog](https://handsontable.com/blog/handsontable-12.2.0).
+
+#### Before
+
+```js
+// insert a row below the last row
+handsontableInstance.alter('insert_row');
+
+// insert a row above row number 10
+handsontableInstance.alter('insert_row', 10);
+
+// insert a column after the last column
+handsontableInstance.alter('insert_col');
+
+// insert a column before column number 10
+handsontableInstance.alter('insert_col', 10);
+```
+
+#### After
+
+```js
+// insert a row below the last row
+handsontableInstance.alter('insert_row_below');
+
+// insert a row above row number 10
+handsontableInstance.alter('insert_row_above', 10);
+
+// insert a column after the last column
+handsontableInstance.alter('insert_col_end');
+
+// insert a column before column number 10
+handsontableInstance.alter('insert_col_start', 10);
+```
+
+## Step 6: The `beforeChange` hook is fired before the `afterSetDataAtCell` and `afterSetDataAtRowProp` hooks
+
+Handsontable 13.0 changes the order of execution for the following hooks:
+
+- [`beforeChange`](@/api/hooks.md#beforechange)
+- [`afterSetDataAtCell`](@/api/hooks.md#aftersetdataatcell)
+- [`afterSetDataAtRowProp`](@/api/hooks.md#aftersetdataatrowprop)
+
+For more details on this change, see this pull request: [#10231](https://github.com/handsontable/handsontable/pull/10231).
+
+#### Before
+
+Up to Handsontable 12.4, the hooks were fired in the following order:
+
+1. [`afterSetDataAtCell`](@/api/hooks.md#aftersetdataatcell) or [`afterSetDataAtRowProp`](@/api/hooks.md#aftersetdataatrowprop)
+2. [`beforeChange`](@/api/hooks.md#beforechange)
+
+#### After
+
+Since Handsontable 13.0, the hooks are fired in the following order:
+
+1. [`beforeChange`](@/api/hooks.md#beforechange)
+2. [`afterSetDataAtCell`](@/api/hooks.md#aftersetdataatcell) or [`afterSetDataAtRowProp`](@/api/hooks.md#aftersetdataatrowprop)

--- a/docs/content/guides/upgrade-and-migration/migrating-from-12.4-to-13.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-12.4-to-13.0.md
@@ -20,15 +20,15 @@ Migrate from Handsontable 12.4 to Handsontable 13.0, released on June 22, 2023.
 
 ## Step 1: Update to Angular 12 or higher
 
-Handsontable 13.0 requires Angular 12 or higher. If you're using an older version of Angular, you need to upgrade it.
+Handsontable 13.0 requires Angular 12 or higher. If you're using an older version of Angular, you need to update it.
 
 If you're having any issues with Handsontable's [Angular wrapper](@/guides/integrate-with-angular/angular-installation.md), contact our
 [technical support](https://handsontable.com/contact?category=technical_support) for help.
 
-## Step 2: Stop using `beforeAutofillInsidePopulate`
+## Step 2: Stop using the `beforeAutofillInsidePopulate` hook
 
 Handsontable 13.0 removes the [`beforeAutofillInsidePopulate`](https://handsontable.com/docs/javascript-data-grid/api/hooks/#beforeautofillinsidepopulate) hook,
-which has been marked as deprecated ever since Handsontable [9.0.0](@/guides/upgrade-and-migration/release-notes.md#deprecated-3).
+which has been marked as deprecated since Handsontable [9.0.0](@/guides/upgrade-and-migration/release-notes.md#deprecated-3).
 
 Make sure you're not using this hook.
 
@@ -38,7 +38,7 @@ The [`populateFromArray()`](@/api/core.md#populatefromarray) method no longer ac
 deprecated [`beforeAutofillInsidePopulate`](https://handsontable.com/docs/javascript-data-grid/api/hooks/#beforeautofillinsidepopulate) hook. Make sure that you
 don't pass these arguments to [`populateFromArray()`](@/api/core.md#populatefromarray).
 
-## Step 4: Instead of `getFirstNotHiddenIndex()`, use `getNearestNotHiddenIndex()`
+## Step 4: Change from `getFirstNotHiddenIndex()` to `getNearestNotHiddenIndex()`
 
 Handsontable 13.0 removes the [`getFirstNotHiddenIndex()`](https://handsontable.com/docs/javascript-data-grid/api/index-mapper/#getfirstnothiddenindex) method,
 which has been marked as deprecated since Handsontable [12.1.0](@/guides/upgrade-and-migration/release-notes.md#deprecated-2). Instead , use the new
@@ -100,7 +100,7 @@ handsontableInstance.alter('insert_col_end');
 handsontableInstance.alter('insert_col_start', 10);
 ```
 
-## Step 6: The `beforeChange` hook is fired before the `afterSetDataAtCell` and `afterSetDataAtRowProp` hooks
+## Step 6: The `beforeChange` hook is now fired before the `afterSetDataAtCell` and `afterSetDataAtRowProp` hooks
 
 Handsontable 13.0 changes the order of execution for the following hooks:
 

--- a/docs/content/guides/upgrade-and-migration/migrating-from-12.4-to-13.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-12.4-to-13.0.md
@@ -18,27 +18,31 @@ Migrate from Handsontable 12.4 to Handsontable 13.0, released on June 22, 2023.
 
 [[toc]]
 
-## Step 1: Update to Angular 12 or higher
+::: only-for javascript
+
+## Update to Angular 12 or higher
 
 Handsontable 13.0 requires Angular 12 or higher. If you're using an older version of Angular, you need to update it.
 
 If you're having any issues with Handsontable's [Angular wrapper](@/guides/integrate-with-angular/angular-installation.md), contact our
 [technical support](https://handsontable.com/contact?category=technical_support) for help.
 
-## Step 2: Stop using the `beforeAutofillInsidePopulate` hook
+:::
+
+## Stop using the `beforeAutofillInsidePopulate` hook
 
 Handsontable 13.0 removes the [`beforeAutofillInsidePopulate`](https://handsontable.com/docs/12.4/javascript-data-grid/api/hooks/#beforeautofillinsidepopulate) hook,
 which has been marked as deprecated since Handsontable [9.0.0](@/guides/upgrade-and-migration/release-notes.md#deprecated-3).
 
 Make sure you're not using this hook.
 
-## Step 3: Remove `direction` and `deltas` from your `populateFromArray()` calls
+## Remove `direction` and `deltas` from your `populateFromArray()` calls
 
 The [`populateFromArray()`](@/api/core.md#populatefromarray) method no longer accepts `direction` and `deltas` arguments, as they were used only by the
 deprecated [`beforeAutofillInsidePopulate`](https://handsontable.com/docs/12.4/javascript-data-grid/api/hooks/#beforeautofillinsidepopulate) hook. Make sure that you
 don't pass these arguments to [`populateFromArray()`](@/api/core.md#populatefromarray).
 
-## Step 4: Change from `getFirstNotHiddenIndex()` to `getNearestNotHiddenIndex()`
+## Change from `getFirstNotHiddenIndex()` to `getNearestNotHiddenIndex()`
 
 Handsontable 13.0 removes the [`getFirstNotHiddenIndex()`](https://handsontable.com/docs/12.4/javascript-data-grid/api/index-mapper/#getfirstnothiddenindex) method,
 which has been marked as deprecated since Handsontable [12.1.0](@/guides/upgrade-and-migration/release-notes.md#deprecated-2). Instead , use the new
@@ -61,7 +65,7 @@ handsontableInstance.getFirstNotHiddenIndex(0, 1, true, 1);
 handsontableInstance.getNearestNotHiddenIndex(0, 1, true);
 ```
 
-## Step 5: Replace `'insert_row'` and `'insert_col'` in your `alter()` calls
+## Replace `'insert_row'` and `'insert_col'` in your `alter()` calls
 
 The [`alter()`](@/api/core.md#alter) method no longer accepts `'insert_row'` and `'insert_col'` arguments, which have been marked as deprecated since
 Handsontable [12.2.0](@/guides/upgrade-and-migration/release-notes.md#deprecated).
@@ -94,7 +98,7 @@ handsontableInstance.alter('insert_col_end');
 handsontableInstance.alter('insert_col_start', 10);
 ```
 
-## Step 6: The `beforeChange` hook is now fired before the `afterSetDataAtCell` and `afterSetDataAtRowProp` hooks
+## The `beforeChange` hook is now fired before the `afterSetDataAtCell` and `afterSetDataAtRowProp` hooks
 
 Handsontable 13.0 changes the order of execution for the following hooks:
 

--- a/docs/content/guides/upgrade-and-migration/migrating-from-12.4-to-13.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-12.4-to-13.0.md
@@ -1,0 +1,21 @@
+---
+id: fgjqkigc
+title: Migrating from 12.4 to 13.0
+metaTitle: Migrate from 12.4 to 13.0 - JavaScript Data Grid | Handsontable
+description: Migrate from Handsontable 12.4 to Handsontable 13.0, released on June 22, 2023.
+permalink: /migration-from-12.4-to-13.0
+canonicalUrl: /migration-from-12.4-to-13.0
+pageClass: migration-guide
+react:
+  id: tvum3ibg
+  metaTitle: Migrate from 12.4 to 13.0 - React Data Grid | Handsontable
+searchCategory: Guides
+---
+
+# Migrate from 12.4 to 13.0
+
+Migrate from Handsontable 12.4 to Handsontable 13.0, released on June 22, 2023.
+
+[[toc]]
+
+## Step 1:

--- a/docs/content/guides/upgrade-and-migration/migrating-from-12.4-to-13.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-12.4-to-13.0.md
@@ -22,7 +22,7 @@ Migrate from Handsontable 12.4 to Handsontable 13.0, released on June 22, 2023.
 
 ## Update to Angular 12 or higher
 
-Handsontable 13.0 is no longer compatible with Angular 11 and lower.
+Handsontable 13.0 is not compatible with Angular 11 and lower.
 
 Officially, Handsontable 13.0 supports only Angular 14-16. Handsontable 13.0 was thoroughly tested and, to the best of our knowledge, works correctly with versions down to Angular 12, but this may change with no further notice.
 

--- a/docs/content/guides/upgrade-and-migration/migrating-from-12.4-to-13.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-12.4-to-13.0.md
@@ -22,7 +22,11 @@ Migrate from Handsontable 12.4 to Handsontable 13.0, released on June 22, 2023.
 
 ## Update to Angular 12 or higher
 
-Handsontable 13.0 requires Angular 12 or higher. If you're using an older version of Angular, you need to update it.
+Handsontable 13.0 is no longer compatible with Angular 11 and lower.
+
+Officially, Handsontable 13.0 supports only Angular 14-16. Handsontable 13.0 was thoroughly tested and, to the best of our knowledge, works correctly with versions down to Angular 12, but this may change with no further notice.
+
+To use Handsontable 13.0 with Angular, you need to update at least to Angular 12, but we recommend using the latest version of Angular.
 
 If you're having any issues with Handsontable's [Angular wrapper](@/guides/integrate-with-angular/angular-installation.md), contact our
 [technical support](https://handsontable.com/contact?category=technical_support) for help.

--- a/docs/content/guides/upgrade-and-migration/release-notes.md
+++ b/docs/content/guides/upgrade-and-migration/release-notes.md
@@ -47,8 +47,8 @@ For more information on this release, see:
 #### Removed
 
 - **Breaking change (Angular)**: Dropped support for Angular 13 and lower. From now on, Handsontable supports only those versions of Angular that are officially supported by the Angular team. Dropping Handsontable's support for any older Angular versions won't be treated as a breaking change. [#10396](https://github.com/handsontable/handsontable/pull/10396)
-- **Breaking change**: Removed the deprecated [`beforeAutofillInsidePopulate`](https://handsontable.com/docs/javascript-data-grid/api/hooks/#beforeautofillinsidepopulate) hook. [#10407](https://github.com/handsontable/handsontable/pull/10407)
-- **Breaking change**: Removed the deprecated [`getFirstNotHiddenIndex`](https://handsontable.com/docs/javascript-data-grid/api/index-mapper/#getfirstnothiddenindex) method. Instead, use the [`getNearestNotHiddenIndex()`](@/api/indexMapper.md#getnearestnothiddenindex) method. [#10407](https://github.com/handsontable/handsontable/pull/10407)
+- **Breaking change**: Removed the deprecated [`beforeAutofillInsidePopulate`](https://handsontable.com/docs/12.4/javascript-data-grid/api/hooks/#beforeautofillinsidepopulate) hook. [#10407](https://github.com/handsontable/handsontable/pull/10407)
+- **Breaking change**: Removed the deprecated [`getFirstNotHiddenIndex`](https://handsontable.com/docs/12.4/javascript-data-grid/api/index-mapper/#getfirstnothiddenindex) method. Instead, use the [`getNearestNotHiddenIndex()`](@/api/indexMapper.md#getnearestnothiddenindex) method. [#10407](https://github.com/handsontable/handsontable/pull/10407)
 - **Breaking change**: Removed the deprecated parameters of the [`alter()`](@/api/core.md#alter) method: `insert_row` and `insert_col`. Instead, use the following parameters: `insert_row_above`, `insert_row_below`, `insert_col_start`, and `insert_col_end`. [#10407](https://github.com/handsontable/handsontable/pull/10407)
 - **Breaking change**: Removed the deprecated parameters of the [`populateFromArray()`](@/api/core.md#populatefromarray) method: `direction` and `deltas`. [#10407](https://github.com/handsontable/handsontable/pull/10407)
 

--- a/docs/content/guides/upgrade-and-migration/release-notes.md
+++ b/docs/content/guides/upgrade-and-migration/release-notes.md
@@ -40,8 +40,8 @@ For more information on this release, see:
 
 #### Changed
 
-- **Breaking change**: Changed the order in which hooks are executed: now, the [`beforeChange`](@/api/hooks.md#beforechange) hook is fired before the [`afterSetDataAtCell`](@/api/hooks.md#aftersetdataatcell) and [`afterSetDataAtRowProp`](@/api/hooks.md#aftersetdataatrowprop) hooks. [#10231](https://github.com/handsontable/handsontable/pull/10231)
-- React, Angular, Vue 2, Vue 3: Changed Handsontable's policy toward supporting frameworks versions. From now on, Handsontable supports only those versions of Angular, React, and Vue that are officially supported by their respective teams. Dropping Handsontable's support for any older versions of the frameworks won't be treated as a breaking change. [#10396](https://github.com/handsontable/handsontable/pull/10396)
+- **Breaking change**: React, Angular, Vue 2, Vue 3: Changed Handsontable's policy toward older versions of supported frameworks. From now on, Handsontable supports only those versions of any supported frameworks that are officially supported by their respective teams. Dropping Handsontable's support for any older framework versions won't be treated as a breaking change. [#10396](https://github.com/handsontable/handsontable/pull/10396)
+- **Breaking change**: Changed the order in which three hooks are executed: now, the [`beforeChange`](@/api/hooks.md#beforechange) hook is fired before the [`afterSetDataAtCell`](@/api/hooks.md#aftersetdataatcell) and [`afterSetDataAtRowProp`](@/api/hooks.md#aftersetdataatrowprop) hooks. [#10231](https://github.com/handsontable/handsontable/pull/10231)
 - Changed the margins of the context menu in the RTL layout direction. [#10375](https://github.com/handsontable/handsontable/pull/10375)
 
 #### Removed

--- a/docs/content/guides/upgrade-and-migration/release-notes.md
+++ b/docs/content/guides/upgrade-and-migration/release-notes.md
@@ -34,17 +34,17 @@ For more information on this release, see:
 - [Documentation (13.0)](https://handsontable.com/docs/13.0)
 - [Migration guide (12.4 → 13.0)](@/guides/upgrade-and-migration/migrating-from-12.4-to-13.0.md)
 
-### Added
+#### Added
 
 - Angular: Added support for Angular 16. [#10396](https://github.com/handsontable/handsontable/pull/10396)
 
-### Changed
+#### Changed
 
 - **Breaking change**: Changed the order in which hooks are executed: now, the [`beforeChange`](@/api/hooks.md#beforechange) hook is fired before the [`afterSetDataAtCell`](@/api/hooks.md#aftersetdataatcell) and [`afterSetDataAtRowProp`](@/api/hooks.md#aftersetdataatrowprop) hooks. [#10231](https://github.com/handsontable/handsontable/pull/10231)
 - React, Angular, Vue 2, Vue 3: Changed Handsontable's policy toward supporting frameworks versions. From now on, Handsontable supports only those versions of Angular, React, and Vue that are officially supported by their respective teams. Dropping Handsontable's support for any older versions of the frameworks won't be treated as a breaking change. [#10396](https://github.com/handsontable/handsontable/pull/10396)
 - Changed the margins of the context menu in the RTL layout direction. [#10375](https://github.com/handsontable/handsontable/pull/10375)
 
-### Removed
+#### Removed
 
 - **Breaking change (Angular)**: Dropped support for Angular 13 and lower. From now on, Handsontable supports only those versions of Angular that are officially supported by the Angular team. Dropping Handsontable's support for any older Angular versions won't be treated as a breaking change. [#10396](https://github.com/handsontable/handsontable/pull/10396)
 - **Breaking change**: Removed the deprecated [`beforeAutofillInsidePopulate`](https://handsontable.com/docs/javascript-data-grid/api/hooks/#beforeautofillinsidepopulate) hook. [#10407](https://github.com/handsontable/handsontable/pull/10407)
@@ -52,7 +52,7 @@ For more information on this release, see:
 - **Breaking change**: Removed the deprecated parameters of the [`alter()`](@/api/core.md#alter) method: `insert_row` and `insert_col`. Instead, use the following parameters: `insert_row_above`, `insert_row_below`, `insert_col_start`, and `insert_col_end`. [#10407](https://github.com/handsontable/handsontable/pull/10407)
 - **Breaking change**: Removed the deprecated parameters of the [`populateFromArray()`](@/api/core.md#populatefromarray) method: `direction` and `deltas`. [#10407](https://github.com/handsontable/handsontable/pull/10407)
 
-### Fixed
+#### Fixed
 
 - Fixed an issue where the "Read only" icon of the context menu displayed incorrectly in the RTL layout direction. [#10375](https://github.com/handsontable/handsontable/pull/10375)
 

--- a/docs/content/guides/upgrade-and-migration/release-notes.md
+++ b/docs/content/guides/upgrade-and-migration/release-notes.md
@@ -40,7 +40,7 @@ For more information on this release, see:
 
 #### Changed
 
-- **Breaking change**: React, Angular, Vue 2, Vue 3: Changed Handsontable's policy toward older versions of supported frameworks. From now on, Handsontable supports only those versions of any supported frameworks that are officially supported by their respective teams. Dropping Handsontable's support for any older framework versions won't be treated as a breaking change. [#10396](https://github.com/handsontable/handsontable/pull/10396)
+- **Breaking change (React, Angular, Vue 2, Vue 3)**: Changed Handsontable's policy toward older versions of supported frameworks. From now on, Handsontable supports only those versions of any supported frameworks that are officially supported by their respective teams. Dropping Handsontable's support for any older framework versions won't be treated as a breaking change. [#10396](https://github.com/handsontable/handsontable/pull/10396)
 - **Breaking change**: Changed the order in which three hooks are executed: now, the [`beforeChange`](@/api/hooks.md#beforechange) hook is fired before the [`afterSetDataAtCell`](@/api/hooks.md#aftersetdataatcell) and [`afterSetDataAtRowProp`](@/api/hooks.md#aftersetdataatrowprop) hooks. [#10231](https://github.com/handsontable/handsontable/pull/10231)
 - Changed the margins of the context menu in the RTL layout direction. [#10375](https://github.com/handsontable/handsontable/pull/10375)
 

--- a/docs/content/guides/upgrade-and-migration/release-notes.md
+++ b/docs/content/guides/upgrade-and-migration/release-notes.md
@@ -46,7 +46,7 @@ For more information on this release, see:
 
 #### Removed
 
-- **Breaking change (Angular)**: Dropped support for Angular 13 and lower. From now on, Handsontable supports only those versions of Angular that are officially supported by the Angular team. Dropping Handsontable's support for any older Angular versions won't be treated as a breaking change. [#10396](https://github.com/handsontable/handsontable/pull/10396)
+- **Breaking change (Angular)**: Dropped support for Angular 13 and lower. From now on, Handsontable supports only those versions of Angular that are officially supported by the Angular team: currently, it's 14-16. However, Handsontable 13.0.0 was thoroughly tested and, to the best of our knowledge, works correctly with versions down to Angular 12. [#10396](https://github.com/handsontable/handsontable/pull/10396)
 - **Breaking change**: Removed the deprecated [`beforeAutofillInsidePopulate`](https://handsontable.com/docs/12.4/javascript-data-grid/api/hooks/#beforeautofillinsidepopulate) hook. [#10407](https://github.com/handsontable/handsontable/pull/10407)
 - **Breaking change**: Removed the deprecated [`getFirstNotHiddenIndex`](https://handsontable.com/docs/12.4/javascript-data-grid/api/index-mapper/#getfirstnothiddenindex) method. Instead, use the [`getNearestNotHiddenIndex()`](@/api/indexMapper.md#getnearestnothiddenindex) method. [#10407](https://github.com/handsontable/handsontable/pull/10407)
 - **Breaking change**: Removed the deprecated parameters of the [`alter()`](@/api/core.md#alter) method: `insert_row` and `insert_col`. Instead, use the following parameters: `insert_row_above`, `insert_row_below`, `insert_col_start`, and `insert_col_end`. [#10407](https://github.com/handsontable/handsontable/pull/10407)

--- a/docs/content/guides/upgrade-and-migration/release-notes.md
+++ b/docs/content/guides/upgrade-and-migration/release-notes.md
@@ -30,7 +30,7 @@ Released on June 22, 2023.
 
 For more information on this release, see:
 
-- [Blog post (13.4.0)](PLACEHOLDER)
+- [Blog post (13.0.0)](PLACEHOLDER)
 - [Documentation (13.0)](https://handsontable.com/docs/13.0)
 - [Migration guide (12.4 → 13.0)](@/guides/upgrade-and-migration/migrating-from-12.4-to-13.0.md)
 

--- a/docs/content/guides/upgrade-and-migration/release-notes.md
+++ b/docs/content/guides/upgrade-and-migration/release-notes.md
@@ -24,6 +24,38 @@ See the full history of changes made to Handsontable in each major, minor, and p
 
 [[toc]]
 
+## 13.0.0
+
+Released on June 22, 2023.
+
+For more information on this release, see:
+
+- [Blog post (13.4.0)](PLACEHOLDER)
+- [Documentation (13.0)](https://handsontable.com/docs/13.0)
+- [Migration guide (12.4 → 13.0)](@/guides/upgrade-and-migration/migrating-from-12.4-to-13.0.md)
+
+### Added
+
+- Angular: Added support for Angular 16. [#10396](https://github.com/handsontable/handsontable/pull/10396)
+
+### Changed
+
+- **Breaking change**: Changed the order in which hooks are executed: now, the [`beforeChange`](@/api/hooks.md#beforechange) hook is fired before the [`afterSetDataAtCell`](@/api/hooks.md#aftersetdataatcell) and [`afterSetDataAtRowProp`](@/api/hooks.md#aftersetdataatrowprop) hooks. [#10231](https://github.com/handsontable/handsontable/pull/10231)
+- React, Angular, Vue 2, Vue 3: Changed Handsontable's policy toward supporting frameworks versions. From now on, Handsontable supports only those versions of Angular, React, and Vue that are officially supported by their respective teams. Dropping Handsontable's support for any older versions of the frameworks won't be treated as a breaking change. [#10396](https://github.com/handsontable/handsontable/pull/10396)
+- Changed the margins of the context menu in the RTL layout direction. [#10375](https://github.com/handsontable/handsontable/pull/10375)
+
+### Removed
+
+- **Breaking change (Angular)**: Dropped support for Angular 13 and lower. From now on, Handsontable supports only those versions of Angular that are officially supported by the Angular team. Dropping Handsontable's support for any older Angular versions won't be treated as a breaking change. [#10396](https://github.com/handsontable/handsontable/pull/10396)
+- **Breaking change**: Removed the deprecated [`beforeAutofillInsidePopulate`](https://handsontable.com/docs/javascript-data-grid/api/hooks/#beforeautofillinsidepopulate) hook. [#10407](https://github.com/handsontable/handsontable/pull/10407)
+- **Breaking change**: Removed the deprecated [`getFirstNotHiddenIndex`](https://handsontable.com/docs/javascript-data-grid/api/index-mapper/#getfirstnothiddenindex) method. Instead, use the [`getNearestNotHiddenIndex()`](@/api/indexMapper.md#getnearestnothiddenindex) method. [#10407](https://github.com/handsontable/handsontable/pull/10407)
+- **Breaking change**: Removed the deprecated parameters of the [`alter()`](@/api/core.md#alter) method: `insert_row` and `insert_col`. Instead, use the following parameters: `insert_row_above`, `insert_row_below`, `insert_col_start`, and `insert_col_end`. [#10407](https://github.com/handsontable/handsontable/pull/10407)
+- **Breaking change**: Removed the deprecated parameters of the [`populateFromArray()`](@/api/core.md#populatefromarray) method: `direction` and `deltas`. [#10407](https://github.com/handsontable/handsontable/pull/10407)
+
+### Fixed
+
+- Fixed an issue where the "Read only" icon of the context menu displayed incorrectly in the RTL layout direction. [#10375](https://github.com/handsontable/handsontable/pull/10375)
+
 ## 12.4.0
 
 Released on May 23, 2023.


### PR DESCRIPTION
This PR:
- Adds a new migration guide: [Migrate from 12.4 to 13.0](http://localhost:8080/docs/javascript-data-grid/migration-from-12.4-to-13.0/)
- Edits the 13.0 changelog entries
- Adds 13.0 release notes
- Makes other minor changes

[skip changelog]