### PR TITLE
Fix columns summary cell meta missing state

### DIFF
--- a/.changelogs/10955.json
+++ b/.changelogs/10955.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed columns summary cell meta missing state after calling the `updateSettings` method.",
+  "type": "fixed",
+  "issueOrPR": 10955,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/columnSummary/__tests__/columnSummary.spec.js
+++ b/handsontable/src/plugins/columnSummary/__tests__/columnSummary.spec.js
@@ -1019,4 +1019,33 @@ describe('ColumnSummarySpec', () => {
       [null, null, null],
     ]);
   });
+
+  it('should not reset the cell meta information after `updateSettings` call', () => {
+    handsontable({
+      data: [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+        [null, null, null],
+      ],
+      columnSummary: [{
+        destinationRow: 3,
+        destinationColumn: 1,
+        type: 'sum'
+      }]
+    });
+
+    expect(getCellMeta(3, 1).readOnly).toBe(true);
+    expect(getCellMeta(3, 1).className).toBe('columnSummaryResult');
+
+    updateSettings({});
+
+    expect(getCellMeta(3, 1).readOnly).toBe(true);
+    expect(getCellMeta(3, 1).className).toBe('columnSummaryResult');
+
+    updateSettings({ columns: [{}, {}, {}, {}] });
+
+    expect(getCellMeta(3, 1).readOnly).toBe(true);
+    expect(getCellMeta(3, 1).className).toBe('columnSummaryResult');
+  });
 });

--- a/handsontable/src/plugins/columnSummary/columnSummary.js
+++ b/handsontable/src/plugins/columnSummary/columnSummary.js
@@ -135,6 +135,7 @@ export class ColumnSummary extends BasePlugin {
 
     this.addHook('afterInit', (...args) => this.#onAfterInit(...args));
     this.addHook('afterChange', (...args) => this.#onAfterChange(...args));
+    this.addHook('afterUpdateSettings', (...args) => this.#onAfterUpdateSettings(...args));
 
     this.addHook('beforeCreateRow', (index, amount, source) => this.endpoints.resetSetupBeforeStructureAlteration('insert_row', index, amount, null, source)); // eslint-disable-line max-len
     this.addHook('beforeCreateCol', (index, amount, source) => this.endpoints.resetSetupBeforeStructureAlteration('insert_col', index, amount, null, source)); // eslint-disable-line max-len
@@ -446,6 +447,18 @@ export class ColumnSummary extends BasePlugin {
    */
   #onAfterInit() {
     this.endpoints.initEndpoints();
+  }
+
+  /**
+   * Called after the settings were updated. There is a need to refresh cell metas after the settings update with
+   * the `columns` property as the Core resets the cell metas to their initial state.
+   *
+   * @param {object} settings The settings object.
+   */
+  #onAfterUpdateSettings(settings) {
+    if (settings.columns !== undefined) {
+      this.endpoints.refreshCellMetas();
+    }
   }
 
   /**

--- a/handsontable/src/plugins/columnSummary/endpoints.js
+++ b/handsontable/src/plugins/columnSummary/endpoints.js
@@ -490,6 +490,26 @@ class Endpoints {
   }
 
   /**
+   * Refreshes the cell meta information for the all endpoints after the `updateSettings` method call which in some
+   * cases (call with `columns` option) can reset the cell metas to the initial state.
+   */
+  refreshCellMetas() {
+    this.endpoints.forEach((endpoint) => {
+      const destinationVisualRow = this.hot.toVisualRow(endpoint.destinationRow);
+
+      if (destinationVisualRow !== null) {
+        const cellMeta = this.hot.getCellMeta(
+          destinationVisualRow,
+          endpoint.destinationColumn
+        );
+
+        cellMeta.readOnly = endpoint.readOnly;
+        cellMeta.className = 'columnSummaryResult';
+      }
+    });
+  }
+
+  /**
    * Calculate and refresh a single endpoint.
    *
    * @param {object} endpoint Contains the endpoint information.


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the bug where the cell meta states set up by the _ColumnSummary_ plugin were reset after calling the `updateSettings` method. The error was visible when one of the options `columns`, `cell` or `cells` was passed in the settings.

The fix restores the cell meta information after the abovementioned method is called.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally, and I covered the fix with a new test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/789

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
