### PR TITLE
Make the cursor turn to `grabbing` for all the elements in the table while moving the columns or rows.

### DIFF
--- a/.changelogs/10852.json
+++ b/.changelogs/10852.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Made the cursor turn to `grabbing` for all the elements in the table while moving the columns or rows.",
+  "type": "changed",
+  "issueOrPR": 10852,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/manualColumnMove/__tests__/ui/cursor.spec.js
+++ b/handsontable/src/plugins/manualColumnMove/__tests__/ui/cursor.spec.js
@@ -1,0 +1,93 @@
+describe('manualColumnMove', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  describe('cursor icon', () => {
+    it('should change the cursor to `grab` when mouse is over a selected header and `manualColumMove` is enabled', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        colHeaders: true,
+        manualColumnMove: true
+      });
+
+      const $headers = spec().$container.find('.ht_clone_top thead th');
+      const $header = $headers.eq(0);
+
+      $header.simulate('mousedown');
+      $header.simulate('mouseup');
+
+      $header.simulate('mouseover');
+      expect($header.css('cursor')).toEqual('grab');
+
+      $header.eq(1).simulate('mouseover');
+      expect($headers.eq(1).css('cursor')).toEqual('default');
+
+      const $cells = spec().$container.find('.ht_master tbody td');
+      const $cell = $cells.eq(0);
+
+      $cell.simulate('mouseover');
+      expect($cell.css('cursor')).toEqual('default');
+    });
+
+    it('should change the cursor to `grabbing` when holding LMB over a selected header and `manualColumMove` is enabled', () => {
+      const hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        colHeaders: true,
+        manualColumnMove: true
+      });
+
+      const $headers = spec().$container.find('.ht_clone_top thead th');
+      const $header = $headers.eq(0);
+
+      $header.simulate('mousedown');
+      $header.simulate('mouseup');
+
+      $header.simulate('mouseover');
+      $header.simulate('mousedown');
+
+      expect($(hot.rootElement).attr('class')).toContain('on-moving--columns');
+      expect($header.css('cursor')).toEqual('grabbing');
+    });
+
+    it('should change the cursor to `grabbing` when holding LMB on a selected header and moving the cursor anywhere ' +
+    'else within the table (and `manualColumMove` is enabled)', () => {
+      const hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        colHeaders: true,
+        manualColumnMove: true
+      });
+
+      const $headers = spec().$container.find('.ht_clone_top thead th');
+      const $header = $headers.eq(0);
+
+      $header.simulate('mousedown');
+      $header.simulate('mouseup');
+
+      $header.simulate('mouseover');
+      $header.simulate('mousedown');
+
+      expect($(hot.rootElement).attr('class')).toContain('on-moving--columns');
+      expect($header.css('cursor')).toEqual('grabbing');
+
+      expect($headers.eq(1).css('cursor')).toEqual('grabbing');
+
+      const $cells = spec().$container.find('.ht_master tbody td');
+
+      expect($cells.eq(0).css('cursor')).toEqual('grabbing');
+      expect($cells.eq(5).css('cursor')).toEqual('grabbing');
+      expect($cells.eq(10).css('cursor')).toEqual('grabbing');
+
+      expect($('.ht__manualColumnMove--guideline').eq(0).css('cursor')).toEqual('grabbing');
+    });
+  });
+});

--- a/handsontable/src/plugins/manualColumnMove/manualColumnMove.css
+++ b/handsontable/src/plugins/manualColumnMove/manualColumnMove.css
@@ -7,7 +7,8 @@
   cursor: -webkit-grab;
   cursor: grab;
 }
