### PR TITLE
Fix an error that is thrown after TAB hit

### DIFF
--- a/handsontable/src/editorManager.js
+++ b/handsontable/src/editorManager.js
@@ -141,9 +141,9 @@ class EditorManager {
       return;
     }
 
-    const { highlight } = this.hot.getSelectedRangeLast();
+    const highlight = this.hot.getSelectedRangeLast()?.highlight;
 
-    if (highlight.isHeader()) {
+    if (!highlight || highlight.isHeader()) {
       return;
     }
 

--- a/handsontable/src/editors/numericEditor/__tests__/keyboardShortcuts.spec.js
+++ b/handsontable/src/editors/numericEditor/__tests__/keyboardShortcuts.spec.js
@@ -1,0 +1,44 @@
+describe('NumericEditor keyboard shortcut', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  describe('"Tab"', () => {
+    it('should not throw an error when pressing on the last column', async() => {
+      const spy = jasmine.createSpyObj('error', ['test']);
+      const prevError = window.onerror;
+
+      window.onerror = function() {
+        spy.test();
+
+        return true;
+      };
+
+      handsontable({
+        type: 'numeric',
+        startRows: 5,
+        startCols: 5,
+        tabNavigation: true,
+      });
+
+      selectCell(0, 4);
+      keyDownUp('enter');
+      keyDownUp('tab');
+
+      await sleep(50);
+
+      expect(spy.test.calls.count()).toBe(0);
+
+      window.onerror = prevError;
+    });
+  });
+});


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes a bug that causes an error when the <kbd>Tab</kbd> key is pressed on the editor in the last column.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally, and I covered the fix with a test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1616

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
