### PR TITLE
Add new `beforeBeginEditing` hook

### DIFF
--- a/.changelogs/10699.json
+++ b/.changelogs/10699.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Added new `beforeBeginEditing` hook",
+  "type": "added",
+  "issueOrPR": 10699,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/__tests__/core/settings.types.ts
+++ b/handsontable/src/__tests__/core/settings.types.ts
@@ -494,6 +494,11 @@ const allSettings: Required<Handsontable.GridSettings> = {
   afterViewRender: (isForced) => {},
   beforeAddChild: (parent, element, index) => {},
   beforeAutofill: (start, end, data) => {},
+  beforeBeginEditing: (row: number, column: number, initialValue, event, fullEditMode: boolean) => {
+    event.preventDefault();
+
+    return true;
+  },
   beforeCellAlignment: (stateBefore, range, type, alignmentClass) => {},
   beforeChange: (changes, source) => { if (changes?.[0] !== null) { changes[0][3] = 10; } return false; },
   beforeChangeRender: (changes, source) => {},

--- a/handsontable/src/__tests__/editorManager/openEditor.spec.js
+++ b/handsontable/src/__tests__/editorManager/openEditor.spec.js
@@ -1,0 +1,96 @@
+describe('EditorManager open editor', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}" style="width: 300px; height: 200px; overflow: auto"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should be possible to open an editor using a mouse', () => {
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+    });
+    selectCell(2, 2);
+    mouseDoubleClick(getCell(2, 2));
+
+    expect(isEditorVisible()).toBe(true);
+    expect(getActiveEditor()).toBeDefined();
+  });
+
+  it('should not be possible to open an editor using a mouse when more than 2 cells are selected (while holding Shift)', () => {
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+    });
+    selectCell(2, 2, 2, 3);
+    keyDown('shift');
+    mouseDoubleClick(getCell(2, 3));
+
+    expect(isEditorVisible()).toBe(false);
+    expect(getActiveEditor()).toBeUndefined();
+  });
+
+  it('should be possible to open an editor using a mouse when 1 cell is selected (while holding Shift)', () => {
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+    });
+    selectCell(2, 2);
+    keyDown('shift');
+    mouseDoubleClick(getCell(2, 2));
+
+    expect(isEditorVisible()).toBe(true);
+    expect(getActiveEditor()).toBeDefined();
+  });
+
+  it('should not be possible to open an editor using a mouse when Ctrl/Cmd key is pressed', () => {
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+    });
+    selectCell(2, 3);
+    keyDown('control/meta');
+    mouseDoubleClick(getCell(2, 3));
+
+    expect(isEditorVisible()).toBe(false);
+    expect(getActiveEditor()).toBeUndefined();
+  });
+
+  it('should be possible to open an editor using Enter key', () => {
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+    });
+    selectCell(2, 2);
+    keyDown('enter');
+
+    expect(isEditorVisible()).toBe(true);
+    expect(getActiveEditor()).toBeDefined();
+  });
+
+  it('should be possible to open an editor using Enter key when more than 2 cells are selected (while holding Shift)', () => {
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+    });
+    selectCell(2, 2, 2, 3);
+    keyDownUp(['shift', 'enter']);
+
+    expect(isEditorVisible()).toBe(true);
+    expect(getActiveEditor()).toBeDefined();
+    expect(getActiveEditor().row).toBe(2);
+    expect(getActiveEditor().col).toBe(2);
+  });
+
+  it('should not be possible to open an editor using Enter key when Ctrl/Cmd key is pressed', () => {
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+    });
+    selectCells([[1, 1], [2, 3]]);
+    keyDownUp(['control/meta', 'enter']);
+
+    expect(isEditorVisible()).toBe(false);
+    expect(getActiveEditor()).toBeDefined();
+  });
+});

--- a/handsontable/src/editorManager.js
+++ b/handsontable/src/editorManager.js
@@ -217,13 +217,13 @@ class EditorManager {
     );
 
     // If the above hook does not return boolean apply default behavior which disallows opening
