### PR TITLE
Fix dataManager null errors

### DIFF
--- a/handsontable/src/plugins/nestedRows/data/dataManager.js
+++ b/handsontable/src/plugins/nestedRows/data/dataManager.js
@@ -105,9 +105,11 @@ class DataManager {
       nodeInfo: new WeakMap()
     };
 
-    rangeEach(0, this.data.length - 1, (i) => {
-      this.cacheNode(this.data[i], 0, null);
-    });
+    if (this.data) {
+      rangeEach(0, this.data.length - 1, (i) => {
+        this.cacheNode(this.data[i], 0, null);
+      });
+    }
   }
 
   /**

--- a/handsontable/src/plugins/nestedRows/ui/collapsing.js
+++ b/handsontable/src/plugins/nestedRows/ui/collapsing.js
@@ -77,7 +77,7 @@ class CollapsingUI extends BaseUI {
       rowIndex = row;
     }
 
-    if (this.dataManager.hasChildren(rowObject)) {
+    if (rowObject && this.dataManager.hasChildren(rowObject)) {
       arrayEach(rowObject.__children, (elem) => {
         rowsToCollapse.push(this.dataManager.getRowIndex(elem));
       });


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
In some cases after updating a table with `nestedRows` enabled, HoT would throw a null error due to trying to iterate over missing data that it assumed was there.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Manually tested to verify HoT null errors no longer occur from these places in my app.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
