### PR TITLE
Add vue 3 codesandbox link to documentation introduction

### DIFF
--- a/docs/content/guides/getting-started/introduction.md
+++ b/docs/content/guides/getting-started/introduction.md
@@ -51,6 +51,7 @@ To jump straight into the sample code, open the demo app at CodeSandbox:
 - [React demo](https://codesandbox.io/s/handsontable-react-data-grid-hello-world-app-14-0-0-xr7mj2)
 - [Angular demo](https://codesandbox.io/s/handsontable-angular-data-grid-hello-world-app-14-0-0-c54xw9)
 - [Vue 2 demo](https://codesandbox.io/s/handsontable-vue-data-grid-hello-world-app-14-0-0-zm9nz6)
+- [Vue 3 demo](https://codesandbox.io/p/sandbox/handsontable-data-grid-v14-1-0-vue-3-demo-ypkddz)
 - [TypeScript demo](https://codesandbox.io/s/handsontable-typescript-data-grid-hello-world-app-14-0-0-3f4lss)
 :::
 


### PR DESCRIPTION
### Context
This PR includes update for missing link in the documentation introduction

### How has this been tested?
Locally

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/1684

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] Add missing vue 3 link in the documentation introduction

[skip changelog]
