### PR TITLE
Add support for new keyboard shortcut that allows scrolling the viewport

### DIFF
--- a/.changelogs/10419.json
+++ b/.changelogs/10419.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Added support for new keyboard shortcut that allows scrolling the viewport",
+  "type": "added",
+  "issueOrPR": 10419,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/shortcutContexts/commands/index.js
+++ b/handsontable/src/shortcutContexts/commands/index.js
@@ -2,6 +2,7 @@ import { getAllCommands as getAllEditorCommands } from './editor';
 import { getAllCommands as getAllSelectionExtendCommands } from './extendCellsSelection';
 import { getAllCommands as getAllSelectionMoveCommands } from './moveCellSelection';
 import { command as emptySelectedCells } from './emptySelectedCells';
+import { command as scrollToFocusedCell } from './scrollToFocusedCell';
 import { command as selectAll } from './selectAll';
 import { command as populateSelectedCellsData } from './populateSelectedCellsData';
 
@@ -10,6 +11,7 @@ const allCommands = [
   ...getAllSelectionExtendCommands(),
   ...getAllSelectionMoveCommands(),
   emptySelectedCells,
+  scrollToFocusedCell,
   selectAll,
   populateSelectedCellsData,
 ];

--- a/handsontable/src/shortcutContexts/commands/scrollToFocusedCell.js
+++ b/handsontable/src/shortcutContexts/commands/scrollToFocusedCell.js
@@ -1,0 +1,33 @@
+export const command = {
+  name: 'scrollToFocusedCell',
+  callback(hot) {
+    const { highlight } = hot.getSelectedRangeLast();
+    const firstVisibleRow = hot.view.getFirstFullyVisibleRow() - 1;
+    const firstVisibleColumn = hot.view.getFirstFullyVisibleColumn() - 1;
+    const lastVisibleRow = hot.view.getLastFullyVisibleRow() + 1;
+    const lastVisibleColumn = hot.view.getLastFullyVisibleColumn() + 1;
+
+    const visibleCoordsFrom = hot._createCellCoords(firstVisibleRow, firstVisibleColumn);
+    const visibleCoordsTo = hot._createCellCoords(lastVisibleRow, lastVisibleColumn);
+    const visibleRange = hot._createCellRange(visibleCoordsFrom, visibleCoordsFrom, visibleCoordsTo);
+
+    if (!visibleRange.includes(highlight) && (highlight.row >= 0 || highlight.col >= 0)) {
+      const offsetRows = Math.floor(hot.countVisibleRows() / 2);
+      const offsetColumns = Math.floor(hot.countVisibleCols() / 2);
+      const scrollX = Math.max(highlight.row - offsetRows, 0);
+      const scrollY = Math.max(highlight.col - offsetColumns, 0);
+      const scrollCoords = [scrollX, scrollY];
+
+      // for row header focus do not change the scroll Y position, leave as it is
+      if (highlight.col < 0) {
+        scrollCoords[1] = null;
+
+      // for column header focus do not change the scroll X position, leave as it is
+      } else if (highlight.row < 0) {
+        scrollCoords[0] = null;
+      }
+
+      hot.scrollViewportTo(...scrollCoords);
+    }
+  },
+};

--- a/handsontable/src/shortcutContexts/grid.js
+++ b/handsontable/src/shortcutContexts/grid.js
@@ -154,5 +154,8 @@ export function shortcutsGridContext(hot) {
   }, {
     keys: [['Shift', 'Tab']],
     callback: () => commandsPool.moveCellSelectionInlineEnd(),
+  }, {
+    keys: [['Control/Meta', 'Backspace']],
+    callback: () => commandsPool.scrollToFocusedCell(),
   }], config);
 }

