### PR TITLE
Fix typo in CopyPaste plugin copy argument method

### DIFF
--- a/.changelogs/10446.json
+++ b/.changelogs/10446.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed a typo in the CopyPaste copy argument method.",
+  "type": "fixed",
+  "issueOrPR": 10446,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/copyPaste/copyPaste.js
+++ b/handsontable/src/plugins/copyPaste/copyPaste.js
@@ -145,10 +145,10 @@ export class CopyPaste extends BasePlugin {
    * Defines the data range to copy. Possible values:
    *  * `'cells-only'` Copy selected cells only;
    *  * `'column-headers-only'` Copy column headers only;
-   *  * `'with-all-column-headers'` Copy cells with all column headers;
+   *  * `'with-column-group-headers'` Copy cells with all column headers;
    *  * `'with-column-headers'` Copy cells with column headers;
    *
-   * @type {'cells-only' | 'column-headers-only' | 'with-all-column-headers' | 'with-column-headers'}
+   * @type {'cells-only' | 'column-headers-only' | 'with-column-group-headers' | 'with-column-headers'}
    */
   #copyMode = 'cells-only';
   /**
@@ -268,12 +268,12 @@ export class CopyPaste extends BasePlugin {
    *
    * Takes an optional parameter (`copyMode`) that defines the scope of copying:
    *
-   * | `copyMode` value            | Description                                                     |
-   * | --------------------------- | --------------------------------------------------------------- |
-   * | `'cells-only'` (default)    | Copy the selected cells                                         |
-   * | `'with-column-headers'`     | - Copy the selected cells<br>- Copy the nearest column headers  |
-   * | `'with-all-column-headers'` | - Copy the selected cells<br>- Copy all related columns headers |
-   * | `'column-headers-only'`     | Copy the nearest column headers (without copying cells)         |
+   * | `copyMode` value              | Description                                                     |
+   * | ----------------------------- | --------------------------------------------------------------- |
+   * | `'cells-only'` (default)      | Copy the selected cells                                         |
+   * | `'with-column-headers'`       | - Copy the selected cells<br>- Copy the nearest column headers  |
+   * | `'with-column-group-headers'` | - Copy the selected cells<br>- Copy all related columns headers |
+   * | `'column-headers-only'`       | Copy the nearest column headers (without copying cells)         |
    *
    * @param {string} [copyMode='cells-only'] Copy mode.
    */


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes a typo in _CopyPaste_ copy plugin method argument.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the Docs locally to check the changes.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1320

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
