### PR TITLE
Add `aria-hidden` to the focus catcher elements

### DIFF
--- a/handsontable/src/core/focusCatcher/__tests__/focusDetector.unit.js
+++ b/handsontable/src/core/focusCatcher/__tests__/focusDetector.unit.js
@@ -1,0 +1,45 @@
+import { installFocusDetector } from './../focusDetector';
+
+describe('focusDetector', () => {
+  let hot;
+  let hooks;
+
+  beforeEach(() => {
+    const rootElement = document.createElement('div');
+
+    rootElement.className = 'handsontable';
+    rootElement.innerHTML = '<div></div><div></div>';
+
+    hot = {
+      rootElement,
+      rootDocument: document,
+      _registerTimeout: jest.fn(),
+      getSettings: () => ({
+        ariaTags: true,
+      }),
+    };
+    hooks = {
+      onFocusFromTop: jest.fn(),
+      onFocusFromBottom: jest.fn(),
+    };
+  });
+
+  afterEach(() => {
+    hot = null;
+    hooks = null;
+  });
+
+  it('should add input traps with correct attributes to the Handsontable root element', () => {
+    installFocusDetector(hot, hooks);
+
+    const inputTrapTop = hot.rootElement.firstChild;
+    const inputTrapBottom = hot.rootElement.lastChild;
+
+    expect(inputTrapTop.className).toBe('htFocusCatcher');
+    expect(inputTrapTop.getAttribute('role')).toBe('presentation');
+    expect(inputTrapTop.getAttribute('aria-hidden')).toBe('true');
+    expect(inputTrapBottom.className).toBe('htFocusCatcher');
+    expect(inputTrapBottom.getAttribute('role')).toBe('presentation');
+    expect(inputTrapBottom.getAttribute('aria-hidden')).toBe('true');
+  });
+});

--- a/handsontable/src/core/focusCatcher/focusDetector.js
+++ b/handsontable/src/core/focusCatcher/focusDetector.js
@@ -1,5 +1,5 @@
 import { setAttribute } from '../../helpers/dom/element';
-import { A11Y_PRESENTATION } from '../../helpers/a11y';
+import { A11Y_PRESENTATION, A11Y_HIDDEN } from '../../helpers/a11y';
 
 /**
  * Installs a focus detector module. The module appends two input elements into the DOM side by side.
@@ -59,7 +59,8 @@ function createInputElement(hot) {
 
   if (hot.getSettings().ariaTags) {
     setAttribute(input, [
-      A11Y_PRESENTATION()
+      A11Y_PRESENTATION(),
+      A11Y_HIDDEN(),
     ]);
   }
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR  adds `aria-hidden=true` to the focus catcher elements. The changes do not remove the elements from the lighthouse results completely, but by adding the mentioned tag, the overall score is higher than without it.

_[skip changelog]_ (hotfix)

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Tested using lighthouse.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1582

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
