### PR TITLE
React wrapper: Add a check that only HotColumn instances are children of HotTable

### DIFF
--- a/.changelogs/10805.json
+++ b/.changelogs/10805.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Add a check that only HotColumn instances are children of HotTable",
+  "type": "added",
+  "issueOrPR": 10805,
+  "breaking": false,
+  "framework": "react"
+}

--- a/wrappers/react/src/helpers.tsx
+++ b/wrappers/react/src/helpers.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { HotTableProps } from './types';
+import { isHotColumn } from './hotColumn'
 
 let bulkComponentContainer = null;
 
@@ -21,6 +22,18 @@ export const OBSOLETE_HOTRENDERER_WARNING = 'Providing a component-based rendere
  */
 export const OBSOLETE_HOTEDITOR_WARNING = 'Providing a component-based editor using `hot-editor`-annotated component is no longer supported. ' +
   'Pass your component using `editor` prop of the `HotTable` or `HotColumn` component instead.';
+
+/**
+ * Warning message for the unexpected children of HotTable component.
+ */
+export const UNEXPECTED_HOTTABLE_CHILDREN_WARNING = 'Unexpected children nodes found in HotTable component. ' +
+    'Only HotColumn components are allowed.';
+
+/**
+ * Warning message for the unexpected children of HotColumn component.
+ */
+export const UNEXPECTED_HOTCOLUMN_CHILDREN_WARNING = 'Unexpected children nodes found in HotColumn component. ' +
+    'HotColumn components do not support any children.';
 
 /**
  * Message for the warning thrown if the Handsontable instance has been destroyed.
@@ -46,14 +59,52 @@ export function warn(...args) {
 
 /**
  * Detect if `hot-renderer` or `hot-editor` is defined, and if so, throw an incompatibility warning.
+ *
+ * @returns {boolean} 'true' if the warning was issued
  */
