### PR TITLE
Fix an error in numeric cell types that occur after entering non-numeric values

### DIFF
--- a/.changelogs/1858.json
+++ b/.changelogs/1858.json
@@ -2,7 +2,7 @@
   "issuesOrigin": "private",
   "title": "Fixed an error in numeric cell types that occur after entering non-numeric values.",
   "type": "fixed",
-  "issueOrPR": 1858,
+  "issueOrPR": 10931,
   "breaking": false,
   "framework": "none"
 }

--- a/.changelogs/1858.json
+++ b/.changelogs/1858.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed an error in numeric cell types that occur after entering non-numeric values.",
+  "type": "fixed",
+  "issueOrPR": 1858,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/helpers/__tests__/number.unit.js
+++ b/handsontable/src/helpers/__tests__/number.unit.js
@@ -128,6 +128,9 @@ describe('Number helper', () => {
       expect(isNumeric('a1.22')).toBeFalsy();
       expect(isNumeric('1.22a')).toBeFalsy();
       expect(isNumeric('1,22')).toBeFalsy();
+      expect(isNumeric('- 122')).toBeFalsy();
+      expect(isNumeric('+ 122')).toBeFalsy();
+      expect(isNumeric('100 000')).toBeFalsy();
       expect(isNumeric('10.0,00')).toBeFalsy();
       expect(isNumeric('10,0.00')).toBeFalsy();
       expect(isNumeric('e+22')).toBeFalsy();
@@ -153,6 +156,7 @@ describe('Number helper', () => {
       expect(isNumeric('0')).toBeTruthy();
       expect(isNumeric('1')).toBeTruthy();
       expect(isNumeric('-10000')).toBeTruthy();
+      expect(isNumeric('+10000')).toBeTruthy();
       expect(isNumeric('10000')).toBeTruthy();
       expect(isNumeric('-10.000')).toBeTruthy();
       expect(isNumeric('10.000')).toBeTruthy();
@@ -181,9 +185,9 @@ describe('Number helper', () => {
       expect(isNumeric('   0.020   ')).toBeTruthy();
       expect(isNumeric('   0   ')).toBeTruthy();
       expect(isNumeric('   1   ')).toBeTruthy();
-      expect(isNumeric('   -   10000   ')).toBeTruthy();
+      expect(isNumeric('   -10000   ')).toBeTruthy();
       expect(isNumeric('   10000   ')).toBeTruthy();
-      expect(isNumeric('   -   10.000   ')).toBeTruthy();
+      expect(isNumeric('   -10.000   ')).toBeTruthy();
       expect(isNumeric('   10.000   ')).toBeTruthy();
       expect(isNumeric('   1e+26   ')).toBeTruthy();
       expect(isNumeric('   1e+26   ')).toBeTruthy();
@@ -206,6 +210,9 @@ describe('Number helper', () => {
       expect(isNumericLike('a1.22')).toBeFalsy();
       expect(isNumericLike('1.22a')).toBeFalsy();
       expect(isNumericLike('1,22a')).toBeFalsy();
+      expect(isNumericLike('- 122')).toBeFalsy();
+      expect(isNumericLike('+ 122')).toBeFalsy();
+      expect(isNumericLike('100 000')).toBeFalsy();
       expect(isNumericLike('10.0,00')).toBeFalsy();
       expect(isNumericLike('10,0.00')).toBeFalsy();
       expect(isNumericLike('e+22')).toBeFalsy();
@@ -233,6 +240,7 @@ describe('Number helper', () => {
       expect(isNumericLike('0')).toBeTruthy();
       expect(isNumericLike('1')).toBeTruthy();
       expect(isNumericLike('-10000')).toBeTruthy();
+      expect(isNumericLike('+10000')).toBeTruthy();
       expect(isNumericLike('10000')).toBeTruthy();
       expect(isNumericLike('-10.000')).toBeTruthy();
       expect(isNumericLike('10.000')).toBeTruthy();
@@ -267,11 +275,11 @@ describe('Number helper', () => {
       expect(isNumericLike('   0,020   ')).toBeTruthy();
       expect(isNumericLike('   0   ')).toBeTruthy();
       expect(isNumericLike('   1   ')).toBeTruthy();
-      expect(isNumericLike('   -   10000   ')).toBeTruthy();
+      expect(isNumericLike('   -10000   ')).toBeTruthy();
       expect(isNumericLike('   10000   ')).toBeTruthy();
-      expect(isNumericLike('   -   10.000   ')).toBeTruthy();
+      expect(isNumericLike('   -10.000   ')).toBeTruthy();
       expect(isNumericLike('   10.000   ')).toBeTruthy();
-      expect(isNumericLike('   -   10,000   ')).toBeTruthy();
+      expect(isNumericLike('   -10,000   ')).toBeTruthy();
       expect(isNumericLike('   10,000   ')).toBeTruthy();
       expect(isNumericLike('   1e+26   ')).toBeTruthy();
       expect(isNumericLike('   1e+26   ')).toBeTruthy();

--- a/handsontable/src/helpers/number.js
+++ b/handsontable/src/helpers/number.js
@@ -4,13 +4,16 @@
  * are considered as numeric values:
  *  - 0.001
  *  - .001
- *  - - 10000
  *  - 10000
  *  - 1e+26
  *  - 22e-26
  *  - .45e+26
  *  - 0xabcdef (hex)
  *  - 0x1 (hex)
+ *
+ * these values are not considered as numeric:
+ *  - - 1000
+ *  - 100 000
  *
  * @param {*} value The value to check.
  * @param {string[]} additionalDelimiters An additional delimiters to be used while checking the numeric value.
@@ -34,7 +37,7 @@ export function isNumeric(value, additionalDelimiters = []) {
       .map(d => `\\${d}`)
       .join('|');
 
-    return new RegExp(`^[+-]?\\s*(((${delimiter})?\\d+((${delimiter})\\d+)?(e[+-]?\\d+)?)|(0x[a-f\\d]+))$`, 'i')
+    return new RegExp(`^[+-]?(((${delimiter})?\\d+((${delimiter})\\d+)?(e[+-]?\\d+)?)|(0x[a-f\\d]+))$`, 'i')
       .test(value.trim());
 
   } else if (type === 'object') {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes an error in numeric cell types that occur after entering non-numeric values like `-  10000` (with spaces between `-/+` sign).

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally, and I covered the fix with tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1858

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
