### PR TITLE
fix: migration guide links

### DIFF
--- a/docs/content/guides/upgrade-and-migration/migrating-from-13.1-to-14.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-13.1-to-14.0.md
@@ -41,7 +41,7 @@ The new Handsontable version comes with an updated set of keyboard shortcuts. Mo
 | Before  | After  |
 | ------------ | ------------ |
 | Iterates through the content list  | Iterates through the menu items. When focused on the search input, the arrow keys allow iterating through the content list  |
-(@/guides/cell-types/cell-type.md)
+
 More information: [Keyboard Shortcuts page in the documentation](@/guides/navigation/keyboard-shortcuts.md)
 
 ### Check if your template looks fine with the updated colors


### PR DESCRIPTION
### Context
remove broken link in the migration guide, (this syncs with prod-docs/14.0.0

### How has this been tested?
locally

[skip changelog]