### PR TITLE
Fix a bug where pressing a Ctrl/Cmd does not trigger non-contiguous selection

### DIFF
--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -4713,11 +4713,8 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
   };
 
   const shortcutManager = createShortcutManager({
-    handleEvent(event) {
-      const isListening = instance.isListening();
-      const isKeyboardEventWithKey = event?.key !== void 0;
-
-      return isListening && isKeyboardEventWithKey;
+    handleEvent() {
+      return instance.isListening();
     },
     beforeKeyDown: (event) => {
       return this.runHooks('beforeKeyDown', event);

--- a/handsontable/src/shortcuts/__tests__/shortcutManager.spec.js
+++ b/handsontable/src/shortcuts/__tests__/shortcutManager.spec.js
@@ -43,7 +43,7 @@ describe('shortcutManager', () => {
 
       keyDown('control');
 
-      expect(shortcutManager.isCtrlPressed()).toBeFalse();
+      expect(shortcutManager.isCtrlPressed()).toBeTrue();
 
       keyUp('control');
 
@@ -61,7 +61,7 @@ describe('shortcutManager', () => {
 
       keyDown('control');
 
-      expect(shortcutManager.isCtrlPressed()).toBeFalse();
+      expect(shortcutManager.isCtrlPressed()).toBeTrue();
 
       keyUp('control');
     });
@@ -74,7 +74,7 @@ describe('shortcutManager', () => {
 
       keyDown('meta');
 
-      expect(shortcutManager.isCtrlPressed()).toBeFalse();
+      expect(shortcutManager.isCtrlPressed()).toBeTrue();
 
       keyUp('meta');
 
@@ -92,7 +92,7 @@ describe('shortcutManager', () => {
 
       keyDown('meta');
 
-      expect(shortcutManager.isCtrlPressed()).toBeFalse();
+      expect(shortcutManager.isCtrlPressed()).toBeTrue();
 
       keyUp('meta');
     });
@@ -461,22 +461,6 @@ describe('shortcutManager', () => {
     keyDownUp(['control', 'b']);
 
     expect(text).toBe('13456');
-  });
-
-  it('should handle event without key property in a proper way', () => {
-    const externalInputElement = document.createElement('input');
-
-    handsontable({});
-
-    document.body.appendChild(externalInputElement);
-    externalInputElement.select();
-
-    expect(() => {
-      $(externalInputElement).simulate('keydown', {});
-      $(externalInputElement).simulate('keyup', {});
-    }).not.toThrow();
-
-    document.body.removeChild(externalInputElement);
   });
 
   it('should check if there is a need of releasing keys on click #dev-1025', () => {

--- a/handsontable/src/shortcuts/recorder.js
+++ b/handsontable/src/shortcuts/recorder.js
@@ -76,6 +76,12 @@ export function useRecorder(ownerWindow, handleEvent, beforeKeyDown, afterKeyDow
    * @param {KeyboardEvent} event The event object
    */
   const onkeydown = (event) => {
+    const pressedKey = normalizeEventKey(event.key);
+
+    if (isModifierKey(pressedKey)) {
+      modifierKeysObserver.press(pressedKey);
+    }
+
     if (handleEvent(event) === false) {
       return;
     }
@@ -89,13 +95,9 @@ export function useRecorder(ownerWindow, handleEvent, beforeKeyDown, afterKeyDow
       return;
     }
 
-    const pressedKey = normalizeEventKey(event.key);
     let extraModifierKeys = [];
 
-    if (isModifierKey(pressedKey)) {
-      modifierKeysObserver.press(pressedKey);
-
-    } else {
+    if (!isModifierKey(pressedKey)) {
       extraModifierKeys = getPressedModifierKeys(event);
     }
 
@@ -118,17 +120,11 @@ export function useRecorder(ownerWindow, handleEvent, beforeKeyDown, afterKeyDow
    * @param {KeyboardEvent} event The event object
    */
   const onkeyup = (event) => {
-    if (handleEvent(event) === false) {
-      return;
-    }
-
     const pressedKey = normalizeEventKey(event.key);
 
-    if (isModifierKey(pressedKey) === false) {
-      return;
+    if (isModifierKey(pressedKey)) {
+      modifierKeysObserver.release(pressedKey);
     }
-
-    modifierKeysObserver.release(pressedKey);
   };
 
   /**


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes a bug where pressing a Ctrl/Cmd does not trigger non-contiguous selection.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and I covered the fix by update tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1025

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
