### PR TITLE
Fix angular custom editor example

### DIFF
--- a/docs/content/guides/integrate-with-angular/angular-custom-editor-example/angular/example1.js
+++ b/docs/content/guides/integrate-with-angular/angular-custom-editor-example/angular/example1.js
@@ -60,7 +60,7 @@ export class CustomEditor extends TextEditor {
 
     this.TEXTAREA = document.createElement('input');
     this.TEXTAREA.setAttribute('placeholder', 'Custom placeholder');
-    this.TEXTAREA.setAttribute('data-hot-input', true);
+    this.TEXTAREA.setAttribute('data-hot-input', 'true');
     this.textareaStyle = this.TEXTAREA.style;
     this.TEXTAREA_PARENT.innerText = '';
     this.TEXTAREA_PARENT.appendChild(this.TEXTAREA);


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the Docs example of the Angular custom editor example.

_[skip changelog]_

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1872

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
