### PR TITLE
Docs: Revert lines brakes in the TIP box

### DIFF
--- a/docs/.vuepress/theme/styles/index.styl
+++ b/docs/.vuepress/theme/styles/index.styl
@@ -181,10 +181,6 @@ a.source-code-link {
       vertical-align: top;
     }
   }
-
-  code {
-    white-space: nowrap;
-  }
 }
 
 /* Larger bottom gap of H1, H2, H3 */
@@ -232,7 +228,7 @@ h1, h2, h3, h4, h5 {
 
   a.header-anchor::before {
     content: '#';
-    visibility: 'hidden'; 
+    visibility: 'hidden';
   }
 
   a.header-anchor:focus {

--- a/docs/content/guides/cell-functions/cell-renderer.md
+++ b/docs/content/guides/cell-functions/cell-renderer.md
@@ -299,7 +299,7 @@ You can set a cell's [`renderer`](@/api/options.md#renderer), [`editor`](@/api/o
 renderer: Handsontable.NumericRenderer,
 editor: Handsontable.editors.NumericEditor,
 validator: Handsontable.NumericValidator,
-type: 'numeric'
+type: 'numeric',
 ```
 
 :::


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR reverts missing the line breaks in the code preview blocks placed into the TIP box.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1132

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
