### PR TITLE
Change the color of the focus selection

### DIFF
--- a/examples/next/visual-tests/angular/demo/src/data-grid/data-grid.component.html
+++ b/examples/next/visual-tests/angular/demo/src/data-grid/data-grid.component.html
@@ -18,6 +18,7 @@
     [afterGetRowHeader]="drawCheckboxInRowHeaders"
     [beforeRenderer]="addClassesToRows"
     [manualRowMove]="true"
+    [navigableHeaders]="true"
     licenseKey="non-commercial-and-evaluation"
   >
     <hot-column data="1"></hot-column>

--- a/examples/next/visual-tests/js/demo/src/index.js
+++ b/examples/next/visual-tests/js/demo/src/index.js
@@ -113,6 +113,7 @@ new Handsontable(example, {
   hiddenColumns: {
     indicators: true
   },
+  navigableHeaders: true,
   contextMenu: true,
   multiColumnSorting: true,
   filters: true,

--- a/examples/next/visual-tests/react/demo/src/index.tsx
+++ b/examples/next/visual-tests/react/demo/src/index.tsx
@@ -47,6 +47,7 @@ const App = () => {
       afterGetRowHeader={drawCheckboxInRowHeaders}
       afterOnCellMouseDown={changeCheckboxCell}
       manualRowMove={true}
+      navigableHeaders={true}
       licenseKey="non-commercial-and-evaluation"
     >
       <HotColumn data={1} />

--- a/examples/next/visual-tests/vue/demo/src/components/DataGrid.vue
+++ b/examples/next/visual-tests/vue/demo/src/components/DataGrid.vue
@@ -33,6 +33,7 @@ export default {
         multiColumnSorting: true,
         filters: true,
         rowHeaders: true,
+        navigableHeaders: true,
         afterOnCellMouseDown: changeCheckboxCell,
         afterGetColHeader: alignHeaders,
         afterGetRowHeader: drawCheckboxInRowHeaders,

--- a/handsontable/src/css/handsontable.scss
+++ b/handsontable/src/css/handsontable.scss
@@ -239,7 +239,7 @@
 
 .handsontable tbody th.current,
 .handsontable thead th.current {
-  box-shadow: inset 0 0 0 2px #5292f7;
+  box-shadow: inset 0 0 0 2px #4b89ff;
 }
 
 .handsontable tbody th.ht__highlight,

--- a/visual-tests/src/helpers.ts
+++ b/visual-tests/src/helpers.ts
@@ -11,6 +11,7 @@ export const helpers = {
     mainTableBody: '> .ht_master.handsontable table tbody',
     mainTableHead: '> .ht_clone_top.handsontable table thead',
     cloneInlineStartTable: '> .ht_clone_inline_start.handsontable table tbody',
+    cloneInlineStartCornerTable: '> .ht_clone_top_inline_start_corner.handsontable table thead',
     dropdownMenu: '.htMenu.htDropdownMenu.handsontable',
   },
 

--- a/visual-tests/tests/navigable-headers.spec.ts
+++ b/visual-tests/tests/navigable-headers.spec.ts
@@ -1,0 +1,18 @@
+import { test } from '../src/test-runner';
+import { helpers } from '../src/helpers';
+
+test(__filename, async({ page }) => {
+  const table = page.locator(helpers.selectors.mainTable);
+
+  await table.waitFor();
+
+  const tbody = table.locator(helpers.selectors.mainTableBody);
+  const cell = tbody.locator(helpers.findCell({ row: 0, column: 0, cellType: 'td' }));
+
+  // move the focus to the corner
+  await cell.click();
+  await page.locator('html').press('ArrowLeft');
+  await page.locator('html').press('ArrowUp');
+
+  await page.screenshot({ path: helpers.screenshotPath() });
+});


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR changes the color of the focus selection in the headers.

_[skip changelog]_ (the fix updates unreleased feature so the changelog is not necessary here)

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally, and I secured the change with a new visual test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1435

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
