### PR TITLE
Fix a bug for cell editors switched dynamically

### DIFF
--- a/.changelogs/10938.json
+++ b/.changelogs/10938.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed a bug for cell editors switched dynamically",
+  "type": "fixed",
+  "issueOrPR": 10938,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -1408,9 +1408,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
     instance.forceFullRender = true; // used when data was changed
     grid.adjustRowsAndCols();
     instance.runHooks('beforeChangeRender', changes, source);
-    editorManager.lockEditor();
     instance._refreshBorders(null);
-    editorManager.unlockEditor();
     instance.view.adjustElementsSize();
     instance.runHooks('afterChange', changes, source || 'edit');
 

--- a/handsontable/src/editors/__tests__/commonCases.spec.js
+++ b/handsontable/src/editors/__tests__/commonCases.spec.js
@@ -1,0 +1,78 @@
+describe('Editor common cases', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  class X1Editor extends Handsontable.editors.TextEditor {
+    setValue(newValue) {
+      super.setValue(newValue);
+    }
+    getValue() {
+      return super.getValue();
+    }
+  }
+  class X100Editor extends Handsontable.editors.TextEditor {
+    setValue(newValue) {
+      super.setValue(newValue / 100);
+    }
+    getValue() {
+      return super.getValue() * 100;
+    }
+  }
+
+  it('should prepare new editor type in the next column after accepting the value by "Tab" key (#dev-1855)', async() => {
+    handsontable({
+      data: Array.from({ length: 1 }, (_, i) => ({ type: 'x100', value: i + 5 })),
+      columns: [
+        {
+          data: 'type',
+          type: 'dropdown',
+          source: ['x1', 'x100'],
+          allowInvalid: false,
+        },
+        {
+          data: 'value',
+          type: 'numeric',
+        },
+      ],
+      cells(row, col, prop) {
+        if (prop !== 'value') {
+          return {};
+        }
+
+        if (this.instance.getDataAtRowProp(row, 'type') === 'x1') {
+          return {
+            editor: X1Editor,
+          };
+        }
+
+        return {
+          editor: X100Editor,
+        };
+      },
+    });
+
+    selectCell(0, 0);
+
+    expect(getCellEditor(0, 1)).toBe(X100Editor);
+
+    keyDownUp('enter');
+    getActiveEditor().TEXTAREA.value = 'x1';
+    keyDownUp('tab');
+
+    await sleep(20);
+
+    keyDownUp('enter');
+
+    expect(getActiveEditor()).toBeInstanceOf(X1Editor);
+  });
+});


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes a bug where the cell editor was not correctly switched to a new one after a table render call.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally, and I covered the fix with a new test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1855

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
