### PR TITLE
MergeCells plugin will toggle cell's copyable state properly

### DIFF
--- a/.changelogs/10456.json
+++ b/.changelogs/10456.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "MergeCells plugin will toggle cell's copyable state properly",
+  "type": "fixed",
+  "issueOrPR": 10456,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/mergeCells/__tests__/mergeCells.spec.js
+++ b/handsontable/src/plugins/mergeCells/__tests__/mergeCells.spec.js
@@ -1721,4 +1721,32 @@ describe('MergeCells', () => {
       expect(coordsOnCellMouseDown).toEqual(jasmine.objectContaining({ row: 0, col: 0 }));
     });
   });
+
+  it('should set/unset "copyable" cell meta attribute after performing merge/unmerge', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(10, 10),
+      mergeCells: true
+    });
+
+    selectCell(2, 2, 4, 4);
+    keyDownUp(['control', 'm']);
+
+    getCell(2, 2);
+
+    expect(getCellMeta(2, 2).copyable).toBe(true);
+    expect(getCellMeta(2, 3).copyable).toBe(false);
+    expect(getCellMeta(2, 4).copyable).toBe(false);
+    expect(getCellMeta(3, 3).copyable).toBe(false);
+    expect(getCellMeta(3, 4).copyable).toBe(false);
+    expect(getCellMeta(4, 4).copyable).toBe(false);
+
+    keyDownUp(['control', 'm']);
+
+    expect(getCellMeta(2, 2).copyable).toBe(true);
+    expect(getCellMeta(2, 3).copyable).toBe(true);
+    expect(getCellMeta(2, 4).copyable).toBe(true);
+    expect(getCellMeta(3, 3).copyable).toBe(true);
+    expect(getCellMeta(3, 4).copyable).toBe(true);
+    expect(getCellMeta(4, 4).copyable).toBe(true);
+  });
 });

--- a/handsontable/src/plugins/mergeCells/__tests__/mergeCells.spec.js
+++ b/handsontable/src/plugins/mergeCells/__tests__/mergeCells.spec.js
@@ -1731,8 +1731,6 @@ describe('MergeCells', () => {
     selectCell(2, 2, 4, 4);
     keyDownUp(['control', 'm']);
 
-    getCell(2, 2);
-
     expect(getCellMeta(2, 2).copyable).toBe(true);
     expect(getCellMeta(2, 3).copyable).toBe(false);
     expect(getCellMeta(2, 4).copyable).toBe(false);
@@ -1748,5 +1746,14 @@ describe('MergeCells', () => {
     expect(getCellMeta(3, 3).copyable).toBe(true);
     expect(getCellMeta(3, 4).copyable).toBe(true);
     expect(getCellMeta(4, 4).copyable).toBe(true);
+
+    keyDownUp(['control', 'm']);
+
+    expect(getCellMeta(2, 2).copyable).toBe(true);
+    expect(getCellMeta(2, 3).copyable).toBe(false);
+    expect(getCellMeta(2, 4).copyable).toBe(false);
+    expect(getCellMeta(3, 3).copyable).toBe(false);
+    expect(getCellMeta(3, 4).copyable).toBe(false);
+    expect(getCellMeta(4, 4).copyable).toBe(false);
   });
 });

--- a/handsontable/src/plugins/mergeCells/mergeCells.js
+++ b/handsontable/src/plugins/mergeCells/mergeCells.js
@@ -495,6 +495,7 @@ export class MergeCells extends BasePlugin {
       rangeEach(0, currentCollection.rowspan - 1, (i) => {
         rangeEach(0, currentCollection.colspan - 1, (j) => {
           this.hot.removeCellMeta(currentCollection.row + i, currentCollection.col + j, 'hidden');
+          this.hot.removeCellMeta(currentCollection.row + i, currentCollection.col + j, 'copyable');
         });
       });
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
After investigation done within PR https://github.com/handsontable/handsontable/pull/10444 it has been found that source of the problem already exist in previous versions of HOT. This PR fixes problem related to MergeCells plugin which hasn't been reseting `copyable` cell meta property after unmerging merged cell area.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/10456
2. https://github.com/handsontable/handsontable/pull/10444

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] My change requires a change to the documentation.
