### PR TITLE
Fix contextMenu keyboard shortcuts implementation

### DIFF
--- a/handsontable/src/plugins/contextMenu/__tests__/keyboardShortcuts/shiftMetaBackslashOrShiftF10.spec.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/keyboardShortcuts/shiftMetaBackslashOrShiftF10.spec.js
@@ -14,6 +14,25 @@ describe('ContextMenu keyboard shortcut', () => {
     ['Shift', 'Control/Meta', '\\'],
     ['Shift', 'F10'],
   ], (keyboardShortcut) => {
+    it('should open a menu after `updateSettings` call', () => {
+      handsontable({
+        contextMenu: true,
+      });
+
+      selectCell(1, 1);
+
+      updateSettings({
+        contextMenu: true,
+      });
+
+      const plugin = getPlugin('contextMenu');
+
+      spyOn(plugin, 'open').and.callThrough();
+      keyDownUp(keyboardShortcut);
+
+      expect(plugin.open).toHaveBeenCalledTimes(1);
+    });
+
     it('should internally call `open()` method with correct cell coordinates', () => {
       handsontable({
         contextMenu: true,

--- a/handsontable/src/plugins/contextMenu/contextMenu.js
+++ b/handsontable/src/plugins/contextMenu/contextMenu.js
@@ -181,8 +181,6 @@ export class ContextMenu extends BasePlugin {
   updatePlugin() {
     this.disablePlugin();
     this.enablePlugin();
-
-    this.unregisterShortcuts();
     super.updatePlugin();
   }
 
@@ -196,6 +194,8 @@ export class ContextMenu extends BasePlugin {
       this.menu.destroy();
       this.menu = null;
     }
+
+    this.unregisterShortcuts();
     super.disablePlugin();
   }
 

--- a/handsontable/src/plugins/dropdownMenu/__tests__/keyboardShortcuts/shiftOptionArrowDown.spec.js
+++ b/handsontable/src/plugins/dropdownMenu/__tests__/keyboardShortcuts/shiftOptionArrowDown.spec.js
@@ -18,6 +18,26 @@ describe('DropdownMenu keyboard shortcut', () => {
   }
 
   describe('"Shift" + "Alt/Option" + "ArrowDown"', () => {
+    it('should open a menu after `updateSettings` call', () => {
+      handsontable({
+        colHeaders: true,
+        dropdownMenu: true,
+      });
+
+      selectCell(1, 1);
+
+      updateSettings({
+        dropdownMenu: true,
+      });
+
+      const plugin = getPlugin('dropdownMenu');
+
+      spyOn(plugin, 'open').and.callThrough();
+      keyDownUp(['shift', 'alt', 'arrowdown']);
+
+      expect(plugin.open).toHaveBeenCalledTimes(1);
+    });
+
     it('should be possible to open the dropdown menu in the correct position triggered from the single cell', () => {
       handsontable({
         data: createSpreadsheetData(3, 8),


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the _ContextMenu_ keyboard shortcuts implementation by changing the moment when the keyboard shortcuts are registered and unregistered.

_[skip changelog]_ (fix for unreleased bug)

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally, and I covered the fix with a new test. A similar test I added to the _DropdownMenu_ plugin.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1508

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
