### PR TITLE
Change the keyboard shortcuts for sorting and dropdown menu

### DIFF
--- a/handsontable/src/plugins/dropdownMenu/__tests__/keyboardShortcuts/metaEnter.spec.js
+++ b/handsontable/src/plugins/dropdownMenu/__tests__/keyboardShortcuts/metaEnter.spec.js
@@ -17,7 +17,7 @@ describe('DropdownMenu keyboard shortcut', () => {
     this.view.appendColHeader(visualColumnsIndex, TH);
   }
 
-  describe('"Shift" + "Enter"', () => {
+  describe('"Control/meta" + "Enter"', () => {
     it('should not be possible to open the dropdown menu (navigableHeaders off)', () => {
       handsontable({
         data: createSpreadsheetData(3, 8),
@@ -28,7 +28,7 @@ describe('DropdownMenu keyboard shortcut', () => {
       });
 
       selectCell(0, 1);
-      keyDownUp(['shift', 'enter']);
+      keyDownUp(['control/meta', 'enter']);
 
       const $dropdownMenu = $(document.body).find('.htDropdownMenu:visible');
 
@@ -46,7 +46,7 @@ describe('DropdownMenu keyboard shortcut', () => {
       });
 
       selectCell(-1, 1);
-      keyDownUp(['shift', 'enter']);
+      keyDownUp(['control/meta', 'enter']);
 
       const cell = getCell(-1, 1, true);
       const $dropdownMenu = $(document.body).find('.htDropdownMenu:visible');
@@ -71,7 +71,7 @@ describe('DropdownMenu keyboard shortcut', () => {
       const lastColumn = countCols() - 1;
 
       selectCell(-1, lastColumn);
-      keyDownUp(['shift', 'enter']);
+      keyDownUp(['control/meta', 'enter']);
 
       const cell = getCell(-1, lastColumn, true);
       const $dropdownMenu = $(document.body).find('.htDropdownMenu:visible');
@@ -98,7 +98,7 @@ describe('DropdownMenu keyboard shortcut', () => {
       });
 
       selectCell(-1, 1);
-      keyDownUp(['shift', 'enter']);
+      keyDownUp(['control/meta', 'enter']);
 
       await sleep(100);
 
@@ -115,8 +115,8 @@ describe('DropdownMenu keyboard shortcut', () => {
       });
 
       selectCell(-1, 1);
-      keyDownUp(['shift', 'enter']);
-      keyDownUp(['shift', 'enter']);
+      keyDownUp(['control/meta', 'enter']);
+      keyDownUp(['control/meta', 'enter']);
 
       const cell = getCell(-1, 1, true);
       const $dropdownMenu = $(document.body).find('.htDropdownMenu:visible');
@@ -140,7 +140,7 @@ describe('DropdownMenu keyboard shortcut', () => {
 
       selectColumns(1, 4, -1);
       listen();
-      keyDownUp(['shift', 'enter']);
+      keyDownUp(['control/meta', 'enter']);
 
       const cell = getCell(-1, 1, true);
       const $dropdownMenu = $(document.body).find('.htDropdownMenu:visible');
@@ -167,7 +167,7 @@ describe('DropdownMenu keyboard shortcut', () => {
       });
 
       selectCell(-1, -1); // corner
-      keyDownUp(['shift', 'enter']);
+      keyDownUp(['control/meta', 'enter']);
 
       {
         expect($(document.body).find('.htDropdownMenu:visible').length).toBe(0);
@@ -175,7 +175,7 @@ describe('DropdownMenu keyboard shortcut', () => {
       }
 
       selectCell(1, -1); // row header
-      keyDownUp(['shift', 'enter']);
+      keyDownUp(['control/meta', 'enter']);
 
       {
         expect($(document.body).find('.htDropdownMenu:visible').length).toBe(0);
@@ -183,7 +183,7 @@ describe('DropdownMenu keyboard shortcut', () => {
       }
 
       selectCell(-3, 1); // the first (top) column header
-      keyDownUp(['shift', 'enter']);
+      keyDownUp(['control/meta', 'enter']);
 
       {
         expect($(document.body).find('.htDropdownMenu:visible').length).toBe(0);
@@ -191,7 +191,7 @@ describe('DropdownMenu keyboard shortcut', () => {
       }
 
       selectCell(-2, 1); // the second column header
-      keyDownUp(['shift', 'enter']);
+      keyDownUp(['control/meta', 'enter']);
 
       {
         expect($(document.body).find('.htDropdownMenu:visible').length).toBe(0);
@@ -199,7 +199,7 @@ describe('DropdownMenu keyboard shortcut', () => {
       }
 
       selectCell(-1, 1); // the third (bottom) column header
-      keyDownUp(['shift', 'enter']);
+      keyDownUp(['control/meta', 'enter']);
 
       {
         expect($(document.body).find('.htDropdownMenu:visible').length).toBe(1);
@@ -217,7 +217,7 @@ describe('DropdownMenu keyboard shortcut', () => {
       });
 
       selectCell(-1, 1);
-      keyDownUp(['shift', 'enter']);
+      keyDownUp(['control/meta', 'enter']);
 
       expect(getActiveEditor()).toBeUndefined();
     });
@@ -236,7 +236,7 @@ describe('DropdownMenu keyboard shortcut', () => {
         });
 
         selectCell(-1, 2);
-        keyDownUp(['shift', 'enter']);
+        keyDownUp(['control/meta', 'enter']);
 
         const cell = getCell(-1, 1, true);
         const $dropdownMenu = $(document.body).find('.htDropdownMenu:visible');

--- a/handsontable/src/plugins/dropdownMenu/__tests__/keyboardShortcuts/rtl/metaEnter.spec.js
+++ b/handsontable/src/plugins/dropdownMenu/__tests__/keyboardShortcuts/rtl/metaEnter.spec.js
@@ -20,7 +20,7 @@ describe('DropdownMenu keyboard shortcut (RTL mode)', () => {
       }
     });
 
-    describe('"Shift" + "Enter"', () => {
+    describe('"Control/meta" + "Enter"', () => {
       it('should be possible to open the dropdown menu in the correct position', async() => {
         handsontable({
           layoutDirection,
@@ -32,7 +32,7 @@ describe('DropdownMenu keyboard shortcut (RTL mode)', () => {
         });
 
         selectCell(-1, 1);
-        keyDownUp(['shift', 'enter']);
+        keyDownUp(['control/meta', 'enter']);
 
         const cell = getCell(-1, 1, true);
         const $dropdownMenu = $(document.body).find('.htDropdownMenu:visible');
@@ -60,63 +60,7 @@ describe('DropdownMenu keyboard shortcut (RTL mode)', () => {
         const lastColumn = countCols() - 1;
 
         selectCell(-1, lastColumn);
-        keyDownUp(['shift', 'enter']);
-
-        const cell = getCell(-1, lastColumn, true);
-        const $dropdownMenu = $(document.body).find('.htDropdownMenu:visible');
-        const menuOffset = $dropdownMenu.offset();
-        const cellOffset = $(cell).offset();
-
-        expect($dropdownMenu.length).toBe(1);
-        expect(menuOffset.top).toBeCloseTo(cellOffset.top + cell.clientHeight + 2);
-        expect(menuOffset.left).toBeCloseTo(cellOffset.left);
-        expect(getSelectedRange()).toEqualCellRange([
-          `highlight: -1,${lastColumn} from: -1,${lastColumn} to: 3,${lastColumn}`
-        ]);
-      });
-    });
-
-    describe('"Shift" + "Alt/Option" + "ArrowDown"', () => {
-      it('should be possible to open the dropdown menu in the correct position', () => {
-        handsontable({
-          layoutDirection,
-          data: createSpreadsheetData(3, 8),
-          colHeaders: true,
-          rowHeaders: true,
-          navigableHeaders: false,
-          dropdownMenu: true
-        });
-
-        selectCell(1, 1);
-        keyDownUp(['shift', 'alt', 'arrowdown']);
-
-        const cell = getCell(-1, 1, true);
-        const $dropdownMenu = $(document.body).find('.htDropdownMenu:visible');
-        const menuOffset = $dropdownMenu.offset();
-        const menuWidth = $dropdownMenu.outerWidth();
-        const cellOffset = $(cell).offset();
-        const cellWidth = $(cell).outerWidth();
-
-        expect($dropdownMenu.length).toBe(1);
-        expect(menuOffset.top).toBeCloseTo(cellOffset.top + cell.clientHeight + 2);
-        expect(menuOffset.left).toBeCloseTo(cellOffset.left - menuWidth + cellWidth);
-        expect(getSelectedRange()).toEqualCellRange(['highlight: 0,1 from: -1,1 to: 2,1']);
-      });
-
-      it('should be possible to open the dropdown menu on the right position when on the left there is no space left', async() => {
-        handsontable({
-          layoutDirection,
-          data: createSpreadsheetData(4, Math.floor(window.innerWidth / 50)),
-          colHeaders: true,
-          rowHeaders: true,
-          navigableHeaders: true,
-          dropdownMenu: true
-        });
-
-        const lastColumn = countCols() - 1;
-
-        selectCell(-1, lastColumn);
-        keyDownUp(['shift', 'alt', 'arrowdown']);
+        keyDownUp(['control/meta', 'enter']);
 
         const cell = getCell(-1, lastColumn, true);
         const $dropdownMenu = $(document.body).find('.htDropdownMenu:visible');

--- a/handsontable/src/plugins/dropdownMenu/__tests__/keyboardShortcuts/rtl/shiftOptionArrowDown.spec.js
+++ b/handsontable/src/plugins/dropdownMenu/__tests__/keyboardShortcuts/rtl/shiftOptionArrowDown.spec.js
@@ -1,0 +1,79 @@
+describe('DropdownMenu keyboard shortcut (RTL mode)', () => {
+  using('configuration object', [
+    { htmlDir: 'rtl', layoutDirection: 'inherit' },
+    { htmlDir: 'ltr', layoutDirection: 'rtl' },
+  ], ({ htmlDir, layoutDirection }) => {
+
+    const id = 'testContainer';
+
+    beforeEach(function() {
+      $('html').attr('dir', htmlDir);
+      this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+    });
+
+    afterEach(function() {
+      $('html').attr('dir', 'ltr');
+
+      if (this.$container) {
+        destroy();
+        this.$container.remove();
+      }
+    });
+
+    describe('"Shift" + "Alt/Option" + "ArrowDown"', () => {
+      it('should be possible to open the dropdown menu in the correct position', () => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(3, 8),
+          colHeaders: true,
+          rowHeaders: true,
+          navigableHeaders: false,
+          dropdownMenu: true
+        });
+
+        selectCell(1, 1);
+        keyDownUp(['shift', 'alt', 'arrowdown']);
+
+        const cell = getCell(-1, 1, true);
+        const $dropdownMenu = $(document.body).find('.htDropdownMenu:visible');
+        const menuOffset = $dropdownMenu.offset();
+        const menuWidth = $dropdownMenu.outerWidth();
+        const cellOffset = $(cell).offset();
+        const cellWidth = $(cell).outerWidth();
+
+        expect($dropdownMenu.length).toBe(1);
+        expect(menuOffset.top).toBeCloseTo(cellOffset.top + cell.clientHeight + 2);
+        expect(menuOffset.left).toBeCloseTo(cellOffset.left - menuWidth + cellWidth);
+        expect(getSelectedRange()).toEqualCellRange(['highlight: 0,1 from: -1,1 to: 2,1']);
+      });
+
+      it('should be possible to open the dropdown menu on the right position when on the left there is no space left', async() => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(4, Math.floor(window.innerWidth / 50)),
+          colHeaders: true,
+          rowHeaders: true,
+          navigableHeaders: true,
+          dropdownMenu: true
+        });
+
+        const lastColumn = countCols() - 1;
+
+        selectCell(-1, lastColumn);
+        keyDownUp(['shift', 'alt', 'arrowdown']);
+
+        const cell = getCell(-1, lastColumn, true);
+        const $dropdownMenu = $(document.body).find('.htDropdownMenu:visible');
+        const menuOffset = $dropdownMenu.offset();
+        const cellOffset = $(cell).offset();
+
+        expect($dropdownMenu.length).toBe(1);
+        expect(menuOffset.top).toBeCloseTo(cellOffset.top + cell.clientHeight + 2);
+        expect(menuOffset.left).toBeCloseTo(cellOffset.left);
+        expect(getSelectedRange()).toEqualCellRange([
+          `highlight: -1,${lastColumn} from: -1,${lastColumn} to: 3,${lastColumn}`
+        ]);
+      });
+    });
+  });
+});

--- a/handsontable/src/plugins/dropdownMenu/dropdownMenu.js
+++ b/handsontable/src/plugins/dropdownMenu/dropdownMenu.js
@@ -271,9 +271,10 @@ export class DropdownMenu extends BasePlugin {
     };
 
     context.addShortcuts([{
-      keys: [['Shift', 'Alt', 'ArrowDown'], ['Shift', 'Enter']],
+      keys: [['Shift', 'Alt', 'ArrowDown'], ['Control/Meta', 'Enter']],
       callback,
       runOnlyIf: () => this.hot.getSelectedRangeLast()?.highlight.isHeader() && !this.menu.isOpened(),
+      captureCtrl: true,
       group: SHORTCUTS_GROUP,
     }, {
       keys: [['Shift', 'Alt', 'ArrowDown']],

--- a/handsontable/src/plugins/multiColumnSorting/__tests__/keyboardShortcuts.spec.js
+++ b/handsontable/src/plugins/multiColumnSorting/__tests__/keyboardShortcuts.spec.js
@@ -19,7 +19,7 @@ describe('MultiColumnSorting keyboard shortcut', () => {
     this.view.appendColHeader(visualColumnsIndex, TH);
   }
 
-  describe('"Control/Meta" + "Enter"', () => {
+  describe('"Shift" + "Enter"', () => {
     it('should be possible to sort columns with correct sort order', () => {
       handsontable({
         data: createSpreadsheetData(3, 8),
@@ -30,25 +30,25 @@ describe('MultiColumnSorting keyboard shortcut', () => {
       });
 
       selectCell(-1, 1);
-      keyDownUp(['control/meta', 'enter']);
+      keyDownUp(['shift', 'enter']);
 
       expect(getPlugin('multiColumnSorting').getSortConfig()).toEqual([{
         column: 1,
         sortOrder: 'asc',
       }]);
 
-      keyDownUp(['control/meta', 'enter']);
+      keyDownUp(['shift', 'enter']);
 
       expect(getPlugin('multiColumnSorting').getSortConfig()).toEqual([{
         column: 1,
         sortOrder: 'desc',
       }]);
 
-      keyDownUp(['control/meta', 'enter']);
+      keyDownUp(['shift', 'enter']);
 
       expect(getPlugin('multiColumnSorting').getSortConfig()).toEqual([]);
 
-      keyDownUp(['control/meta', 'enter']);
+      keyDownUp(['shift', 'enter']);
 
       expect(getPlugin('multiColumnSorting').getSortConfig()).toEqual([{
         column: 1,
@@ -66,7 +66,7 @@ describe('MultiColumnSorting keyboard shortcut', () => {
       });
 
       selectCell(-1, 1);
-      keyDownUp(['control/meta', 'enter']);
+      keyDownUp(['shift', 'enter']);
 
       expect(getPlugin('multiColumnSorting').getSortConfig()).toEqual([{
         column: 1,
@@ -74,7 +74,7 @@ describe('MultiColumnSorting keyboard shortcut', () => {
       }]);
 
       selectCell(-1, 3);
-      keyDownUp(['control/meta', 'enter']);
+      keyDownUp(['shift', 'enter']);
 
       expect(getPlugin('multiColumnSorting').getSortConfig()).toEqual([
         {
@@ -87,7 +87,7 @@ describe('MultiColumnSorting keyboard shortcut', () => {
         }
       ]);
 
-      keyDownUp(['control/meta', 'enter']);
+      keyDownUp(['shift', 'enter']);
 
       expect(getPlugin('multiColumnSorting').getSortConfig()).toEqual([
         {
@@ -100,7 +100,7 @@ describe('MultiColumnSorting keyboard shortcut', () => {
         }
       ]);
 
-      keyDownUp(['control/meta', 'enter']);
+      keyDownUp(['shift', 'enter']);
 
       expect(getPlugin('multiColumnSorting').getSortConfig()).toEqual([{
         column: 1,
@@ -108,7 +108,7 @@ describe('MultiColumnSorting keyboard shortcut', () => {
       }]);
 
       selectCell(-1, 5);
-      keyDownUp(['control/meta', 'enter']);
+      keyDownUp(['shift', 'enter']);
 
       expect(getPlugin('multiColumnSorting').getSortConfig()).toEqual([
         {
@@ -122,7 +122,7 @@ describe('MultiColumnSorting keyboard shortcut', () => {
       ]);
 
       selectCell(-1, 1);
-      keyDownUp(['control/meta', 'enter']);
+      keyDownUp(['shift', 'enter']);
 
       expect(getPlugin('multiColumnSorting').getSortConfig()).toEqual([
         {
@@ -147,7 +147,7 @@ describe('MultiColumnSorting keyboard shortcut', () => {
 
       selectColumns(1, 4, -1);
       listen();
-      keyDownUp(['control/meta', 'enter']);
+      keyDownUp(['shift', 'enter']);
 
       expect(getPlugin('multiColumnSorting').getSortConfig()).toEqual([{
         column: 1,
@@ -169,27 +169,27 @@ describe('MultiColumnSorting keyboard shortcut', () => {
       });
 
       selectCell(-1, -1); // corner
-      keyDownUp(['control/meta', 'enter']);
+      keyDownUp(['shift', 'enter']);
 
       expect(getPlugin('multiColumnSorting').getSortConfig()).toEqual([]);
 
       selectCell(1, -1); // row header
-      keyDownUp(['control/meta', 'enter']);
+      keyDownUp(['shift', 'enter']);
 
       expect(getPlugin('multiColumnSorting').getSortConfig()).toEqual([]);
 
       selectCell(-3, 1); // the first (top) column header
-      keyDownUp(['control/meta', 'enter']);
+      keyDownUp(['shift', 'enter']);
 
       expect(getPlugin('multiColumnSorting').getSortConfig()).toEqual([]);
 
       selectCell(-2, 1); // the second column header
-      keyDownUp(['control/meta', 'enter']);
+      keyDownUp(['shift', 'enter']);
 
       expect(getPlugin('multiColumnSorting').getSortConfig()).toEqual([]);
 
       selectCell(-1, 1); // the third (bottom) column header
-      keyDownUp(['control/meta', 'enter']);
+      keyDownUp(['shift', 'enter']);
 
       expect(getPlugin('multiColumnSorting').getSortConfig()).toEqual([{
         column: 1,
@@ -207,7 +207,7 @@ describe('MultiColumnSorting keyboard shortcut', () => {
       });
 
       selectCell(-1, 1);
-      keyDownUp(['control/meta', 'enter']);
+      keyDownUp(['shift', 'enter']);
 
       expect(getActiveEditor()).toBeUndefined();
     });

--- a/handsontable/src/plugins/multiColumnSorting/multiColumnSorting.js
+++ b/handsontable/src/plugins/multiColumnSorting/multiColumnSorting.js
@@ -128,7 +128,7 @@ export class MultiColumnSorting extends ColumnSorting {
     this.hot.getShortcutManager()
       .getContext('grid')
       .addShortcut({
-        keys: [['Control/Meta', 'Enter']],
+        keys: [['Shift', 'Enter']],
         callback: () => {
           const { highlight } = this.hot.getSelectedRangeLast();
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR changes the keyboard shortcuts for some existed features

#### Changes
* Change the shortcut for the _MultipleColumnSorting_ plugin (sorting action) from <kbd>Cmd/Ctrl + Enter</kbd> to <kbd>Shift + Enter</kbd>;
* Change the shortcut for the _DropdownMenu_ plugin (open menu action) from <kbd>Shift + Enter</kbd> to <kbd>Cmd/Ctrl + Enter</kbd>; 

_[skip changelog]_ (the PR updates non-released feature so the changelog is not necessary here)

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and updated the tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1466

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
