### PR TITLE
Make private properties of the ManualColumnMove and ManualRowMove plugins private 

### DIFF
--- a/handsontable/src/plugins/manualColumnMove/manualColumnMove.js
+++ b/handsontable/src/plugins/manualColumnMove/manualColumnMove.js
@@ -58,17 +58,15 @@ export class ManualColumnMove extends BasePlugin {
   /**
    * Backlight UI object.
    *
-   * @private
    * @type {object}
    */
-  backlight = new BacklightUI(this.hot);
+  #backlight = new BacklightUI(this.hot);
   /**
    * Guideline UI object.
    *
-   * @private
    * @type {object}
    */
-  guideline = new GuidelineUI(this.hot);
+  #guideline = new GuidelineUI(this.hot);
   /**
    * @type {number[]}
    */
@@ -160,8 +158,8 @@ export class ManualColumnMove extends BasePlugin {
     removeClass(this.hot.rootElement, CSS_PLUGIN);
 
     this.unregisterEvents();
-    this.backlight.destroy();
-    this.guideline.destroy();
+    this.#backlight.destroy();
+    this.#guideline.destroy();
 
     super.disablePlugin();
   }
@@ -426,8 +424,8 @@ export class ManualColumnMove extends BasePlugin {
     let tdOffsetStart = this.hot.view.THEAD.offsetLeft + this.getColumnsWidth(0, this.#hoveredColumn - 1);
     const hiderWidth = wtTable.hider.offsetWidth;
     const tbodyOffsetLeft = wtTable.TBODY.offsetLeft;
-    const backlightElemMarginStart = this.backlight.getOffset().start;
-    const backlightElemWidth = this.backlight.getSize().width;
+    const backlightElemMarginStart = this.#backlight.getOffset().start;
+    const backlightElemWidth = this.#backlight.getSize().width;
     let rowHeaderWidth = 0;
     let mouseOffsetStart = 0;
 
@@ -499,8 +497,8 @@ export class ManualColumnMove extends BasePlugin {
       guidelineStart -= ((this.#rootElementOffset <= scrollableElement.scrollX) ? this.#rootElementOffset : 0);
     }
 
-    this.backlight.setPosition(null, backlightStart);
-    this.guideline.setPosition(null, guidelineStart);
+    this.#backlight.setPosition(null, backlightStart);
+    this.#guideline.setPosition(null, guidelineStart);
   }
 
   /**
@@ -548,12 +546,12 @@ export class ManualColumnMove extends BasePlugin {
       return;
     }
 
-    const guidelineIsNotReady = this.guideline.isBuilt() && !this.guideline.isAppended();
-    const backlightIsNotReady = this.backlight.isBuilt() && !this.backlight.isAppended();
+    const guidelineIsNotReady = this.#guideline.isBuilt() && !this.#guideline.isAppended();
+    const backlightIsNotReady = this.#backlight.isBuilt() && !this.#backlight.isAppended();
 
     if (guidelineIsNotReady && backlightIsNotReady) {
-      this.guideline.appendTo(wtTable.hider);
-      this.backlight.appendTo(wtTable.hider);
+      this.#guideline.appendTo(wtTable.hider);
+      this.#backlight.appendTo(wtTable.hider);
     }
 
     const { from, to } = selection;
@@ -585,9 +583,9 @@ export class ManualColumnMove extends BasePlugin {
       const inlinePos = this.getColumnsWidth(countColumnsFrom, start - 1) +
         (fixedColumnsStart ? horizontalScrollPosition : 0) + inlineOffset;
 
-      this.backlight.setPosition(topPos, inlinePos);
-      this.backlight.setSize(this.getColumnsWidth(start, end), wtTable.hider.offsetHeight - topPos);
-      this.backlight.setOffset(null, -inlineOffset);
+      this.#backlight.setPosition(topPos, inlinePos);
+      this.#backlight.setSize(this.getColumnsWidth(start, end), wtTable.hider.offsetHeight - topPos);
+      this.#backlight.setOffset(null, -inlineOffset);
 
       addClass(this.hot.rootElement, CSS_ON_MOVING);
 
@@ -689,8 +687,8 @@ export class ManualColumnMove extends BasePlugin {
     const scrollTop = wtTable.holder.scrollTop;
     const posTop = headerHeight + scrollTop;
 
-    this.backlight.setPosition(posTop);
-    this.backlight.setSize(null, wtTable.hider.offsetHeight - posTop);
+    this.#backlight.setPosition(posTop);
+    this.#backlight.setSize(null, wtTable.hider.offsetHeight - posTop);
   }
 
   /**
@@ -699,8 +697,8 @@ export class ManualColumnMove extends BasePlugin {
    * @private
    */
   buildPluginUI() {
-    this.backlight.build();
-    this.guideline.build();
+    this.#backlight.build();
+    this.#guideline.build();
   }
 
   /**
@@ -716,8 +714,8 @@ export class ManualColumnMove extends BasePlugin {
    * Destroys the plugin instance.
    */
   destroy() {
-    this.backlight.destroy();
-    this.guideline.destroy();
+    this.#backlight.destroy();
+    this.#guideline.destroy();
 
     super.destroy();
   }

--- a/handsontable/src/plugins/manualRowMove/manualRowMove.js
+++ b/handsontable/src/plugins/manualRowMove/manualRowMove.js
@@ -56,17 +56,15 @@ export class ManualRowMove extends BasePlugin {
   /**
    * Backlight UI object.
    *
-   * @private
    * @type {object}
    */
-  backlight = new BacklightUI(this.hot);
+  #backlight = new BacklightUI(this.hot);
   /**
    * Guideline UI object.
    *
-   * @private
    * @type {object}
    */
-  guideline = new GuidelineUI(this.hot);
+  #guideline = new GuidelineUI(this.hot);
   /**
    * @type {number[]}
    */
@@ -138,8 +136,8 @@ export class ManualRowMove extends BasePlugin {
     removeClass(this.hot.rootElement, CSS_PLUGIN);
 
     this.unregisterEvents();
-    this.backlight.destroy();
-    this.guideline.destroy();
+    this.#backlight.destroy();
+    this.#guideline.destroy();
 
     super.disablePlugin();
   }
@@ -431,8 +429,8 @@ export class ManualRowMove extends BasePlugin {
     const pixelsRelToTableStart = this.#target.eventPageY - pixelsAbove + tableScroll;
     const hiderHeight = wtTable.hider.offsetHeight;
     const tbodyOffsetTop = wtTable.TBODY.offsetTop;
-    const backlightElemMarginTop = this.backlight.getOffset().top;
-    const backlightElemHeight = this.backlight.getSize().height;
+    const backlightElemMarginTop = this.#backlight.getOffset().top;
+    const backlightElemHeight = this.#backlight.getSize().height;
     const tdMiddle = (TD.offsetHeight / 2);
     const tdHeight = TD.offsetHeight;
     let tdStartPixel = this.hot.view.THEAD.offsetHeight + this.getRowsHeight(0, coords.row - 1);
@@ -473,8 +471,8 @@ export class ManualRowMove extends BasePlugin {
       guidelineTop = hiderHeight - 1;
     }
 
-    this.backlight.setPosition(backlightTop);
-    this.guideline.setPosition(guidelineTop);
+    this.#backlight.setPosition(backlightTop);
+    this.#guideline.setPosition(guidelineTop);
   }
 
   /**
@@ -520,12 +518,12 @@ export class ManualRowMove extends BasePlugin {
       return;
     }
 
-    const guidelineIsNotReady = this.guideline.isBuilt() && !this.guideline.isAppended();
-    const backlightIsNotReady = this.backlight.isBuilt() && !this.backlight.isAppended();
+    const guidelineIsNotReady = this.#guideline.isBuilt() && !this.#guideline.isAppended();
+    const backlightIsNotReady = this.#backlight.isBuilt() && !this.#backlight.isAppended();
 
     if (guidelineIsNotReady && backlightIsNotReady) {
-      this.guideline.appendTo(wtTable.hider);
-      this.backlight.appendTo(wtTable.hider);
+      this.#guideline.appendTo(wtTable.hider);
+      this.#backlight.appendTo(wtTable.hider);
     }
 
     const { from, to } = selection;
@@ -544,9 +542,9 @@ export class ManualRowMove extends BasePlugin {
       const leftPos = wtTable.holder.scrollLeft + wtViewport.getRowHeaderWidth();
       const topOffset = this.getRowsHeight(start, coords.row - 1) + event.offsetY;
 
-      this.backlight.setPosition(null, leftPos);
-      this.backlight.setSize(wtTable.hider.offsetWidth - leftPos, this.getRowsHeight(start, end));
-      this.backlight.setOffset(-topOffset, null);
+      this.#backlight.setPosition(null, leftPos);
+      this.#backlight.setSize(wtTable.hider.offsetWidth - leftPos, this.getRowsHeight(start, end));
+      this.#backlight.setOffset(-topOffset, null);
 
       addClass(this.hot.rootElement, CSS_ON_MOVING);
 
@@ -649,8 +647,8 @@ export class ManualRowMove extends BasePlugin {
     const scrollLeft = wtTable.holder.scrollLeft;
     const posLeft = headerWidth + scrollLeft;
 
-    this.backlight.setPosition(null, posLeft);
-    this.backlight.setSize(wtTable.hider.offsetWidth - posLeft);
+    this.#backlight.setPosition(null, posLeft);
+    this.#backlight.setSize(wtTable.hider.offsetWidth - posLeft);
   }
 
   /**
@@ -659,8 +657,8 @@ export class ManualRowMove extends BasePlugin {
    * @private
    */
   buildPluginUI() {
-    this.backlight.build();
-    this.guideline.build();
+    this.#backlight.build();
+    this.#guideline.build();
   }
 
   /**
@@ -674,8 +672,8 @@ export class ManualRowMove extends BasePlugin {
    * Destroys the plugin instance.
    */
   destroy() {
-    this.backlight.destroy();
-    this.guideline.destroy();
+    this.#backlight.destroy();
+    this.#guideline.destroy();
 
     super.destroy();
   }


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Fix documentation of the ManualColumnMove and ManualRowMove plugins.

_[skip changelog]_

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
