### PR TITLE
Fix getCellMeta link in documentation params

### DIFF
--- a/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
+++ b/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
@@ -117,7 +117,7 @@ export class AutocompleteEditor extends HandsontableEditor {
    * @param {number|string} prop The column property (passed when datasource is an array of objects).
    * @param {HTMLTableCellElement} td The rendered cell element.
    * @param {*} value The rendered value.
-   * @param {object} cellProperties The cell meta object ({@see Core#getCellMeta}).
+   * @param {object} cellProperties The cell meta object (see {@link Core#getCellMeta}).
    */
   prepare(row, col, prop, td, value, cellProperties) {
     super.prepare(row, col, prop, td, value, cellProperties);

--- a/handsontable/src/editors/baseEditor/baseEditor.js
+++ b/handsontable/src/editors/baseEditor/baseEditor.js
@@ -163,7 +163,7 @@ export class BaseEditor {
    * @param {number|string} prop The column property (passed when datasource is an array of objects).
    * @param {HTMLTableCellElement} td The rendered cell element.
    * @param {*} value The rendered value.
-   * @param {object} cellProperties The cell meta object ({@see Core#getCellMeta}).
+   * @param {object} cellProperties The cell meta object (see {@link Core#getCellMeta}).
    */
   prepare(row, col, prop, td, value, cellProperties) {
     this.TD = td;

--- a/handsontable/src/editors/dateEditor/dateEditor.js
+++ b/handsontable/src/editors/dateEditor/dateEditor.js
@@ -101,7 +101,7 @@ export class DateEditor extends TextEditor {
    * @param {number|string} prop The column property (passed when datasource is an array of objects).
    * @param {HTMLTableCellElement} td The rendered cell element.
    * @param {*} value The rendered value.
-   * @param {object} cellProperties The cell meta object ({@see Core#getCellMeta}).
+   * @param {object} cellProperties The cell meta object (see {@link Core#getCellMeta}).
    */
   prepare(row, col, prop, td, value, cellProperties) {
     super.prepare(row, col, prop, td, value, cellProperties);

--- a/handsontable/src/editors/dropdownEditor/dropdownEditor.js
+++ b/handsontable/src/editors/dropdownEditor/dropdownEditor.js
@@ -18,7 +18,7 @@ export class DropdownEditor extends AutocompleteEditor {
    * @param {number|string} prop The column property (passed when datasource is an array of objects).
    * @param {HTMLTableCellElement} td The rendered cell element.
    * @param {*} value The rendered value.
-   * @param {object} cellProperties The cell meta object ({@see Core#getCellMeta}).
+   * @param {object} cellProperties The cell meta object (see {@link Core#getCellMeta}).
    */
   prepare(row, col, prop, td, value, cellProperties) {
     super.prepare(row, col, prop, td, value, cellProperties);

--- a/handsontable/src/editors/handsontableEditor/handsontableEditor.js
+++ b/handsontable/src/editors/handsontableEditor/handsontableEditor.js
@@ -68,7 +68,7 @@ export class HandsontableEditor extends TextEditor {
    * @param {number|string} prop The column property (passed when datasource is an array of objects).
    * @param {HTMLTableCellElement} td The rendered cell element.
    * @param {*} value The rendered value.
-   * @param {object} cellProperties The cell meta object ({@see Core#getCellMeta}).
+   * @param {object} cellProperties The cell meta object (see {@link Core#getCellMeta}).
    */
   prepare(row, col, prop, td, value, cellProperties) {
     super.prepare(row, col, prop, td, value, cellProperties);

--- a/handsontable/src/editors/selectEditor/selectEditor.js
+++ b/handsontable/src/editors/selectEditor/selectEditor.js
@@ -111,7 +111,7 @@ export class SelectEditor extends BaseEditor {
    * @param {number|string} prop The column property (passed when datasource is an array of objects).
    * @param {HTMLTableCellElement} td The rendered cell element.
    * @param {*} value The rendered value.
-   * @param {object} cellProperties The cell meta object ({@see Core#getCellMeta}).
+   * @param {object} cellProperties The cell meta object (see {@link Core#getCellMeta}).
    */
   prepare(row, col, prop, td, value, cellProperties) {
     super.prepare(row, col, prop, td, value, cellProperties);

--- a/handsontable/src/editors/textEditor/textEditor.js
+++ b/handsontable/src/editors/textEditor/textEditor.js
@@ -149,7 +149,7 @@ export class TextEditor extends BaseEditor {
    * @param {number|string} prop The column property (passed when datasource is an array of objects).
    * @param {HTMLTableCellElement} td The rendered cell element.
    * @param {*} value The rendered value.
-   * @param {object} cellProperties The cell meta object ({@see Core#getCellMeta}).
+   * @param {object} cellProperties The cell meta object (see {@link Core#getCellMeta}).
    */
   prepare(row, col, prop, td, value, cellProperties) {
     const previousState = this.state;

--- a/handsontable/src/editors/timeEditor/timeEditor.js
+++ b/handsontable/src/editors/timeEditor/timeEditor.js
@@ -19,7 +19,7 @@ export class TimeEditor extends TextEditor {
    * @param {number|string} prop The column property (passed when datasource is an array of objects).
    * @param {HTMLTableCellElement} td The rendered cell element.
    * @param {*} value The rendered value.
-   * @param {object} cellProperties The cell meta object ({@see Core#getCellMeta}).
+   * @param {object} cellProperties The cell meta object (see {@link Core#getCellMeta}).
    */
   prepare(row, col, prop, td, value, cellProperties) {
     super.prepare(row, col, prop, td, value, cellProperties);

--- a/handsontable/src/renderers/autocompleteRenderer/autocompleteRenderer.js
+++ b/handsontable/src/renderers/autocompleteRenderer/autocompleteRenderer.js
@@ -18,7 +18,7 @@ export const RENDERER_TYPE = 'autocomplete';
  * @param {number} col The visual column index.
  * @param {number|string} prop The column property (passed when datasource is an array of objects).
  * @param {*} value The rendered value.
- * @param {object} cellProperties The cell meta object ({@see Core#getCellMeta}).
+ * @param {object} cellProperties The cell meta object (see {@link Core#getCellMeta}).
  */
 export function autocompleteRenderer(hotInstance, TD, row, col, prop, value, cellProperties) {
   const { rootDocument } = hotInstance;

--- a/handsontable/src/renderers/baseRenderer/baseRenderer.js
+++ b/handsontable/src/renderers/baseRenderer/baseRenderer.js
@@ -18,7 +18,7 @@ export const RENDERER_TYPE = 'base';
  * @param {number} col The visual column index.
  * @param {number|string} prop The column property (passed when datasource is an array of objects).
  * @param {*} value The rendered value.
- * @param {object} cellProperties The cell meta object ({@see Core#getCellMeta}).
+ * @param {object} cellProperties The cell meta object (see {@link Core#getCellMeta}).
  */
 export function baseRenderer(hotInstance, TD, row, col, prop, value, cellProperties) {
   const ariaEnabled = cellProperties.ariaTags;

--- a/handsontable/src/renderers/checkboxRenderer/checkboxRenderer.js
+++ b/handsontable/src/renderers/checkboxRenderer/checkboxRenderer.js
@@ -54,7 +54,7 @@ Hooks.getSingleton().add('modifyAutoColumnSizeSeed', function(bundleSeed, cellMe
  * @param {number} col The visual column index.
  * @param {number|string} prop The column property (passed when datasource is an array of objects).
  * @param {*} value The rendered value.
- * @param {object} cellProperties The cell meta object ({@see Core#getCellMeta}).
+ * @param {object} cellProperties The cell meta object (see {@link Core#getCellMeta}).
  */
 export function checkboxRenderer(hotInstance, TD, row, col, prop, value, cellProperties) {
   const { rootDocument } = hotInstance;

--- a/handsontable/src/renderers/dateRenderer/dateRenderer.js
+++ b/handsontable/src/renderers/dateRenderer/dateRenderer.js
@@ -12,7 +12,7 @@ export const RENDERER_TYPE = 'date';
  * @param {number} col The visual column index.
  * @param {number|string} prop The column property (passed when datasource is an array of objects).
  * @param {*} value The rendered value.
- * @param {object} cellProperties The cell meta object ({@see Core#getCellMeta}).
+ * @param {object} cellProperties The cell meta object (see {@link Core#getCellMeta}).
  */
 export function dateRenderer(hotInstance, TD, row, col, prop, value, cellProperties) {
   autocompleteRenderer.apply(this, [hotInstance, TD, row, col, prop, value, cellProperties]);

--- a/handsontable/src/renderers/dropdownRenderer/dropdownRenderer.js
+++ b/handsontable/src/renderers/dropdownRenderer/dropdownRenderer.js
@@ -12,7 +12,7 @@ export const RENDERER_TYPE = 'dropdown';
  * @param {number} col The visual column index.
  * @param {number|string} prop The column property (passed when datasource is an array of objects).
  * @param {*} value The rendered value.
- * @param {object} cellProperties The cell meta object ({@see Core#getCellMeta}).
+ * @param {object} cellProperties The cell meta object (see {@link Core#getCellMeta}).
  */
 export function dropdownRenderer(hotInstance, TD, row, col, prop, value, cellProperties) {
   autocompleteRenderer.apply(this, [hotInstance, TD, row, col, prop, value, cellProperties]);

--- a/handsontable/src/renderers/handsontableRenderer/handsontableRenderer.js
+++ b/handsontable/src/renderers/handsontableRenderer/handsontableRenderer.js
@@ -12,7 +12,7 @@ export const RENDERER_TYPE = 'handsontable';
  * @param {number} col The visual column index.
  * @param {number|string} prop The column property (passed when datasource is an array of objects).
  * @param {*} value The rendered value.
- * @param {object} cellProperties The cell meta object ({@see Core#getCellMeta}).
+ * @param {object} cellProperties The cell meta object (see {@link Core#getCellMeta}).
  */
 export function handsontableRenderer(hotInstance, TD, row, col, prop, value, cellProperties) {
   autocompleteRenderer.apply(this, [hotInstance, TD, row, col, prop, value, cellProperties]);

--- a/handsontable/src/renderers/htmlRenderer/htmlRenderer.js
+++ b/handsontable/src/renderers/htmlRenderer/htmlRenderer.js
@@ -11,7 +11,7 @@ export const RENDERER_TYPE = 'html';
  * @param {number} col The visual column index.
  * @param {number|string} prop The column property (passed when datasource is an array of objects).
  * @param {*} value The rendered value.
- * @param {object} cellProperties The cell meta object ({@see Core#getCellMeta}).
+ * @param {object} cellProperties The cell meta object (see {@link Core#getCellMeta}).
  */
 export function htmlRenderer(hotInstance, TD, row, col, prop, value, cellProperties) {
   baseRenderer.apply(this, [hotInstance, TD, row, col, prop, value, cellProperties]);

--- a/handsontable/src/renderers/numericRenderer/numericRenderer.js
+++ b/handsontable/src/renderers/numericRenderer/numericRenderer.js
@@ -44,7 +44,7 @@ export function getRenderedValue(value, cellProperties) {
  * @param {number} col The visual column index.
  * @param {number|string} prop The column property (passed when datasource is an array of objects).
  * @param {*} value The rendered value.
- * @param {object} cellProperties The cell meta object ({@see Core#getCellMeta}).
+ * @param {object} cellProperties The cell meta object (see {@link Core#getCellMeta}).
  */
 export function numericRenderer(hotInstance, TD, row, col, prop, value, cellProperties) {
   let newValue = value;

--- a/handsontable/src/renderers/passwordRenderer/passwordRenderer.js
+++ b/handsontable/src/renderers/passwordRenderer/passwordRenderer.js
@@ -12,7 +12,7 @@ export const RENDERER_TYPE = 'password';
  * @param {number} col The visual column index.
  * @param {number|string} prop The column property (passed when datasource is an array of objects).
  * @param {*} value The rendered value.
- * @param {object} cellProperties The cell meta object ({@see Core#getCellMeta}).
+ * @param {object} cellProperties The cell meta object (see {@link Core#getCellMeta}).
  */
 export function passwordRenderer(hotInstance, TD, row, col, prop, value, cellProperties) {
   textRenderer.apply(this, [hotInstance, TD, row, col, prop, value, cellProperties]);

--- a/handsontable/src/renderers/selectRenderer/selectRenderer.js
+++ b/handsontable/src/renderers/selectRenderer/selectRenderer.js
@@ -10,7 +10,7 @@ export const RENDERER_TYPE = 'select';
  * @param {number} col The visual column index.
  * @param {number|string} prop The column property (passed when datasource is an array of objects).
  * @param {*} value The rendered value.
- * @param {object} cellProperties The cell meta object ({@see Core#getCellMeta}).
+ * @param {object} cellProperties The cell meta object (see {@link Core#getCellMeta}).
  */
 export function selectRenderer(hotInstance, TD, row, col, prop, value, cellProperties) {
   textRenderer.apply(this, [hotInstance, TD, row, col, prop, value, cellProperties]);

--- a/handsontable/src/renderers/textRenderer/textRenderer.js
+++ b/handsontable/src/renderers/textRenderer/textRenderer.js
@@ -14,7 +14,7 @@ export const RENDERER_TYPE = 'text';
  * @param {number} col The visual column index.
  * @param {number|string} prop The column property (passed when datasource is an array of objects).
  * @param {*} value The rendered value.
- * @param {object} cellProperties The cell meta object ({@see Core#getCellMeta}).
+ * @param {object} cellProperties The cell meta object (see {@link Core#getCellMeta}).
  */
 export function textRenderer(hotInstance, TD, row, col, prop, value, cellProperties) {
   baseRenderer.apply(this, [hotInstance, TD, row, col, prop, value, cellProperties]);

--- a/handsontable/src/renderers/timeRenderer/timeRenderer.js
+++ b/handsontable/src/renderers/timeRenderer/timeRenderer.js
@@ -12,7 +12,7 @@ export const RENDERER_TYPE = 'time';
  * @param {number} col The visual column index.
  * @param {number|string} prop The column property (passed when datasource is an array of objects).
  * @param {*} value The rendered value.
- * @param {object} cellProperties The cell meta object ({@see Core#getCellMeta}).
+ * @param {object} cellProperties The cell meta object (see {@link Core#getCellMeta}).
  */
 export function timeRenderer(hotInstance, TD, row, col, prop, value, cellProperties) {
   textRenderer.apply(this, [hotInstance, TD, row, col, prop, value, cellProperties]);


### PR DESCRIPTION
### Context
This PR includes fix for cellProperties link in documentation params

### How has this been tested?
Locally

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/1116

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] Fix documentation link to Core#getCellMeta

[skip changelog]