### PR TITLE
Extend the hit zone of the sortable column headers to include the sorting indicator.

### DIFF
--- a/.changelogs/10598.json
+++ b/.changelogs/10598.json
@@ -1,8 +1,0 @@
-{
-  "issuesOrigin": "private",
-  "title": "Fixed a problem where clicking on a sorting indicator would not sort the column.",
-  "type": "fixed",
-  "issueOrPR": 10598,
-  "breaking": false,
-  "framework": "none"
-}

--- a/.changelogs/10598.json
+++ b/.changelogs/10598.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed a problem where clicking on a sorting indicator would not sort the column.",
+  "type": "fixed",
+  "issueOrPR": 10598,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/columnSorting/__tests__/columnSorting.spec.js
+++ b/handsontable/src/plugins/columnSorting/__tests__/columnSorting.spec.js
@@ -5,16 +5,18 @@ describe('ColumnSorting', () => {
   beforeEach(function() {
     this.$container = $(`<div id="${id}" style="overflow: auto; width: 300px; height: 200px;"></div>`).appendTo('body');
 
-    this.sortByClickOnColumnHeader = (columnIndex) => {
+    this.sortByClickOnColumnHeader = (columnIndex, useIndicator = false) => {
       const hot = this.$container.data('handsontable');
       const $columnHeader = $(hot.view._wt.wtTable.getColumnHeader(columnIndex));
       const $spanInsideHeader = $columnHeader.find('.columnSorting');
+      const $sortingIndicator = $columnHeader.find('.columnSortingIndicator');
+      const $clickableElement = useIndicator ? $sortingIndicator : $spanInsideHeader;
 
-      if ($spanInsideHeader.length === 0) {
+      if ($clickableElement.length === 0) {
         throw Error('Please check the test scenario. The header doesn\'t exist.');
       }
 
-      simulateClick($spanInsideHeader);
+      simulateClick($clickableElement);
     };
   });
 
@@ -70,6 +72,38 @@ describe('ColumnSorting', () => {
     expect(htCore.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('3');
     expect(htCore.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('0');
     expect(htCore.find('tbody tr:eq(0) td:eq(3)').text()).toEqual('5');
+  });
+
+  it('should sort table by first visible column when clicking on the first column\'s sorting indicator', () => {
+    handsontable({
+      data: [
+        [1, 9, 3, 4, 5, 6, 7, 8, 9],
+        [9, 8, 7, 6, 5, 4, 3, 2, 1],
+        [8, 7, 6, 5, 4, 3, 3, 1, 9],
+        [0, 3, 0, 5, 6, 7, 8, 9, 1]
+      ],
+      colHeaders: true,
+      columnSorting: {
+        initialConfig: {
+          column: 0,
+          sortOrder: 'asc'
+        }
+      }
+    });
+
+    const htCore = getHtCore();
+
+    spec().sortByClickOnColumnHeader(0, true);
+
+    expect(htCore.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('9');
+    expect(htCore.find('tbody tr:eq(0) td:eq(1)').text()).toEqual('8');
+    expect(htCore.find('tbody tr:eq(0) td:eq(2)').text()).toEqual('7');
+    expect(htCore.find('tbody tr:eq(0) td:eq(3)').text()).toEqual('6');
+
+    expect(htCore.find('tbody tr:eq(0) td:eq(0)').text()).toEqual('9');
+    expect(htCore.find('tbody tr:eq(1) td:eq(0)').text()).toEqual('8');
+    expect(htCore.find('tbody tr:eq(2) td:eq(0)').text()).toEqual('1');
+    expect(htCore.find('tbody tr:eq(3) td:eq(0)').text()).toEqual('0');
   });
 
   it('should not change row indexes in the sorted table after using `disablePlugin` until next render is called', () => {

--- a/handsontable/src/plugins/columnSorting/columnSorting.js
+++ b/handsontable/src/plugins/columnSorting/columnSorting.js
@@ -1,6 +1,7 @@
 import {
   addClass,
   appendElement,
+  hasClass,
   removeClass,
   setAttribute,
 } from '../../helpers/dom/element';
@@ -13,6 +14,7 @@ import { IndexesSequence, PhysicalIndexToValueMap as IndexToValueMap } from '../
 import Hooks from '../../pluginHooks';
 import { ColumnStatesManager } from './columnStatesManager';
 import {
+  HEADER_SPAN_CLASS,
   getNextSortOrder,
   areValidSortStates,
   getHeaderSpanElement,
@@ -820,7 +822,10 @@ export class ColumnSorting extends BasePlugin {
     const pluginSettingsForColumn = this.getFirstCellSettings(column)[this.pluginKey];
     const headerActionEnabled = pluginSettingsForColumn.headerAction;
 
-    return headerActionEnabled && event.target.nodeName === 'SPAN';
+    return (
+      headerActionEnabled &&
+      (hasClass(event.target, HEADER_SPAN_CLASS) || hasClass(event.target, SORTING_INDICATOR_CLASS))
+    );
   }
 
   /**


### PR DESCRIPTION
### Context
This PR builds upon https://github.com/handsontable/handsontable/pull/10540 and extends the hit zone of the sortable column headers' clickable element to include the sorting indicators.

[skip changelog]

### How has this been tested?
Tested manually and added a test case.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#1569
2. https://github.com/handsontable/handsontable/pull/10540


### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
