### PR TITLE
Improve TS typings for BindRowsWithHeaders plugin

### DIFF
--- a/.changelogs/10663.json
+++ b/.changelogs/10663.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Improved TS typings for the BindRowsWithHeaders plugin",
+  "type": "changed",
+  "issueOrPR": 10663,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/bindRowsWithHeaders/__tests__/bindRowsWithHeaders.types.ts
+++ b/handsontable/src/plugins/bindRowsWithHeaders/__tests__/bindRowsWithHeaders.types.ts
@@ -1,0 +1,11 @@
+import Handsontable from 'handsontable';
+
+new Handsontable(document.createElement('div'), {
+  bindRowsWithHeaders: true,
+});
+new Handsontable(document.createElement('div'), {
+  bindRowsWithHeaders: 'loose',
+});
+new Handsontable(document.createElement('div'), {
+  bindRowsWithHeaders: 'strict',
+});

--- a/handsontable/types/plugins/bindRowsWithHeaders/bindRowsWithHeaders.d.ts
+++ b/handsontable/types/plugins/bindRowsWithHeaders/bindRowsWithHeaders.d.ts
@@ -1,7 +1,7 @@
 import Core from '../../core';
 import { BasePlugin } from '../base';
 
-export type Settings = boolean;
+export type Settings = boolean | 'loose' | 'strict';
 
 export class BindRowsWithHeaders extends BasePlugin {
   constructor(hotInstance: Core);


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR improves TS typings for the _BindRowsWithHeaders_ plugin.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally, and I covered the improvement with a test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
