### PR TITLE
Narrow the event stop propagation only to internal elements

### DIFF
--- a/.changelogs/10888.json
+++ b/.changelogs/10888.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed Dropdown plugin logic that in some cases could block click events coming from custom editors.",
+  "type": "fixed",
+  "issueOrPR": 10888,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/dropdownMenu/dropdownMenu.js
+++ b/handsontable/src/plugins/dropdownMenu/dropdownMenu.js
@@ -420,12 +420,11 @@ export class DropdownMenu extends BasePlugin {
    * @param {Event} event The mouse event object.
    */
   #onTableClick(event) {
-    event.stopPropagation();
-
     if (hasClass(event.target, BUTTON_CLASS_NAME)) {
       const offset = getDocumentOffsetByElement(this.menu.container, this.hot.rootDocument);
       const rect = event.target.getBoundingClientRect();
 
+      event.stopPropagation();
       this.#isButtonClicked = false;
 
       this.open({


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR narrows the events stop propagation (`event.stopPropagation()`) calls to internal elements only. The fix allows implementing custom editors more easily. 

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally. I wasn't able to emulate the bug in tests. I tried to cover the fix using Vanilla JS or React env, but with no success.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/1710

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
