### PR TITLE
Add `role=row` to the corner headers to prevent arrow navigation problems and header announcement mismatch on the main table.

### DIFF
--- a/handsontable/src/3rdparty/walkontable/src/renderer/columnHeaders.js
+++ b/handsontable/src/3rdparty/walkontable/src/renderer/columnHeaders.js
@@ -7,6 +7,7 @@ import BaseRenderer from './_base';
 import {
   A11Y_COLINDEX,
   A11Y_COLUMNHEADER,
+  A11Y_HIDDEN,
   A11Y_ROW,
   A11Y_ROWGROUP,
   A11Y_ROWINDEX,
@@ -115,7 +116,11 @@ export default class ColumnHeadersRenderer extends BaseRenderer {
             A11Y_COLUMNHEADER(),
             ...(renderedColumnIndex >= 0 ? [
               A11Y_SCOPE_COL(),
-            ] : []),
+            ] : [
+              // Adding `aria-hidden` to the corner headers to prevent
+              // https://github.com/handsontable/dev-handsontable/issues/1574
+              A11Y_HIDDEN()
+            ]),
           ]);
         }
 

--- a/handsontable/src/3rdparty/walkontable/src/renderer/columnHeaders.js
+++ b/handsontable/src/3rdparty/walkontable/src/renderer/columnHeaders.js
@@ -7,7 +7,6 @@ import BaseRenderer from './_base';
 import {
   A11Y_COLINDEX,
   A11Y_COLUMNHEADER,
-  A11Y_HIDDEN,
   A11Y_ROW,
   A11Y_ROWGROUP,
   A11Y_ROWINDEX,
@@ -117,9 +116,9 @@ export default class ColumnHeadersRenderer extends BaseRenderer {
             ...(renderedColumnIndex >= 0 ? [
               A11Y_SCOPE_COL(),
             ] : [
-              // Adding `aria-hidden` to the corner headers to prevent
+              // Adding `role=row` to the corner headers to prevent
               // https://github.com/handsontable/dev-handsontable/issues/1574
-              A11Y_HIDDEN()
+              A11Y_ROW()
             ]),
           ]);
         }


### PR DESCRIPTION
### Context
This PR aims to:
- Prevent column header announcement mismatch issues on the main table.
- Arrow navigation issues (https://github.com/handsontable/dev-handsontable/issues/1574).

Known issues:
- The column header announcement in NVDA (and possibly JAWS) is still mismatched on the fixed columns (the readers tie cells with headers from one column back)

[skip changelog]

### How has this been tested?
Tested manually.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/1574

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
