### PR TITLE
Add TS typings test for ManualColumnFreeze plugin

### DIFF
--- a/handsontable/src/plugins/manualColumnFreeze/__tests__/manualColumnFreeze.types.ts
+++ b/handsontable/src/plugins/manualColumnFreeze/__tests__/manualColumnFreeze.types.ts
@@ -1,0 +1,9 @@
+import Handsontable from 'handsontable';
+
+const hot = new Handsontable(document.createElement('div'), {
+  manualColumnFreeze: true,
+});
+const manualColumnFreeze = hot.getPlugin('manualColumnFreeze');
+
+manualColumnFreeze.freezeColumn(1);
+manualColumnFreeze.unfreezeColumn(1);


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adds TS typings test for the _ManualColumnFreeze_ plugin.

_[skip changelog] (internal change)_

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
