### PR TITLE
Prevent all cells from being selected when `Cmd/Ctrl + A` is pressed while a header element is selected.

### DIFF
--- a/.changelogs/10853.json
+++ b/.changelogs/10853.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Blocked the `Cmd/Ctrl + A` action for situations where the focus is placed on the headers.",
+  "type": "fixed",
+  "issueOrPR": 10853,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/selection/__tests__/keyboardShortcuts/selectionExtending.spec.js
+++ b/handsontable/src/selection/__tests__/keyboardShortcuts/selectionExtending.spec.js
@@ -2867,6 +2867,28 @@ describe('Selection extending', () => {
       `).toBeMatchToSelectionPattern();
       expect(getSelectedRange()).toEqualCellRange(['highlight: 2,2 from: -1,-1 to: 4,4']);
     });
+
+    it('should do nothing when pressing the shortcut with a header being selected', () => {
+      handsontable({
+        rowHeaders: true,
+        colHeaders: true,
+        navigableHeaders: true,
+        startRows: 5,
+        startCols: 5
+      });
+
+      selectCell(0, 0);
+      keyDownUp(['ArrowLeft']);
+      keyDownUp(['control/meta', 'a']);
+
+      expect(getSelectedRange()).toEqualCellRange(['highlight: 0,-1 from: 0,-1 to: 0,-1']);
+
+      selectCell(0, 0);
+      keyDownUp(['ArrowUp']);
+      keyDownUp(['control/meta', 'a']);
+
+      expect(getSelectedRange()).toEqualCellRange(['highlight: -1,0 from: -1,0 to: -1,0']);
+    });
   });
 
   describe('"Ctrl/Cmd + Shift + Space"', () => {

--- a/handsontable/src/shortcutContexts/grid.js
+++ b/handsontable/src/shortcutContexts/grid.js
@@ -37,6 +37,12 @@ export function shortcutsGridContext(hot) {
   context.addShortcuts([{
     keys: [['Control/Meta', 'A']],
     callback: () => commandsPool.selectAllCells(),
+    runOnlyIf: () => !hot.getSelectedRangeLast().highlight.isHeader(),
+  }, {
+    keys: [['Control/Meta', 'A']],
+    callback: () => {},
+    runOnlyIf: () => hot.getSelectedRangeLast().highlight.isHeader(),
+    preventDefault: true,
   }, {
     keys: [['Control/Meta', 'Shift', 'Space']],
     callback: () => commandsPool.selectAllCellsAndHeaders(),


### PR DESCRIPTION
### Context
This PR blocks the `Cmd/Ctrl + A` action for header elements.

### How has this been tested?
Added a test case.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#1771

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
