### PR TITLE
Post-`13.0.0`-release corrections.

### DIFF
--- a/examples/13.0.0/docs/angular-12/demo/angular.json
+++ b/examples/13.0.0/docs/angular-12/demo/angular.json
@@ -27,7 +27,7 @@
             "tsConfig": "tsconfig.app.json",
             "aot": true,
             "styles": [
-              "../node_modules/handsontable/dist/handsontable.full.css"
+              "node_modules/handsontable/dist/handsontable.full.css"
             ],
             "scripts": [],
             "preserveSymlinks": true,

--- a/examples/13.0.0/docs/angular-13/demo/angular.json
+++ b/examples/13.0.0/docs/angular-13/demo/angular.json
@@ -27,7 +27,7 @@
             "tsConfig": "tsconfig.app.json",
             "aot": true,
             "styles": [
-              "../node_modules/handsontable/dist/handsontable.full.css"
+              "node_modules/handsontable/dist/handsontable.full.css"
             ],
             "scripts": [],
             "preserveSymlinks": true,

--- a/examples/13.0.0/docs/angular-14/demo/angular.json
+++ b/examples/13.0.0/docs/angular-14/demo/angular.json
@@ -27,7 +27,7 @@
             "tsConfig": "tsconfig.app.json",
             "aot": true,
             "styles": [
-              "../node_modules/handsontable/dist/handsontable.full.css"
+              "node_modules/handsontable/dist/handsontable.full.css"
             ],
             "scripts": [],
             "preserveSymlinks": true,

--- a/examples/13.0.0/docs/angular-15/demo/angular.json
+++ b/examples/13.0.0/docs/angular-15/demo/angular.json
@@ -27,7 +27,7 @@
             "tsConfig": "tsconfig.app.json",
             "aot": true,
             "styles": [
-              "../node_modules/handsontable/dist/handsontable.full.css"
+              "node_modules/handsontable/dist/handsontable.full.css"
             ],
             "scripts": [],
             "preserveSymlinks": true,

--- a/examples/13.0.0/docs/angular-16/demo/angular.json
+++ b/examples/13.0.0/docs/angular-16/demo/angular.json
@@ -27,7 +27,7 @@
             "tsConfig": "tsconfig.app.json",
             "aot": true,
             "styles": [
-              "../node_modules/handsontable/dist/handsontable.full.css"
+              "node_modules/handsontable/dist/handsontable.full.css"
             ],
             "scripts": [],
             "preserveSymlinks": true,

--- a/examples/13.0.0/docs/angular-next/demo/angular.json
+++ b/examples/13.0.0/docs/angular-next/demo/angular.json
@@ -27,7 +27,7 @@
             "tsConfig": "tsconfig.app.json",
             "aot": true,
             "styles": [
-              "../node_modules/handsontable/dist/handsontable.full.css"
+              "node_modules/handsontable/dist/handsontable.full.css"
             ],
             "scripts": [],
             "preserveSymlinks": true,

--- a/examples/13.0.0/docs/angular/demo/angular.json
+++ b/examples/13.0.0/docs/angular/demo/angular.json
@@ -27,7 +27,7 @@
             "tsConfig": "tsconfig.app.json",
             "aot": true,
             "styles": [
-              "../node_modules/handsontable/dist/handsontable.full.css"
+              "node_modules/handsontable/dist/handsontable.full.css"
             ],
             "scripts": [],
             "preserveSymlinks": true,

--- a/examples/13.0.0/docs/angular/package-lock.json
+++ b/examples/13.0.0/docs/angular/package-lock.json
@@ -1,19 +1,19 @@
 {
-  "name": "examples-angular",
-  "version": "0.0.0",
+  "name": "examples-angular-13.0.0",
+  "version": "13.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "examples-angular",
-      "version": "0.0.0",
+      "name": "examples-angular-13.0.0",
+      "version": "13.0.0",
       "workspaces": [
         "@(!(node_modules))/"
       ]
     },
     "basic-example": {
       "name": "angular-basic-example",
-      "version": "0.0.0",
+      "version": "13.0.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@angular/animations": "latest",
@@ -24,8 +24,8 @@
         "@angular/platform-browser": "latest",
         "@angular/platform-browser-dynamic": "latest",
         "@angular/router": "latest",
-        "@handsontable/angular": "latest",
-        "handsontable": "latest",
+        "@handsontable/angular": "13.0.0",
+        "handsontable": "13.0.0",
         "rxjs": "6.6.7",
         "tslib": "2.1.0",
         "zone.js": "0.13.0"
@@ -45,9 +45,50 @@
         "typescript": "4.9.3"
       }
     },
