### PR TITLE
Add missing css part to the documentation conditional formatting demo

### DIFF
--- a/docs/content/guides/cell-features/conditional-formatting.md
+++ b/docs/content/guides/cell-features/conditional-formatting.md
@@ -23,12 +23,6 @@ Conditional formatting can be used to set the font, color, typeface, etc., for c
 
 ## Example of conditional formatting
 
-<style>
-.make-me-red {
-  color: #FF5A12;
-}
-</style>
-
 This demo shows how to use the cell type renderer feature to make some conditional formatting:
 
 1. The first row is read-only and formatted as bold green text.
@@ -38,7 +32,13 @@ This demo shows how to use the cell type renderer feature to make some condition
 
 ::: only-for javascript
 
-::: example #example1
+::: example #example1 --css 1 --js 2
+
+```css
+.make-me-red {
+  color: #FF5A12;
+}
+```
 
 ```js
 import Handsontable from 'handsontable';
@@ -124,7 +124,13 @@ const hot = new Handsontable(container, {
 
 ::: only-for react
 
-::: example #example1 :react
+::: example #example1 :react --css 1 --js 2
+
+```css
+.make-me-red {
+  color: #FF5A12;
+}
+```
 
 ```jsx
 import { HotTable } from '@handsontable/react';


### PR DESCRIPTION
### Context
This PR includes update for conditional formatting demo missing css part in the documentation

### How has this been tested?
Locally

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/243

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] Fix css in conditional formatting demo

[skip changelog]
