### PR TITLE
Fix documentation column-filter page demo style

### DIFF
--- a/docs/content/guides/columns/column-filter.md
+++ b/docs/content/guides/columns/column-filter.md
@@ -1917,7 +1917,7 @@ const handsontableInstance = new Handsontable(container, {
 ```
 
 ```css
-.customFilterButtonExample1 .changeType {
+.handsontable.customFilterButtonExample1 .changeType {
   background: #e2e2e2;
   border-radius: 100%;
   width: 16px;
@@ -1927,7 +1927,7 @@ const handsontableInstance = new Handsontable(container, {
   border: none;
 }
 
-.customFilterButtonExample1 .changeType::before {
+.handsontable.customFilterButtonExample1 .changeType::before {
   content: '▼ ';
   zoom: 0.9;
 }
@@ -2057,7 +2057,7 @@ ReactDOM.render(<App />, document.getElementById('exampleCustomFilterButton'));
 ```
 
 ```css
-.customFilterButtonExample1 .changeType {
+.handsontable.customFilterButtonExample1 .changeType {
   background: #e2e2e2;
   border-radius: 100%;
   width: 16px;
@@ -2067,7 +2067,7 @@ ReactDOM.render(<App />, document.getElementById('exampleCustomFilterButton'));
   border: none;
 }
 
-.customFilterButtonExample1 .changeType::before {
+.handsontable.customFilterButtonExample1 .changeType::before {
   content: '▼ ';
   zoom: 0.9;
 }


### PR DESCRIPTION
### Context
This PR includes fix for column-filter page demo style in JSFiddle 

### How has this been tested?
Locally

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/1588

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] Fix .customFilterButtonExample1 style in JSFiddle example

[skip changelog]
