### PR TITLE
Modify the vue wrappers' `simpleEqual` helper to support comparing functions.

### DIFF
--- a/.changelogs/10686.json
+++ b/.changelogs/10686.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed a problem where updating the hook callback in the Vue and Vue3 wrappers did not update the underlying instance's settings.",
+  "type": "fixed",
+  "issueOrPR": 10686,
+  "breaking": false,
+  "framework": "vue"
+}

--- a/wrappers/vue/src/helpers.ts
+++ b/wrappers/vue/src/helpers.ts
@@ -266,5 +266,13 @@ function simpleEqual(objectA, objectB) {
     };
   }());
 
-  return JSON.stringify(objectA, circularReplacer) === JSON.stringify(objectB, circularReplacer);
+  if (typeof objectA === 'function' && typeof objectB === 'function') {
+    return objectA.toString() === objectB.toString();
+
+  } else if (typeof objectA !== typeof objectB) {
+    return false;
+
+  } else {
+    return JSON.stringify(objectA, circularReplacer) === JSON.stringify(objectB, circularReplacer);
+  }
 }

--- a/wrappers/vue/test/hotTable.spec.ts
+++ b/wrappers/vue/test/hotTable.spec.ts
@@ -51,8 +51,8 @@ describe('Updating the Handsontable settings', () => {
   });
 
   it('should update the previously initialized Handsontable instance only once with multiple changed properties', async() => {
-    const initialAfterChangeHook = () => {/* initial hook */};
-    const modifiedAfterChangeHook = () => {/* modified hook */};
+    const initialAfterChangeHook = () => { /* initial hook */ };
+    const modifiedAfterChangeHook = () => { /* modified hook */ };
     const App = Vue.extend({
       data: function () {
         return {

--- a/wrappers/vue/test/hotTable.spec.ts
+++ b/wrappers/vue/test/hotTable.spec.ts
@@ -51,12 +51,15 @@ describe('Updating the Handsontable settings', () => {
   });
 
   it('should update the previously initialized Handsontable instance only once with multiple changed properties', async() => {
-    let App = Vue.extend({
+    const initialAfterChangeHook = () => {/* initial hook */};
+    const modifiedAfterChangeHook = () => {/* modified hook */};
+    const App = Vue.extend({
       data: function () {
         return {
           rowHeaders: true,
           colHeaders: true,
           readOnly: true,
+          afterChange: initialAfterChangeHook
         }
       },
       methods: {
@@ -64,6 +67,7 @@ describe('Updating the Handsontable settings', () => {
           this.rowHeaders = false;
           this.colHeaders = false;
           this.readOnly = false;
+          this.afterChange = modifiedAfterChangeHook;
         }
       },
       render(h) {
@@ -74,6 +78,7 @@ describe('Updating the Handsontable settings', () => {
             rowHeaders: this.rowHeaders,
             colHeaders: this.colHeaders,
             readOnly: this.readOnly,
+            afterChange: this.afterChange,
             afterUpdateSettings: function () {
               updateSettingsCalls++;
             }
@@ -93,6 +98,8 @@ describe('Updating the Handsontable settings', () => {
     expect(hotTableComponent.hotInstance.getSettings().rowHeaders).toEqual(true);
     expect(hotTableComponent.hotInstance.getSettings().colHeaders).toEqual(true);
     expect(hotTableComponent.hotInstance.getSettings().readOnly).toEqual(true);
+    expect(hotTableComponent.hotInstance.pluginHookBucket.afterChange.includes(initialAfterChangeHook)).toBe(true);
+    expect(hotTableComponent.hotInstance.pluginHookBucket.afterChange.includes(modifiedAfterChangeHook)).toBe(false);
 
     testWrapper.vm.updateData();
 
@@ -101,6 +108,8 @@ describe('Updating the Handsontable settings', () => {
     expect(hotTableComponent.hotInstance.getSettings().rowHeaders).toEqual(false);
     expect(hotTableComponent.hotInstance.getSettings().colHeaders).toEqual(false);
     expect(hotTableComponent.hotInstance.getSettings().readOnly).toEqual(false);
+    expect(hotTableComponent.hotInstance.pluginHookBucket.afterChange.includes(initialAfterChangeHook)).toBe(false);
+    expect(hotTableComponent.hotInstance.pluginHookBucket.afterChange.includes(modifiedAfterChangeHook)).toBe(true);
   });
 
   it('should update the previously initialized Handsontable instance with only the options that are passed to the' +

--- a/wrappers/vue3/src/helpers.ts
+++ b/wrappers/vue3/src/helpers.ts
@@ -152,5 +152,13 @@ function simpleEqual(objectA, objectB) {
     };
   }());
 
-  return JSON.stringify(objectA, circularReplacer) === JSON.stringify(objectB, circularReplacer);
+  if (typeof objectA === 'function' && typeof objectB === 'function') {
+    return objectA.toString() === objectB.toString();
+
+  } else if (typeof objectA !== typeof objectB) {
+    return false;
+
+  } else {
+    return JSON.stringify(objectA, circularReplacer) === JSON.stringify(objectB, circularReplacer);
+  }
 }

--- a/wrappers/vue3/test/hotTable.spec.ts
+++ b/wrappers/vue3/test/hotTable.spec.ts
@@ -77,8 +77,8 @@ describe('Updating the Handsontable settings', () => {
   });
 
   it('should update the previously initialized Handsontable instance only once with multiple changed properties', async() => {
-    const initialAfterChangeHook = () => {/* initial hook */};
-    const modifiedAfterChangeHook = () => {/* modified hook */};
+    const initialAfterChangeHook = () => { /* initial hook */ };
+    const modifiedAfterChangeHook = () => { /* modified hook */ };
     const App = {
       components: { HotTable },
       template: `

--- a/wrappers/vue3/test/hotTable.spec.ts
+++ b/wrappers/vue3/test/hotTable.spec.ts
@@ -77,6 +77,8 @@ describe('Updating the Handsontable settings', () => {
   });
 
   it('should update the previously initialized Handsontable instance only once with multiple changed properties', async() => {
+    const initialAfterChangeHook = () => {/* initial hook */};
+    const modifiedAfterChangeHook = () => {/* modified hook */};
     const App = {
       components: { HotTable },
       template: `
@@ -85,6 +87,7 @@ describe('Updating the Handsontable settings', () => {
           :rowHeaders="rowHeaders"
           :colHeaders="colHeaders"
           :readOnly="readOnly"
+          :afterChange="afterChange"
           :afterUpdateSettings="() => { this.updateSettingsCalls ++ }"
           ></HotTable>`,
       data() {
@@ -93,6 +96,7 @@ describe('Updating the Handsontable settings', () => {
           colHeaders: true,
           readOnly: true,
           updateSettingsCalls: 0,
+          afterChange: initialAfterChangeHook,
         };
       },
       methods: {
@@ -100,6 +104,7 @@ describe('Updating the Handsontable settings', () => {
           this.rowHeaders = false;
           this.colHeaders = false;
           this.readOnly = false;
+          this.afterChange = modifiedAfterChangeHook;
         },
       },
     };
@@ -112,6 +117,8 @@ describe('Updating the Handsontable settings', () => {
     expect(hotTableComponent.hotInstance.getSettings().rowHeaders).toBe(true);
     expect(hotTableComponent.hotInstance.getSettings().colHeaders).toBe(true);
     expect(hotTableComponent.hotInstance.getSettings().readOnly).toBe(true);
+    expect(hotTableComponent.hotInstance.pluginHookBucket.afterChange.includes(initialAfterChangeHook)).toBe(true);
+    expect(hotTableComponent.hotInstance.pluginHookBucket.afterChange.includes(modifiedAfterChangeHook)).toBe(false);
 
     await testWrapper.vm.updateData();
 
@@ -119,6 +126,8 @@ describe('Updating the Handsontable settings', () => {
     expect(hotTableComponent.hotInstance.getSettings().rowHeaders).toBe(false);
     expect(hotTableComponent.hotInstance.getSettings().colHeaders).toBe(false);
     expect(hotTableComponent.hotInstance.getSettings().readOnly).toBe(false);
+    expect(hotTableComponent.hotInstance.pluginHookBucket.afterChange.includes(initialAfterChangeHook)).toBe(false);
+    expect(hotTableComponent.hotInstance.pluginHookBucket.afterChange.includes(modifiedAfterChangeHook)).toBe(true);
 
     testWrapper.unmount();
   });


### PR DESCRIPTION
### Context
Currently, the Vue and Vue3 wrappers utilize a `simpleEqual` helper that compares two objects by stringifying them to the JSON format. 
This PR adds support for comparing functions in a similar, simple way, by stringifying them.

### How has this been tested?
- Tested manually
- Extended one of the test cases for each of the modified wrappers

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #10686 

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [x] `@handsontable/vue`
- [x] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
