### PR TITLE
chore: update peerDependencies of vue3 wrapper

### DIFF
--- a/.changelogs/10571.json
+++ b/.changelogs/10571.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "chore: update peerDependencies of vue3 wrapper",
+  "type": "fixed",
+  "issueOrPR": 10571,
+  "breaking": false,
+  "framework": "vue"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -130,6 +130,7 @@
       }
     },
     "handsontable/.config/plugin/eslint": {
+      "name": "eslint-plugin-handsontable",
       "version": "1.0.0",
       "dev": true
     },
@@ -38660,7 +38661,7 @@
       },
       "peerDependencies": {
         "handsontable": ">=14.0.0",
-        "vue": "next"
+        "vue": "^3.2.22"
       }
     },
     "wrappers/vue3/node_modules/@vue/server-renderer": {

--- a/wrappers/vue3/package.json
+++ b/wrappers/vue3/package.json
@@ -54,7 +54,7 @@
   },
   "peerDependencies": {
     "handsontable": ">=14.0.0",
-    "vue": "next"
+    "vue": "^3.2.22"
   },
   "devDependencies": {
     "@babel/cli": "^7.11.0",


### PR DESCRIPTION
### Context
The following warning occurs when I using pnpm to install @handsontable/vue3
<img width="357" alt="image" src="https://github.com/handsontable/handsontable/assets/13096985/6dd61dd5-5eec-4829-a134-038984694ce0">

You can check the vue tag and verison in https://www.npmjs.com/package/vue?activeTab=versions, and there is no next tag anymore, so I use `^3.2.22` as the peerDependencies verison which is also the verison of vue in dependencies.

### How has this been tested?
I rebuilt the @handsontable/vue3, published it to my private npm registry, and use it as the dependency.

Then, I executed pnpm install again, no warning apeared.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/10571

### Affected project(s):
- [x] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
