### PR TITLE
Fix canonical urls for Docs 12.1

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -14,18 +14,18 @@ jobs:
     name: SonarCloud
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # https://github.com/actions/checkout/releases/tag/v3.1.0
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # https://github.com/actions/checkout/releases/tag/v4.1.1
         with:
           fetch-depth: 0
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@5392662532e48780d7e796d79e55351fcb7ee3c9 # Commits on Sep 16, 2021
+        uses: SonarSource/sonarcloud-github-action@c25d2e7e3def96d0d1781000d3c429da22cd6252 # https://github.com/SonarSource/sonarcloud-github-action/releases/tag/v2.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
       - name: SonarQube Quality Gate check
-        uses: sonarsource/sonarqube-quality-gate-action@6a7dcc22310cef7cb83b0dfcf37c225113fb37cf # Commits on Jun 25, 2021
+        uses: SonarSource/sonarqube-quality-gate-action@d304d050d930b02a896b0f85935344f023928496 # https://github.com/SonarSource/sonarqube-quality-gate-action/releases/tag/v1.1.0
         # Force to fail step after specific time
         timeout-minutes: 1
         env:

--- a/docs/.vuepress/enhanceApp.js
+++ b/docs/.vuepress/enhanceApp.js
@@ -72,16 +72,8 @@ export default async({ router, siteData, isServer }) => {
 
   const response = await fetch(`${window.location.origin}/docs/${pathVersion}data/common.json`);
   const docsData = await response.json();
-  const canonicalURLs = new Map(docsData.urls);
 
   siteData.pages.forEach((page) => {
-    const frontmatter = page.frontmatter;
-    const canonicalShortUrl = frontmatter.canonicalShortUrl;
-    const docsVersion = canonicalURLs.get(canonicalShortUrl);
-    const docsVersionPath = docsVersion === '' ? '' : `/${docsVersion}`;
-
-    frontmatter.canonicalUrl = `${page.hostname}/docs${docsVersionPath}/${canonicalShortUrl}/`;
-
     page.versions = docsData.versions;
     page.latestVersion = docsData.latestVersion;
   });

--- a/docs/.vuepress/plugins/extend-page-data/index.js
+++ b/docs/.vuepress/plugins/extend-page-data/index.js
@@ -106,6 +106,7 @@ SHA: ${getDocsRepoSHA()}
       }
 
       const frameworkPath = currentFramework + FRAMEWORK_SUFFIX;
+      const hostWithBase = getDocsHostname() + getDocsBase();
 
       if ($page.frontmatter.canonicalUrl) {
         const canonicalShortUrl = removeEndingSlashes(frameworkPath + $page.frontmatter.canonicalUrl);
@@ -113,13 +114,12 @@ SHA: ${getDocsRepoSHA()}
         // The "canonicalShortUrl" property is used by "dump-docs-data" plugin. The property holds the
         // canonical URL without slashes at the beginning and ending of the URL path and without Docs base.
         $page.frontmatter.canonicalShortUrl = canonicalShortUrl;
+        $page.frontmatter.canonicalUrl = `${hostWithBase}${dedupeSlashes(`/${canonicalShortUrl}/`)}`;
       }
 
       if ($page.frontmatter.permalink) {
         $page.frontmatter.permalink = `/${frameworkPath}${$page.frontmatter.permalink}`;
       }
-
-      const hostWithBase = getDocsHostname() + getDocsBase();
 
       // Add OpenGraph entries
       frontmatter.meta = [

--- a/docs/.vuepress/theme/templates/ssr.html
+++ b/docs/.vuepress/theme/templates/ssr.html
@@ -7,6 +7,7 @@
   <meta name="generator" content="VuePress {{ version }}">
   {{{ userHeadTags }}}
   {{{ pageMeta }}}
+  {{{ canonicalLink }}}
   {{{ renderResourceHints() }}}
   {{{ renderStyles() }}}
 </head>

--- a/docs/content/guides/columns/column-sorting.md
+++ b/docs/content/guides/columns/column-sorting.md
@@ -4,7 +4,7 @@ title: Column sorting
 metaTitle: Column sorting - JavaScript Data Grid | Handsontable
 description: Sort the view (not the source data) in ascending, descending, or a custom order, across one or multiple columns of the data grid.
 permalink: /column-sorting
-canonicalUrl: /column-sorting
+canonicalUrl: /rows-sorting
 react:
   id: sf7d7hjc
   metaTitle: Column sorting - React Data Grid | Handsontable

--- a/docs/content/guides/rows/row-sorting.md
+++ b/docs/content/guides/rows/row-sorting.md
@@ -4,7 +4,7 @@ title: Row sorting
 metaTitle: Row sorting - JavaScript Data Grid | Handsontable
 description: Sort your data in ascending, descending, or a custom order, across one or multiple rows of the data grid.
 permalink: /row-sorting
-canonicalUrl: /row-sorting
+canonicalUrl: /rows-sorting
 react:
   id: h4jfevxj
   metaTitle: Row sorting - React Data Grid | Handsontable


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the canonical URLs for Docs 12.1.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. solves the canonical part of the https://github.com/handsontable/dev-handsontable/issues/1815

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
