### PR TITLE
React wrapper: Rewrite HotTable & HotColumn into functional components

### DIFF
--- a/.changelogs/10799.json
+++ b/.changelogs/10799.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Rewrite HotTable & HotColumn into functional components",
+  "type": "changed",
+  "issueOrPR": 10799,
+  "breaking": true,
+  "framework": "react"
+}

--- a/wrappers/react/src/helpers.tsx
+++ b/wrappers/react/src/helpers.tsx
@@ -171,3 +171,21 @@ export function superBound<T>(that: T): T {
 
   return superBoundObj;
 }
+
+/**
+ * A variant of React.useEffect hook that does not trigger on initial mount, only updates
+ *
+ * @param effect Effect function
+ * @param deps Effect dependencies
+ */
+export function useUpdateEffect(effect: React.EffectCallback, deps?: React.DependencyList): void {
+  const notInitialRender = React.useRef(false);
+
+  React.useEffect(() => {
+    if (notInitialRender.current) {
+      return effect();
+    } else {
+      notInitialRender.current = true;
+    }
+  }, deps);
+}

--- a/wrappers/react/src/hotColumn.tsx
+++ b/wrappers/react/src/hotColumn.tsx
@@ -6,7 +6,7 @@ import {
 } from './helpers';
 import { SettingsMapper } from './settingsMapper';
 import Handsontable from 'handsontable/base';
-import { HotTableContext } from './hotTableContext'
+import { useHotTableContext } from './hotTableContext'
 import { useHotColumnContext } from './hotColumnContext'
 import { EditorContextProvider, makeEditorClass } from "./hotEditor";
 
@@ -14,121 +14,79 @@ const isHotColumn = (childNode: any): childNode is React.ReactElement => childNo
 
 const internalProps = ['_columnIndex', '_getOwnerDocument', 'children'];
 
