### PR TITLE
Fix an issue related to the "listen/unlisten" table's state

### DIFF
--- a/.changelogs/10648.json
+++ b/.changelogs/10648.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed an issue related to the \"listen/unlisten\" table's state.",
+  "type": "fixed",
+  "issueOrPR": 10648,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/tableView.js
+++ b/handsontable/src/tableView.js
@@ -327,7 +327,7 @@ class TableView {
 
       const isOutsideInputElement = isOutsideInput(rootDocument.activeElement);
 
-      if (!isOutsideInputElement) {
+      if (isInput(rootDocument.activeElement) && !isOutsideInputElement) {
         return;
       }
 

--- a/handsontable/test/e2e/hooks/afterUnlisten.spec.js
+++ b/handsontable/test/e2e/hooks/afterUnlisten.spec.js
@@ -69,5 +69,23 @@ describe('Hook', () => {
       expect(afterUnlisten1).toHaveBeenCalledTimes(0);
       expect(afterUnlisten2).toHaveBeenCalledTimes(1);
     });
+
+    it('should be fired once after the element that is not belong to the root element is clicked', () => {
+      const afterUnlisten = jasmine.createSpy('afterUnlisten');
+
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        afterUnlisten,
+      }, true);
+      listen();
+      simulateClick(document.body);
+
+      expect(afterUnlisten).toHaveBeenCalled();
+
+      listen();
+      simulateClick(document.querySelector('.hot-display-license-info'));
+
+      expect(afterUnlisten).toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes a bug where the table did not go into the "unlisten" state after clicking the element that does not belong to the Handsontable root element.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally, and I covered the fix with a new test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1641

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
