### PR TITLE
Revert license banner for UMD min files

### DIFF
--- a/handsontable/.config/production.js
+++ b/handsontable/.config/production.js
@@ -23,20 +23,17 @@ module.exports.create = function create(envArgs) {
     c.devtool = false;
     c.output.filename = c.output.filename.replace(/\.js$/, '.min.js');
 
+    c.mode = 'production';
     c.optimization = {
       minimize: true,
       minimizer: [
         new TerserPlugin({
           extractComments: false,
-          terserOptions: {
-            format: {
-              comments: false,
-            },
-          },
         }),
         new CssMinimizerPlugin(),
       ],
     };
+
     // Remove all 'MiniCssExtractPlugin' instances
     c.plugins = c.plugins.filter(function(plugin) {
       return !(plugin instanceof MiniCssExtractPlugin);


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR reverts the license text for UMD min files.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
