### PR TITLE
Shorten the articles title and header for Vue 2 and 3 guide

### DIFF
--- a/docs/content/guides/integrate-with-vue/vue-custom-id-class-style/vue-custom-id-class-style.md
+++ b/docs/content/guides/integrate-with-vue/vue-custom-id-class-style/vue-custom-id-class-style.md
@@ -1,6 +1,6 @@
 ---
 id: oriujz8y
-title: Custom ID, Class, Style and other attributes in Vue 2
+title: Custom ID, Class and other attributes in Vue 2
 metaTitle: Custom ID, class, and style - Vue 2 Data Grid | Handsontable
 description: Pass a custom ID, class, and style to the "HotTable" component, to further customize your Vue 2 data grid.
 permalink: /vue-custom-id-class-style
@@ -8,7 +8,7 @@ canonicalUrl: /vue-custom-id-class-style
 searchCategory: Guides
 ---
 
-# Custom ID, class, style, and other attributes in Vue 2
+# Custom ID, class, and other attributes in Vue 2
 
 Pass a custom ID, class, and style to the `HotTable` component, to further customize your Vue 2 data grid.
 

--- a/docs/content/guides/integrate-with-vue3/vue3-custom-id-class-style/vue3-custom-id-class-style.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-custom-id-class-style/vue3-custom-id-class-style.md
@@ -1,6 +1,6 @@
 ---
 id: 2kg0f1og
-title: Custom ID, Class, Style and other attributes in Vue 3
+title: Custom ID, Class and other attributes in Vue 3
 metaTitle: Custom ID, class, and style - Vue 3 Data Grid | Handsontable
 description: Pass a custom ID, class, and style to the "HotTable" component, to further customize your Vue 3 data grid.
 permalink: /vue3-custom-id-class-style
@@ -8,7 +8,7 @@ canonicalUrl: /vue3-custom-id-class-style
 searchCategory: Guides
 ---
 
-# Custom ID, Class, Style, and other attributes in Vue 3
+# Custom ID, Class, and other attributes in Vue 3
 
 Pass a custom ID, class, and style to the "HotTable" component, to further customize your Vue 3 data grid.
 


### PR DESCRIPTION
### Context

This PR shortens the title for the following guides headers:

- https://handsontable.com/docs/javascript-data-grid/vue-custom-id-class-style/
- https://handsontable.com/docs/javascript-data-grid/vue3-custom-id-class-style/

The reason for this change is to avoid line-breaking with the Vue version number.

### How has this been tested?

Locally

### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/1026

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [x] `@handsontable/vue`
- [x] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]
