### PR TITLE
Add search tags to react redux page in the documentation

### DIFF
--- a/docs/content/guides/getting-started/react-redux.md
+++ b/docs/content/guides/getting-started/react-redux.md
@@ -7,6 +7,13 @@ permalink: /redux
 canonicalUrl: /redux
 react:
   metaTitle: Integration with Redux - React Data Grid | Handsontable
+  tags:
+    - state manager
+    - react redux
+    - connect component
+    - immutable data
+    - redux
+    - state management
 searchCategory: Guides
 ---
 


### PR DESCRIPTION
### Context
This PR includes extra tags for react redux page in the documentation

### How has this been tested?
Locally

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/1392

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] Add tags to react redux page in the documentation

[skip changelog]
