### PR TITLE
Fix the filters error that was thrown in specific setup

### DIFF
--- a/.changelogs/10637.json
+++ b/.changelogs/10637.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed the TypeError that was thrown in Filters plugin in some specific setup cases",
+  "type": "fixed",
+  "issueOrPR": 10637,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
@@ -4450,4 +4450,32 @@ describe('Filters UI', () => {
 
     expect(byValueMultipleSelect().getItemsBox().getSettings().layoutDirection).toBe('ltr');
   });
+
+  it('should not throw an error after filtering the dataset when the UI is limited (#dev-1629)', () => {
+    const spy = jasmine.createSpyObj('error', ['test']);
+    const prevError = window.onerror;
+
+    window.onerror = function() {
+      spy.test();
+
+      return true;
+    };
+
+    handsontable({
+      data: getDataForFilters(),
+      columns: getColumnsForFilters(),
+      dropdownMenu: ['filter_by_condition', 'filter_by_value', 'filter_action_bar'],
+      filters: true,
+      width: 500,
+      height: 300
+    });
+
+    dropdownMenu(0);
+    $(dropdownMenuRootElement().querySelector('.htUIButton.htUIButtonOK input'))
+      .simulate('click');
+
+    expect(spy.test.calls.count()).toBe(0);
+
+    window.onerror = prevError;
+  });
 });

--- a/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
@@ -4452,14 +4452,7 @@ describe('Filters UI', () => {
   });
 
   it('should not throw an error after filtering the dataset when the UI is limited (#dev-1629)', () => {
-    const spy = jasmine.createSpyObj('error', ['test']);
-    const prevError = window.onerror;
-
-    window.onerror = function() {
-      spy.test();
-
-      return true;
-    };
+    const onErrorSpy = spyOn(window, 'onerror').and.returnValue(true);
 
     handsontable({
       data: getDataForFilters(),
@@ -4474,8 +4467,6 @@ describe('Filters UI', () => {
     $(dropdownMenuRootElement().querySelector('.htUIButton.htUIButtonOK input'))
       .simulate('click');
 
-    expect(spy.test.calls.count()).toBe(0);
-
-    window.onerror = prevError;
+    expect(onErrorSpy).not.toHaveBeenCalled();
   });
 });

--- a/handsontable/src/plugins/filters/ui/radioInput.js
+++ b/handsontable/src/plugins/filters/ui/radioInput.js
@@ -68,7 +68,7 @@ export class RadioInputUI extends BaseUI {
    * @returns {boolean}
    */
   isChecked() {
-    return this.#input.checked;
+    return this.isBuilt() ? this.#input.checked : false;
   }
 
   /**


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes a bug where, in some specific setup, the _Filters_ plugin threw `TypeError`.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and I covered the fix with a new test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1629

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
