### PR TITLE
Docs: Expand the `readOnly` docs

### DIFF
--- a/docs/content/guides/cell-features/comments.md
+++ b/docs/content/guides/cell-features/comments.md
@@ -176,7 +176,7 @@ ReactDOM.render(<ExampleComponent />, document.getElementById('example1'));
 
 ## Make a comment read-only
 
-By default, all comments are editable. To change this, set the [`readOnly`](@/api/options.md#comments) configuration option to `true` when adding a comment. This example makes the "Tesla" comment attached to a cell read-only, whereas the "Honda" comment attached to another cell is editable.
+By default, all comments are editable. To change this, set the [`readOnly`](@/api/options.md#readonly) configuration option to `true` when adding a comment. This example makes the "Tesla" comment attached to a cell read-only, whereas the "Honda" comment attached to another cell is editable.
 
 ::: only-for javascript
 

--- a/docs/content/guides/cell-features/disabled-cells.md
+++ b/docs/content/guides/cell-features/disabled-cells.md
@@ -34,6 +34,80 @@ Disabling a cell makes the cell read-only or non-editable. Both have similar out
 | Drag-to-fill doesn't work                                                    | Drag-to-fill works                                                         |
 | Can't be changed by [`populateFromArray()`](@/api/core.md#populatefromarray) | Can be changed by [`populateFromArray()`](@/api/core.md#populatefromarray) |
 
+## Read-only grid
+
+You can make the entire grid read-only by setting [`readOnly`](@/api/options.md#readonly) to `true` as a [top-level grid option](@/guides/getting-started/configuration-options.md#set-grid-options).
+
+::: only-for javascript
+
+::: example #exampleReadOnlyGrid
+
+```js
+import Handsontable from 'handsontable';
+import 'handsontable/dist/handsontable.full.min.css';
+
+const container = document.querySelector('#exampleReadOnlyGrid');
+const hot = new Handsontable(container, {
+  data: [
+    { car: 'Tesla', year: 2017, chassis: 'black', bumper: 'black' },
+    { car: 'Nissan', year: 2018, chassis: 'blue', bumper: 'blue' },
+    { car: 'Chrysler', year: 2019, chassis: 'yellow', bumper: 'black' },
+    { car: 'Volvo', year: 2020, chassis: 'white', bumper: 'gray' }
+  ],
+  height: 'auto',
+  colHeaders: ['Car', 'Year', 'Chassis color', 'Bumper color'],
+  licenseKey: 'non-commercial-and-evaluation',
+  // make the entire grid read-only
+  readOnly: true,
+  autoWrapRow: true,
+  autoWrapCol: true
+});
+```
+
+:::
+
+:::
+
+::: only-for react
+
+::: example #exampleReadOnlyGrid :react
+
+```jsx
+import { HotTable } from '@handsontable/react';
+import { registerAllModules } from 'handsontable/registry';
+import 'handsontable/dist/handsontable.full.min.css';
+
+// register Handsontable's modules
+registerAllModules();
+
+export const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={[
+        { car: 'Tesla', year: 2017, chassis: 'black', bumper: 'black' },
+        { car: 'Nissan', year: 2018, chassis: 'blue', bumper: 'blue' },
+        { car: 'Chrysler', year: 2019, chassis: 'yellow', bumper: 'black' },
+        { car: 'Volvo', year: 2020, chassis: 'white', bumper: 'gray' }
+      ]}
+      height="auto"
+      colHeaders={['Car', 'Year', 'Chassis color', 'Bumper color']}
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+      readOnly={true}
+    />
+  );
+};
+
+/* start:skip-in-preview */
+ReactDOM.render(<ExampleComponent />, document.getElementById('exampleReadOnlyGrid'));
+/* end:skip-in-preview */
+```
+
+:::
+
+:::
+
 ## Read-only columns
 
 In many use cases, you will need to configure a certain column to be read-only. This column will be available for keyboard navigation and copying data (<kbd>**Ctrl**</kbd>/<kbd>**Cmd**</kbd>+<kbd>**C**</kbd>). Editing and pasting data will be disabled.

--- a/docs/content/guides/getting-started/configuration-options.md
+++ b/docs/content/guides/getting-started/configuration-options.md
@@ -155,18 +155,17 @@ To find out if an option comes from a plugin, check the `Category` label in the 
 
 ## Set grid options
 
-To apply configuration options to the entire grid:
+
 
 ::: only-for javascript
 
-- Pass your options as a second argument of the Handsontable constructor, using the object literal notation.
+To apply configuration options to the entire grid, pass your options as a second argument of the Handsontable constructor, using the object literal notation.
 
 :::
 
 ::: only-for react
 
-- Pass your options as individual props of the [`HotTable`](@/guides/getting-started/installation.md#_4-use-the-hottable-component) or [`HotColumn`](@/guides/columns/react-hot-column.md) components.
-- You can also pass your options as an object, using the `settings` prop.
+To apply configuration options to the entire grid, pass your options as individual props of the [`HotTable`](@/guides/getting-started/installation.md#_4-use-the-hottable-component) or [`HotColumn`](@/guides/columns/react-hot-column.md) components. You can also pass your options as an object, using the `settings` prop.
 
 :::
 

--- a/handsontable/src/dataMap/metaManager/metaSchema.js
+++ b/handsontable/src/dataMap/metaManager/metaSchema.js
@@ -2309,7 +2309,7 @@ export default () => {
      *
      * You can set the `fragmentSelection` option to one of the following:
      *
-     * | Setting           | Decription                                        |
+     * | Setting           | Description                                        |
      * | ----------------- | ------------------------------------------------- |
      * | `false` (default) | Disable text selection                            |
      * | `true`            | Enable text selection in multiple cells at a time |
@@ -3592,11 +3592,11 @@ export default () => {
 
     /**
      * @description
-     * The `readOnly` option determines whether a cell, column or comment is editable or not.
+     * The `readOnly` option determines whether a [cell](@/guides/cell-features/disabled-cells.md#read-only-specific-cells),
+     * [comment](@/guides/cell-features/comments.md#make-a-comment-read-only), [column](@/guides/cell-features/disabled-cells.md#read-only-columns)
+     * or the [entire grid](@/guides/cell-features/disabled-cells.md#read-only-grid) is editable or not. You can configure it as follows:
      *
-     * You can set the `readOnly` option to one of the following:
-     *
-     * | Setting           | Decription                                                                                                                |
+     * | Setting           | Description                                                                                                                |
      * | ----------------- | ------------------------------------------------------------------------------------------------------------------------- |
      * | `false` (default) | Set as editable                                                                                                           |
      * | `true`            | - Set as read-only<br>- Add the [`readOnlyCellClassName`](#readOnlyCellClassName) CSS class name (by default: `htDimmed`) |
@@ -3604,6 +3604,7 @@ export default () => {
      * `readOnly` cells can't be changed by the [`populateFromArray()`](@/api/core.md#populatefromarray) method.
      *
      * Read more:
+     * - [Disabled cells](@/guides/cell-features/disabled-cells.md)
      * - [Configuration options: Cascading configuration](@/guides/getting-started/configuration-options.md#cascading-configuration)
      *
      * @memberof Options#
@@ -3613,8 +3614,31 @@ export default () => {
      *
      * @example
      * ```js
-     * // set as read-only
-     * readOnly: true,
+     * // make the entire grid read-only
+     * const configurationOptions = {
+     *   columnSorting: true,
+     * };
+     *
+     * // make the third column read-only
+     * const configurationOptions = {
+     *   columns: [
+     *     {},
+     *     {},
+     *     {
+     *       readOnly: true,
+     *     },
+     *   ],
+     * };
+     *
+     * // make a specific cell read-only
+     * const configurationOptions = {
+     *   cell: [
+     *     {
+     *       row: 0,
+     *       col: 0,
+     *       readOnly: true,
+     *     },
+     * };
      * ```
      */
     readOnly: false,


### PR DESCRIPTION
As requested [here](https://handsoncode.slack.com/archives/C01KNSJ4M08/p1704284082973129), this PR adds info on making the entire grid read-only. It also fixes a link, corrects a few typos etc.

### Updated sections
- http://localhost:8080/docs/javascript-data-grid/api/options/#readonly
- http://localhost:8080/docs/javascript-data-grid/disabled-cells/#read-only-grid [new section]

[skip changelog]