### PR TITLE
Update accessibility links in column and row virtualization guides

### DIFF
--- a/docs/content/guides/columns/column-virtualization.md
+++ b/docs/content/guides/columns/column-virtualization.md
@@ -123,7 +123,7 @@ Using column virtualization has the following side effects:
 
 - The browser's native search will work only for the visible part of the grid.
 - Screen readers may announce the wrong total number of columns. Read more in the
-  [Accessibility](@/guides/accessibility/accessibility.md#configure-virtualization) guide.
+  [Accessibility](@/guides/accessibility/accessibility.md#disabling-dom-virtualization-for-improved-accessibility) guide.
 
 ## Related articles
 

--- a/docs/content/guides/rows/row-virtualization.md
+++ b/docs/content/guides/rows/row-virtualization.md
@@ -127,7 +127,7 @@ Using row virtualization has the following side effects:
 
 - The browser's native search will work only for the visible part of the grid.
 - Screen readers may announce the wrong total number of rows. Read more in the
-  [Accessibility](@/guides/accessibility/accessibility.md#configure-virtualization) guide.
+  [Accessibility](@/guides/accessibility/accessibility.md#disabling-dom-virtualization-for-improved-accessibility) guide.
 
 ## Related articles
 

--- a/handsontable/src/plugins/columnSummary/columnSummary.js
+++ b/handsontable/src/plugins/columnSummary/columnSummary.js
@@ -32,7 +32,7 @@ export const PLUGIN_PRIORITY = 220;
  * | `reversedRowCoords` | No | Boolean | `false` | [Reverses row coordinates](@/guides/columns/column-summary.md#step-5-make-room-for-the-destination-cell) |
  * | `suppressDataTypeErrors` | No | Boolean | `true` | [Suppresses data type errors](@/guides/columns/column-summary.md#throw-data-type-errors) |
  * | `readOnly` | No | Boolean | `true` | Makes summary cell read-only |
- * | `roundFloat` | No | Number/Boolean | - | [Rounds summary result](@/guides/columns/column-summary.md#round-a-column-summary-result) |
+ * | `roundFloat` | No | Number/<br>Boolean | - | [Rounds summary result](@/guides/columns/column-summary.md#round-a-column-summary-result) |
  * | `customFunction` | No | Function | - | [Lets you add a custom summary function](@/guides/columns/column-summary.md#implement-a-custom-summary-function) |
  *
  * @example


### PR DESCRIPTION
[skip changelog]
Update links to accessibility.md in

- docs/content/guides/columns/column-virtualization.md
- docs/content/guides/rows/row-virtualization.md

### How has this been tested?
Locally
