### PR TITLE
add extra path filter to trigger visual tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,7 @@ jobs:
       test-react: ${{ steps.path-filter.outputs.test-react }}
       test-vue: ${{ steps.path-filter.outputs.test-vue }}
       test-vue3: ${{ steps.path-filter.outputs.test-vue3 }}
+      test-visual: ${{ steps.path-filter.outputs.test-visual }}
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # https://github.com/actions/checkout/releases/tag/v3.1.0
         if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
@@ -98,6 +99,9 @@ jobs:
             test-vue3:
               - *hot-shared
               - 'wrappers/vue3/**'
+            test-visual:
+              - './examples/next/visual-tests/**'
+              - './visual-tests/**'
 
   build-handsontable-umd:
     name: "[BUILD] Handsontable: UMD"
@@ -446,7 +450,8 @@ jobs:
         needs.test-angular.result == 'success' ||
         needs.test-react.result == 'success' ||
         needs.test-vue.result == 'success' ||
-        needs.test-vue3.result == 'success'
+        needs.test-vue3.result == 'success' ||
+        needs.check-scope.outputs.test-visual == 'true'
         )
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # https://github.com/actions/checkout/releases/tag/v3.1.0

--- a/examples/next/visual-tests/react/basic-example/README.md
+++ b/examples/next/visual-tests/react/basic-example/README.md
@@ -1,4 +1,3 @@
-# TEST
 # React Basic Example
 
 ## Description

--- a/examples/next/visual-tests/react/basic-example/README.md
+++ b/examples/next/visual-tests/react/basic-example/README.md
@@ -1,3 +1,4 @@
+# TEST
 # React Basic Example
 
 ## Description


### PR DESCRIPTION
[skip changelog]

### Context
visual tests not triggered when required - need for extra trigger commit https://github.com/handsontable/handsontable/pull/10576/commits

### How has this been tested?
Making a change in 
- './examples/next/visual-tests/**'
- './visual-tests/**'
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/1554


