### PR TITLE
fix: allow propToCol to infer return based on usage

### DIFF
--- a/.changelogs/10631.json
+++ b/.changelogs/10631.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed propToCol return type inference",
+  "type": "fixed",
+  "issueOrPR": 10631,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/types/core.d.ts
+++ b/handsontable/types/core.d.ts
@@ -118,7 +118,7 @@ export default class Core {
   loadData(data: CellValue[][] | RowObject[], source?: string): void;
   populateFromArray(row: number, column: number, input: CellValue[][], endRow?: number,
     endColumn?: number, source?: string, method?: 'shift_down' | 'shift_right' | 'overwrite'): void;
-  propToCol(prop: string | number): string | number;
+  propToCol<T extends number | string>(prop: string | number): T;
   redo(): void;
   refreshDimensions(): void;
   removeCellMeta(row: number, column: number, key: (keyof CellMeta) | string): void;

--- a/handsontable/types/tslint.json
+++ b/handsontable/types/tslint.json
@@ -2,6 +2,7 @@
   "extends": "dtslint/dtslint.json",
   "rules": {
     "semicolon": true,
-    "strict-export-declare-modifiers": false
+    "strict-export-declare-modifiers": false,
+    "no-unnecessary-generics": false
   }
 }


### PR DESCRIPTION
### Context
In a recent update, we modified the input/return type of `propToCol` to `number | string`, which is accurate given the function's behavior. However, this change has resulted in a degraded experience for TypeScript users.

I propose refining the type definition to `propToCol<T extends number | string>(prop: string | number): T;`. This modification provides TypeScript users with the clarity to understand that the function can accept either a number or a string. Moreover, it allows TypeScript to infer the type based on usage. For instance, when used with `setCellMeta`, which expects a number, TypeScript can now appropriately infer that type.

See the following example

<img width="734" alt="image" src="https://github.com/handsontable/handsontable/assets/11815608/e67a2a12-dd52-45e8-880c-4a262bd97bd4">

[Playground](https://www.typescriptlang.org/play?#code/C4TwDgpgBAwhA28CyFgEMoF4oG8C+A3ALABQokUACgE4D2YAKrTLfA+BADwNQQAewCADsAJgGcoQgK4BbAEYRqUAD5QxwagEshAcwB8WKAAowdMAC41G7TpWTZC6gEosBhsRIBjeGjESW1NA4pFChUAD04VAAAsBiALSaOkK0gWqaMlI+wDZQIgB0cSFhpvRMLPDcvALC4vbyinbqWrp6JmaWzbmq0g3Olu7FoZExcYnJqdBiGVloObp5hWJDaqhwiCjoRnQA7pa9jgA0UJ6sskL7DorHANYQIJ3WuscAbmjwlmhCIE6WL7SaEQeMIRKKxBJJFJpaaZbK5ApFEggsRrBDIVBoTgAaWqglEEjuIFoADNYGjNmg2rtLn1jqd4OcaUcoITLFjXu9LOt0egANpYgC6vyg-0BwLCI3B4yhUxmcIWCOWSLCKOA3IpAHk5AArCCeYDbWh7erM+mMk3XKClCxkjYY4WioGkPCkUinITqKC7QwARldXloHuAuGt5VYx1V6oxeEMQggO1gkyMTg8I3i6c8UmA6fibsDnv4aBkYHg0GwkfJGKMK12xxWoeYrCMAHJCQB9QvF0vNpx15XDKJhAB6AH4Vs23vBAXNUs3Ditk65cC6SE5-e6C3wiyWIBq44YGxUW52dz3SCNh2OA0HqtvSwwdrRHi1bNhD02fQAmADMa5IF9CUc8xvE97wAC0CCAmUaN8zDDeBjy3LsIDPf9B0Aq8gA)

### How has this been tested?
locally, and tests run.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/10631

### Affected project(s):
- [x] `handsontable`