### PR TITLE
Make the Vue/Vue3 wrappers' `simpleEqual` helper correctly recognize the same objects.

### DIFF
--- a/.changelogs/10896.json
+++ b/.changelogs/10896.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed a problem where the Vue/Vue3 wrappers' `simpleEqual` helper return incorrect result when comparing identical objects.",
+  "type": "fixed",
+  "issueOrPR": 10896,
+  "breaking": false,
+  "framework": "vue"
+}

--- a/wrappers/vue/src/helpers.ts
+++ b/wrappers/vue/src/helpers.ts
@@ -267,7 +267,7 @@ function simpleEqual(objectA, objectB) {
       };
     }());
 
-    return JSON.stringify(value, circularReplacer);
+    return JSON.stringify(val, circularReplacer);
   };
 
   if (typeof objectA === 'function' && typeof objectB === 'function') {

--- a/wrappers/vue/src/helpers.ts
+++ b/wrappers/vue/src/helpers.ts
@@ -253,7 +253,7 @@ export function createVueComponent(vNode: VNode, parent: Vue, props: object, dat
  * @returns {boolean} `true` if they're the same, `false` otherwise.
  */
 function simpleEqual(objectA, objectB) {
-  const stringifyToJSON = (value) => {
+  const stringifyToJSON = (val) => {
     const circularReplacer = (function() {
       const seen = new WeakSet();
 

--- a/wrappers/vue/src/helpers.ts
+++ b/wrappers/vue/src/helpers.ts
@@ -253,18 +253,22 @@ export function createVueComponent(vNode: VNode, parent: Vue, props: object, dat
  * @returns {boolean} `true` if they're the same, `false` otherwise.
  */
 function simpleEqual(objectA, objectB) {
-  const circularReplacer = (function() {
-    const seen = new WeakSet();
+  const stringifyToJSON = (value) => {
+    const circularReplacer = (function() {
+      const seen = new WeakSet();
 
-    return function(key, value) {
-      if (typeof value === 'object' && value !== null) {
-        if (seen.has(value)) return;
-        seen.add(value);
-      }
+      return function(key, value) {
+        if (typeof value === 'object' && value !== null) {
+          if (seen.has(value)) return;
+          seen.add(value);
+        }
 
-      return value;
-    };
-  }());
+        return value;
+      };
+    }());
+
+    return JSON.stringify(value, circularReplacer);
+  };
 
   if (typeof objectA === 'function' && typeof objectB === 'function') {
     return objectA.toString() === objectB.toString();
@@ -273,6 +277,6 @@ function simpleEqual(objectA, objectB) {
     return false;
 
   } else {
-    return JSON.stringify(objectA, circularReplacer) === JSON.stringify(objectB, circularReplacer);
+    return stringifyToJSON(objectA) === stringifyToJSON(objectB);
   }
 }

--- a/wrappers/vue/test/hotTableHelpers.spec.ts
+++ b/wrappers/vue/test/hotTableHelpers.spec.ts
@@ -1,3 +1,4 @@
+import { GridSettings } from 'handsontable/settings';
 import {
   rewriteSettings,
   prepareSettings,
@@ -86,5 +87,16 @@ describe('prepareSettings', () => {
     expect(preparedSettings.readOnly).toBe(true);
     expect(preparedSettings.whatever.foo).toBe('bar');
     expect(preparedSettings.whatever.myself.foo).toBe('bar');
+  });
+
+  it('should not recognize passing of the same array twice as a changed object', () => {
+    const settings1: GridSettings = {
+      mergeCells: [{ row: 1, col: 1, colspan: 1, rowspan: 1 }],
+    };
+
+    const preparedSettings = prepareSettings({ settings: settings1 }, settings1);
+
+    expect(preparedSettings.mergeCells).toBe(undefined);
+    expect(Object.keys(preparedSettings).length).toBe(0);
   });
 });

--- a/wrappers/vue3/src/helpers.ts
+++ b/wrappers/vue3/src/helpers.ts
@@ -139,7 +139,7 @@ export function prepareSettings(props: HotTableProps, currentSettings?: Handsont
  * @returns {boolean} `true` if they're the same, `false` otherwise.
  */
 function simpleEqual(objectA, objectB) {
-  const stringifyToJSON = (value) => {
+  const stringifyToJSON = (val) => {
     const circularReplacer = (function() {
       const seen = new WeakSet();
 

--- a/wrappers/vue3/src/helpers.ts
+++ b/wrappers/vue3/src/helpers.ts
@@ -139,18 +139,22 @@ export function prepareSettings(props: HotTableProps, currentSettings?: Handsont
  * @returns {boolean} `true` if they're the same, `false` otherwise.
  */
 function simpleEqual(objectA, objectB) {
-  const circularReplacer = (function() {
-    const seen = new WeakSet();
+  const stringifyToJSON = (value) => {
+    const circularReplacer = (function() {
+      const seen = new WeakSet();
 
-    return function(key, value) {
-      if (typeof value === 'object' && value !== null) {
-        if (seen.has(value)) return;
-        seen.add(value);
-      }
+      return function(key, value) {
+        if (typeof value === 'object' && value !== null) {
+          if (seen.has(value)) return;
+          seen.add(value);
+        }
 
-      return value;
-    };
-  }());
+        return value;
+      };
+    }());
+
+    return JSON.stringify(value, circularReplacer);
+  };
 
   if (typeof objectA === 'function' && typeof objectB === 'function') {
     return objectA.toString() === objectB.toString();
@@ -159,6 +163,6 @@ function simpleEqual(objectA, objectB) {
     return false;
 
   } else {
-    return JSON.stringify(objectA, circularReplacer) === JSON.stringify(objectB, circularReplacer);
+    return stringifyToJSON(objectA) === stringifyToJSON(objectB);
   }
 }

--- a/wrappers/vue3/src/helpers.ts
+++ b/wrappers/vue3/src/helpers.ts
@@ -153,7 +153,7 @@ function simpleEqual(objectA, objectB) {
       };
     }());
 
-    return JSON.stringify(value, circularReplacer);
+    return JSON.stringify(val, circularReplacer);
   };
 
   if (typeof objectA === 'function' && typeof objectB === 'function') {

--- a/wrappers/vue3/test/hotTableHelpers.spec.ts
+++ b/wrappers/vue3/test/hotTableHelpers.spec.ts
@@ -1,3 +1,4 @@
+import { GridSettings } from 'handsontable/settings';
 import {
   prepareSettings,
   propFactory
@@ -59,5 +60,16 @@ describe('prepareSettings', () => {
     expect(preparedSettings.readOnly).toBe(true);
     expect(preparedSettings.whatever.foo).toBe('bar');
     expect(preparedSettings.whatever.myself.foo).toBe('bar');
+  });
+
+  it('should not recognize passing of the same array twice as a changed object', () => {
+    const settings1: GridSettings = {
+      mergeCells: [{ row: 1, col: 1, colspan: 1, rowspan: 1 }],
+    };
+
+    const preparedSettings = prepareSettings({ settings: settings1 }, settings1);
+
+    expect(preparedSettings.mergeCells).toBe(undefined);
+    expect(Object.keys(preparedSettings).length).toBe(0);
   });
 });


### PR DESCRIPTION
### Context
This PR fixes a problem where the Vue/Vue3 wrappers' `simpleEqual` function treated object-based config options as a circular reference, thus performing additional unneeded updates.

### How has this been tested?
Added a test case.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#1777

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [x] `@handsontable/vue`
- [x] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