+    "basic-example/node_modules/@handsontable/angular": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@handsontable/angular/-/angular-13.0.0.tgz",
+      "integrity": "sha512-wbka5xCFdD9gdtceu7UuVac+0I4zg5RDlK/u6vv9ACmrgPbYTkR5W/KqhG2FLmpUfICGEqV1cyzmQRavdQH1UQ==",
+      "optionalDependencies": {
+        "tslib": "^2.2.0"
+      },
+      "peerDependencies": {
+        "@angular/animations": ">=12.0.0",
+        "@angular/common": ">=12.0.0",
+        "@angular/compiler": ">=12.0.0",
+        "@angular/core": ">=12.0.0",
+        "@angular/forms": ">=12.0.0",
+        "@angular/platform-browser": ">=12.0.0",
+        "@angular/platform-browser-dynamic": ">=12.0.0",
+        "@angular/router": ">=12.0.0",
+        "handsontable": "^13.0.0"
+      }
+    },
+    "basic-example/node_modules/@handsontable/angular/node_modules/tslib": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
+      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+      "optional": true
+    },
+    "basic-example/node_modules/handsontable": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/handsontable/-/handsontable-13.0.0.tgz",
+      "integrity": "sha512-qjfUQCJCeD5OJbUnXpEaruJJ8MfI2/yZI6q0wAGd+85tCAcpknJODR9FqRHpcTrKf+Mc9HO/CJ6qBAJHiXSrhA==",
+      "dependencies": {
+        "@types/pikaday": "1.7.4",
+        "core-js": "^3.0.0",
+        "dompurify": "^2.1.1",
+        "moment": "2.29.4",
+        "numbro": "2.1.2",
+        "pikaday": "1.8.2"
+      },
+      "optionalDependencies": {
+        "hyperformula": "^2.4.0"
+      }
+    },
     "demo": {
       "name": "angular-demo",
-      "version": "0.0.0",
+      "version": "13.0.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@angular/animations": "latest",
@@ -58,8 +99,8 @@
         "@angular/platform-browser": "latest",
         "@angular/platform-browser-dynamic": "latest",
         "@angular/router": "latest",
-        "@handsontable/angular": "latest",
-        "handsontable": "latest",
+        "@handsontable/angular": "13.0.0",
+        "handsontable": "13.0.0",
         "rxjs": "6.6.7",
         "tslib": "2.1.0",
         "zone.js": "0.13.0"
@@ -77,6 +118,47 @@
         "puppeteer": "14.3.0",
         "ts-node": "8.3.0",
         "typescript": "4.9.3"
+      }
+    },
+    "demo/node_modules/@handsontable/angular": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@handsontable/angular/-/angular-13.0.0.tgz",
+      "integrity": "sha512-wbka5xCFdD9gdtceu7UuVac+0I4zg5RDlK/u6vv9ACmrgPbYTkR5W/KqhG2FLmpUfICGEqV1cyzmQRavdQH1UQ==",
+      "optionalDependencies": {
+        "tslib": "^2.2.0"
+      },
+      "peerDependencies": {
+        "@angular/animations": ">=12.0.0",
+        "@angular/common": ">=12.0.0",
+        "@angular/compiler": ">=12.0.0",
+        "@angular/core": ">=12.0.0",
+        "@angular/forms": ">=12.0.0",
+        "@angular/platform-browser": ">=12.0.0",
+        "@angular/platform-browser-dynamic": ">=12.0.0",
+        "@angular/router": ">=12.0.0",
+        "handsontable": "^13.0.0"
+      }
+    },
+    "demo/node_modules/@handsontable/angular/node_modules/tslib": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
+      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+      "optional": true
+    },
+    "demo/node_modules/handsontable": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/handsontable/-/handsontable-13.0.0.tgz",
+      "integrity": "sha512-qjfUQCJCeD5OJbUnXpEaruJJ8MfI2/yZI6q0wAGd+85tCAcpknJODR9FqRHpcTrKf+Mc9HO/CJ6qBAJHiXSrhA==",
+      "dependencies": {
+        "@types/pikaday": "1.7.4",
+        "core-js": "^3.0.0",
+        "dompurify": "^2.1.1",
+        "moment": "2.29.4",
+        "numbro": "2.1.2",
+        "pikaday": "1.8.2"
+      },
+      "optionalDependencies": {
+        "hyperformula": "^2.4.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3156,31 +3238,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/@handsontable/angular": {
-      "version": "12.4.0",
-      "resolved": "https://registry.npmjs.org/@handsontable/angular/-/angular-12.4.0.tgz",
-      "integrity": "sha512-QWJlHSahIuWaYS58RQC5jWupNOC+ooFCvoe39TbDPwtd3rSzgyFHj5Le+DOHmD3TFVDaLiVqzy6Ah7QU4IcbQQ==",
-      "optionalDependencies": {
-        "tslib": "^1.10.0"
-      },
-      "peerDependencies": {
-        "@angular/animations": ">=9.0.0",
-        "@angular/common": ">=9.0.0",
-        "@angular/compiler": ">=9.0.0",
-        "@angular/core": ">=9.0.0",
-        "@angular/forms": ">=9.0.0",
-        "@angular/platform-browser": ">=9.0.0",
-        "@angular/platform-browser-dynamic": ">=9.0.0",
-        "@angular/router": ">=9.0.0",
-        "handsontable": "^12.0.0"
-      }
-    },
-    "node_modules/@handsontable/angular/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "optional": true
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -6452,22 +6509,6 @@
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
       "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
       "dev": true
-    },
-    "node_modules/handsontable": {
-      "version": "12.4.0",
-      "resolved": "https://registry.npmjs.org/handsontable/-/handsontable-12.4.0.tgz",
-      "integrity": "sha512-bivyvW41RKT3SNIo+f2SOgvV376NbtTkfWYYRCSTOW/bx6EnjH4S2Pl4vfVpFPRQLOFPGTEWniuXLg8b1VkpBQ==",
-      "dependencies": {
-        "@types/pikaday": "1.7.4",
-        "core-js": "^3.0.0",
-        "dompurify": "^2.1.1",
-        "moment": "2.29.4",
-        "numbro": "2.1.2",
-        "pikaday": "1.8.2"
-      },
-      "optionalDependencies": {
-        "hyperformula": "^2.4.0"
-      }
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -14041,22 +14082,6 @@
       "dev": true,
       "optional": true
     },
