### PR TITLE
React wrapper: Simplify useHotEditor API

### DIFF
--- a/docs/content/guides/cell-functions/cell-editor.md
+++ b/docs/content/guides/cell-functions/cell-editor.md
@@ -59,38 +59,19 @@ const EditorComponent = (props) => {
     padding: '15px',
     zIndex: 999
   };
-  
-  // Let's use ref instead of state to apply the changes immediately, 
-  // without waiting for the next component rerender.
-  const valueRef = React.useRef('');
 
-  // A hook that takes a factory function that provides the set of methods
-  // from BaseEditor that your custom editor needs to override. It also provides the editor instance
-  // reference in case other functions need to access its methods, like `finishEditing`.
-  const hotCustomEditorInstanceRef = useHotEditor((runSuper) => ({
-    setValue(value) {
-      valueRef.current = value;
-    },
-
-    getValue() {
-      return valueRef.current;
-    },
-
-    open() {
+  // A hook that takes a set of methods that your custom editor needs to override.
+  // It also provides partial editor API in case other functions need to access it, like `finishEditing`.
+  const { value, setValue, finishEditing } = useHotEditor({
+    onOpen() {
       mainElementRef.current.style.display = 'block';
     },
 
-    close() {
+    onClose() {
       mainElementRef.current.style.display = 'none';
     },
 
-    prepare(row, col, prop, td, originalValue, cellProperties) {
-      // We'll need to call the `prepare` method from
-      // the editor instance base class, as it provides
-      // the component with the information needed to use the editor
-      // (hotInstance, row, col, prop, TD, originalValue, cellProperties)
-      runSuper().prepare(row, col, prop, td, originalValue, cellProperties);
-
+    onPrepare(row, col, prop, td, originalValue, cellProperties) {
       const tdPosition = td.getBoundingClientRect();
 
       // As the `prepare` method is triggered after selecting
@@ -99,21 +80,21 @@ const EditorComponent = (props) => {
       mainElementRef.current.style.left = tdPosition.left + window.pageXOffset + 'px';
       mainElementRef.current.style.top = tdPosition.top + window.pageYOffset + 'px';
     }
-  }), [valueRef]);
+  });
 
   const setLowerCase = React.useCallback(() => {
-    valueRef.current = valueRef.current.toString().toLowerCase();
+    setValue(value.toString().toLowerCase());
     
-    // Close the editor by accessing the underlying editor instance.
-    hotCustomEditorInstanceRef.current.finishEditing();
-  }, [valueRef, hotCustomEditorInstanceRef]);
+    // Close the editor by the editor API method.
+    finishEditing();
+  }, [setValue, value, finishEditing]);
 
   const setUpperCase = React.useCallback(() => {
-    valueRef.current = valueRef.current.toString().toUpperCase();
+    setValue(value.toString().toUpperCase());
     
-    // Close the editor by accessing the underlying editor instance.
-    hotCustomEditorInstanceRef.current.finishEditing();
-  }, [valueRef, hotCustomEditorInstanceRef]);
+    // Close the editor by the editor API method.
+    finishEditing();
+  }, [setValue, value, finishEditing]);
 
   const stopMousedownPropagation = React.useCallback((e) => {
     e.stopPropagation();
@@ -127,10 +108,10 @@ const EditorComponent = (props) => {
         id="editorElement"
       >
         <button onClick={setLowerCase}>
-          {valueRef.current.toLowerCase()}
+          {value.toLowerCase()}
         </button>
         <button onClick={setUpperCase}>
-          {valueRef.current.toUpperCase()}
+          {value.toUpperCase()}
         </button>
       </div>
   );

--- a/docs/content/guides/cell-functions/cell-editor.md
+++ b/docs/content/guides/cell-functions/cell-editor.md
@@ -62,7 +62,7 @@ const EditorComponent = (props) => {
 
   // A hook that takes a set of methods that your custom editor needs to override.
   // It also provides partial editor API in case other functions need to access it, like `finishEditing`.
-  const editor = useHotEditor({
+  const { value, setValue, finishEditing } = useHotEditor({
     onOpen() {
       mainElementRef.current.style.display = 'block';
     },
@@ -83,18 +83,18 @@ const EditorComponent = (props) => {
   });
 
   const setLowerCase = React.useCallback(() => {
-    editor.setValue(editor.value.toString().toLowerCase());
+    setValue(value.toString().toLowerCase());
     
     // Close the editor by the editor API method.
-    editor.finishEditing();
-  }, [editor]);
+    finishEditing();
+  }, [setValue, value, finishEditing]);
 
   const setUpperCase = React.useCallback(() => {
-    editor.setValue(editor.value.toString().toUpperCase());
+    setValue(value.toString().toUpperCase());
     
     // Close the editor by the editor API method.
-    editor.finishEditing();
-  }, [editor]);
+    finishEditing();
+  }, [setValue, value, finishEditing]);
 
   const stopMousedownPropagation = React.useCallback((e) => {
     e.stopPropagation();
@@ -108,10 +108,10 @@ const EditorComponent = (props) => {
         id="editorElement"
       >
         <button onClick={setLowerCase}>
-          {editor.value.toLowerCase()}
+          {value.toLowerCase()}
         </button>
         <button onClick={setUpperCase}>
-          {editor.value.toUpperCase()}
+          {value.toUpperCase()}
         </button>
       </div>
   );

--- a/docs/content/guides/cell-functions/cell-editor.md
+++ b/docs/content/guides/cell-functions/cell-editor.md
@@ -101,19 +101,19 @@ const EditorComponent = (props) => {
   }, []);
 
   return (
-      <div
-        style={containerStyle}
-        ref={mainElementRef}
-        onMouseDown={stopMousedownPropagation}
-        id="editorElement"
-      >
-        <button onClick={setLowerCase}>
-          {value.toLowerCase()}
-        </button>
-        <button onClick={setUpperCase}>
-          {value.toUpperCase()}
-        </button>
-      </div>
+    <div
+      style={containerStyle}
+      ref={mainElementRef}
+      onMouseDown={stopMousedownPropagation}
+      id="editorElement"
+    >
+      <button onClick={setLowerCase}>
+        {value?.toLowerCase()}
+      </button>
+      <button onClick={setUpperCase}>
+        {value?.toUpperCase()}
+      </button>
+    </div>
   );
 };
 

--- a/docs/content/guides/cell-functions/cell-editor.md
+++ b/docs/content/guides/cell-functions/cell-editor.md
@@ -62,7 +62,7 @@ const EditorComponent = (props) => {
 
   // A hook that takes a set of methods that your custom editor needs to override.
   // It also provides partial editor API in case other functions need to access it, like `finishEditing`.
-  const { value, setValue, finishEditing } = useHotEditor({
+  const editor = useHotEditor({
     onOpen() {
       mainElementRef.current.style.display = 'block';
     },
@@ -83,18 +83,18 @@ const EditorComponent = (props) => {
   });
 
   const setLowerCase = React.useCallback(() => {
-    setValue(value.toString().toLowerCase());
+    editor.setValue(editor.value.toString().toLowerCase());
     
     // Close the editor by the editor API method.
-    finishEditing();
-  }, [setValue, value, finishEditing]);
+    editor.finishEditing();
+  }, [editor]);
 
   const setUpperCase = React.useCallback(() => {
-    setValue(value.toString().toUpperCase());
+    editor.setValue(editor.value.toString().toUpperCase());
     
     // Close the editor by the editor API method.
-    finishEditing();
-  }, [setValue, value, finishEditing]);
+    editor.finishEditing();
+  }, [editor]);
 
   const stopMousedownPropagation = React.useCallback((e) => {
     e.stopPropagation();
@@ -108,10 +108,10 @@ const EditorComponent = (props) => {
         id="editorElement"
       >
         <button onClick={setLowerCase}>
-          {value.toLowerCase()}
+          {editor.value.toLowerCase()}
         </button>
         <button onClick={setUpperCase}>
-          {value.toUpperCase()}
+          {editor.value.toUpperCase()}
         </button>
       </div>
   );

--- a/docs/content/guides/getting-started/react-redux.md
+++ b/docs/content/guides/getting-started/react-redux.md
@@ -241,7 +241,7 @@ const UnconnectedColorPickerEditor = (props) => {
     e.stopPropagation();
   }, []);
 
-  const editor = useHotEditor({
+  const { value, setValue, row, col, finishEditing } = useHotEditor({
     onOpen() {
       editorRef.current.style.display = 'block';
     },
@@ -260,7 +260,6 @@ const UnconnectedColorPickerEditor = (props) => {
   
   const applyColor = React.useCallback(() => {
     const dispatch = props.dispatch;
-    const { value, finishEditing, row, col } = editor;
 
     if (col === 1) {
       dispatch({
@@ -276,13 +275,13 @@ const UnconnectedColorPickerEditor = (props) => {
       });
     }
     finishEditing();
-  }, [props.dispatch, editor]);
+  }, [props.dispatch, value, row, col, finishEditing]);
   
   return (
     <div style={editorContainerStyle} ref={editorRef} onMouseDown={stopMousedownPropagation}>
       <HexColorPicker
-        color={editor.value}
-        onChange={editor.setValue}
+        color={value}
+        onChange={setValue}
       />
       <button
         style={{ width: '100%', height: '33px', marginTop: '10px' }}

--- a/docs/content/guides/getting-started/react-redux.md
+++ b/docs/content/guides/getting-started/react-redux.md
@@ -241,7 +241,7 @@ const UnconnectedColorPickerEditor = (props) => {
     e.stopPropagation();
   }, []);
 
-  const { value, setValue, finishEditing, row, col } = useHotEditor({
+  const editor = useHotEditor({
     onOpen() {
       editorRef.current.style.display = 'block';
     },
@@ -257,13 +257,10 @@ const UnconnectedColorPickerEditor = (props) => {
       editorRef.current.style.top = tdPosition.top + window.pageYOffset + 'px';
     }
   });
-
-  const onPickedColor = React.useCallback((color) => {
-    setValue(color);
-  }, [setValue]);
-
+  
   const applyColor = React.useCallback(() => {
     const dispatch = props.dispatch;
+    const { value, finishEditing, row, col } = editor;
 
     if (col === 1) {
       dispatch({
@@ -279,13 +276,13 @@ const UnconnectedColorPickerEditor = (props) => {
       });
     }
     finishEditing();
-  }, [props.dispatch, row, col, value, finishEditing]);
+  }, [props.dispatch, editor]);
   
   return (
     <div style={editorContainerStyle} ref={editorRef} onMouseDown={stopMousedownPropagation}>
       <HexColorPicker
-        color={value}
-        onChange={onPickedColor}
+        color={editor.value}
+        onChange={editor.setValue}
       />
       <button
         style={{ width: '100%', height: '33px', marginTop: '10px' }}
@@ -422,7 +419,7 @@ export const ExampleComponent = () => {
                    editor={ColorPickerEditor} />
         <HotColumn width={150} 
                    renderer={ColorPickerRenderer} 
-                   edidtor={ColorPickerEditor} />
+                   editor={ColorPickerEditor} />
       </HotTable>
     </Provider>
   );

--- a/docs/content/guides/getting-started/react-redux.md
+++ b/docs/content/guides/getting-started/react-redux.md
@@ -237,66 +237,54 @@ const UnconnectedColorPickerEditor = (props) => {
     border: '1px solid #cecece'
   };
 
-  const valueRef = React.useRef('');
-
   const stopMousedownPropagation = React.useCallback((e) => {
     e.stopPropagation();
   }, []);
 
-  const hotCustomEditorInstanceRef = useHotEditor((runSuper) => ({
-    setValue(value) {
-      valueRef.current = value;
-    },
-
-    getValue() {
-      return valueRef.current;
-    },
-
-    open() {
+  const { value, getValue, finishEditing, row, col } = useHotEditor({
+    onOpen() {
       editorRef.current.style.display = 'block';
     },
 
-    close() {
+    onClose() {
       editorRef.current.style.display = 'none';
     },
 
-    prepare(row, col, prop, td, originalValue, cellProperties) {
-      runSuper().prepare(row, col, prop, td, originalValue, cellProperties);
-
+    onPrepare(row, col, prop, td, originalValue, cellProperties) {
       const tdPosition = td.getBoundingClientRect();
 
       editorRef.current.style.left = tdPosition.left + window.pageXOffset + 'px';
       editorRef.current.style.top = tdPosition.top + window.pageYOffset + 'px';
     }
-  }), [valueRef]);
+  });
 
   const onPickedColor = React.useCallback((color) => {
-    valueRef.current = color;
-  }, [valueRef]);
+    setValue(color);
+  }, [setValue]);
 
   const applyColor = React.useCallback(() => {
     const dispatch = props.dispatch;
 
-    if (hotCustomEditorInstanceRef.current.col === 1) {
+    if (col === 1) {
       dispatch({
         type: 'updateActiveStarColor',
-        row: hotCustomEditorInstanceRef.current.row,
-        hexColor: hotCustomEditorInstanceRef.current.getValue()
+        row: row,
+        hexColor: getValue()
       });
-    } else if (hotCustomEditorInstanceRef.current.col === 2) {
+    } else if (col === 2) {
       dispatch({
         type: 'updateInactiveStarColor',
-        row: hotCustomEditorInstanceRef.current.row,
-        hexColor: hotCustomEditorInstanceRef.current.getValue()
+        row: row,
+        hexColor: getValue()
       });
     }
-    hotCustomEditorInstanceRef.current.finishEditing();
-  }, [props.dispatch, hotCustomEditorInstanceRef]);
+    finishEditing();
+  }, [props.dispatch, row, col, getValue, finishEditing]);
   
   return (
     <div style={editorContainerStyle} ref={editorRef} onMouseDown={stopMousedownPropagation}>
       <HexColorPicker
-        color={valueRef.current}
+        color={value}
         onChange={onPickedColor}
       />
       <button

--- a/docs/content/guides/getting-started/react-redux.md
+++ b/docs/content/guides/getting-started/react-redux.md
@@ -241,7 +241,7 @@ const UnconnectedColorPickerEditor = (props) => {
     e.stopPropagation();
   }, []);
 
-  const { value, getValue, finishEditing, row, col } = useHotEditor({
+  const { value, setValue, finishEditing, row, col } = useHotEditor({
     onOpen() {
       editorRef.current.style.display = 'block';
     },
@@ -269,17 +269,17 @@ const UnconnectedColorPickerEditor = (props) => {
       dispatch({
         type: 'updateActiveStarColor',
         row: row,
-        hexColor: getValue()
+        hexColor: value
       });
     } else if (col === 2) {
       dispatch({
         type: 'updateInactiveStarColor',
         row: row,
-        hexColor: getValue()
+        hexColor: value
       });
     }
     finishEditing();
-  }, [props.dispatch, row, col, getValue, finishEditing]);
+  }, [props.dispatch, row, col, value, finishEditing]);
   
   return (
     <div style={editorContainerStyle} ref={editorRef} onMouseDown={stopMousedownPropagation}>

--- a/docs/content/guides/getting-started/react-redux.md
+++ b/docs/content/guides/getting-started/react-redux.md
@@ -183,9 +183,9 @@ ReactDOM.render(
 
 ## Advanced example
 
-This example shows:
-- A [custom editor](@/guides/cell-functions/cell-editor.md#component-based-editors) component (built with an external dependency, `HexColorPicker`). This component acts both as an editor and as a renderer.
-- A [custom renderer](@/guides/cell-functions/cell-renderer.md#declare-a-custom-renderer-as-a-component) component, built with an external dependency (`StarRatingComponent`).
+This example shows two Redux-connected components:
+- A [custom editor](@/guides/cell-functions/cell-editor.md#component-based-editors) component (built with an external dependency, `HexColorPicker`).
+- A [custom renderer](@/guides/cell-functions/cell-renderer.md#declare-a-custom-renderer-as-a-component) component for stars, built with an external dependency (`StarRatingComponent`).
 
 The editor component changes the behavior of the renderer component, by passing information through Redux (and the `connect()` method of `react-redux`).
 

--- a/wrappers/react/src/helpers.tsx
+++ b/wrappers/react/src/helpers.tsx
@@ -205,27 +205,6 @@ export function isCSR(): boolean {
 }
 
 /**
- * Creates a copy of the class instance that is still bound to this but allows calling its super (prototype) methods.
- *
- * @param {T} that An instance to look for prototype methods.
- * @returns {T} Copy of the instance with super methods access.
- */
-export function superBound<T>(that: T): T {
-  const proto = Object.getPrototypeOf(Object.getPrototypeOf(that));
-  const superBoundObj = {} as T;
-
-  (Object.getOwnPropertyNames(proto) as (keyof T)[]).forEach((key: keyof T) => {
-    if (typeof proto[key] === 'function') {
-      superBoundObj[key] = proto[key].bind(that);
-    } else {
-      superBoundObj[key] = proto[key];
-    }
-  })
-
-  return superBoundObj;
-}
-
-/**
  * A variant of React.useEffect hook that does not trigger on initial mount, only updates
  *
  * @param effect Effect function

--- a/wrappers/react/src/hotEditor.tsx
+++ b/wrappers/react/src/hotEditor.tsx
@@ -36,13 +36,17 @@ export function makeEditorClass(hooksRef: React.MutableRefObject<HotEditorHooks 
 
         const baseMethod = Handsontable.editors.BaseEditor.prototype[propName];
         (CustomEditor.prototype as any)[propName] = function (this: CustomEditor, ...args: any[]) {
+          let result;
+
           if (!AbstractMethods.includes(propName)) {
-            baseMethod.call(this, ...args); // call super
+            result = baseMethod.call(this, ...args); // call super
           }
 
           if (MethodsMap[propName] && hooksRef.current?.[MethodsMap[propName]!]) {
-            (hooksRef.current[MethodsMap[propName]!] as any).call(this, ...args);
+            result = (hooksRef.current[MethodsMap[propName]!] as any).call(this, ...args);
           }
+
+          return result;
         }.bind(this);
       });
     }

--- a/wrappers/react/src/hotEditor.tsx
+++ b/wrappers/react/src/hotEditor.tsx
@@ -1,9 +1,18 @@
 import React from 'react';
 import Handsontable from 'handsontable/base';
-import { HotEditorHooks } from './types';
-import { superBound } from "./helpers";
+import { HotEditorHooks, UseHotEditorImpl } from './types';
 
 type HookPropName = (keyof Handsontable.editors.BaseEditor & keyof HotEditorHooks) | 'constructor'
+
+const AbstractMethods: (keyof Handsontable.editors.BaseEditor)[] = ['close', 'focus', 'open']
+const ExcludedMethods: (keyof Handsontable.editors.BaseEditor)[] = ['getValue', 'setValue']
+
+const MethodsMap: Partial<Record<keyof Handsontable.editors.BaseEditor, keyof HotEditorHooks>> = {
+  open: 'onOpen',
+  close: 'onClose',
+  prepare: 'onPrepare',
+  focus: 'onFocus',
+}
 
 /**
  * Create a class to be passed to the Handsontable's settings.
@@ -14,21 +23,25 @@ type HookPropName = (keyof Handsontable.editors.BaseEditor & keyof HotEditorHook
  */
 export function makeEditorClass(hooksRef: React.MutableRefObject<HotEditorHooks | null>, instanceRef: React.MutableRefObject<Handsontable.editors.BaseEditor | null>): typeof Handsontable.editors.BaseEditor {
   return class CustomEditor extends Handsontable.editors.BaseEditor implements Handsontable.editors.BaseEditor {
+    private value: any;
+
     constructor(hotInstance: Handsontable.Core) {
       super(hotInstance);
       instanceRef.current = this;
 
       (Object.getOwnPropertyNames(Handsontable.editors.BaseEditor.prototype) as HookPropName[]).forEach((propName) => {
-        if (propName === 'constructor') {
+        if (propName === 'constructor' || ExcludedMethods.includes(propName)) {
           return;
         }
 
         const baseMethod = Handsontable.editors.BaseEditor.prototype[propName];
         (CustomEditor.prototype as any)[propName] = function (this: CustomEditor, ...args: any[]) {
-          if (hooksRef.current?.[propName]) {
-            return hooksRef.current[propName].call(this, ...args);
-          } else {
-            return baseMethod.call(this, ...args);
+          if (!AbstractMethods.includes(propName)) {
+            baseMethod.call(this, ...args); // call super
+          }
+
+          if (MethodsMap[propName] && hooksRef.current?.[MethodsMap[propName]]) {
+            hooksRef.current[MethodsMap[propName]].call(this, ...args);
           }
         }.bind(this);
       });
@@ -38,9 +51,11 @@ export function makeEditorClass(hooksRef: React.MutableRefObject<HotEditorHooks 
     }
 
     getValue() {
+      return this.value
     }
 
-    setValue() {
+    setValue(value: any) {
+      this.value = value
     }
 
     open() {
@@ -83,14 +98,26 @@ export const EditorContextProvider: React.FC<EditorContextProviderProps> = ({ ho
 /**
  * Hook that allows encapsulating custom behaviours of component-based editor by customizing passed ref with overridden hooks object.
  *
- * @param {Function} overriddenHooks Function that provides the overrides specific for the custom editor.
- *  It gets an object that emulates super calls to BaseEditor methods, if needed.
+ * @param {HotEditorHooks} overriddenHooks Overrides specific for the custom editor.
  * @param {React.DependencyList} deps Overridden hooks object React dependency list.
- * @returns {React.RefObject} Reference to Handsontable-native editor instance.
+ * @returns {UseHotEditorImpl} Editor API methods
  */
-export function useHotEditor(overriddenHooks?: (runSuper: () => Handsontable.editors.BaseEditor) => HotEditorHooks, deps?: React.DependencyList): React.RefObject<Handsontable.editors.BaseEditor> {
+export function useHotEditor(overriddenHooks?: HotEditorHooks, deps?: React.DependencyList): UseHotEditorImpl {
   const { hooksRef, hotCustomEditorInstanceRef } = React.useContext(EditorContext)!;
-  const runSuper = () => superBound(hotCustomEditorInstanceRef.current!);
-  React.useImperativeHandle(hooksRef, () => overriddenHooks?.(runSuper) || {}, deps);
-  return hotCustomEditorInstanceRef;
+  React.useImperativeHandle(hooksRef, () => overriddenHooks || {}, deps);
+
+  return React.useMemo(() => ({
+    get value() {
+      return hotCustomEditorInstanceRef.current?.getValue();
+    },
+    setValue(newValue) {
+      hotCustomEditorInstanceRef.current?.setValue(newValue);
+    },
+    get isOpen() {
+      return hotCustomEditorInstanceRef.current?.isOpened() ?? false;
+    },
+    finishEditing() {
+      hotCustomEditorInstanceRef.current?.finishEditing();
+    }
+  }), [hotCustomEditorInstanceRef]);
 }

--- a/wrappers/react/src/hotEditor.tsx
+++ b/wrappers/react/src/hotEditor.tsx
@@ -2,17 +2,17 @@ import React from 'react';
 import Handsontable from 'handsontable/base';
 import { HotEditorHooks, UseHotEditorImpl } from './types';
 
-type HookPropName = (keyof Handsontable.editors.BaseEditor & keyof HotEditorHooks) | 'constructor'
+type HookPropName = (keyof Handsontable.editors.BaseEditor & keyof HotEditorHooks) | 'constructor';
 
-const AbstractMethods: (keyof Handsontable.editors.BaseEditor)[] = ['close', 'focus', 'open']
-const ExcludedMethods: (keyof Handsontable.editors.BaseEditor)[] = ['getValue', 'setValue']
+const AbstractMethods: (keyof Handsontable.editors.BaseEditor)[] = ['close', 'focus', 'open'];
+const ExcludedMethods: (keyof Handsontable.editors.BaseEditor)[] = ['getValue', 'setValue'];
 
 const MethodsMap: Partial<Record<keyof Handsontable.editors.BaseEditor, keyof HotEditorHooks>> = {
   open: 'onOpen',
   close: 'onClose',
   prepare: 'onPrepare',
   focus: 'onFocus',
-}
+};
 
 /**
  * Create a class to be passed to the Handsontable's settings.
@@ -51,11 +51,11 @@ export function makeEditorClass(hooksRef: React.MutableRefObject<HotEditorHooks 
     }
 
     getValue() {
-      return this.value
+      return this.value;
     }
 
-    setValue(value: any) {
-      this.value = value
+    setValue(newValue: any) {
+      this.value = newValue;
     }
 
     open() {

--- a/wrappers/react/src/hotEditor.tsx
+++ b/wrappers/react/src/hotEditor.tsx
@@ -108,13 +108,13 @@ export const EditorContextProvider: React.FC<EditorContextProviderProps> = ({ ho
  */
 export function useHotEditor(overriddenHooks?: HotEditorHooks, deps?: React.DependencyList): UseHotEditorImpl {
   const { hooksRef, hotCustomEditorInstanceRef } = React.useContext(EditorContext)!;
-  const [rerenderTrigger, setRerenderTriggerT] = React.useState(0);
+  const [rerenderTrigger, setRerenderTrigger] = React.useState(0);
 
   React.useImperativeHandle(hooksRef, () => ({
     ...overriddenHooks,
     onOpen() {
       overriddenHooks?.onOpen?.();
-      setRerenderTriggerT((t) => t + 1);
+      setRerenderTrigger((t) => t + 1);
     },
   }), deps);
 

--- a/wrappers/react/src/hotEditor.tsx
+++ b/wrappers/react/src/hotEditor.tsx
@@ -118,6 +118,12 @@ export function useHotEditor(overriddenHooks?: HotEditorHooks, deps?: React.Depe
     },
     finishEditing() {
       hotCustomEditorInstanceRef.current?.finishEditing();
+    },
+    get row() {
+      return hotCustomEditorInstanceRef.current?.row;
+    },
+    get col() {
+      return hotCustomEditorInstanceRef.current?.col;
     }
   }), [hotCustomEditorInstanceRef]);
 }

--- a/wrappers/react/src/hotEditor.tsx
+++ b/wrappers/react/src/hotEditor.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Handsontable from 'handsontable/base';
 import { HotEditorHooks, UseHotEditorImpl } from './types';
 
-type HookPropName = (keyof Handsontable.editors.BaseEditor & keyof HotEditorHooks) | 'constructor';
+type HookPropName = (keyof Handsontable.editors.BaseEditor) | 'constructor';
 
 const AbstractMethods: (keyof Handsontable.editors.BaseEditor)[] = ['close', 'focus', 'open'];
 const ExcludedMethods: (keyof Handsontable.editors.BaseEditor)[] = ['getValue', 'setValue'];
@@ -40,8 +40,8 @@ export function makeEditorClass(hooksRef: React.MutableRefObject<HotEditorHooks 
             baseMethod.call(this, ...args); // call super
           }
 
-          if (MethodsMap[propName] && hooksRef.current?.[MethodsMap[propName]]) {
-            hooksRef.current[MethodsMap[propName]].call(this, ...args);
+          if (MethodsMap[propName] && hooksRef.current?.[MethodsMap[propName]!]) {
+            (hooksRef.current[MethodsMap[propName]!] as any).call(this, ...args);
           }
         }.bind(this);
       });

--- a/wrappers/react/src/hotEditor.tsx
+++ b/wrappers/react/src/hotEditor.tsx
@@ -108,7 +108,15 @@ export const EditorContextProvider: React.FC<EditorContextProviderProps> = ({ ho
  */
 export function useHotEditor(overriddenHooks?: HotEditorHooks, deps?: React.DependencyList): UseHotEditorImpl {
   const { hooksRef, hotCustomEditorInstanceRef } = React.useContext(EditorContext)!;
-  React.useImperativeHandle(hooksRef, () => overriddenHooks || {}, deps);
+  const [rerenderTrigger, setRerenderTriggerT] = React.useState(0);
+
+  React.useImperativeHandle(hooksRef, () => ({
+    ...overriddenHooks,
+    onOpen() {
+      overriddenHooks?.onOpen?.();
+      setRerenderTriggerT((t) => t + 1);
+    },
+  }), deps);
 
   return React.useMemo(() => ({
     get value() {
@@ -129,5 +137,5 @@ export function useHotEditor(overriddenHooks?: HotEditorHooks, deps?: React.Depe
     get col() {
       return hotCustomEditorInstanceRef.current?.col;
     }
-  }), [hotCustomEditorInstanceRef]);
+  }), [rerenderTrigger, hotCustomEditorInstanceRef]);
 }

--- a/wrappers/react/src/types.tsx
+++ b/wrappers/react/src/types.tsx
@@ -22,7 +22,22 @@ export interface HotRendererProps {
 /**
  * Interface for component-based editor overridden hooks object.
  */
-export type HotEditorHooks = Partial<Handsontable.editors.BaseEditor> & { hotCustomEditorInstance?: Handsontable.editors.BaseEditor };
+export interface HotEditorHooks {
+  onOpen?: () => void
+  onClose?: () => void
+  onPrepare?: (row: number, column: number, prop: string | number, TD: HTMLTableCellElement, originalValue: any, cellProperties: Handsontable.CellProperties) => void
+  onFocus?: () => void
+}
+
+/**
+ * Interface for custom component-based editor API exposed by useHotEditor
+ */
+export interface UseHotEditorImpl {
+  value: any
+  setValue: React.Dispatch<any>
+  isOpen: boolean
+  finishEditing: React.DispatchWithoutAction
+}
 
 /**
  * Helper type to expose GridSettings/ColumnSettings props with native renderers/editors separately

--- a/wrappers/react/src/types.tsx
+++ b/wrappers/react/src/types.tsx
@@ -37,6 +37,8 @@ export interface UseHotEditorImpl {
   setValue: React.Dispatch<any>
   isOpen: boolean
   finishEditing: React.DispatchWithoutAction
+  row?: number
+  col?: number
 }
 
 /**

--- a/wrappers/react/src/types.tsx
+++ b/wrappers/react/src/types.tsx
@@ -33,7 +33,7 @@ export interface HotEditorHooks {
  * Interface for custom component-based editor API exposed by useHotEditor
  */
 export interface UseHotEditorImpl {
-  value: any
+  value?: any
   setValue: React.Dispatch<any>
   isOpen: boolean
   finishEditing: React.DispatchWithoutAction

--- a/wrappers/react/test/_helpers.tsx
+++ b/wrappers/react/test/_helpers.tsx
@@ -225,35 +225,24 @@ export const EditorComponent: React.FC<EditorComponentProps> = ({ tap, ...props 
     display: 'none'
   };
 
-  const valueRef = React.useRef('');
-
-  const hotCustomEditorInstanceRef = useHotEditor((runSuper) => ({
-    getValue() {
-      return valueRef.current;
-    },
-
-    setValue(value) {
-      valueRef.current = value;
-    },
-
-    prepare(row, col, prop, TD, originalValue, cellProperties): any {
-      runSuper().prepare(row, col, prop, TD, originalValue, cellProperties)
+  const { setValue, finishEditing } = useHotEditor({
+    onPrepare() {
       mainElementRef.current!.style.backgroundColor = props.background!;
     },
 
-    open() {
+    onOpen() {
       mainElementRef.current!.style.display = 'block';
     },
 
-    close() {
+    onClose() {
       mainElementRef.current!.style.display = 'none';
     }
-  }), [valueRef]);
+  });
 
   const setNewValue = React.useCallback(() => {
-    valueRef.current = 'new-value';
-    hotCustomEditorInstanceRef.current!.finishEditing();
-  }, [valueRef, mainElementRef]);
+    setValue('new-value');
+    finishEditing();
+  }, [setValue, finishEditing]);
 
   tap?.(props);
 


### PR DESCRIPTION
### Context

Follow-up on improving custom component-based editor developer experience as proposed by @evanSe in https://github.com/handsontable/handsontable/pull/10831#issuecomment-1983650294.

### How has this been tested?

* all unit tests still pass
* examples still run correctly

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/pull/10831#issuecomment-1983650294

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [x] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]