### PR TITLE
Cells pasted from clipboard's tables won't contain unnecessary line breaks

### DIFF
--- a/.changelogs/10745.json
+++ b/.changelogs/10745.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Cells pasted from clipboard's tables won't contain unnecessary line breaks",
+  "type": "fixed",
+  "issueOrPR": 10745,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/utils/__tests__/parseTable.unit.js
+++ b/handsontable/src/utils/__tests__/parseTable.unit.js
@@ -3,6 +3,7 @@ import Handsontable from '../../index';
 import { registerCellType, TextCellType } from '../../cellTypes';
 import { IntersectionObserverMock } from '../../../test/__mocks__/intersectionObserverMock';
 import { ResizeObserverMock } from '../../../test/__mocks__/resizeObserverMock';
+import { toSingleLine } from '../../helpers/templateLiteralTag';
 
 registerCellType(TextCellType);
 
@@ -302,6 +303,85 @@ describe('htmlToGridSettings', () => {
     expect(config.mergeCells[1].row).toBe(3);
     expect(config.mergeCells[1].colspan).toBe(1);
     expect(config.mergeCells[1].rowspan).toBe(4);
+  });
+
+  it('should parse table copied from Word properly', () => {
+    const htmlToParse = `
+      <table class=MsoTableGrid border=1 cellspacing=0 cellpadding=0
+       style='border-collapse:collapse;border:none;mso-border-alt:solid windowtext .5pt;
+       mso-yfti-tbllook:1184;mso-padding-alt:0cm 5.4pt 0cm 5.4pt'>
+       <tr style='mso-yfti-irow:0;mso-yfti-firstrow:yes'>
+        <td width=604 valign=top style='width:453.1pt;border:solid windowtext 1.0pt;
+        mso-border-alt:solid windowtext .5pt;padding:0cm 5.4pt 0cm 5.4pt'>
+        <p class=MsoNormal><span style='font-size:11.0pt;mso-font-kerning:0pt;
+        mso-ligatures:none'>Some very long text with no line breaks inside table
+        cell. Some very long text with no line breaks<o:p></o:p></span></p>
+        <p class=MsoNormal><span style='font-size:11.0pt;mso-font-kerning:0pt;
+        mso-ligatures:none'><o:p>&nbsp;</o:p></span></p>
+        <p class=MsoNormal><span style='font-size:11.0pt;mso-font-kerning:0pt;
+        mso-ligatures:none'><o:p>&nbsp;</o:p></span></p>
+        <p class=MsoNormal><span style='font-size:11.0pt;mso-font-kerning:0pt;
+        mso-ligatures:none'>ins table cell. Some very long text with no line breaks
+        inside table cell. Some very long text with no line breaks inside table cell.
+        Some very long text with no line breaks inside table cell. Some very long
+        text with no line breaks inside table cell. Some very long text with no line
+        breaks inside table cell. Some very long text with no line breaks inside
+        table cell. Some very long text with no line breaks inside table cell. Some
+        very long text with no line breaks inside table cell. Some very long text
+        with no line breaks inside table cell. Some very long text with no line
+        breaks inside table cell. Some very long text with no line breaks inside
+        table cell. Some very long text with no line breaks inside table cell. Some
+        very long text with no line breaks inside table cell. Some very long text
+        with no line breaks inside table cell. Some very long text with no line
+        breaks inside table cell. Some very long text with no line breaks inside
+        table cell. Some very long text with no line breaks inside table cell. Some
+        very long text with no line breaks inside table cell. Some very long text
+        with no line breaks inside table cell. Some very long text with no line
+        breaks inside table cell. Some very long text with no line breaks inside
+        table cell. Some very long text with no line breaks inside table cell.<o:p></o:p></span></p>
+        </td>
+       </tr>
+       <tr style='mso-yfti-irow:1;mso-yfti-lastrow:yes'>
+        <td width=604 valign=top style='width:453.1pt;border:solid windowtext 1.0pt;
+        border-top:none;mso-border-top-alt:solid windowtext .5pt;mso-border-alt:solid windowtext .5pt;
+        padding:0cm 5.4pt 0cm 5.4pt'>
+        <p class=MsoNormal><span style='font-size:11.0pt;mso-font-kerning:0pt;
+        mso-ligatures:none'>Another very long text with no line breaks inside table
+        cell. <span style='mso-spacerun:yes'>       </span>Some very long text with
+        no line breaks <span style='mso-spacerun:yes'>     </span>o line breo line
+        breo line breo line breo line bre<o:p></o:p></span></p>
+        <p class=MsoNormal><span style='font-size:11.0pt;mso-font-kerning:0pt;
+        mso-ligatures:none'><o:p>&nbsp;</o:p></span></p>
+        <p class=MsoNormal><span style='font-size:11.0pt;mso-font-kerning:0pt;
+        mso-ligatures:none'>NEW LINE<o:p></o:p></span></p>
+        </td>
+       </tr>
+      </table>`;
+
+    const config = htmlToGridSettings(htmlToParse);
+
+    expect(config.data).toEqual([[
+      'Some very long text with no line breaks inside table cell. Some very long text with no line breaks' +
+      '\n\n\n' +
+      'ins table cell. Some very long text with no line breaks inside table cell. Some very long text with no line ' +
+      'breaks inside table cell. Some very long text with no line breaks inside table cell. Some very long text with ' +
+      'no line breaks inside table cell. Some very long text with no line breaks inside table cell. Some very long ' +
+      'text with no line breaks inside table cell. Some very long text with no line breaks inside table cell. Some ' +
+      'very long text with no line breaks inside table cell. Some very long text with no line breaks inside table ' +
+      'cell. Some very long text with no line breaks inside table cell. Some very long text with no line breaks ' +
+      'inside table cell. Some very long text with no line breaks inside table cell. Some very long text with no ' +
+      'line breaks inside table cell. Some very long text with no line breaks inside table cell. Some very long ' +
+      'text with no line breaks inside table cell. Some very long text with no line breaks inside table cell. Some ' +
+      'very long text with no line breaks inside table cell. Some very long text with no line breaks inside table ' +
+      'cell. Some very long text with no line breaks inside table cell. Some very long text with no line breaks ' +
+      'inside table cell. Some very long text with no line breaks inside table cell. Some very long text with no ' +
+      'line breaks inside table cell.'
+    ], [
+      'Another very long text with no line breaks inside table cell.        Some very long text with no line ' +
+      'breaks      o line breo line breo line breo line breo line bre' +
+      '\n\n' +
+      'NEW LINE'
+    ]]);
   });
 
   describe('nestedHeaders', () => {

--- a/handsontable/src/utils/__tests__/parseTable.unit.js
+++ b/handsontable/src/utils/__tests__/parseTable.unit.js
@@ -305,6 +305,7 @@ describe('htmlToGridSettings', () => {
   });
 
   it('should parse table with long text properly', () => {
+    /* eslint-disable no-irregular-whitespace */
     const htmlToParse = `
       <table>
        <tr>
@@ -344,6 +345,7 @@ describe('htmlToGridSettings', () => {
         </td>
        </tr>
       </table>`;
+    /* eslint-enable */
 
     const config = htmlToGridSettings(htmlToParse);
 

--- a/handsontable/src/utils/__tests__/parseTable.unit.js
+++ b/handsontable/src/utils/__tests__/parseTable.unit.js
@@ -3,7 +3,6 @@ import Handsontable from '../../index';
 import { registerCellType, TextCellType } from '../../cellTypes';
 import { IntersectionObserverMock } from '../../../test/__mocks__/intersectionObserverMock';
 import { ResizeObserverMock } from '../../../test/__mocks__/resizeObserverMock';
-import { toSingleLine } from '../../helpers/templateLiteralTag';
 
 registerCellType(TextCellType);
 
@@ -305,23 +304,16 @@ describe('htmlToGridSettings', () => {
     expect(config.mergeCells[1].rowspan).toBe(4);
   });
 
-  it('should parse table copied from Word properly', () => {
+  it('should parse table with long text properly', () => {
     const htmlToParse = `
-      <table class=MsoTableGrid border=1 cellspacing=0 cellpadding=0
-       style='border-collapse:collapse;border:none;mso-border-alt:solid windowtext .5pt;
-       mso-yfti-tbllook:1184;mso-padding-alt:0cm 5.4pt 0cm 5.4pt'>
-       <tr style='mso-yfti-irow:0;mso-yfti-firstrow:yes'>
-        <td width=604 valign=top style='width:453.1pt;border:solid windowtext 1.0pt;
-        mso-border-alt:solid windowtext .5pt;padding:0cm 5.4pt 0cm 5.4pt'>
-        <p class=MsoNormal><span style='font-size:11.0pt;mso-font-kerning:0pt;
-        mso-ligatures:none'>Some very long text with no line breaks inside table
-        cell. Some very long text with no line breaks<o:p></o:p></span></p>
-        <p class=MsoNormal><span style='font-size:11.0pt;mso-font-kerning:0pt;
-        mso-ligatures:none'><o:p>&nbsp;</o:p></span></p>
-        <p class=MsoNormal><span style='font-size:11.0pt;mso-font-kerning:0pt;
-        mso-ligatures:none'><o:p>&nbsp;</o:p></span></p>
-        <p class=MsoNormal><span style='font-size:11.0pt;mso-font-kerning:0pt;
-        mso-ligatures:none'>ins table cell. Some very long text with no line breaks
+      <table>
+       <tr>
+        <td>
+        <p><span>Some very long text with no line breaks inside table
+        cell. Some very long text with no line breaks</span></p>
+        <p><span>&nbsp;</span></p>
+        <p><span>&nbsp;</span></p>
+        <p><span>ins table cell. Some very long text with no line breaks
         inside table cell. Some very long text with no line breaks inside table cell.
         Some very long text with no line breaks inside table cell. Some very long
         text with no line breaks inside table cell. Some very long text with no line
@@ -338,22 +330,17 @@ describe('htmlToGridSettings', () => {
         very long text with no line breaks inside table cell. Some very long text
         with no line breaks inside table cell. Some very long text with no line
         breaks inside table cell. Some very long text with no line breaks inside
-        table cell. Some very long text with no line breaks inside table cell.<o:p></o:p></span></p>
+        table cell. Some very long text with no line breaks inside table cell.</span></p>
         </td>
        </tr>
-       <tr style='mso-yfti-irow:1;mso-yfti-lastrow:yes'>
-        <td width=604 valign=top style='width:453.1pt;border:solid windowtext 1.0pt;
-        border-top:none;mso-border-top-alt:solid windowtext .5pt;mso-border-alt:solid windowtext .5pt;
-        padding:0cm 5.4pt 0cm 5.4pt'>
-        <p class=MsoNormal><span style='font-size:11.0pt;mso-font-kerning:0pt;
-        mso-ligatures:none'>Another very long text with no line breaks inside table
-        cell. <span style='mso-spacerun:yes'>       </span>Some very long text with
-        no line breaks <span style='mso-spacerun:yes'>     </span>o line breo line
-        breo line breo line breo line bre<o:p></o:p></span></p>
-        <p class=MsoNormal><span style='font-size:11.0pt;mso-font-kerning:0pt;
-        mso-ligatures:none'><o:p>&nbsp;</o:p></span></p>
-        <p class=MsoNormal><span style='font-size:11.0pt;mso-font-kerning:0pt;
-        mso-ligatures:none'>NEW LINE<o:p></o:p></span></p>
+       <tr>
+        <td>
+        <p><span>Another very long text with no line breaks inside table
+        cell. <span>       </span>Some very long text with
+        no line breaks <span>     </span>o line breo line
+        breo line breo line breo line bre</span></p>
+        <p><span>&nbsp;</span></p>
+        <p><span>NEW LINE</span></p>
         </td>
        </tr>
       </table>`;

--- a/handsontable/src/utils/parseTable.js
+++ b/handsontable/src/utils/parseTable.js
@@ -171,8 +171,16 @@ export function htmlToGridSettings(element, rootDocument = document) {
   if (typeof checkElement === 'string') {
     const escapedAdjacentHTML = checkElement.replace(/<td\b[^>]*?>([\s\S]*?)<\/\s*td>/g, (cellFragment) => {
       const openingTag = cellFragment.match(/<td\b[^>]*?>/g)[0];
+      const paragraphRegexp = /<p.*?>/g;
       const cellValue = cellFragment
-        .substring(openingTag.length, cellFragment.lastIndexOf('<')).replace(/(<(?!br)([^>]+)>)/gi, '');
+        .substring(openingTag.length, cellFragment.lastIndexOf('<'))
+        .trim() // Removing whitespaces from the start and the end of HTML fragment
+        .replaceAll(/\n\s+/g, ' ') // HTML tags may be split using multiple new lines and whitespaces
+        .replaceAll(paragraphRegexp, '\n') // Only paragraphs should split text using new line characters
+        .replace('\n', '') // First paragraph shouldn't start with new line characters
+        .replaceAll(/<\/(.*)>\s+$/mg, '</$1>') // HTML tags may end with whitespace.
+        .replace(/(<(?!br)([^>]+)>)/gi, '') // Removing HTML tags
+        .replaceAll(/^&nbsp;$/mg, ''); // Removing single &nbsp; characters separating new lines
       const closingTag = '</td>';
 
       return `${openingTag}${cellValue}${closingTag}`;


### PR DESCRIPTION
### Context
The [described bug](https://github.com/handsontable/dev-handsontable/issues/1597) also occurs for MacOS and Chrome browser. I've found a case which shows that problem. Finally, after a deeper investigation, I've discovered that it's not related only to Word files and tables inside them. The issue relates to how we parsed whitespaces as part of the HTML snippet. Word splits long text into a few lines for better readability. Until now, extra spaces (added to break text) have been preserved. That won't be done anymore. The only spaces are stored as `&nbsp` elements inside HTML elements, and we filter out other space characters.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Tested different tables with spaces at the start and the end of a single line/whole snippet.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/1597

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] My change requires a change to the documentation.
