### PR TITLE
Fixed problems related to not syncing sheet rename from HF to HOT

### DIFF
--- a/.changelogs/10719.json
+++ b/.changelogs/10719.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed problems related to not syncing sheet rename from HF to HOT",
+  "type": "fixed",
+  "issueOrPR": 10719,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/formulas/__tests__/formulas.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/formulas.spec.js
@@ -2953,7 +2953,7 @@ describe('Formulas general', () => {
 
   describe('renaming sheet for HF instance', () => {
     it('should update HOT\'s plugin internal property', () => {
-      let hookTriggered = false;
+      let sheetNameInsideHook = '';
       const hfInstance = HyperFormula.buildEmpty({});
       const hot = handsontable({
         data: [
@@ -2971,15 +2971,13 @@ describe('Formulas general', () => {
       });
 
       hot.addHook('afterSheetRenamed', () => {
-        expect(hot.getPlugin('formulas').sheetName).toBe('Lorem Ipsum');
-
-        hookTriggered = true;
+        sheetNameInsideHook = hot.getPlugin('formulas').sheetName;
       });
 
       hfInstance.renameSheet(0, 'Lorem Ipsum');
 
       expect(hot.getPlugin('formulas').sheetName).toBe('Lorem Ipsum');
-      expect(hookTriggered).toBe(true);
+      expect(sheetNameInsideHook).toBe('Lorem Ipsum');
     });
 
     it('should not throw an error while performing actions on HOT with renamed sheet', () => {

--- a/handsontable/src/plugins/formulas/__tests__/formulas.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/formulas.spec.js
@@ -2951,6 +2951,65 @@ describe('Formulas general', () => {
     ]);
   });
 
+  describe('renaming sheet for HF instance', () => {
+    it('should update HOT\'s plugin internal property', () => {
+      let hookTriggered = false;
+      const hfInstance = HyperFormula.buildEmpty({});
+      const hot = handsontable({
+        data: [
+          ['01/03/1900'],
+          ['=A1']
+        ],
+        formulas: {
+          engine: hfInstance,
+          sheetName: 'Sheet1'
+        },
+        columns: [{
+          type: 'date',
+          dateFormat: 'DD/MM/YYYY'
+        }],
+      });
+
+      hot.addHook('afterSheetRenamed', () => {
+        expect(hot.getPlugin('formulas').sheetName).toBe('Lorem Ipsum');
+
+        hookTriggered = true;
+      });
+
+      hfInstance.renameSheet(0, 'Lorem Ipsum');
+
+      expect(hot.getPlugin('formulas').sheetName).toBe('Lorem Ipsum');
+      expect(hookTriggered).toBe(true);
+    });
+
+    it('should not throw an error while performing actions on HOT with renamed sheet', () => {
+      const hfInstance = HyperFormula.buildEmpty({});
+
+      handsontable({
+        data: [
+          ['01/03/1900'],
+          ['=A1']
+        ],
+        formulas: {
+          engine: hfInstance,
+          sheetName: 'Sheet1'
+        },
+        columns: [{
+          type: 'date',
+          dateFormat: 'DD/MM/YYYY'
+        }],
+      });
+
+      hfInstance.renameSheet(0, 'Lorem Ipsum');
+
+      expect(() => {
+        setDataAtCell(0, 1, 'new value');
+      }).not.toThrow();
+
+      expect(getDataAtCell(0, 1)).toBe('new value');
+    });
+  });
+
   describe('handling dates', () => {
     it('should handle date functions properly', () => {
       handsontable({

--- a/handsontable/src/plugins/formulas/formulas.js
+++ b/handsontable/src/plugins/formulas/formulas.js
@@ -1266,6 +1266,8 @@ export class Formulas extends BasePlugin {
    * @param {string} newDisplayName The new name of the sheet.
    */
   #onEngineSheetRenamed(oldDisplayName, newDisplayName) {
+    this.sheetName = newDisplayName;
+
     this.hot.runHooks('afterSheetRenamed', oldDisplayName, newDisplayName);
   }
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Added missing action syncing changes from HF to HOT.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Tested just case [from the issue](https://github.com/handsontable/dev-handsontable/issues/1362).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/1362

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] My change requires a change to the documentation.
