### PR TITLE
Fix Handsontable-type editors

### DIFF
--- a/handsontable/src/editors/handsontableEditor/__tests__/handsontableEditor.spec.js
+++ b/handsontable/src/editors/handsontableEditor/__tests__/handsontableEditor.spec.js
@@ -526,6 +526,38 @@ describe('HandsontableEditor', () => {
     window.onerror = prevError;
   });
 
+  it('should not throw an error while closing editor that is not visible in the viewport', async() => {
+    const spy = jasmine.createSpyObj('error', ['test']);
+    const prevError = window.onerror;
+
+    window.onerror = function() {
+      spy.test();
+
+      return true;
+    };
+    handsontable({
+      data: createSpreadsheetData(100, 1),
+      width: 300,
+      height: 200,
+      columns: [{
+        type: 'handsontable',
+        handsontable: {
+          data: [['Marque'], ['Country'], ['Parent company']]
+        }
+      }],
+    });
+
+    selectCell(0, 0);
+    keyDownUp('enter');
+    scrollViewportTo({ row: 95 });
+
+    await sleep(100);
+
+    expect(spy.test.calls.count()).toBe(0);
+
+    window.onerror = prevError;
+  });
+
   it('Enter pressed in nested HT should set the value and hide the editor', () => {
     handsontable({
       columns: [

--- a/handsontable/src/editors/handsontableEditor/handsontableEditor.js
+++ b/handsontable/src/editors/handsontableEditor/handsontableEditor.js
@@ -66,7 +66,7 @@ export class HandsontableEditor extends TextEditor {
     this.removeHooksByKey('beforeKeyDown');
     super.close();
 
-    if (this.hot.getSettings().ariaTags) {
+    if (this.TD && this.hot.getSettings().ariaTags) {
       setAttribute(this.TD, [
         A11Y_EXPANDED('false'),
       ]);


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes a type error that was thrown in cases when the editor was rendered out of the table's viewport. The fix applies to the Dropdown, Autocomplete, and Handsontable cell types. I checked other cell types and did not find similar issues.

_[skip changelog]_ (hotfix)

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I covered the fix with a new test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1548

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