--- a/handsontable/test/e2e/keyboardShortcuts/viewportScroll.spec.js
+++ b/handsontable/test/e2e/keyboardShortcuts/viewportScroll.spec.js
@@ -1,0 +1,338 @@
+describe('Core viewport scroll keyboard shortcuts', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  function getCurrentScrollPosition() {
+    return {
+      x: hot().view._wt.wtOverlays.inlineStartOverlay.getScrollPosition(),
+      y: hot().view._wt.wtOverlays.topOverlay.getScrollPosition(),
+    };
+  }
+
+  describe('"Ctrl/Cmd + Backspace"', () => {
+    it('should not scroll the viewport when the focused cell is already in the viewport (focus is placed on the top-left position)', () => {
+      handsontable({
+        data: createSpreadsheetData(100, 50),
+        width: 370,
+        height: 300,
+      });
+
+      selectCell(0, 0);
+      // move the viewport to position that the focused cell is partially visible
+      scrollViewportTo(12, 7, true, true);
+
+      const scrollPosition = getCurrentScrollPosition();
+
+      expect(scrollPosition).toEqual({ x: 45, y: 15 });
+
+      keyDownUp(['control/meta', 'backspace']);
+
+      expect(getCurrentScrollPosition()).toEqual(scrollPosition);
+    });
+
+    it('should not scroll the viewport when the focused cell is already in the viewport (focus is placed on the top-right position)', () => {
+      handsontable({
+        data: createSpreadsheetData(100, 50),
+        width: 370,
+        height: 300,
+      });
+
+      selectCell(0, 7);
+      // move the viewport to position that the focused cell is partially visible
+      scrollViewportTo(0, 0, true, true);
+
+      const scrollPosition = getCurrentScrollPosition();
+
+      expect(scrollPosition).toEqual({ x: 0, y: 0 });
+
+      keyDownUp(['control/meta', 'backspace']);
+
+      expect(getCurrentScrollPosition()).toEqual(scrollPosition);
+    });
+
+    it('should not scroll the viewport when the focused cell is already in the viewport (focus is placed on the bottom-right position)', () => {
+      handsontable({
+        data: createSpreadsheetData(100, 50),
+        width: 370,
+        height: 300,
+      });
+
+      selectCell(12, 7);
+      // move the viewport to position that the focused cell is partially visible
+      scrollViewportTo(0, 0, true, true);
+
+      const scrollPosition = getCurrentScrollPosition();
+
+      expect(scrollPosition).toEqual({ x: 0, y: 0 });
+
+      keyDownUp(['control/meta', 'backspace']);
+
+      expect(getCurrentScrollPosition()).toEqual(scrollPosition);
+    });
+
+    it('should not scroll the viewport when the focused cell is already in the viewport (focus is placed on the bottom-left position)', () => {
+      handsontable({
+        data: createSpreadsheetData(100, 50),
+        width: 370,
+        height: 300,
+      });
+
+      selectCell(12, 0);
+      // move the viewport to position that the focused cell is partially visible
+      scrollViewportTo(0, 7, true, true);
+
+      const scrollPosition = getCurrentScrollPosition();
+
+      expect(scrollPosition).toEqual({ x: 45, y: 0 });
+
+      keyDownUp(['control/meta', 'backspace']);
+
+      expect(getCurrentScrollPosition()).toEqual(scrollPosition);
+    });
+
+    it('should scroll the viewport down to the focused cell', async() => {
+      handsontable({
+        data: createSpreadsheetData(100, 50),
+        width: 370,
+        height: 300,
+      });
+
+      selectCell(90, 1);
+      scrollViewportTo(0, 0, true, true);
+
+      await sleep(100);
+
+      keyDownUp(['control/meta', 'backspace']);
+
+      expect(getCurrentScrollPosition()).toEqual({ x: 0, y: 1932 });
+    });
+
+    it('should scroll the viewport right to the focused cell', async() => {
+      handsontable({
+        data: createSpreadsheetData(100, 50),
+        width: 370,
+        height: 300,
+      });
+
+      selectCell(1, 40);
+      scrollViewportTo(0, 0, true, true);
+
+      await sleep(100);
+
+      keyDownUp(['control/meta', 'backspace']);
+
+      expect(getCurrentScrollPosition()).toEqual({ x: 1850, y: 0 });
+    });
+
+    it('should scroll the viewport left to the focused cell', async() => {
+      handsontable({
+        data: createSpreadsheetData(100, 50),
+        width: 370,
+        height: 300,
+      });
+
+      selectCell(1, 10);
+      scrollViewportTo(99, 49, true, true);
+
+      await sleep(100);
+
+      keyDownUp(['control/meta', 'backspace']);
+
+      expect(getCurrentScrollPosition()).toEqual({ x: 350, y: 0 });
+    });
+
+    it('should scroll the viewport up to the focused cell', async() => {
+      handsontable({
+        data: createSpreadsheetData(100, 50),
+        width: 370,
+        height: 300,
+      });
+
+      selectCell(10, 1);
+      scrollViewportTo(99, 0, true, true);
+
+      await sleep(100);
+
+      keyDownUp(['control/meta', 'backspace']);
+
+      expect(getCurrentScrollPosition()).toEqual({ x: 0, y: 92 });
+    });
+
+    it('should scroll the viewport to the focused cell by positioning the viewport in the center of the cell', async() => {
+      handsontable({
+        data: createSpreadsheetData(100, 50),
+        width: 370,
+        height: 300,
+      });
+
+      selectCell(50, 25);
+      scrollViewportTo(0, 0, true, true);
+
+      await sleep(100);
+
+      keyDownUp(['control/meta', 'backspace']);
+
+      expect(getCurrentScrollPosition()).toEqual({ x: 1100, y: 1012 });
+    });
+
+    it('should scroll the viewport horizontally only when the column header is focused', async() => {
+      handsontable({
+        data: createSpreadsheetData(100, 50),
+        width: 370,
+        height: 300,
+        rowHeaders: true,
+        colHeaders: true,
+        navigableHeaders: true,
+      });
+
+      selectCell(-1, 25);
+      scrollViewportTo(90, 1, true, true);
+
+      await sleep(100);
+
+      keyDownUp(['control/meta', 'backspace']);
+
+      expect(getCurrentScrollPosition()).toEqual({ x: 1100, y: 1835 });
+    });
+
+    it('should scroll the viewport horizontally when the column header is focused and all rows are trimmed', async() => {
+      handsontable({
+        data: createSpreadsheetData(1, 50),
+        width: 370,
+        height: 300,
+        rowHeaders: true,
+        colHeaders: true,
+        navigableHeaders: true,
+      });
+
+      rowIndexMapper().createAndRegisterIndexMap('my-trimming-map', 'trimming', true);
+      render();
+
+      selectCell(-1, 25, -1, 25, false);
+
+      await sleep(100);
+
+      keyDownUp(['control/meta', 'backspace']);
+
+      expect(getCurrentScrollPosition()).toEqual({ x: 1100, y: 0 });
+    });
+
+    it('should scroll the viewport horizontally when the column header is focused and all rows are hidden', async() => {
+      handsontable({
+        data: createSpreadsheetData(1, 50),
+        width: 370,
+        height: 300,
+        rowHeaders: true,
+        colHeaders: true,
+        navigableHeaders: true,
+      });
+
+      rowIndexMapper().createAndRegisterIndexMap('my-trimming-map', 'hiding', true);
+      render();
+
+      selectCell(-1, 25, -1, 25, false);
+
+      await sleep(100);
+
+      keyDownUp(['control/meta', 'backspace']);
+
+      expect(getCurrentScrollPosition()).toEqual({ x: 1100, y: 0 });
+    });
+
+    it('should scroll the viewport vertically only when the row header is focused', async() => {
+      handsontable({
+        data: createSpreadsheetData(100, 50),
+        width: 370,
+        height: 300,
+        rowHeaders: true,
+        colHeaders: true,
+        navigableHeaders: true,
+      });
+
+      selectCell(50, -1);
+      scrollViewportTo(1, 40, true, true);
+
+      await sleep(100);
+
+      keyDownUp(['control/meta', 'backspace']);
+
+      expect(getCurrentScrollPosition()).toEqual({ x: 1745, y: 1035 });
+    });
+
+    it('should scroll the viewport vertically when the row header is focused and all columns are trimmed', async() => {
+      handsontable({
+        data: createSpreadsheetData(100, 1),
+        width: 370,
+        height: 300,
+        rowHeaders: true,
+        colHeaders: true,
+        navigableHeaders: true,
+      });
+
+      columnIndexMapper().createAndRegisterIndexMap('my-trimming-map', 'trimming', true);
+      render();
+
+      selectCell(50, -1, 50, -1, false);
+
+      await sleep(100);
+
+      keyDownUp(['control/meta', 'backspace']);
+
+      expect(getCurrentScrollPosition()).toEqual({ x: 0, y: 1035 });
+    });
+
+    it('should scroll the viewport vertically when the row header is focused and all columns are hidden', async() => {
+      handsontable({
+        data: createSpreadsheetData(100, 1),
+        width: 370,
+        height: 300,
+        rowHeaders: true,
+        colHeaders: true,
+        navigableHeaders: true,
+      });
+
+      columnIndexMapper().createAndRegisterIndexMap('my-trimming-map', 'hiding', true);
+      render();
+
+      selectCell(50, -1, 50, -1, false);
+
+      await sleep(100);
+
+      keyDownUp(['control/meta', 'backspace']);
+
+      expect(getCurrentScrollPosition()).toEqual({ x: 0, y: 1035 });
+    });
+
+    it('should not scroll the viewport when corner is focused', async() => {
+      handsontable({
+        data: createSpreadsheetData(100, 50),
+        width: 370,
+        height: 300,
+        rowHeaders: true,
+        colHeaders: true,
+        navigableHeaders: true,
+      });
+
+      selectCell(-1, -1);
+      scrollViewportTo(50, 25, true, true);
+
+      await sleep(100);
+
+      expect(getCurrentScrollPosition()).toEqual({ x: 995, y: 915 });
+
+      keyDownUp(['control/meta', 'backspace']);
+
+      expect(getCurrentScrollPosition()).toEqual({ x: 995, y: 915 });
+    });
+  });
+});


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adds support for a new keyboard shortcut that allows scrolling the table viewport to the focused cell.

