### PR TITLE
Fix focus position for `disableTabNavigation` option

### DIFF
--- a/handsontable/src/core/focusCatcher/index.js
+++ b/handsontable/src/core/focusCatcher/index.js
@@ -38,11 +38,19 @@ export function installFocusCatcher(hot) {
     wrapped: false,
     flipped: false,
   };
+  let isSavingCoordsEnabled = true;
+  let isTabOrShiftTabPressed = false;
 
   hot.addHook('afterListen', () => deactivate());
   hot.addHook('afterUnlisten', () => activate());
-  hot.addHook('afterSelection', () => {
-    recentlyAddedFocusCoords = hot.getSelectedRangeLast()?.highlight;
+  hot.addHook('afterSelection', (row, column, row2, column2, preventScrolling) => {
+    if (isTabOrShiftTabPressed && rowWrapState.wrapped && rowWrapState.flipped) {
+      preventScrolling.value = true;
+    }
+
+    if (isSavingCoordsEnabled) {
+      recentlyAddedFocusCoords = hot.getSelectedRangeLast()?.highlight;
+    }
   });
   hot.addHook('beforeRowWrap', (isWrapEnabled, newCoords, isFlipped) => {
     rowWrapState.wrapped = true;
@@ -59,39 +67,59 @@ export function installFocusCatcher(hot) {
     hot.unlisten();
   }
 
+  const shortcutOptions = {
+    keys: [['Tab'], ['Shift', 'Tab']],
+    runOnlyIf: () => !hot.getSettings().minSpareCols,
+    preventDefault: false,
+    stopPropagation: false,
+    relativeToGroup: GRID_GROUP,
+    group: 'focusCatcher',
+  };
+
   hot.getShortcutManager()
     .getContext('grid')
-    .addShortcut({
-      keys: [['Tab'], ['Shift', 'Tab']],
-      callback: (event) => {
-        const { disableTabNavigation, autoWrapRow } = hot.getSettings();
+    .addShortcuts([
+      {
+        ...shortcutOptions,
+        callback: () => {
+          isTabOrShiftTabPressed = true;
 
-        if (
-          disableTabNavigation ||
-          !hot.selection.isSelected() ||
-          autoWrapRow && rowWrapState.wrapped && rowWrapState.flipped ||
-          !autoWrapRow && rowWrapState.wrapped
-        ) {
-          if (autoWrapRow && rowWrapState.wrapped && rowWrapState.flipped) {
-            recentlyAddedFocusCoords = event.shiftKey
-              ? getMostTopStartPosition(hot) : getMostBottomEndPosition(hot);
+          if (hot.getSelectedRangeLast() && hot.getSettings().disableTabNavigation) {
+            isSavingCoordsEnabled = false;
+          }
+        },
+        position: 'before',
+      },
+      {
+        ...shortcutOptions,
+        callback: (event) => {
+          const { disableTabNavigation, autoWrapRow } = hot.getSettings();
+
+          isTabOrShiftTabPressed = false;
+          isSavingCoordsEnabled = true;
+
+          if (
+            disableTabNavigation ||
+            !hot.selection.isSelected() ||
+            autoWrapRow && rowWrapState.wrapped && rowWrapState.flipped ||
+            !autoWrapRow && rowWrapState.wrapped
+          ) {
+            if (autoWrapRow && rowWrapState.wrapped && rowWrapState.flipped) {
+              recentlyAddedFocusCoords = event.shiftKey
+                ? getMostTopStartPosition(hot) : getMostBottomEndPosition(hot);
+            }
+
+            deactivateTable();
+
+            return false;
           }
 
-          deactivateTable();
-
-          return false;
-        }
-
-        // if the selection is still within the table's range then prevent default action
-        event.preventDefault();
-      },
-      runOnlyIf: () => !hot.getSettings().minSpareCols,
-      preventDefault: false,
-      stopPropagation: false,
-      position: 'after',
-      relativeToGroup: GRID_GROUP,
-      group: 'focusCatcher',
-    });
+          // if the selection is still within the table's range then prevent default action
+          event.preventDefault();
+        },
+        position: 'after',
+      }
+    ]);
 }
 
 /**

--- a/handsontable/test/e2e/keyboardShortcuts/tabNavigation.spec.js
+++ b/handsontable/test/e2e/keyboardShortcuts/tabNavigation.spec.js
@@ -820,4 +820,96 @@ describe('Core navigation keyboard shortcuts', () => {
       expect(hot1.isListening()).toBe(false);
     });
   });
+
+  it('should activate the table, reselect the recently selected cell without changing ' +
+     'the coords, and then leave the table (#dev-1546)', async() => {
+    const hot = handsontable({
+      data: createSpreadsheetData(3, 3),
+      rowHeaders: true,
+      colHeaders: true,
+      navigableHeaders: true,
+      disableTabNavigation: true,
+      autoWrapRow: false,
+    });
+    const hot1 = handsontable({
+      data: createSpreadsheetData(3, 3),
+      rowHeaders: true,
+      colHeaders: true,
+      navigableHeaders: true,
+      disableTabNavigation: true,
+      autoWrapRow: false,
+    }, false, spec().$container1);
+
+    hot.selectCell(1, 1);
+    hot1.selectCell(0, 0);
+    hot.deselectCell();
+    hot1.deselectCell();
+
+    triggerTabNavigationFromTop(); // emulates native browser Tab navigation
+
+    expect(hot.getSelectedRange()).toEqualCellRange(['highlight: 1,1 from: 1,1 to: 1,1']);
+    expect(hot1.getSelectedRange()).toBeUndefined();
+
+    keyDownUp('tab');
+    triggerTabNavigationFromTop(hot1); // emulates native browser Tab navigation
+
+    expect(hot.getSelectedRange()).toBeUndefined();
+    expect(hot1.getSelectedRange()).toEqualCellRange(['highlight: 0,0 from: 0,0 to: 0,0']);
+
+    keyDownUp(['shift', 'tab']);
+    triggerTabNavigationFromBottom(); // emulates native browser Tab navigation
+
+    expect(hot.getSelectedRange()).toEqualCellRange(['highlight: 1,1 from: 1,1 to: 1,1']);
+    expect(hot1.getSelectedRange()).toBeUndefined();
+
+    keyDownUp('tab');
+    triggerTabNavigationFromTop(hot1); // emulates native browser Tab navigation
+
+    expect(hot.getSelectedRange()).toBeUndefined();
+    expect(hot1.getSelectedRange()).toEqualCellRange(['highlight: 0,0 from: 0,0 to: 0,0']);
+  });
+
+  it('should not scroll the viewport of the table after navigating between the tables', async() => {
+    const hot = handsontable({
+      data: createSpreadsheetData(50, 30),
+      width: 200,
+      height: 200,
+      rowHeaders: true,
+      colHeaders: true,
+      disableTabNavigation: true,
+      autoWrapRow: true,
+    });
+    const hot1 = handsontable({
+      data: createSpreadsheetData(50, 30),
+      width: 200,
+      height: 200,
+      rowHeaders: true,
+      colHeaders: true,
+      disableTabNavigation: true,
+      autoWrapRow: true,
+    }, false, spec().$container1);
+
+    hot.selectCell(0, 0);
+    hot.deselectCell();
+    hot1.deselectCell();
+
+    triggerTabNavigationFromTop(); // emulates native browser Tab navigation
+
+    expect(hot.getSelectedRange()).toEqualCellRange(['highlight: 0,0 from: 0,0 to: 0,0']);
+    expect(hot1.getSelectedRange()).toBeUndefined();
+
+    keyDownUp('tab');
+    triggerTabNavigationFromTop(hot1); // emulates native browser Tab navigation
+
+    expect(hot.getSelectedRange()).toBeUndefined();
+    expect(hot1.getSelectedRange()).toEqualCellRange(['highlight: 0,0 from: 0,0 to: 0,0']);
+
+    keyDownUp(['shift', 'tab']);
+    triggerTabNavigationFromBottom(); // emulates native browser Tab navigation
+
+    expect(hot1.view._wt.wtOverlays.topOverlay.getScrollPosition()).toBe(0);
+    expect(hot1.view._wt.wtOverlays.inlineStartOverlay.getScrollPosition()).toBe(0);
+    expect(hot.getSelectedRange()).toEqualCellRange(['highlight: 0,0 from: 0,0 to: 0,0']);
+    expect(hot1.getSelectedRange()).toBeUndefined();
+  });
 });


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes an issue where the focus position did not stay in the same position after table reactivation. The bug occurred when the `disableTabNavigation` option was set as `true`, and the table was activated by TAB or SHIFT+TAB keys.

_[skip changelog]_ (hotfix)

Before:
![Kapture 2023-11-14 at 13 48 34](https://github.com/handsontable/handsontable/assets/571316/43c67c2b-27d8-4713-8dcd-708da1826cc4)

After:
![Kapture 2023-11-14 at 13 49 04](https://github.com/handsontable/handsontable/assets/571316/4adb3ca7-b1c7-4e7c-93c5-014a35b78687)

The PR also fixes an issue where, in some cases, the viewport was scrolled incorrectly.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and I covered the fix with new E2E tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1546

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
