### PR TITLE
Prevent the mobile selection handles from showing up on "handsontable-in-handsontable" instances

### DIFF
--- a/.changelogs/10816.json
+++ b/.changelogs/10816.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed a problem where the mobile selection handles were displayed on the context menus/dropdown menus.",
+  "type": "fixed",
+  "issueOrPR": 10816,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/.config/test-mobile.js
+++ b/handsontable/.config/test-mobile.js
@@ -8,6 +8,7 @@ const configFactory = require('./test-e2e');
 const JasmineHtml = require('./plugin/jasmine-html');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const fsExtra = require('fs-extra');
+const { getClosest }  = require('./helper/path');
 
 module.exports.create = function create(envArgs) {
   const config = configFactory.create(envArgs);
@@ -28,19 +29,20 @@ module.exports.create = function create(envArgs) {
         externalCssFiles: [
           'lib/normalize.css',
           '../dist/handsontable.css',
+          `${getClosest('../node_modules/@handsontable/pikaday', true)}/css/pikaday.css`,
           'helpers/common.css',
         ],
         externalJsFiles: [
           'helpers/jasmine-bridge-reporter.js',
           'lib/jquery.min.js',
           'lib/jquery.simulate.js',
-          '../node_modules/numbro/dist/numbro.js',
-          '../node_modules/numbro/dist/languages.min.js',
-          '../dist/moment/moment.js',
-          '../dist/pikaday/pikaday.js',
-          '../node_modules/dompurify/dist/purify.js',
-          '../dist/handsontable.js',
-          '../dist/languages/all.js',
+          `${getClosest('../node_modules/numbro', true)}/dist/numbro.js`,
+          `${getClosest('../node_modules/numbro', true)}/dist/languages.min.js`,
+          `${getClosest('../node_modules/moment', true)}/moment.js`,
+          `${getClosest('../node_modules/@handsontable/pikaday', true)}/pikaday.js`,
+          `${getClosest('../node_modules/dompurify', true)}/dist/purify.js`,
+          `../dist/handsontable.js`,
+          `../dist/languages/all.js`,
         ],
       })
     );

--- a/handsontable/src/3rdparty/walkontable/src/selection/border/border.js
+++ b/handsontable/src/3rdparty/walkontable/src/selection/border/border.js
@@ -202,7 +202,7 @@ class Border {
       this.cornerDefaultStyle.borderColor
     ].join(' ');
 
