### PR TITLE
Fix focus position after Handsontable options change

### DIFF
--- a/.changelogs/10642.json
+++ b/.changelogs/10642.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed the focus position after Handsontable options or dataset change",
+  "type": "fixed",
+  "issueOrPR": 10642,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/core/focusCatcher/index.js
+++ b/handsontable/src/core/focusCatcher/index.js
@@ -9,11 +9,12 @@ import { installFocusDetector } from './focusDetector';
  * @param {Core} hot The Handsontable instance.
  */
 export function installFocusCatcher(hot) {
+  const clampCoordsIfNeeded = normalizeCoordsIfNeeded(hot);
   let recentlyAddedFocusCoords;
 
   const { activate, deactivate } = installFocusDetector(hot, {
     onFocusFromTop() {
-      const mostTopStartCoords = recentlyAddedFocusCoords ?? getMostTopStartPosition(hot);
+      const mostTopStartCoords = clampCoordsIfNeeded(recentlyAddedFocusCoords) ?? getMostTopStartPosition(hot);
 
       if (mostTopStartCoords) {
         hot.runHooks('modifyFocusOnTabNavigation', 'from_above', mostTopStartCoords);
@@ -23,7 +24,7 @@ export function installFocusCatcher(hot) {
       hot.listen();
     },
     onFocusFromBottom() {
-      const mostBottomEndCoords = recentlyAddedFocusCoords ?? getMostBottomEndPosition(hot);
+      const mostBottomEndCoords = clampCoordsIfNeeded(recentlyAddedFocusCoords) ?? getMostBottomEndPosition(hot);
 
       if (mostBottomEndCoords) {
         hot.runHooks('modifyFocusOnTabNavigation', 'from_below', mostBottomEndCoords);
@@ -180,4 +181,37 @@ function getMostBottomEndPosition(hot) {
     rowIndexMapper.getVisualFromRenderableIndex(bottomRow) ?? bottomRow,
     columnIndexMapper.getVisualFromRenderableIndex(endColumn) ?? endColumn,
   );
+}
+
+/**
+ * Normalizes the coordinates (clamps to nearest visible cell position within dataset range).
+ *
+ * @param {Core} hot The Handsontable instance.
+ * @returns {function(Coords | undefined): Coords | null}
+ */
+function normalizeCoordsIfNeeded(hot) {
+  return (coords) => {
+    if (!coords) {
+      return null;
+    }
+
+    const mostTopStartCoords = getMostTopStartPosition(hot);
+    const mostBottomEndCoords = getMostBottomEndPosition(hot);
+
+    if (coords.col < mostTopStartCoords.col) {
+      coords.col = mostTopStartCoords.col;
+    }
+    if (coords.col > mostBottomEndCoords.col) {
+      coords.col = mostBottomEndCoords.col;
+    }
+
+    if (coords.row < mostTopStartCoords.row) {
+      coords.row = mostTopStartCoords.row;
+    }
+    if (coords.row > mostBottomEndCoords.row) {
+      coords.row = mostBottomEndCoords.row;
+    }
+
+    return coords;
+  };
 }

--- a/handsontable/test/e2e/keyboardShortcuts/tabNavigation.spec.js
+++ b/handsontable/test/e2e/keyboardShortcuts/tabNavigation.spec.js
@@ -912,4 +912,90 @@ describe('Core navigation keyboard shortcuts', () => {
     expect(hot.getSelectedRange()).toEqualCellRange(['highlight: 0,0 from: 0,0 to: 0,0']);
     expect(hot1.getSelectedRange()).toBeUndefined();
   });
+
+  it('should update the coords for the cell when the previous one pointed to the header ' +
+      '(updateSettings with navigableHeaders to `false`)', async() => {
+    const hot = handsontable({
+      data: createSpreadsheetData(50, 30),
+      width: 200,
+      height: 200,
+      rowHeaders: true,
+      colHeaders: true,
+      tabNavigation: false,
+      navigableHeaders: true,
+    });
+    const hot1 = handsontable({
+      data: createSpreadsheetData(50, 30),
+      width: 200,
+      height: 200,
+      rowHeaders: true,
+      colHeaders: true,
+      tabNavigation: false,
+      navigableHeaders: true,
+    }, false, spec().$container1);
+
+    hot.selectCell(-1, -1);
+    hot.deselectCell();
+    hot1.deselectCell();
+
+    triggerTabNavigationFromTop(); // emulates native browser Tab navigation
+
+    expect(hot.getSelectedRange()).toEqualCellRange(['highlight: -1,-1 from: -1,-1 to: -1,-1']);
+    expect(hot1.getSelectedRange()).toBeUndefined();
+
+    updateSettings({
+      navigableHeaders: false,
+    });
+
+    keyDownUp('tab');
+    triggerTabNavigationFromTop(hot1); // emulates native browser Tab navigation
+    keyDownUp(['shift', 'tab']);
+    triggerTabNavigationFromBottom(); // emulates native browser Tab navigation
+
+    expect(hot.getSelectedRange()).toEqualCellRange(['highlight: 0,0 from: 0,0 to: 0,0']);
+    expect(hot1.getSelectedRange()).toBeUndefined();
+  });
+
+  it('should update the coords to the nearest visible cell when previously it pointed to a range outside the table ' +
+      '(loading smaller dataset)', async() => {
+    const hot = handsontable({
+      data: createSpreadsheetData(50, 30),
+      width: 200,
+      height: 200,
+      rowHeaders: true,
+      colHeaders: true,
+      tabNavigation: false,
+      navigableHeaders: true,
+    });
+    const hot1 = handsontable({
+      data: createSpreadsheetData(50, 30),
+      width: 200,
+      height: 200,
+      rowHeaders: true,
+      colHeaders: true,
+      tabNavigation: false,
+      navigableHeaders: true,
+    }, false, spec().$container1);
+
+    hot.selectCell(10, 5);
+    hot.deselectCell();
+    hot1.deselectCell();
+
+    triggerTabNavigationFromTop(); // emulates native browser Tab navigation
+
+    expect(hot.getSelectedRange()).toEqualCellRange(['highlight: 10,5 from: 10,5 to: 10,5']);
+    expect(hot1.getSelectedRange()).toBeUndefined();
+
+    updateSettings({
+      data: [[1, 2, 3]]
+    });
+
+    keyDownUp('tab');
+    triggerTabNavigationFromTop(hot1); // emulates native browser Tab navigation
+    keyDownUp(['shift', 'tab']);
+    triggerTabNavigationFromBottom(); // emulates native browser Tab navigation
+
+    expect(hot.getSelectedRange()).toEqualCellRange(['highlight: 0,2 from: 0,2 to: 0,2']);
+    expect(hot1.getSelectedRange()).toBeUndefined();
+  });
 });


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the focus position bug when Handsontable options are changed, or the loaded dataset is smaller than before.

#### Before (v14.0.0)
![Kapture 2023-12-05 at 15 00 04](https://github.com/handsontable/handsontable/assets/571316/10232e18-0de2-447a-951a-e339985a3b46)

#### After
![Kapture 2023-12-05 at 15 00 51](https://github.com/handsontable/handsontable/assets/571316/da03a7f1-cfdd-43d7-9807-51af16937c4b)

The focus is clamped to the coordinates pointing to the cell (or header) within the current dataset range and table's options.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally, and I covered the fix with two new tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1632

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
