### PR TITLE
Fix editor incorrect width and height calculations

### DIFF
--- a/.changelogs/10504.json
+++ b/.changelogs/10504.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed editor incorrect width and height calculations.",
+  "type": "fixed",
+  "issueOrPR": 10504,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/editors/baseEditor/__tests__/API.spec.js
+++ b/handsontable/src/editors/baseEditor/__tests__/API.spec.js
@@ -93,7 +93,7 @@ describe('BaseEditor API', () => {
               width: 51,
               maxWidth: 51,
               height: 24,
-              // maxHeight: ?, // returns wrong value! it will be fixed within #9206
+              maxHeight: 162,
             }));
           });
 
@@ -120,7 +120,7 @@ describe('BaseEditor API', () => {
               width: 51,
               maxWidth: 50,
               height: 24,
-              // maxHeight: ?, // returns wrong value! it will be fixed within #9206
+              maxHeight: document.documentElement.clientHeight - 23,
             }));
           });
         });
@@ -190,9 +190,9 @@ describe('BaseEditor API', () => {
               start: 49,
               top: 23,
               width: 51,
-              // maxWidth: ?, // returns wrong value! it will be fixed within #9206
+              maxWidth: 236,
               height: 24,
-              // maxHeight: ?, // returns wrong value! it will be fixed within #9206
+              maxHeight: 162,
             }));
           });
 
@@ -212,9 +212,9 @@ describe('BaseEditor API', () => {
               start: document.documentElement.scrollLeft + 49, // 49 - the width of the first cell
               top: document.documentElement.offsetHeight - document.documentElement.clientHeight + 23,
               width: 51,
-              // maxWidth: ?, // returns wrong value! it will be fixed within #9206
+              maxWidth: document.documentElement.clientWidth - 49,
               height: 24,
-              // maxHeight: ?, // returns wrong value! it will be fixed within #9206
+              maxHeight: document.documentElement.clientHeight - 23,
             }));
           });
         });
@@ -281,7 +281,7 @@ describe('BaseEditor API', () => {
               start: 49,
               top: 161,
               width: 51,
-              // maxWidth: ?, // returns wrong value! it will be fixed within #9206
+              maxWidth: 236,
               height: 24,
               maxHeight: 24,
             }));
@@ -302,7 +302,7 @@ describe('BaseEditor API', () => {
               start: document.documentElement.scrollLeft + 49, // 49 - the width of the first cell
               top: document.documentElement.offsetHeight - 24, // 24 - the height of the last cell
               width: 51,
-              // maxWidth: ?, // returns wrong value! it will be fixed within #9206
+              maxWidth: document.documentElement.clientWidth - 49,
               height: 24,
               maxHeight: 24,
             }));
@@ -329,7 +329,7 @@ describe('BaseEditor API', () => {
               width: 50,
               maxWidth: 285,
               height: 24,
-              // maxHeight: ?, // returns wrong value! it will be fixed within #9206
+              maxHeight: 47,
             }));
           });
 
@@ -350,7 +350,7 @@ describe('BaseEditor API', () => {
               width: 50,
               maxWidth: document.documentElement.clientWidth,
               height: 24,
-              // maxHeight: ?, // returns wrong value! it will be fixed within #9206
+              maxHeight: 62,
             }));
           });
         });
@@ -374,9 +374,9 @@ describe('BaseEditor API', () => {
               start: 0,
               top: 138,
               width: 50,
-              // maxWidth: ?, // returns wrong value! it will be fixed within #9206
+              maxWidth: 285,
               height: 24,
-              // maxHeight: ?, // returns wrong value! it will be fixed within #9206
+              maxHeight: 47,
             }));
           });
 
@@ -396,9 +396,9 @@ describe('BaseEditor API', () => {
               start: document.documentElement.scrollLeft,
               top: document.documentElement.offsetHeight - 47,
               width: 50,
-              // maxWidth: ?, // returns wrong value! it will be fixed within #9206
+              maxWidth: document.documentElement.clientWidth,
               height: 24,
-              // maxHeight: ?, // returns wrong value! it will be fixed within #9206
+              maxHeight: 62,
             }));
           });
         });
@@ -422,7 +422,7 @@ describe('BaseEditor API', () => {
               width: 50, // 48px (the default cell width closest to the left side of the table) - 8px (padding)
               maxWidth: 285,
               height: 24,
-              // maxHeight: ?, // returns wrong value! it will be fixed within #9206
+              maxHeight: 47,
             }));
           });
 