-    if (isMobileBrowser()) {
+    if (isMobileBrowser() && this.instance.getSetting('isDataViewInstance')) {
       this.createMultipleSelectorHandles();
     }
     this.disappear();
@@ -601,7 +601,7 @@ class Border {
       this.cornerStyle.display = 'block';
     }
 
-    if (isMobileBrowser()) {
+    if (isMobileBrowser() && this.instance.getSetting('isDataViewInstance')) {
       this.updateMultipleSelectionHandlesPosition(toRow, toColumn, top, inlineStartPos, width, height);
     }
   }
@@ -773,7 +773,7 @@ class Border {
     this.endStyle.display = 'none';
     this.cornerStyle.display = 'none';
 
-    if (isMobileBrowser()) {
+    if (isMobileBrowser() && this.instance.getSetting('isDataViewInstance')) {
       this.selectionHandles.styles.top.display = 'none';
       this.selectionHandles.styles.topHitArea.display = 'none';
       this.selectionHandles.styles.bottom.display = 'none';

--- a/handsontable/src/dataMap/metaManager/metaSchema.js
+++ b/handsontable/src/dataMap/metaManager/metaSchema.js
@@ -3298,7 +3298,7 @@ export default () => {
      * | `true`            | Enable the [`NestedRows`](@/api/nestedRows.md) plugin  |
      *
      * Read more:
-     * - [Plugins: `NestedRows`](@/api/nestedRows.md)
+     * - [Plugins: `NestedRows`](@/guides/rows/row-parent-child.md)
      *
      * @example
      * ```js

--- a/handsontable/src/plugins/multipleSelectionHandles/__tests__/mobile/general.spec.js
+++ b/handsontable/src/plugins/multipleSelectionHandles/__tests__/mobile/general.spec.js
@@ -81,4 +81,93 @@ describe('MultipleSelectionHandles', () => {
     expect(bottomSelectionHandle.is(':visible')).toBe(false);
     expect(bottomSelectionHandleHitArea.is(':visible')).toBe(false);
   });
+
+  it('should not show the selection handlers on context menu', () => {
+    handsontable({
+      data: createSpreadsheetData(5, 8),
+      contextMenu: true,
+    });
+
+    selectCell(0, 0);
+
+    contextMenu();
+
+    getPlugin('contextMenu').menu.hotMenu.selectCell(0, 0);
+
+    const topSelectionHandle = $('.htContextMenu').eq(0)
+      .find('.ht_master .htBorders div:first-child .topSelectionHandle');
+    const topSelectionHandleHitArea = $('.htContextMenu').eq(0)
+      .find('.ht_master .htBorders div:first-child .topSelectionHandle-HitArea');
+    const bottomSelectionHandle = $('.htContextMenu').eq(0)
+      .find('.ht_master .htBorders div:first-child .bottomSelectionHandle');
+    const bottomSelectionHandleHitArea = $('.htContextMenu').eq(0)
+      .find('.ht_master .htBorders div:first-child .bottomSelectionHandle-HitArea');
+
+    expect(topSelectionHandle.size()).toBe(0);
+    expect(topSelectionHandleHitArea.size()).toBe(0);
+    expect(bottomSelectionHandle.size()).toBe(0);
+    expect(bottomSelectionHandleHitArea.size()).toBe(0);
+  });
+
+  it('should not show the selection handlers on the autocomplete dropdown', async() => {
+    handsontable({
+      data: createSpreadsheetData(5, 1),
+      columns: [
+        {
+          type: 'autocomplete',
+          source: ['1', '2', '3'],
+          filter: false,
+          strict: true
+        }
+      ]
+    });
+
+    selectCell(0, 0);
+
+    keyDownUp('enter');
+
+    await sleep(50);
+
+    getActiveEditor().htEditor.selectCell(0, 0);
+
+    const topSelectionHandle = $('.autocompleteEditor').eq(0)
+      .find('.ht_master .htBorders div:first-child .topSelectionHandle');
+    const topSelectionHandleHitArea = $('.autocompleteEditor').eq(0)
+      .find('.ht_master .htBorders div:first-child .topSelectionHandle-HitArea');
+    const bottomSelectionHandle = $('.autocompleteEditor').eq(0)
+      .find('.ht_master .htBorders div:first-child .bottomSelectionHandle');
+    const bottomSelectionHandleHitArea = $('.autocompleteEditor').eq(0)
+      .find('.ht_master .htBorders div:first-child .bottomSelectionHandle-HitArea');
+
+    expect(topSelectionHandle.size()).toBe(0);
+    expect(topSelectionHandleHitArea.size()).toBe(0);
+    expect(bottomSelectionHandle.size()).toBe(0);
+    expect(bottomSelectionHandleHitArea.size()).toBe(0);
+  });
+
+  it('should not show the selection handlers on the dropdown menu', async() => {
+    handsontable({
+      data: createSpreadsheetData(5, 1),
+      colHeaders: true,
+      dropdownMenu: true,
+    });
+
+    dropdownMenu(0);
+
+    await sleep(50);
+
+    const topSelectionHandle = $('.htDropdownMenu').eq(0)
+      .find('.ht_master .htBorders div:first-child .topSelectionHandle');
+    const topSelectionHandleHitArea = $('.htDropdownMenu').eq(0)
+      .find('.ht_master .htBorders div:first-child .topSelectionHandle-HitArea');
+    const bottomSelectionHandle = $('.htDropdownMenu').eq(0)
+      .find('.ht_master .htBorders div:first-child .bottomSelectionHandle');
+    const bottomSelectionHandleHitArea = $('.htDropdownMenu').eq(0)
+      .find('.ht_master .htBorders div:first-child .bottomSelectionHandle-HitArea');
+
+    expect(topSelectionHandle.size()).toBe(0);
+    expect(topSelectionHandleHitArea.size()).toBe(0);
+    expect(bottomSelectionHandle.size()).toBe(0);
+    expect(bottomSelectionHandleHitArea.size()).toBe(0);
+  });
 });

--- a/handsontable/test/e2e/mobile/focusing.spec.js
+++ b/handsontable/test/e2e/mobile/focusing.spec.js
@@ -11,23 +11,4 @@ describe('Focusing', () => {
       this.$container.remove();
     }
   });
-
-  it('should not call the `select` method on the "focusable" textarea when selecting a cell', async() => {
-    const hot = handsontable({
-      data: [['test']],
-      width: 400,
-      height: 400
-    });
-
-    hot.selectCell(0, 0);
-
-    const copyPastePlugin = hot.getPlugin('copyPaste');
-    const focusableElement = copyPastePlugin.focusableElement.getFocusableElement();
-
-    spyOn(focusableElement, 'select');
-
-    hot.selectCell(0, 0);
-
-    expect(focusableElement.select).not.toHaveBeenCalled();
-  });
 });


### PR DESCRIPTION
### Context
This PR:
- Prevents the mobile selection handles from showing up on _"handsontable-in-handsontable"_ instances
- Remove a failing mobile test on `focusableElement` (not longer applicable)
- Add test cases for handsontable/dev-handsontable#1688

### How has this been tested?
Added test cases

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#1688

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

