### PR TITLE
Fix variable misspell in a code snippet

### DIFF
--- a/handsontable/src/dataMap/metaManager/metaSchema.js
+++ b/handsontable/src/dataMap/metaManager/metaSchema.js
@@ -2268,7 +2268,7 @@ export default () => {
      *
      * formulas: {
      *   // set `engine` to a HyperFormula instance
-     *   engine: hyperFormulaInstance,
+     *   engine: hyperformulaInstance,
      *   sheetId: 1,
      *   sheetName: 'Sheet 1'
      * }
@@ -2277,7 +2277,7 @@ export default () => {
      * formulas: {
      *   // set `engine` to a HyperFormula configuration object
      *   engine: {
-     *     hyperformula: HyperFormula // or `engine: hyperFormulaInstance`
+     *     hyperformula: HyperFormula // or `engine: hyperformulaInstance`
      *     leapYear1900: false,       // this option comes from HyperFormula
      *     // add more HyperFormula configuration options
      *   },


### PR DESCRIPTION
### Context
This PR includes fix for hyperformulaInstance variable misspell in a code snippet

### How has this been tested?
Locally

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/1754

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] Fix variable misspell in code snippet

[skip changelog]
