### PR TITLE
Fix for #10756 (typo correction)

### DIFF
--- a/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
@@ -1091,27 +1091,32 @@ describe('Filters UI', () => {
       'is numeric-typed', () => {
       handsontable({
         data: [
-          [1],
-          [2],
-          [3],
-          [4],
-          [5],
+          [1, 6],
+          [2, 7],
+          [3, 8],
+          [4, 9],
+          [5, 10],
         ],
         colHeaders: true,
         dropdownMenu: true,
         filters: true,
-        type: 'numeric',
-        numericFormat: {
-          pattern: '$0,0.00',
-        }
+        columns: [
+          {},
+          {
+            type: 'numeric',
+            numericFormat: {
+              pattern: '$0,0.00',
+            }
+          }
+        ]
       });
 
-      dropdownMenu(0);
+      dropdownMenu(1);
 
-      for (let i = 0; i < 5; i++) {
+      for (let i = 0; i < countRows(); i++) {
         expect(
           byValueMultipleSelect().element.querySelectorAll('.htCore td')[i].textContent
-        ).toBe(`$${getDataAtCell(i, 0)}.00`);
+        ).toBe(`$${getDataAtCell(i, 1)}.00`);
       }
     });
 

--- a/handsontable/src/plugins/filters/component/value.js
+++ b/handsontable/src/plugins/filters/component/value.js
@@ -297,7 +297,7 @@ export class ValueComponent extends BaseComponent {
     return arrayMap(this.hot.getDataAtCol(selectedColumn.visualIndex), (v, rowIndex) => {
       return {
         value: toEmptyString(v),
-        meta: this.hot.getCellMeta(selectedColumn.visualIndex, rowIndex),
+        meta: this.hot.getCellMeta(rowIndex, selectedColumn.visualIndex),
       };
     });
   }


### PR DESCRIPTION
### Context
This PR:
- Corrects a typo in a `getCellMeta` call, introduced by #10756
- Modifies the test case from #10756 to test the problem the typo caused

[skip changelog]

### How has this been tested?
Modified the test case, tested manually.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #10756

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
