### PR TITLE
Add 'aria-sort' attributes to column headers

### DIFF
--- a/handsontable/src/plugins/columnSorting/columnSorting.js
+++ b/handsontable/src/plugins/columnSorting/columnSorting.js
@@ -1,5 +1,5 @@
 import {
-  addClass,
+  addClass, removeAttribute,
   removeClass,
   setAttribute,
 } from '../../helpers/dom/element';
@@ -20,7 +20,7 @@ import {
 } from './utils';
 import {
   getClassesToRemove,
-  getClassesToAdd
+  getClassesToAdd, getAriaSortAttrToAdd, getAriaSortAttrToRemove
 } from './domHelpers';
 import { rootComparator } from './rootComparator';
 import { registerRootComparator, sort } from './sortService';
@@ -185,7 +185,7 @@ export class ColumnSorting extends BasePlugin {
         return;
       }
 
-      this.updateHeaderClasses(headerSpanElement);
+      this.updateHeaderClassesAndAriaSortAttributes(headerSpanElement);
     };
 
     // Changing header width and removing indicator.
@@ -715,7 +715,7 @@ export class ColumnSorting extends BasePlugin {
     const showSortIndicator = pluginSettingsForColumn.indicator;
     const headerActionEnabled = pluginSettingsForColumn.headerAction;
 
-    this.updateHeaderClasses(
+    this.updateHeaderClassesAndAriaSortAttributes(
       headerSpanElement,
       this.columnStatesManager,
       column,
@@ -731,17 +731,19 @@ export class ColumnSorting extends BasePlugin {
   }
 
   /**
-   * Update header classes.
+   * Update header classes and aria-sort attributes.
    *
    * @private
    * @param {HTMLElement} headerSpanElement Header span element.
    * @param {...*} args Extra arguments for helpers.
    */
-  updateHeaderClasses(headerSpanElement, ...args) {
+  updateHeaderClassesAndAriaSortAttributes(headerSpanElement, ...args) {
     removeClass(headerSpanElement, getClassesToRemove(headerSpanElement));
-
+    removeAttribute(headerSpanElement, getAriaSortAttrToRemove());
+    
     if (this.enabled !== false) {
       addClass(headerSpanElement, getClassesToAdd(...args));
+      setAttribute(headerSpanElement, getAriaSortAttrToAdd(...args));
     }
   }
 

--- a/handsontable/src/plugins/columnSorting/domHelpers.js
+++ b/handsontable/src/plugins/columnSorting/domHelpers.js
@@ -12,6 +12,16 @@ const orderToCssClass = new Map([
   [DESC_SORT_STATE, HEADER_CLASS_DESC_SORT]
 ]);
 
+const HEADER_ARIA_SORT_KEY = 'aria-sort';
+const HEADER_ARIA_SORT_ASC = 'ascending';
+const HEADER_ARIA_SORT_DESC = 'descending';
+const HEADER_ARIA_SORT_NONE = 'none';
+
+const orderToAriaSort = new Map([
+  [ASC_SORT_STATE, HEADER_ARIA_SORT_ASC],
+  [DESC_SORT_STATE, HEADER_ARIA_SORT_DESC]
+]);
+
 /**
  * Get CSS classes which should be added to particular column header.
  *
@@ -51,4 +61,30 @@ export function getClassesToAdd(columnStatesManager, column, showSortIndicator, 
 export function getClassesToRemove() {
   return Array.from(orderToCssClass.values())
     .concat(HEADER_ACTION_CLASS, HEADER_CLASS_INDICATOR_DISABLED, HEADER_SORT_CLASS);
+}
+
+/**
+ * TBP
+ *
+ * @param {object} columnStatesManager Instance of column state manager.
+ * @param {number} column Visual column index.
+ * @returns {Array} Array of pairs of strings (key and value).
+ */
+export function getAriaSortAttrToAdd(columnStatesManager, column) {
+  const columnOrder = columnStatesManager.getSortOrderOfColumn(column);
+
+  const ariaSortAttrValue = isDefined(columnOrder)
+    ? orderToAriaSort.get(columnOrder) ?? HEADER_ARIA_SORT_NONE
+    : HEADER_ARIA_SORT_NONE
+
+  return [[HEADER_ARIA_SORT_KEY, ariaSortAttrValue ]];
+}
+
+/**
+ * TBP
+ *
+ * @returns {Array} Array of attribute keys.
+ */
+export function getAriaSortAttrToRemove() {
+  return [ HEADER_ARIA_SORT_KEY ];
 }

--- a/handsontable/src/plugins/columnSorting/domHelpers.js
+++ b/handsontable/src/plugins/columnSorting/domHelpers.js
@@ -64,7 +64,7 @@ export function getClassesToRemove() {
 }
 
 /**
- * TBP
+ * Get aria-sort attributes which should be added to particular column header.
  *
  * @param {object} columnStatesManager Instance of column state manager.
  * @param {number} column Visual column index.
@@ -81,7 +81,7 @@ export function getAriaSortAttrToAdd(columnStatesManager, column) {
 }
 
 /**
- * TBP
+ * Get aria-sort attributes which should be removed from column header.
  *
  * @returns {Array} Array of attribute keys.
  */

--- a/handsontable/src/plugins/multiColumnSorting/multiColumnSorting.js
+++ b/handsontable/src/plugins/multiColumnSorting/multiColumnSorting.js
@@ -4,12 +4,13 @@ import {
 } from '../columnSorting';
 import { registerRootComparator } from '../columnSorting/sortService';
 import { wasHeaderClickedProperly } from '../columnSorting/utils';
-import { addClass, removeClass } from '../../helpers/dom/element';
+import {addClass, removeAttribute, removeClass, setAttribute} from '../../helpers/dom/element';
 import { rootComparator } from './rootComparator';
 import { warnAboutPluginsConflict } from './utils';
 import { getClassesToAdd, getClassesToRemove } from './domHelpers';
 
 import './multiColumnSorting.scss';
+import {getAriaSortAttrToAdd, getAriaSortAttrToRemove} from "../columnSorting/domHelpers";
 
 export const PLUGIN_KEY = 'multiColumnSorting';
 export const PLUGIN_PRIORITY = 170;
@@ -262,13 +263,15 @@ export class MultiColumnSorting extends ColumnSorting {
    * @param {HTMLElement} headerSpanElement Header span element.
    * @param {...*} args Extra arguments for helpers.
    */
-  updateHeaderClasses(headerSpanElement, ...args) {
-    super.updateHeaderClasses(headerSpanElement, ...args);
+  updateHeaderClassesAndAriaSortAttributes(headerSpanElement, ...args) {
+    super.updateHeaderClassesAndAriaSortAttributes(headerSpanElement, ...args);
 
     removeClass(headerSpanElement, getClassesToRemove(headerSpanElement));
+    removeAttribute(headerSpanElement, getAriaSortAttrToRemove());
 
     if (this.enabled !== false) {
       addClass(headerSpanElement, getClassesToAdd(...args));
+      setAttribute(headerSpanElement, getAriaSortAttrToAdd(...args));
     }
   }
 

--- a/handsontable/src/plugins/multiColumnSorting/multiColumnSorting.js
+++ b/handsontable/src/plugins/multiColumnSorting/multiColumnSorting.js
@@ -257,7 +257,7 @@ export class MultiColumnSorting extends ColumnSorting {
   }
 
   /**
-   * Update header classes.
+   * Update header classes and aria-sort attributes.
    *
    * @private
    * @param {HTMLElement} headerSpanElement Header span element.


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->

TBP

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

TBP

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/1441
2.
3.

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
