### PR TITLE
Extend the `manualRowResize` plugin with a method allowing to retrieve the last desired row height.

### DIFF
--- a/.changelogs/10941.json
+++ b/.changelogs/10941.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Extended the `manualRowResize` plugin with a method that retrieves the row height value from the last attempt at manually changing said row height.",
+  "type": "added",
+  "issueOrPR": 10941,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
+++ b/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
@@ -1091,5 +1091,35 @@ describe('manualRowResize', () => {
       expect(beforeRowResizeCallback.calls.mostRecent().args).toEqual([23, 2, false]);
       expect(afterRowResizeCallback.calls.mostRecent().args).toEqual([23, 2, false]);
     });
+
+    it('should be able to get the last desired row height from the `getLastDesiredRowHeight` method in the ' +
+    '`afterRowResize` hook callback', async() => {
+      const desiredHeightsLog = [];
+
+      handsontable({
+        data: [['value \n value \n value \n value \n value']],
+        rowHeaders: true,
+        manualRowResize: true,
+        // eslint-disable-next-line object-shorthand
+        afterRowResize: function() {
+          desiredHeightsLog.push(this.getPlugin('manualRowResize').getLastDesiredRowHeight());
+        },
+      });
+
+      const $rowHeader = getInlineStartClone().find('tbody tr:eq(0) th:eq(0)');
+
+      $rowHeader.simulate('mouseover');
+
+      const $resizer = spec().$container.find('.manualRowResizer');
+      const resizerPosition = $resizer.position();
+
+      await sleep(100);
+
+      $resizer.simulate('mousedown', { clientY: resizerPosition.top });
+      $resizer.simulate('mousemove', { clientY: resizerPosition.top + $resizer.height() - 50 });
+      $resizer.simulate('mouseup');
+
+      expect(desiredHeightsLog).toEqual([$rowHeader.height() + 1 - 50 + 6]);
+    });
   });
 });

--- a/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.types.ts
+++ b/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.types.ts
@@ -6,6 +6,7 @@ const hot = new Handsontable(document.createElement('div'), {
 const manualRowResize = hot.getPlugin('manualRowResize');
 
 manualRowResize.saveManualRowHeights();
+manualRowResize.getLastDesiredRowHeight();
 
 const height: number = manualRowResize.setManualSize(0, 5);
 const heights: Array<number | null> = manualRowResize.loadManualRowHeights();

--- a/handsontable/src/plugins/manualRowResize/manualRowResize.js
+++ b/handsontable/src/plugins/manualRowResize/manualRowResize.js
@@ -212,6 +212,15 @@ export class ManualRowResize extends BasePlugin {
   }
 
   /**
+   * Returns the last desired row height set manually with the resize handle.
+   *
+   * @returns {number} The last desired row height.
+   */
+  getLastDesiredRowHeight() {
+    return this.#currentHeight;
+  }
+
+  /**
    * Sets the resize handle position.
    *
    * @private

--- a/handsontable/types/plugins/manualRowResize/manualRowResize.d.ts
+++ b/handsontable/types/plugins/manualRowResize/manualRowResize.d.ts
@@ -26,4 +26,5 @@ export class ManualRowResize extends BasePlugin {
   saveManualRowHeights(): void;
   loadManualRowHeights(): Array<number | null>;
   setManualSize(row: number, height: number): number;
+  getLastDesiredRowHeight(): number;
 }


### PR DESCRIPTION
### Context
This PR extends the `manualRowResize` plugin with a method that retrieves the row height value from the last attempt at manually changing the row height (even if the actual row height didn't change, because of the nature of the `TD` elements).

### How has this been tested?
Added a test case.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#1868

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
