### PR TITLE
Add TS typings test for DragToScroll plugin

### DIFF
--- a/handsontable/src/plugins/dragToScroll/__tests__/dragToScroll.types.ts
+++ b/handsontable/src/plugins/dragToScroll/__tests__/dragToScroll.types.ts
@@ -1,0 +1,11 @@
+import Handsontable from 'handsontable';
+
+const hot = new Handsontable(document.createElement('div'), {
+  dragToScroll: true,
+});
+const dragToScroll = hot.getPlugin('dragToScroll');
+const element = document.createElement('div');
+
+dragToScroll.setBoundaries(element.getBoundingClientRect());
+dragToScroll.setCallback(() => {});
+dragToScroll.check(0, 0);


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adds TS typings test for the _DragToScroll_ plugin.

_[skip changelog]_

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