-    "@handsontable/angular": {
-      "version": "12.4.0",
-      "resolved": "https://registry.npmjs.org/@handsontable/angular/-/angular-12.4.0.tgz",
-      "integrity": "sha512-QWJlHSahIuWaYS58RQC5jWupNOC+ooFCvoe39TbDPwtd3rSzgyFHj5Le+DOHmD3TFVDaLiVqzy6Ah7QU4IcbQQ==",
-      "requires": {
-        "tslib": "^1.10.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "optional": true
-        }
-      }
-    },
     "@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -14913,10 +14938,10 @@
         "@angular/platform-browser-dynamic": "latest",
         "@angular/router": "latest",
         "@angular/service-worker": "latest",
-        "@handsontable/angular": "latest",
+        "@handsontable/angular": "13.0.0",
         "@types/jasmine": "3.6.9",
         "@types/node": "12.20.7",
-        "handsontable": "latest",
+        "handsontable": "13.0.0",
         "jasmine": "3.7.0",
         "jasmine-console-reporter": "3.1.0",
         "puppeteer": "14.3.0",
@@ -14925,6 +14950,38 @@
         "tslib": "2.1.0",
         "typescript": "4.9.3",
         "zone.js": "0.13.0"
+      },
+      "dependencies": {
+        "@handsontable/angular": {
+          "version": "13.0.0",
+          "resolved": "https://registry.npmjs.org/@handsontable/angular/-/angular-13.0.0.tgz",
+          "integrity": "sha512-wbka5xCFdD9gdtceu7UuVac+0I4zg5RDlK/u6vv9ACmrgPbYTkR5W/KqhG2FLmpUfICGEqV1cyzmQRavdQH1UQ==",
+          "requires": {
+            "tslib": "^2.2.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "2.5.3",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
+              "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+              "optional": true
+            }
+          }
+        },
+        "handsontable": {
+          "version": "13.0.0",
+          "resolved": "https://registry.npmjs.org/handsontable/-/handsontable-13.0.0.tgz",
+          "integrity": "sha512-qjfUQCJCeD5OJbUnXpEaruJJ8MfI2/yZI6q0wAGd+85tCAcpknJODR9FqRHpcTrKf+Mc9HO/CJ6qBAJHiXSrhA==",
+          "requires": {
+            "@types/pikaday": "1.7.4",
+            "core-js": "^3.0.0",
+            "dompurify": "^2.1.1",
+            "hyperformula": "^2.4.0",
+            "moment": "2.29.4",
+            "numbro": "2.1.2",
+            "pikaday": "1.8.2"
+          }
+        }
       }
     },
     "angular-demo": {
@@ -14943,10 +15000,10 @@
         "@angular/platform-browser-dynamic": "latest",
         "@angular/router": "latest",
         "@angular/service-worker": "latest",
-        "@handsontable/angular": "latest",
+        "@handsontable/angular": "13.0.0",
         "@types/jasmine": "3.6.9",
         "@types/node": "12.20.7",
-        "handsontable": "latest",
+        "handsontable": "13.0.0",
         "jasmine": "3.7.0",
         "jasmine-console-reporter": "3.1.0",
         "puppeteer": "14.3.0",
@@ -14955,6 +15012,38 @@
         "tslib": "2.1.0",
         "typescript": "4.9.3",
         "zone.js": "0.13.0"
+      },
+      "dependencies": {
+        "@handsontable/angular": {
+          "version": "13.0.0",
+          "resolved": "https://registry.npmjs.org/@handsontable/angular/-/angular-13.0.0.tgz",
+          "integrity": "sha512-wbka5xCFdD9gdtceu7UuVac+0I4zg5RDlK/u6vv9ACmrgPbYTkR5W/KqhG2FLmpUfICGEqV1cyzmQRavdQH1UQ==",
+          "requires": {
+            "tslib": "^2.2.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "2.5.3",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
+              "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+              "optional": true
+            }
+          }
+        },
+        "handsontable": {
+          "version": "13.0.0",
+          "resolved": "https://registry.npmjs.org/handsontable/-/handsontable-13.0.0.tgz",
+          "integrity": "sha512-qjfUQCJCeD5OJbUnXpEaruJJ8MfI2/yZI6q0wAGd+85tCAcpknJODR9FqRHpcTrKf+Mc9HO/CJ6qBAJHiXSrhA==",
+          "requires": {
+            "@types/pikaday": "1.7.4",
+            "core-js": "^3.0.0",
+            "dompurify": "^2.1.1",
+            "hyperformula": "^2.4.0",
+            "moment": "2.29.4",
+            "numbro": "2.1.2",
+            "pikaday": "1.8.2"
+          }
+        }
       }
     },
     "ansi-colors": {
@@ -16659,20 +16748,6 @@
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
       "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
       "dev": true
-    },
-    "handsontable": {
-      "version": "12.4.0",
-      "resolved": "https://registry.npmjs.org/handsontable/-/handsontable-12.4.0.tgz",
-      "integrity": "sha512-bivyvW41RKT3SNIo+f2SOgvV376NbtTkfWYYRCSTOW/bx6EnjH4S2Pl4vfVpFPRQLOFPGTEWniuXLg8b1VkpBQ==",
-      "requires": {
-        "@types/pikaday": "1.7.4",
-        "core-js": "^3.0.0",
-        "dompurify": "^2.1.1",
-        "hyperformula": "^2.4.0",
-        "moment": "2.29.4",
-        "numbro": "2.1.2",
-        "pikaday": "1.8.2"
-      }
     },
     "has": {
       "version": "1.0.3",

--- a/examples/next/docs/angular-12/demo/angular.json
+++ b/examples/next/docs/angular-12/demo/angular.json
@@ -27,7 +27,7 @@
             "tsConfig": "tsconfig.app.json",
             "aot": true,
             "styles": [
-              "../node_modules/handsontable/dist/handsontable.full.css"
+              "node_modules/handsontable/dist/handsontable.full.css"
             ],
             "scripts": [],
             "preserveSymlinks": true,

--- a/examples/next/docs/angular-13/demo/angular.json
+++ b/examples/next/docs/angular-13/demo/angular.json
@@ -27,7 +27,7 @@
             "tsConfig": "tsconfig.app.json",
             "aot": true,
             "styles": [
-              "../node_modules/handsontable/dist/handsontable.full.css"
+              "node_modules/handsontable/dist/handsontable.full.css"
             ],
             "scripts": [],
             "preserveSymlinks": true,

--- a/examples/next/docs/angular-14/demo/angular.json
+++ b/examples/next/docs/angular-14/demo/angular.json
@@ -27,7 +27,7 @@
             "tsConfig": "tsconfig.app.json",
             "aot": true,
             "styles": [
-              "../node_modules/handsontable/dist/handsontable.full.css"
+              "node_modules/handsontable/dist/handsontable.full.css"
             ],
             "scripts": [],
             "preserveSymlinks": true,

--- a/examples/next/docs/angular-15/demo/angular.json
+++ b/examples/next/docs/angular-15/demo/angular.json
@@ -27,7 +27,7 @@
             "tsConfig": "tsconfig.app.json",
             "aot": true,
             "styles": [
-              "../node_modules/handsontable/dist/handsontable.full.css"
+              "node_modules/handsontable/dist/handsontable.full.css"
             ],
             "scripts": [],
             "preserveSymlinks": true,

--- a/examples/next/docs/angular-16/demo/angular.json
+++ b/examples/next/docs/angular-16/demo/angular.json
@@ -27,7 +27,7 @@
             "tsConfig": "tsconfig.app.json",
             "aot": true,
             "styles": [
-              "../node_modules/handsontable/dist/handsontable.full.css"
+              "node_modules/handsontable/dist/handsontable.full.css"
             ],
             "scripts": [],
             "preserveSymlinks": true,

--- a/examples/next/docs/angular-next/demo/angular.json
+++ b/examples/next/docs/angular-next/demo/angular.json
@@ -27,7 +27,7 @@
             "tsConfig": "tsconfig.app.json",
             "aot": true,
             "styles": [
-              "../node_modules/handsontable/dist/handsontable.full.css"
+              "node_modules/handsontable/dist/handsontable.full.css"
             ],
             "scripts": [],
             "preserveSymlinks": true,

--- a/examples/next/docs/angular/demo/angular.json
+++ b/examples/next/docs/angular/demo/angular.json
@@ -27,7 +27,7 @@
             "tsConfig": "tsconfig.app.json",
             "aot": true,
             "styles": [
-              "../node_modules/handsontable/dist/handsontable.full.css"
+              "node_modules/handsontable/dist/handsontable.full.css"
             ],
             "scripts": [],
             "preserveSymlinks": true,

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -83,12 +83,6 @@ displaySeparator();
       // Create a new branch based on the git tag (not `develop` branch). Thanks to that, the docs
       // branch will not contain the code changes made between freeze and release.
       await spawnProcess(`git checkout -b ${docsVersion} ${releaseVersion}`);
-      // Remove "/content/api/" entry from the ./docs/.gitignore file so generated API
-      // docs can be committed to the branch.
-      await execa.command('cat ./.gitignore | grep -v "^/content/api/$" | tee .gitignore', {
-        cwd: 'docs',
-        shell: true,
-      });
 
       const linesCount = parseInt((await execa.command('wc -l < .gitignore', {
         cwd: 'docs',


### PR DESCRIPTION
### Context
This PR should:
- fix the failing `Code Examples Deployment` workflow: https://github.com/handsontable/handsontable/actions/runs/5344732941
- fix a problem with the release script, which failed during the release of `13.0.0`

### How has this been tested?
- Manually tested some of the angular example builds with `13.0.0`
- Manually removed the problematic section of the release script during the `13.0.0` release.