### Expected working new keyboard shortcuts
 - <kbd>Cmd/Ctrl</kbd>+<kbd>Backspace</kbd> Scroll the table viewport to the focused cell. The viewport is always scrolled to the cell in a way that it's positioned right in the middle of the table.

Viewport scroll to the focused cell:
![Kapture 2023-06-20 at 15 06 13](https://github.com/handsontable/handsontable/assets/571316/a9cacfb4-8d74-4374-a771-d0f6a7c75a25)

When the column header is focused, the viewport is only scrolled horizontally, keeping the scroll Y position untouched:
![Kapture 2023-06-20 at 15 08 30](https://github.com/handsontable/handsontable/assets/571316/cd9fd5c5-a341-4fce-bff8-acb8545ced99)

When the row header is focused, the viewport is only scrolled vertically, keeping the scroll X position untouched:
![Kapture 2023-06-20 at 15 09 44](https://github.com/handsontable/handsontable/assets/571316/02fba994-e7cf-48b7-8759-e41361033198)

When the corner is selected, the keyboard shortcut is inactive:
![Kapture 2023-06-20 at 15 10 43](https://github.com/handsontable/handsontable/assets/571316/5aafc5f6-a462-491e-99f2-df6b432ae1f6)

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally, and I covered the feature with new E2E tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1371

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
