### PR TITLE
Fix a problem with the text editor missing the vertical scrollbar on cells with larger amounts of content.

### DIFF
--- a/.changelogs/10722.json
+++ b/.changelogs/10722.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed a problem with the text editor missing the vertical scrollbar on cells with larger amounts of content.",
+  "type": "fixed",
+  "issueOrPR": 10722,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/editors/textEditor/__tests__/textEditor.spec.js
+++ b/handsontable/src/editors/textEditor/__tests__/textEditor.spec.js
@@ -1820,6 +1820,57 @@ describe('TextEditor', () => {
     expect($editorInput.height()).toBe(84);
   });
 
+  it('allow scrolling the editor if its content exceeds the viewport height', async () => {
+    spec().$container[0].style.width = '';
+    spec().$container[0].style.height = '';
+    spec().$container[0].style.overflow = '';
+
+    handsontable({
+      data: createSpreadsheetData(4, 4),
+      wordWrap: false,
+      height: 250
+    });
+
+    setDataAtCell(2, 2, `\
+    The Dude abides...
+
+    I don't know about you, but I take
+    comfort in that. It's good knowin'
+    he's out there, the Dude, takin'
+    her easy for all us sinners.
+    Shoosh. I sure hope he makes The
+    finals. Welp, that about does her,
+    wraps her all up. Things seem to've
+    worked out pretty good for the
+    Dude'n Walter, and it was a purt
+    good story, dontcha think? Made me
+    laugh to beat the band. Parts,
+    anyway. I didn't like seein' Donny
+    go. But then, I happen to know that
+    there's a little Lebowski on the
+    way. I guess that's the way the
+    whole durned human comedy keeps
+    perpetuatin' it-self, down through
+    the generations, westward the
+    wagons, across the sands a time
+    until we-- aw, look at me, I'm
+    ramblin' again. Wal, uh hope you
+    folks enjoyed yourselves.
+    `);
+
+    selectCell(2, 2);
+
+    await sleep(150);
+
+    keyDownUp('enter');
+
+    const textareaElement = document.querySelector('textarea.handsontableInput');
+
+    await sleep(150);
+
+    expect(textareaElement.style.overflowY).toEqual('visible');
+  });
+
   // Input element can not lose the focus while entering new characters. It breaks IME editor functionality.
   it('should not lose the focus on input element while inserting new characters if `imeFastEdit` is enabled (#839)', async() => {
     const hot = handsontable({

--- a/handsontable/src/editors/textEditor/__tests__/textEditor.spec.js
+++ b/handsontable/src/editors/textEditor/__tests__/textEditor.spec.js
@@ -1820,7 +1820,7 @@ describe('TextEditor', () => {
     expect($editorInput.height()).toBe(84);
   });
 
-  it('allow scrolling the editor if its content exceeds the viewport height', async () => {
+  it('allow scrolling the editor if its content exceeds the viewport height', async() => {
     spec().$container[0].style.width = '';
     spec().$container[0].style.height = '';
     spec().$container[0].style.overflow = '';

--- a/handsontable/src/editors/textEditor/textEditor.js
+++ b/handsontable/src/editors/textEditor/textEditor.js
@@ -276,7 +276,6 @@ export class TextEditor extends BaseEditor {
     this.textareaParentStyle.opacity = '1';
 
     this.textareaStyle.textIndent = '';
-    this.textareaStyle.overflowY = 'hidden';
 
     const childNodes = this.TEXTAREA_PARENT.childNodes;
     let hasClassHandsontableEditor = false;

--- a/handsontable/src/utils/autoResize.js
+++ b/handsontable/src/utils/autoResize.js
@@ -197,7 +197,6 @@ export function createInputElementResizer(ownerDocument) {
 
     if (observedElement.nodeName === 'TEXTAREA') {
       observedElement.style.resize = 'none';
-      observedElement.style.overflowY = '';
       observedElement.style.height = `${defaults.minHeight}px`;
       observedElement.style.minWidth = `${defaults.minWidth}px`;
       observedElement.style.maxWidth = `${defaults.maxWidth}px`;


### PR DESCRIPTION
### Context
This PR removes a duplicate `TEXTAREA.style.overflowY` assignment from `textEditor`. With it present, the adjustments done by [`autoResize`](https://github.com/handsontable/handsontable/blob/30d8cc5603002b3de1ec2ce7dbc365a1253a5be1/handsontable/src/utils/autoResize.js) were canceled out.

### How has this been tested?
Added a test case with larger amounts of data.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#1664

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
