### PR TITLE
Remove the `renderAllRows` and `renderAllColumns` from init-time option type

### DIFF
--- a/handsontable/src/dataMap/metaManager/mods/extendMetaProperties.js
+++ b/handsontable/src/dataMap/metaManager/mods/extendMetaProperties.js
@@ -46,20 +46,21 @@ export class ExtendMetaPropertiesMod {
         }
       }
     }],
-    ['renderAllColumns', {
-      onChange(propName, value, isInitialChange) {
-        if (!isInitialChange) {
-          throw new Error(`The \`${propName}\` option can not be updated after the Handsontable is initialized.`);
-        }
-      }
-    }],
-    ['renderAllRows', {
-      onChange(propName, value, isInitialChange) {
-        if (!isInitialChange) {
-          throw new Error(`The \`${propName}\` option can not be updated after the Handsontable is initialized.`);
-        }
-      }
-    }],
+    // Temporary commented out due to the bug in the React wrapper.
+    // ['renderAllColumns', {
+    //   onChange(propName, value, isInitialChange) {
+    //     if (!isInitialChange) {
+    //       throw new Error(`The \`${propName}\` option can not be updated after the Handsontable is initialized.`);
+    //     }
+    //   }
+    // }],
+    // ['renderAllRows', {
+    //   onChange(propName, value, isInitialChange) {
+    //     if (!isInitialChange) {
+    //       throw new Error(`The \`${propName}\` option can not be updated after the Handsontable is initialized.`);
+    //     }
+    //   }
+    // }],
   ]);
 
   constructor(metaManager) {

--- a/handsontable/test/e2e/settings/renderAllColumns.spec.js
+++ b/handsontable/test/e2e/settings/renderAllColumns.spec.js
@@ -26,17 +26,5 @@ describe('settings', () => {
 
       expect(hot.view._wt.getSetting('renderAllColumns')).toBe(true);
     });
-
-    it('should not be possible to change the value after table initialization', () => {
-      handsontable({
-        renderAllColumns: false,
-      });
-
-      expect(() => {
-        updateSettings({
-          renderAllColumns: true,
-        });
-      }).toThrowError('The `renderAllColumns` option can not be updated after the Handsontable is initialized.');
-    });
   });
 });

--- a/handsontable/test/e2e/settings/renderAllRows.spec.js
+++ b/handsontable/test/e2e/settings/renderAllRows.spec.js
@@ -26,17 +26,5 @@ describe('settings', () => {
 
       expect(hot.view._wt.getSetting('renderAllRows')).toBe(true);
     });
-
-    it('should not be possible to change the value after table initialization', () => {
-      handsontable({
-        renderAllRows: false,
-      });
-
-      expect(() => {
-        updateSettings({
-          renderAllRows: true,
-        });
-      }).toThrowError('The `renderAllRows` option can not be updated after the Handsontable is initialized.');
-    });
   });
 });


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR removes the `renderAllRows` and `renderAllColumns` options from the init-time option types.

_[skip changelog]_

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