-    // an editor for non-contiguous selection (while pressing Ctrl/Cmd) and for multiple selected
-    // cells (while pressing SHIFT).
+    // an editor after double mouse click for non-contiguous selection (while pressing Ctrl/Cmd) and
+    // for multiple selected cells (while pressing SHIFT).
     if (event instanceof MouseEvent && typeof allowOpening !== 'boolean') {
       allowOpening = this.hot.selection.getLayerLevel() === 0 && selection.isSingle();
     }
 
-    if (!allowOpening) {
+    if (allowOpening === false) {
       this.clearActiveEditor();
 
       return;

--- a/handsontable/src/editorManager.js
+++ b/handsontable/src/editorManager.js
@@ -206,6 +206,29 @@ class EditorManager {
       return;
     }
 
+    const selection = this.hot.getSelectedRangeLast();
+    let allowOpening = this.hot.runHooks(
+      'beforeBeginEditing',
+      selection.highlight.row,
+      selection.highlight.col,
+      newInitialValue,
+      event,
+      enableFullEditMode,
+    );
+
+    // If the above hook does not return boolean apply default behavior which disallows opening
+    // an editor for non-contiguous selection (while pressing Ctrl/Cmd) and for multiple selected
+    // cells (while pressing SHIFT).
+    if (event instanceof MouseEvent && typeof allowOpening !== 'boolean') {
+      allowOpening = this.hot.selection.getLayerLevel() === 0 && selection.isSingle();
+    }
+
+    if (!allowOpening) {
+      this.clearActiveEditor();
+
+      return;
+    }
+
     if (!this.activeEditor) {
       this.hot.scrollToFocusedCell();
       this.prepareEditor();
@@ -374,11 +397,9 @@ class EditorManager {
    *
    * @param {MouseEvent} event The mouse event object.
    * @param {object} coords The cell coordinates.
-   * @param {HTMLTableCellElement|HTMLTableHeaderCellElement} elem The element which triggers the action.
    */
-  #onCellDblClick(event, coords, elem) {
-    // may be TD or TH
-    if (elem.nodeName === 'TD') {
+  #onCellDblClick(event, coords) {
+    if (coords.isCell()) {
       this.openEditor(null, event, true);
     }
   }

--- a/handsontable/src/pluginHooks.js
+++ b/handsontable/src/pluginHooks.js
@@ -2576,6 +2576,25 @@ const REGISTERED_HOOKS = [
   'afterDetachChild',
 
   /**
+   * Fired before the editor is opened and rendered.
+   *
+   * @since 14.1.0
+   * @event Hooks#beforeBeginEditing
+   * @param {number} row Visual row index of the edited cell.
+   * @param {number} column Visual column index of the edited cell.
+   * @param {*} initialValue The initial editor value.
+   * @param {MouseEvent | KeyboardEvent} event The event which was responsible for opening the editor.
+   * @param {boolean} fullEditMode `true` if the editor is opened in full edit mode, `false` otherwise.
+   * Editor opened in full edit mode does not close after pressing Arrow keys.
+   * @returns {boolean | undefined} If the callback returns `false,` the editor won't be opened after
+   * the mouse double click or after pressing the Enter key. Returning `undefined` (or other value
+   * than boolean) will result in default behavior, which disallows opening an editor for non-contiguous
+   * selection (while pressing Ctrl/Cmd) and for multiple selected cells (while pressing SHIFT).
+   * Returning `true` removes those restrictions.
+   */
+  'beforeBeginEditing',
+
+  /**
    * Fired after the editor is opened and rendered.
    *
    * @event Hooks#afterBeginEditing

--- a/handsontable/src/plugins/mergeCells/__tests__/openEditor.spec.js
+++ b/handsontable/src/plugins/mergeCells/__tests__/openEditor.spec.js
@@ -1,0 +1,117 @@
+describe('MergeCells open editor', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}" style="width: 300px; height: 200px; overflow: auto"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should be possible to open an editor using a mouse when merge cell is selected', () => {
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+      mergeCells: [
+        { row: 1, col: 1, rowspan: 2, colspan: 2 }
+      ]
+    });
+    selectCell(1, 1);
+    mouseDoubleClick(getCell(1, 1));
+
+    expect(isEditorVisible()).toBe(true);
+    expect(getActiveEditor()).toBeDefined();
+  });
+
+  it('should be possible to open an editor using a mouse when merge cell is selected (while holding Shift)', () => {
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+      mergeCells: [
+        { row: 1, col: 1, rowspan: 2, colspan: 2 }
+      ]
+    });
+    selectCell(1, 1);
+    keyDown('shift');
+    mouseDoubleClick(getCell(1, 1));
+
+    expect(isEditorVisible()).toBe(true);
+    expect(getActiveEditor()).toBeDefined();
+  });
+
+  it('should not be possible to open an editor using a mouse when more than 2 cells are selected (while holding Shift)', () => {
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+      mergeCells: [
+        { row: 1, col: 1, rowspan: 2, colspan: 2 }
+      ]
+    });
+    selectCell(1, 1, 2, 3);
+    keyDown('shift');
+    mouseDoubleClick(getCell(2, 3));
+
+    expect(isEditorVisible()).toBe(false);
+    expect(getActiveEditor()).toBeUndefined();
+  });
+
+  it('should not be possible to open an editor using a mouse when Ctrl/Cmd key is pressed', () => {
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+      mergeCells: [
+        { row: 1, col: 1, rowspan: 2, colspan: 2 }
+      ]
+    });
+    selectCell(1, 1);
+    keyDown('control/meta');
+    mouseDoubleClick(getCell(1, 1));
+
+    expect(isEditorVisible()).toBe(false);
+    expect(getActiveEditor()).toBeUndefined();
+  });
+
+  it('should be possible to open an editor for merged cell using Enter key', () => {
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+      mergeCells: [
+        { row: 1, col: 1, rowspan: 2, colspan: 2 }
+      ]
+    });
+    selectCell(1, 1);
+    keyDown('enter');
+
+    expect(isEditorVisible()).toBe(true);
+    expect(getActiveEditor()).toBeDefined();
+  });
+
+  it('should be possible to open an editor for merged cell using Enter (while holding Shift)', () => {
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+      mergeCells: [
+        { row: 1, col: 1, rowspan: 2, colspan: 2 }
+      ]
+    });
+    selectCell(1, 1);
+    keyDownUp(['shift', 'enter']);
+
+    expect(isEditorVisible()).toBe(true);
+    expect(getActiveEditor()).toBeDefined();
+    expect(getActiveEditor().row).toBe(1);
+    expect(getActiveEditor().col).toBe(1);
+  });
+
+  it('should not be possible to open an editor using Enter key when Ctrl/Cmd key is pressed', () => {
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+      mergeCells: [
+        { row: 1, col: 1, rowspan: 2, colspan: 2 }
+      ]
+    });
+    selectCells([[1, 1], [3, 4]]);
+    keyDownUp(['control/meta', 'enter']);
+
+    expect(isEditorVisible()).toBe(false);
+    expect(getActiveEditor()).toBeDefined();
+  });
+});

--- a/handsontable/src/plugins/mergeCells/cellsCollection.js
+++ b/handsontable/src/plugins/mergeCells/cellsCollection.js
@@ -75,7 +75,7 @@ class MergedCellsCollection {
   }
 
   /**
-   * Get a merged cell containing the provided range.
+   * Get the first-found merged cell containing the provided range.
    *
    * @param {CellRange|object} range The range to search merged cells for.
    * @returns {MergedCellCoords|boolean}

--- a/handsontable/src/plugins/mergeCells/mergeCells.js
+++ b/handsontable/src/plugins/mergeCells/mergeCells.js
@@ -1263,12 +1263,13 @@ export class MergeCells extends BasePlugin {
   /**
    * Allows to prevent opening the editor while more than one merged cell is selected.
    *
-   * @param {CellCoords} coords Cell coords.
+   * @param {number} row Visual row index of the edited cell.
+   * @param {number} column Visual column index of the edited cell.
    * @param {string | null} initialValue The initial editor value.
    * @param {MouseEvent | KeyboardEvent} event The event which was responsible for opening the editor.
    * @returns {boolean | undefined}
    */
-  #onBeforeBeginEditing(coords, initialValue, event) {
+  #onBeforeBeginEditing(row, column, initialValue, event) {
     if (!(event instanceof MouseEvent)) {
       return;
     }

--- a/handsontable/test/e2e/hooks/afterBeginEditing.spec.js
+++ b/handsontable/test/e2e/hooks/afterBeginEditing.spec.js
@@ -1,0 +1,47 @@
+describe('Hook', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  describe('afterBeginEditing', () => {
+    it('should be fired after editing the editor\'s value', () => {
+      const afterBeginEditing = jasmine.createSpy('afterBeginEditing');
+
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        afterBeginEditing,
+      });
+
+      selectCell(1, 2);
+      keyDownUp('enter'); // open editor
+      keyDownUp('enter'); // save and close editor
+
+      expect(afterBeginEditing).toHaveBeenCalledWith(1, 2);
+    });
+
+    it('should not be fired when editor was blocked by `beforeBeginEditing` hook', () => {
+      const afterBeginEditing = jasmine.createSpy('afterBeginEditing');
+
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        beforeBeginEditing: () => false,
+        afterBeginEditing,
+      });
+
+      selectCell(1, 2);
+      keyDownUp('enter'); // open editor
+      keyDownUp('enter'); // save and close editor
+
+      expect(afterBeginEditing).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/handsontable/test/e2e/hooks/beforeBeginEditing.spec.js
+++ b/handsontable/test/e2e/hooks/beforeBeginEditing.spec.js
@@ -1,0 +1,103 @@
+describe('Hook', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  describe('beforeBeginEditing', () => {
+    it('should be fired after opening the editor using Enter key', () => {
+      const beforeBeginEditing = jasmine.createSpy('beforeBeginEditing');
+
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        beforeBeginEditing,
+      });
+
+      selectCell(1, 2);
+      keyDownUp('enter');
+
+      expect(beforeBeginEditing).toHaveBeenCalledWith(1, 2, null, jasmine.any(Event), true);
+    });
+
+    it('should be fired after opening the editor using F2 key', () => {
+      const beforeBeginEditing = jasmine.createSpy('beforeBeginEditing');
+
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        beforeBeginEditing,
+      });
+
+      selectCell(1, 2);
+      keyDownUp('f2');
+
+      expect(beforeBeginEditing).toHaveBeenCalledWith(1, 2, null, jasmine.any(Event), true);
+    });
+
+    it('should be fired after opening the editor by typing any printable character', () => {
+      const beforeBeginEditing = jasmine.createSpy('beforeBeginEditing');
+
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        beforeBeginEditing,
+      });
+
+      selectCell(1, 2);
+      keyDownUp('g');
+
+      expect(beforeBeginEditing).toHaveBeenCalledWith(1, 2, '', jasmine.any(Event), false);
+    });
+
+    it('should be fired after calling the `openEditor` method', () => {
+      const beforeBeginEditing = jasmine.createSpy('beforeBeginEditing');
+
+      const hot = handsontable({
+        data: createSpreadsheetData(5, 5),
+        beforeBeginEditing,
+      });
+
+      selectCell(1, 2);
+      hot._getEditorManager().openEditor('test');
+
+      expect(beforeBeginEditing).toHaveBeenCalledWith(1, 2, 'test', undefined, false);
+    });
+
+    it('should be fired before the `afterBeginEditing` hook', () => {
+      const beforeBeginEditing = jasmine.createSpy('beforeBeginEditing');
+      const afterBeginEditing = jasmine.createSpy('afterBeginEditing');
+
+      const hot = handsontable({
+        data: createSpreadsheetData(5, 5),
+        beforeBeginEditing,
+        afterBeginEditing,
+      });
+
+      selectCell(1, 2);
+      hot._getEditorManager().openEditor('test');
+
+      expect(beforeBeginEditing).toHaveBeenCalledWith(1, 2, 'test', undefined, false);
+      expect(beforeBeginEditing).toHaveBeenCalledBefore(afterBeginEditing);
+    });
+
+    it('should be possible to prevent opening the editor', () => {
+      const beforeBeginEditing = jasmine.createSpy('beforeBeginEditing').and.returnValue(false);
+
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        beforeBeginEditing,
+      });
+
+      selectCell(1, 2);
+      keyDownUp('enter');
+
+      expect(getActiveEditor()).toBeUndefined();
+    });
+  });
+});

