### PR TITLE
Fix canonical urls for Docs 12.0

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -14,18 +14,18 @@ jobs:
     name: SonarCloud
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # https://github.com/actions/checkout/releases/tag/v3.1.0
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # https://github.com/actions/checkout/releases/tag/v4.1.1
         with:
           fetch-depth: 0
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@5392662532e48780d7e796d79e55351fcb7ee3c9 # Commits on Sep 16, 2021
+        uses: SonarSource/sonarcloud-github-action@c25d2e7e3def96d0d1781000d3c429da22cd6252 # https://github.com/SonarSource/sonarcloud-github-action/releases/tag/v2.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
       - name: SonarQube Quality Gate check
-        uses: sonarsource/sonarqube-quality-gate-action@6a7dcc22310cef7cb83b0dfcf37c225113fb37cf # Commits on Jun 25, 2021
+        uses: SonarSource/sonarqube-quality-gate-action@d304d050d930b02a896b0f85935344f023928496 # https://github.com/SonarSource/sonarqube-quality-gate-action/releases/tag/v1.1.0
         # Force to fail step after specific time
         timeout-minutes: 1
         env:

--- a/docs/.vuepress/enhanceApp.js
+++ b/docs/.vuepress/enhanceApp.js
@@ -54,19 +54,8 @@ export default async({ router, siteData, isServer }) => {
 
     const response = await fetch(`${window.location.origin}/docs/${pathVersion}data/common.json`);
     const docsData = await response.json();
-    const canonicalURLs = new Map(docsData.urls);
 
     siteData.pages.forEach((page) => {
-      const frontmatter = page.frontmatter;
-      const canonicalUrl = frontmatter.canonicalUrl;
-      const canonicalUrlNorm = canonicalUrl.replace(/^\/docs\//, '').replace(/\/$/, '');
-
-      if (canonicalURLs.has(canonicalUrlNorm) && canonicalURLs.get(canonicalUrlNorm) !== '') {
-        const docsVersion = canonicalURLs.get(canonicalUrlNorm);
-
-        frontmatter.canonicalUrl = canonicalUrl.replace(/^\/docs\//, `/docs/${docsVersion}/`);
-      }
-
       page.versions = docsData.versions;
       page.latestVersion = docsData.latestVersion;
     });

--- a/docs/.vuepress/plugins/extend-page-data/index.js
+++ b/docs/.vuepress/plugins/extend-page-data/index.js
@@ -8,6 +8,16 @@ const buildMode = process.env.BUILD_MODE;
 const pluginName = 'hot/extend-page-data';
 
 /**
+ * Remove the slash from the beginning and ending of the string.
+ *
+ * @param {string} string String to process.
+ * @returns {string}
+ */
+function removeEndingSlashes(string) {
+  return string.replace(/^\//, '').replace(/\/$/, '');
+}
+
+/**
  * Dedupes the slashes in the string.
  *
  * @param {string} string String to process.
@@ -43,7 +53,16 @@ module.exports = (options, context) => {
       $page.buildMode = buildMode;
       $page.baseUrl = getDocsBaseUrl();
       $page.lastUpdatedFormat = formatDate($page.lastUpdated);
-      $page.frontmatter.canonicalUrl = dedupeSlashes(`/docs${$page.frontmatter.canonicalUrl}/`);
+
+      if ($page.frontmatter.canonicalUrl) {
+        let canonicalShortUrl = removeEndingSlashes($page.frontmatter.canonicalUrl);
+
+        if (!canonicalShortUrl.match(/(javascript|react)\-data\-grid\//)) {
+          canonicalShortUrl = `javascript-data-grid/${canonicalShortUrl}`;
+        }
+
+        $page.frontmatter.canonicalUrl = `${getDocsBaseUrl()}/docs${dedupeSlashes(`/${canonicalShortUrl}/`)}`;
+      }
     },
   };
 };

--- a/docs/.vuepress/plugins/extend-page-data/index.js
+++ b/docs/.vuepress/plugins/extend-page-data/index.js
@@ -57,7 +57,7 @@ module.exports = (options, context) => {
       if ($page.frontmatter.canonicalUrl) {
         let canonicalShortUrl = removeEndingSlashes($page.frontmatter.canonicalUrl);
 
-        if (!canonicalShortUrl.match(/(javascript|react)\-data\-grid\//)) {
+        if (!canonicalShortUrl.match(/(javascript|react)-data-grid\//)) {
           canonicalShortUrl = `javascript-data-grid/${canonicalShortUrl}`;
         }
 

--- a/docs/.vuepress/theme/components/Versions.vue
+++ b/docs/.vuepress/theme/components/Versions.vue
@@ -25,6 +25,7 @@ export default {
               text: `${this.addLatest(v)}`,
               link: this.getLink(v),
               target: '_self',
+              rel: this.$page.latestVersion === v ? undefined : 'nofollow',
               isHtmlLink: true
             })) : []),
             ...this.getLegacyVersions()
@@ -69,7 +70,8 @@ export default {
         '4.0.0',
       ].map(version => ({
         text: version.replace(/\.\d+$/, ''),
-        link: `${this.$page.baseUrl}/docs/${version}/`
+        link: `${this.$page.baseUrl}/docs/${version}/`,
+        rel: 'nofollow',
       }));
     }
   }

--- a/docs/.vuepress/theme/templates/ssr.html
+++ b/docs/.vuepress/theme/templates/ssr.html
@@ -7,6 +7,7 @@
     <meta name="generator" content="VuePress {{ version }}">
     {{{ userHeadTags }}}
     {{{ pageMeta }}}
+    {{{ canonicalLink }}}
     {{{ renderResourceHints() }}}
     {{{ renderStyles() }}}
 </head>

--- a/docs/content/guides/columns/column-sorting.md
+++ b/docs/content/guides/columns/column-sorting.md
@@ -3,7 +3,7 @@ id: jirjthah
 title: Column sorting
 metaTitle: Column sorting - Guide - Handsontable Documentation
 permalink: /column-sorting
-canonicalUrl: /column-sorting
+canonicalUrl: /rows-sorting
 ---
 
 # Column sorting

--- a/docs/content/guides/integrate-with-angular/angular-setting-up-a-language.md
+++ b/docs/content/guides/integrate-with-angular/angular-setting-up-a-language.md
@@ -3,7 +3,7 @@ id: pzccidkj
 title: 'Setting up a translation in Angular'
 metaTitle: 'Setting up a translation in Angular - Guide - Handsontable Documentation'
 permalink: /angular-setting-up-a-language
-canonicalUrl: /angular-setting-up-a-language
+canonicalUrl: /angular-setting-up-a-translation
 ---
 
 # Setting up a translation in Angular

--- a/docs/content/guides/integrate-with-angular/angular-simple-example.md
+++ b/docs/content/guides/integrate-with-angular/angular-simple-example.md
@@ -3,7 +3,7 @@ id: qpna498b
 title: 'Basic example in Angular'
 metaTitle: 'Basic example in Angular - Guide - Handsontable Documentation'
 permalink: /angular-simple-example
-canonicalUrl: /angular-simple-example
+canonicalUrl: /angular-basic-example
 ---
 
 # Basic example in Angular

--- a/docs/content/guides/integrate-with-react/react-custom-context-menu-example.md
+++ b/docs/content/guides/integrate-with-react/react-custom-context-menu-example.md
@@ -3,7 +3,7 @@ id: r2x6mh6h
 title: 'Custom context menu in React'
 metaTitle: 'Custom context menu in React - Guide - Handsontable Documentation'
 permalink: /react-custom-context-menu-example
-canonicalUrl: /react-custom-context-menu-example
+canonicalUrl: /react-data-grid/context-menu
 ---
 
 # Custom context menu in React

--- a/docs/content/guides/integrate-with-react/react-custom-editor-example.md
+++ b/docs/content/guides/integrate-with-react/react-custom-editor-example.md
@@ -3,7 +3,7 @@ id: 6i8ttta0
 title: 'Custom editor in React'
 metaTitle: 'Custom editor in React - Guide - Handsontable Documentation'
 permalink: /react-custom-editor-example
-canonicalUrl: /react-custom-editor-example
+canonicalUrl: /react-data-grid/cell-editor
 ---
 
 # Custom editor in React

--- a/docs/content/guides/integrate-with-react/react-custom-renderer-example.md
+++ b/docs/content/guides/integrate-with-react/react-custom-renderer-example.md
@@ -3,7 +3,7 @@ id: 2ej30mcg
 title: 'Custom renderer in React'
 metaTitle: 'Custom renderer in React - Guide - Handsontable Documentation'
 permalink: /react-custom-renderer-example
-canonicalUrl: /react-custom-renderer-example
+canonicalUrl: /react-data-grid/cell-renderer
 ---
 
 # Custom renderer in React

--- a/docs/content/guides/integrate-with-react/react-hot-column.md
+++ b/docs/content/guides/integrate-with-react/react-hot-column.md
@@ -3,7 +3,7 @@ id: h5waqmlx
 title: 'Using the `HotColumn` component in React'
 metaTitle: 'Using the HotColumn component in React - Guide - Handsontable Documentation'
 permalink: /react-hot-column
-canonicalUrl: /react-hot-column
+canonicalUrl: /react-data-grid/hot-column
 ---
 
 # Using the `HotColumn` component in React

--- a/docs/content/guides/integrate-with-react/react-hot-reference.md
+++ b/docs/content/guides/integrate-with-react/react-hot-reference.md
@@ -3,7 +3,7 @@ id: dceorl8m
 title: 'Referencing the Handsontable instance in React'
 metaTitle: 'Referencing the Handsontable instance in React - Guide - Handsontable Documentation'
 permalink: /react-hot-reference
-canonicalUrl: /react-hot-reference
+canonicalUrl: /react-data-grid/instance-methods
 ---
 
 # Referencing the Handsontable instance in React

--- a/docs/content/guides/integrate-with-react/react-installation.md
+++ b/docs/content/guides/integrate-with-react/react-installation.md
@@ -3,7 +3,7 @@ id: zqk2jjw3
 title: 'Installation in React'
 metaTitle: 'Installation in React - Guide - Handsontable Documentation'
 permalink: /react-installation
-canonicalUrl: /react-installation
+canonicalUrl: /react-data-grid/installation
 ---
 
 # Installation in React

--- a/docs/content/guides/integrate-with-react/react-language-change-example.md
+++ b/docs/content/guides/integrate-with-react/react-language-change-example.md
@@ -3,7 +3,7 @@ id: qz0qgi9f
 title: 'Language change in React'
 metaTitle: 'Language change in React - Guide - Handsontable Documentation'
 permalink: /react-language-change-example
-canonicalUrl: /react-language-change-example
+canonicalUrl: /react-data-grid/installation
 ---
 
 # Language change in React

--- a/docs/content/guides/integrate-with-react/react-modules.md
+++ b/docs/content/guides/integrate-with-react/react-modules.md
@@ -3,7 +3,7 @@ id: weudz1vh
 title: 'Modules in React'
 metaTitle: 'Modules in React - Guide - Handsontable Documentation'
 permalink: /react-modules
-canonicalUrl: /react-modules
+canonicalUrl: /react-data-grid/modules
 ---
 
 # Modules in React

--- a/docs/content/guides/integrate-with-react/react-redux-example.md
+++ b/docs/content/guides/integrate-with-react/react-redux-example.md
@@ -3,7 +3,7 @@ id: kbk0pm8t
 title: 'Redux example'
 metaTitle: 'Redux example - Guide - Handsontable Documentation'
 permalink: /react-redux-example
-canonicalUrl: /react-redux-example
+canonicalUrl: /react-data-grid/redux
 ---
 
 # Redux example

--- a/docs/content/guides/integrate-with-react/react-setting-up-a-language.md
+++ b/docs/content/guides/integrate-with-react/react-setting-up-a-language.md
@@ -3,7 +3,7 @@ id: 1ueuuazs
 title: 'Setting up a translation in React'
 metaTitle: 'Setting up a translation in React - Guide - Handsontable Documentation'
 permalink: /react-setting-up-a-language
-canonicalUrl: /react-setting-up-a-language
+canonicalUrl: /react-data-grid/language
 ---
 
 # Setting up a translation in React

--- a/docs/content/guides/integrate-with-react/react-simple-example.md
+++ b/docs/content/guides/integrate-with-react/react-simple-example.md
@@ -3,7 +3,7 @@ id: ccqbm8hn
 title: 'Basic examples in React'
 metaTitle: 'Basic examples in React - Guide - Handsontable Documentation'
 permalink: /react-simple-example
-canonicalUrl: /react-simple-example
+canonicalUrl: /react-data-grid/binding-to-data
 ---
 
 # Basic examples in React

--- a/docs/content/guides/integrate-with-vue/vue-setting-up-a-language.md
+++ b/docs/content/guides/integrate-with-vue/vue-setting-up-a-language.md
@@ -3,7 +3,7 @@ id: 6i276a7s
 title: 'Setting up a translation in Vue 2'
 metaTitle: 'Setting up a translation in Vue 2 - Guide - Handsontable Documentation'
 permalink: /vue-setting-up-a-language
-canonicalUrl: /vue-setting-up-a-language
+canonicalUrl: /vue-setting-up-a-translation
 ---
 
 # Setting up a translation in Vue 2

--- a/docs/content/guides/integrate-with-vue/vue-simple-example.md
+++ b/docs/content/guides/integrate-with-vue/vue-simple-example.md
@@ -3,7 +3,7 @@ id: wwkiqxi9
 title: 'Basic example in Vue 2'
 metaTitle: 'Basic example in Vue 2 - Guide - Handsontable Documentation'
 permalink: /vue-simple-example
-canonicalUrl: /vue-simple-example
+canonicalUrl: /vue-basic-example
 ---
 
 # Basic example in Vue 2

--- a/docs/content/guides/integrate-with-vue3/vue3-setting-up-a-language.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-setting-up-a-language.md
@@ -3,7 +3,7 @@ id: 7ezlo7y5
 title: 'Setting up a translation in Vue 3'
 metaTitle: 'Setting up a translation in Vue 3 - Guide - Handsontable Documentation'
 permalink: /vue3-setting-up-a-language
-canonicalUrl: /vue3-setting-up-a-language
+canonicalUrl: /vue3-setting-up-a-translation
 ---
 
 # Setting up a translation in Vue 3

--- a/docs/content/guides/integrate-with-vue3/vue3-simple-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-simple-example.md
@@ -3,7 +3,7 @@ id: exlnnr23
 title: 'Basic example in Vue 3'
 metaTitle: 'Basic example in Vue 3 - Guide - Handsontable Documentation'
 permalink: /vue3-simple-example
-canonicalUrl: /vue3-simple-example
+canonicalUrl: /vue3-basic-example
 ---
 
 # Basic example in Vue 3

--- a/docs/content/guides/rows/row-sorting.md
+++ b/docs/content/guides/rows/row-sorting.md
@@ -3,7 +3,7 @@ id: 6o0zftmc
 title: Row sorting
 metaTitle: Row sorting - Guide - Handsontable Documentation
 permalink: /row-sorting
-canonicalUrl: /row-sorting
+canonicalUrl: /rows-sorting
 ---
 
 # Row sorting


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the canonical URLs for Docs 12.0.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. solves the canonical part of the https://github.com/handsontable/dev-handsontable/issues/1815

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
