### PR TITLE
Fix cell meta coordinates overwrite by GhostTable

### DIFF
--- a/.changelogs/10961.json
+++ b/.changelogs/10961.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed cell meta coordinates overwrite by _GhostTable_",
+  "type": "fixed",
+  "issueOrPR": 10961,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/utils/__tests__/ghostTable.spec.js
+++ b/handsontable/src/utils/__tests__/ghostTable.spec.js
@@ -297,4 +297,54 @@ describe('GhostTable', () => {
     expect(gt.isVertical()).toBe(false);
     expect(gt.isHorizontal()).toBe(true);
   });
+
+  it('should not change the coords of the cell meta after row rendering', () => {
+    const hot = handsontable(hotSettings);
+
+    gt = new Handsontable.__GhostTable(hot);
+
+    spyOn(hot, 'getCellMeta').and.returnValue({
+      row: 3,
+      col: 4,
+      visualRow: 5,
+      visualCol: 6,
+      renderer: jasmine.createSpy('renderer'),
+    });
+
+    gt.samples = new Map([[0, { strings: [{ col: 0, value: 'test' }] }]]);
+    gt.createRow(0);
+
+    const cellMeta = getCellMeta(0, 0);
+
+    expect(cellMeta.renderer).toHaveBeenCalledTimes(1);
+    expect(cellMeta.row).toBe(3);
+    expect(cellMeta.col).toBe(4);
+    expect(cellMeta.visualRow).toBe(5);
+    expect(cellMeta.visualCol).toBe(6);
+  });
+
+  it('should not change the coords of the cell meta after column rendering', () => {
+    const hot = handsontable(hotSettings);
+
+    gt = new Handsontable.__GhostTable(hot);
+
+    spyOn(hot, 'getCellMeta').and.returnValue({
+      row: 3,
+      col: 4,
+      visualRow: 5,
+      visualCol: 6,
+      renderer: jasmine.createSpy('renderer'),
+    });
+
+    gt.samples = new Map([[0, { strings: [{ row: 0, value: 'test' }] }]]);
+    gt.createCol(0);
+
+    const cellMeta = getCellMeta(0, 0);
+
+    expect(cellMeta.renderer).toHaveBeenCalledTimes(1);
+    expect(cellMeta.row).toBe(3);
+    expect(cellMeta.col).toBe(4);
+    expect(cellMeta.visualRow).toBe(5);
+    expect(cellMeta.visualCol).toBe(6);
+  });
 });

--- a/handsontable/src/utils/ghostTable.js
+++ b/handsontable/src/utils/ghostTable.js
@@ -269,10 +269,6 @@ class GhostTable {
       arrayEach(sample.strings, (string) => {
         const column = string.col;
         const cellProperties = this.hot.getCellMeta(row, column);
-
-        cellProperties.col = column;
-        cellProperties.row = row;
-
         const renderer = this.hot.getCellRenderer(cellProperties);
         const td = rootDocument.createElement('td');
 
@@ -337,10 +333,6 @@ class GhostTable {
       arrayEach(sample.strings, (string) => {
         const row = string.row;
         const cellProperties = this.hot.getCellMeta(row, column);
-
-        cellProperties.col = column;
-        cellProperties.row = row;
-
         const renderer = this.hot.getCellRenderer(cellProperties);
         const td = rootDocument.createElement('td');
         const tr = rootDocument.createElement('tr');


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes an issue where the _GhostTable_ (module used to calculate the rows/columns widths/heights) overwrites the cell meta coordinates (`row` and `col` properties) to local ones, which resulted in weird behavior in other modules in the table, such as validation or so. The coordinates should not be changed that way as all the objects are cached, and the changes are reflected in all modules.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and I covered the fix with new tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1164

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
