### PR TITLE
Fix table's viewport scrolling issues for NestedHeaders

### DIFF
--- a/handsontable/src/3rdparty/walkontable/src/overlay/bottom.js
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/bottom.js
@@ -136,7 +136,7 @@ export class BottomOverlay extends Overlay {
    * Triggers onScroll hook callback.
    */
   onScroll() {
-    this.wtSettings.getSetting('onScrollHorizontally');
+    this.wtSettings.getSetting('onAfterScrollHorizontally');
   }
 
   /**

--- a/handsontable/src/3rdparty/walkontable/src/overlay/inlineStart.js
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/inlineStart.js
@@ -114,7 +114,7 @@ export class InlineStartOverlay extends Overlay {
    * Triggers onScroll hook callback.
    */
   onScroll() {
-    this.wtSettings.getSetting('onScrollVertically');
+    this.wtSettings.getSetting('onAfterScrollVertically');
   }
 
   /**

--- a/handsontable/src/3rdparty/walkontable/src/overlay/top.js
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/top.js
@@ -136,7 +136,7 @@ export class TopOverlay extends Overlay {
    * Triggers onScroll hook callback.
    */
   onScroll() {
-    this.wtSettings.getSetting('onScrollHorizontally');
+    this.wtSettings.getSetting('onAfterScrollHorizontally');
   }
 
   /**

--- a/handsontable/src/3rdparty/walkontable/src/scroll.js
+++ b/handsontable/src/3rdparty/walkontable/src/scroll.js
@@ -96,10 +96,14 @@ class Scroll {
     // if there is no fully visible columns use the supporting variable (lastScrolledColumnPos) to
     // determine the snapping direction (left or right)
     if (firstVisibleColumn === -1) {
+      column = this.dataAccessObject.wtSettings.getSetting('onBeforeScrollHorizontally', column);
+
       result = inlineStartOverlay
         .scrollTo(column, autoSnapping ? column > this.lastScrolledColumnPos : snapToRight);
 
     } else if (autoSnapping && (column < firstVisibleColumn || column > lastVisibleColumn) || !autoSnapping) {
+      column = this.dataAccessObject.wtSettings.getSetting('onBeforeScrollHorizontally', column);
+
       // if there is at least one fully visible column determine the snapping direction based on
       // that columns or by snapToRight/snapToLeft flags, if provided.
       result = inlineStartOverlay
@@ -152,9 +156,13 @@ class Scroll {
     // if there is no fully visible rows use the supporting variable (lastScrolledRowPos) to
     // determine the snapping direction (top or bottom)
     if (firstVisibleRow === -1) {
+      row = this.dataAccessObject.wtSettings.getSetting('onBeforeScrollVertically', row);
+
       result = topOverlay.scrollTo(row, autoSnapping ? row > this.lastScrolledRowPos : snapToBottom);
 
     } else if (autoSnapping && (row < firstVisibleRow || row > lastVisibleRow) || !autoSnapping) {
+      row = this.dataAccessObject.wtSettings.getSetting('onBeforeScrollVertically', row);
+
       // if there is at least one fully visible row determine the snapping direction based on
       // that rows or by snapToTop/snapToBottom flags, if provided.
       result = topOverlay.scrollTo(row, autoSnapping ? row > lastVisibleRow : snapToBottom);

--- a/handsontable/src/3rdparty/walkontable/src/settings.js
+++ b/handsontable/src/3rdparty/walkontable/src/settings.js
@@ -57,8 +57,10 @@ import { objectEach } from '../../../helpers/object';
  * @property {?Option} onDraw Option `onDraw`.
  * @property {?Option} onModifyGetCellCoords Option `onModifyGetCellCoords`.
  * @property {?Option} onModifyRowHeaderWidth Option `onModifyRowHeaderWidth`.
- * @property {?Option} onScrollHorizontally Option `onScrollHorizontally`.
- * @property {?Option} onScrollVertically Option `onScrollVertically`.
+ * @property {?Option} onBeforeScrollHorizontally Option `onBeforeScrollHorizontally`.
+ * @property {?Option} onAfterScrollHorizontally Option `onAfterScrollHorizontally`.
+ * @property {?Option} onBeforeScrollVertically Option `onBeforeScrollVertically`.
+ * @property {?Option} onAfterScrollVertically Option `onAfterScrollVertically`.
  * @property {?Option} onWindowResize Option `onWindowResize`.
  * @property {?Option} rowHeaderWidth Option `rowHeaderWidth`.
  * @property {?Option} selections Option `selections`.
@@ -205,8 +207,10 @@ export default class Settings {
       onBeforeRemoveCellClassNames: null,
       onAfterDrawSelection: null,
       onBeforeDrawBorders: null,
-      onScrollVertically: null,
-      onScrollHorizontally: null,
+      onBeforeScrollHorizontally: column => column,
+      onAfterScrollHorizontally: null,
+      onBeforeScrollVertically: row => row,
+      onAfterScrollVertically: null,
       onBeforeTouchScroll: null,
       onAfterMomentumScroll: null,
       onBeforeStretchingColumnWidth: width => width,

--- a/handsontable/src/plugins/nestedHeaders/nestedHeaders.js
+++ b/handsontable/src/plugins/nestedHeaders/nestedHeaders.js
@@ -136,6 +136,7 @@ export class NestedHeaders extends BasePlugin {
     this.addHook('beforeOnCellMouseOver', (...args) => this.onBeforeOnCellMouseOver(...args));
     this.addHook('modifyTransformStart', (...args) => this.onModifyTransformStart(...args));
     this.addHook('afterSelection', () => this.updateFocusHighlightPosition());
+    this.addHook('beforeScrollHorizontally', (...args) => this.onBeforeScrollHorizontally(...args));
     this.addHook('afterGetColumnHeaderRenderers', array => this.onAfterGetColumnHeaderRenderers(array));
     this.addHook('modifyColWidth', (...args) => this.onModifyColWidth(...args));
     this.addHook('modifyColumnHeaderValue', (...args) => this.onModifyColumnHeaderValue(...args));
@@ -413,6 +414,9 @@ export class NestedHeaders extends BasePlugin {
       focusHighlight.commit();
     }
   }
+
+  // onBeforeScrollHorizontally(cellCoords) {
+  // }
 
   /**
    * Allows to control which header DOM element will be used to highlight.

--- a/handsontable/src/tableView.js
+++ b/handsontable/src/tableView.js
@@ -887,11 +887,51 @@ class TableView {
       },
       beforeDraw: (force, skipRender) => this.beforeRender(force, skipRender),
       onDraw: force => this.afterRender(force),
-      onScrollVertically: () => {
+      onBeforeScrollVertically: (renderableRow) => {
+        const rowMapper = this.instance.rowIndexMapper;
+        const areColumnHeadersSelected = renderableRow < 0;
+        let visualRow = renderableRow;
+
+        if (!areColumnHeadersSelected) {
+          visualRow = rowMapper.getVisualFromRenderableIndex(renderableRow);
+        }
+
+        visualRow = this.instance.runHooks('beforeScrollVertically', visualRow);
+        this.instance.runHooks('beforeScroll');
+
+        console.log('visualRow', visualRow);
+
+        if (!areColumnHeadersSelected) {
+          return rowMapper.getRenderableFromVisualIndex(visualRow);
+        }
+
+        return visualRow;
+      },
+      onAfterScrollVertically: () => {
         this.instance.runHooks('afterScrollVertically');
         this.instance.runHooks('afterScroll');
       },
-      onScrollHorizontally: () => {
+      onBeforeScrollHorizontally: (renderableColumn) => {
+        const columnMapper = this.instance.rowIndexMapper;
+        const areColumnHeadersSelected = renderableColumn < 0;
+        let visualColumn = renderableColumn;
+
+        if (!areColumnHeadersSelected) {
+          visualColumn = columnMapper.getVisualFromRenderableIndex(renderableColumn);
+        }
+
+        visualColumn = this.instance.runHooks('beforeScrollVertically', visualColumn);
+        this.instance.runHooks('beforeScroll');
+
+        console.log('visualColumn', visualColumn);
+
+        if (!areColumnHeadersSelected) {
+          return columnMapper.getRenderableFromVisualIndex(visualColumn);
+        }
+
+        return visualColumn;
+      },
+      onAfterScrollHorizontally: () => {
         this.instance.runHooks('afterScrollHorizontally');
         this.instance.runHooks('afterScroll');
       },


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
[WIP] The PR fixes the wrong table's viewport scrolling issue. The bug appears in cases when a user navigates the table through the nested headers (the `navigableHeaders` option is on).

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1437

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