-interface HotColumnInnerProps extends HotColumnProps {
-  _columnIndex: number;
-  _getOwnerDocument: () => Document | null;
-}
-
-class HotColumnInner extends React.Component<HotColumnInnerProps, {}> {
-  columnSettings: Handsontable.ColumnSettings;
+const HotColumn: React.FC<HotColumnProps> = (props) => {
+  const { componentRendererColumns, emitColumnSettings, getRendererWrapper } = useHotTableContext();
+  const { columnIndex, getOwnerDocument } = useHotColumnContext();
 
   /**
    * Reference to component-based editor overridden hooks object.
-   * @private
    */
-  private localEditorHooksRef = React.createRef<HotEditorHooks>();
+  const localEditorHooksRef = React.useRef<HotEditorHooks>();
 
   /**
    * Reference to HOT-native custom editor class instance.
-   * @private
    */
-  private localEditorClassInstance = React.createRef<Handsontable.editors.BaseEditor>();
+  const localEditorClassInstance = React.useRef<Handsontable.editors.BaseEditor>();
 
   /**
-   * HotTableContext type assignment
+   * Logic performed after mounting & updating of the HotColumn component.
    */
-  static contextType = HotTableContext;
+  React.useEffect(() => {
 
-  declare context: React.ContextType<typeof HotTableContext>;
+    /**
+     * Filter out all the internal properties and return an object with just the Handsontable-related props.
+     *
+     * @returns {Object}
+     */
+    const getSettingsProps = (): HotTableProps => {
+      return Object.keys(props)
+        .filter(key => !internalProps.includes(key))
+        .reduce((obj, key) => {
+          obj[key] = props[key];
+          return obj;
+        }, {});
+    };
 
-  /**
-   * Filter out all the internal properties and return an object with just the Handsontable-related props.
-   *
-   * @returns {Object}
-   */
-  getSettingsProps(): HotTableProps {
-    return Object.keys(this.props)
-      .filter(key => {
-        return !internalProps.includes(key);
-      })
-      .reduce((obj, key) => {
-        obj[key] = this.props[key];
+    /**
+     * Create the column settings based on the data provided to the `HotColumn` component and its child components.
+     */
+    const createColumnSettings = (): Handsontable.ColumnSettings => {
+      const columnSettings = SettingsMapper.getSettings(getSettingsProps()) as unknown as Handsontable.ColumnSettings;
 
-        return obj;
-      }, {});
-  }
+      if (props.renderer) {
+        columnSettings.renderer = getRendererWrapper(props.renderer);
+        componentRendererColumns.set(columnIndex, true);
+      } else if (props.hotRenderer) {
+        columnSettings.renderer = props.hotRenderer;
+      }
 
-  /**
-   * Create the column settings based on the data provided to the `HotColumn` component and it's child components.
-   */
-  createColumnSettings(): void {
-    this.columnSettings = SettingsMapper.getSettings(this.getSettingsProps()) as unknown as Handsontable.ColumnSettings;
+      if (props.editor) {
+        columnSettings.editor = makeEditorClass(localEditorHooksRef, localEditorClassInstance);
+      } else if (props.hotEditor) {
+        columnSettings.editor = props.hotEditor;
+      }
 
-    if (this.props.renderer) {
-      this.columnSettings.renderer = this.context.getRendererWrapper(this.props.renderer);
-      this.context.componentRendererColumns.set(this.props._columnIndex, true);
-    } else if (this.props.hotRenderer) {
-      this.columnSettings.renderer = this.props.hotRenderer;
-    }
+      return columnSettings
+    };
 
-    if (this.props.editor) {
-      this.columnSettings.editor = makeEditorClass(this.localEditorHooksRef, this.localEditorClassInstance);
-    } else if (this.props.hotEditor) {
-      this.columnSettings.editor = this.props.hotEditor;
-    }
-  }
+    const columnSettings = createColumnSettings();
+    emitColumnSettings(columnSettings, columnIndex);
+    displayObsoleteRenderersEditorsWarning(props.children);
+  });
 
-  /**
-   * Emit the column settings to the parent using a prop passed from the parent.
-   */
-  emitColumnSettings(): void {
-    this.context.emitColumnSettings(this.columnSettings, this.props._columnIndex);
-  }
-
-  /*
-  ---------------------------------------
-  ------- React lifecycle methods -------
-  ---------------------------------------
-  */
-
-  /**
-   * Logic performed after the mounting of the HotColumn component.
-   */
-  componentDidMount(): void {
-    this.createColumnSettings();
-    this.emitColumnSettings();
-    displayObsoleteRenderersEditorsWarning(this.props.children);
-  }
-
-  /**
-   * Logic performed after the updating of the HotColumn component.
-   */
-  componentDidUpdate(): void {
-    this.createColumnSettings();
-    this.emitColumnSettings();
-    displayObsoleteRenderersEditorsWarning(this.props.children);
-  }
+  const editorPortal = createEditorPortal(getOwnerDocument(), props.editor);
 
   /**
    * Render the portals of the editors, if there are any.
    *
    * @returns {React.ReactElement}
    */
-  render(): React.ReactElement {
-    const editorPortal = createEditorPortal(this.props._getOwnerDocument(), this.props.editor);
-
-    return (
-      <EditorContextProvider hooksRef={this.localEditorHooksRef}
-                             hotCustomEditorInstanceRef={this.localEditorClassInstance}>
-        {editorPortal}
-      </EditorContextProvider>
-    )
-  }
-}
-
-const HotColumn: React.FC<HotColumnProps> = (props) => {
-  const { columnIndex, getOwnerDocument } = useHotColumnContext()
-  return <HotColumnInner {...props} _columnIndex={columnIndex} _getOwnerDocument={getOwnerDocument} />
+  return (
+    <EditorContextProvider hooksRef={localEditorHooksRef}
+                           hotCustomEditorInstanceRef={localEditorClassInstance}>
+      {editorPortal}
+    </EditorContextProvider>
+  )
 }
 
 export { HotColumn, isHotColumn };

--- a/wrappers/react/src/hotTable.tsx
+++ b/wrappers/react/src/hotTable.tsx
@@ -1,7 +1,7 @@
 import React, { ForwardRefExoticComponent, RefAttributes } from 'react';
 import * as packageJson from '../package.json';
-import { HotTableClass, HotTableRef } from './hotTableClass';
-import { HotTableProps } from './types';
+import { HotTableInner } from './hotTableInner';
+import { HotTableProps, HotTableRef } from './types';
 import { HotTableContextProvider } from './hotTableContext';
 
 interface Version {
@@ -36,9 +36,9 @@ const HotTable: HotTable = React.forwardRef<HotTableRef, HotTableProps>(({ child
 
   return (
     <HotTableContextProvider>
-      <HotTableClass id={componentId} {...props} ref={ref}>
+      <HotTableInner id={componentId} {...props} ref={ref}>
         {children}
-      </HotTableClass>
+      </HotTableInner>
     </HotTableContextProvider>
   );
 })

--- a/wrappers/react/src/hotTable.tsx
+++ b/wrappers/react/src/hotTable.tsx
@@ -1,16 +1,36 @@
 import React, { ForwardRefExoticComponent, RefAttributes } from 'react';
-import { HotTableClass } from './hotTableClass';
+import * as packageJson from '../package.json';
+import { HotTableClass, HotTableRef } from './hotTableClass';
 import { HotTableProps } from './types';
-import { HotTableContextProvider } from './hotTableContext'
+import { HotTableContextProvider } from './hotTableContext';
 
 interface Version {
   version?: string;
 }
 
-type HotTable = ForwardRefExoticComponent<HotTableProps & RefAttributes<HotTableClass>> & Version;
+type HotTable = ForwardRefExoticComponent<HotTableProps & RefAttributes<HotTableRef>> & Version;
 
-// Use global React variable for `forwardRef` access (React 16 support)
-const HotTable: HotTable = React.forwardRef<HotTableClass, HotTableProps>(({ children, ...props }, ref) => {
+/**
+ * A Handsontable-ReactJS wrapper.
+ *
+ * To implement, use the `HotTable` tag with properties corresponding to Handsontable options.
+ * For example:
+ *
+ * ```js
+ * <HotTable id="hot" data={dataObject} contextMenu={true} colHeaders={true} width={600} height={300} stretchH="all" />
+ *
+ * // is analogous to
+ * let hot = new Handsontable(document.getElementById('hot'), {
+ *    data: dataObject,
+ *    contextMenu: true,
+ *    colHeaders: true,
+ *    width: 600
+ *    height: 300
+ * });
+ *
+ * ```
+ */
+const HotTable: HotTable = React.forwardRef<HotTableRef, HotTableProps>(({ children, ...props }, ref) => {
   const generatedId = typeof React.useId === 'function' ? React.useId() : undefined;
   const componentId = props.id ?? generatedId;
 
@@ -23,7 +43,12 @@ const HotTable: HotTable = React.forwardRef<HotTableClass, HotTableProps>(({ chi
   );
 })
 
-HotTable.version = HotTableClass.version;
+/**
+ * Package version.
+ *
+ * @returns The version number of the package.
+ */
+HotTable.version = (packageJson as any).version;
 
 export default HotTable;
 export { HotTable };

--- a/wrappers/react/src/hotTableContext.tsx
+++ b/wrappers/react/src/hotTableContext.tsx
@@ -149,4 +149,13 @@ const HotTableContextProvider: React.FC<React.PropsWithChildren> = ({ children }
   );
 };
 
-export { HotTableContext, HotTableContextProvider };
+/**
+ * Exposes the table context object to components
+ *
+ * @returns HotTableContext
+ */
+function useHotTableContext() {
+  return React.useContext(HotTableContext);
+}
+
+export { HotTableContextProvider, useHotTableContext };

--- a/wrappers/react/src/hotTableContext.tsx
+++ b/wrappers/react/src/hotTableContext.tsx
@@ -2,7 +2,7 @@ import Handsontable from 'handsontable/base';
 import React from 'react';
 import { ScopeIdentifier, HotRendererProps } from './types'
 import { createPortal } from './helpers'
-import { RenderersPortalManager } from './renderersPortalManager'
+import { RenderersPortalManagerRef } from './renderersPortalManager'
 
 export interface HotTableContextImpl {
   /**
@@ -43,11 +43,11 @@ export interface HotTableContextImpl {
   readonly clearRenderedCellCache: () => void;
 
   /**
-   * Set the renderers portal manager ref.
+   * Set the renderers portal manager dispatch function.
    *
-   * @param {RenderersPortalManager} pmComponent The PortalManager component.
+   * @param {RenderersPortalManagerRef} pm The PortalManager dispatch function.
    */
-  readonly setRenderersPortalManagerRef: (pmComponent: RenderersPortalManager) => void;
+  readonly setRenderersPortalManagerRef: (pm: RenderersPortalManagerRef) => void;
 
   /**
    * Puts cell portals into portal manager and purges portals cache.
@@ -121,16 +121,14 @@ const HotTableContextProvider: React.FC<React.PropsWithChildren> = ({ children }
     };
   }, []);
 
-  const renderersPortalManager = React.useRef<RenderersPortalManager | null>(null);
+  const renderersPortalManager = React.useRef<RenderersPortalManagerRef>(() => undefined);
 
-  const setRenderersPortalManagerRef = React.useCallback((pmComponent: RenderersPortalManager) => {
+  const setRenderersPortalManagerRef = React.useCallback((pmComponent: RenderersPortalManagerRef) => {
     renderersPortalManager.current = pmComponent;
   }, []);
 
   const pushCellPortalsIntoPortalManager = React.useCallback(() => {
-    renderersPortalManager.current!.setState({
-      portals: [...portalCache.current.values()]
-    });
+    renderersPortalManager.current!([...portalCache.current.values()]);
   }, []);
 
   const contextImpl: HotTableContextImpl = React.useMemo(() => ({
@@ -142,7 +140,7 @@ const HotTableContextProvider: React.FC<React.PropsWithChildren> = ({ children }
     clearRenderedCellCache,
     setRenderersPortalManagerRef,
     pushCellPortalsIntoPortalManager
-  }), [setHotColumnSettings, getRendererWrapper, clearRenderedCellCache, setRenderersPortalManagerRef]);
+  }), [setHotColumnSettings, getRendererWrapper, clearRenderedCellCache, setRenderersPortalManagerRef, pushCellPortalsIntoPortalManager]);
 
   return (
     <HotTableContext.Provider value={contextImpl}>{children}</HotTableContext.Provider>

--- a/wrappers/react/src/hotTableInner.tsx
+++ b/wrappers/react/src/hotTableInner.tsx
@@ -3,7 +3,7 @@ import Handsontable from 'handsontable/base';
 import { SettingsMapper } from './settingsMapper';
 import { RenderersPortalManager } from './renderersPortalManager';
 import { isHotColumn } from './hotColumn';
-import { HotEditorHooks, HotTableProps } from './types';
+import { HotEditorHooks, HotTableProps, HotTableRef } from './types';
 import {
   HOT_DESTROYED_WARNING,
   AUTOSIZE_WARNING,
@@ -21,15 +21,7 @@ import { useHotTableContext } from './hotTableContext'
 import { HotColumnContextProvider } from './hotColumnContext'
 import { EditorContextProvider, makeEditorClass } from "./hotEditor";
 
-/**
- * Type of interface exposed to parent components by HotTable instance via React ref
- */
-interface HotTableRef {
-  hotElementRef: HTMLElement
-  hotInstance: Handsontable | null
-}
-
-const HotTableClass = React.forwardRef<HotTableRef, HotTableProps>((props, ref) => {
+const HotTableInner = React.forwardRef<HotTableRef, HotTableProps>((props, ref) => {
 
   /**
    * Reference to the Handsontable instance.
@@ -233,11 +225,11 @@ const HotTableClass = React.forwardRef<HotTableRef, HotTableProps>((props, ref) 
 /**
  * Prop types to be checked at runtime.
  */
-HotTableClass.propTypes = {
+HotTableInner.propTypes = {
   style: PropTypes.object,
   id: PropTypes.string,
   className: PropTypes.string
 };
 
-export default HotTableClass;
-export { HotTableClass, HotTableRef };
+export default HotTableInner;
+export { HotTableInner };

--- a/wrappers/react/src/index.tsx
+++ b/wrappers/react/src/index.tsx
@@ -1,6 +1,6 @@
 export * from './hotColumn';
 export * from './hotTable';
-export * from './hotTableClass';
+export * from './hotTableInner';
 export { useHotEditor } from './hotEditor';
 export * from './types';
 export { default } from './hotTable';

--- a/wrappers/react/src/index.tsx
+++ b/wrappers/react/src/index.tsx
@@ -1,6 +1,5 @@
 export * from './hotColumn';
 export * from './hotTable';
-export * from './hotTableInner';
 export { useHotEditor } from './hotEditor';
 export * from './types';
 export { default } from './hotTable';

--- a/wrappers/react/src/renderersPortalManager.tsx
+++ b/wrappers/react/src/renderersPortalManager.tsx
@@ -1,18 +1,17 @@
 import React from 'react';
 
-/**
- * Component class used to manage the renderer component portals.
- */
-export class RenderersPortalManager extends React.Component<{}, { portals?: React.ReactPortal[] }> {
-  state = {
-    portals: []
-  };
+export type RenderersPortalManagerRef = React.Dispatch<React.ReactPortal[]>;
 
-  render() {
-    return (
+/**
+ * Component used to manage the renderer component portals.
+ */
+export const RenderersPortalManager = React.forwardRef<RenderersPortalManagerRef, {}>((_, ref) => {
+  const [portals, setPortals] = React.useState<React.ReactPortal[]>([]);
+  React.useImperativeHandle(ref, () => setPortals);
+
+  return (
       <React.Fragment>
-        {this.state.portals}
+        {portals}
       </React.Fragment>
-    )
-  }
-}
+  );
+});

--- a/wrappers/react/src/types.tsx
+++ b/wrappers/react/src/types.tsx
@@ -52,3 +52,19 @@ export interface HotTableProps extends ReplaceRenderersEditors<Handsontable.Grid
 export interface HotColumnProps extends ReplaceRenderersEditors<Handsontable.ColumnSettings> {
   children?: React.ReactNode;
 }
+
+
+/**
+ * Type of interface exposed to parent components by HotTable instance via React ref
+ */
+export interface HotTableRef {
+  /**
+   * Reference to the main Handsontable DOM element.
+   */
+  hotElementRef: HTMLElement
+
+  /**
+   * Reference to the Handsontable instance.
+   */
+  hotInstance: Handsontable | null
+}

--- a/wrappers/react/test/_helpers.tsx
+++ b/wrappers/react/test/_helpers.tsx
@@ -3,7 +3,7 @@ import { createRoot } from 'react-dom/client';
 import Handsontable from 'handsontable';
 import { act } from '@testing-library/react';
 import { HotTable } from '../src/hotTable';
-import { HotRendererProps } from '../src/types'
+import { HotRendererProps, HotTableRef, HotTableProps } from '../src/types'
 import { useHotEditor } from "../src/hotEditor";
 
 const SPEC = {
@@ -51,12 +51,16 @@ export function mountComponentWithRef(Component, strictMode = true) {
   return hotTableComponent.current;
 }
 
-export function renderComponentWithProps<P>(ComponentType: React.ComponentType<P>, props: P, strictMode = true) {
+export function renderHotTableWithProps(props: HotTableProps, strictMode = true, hotTableRef: React.RefObject<HotTableRef> = React.createRef()): React.RefObject<HotTableRef> {
   act(() => {
     SPEC.root.render(
-      strictMode ? <React.StrictMode><ComponentType {...props} /></React.StrictMode> : <ComponentType {...props} />
+      strictMode
+          ? <React.StrictMode><HotTable {...props} ref={hotTableRef} /></React.StrictMode>
+          : <HotTable {...props} ref={hotTableRef} />
     );
   });
+
+  return hotTableRef;
 }
 
 export function mountComponent(Component) {
@@ -189,31 +193,6 @@ export function simulateMouseEvent(element, type) {
 
   element.dispatchEvent(event);
 }
-
-class IndividualPropsWrapper extends React.Component<{ref?: string, id?: string}, {hotSettings?: object}> {
-  hotTable: typeof HotTable;
-  state = {};
-
-  private setHotElementRef(component: typeof HotTable): void {
-    this.hotTable = component;
-  }
-
-  render(): React.ReactElement {
-    return (
-      <div>
-        <HotTable
-          licenseKey="non-commercial-and-evaluation"
-          ref={this.setHotElementRef.bind(this)}
-          id="hot" {...this.state.hotSettings}
-          autoRowSize={false}
-          autoColumnSize={false}
-        />
-      </div>
-    );
-  }
-}
-
-export { IndividualPropsWrapper };
 
 export const RendererComponent: React.FC<HotRendererProps & { tap?: (props: HotRendererProps) => void }> = ({ tap, ...props }) => {
   tap?.(props);

--- a/wrappers/react/test/componentInternals.spec.tsx
+++ b/wrappers/react/test/componentInternals.spec.tsx
@@ -6,7 +6,7 @@ import {
   createSpreadsheetData,
   mockElementDimensions,
   mountComponentWithRef,
-  renderComponentWithProps,
+  renderHotTableWithProps,
   sleep,
 } from './_helpers';
 import { HOT_DESTROYED_WARNING } from "../src/helpers";
@@ -14,33 +14,24 @@ import { HotTableProps, HotRendererProps } from '../src'
 
 describe('Component lifecyle', () => {
   it('renderer components should trigger their lifecycle methods', async () => {
-    class RendererComponent2 extends React.Component<HotRendererProps, any, any> {
-      constructor(props) {
-        super(props);
-
-        rendererCounters.set(`${this.props.row}-${this.props.col}`, {
-          didMount: 0,
+    function RendererComponent2(props: HotRendererProps) {
+      React.useEffect(() => {
+        rendererCounters.set(`${props.row}-${props.col}`, {
+          didMount: 1,
           willUnmount: 0
         });
-      }
 
-      componentDidMount(): void {
-        const counters = rendererCounters.get(`${this.props.row}-${this.props.col}`);
-        counters.didMount++;
-      }
+        return () => {
+          const counters = rendererCounters.get(`${props.row}-${props.col}`);
+          counters.willUnmount++;
+        };
+      }, []);
 
-      componentWillUnmount(): void {
-        const counters = rendererCounters.get(`${this.props.row}-${this.props.col}`);
-        counters.willUnmount++;
-      }
-
-      render(): React.ReactElement<string> {
-        return (
-          <>
-            test
-          </>
-        );
-      }
+      return (
+        <>
+          test
+        </>
+      );
     }
 
     let secondGo = false;
@@ -129,13 +120,13 @@ describe('Component lifecyle', () => {
       editor: (props) => <EditorComponent2 {...props} key={Math.random()} />
     };
 
-    renderComponentWithProps(HotTable, props, false);
+    renderHotTableWithProps(props, false);
 
     expect(editorCounters.didMount).toEqual(1);
     expect(editorCounters.willUnmount).toEqual(0);
 
     // rerender
-    renderComponentWithProps(HotTable, { ...props, editor: undefined }, false);
+    renderHotTableWithProps({ ...props, editor: undefined }, false);
 
     expect(editorCounters.didMount).toEqual(1);
     expect(editorCounters.willUnmount).toEqual(1);


### PR DESCRIPTION
### Context

Getting rid of the class-based approach in favor of functional components.

Basically, internal structure change, but I'm marking it as a breaking change because if someone had used `ref` on `HotTable` they used to get the component class instance while now the dedicated `HotTableRef` interface is provided. Also, previously exported `HotTableClass` is now replaced with `HotTableInner`, although as there is no reason for it to be public anymore, it is not exported.

<!--- Why is this change required? What problem does it solve? -->

### How has this been tested?

* all the unit tests still pass
* all the demo projects still run correctly
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. Proposal in [RFC](https://github.com/handsontable/handsontable/discussions/10767)

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [x] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
