### PR TITLE
Maintain the last selected row/column selection after removal

### DIFF
--- a/.changelogs/10690.json
+++ b/.changelogs/10690.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Maintain the last selected row/column selection after record removal",
+  "type": "changed",
+  "issueOrPR": 10690,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -843,10 +843,19 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
           }
 
           if (selectionChanged) {
-            instance.selectCell(fromRow, fromCol, toRow, toCol);
+            if (fromCol < 0) {
+              instance.selectRows(fromRow, toRow, fromCol);
+
+            } else if (fromRow < 0) {
+              instance.selectColumns(fromCol, toCol, fromRow);
+
+            } else {
+              instance.selectCell(fromRow, fromCol, toRow, toCol);
+            }
           }
         });
       }
+
       if (instance.view) {
         instance.view.adjustElementsSize();
       }

--- a/handsontable/src/selection/__tests__/general.spec.js
+++ b/handsontable/src/selection/__tests__/general.spec.js
@@ -1521,6 +1521,136 @@ describe('Selection', () => {
         | - ║   :   :   : 0 : 0 : 0 :   :   :   :   :   :   :   |
       `).toBeMatchToSelectionPattern();
     });
+
+    it('should transform removed last column header selection to the last visible column', () => {
+      handsontable({
+        rowHeaders: true,
+        colHeaders: true,
+        startRows: 3,
+        startCols: 5,
+      });
+
+      selectColumns(4, 4);
+      alter('remove_col', 4);
+
+      expect(getSelectedRange()).toEqualCellRange(['highlight: 0,3 from: -1,3 to: 2,3']);
+      expect(`
+        |   ║   :   :   : * |
+        |===:===:===:===:===|
+        | - ║   :   :   : A |
+        | - ║   :   :   : 0 |
+        | - ║   :   :   : 0 |
+      `).toBeMatchToSelectionPattern();
+
+      loadData([[1, 2, 3], [1, 2, 3], [1, 2, 3]]);
+
+      expect(getSelectedRange()).toEqualCellRange(['highlight: 0,2 from: -1,2 to: 2,2']);
+      expect(`
+        |   ║   :   : * |
+        |===:===:===:===|
+        | - ║   :   : A |
+        | - ║   :   : 0 |
+        | - ║   :   : 0 |
+      `).toBeMatchToSelectionPattern();
+    });
+
+    it('should transform removed last column selection to the last visible column', () => {
+      handsontable({
+        rowHeaders: true,
+        colHeaders: true,
+        startRows: 3,
+        startCols: 5,
+      });
+
+      selectCells([[1, 4, 0, 4]]);
+      alter('remove_col', 4);
+
+      expect(getSelectedRange()).toEqualCellRange(['highlight: 1,3 from: 1,3 to: 0,3']);
+      expect(`
+        |   ║   :   :   : - |
+        |===:===:===:===:===|
+        | - ║   :   :   : 0 |
+        | - ║   :   :   : A |
+        |   ║   :   :   :   |
+      `).toBeMatchToSelectionPattern();
+
+      loadData([[1, 2, 3], [1, 2, 3], [1, 2, 3]]);
+
+      expect(getSelectedRange()).toEqualCellRange(['highlight: 1,2 from: 1,2 to: 0,2']);
+      expect(`
+        |   ║   :   : - |
+        |===:===:===:===|
+        | - ║   :   : 0 |
+        | - ║   :   : A |
+        |   ║   :   :   |
+      `).toBeMatchToSelectionPattern();
+    });
+
+    it('should transform removed last row header selection to the last visible row', () => {
+      handsontable({
+        rowHeaders: true,
+        colHeaders: true,
+        startRows: 5,
+        startCols: 3,
+      });
+
+      selectRows(4, 4);
+      alter('remove_row', 4);
+
+      expect(getSelectedRange()).toEqualCellRange(['highlight: 3,0 from: 3,-1 to: 3,2']);
+      expect(`
+        |   ║ - : - : - |
+        |===:===:===:===|
+        |   ║   :   :   |
+        |   ║   :   :   |
+        |   ║   :   :   |
+        | * ║ A : 0 : 0 |
+      `).toBeMatchToSelectionPattern();
+
+      loadData([[1, 2, 3], [1, 2, 3], [1, 2, 3]]);
+
+      expect(getSelectedRange()).toEqualCellRange(['highlight: 2,0 from: 2,-1 to: 2,2']);
+      expect(`
+        |   ║ - : - : - |
+        |===:===:===:===|
+        |   ║   :   :   |
+        |   ║   :   :   |
+        | * ║ A : 0 : 0 |
+      `).toBeMatchToSelectionPattern();
+    });
+
+    it('should transform removed last row selection to the last visible row', () => {
+      handsontable({
+        rowHeaders: true,
+        colHeaders: true,
+        startRows: 5,
+        startCols: 3,
+      });
+
+      selectCells([[4, 1, 4, 0]]);
+      alter('remove_row', 4);
+
+      expect(getSelectedRange()).toEqualCellRange(['highlight: 3,1 from: 3,1 to: 3,0']);
+      expect(`
+        |   ║ - : - :   |
+        |===:===:===:===|
+        |   ║   :   :   |
+        |   ║   :   :   |
+        |   ║   :   :   |
+        | - ║ 0 : A :   |
+      `).toBeMatchToSelectionPattern();
+
+      loadData([[1, 2, 3], [1, 2, 3], [1, 2, 3]]);
+
+      expect(getSelectedRange()).toEqualCellRange(['highlight: 2,1 from: 2,1 to: 2,0']);
+      expect(`
+        |   ║ - : - :   |
+        |===:===:===:===|
+        |   ║   :   :   |
+        |   ║   :   :   |
+        | - ║ 0 : A :   |
+      `).toBeMatchToSelectionPattern();
+    });
   });
 
   it('should select cells properly while using non-consecutive selection for two instances', () => {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR restores the behavior from the 7.4.2 version, where the removed row or column selection (after record removal) did not move to the new position (nearest visible record).

#### Before
![Kapture 2024-01-02 at 15 19 34](https://github.com/handsontable/handsontable/assets/571316/4bde77a0-c79f-4055-b1e4-ca323ec14b7e)

#### After
![Kapture 2024-01-02 at 15 20 09](https://github.com/handsontable/handsontable/assets/571316/60b69cba-09bc-4e99-8b39-5d9423cd2685)

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and I covered the fix with new tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/371

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
