### PR TITLE
Add renderAllColumns reference to Column virtualization documentation page

### DIFF
--- a/docs/content/guides/columns/column-virtualization.md
+++ b/docs/content/guides/columns/column-virtualization.md
@@ -136,3 +136,4 @@ Using column virtualization has the following side effects:
 
 - Configuration options:
   - [`viewportColumnRenderingOffset`](@/api/options.md#viewportcolumnrenderingoffset)
+  - [`renderAllColumns`](@/api/options.md#renderallcolumns)


### PR DESCRIPTION
### Context
This PR includes update for "Column virtualization" documentation page with renderAllColumns reference in Related API reference section

### How has this been tested?
Locally

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/1716

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] renderAllColumns reference is present in "Column virtualization" documentation page

[skip changelog]