### PR TITLE
Fix screen readers Esc for menus

### DIFF
--- a/handsontable/src/plugins/contextMenu/__tests__/contextMenu.spec.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/contextMenu.spec.js
@@ -177,6 +177,20 @@ describe('ContextMenu', () => {
       expect($('.htContextMenu').is(':visible')).toBe(true);
     });
 
+    it('should open menu after right click on table cell and do not select any items by default', () => {
+      handsontable({
+        contextMenu: true,
+        height: 100
+      });
+
+      contextMenu();
+
+      const menu = getPlugin('contextMenu').menu;
+
+      expect(menu.getSelectedItem()).toBe(null);
+      expect(document.activeElement).toBe(menu.hotMenu.rootElement);
+    });
+
     it('should not open context menu after right click on inner htCore', async() => {
       handsontable({
         contextMenu: true,

--- a/handsontable/src/plugins/contextMenu/__tests__/keyboardShortcuts/shiftMetaBackslashOrShiftF10.spec.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/keyboardShortcuts/shiftMetaBackslashOrShiftF10.spec.js
@@ -163,6 +163,19 @@ describe('ContextMenu keyboard shortcut', () => {
       });
     });
 
+    it('should open the menu and select the first item by default', () => {
+      handsontable({
+        contextMenu: true,
+      });
+
+      selectCell(1, 1);
+      keyDownUp(keyboardShortcut);
+
+      const firstItem = getPlugin('contextMenu').menu.hotMenu.getCell(0, 0);
+
+      expect(document.activeElement).toBe(firstItem);
+    });
+
     it('should scroll the viewport when the focused cell is outside the table and call the `open` method', async() => {
       const hot = handsontable({
         data: createSpreadsheetData(500, 50),

--- a/handsontable/src/plugins/contextMenu/contextMenu.js
+++ b/handsontable/src/plugins/contextMenu/contextMenu.js
@@ -210,6 +210,9 @@ export class ContextMenu extends BasePlugin {
             left: rect.width,
             above: -rect.height,
           });
+          // Make sure the first item is selected (role=menuitem). Otherwise, screen readers
+          // will block the Esc key for the whole menu.
+          this.menu.getNavigator().toFirstItem();
         },
         runOnlyIf: () => {
           const highlight = this.hot.getSelectedRangeLast()?.highlight;

--- a/handsontable/src/plugins/dropdownMenu/__tests__/dropdownMenu.spec.js
+++ b/handsontable/src/plugins/dropdownMenu/__tests__/dropdownMenu.spec.js
@@ -117,6 +117,21 @@ describe('DropdownMenu', () => {
       expect($('.htDropdownMenu').is(':visible')).toBe(true);
     });
 
+    it('should open menu after click on table header button and do not select any items by default', () => {
+      handsontable({
+        dropdownMenu: true,
+        colHeaders: true,
+        height: 100
+      });
+
+      dropdownMenu(0);
+
+      const menu = getPlugin('dropdownMenu').menu;
+
+      expect(menu.getSelectedItem()).toBe(null);
+      expect(document.activeElement).toBe(menu.hotMenu.rootElement);
+    });
+
     it('should be possible to define a custom container for DropdownMenu\'s UI elements', () => {
       const uiContainer = $('<div/>').addClass('uiContainer');
 

--- a/handsontable/src/plugins/dropdownMenu/__tests__/keyboardShortcuts/metaEnter.spec.js
+++ b/handsontable/src/plugins/dropdownMenu/__tests__/keyboardShortcuts/metaEnter.spec.js
@@ -118,7 +118,7 @@ describe('DropdownMenu keyboard shortcut', () => {
       ]);
     });
 
-    it('should not highlight first item of the menu after open it', async() => {
+    it('should highlight first item of the menu after open it (triggered by hotkey)', async() => {
       handsontable({
         data: createSpreadsheetData(3, 8),
         colHeaders: true,
@@ -132,7 +132,7 @@ describe('DropdownMenu keyboard shortcut', () => {
 
       await sleep(100);
 
-      expect(getPlugin('dropdownMenu').menu.hotMenu.getSelected()).toBeUndefined();
+      expect(getPlugin('dropdownMenu').menu.hotMenu.getSelected()).toEqual([[0, 0, 0, 0]]);
     });
 
     it('should not be possible to close already opened the dropdown menu', () => {

--- a/handsontable/src/plugins/dropdownMenu/__tests__/keyboardShortcuts/shiftOptionArrowDown.spec.js
+++ b/handsontable/src/plugins/dropdownMenu/__tests__/keyboardShortcuts/shiftOptionArrowDown.spec.js
@@ -68,6 +68,20 @@ describe('DropdownMenu keyboard shortcut', () => {
       expect(plugin.open).toHaveBeenCalledTimes(1);
     });
 
+    it('should open the menu and select the first item by default', () => {
+      handsontable({
+        colHeaders: true,
+        dropdownMenu: true,
+      });
+
+      selectCell(1, 1);
+      keyDownUp(['shift', 'alt', 'arrowdown']);
+
+      const firstItem = getPlugin('dropdownMenu').menu.hotMenu.getCell(0, 0);
+
+      expect(document.activeElement).toBe(firstItem);
+    });
+
     it('should be possible to open the dropdown menu in the correct position triggered from the single cell', () => {
       handsontable({
         data: createSpreadsheetData(3, 8),

--- a/handsontable/src/plugins/dropdownMenu/dropdownMenu.js
+++ b/handsontable/src/plugins/dropdownMenu/dropdownMenu.js
@@ -261,6 +261,9 @@ export class DropdownMenu extends BasePlugin {
         }, {
           left: rect.width,
         });
+        // Make sure the first item is selected (role=menuitem). Otherwise, screen readers
+        // will block the Esc key for the whole menu.
+        this.menu.getNavigator().toFirstItem();
       }
     };
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes an issue where the <kbd>Escape</kbd> hotkey did not work when the menu was triggered while screen readers ran in the background. After the menu opening, I select the first menu item with `role=menuitem`, which seems to resolve the problem. The first item is only selected when the hotkey triggers the menu. For pointers (e.g. mouse), the bug is still there - as I think it's a bad idea to select the first item here, but seems to be more minor.

_[skip changelog]_ (hotfix)

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally, and I covered the fix with new tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1613

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
