### PR TITLE
Docs: Remove notes about modules

### DIFF
--- a/docs/content/guides/getting-started/configuration-options.md
+++ b/docs/content/guides/getting-started/configuration-options.md
@@ -444,12 +444,6 @@ To apply configuration options to an individual row (or a range of rows), use th
 
 Any options modified through [`cells`](@/api/options.md#cells) overwrite all other options.
 
-::: tip
-
-The [`cells`](@/api/options.md#cells) option is a function invoked before Handsontable's [rendering cycle](@/guides/optimization/batch-operations.md). Implemented incorrectly, it can slow Handsontable down. Use the [`cells`](@/api/options.md#cells) option only if the [`cell`](@/api/options.md#cell) option, the [`columns`](@/api/options.md#columns) option, and the [`setCellMeta()`](#change-cell-options) method don't meet your needs.
-
-:::
-
 ::: only-for javascript
 
  The function can take three arguments:<br>
@@ -922,12 +916,6 @@ hot.getCellMeta(1, 1).readOnly;
 You can apply configuration options to individual grid elements (columns, rows, cells), based on any logic you implement, using the [`cells`](@/api/options.md#cells) option.
 
 The [`cells`](@/api/options.md#cells) option overwrites all other options.
-
-::: tip
-
-The [`cells`](@/api/options.md#cells) option is a function invoked before Handsontable's [rendering cycle](@/guides/optimization/batch-operations.md). Implemented incorrectly, it can slow Handsontable down. Use the [`cells`](@/api/options.md#cells) option only if the [`cell`](@/api/options.md#cell) option, the [`columns`](@/api/options.md#columns) option, and the [`setCellMeta()`](#change-cell-options) method don't meet your needs.
-
-:::
 
 ::: only-for javascript
 

--- a/docs/content/guides/getting-started/configuration-options.md
+++ b/docs/content/guides/getting-started/configuration-options.md
@@ -192,12 +192,6 @@ const hot = new Handsontable(container, {
 
 :::
 
-::: tip
-
-If you use Handsontable through [modules](@/guides/tools-and-building/modules.md): to use an option that comes from a Handsontable plugin, import and register that plugin when initializing your Handsontable instance.
-
-:::
-
 #### Example
 
 To configure each cell in the grid as read-only, apply the [`readOnly`](@/api/options.md#readonly) option as a top-level grid option.
@@ -331,12 +325,6 @@ Alternatively, you can use the [`HotColumn`](@/guides/columns/react-hot-column.m
   <HotColumn width={100}/>
 </HotTable>
 ```
-
-:::
-
-::: tip
-
-If you use Handsontable through [modules](@/guides/tools-and-building/modules.md): to use an option that comes from a Handsontable plugin, import and register that plugin when initializing your Handsontable instance.
 
 :::
 
@@ -512,12 +500,6 @@ The function can take three arguments:<br>
 
 :::
 
-::: tip
-
-If you use Handsontable through [modules](@/guides/tools-and-building/modules.md): to use an option that comes from a Handsontable plugin, import and register that plugin when initializing your Handsontable instance.
-
-:::
-
 #### Example
 
 In the example below, the [`cells`](@/api/options.md#cells) option sets each cell in the first and fourth row as [`readOnly`](@/api/options.md#readonly).
@@ -669,12 +651,6 @@ const hot = new Handsontable(container, {
   }
 ]}/>
 ```
-
-:::
-
-::: tip
-
-If you use Handsontable through [modules](@/guides/tools-and-building/modules.md): to use an option that comes from a Handsontable plugin, import and register that plugin when initializing your Handsontable instance.
 
 :::
 


### PR DESCRIPTION
This PR removes the notes about using modules from the "Configuration options" guide, to declutter the page.

### Updated sections
- http://localhost:8080/docs/javascript-data-grid/configuration-options/
- http://localhost:8080/docs/react-data-grid/configuration-options/

[skip changelog]