### PR TITLE
Drop settings prop from HotTable

### DIFF
--- a/wrappers/react/src/hotTableClass.tsx
+++ b/wrappers/react/src/hotTableClass.tsx
@@ -355,7 +355,7 @@ class HotTableClass extends React.Component<HotTableProps, {}> {
       newSettings.editor = this.getEditorClass(globalEditorNode, GLOBAL_EDITOR_SCOPE);
 
     } else {
-      newSettings.editor = this.props.editor || (this.props.settings ? this.props.settings.editor : void 0);
+      newSettings.editor = this.props.editor || undefined;
     }
 
     if (globalRendererNode) {
@@ -363,7 +363,7 @@ class HotTableClass extends React.Component<HotTableProps, {}> {
       this.componentRendererColumns.set('global', true);
 
     } else {
-      newSettings.renderer = this.props.renderer || (this.props.settings ? this.props.settings.renderer : void 0);
+      newSettings.renderer = this.props.renderer || undefined;
     }
 
     return newSettings;

--- a/wrappers/react/src/settingsMapper.ts
+++ b/wrappers/react/src/settingsMapper.ts
@@ -3,7 +3,7 @@ import { HotTableProps } from './types';
 
 export class SettingsMapper {
   /**
-   * Parse component settings into Handosntable-compatible settings.
+   * Parse component settings into Handsontable-compatible settings.
    *
    * @param {Object} properties Object containing properties from the HotTable object.
    * @returns {Object} Handsontable-compatible settings object.
@@ -11,17 +11,8 @@ export class SettingsMapper {
   static getSettings(properties: HotTableProps): Handsontable.GridSettings {
     let newSettings: Handsontable.GridSettings = {};
 
-    if (properties.settings) {
-      let settings = properties.settings;
-      for (const key in settings) {
-        if (settings.hasOwnProperty(key)) {
-          newSettings[key] = settings[key];
-        }
-      }
-    }
-
     for (const key in properties) {
-      if (key !== 'settings' && key !== 'children' && properties.hasOwnProperty(key)) {
+      if (key !== 'children' && properties.hasOwnProperty(key)) {
         newSettings[key] = properties[key];
       }
     }

--- a/wrappers/react/src/types.tsx
+++ b/wrappers/react/src/types.tsx
@@ -25,7 +25,6 @@ export interface HotTableProps extends Handsontable.GridSettings {
   id?: string,
   className?: string,
   style?: React.CSSProperties,
-  settings?: Handsontable.GridSettings
   children?: React.ReactNode
 }
 
@@ -43,7 +42,6 @@ export interface HotEditorProps {
  * Properties related to the HotColumn architecture.
  */
 export interface HotColumnProps extends Handsontable.ColumnSettings {
-  settings?: Handsontable.ColumnSettings;
   _componentRendererColumns?: Map<number | string, boolean>;
   _emitColumnSettings?: (columnSettings: Handsontable.ColumnSettings, columnIndex: number) => void;
   _columnIndex?: number,

--- a/wrappers/react/test/_helpers.tsx
+++ b/wrappers/react/test/_helpers.tsx
@@ -205,32 +205,6 @@ class IndividualPropsWrapper extends React.Component<{ref?: string, id?: string}
 
 export { IndividualPropsWrapper };
 
-class SingleObjectWrapper extends React.Component<{ref?: string, id?: string}, {hotSettings?: object}> {
-  hotTable: typeof HotTable;
-  state = {};
-
-  private setHotElementRef(component: typeof HotTable): void {
-    this.hotTable = component;
-  }
-
-  render(): React.ReactElement {
-    return (
-      <div>
-        <HotTable
-          licenseKey="non-commercial-and-evaluation"
-          ref={this.setHotElementRef.bind(this)}
-          id="hot"
-          settings={this.state.hotSettings}
-          autoRowSize={false}
-          autoColumnSize={false}
-        />
-      </div>
-    );
-  }
-}
-
-export { SingleObjectWrapper };
-
 export class RendererComponent extends React.Component<any, any> {
   render(): React.ReactElement<string> {
     return (

--- a/wrappers/react/test/hotColumn.spec.tsx
+++ b/wrappers/react/test/hotColumn.spec.tsx
@@ -53,20 +53,6 @@ describe('Passing column settings using HotColumn', () => {
 
     expect(hotInstance.getCell(0, 0).innerHTML).toEqual(dataKeyCellValue);
   });
-
-  it('should apply column settings through the `settings` prop', async () => {
-    const hotInstance = mountComponentWithRef((
-      <HotTable
-        licenseKey="non-commercial-and-evaluation"
-        colHeaders={true}
-      >
-        <HotColumn settings={{ title: 'test', readOnly: true }}></HotColumn>
-      </HotTable>
-    )).hotInstance;
-
-    expect(hotInstance.getCellMeta(0, 0).readOnly).toBe(true);
-    expect(hotInstance.getCell(-1, 0).querySelector('span').innerHTML).toBe('test');
-  });
 });
 
 describe('Renderer configuration using React components', () => {

--- a/wrappers/react/test/hotTable.spec.tsx
+++ b/wrappers/react/test/hotTable.spec.tsx
@@ -9,7 +9,6 @@ import {
   mockElementDimensions,
   RendererComponent,
   EditorComponent,
-  SingleObjectWrapper,
   sleep,
   simulateKeyboardEvent,
   simulateMouseEvent,
@@ -52,7 +51,7 @@ describe('Handsontable initialization', () => {
 });
 
 describe('Updating the Handsontable settings', () => {
-  it('should call the updateSettings method of Handsontable, when the component properties get updated (when providing properties individually)', async () => {
+  it('should call the updateSettings method of Handsontable, when the component properties get updated', async () => {
     const componentInstance = mountComponentWithRef((
       <IndividualPropsWrapper/>
     ));
@@ -80,64 +79,9 @@ describe('Updating the Handsontable settings', () => {
     expect(updateSettingsCount).toEqual(1);
   });
 
-  it('should call the updateSettings method of Handsontable, when the component properties get updated (when providing properties as a single settings object)', async () => {
-    const componentInstance = mountComponentWithRef((
-      <SingleObjectWrapper/>
-    ));
-
-    const hotInstance = componentInstance.hotTable.hotInstance;
-    let updateSettingsCount = 0;
-
-    hotInstance.addHook('afterUpdateSettings', () => {
-      updateSettingsCount++;
-    });
-
-    await sleep(300);
-
-    await act(async () => {
-      componentInstance.setState({
-        hotSettings: {
-          data: [[2]],
-          contextMenu: true,
-          readOnly: true
-        }
-      });
-    });
-
-    expect(updateSettingsCount).toEqual(1);
-  });
-
-  it('should update the Handsontable options, when the component properties get updated (when providing properties individually)', async () => {
+  it('should update the Handsontable options, when the component properties get updated', async () => {
     const componentInstance = mountComponentWithRef((
       <IndividualPropsWrapper/>
-    ));
-
-    const hotInstance = componentInstance.hotTable.hotInstance;
-
-    expect(hotInstance.getSettings().contextMenu).toEqual(void 0);
-    expect(hotInstance.getSettings().readOnly).toEqual(false);
-    expect(JSON.stringify(hotInstance.getSettings().data)).toEqual('[[null,null,null,null,null],[null,null,null,null,null],[null,null,null,null,null],[null,null,null,null,null],[null,null,null,null,null]]');
-
-    await sleep(300);
-
-    await act(async () => {
-      componentInstance.setState({
-        hotSettings: {
-          data: [[2]],
-          contextMenu: true,
-          readOnly: true
-        }
-      });
-    });
-
-    expect(hotInstance.getSettings().contextMenu).toBe(true);
-    expect(hotInstance.getSettings().readOnly).toBe(true);
-    expect(JSON.stringify(hotInstance.getSettings().data)).toEqual('[[2]]');
-  });
-
-  it('should update the Handsontable options, when the component properties get updated (when providing properties as a single settings object)', async () => {
-    const componentInstance = mountComponentWithRef((
-      <SingleObjectWrapper/>
     ));
 
     const hotInstance = componentInstance.hotTable.hotInstance;

--- a/wrappers/react/test/settingsMapper.spec.tsx
+++ b/wrappers/react/test/settingsMapper.spec.tsx
@@ -3,7 +3,7 @@ import { HotTableProps } from '../src/types';
 
 describe('Settings mapper unit tests', () => {
   describe('getSettings', () => {
-    it('should return a valid settings object, when provided an object with settings (including the hooks prefixed with "on")', () => {
+    it('should return a valid settings object, when provided an object with settings (including the hooks)', () => {
       const settingsMapper = new SettingsMapper();
 
       const initial: HotTableProps = {
@@ -33,74 +33,6 @@ describe('Settings mapper unit tests', () => {
       expect(JSON.stringify(result.afterRender)).toEqual(JSON.stringify(initial.afterRender));
       expect(result.afterChange()).toEqual('works!');
       expect(result.afterRender()).toEqual('also works!');
-    });
-
-    it('should return a valid settings object, when provided an object with settings inside a "settings" property (including the hooks prefixed with "on")', () => {
-      const settingsMapper = new SettingsMapper();
-      const initial = {
-        settings: {
-          width: 300,
-          height: 300,
-          contextMenu: true,
-          columns: [
-            {label: 'first label'},
-            {label: 'second label'}
-          ],
-          afterChange: () => {
-            return 'works!';
-          },
-          afterRender: () => {
-            return 'also works!';
-          }
-        }
-      };
-      const result: {[key: string]: any} = SettingsMapper.getSettings(initial);
-
-      expect(!!result.width && !!result.height && !!result.contextMenu && !!result.columns && !!result.afterChange && !!result.afterRender).toEqual(true);
-      expect(Object.keys(initial.settings).length).toEqual(Object.keys(result).length);
-      expect(result.width).toEqual(300);
-      expect(result.height).toEqual(300);
-      expect(result.contextMenu).toEqual(true);
-      expect(JSON.stringify(initial.settings.columns)).toEqual(JSON.stringify(result.columns));
-      expect(JSON.stringify(result.afterChange)).toEqual(JSON.stringify(initial.settings.afterChange));
-      expect(JSON.stringify(result.afterRender)).toEqual(JSON.stringify(initial.settings.afterRender));
-      expect(result.afterChange()).toEqual('works!');
-      expect(result.afterRender()).toEqual('also works!');
-      expect(result.settings).toEqual(void 0);
-    });
-
-    it('should return a valid settings object, when provided an object with settings inside a "settings" property as well as individually (including the hooks prefixed with "on")', () => {
-      const settingsMapper = new SettingsMapper();
-      const initial = {
-        width: 300,
-        height: 300,
-        settings: {
-          contextMenu: true,
-          columns: [
-            {label: 'first label'},
-            {label: 'second label'}
-          ],
-          afterChange: () => {
-            return 'works!';
-          },
-          afterRender: () => {
-            return 'also works!';
-          }
-        }
-      };
-      const result: {[key: string]: any} = SettingsMapper.getSettings(initial);
-
-      expect(!!result.width && !!result.height && !!result.contextMenu && !!result.columns && !!result.afterChange && !!result.afterRender).toEqual(true);
-      expect(Object.keys(initial.settings).length + Object.keys(initial).length - 1).toEqual(Object.keys(result).length);
-      expect(result.width).toEqual(300);
-      expect(result.height).toEqual(300);
-      expect(result.contextMenu).toEqual(true);
-      expect(JSON.stringify(initial.settings.columns)).toEqual(JSON.stringify(result.columns));
-      expect(JSON.stringify(result.afterChange)).toEqual(JSON.stringify(initial.settings.afterChange));
-      expect(JSON.stringify(result.afterRender)).toEqual(JSON.stringify(initial.settings.afterRender));
-      expect(result.afterChange()).toEqual('works!');
-      expect(result.afterRender()).toEqual('also works!');
-      expect(result.settings).toEqual(void 0);
     });
   });
 });


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
I don't see any usages of `settings` prop in docs or examples and it creates a dual interface - a user can pass things both directly into `HotTable` props or via `settings` object. Firstly, it's not clear which one wins in case of conflicts. Secondly, passing objects into props unnecessarily increase the risk of re-renders caused by new object instances being created on every parent render. Thirdly, it creates a bit of complexity to the internal code. 

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Unit tests ensuring the preferred method of passing settings (in props directly) still works. But mostly code removal.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. Discussion in RFC: https://gist.github.com/evanSe/8c67315d837873c7f32f7446f027e5e7?permalink_comment_id=4824890#gistcomment-4824890

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [x] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
