### PR TITLE
Removing all columns/rows when HyperFormula is enabled won't cause an error

### DIFF
--- a/.changelogs/10710.json
+++ b/.changelogs/10710.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Removing all columns/rows when HyperFormula is enabled won't cause an error",
+  "type": "fixed",
+  "issueOrPR": 10710,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/formulas/__tests__/formulas.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/formulas.spec.js
@@ -685,6 +685,36 @@ describe('Formulas general', () => {
       expect(hot.getDataAtRow(3)).toEqual([2012, 6033, 8049, '#REF!', 12, '=SUM(E5)']);
     });
 
+    it('should not throw an error after removing all rows', () => {
+      expect(() => {
+        handsontable({
+          data: getDataSimpleExampleFormulas(),
+          formulas: {
+            engine: HyperFormula
+          },
+          width: 500,
+          height: 300
+        });
+
+        alter('remove_row', 0, 5);
+      }).not.toThrow();
+    });
+
+    it('should not throw an error after removing all columns', () => {
+      expect(() => {
+        handsontable({
+          data: getDataSimpleExampleFormulas(),
+          formulas: {
+            engine: HyperFormula
+          },
+          width: 500,
+          height: 300
+        });
+
+        alter('remove_col', 0, 6);
+      }).not.toThrow();
+    });
+
     it('should recalculate table and replace coordinates in formula expressions into #REF! value (removing 2 rows)',
       () => {
         const hot = handsontable({

--- a/handsontable/src/plugins/formulas/indexSyncer/axisSyncer.js
+++ b/handsontable/src/plugins/formulas/indexSyncer/axisSyncer.js
@@ -270,7 +270,7 @@ class AxisSyncer {
 
       const newSequence = this.#indexMapper.getIndexesSequence();
 
-      if (source === 'update') {
+      if (source === 'update' && newSequence.length > 0) {
         const relativeTransformation = this.#indexesSequence.map(index => newSequence.indexOf(index));
         const sheetDimensions = this.#indexSyncer.getEngine().getSheetDimensions(this.#indexSyncer.getSheetId());
         let sizeForAxis;


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
There was a need to add an extra conditional as remove action on index mapper is already updating an indexes and no more action related to updating is needed.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Tested row/column removal with UndoRedo plugin.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/1362

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] My change requires a change to the documentation.
