### PR TITLE
Mark an internal prop of the React wrapper's base editor component as optional.

### DIFF
--- a/.changelogs/10429.json
+++ b/.changelogs/10429.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Mark an internal prop of the React wrapper's base editor component as optional.",
+  "type": "fixed",
+  "issueOrPR": 10429,
+  "breaking": false,
+  "framework": "react"
+}

--- a/wrappers/react/src/baseEditorComponent.tsx
+++ b/wrappers/react/src/baseEditorComponent.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import Handsontable from 'handsontable/base';
-import { HotEditorProps } from './types';
+import { EditorScopeIdentifier, HotEditorProps } from './types';
 
 interface BaseEditorProps extends HotEditorProps {
-  editorColumnScope: number;
-  emitEditorInstance?: (editor: BaseEditorComponent, column: number) => void,
+  editorColumnScope?: EditorScopeIdentifier;
+  emitEditorInstance?: (editor: BaseEditorComponent, column: EditorScopeIdentifier) => void,
 }
 
 class BaseEditorComponent<P = {}, S = {}, SS = any> extends React.Component<P & BaseEditorProps, S, SS> implements Handsontable.editors.BaseEditor {

--- a/wrappers/react/src/helpers.tsx
+++ b/wrappers/react/src/helpers.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {
+  EditorScopeIdentifier,
   HotEditorCache,
   HotEditorElement
 } from './types';
@@ -104,15 +105,15 @@ export function createEditorPortal(doc: Document = document, editorElement: HotE
 }
 
 /**
- * Get an editor element extended with a instance-emitting method.
+ * Get an editor element extended with an instance-emitting method.
  *
  * @param {React.ReactNode} children Component children.
  * @param {Map} editorCache Component's editor cache.
- * @param {string|number} [editorColumnScope] The editor scope (column index or a 'global' string). Defaults to
+ * @param {EditorScopeIdentifier} [editorColumnScope] The editor scope (column index or a 'global' string). Defaults to
  * 'global'.
  * @returns {React.ReactElement} An editor element containing the additional methods.
  */
-export function getExtendedEditorElement(children: React.ReactNode, editorCache: HotEditorCache, editorColumnScope: string | number = GLOBAL_EDITOR_SCOPE): React.ReactElement | null {
+export function getExtendedEditorElement(children: React.ReactNode, editorCache: HotEditorCache, editorColumnScope: EditorScopeIdentifier = GLOBAL_EDITOR_SCOPE): React.ReactElement | null {
   const editorElement = getChildElementByType(children, 'hot-editor');
   const editorClass = getOriginalEditorClass(editorElement);
 


### PR DESCRIPTION
### Context

As pointed out by @samsullivan in https://github.com/handsontable/handsontable/pull/10263#discussion_r1242555846, the React wrapper's internal `editorColumnScope` prop should be marked as optional.

This PR:
- Marks the `editorColumnScope` in the base editor component as optional.
- Makes the `editorColumnScope` types more precise.

### How has this been tested?
Tested manually + automatically.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [x] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
