### PR TITLE
Disable "Comments" menu item when all cells are selected

### DIFF
--- a/handsontable/src/plugins/comments/__tests__/contextMenuItem/commentsAddEdit.spec.js
+++ b/handsontable/src/plugins/comments/__tests__/contextMenuItem/commentsAddEdit.spec.js
@@ -14,6 +14,44 @@ describe('ContextMenu', () => {
 
   describe('add/edit comment', () => {
     describe('UI', () => {
+      it('should disable the item when all cells are selected (using keyboard shortcut)', () => {
+        handsontable({
+          data: createSpreadsheetData(5, 5),
+          comments: true,
+          colHeaders: true,
+          contextMenu: true,
+        });
+
+        selectCell(1, 1);
+        keyDownUp(['control/meta', 'a']);
+        contextMenu(getCell(1, 1));
+
+        const menuItem = $('.htContextMenu tbody tr td').filter(function() {
+          return this.textContent === 'Add comment';
+        });
+
+        expect(menuItem.hasClass('htDisabled')).toBe(true);
+      });
+
+      it('should disable the item when all cells are selected (using `selectAll` method)', () => {
+        handsontable({
+          data: createSpreadsheetData(5, 5),
+          comments: true,
+          colHeaders: true,
+          contextMenu: true,
+        });
+
+        selectCell(1, 1);
+        selectAll();
+        contextMenu(getCell(1, 1));
+
+        const menuItem = $('.htContextMenu tbody tr td').filter(function() {
+          return this.textContent === 'Add comment';
+        });
+
+        expect(menuItem.hasClass('htDisabled')).toBe(true);
+      });
+
       it('should disable the item when all rows are hidden', () => {
         handsontable({
           data: createSpreadsheetData(5, 5),
@@ -27,11 +65,11 @@ describe('ContextMenu', () => {
 
         contextMenu(getCell(-1, 1)); // Column header "B"
 
-        const readOnlyItem = $('.htContextMenu tbody tr td').filter(function() {
+        const menuItem = $('.htContextMenu tbody tr td').filter(function() {
           return this.textContent === 'Add comment';
         });
 
-        expect(readOnlyItem.hasClass('htDisabled')).toBe(true);
+        expect(menuItem.hasClass('htDisabled')).toBe(true);
       });
 
       it('should disable the item when all columns are hidden', () => {
@@ -47,11 +85,11 @@ describe('ContextMenu', () => {
 
         contextMenu(getCell(1, -1)); // Row header "2"
 
-        const readOnlyItem = $('.htContextMenu tbody tr td').filter(function() {
+        const menuItem = $('.htContextMenu tbody tr td').filter(function() {
           return this.textContent === 'Add comment';
         });
 
-        expect(readOnlyItem.hasClass('htDisabled')).toBe(true);
+        expect(menuItem.hasClass('htDisabled')).toBe(true);
       });
 
       it('should disable the item when all rows are trimmed', () => {
@@ -65,11 +103,11 @@ describe('ContextMenu', () => {
 
         contextMenu(getCell(-1, 1)); // Column header "B"
 
-        const readOnlyItem = $('.htContextMenu tbody tr td').filter(function() {
+        const menuItem = $('.htContextMenu tbody tr td').filter(function() {
           return this.textContent === 'Add comment';
         });
 
-        expect(readOnlyItem.hasClass('htDisabled')).toBe(true);
+        expect(menuItem.hasClass('htDisabled')).toBe(true);
       });
 
       it('should disable the item when all columns are trimmed', () => {
@@ -83,11 +121,11 @@ describe('ContextMenu', () => {
 
         contextMenu(getCell(1, -1)); // Row header "2"
 
-        const readOnlyItem = $('.htContextMenu tbody tr td').filter(function() {
+        const menuItem = $('.htContextMenu tbody tr td').filter(function() {
           return this.textContent === 'Add comment';
         });
 
-        expect(readOnlyItem.hasClass('htDisabled')).toBe(true);
+        expect(menuItem.hasClass('htDisabled')).toBe(true);
       });
 
       it('should be disabled when the single row header is selected', () => {
@@ -103,11 +141,11 @@ describe('ContextMenu', () => {
         selectCell(1, -1);
         getPlugin('contextMenu').open($(getCell(1, -1)).offset());
 
-        const readOnlyItem = $('.htContextMenu tbody tr td').filter(function() {
+        const menuItem = $('.htContextMenu tbody tr td').filter(function() {
           return this.textContent === 'Add comment';
         });
 
-        expect(readOnlyItem.hasClass('htDisabled')).toBe(true);
+        expect(menuItem.hasClass('htDisabled')).toBe(true);
       });
 
       it('should be disabled when the single column header is selected', () => {
@@ -123,11 +161,11 @@ describe('ContextMenu', () => {
         selectCell(-1, 1);
         getPlugin('contextMenu').open($(getCell(-1, 1)).offset());
 
-        const readOnlyItem = $('.htContextMenu tbody tr td').filter(function() {
+        const menuItem = $('.htContextMenu tbody tr td').filter(function() {
           return this.textContent === 'Add comment';
         });
 
-        expect(readOnlyItem.hasClass('htDisabled')).toBe(true);
+        expect(menuItem.hasClass('htDisabled')).toBe(true);
       });
 
       it('should be disabled when the single corner is selected', () => {
@@ -143,11 +181,11 @@ describe('ContextMenu', () => {
         selectCell(-1, -1);
         getPlugin('contextMenu').open($(getCell(-1, -1)).offset());
 
-        const readOnlyItem = $('.htContextMenu tbody tr td').filter(function() {
+        const menuItem = $('.htContextMenu tbody tr td').filter(function() {
           return this.textContent === 'Add comment';
         });
 
-        expect(readOnlyItem.hasClass('htDisabled')).toBe(true);
+        expect(menuItem.hasClass('htDisabled')).toBe(true);
       });
     });
   });

--- a/handsontable/src/plugins/comments/__tests__/contextMenuItem/commentsReadOnly.spec.js
+++ b/handsontable/src/plugins/comments/__tests__/contextMenuItem/commentsReadOnly.spec.js
@@ -14,6 +14,44 @@ describe('ContextMenu', () => {
 
   describe('read-only comment', () => {
     describe('UI', () => {
+      it('should disable the item when all cells are selected (using keyboard shortcut)', () => {
+        handsontable({
+          data: createSpreadsheetData(5, 5),
+          comments: true,
+          colHeaders: true,
+          contextMenu: true,
+        });
+
+        selectCell(1, 1);
+        keyDownUp(['control/meta', 'a']);
+        contextMenu(getCell(1, 1));
+
+        const menuItem = $('.htContextMenu tbody tr td').filter(function() {
+          return this.textContent === 'Read-only comment';
+        });
+
+        expect(menuItem.hasClass('htDisabled')).toBe(true);
+      });
+
+      it('should disable the item when all cells are selected (using `selectAll` method)', () => {
+        handsontable({
+          data: createSpreadsheetData(5, 5),
+          comments: true,
+          colHeaders: true,
+          contextMenu: true,
+        });
+
+        selectCell(1, 1);
+        selectAll();
+        contextMenu(getCell(1, 1));
+
+        const menuItem = $('.htContextMenu tbody tr td').filter(function() {
+          return this.textContent === 'Read-only comment';
+        });
+
+        expect(menuItem.hasClass('htDisabled')).toBe(true);
+      });
+
       it('should disable the item when all rows are hidden', () => {
         handsontable({
           data: createSpreadsheetData(5, 5),
@@ -27,11 +65,11 @@ describe('ContextMenu', () => {
 
         contextMenu(getCell(-1, 1)); // Column header "B"
 
-        const readOnlyItem = $('.htContextMenu tbody tr td').filter(function() {
+        const menuItem = $('.htContextMenu tbody tr td').filter(function() {
           return this.textContent === 'Read-only comment';
         });
 
-        expect(readOnlyItem.hasClass('htDisabled')).toBe(true);
+        expect(menuItem.hasClass('htDisabled')).toBe(true);
       });
 
       it('should disable the item when all columns are hidden', () => {
@@ -47,11 +85,11 @@ describe('ContextMenu', () => {
 
         contextMenu(getCell(1, -1)); // Row header "2"
 
-        const readOnlyItem = $('.htContextMenu tbody tr td').filter(function() {
+        const menuItem = $('.htContextMenu tbody tr td').filter(function() {
           return this.textContent === 'Read-only comment';
         });
 
-        expect(readOnlyItem.hasClass('htDisabled')).toBe(true);
+        expect(menuItem.hasClass('htDisabled')).toBe(true);
       });
 
       it('should disable the item when all rows are trimmed', () => {
@@ -65,11 +103,11 @@ describe('ContextMenu', () => {
 
         contextMenu(getCell(-1, 1)); // Column header "B"
 
-        const readOnlyItem = $('.htContextMenu tbody tr td').filter(function() {
+        const menuItem = $('.htContextMenu tbody tr td').filter(function() {
           return this.textContent === 'Read-only comment';
         });
 
-        expect(readOnlyItem.hasClass('htDisabled')).toBe(true);
+        expect(menuItem.hasClass('htDisabled')).toBe(true);
       });
 
       it('should disable the item when all columns are trimmed', () => {
@@ -83,11 +121,11 @@ describe('ContextMenu', () => {
 
         contextMenu(getCell(1, -1)); // Row header "2"
 
-        const readOnlyItem = $('.htContextMenu tbody tr td').filter(function() {
+        const menuItem = $('.htContextMenu tbody tr td').filter(function() {
           return this.textContent === 'Read-only comment';
         });
 
-        expect(readOnlyItem.hasClass('htDisabled')).toBe(true);
+        expect(menuItem.hasClass('htDisabled')).toBe(true);
       });
 
       it('should be disabled when the single row header is selected', () => {
@@ -103,11 +141,11 @@ describe('ContextMenu', () => {
         selectCell(1, -1);
         getPlugin('contextMenu').open($(getCell(1, -1)).offset());
 
-        const readOnlyItem = $('.htContextMenu tbody tr td').filter(function() {
+        const menuItem = $('.htContextMenu tbody tr td').filter(function() {
           return this.textContent === 'Read-only comment';
         });
 
-        expect(readOnlyItem.hasClass('htDisabled')).toBe(true);
+        expect(menuItem.hasClass('htDisabled')).toBe(true);
       });
 
       it('should be disabled when the single column header is selected', () => {
@@ -123,11 +161,11 @@ describe('ContextMenu', () => {
         selectCell(-1, 1);
         getPlugin('contextMenu').open($(getCell(-1, 1)).offset());
 
-        const readOnlyItem = $('.htContextMenu tbody tr td').filter(function() {
+        const menuItem = $('.htContextMenu tbody tr td').filter(function() {
           return this.textContent === 'Read-only comment';
         });
 
-        expect(readOnlyItem.hasClass('htDisabled')).toBe(true);
+        expect(menuItem.hasClass('htDisabled')).toBe(true);
       });
 
       it('should be disabled when the single corner is selected', () => {
@@ -143,11 +181,11 @@ describe('ContextMenu', () => {
         selectCell(-1, -1);
         getPlugin('contextMenu').open($(getCell(-1, -1)).offset());
 
-        const readOnlyItem = $('.htContextMenu tbody tr td').filter(function() {
+        const menuItem = $('.htContextMenu tbody tr td').filter(function() {
           return this.textContent === 'Read-only comment';
         });
 
-        expect(readOnlyItem.hasClass('htDisabled')).toBe(true);
+        expect(menuItem.hasClass('htDisabled')).toBe(true);
       });
     });
   });

--- a/handsontable/src/plugins/comments/__tests__/contextMenuItem/commentsRemove.spec.js
+++ b/handsontable/src/plugins/comments/__tests__/contextMenuItem/commentsRemove.spec.js
@@ -14,6 +14,44 @@ describe('ContextMenu', () => {
 
   describe('delete comment', () => {
     describe('UI', () => {
+      it('should disable the item when all cells are selected (using keyboard shortcut)', () => {
+        handsontable({
+          data: createSpreadsheetData(5, 5),
+          comments: true,
+          colHeaders: true,
+          contextMenu: true,
+        });
+
+        selectCell(1, 1);
+        keyDownUp(['control/meta', 'a']);
+        contextMenu(getCell(1, 1));
+
+        const menuItem = $('.htContextMenu tbody tr td').filter(function() {
+          return this.textContent === 'Delete comment';
+        });
+
+        expect(menuItem.hasClass('htDisabled')).toBe(true);
+      });
+
+      it('should disable the item when all cells are selected (using `selectAll` method)', () => {
+        handsontable({
+          data: createSpreadsheetData(5, 5),
+          comments: true,
+          colHeaders: true,
+          contextMenu: true,
+        });
+
+        selectCell(1, 1);
+        selectAll();
+        contextMenu(getCell(1, 1));
+
+        const menuItem = $('.htContextMenu tbody tr td').filter(function() {
+          return this.textContent === 'Delete comment';
+        });
+
+        expect(menuItem.hasClass('htDisabled')).toBe(true);
+      });
+
       it('should disable the item when all rows are hidden', () => {
         handsontable({
           data: createSpreadsheetData(5, 5),
@@ -27,11 +65,11 @@ describe('ContextMenu', () => {
 
         contextMenu(getCell(-1, 1)); // Column header "B"
 
-        const readOnlyItem = $('.htContextMenu tbody tr td').filter(function() {
+        const menuItem = $('.htContextMenu tbody tr td').filter(function() {
           return this.textContent === 'Delete comment';
         });
 
-        expect(readOnlyItem.hasClass('htDisabled')).toBe(true);
+        expect(menuItem.hasClass('htDisabled')).toBe(true);
       });
 
       it('should disable the item when all columns are hidden', () => {
@@ -47,11 +85,11 @@ describe('ContextMenu', () => {
 
         contextMenu(getCell(1, -1)); // Row header "2"
 
-        const readOnlyItem = $('.htContextMenu tbody tr td').filter(function() {
+        const menuItem = $('.htContextMenu tbody tr td').filter(function() {
           return this.textContent === 'Delete comment';
         });
 
-        expect(readOnlyItem.hasClass('htDisabled')).toBe(true);
+        expect(menuItem.hasClass('htDisabled')).toBe(true);
       });
 
       it('should disable the item when all rows are trimmed', () => {
@@ -65,11 +103,11 @@ describe('ContextMenu', () => {
 
         contextMenu(getCell(-1, 1)); // Column header "B"
 
-        const readOnlyItem = $('.htContextMenu tbody tr td').filter(function() {
+        const menuItem = $('.htContextMenu tbody tr td').filter(function() {
           return this.textContent === 'Delete comment';
         });
 
-        expect(readOnlyItem.hasClass('htDisabled')).toBe(true);
+        expect(menuItem.hasClass('htDisabled')).toBe(true);
       });
 
       it('should disable the item when all columns are trimmed', () => {
@@ -83,11 +121,11 @@ describe('ContextMenu', () => {
 
         contextMenu(getCell(1, -1)); // Row header "2"
 
-        const readOnlyItem = $('.htContextMenu tbody tr td').filter(function() {
+        const menuItem = $('.htContextMenu tbody tr td').filter(function() {
           return this.textContent === 'Delete comment';
         });
 
-        expect(readOnlyItem.hasClass('htDisabled')).toBe(true);
+        expect(menuItem.hasClass('htDisabled')).toBe(true);
       });
 
       it('should be disabled when the single row header is selected', () => {
@@ -103,11 +141,11 @@ describe('ContextMenu', () => {
         selectCell(1, -1);
         getPlugin('contextMenu').open($(getCell(1, -1)).offset());
 
-        const readOnlyItem = $('.htContextMenu tbody tr td').filter(function() {
+        const menuItem = $('.htContextMenu tbody tr td').filter(function() {
           return this.textContent === 'Delete comment';
         });
 
-        expect(readOnlyItem.hasClass('htDisabled')).toBe(true);
+        expect(menuItem.hasClass('htDisabled')).toBe(true);
       });
 
       it('should be disabled when the single column header is selected', () => {
@@ -123,11 +161,11 @@ describe('ContextMenu', () => {
         selectCell(-1, 1);
         getPlugin('contextMenu').open($(getCell(-1, 1)).offset());
 
-        const readOnlyItem = $('.htContextMenu tbody tr td').filter(function() {
+        const menuItem = $('.htContextMenu tbody tr td').filter(function() {
           return this.textContent === 'Delete comment';
         });
 
-        expect(readOnlyItem.hasClass('htDisabled')).toBe(true);
+        expect(menuItem.hasClass('htDisabled')).toBe(true);
       });
 
       it('should be disabled when the single corner is selected', () => {
@@ -143,11 +181,11 @@ describe('ContextMenu', () => {
         selectCell(-1, -1);
         getPlugin('contextMenu').open($(getCell(-1, -1)).offset());
 
-        const readOnlyItem = $('.htContextMenu tbody tr td').filter(function() {
+        const menuItem = $('.htContextMenu tbody tr td').filter(function() {
           return this.textContent === 'Delete comment';
         });
 
-        expect(readOnlyItem.hasClass('htDisabled')).toBe(true);
+        expect(menuItem.hasClass('htDisabled')).toBe(true);
       });
     });
   });

--- a/handsontable/src/plugins/comments/contextMenuItem/addEditComment.js
+++ b/handsontable/src/plugins/comments/contextMenuItem/addEditComment.js
@@ -28,15 +28,16 @@ export default function addEditCommentItem(plugin) {
     disabled() {
       const range = this.getSelectedRangeLast();
 
-      if (!range) {
+      if (
+        !range ||
+        range.highlight.isHeader() ||
+        this.selection.isEntireRowSelected() && this.selection.isEntireColumnSelected() ||
+        this.countRenderedRows() === 0 || this.countRenderedCols() === 0
+      ) {
         return true;
       }
 
-      if (range.highlight.isHeader()) {
-        return true;
-      }
-
-      return this.countRenderedRows() === 0 || this.countRenderedCols() === 0;
+      return false;
     }
   };
 }

--- a/handsontable/src/plugins/comments/contextMenuItem/readOnlyComment.js
+++ b/handsontable/src/plugins/comments/contextMenuItem/readOnlyComment.js
@@ -33,19 +33,17 @@ export default function readOnlyCommentItem(plugin) {
     disabled() {
       const range = this.getSelectedRangeLast();
 
-      if (!range) {
+      if (
+        !range ||
+        range.highlight.isHeader() ||
+        !plugin.getCommentAtCell(range.highlight.row, range.highlight.col) ||
+        this.selection.isEntireRowSelected() && this.selection.isEntireColumnSelected() ||
+        this.countRenderedRows() === 0 || this.countRenderedCols() === 0
+      ) {
         return true;
       }
 
-      if (range.highlight.isHeader()) {
-        return true;
-      }
-
-      if (!plugin.getCommentAtCell(range.highlight.row, range.highlight.col)) {
-        return true;
-      }
-
-      return this.countRenderedRows() === 0 || this.countRenderedCols() === 0;
+      return false;
     }
   };
 }

--- a/handsontable/src/plugins/comments/contextMenuItem/removeComment.js
+++ b/handsontable/src/plugins/comments/contextMenuItem/removeComment.js
@@ -24,15 +24,16 @@ export default function removeCommentItem(plugin) {
     disabled() {
       const range = this.getSelectedRangeLast();
 
-      if (!range) {
+      if (
+        !range ||
+        range.highlight.isHeader() ||
+        this.selection.isEntireRowSelected() && this.selection.isEntireColumnSelected() ||
+        this.countRenderedRows() === 0 || this.countRenderedCols() === 0
+      ) {
         return true;
       }
 
-      if (range.highlight.isHeader()) {
-        return true;
-      }
-
-      return this.countRenderedRows() === 0 || this.countRenderedCols() === 0;
+      return false;
     }
   };
 }


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the regression bug that occurs in enabling the Comments menu item entries when all cells are selected.

_[skip changelog]_ (hotfix)

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally, and I covered the fix with new tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1521

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)