--- a/handsontable/test/e2e/hooks/beforeBeginEditing.spec.js
+++ b/handsontable/test/e2e/hooks/beforeBeginEditing.spec.js
@@ -97,6 +97,7 @@ describe('Hook', () => {
       selectCell(1, 2);
       keyDownUp('enter');
 
+      expect(isEditorVisible()).toBe(false);
       expect(getActiveEditor()).toBeUndefined();
     });
   });

--- a/handsontable/types/pluginHooks.d.ts
+++ b/handsontable/types/pluginHooks.d.ts
@@ -157,6 +157,7 @@ export interface Events {
   afterViewRender?: (isForced: boolean) => void;
   beforeAddChild?: (parent: RowObject, element?: RowObject, index?: number) => void;
   beforeAutofill?: (selectionData: CellValue[][], sourceRange: CellRange, targetRange: CellRange, direction: 'up' | 'down' | 'left' | 'right') => CellValue[][] | boolean | void;
+  beforeBeginEditing?: (row: number, column: number, initialValue: any, event: MouseEvent | KeyboardEvent, fullEditMode: boolean) => boolean | void;
   beforeCellAlignment?: (stateBefore: { [row: number]: string[] }, range: CellRange[], type: 'horizontal' | 'vertical',
     alignmentClass: 'htLeft' | 'htCenter' | 'htRight' | 'htJustify' | 'htTop' | 'htMiddle' | 'htBottom') => void;
   beforeChange?: (changes: Array<CellChange | null>, source: ChangeSource) => void | boolean;

--- a/wrappers/angular/projects/hot-table/src/lib/hot-table.component.ts
+++ b/wrappers/angular/projects/hot-table/src/lib/hot-table.component.ts
@@ -261,6 +261,7 @@ export class HotTableComponent implements AfterViewInit, OnChanges, OnDestroy {
   @Input() afterViewRender: Handsontable.GridSettings['afterViewRender'];
   @Input() beforeAddChild: Handsontable.GridSettings['beforeAddChild'];
   @Input() beforeAutofill: Handsontable.GridSettings['beforeAutofill'];
+  @Input() beforeBeginEditing: Handsontable.GridSettings['beforeBeginEditing'];
   @Input() beforeCellAlignment: Handsontable.GridSettings['beforeCellAlignment'];
   @Input() beforeChange: Handsontable.GridSettings['beforeChange'];
   @Input() beforeChangeRender: Handsontable.GridSettings['beforeChangeRender'];


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adds a new `beforeBeginEditing` hook that allows controlling when the cell editor can (or not) be opened based on the custom condition. When the hook is not used, or if it returns a value other than a boolean, the default behavior is enabled. By default - which is changed within this PR, a cell editor can not be opened by double mouse click for non-contiguous selection (while pressing <kbd>Ctrl/Cmd</kbd>) and for multiple selected cells (while pressing <kbd>Shift</kbd>).

#### Before
![Kapture 2024-01-08 at 11 44 55](https://github.com/handsontable/handsontable/assets/571316/1ec839d2-7916-4e82-860f-cd099fb351b4)

#### After
![Kapture 2024-01-08 at 11 44 09](https://github.com/handsontable/handsontable/assets/571316/a531bba8-12a2-4444-90e2-1de82347963f)

#### Hook example usage
Prevent the editor from being opened for the mouse double click. <kbd>Enter</kbd> or <kbd>F2</kbd> or API calls would still work.
```js
hot.addHook('beforeBeginEditing', (row, column, initialValue, event, fullEditMode) => {
  return !(event instanceof MouseEvent);
});
```
Prevent the editor from being opened for specific coordinates (row 0, column 0)
```js
hot.addHook('beforeBeginEditing', (row, column, initialValue, event, fullEditMode) => {
  return row === 0 && column === 0 ? false : true;
});
```

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and I covered the feature with new tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/420
2. fixes https://github.com/handsontable/dev-handsontable/issues/421
3. fixes https://github.com/handsontable/dev-handsontable/issues/480

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
