### PR TITLE
Add missing typing for `focusEditor` method

### DIFF
--- a/handsontable/src/plugins/comments/__tests__/comments.types.ts
+++ b/handsontable/src/plugins/comments/__tests__/comments.types.ts
@@ -1,0 +1,30 @@
+import Handsontable, { CellCoords } from 'handsontable';
+
+const hot = new Handsontable(document.createElement('div'), {
+  comments: true,
+});
+new Handsontable(document.createElement('div'), {
+  comments: {
+    displayDelay: 100,
+  },
+});
+const comments = hot.getPlugin('comments');
+
+comments.focusEditor();
+comments.setRange({ from: new CellCoords(1, 1), to: new CellCoords(2, 2) });
+comments.clearRange();
+comments.setCommentAtCell(1, 2, 'test');
+comments.removeComment();
+comments.removeComment(true);
+comments.removeCommentAtCell(1, 2);
+comments.removeCommentAtCell(1, 2, true);
+comments.hide();
+comments.refreshEditor();
+comments.refreshEditor(true);
+comments.updateCommentMeta(1, 2, { test: 'test' });
+
+const comment: string = comments.getComment();
+const commentAt: string = comments.getCommentAtCell(1, 2);
+const isShown: boolean = comments.show();
+const isShownAt: boolean = comments.showAtCell(1, 2);
+const testMeta: string = comments.getCommentMeta(1, 2, 'test');

--- a/handsontable/types/plugins/comments/comments.d.ts
+++ b/handsontable/types/plugins/comments/comments.d.ts
@@ -33,6 +33,7 @@ export class Comments extends BasePlugin {
   range: CommentsRangeObject;
 
   isEnabled(): boolean;
+  focusEditor(): void;
   setRange(range: CommentsRangeObject): void;
   clearRange(): void;
   setComment(value: string): void;


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adds missing TS typings for the Comments `focusEditor` method. 

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I added a test case.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
