### PR TITLE
Add backward-compatible support for `scrollViewportTo` method

### DIFF
--- a/handsontable/src/__tests__/core/methods.types.ts
+++ b/handsontable/src/__tests__/core/methods.types.ts
@@ -134,6 +134,8 @@ hot.scrollViewportTo({ row: 0, col: 0, verticalSnap: 'bottom' });
 hot.scrollViewportTo({ row: 0, col: 0, horizontalSnap: 'start' });
 hot.scrollViewportTo({ row: 0, col: 0, horizontalSnap: 'end' });
 hot.scrollViewportTo({ row: 0, col: 0, considerHiddenIndexes: false });
+hot.scrollViewportTo(0, 10);
+hot.scrollViewportTo(0, 10, true, true, true);
 hot.scrollToFocusedCell();
 hot.scrollToFocusedCell(() => {});
 hot.selectAll();

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -4374,7 +4374,28 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
    * may be rendered when they are in the viewport (we don't consider hidden indexes as they aren't rendered).
    * @returns {boolean} `true` if viewport was scrolled, `false` otherwise.
    */
-  this.scrollViewportTo = function({ row, col, verticalSnap, horizontalSnap, considerHiddenIndexes } = {}) {
+  this.scrollViewportTo = function(options) {
+    // Support for backward compatibility arguments: (row, col, snapToBottom, snapToRight, considerHiddenIndexes)
+    if (typeof options === 'number') {
+      /* eslint-disable prefer-rest-params */
+      options = {
+        row: arguments[0],
+        col: arguments[1],
+        verticalSnap: arguments[2] ? 'bottom' : 'top',
+        horizontalSnap: arguments[3] ? 'end' : 'start',
+        considerHiddenIndexes: arguments[4] ?? true,
+      };
+      /* eslint-enable prefer-rest-params */
+    }
+
+    const {
+      row,
+      col,
+      verticalSnap,
+      horizontalSnap,
+      considerHiddenIndexes
+    } = options ?? {};
+
     let snapToTop;
     let snapToBottom;
     let snapToInlineStart;

--- a/handsontable/test/e2e/core/scrollViewportTo.spec.js
+++ b/handsontable/test/e2e/core/scrollViewportTo.spec.js
@@ -888,4 +888,48 @@ describe('Core.scrollViewportTo', () => {
     expect(scrollResult2).toBe(false);
     expect(hot.view._wt.wtTable.getFirstVisibleRow()).toBe(-1);
   });
+
+  describe('using backward-compatible arguments', () => {
+    it('should scroll the viewport using default snapping (top, start)', () => {
+      const hot = handsontable({
+        data: createSpreadsheetData(50, 50),
+        width: 200,
+        height: 200,
+      });
+
+      spyOn(hot.view, 'scrollViewport');
+
+      scrollViewportTo(40, 45);
+
+      expect(hot.view.scrollViewport).toHaveBeenCalledWith(cellCoords(40, 45), true, false, false, true);
+    });
+
+    it('should scroll the viewport using bottom snapping', () => {
+      const hot = handsontable({
+        data: createSpreadsheetData(50, 50),
+        width: 200,
+        height: 200,
+      });
+
+      spyOn(hot.view, 'scrollViewport');
+
+      scrollViewportTo(40, 45, true, false);
+
+      expect(hot.view.scrollViewport).toHaveBeenCalledWith(cellCoords(40, 45), false, false, true, true);
+    });
+
+    it('should scroll the viewport using end (right) snapping', () => {
+      const hot = handsontable({
+        data: createSpreadsheetData(50, 50),
+        width: 200,
+        height: 200,
+      });
+
+      spyOn(hot.view, 'scrollViewport');
+
+      scrollViewportTo(40, 45, true, true);
+
+      expect(hot.view.scrollViewport).toHaveBeenCalledWith(cellCoords(40, 45), false, true, true, false);
+    });
+  });
 });

--- a/handsontable/types/core.d.ts
+++ b/handsontable/types/core.d.ts
@@ -133,6 +133,7 @@ export default class Core {
   rowIndexMapper: IndexMapper;
   runHooks(key: keyof Events, p1?: any, p2?: any, p3?: any, p4?: any, p5?: any, p6?: any): any;
   scrollViewportTo(options: { row?: number, col?: number, verticalSnap?: 'top' | 'bottom', horizontalSnap?: 'start' | 'end', considerHiddenIndexes?: boolean }): boolean;
+  scrollViewportTo(row?: number, column?: number, snapToBottom?: boolean, snapToRight?: boolean, considerHiddenIndexes?: boolean): boolean;
   scrollToFocusedCell(callback?: () => void): void;
   selectAll(includeRowHeaders?: boolean, includeColumnHeaders?: boolean, options?: { focusPosition?: { row: number, col: number }, disableHeadersHighlight?: boolean }): void;
   selectCell(row: number, col: number, endRow?: number, endCol?: number, scrollToCell?: boolean, changeListener?: boolean): boolean;


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adds backward-compatible support for the `scrollViewportTo` method broken within unreleased 14.0 changes. After releasing 14.0, it will still be possible to use the method using a multi-arguments way.

_[skip changelog]_ (fix for unreleased change)

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I covered the fix with tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1545

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
