### PR TITLE
Update typings for the Formulas plugin

### DIFF
--- a/.changelogs/10653.json
+++ b/.changelogs/10653.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Updated typings for the Formulas plugin",
+  "type": "changed",
+  "issueOrPR": 10653,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/formulas/__tests__/formulas.types.ts
+++ b/handsontable/src/plugins/formulas/__tests__/formulas.types.ts
@@ -1,5 +1,22 @@
+import Hyperformula from 'hyperformula';
 import Handsontable from 'handsontable';
 
+new Handsontable(document.createElement('div'), {
+  formulas: {
+    engine: Hyperformula,
+  },
+});
+new Handsontable(document.createElement('div'), {
+  formulas: {
+    engine: Hyperformula.buildEmpty(),
+  },
+});
+new Handsontable(document.createElement('div'), {
+  formulas: {
+    engine: Hyperformula,
+    sheetName: 'sheet1',
+  },
+});
 const hot = new Handsontable(document.createElement('div'), {});
 const formulas = hot.getPlugin('formulas');
 

--- a/handsontable/types/plugins/formulas/formulas.d.ts
+++ b/handsontable/types/plugins/formulas/formulas.d.ts
@@ -12,6 +12,7 @@ export interface HyperFormulaSettings extends Partial<ConfigParams> {
 }
 export interface DetailedSettings {
   engine: typeof HyperFormula | HyperFormula | HyperFormulaSettings;
+  sheetName?: string;
 }
 
 export type Settings = DetailedSettings;


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adds missing typing for the `sheetName` property of the _Formulas_ plugin.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I covered the fix with tests;

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/450
2. fixes https://github.com/handsontable/handsontable/issues/10023

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
