### PR TITLE
Makes the selection handlers always on top of the table

### DIFF
--- a/.changelogs/10447.json
+++ b/.changelogs/10447.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixes the selection handlers (mobile) that disappear below the headers for multiple cells selection.",
+  "type": "fixed",
+  "issueOrPR": 10447,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/css/mobile.handsontable.scss
+++ b/handsontable/src/css/mobile.handsontable.scss
@@ -23,11 +23,6 @@
   -webkit-appearance: none;
 }
 
-.topSelectionHandle:not(.ht_master .topSelectionHandle),
-.topSelectionHandle-HitArea:not(.ht_master .topSelectionHandle-HitArea) {
-  z-index: 9999;
-}
-
 /* Initial left/top coordinates - overwritten when actual position is set */
 .handsontable .topSelectionHandle,
 .handsontable .topSelectionHandle-HitArea,
@@ -36,6 +31,7 @@
   inset-inline-start: -10000px;
   inset-inline-end: unset;
   top: -10000px;
+  z-index: 9999;
 }
 
 .handsontable.hide-tween {

--- a/handsontable/src/plugins/multipleSelectionHandles/__tests__/mobile/positioning.spec.js
+++ b/handsontable/src/plugins/multipleSelectionHandles/__tests__/mobile/positioning.spec.js
@@ -40,6 +40,8 @@ describe('MultipleSelectionHandles', () => {
 
       expect(topSelectionHandle.is(':visible')).toBe(true);
       expect(bottomSelectionHandle.is(':visible')).toBe(true);
+      expect(topSelectionHandle.css('z-index')).toBe('9999');
+      expect(bottomSelectionHandle.css('z-index')).toBe('9999');
       expect(topSelectionHandle.offset()).toEqual({
         top: cellOffset.top - topSelectionHandleSize,
         left: cellOffset.left - topSelectionHandleSize,
@@ -84,6 +86,8 @@ describe('MultipleSelectionHandles', () => {
 
       expect(topSelectionHandle.is(':visible')).toBe(true);
       expect(bottomSelectionHandle.is(':visible')).toBe(true);
+      expect(topSelectionHandle.css('z-index')).toBe('9999');
+      expect(bottomSelectionHandle.css('z-index')).toBe('9999');
       expect(topSelectionHandle.offset()).toEqual({
         top: cellFromOffset.top - topSelectionHandleSize,
         left: cellFromOffset.left - topSelectionHandleSize,
@@ -129,6 +133,8 @@ describe('MultipleSelectionHandles', () => {
 
       expect(topSelectionHandle.is(':visible')).toBe(true);
       expect(bottomSelectionHandle.is(':visible')).toBe(true);
+      expect(topSelectionHandle.css('z-index')).toBe('9999');
+      expect(bottomSelectionHandle.css('z-index')).toBe('9999');
       expect(topSelectionHandle.offset()).toEqual({
         top: cellFromOffset.top - topSelectionHandleSize,
         left: cellFromOffset.left - topSelectionHandleSize,

--- a/handsontable/src/plugins/multipleSelectionHandles/__tests__/mobile/rtl/positioning.spec.js
+++ b/handsontable/src/plugins/multipleSelectionHandles/__tests__/mobile/rtl/positioning.spec.js
@@ -41,6 +41,8 @@ describe('MultipleSelectionHandles (RTL mode)', () => {
 
       expect(topSelectionHandle.is(':visible')).toBe(true);
       expect(bottomSelectionHandle.is(':visible')).toBe(true);
+      expect(topSelectionHandle.css('z-index')).toBe('9999');
+      expect(bottomSelectionHandle.css('z-index')).toBe('9999');
       expect(topSelectionHandle.offset()).toEqual({
         top: cellOffset.top - topSelectionHandleSize,
         left: cellOffset.left + cellWidth,
@@ -86,6 +88,8 @@ describe('MultipleSelectionHandles (RTL mode)', () => {
 
       expect(topSelectionHandle.is(':visible')).toBe(true);
       expect(bottomSelectionHandle.is(':visible')).toBe(true);
+      expect(topSelectionHandle.css('z-index')).toBe('9999');
+      expect(bottomSelectionHandle.css('z-index')).toBe('9999');
       expect(topSelectionHandle.offset()).toEqual({
         top: cellFromOffset.top - topSelectionHandleSize,
         left: cellFromOffset.left + cellFromWidth,
@@ -132,6 +136,8 @@ describe('MultipleSelectionHandles (RTL mode)', () => {
 
       expect(topSelectionHandle.is(':visible')).toBe(true);
       expect(bottomSelectionHandle.is(':visible')).toBe(true);
+      expect(topSelectionHandle.css('z-index')).toBe('9999');
+      expect(bottomSelectionHandle.css('z-index')).toBe('9999');
       expect(topSelectionHandle.offset()).toEqual({
         top: cellFromOffset.top - topSelectionHandleSize,
         left: cellFromOffset.left + cellFromWidth,


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes a bug where the selection handlers (mobile) disappear below the headers when more then 1 column was selected.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally, and I cover the fix with updated E2E tests;

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/884

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
