### PR TITLE
Fix input problems when using the browser's autocomplete + fix event listener leak.

### DIFF
--- a/.changelogs/10795.json
+++ b/.changelogs/10795.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed input problems when using the browser's autocomplete + fixed an event listener leak.",
+  "type": "fixed",
+  "issueOrPR": 10795,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/test/e2e/MemoryLeakTest.js
+++ b/handsontable/test/e2e/MemoryLeakTest.js
@@ -12,7 +12,7 @@ describe('MemoryLeakTest', () => {
     expect(document.querySelectorAll('#testContainer').length).toBe(0);
   });
 
-  it('should not leave any any DOM containers, except for those created by Jasmine', () => {
+  it('should not leave any any DOM containers, except for those created by Jasmine', async() => {
     let leftoverNodesCount = 0;
 
     Array.from(document.body.children).forEach((child) => {
@@ -22,5 +22,84 @@ describe('MemoryLeakTest', () => {
     });
 
     expect(leftoverNodesCount).toBe(0);
+  });
+
+  describe('Event Listeners', () => {
+    const id = 'testContainer';
+
+    beforeEach(function() {
+      this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+    });
+
+    afterEach(function() {
+      if (this.$container) {
+        destroy();
+        this.$container.remove();
+      }
+    });
+
+    // Currently it's not possible to run it in the browser.
+    // `getEventListeners` is a non-standard function available only in Chrome DevTools and in the current Puppeteer setup.
+    if (typeof getEventListeners === 'undefined') {
+      xit('Available in command-line: "should not leave any event listeners attached to the HTML element after being destroyed"', () => { });
+
+    } else {
+      it('should not leave any event listeners attached to the HTML element after being destroyed', async() => {
+        const htmlListenersBefore = await getEventListeners(document.documentElement);
+        const bodyListenersBefore = await getEventListeners(document.body);
+        const countListenersOfType = (listeners, type) =>
+          (listeners.filter(listener => listener.type === type) || []).length;
+
+        const hot = handsontable({
+          data: [['a', 'b'], ['c', 'd']],
+          columns: [
+            {
+              type: 'autocomplete',
+              source: [''],
+              strict: false
+            },
+          ],
+        });
+
+        selectCell(0, 0);
+        keyDownUp('enter');
+        keyDownUp('enter');
+
+        hot.destroy();
+
+        const htmlListenersAfter = await getEventListeners(document.documentElement);
+        const bodyListenersAfter = await getEventListeners(document.body);
+
+        expect(countListenersOfType(htmlListenersBefore.listeners, 'keydown'))
+          .toEqual(countListenersOfType(htmlListenersAfter.listeners, 'keydown'));
+        expect(countListenersOfType(htmlListenersBefore.listeners, 'keyup'))
+          .toEqual(countListenersOfType(htmlListenersAfter.listeners, 'keyup'));
+        expect(countListenersOfType(htmlListenersBefore.listeners, 'mousedown'))
+          .toEqual(countListenersOfType(htmlListenersAfter.listeners, 'mousedown'));
+        expect(countListenersOfType(htmlListenersBefore.listeners, 'mouseup'))
+          .toEqual(countListenersOfType(htmlListenersAfter.listeners, 'mouseup'));
+        expect(countListenersOfType(htmlListenersBefore.listeners, 'focus'))
+          .toEqual(countListenersOfType(htmlListenersAfter.listeners, 'focus'));
+        expect(countListenersOfType(htmlListenersBefore.listeners, 'blur'))
+          .toEqual(countListenersOfType(htmlListenersAfter.listeners, 'blur'));
+        expect(countListenersOfType(htmlListenersBefore.listeners, 'click'))
+          .toEqual(countListenersOfType(htmlListenersAfter.listeners, 'click'));
+
+        expect(countListenersOfType(bodyListenersBefore.listeners, 'keydown'))
+          .toEqual(countListenersOfType(bodyListenersAfter.listeners, 'keydown'));
+        expect(countListenersOfType(bodyListenersBefore.listeners, 'keyup'))
+          .toEqual(countListenersOfType(bodyListenersAfter.listeners, 'keyup'));
+        expect(countListenersOfType(bodyListenersBefore.listeners, 'mousedown'))
+          .toEqual(countListenersOfType(bodyListenersAfter.listeners, 'mousedown'));
+        expect(countListenersOfType(bodyListenersBefore.listeners, 'mouseup'))
+          .toEqual(countListenersOfType(bodyListenersAfter.listeners, 'mouseup'));
+        expect(countListenersOfType(bodyListenersBefore.listeners, 'focus'))
+          .toEqual(countListenersOfType(bodyListenersAfter.listeners, 'focus'));
+        expect(countListenersOfType(bodyListenersBefore.listeners, 'blur'))
+          .toEqual(countListenersOfType(bodyListenersAfter.listeners, 'blur'));
+        expect(countListenersOfType(bodyListenersBefore.listeners, 'click'))
+          .toEqual(countListenersOfType(bodyListenersAfter.listeners, 'click'));
+      });
+    }
   });
 });

--- a/handsontable/test/e2e/MemoryLeakTest.js
+++ b/handsontable/test/e2e/MemoryLeakTest.js
@@ -12,7 +12,7 @@ describe('MemoryLeakTest', () => {
     expect(document.querySelectorAll('#testContainer').length).toBe(0);
   });
 
-  it('should not leave any any DOM containers, except for those created by Jasmine', async() => {
+  it('should not leave any any DOM containers, except for those created by Jasmine', () => {
     let leftoverNodesCount = 0;
 
     Array.from(document.body.children).forEach((child) => {


### PR DESCRIPTION
### Context
This PR should:

1. Fix a problem, when errors were thrown after using the browser's autocomplete dropdown on an input outside of Handsontable (described in handsontable/dev-handsontable#1735)
2. Fix an event listener leak - in certain situations (for example, using handsontable-based editors) not all `keydown` and `keyup` event listeners were removed after destroying the Handsontable instance

To prevent leaks in the future, I added a test case to check that. Unfortunately, the `getEventListeners` function I'm using in the tests is non-standard and cannot be used when running the tests in the browser. I implemented it in our Puppeteer setup + it can be used in the Chrome's devtools for debugging.

### How has this been tested?
Added a test case for the leak problem. I wasn't sure how to test the first issue (as it's dependent on the browser's history, and I don't know how to reproduce it in the test environment), so I only tested that manually.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#1735

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
