### PR TITLE
Fixed a bug that prevented extending an already extended selection

### DIFF
--- a/handsontable/src/selection/__tests__/keyboardShortcuts/selectionExtending.spec.js
+++ b/handsontable/src/selection/__tests__/keyboardShortcuts/selectionExtending.spec.js
@@ -1,8 +1,6 @@
 describe('Selection extending', () => {
-  const id = 'testContainer';
-
   beforeEach(function() {
-    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+    this.$container = $('<div id="testContainer"></div>').appendTo('body');
   });
 
   afterEach(function() {
@@ -194,6 +192,50 @@ describe('Selection extending', () => {
         |===:===:===:===:===:===|
       `).toBeMatchToSelectionPattern();
       expect(getSelectedRange()).toEqualCellRange(['highlight: -1,1 from: -1,1 to: 4,4']);
+    });
+
+    it('should extend the selection done by Cmd+Shift+ArrowUp to the right', () => {
+      handsontable({
+        data: createSpreadsheetData(3, 3),
+        rowHeaders: true,
+        colHeaders: true,
+        navigableHeaders: true,
+      });
+
+      selectCell(1, 1);
+      keyDownUp(['control/meta', 'shift', 'arrowup']);
+      keyDownUp(['control/meta', 'shift', 'arrowright']);
+
+      expect(`
+        |   ║   : - : - |
+        |===:===:===:===|
+        | - ║   : 0 : 0 |
+        | - ║   : A : 0 |
+        |   ║   :   :   |
+      `).toBeMatchToSelectionPattern();
+      expect(getSelectedRange()).toEqualCellRange(['highlight: 1,1 from: 1,1 to: 0,2']);
+    });
+
+    it('should extend the selection done by Cmd+Shift+ArrowDown to the right', () => {
+      handsontable({
+        data: createSpreadsheetData(3, 3),
+        rowHeaders: true,
+        colHeaders: true,
+        navigableHeaders: true,
+      });
+
+      selectCell(1, 1);
+      keyDownUp(['control/meta', 'shift', 'arrowdown']);
+      keyDownUp(['control/meta', 'shift', 'arrowright']);
+
+      expect(`
+        |   ║   : - : - |
+        |===:===:===:===|
+        |   ║   :   :   |
+        | - ║   : A : 0 |
+        | - ║   : 0 : 0 |
+      `).toBeMatchToSelectionPattern();
+      expect(getSelectedRange()).toEqualCellRange(['highlight: 1,1 from: 1,1 to: 2,2']);
     });
 
     it('should not change the selection when row header is selected', () => {
@@ -786,6 +828,50 @@ describe('Selection extending', () => {
         |===:===:===:===:===:===|
       `).toBeMatchToSelectionPattern();
       expect(getSelectedRange()).toEqualCellRange(['highlight: -1,3 from: -1,3 to: 4,0']);
+    });
+
+    it('should extend the selection done by Cmd+Shift+ArrowUp to the left', () => {
+      handsontable({
+        data: createSpreadsheetData(3, 3),
+        rowHeaders: true,
+        colHeaders: true,
+        navigableHeaders: true,
+      });
+
+      selectCell(1, 1);
+      keyDownUp(['control/meta', 'shift', 'arrowup']);
+      keyDownUp(['control/meta', 'shift', 'arrowleft']);
+
+      expect(`
+        |   ║ - : - :   |
+        |===:===:===:===|
+        | - ║ 0 : 0 :   |
+        | - ║ 0 : A :   |
+        |   ║   :   :   |
+      `).toBeMatchToSelectionPattern();
+      expect(getSelectedRange()).toEqualCellRange(['highlight: 1,1 from: 1,1 to: 0,0']);
+    });
+
+    it('should extend the selection done by Cmd+Shift+ArrowDown to the left', () => {
+      handsontable({
+        data: createSpreadsheetData(3, 3),
+        rowHeaders: true,
+        colHeaders: true,
+        navigableHeaders: true,
+      });
+
+      selectCell(1, 1);
+      keyDownUp(['control/meta', 'shift', 'arrowdown']);
+      keyDownUp(['control/meta', 'shift', 'arrowleft']);
+
+      expect(`
+        |   ║ - : - :   |
+        |===:===:===:===|
+        |   ║   :   :   |
+        | - ║ 0 : A :   |
+        | - ║ 0 : 0 :   |
+      `).toBeMatchToSelectionPattern();
+      expect(getSelectedRange()).toEqualCellRange(['highlight: 1,1 from: 1,1 to: 2,0']);
     });
 
     it('should not change the selection when row header is selected', () => {
@@ -1385,6 +1471,50 @@ describe('Selection extending', () => {
         |   |
       `).toBeMatchToSelectionPattern();
       expect(getSelectedRange()).toEqualCellRange(['highlight: 3,-1 from: 3,-1 to: 0,4']);
+    });
+
+    it('should extend the selection done by Cmd+Shift+ArrowRight to the top', () => {
+      handsontable({
+        data: createSpreadsheetData(3, 3),
+        rowHeaders: true,
+        colHeaders: true,
+        navigableHeaders: true,
+      });
+
+      selectCell(1, 1);
+      keyDownUp(['control/meta', 'shift', 'arrowright']);
+      keyDownUp(['control/meta', 'shift', 'arrowup']);
+
+      expect(`
+        |   ║   : - : - |
+        |===:===:===:===|
+        | - ║   : 0 : 0 |
+        | - ║   : A : 0 |
+        |   ║   :   :   |
+      `).toBeMatchToSelectionPattern();
+      expect(getSelectedRange()).toEqualCellRange(['highlight: 1,1 from: 1,1 to: 0,2']);
+    });
+
+    it('should extend the selection done by Cmd+Shift+ArrowLeft to the top', () => {
+      handsontable({
+        data: createSpreadsheetData(3, 3),
+        rowHeaders: true,
+        colHeaders: true,
+        navigableHeaders: true,
+      });
+
+      selectCell(1, 1);
+      keyDownUp(['control/meta', 'shift', 'arrowleft']);
+      keyDownUp(['control/meta', 'shift', 'arrowup']);
+
+      expect(`
+        |   ║ - : - :   |
+        |===:===:===:===|
+        | - ║ 0 : 0 :   |
+        | - ║ 0 : A :   |
+        |   ║   :   :   |
+      `).toBeMatchToSelectionPattern();
+      expect(getSelectedRange()).toEqualCellRange(['highlight: 1,1 from: 1,1 to: 0,0']);
     });
 
     it('should not change the selection when column header is selected', () => {
@@ -1991,6 +2121,50 @@ describe('Selection extending', () => {
         | * |
       `).toBeMatchToSelectionPattern();
       expect(getSelectedRange()).toEqualCellRange(['highlight: 1,-1 from: 1,-1 to: 4,4']);
+    });
+
+    it('should extend the selection done by Cmd+Shift+ArrowRight to the bottom', () => {
+      handsontable({
+        data: createSpreadsheetData(3, 3),
+        rowHeaders: true,
+        colHeaders: true,
+        navigableHeaders: true,
+      });
+
+      selectCell(1, 1);
+      keyDownUp(['control/meta', 'shift', 'arrowright']);
+      keyDownUp(['control/meta', 'shift', 'arrowdown']);
+
+      expect(`
+        |   ║   : - : - |
+        |===:===:===:===|
+        |   ║   :   :   |
+        | - ║   : A : 0 |
+        | - ║   : 0 : 0 |
+      `).toBeMatchToSelectionPattern();
+      expect(getSelectedRange()).toEqualCellRange(['highlight: 1,1 from: 1,1 to: 2,2']);
+    });
+
+    it('should extend the selection done by Cmd+Shift+ArrowLeft to the bottom', () => {
+      handsontable({
+        data: createSpreadsheetData(3, 3),
+        rowHeaders: true,
+        colHeaders: true,
+        navigableHeaders: true,
+      });
+
+      selectCell(1, 1);
+      keyDownUp(['control/meta', 'shift', 'arrowleft']);
+      keyDownUp(['control/meta', 'shift', 'arrowdown']);
+
+      expect(`
+        |   ║ - : - :   |
+        |===:===:===:===|
+        |   ║   :   :   |
+        | - ║ 0 : A :   |
+        | - ║ 0 : 0 :   |
+      `).toBeMatchToSelectionPattern();
+      expect(getSelectedRange()).toEqualCellRange(['highlight: 1,1 from: 1,1 to: 2,0']);
     });
 
     it('should not change the selection when column header is selected', () => {

--- a/handsontable/src/shortcutContexts/commands/extendCellsSelection/toMostBottom.js
+++ b/handsontable/src/shortcutContexts/commands/extendCellsSelection/toMostBottom.js
@@ -3,12 +3,18 @@ export const command = {
   callback(hot) {
     const { selection, rowIndexMapper } = hot;
     const { highlight, from, to } = hot.getSelectedRangeLast();
+    const isFocusHighlightedByHeader = highlight.isHeader() && hot.selection.isSelectedByRowHeader();
 
-    if (highlight.isCell() || highlight.isHeader() && hot.selection.isSelectedByRowHeader()) {
+    if (highlight.isCell() || isFocusHighlightedByHeader) {
       const row = rowIndexMapper.getNearestNotHiddenIndex(hot.countRows() - 1, -1);
 
       selection.setRangeStart(from.clone());
-      selection.selectedByRowHeader.add(selection.getLayerLevel());
+
+      // Restore the row highlight by header flag after setting up a new selection.
+      if (isFocusHighlightedByHeader) {
+        selection.selectedByRowHeader.add(selection.getLayerLevel());
+      }
+
       selection.setRangeEnd(hot._createCellCoords(row, to.col));
     }
   },

--- a/handsontable/src/shortcutContexts/commands/extendCellsSelection/toMostLeft.js
+++ b/handsontable/src/shortcutContexts/commands/extendCellsSelection/toMostLeft.js
@@ -3,14 +3,20 @@ export const command = {
   callback(hot) {
     const { selection, columnIndexMapper } = hot;
     const { highlight, from, to } = hot.getSelectedRangeLast();
+    const isFocusHighlightedByHeader = highlight.isHeader() && hot.selection.isSelectedByColumnHeader();
 
-    if (highlight.isCell() || highlight.isHeader() && hot.selection.isSelectedByColumnHeader()) {
+    if (highlight.isCell() || isFocusHighlightedByHeader) {
       const column = columnIndexMapper.getNearestNotHiddenIndex(
         ...(hot.isRtl() ? [hot.countCols() - 1, -1] : [0, 1])
       );
 
       selection.setRangeStart(from.clone());
-      selection.selectedByColumnHeader.add(selection.getLayerLevel());
+
+      // Restore the column highlight by header flag after setting up a new selection.
+      if (isFocusHighlightedByHeader) {
+        selection.selectedByColumnHeader.add(selection.getLayerLevel());
+      }
+
       selection.setRangeEnd(hot._createCellCoords(to.row, column));
     }
   },

--- a/handsontable/src/shortcutContexts/commands/extendCellsSelection/toMostRight.js
+++ b/handsontable/src/shortcutContexts/commands/extendCellsSelection/toMostRight.js
@@ -3,14 +3,20 @@ export const command = {
   callback(hot) {
     const { selection, columnIndexMapper } = hot;
     const { highlight, from, to } = hot.getSelectedRangeLast();
+    const isFocusHighlightedByHeader = highlight.isHeader() && hot.selection.isSelectedByColumnHeader();
 
-    if (highlight.isCell() || highlight.isHeader() && hot.selection.isSelectedByColumnHeader()) {
+    if (highlight.isCell() || isFocusHighlightedByHeader) {
       const column = columnIndexMapper.getNearestNotHiddenIndex(
         ...(hot.isRtl() ? [0, 1] : [hot.countCols() - 1, -1])
       );
 
       selection.setRangeStart(from.clone());
-      selection.selectedByColumnHeader.add(selection.getLayerLevel());
+
+      // Restore the column highlight by header flag after setting up a new selection.
+      if (isFocusHighlightedByHeader) {
+        selection.selectedByColumnHeader.add(selection.getLayerLevel());
+      }
+
       selection.setRangeEnd(hot._createCellCoords(to.row, column));
     }
   },

--- a/handsontable/src/shortcutContexts/commands/extendCellsSelection/toMostTop.js
+++ b/handsontable/src/shortcutContexts/commands/extendCellsSelection/toMostTop.js
@@ -3,12 +3,18 @@ export const command = {
   callback(hot) {
     const { selection, rowIndexMapper } = hot;
     const { highlight, from, to } = hot.getSelectedRangeLast();
+    const isFocusHighlightedByHeader = highlight.isHeader() && hot.selection.isSelectedByRowHeader();
 
-    if (highlight.isCell() || highlight.isHeader() && hot.selection.isSelectedByRowHeader()) {
+    if (highlight.isCell() || isFocusHighlightedByHeader) {
       const row = rowIndexMapper.getNearestNotHiddenIndex(0, 1);
 
       selection.setRangeStart(from.clone());
-      selection.selectedByRowHeader.add(selection.getLayerLevel());
+
+      // Restore the row highlight by header flag after setting up a new selection.
+      if (isFocusHighlightedByHeader) {
+        selection.selectedByRowHeader.add(selection.getLayerLevel());
+      }
+
       selection.setRangeEnd(hot._createCellCoords(row, to.col));
     }
   },


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes a regression bug that disallows expanding the selection that was already expanded. 

_There is no changelog necessary as the bug did not have a chance to appear on the production build (release). It was caught on the unreleased epic branch._

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and I covered the fix with new tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1382

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
