### PR TITLE
Docs: Drop iPad support

### DIFF
--- a/docs/content/guides/technical-specification/supported-browsers.md
+++ b/docs/content/guides/technical-specification/supported-browsers.md
@@ -29,7 +29,7 @@ We carefully test our code on the **two latest versions** of every modern browse
 
 Tests are run in [BrowserStack](https://www.browserstack.com/) as well as on a limited number of physical desktop and mobile devices. Access to physical machines gives us an opportunity to measure the performance better which is hard to do with virtual machines.
 
-## List of browsers
+## List of supported browsers
 
 | Desktop Browsers | Mobile Browsers     |
 | :--------------- | :------------------ |
@@ -42,6 +42,6 @@ Tests are run in [BrowserStack](https://www.browserstack.com/) as well as on a l
 
 ::: tip
 
-Handsontable 11.x is the long-term support (LTS) version for Internet Explorer 11 and Edge Legacy (the non-Chromium version of Edge), until the end of 2023.
+Handsontable doesn't support iPads.
 
 :::

--- a/handsontable/src/pluginHooks.js
+++ b/handsontable/src/pluginHooks.js
@@ -434,7 +434,7 @@ const REGISTERED_HOOKS = [
   'afterUpdateData',
 
   /**
-   * Fired after a scroll event, which is identified as a momentum scroll (e.g. On an iPad).
+   * Fired after a scroll event, which is identified as a momentum scroll.
    *
    * @event Hooks#afterMomentumScroll
    */


### PR DESCRIPTION
This PR:
- Adds a note that Handsontable doesn't support iPads (fixing [#1431](https://github.com/handsontable/dev-handsontable/issues/1431))
- Removes the note about IE and Edge Legacy support (since it's the end of 2023)

[skip changelog]