### PR TITLE
Fix ampersand copy/paste issue

### DIFF
--- a/handsontable/src/plugins/copyPaste/__tests__/copy.spec.js
+++ b/handsontable/src/plugins/copyPaste/__tests__/copy.spec.js
@@ -49,9 +49,9 @@ describe('CopyPaste', () => {
 
     it('should copy special characters to the clipboard', () => {
       handsontable({
-        colHeaders: ['!@#$%^&*()_+-={[', ']};:\'"\\|,<.>/?~'],
+        colHeaders: ['!@#$%^&*()_+-={[', ']};:\'"\\|,<.>/?~&LTE'],
         data: [
-          ['!@#$%^&*()_+-={[', ']};:\'"\\|,<.>/?~']
+          ['!@#$%^&*()_+-={[', ']};:\'"\\|,<.>/?~&LTE']
         ],
       });
 
@@ -64,13 +64,13 @@ describe('CopyPaste', () => {
       plugin.onCopy(copyEvent); // emulate native "copy" event
 
       expect(copyEvent.clipboardData.getData('text/plain'))
-        .toBe('!@#$%^&*()_+-={[\t]};:\'"\\|,<.>/?~\n!@#$%^&*()_+-={[\t]};:\'"\\|,<.>/?~');
+        .toBe('!@#$%^&*()_+-={[\t]};:\'"\\|,<.>/?~&LTE\n!@#$%^&*()_+-={[\t]};:\'"\\|,<.>/?~&LTE');
       expect(copyEvent.clipboardData.getData('text/html')).toBe([
         '<meta name="generator" content="Handsontable"/>' +
           '<style type="text/css">td{white-space:normal}br{mso-data-placement:same-cell}</style>',
         '<table><tbody>',
-        '<tr><td>!@#$%^&*()_+-={[</td><td>]};:\'"\\|,&lt;.&gt;/?~</td></tr>',
-        '<tr><td>!@#$%^&*()_+-={[</td><td>]};:\'"\\|,&lt;.&gt;/?~</td></tr>',
+        '<tr><td>!@#$%^&amp;*()_+-={[</td><td>]};:\'"\\|,&lt;.&gt;/?~&amp;LTE</td></tr>',
+        '<tr><td>!@#$%^&amp;*()_+-={[</td><td>]};:\'"\\|,&lt;.&gt;/?~&amp;LTE</td></tr>',
         '</tbody></table>',
       ].join(''));
     });

--- a/handsontable/src/utils/parseTable.js
+++ b/handsontable/src/utils/parseTable.js
@@ -126,6 +126,7 @@ export function _dataToHTML(input) {
       const parsedCellData = isEmpty(cellData) ?
         '' :
         cellData.toString()
+          .replace(/&/g, '&amp;')
           .replace(/</g, '&lt;')
           .replace(/>/g, '&gt;')
           .replace(/(<br(\s*|\/)>(\r\n|\n)?|\r\n|\n)/g, '<br>\r\n')


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes an issue where coping values that contains ampersand result in wrong values after paste. 

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and cover the fix by updating the E2E test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/491

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
