### PR TITLE
Select all cells with headers keyboard shortcut fix

### DIFF
--- a/handsontable/src/selection/__tests__/keyboardShortcuts/selectionExtending.spec.js
+++ b/handsontable/src/selection/__tests__/keyboardShortcuts/selectionExtending.spec.js
@@ -2845,7 +2845,7 @@ describe('Selection extending', () => {
   });
 
   describe('"Ctrl/Cmd + A"', () => {
-    it('should reset the current selection and select all cells with headers', () => {
+    it('should reset the current selection and select all cells without headers', () => {
       handsontable({
         rowHeaders: true,
         colHeaders: true,
@@ -2882,13 +2882,13 @@ describe('Selection extending', () => {
       keyDownUp(['control/meta', 'shift', 'space']);
 
       expect(`
-        |   ║ - : - : - : - : - |
+        | * ║ * : * : * : * : * |
         |===:===:===:===:===:===|
-        | - ║ 0 : 0 : 0 : 0 : 0 |
-        | - ║ 0 : 0 : 0 : 0 : 0 |
-        | - ║ 0 : 0 : A : 0 : 0 |
-        | - ║ 0 : 0 : 0 : 0 : 0 |
-        | - ║ 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : A : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 |
+        | * ║ 0 : 0 : 0 : 0 : 0 |
       `).toBeMatchToSelectionPattern();
       expect(getSelectedRange()).toEqualCellRange(['highlight: 2,2 from: -1,-1 to: 4,4']);
     });

--- a/handsontable/src/shortcutContexts/commands/index.js
+++ b/handsontable/src/shortcutContexts/commands/index.js
@@ -3,7 +3,8 @@ import { getAllCommands as getAllSelectionExtendCommands } from './extendCellsSe
 import { getAllCommands as getAllSelectionMoveCommands } from './moveCellSelection';
 import { command as emptySelectedCells } from './emptySelectedCells';
 import { command as scrollToFocusedCell } from './scrollToFocusedCell';
-import { command as selectAll } from './selectAll';
+import { command as selectAllCells } from './selectAllCells';
+import { command as selectAllCellsAndHeaders } from './selectAllCellsAndHeaders';
 import { command as populateSelectedCellsData } from './populateSelectedCellsData';
 
 const allCommands = [
@@ -12,7 +13,8 @@ const allCommands = [
   ...getAllSelectionMoveCommands(),
   emptySelectedCells,
   scrollToFocusedCell,
-  selectAll,
+  selectAllCells,
+  selectAllCellsAndHeaders,
   populateSelectedCellsData,
 ];
 

--- a/handsontable/src/shortcutContexts/commands/selectAllCells.js
+++ b/handsontable/src/shortcutContexts/commands/selectAllCells.js
@@ -1,5 +1,5 @@
 export const command = {
-  name: 'selectAll',
+  name: 'selectAllCells',
   callback(hot) {
     hot.selection.selectAll(true, true, {
       disableHeadersHighlight: true,

--- a/handsontable/src/shortcutContexts/commands/selectAllCellsAndHeaders.js
+++ b/handsontable/src/shortcutContexts/commands/selectAllCellsAndHeaders.js
@@ -1,0 +1,8 @@
+export const command = {
+  name: 'selectAllCellsAndHeaders',
+  callback(hot) {
+    hot.selection.selectAll(true, true, {
+      disableHeadersHighlight: false,
+    });
+  },
+};

--- a/handsontable/src/shortcutContexts/grid.js
+++ b/handsontable/src/shortcutContexts/grid.js
@@ -35,8 +35,11 @@ export function shortcutsGridContext(hot) {
   });
 
   context.addShortcuts([{
-    keys: [['Control/Meta', 'A'], ['Control/Meta', 'Shift', 'Space']],
-    callback: () => commandsPool.selectAll(),
+    keys: [['Control/Meta', 'A']],
+    callback: () => commandsPool.selectAllCells(),
+  }, {
+    keys: [['Control/Meta', 'Shift', 'Space']],
+    callback: () => commandsPool.selectAllCellsAndHeaders(),
   }, {
     keys: [['Control/Meta', 'Enter']],
     callback: () => commandsPool.populateSelectedCellsData(),


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the <kbd>Ctrl/Cmd</kbd> + <kbd>Shift</kbd> + <kbd>Space</kbd> keyboard shortcut, where it selects all cells with headers.

_[skip changelog]_ (hotfix)

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally, and I covered the fix with a new test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1609

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
