### PR TITLE
Add TS typings test for ManualMove and Resize plugins

### DIFF
--- a/handsontable/src/plugins/manualColumnMove/__tests__/manualColumnMove.types.ts
+++ b/handsontable/src/plugins/manualColumnMove/__tests__/manualColumnMove.types.ts
@@ -1,6 +1,8 @@
 import Handsontable from 'handsontable';
 
-const hot = new Handsontable(document.createElement('div'), {});
+const hot = new Handsontable(document.createElement('div'), {
+  manualColumnMove: true
+});
 const manualColumnMove = hot.getPlugin('manualColumnMove');
 
 manualColumnMove.isMovePossible([0], 3);

--- a/handsontable/src/plugins/manualColumnResize/__tests__/manualColumnResize.types.ts
+++ b/handsontable/src/plugins/manualColumnResize/__tests__/manualColumnResize.types.ts
@@ -1,0 +1,12 @@
+import Handsontable from 'handsontable';
+
+const hot = new Handsontable(document.createElement('div'), {
+  manualColumnResize: true
+});
+const manualColumnResize = hot.getPlugin('manualColumnResize');
+
+manualColumnResize.saveManualColumnWidths();
+manualColumnResize.clearManualSize(0);
+
+const width: number = manualColumnResize.setManualSize(0, 5);
+const widths: Array<number | null> = manualColumnResize.loadManualColumnWidths();

--- a/handsontable/src/plugins/manualRowMove/__tests__/manualRowMove.types.ts
+++ b/handsontable/src/plugins/manualRowMove/__tests__/manualRowMove.types.ts
@@ -1,6 +1,8 @@
 import Handsontable from 'handsontable';
 
-const hot = new Handsontable(document.createElement('div'), {});
+const hot = new Handsontable(document.createElement('div'), {
+  manualRowMove: true,
+});
 const manualRowMove = new Handsontable.plugins.ManualRowMove(hot);
 
 manualRowMove.isMovePossible([0], 3);

--- a/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.types.ts
+++ b/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.types.ts
@@ -1,0 +1,11 @@
+import Handsontable from 'handsontable';
+
+const hot = new Handsontable(document.createElement('div'), {
+  manualRowResize: true
+});
+const manualRowResize = hot.getPlugin('manualRowResize');
+
+manualRowResize.saveManualRowHeights();
+
+const height: number = manualRowResize.setManualSize(0, 5);
+const heights: Array<number | null> = manualRowResize.loadManualRowHeights();


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adds TS typings test for the _ManualRowResize_ and _ManaulColumnResize_ plugins and improves others.

_[skip changelog] (the PR adds only new tests to the codebase)_

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
