### PR TITLE
Fix table jumps after TAB hit

### DIFF
--- a/handsontable/src/core/focusCatcher/__tests__/focusDetector.unit.js
+++ b/handsontable/src/core/focusCatcher/__tests__/focusDetector.unit.js
@@ -42,4 +42,6 @@ describe('focusDetector', () => {
     expect(inputTrapBottom.getAttribute('role')).toBe('presentation');
     expect(inputTrapBottom.getAttribute('aria-hidden')).toBe('true');
   });
+
+  // More tests around the focusCatcher module you'll find here ./handsontable/test/e2e/keyboardShortcuts/tabNavigation.spec.js
 });

--- a/handsontable/src/core/focusCatcher/index.js
+++ b/handsontable/src/core/focusCatcher/index.js
@@ -40,11 +40,13 @@ export function installFocusCatcher(hot) {
   };
   let isSavingCoordsEnabled = true;
   let isTabOrShiftTabPressed = false;
+  let preventViewportScroll = false;
 
   hot.addHook('afterListen', () => deactivate());
   hot.addHook('afterUnlisten', () => activate());
   hot.addHook('afterSelection', (row, column, row2, column2, preventScrolling) => {
-    if (isTabOrShiftTabPressed && rowWrapState.wrapped && rowWrapState.flipped) {
+    if (isTabOrShiftTabPressed && (rowWrapState.wrapped && rowWrapState.flipped || preventViewportScroll)) {
+      preventViewportScroll = false;
       preventScrolling.value = true;
     }
 
@@ -81,10 +83,16 @@ export function installFocusCatcher(hot) {
       {
         ...shortcutOptions,
         callback: () => {
+          const { tabNavigation } = hot.getSettings();
+
           isTabOrShiftTabPressed = true;
 
-          if (hot.getSelectedRangeLast() && !hot.getSettings().tabNavigation) {
+          if (hot.getSelectedRangeLast() && !tabNavigation) {
             isSavingCoordsEnabled = false;
+          }
+
+          if (!tabNavigation) {
+            preventViewportScroll = true;
           }
         },
         position: 'before',

--- a/handsontable/test/e2e/keyboardShortcuts/tabNavigation.spec.js
+++ b/handsontable/test/e2e/keyboardShortcuts/tabNavigation.spec.js
@@ -912,4 +912,61 @@ describe('Core navigation keyboard shortcuts', () => {
     expect(hot.getSelectedRange()).toEqualCellRange(['highlight: 0,0 from: 0,0 to: 0,0']);
     expect(hot1.getSelectedRange()).toBeUndefined();
   });
+
+  it('should not scroll the viewport of the table after navigating between the tables (navigableHeaders on)', async() => {
+    const hot = handsontable({
+      data: createSpreadsheetData(50, 30),
+      width: 200,
+      height: 200,
+      rowHeaders: true,
+      colHeaders: true,
+      tabNavigation: false,
+      navigableHeaders: true,
+      autoWrapRow: true,
+    });
+    const hot1 = handsontable({
+      data: createSpreadsheetData(50, 30),
+      width: 200,
+      height: 200,
+      rowHeaders: true,
+      colHeaders: true,
+      tabNavigation: false,
+      navigableHeaders: true,
+      autoWrapRow: true,
+    }, false, spec().$container1);
+
+    hot.selectCell(0, -1);
+    hot.deselectCell();
+    hot1.selectCell(0, -1);
+    hot1.deselectCell();
+
+    triggerTabNavigationFromTop(); // emulates native browser Tab navigation
+
+    expect(hot.getSelectedRange()).toEqualCellRange(['highlight: 0,-1 from: 0,-1 to: 0,-1']);
+    expect(hot1.getSelectedRange()).toBeUndefined();
+    expect(topOverlay().getScrollPosition()).toBe(0);
+    expect(inlineStartOverlay().getScrollPosition()).toBe(0);
+    expect(hot1.view._wt.wtOverlays.topOverlay.getScrollPosition()).toBe(0);
+    expect(hot1.view._wt.wtOverlays.inlineStartOverlay.getScrollPosition()).toBe(0);
+
+    keyDownUp('tab');
+    triggerTabNavigationFromTop(hot1); // emulates native browser Tab navigation
+
+    expect(hot.getSelectedRange()).toBeUndefined();
+    expect(hot1.getSelectedRange()).toEqualCellRange(['highlight: 0,-1 from: 0,-1 to: 0,-1']);
+    expect(topOverlay().getScrollPosition()).toBe(0);
+    expect(inlineStartOverlay().getScrollPosition()).toBe(0);
+    expect(hot1.view._wt.wtOverlays.topOverlay.getScrollPosition()).toBe(0);
+    expect(hot1.view._wt.wtOverlays.inlineStartOverlay.getScrollPosition()).toBe(0);
+
+    keyDownUp(['shift', 'tab']);
+    triggerTabNavigationFromBottom(); // emulates native browser Tab navigation
+
+    expect(hot.getSelectedRange()).toEqualCellRange(['highlight: 0,-1 from: 0,-1 to: 0,-1']);
+    expect(hot1.getSelectedRange()).toBeUndefined();
+    expect(topOverlay().getScrollPosition()).toBe(0);
+    expect(inlineStartOverlay().getScrollPosition()).toBe(0);
+    expect(hot1.view._wt.wtOverlays.topOverlay.getScrollPosition()).toBe(0);
+    expect(hot1.view._wt.wtOverlays.inlineStartOverlay.getScrollPosition()).toBe(0);
+  });
 });


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the jump effect (viewport scroll) after using the <kbd>Tab</kbd> key. 

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally, and I covered the fix with a new test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1625

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
