### PR TITLE
React wrapper: Wrap internal utilities into a context provided from HotTable to its children

### DIFF
--- a/.changelogs/10789.json
+++ b/.changelogs/10789.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "React wrapper: Wrap internal utilities into a context provided from HotTable to its children",
+  "type": "changed",
+  "issueOrPR": 10789,
+  "breaking": false,
+  "framework": "react"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -37008,7 +37008,6 @@
       "devDependencies": {
         "@babel/cli": "^7.8.4",
         "@babel/core": "^7.9.0",
-        "@babel/plugin-proposal-class-properties": "^7.8.3",
         "@babel/plugin-transform-runtime": "^7.9.0",
         "@babel/polyfill": "^7.8.7",
         "@babel/preset-env": "^7.9.0",

--- a/wrappers/react/.babelrc
+++ b/wrappers/react/.babelrc
@@ -6,11 +6,15 @@
     "test": {
       "presets": [
         "@babel/env",
-        "@babel/preset-typescript"
+        [
+          "@babel/preset-typescript",
+          {
+            "allowDeclareFields": true
+          }
+        ]
       ],
       "plugins": [
-        "@babel/transform-runtime",
-        "@babel/plugin-proposal-class-properties"
+        "@babel/transform-runtime"
       ]
     }
   }

--- a/wrappers/react/package.json
+++ b/wrappers/react/package.json
@@ -54,7 +54,6 @@
   "devDependencies": {
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.9.0",
-    "@babel/plugin-proposal-class-properties": "^7.8.3",
     "@babel/plugin-transform-runtime": "^7.9.0",
     "@babel/polyfill": "^7.8.7",
     "@babel/preset-env": "^7.9.0",

--- a/wrappers/react/src/helpers.tsx
+++ b/wrappers/react/src/helpers.tsx
@@ -23,7 +23,7 @@ export const HOT_DESTROYED_WARNING = 'The Handsontable instance bound to this co
 /**
  * String identifier for the global-scoped editor components.
  */
-export const GLOBAL_EDITOR_SCOPE = 'global';
+export const GLOBAL_EDITOR_SCOPE: EditorScopeIdentifier = 'global';
 
 /**
  * Default classname given to the wrapper container.

--- a/wrappers/react/src/hotColumnContext.tsx
+++ b/wrappers/react/src/hotColumnContext.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+export interface HotColumnContextImpl {
+  /**
+   * Column index within a HotTable.
+   */
+  readonly columnIndex: number;
+
+  /**
+   * Get the `Document` object corresponding to the main component element.
+   *
+   * @returns The `Document` object used by the component.
+   */
+  readonly getOwnerDocument: () => Document | null;
+}
+
+const HotColumnContext = React.createContext<HotColumnContextImpl | undefined>(undefined);
+
+const HotColumnContextProvider: React.FC<React.PropsWithChildren<HotColumnContextImpl>> = ({ columnIndex, getOwnerDocument, children }) => {
+
+  const contextImpl: HotColumnContextImpl = React.useMemo(() => ({
+    columnIndex,
+    getOwnerDocument
+  }), [columnIndex, getOwnerDocument]);
+
+  return (
+    <HotColumnContext.Provider value={contextImpl}>{children}</HotColumnContext.Provider>
+  );
+};
+
+const useHotColumnContext = () => React.useContext(HotColumnContext);
+
+export { useHotColumnContext, HotColumnContextProvider };

--- a/wrappers/react/src/hotTable.tsx
+++ b/wrappers/react/src/hotTable.tsx
@@ -1,6 +1,7 @@
 import React, { ForwardRefExoticComponent, RefAttributes } from 'react';
 import { HotTableClass } from './hotTableClass';
 import { HotTableProps } from './types';
