### PR TITLE
Revert "Hovering "handsontable" cell type header handles won't throw an error (#10458)"

### DIFF
--- a/.changelogs/9317.json
+++ b/.changelogs/9317.json
@@ -1,8 +1,0 @@
-{
-  "issuesOrigin": "public",
-  "title": "Hovering \"handsontable\" cell type header handles won't throw an error",
-  "type": "fixed",
-  "issueOrPR": 9317,
-  "breaking": false,
-  "framework": "none"
-}

--- a/handsontable/src/plugins/manualColumnResize/__tests__/manualColumnResize.spec.js
+++ b/handsontable/src/plugins/manualColumnResize/__tests__/manualColumnResize.spec.js
@@ -22,35 +22,6 @@ describe('manualColumnResize', () => {
     expect(colWidth(spec().$container, 2)).toBe(180);
   });
 
-  it('should not throw an error while performing a mouse over on HOT in HOT header', () => {
-    handsontable({
-      colHeaders: true,
-      manualColumnResize: true,
-      columns: [
-        {
-          type: 'handsontable',
-          handsontable: {
-            colHeaders: true,
-            data: Handsontable.helper.createSpreadsheetData(5, 5),
-            manualColumnResize: true,
-          }
-        },
-      ],
-    });
-
-    selectCell(0, 0);
-    keyDownUp('enter');
-
-    const $editor = $('.handsontableEditor');
-
-    expect(() => {
-      $editor.find('thead tr:eq(0) th:eq(0)').simulate('mouseover');
-      $editor.find('thead tr:eq(0) th:eq(0)').simulate('mousedown');
-      $editor.find('thead tr:eq(0) th:eq(1)').simulate('mouseover');
-      $editor.find('thead tr:eq(0) th:eq(1)').simulate('mousemove');
-    }).not.toThrow();
-  });
-
   it('should be enabled after specifying it in updateSettings config', () => {
     handsontable({
       data: [

--- a/handsontable/src/plugins/manualColumnResize/manualColumnResize.js
+++ b/handsontable/src/plugins/manualColumnResize/manualColumnResize.js
@@ -1,6 +1,5 @@
 import { BasePlugin } from '../base';
-import { addClass, closest, hasClass, removeClass, outerHeight, isDetached,
-  overlayContainsElement } from '../../helpers/dom/element';
+import { addClass, closest, hasClass, removeClass, outerHeight, isDetached } from '../../helpers/dom/element';
 import EventManager from '../../eventManager';
 import { arrayEach } from '../../helpers/array';
 import { rangeEach } from '../../helpers/number';
@@ -238,14 +237,6 @@ export class ManualColumnResize extends BasePlugin {
     }
 
     this.currentTH = TH;
-
-    const hotRootElement = this.hot.rootElement;
-
-    // Handling elements placed only inside columns header of the main instance.
-    if (overlayContainsElement('top_inline_start_corner', this.currentTH, hotRootElement) === false &&
-      overlayContainsElement('top', this.currentTH, hotRootElement) === false) {
-      return;
-    }
 
     const { _wt: wt } = this.hot.view;
     const cellCoords = wt.wtTable.getCoords(this.currentTH);


### PR DESCRIPTION
### Context
This reverts the changes made in #10458 after finding issues caused by them:
- handsontable/dev-handsontable#1414

Analogous changes were made to the `release/13.1.0` branch: 
- 49115ac4a7abb177d36d07c9c97302c4f01f82bc

[skip changelog]

### How has this been tested?
Tested #1414 manually.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #10458 
2. https://github.com/handsontable/handsontable/issues/9317
3. https://github.com/handsontable/handsontable/issues/10359

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
