### PR TITLE
Change the color of the filters OK button

### DIFF
--- a/.changelogs/10558.json
+++ b/.changelogs/10558.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Changed the default styling for the OK button in filters.",
+  "type": "changed",
+  "issueOrPR": 10558,
+  "breaking": true,
+  "framework": "none"
+}

--- a/.changelogs/10558.json
+++ b/.changelogs/10558.json
@@ -1,8 +1,8 @@
 {
   "issuesOrigin": "private",
-  "title": "Changed the default styling for the OK button in filters.",
+  "title": "Changed the default styling for the OK button in filters when focused.",
   "type": "changed",
   "issueOrPR": 10558,
-  "breaking": true,
+  "breaking": false,
   "framework": "none"
 }

--- a/handsontable/src/plugins/filters/filters.scss
+++ b/handsontable/src/plugins/filters/filters.scss
@@ -204,12 +204,12 @@
 }
 
 .handsontable .htUIInput.htUIButtonOK input {
-  background-color: #0f9d58;
-  border-color: #18804e;
-  color: #fff;
+  background-color: #92dd8d;
+  border-color: #7cb878;
+  color: #000;
 }
 .handsontable .htUIInput.htUIButtonOK input:hover {
-  border-color: #1a6f46;
+  border-color: #6fa36c;
 }
 
 /* Select */

--- a/handsontable/src/plugins/filters/filters.scss
+++ b/handsontable/src/plugins/filters/filters.scss
@@ -204,12 +204,19 @@
 }
 
 .handsontable .htUIInput.htUIButtonOK input {
+  background-color: #0f9d58;
+  border-color: #18804e;
+  color: #fff;
+}
+
+.handsontable .htUIInput.htUIButtonOK input:focus-visible {
   background-color: #92dd8d;
   border-color: #7cb878;
   color: #000;
 }
+
 .handsontable .htUIInput.htUIButtonOK input:hover {
-  border-color: #6fa36c;
+  border-color: #1a6f46;
 }
 
 /* Select */


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR changes the styling of the filters OK button to meet a better contrast ratio according to this suggestion: https://github.com/handsontable/dev-handsontable/issues/1509.

~Changing the button's default color can be considered a breaking change.~ The background color is only changed when the user focuses the element through tab navigation (`:focus-visible`). This is not considered as a breaking change but a minor (feature) change.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1509

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
