### PR TITLE
setup sentry to save replays on error only

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -86,6 +86,8 @@ module.exports = {
       `
       window.sentryOnLoad = function () {
         Sentry.init({
+          replaysSessionSampleRate: 0,
+          replaysOnErrorSampleRate: 1.0,
           integrations: [
             // If you use a bundle with performance monitoring enabled, add the BrowserTracing integration
             new Sentry.BrowserTracing(),


### PR DESCRIPTION
[skip changelog]
### Context
we want to limit the numbers of replay recorded by sentry - this is achieved by setting sample rate : https://docs.sentry.io/platforms/javascript/session-replay/#replay-captures-on-errors-only

### How has this been tested?
tested on staging

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
