### PR TITLE
Fix Control+Shift+Backspace keyboard shortcut for Windows

### DIFF
--- a/handsontable/src/plugins/contextMenu/__tests__/keyboardShortcuts/shiftMetaBackslashOrShiftF10.spec.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/keyboardShortcuts/shiftMetaBackslashOrShiftF10.spec.js
@@ -11,7 +11,7 @@ describe('ContextMenu keyboard shortcut', () => {
   });
 
   using('', [
-    ['Shift', 'Control/Meta', '\\'],
+    ['Shift', 'Control/Meta', 'Backslash'],
     ['Shift', 'F10'],
   ], (keyboardShortcut) => {
     it('should not throw an error when triggered on selection that points on the hidden records', () => {

--- a/handsontable/src/plugins/contextMenu/contextMenu.js
+++ b/handsontable/src/plugins/contextMenu/contextMenu.js
@@ -194,7 +194,7 @@ export class ContextMenu extends BasePlugin {
     this.hot.getShortcutManager()
       .getContext('grid')
       .addShortcut({
-        keys: [['Control/Meta', 'Shift', '\\'], ['Shift', 'F10']],
+        keys: [['Control/Meta', 'Shift', 'Backslash'], ['Shift', 'F10']],
         callback: () => {
           const { highlight } = this.hot.getSelectedRangeLast();
 

--- a/handsontable/src/shortcuts/__tests__/utils.unit.js
+++ b/handsontable/src/shortcuts/__tests__/utils.unit.js
@@ -19,6 +19,76 @@ describe('utils', () => {
 
       expect(key).toBe('3');
     });
+
+    it('should get the shortcut key from the `code` property when it is a Minus', () => {
+      // emulates pressing the Shift+Minus keys
+      const key = normalizeEventKey({ key: '_', code: 'Minus' });
+
+      expect(key).toBe('minus');
+    });
+
+    it('should get the shortcut key from the `code` property when it is a Equal', () => {
+      // emulates pressing the Shift+Equal keys
+      const key = normalizeEventKey({ key: '+', code: 'Equal' });
+
+      expect(key).toBe('equal');
+    });
+
+    it('should get the shortcut key from the `code` property when it is a BracketLeft', () => {
+      // emulates pressing the Shift+BracketLeft keys
+      const key = normalizeEventKey({ key: '{', code: 'BracketLeft' });
+
+      expect(key).toBe('bracketleft');
+    });
+
+    it('should get the shortcut key from the `code` property when it is a BracketRight', () => {
+      // emulates pressing the Shift+BracketRight keys
+      const key = normalizeEventKey({ key: '}', code: 'BracketRight' });
+
+      expect(key).toBe('bracketright');
+    });
+
+    it('should get the shortcut key from the `code` property when it is a Backslash', () => {
+      // emulates pressing the Shift+Backslash keys
+      const key = normalizeEventKey({ key: '|', code: 'Backslash' });
+
+      expect(key).toBe('backslash');
+    });
+
+    it('should get the shortcut key from the `code` property when it is a Semicolon', () => {
+      // emulates pressing the Shift+Semicolon keys
+      const key = normalizeEventKey({ key: ':', code: 'Semicolon' });
+
+      expect(key).toBe('semicolon');
+    });
+
+    it('should get the shortcut key from the `code` property when it is a Quote', () => {
+      // emulates pressing the Shift+Quote keys
+      const key = normalizeEventKey({ key: '"', code: 'Quote' });
+
+      expect(key).toBe('quote');
+    });
+
+    it('should get the shortcut key from the `code` property when it is a Comma', () => {
+      // emulates pressing the Shift+Comma keys
+      const key = normalizeEventKey({ key: '>', code: 'Comma' });
+
+      expect(key).toBe('comma');
+    });
+
+    it('should get the shortcut key from the `code` property when it is a Period', () => {
+      // emulates pressing the Shift+Period keys
+      const key = normalizeEventKey({ key: '<', code: 'Period' });
+
+      expect(key).toBe('period');
+    });
+
+    it('should get the shortcut key from the `code` property when it is a Slash', () => {
+      // emulates pressing the Shift+Slash keys
+      const key = normalizeEventKey({ key: '?', code: 'Slash' });
+
+      expect(key).toBe('slash');
+    });
   });
 
   describe('normalizeKeys', () => {

--- a/handsontable/src/shortcuts/utils.js
+++ b/handsontable/src/shortcuts/utils.js
@@ -56,6 +56,19 @@ export const getKeysList = (normalizedKeys) => {
  * the string.
  */
 const codeToKeyRegExp = new RegExp('^(?:Key|Digit)([A-Z0-9])$');
+const keyCodeNames = new Set([
+  'Backquote',
+  'Minus',
+  'Equal',
+  'BracketLeft',
+  'BracketRight',
+  'Backslash',
+  'Semicolon',
+  'Quote',
+  'Comma',
+  'Period',
+  'Slash',
+]);
 
 /**
  * Normalizes a keyboard event key value to a key before its modification. When the keyboard event
@@ -68,5 +81,14 @@ const codeToKeyRegExp = new RegExp('^(?:Key|Digit)([A-Z0-9])$');
  * @returns {string}
  */
 export const normalizeEventKey = ({ key, code }) => {
-  return (codeToKeyRegExp.test(code) ? code.replace(codeToKeyRegExp, '$1') : key).toLowerCase();
+  let normalizedKey = key;
+
+  if (codeToKeyRegExp.test(code)) {
+    normalizedKey = code.replace(codeToKeyRegExp, '$1');
+
+  } else if (keyCodeNames.has(code)) {
+    normalizedKey = code.toLowerCase();
+  }
+
+  return normalizedKey.toLowerCase();
 };

--- a/handsontable/src/shortcuts/utils.js
+++ b/handsontable/src/shortcuts/utils.js
@@ -87,7 +87,7 @@ export const normalizeEventKey = ({ key, code }) => {
     normalizedKey = code.replace(codeToKeyRegExp, '$1');
 
   } else if (keyCodeNames.has(code)) {
-    normalizedKey = code.toLowerCase();
+    normalizedKey = code;
   }
 
   return normalizedKey.toLowerCase();


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the <kbd>Control</kbd>+<kbd>Shift</kbd>+<kbd>Backspace</kbd> keyboard shortcut for Windows. The fix sits in the _ShortcutManager_ module. The PR fixes a bug in the key code normalization function. The bug occurred when the keyboard shortcut used mod keys (like <kbd>Alt</kbd> or <kbd>Shift</kbd>) with non-Key (`KeyA`, `KeyF`, etc.) or non-Digit (`Digit0`, `Digit1`, etc.) keys. The <kbd>Shift</kbd>+<kbd>\\</kbd> key modified the `event.key` value as `|` where the module expected `\` that's why the combination was not triggered.

_[skip changelog]_ (hotfix)

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally, and I covered the fix with new tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1604

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
