### PR TITLE
Fix row height miscalculations for hidden indexes

### DIFF
--- a/handsontable/src/plugins/autoRowSize/__tests__/autoRowSize.spec.js
+++ b/handsontable/src/plugins/autoRowSize/__tests__/autoRowSize.spec.js
@@ -584,6 +584,28 @@ describe('AutoRowSize', () => {
     expect(getRowHeight(2)).toBe(23);
   });
 
+  it('should correctly apply the column widths to the measured row when the first column is hidden (#dev-569)', () => {
+    const data = createSpreadsheetData(1, 6);
+
+    data[0][2] = 'Some text';
+    data[0][4] = 'Some longer text';
+    data[0][5] = 'Very long text that causes the column to be wide';
+
+    handsontable({
+      data,
+      colHeaders: true,
+      autoRowSize: true,
+      autoColumnSize: true, // this is required to replicate the issue
+    });
+
+    const hidingMap = columnIndexMapper().createAndRegisterIndexMap('my-hiding-map', 'hiding');
+
+    hidingMap.setValueAtIndex(0, true);
+    render();
+
+    expect(getRowHeight(0)).toBe(23);
+  });
+
   it('should not throw error while traversing header\'s DOM elements', () => {
     const onErrorSpy = spyOn(window, 'onerror');
 

--- a/handsontable/src/utils/ghostTable.js
+++ b/handsontable/src/utils/ghostTable.js
@@ -59,7 +59,7 @@ class GhostTable {
   /**
    * Add row.
    *
-   * @param {number} row Row index.
+   * @param {number} row Visual row index.
    * @param {Map} samples Samples Map object.
    */
   addRow(row, samples) {
@@ -112,7 +112,7 @@ class GhostTable {
   /**
    * Add column.
    *
-   * @param {number} column Column index.
+   * @param {number} column Visual column index.
    * @param {Map} samples A map with sampled table values.
    */
   addColumn(column, samples) {
@@ -251,7 +251,7 @@ class GhostTable {
   /**
    * Create table row element.
    *
-   * @param {number} row Row index.
+   * @param {number} row Visual row index.
    * @returns {DocumentFragment} Returns created table row elements.
    */
   createRow(row) {
@@ -326,7 +326,7 @@ class GhostTable {
   /**
    * Create table column elements.
    *
-   * @param {number} column Column index.
+   * @param {number} column Visual column index.
    * @returns {DocumentFragment} Returns created column table column elements.
    */
   createCol(column) {
@@ -410,11 +410,11 @@ class GhostTable {
       colspan = this.hot.getCellMeta(row, column).colspan;
     }
 
-    let width = this.hot.view._wt.wtTable.getStretchedColumnWidth(column);
+    let width = this.hot.getColWidth(column);
 
     if (colspan > 1) {
       for (let nextColumn = column + 1; nextColumn < column + colspan; nextColumn++) {
-        width += this.hot.view._wt.wtTable.getStretchedColumnWidth(nextColumn);
+        width += this.hot.getColWidth(nextColumn);
       }
     }
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the row height miscalculations for hidden columns. It's turned out that there is an argument mismatch in the _GhostTable_ module. The wrong method was used to calculate the columns' widths when generating columns for rows. The visual column was passed to the method that accepts the renderable column indexes. The PR fixes that by using the correct method for this job.

This PR is a continuation of [that changes](https://github.com/handsontable/handsontable/pull/10705).

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally using the demo provided in [the issue](https://github.com/handsontable/dev-handsontable/issues/569), and I covered the fix with a new test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/569

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
