### PR TITLE
Mark the private plugins hooks with `@private` tags

### DIFF
--- a/handsontable/src/plugins/nestedRows/nestedRows.js
+++ b/handsontable/src/plugins/nestedRows/nestedRows.js
@@ -247,6 +247,7 @@ export class NestedRows extends BasePlugin {
   /**
    * The modifyRowData hook callback.
    *
+   * @private
    * @param {number} row Visual row index.
    * @returns {boolean}
    */
@@ -261,6 +262,7 @@ export class NestedRows extends BasePlugin {
   /**
    * Modify the source data length to match the length of the nested structure.
    *
+   * @private
    * @returns {number}
    */
   onModifySourceLength() {
@@ -272,6 +274,7 @@ export class NestedRows extends BasePlugin {
   }
 
   /**
+   * @private
    * @param {number} index The index where the data was spliced.
    * @param {number} amount An amount of items to remove.
    * @param {object} element An element to add.


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the _NestedRows_ plugin documentation.

_[skip changelog]_ (hotfix)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1583

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
