### PR TITLE
Restore menu item highlight after TAB navigation

### DIFF
--- a/handsontable/src/plugins/filters/filters.js
+++ b/handsontable/src/plugins/filters/filters.js
@@ -252,7 +252,18 @@ export class Filters extends BasePlugin {
         // A fake menu item that once focused allows escaping from the focus navigation (using Tab keys)
         // to the menu navigation using arrow keys.
         {
-          focus: () => mainMenu.focus(),
+          focus: () => {
+            const menuNavigator = mainMenu.getNavigator();
+            const lastSelectedMenuItem = this.#menuFocusNavigator.getLastMenuPage();
+
+            mainMenu.focus();
+
+            if (lastSelectedMenuItem > 0) {
+              menuNavigator.setCurrentPage(lastSelectedMenuItem);
+            } else {
+              menuNavigator.toFirstItem();
+            }
+          },
         },
         ...Array.from(this.components)
           .map(([, component]) => component.getElements())

--- a/visual-tests/tests/filters/shift-tab-navigation-through-all-components.spec.ts
+++ b/visual-tests/tests/filters/shift-tab-navigation-through-all-components.spec.ts
@@ -69,7 +69,7 @@ test(__filename, async({ page }) => {
 
   await page.keyboard.press('Shift+Tab');
 
-  // take a screenshot of the focused menu
+  // take a screenshot of the focused menu with the last highlighted item
   await page.screenshot({ path: helpers.screenshotPath() });
 
   await page.keyboard.press('Shift+Tab');

--- a/visual-tests/tests/filters/tab-navigation-through-all-components.spec.ts
+++ b/visual-tests/tests/filters/tab-navigation-through-all-components.spec.ts
@@ -117,7 +117,7 @@ test(__filename, async({ page }) => {
 
   await page.keyboard.press('Tab');
 
-  // take a screenshot of the focused menu
+  // take a screenshot of the focused menu with the last highlighted item
   await page.screenshot({ path: helpers.screenshotPath() });
 
   await page.keyboard.press('Tab');


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR restores the menu item highlight after TAB or SHIFT+TAB navigation in the column menu with enabled filter components. The last selected menu item is highlighted once the user ends looping the focusable elements. 

_[skip changelog]_ (hotfix)

#### Before
![Kapture 2023-11-23 at 12 42 47](https://github.com/handsontable/handsontable/assets/571316/20bb2677-18b2-4f99-85b3-97a468423715)
There is an invisible UI state that allows navigating the menu items using arrow keys.

#### After
![Kapture 2023-11-23 at 12 44 27](https://github.com/handsontable/handsontable/assets/571316/c591fbcc-fbda-418c-88f7-6ca64473e203)
After ending the TAB navigation loop, the menu item is again highlighted, indicating that the navigation using arrow keys is allowed. 

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Visual tests already capture that change.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1581

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
