### PR TITLE
Remove presentation role from the headers in the corner

### DIFF
--- a/handsontable/src/3rdparty/walkontable/src/renderer/columnHeaders.js
+++ b/handsontable/src/3rdparty/walkontable/src/renderer/columnHeaders.js
@@ -11,7 +11,7 @@ import {
   A11Y_ROW,
   A11Y_ROWINDEX,
   A11Y_SCOPE_COL,
-  A11Y_TABINDEX
+  A11Y_TABINDEX,
 } from '../../../../helpers/a11y';
 
 /**
@@ -112,10 +112,10 @@ export default class ColumnHeadersRenderer extends BaseRenderer {
           setAttribute(TH, [
             A11Y_COLINDEX(renderedColumnIndex + 1 + this.table.rowHeadersCount),
             A11Y_TABINDEX(-1),
-            ...(renderedColumnIndex < 0 ? [A11Y_PRESENTATION()] : [
-              A11Y_COLUMNHEADER(),
-              A11Y_SCOPE_COL()
-            ]),
+            A11Y_COLUMNHEADER(),
+            ...(renderedColumnIndex >= 0 ? [
+              A11Y_SCOPE_COL(),
+            ] : []),
           ]);
         }
 

--- a/handsontable/src/__tests__/a11y/headers.spec.js
+++ b/handsontable/src/__tests__/a11y/headers.spec.js
@@ -47,17 +47,17 @@ describe('header-related a11y config', () => {
           ).length;
         };
 
-        expect(countElementsWithTabindex(getMaster())).toEqual(101);
+        expect(countElementsWithTabindex(getMaster())).toBe(101);
 
-        expect(countElementsWithTabindex(getInlineStartClone())).toEqual(53);
+        expect(countElementsWithTabindex(getInlineStartClone())).toBe(53);
 
-        expect(countElementsWithTabindex(getTopClone())).toEqual(53);
+        expect(countElementsWithTabindex(getTopClone())).toBe(53);
 
-        expect(countElementsWithTabindex(getTopInlineStartClone())).toEqual(5);
+        expect(countElementsWithTabindex(getTopInlineStartClone())).toBe(5);
 
-        expect(countElementsWithTabindex(getBottomInlineStartClone())).toEqual(2);
+        expect(countElementsWithTabindex(getBottomInlineStartClone())).toBe(2);
 
-        expect(countElementsWithTabindex(getBottomClone())).toEqual(2);
+        expect(countElementsWithTabindex(getBottomClone())).toBe(2);
       });
 
       describe('row headers', () => {
@@ -82,17 +82,17 @@ describe('header-related a11y config', () => {
             ).length;
           };
 
-          expect(countElementsWithAriaRowHeader(getMaster())).toEqual(50);
+          expect(countElementsWithAriaRowHeader(getMaster())).toBe(50);
 
-          expect(countElementsWithAriaRowHeader(getInlineStartClone())).toEqual(50);
+          expect(countElementsWithAriaRowHeader(getInlineStartClone())).toBe(50);
 
-          expect(countElementsWithAriaRowHeader(getTopClone())).toEqual(2);
+          expect(countElementsWithAriaRowHeader(getTopClone())).toBe(2);
 
-          expect(countElementsWithAriaRowHeader(getTopInlineStartClone())).toEqual(2);
+          expect(countElementsWithAriaRowHeader(getTopInlineStartClone())).toBe(2);
 
-          expect(countElementsWithAriaRowHeader(getBottomInlineStartClone())).toEqual(2);
+          expect(countElementsWithAriaRowHeader(getBottomInlineStartClone())).toBe(2);
 
-          expect(countElementsWithAriaRowHeader(getBottomClone())).toEqual(2);
+          expect(countElementsWithAriaRowHeader(getBottomClone())).toBe(2);
         });
 
         it('should add the `scope=row` aria tag to every row headers in the table', () => {
@@ -116,17 +116,17 @@ describe('header-related a11y config', () => {
             ).length;
           };
 
-          expect(countElementsWithAriaScopeRow(getMaster())).toEqual(50);
+          expect(countElementsWithAriaScopeRow(getMaster())).toBe(50);
 
-          expect(countElementsWithAriaScopeRow(getInlineStartClone())).toEqual(50);
+          expect(countElementsWithAriaScopeRow(getInlineStartClone())).toBe(50);
 
-          expect(countElementsWithAriaScopeRow(getTopClone())).toEqual(2);
+          expect(countElementsWithAriaScopeRow(getTopClone())).toBe(2);
 
-          expect(countElementsWithAriaScopeRow(getTopInlineStartClone())).toEqual(2);
+          expect(countElementsWithAriaScopeRow(getTopInlineStartClone())).toBe(2);
 
-          expect(countElementsWithAriaScopeRow(getBottomInlineStartClone())).toEqual(2);
+          expect(countElementsWithAriaScopeRow(getBottomInlineStartClone())).toBe(2);
 
-          expect(countElementsWithAriaScopeRow(getBottomClone())).toEqual(2);
+          expect(countElementsWithAriaScopeRow(getBottomClone())).toBe(2);
         });
       });
 
@@ -152,13 +152,10 @@ describe('header-related a11y config', () => {
             ).length;
           };
 
-          expect(countElementsWithAriaColumnHeader(getMaster())).toEqual(50);
-
-          expect(countElementsWithAriaColumnHeader(getInlineStartClone())).toEqual(2);
-
-          expect(countElementsWithAriaColumnHeader(getTopClone())).toEqual(50);
-
-          expect(countElementsWithAriaColumnHeader(getTopInlineStartClone())).toEqual(2);
+          expect(countElementsWithAriaColumnHeader(getMaster())).toBe(51); // 50 + 1 for the corner header
+          expect(countElementsWithAriaColumnHeader(getInlineStartClone())).toBe(3); // 2 + 1 for the corner header
+          expect(countElementsWithAriaColumnHeader(getTopClone())).toBe(51); // 50 + 1 for the corner header
+          expect(countElementsWithAriaColumnHeader(getTopInlineStartClone())).toBe(3); // 2 + 1 for the corner header
         });
 
         it('should add the `scope=col` aria tag to every row headers in the table', () => {
@@ -182,18 +179,18 @@ describe('header-related a11y config', () => {
             ).length;
           };
 
-          expect(countElementsWithAriaScopeCol(getMaster())).toEqual(50);
+          expect(countElementsWithAriaScopeCol(getMaster())).toBe(50);
 
-          expect(countElementsWithAriaScopeCol(getInlineStartClone())).toEqual(2);
+          expect(countElementsWithAriaScopeCol(getInlineStartClone())).toBe(2);
 
-          expect(countElementsWithAriaScopeCol(getTopClone())).toEqual(50);
+          expect(countElementsWithAriaScopeCol(getTopClone())).toBe(50);
 
-          expect(countElementsWithAriaScopeCol(getTopInlineStartClone())).toEqual(2);
+          expect(countElementsWithAriaScopeCol(getTopInlineStartClone())).toBe(2);
         });
       });
 
       describe('corner headers', () => {
-        it('should add the `role=presentation` aria tag to the corner headers', () => {
+        it('should add the `role=columnheader` aria tag to the corner headers', () => {
           handsontable({
             data: Handsontable.helper.createSpreadsheetData(50, 15),
             rowHeaders: true,
@@ -207,19 +204,19 @@ describe('header-related a11y config', () => {
 
           expect(
             getTopInlineStartClone().get(0).querySelector('thead th:first-of-type').getAttribute('role')
-          ).toEqual('presentation');
+          ).toBe('columnheader');
 
           expect(
             getMaster().get(0).querySelector('thead th:first-of-type').getAttribute('role')
-          ).toEqual('presentation');
+          ).toBe('columnheader');
 
           expect(
             getInlineStartClone().get(0).querySelector('thead th:first-of-type').getAttribute('role')
-          ).toEqual('presentation');
+          ).toBe('columnheader');
 
           expect(
             getTopClone().get(0).querySelector('thead th:first-of-type').getAttribute('role')
-          ).toEqual('presentation');
+          ).toBe('columnheader');
         });
       });
     });


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR removes the `presentation` role from the headers of the table corner. Once focused, the element with that role causes the screen readers (NVDA/JAWA) to capture the keyboard event triggered by the arrow keys, thus causing the table misalignment once pressed.

_[skip changelog]_ (hotfix)

#### Before
![Kapture 2023-11-22 at 14 47 33](https://github.com/handsontable/handsontable/assets/571316/d4ace49f-337a-4d21-b6b7-828c77590c8f)

#### After
![Kapture 2023-11-22 at 14 45 30](https://github.com/handsontable/handsontable/assets/571316/0b105a29-b78e-4405-b6df-b38051af4247)

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1574

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
