### PR TITLE
Disable viewport scrolling on paste

### DIFF
--- a/.changelogs/10630.json
+++ b/.changelogs/10630.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Disabled table's viewport scrolling on data paste.",
+  "type": "changed",
+  "issueOrPR": 10630,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/copyPaste/__tests__/paste.spec.js
+++ b/handsontable/src/plugins/copyPaste/__tests__/paste.spec.js
@@ -515,6 +515,27 @@ describe('CopyPaste', () => {
       expect(getSelectedRangeLast().to.col).toBe(9);
     });
 
+    it('should paste data without scrolling the viewport', async() => {
+      handsontable({
+        data: createSpreadsheetData(50, 50),
+        width: 200,
+        height: 200,
+      });
+
+      selectCell(6, 2);
+      triggerPaste([
+        'test\ttest\ttest\ttest\ttest\ttest',
+        'test\ttest\ttest\ttest\ttest\ttest',
+        'test\ttest\ttest\ttest\ttest\ttest',
+        'test\ttest\ttest\ttest\ttest\ttest',
+        'test\ttest\ttest\ttest\ttest\ttest',
+        'test\ttest\ttest\ttest\ttest\ttest',
+      ].join('\n'));
+
+      expect(topOverlay().getScrollPosition()).toBe(0);
+      expect(inlineStartOverlay().getScrollPosition()).toBe(0);
+    });
+
     it('should sanitize pasted HTML', async() => {
       handsontable();
 

--- a/handsontable/src/plugins/copyPaste/copyPaste.js
+++ b/handsontable/src/plugins/copyPaste/copyPaste.js
@@ -778,6 +778,12 @@ export class CopyPaste extends BasePlugin {
 
   /**
    * Disables the viewport scroll after pasting the data.
+   *
+   * @param {number} fromRow Selection start row visual index.
+   * @param {number} fromColumn Selection start column visual index.
+   * @param {number} toRow Selection end row visual index.
+   * @param {number} toColumn Selection end column visual index.
+   * @param {object} preventScrolling Object with `value` property. If `true`, the viewport scroll will be prevented.
    */
   #onAfterSelection(fromRow, fromColumn, toRow, toColumn, preventScrolling) {
     if (this.#preventViewportScrollOnPaste) {

--- a/handsontable/src/plugins/copyPaste/copyPaste.js
+++ b/handsontable/src/plugins/copyPaste/copyPaste.js
@@ -181,6 +181,12 @@ export class CopyPaste extends BasePlugin {
     countColumnHeaders: () => this.hot.view.getColumnHeadersCount(),
   });
   /**
+   * Flag that indicates if the viewport scroll should be prevented after pasting the data.
+   *
+   * @type {boolean}
+   */
+  #preventViewportScrollOnPaste = false;
+  /**
    * Ranges of the cells coordinates, which should be used to copy/cut/paste actions.
    *
    * @private
@@ -220,6 +226,7 @@ export class CopyPaste extends BasePlugin {
     }
 
     this.addHook('afterContextMenuDefaultOptions', options => this.#onAfterContextMenuDefaultOptions(options));
+    this.addHook('afterSelection', (...args) => this.#onAfterSelection(...args));
     this.addHook('afterSelectionEnd', () => this.#onAfterSelectionEnd());
 
     this.eventManager.addEventListener(this.hot.rootDocument, 'copy', (...args) => this.onCopy(...args));
@@ -561,6 +568,7 @@ export class CopyPaste extends BasePlugin {
       newRows.push(newRow);
     }
 
+    this.#preventViewportScrollOnPaste = true;
     this.hot.populateFromArray(startRow, startColumn, newRows, undefined, undefined, 'CopyPaste.paste', this.pasteMode);
 
     return [startRow, startColumn, lastVisualRow, lastVisualColumn];
@@ -766,6 +774,17 @@ export class CopyPaste extends BasePlugin {
     }
 
     options.items.push(cutItem(this));
+  }
+
+  /**
+   * Disables the viewport scroll after pasting the data.
+   */
+  #onAfterSelection(fromRow, fromColumn, toRow, toColumn, preventScrolling) {
+    if (this.#preventViewportScrollOnPaste) {
+      preventScrolling.value = true;
+    }
+
+    this.#preventViewportScrollOnPaste = false;
   }
 
   /**


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes an issue related to the viewport scrolling issue after data pasting. As [the issue](https://github.com/handsontable/dev-handsontable/issues/1458) points out, there should be no viewport move after paste. 

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally, and I covered the fix with a test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1458

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
