### PR TITLE
Undo will work for moving columns

### DIFF
--- a/.changelogs/10746.json
+++ b/.changelogs/10746.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Undo will work for moving columns",
+  "type": "added",
+  "issueOrPR": 10746,
+  "breaking": false,
+  "framework": "none"
+}

--- a/docs/content/guides/getting-started/installation.md
+++ b/docs/content/guides/getting-started/installation.md
@@ -147,6 +147,8 @@ const hot = new Handsontable(container, {
   rowHeaders: true,
   colHeaders: true,
   height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
   licenseKey: 'non-commercial-and-evaluation' // for non-commercial use only
 });
 ```

--- a/handsontable/src/helpers/moves.js
+++ b/handsontable/src/helpers/moves.js
@@ -1,0 +1,92 @@
+/**
+ * Gets first position where to move element (respecting the fact that some element will be sooner or later
+ * taken out of the dataset in order to move them).
+ *
+ * @param {Array<number>} movedIndexes Sequence of moved indexes for certain axis.
+ * @param {number} finalIndex Final place where to move rows.
+ * @param {number} numberOfIndexes Number of indexes in a dataset.
+ * @returns {number} Index informing where to move the first element.
+ */
+function getMoveLine(movedIndexes, finalIndex, numberOfIndexes) {
+  const notMovedElements = Array.from(Array(numberOfIndexes).keys())
+    .filter(index => movedIndexes.includes(index) === false);
+
+  if (finalIndex === 0) {
+    return notMovedElements[finalIndex] ?? 0; // Moving before the first dataset's element.
+  }
+
+  return notMovedElements[finalIndex - 1] + 1; // Moving before another element.
+}
+
+/**
+ * Gets initially calculated move positions.
+ *
+ * @param {Array<number>} movedIndexes Sequence of moved indexes for certain axis.
+ * @param {number} moveLine Final place where to move rows.
+ * @returns {Array<{from: number, to: number}>} Initially calculated move positions.
+ */
+function getInitiallyCalculatedMoves(movedIndexes, moveLine) {
+  const moves = [];
+
+  movedIndexes.forEach((movedIndex) => {
+    const move = {
+      from: movedIndex,
+      to: moveLine,
+    };
+
+    moves.forEach((previouslyMovedIndex) => {
+      const isMovingFromEndToStart = previouslyMovedIndex.from > previouslyMovedIndex.to;
+      const isMovingElementBefore = previouslyMovedIndex.to <= move.from;
+      const isMovingAfterElement = previouslyMovedIndex.from > move.from;
+
+      if (isMovingAfterElement && isMovingElementBefore && isMovingFromEndToStart) {
+        move.from += 1;
+      }
+    });
+
+    // Moved element from right to left (or bottom to top).
+    if (move.from >= moveLine) {
+      moveLine += 1;
+    }
+
+    moves.push(move);
+  });
+
+  return moves;
+}
+
+/**
+ * Gets finally calculated move positions (after adjusting).
+ *
+ * @param {Array<{from: number, to: number}>} moves Initially calculated move positions.
+ * @returns {Array<{from: number, to: number}>} Finally calculated move positions (after adjusting).
+ */
+function adjustedCalculatedMoves(moves) {
+  moves.forEach((move, index) => {
+    const nextMoved = moves.slice(index + 1);
+
+    nextMoved.forEach((nextMovedIndex) => {
+      const isMovingFromStartToEnd = nextMovedIndex.from < nextMovedIndex.to;
+
+      if (nextMovedIndex.from > move.from && isMovingFromStartToEnd) {
+        nextMovedIndex.from -= 1;
+      }
+    });
+  });
+
+  return moves;
+}
+
+/**
+ * Get list of move positions.
+ *
+ * @param {Array<number>} movedIndexes Sequence of moved indexes for certain axis.
+ * @param {number} finalIndex Final place where to move rows.
+ * @param {number} numberOfIndexes Number of indexes in a dataset.
+ * @returns {Array<{from: number, to: number}>}
+ */
+export function getMoves(movedIndexes, finalIndex, numberOfIndexes) {
+  const moves = getInitiallyCalculatedMoves(movedIndexes, getMoveLine(movedIndexes, finalIndex, numberOfIndexes));
+
+  return adjustedCalculatedMoves(moves);
+}

--- a/handsontable/src/plugins/formulas/indexSyncer/axisSyncer.js
+++ b/handsontable/src/plugins/formulas/indexSyncer/axisSyncer.js
@@ -1,4 +1,5 @@
 import { toUpperCaseFirst } from '../../../helpers/string';
+import { getMoves } from '../../../helpers/moves';
 
 /**
  * @private
@@ -146,89 +147,6 @@ class AxisSyncer {
   }
 
   /**
-   * Gets first position where to move element (respecting the fact that some element will be sooner or later
-   * taken out of the dataset in order to move them).
-   *
-   * @param {Array<number>} movedHfIndexes Sequence of moved HF indexes for certain axis.
-   * @param {number} finalHfIndex Final HF place where to move rows.
-   * @returns {number} HF's index informing where to move the first element.
-   * @private
-   */
-  getMoveLine(movedHfIndexes, finalHfIndex) {
-    const numberOfElements = this.#indexMapper.getNumberOfIndexes();
-    const notMovedElements = Array.from(Array(numberOfElements).keys())
-      .filter(index => movedHfIndexes.includes(index) === false);
-
-    if (finalHfIndex === 0) {
-      return notMovedElements[finalHfIndex] ?? 0; // Moving before the first dataset's element.
-    }
-
-    return notMovedElements[finalHfIndex - 1] + 1; // Moving before another element.
-  }
-
-  /**
-   * Gets initially calculated HF's move positions.
-   *
-   * @private
-   * @param {Array<number>} movedHfIndexes Sequence of moved HF indexes for certain axis.
-   * @param {number} finalHfIndex Final HF place where to move rows.
-   * @returns {Array<{from: number, to: number}>} Initially calculated HF's move positions.
-   */
-  getInitiallyCalculatedMoves(movedHfIndexes, finalHfIndex) {
-    let moveLine = this.getMoveLine(movedHfIndexes, finalHfIndex);
-    const moves = [];
-
-    movedHfIndexes.forEach((movedHfIndex) => {
-      const move = {
-        from: movedHfIndex,
-        to: moveLine,
-      };
-
-      moves.forEach((previouslyMovedIndex) => {
-        const isMovingFromEndToStart = previouslyMovedIndex.from > previouslyMovedIndex.to;
-        const isMovingElementBefore = previouslyMovedIndex.to <= move.from;
-        const isMovingAfterElement = previouslyMovedIndex.from > move.from;
-
-        if (isMovingAfterElement && isMovingElementBefore && isMovingFromEndToStart) {
-          move.from += 1;
-        }
-      });
-
-      // Moved element from right to left (or bottom to top).
-      if (move.from >= moveLine) {
-        moveLine += 1;
-      }
-
-      moves.push(move);
-    });
-
-    return moves;
-  }
-
-  /**
-   * Gets finally calculated HF's move positions (after adjusting).
-   *
-   * @private
-   * @param {Array<{from: number, to: number}>} moves Initially calculated HF's move positions.
-   * @returns {Array<{from: number, to: number}>} Finally calculated HF's move positions (after adjusting).
-   */
-  adjustedCalculatedMoves(moves) {
-    moves.forEach((move, index) => {
-      const nextMoved = moves.slice(index + 1);
-
-      nextMoved.forEach((nextMovedIndex) => {
-        const isMovingFromStartToEnd = nextMovedIndex.from < nextMovedIndex.to;
-
-        if (nextMovedIndex.from > move.from && isMovingFromStartToEnd) {
-          nextMovedIndex.from -= 1;
-        }
-      });
-    });
-
-    return moves;
-  }
-
-  /**
    * Calculating where to move HF elements and performing already calculated moves.
    *
    * @param {boolean} movePossible Indicates if it was possible to move HOT indexes to the desired position.
@@ -243,9 +161,7 @@ class AxisSyncer {
       return;
     }
 
-    const calculatedMoves = this.adjustedCalculatedMoves(
-      this.getInitiallyCalculatedMoves(this.#movedIndexes, this.#finalIndex)
-    );
+    const calculatedMoves = getMoves(this.#movedIndexes, this.#finalIndex, this.#indexMapper.getNumberOfIndexes());
 
     if (this.#indexSyncer.getSheetId() === null) {
       this.#indexSyncer.getPostponeAction(() => this.syncMoves(calculatedMoves));

--- a/handsontable/src/plugins/manualColumnMove/__tests__/manualColumnMove.spec.js
+++ b/handsontable/src/plugins/manualColumnMove/__tests__/manualColumnMove.spec.js
@@ -1411,6 +1411,26 @@ describe('manualColumnMove', () => {
 
         expect(hot.getDataAtRow(0)).toEqual(['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1', 'J1']);
       });
+
+      it('when moving using few actions', () => {
+        const hot = handsontable({
+          data: Handsontable.helper.createSpreadsheetData(10, 10),
+          colHeaders: true,
+          manualColumnMove: true,
+        });
+
+        hot.getPlugin('manualColumnMove').moveColumn(0, 9);
+        hot.getPlugin('manualColumnMove').moveColumn(0, 9);
+        hot.render();
+
+        hot.undo();
+
+        expect(hot.getDataAtRow(0)).toEqual(['B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1', 'J1', 'A1']);
+
+        hot.undo();
+
+        expect(hot.getDataAtRow(0)).toEqual(['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1', 'J1']);
+      });
     });
 
     describe('should revert changes', () => {
@@ -1476,6 +1496,29 @@ describe('manualColumnMove', () => {
         hot.redo();
 
         expect(hot.getDataAtRow(0)).toEqual(['C1', 'D1', 'A1', 'B1', 'I1', 'E1', 'H1', 'F1', 'G1', 'J1']);
+      });
+
+      it('when moving using few actions', () => {
+        const hot = handsontable({
+          data: Handsontable.helper.createSpreadsheetData(10, 10),
+          colHeaders: true,
+          manualColumnMove: true,
+        });
+
+        hot.getPlugin('manualColumnMove').moveColumn(0, 9);
+        hot.getPlugin('manualColumnMove').moveColumn(0, 9);
+        hot.render();
+
+        hot.undo();
+        hot.undo();
+
+        hot.redo();
+
+        expect(hot.getDataAtRow(0)).toEqual(['B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1', 'J1', 'A1']);
+
+        hot.redo();
+
+        expect(hot.getDataAtRow(0)).toEqual(['C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1', 'J1', 'A1', 'B1']);
       });
     });
   });

--- a/handsontable/src/plugins/manualColumnMove/__tests__/manualColumnMove.spec.js
+++ b/handsontable/src/plugins/manualColumnMove/__tests__/manualColumnMove.spec.js
@@ -1349,4 +1349,134 @@ describe('manualColumnMove', () => {
       });
     });
   });
+
+  describe('undoRedo', () => {
+    describe('should back changes', () => {
+      it('when moving single row from the left to the right', () => {
+        const hot = handsontable({
+          data: Handsontable.helper.createSpreadsheetData(10, 10),
+          colHeaders: true,
+          manualColumnMove: true,
+        });
+
+        hot.getPlugin('manualColumnMove').moveColumn(1, 4);
+        hot.render();
+
+        hot.undo();
+
+        expect(hot.getDataAtRow(0)).toEqual(['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1', 'J1']);
+      });
+
+      it('when moving multiple columns from the left to the right', () => {
+        const hot = handsontable({
+          data: Handsontable.helper.createSpreadsheetData(10, 10),
+          colHeaders: true,
+          manualColumnMove: true,
+        });
+
+        hot.getPlugin('manualColumnMove').moveColumns([0, 1], 4);
+        hot.render();
+
+        hot.undo();
+
+        expect(hot.getDataAtRow(0)).toEqual(['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1', 'J1']);
+      });
+
+      it('when moving multiple columns from the right to the left', () => {
+        const hot = handsontable({
+          data: Handsontable.helper.createSpreadsheetData(10, 10),
+          colHeaders: true,
+          manualColumnMove: true,
+        });
+
+        hot.getPlugin('manualColumnMove').moveColumns([4, 5], 1);
+        hot.render();
+
+        hot.undo();
+
+        expect(hot.getDataAtRow(0)).toEqual(['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1', 'J1']);
+      });
+
+      it('when moving multiple columns with mixed indexes', () => {
+        const hot = handsontable({
+          data: Handsontable.helper.createSpreadsheetData(10, 10),
+          colHeaders: true,
+          manualColumnMove: true,
+        });
+
+        hot.getPlugin('manualColumnMove').moveColumns([0, 1, 8, 4, 7], 2);
+        hot.render();
+
+        hot.undo();
+
+        expect(hot.getDataAtRow(0)).toEqual(['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1', 'J1']);
+      });
+    });
+
+    describe('should revert changes', () => {
+      it('when moving single row from the left to the right', () => {
+        const hot = handsontable({
+          data: Handsontable.helper.createSpreadsheetData(10, 10),
+          colHeaders: true,
+          manualColumnMove: true,
+        });
+
+        hot.getPlugin('manualColumnMove').moveColumn(1, 4);
+        hot.render();
+
+        hot.undo();
+        hot.redo();
+
+        expect(hot.getDataAtRow(0)).toEqual(['A1', 'C1', 'D1', 'E1', 'B1', 'F1', 'G1', 'H1', 'I1', 'J1']);
+      });
+
+      it('when moving multiple columns from the left to the right', () => {
+        const hot = handsontable({
+          data: Handsontable.helper.createSpreadsheetData(10, 10),
+          colHeaders: true,
+          manualColumnMove: true,
+        });
+
+        hot.getPlugin('manualColumnMove').moveColumns([0, 1], 4);
+        hot.render();
+
+        hot.undo();
+        hot.redo();
+
+        expect(hot.getDataAtRow(0)).toEqual(['C1', 'D1', 'E1', 'F1', 'A1', 'B1', 'G1', 'H1', 'I1', 'J1']);
+      });
+
+      it('when moving multiple columns from the right to the left', () => {
+        const hot = handsontable({
+          data: Handsontable.helper.createSpreadsheetData(10, 10),
+          colHeaders: true,
+          manualColumnMove: true,
+        });
+
+        hot.getPlugin('manualColumnMove').moveColumns([4, 5], 1);
+        hot.render();
+
+        hot.undo();
+        hot.redo();
+
+        expect(hot.getDataAtRow(0)).toEqual(['A1', 'E1', 'F1', 'B1', 'C1', 'D1', 'G1', 'H1', 'I1', 'J1']);
+      });
+
+      it('when moving multiple columns with mixed indexes', () => {
+        const hot = handsontable({
+          data: Handsontable.helper.createSpreadsheetData(10, 10),
+          colHeaders: true,
+          manualColumnMove: true,
+        });
+
+        hot.getPlugin('manualColumnMove').moveColumns([0, 1, 8, 4, 7], 2);
+        hot.render();
+
+        hot.undo();
+        hot.redo();
+
+        expect(hot.getDataAtRow(0)).toEqual(['C1', 'D1', 'A1', 'B1', 'I1', 'E1', 'H1', 'F1', 'G1', 'J1']);
+      });
+    });
+  });
 });

--- a/handsontable/src/plugins/manualColumnMove/__tests__/selection.spec.js
+++ b/handsontable/src/plugins/manualColumnMove/__tests__/selection.spec.js
@@ -61,9 +61,8 @@ describe('manualColumnMove', () => {
       expect(getSelected()).toEqual([[-1, 1, 9, 3]]);
     });
 
-    // The `ManualColumnMove` plugin doesn't cooperate with the `UndoRedo` plugin.
     describe('should be shown properly after undo action', () => {
-      xit('when moving multiple columns from the left to the right', () => {
+      it('when moving multiple columns from the left to the right', () => {
         const hot = handsontable({
           data: Handsontable.helper.createSpreadsheetData(10, 10),
           colHeaders: true,
@@ -86,10 +85,10 @@ describe('manualColumnMove', () => {
 
         hot.undo();
 
-        expect(getSelected()).toEqual([[0, 0, 9, 2]]);
+        expect(getSelected()).toEqual([[-1, 0, 9, 2]]);
       });
 
-      xit('when moving multiple columns from the right to the left', () => {
+      it('when moving multiple columns from the right to the left', () => {
         const hot = handsontable({
           data: Handsontable.helper.createSpreadsheetData(10, 10),
           colHeaders: true,
@@ -112,12 +111,12 @@ describe('manualColumnMove', () => {
 
         hot.undo();
 
-        expect(getSelected()).toEqual([[0, 3, 9, 5]]);
+        expect(getSelected()).toEqual([[-1, 3, 9, 5]]);
       });
     });
 
     describe('should be shown properly after redo action', () => {
-      xit('when moving multiple columns from the left to the right', () => {
+      it('when moving multiple columns from the left to the right', () => {
         const hot = handsontable({
           data: Handsontable.helper.createSpreadsheetData(10, 10),
           colHeaders: true,
@@ -141,10 +140,10 @@ describe('manualColumnMove', () => {
         hot.undo();
         hot.redo();
 
-        expect(getSelected()).toEqual([[0, 1, 9, 3]]);
+        expect(getSelected()).toEqual([[-1, 1, 9, 3]]);
       });
 
-      xit('when moving multiple columns from the right to the left', () => {
+      it('when moving multiple columns from the right to the left', () => {
         const hot = handsontable({
           data: Handsontable.helper.createSpreadsheetData(10, 10),
           colHeaders: true,
@@ -168,7 +167,7 @@ describe('manualColumnMove', () => {
         hot.undo();
         hot.redo();
 
-        expect(getSelected()).toEqual([[0, 1, 9, 3]]);
+        expect(getSelected()).toEqual([[-1, 1, 9, 3]]);
       });
     });
   });

--- a/handsontable/src/plugins/manualRowMove/__tests__/manualRowMove.spec.js
+++ b/handsontable/src/plugins/manualRowMove/__tests__/manualRowMove.spec.js
@@ -897,6 +897,26 @@ describe('manualRowMove', () => {
 
         expect(hot.getDataAtCol(0)).toEqual(['A1', 'A2', 'A3', 'A4', 'A5', 'A6', 'A7', 'A8', 'A9', 'A10']);
       });
+
+      it('when moving using few actions', () => {
+        const hot = handsontable({
+          data: Handsontable.helper.createSpreadsheetData(10, 10),
+          rowHeaders: true,
+          manualRowMove: true,
+        });
+
+        hot.getPlugin('manualRowMove').moveRow(0, 9);
+        hot.getPlugin('manualRowMove').moveRow(0, 9);
+        hot.render();
+
+        hot.undo();
+
+        expect(hot.getDataAtCol(0)).toEqual(['A2', 'A3', 'A4', 'A5', 'A6', 'A7', 'A8', 'A9', 'A10', 'A1']);
+
+        hot.undo();
+
+        expect(hot.getDataAtCol(0)).toEqual(['A1', 'A2', 'A3', 'A4', 'A5', 'A6', 'A7', 'A8', 'A9', 'A10']);
+      });
     });
 
     describe('should revert changes', () => {
@@ -962,6 +982,29 @@ describe('manualRowMove', () => {
         hot.redo();
 
         expect(hot.getDataAtCol(0)).toEqual(['A3', 'A4', 'A1', 'A2', 'A9', 'A5', 'A8', 'A6', 'A7', 'A10']);
+      });
+
+      it('when moving using few actions', () => {
+        const hot = handsontable({
+          data: Handsontable.helper.createSpreadsheetData(10, 10),
+          rowHeaders: true,
+          manualRowMove: true,
+        });
+
+        hot.getPlugin('manualRowMove').moveRow(0, 9);
+        hot.getPlugin('manualRowMove').moveRow(0, 9);
+        hot.render();
+
+        hot.undo();
+        hot.undo();
+
+        hot.redo();
+
+        expect(hot.getDataAtCol(0)).toEqual(['A2', 'A3', 'A4', 'A5', 'A6', 'A7', 'A8', 'A9', 'A10', 'A1']);
+
+        hot.redo();
+
+        expect(hot.getDataAtCol(0)).toEqual(['A3', 'A4', 'A5', 'A6', 'A7', 'A8', 'A9', 'A10', 'A1', 'A2', ]);
       });
     });
   });

--- a/handsontable/src/plugins/manualRowMove/__tests__/manualRowMove.spec.js
+++ b/handsontable/src/plugins/manualRowMove/__tests__/manualRowMove.spec.js
@@ -1004,7 +1004,7 @@ describe('manualRowMove', () => {
 
         hot.redo();
 
-        expect(hot.getDataAtCol(0)).toEqual(['A3', 'A4', 'A5', 'A6', 'A7', 'A8', 'A9', 'A10', 'A1', 'A2', ]);
+        expect(hot.getDataAtCol(0)).toEqual(['A3', 'A4', 'A5', 'A6', 'A7', 'A8', 'A9', 'A10', 'A1', 'A2']);
       });
     });
   });


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
As the title says. Works similarly to the undo operation of moving rows

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Moving single and multiple rows.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/933

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] My change requires a change to the documentation.
