### PR TITLE
Remove box about nestedHeaders from hidden rows documentation

### DIFF
--- a/docs/content/guides/rows/row-hiding.md
+++ b/docs/content/guides/rows/row-hiding.md
@@ -237,12 +237,6 @@ To easily see which rows are currently hidden, display UI indicators.
 
 To enable the UI indicators, in the `hiddenRows` object, set the `indicators` property to `true`:
 
-::: tip
-
-If you use both the [`NestedHeaders`](@/api/nestedHeaders.md) plugin and the [`HiddenRows`](@/api/hiddenRows.md) plugin, you also need to set the `colHeaders` property to `true`. Otherwise, `indicators` won't work.
-
-:::
-
 ::: only-for javascript
 
 ::: example #example3


### PR DESCRIPTION
### Context
This PR includes update to hidden rows documentation part 

### How has this been tested?
Locally

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/1660

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] Remove box about nestedHeaders from hidden rows guide

[skip changelog]
