### PR TITLE
Fix JSDoc type for CellCoords assign method

### DIFF
--- a/handsontable/src/3rdparty/walkontable/src/cell/coords.js
+++ b/handsontable/src/3rdparty/walkontable/src/cell/coords.js
@@ -198,7 +198,8 @@ class CellCoords {
    * Assigns the coordinates from another `CellCoords` instance (or compatible literal object)
    * to your `CellCoords` instance.
    *
-   * @param {CellCoords | { row?: number, col?: number }} coords The CellCoords instance or compatible literal object.
+   * @param {CellCoords | { row: number | undefined, col: number | undefined }} coords The CellCoords
+   * instance or compatible literal object.
    * @returns {CellCoords}
    */
   assign(coords) {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes JSDoc type for the `CellCoords` assign method.

_[skip changelog]_

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
