### PR TITLE
Improve selection after filtering

### DIFF
--- a/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
@@ -1420,7 +1420,7 @@ describe('Filters UI', () => {
     });
   });
 
-  describe('"action_bar" component', () => {
+  describe('"action_bar" (buttons bar) component', () => {
     it('should appear under dropdown menu', async() => {
       handsontable({
         data: getDataForFilters(),
@@ -1619,7 +1619,7 @@ describe('Filters UI', () => {
     });
   });
 
-  it('should deselect all values in "Filter by value" after clicking "Clear" link', (done) => {
+  it('should deselect all values in "Filter by value" after clicking "Clear" link', async() => {
     handsontable({
       data: getDataForFilters(),
       columns: getColumnsForFilters(),
@@ -1631,15 +1631,14 @@ describe('Filters UI', () => {
 
     dropdownMenu(1);
 
-    setTimeout(() => {
-      $(dropdownMenuRootElement().querySelector('.htUIClearAll a')).simulate('click');
+    await sleep(100);
 
-      expect(byValueMultipleSelect().getItems().map(o => o.checked).indexOf(true)).toBe(-1);
-      done();
-    }, 100);
+    $(dropdownMenuRootElement().querySelector('.htUIClearAll a')).simulate('click');
+
+    expect(byValueMultipleSelect().getItems().map(o => o.checked).indexOf(true)).toBe(-1);
   });
 
-  it('should select all values in "Filter by value" after clicking "Select all" link', (done) => {
+  it('should select all values in "Filter by value" after clicking "Select all" link', async() => {
     handsontable({
       data: getDataForFilters(),
       columns: getColumnsForFilters(),
@@ -1651,16 +1650,15 @@ describe('Filters UI', () => {
 
     dropdownMenu(1);
 
-    setTimeout(() => {
-      $(dropdownMenuRootElement().querySelector('.htUIClearAll a')).simulate('click');
+    await sleep(100);
 
-      expect(byValueMultipleSelect().getItems().map(o => o.checked).indexOf(true)).toBe(-1);
+    $(dropdownMenuRootElement().querySelector('.htUIClearAll a')).simulate('click');
 
-      $(dropdownMenuRootElement().querySelector('.htUISelectAll a')).simulate('click');
+    expect(byValueMultipleSelect().getItems().map(o => o.checked).indexOf(true)).toBe(-1);
 
-      expect(byValueMultipleSelect().getItems().map(o => o.checked).indexOf(false)).toBe(-1);
-      done();
-    }, 100);
+    $(dropdownMenuRootElement().querySelector('.htUISelectAll a')).simulate('click');
+
+    expect(byValueMultipleSelect().getItems().map(o => o.checked).indexOf(false)).toBe(-1);
   });
 
   it('should not reset the selection status of the "Filter by value" section after scrolling the table outside of' +
@@ -1911,35 +1909,65 @@ describe('Filters UI', () => {
     }
   });
 
-  describe('Simple filtering (one column)', () => {
-    it('should select the first visible row after filtering', () => {
-      handsontable({
-        data: getDataForFilters(),
-        columns: getColumnsForFilters(),
-        dropdownMenu: true,
-        filters: true,
-        width: 500,
-        height: 300
-      });
-
-      dropdownMenu(2);
-      openDropdownByConditionMenu();
-      selectDropdownByConditionMenuOption('Is empty');
-
-      $(dropdownMenuRootElement().querySelector('.htUIButton.htUIButtonOK input'))
-        .simulate('click');
-
-      expect(getSelected()).toBeUndefined();
-
-      dropdownMenu(2);
-      openDropdownByConditionMenu();
-      selectDropdownByConditionMenuOption('None');
-      $(dropdownMenuRootElement().querySelector('.htUIButton.htUIButtonOK input'))
-        .simulate('click');
-
-      expect(getSelected()).toEqual([[0, 2, 0, 2]]);
+  it('should select the first visible row after filtering (navigableHeaders: false)', () => {
+    handsontable({
+      data: getDataForFilters(),
+      columns: getColumnsForFilters(),
+      dropdownMenu: true,
+      filters: true,
+      navigableHeaders: false,
+      width: 500,
+      height: 300
     });
 
+    dropdownMenu(2);
+    openDropdownByConditionMenu();
+    selectDropdownByConditionMenuOption('Is empty');
+
+    $(dropdownMenuRootElement().querySelector('.htUIButton.htUIButtonOK input'))
+      .simulate('click');
+
+    expect(getSelectedRange()).toBeUndefined();
+
+    dropdownMenu(2);
+    openDropdownByConditionMenu();
+    selectDropdownByConditionMenuOption('None');
+    $(dropdownMenuRootElement().querySelector('.htUIButton.htUIButtonOK input'))
+      .simulate('click');
+
+    expect(getSelectedRange()).toEqualCellRange(['highlight: 0,2 from: 0,2 to: 0,2']);
+  });
+
+  it('should select the column header after filtering (navigableHeaders: true)', () => {
+    handsontable({
+      data: getDataForFilters(),
+      columns: getColumnsForFilters(),
+      dropdownMenu: true,
+      filters: true,
+      navigableHeaders: true,
+      width: 500,
+      height: 300
+    });
+
+    dropdownMenu(2);
+    openDropdownByConditionMenu();
+    selectDropdownByConditionMenuOption('Is empty');
+
+    $(dropdownMenuRootElement().querySelector('.htUIButton.htUIButtonOK input'))
+      .simulate('click');
+
+    expect(getSelectedRange()).toEqualCellRange(['highlight: -1,2 from: -1,2 to: -1,2']);
+
+    dropdownMenu(2);
+    openDropdownByConditionMenu();
+    selectDropdownByConditionMenuOption('None');
+    $(dropdownMenuRootElement().querySelector('.htUIButton.htUIButtonOK input'))
+      .simulate('click');
+
+    expect(getSelectedRange()).toEqualCellRange(['highlight: -1,2 from: -1,2 to: -1,2']);
+  });
+
+  describe('Simple filtering (one column)', () => {
     it('should filter empty values and revert back after removing filter', () => {
       handsontable({
         data: getDataForFilters(),

--- a/handsontable/src/plugins/filters/filters.js
+++ b/handsontable/src/plugins/filters/filters.js
@@ -318,8 +318,14 @@ export class Filters extends BasePlugin {
         keys: [['Alt', 'A']],
         stopPropagation: true,
         callback: () => {
+          const selection = this.hot.getSelected();
+
           this.clearConditions();
           this.filter();
+
+          if (selection) {
+            this.hot.selectCells(selection);
+          }
         },
         group: SHORTCUTS_GROUP,
       });
@@ -492,6 +498,7 @@ export class Filters extends BasePlugin {
    * @fires Hooks#afterFilter
    */
   filter() {
+    const { navigableHeaders } = this.hot.getSettings();
     const dataFilter = this._createDataFilter();
     const needToFilter = !this.conditionCollection.isEmpty();
     let visibleVisualRows = [];
@@ -521,7 +528,7 @@ export class Filters extends BasePlugin {
           });
         }, true);
 
-        if (!visibleVisualRows.length) {
+        if (!navigableHeaders && !visibleVisualRows.length) {
           this.hot.deselectCell();
         }
       } else {
@@ -533,6 +540,13 @@ export class Filters extends BasePlugin {
 
     this.hot.view.adjustElementsSize(true);
     this.hot.render();
+
+    if (this.hot.selection.isSelected()) {
+      this.hot.selectCell(
+        navigableHeaders ? -1 : 0,
+        this.hot.getSelectedRangeLast().highlight.col,
+      );
+    }
   }
 
   /**
@@ -744,7 +758,6 @@ export class Filters extends BasePlugin {
       this.components.forEach(component => component.saveState(physicalIndex));
       this.filtersRowsMap.clear();
       this.filter();
-      this.hot.selectCell(0, selectedColumn.visualIndex);
     }
 
     this.dropdownMenuPlugin?.close();


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes a bug related to the missing cell selection after undoing filtering ([#1507](https://github.com/handsontable/dev-handsontable/issues/1507)) and improves the selection UX when the `navigableHeaders` option is enabled.

With `navigableHeaders` enabled the cell selection points to the column header
PR:
![Kapture 2023-10-27 at 15 08 29](https://github.com/handsontable/handsontable/assets/571316/bf3a3198-9e09-4957-be93-be974fa23a1c)

Before:
![Kapture 2023-10-27 at 15 09 16](https://github.com/handsontable/handsontable/assets/571316/b4c66f48-c6ac-40fb-a775-0083ea3073fc)

_[skip changelog]_ (fix for unreleased feature)

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally, and I covered the fix with new tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1507

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
