### PR TITLE
Change the way checkbox-typed cells react to pressing `SPACE` and `ENTER` keys.

### DIFF
--- a/.changelogs/10802.json
+++ b/.changelogs/10802.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Changed the way checkbox-typed cells react to pressing `SPACE` and `ENTER` keys.",
+  "type": "changed",
+  "issueOrPR": 10802,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/renderers/checkboxRenderer/__tests__/checkboxRenderer.spec.js
+++ b/handsontable/src/renderers/checkboxRenderer/__tests__/checkboxRenderer.spec.js
@@ -267,7 +267,73 @@ describe('CheckboxRenderer', () => {
     expect(getDataAtCell(199, 0)).toEqual(true);
   });
 
-  it('should reverse checkboxes state after hitting space, when multiple cells are selected', () => {
+  it('should reverse checkboxes state after hitting space, when multiple cells are selected and all of the cells share ' +
+    'the same value', () => {
+    handsontable({
+      data: [[true], [true], [true]],
+      columns: [
+        { type: 'checkbox' }
+      ]
+    });
+
+    const afterChangeCallback1 = jasmine.createSpy('afterChangeCallback');
+
+    addHook('afterChange', afterChangeCallback1);
+
+    let checkboxes = spec().$container.find(':checkbox');
+
+    expect(checkboxes.eq(0).prop('checked')).toBe(true);
+    expect(checkboxes.eq(1).prop('checked')).toBe(true);
+    expect(checkboxes.eq(2).prop('checked')).toBe(true);
+    expect(getData()).toEqual([[true], [true], [true]]);
+
+    selectCell(0, 0, 2, 0);
+
+    keyDownUp(' ');
+
+    checkboxes = spec().$container.find(':checkbox');
+
+    expect(checkboxes.eq(0).prop('checked')).toBe(false);
+    expect(checkboxes.eq(1).prop('checked')).toBe(false);
+    expect(checkboxes.eq(2).prop('checked')).toBe(false);
+    expect(getData()).toEqual([[false], [false], [false]]);
+    expect(afterChangeCallback1.calls.count()).toEqual(1);
+    expect(afterChangeCallback1).toHaveBeenCalledWith([
+      [0, 0, true, false],
+      [1, 0, true, false],
+      [2, 0, true, false]
+    ], 'edit');
+
+    updateData([[false], [false], [false]]);
+
+    const afterChangeCallback2 = jasmine.createSpy('afterChangeCallback');
+
+    addHook('afterChange', afterChangeCallback2);
+
+    expect(checkboxes.eq(0).prop('checked')).toBe(false);
+    expect(checkboxes.eq(1).prop('checked')).toBe(false);
+    expect(checkboxes.eq(2).prop('checked')).toBe(false);
+    expect(getData()).toEqual([[false], [false], [false]]);
+
+    selectCell(0, 0, 2, 0);
+
+    keyDownUp(' ');
+
+    checkboxes = spec().$container.find(':checkbox');
+
+    expect(checkboxes.eq(0).prop('checked')).toBe(true);
+    expect(checkboxes.eq(1).prop('checked')).toBe(true);
+    expect(checkboxes.eq(2).prop('checked')).toBe(true);
+    expect(getData()).toEqual([[true], [true], [true]]);
+    expect(afterChangeCallback2.calls.count()).toEqual(1);
+    expect(afterChangeCallback2).toHaveBeenCalledWith([
+      [0, 0, false, true],
+      [1, 0, false, true],
+      [2, 0, false, true]
+    ], 'edit');
+  });
+
+  it('should make all checkboxes checked after hitting space, when multiple cells are selected and they vary in value', () => {
     handsontable({
       data: [[true], [false], [true]],
       columns: [
@@ -292,38 +358,41 @@ describe('CheckboxRenderer', () => {
 
     checkboxes = spec().$container.find(':checkbox');
 
-    expect(checkboxes.eq(0).prop('checked')).toBe(false);
+    expect(checkboxes.eq(0).prop('checked')).toBe(true);
     expect(checkboxes.eq(1).prop('checked')).toBe(true);
-    expect(checkboxes.eq(2).prop('checked')).toBe(false);
-    expect(getData()).toEqual([[false], [true], [false]]);
+    expect(checkboxes.eq(2).prop('checked')).toBe(true);
+    expect(getData()).toEqual([[true], [true], [true]]);
     expect(afterChangeCallback.calls.count()).toEqual(1);
     expect(afterChangeCallback).toHaveBeenCalledWith([
-      [0, 0, true, false],
+      [0, 0, true, true],
       [1, 0, false, true],
-      [2, 0, true, false]
+      [2, 0, true, true]
     ], 'edit');
   });
 
-  it('should reverse checkboxes state after hitting space, when multiple non-contiguous cells are selected', () => {
+  it('should reverse checkboxes state within sub-selection after hitting space, when multiple non-contiguous cells are ' +
+  'selected and all of the cells in their respective selection share the same value', () => {
     handsontable({
-      data: [[true], [false], [true]],
+      data: [[true, true], [true, true]],
       columns: [
-        { type: 'checkbox' }
+        { type: 'checkbox' },
+        { type: 'checkbox' },
       ]
     });
 
-    const afterChangeCallback = jasmine.createSpy('afterChangeCallback');
+    const afterChangeCallback1 = jasmine.createSpy('afterChangeCallback');
 
-    addHook('afterChange', afterChangeCallback);
+    addHook('afterChange', afterChangeCallback1);
 
     let checkboxes = spec().$container.find(':checkbox');
 
     expect(checkboxes.eq(0).prop('checked')).toBe(true);
-    expect(checkboxes.eq(1).prop('checked')).toBe(false);
+    expect(checkboxes.eq(1).prop('checked')).toBe(true);
     expect(checkboxes.eq(2).prop('checked')).toBe(true);
-    expect(getData()).toEqual([[true], [false], [true]]);
+    expect(checkboxes.eq(3).prop('checked')).toBe(true);
+    expect(getData()).toEqual([[true, true], [true, true]]);
 
-    selectCells([[0, 0], [2, 0]]);
+    selectCells([[0, 0, 0, 1], [1, 0, 1, 1]]);
 
     keyDownUp(' ');
 
@@ -332,8 +401,71 @@ describe('CheckboxRenderer', () => {
     expect(checkboxes.eq(0).prop('checked')).toBe(false);
     expect(checkboxes.eq(1).prop('checked')).toBe(false);
     expect(checkboxes.eq(2).prop('checked')).toBe(false);
-    expect(getData()).toEqual([[false], [false], [false]]);
-    expect(afterChangeCallback.calls.count()).toEqual(2);
+    expect(checkboxes.eq(3).prop('checked')).toBe(false);
+    expect(getData()).toEqual([[false, false], [false, false]]);
+    expect(afterChangeCallback1.calls.count()).toEqual(2);
+
+    updateData([[true, true], [false, false]]);
+
+    const afterChangeCallback2 = jasmine.createSpy('afterChangeCallback');
+
+    addHook('afterChange', afterChangeCallback2);
+
+    checkboxes = spec().$container.find(':checkbox');
+
+    expect(checkboxes.eq(0).prop('checked')).toBe(true);
+    expect(checkboxes.eq(1).prop('checked')).toBe(true);
+    expect(checkboxes.eq(2).prop('checked')).toBe(false);
+    expect(checkboxes.eq(3).prop('checked')).toBe(false);
+    expect(getData()).toEqual([[true, true], [false, false]]);
+
+    selectCells([[0, 0, 0, 1], [1, 0, 1, 1]]);
+
+    keyDownUp(' ');
+
+    checkboxes = spec().$container.find(':checkbox');
+
+    expect(checkboxes.eq(0).prop('checked')).toBe(false);
+    expect(checkboxes.eq(1).prop('checked')).toBe(false);
+    expect(checkboxes.eq(2).prop('checked')).toBe(true);
+    expect(checkboxes.eq(3).prop('checked')).toBe(true);
+    expect(getData()).toEqual([[false, false], [true, true]]);
+    expect(afterChangeCallback2.calls.count()).toEqual(2);
+  });
+
+  it('should make appropriate changes to the checkboxes\' states within their own respective sub-selections', () => {
+    handsontable({
+      data: [[true, false], [true, true]],
+      columns: [
+        { type: 'checkbox' },
+        { type: 'checkbox' },
+      ]
+    });
+
+    const afterChangeCallback1 = jasmine.createSpy('afterChangeCallback');
+
+    addHook('afterChange', afterChangeCallback1);
+
+    let checkboxes = spec().$container.find(':checkbox');
+
+    expect(checkboxes.eq(0).prop('checked')).toBe(true);
+    expect(checkboxes.eq(1).prop('checked')).toBe(false);
+    expect(checkboxes.eq(2).prop('checked')).toBe(true);
+    expect(checkboxes.eq(3).prop('checked')).toBe(true);
+    expect(getData()).toEqual([[true, false], [true, true]]);
+
+    selectCells([[0, 0, 0, 1], [1, 0, 1, 1]]);
+
+    keyDownUp(' ');
+
+    checkboxes = spec().$container.find(':checkbox');
+
+    expect(checkboxes.eq(0).prop('checked')).toBe(true);
+    expect(checkboxes.eq(1).prop('checked')).toBe(true);
+    expect(checkboxes.eq(2).prop('checked')).toBe(false);
+    expect(checkboxes.eq(3).prop('checked')).toBe(false);
+    expect(getData()).toEqual([[true, true], [false, false]]);
+    expect(afterChangeCallback1.calls.count()).toEqual(2);
   });
 
   it('should reverse checkboxes state after hitting enter, when multiple non-contiguous cells are selected', () => {
@@ -368,7 +500,46 @@ describe('CheckboxRenderer', () => {
     expect(afterChangeCallback.calls.count()).toEqual(2);
   });
 
-  it('should reverse checkboxes state after hitting space, when multiple cells are selected and selStart > selEnd', () => {
+  it('should reverse checkboxes state after hitting space, when multiple cells are selected and selStart > selEnd' +
+  '+ all the selected checkboxes have the same value', () => {
+    handsontable({
+      data: [[true], [true], [true]],
+      columns: [
+        { type: 'checkbox' }
+      ]
+    });
+
+    const afterChangeCallback = jasmine.createSpy('afterChangeCallback');
+
+    addHook('afterChange', afterChangeCallback);
+
+    let checkboxes = spec().$container.find(':checkbox');
+
+    expect(checkboxes.eq(0).prop('checked')).toBe(true);
+    expect(checkboxes.eq(1).prop('checked')).toBe(true);
+    expect(checkboxes.eq(2).prop('checked')).toBe(true);
+    expect(getData()).toEqual([[true], [true], [true]]);
+
+    selectCell(2, 0, 0, 0); // selStart = [2,0], selEnd = [0,0]
+
+    keyDownUp(' ');
+
+    checkboxes = spec().$container.find(':checkbox');
+
+    expect(checkboxes.eq(0).prop('checked')).toBe(false);
+    expect(checkboxes.eq(1).prop('checked')).toBe(false);
+    expect(checkboxes.eq(2).prop('checked')).toBe(false);
+    expect(getData()).toEqual([[false], [false], [false]]);
+    expect(afterChangeCallback.calls.count()).toEqual(1);
+    expect(afterChangeCallback).toHaveBeenCalledWith([
+      [0, 0, true, false],
+      [1, 0, true, false],
+      [2, 0, true, false]
+    ], 'edit');
+  });
+
+  it('should check all of the checkboxes in the selection after hitting space, when multiple cells are selected ' +
+  'and selStart > selEnd + the selected checkboxes differ in values', () => {
     handsontable({
       data: [[true], [false], [true]],
       columns: [
@@ -393,15 +564,15 @@ describe('CheckboxRenderer', () => {
 
     checkboxes = spec().$container.find(':checkbox');
 
-    expect(checkboxes.eq(0).prop('checked')).toBe(false);
+    expect(checkboxes.eq(0).prop('checked')).toBe(true);
     expect(checkboxes.eq(1).prop('checked')).toBe(true);
-    expect(checkboxes.eq(2).prop('checked')).toBe(false);
-    expect(getData()).toEqual([[false], [true], [false]]);
+    expect(checkboxes.eq(2).prop('checked')).toBe(true);
+    expect(getData()).toEqual([[true], [true], [true]]);
     expect(afterChangeCallback.calls.count()).toEqual(1);
     expect(afterChangeCallback).toHaveBeenCalledWith([
-      [0, 0, true, false],
+      [0, 0, true, true],
       [1, 0, false, true],
-      [2, 0, true, false]
+      [2, 0, true, true]
     ], 'edit');
   });
 

--- a/handsontable/src/renderers/checkboxRenderer/checkboxRenderer.js
+++ b/handsontable/src/renderers/checkboxRenderer/checkboxRenderer.js
@@ -213,11 +213,15 @@ export function checkboxRenderer(hotInstance, TD, row, col, prop, value, cellPro
     for (let key = 0; key < selRange.length; key++) {
       const { row: startRow, col: startColumn } = selRange[key].getTopStartCorner();
       const { row: endRow, col: endColumn } = selRange[key].getBottomEndCorner();
-      const changes = [];
+      let changes = [];
 
       for (let visualRow = startRow; visualRow <= endRow; visualRow += 1) {
         for (let visualColumn = startColumn; visualColumn <= endColumn; visualColumn += 1) {
           const cachedCellProperties = hotInstance.getCellMeta(visualRow, visualColumn);
+          const templates = {
+            checkedTemplate: cachedCellProperties.checkedTemplate,
+            uncheckedTemplate: cachedCellProperties.uncheckedTemplate,
+          };
 
           if (cachedCellProperties.type !== 'checkbox') {
             return;
@@ -239,16 +243,24 @@ export function checkboxRenderer(hotInstance, TD, row, col, prop, value, cellPro
 
           if (uncheckCheckbox === false) {
             if ([cachedCellProperties.checkedTemplate, cachedCellProperties.checkedTemplate.toString()].includes(dataAtCell)) { // eslint-disable-line max-len
-              changes.push([visualRow, visualColumn, cachedCellProperties.uncheckedTemplate]);
+              changes.push([visualRow, visualColumn, cachedCellProperties.uncheckedTemplate, templates]);
 
             } else if ([cachedCellProperties.uncheckedTemplate, cachedCellProperties.uncheckedTemplate.toString(), null, undefined].includes(dataAtCell)) { // eslint-disable-line max-len
-              changes.push([visualRow, visualColumn, cachedCellProperties.checkedTemplate]);
+              changes.push([visualRow, visualColumn, cachedCellProperties.checkedTemplate, templates]);
             }
 
           } else {
-            changes.push([visualRow, visualColumn, cachedCellProperties.uncheckedTemplate]);
+            changes.push([visualRow, visualColumn, cachedCellProperties.uncheckedTemplate, templates]);
           }
         }
+      }
+
+      if (!changes.every(([, , cellValue]) => cellValue === changes[0][2])) {
+        changes = changes.map(
+          ([visualRow, visualColumn, , templates]) => [visualRow, visualColumn, templates.checkedTemplate]
+        );
+      } else {
+        changes = changes.map(([visualRow, visualColumn, cellValue]) => [visualRow, visualColumn, cellValue]);
       }
 
       if (changes.length > 0) {


### PR DESCRIPTION
### Context
This PR changes the way checkbox-typed cells react to pressing <kbd>SPACE</kbd> and <kbd>ENTER</kbd> keys.

Before:
- Pressing <kbd>SPACE</kbd>/<kbd>ENTER</kbd> on a selection containing checkbox-typed cells reversed their state

After:
- If all the checkboxes in a selection share the same value:
  - Their values get reversed.
- If the selected checkboxes differ in values:
  - All of the checkboxes are marked as checked.

Note: This changes the behavior that was present in Handsontable since ~2013 and was covered with test cases, ensuring this feature works the way it does. This makes me think the current change should be considered a breaking change, not a bugfix.
CC: @evanSe, WDYT?

### How has this been tested?
- Modified the existing test cases
- Added new ones for the changed functionality

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#1747

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
