### PR TITLE
fix: reload on navigableHeaders change

### DIFF
--- a/docs/.vuepress/tools/example-checker/testCases.js
+++ b/docs/.vuepress/tools/example-checker/testCases.js
@@ -47,7 +47,7 @@ const testCases = [
       ['/react-data-grid/demo', { expectedCount: 1 }],
       // The a11y demo hot reloads handsontable, this makes the test detect an extra instance, we need to do -1 to
       // make it pass
-      ['/javascript-data-grid/accessibility', { expectedCount: -1 }],
+      ['/javascript-data-grid/accessibility', { expectedCount: -2 }],
     ]);
 
     /**

--- a/docs/content/guides/accessibility/accessibility.md
+++ b/docs/content/guides/accessibility/accessibility.md
@@ -1082,8 +1082,7 @@ setupCheckbox(
 setupCheckbox(
   document.querySelector("#enable-cell-virtualization"),
   (checked) => {
-
-    hotOptions.renderAllRows= !checked;
+    hotOptions.renderAllRows = !checked;
     hotOptions.viewportColumnRenderingOffset = checked ? "auto" : 9;
     hotInstance.destroy();
     hotInstance = new Handsontable(document.getElementById("example1"), hotOptions);

--- a/docs/content/guides/accessibility/accessibility.md
+++ b/docs/content/guides/accessibility/accessibility.md
@@ -1069,9 +1069,8 @@ setupCheckbox(
   document.querySelector("#enable-header-navigation"),
   (checked) => {
     hotOptions.navigableHeaders = checked;
-    hotInstance.updateSettings({
-      navigableHeaders: hotOptions.navigableHeaders,
-    });
+    hotInstance.destroy();
+    hotInstance = new Handsontable(document.getElementById("example1"), hotOptions);
     console.log(
       `Updated setting: navigableHeaders to`,
       hotInstance.getSettings().navigableHeaders
@@ -1083,12 +1082,11 @@ setupCheckbox(
 setupCheckbox(
   document.querySelector("#enable-cell-virtualization"),
   (checked) => {
+
+    hotOptions.renderAllRows= !checked;
+    hotOptions.viewportColumnRenderingOffset = checked ? "auto" : 9;
     hotInstance.destroy();
-    hotInstance = new Handsontable(document.getElementById("example1"), {
-      ...hotOptions,
-      renderAllRows: !checked,
-      viewportColumnRenderingOffset: checked ? "auto" : 9,
-    });
+    hotInstance = new Handsontable(document.getElementById("example1"), hotOptions);
     console.log(
       `Updated setting: renderAllRows to`,
       hotInstance.getSettings().renderAllRows
@@ -1156,7 +1154,6 @@ setupCheckbox(
   }
 );
 ```
-
 :::
 
 :::
@@ -1768,9 +1765,9 @@ function App() {
 
       {/* Handsontable component with dynamic options */}
       <HotTable
-        // Handsontable needs to reload when changing virtualization
+        // Handsontable needs to reload when changing virtualization, navigable headers
         // by changing the key, we force the component to reload
-        key={String(toggleableOptions.renderAllRows)}
+        key={`${toggleableOptions.renderAllRows}-${toggleableOptions.navigableHeaders}`}
         {...hotOptions}
         // Pass in the options which can change for demo
         {...toggleableOptions}


### PR DESCRIPTION
### Context
In our accessibility demo focus would get lost, in a typical use case this is not an issue as a user does not update their settings in such a dynamic way.

we have a fix for this coming in the future, this resolves the issue in the documentation now so we do not have to wait for next release.

### How has this been tested?
locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

[skip changelog]