### PR TITLE
React wrapper: Remove unnecessary and no longer valid test elements

### DIFF
--- a/wrappers/react/test/componentInternals.spec.tsx
+++ b/wrappers/react/test/componentInternals.spec.tsx
@@ -34,8 +34,6 @@ describe('Component lifecyle', () => {
       );
     }
 
-    let secondGo = false;
-    const rendererRefs = new Map();
     const rendererCounters = new Map();
 
     const hotInstance = mountComponentWithRef((
@@ -51,17 +49,9 @@ describe('Component lifecyle', () => {
                 init={function () {
                   mockElementDimensions(this.rootElement, 300, 300);
                 }}
-                renderer={(props) => <RendererComponent2 {...props} ref={function (instance) {
-                  if (!secondGo && instance) {
-                    rendererRefs.set(`${props.row}-${props.col}`, instance);
-                  }
-                }} />}>
+                renderer={(props) => <RendererComponent2 {...props} />}>
         <HotColumn/>
-        <HotColumn renderer={(props) => <RendererComponent2 {...props} ref={function (instance) {
-          if (!secondGo && instance) {
-            rendererRefs.set(`${props.row}-${props.col}`, instance);
-          }
-        }} />}/>
+        <HotColumn renderer={(props) => <RendererComponent2 {...props} />}/>
       </HotTable>
     ), false).hotInstance;
 
@@ -71,8 +61,6 @@ describe('Component lifecyle', () => {
       expect(counters.didMount).toEqual(1);
       expect(counters.willUnmount).toEqual(0);
     });
-
-    secondGo = true;
 
     await act(async () => {
       hotInstance.render();


### PR DESCRIPTION
### Context

[skip changelog]

There is a remaining ref in `componentInternals.spec` pointing to a component that is now functional and isn't compatible with refs, so a warning is printed. The elements of the test are obsolete anyway, so this PR removes them.
 
### How has this been tested?

- tests still pass
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #10799 

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [x] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
