### PR TITLE
Fix focus header position for nested headers

### DIFF
--- a/handsontable/src/plugins/nestedHeaders/nestedHeaders.js
+++ b/handsontable/src/plugins/nestedHeaders/nestedHeaders.js
@@ -96,7 +96,6 @@ export class NestedHeaders extends BasePlugin {
    */
   // @TODO This should be changed after refactor handsontable/utils/ghostTable.
   ghostTable = new GhostTable(this.hot, (row, column) => this.getHeaderSettings(row, column));
-
   /**
    * The flag which determines that the nested header settings contains overlapping headers
    * configuration.
@@ -597,7 +596,7 @@ export class NestedHeaders extends BasePlugin {
     const selectedRange = this.hot.getSelectedRangeLast();
     const topStartCoords = selectedRange.getTopStartCorner();
     const bottomEndCoords = selectedRange.getBottomEndCorner();
-    const { from } = selectedRange;
+    const { from, highlight } = selectedRange;
 
     // Block the Selection module in controlling how the columns and cells are selected.
     // From now on, the plugin is responsible for the selection.
@@ -607,13 +606,13 @@ export class NestedHeaders extends BasePlugin {
     const columnsToSelect = [];
 
     if (coords.col < from.col) {
-      columnsToSelect.push(bottomEndCoords.col, columnIndex, coords.row);
+      columnsToSelect.push(bottomEndCoords.col, columnIndex, highlight.row);
 
     } else if (coords.col > from.col) {
-      columnsToSelect.push(topStartCoords.col, columnIndex + origColspan - 1, coords.row);
+      columnsToSelect.push(topStartCoords.col, columnIndex + origColspan - 1, highlight.row);
 
     } else {
-      columnsToSelect.push(columnIndex, columnIndex + origColspan - 1, coords.row);
+      columnsToSelect.push(columnIndex, columnIndex + origColspan - 1, highlight.row);
     }
 
     this.hot.selection.selectColumns(...columnsToSelect);


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the focus header position for the _NestedHeaders_ plugin.

_[skip changelog]_ (fix for unreleased bug)

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1348

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
