### PR TITLE
Update viewportRowsRenderingOffset link in documentation

### DIFF
--- a/docs/content/guides/rows/row-virtualization.md
+++ b/docs/content/guides/rows/row-virtualization.md
@@ -140,4 +140,4 @@ Using row virtualization has the following side effects:
 
 - Configuration options:
   - [`renderAllRows`](@/api/options.md#renderallrows)
-  - [`viewportRowsRenderingOffset`](@/api/options.md#viewportrowsrenderingoffset)
+  - [`viewportRowsRenderingOffset`](@/api/options.md#viewportrowrenderingoffset)


### PR DESCRIPTION
### Context
PR includes update for viewportRowsRenderingOffset link in documentation

### How has this been tested?
Locally

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/1463

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] Fix link in documentation for viewportRowsRenderingOffset

[skip changelog]
