### PR TITLE
Fix columns width calculations for `stretchH: 'all'`

### DIFF
--- a/handsontable/src/3rdparty/walkontable/src/utils/columnStretching.js
+++ b/handsontable/src/3rdparty/walkontable/src/utils/columnStretching.js
@@ -83,6 +83,10 @@ export class ColumnStretching {
       return;
     }
 
+    this.stretchAllRatio = 0;
+    this.stretchAllColumnsWidth = [];
+    this.needVerifyLastColumnWidth = true;
+    this.stretchLastWidth = 0;
     this.#totalTargetWidth = totalWidth;
 
     let sumAll = 0;

--- a/handsontable/test/e2e/settings/stretchH.spec.js
+++ b/handsontable/test/e2e/settings/stretchH.spec.js
@@ -1,0 +1,39 @@
+describe('settings', () => {
+  describe('stretchH', () => {
+    const id = 'testContainer';
+
+    beforeEach(function() {
+      this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+    });
+
+    afterEach(function() {
+      if (this.$container) {
+        destroy();
+        this.$container.remove();
+      }
+    });
+
+    it('should correctly stretch the column after changing the cell value (#dev-1727)', () => {
+      const data = createSpreadsheetData(1, 5);
+
+      data[0][4] = 'very long text is here to make the column wider';
+
+      handsontable({
+        data,
+        width: 400,
+        height: 300,
+        stretchH: 'all',
+      });
+
+      expect(getCell(0, 4).clientWidth).toBe(258);
+
+      setDataAtCell(0, 4, 'text');
+
+      expect(getCell(0, 4).clientWidth).toBe(79);
+
+      setDataAtCell(0, 4, 'very long text is here to make the column wider');
+
+      expect(getCell(0, 4).clientWidth).toBe(258);
+    });
+  });
+});


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes a bug where the internal states were not cleared after changing the dataset, which causes miscalculations of the column's width when the `stretch: 'all'` option was used.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally, and I covered the fix with a new test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1727

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
