### PR TITLE
Changed unnatural checkbox behaviour after double click

### DIFF
--- a/.changelogs/10748.json
+++ b/.changelogs/10748.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Changed unnatural checkbox behaviour after double click",
+  "type": "changed",
+  "issueOrPR": 10748,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/10748.json
+++ b/.changelogs/10748.json
@@ -3,6 +3,6 @@
   "title": "Changed unnatural checkbox behaviour after double click",
   "type": "changed",
   "issueOrPR": 10748,
-  "breaking": true,
+  "breaking": false,
   "framework": "none"
 }

--- a/.changelogs/10748.json
+++ b/.changelogs/10748.json
@@ -3,6 +3,6 @@
   "title": "Changed unnatural checkbox behaviour after double click",
   "type": "changed",
   "issueOrPR": 10748,
-  "breaking": false,
+  "breaking": true,
   "framework": "none"
 }

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -4837,9 +4837,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
    */
   this._refreshBorders = function(revertOriginal = false, prepareEditorIfNeeded = true) {
     editorManager.destroyEditor(revertOriginal);
-    // console.time('render');
     instance.view.render();
-    // console.timeEnd('render');
 
     if (prepareEditorIfNeeded && selection.isSelected()) {
       editorManager.prepareEditor();

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -4837,7 +4837,9 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
    */
   this._refreshBorders = function(revertOriginal = false, prepareEditorIfNeeded = true) {
     editorManager.destroyEditor(revertOriginal);
+    // console.time('render');
     instance.view.render();
+    // console.timeEnd('render');
 
     if (prepareEditorIfNeeded && selection.isSelected()) {
       editorManager.prepareEditor();

--- a/handsontable/src/editors/checkboxEditor/checkboxEditor.js
+++ b/handsontable/src/editors/checkboxEditor/checkboxEditor.js
@@ -1,5 +1,4 @@
 import { BaseEditor } from '../baseEditor';
-import { hasClass } from '../../helpers/dom/element';
 
 export const EDITOR_TYPE = 'checkbox';
 
@@ -12,20 +11,7 @@ export class CheckboxEditor extends BaseEditor {
     return EDITOR_TYPE;
   }
 
-  beginEditing(initialValue, event) {
-    // Just some events connected with checkbox editor are delegated here. Some `keydown` events like `enter` and `space` key press
-    // are handled inside `checkboxRenderer`. Some events come here from `editorManager`. Below `if` statement was created by author
-    // for purpose of handling only `doubleclick` event which may be done on a cell with checkbox.
-
-    if (event && event.type === 'mouseup') {
-      const checkbox = this.TD.querySelector('input[type="checkbox"]');
-
-      if (!hasClass(checkbox, 'htBadValue')) {
-        checkbox.click();
-      }
-    }
-  }
-
+  beginEditing() {}
   finishEditing() {}
   init() {}
   open() {}

--- a/handsontable/src/editors/checkboxEditor/checkboxEditor.js
+++ b/handsontable/src/editors/checkboxEditor/checkboxEditor.js
@@ -1,4 +1,5 @@
 import { BaseEditor } from '../baseEditor';
+import { hasClass } from '../../helpers/dom/element';
 
 export const EDITOR_TYPE = 'checkbox';
 
@@ -11,7 +12,21 @@ export class CheckboxEditor extends BaseEditor {
     return EDITOR_TYPE;
   }
 
-  beginEditing() {}
+  beginEditing(initialValue, event) {
+    // Just some events connected with the checkbox editor are delegated here. Some `keydown` events like `enter` and
+    // `space` key presses are handled inside `checkboxRenderer`. Some events come here from `editorManager`. The below
+    // `if` statement was created by the author for the purpose of handling only the `doubleclick` event on the TD
+    // element with a checkbox.
+
+    if (event && event.type === 'mouseup' && event.target.nodeName === 'TD') {
+      const checkbox = this.TD.querySelector('input[type="checkbox"]');
+
+      if (!hasClass(checkbox, 'htBadValue')) {
+        checkbox.click();
+      }
+    }
+  }
+
   finishEditing() {}
   init() {}
   open() {}

--- a/handsontable/src/renderers/checkboxRenderer/__tests__/checkboxRenderer.spec.js
+++ b/handsontable/src/renderers/checkboxRenderer/__tests__/checkboxRenderer.spec.js
@@ -423,7 +423,7 @@ describe('CheckboxRenderer', () => {
     expect(getDataAtCell(0, 0)).toBe(false);
   });
 
-  it('double click on checkbox cell should work properly', () => {
+  it('double click on checkbox cell should invert the value', () => {
     handsontable({
       data: [
         [true],
@@ -435,10 +435,36 @@ describe('CheckboxRenderer', () => {
       ]
     });
 
+    selectCell(0, 0);
+
+    mouseDoubleClick(getCell(0, 0));
+    expect(getDataAtCell(0, 0)).toBe(false);
+
     mouseDoubleClick(getCell(0, 0));
     expect(getDataAtCell(0, 0)).toBe(true);
 
-    mouseDoubleClick(getCell(1, 0));
+    mouseDoubleClick(getCell(0, 0));
+    expect(getDataAtCell(0, 0)).toBe(false);
+  });
+
+  it('double click on input[type=checkbox] element inside checkbox cell should not invert the value', () => {
+    handsontable({
+      data: [
+        [true],
+        [false],
+        [true]
+      ],
+      columns: [
+        { type: 'checkbox' }
+      ]
+    });
+
+    selectCell(0, 0);
+
+    mouseDoubleClick($(getCell(0, 0)).find('input[type=checkbox]'));
+    expect(getDataAtCell(0, 0)).toBe(true);
+
+    mouseDoubleClick($(getCell(1, 0)).find('input[type=checkbox]'));
     expect(getDataAtCell(1, 0)).toBe(false);
   });
 

--- a/handsontable/src/renderers/checkboxRenderer/__tests__/checkboxRenderer.spec.js
+++ b/handsontable/src/renderers/checkboxRenderer/__tests__/checkboxRenderer.spec.js
@@ -423,7 +423,7 @@ describe('CheckboxRenderer', () => {
     expect(getDataAtCell(0, 0)).toBe(false);
   });
 
-  it('double click on checkbox cell should invert the value', () => {
+  it('double click on checkbox cell should work properly', () => {
     handsontable({
       data: [
         [true],
@@ -435,16 +435,11 @@ describe('CheckboxRenderer', () => {
       ]
     });
 
-    selectCell(0, 0);
-
-    mouseDoubleClick(getCell(0, 0));
-    expect(getDataAtCell(0, 0)).toBe(false);
-
     mouseDoubleClick(getCell(0, 0));
     expect(getDataAtCell(0, 0)).toBe(true);
 
-    mouseDoubleClick(getCell(0, 0));
-    expect(getDataAtCell(0, 0)).toBe(false);
+    mouseDoubleClick(getCell(1, 0));
+    expect(getDataAtCell(1, 0)).toBe(false);
   });
 
   it('should change checkbox state from checked to unchecked after hitting ENTER', () => {


### PR DESCRIPTION
### Context
I can see two problems.

1. Unnatural checkbox behaviour after double click.

~After a double click, a value has been inverted. I can't see a reason for such behaviour. It was introduced within https://github.com/handsontable/handsontable/commit/1c7a93a8e5bbd17167b134c039a92883c4499259 (2013 year), and it's very hard to find a reason for that feature. I can't see similar behaviour in Google Sheets or the Excel desktop. I propose to get rid of this solution. This PR did it.~

So far, double-clicking on a cell (`TD` element) has been inverting the checkbox value. However, it had side effects when a click was performed directly on the `input[type=checkbox]` element. This PR fixes that.

2. Big lag.

The lag problem shown within the issue is related to the `setDataAtCell` method. It's very clearly visible after clicking on the checkbox, as it is the easiest way of changing value. A lag can also be seen in changing value using fast editing or from API. The longest time is spent executing the `instance.view.render` method, which also takes much time when displaying the Handsontable instance with a big dataset for the first time. We don't have a method which re-renders only part of the cells visible in the viewport. Probably, it should be done within another, bigger task.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested a checkbox using clicks, double clicks, and space presses.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/1540

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] My change requires a change to the documentation.
