### PR TITLE
Fix a problem with the dropdown editor throwing an error when the cell value was represented by a `td` outside of the initial editor viewport.

### DIFF
--- a/.changelogs/10763.json
+++ b/.changelogs/10763.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed a problem with the dropdown editor throwing an error when the cell value was represented by a `td` outside of the initial editor viewport.",
+  "type": "fixed",
+  "issueOrPR": 10763,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
+++ b/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
@@ -187,7 +187,7 @@ export class AutocompleteEditor extends HandsontableEditor {
 
         TD.innerHTML = cellValue;
       },
-      afterSelection: (startRow, startCol) => {
+      afterSelectionEnd: (startRow, startCol) => {
         if (rootInstanceAriaTagsEnabled) {
           const TD = this.htEditor.getCell(startRow, startCol, true);
 

--- a/handsontable/src/editors/dropdownEditor/__tests__/dropdownEditor.spec.js
+++ b/handsontable/src/editors/dropdownEditor/__tests__/dropdownEditor.spec.js
@@ -319,6 +319,42 @@ describe('DropdownEditor', () => {
 
       window.onerror = prevError;
     });
+
+    it('should not throw any errors after opening the editor, when the saved value is represented by a option-cell ' +
+    'outside of the editor\'s initially loaded viewport', async() => {
+      const spy = jasmine.createSpyObj('error', ['test']);
+      const prevError = window.onerror;
+
+      window.onerror = function() {
+        spy.test();
+      };
+
+      handsontable({
+        data: [['49']],
+        columns: [
+          {
+            editor: 'dropdown',
+            source: (() => {
+              const arr = [];
+
+              for (let i = 0; i < 50; i++) {
+                arr.push(`${i}`);
+              }
+
+              return arr;
+            })(),
+          }
+        ]
+      });
+
+      selectCell(0, 0);
+      keyDownUp('enter');
+      await sleep(100);
+
+      expect(spy.test).not.toHaveBeenCalled();
+
+      window.onerror = prevError;
+    });
   });
 
   describe('closing the editor', () => {

--- a/handsontable/src/editors/dropdownEditor/__tests__/dropdownEditor.spec.js
+++ b/handsontable/src/editors/dropdownEditor/__tests__/dropdownEditor.spec.js
@@ -320,6 +320,7 @@ describe('DropdownEditor', () => {
       window.onerror = prevError;
     });
 
+    // https://github.com/handsontable/dev-handsontable/issues/1724
     it('should not throw any errors after opening the editor, when the saved value is represented by a option-cell ' +
     'outside of the editor\'s initially loaded viewport', async() => {
       const spy = jasmine.createSpyObj('error', ['test']);


### PR DESCRIPTION
### Context
This PR modifies the `autocompleteEditor`'s `afterSelection` hook callback to `afterSelectionEnd` to allow targeting the selected `td` element. 
The `afterSelection` hook fires before the table is scrolled into position, so the selected cell may not be rendered yet at this point.

### How has this been tested?
Added a test case.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#1724


### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