-export function displayObsoleteRenderersEditorsWarning(children: React.ReactNode): void {
+export function displayObsoleteRenderersEditorsWarning(children: React.ReactNode): boolean {
   if (hasChildElementOfType(children, 'hot-renderer')) {
     warn(OBSOLETE_HOTRENDERER_WARNING);
+    return true;
   }
   if (hasChildElementOfType(children, 'hot-editor')) {
     warn(OBSOLETE_HOTEDITOR_WARNING);
+    return true;
   }
+
+  return false
+}
+
+/**
+ * Detect if non-HotColumn children is defined, and if so, throw an incompatibility warning.
+ *
+ * @returns {boolean} 'true' if the warning was issued
+ */
+export function displayNonHotColumnChildWarning(children: React.ReactNode): boolean {
+  const childrenArray: React.ReactNode[] = React.Children.toArray(children);
+
+  if (childrenArray.some((child) => !isHotColumn(child))) {
+    warn(UNEXPECTED_HOTTABLE_CHILDREN_WARNING);
+    return true;
+  }
+
+  return false
+}
+
+/**
+ * Detect if children is defined, and if so, throw an incompatibility warning.
+ *
+ * @returns {boolean} 'true' if the warning was issued
+ */
+export function displayChildrenWarning(children: React.ReactNode): boolean {
+  const childrenArray: React.ReactNode[] = React.Children.toArray(children);
+
+  if (childrenArray.length) {
+    warn(UNEXPECTED_HOTCOLUMN_CHILDREN_WARNING);
+    return true;
+  }
+
+  return false
 }
 
 /**

--- a/wrappers/react/src/helpers.tsx
+++ b/wrappers/react/src/helpers.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { HotTableProps } from './types';
-import { isHotColumn } from './hotColumn'
 
 let bulkComponentContainer = null;
 
@@ -76,14 +75,16 @@ export function displayObsoleteRenderersEditorsWarning(children: React.ReactNode
 }
 
 /**
- * Detect if non-HotColumn children is defined, and if so, throw an incompatibility warning.
+ * Detect if children of specified type are defined, and if so, throw an incompatibility warning.
  *
+ * @param {React.ReactNode} children Component children nodes
+ * @param {React.ComponentType} Component Component type to check
  * @returns {boolean} 'true' if the warning was issued
  */
-export function displayNonHotColumnChildWarning(children: React.ReactNode): boolean {
+export function displayChildrenOfTypeWarning(children: React.ReactNode, Component: React.ComponentType): boolean {
   const childrenArray: React.ReactNode[] = React.Children.toArray(children);
 
-  if (childrenArray.some((child) => !isHotColumn(child))) {
+  if (childrenArray.some((child) => (child as React.ReactElement).type !== Component)) {
     warn(UNEXPECTED_HOTTABLE_CHILDREN_WARNING);
     return true;
   }
@@ -94,9 +95,10 @@ export function displayNonHotColumnChildWarning(children: React.ReactNode): bool
 /**
  * Detect if children is defined, and if so, throw an incompatibility warning.
  *
+ * @param {React.ReactNode} children Component children nodes
  * @returns {boolean} 'true' if the warning was issued
  */
-export function displayChildrenWarning(children: React.ReactNode): boolean {
+export function displayAnyChildrenWarning(children: React.ReactNode): boolean {
   const childrenArray: React.ReactNode[] = React.Children.toArray(children);
 
   if (childrenArray.length) {

--- a/wrappers/react/src/hotColumn.tsx
+++ b/wrappers/react/src/hotColumn.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { HotTableProps, HotColumnProps, HotEditorHooks } from './types';
 import {
   createEditorPortal,
-  displayChildrenWarning,
+  displayAnyChildrenWarning,
   displayObsoleteRenderersEditorsWarning
 } from './helpers';
 import { SettingsMapper } from './settingsMapper';
@@ -74,7 +74,7 @@ const HotColumn: React.FC<HotColumnProps> = (props) => {
     emitColumnSettings(columnSettings, columnIndex);
 
     if (!displayObsoleteRenderersEditorsWarning(props.children)) {
-      displayChildrenWarning(props.children);
+      displayAnyChildrenWarning(props.children);
     }
   });
 

--- a/wrappers/react/src/hotColumn.tsx
+++ b/wrappers/react/src/hotColumn.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { HotTableProps, HotColumnProps, HotEditorHooks } from './types';
 import {
   createEditorPortal,
+  displayChildrenWarning,
   displayObsoleteRenderersEditorsWarning
 } from './helpers';
 import { SettingsMapper } from './settingsMapper';
@@ -71,7 +72,10 @@ const HotColumn: React.FC<HotColumnProps> = (props) => {
 
     const columnSettings = createColumnSettings();
     emitColumnSettings(columnSettings, columnIndex);
-    displayObsoleteRenderersEditorsWarning(props.children);
+
+    if (!displayObsoleteRenderersEditorsWarning(props.children)) {
+      displayChildrenWarning(props.children);
+    }
   });
 
   const editorPortal = createEditorPortal(getOwnerDocument(), props.editor);

--- a/wrappers/react/src/hotTableInner.tsx
+++ b/wrappers/react/src/hotTableInner.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Handsontable from 'handsontable/base';
 import { SettingsMapper } from './settingsMapper';
 import { RenderersPortalManager } from './renderersPortalManager';
-import { isHotColumn } from './hotColumn';
+import { HotColumn, isHotColumn } from './hotColumn';
 import { HotEditorHooks, HotTableProps, HotTableRef } from './types';
 import {
   HOT_DESTROYED_WARNING,
@@ -13,7 +13,7 @@ import {
   warn,
   displayObsoleteRenderersEditorsWarning,
   useUpdateEffect,
-  displayNonHotColumnChildWarning
+  displayChildrenOfTypeWarning
 } from './helpers';
 import PropTypes from 'prop-types';
 import { getRenderer } from 'handsontable/renderers/registry';
@@ -157,7 +157,7 @@ const HotTableInner = React.forwardRef<HotTableRef, HotTableProps>((props, ref) 
     displayAutoSizeWarning(__hotInstance.current);
 
     if (!displayObsoleteRenderersEditorsWarning(props.children)) {
-      displayNonHotColumnChildWarning(props.children);
+      displayChildrenOfTypeWarning(props.children, HotColumn);
     }
 
     /**

--- a/wrappers/react/src/hotTableInner.tsx
+++ b/wrappers/react/src/hotTableInner.tsx
@@ -12,7 +12,8 @@ import {
   isCSR,
   warn,
   displayObsoleteRenderersEditorsWarning,
-  useUpdateEffect
+  useUpdateEffect,
+  displayNonHotColumnChildWarning
 } from './helpers';
 import PropTypes from 'prop-types';
 import { getRenderer } from 'handsontable/renderers/registry';
@@ -154,7 +155,10 @@ const HotTableInner = React.forwardRef<HotTableRef, HotTableProps>((props, ref) 
     __hotInstance.current.init();
 
     displayAutoSizeWarning(__hotInstance.current);
-    displayObsoleteRenderersEditorsWarning(props.children);
+
+    if (!displayObsoleteRenderersEditorsWarning(props.children)) {
+      displayNonHotColumnChildWarning(props.children);
+    }
 
     /**
      * Destroy the Handsontable instance when the parent component unmounts.

--- a/wrappers/react/test/hotColumn.spec.tsx
+++ b/wrappers/react/test/hotColumn.spec.tsx
@@ -16,7 +16,11 @@ import {
   CustomNativeEditor,
   renderHotTableWithProps
 } from './_helpers';
-import { OBSOLETE_HOTEDITOR_WARNING, OBSOLETE_HOTRENDERER_WARNING } from '../src/helpers'
+import {
+  OBSOLETE_HOTEDITOR_WARNING,
+  OBSOLETE_HOTRENDERER_WARNING,
+  UNEXPECTED_HOTCOLUMN_CHILDREN_WARNING
+} from '../src/helpers'
 import { HotTableProps } from '../src/types'
 
 // register Handsontable's modules
@@ -381,6 +385,7 @@ describe('Editor configuration using React components', () => {
 
     expect(document.querySelector('#editorComponentContainer')).not.toBeTruthy();
     expect(console.warn).toHaveBeenCalledWith(OBSOLETE_HOTEDITOR_WARNING);
+    expect(console.warn).not.toHaveBeenCalledWith(UNEXPECTED_HOTCOLUMN_CHILDREN_WARNING);
   });
 });
 
@@ -525,5 +530,31 @@ describe('Miscellaneous scenarios with `HotColumn` config', () => {
     expect(onAfterValidate).toHaveBeenCalledWith(false, 'test3', 2, 0, 'populateFromArray');
     expect(onAfterValidate).toHaveBeenCalledWith(false, 'test2', 1, 0, 'populateFromArray');
     expect(onAfterValidate).toHaveBeenCalledWith(false, 'test', 0, 0, 'populateFromArray');
+  });
+});
+
+
+describe('Passing children', () => {
+  it('should issue a warning when anything is nested under HotColumn', async () => {
+    console.warn = jasmine.createSpy('warn');
+
+    mountComponentWithRef((
+        <HotTable licenseKey="non-commercial-and-evaluation"
+                  id="test-hot"
+                  data={createSpreadsheetData(3, 2)}
+                  width={300}
+                  height={300}
+                  rowHeights={23}
+                  colWidths={50}
+                  init={function () {
+                    mockElementDimensions(this.rootElement, 300, 300);
+                  }}>
+          <HotColumn>
+            <div>Something unexpected</div>
+          </HotColumn>
+        </HotTable>
+    ));
+
+    expect(console.warn).toHaveBeenCalledWith(UNEXPECTED_HOTCOLUMN_CHILDREN_WARNING);
   });
 });


### PR DESCRIPTION
### Context

The structure of components in React wrapper is now straightforward: `HotTable` contains zero or more `HotColumn` children and nothing else, and `HotColumn` never have children. Any other scenario is incorrect and throws a warning.

### How has this been tested?

* all the unit tests + new unit tests for the feature passing

<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. Proposal in [RFC](https://github.com/handsontable/handsontable/discussions/10767)

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [x] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
