### PR TITLE
Update copyable col param in documentation

### DIFF
--- a/handsontable/src/dataMap/metaManager/metaSchema.js
+++ b/handsontable/src/dataMap/metaManager/metaSchema.js
@@ -1199,7 +1199,7 @@ export default () => {
      * // enable copying for specific cells
      * cell: [
      *   {
-     *     coll: 0,
+     *     col: 0,
      *     row: 0,
      *     // disable copying for cell (0, 0)
      *     copyable: false,


### PR DESCRIPTION
### Context
This PR includes fix for col key in code sample for "copyable" option in documentation

### How has this been tested?
Locally

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/1432

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] "copyable" option in documentation have correct object structure 

[skip changelog]
