### PR TITLE
Make the Autofill plugin treat cells filled with `0` as non-empty.

### DIFF
--- a/.changelogs/10817.json
+++ b/.changelogs/10817.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed a problem where the Autofill plugin's double-click feature treated cells filled with `0`s as empty.",
+  "type": "fixed",
+  "issueOrPR": 10817,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/autofill/__tests__/autofill.spec.js
+++ b/handsontable/src/plugins/autofill/__tests__/autofill.spec.js
@@ -732,7 +732,7 @@ describe('AutoFill', () => {
     document.body.removeChild($table[0]);
   });
 
-  it('should fill cells below until the end of content in the neighbouring column with current cell\'s data', () => {
+  it('should fill empty cells below until the end of content in the neighbouring column with current cell\'s data', () => {
     handsontable({
       data: [
         [1, 2, 3, 4, 5, 6],
@@ -755,6 +755,37 @@ describe('AutoFill', () => {
 
     expect(getDataAtCell(2, 2)).toEqual(3);
     expect(getDataAtCell(3, 2)).toEqual(3);
+  });
+
+  // https://github.com/handsontable/dev-handsontable/issues/1757
+  it('should fill empty cells below until the end of content in the neighbouring column with current cell\'s data' +
+    'and NOT treat cells filled with 0s as empty', () => {
+    handsontable({
+      data: [
+        [1, 2, 3, 4, 5, 6],
+        [1, 2, 0, 4, 5, 6],
+        [1, 2, 0, null, null, null],
+        [1, 2, 0, null, null, null],
+        [1, 2, null, null, null, null]
+      ]
+    });
+
+    selectCell(0, 2);
+    const fillHandle = spec().$container.find('.wtBorder.current.corner')[0];
+
+    mouseDoubleClick(fillHandle);
+
+    expect(getDataAtCell(1, 2)).toEqual(0);
+    expect(getDataAtCell(2, 2)).toEqual(0);
+    expect(getDataAtCell(3, 2)).toEqual(0);
+    expect(getDataAtCell(4, 2)).toEqual(null);
+
+    selectCell(1, 3);
+    mouseDoubleClick(fillHandle);
+
+    expect(getDataAtCell(2, 3)).toEqual(4);
+    expect(getDataAtCell(3, 3)).toEqual(4);
+    expect(getDataAtCell(4, 3)).toEqual(null);
   });
 
   it('should fill cells below until the end of content in the neighbouring column with the currently selected area\'s data', () => {

--- a/handsontable/src/plugins/autofill/autofill.js
+++ b/handsontable/src/plugins/autofill/autofill.js
@@ -426,13 +426,14 @@ export class Autofill extends BasePlugin {
   getIndexOfLastAdjacentFilledInRow(cornersOfSelectedCells) {
     const data = this.hot.getData();
     const nrOfTableRows = this.hot.countRows();
+    const isEmptyCell = cellContent => cellContent === null || cellContent === void 0 || cellContent === '';
     let lastFilledInRowIndex;
 
     for (let rowIndex = cornersOfSelectedCells[2] + 1; rowIndex < nrOfTableRows; rowIndex++) {
       for (let columnIndex = cornersOfSelectedCells[1]; columnIndex <= cornersOfSelectedCells[3]; columnIndex++) {
         const dataInCell = data[rowIndex][columnIndex];
 
-        if (dataInCell) {
+        if (!isEmptyCell(dataInCell)) {
           return -1;
         }
       }
@@ -440,7 +441,7 @@ export class Autofill extends BasePlugin {
       const dataInNextLeftCell = data[rowIndex][cornersOfSelectedCells[1] - 1];
       const dataInNextRightCell = data[rowIndex][cornersOfSelectedCells[3] + 1];
 
-      if (!!dataInNextLeftCell || !!dataInNextRightCell) {
+      if (!isEmptyCell(dataInNextLeftCell) || !isEmptyCell(dataInNextRightCell)) {
         lastFilledInRowIndex = rowIndex;
       }
     }

--- a/handsontable/src/plugins/autofill/autofill.js
+++ b/handsontable/src/plugins/autofill/autofill.js
@@ -426,7 +426,7 @@ export class Autofill extends BasePlugin {
   getIndexOfLastAdjacentFilledInRow(cornersOfSelectedCells) {
     const data = this.hot.getData();
     const nrOfTableRows = this.hot.countRows();
-    const isEmptyCell = cellContent => cellContent === null || cellContent === void 0 || cellContent === '';
+    const isEmptyCell = cellContent => cellContent === null || cellContent === undefined || cellContent === '';
     let lastFilledInRowIndex;
 
     for (let rowIndex = cornersOfSelectedCells[2] + 1; rowIndex < nrOfTableRows; rowIndex++) {

--- a/handsontable/src/plugins/autofill/autofill.js
+++ b/handsontable/src/plugins/autofill/autofill.js
@@ -2,6 +2,7 @@ import { BasePlugin } from '../base';
 import Hooks from '../../pluginHooks';
 import { offset, outerHeight, outerWidth } from '../../helpers/dom/element';
 import { arrayEach, arrayMap } from '../../helpers/array';
+import { isEmpty } from '../../helpers/mixed';
 import { getDragDirectionAndRange, DIRECTIONS, getMappedFillHandleSetting } from './utils';
 
 Hooks.getSingleton().register('modifyAutofillRange');
@@ -426,14 +427,13 @@ export class Autofill extends BasePlugin {
   getIndexOfLastAdjacentFilledInRow(cornersOfSelectedCells) {
     const data = this.hot.getData();
     const nrOfTableRows = this.hot.countRows();
-    const isEmptyCell = cellContent => cellContent === null || cellContent === undefined || cellContent === '';
     let lastFilledInRowIndex;
 
     for (let rowIndex = cornersOfSelectedCells[2] + 1; rowIndex < nrOfTableRows; rowIndex++) {
       for (let columnIndex = cornersOfSelectedCells[1]; columnIndex <= cornersOfSelectedCells[3]; columnIndex++) {
         const dataInCell = data[rowIndex][columnIndex];
 
-        if (!isEmptyCell(dataInCell)) {
+        if (!isEmpty(dataInCell)) {
           return -1;
         }
       }
@@ -441,7 +441,7 @@ export class Autofill extends BasePlugin {
       const dataInNextLeftCell = data[rowIndex][cornersOfSelectedCells[1] - 1];
       const dataInNextRightCell = data[rowIndex][cornersOfSelectedCells[3] + 1];
 
-      if (!isEmptyCell(dataInNextLeftCell) || !isEmptyCell(dataInNextRightCell)) {
+      if (!isEmpty(dataInNextLeftCell) || !isEmpty(dataInNextRightCell)) {
         lastFilledInRowIndex = rowIndex;
       }
     }


### PR DESCRIPTION
### Context
This PR:
- Makes the Autofill plugin treat cells filled with `0` as non-empty.
- Adds a test case for the problem described in handsontable/dev-handsontable#1757.

### How has this been tested?
Added a test case.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#1757

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

