### PR TITLE
Update path to visual tests in `run-tests.mjs`

### DIFF
--- a/visual-tests/scripts/run-tests.mjs
+++ b/visual-tests/scripts/run-tests.mjs
@@ -15,7 +15,7 @@ import { WRAPPERS, REFERENCE_FRAMEWORK, EXAMPLES_SERVER_PORT } from '../src/conf
 const playwrightVersion = mainPackageJSON.devDependencies.playwright;
 const pathToMount = path.resolve(process.cwd(), '..');
 const dirs = {
-  examples: '../examples/visual-tests',
+  examples: '../examples/next/visual-tests',
   codeToRun: 'demo',
   screenshots: './screenshots',
 };


### PR DESCRIPTION
### Context
After rearranging the examples in https://github.com/handsontable/handsontable/pull/10766, the visual tests stopped working on `develop`. This PR corrects the path to the visual tests in the `test` script of the `visual-tests` package.

### How has this been tested?
Tested locally

