### PR TITLE
Add missing 'updateData' ChangeSource type

### DIFF
--- a/handsontable/types/common.d.ts
+++ b/handsontable/types/common.d.ts
@@ -49,7 +49,7 @@ export interface RangeType {
 /**
  * The default sources for which the table triggers hooks.
  */
-export type ChangeSource = 'auto' | 'edit' | 'loadData' | 'populateFromArray' | 'spliceCol' |
+export type ChangeSource = 'auto' | 'edit' | 'loadData' | 'updateData' | 'populateFromArray' | 'spliceCol' |
                            'spliceRow' | 'timeValidate' | 'dateValidate' | 'validateCells' |
                            'Autofill.fill' | 'ContextMenu.clearColumn' | 'ContextMenu.columnLeft' |
                            'ContextMenu.columnRight' | 'ContextMenu.removeColumn' |


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adds the missing 'updateData' type to the `ChangeSource` type.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
\-

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1397

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
