### PR TITLE
Change the colors of the invalid cells and the arrow buttons of the autocomplete-typed cells.

### DIFF
--- a/.changelogs/10520.json
+++ b/.changelogs/10520.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Changed the colors of the invalid cells and the arrow buttons of the autocomplete-typed cells.",
+  "type": "changed",
+  "issueOrPR": 10520,
+  "breaking": true,
+  "framework": "none"
+}

--- a/handsontable/src/css/handsontable.scss
+++ b/handsontable/src/css/handsontable.scss
@@ -19,7 +19,7 @@
 
 .handsontable td.htInvalid {
   /*gives priority over td.area selection background*/
-  background-color: #ff4c42 !important;
+  background-color: #ffbeba !important;
 }
 
 .handsontable td.htNoWrap {

--- a/handsontable/src/renderers/autocompleteRenderer/autocompleteRenderer.scss
+++ b/handsontable/src/renderers/autocompleteRenderer/autocompleteRenderer.scss
@@ -5,10 +5,18 @@ AutocompleteRenderer down arrow
 .handsontable .htAutocompleteArrow {
   float: inline-end;
   font-size: 10px;
-  color: #EEE;
+  color: #bbbbbb;
   cursor: default;
   width: 16px;
   text-align: center;
+}
+
+.handsontable td.htInvalid .htAutocompleteArrow {
+  color: #555555;
+}
+
+.handsontable td.htInvalid .htAutocompleteArrow:hover {
+  color: #1a1a1a;
 }
 
 .handsontable td .htAutocompleteArrow:hover {


### PR DESCRIPTION
### Context
This PR:
1. Changes the background color of the invalid cells from `#ff4c42` to `#ffbeba`.
2. Changes the color of the arrow-down button of the autocomplete-typed cells (change also affects autocomplete derivatives like  dropdown, date etc.):
    - from `#eeeeee` to `#bbbbbb` for regular cells
    - from `#eeeeee` to `#555555` for cells marked as invalid
3. Additionally, I changed the color of the `hover` state of the arrow-down button on invalid cells to get darker on hover, similarly to the regular cells.
    - from `#777777` to `#1a1a1a` when hovering over cells marked as invalid

### How has this been tested?
Tested manually. (in the future the visual tests should handle it)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1445
5. fixes https://github.com/handsontable/dev-handsontable/issues/1446


### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