@@ -442,7 +442,7 @@ describe('BaseEditor API', () => {
               width: 50,
               maxWidth: document.documentElement.clientWidth,
               height: 24,
-              // maxHeight: ?, // returns wrong value! it will be fixed within #9206
+              maxHeight: 62,
             }));
           });
         });
@@ -467,7 +467,7 @@ describe('BaseEditor API', () => {
               width: 51,
               maxWidth: 51,
               height: 24,
-              // maxHeight: ?, // returns wrong value! it will be fixed within #9206
+              maxHeight: 24,
             }));
           });
 
@@ -497,7 +497,7 @@ describe('BaseEditor API', () => {
               width: 51,
               maxWidth: 51,
               height: 24,
-              // maxHeight: ?, // returns wrong value! it will be fixed within #9206
+              maxHeight: 39, // returns wrong value! it will be fixed within #9206
             }));
           });
         });

--- a/handsontable/src/editors/baseEditor/baseEditor.js
+++ b/handsontable/src/editors/baseEditor/baseEditor.js
@@ -531,7 +531,21 @@ export class BaseEditor {
     const horizontalScrollPosition = Math.abs(wtOverlays.inlineStartOverlay.getScrollPosition());
     const verticalScrollPosition = wtOverlays.topOverlay.getScrollPosition();
     const scrollbarWidth = getScrollbarWidth(this.hot.rootDocument);
-    const cellTopOffset = TD.offsetTop + firstRowOffset - verticalScrollPosition;
+    let cellTopOffset = TD.offsetTop;
+
+    if (['inline_start', 'master'].includes(overlayName)) {
+      cellTopOffset += firstRowOffset - verticalScrollPosition;
+    }
+
+    if (['bottom', 'bottom_inline_start_corner'].includes(overlayName)) {
+      const {
+        wtViewport: bottomWtViewport,
+        wtTable: bottomWtTable,
+      } = wtOverlays.bottomOverlay.clone;
+
+      cellTopOffset += bottomWtViewport.getWorkspaceHeight() - bottomWtTable.getHeight() - scrollbarWidth;
+    }
+
     let cellStartOffset = 0;
 
     if (this.hot.isRtl()) {
@@ -548,7 +562,11 @@ export class BaseEditor {
 
       cellStartOffset += firstColumnOffset - horizontalScrollPosition - cellWidth;
     } else {
-      cellStartOffset = TD.offsetLeft + firstColumnOffset - horizontalScrollPosition;
+      cellStartOffset = TD.offsetLeft;
+
+      if (['top', 'master', 'bottom'].includes(overlayName)) {
+        cellStartOffset += firstColumnOffset - horizontalScrollPosition;
+      }
     }
 
     const cellComputedStyle = getComputedStyle(this.TD, this.hot.rootWindow);

--- a/handsontable/src/editors/baseEditor/baseEditor.js
+++ b/handsontable/src/editors/baseEditor/baseEditor.js
@@ -546,27 +546,22 @@ export class BaseEditor {
       cellTopOffset += bottomWtViewport.getWorkspaceHeight() - bottomWtTable.getHeight() - scrollbarWidth;
     }
 
-    let cellStartOffset = 0;
+    let cellStartOffset = TD.offsetLeft;
 
     if (this.hot.isRtl()) {
-      const cellOffset = TD.offsetLeft;
-
-      if (cellOffset >= 0) {
+      if (cellStartOffset >= 0) {
         cellStartOffset = overlayTable.getWidth() - TD.offsetLeft;
       } else {
         // The `offsetLeft` returns negative values when the parent offset element has position relative
         // (it happens when on the cell the selection is applied - the `area` CSS class).
         // When it happens the `offsetLeft` value is calculated from the right edge of the parent element.
-        cellStartOffset = Math.abs(cellOffset);
+        cellStartOffset = Math.abs(cellStartOffset);
       }
 
       cellStartOffset += firstColumnOffset - horizontalScrollPosition - cellWidth;
-    } else {
-      cellStartOffset = TD.offsetLeft;
 
-      if (['top', 'master', 'bottom'].includes(overlayName)) {
-        cellStartOffset += firstColumnOffset - horizontalScrollPosition;
-      }
+    } else if (['top', 'master', 'bottom'].includes(overlayName)) {
+      cellStartOffset += firstColumnOffset - horizontalScrollPosition;
     }
 
     const cellComputedStyle = getComputedStyle(this.TD, this.hot.rootWindow);


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes a bug where the editor's max width and max height were incorrectly calculated. The bug appeared when the editor was opened on one of the overlays and the viewport was scrolled.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and covered the fix with new E2E tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/96

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
