### PR TITLE
Focus on the Handsontable instance within the iframe won't persist for clicking outside the iframe

### DIFF
--- a/.changelogs/10752.json
+++ b/.changelogs/10752.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Focus on the Handsontable instance within the iframe won't persist for clicking outside the iframe",
+  "type": "fixed",
+  "issueOrPR": 10752,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/test/e2e/Core_listen.spec.js
+++ b/handsontable/test/e2e/Core_listen.spec.js
@@ -128,6 +128,37 @@ describe('Core_listen', () => {
     $container2.remove();
   });
 
+  it('should unlisten after click outside an iframe', () => {
+    const $iframe = $('<iframe width="500px" height="300px"/>').appendTo(spec().$container);
+    const doc = $iframe[0].contentDocument;
+
+    doc.open('text/html', 'replace');
+    doc.write(`
+      <!doctype html>
+      <head>
+        <link type="text/css" rel="stylesheet" href="../dist/handsontable.css">
+      </head>
+    `);
+    doc.close();
+
+    const $iframeContainer = $('<div/>').appendTo(doc.body);
+    const $input = $('<input id="text"/>').appendTo(spec().$container);
+    const afterUnlisten = jasmine.createSpy();
+
+    $iframeContainer.handsontable({
+      afterUnlisten,
+    });
+
+    simulateClick($iframeContainer.find('tr:eq(0) td:eq(0)'));
+    simulateClick(spec().$container.find('#text'));
+
+    expect(afterUnlisten).toHaveBeenCalledOnceWith();
+
+    $iframeContainer.handsontable('destroy');
+    $iframe.remove();
+    $input.remove();
+  });
+
   describe('hooks', () => {
     it('should call `afterListen` after set listen on instance', () => {
       const afterListenCallback = jasmine.createSpy('afterListenCallback');


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
There was a need to add an extra HOT's `unlisten` call.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Tested on pages containing iframes.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/1643

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] My change requires a change to the documentation.
