### PR TITLE
Improve accessibility of the dropdown menu.

### DIFF
--- a/handsontable/src/plugins/contextMenu/menu/menu.js
+++ b/handsontable/src/plugins/contextMenu/menu/menu.js
@@ -266,8 +266,8 @@ export class Menu {
     this.navigator.setMenu(this.hotMenu);
 
     const shortcutManager = this.hotMenu.getShortcutManager();
-    const menuContext = shortcutManager.addContext(SHORTCUTS_GROUP);
-    const config = { group: SHORTCUTS_CONTEXT };
+    const menuContext = shortcutManager.addContext(SHORTCUTS_CONTEXT);
+    const config = { group: SHORTCUTS_GROUP };
     const menuContextConfig = {
       ...config,
       runOnlyIf: event => !isInput(event.target) || !this.container.contains(event.target),
@@ -369,6 +369,8 @@ export class Menu {
     if (!this.isOpened()) {
       return;
     }
+
+    this.runLocalHooks('beforeClose');
 
     if (closeParent && this.isSubMenu()) {
       this.parentMenu.close();

--- a/handsontable/src/plugins/dropdownMenu/__tests__/keyboardShortcuts/metaA.spec.js
+++ b/handsontable/src/plugins/dropdownMenu/__tests__/keyboardShortcuts/metaA.spec.js
@@ -11,18 +11,21 @@ describe('DropdownMenu keyboard shortcut', () => {
   });
 
   describe('"Control/Meta" + "A"', () => {
-    it('should close the menu and move the selection of the main table to the previous cell', () => {
+    it('should not close the dropdown menu, nor select all cells in the main table', () => {
       handsontable({
         colHeaders: true,
         dropdownMenu: generateRandomDropdownMenuItems(10),
       });
 
       dropdownMenu(1);
+
+      const initialSelectionState = getSelectedRange();
+
       keyDownUp(['Control/Meta', 'A']);
 
-      expect(getPlugin('dropdownMenu').menu.isOpened()).toBe(false);
-      expect(getSelectedRange()).toEqualCellRange(['highlight: 0,1 from: -1,0 to: 4,4']);
-      expect(isListening()).toBe(true);
+      expect(getPlugin('dropdownMenu').menu.isOpened()).toBe(true);
+      expect(getSelectedRange()).toEqual(initialSelectionState);
+      expect(isListening()).toBe(false);
     });
   });
 });


### PR DESCRIPTION
### Context
This PR:
- Adds `aria-haspopup` to the `TH` elements containing the dropdownMenu buttons.
- Excludes the dropdown menu from reacting to <kbd>Cmd/Ctrl</kbd>+<kbd>A</kbd>, previously introduced by #10519.

[skip changelog]

### How has this been tested?
Modified the existing test case for <kbd>Cmd/Ctrl</kbd>+<kbd>A</kbd> to match the current requirements.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#1465

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
