### PR TITLE
Add horizontal scroll to the Filter's by value component

### DIFF
--- a/.changelogs/10940.json
+++ b/.changelogs/10940.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Added horizontal scroll to the Filter's \"by value\" component",
+  "type": "fixed",
+  "issueOrPR": 10940,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
@@ -1148,7 +1148,7 @@ describe('Filters UI', () => {
         width: 500,
         height: 300,
         modifyFiltersMultiSelectValue: (value) => {
-          return `Custom ${value}`;
+          return `Pre ${value}`;
         },
       });
 
@@ -1161,7 +1161,7 @@ describe('Filters UI', () => {
       for (let i = 0; i < unifiedColDataSample.length; i++) {
         expect(
           byValueMultipleSelect().element.querySelectorAll('.htCore td')[i].textContent
-        ).toBe(`Custom ${unifiedColDataSample[i]}`);
+        ).toBe(`Pre ${unifiedColDataSample[i]}`);
       }
       expect(unifiedColDataSample.length).toBe(6);
     });

--- a/handsontable/src/plugins/filters/filters.scss
+++ b/handsontable/src/plugins/filters/filters.scss
@@ -132,7 +132,7 @@
 }
 
 .htUIMultipleSelect .ht_master .wtHolder {
-  overflow-y: scroll;
+  overflow: auto;
 }
 
 .handsontable .htFiltersActive .changeType {

--- a/handsontable/src/plugins/filters/ui/multipleSelect.js
+++ b/handsontable/src/plugins/filters/ui/multipleSelect.js
@@ -230,12 +230,19 @@ export class MultipleSelectUI extends BaseUI {
         beforeOnCellMouseUp: () => {
           this.#itemsBox.listen();
         },
+        modifyColWidth: (width) => {
+          const minWidth = this.#itemsBox.container.scrollWidth - getScrollbarWidth(rootDocument);
+
+          if (width !== undefined && width < minWidth) {
+            return minWidth;
+          }
+
+          return width;
+        },
         hiddenRows: true,
         maxCols: 1,
         autoWrapCol: true,
         height: 110,
-        // Workaround for #151.
-        colWidths: () => this.#itemsBox.container.scrollWidth - getScrollbarWidth(rootDocument),
         copyPaste: false,
         disableVisualSelection: 'area',
         fillHandle: false,


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR improves the Filter's "by value" component by adding a horizontal scroll when the width of the values are wider than the component viewport size. 
 
#### Before
![Kapture 2024-04-23 at 11 27 27](https://github.com/handsontable/handsontable/assets/571316/fa019962-0c89-4172-938e-05c612afb31f)

#### After
![Kapture 2024-04-23 at 11 26 59](https://github.com/handsontable/handsontable/assets/571316/3a586ad4-6a23-4d02-91bc-a6e9486ab72b)

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally, and I covered the fix with updated tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1863

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
