### PR TITLE
Undoing/redoing removal of cells will restore also cell meta

### DIFF
--- a/.changelogs/10649.json
+++ b/.changelogs/10649.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Undoing/redoing removal of cells will restore also cell meta",
+  "type": "fixed",
+  "issueOrPR": 10649,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/undoRedo/__tests__/UndoRedo.spec.js
+++ b/handsontable/src/plugins/undoRedo/__tests__/UndoRedo.spec.js
@@ -2595,6 +2595,78 @@ describe('UndoRedo', () => {
         }
       });
 
+      it('should undo row removal with cell meta', () => {
+        const hot = handsontable({
+          data: Handsontable.helper.createSpreadsheetData(5, 5),
+          cells(row, column) {
+            const cellProperties = { readOnly: false };
+
+            if (row % 2 === 0 && column % 2 === 0) {
+              cellProperties.readOnly = true;
+            }
+
+            return cellProperties;
+          },
+        });
+
+        alter('remove_row', 0, 3);
+        undo();
+
+        expect(hot.getCellMeta(0, 0).readOnly).toBe(true);
+        expect(hot.getCellMeta(0, 1).readOnly).toBe(false);
+        expect(hot.getCellMeta(0, 2).readOnly).toBe(true);
+        expect(hot.getCellMeta(0, 3).readOnly).toBe(false);
+        expect(hot.getCellMeta(0, 4).readOnly).toBe(true);
+
+        expect(hot.getCellMeta(1, 0).readOnly).toBe(false);
+        expect(hot.getCellMeta(1, 1).readOnly).toBe(false);
+        expect(hot.getCellMeta(1, 2).readOnly).toBe(false);
+        expect(hot.getCellMeta(1, 3).readOnly).toBe(false);
+        expect(hot.getCellMeta(1, 4).readOnly).toBe(false);
+
+        expect(hot.getCellMeta(2, 0).readOnly).toBe(true);
+        expect(hot.getCellMeta(2, 1).readOnly).toBe(false);
+        expect(hot.getCellMeta(2, 2).readOnly).toBe(true);
+        expect(hot.getCellMeta(2, 3).readOnly).toBe(false);
+        expect(hot.getCellMeta(2, 4).readOnly).toBe(true);
+      });
+
+      it('should undo column removal with cell meta', () => {
+        const hot = handsontable({
+          data: Handsontable.helper.createSpreadsheetData(5, 5),
+          cells(row, column) {
+            const cellProperties = { readOnly: false };
+
+            if (row % 2 === 0 && column % 2 === 0) {
+              cellProperties.readOnly = true;
+            }
+
+            return cellProperties;
+          },
+        });
+
+        alter('remove_col', 0, 3);
+        undo();
+
+        expect(hot.getCellMeta(0, 0).readOnly).toBe(true);
+        expect(hot.getCellMeta(0, 1).readOnly).toBe(false);
+        expect(hot.getCellMeta(0, 2).readOnly).toBe(true);
+        expect(hot.getCellMeta(0, 3).readOnly).toBe(false);
+        expect(hot.getCellMeta(0, 4).readOnly).toBe(true);
+
+        expect(hot.getCellMeta(1, 0).readOnly).toBe(false);
+        expect(hot.getCellMeta(1, 1).readOnly).toBe(false);
+        expect(hot.getCellMeta(1, 2).readOnly).toBe(false);
+        expect(hot.getCellMeta(1, 3).readOnly).toBe(false);
+        expect(hot.getCellMeta(1, 4).readOnly).toBe(false);
+
+        expect(hot.getCellMeta(2, 0).readOnly).toBe(true);
+        expect(hot.getCellMeta(2, 1).readOnly).toBe(false);
+        expect(hot.getCellMeta(2, 2).readOnly).toBe(true);
+        expect(hot.getCellMeta(2, 3).readOnly).toBe(false);
+        expect(hot.getCellMeta(2, 4).readOnly).toBe(true);
+      });
+
       it('should not throw an error after undoing the row header aligning', () => {
         handsontable({
           data: Handsontable.helper.createSpreadsheetData(5, 5),

--- a/handsontable/src/plugins/undoRedo/__tests__/UndoRedo.spec.js
+++ b/handsontable/src/plugins/undoRedo/__tests__/UndoRedo.spec.js
@@ -2595,7 +2595,7 @@ describe('UndoRedo', () => {
         }
       });
 
-      it('should undo row removal with cell meta', () => {
+      it('should undo/redo row removal with cell meta', () => {
         const hot = handsontable({
           data: Handsontable.helper.createSpreadsheetData(5, 5),
           cells(row, column) {
@@ -2609,7 +2609,32 @@ describe('UndoRedo', () => {
           },
         });
 
-        alter('remove_row', 0, 3);
+        alter('remove_row', 0, 1);
+        alter('remove_row', 0, 2);
+        undo();
+        undo();
+
+        expect(hot.getCellMeta(0, 0).readOnly).toBe(true);
+        expect(hot.getCellMeta(0, 1).readOnly).toBe(false);
+        expect(hot.getCellMeta(0, 2).readOnly).toBe(true);
+        expect(hot.getCellMeta(0, 3).readOnly).toBe(false);
+        expect(hot.getCellMeta(0, 4).readOnly).toBe(true);
+
+        expect(hot.getCellMeta(1, 0).readOnly).toBe(false);
+        expect(hot.getCellMeta(1, 1).readOnly).toBe(false);
+        expect(hot.getCellMeta(1, 2).readOnly).toBe(false);
+        expect(hot.getCellMeta(1, 3).readOnly).toBe(false);
+        expect(hot.getCellMeta(1, 4).readOnly).toBe(false);
+
+        expect(hot.getCellMeta(2, 0).readOnly).toBe(true);
+        expect(hot.getCellMeta(2, 1).readOnly).toBe(false);
+        expect(hot.getCellMeta(2, 2).readOnly).toBe(true);
+        expect(hot.getCellMeta(2, 3).readOnly).toBe(false);
+        expect(hot.getCellMeta(2, 4).readOnly).toBe(true);
+
+        redo();
+        redo();
+        undo();
         undo();
 
         expect(hot.getCellMeta(0, 0).readOnly).toBe(true);
@@ -2631,7 +2656,7 @@ describe('UndoRedo', () => {
         expect(hot.getCellMeta(2, 4).readOnly).toBe(true);
       });
 
-      it('should undo column removal with cell meta', () => {
+      it('should undo/redo column removal with cell meta', () => {
         const hot = handsontable({
           data: Handsontable.helper.createSpreadsheetData(5, 5),
           cells(row, column) {
@@ -2645,7 +2670,32 @@ describe('UndoRedo', () => {
           },
         });
 
-        alter('remove_col', 0, 3);
+        alter('remove_col', 0, 1);
+        alter('remove_col', 0, 2);
+        undo();
+        undo();
+
+        expect(hot.getCellMeta(0, 0).readOnly).toBe(true);
+        expect(hot.getCellMeta(0, 1).readOnly).toBe(false);
+        expect(hot.getCellMeta(0, 2).readOnly).toBe(true);
+        expect(hot.getCellMeta(0, 3).readOnly).toBe(false);
+        expect(hot.getCellMeta(0, 4).readOnly).toBe(true);
+
+        expect(hot.getCellMeta(1, 0).readOnly).toBe(false);
+        expect(hot.getCellMeta(1, 1).readOnly).toBe(false);
+        expect(hot.getCellMeta(1, 2).readOnly).toBe(false);
+        expect(hot.getCellMeta(1, 3).readOnly).toBe(false);
+        expect(hot.getCellMeta(1, 4).readOnly).toBe(false);
+
+        expect(hot.getCellMeta(2, 0).readOnly).toBe(true);
+        expect(hot.getCellMeta(2, 1).readOnly).toBe(false);
+        expect(hot.getCellMeta(2, 2).readOnly).toBe(true);
+        expect(hot.getCellMeta(2, 3).readOnly).toBe(false);
+        expect(hot.getCellMeta(2, 4).readOnly).toBe(true);
+
+        redo();
+        redo();
+        undo();
         undo();
 
         expect(hot.getCellMeta(0, 0).readOnly).toBe(true);


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
This PR gives the ability to restore cell metadata for removed elements. It stores information about removed cell meta inside the action.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Manually tested undo&redo removing of elements with different cell meta.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/585

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
