### PR TITLE
Prevent the focus manager from selecting the text editor's TEXTAREA contents when it's opened.

### DIFF
--- a/.changelogs/10595.json
+++ b/.changelogs/10595.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed a problem with the text editor's TEXTAREA element's contents being selected after opening the editor with a double-click.",
+  "type": "fixed",
+  "issueOrPR": 10595,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/editors/textEditor/__tests__/textEditor.spec.js
+++ b/handsontable/src/editors/textEditor/__tests__/textEditor.spec.js
@@ -2030,5 +2030,38 @@ describe('TextEditor', () => {
       expect($(textarea).width()).toBe(143);
       expect($(textarea).height()).toBe(23);
     });
+
+    it('should not select the TEXTAREA contents after double-clicking on a cell when `imeFastEdit` is enabled', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 2),
+        imeFastEdit: true,
+      });
+      const cell = $(getCell(0, 0));
+
+      selectCell(0, 0);
+      window.scrollTo(0, cell.offset().top);
+
+      await sleep(0);
+
+      cell
+        .simulate('mousedown')
+        .simulate('mouseup')
+        .simulate('click');
+
+      await sleep(100);
+
+      cell
+        .simulate('mousedown')
+        .simulate('mouseup')
+        .simulate('click');
+
+      await sleep(100);
+
+      const editor = getActiveEditor();
+
+      expect(editor.isOpened()).toBe(true);
+      expect(Handsontable.dom.getCaretPosition(editor.TEXTAREA)).toBe(getDataAtCell(0, 0).length);
+      expect(Handsontable.dom.getSelectionEndPosition(editor.TEXTAREA)).toBe(getDataAtCell(0, 0).length);
+    });
   });
 });

--- a/handsontable/src/focusManager.js
+++ b/handsontable/src/focusManager.js
@@ -163,6 +163,7 @@ export class FocusManager {
     // Re-focus on the editor's `TEXTAREA` element (or a predefined element) if the `imeFastEdit` option is enabled.
     if (
       this.#hot.getSettings().imeFastEdit &&
+      !this.#hot.getActiveEditor()?.isOpened() &&
       !!refocusElement
     ) {
       this.#hot._registerTimeout(() => {


### PR DESCRIPTION
### Context
This PR prevents the focus manager from selecting the text editor's `TEXTAREA` element's contents after it's already been opened.

### How has this been tested?
Tested manually and added a test case.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#1565


### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
