### PR TITLE
Fix errors in manual row and column resize plugins

### DIFF
--- a/.changelogs/10650.json
+++ b/.changelogs/10650.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed manual row and column resize plugins that throw an error when the cell renderer render the cell value in HTML table element.",
+  "type": "fixed",
+  "issueOrPR": 10650,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/css/walkontable.scss
+++ b/handsontable/src/3rdparty/walkontable/css/walkontable.scss
@@ -230,9 +230,9 @@ innerBorderBottom - Property controlled by bottom overlay
   overflow: auto;
 }
 
-.handsontable .ht_master thead,
-.handsontable .ht_master tr th,
-.handsontable .ht_clone_inline_start thead {
+.handsontable .ht_master table.htCore > thead,
+.handsontable .ht_master table.htCore > tbody > tr > th,
+.handsontable .ht_clone_inline_start table.htCore > thead {
   visibility: hidden;
 }
 

--- a/handsontable/src/plugins/manualColumnResize/__tests__/manualColumnResize.spec.js
+++ b/handsontable/src/plugins/manualColumnResize/__tests__/manualColumnResize.spec.js
@@ -244,6 +244,37 @@ describe('manualColumnResize', () => {
     expect($columnHeaders.eq(3).width()).toBe(34);
   });
 
+  it('should show resizer for fixed columns', () => {
+    handsontable({
+      data: createSpreadsheetData(10, 20),
+      colHeaders: true,
+      rowHeaders: true,
+      fixedColumnsStart: 2,
+      manualColumnResize: true
+    });
+
+    getTopClone()
+      .find('thead tr:eq(0) th:eq(3)')
+      .simulate('mouseover');
+
+    const $resizer = spec().$container.find('.manualColumnResizer');
+
+    expect($resizer.position()).toEqual({
+      top: 0,
+      left: 194,
+    });
+
+    // after hovering over fixed column, resizer should be moved to the fixed column
+    getTopInlineStartClone()
+      .find('thead tr:eq(0) th:eq(1)')
+      .simulate('mouseover');
+
+    expect($resizer.position()).toEqual({
+      top: 0,
+      left: 94,
+    });
+  });
+
   it('should resize (expanding) selected columns', async() => {
     handsontable({
       data: Handsontable.helper.createSpreadsheetData(10, 20),

--- a/handsontable/src/plugins/manualColumnResize/__tests__/manualColumnResize.spec.js
+++ b/handsontable/src/plugins/manualColumnResize/__tests__/manualColumnResize.spec.js
@@ -801,6 +801,40 @@ describe('manualColumnResize', () => {
     window.onerror = nativeOnError;
   });
 
+  it('should not throw any errors, when the cell renderers use HTML table to present the value (#dev-1298)', () => {
+    const onErrorSpy = spyOn(window, 'onerror').and.returnValue(true);
+
+    handsontable({
+      data: createSpreadsheetData(10, 10),
+      colHeaders: true,
+      manualColumnResize: true,
+      renderer(hot, td, row, column, value) {
+        td.innerHTML = `
+          <table>
+            <thead>
+              <tr>
+                <th>${value}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th>${value}</th>
+              </tr>
+            </tbody>
+          </table>`;
+      }
+    });
+
+    const rendererTH = $(getCell(0, 0).querySelector('thead th'));
+
+    rendererTH
+      .simulate('mouseover')
+      .simulate('mousedown')
+      .simulate('click');
+
+    expect(onErrorSpy).not.toHaveBeenCalled();
+  });
+
   describe('handle position in a table positioned using CSS\'s `transform`', () => {
     it('should display the handles in the correct position, with holder as a scroll parent', async() => {
       spec().$container.css('transform', 'translate(50px, 120px)');

--- a/handsontable/src/plugins/manualColumnResize/manualColumnResize.js
+++ b/handsontable/src/plugins/manualColumnResize/manualColumnResize.js
@@ -394,8 +394,12 @@ export class ManualColumnResize extends BasePlugin {
    */
   checkIfColumnHeader(element) {
     const thead = closest(element, ['THEAD'], this.hot.rootElement);
+    const { topOverlay, topInlineStartCornerOverlay } = this.hot.view._wt.wtOverlays;
 
-    return thead === this.hot.view._wt.wtOverlays.topOverlay.clone.wtTable.THEAD;
+    return [
+      topOverlay.clone.wtTable.THEAD,
+      topInlineStartCornerOverlay.clone.wtTable.THEAD,
+    ].includes(thead);
   }
 
   /**

--- a/handsontable/src/plugins/manualColumnResize/manualColumnResize.js
+++ b/handsontable/src/plugins/manualColumnResize/manualColumnResize.js
@@ -393,7 +393,9 @@ export class ManualColumnResize extends BasePlugin {
    * @returns {boolean}
    */
   checkIfColumnHeader(element) {
-    return !!closest(element, ['THEAD'], this.hot.rootElement);
+    const thead = closest(element, ['THEAD'], this.hot.rootElement);
+
+    return thead === this.hot.view._wt.wtOverlays.topOverlay.clone.wtTable.THEAD;
   }
 
   /**

--- a/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
+++ b/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
@@ -591,6 +591,40 @@ describe('manualRowResize', () => {
     window.onerror = nativeOnError;
   });
 
+  it('should not throw any errors, when the cell renderers use HTML table to present the value (#dev-1298)', () => {
+    const onErrorSpy = spyOn(window, 'onerror').and.returnValue(true);
+
+    handsontable({
+      data: createSpreadsheetData(10, 10),
+      rowHeaders: true,
+      manualRowResize: true,
+      renderer(hot, td, row, column, value) {
+        td.innerHTML = `
+          <table>
+            <thead>
+              <tr>
+                <th>${value}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th>${value}</th>
+              </tr>
+            </tbody>
+          </table>`;
+      }
+    });
+
+    const rendererTH = $(getCell(0, 0).querySelector('tbody th'));
+
+    rendererTH
+      .simulate('mouseover')
+      .simulate('mousedown')
+      .simulate('click');
+
+    expect(onErrorSpy).not.toHaveBeenCalled();
+  });
+
   describe('handle position in a table positioned using CSS\'s `transform`', () => {
     it('should display the handles in the correct position, with holder as a scroll parent', async() => {
       spec().$container.css('transform', 'translate(50px, 120px)');

--- a/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
+++ b/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
@@ -496,7 +496,7 @@ describe('manualRowResize', () => {
     expect($rowsHeaders.eq(3).height()).toEqual(35);
   });
 
-  it('should show resizer for fixed rows', () => {
+  it('should show resizer for fixed top rows', () => {
     handsontable({
       data: createSpreadsheetData(10, 20),
       colHeaders: true,
@@ -523,6 +523,37 @@ describe('manualRowResize', () => {
 
     expect($resizer.position()).toEqual({
       top: 67,
+      left: 0,
+    });
+  });
+
+  it('should show resizer for fixed bottom rows', () => {
+    handsontable({
+      data: createSpreadsheetData(10, 20),
+      colHeaders: true,
+      rowHeaders: true,
+      fixedRowsBottom: 2,
+      manualRowResize: true
+    });
+
+    getInlineStartClone()
+      .find('tbody tr:eq(3) th:eq(0)')
+      .simulate('mouseover');
+
+    const $resizer = spec().$container.find('.manualRowResizer');
+
+    expect($resizer.position()).toEqual({
+      top: 113,
+      left: 0,
+    });
+
+    // after hovering over fixed row, resizer should be moved to the fixed row
+    getBottomInlineStartClone()
+      .find('tbody tr:eq(0) th:eq(0)')
+      .simulate('mouseover');
+
+    expect($resizer.position()).toEqual({
+      top: 18,
       left: 0,
     });
   });

--- a/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
+++ b/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
@@ -496,6 +496,37 @@ describe('manualRowResize', () => {
     expect($rowsHeaders.eq(3).height()).toEqual(35);
   });
 
+  it('should show resizer for fixed rows', () => {
+    handsontable({
+      data: createSpreadsheetData(10, 20),
+      colHeaders: true,
+      rowHeaders: true,
+      fixedRowsTop: 2,
+      manualRowResize: true
+    });
+
+    getInlineStartClone()
+      .find('tbody tr:eq(3) th:eq(0)')
+      .simulate('mouseover');
+
+    const $resizer = spec().$container.find('.manualRowResizer');
+
+    expect($resizer.position()).toEqual({
+      top: 113,
+      left: 0,
+    });
+
+    // after hovering over fixed row, resizer should be moved to the fixed row
+    getTopInlineStartClone()
+      .find('tbody tr:eq(1) th:eq(0)')
+      .simulate('mouseover');
+
+    expect($resizer.position()).toEqual({
+      top: 67,
+      left: 0,
+    });
+  });
+
   it('should resize proper row after resizing element adjacent to a selection', () => {
     handsontable({
       data: Handsontable.helper.createSpreadsheetData(5, 5),

--- a/handsontable/src/plugins/manualRowResize/manualRowResize.js
+++ b/handsontable/src/plugins/manualRowResize/manualRowResize.js
@@ -352,8 +352,12 @@ export class ManualRowResize extends BasePlugin {
    */
   checkIfRowHeader(element) {
     const tbody = closest(element, ['TBODY'], this.hot.rootElement);
+    const { inlineStartOverlay, topInlineStartCornerOverlay } = this.hot.view._wt.wtOverlays;
 
-    return tbody === this.hot.view._wt.wtOverlays.inlineStartOverlay.clone.wtTable.TBODY;
+    return [
+      inlineStartOverlay.clone.wtTable.TBODY,
+      topInlineStartCornerOverlay.clone.wtTable.TBODY,
+    ].includes(tbody);
   }
 
   /**

--- a/handsontable/src/plugins/manualRowResize/manualRowResize.js
+++ b/handsontable/src/plugins/manualRowResize/manualRowResize.js
@@ -352,7 +352,11 @@ export class ManualRowResize extends BasePlugin {
    */
   checkIfRowHeader(element) {
     const tbody = closest(element, ['TBODY'], this.hot.rootElement);
-    const { inlineStartOverlay, topInlineStartCornerOverlay, bottomInlineStartCornerOverlay } = this.hot.view._wt.wtOverlays;
+    const {
+      inlineStartOverlay,
+      topInlineStartCornerOverlay,
+      bottomInlineStartCornerOverlay,
+    } = this.hot.view._wt.wtOverlays;
 
     return [
       inlineStartOverlay.clone.wtTable.TBODY,

--- a/handsontable/src/plugins/manualRowResize/manualRowResize.js
+++ b/handsontable/src/plugins/manualRowResize/manualRowResize.js
@@ -352,11 +352,12 @@ export class ManualRowResize extends BasePlugin {
    */
   checkIfRowHeader(element) {
     const tbody = closest(element, ['TBODY'], this.hot.rootElement);
-    const { inlineStartOverlay, topInlineStartCornerOverlay } = this.hot.view._wt.wtOverlays;
+    const { inlineStartOverlay, topInlineStartCornerOverlay, bottomInlineStartCornerOverlay } = this.hot.view._wt.wtOverlays;
 
     return [
       inlineStartOverlay.clone.wtTable.TBODY,
       topInlineStartCornerOverlay.clone.wtTable.TBODY,
+      bottomInlineStartCornerOverlay.clone.wtTable.TBODY,
     ].includes(tbody);
   }
 

--- a/handsontable/src/plugins/manualRowResize/manualRowResize.js
+++ b/handsontable/src/plugins/manualRowResize/manualRowResize.js
@@ -351,9 +351,9 @@ export class ManualRowResize extends BasePlugin {
    * @returns {boolean}
    */
   checkIfRowHeader(element) {
-    const thElement = closest(element, ['TH'], this.hot.rootElement);
+    const tbody = closest(element, ['TBODY'], this.hot.rootElement);
 
-    return thElement && element.parentNode?.parentNode?.tagName === 'TBODY';
+    return tbody === this.hot.view._wt.wtOverlays.inlineStartOverlay.clone.wtTable.TBODY;
   }
 
   /**


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes errors caused by the _ManualRowResize_ and _ManualColumnResize_ plugins when the cell renderer uses the HTML table element to present the value. In that case, mouse movement above the table causes the errors. The fix corrects the code to be more specific about detecting the correct row/column headers. Moreover, the PR changes the CSS selectors to be more specific about what table elements are hidden.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally, and I covered the fix with two new tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1298

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
