### PR TITLE
Implement the `select` cell type.

### DIFF
--- a/.changelogs/10529.json
+++ b/.changelogs/10529.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Implemented the `select` renderer and cell type.",
+  "type": "added",
+  "issueOrPR": 10529,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/__tests__/registry/registerAllCellTypes.unit.js
+++ b/handsontable/src/__tests__/registry/registerAllCellTypes.unit.js
@@ -20,6 +20,7 @@ describe('`registerAllCellTypes`', () => {
       'handsontable',
       'numeric',
       'password',
+      'select',
       'time',
     ]);
     expect(getRegisteredEditorNames()).toEqual([
@@ -31,6 +32,7 @@ describe('`registerAllCellTypes`', () => {
       'handsontable',
       'numeric',
       'password',
+      'select',
       'time',
     ]);
     expect(getPluginsNames()).toEqual([]);
@@ -43,6 +45,7 @@ describe('`registerAllCellTypes`', () => {
       'handsontable',
       'numeric',
       'password',
+      'select',
       'time',
     ]);
     expect(getRegisteredValidatorNames()).toEqual([

--- a/handsontable/src/cellTypes/index.js
+++ b/handsontable/src/cellTypes/index.js
@@ -5,6 +5,7 @@ import { DropdownCellType, CELL_TYPE as DROPDOWN_TYPE } from './dropdownType';
 import { HandsontableCellType, CELL_TYPE as HANDSONTABLE_TYPE } from './handsontableType';
 import { NumericCellType, CELL_TYPE as NUMERIC_TYPE } from './numericType';
 import { PasswordCellType, CELL_TYPE as PASSWORD_TYPE } from './passwordType';
+import { SelectCellType, CELL_TYPE as SELECT_TYPE } from './selectType';
 import { TextCellType, CELL_TYPE as TEXT_TYPE } from './textType';
 import { TimeCellType, CELL_TYPE as TIME_TYPE } from './timeType';
 import {
@@ -22,6 +23,7 @@ export function registerAllCellTypes() {
   registerCellType(HandsontableCellType);
   registerCellType(NumericCellType);
   registerCellType(PasswordCellType);
+  registerCellType(SelectCellType);
   registerCellType(TextCellType);
   registerCellType(TimeCellType);
 }
@@ -34,6 +36,7 @@ export {
   HandsontableCellType, HANDSONTABLE_TYPE,
   NumericCellType, NUMERIC_TYPE,
   PasswordCellType, PASSWORD_TYPE,
+  SelectCellType, SELECT_TYPE,
   TextCellType, TEXT_TYPE,
   TimeCellType, TIME_TYPE,
 };

--- a/handsontable/src/cellTypes/selectType/__tests__/selectType.unit.js
+++ b/handsontable/src/cellTypes/selectType/__tests__/selectType.unit.js
@@ -1,0 +1,65 @@
+import {
+  CELL_TYPE,
+  SelectCellType,
+} from '../';
+import {
+  getCellType,
+  getRegisteredCellTypeNames,
+  registerCellType,
+} from '../../registry';
+import {
+  getEditor,
+  getRegisteredEditorNames,
+} from '../../../editors';
+import {
+  getRegisteredRendererNames,
+  getRenderer,
+} from '../../../renderers';
+import {
+  getRegisteredValidatorNames,
+} from '../../../validators';
+
+describe('SelectCellType', () => {
+  describe('registering', () => {
+    it('should not auto-register after import', () => {
+      expect(getRegisteredEditorNames()).toEqual([]);
+      expect(() => {
+        getEditor('select');
+      }).toThrowError();
+
+      expect(getRegisteredRendererNames()).toEqual([]);
+      expect(() => {
+        getRenderer('select');
+      }).toThrowError();
+
+      expect(getRegisteredValidatorNames()).toEqual([]);
+      expect(() => {
+        getValidator('select');
+      }).toThrowError();
+
+      expect(getRegisteredCellTypeNames()).toEqual([]);
+      expect(() => {
+        getCellType('select');
+      }).toThrowError();
+    });
+    it('should register cell type', () => {
+      registerCellType(CELL_TYPE, SelectCellType);
+
+      expect(getRegisteredEditorNames()).toEqual(['select']);
+      expect(getEditor('select')).toBeInstanceOf(Function);
+
+      expect(getRegisteredRendererNames()).toEqual(['select']);
+      expect(getRenderer('select')).toBeInstanceOf(Function);
+
+      expect(getRegisteredValidatorNames()).toEqual([]);
+
+      expect(getRegisteredCellTypeNames()).toEqual(['select']);
+      expect(getCellType('select')).toEqual(SelectCellType);
+      expect(getCellType('select')).toEqual({
+        CELL_TYPE,
+        editor: getEditor('select'),
+        renderer: getRenderer('select'),
+      });
+    });
+  });
+});

--- a/handsontable/src/cellTypes/selectType/index.js
+++ b/handsontable/src/cellTypes/selectType/index.js
@@ -1,0 +1,4 @@
+export {
+  CELL_TYPE,
+  SelectCellType,
+} from './selectType';

--- a/handsontable/src/cellTypes/selectType/selectType.js
+++ b/handsontable/src/cellTypes/selectType/selectType.js
@@ -1,0 +1,9 @@
+import { SelectEditor } from '../../editors/selectEditor';
+import { selectRenderer } from '../../renderers/selectRenderer';
+
+export const CELL_TYPE = 'select';
+export const SelectCellType = {
+  CELL_TYPE,
+  editor: SelectEditor,
+  renderer: selectRenderer,
+};

--- a/handsontable/src/renderers/selectRenderer/__tests__/a11y/attributes.spec.js
+++ b/handsontable/src/renderers/selectRenderer/__tests__/a11y/attributes.spec.js
@@ -1,0 +1,28 @@
+describe('a11y DOM attributes (ARIA tags)', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should add an `aria-haspopup` attribute to select-typed cells' +
+    ' had been checked', () => {
+    handsontable({
+      data: [['test 1']],
+      columns: [
+        {
+          type: 'select'
+        }
+      ]
+    });
+
+    expect(getCell(0, 0).getAttribute('aria-haspopup')).toEqual('listbox');
+  });
+});

--- a/handsontable/src/renderers/selectRenderer/__tests__/selectRenderer.unit.js
+++ b/handsontable/src/renderers/selectRenderer/__tests__/selectRenderer.unit.js
@@ -1,0 +1,26 @@
+import {
+  RENDERER_TYPE,
+  selectRenderer,
+} from '../';
+import {
+  getRegisteredRendererNames,
+  getRenderer,
+  registerRenderer,
+} from '../../registry';
+import {
+  registerCellType,
+  SelectCellType,
+} from '../../../cellTypes';
+
+registerCellType(SelectCellType);
+
+describe('selectRenderer', () => {
+  describe('registering', () => {
+    it('should register renderer', () => {
+      registerRenderer(RENDERER_TYPE, selectRenderer);
+
+      expect(getRegisteredRendererNames()).toEqual([RENDERER_TYPE]);
+      expect(getRenderer(RENDERER_TYPE)).toBeInstanceOf(Function);
+    });
+  });
+});

--- a/handsontable/src/renderers/selectRenderer/index.js
+++ b/handsontable/src/renderers/selectRenderer/index.js
@@ -1,0 +1,4 @@
+export {
+  RENDERER_TYPE,
+  selectRenderer,
+} from './selectRenderer';

--- a/handsontable/src/renderers/selectRenderer/selectRenderer.js
+++ b/handsontable/src/renderers/selectRenderer/selectRenderer.js
@@ -1,0 +1,24 @@
+import { textRenderer } from '../textRenderer';
+import { A11Y_HASPOPUP } from '../../helpers/a11y';
+
+export const RENDERER_TYPE = 'select';
+
+/**
+ * @private
+ * @param {Core} instance The Handsontable instance.
+ * @param {HTMLTableCellElement} TD The rendered cell element.
+ * @param {number} row The visual row index.
+ * @param {number} col The visual column index.
+ * @param {number|string} prop The column property (passed when datasource is an array of objects).
+ * @param {*} value The rendered value.
+ * @param {object} cellProperties The cell meta object ({@see Core#getCellMeta}).
+ */
+export function selectRenderer(instance, TD, row, col, prop, value, cellProperties) {
+  textRenderer.apply(this, [instance, TD, row, col, prop, value, cellProperties]);
+
+  if (instance.getSettings().ariaTags) {
+    TD.setAttribute(...A11Y_HASPOPUP());
+  }
+}
+
+selectRenderer.RENDERER_TYPE = RENDERER_TYPE;

--- a/handsontable/test/types/modules/cellTypes.types.ts
+++ b/handsontable/test/types/modules/cellTypes.types.ts
@@ -7,6 +7,7 @@ import {
   HandsontableCellType,
   NumericCellType,
   PasswordCellType,
+  SelectCellType,
   TextCellType,
   TimeCellType,
   getCellType,
@@ -23,6 +24,7 @@ registerCellType(DropdownCellType);
 registerCellType(HandsontableCellType);
 registerCellType(NumericCellType);
 registerCellType(PasswordCellType);
+registerCellType(SelectCellType);
 registerCellType(TimeCellType);
 registerCellType(TextCellType);
 

--- a/handsontable/types/cellTypes/index.d.ts
+++ b/handsontable/types/cellTypes/index.d.ts
@@ -5,6 +5,7 @@ import { DropdownCellType, CELL_TYPE as DROPDOWN_TYPE } from './dropdownType';
 import { HandsontableCellType, CELL_TYPE as HANDSONTABLE_TYPE } from './handsontableType';
 import { NumericCellType, CELL_TYPE as NUMERIC_TYPE } from './numericType';
 import { PasswordCellType, CELL_TYPE as PASSWORD_TYPE } from './passwordType';
+import { SelectCellType, CELL_TYPE as SELECT_TYPE } from './selectType';
 import { TextCellType, CELL_TYPE as TEXT_TYPE } from './textType';
 import { TimeCellType, CELL_TYPE as TIME_TYPE } from './timeType';
 
@@ -18,6 +19,7 @@ export interface CellTypes {
   handsontable: typeof HandsontableCellType;
   numeric: typeof NumericCellType;
   password: typeof PasswordCellType;
+  select: typeof SelectCellType;
   text: typeof TextCellType;
   time: typeof TimeCellType;
 }
@@ -35,6 +37,7 @@ export {
   HandsontableCellType, HANDSONTABLE_TYPE,
   NumericCellType, NUMERIC_TYPE,
   PasswordCellType, PASSWORD_TYPE,
+  SelectCellType, SELECT_TYPE,
   TextCellType, TEXT_TYPE,
   TimeCellType, TIME_TYPE
 };

--- a/handsontable/types/cellTypes/selectType/index.d.ts
+++ b/handsontable/types/cellTypes/selectType/index.d.ts
@@ -1,0 +1,1 @@
+export * from './selectType';

--- a/handsontable/types/cellTypes/selectType/selectType.d.ts
+++ b/handsontable/types/cellTypes/selectType/selectType.d.ts
@@ -1,0 +1,14 @@
+import { CellTypeObject } from '../base';
+import { SelectEditor } from '../../editors/selectEditor';
+import { selectRenderer } from '../../renderers/selectRenderer';
+
+export const CELL_TYPE: 'select';
+export interface SelectCellType extends CellTypeObject {
+  editor: typeof SelectEditor;
+  renderer: typeof selectRenderer;
+}
+
+export namespace SelectCellType {
+  export { SelectEditor as editor };
+  export { selectRenderer as renderer };
+}

--- a/handsontable/types/renderers/index.d.ts
+++ b/handsontable/types/renderers/index.d.ts
@@ -4,6 +4,7 @@ import { checkboxRenderer, RENDERER_TYPE as CHECKBOX_RENDERER } from './checkbox
 import { htmlRenderer, RENDERER_TYPE as HTML_RENDERER } from './htmlRenderer';
 import { numericRenderer, RENDERER_TYPE as NUMERIC_RENDERER } from './numericRenderer';
 import { passwordRenderer, RENDERER_TYPE as PASSWORD_RENDERER } from './passwordRenderer';
+import { selectRenderer, RENDERER_TYPE as SELECT_RENDERER } from './selectRenderer';
 import { textRenderer, RENDERER_TYPE as TEXT_RENDERER } from './textRenderer';
 import { timeRenderer, RENDERER_TYPE as TIME_RENDERER } from './timeRenderer';
 
@@ -16,6 +17,7 @@ export interface Renderers {
   html: typeof htmlRenderer;
   numeric: typeof numericRenderer;
   password: typeof passwordRenderer;
+  select: typeof selectRenderer;
   text: typeof textRenderer;
   time: typeof timeRenderer;
 }
@@ -32,6 +34,7 @@ export {
   htmlRenderer, HTML_RENDERER,
   numericRenderer, NUMERIC_RENDERER,
   passwordRenderer, PASSWORD_RENDERER,
+  selectRenderer, SELECT_RENDERER,
   textRenderer, TEXT_RENDERER,
   timeRenderer, TIME_RENDERER
 };

--- a/handsontable/types/renderers/selectRenderer/index.d.ts
+++ b/handsontable/types/renderers/selectRenderer/index.d.ts
@@ -1,0 +1,1 @@
+export { RENDERER_TYPE, selectRenderer } from './selectRenderer';

--- a/handsontable/types/renderers/selectRenderer/selectRenderer.d.ts
+++ b/handsontable/types/renderers/selectRenderer/selectRenderer.d.ts
@@ -1,0 +1,5 @@
+import Core from '../../core';
+import { CellProperties } from '../../settings';
+
+export const RENDERER_TYPE: 'select';
+export function selectRenderer(instance: Core, TD: HTMLTableCellElement, row: number, col: number, prop: string | number, value: any, cellProperties: CellProperties): void;


### PR DESCRIPTION
### Context
In order to add the aria tags from handsontable/dev-handsontable#1462 to the select renderer, I figured it would be good to implement a `select` cell type.

Up until `13.1.0`, `select` is still just an editor, despite [being called a cell type in the docs](https://handsontable.com/docs/javascript-data-grid/select-cell-type/).

This PR:
- Implements a `select` renderer (basically a text renderer with the aria tag added - currently the docs suggest using the default `text` renderer).
- Implements a `select` cell type (with the `selectEditor` as the editor and the new `selectRenderer` as the renderer).
- Adds the `aria-haspopup` attribute to the `selectRenderer`.
- Updates the `select-cell-type` guide from the docs with `type: 'select'`.

### How has this been tested?
Added test cases for the new cell type and renderer + the aria tags.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#1462

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