-.handsontable.ht__manualColumnMove.on-moving--columns,
+.handsontable.ht__manualColumnMove.on-moving--columns *,
+/* Additional specific selector may be needed, because `grab` got assigned very specificaly */
 .handsontable.ht__manualColumnMove.on-moving--columns thead th.ht__highlight {
   cursor: move;
   cursor: -moz-grabbing;

--- a/handsontable/src/plugins/manualRowMove/__tests__/ui/cursor.spec.js
+++ b/handsontable/src/plugins/manualRowMove/__tests__/ui/cursor.spec.js
@@ -1,0 +1,93 @@
+describe('manualRowMove', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  describe('cursor icon', () => {
+    it('should change the cursor to `grab` when mouse is over a selected header and `manualRowMove` is enabled', () => {
+      handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        manualRowMove: true
+      });
+
+      const $headers = spec().$container.find('.ht_clone_inline_start tbody th');
+      const $header = $headers.eq(0);
+
+      $header.simulate('mousedown');
+      $header.simulate('mouseup');
+
+      $header.simulate('mouseover');
+      expect($header.css('cursor')).toEqual('grab');
+
+      $header.eq(1).simulate('mouseover');
+      expect($headers.eq(1).css('cursor')).toEqual('default');
+
+      const $cells = spec().$container.find('.ht_master tbody td');
+      const $cell = $cells.eq(0);
+
+      $cell.simulate('mouseover');
+      expect($cell.css('cursor')).toEqual('default');
+    });
+
+    it('should change the cursor to `grabbing` when holding LMB over a selected header and `manualRowMove` is enabled', () => {
+      const hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        manualRowMove: true
+      });
+
+      const $headers = spec().$container.find('.ht_clone_inline_start tbody th');
+      const $header = $headers.eq(0);
+
+      $header.simulate('mousedown');
+      $header.simulate('mouseup');
+
+      $header.simulate('mouseover');
+      $header.simulate('mousedown');
+
+      expect($(hot.rootElement).attr('class')).toContain('on-moving--rows');
+      expect($header.css('cursor')).toEqual('grabbing');
+    });
+
+    it('should change the cursor to `grabbing` when holding LMB on a selected header and moving the cursor anywhere ' +
+    'else within the table (and `manualRowMove` is enabled)', () => {
+      const hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        manualRowMove: true
+      });
+
+      const $headers = spec().$container.find('.ht_clone_inline_start tbody th');
+      const $header = $headers.eq(0);
+
+      $header.simulate('mousedown');
+      $header.simulate('mouseup');
+
+      $header.simulate('mouseover');
+      $header.simulate('mousedown');
+
+      expect($(hot.rootElement).attr('class')).toContain('on-moving--rows');
+      expect($header.css('cursor')).toEqual('grabbing');
+
+      expect($headers.eq(1).css('cursor')).toEqual('grabbing');
+
+      const $cells = spec().$container.find('.ht_master tbody td');
+
+      expect($cells.eq(0).css('cursor')).toEqual('grabbing');
+      expect($cells.eq(5).css('cursor')).toEqual('grabbing');
+      expect($cells.eq(10).css('cursor')).toEqual('grabbing');
+
+      expect($('.ht__manualRowMove--guideline').eq(0).css('cursor')).toEqual('grabbing');
+    });
+  });
+});

--- a/handsontable/src/plugins/manualRowMove/manualRowMove.css
+++ b/handsontable/src/plugins/manualRowMove/manualRowMove.css
@@ -7,7 +7,8 @@
   cursor: -webkit-grab;
   cursor: grab;
 }
-.handsontable.ht__manualRowMove.on-moving--rows,
+.handsontable.ht__manualRowMove.on-moving--rows *,
+/* Additional specific selector may be needed, because `grab` got assigned very specificaly */
 .handsontable.ht__manualRowMove.on-moving--rows tbody th.ht__highlight {
   cursor: move;
   cursor: -moz-grabbing;


### PR DESCRIPTION
### Context
This PR makes the cursor turn to `grabbing` for all the elements in the table while moving the columns or rows.

### How has this been tested?
Added test cases for checking the cursor while moving columns and rows.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#1698


### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
