### PR TITLE
Add key shortcuts and role attributes to the filtering menu's links.

### DIFF
--- a/handsontable/src/plugins/filters/__tests__/a11y/attributes.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/a11y/attributes.spec.js
@@ -1,0 +1,27 @@
+describe('a11y DOM attributes (ARIA tags)', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should assign the `role=button` to the `Select All` and `Clear` links', async() => {
+    handsontable({
+      colHeaders: true,
+      filters: true,
+      dropdownMenu: true,
+    });
+
+    dropdownMenu(0);
+
+    expect(document.querySelector('.htUISelectAll').getAttribute('role')).toEqual('button');
+    expect(document.querySelector('.htUIClearAll').getAttribute('role')).toEqual('button');
+  });
+});

--- a/handsontable/src/plugins/filters/__tests__/keyboardShortcuts.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/keyboardShortcuts.spec.js
@@ -131,4 +131,49 @@ describe('Filters keyboard shortcut', () => {
       expect(getSelectedRange()).toEqualCellRange(['highlight: -1,-1 from: -1,-1 to: -1,-1']);
     });
   });
+
+  describe('LinkUI buttons', () => {
+    it('should react to both `Enter` and `Space`', async() => {
+      const countCheckedCheckboxes = () => {
+        return Array.from(
+          document.querySelectorAll('.htUIMultipleSelectHot input[type=checkbox]')
+        ).filter(el => el.checked).length;
+      };
+
+      handsontable({
+        data: getDataForFilters().splice(0, 10),
+        rowHeaders: true,
+        colHeaders: true,
+        filters: true,
+        dropdownMenu: true,
+        navigableHeaders: true,
+      });
+
+      dropdownMenu(1);
+
+      document.querySelector('.htUIClearAll a').focus();
+
+      keyDownUp('enter');
+      await sleep(15);
+      expect(countCheckedCheckboxes()).toEqual(0);
+
+      document.querySelector('.htUISelectAll a').focus();
+
+      keyDownUp('enter');
+      await sleep(15);
+      expect(countCheckedCheckboxes()).toEqual(10);
+
+      document.querySelector('.htUIClearAll a').focus();
+
+      keyDownUp('space');
+      await sleep(15);
+      expect(countCheckedCheckboxes()).toEqual(0);
+
+      document.querySelector('.htUISelectAll a').focus();
+
+      keyDownUp('space');
+      await sleep(15);
+      expect(countCheckedCheckboxes()).toEqual(10);
+    });
+  });
 });

--- a/handsontable/src/plugins/filters/menu/focusController.js
+++ b/handsontable/src/plugins/filters/menu/focusController.js
@@ -1,6 +1,7 @@
 import { createFocusNavigator } from './focusNavigator';
 import { SelectUI } from '../ui/select';
 import { BaseUI } from '../ui/_base';
+import { LinkUI } from '../ui/link';
 
 const SHORTCUTS_MENU_CONTEXT = 'filters';
 
@@ -100,6 +101,12 @@ export function createMenuFocusController(mainMenu, menuItems) {
           element.openOptions();
           event.preventDefault();
         }
+
+        if (element instanceof LinkUI) {
+          element.activate();
+          event.preventDefault();
+        }
+
         if (!(element instanceof BaseUI)) {
           event.preventDefault();
         }

--- a/handsontable/src/plugins/filters/ui/link.js
+++ b/handsontable/src/plugins/filters/ui/link.js
@@ -11,6 +11,7 @@ export class LinkUI extends BaseUI {
       href: '#',
       tagName: 'a',
       tabIndex: -1,
+      role: 'button',
     });
   }
 
@@ -52,5 +53,12 @@ export class LinkUI extends BaseUI {
     if (this.isBuilt()) {
       this.#link.focus();
     }
+  }
+
+  /**
+   * Activate the element.
+   */
+  activate() {
+    this.#link.click();
   }
 }


### PR DESCRIPTION
### Context
This PR:
- Makes the `Select All` and `Clear` links react to both <kbd>Enter</kbd> and <kbd>Space</kbd> keys.
- Adds `role=button` to those elements.

[skip changelog]

### How has this been tested?
Added test cases.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#1485

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
