### PR TITLE
Remove 'getFirstNotHiddenIndex' leftovers from the type definitions.

### DIFF
--- a/handsontable/types/translations/indexMapper.d.ts
+++ b/handsontable/types/translations/indexMapper.d.ts
@@ -28,8 +28,6 @@ export class IndexMapper {
   getVisualFromPhysicalIndex(physicalIndex: number): number;
   getVisualFromRenderableIndex(renderableIndex: number): number;
   getRenderableFromVisualIndex(visualIndex: number): number;
-  getFirstNotHiddenIndex(fromVisualIndex: number, incrementBy: number,
-    searchAlsoOtherWayAround?: boolean, indexForNextSearch?: number): number | null;
   getNearestNotHiddenIndex(fromVisualIndex: number, searchDirection: 1|-1,
     searchAlsoOtherWayAround?: boolean): number | null;
   initToLength(length?: number): void;


### PR DESCRIPTION
### Context
The PR removes `getFirstNotHiddenIndex` from the type definitions - it was left there by mistake, should've been removed in #10407

[skip changelog]
