### PR TITLE
Added `beforeBeginEditing` hook to the Cell editor guide API list

### DIFF
--- a/docs/content/guides/cell-functions/cell-editor.md
+++ b/docs/content/guides/cell-functions/cell-editor.md
@@ -1431,6 +1431,7 @@ const hot = new Handsontable(container, {
   - [`setCellMetaObject()`](@/api/core.md#setcellmetaobject)
   - [`removeCellMeta()`](@/api/core.md#removecellmeta)
 - Hooks:
+  - [`beforeBeginEditing`](@/api/hooks.md#beforebeginediting)
   - [`afterBeginEditing`](@/api/hooks.md#afterbeginediting)
   - [`afterGetCellMeta`](@/api/hooks.md#aftergetcellmeta)
   - [`beforeGetCellMeta`](@/api/hooks.md#beforegetcellmeta)


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
As in https://github.com/handsontable/dev-handsontable/issues/1789 we introduced a new hook in v14.2 and should link it on the Cell editor page.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] change in the docs

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/1789

### Affected project(s):
- [x] docs

### Checklist:
- [x] My change requires a change to the documentation.

[skip changelog]
