### PR TITLE
Fix documentation console error

### DIFF
--- a/docs/patches/@vuepress+theme-default+1.9.10.patch
+++ b/docs/patches/@vuepress+theme-default+1.9.10.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@vuepress/theme-default/global-components/CodeGroup.vue b/node_modules/@vuepress/theme-default/global-components/CodeGroup.vue
+index ac6ec55..2e482dc 100644
+--- a/node_modules/@vuepress/theme-default/global-components/CodeGroup.vue
++++ b/node_modules/@vuepress/theme-default/global-components/CodeGroup.vue
+@@ -75,7 +75,7 @@ export default {
+         }
+       })
+ 
+-      if (this.codeTabs[index].elm) {
++      if (this.codeTabs[index]?.elm) {
+         this.codeTabs[index].elm.classList.add('theme-code-block__active')
+       }
+     }


### PR DESCRIPTION
### Context
This PR contains fixe for docs console error in case when <code-group> tag is used in md file

### How has this been tested?
locally

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.https://github.com/handsontable/dev-handsontable/issues/309

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] Fix console error on some documentation pages