### PR TITLE
Add missing TS definition for `forwardToContext` option

### DIFF
--- a/handsontable/src/shortcuts/__tests__/shortcutManager.types.ts
+++ b/handsontable/src/shortcuts/__tests__/shortcutManager.types.ts
@@ -12,7 +12,7 @@ shortcutManager.isCtrlPressed();
 shortcutManager.destroy();
 
 const shortcut = { group: 'group', keys: [['control/meta', 'a']], callback: () => {} };
-const shortcut2 = {
+const withAllOptions = {
   group: 'group2',
   keys: [['control/meta', 'a']],
   callback: () => {},
@@ -24,11 +24,18 @@ const shortcut2 = {
   position: 'before' as const,
   forwardToContext: context,
 };
+const minimalSetup = {
+  group: 'group3',
+  keys: [['control/meta', 'z']],
+  callback: () => {},
+};
 
 context.addShortcut(shortcut);
-context.addShortcut(shortcut2);
+context.addShortcut(withAllOptions);
+context.addShortcut(minimalSetup);
 context.addShortcuts([shortcut]);
-context.addShortcuts([shortcut2]);
+context.addShortcuts([withAllOptions]);
+context.addShortcuts([minimalSetup]);
 context.getShortcuts();
 context.hasShortcut(['control/meta', 'a']);
 context.removeShortcutsByKeys(['control/meta', 'a']);

--- a/handsontable/src/shortcuts/__tests__/shortcutManager.types.ts
+++ b/handsontable/src/shortcuts/__tests__/shortcutManager.types.ts
@@ -22,6 +22,7 @@ const shortcut2 = {
   stopPropagation: false,
   relativeToGroup: 'group2',
   position: 'before' as const,
+  forwardToContext: context,
 };
 
 context.addShortcut(shortcut);

--- a/handsontable/types/shortcuts/context.d.ts
+++ b/handsontable/types/shortcuts/context.d.ts
@@ -8,6 +8,7 @@ interface Shortcut {
   stopPropagation?: boolean;
   relativeToGroup?: string;
   position?: 'before' | 'after';
+  forwardToContext?: Context;
 }
 
 export interface Context {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adds missing TS definition for `forwardToContext` option.

_[skip changelog]_ (fix for unreleased feature)

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and I covered the fix with new test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1505

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)