+import { HotTableContextProvider } from './hotTableContext'
 
 interface Version {
   version?: string;
@@ -14,9 +15,11 @@ const HotTable: HotTable = React.forwardRef<HotTableClass, HotTableProps>(({ chi
   const componentId = props.id ?? generatedId;
 
   return (
-    <HotTableClass id={componentId} {...props} ref={ref}>
-      {children}
-    </HotTableClass>
+    <HotTableContextProvider>
+      <HotTableClass id={componentId} {...props} ref={ref}>
+        {children}
+      </HotTableClass>
+    </HotTableContextProvider>
   );
 })
 

--- a/wrappers/react/src/hotTableContext.tsx
+++ b/wrappers/react/src/hotTableContext.tsx
@@ -1,0 +1,225 @@
+import Handsontable from 'handsontable/base';
+import React from 'react';
+import { EditorScopeIdentifier, HotEditorCache, HotEditorElement } from './types'
+import { createPortal, getOriginalEditorClass, GLOBAL_EDITOR_SCOPE } from './helpers'
+import { RenderersPortalManager } from './renderersPortalManager'
+
+export interface HotTableContextImpl {
+  /**
+   * Map with column indexes (or a string = 'global') as keys, and booleans as values. Each key represents a component-based editor
+   * declared for the used column index, or a global one, if the key is the `global` string.
+   */
+  readonly componentRendererColumns: Map<EditorScopeIdentifier, boolean>;
+
+  /**
+   * Array of object containing the column settings.
+   */
+  readonly columnsSettings: Handsontable.ColumnSettings[];
+
+  /**
+   * Sets the column settings based on information received from HotColumn.
+   *
+   * @param {HotTableProps} columnSettings Column settings object.
+   * @param {Number} columnIndex Column index.
+   */
+  readonly emitColumnSettings: (columnSettings: Handsontable.ColumnSettings, columnIndex: number) => void;
+
+  /**
+   * Editor cache.
+   */
+  readonly editorCache: HotEditorCache;
+
+  /**
+   * Return a renderer wrapper function for the provided renderer component.
+   *
+   * @param {React.ReactElement} rendererElement React renderer component.
+   * @returns {Handsontable.renderers.Base} The Handsontable rendering function.
+   */
+  readonly getRendererWrapper: (rendererNode: React.ReactElement) => typeof Handsontable.renderers.BaseRenderer;
+
+  /**
+   * Clears portals cache.
+   */
+  readonly clearPortalCache: () => void;
+
+  /**
+   * Clears rendered cells cache.
+   */
+  readonly clearRenderedCellCache: () => void;
+
+  /**
+   * Create a fresh class to be used as an editor, based on the provided editor React element.
+   *
+   * @param {React.ReactElement} editorElement React editor component.
+   * @param {string|number} [editorColumnScope] The editor scope (column index or a 'global' string). Defaults to
+   * 'global'.
+   * @returns {Function} A class to be passed to the Handsontable editor settings.
+   */
+  readonly getEditorClass: (editorElement: HotEditorElement, editorColumnScope?: EditorScopeIdentifier) => typeof Handsontable.editors.BaseEditor | undefined;
+
+  /**
+   * Set the renderers portal manager ref.
+   *
+   * @param {React.ReactComponent} pmComponent The PortalManager component.
+   */
+  readonly setRenderersPortalManagerRef: (pmComponent: RenderersPortalManager) => void;
+
+  /**
+   * Puts cell portals into portal manager and purges portals cache.
+   */
+  readonly pushCellPortalsIntoPortalManager: () => void;
+}
+
+const HotTableContext = React.createContext<HotTableContextImpl | undefined>(undefined);
+
+/**
+ * Create a class to be passed to the Handsontable's settings.
+ *
+ * @param {React.ReactElement} editorComponent React editor component.
+ * @returns {Function} A class to be passed to the Handsontable editor settings.
+ */
+function makeEditorClass(editorComponent: React.Component): typeof Handsontable.editors.BaseEditor {
+  const customEditorClass = class CustomEditor extends Handsontable.editors.BaseEditor implements Handsontable.editors.BaseEditor {
+    editorComponent: React.Component;
+
+    constructor(hotInstance: Handsontable.Core) {
+      super(hotInstance);
+
+      (editorComponent as any).hotCustomEditorInstance = this;
+
+      this.editorComponent = editorComponent;
+    }
+
+    focus() {
+    }
+
+    getValue() {
+    }
+
+    setValue() {
+    }
+
+    open() {
+    }
+
+    close() {
+    }
+  };
+
+  // Fill with the rest of the BaseEditor methods
+  Object.getOwnPropertyNames(Handsontable.editors.BaseEditor.prototype).forEach(propName => {
+    if (propName === 'constructor') {
+      return;
+    }
+
+    (customEditorClass as any).prototype[propName] = function (...args: any[]) {
+      return (editorComponent as any)[propName].call(editorComponent, ...args);
+    }
+  });
+
+  return customEditorClass;
+}
+
+const HotTableContextProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const columnsSettings = React.useRef<Handsontable.ColumnSettings[]>([]);
+
+  const setHotColumnSettings = React.useCallback((columnSettings: Handsontable.ColumnSettings, columnIndex: number) => {
+    columnsSettings.current[columnIndex] = columnSettings;
+  }, [])
+
+  const componentRendererColumns = React.useRef<Map<number | 'global', boolean>>(new Map());
+  const editorCache = React.useRef<HotEditorCache>(new Map());
+  const renderedCellCache = React.useRef<Map<string, HTMLTableCellElement>>(new Map());
+  const clearRenderedCellCache = React.useCallback(() => renderedCellCache.current.clear(), []);
+  const portalCache = React.useRef<Map<string, React.ReactPortal>>(new Map());
+  const clearPortalCache = React.useCallback(() => portalCache.current.clear(), []);
+  const portalContainerCache = React.useRef<Map<string, HTMLElement>>(new Map());
+
+  const getRendererWrapper = React.useCallback((rendererElement: React.ReactElement): typeof Handsontable.renderers.BaseRenderer => {
+    return function (instance, TD, row, col, prop, value, cellProperties) {
+      const key = `${row}-${col}`;
+
+      // Handsontable.Core type is missing guid
+      const instanceGuid = (instance as unknown as { guid: string }).guid;
+
+      const portalContainerKey = `${instanceGuid}-${key}`
+      const portalKey = `${key}-${instanceGuid}`
+
+      if (renderedCellCache.current.has(key)) {
+        TD.innerHTML = renderedCellCache.current.get(key).innerHTML;
+      }
+
+      if (TD && !TD.getAttribute('ghost-table')) {
+        const cachedPortal = portalCache.current.get(portalKey);
+        const cachedPortalContainer = portalContainerCache.current.get(portalContainerKey);
+
+        while (TD.firstChild) {
+          TD.removeChild(TD.firstChild);
+        }
+
+        // if portal already exists, do not recreate
+        if (cachedPortal && cachedPortalContainer) {
+          TD.appendChild(cachedPortalContainer);
+        } else {
+          const { portal, portalContainer } = createPortal(rendererElement, {
+            TD,
+            row,
+            col,
+            prop,
+            value,
+            cellProperties,
+            isRenderer: true
+          }, TD.ownerDocument, portalKey, cachedPortalContainer);
+
+          portalContainerCache.current.set(portalContainerKey, portalContainer);
+          TD.appendChild(portalContainer);
+
+          portalCache.current.set(portalKey, portal);
+        }
+      }
+
+      renderedCellCache.current.set(`${row}-${col}`, TD);
+      return TD;
+    };
+  }, []);
+
+  const getEditorClass = React.useCallback((editorElement: HotEditorElement, editorColumnScope: EditorScopeIdentifier = GLOBAL_EDITOR_SCOPE): typeof Handsontable.editors.BaseEditor | undefined => {
+    const editorClass = getOriginalEditorClass(editorElement);
+    const cachedComponent = editorCache.current.get(editorClass)?.get(editorColumnScope);
+
+    if (cachedComponent) {
+      return makeEditorClass(cachedComponent);
+    }
+  }, []);
+
+  const renderersPortalManager = React.useRef<RenderersPortalManager | null>(null);
+
+  const setRenderersPortalManagerRef = React.useCallback((pmComponent: RenderersPortalManager) => {
+    renderersPortalManager.current = pmComponent;
+  }, []);
+
+  const pushCellPortalsIntoPortalManager = React.useCallback(() => {
+    renderersPortalManager.current!.setState({
+      portals: [...portalCache.current.values()]
+    });
+  }, []);
+
+  const contextImpl: HotTableContextImpl = React.useMemo(() => ({
+    componentRendererColumns: componentRendererColumns.current,
+    columnsSettings: columnsSettings.current,
+    emitColumnSettings: setHotColumnSettings,
+    editorCache: editorCache.current,
+    getRendererWrapper,
+    clearPortalCache,
+    clearRenderedCellCache,
+    getEditorClass,
+    setRenderersPortalManagerRef,
+    pushCellPortalsIntoPortalManager
+  }), [setHotColumnSettings, getRendererWrapper, clearRenderedCellCache, getEditorClass, setRenderersPortalManagerRef]);
+
+  return (
+    <HotTableContext.Provider value={contextImpl}>{children}</HotTableContext.Provider>
+  );
+};
+
+export { HotTableContext, HotTableContextProvider };


### PR DESCRIPTION
### Context

Changing the way `HotTable` communicates with `HotColumn`s below. Right now, to avoid props passing and expose simple `<HotTable ...><HotColumn ... /></HotTable>` children-based API, the utilities are shared from `HotTable` to HotColumn via [React.Children iteration and cloneElement "magic"](https://github.com/handsontable/handsontable/blob/develop/wrappers/react/src/hotTableClass.tsx#L496). We agreed it's not idiomatic React and React way to do it would be to use context. 

However, it turned out that besides shared utils, the `HotColumn` instances get `columnIndex` prop which obviously its different for each children, so the only way to do it without forcing end-users to specify these indices is to keep a part of the current approach.

I also skipped moving `hotInstance` access to the context as right now there's no need to do so. `HotInstance` is initialized and accessed only from `HotTable` - moving it elsewhere will only introduce unnecessary complexity.

### How has this been tested?

* All the unit tests still pass. No new unit tests as this is an internal structural change with no intention to be observable from the outside.
* Example projects from the repo still work properly.
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

☝️ actually, none of them. This is purely a structural change with no behavior change intended.

### Related issue(s):
1. Proposal in [RFC](https://github.com/handsontable/handsontable/discussions/10767)
2. Already pre-reviewed discussion with @evanSe in [my private fork](https://github.com/NOtherDev/handsontable/pull/2)

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [x] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
