### PR TITLE
Trigger `modifyFocusedElement` hook on hidden cells

### DIFF
--- a/handsontable/src/focusManager.js
+++ b/handsontable/src/focusManager.js
@@ -141,7 +141,7 @@ export class FocusManager {
     const focusElement = (element) => {
       const currentHighlightCoords = this.#hot.getSelectedRangeLast()?.highlight;
 
-      if (!currentHighlightCoords || !element) {
+      if (!currentHighlightCoords) {
         return;
       }
 
@@ -203,7 +203,7 @@ export class FocusManager {
   #getSelectedCell(callback) {
     const highlight = this.#hot.getSelectedRangeLast()?.highlight;
 
-    if (!highlight) {
+    if (!highlight || !this.#hot.selection.isCellVisible(highlight)) {
       callback(null);
 
       return;

--- a/handsontable/test/e2e/hooks/modifyFocusedElement.spec.js
+++ b/handsontable/test/e2e/hooks/modifyFocusedElement.spec.js
@@ -31,6 +31,27 @@ describe('`modifyFocusedElement` hook', () => {
     expect(hookSpy).toHaveBeenCalledWith(2, 2, getCell(2, 2, true));
   });
 
+  it('should trigger the hook with the correct arguments when the hidden cell is selected', () => {
+    const hookSpy = jasmine.createSpy('modifyFocusedElementSpy');
+
+    handsontable({
+      data: createSpreadsheetData(10, 4),
+      colHeaders: true,
+      rowHeaders: true,
+      modifyFocusedElement: hookSpy
+    });
+
+    const hidingMap = rowIndexMapper().createAndRegisterIndexMap('my-hiding-map', 'hiding');
+
+    hidingMap.setValueAtIndex(1, true);
+    render();
+
+    selectCell(1, 1);
+
+    expect(hookSpy).toHaveBeenCalledTimes(1);
+    expect(hookSpy).toHaveBeenCalledWith(1, 1, null);
+  });
+
   it('should allow modifying which element is being focused by returning an HTML element from the hook\'s callback', () => {
     const dummyElement = document.createElement('DIV');
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The hotfix for [PR](https://github.com/handsontable/handsontable/pull/10611) fixes an issue where the  `modifyFocusedElement` was not triggered for the hidden cells.

_[skip changelog]_ (hotfix)

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and I covered the thing with a new test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
