### PR TITLE
Improve Docs SEO score

### DIFF
--- a/docs/.vuepress/tools/jsdoc-convert/configuration.mjs
+++ b/docs/.vuepress/tools/jsdoc-convert/configuration.mjs
@@ -484,5 +484,14 @@ export default {
         metaTitle: 'TrimmingMap - React Data Grid | Handsontable',
       },
     },
+    'EventManager.md': {
+      id: '3k9p5r7t',
+      metaTitle: 'EventManager - JavaScript Data Grid | Handsontable',
+      description: 'Options, members, and methods of Handsontable\'s EventManager API.',
+      react: {
+        id: '5j7d9k2r',
+        metaTitle: 'EventManager - React Data Grid | Handsontable',
+      },
+    },
   }
 };

--- a/docs/.vuepress/tools/jsdoc-convert/parser/parser.mjs
+++ b/docs/.vuepress/tools/jsdoc-convert/parser/parser.mjs
@@ -20,6 +20,7 @@ export const buildParser = ({ logger, parseJsdoc }) => function* () {
     'utils/samplesGenerator.js',
     'pluginHooks.js',
     'core.js',
+    'eventManager.js',
     'editors/!(__tests__)/!(index).js',
     'plugins/!(__tests__)/!(index).js',
     'translations/maps/!(index).js',

--- a/docs/patches/vue-tabs-component+1.5.0.patch
+++ b/docs/patches/vue-tabs-component+1.5.0.patch
@@ -1,60 +1,26 @@
 diff --git a/node_modules/vue-tabs-component/dist/index.js b/node_modules/vue-tabs-component/dist/index.js
-index d285ef4..8216328 100644
+index d285ef4..89f4890 100644
 --- a/node_modules/vue-tabs-component/dist/index.js
 +++ b/node_modules/vue-tabs-component/dist/index.js
-@@ -361,10 +361,10 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
-             },
-             hash: function hash() {
-                 if (this.isDisabled) {
--                    return '#';
-+                    return '';
-                 }
- 
--                return '#' + this.computedId;
-+                return '' + this.computedId;
-             }
-         }
-     };
-@@ -499,8 +499,8 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
-                 return;
-             }
- 
--            if (this.options.defaultTabHash !== null && this.findTab("#" + this.options.defaultTabHash)) {
--                this.selectTab("#" + this.options.defaultTabHash);
-+            if (this.options.defaultTabHash !== null && this.findTab("" + this.options.defaultTabHash)) {
-+                this.selectTab("" + this.options.defaultTabHash);
-                 return;
-             }
- 
-diff --git a/node_modules/vue-tabs-component/src/components/Tab.vue b/node_modules/vue-tabs-component/src/components/Tab.vue
-index 31d7cc1..103c9f0 100644
---- a/node_modules/vue-tabs-component/src/components/Tab.vue
-+++ b/node_modules/vue-tabs-component/src/components/Tab.vue
-@@ -35,10 +35,10 @@
- 
-             hash() {
-                 if (this.isDisabled) {
--                    return '#';
-+                    return '';
-                 }
- 
--                return '#' + this.computedId;
-+                return '' + this.computedId;
-             },
-         },
-     };
+@@ -976,7 +976,7 @@ module.exports={render:function (){var _vm=this;var _h=_vm.$createElement;var _c
+     }, [_c('a', {
+       staticClass: "tabs-component-tab-a",
+       attrs: {
+-        "aria-controls": tab.hash,
++        "aria-controls": tab.computedId,
+         "aria-selected": tab.isActive,
+         "href": tab.hash,
+         "role": "tab"
 diff --git a/node_modules/vue-tabs-component/src/components/Tabs.vue b/node_modules/vue-tabs-component/src/components/Tabs.vue
-index 2a87c6c..7d18a02 100644
+index 2a87c6c..dc311c7 100644
 --- a/node_modules/vue-tabs-component/src/components/Tabs.vue
 +++ b/node_modules/vue-tabs-component/src/components/Tabs.vue
-@@ -75,8 +75,8 @@
-                 return;
-             }
- 
--            if(this.options.defaultTabHash !== null && this.findTab("#" + this.options.defaultTabHash)) {
--                this.selectTab("#" + this.options.defaultTabHash);
-+            if(this.options.defaultTabHash !== null && this.findTab("" + this.options.defaultTabHash)) {
-+                this.selectTab("" + this.options.defaultTabHash);
-                 return;
-             }
- 
+@@ -10,7 +10,7 @@
+                 v-show="tab.isVisible"
+             >
+                 <a v-html="tab.header"
+-                   :aria-controls="tab.hash"
++                   :aria-controls="tab.computedId"
+                    :aria-selected="tab.isActive"
+                    @click="selectTab(tab.hash, $event)"
+                    :href="tab.hash"

--- a/handsontable/src/eventManager.js
+++ b/handsontable/src/eventManager.js
@@ -11,7 +11,6 @@ let listenersCounter = 0;
  * Event DOM manager for internal use in Handsontable.
  *
  * @class EventManager
- * @util
  */
 class EventManager {
   /**
@@ -43,6 +42,7 @@ class EventManager {
    */
   addEventListener(element, eventName, callback, options = false) {
     /**
+     * @private
      * @param {Event} event The event object.
      */
     function callbackProxy(event) {
@@ -220,6 +220,7 @@ function extendEvent(event) {
 export default EventManager;
 
 /**
+ * @private
  * @returns {number}
  */
 export function getListenersCounter() {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Improve Docs SEO score by:
 * Fixing the Tabs component (wrong `href` value that causes 404) by reverting some changes from #10574 and fixing the value of the `aria-controls` attribute of the tab button to the tab content element.
 * Expose the `EventManager` class as it's used as a reference in the `BasePlugin`;

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested on staging.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1620

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
