### PR TITLE
Fix date picker position in overlays

### DIFF
--- a/handsontable/src/editors/dateEditor/__tests__/dateEditor.spec.js
+++ b/handsontable/src/editors/dateEditor/__tests__/dateEditor.spec.js
@@ -888,6 +888,176 @@ describe('DateEditor', () => {
     expect(pikaElement.is(':visible')).toBe(false);
   });
 
+  it('should show datepicker in the right position when cell is opened in the top overlay', async() => {
+    handsontable({
+      data: createSpreadsheetData(50, 20),
+      fixedRowsTop: 3,
+      width: 200,
+      height: 200,
+      type: 'date',
+    });
+
+    selectCell(1, 1);
+    keyDownUp('enter');
+    setScrollTop(100);
+
+    const editorElement = $(getActiveEditor().TD);
+    const pikaElement = $('.pika-single');
+
+    await sleep(50);
+
+    expect(pikaElement.offset()).toEqual({
+      top: editorElement.offset().top + 23, // 23 is a height of the editor cell
+      left: editorElement.offset().left,
+    });
+    expect(pikaElement.is(':visible')).toBe(true);
+
+    setScrollTop(130);
+
+    await sleep(50);
+
+    expect(pikaElement.offset()).toEqual({
+      top: editorElement.offset().top + 23, // 23 is a height of the editor cell
+      left: editorElement.offset().left,
+    });
+    expect(pikaElement.is(':visible')).toBe(true);
+  });
+
+  it('should show datepicker in the right position when cell is opened in the left overlay', async() => {
+    handsontable({
+      data: createSpreadsheetData(50, 20),
+      fixedColumnsStart: 3,
+      width: 200,
+      height: 200,
+      type: 'date',
+    });
+
+    selectCell(1, 1);
+    keyDownUp('enter');
+    setScrollLeft(100);
+
+    const editorElement = $(getActiveEditor().TD);
+    const pikaElement = $('.pika-single');
+
+    await sleep(50);
+
+    expect(pikaElement.offset()).toEqual({
+      top: editorElement.offset().top + 23, // 23 is a height of the editor cell
+      left: editorElement.offset().left,
+    });
+    expect(pikaElement.is(':visible')).toBe(true);
+
+    setScrollLeft(130);
+
+    await sleep(50);
+
+    expect(pikaElement.offset()).toEqual({
+      top: editorElement.offset().top + 23, // 23 is a height of the editor cell
+      left: editorElement.offset().left,
+    });
+    expect(pikaElement.is(':visible')).toBe(true);
+  });
+
+  it('should show datepicker in the right position when cell is opened in the bottom overlay', async() => {
+    handsontable({
+      data: createSpreadsheetData(50, 20),
+      fixedRowsBottom: 3,
+      width: 200,
+      height: 200,
+      type: 'date',
+    });
+
+    selectCell(48, 1);
+    keyDownUp('enter');
+
+    const editorElement = $(getActiveEditor().TD);
+    const pikaElement = $('.pika-single');
+
+    expect(pikaElement.offset()).toEqual({
+      top: editorElement.offset().top + 23, // 23 is a height of the editor cell
+      left: editorElement.offset().left,
+    });
+    expect(pikaElement.is(':visible')).toBe(true);
+
+    setScrollTop(130);
+
+    await sleep(50);
+
+    expect(pikaElement.offset()).toEqual({
+      top: editorElement.offset().top + 23, // 23 is a height of the editor cell
+      left: editorElement.offset().left,
+    });
+    expect(pikaElement.is(':visible')).toBe(true);
+  });
+
+  it('should show datepicker in the right position when cell is opened in the top-start corner', async() => {
+    handsontable({
+      data: createSpreadsheetData(50, 20),
+      fixedRowsTop: 3,
+      fixedColumnsStart: 3,
+      width: 200,
+      height: 200,
+      type: 'date',
+    });
+
+    selectCell(1, 1);
+    keyDownUp('enter');
+
+    const editorElement = $(getActiveEditor().TD);
+    const pikaElement = $('.pika-single');
+
+    expect(pikaElement.offset()).toEqual({
+      top: editorElement.offset().top + 23, // 23 is a height of the editor cell
+      left: editorElement.offset().left,
+    });
+    expect(pikaElement.is(':visible')).toBe(true);
+
+    setScrollTop(100);
+    setScrollLeft(100);
+
+    await sleep(50);
+
+    expect(pikaElement.offset()).toEqual({
+      top: editorElement.offset().top + 23, // 23 is a height of the editor cell
+      left: editorElement.offset().left,
+    });
+    expect(pikaElement.is(':visible')).toBe(true);
+  });
+
+  it('should show datepicker in the right position when cell is opened in the bottom-start corner', async() => {
+    handsontable({
+      data: createSpreadsheetData(50, 20),
+      fixedRowsBottom: 3,
+      fixedColumnsStart: 3,
+      width: 200,
+      height: 200,
+      type: 'date',
+    });
+
+    selectCell(48, 1);
+    keyDownUp('enter');
+
+    const editorElement = $(getActiveEditor().TD);
+    const pikaElement = $('.pika-single');
+
+    expect(pikaElement.offset()).toEqual({
+      top: editorElement.offset().top + 23, // 23 is a height of the editor cell
+      left: editorElement.offset().left,
+    });
+    expect(pikaElement.is(':visible')).toBe(true);
+
+    setScrollTop(100);
+    setScrollLeft(100);
+
+    await sleep(50);
+
+    expect(pikaElement.offset()).toEqual({
+      top: editorElement.offset().top + 23, // 23 is a height of the editor cell
+      left: editorElement.offset().left,
+    });
+    expect(pikaElement.is(':visible')).toBe(true);
+  });
+
   it('should display Pikaday Calendar right-bottom of the selected cell when table have scrolls', () => {
     const container = $('#testContainer');
 

--- a/handsontable/src/editors/dateEditor/dateEditor.js
+++ b/handsontable/src/editors/dateEditor/dateEditor.js
@@ -312,11 +312,18 @@ export class DateEditor extends TextEditor {
       return;
     }
 
-    const view = this.hot.view;
+    const { rowIndexMapper, columnIndexMapper } = this.hot;
+    const { wtOverlays } = this.hot.view._wt;
+    const { wtTable } = wtOverlays.getParentOverlay(this.TD) ?? this.hot.view._wt;
+
+    const firstVisibleRow = rowIndexMapper.getVisualFromRenderableIndex(wtTable.getFirstPartiallyVisibleRow());
+    const lastVisibleRow = rowIndexMapper.getVisualFromRenderableIndex(wtTable.getLastPartiallyVisibleRow());
+    const firstVisibleColumn = columnIndexMapper.getVisualFromRenderableIndex(wtTable.getFirstPartiallyVisibleColumn());
+    const lastVisibleColumn = columnIndexMapper.getVisualFromRenderableIndex(wtTable.getLastPartiallyVisibleColumn());
 
     if (
-      this.col >= view.getFirstPartiallyVisibleColumn() && this.col <= view.getLastPartiallyVisibleColumn() &&
-      this.row >= view.getFirstPartiallyVisibleRow() && this.row <= view.getLastPartiallyVisibleRow()
+      this.row >= firstVisibleRow && this.row <= lastVisibleRow &&
+      this.col >= firstVisibleColumn && this.col <= lastVisibleColumn
     ) {
       const offset = this.TD.getBoundingClientRect();
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the date picker position for editors opened in the overlays. The PR is a hotfix for https://github.com/handsontable/handsontable/pull/10892.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and I covered the fix with new tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/handsontable/pull/10892

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
