### PR TITLE
Allow `setDataAtRowProp` saving data into trimmed columns.

### DIFF
--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -1304,8 +1304,17 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
 
     for (let i = changes.length - 1; i >= 0; i--) {
       const [row, prop, , newValue] = changes[i];
-      const col = datamap.propToCol(prop);
-      const cellProperties = instance.getCellMeta(row, col);
+      const visualCol = datamap.propToCol(prop);
+      let cellProperties;
+
+      if (Number.isInteger(visualCol)) {
+        cellProperties = instance.getCellMeta(row, visualCol);
+
+      } else {
+        // If there's no requested visual column, we can use the table meta as the cell properties when retrieving
+        // the cell validator.
+        cellProperties = { ...Object.getPrototypeOf(tableMeta), ...tableMeta };
+      }
 
       if (cellProperties.type === 'numeric' && typeof newValue === 'string' && isNumericLike(newValue)) {
         changes[i][3] = getParsedNumber(newValue);
@@ -1653,6 +1662,8 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
       ]);
     }
 
+    // TODO: I don't think `prop` should be used as `changeSource` here, but removing it would be a breaking change.
+    // We should remove it with the next major release.
     if (!changeSource && typeof row === 'object') {
       changeSource = prop;
     }
@@ -2812,7 +2823,12 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
       renderableRowIndex = this.rowIndexMapper.getRenderableFromVisualIndex(row);
     }
 
-    if (renderableRowIndex === null || renderableColumnIndex === null) {
+    if (
+      renderableRowIndex === null ||
+      renderableColumnIndex === null ||
+      renderableRowIndex === undefined ||
+      renderableColumnIndex === undefined
+    ) {
       return null;
     }
 

--- a/handsontable/src/editors/dropdownEditor/dropdownEditor.js
+++ b/handsontable/src/editors/dropdownEditor/dropdownEditor.js
@@ -28,12 +28,16 @@ export class DropdownEditor extends AutocompleteEditor {
 }
 
 Hooks.getSingleton().add('beforeValidate', function(value, row, col) {
-  const cellMeta = this.getCellMeta(row, this.propToCol(col));
+  const visualColumnIndex = this.propToCol(col);
 
-  if (cellMeta.editor === DropdownEditor) {
-    if (cellMeta.strict === undefined) {
-      cellMeta.filter = false;
-      cellMeta.strict = true;
+  if (Number.isInteger(visualColumnIndex)) {
+    const cellMeta = this.getCellMeta(row, visualColumnIndex);
+
+    if (cellMeta.editor === DropdownEditor) {
+      if (cellMeta.strict === undefined) {
+        cellMeta.filter = false;
+        cellMeta.strict = true;
+      }
     }
   }
 });

--- a/handsontable/test/e2e/core/setDataAtRowProp.spec.js
+++ b/handsontable/test/e2e/core/setDataAtRowProp.spec.js
@@ -1,0 +1,126 @@
+describe('Core.setDataAtRowProp', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+
+    this.datasetAoO = [
+      { a: 1, b: 2, c: 3, d: { e: 'nested1', f: 'nested2_1' } },
+      { a: 4, b: 5, c: 6, d: { e: 'nested2', f: 'nested2_2' } },
+      { a: 7, b: 8, c: 9, d: { e: 'nested3', f: 'nested2_3' } }
+    ];
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+      this.datasetAoO = null;
+    }
+  });
+
+  it('should apply the content to the provided visual row and (physical) prop arguments', () => {
+    handsontable({
+      data: spec().datasetAoO,
+    });
+
+    setDataAtRowProp(0, 'a', 'changed!');
+
+    expect(getDataAtCell(0, 0)).toEqual('changed!');
+
+    updateSettings({
+      manualRowMove: [1, 0, 2]
+    });
+
+    setDataAtRowProp(0, 'a', 'changed again!');
+
+    expect(getDataAtCell(0, 0)).toEqual('changed again!');
+  });
+
+  it('should apply the content to the provided visual row and (physical) prop arguments by passing' +
+  'an array of changes to the method', () => {
+    handsontable({
+      data: spec().datasetAoO,
+    });
+
+    setDataAtRowProp([
+      [0, 'a', 'changed!'],
+      [0, 'b', 'changed too!']
+    ]);
+
+    expect(getDataAtCell(0, 0)).toEqual('changed!');
+    expect(getDataAtCell(0, 1)).toEqual('changed too!');
+
+    updateSettings({
+      manualRowMove: [1, 0, 2]
+    });
+
+    setDataAtRowProp([
+      [0, 'a', 'changed again!'],
+      [0, 'b', 'changed again too!']
+    ]);
+
+    expect(getDataAtCell(0, 0)).toEqual('changed again!');
+    expect(getDataAtCell(0, 1)).toEqual('changed again too!');
+  });
+
+  it('should allow setting content to the trimmed columns', () => {
+    handsontable({
+      data: spec().datasetAoO,
+      columns: [
+        { data: 'a' },
+      ]
+    });
+
+    setDataAtRowProp(0, 'b', 'changed!');
+
+    expect(getSourceDataAtCell(0, 'b')).toEqual('changed!');
+  });
+
+  it('should allow setting content to the trimmed columns by passing an array of changes to the method', () => {
+    handsontable({
+      data: spec().datasetAoO,
+      columns: [
+        { data: 'a' },
+      ]
+    });
+
+    setDataAtRowProp([
+      [0, 'a', 'changed!'],
+      [0, 'b', 'changed too!']
+    ]);
+
+    expect(getSourceDataAtCell(0, 'a')).toEqual('changed!');
+    expect(getSourceDataAtCell(0, 'b')).toEqual('changed too!');
+  });
+
+  it('should be possible to prevent setting of content into a cell if the cell type is defined globally, as well as' +
+  'allowInvalid is set to `false`', async() => {
+    handsontable({
+      data: spec().datasetAoO,
+      columns: [
+        { data: 'a' },
+      ],
+      type: 'numeric',
+      allowInvalid: false,
+    });
+
+    setDataAtRowProp([
+      [0, 'a', 'changed!'],
+      [0, 'b', 'changed too!'],
+      [1, 'a', 777],
+      [1, 'b', 'changed too!'],
+      [2, 'a', 'changed'],
+      [2, 'b', 777],
+    ]);
+
+    await sleep(100);
+
+    expect(getSourceDataAtCell(0, 'a')).toEqual(1);
+    expect(getSourceDataAtCell(0, 'b')).toEqual(2);
+    expect(getSourceDataAtCell(1, 'a')).toEqual(777);
+    expect(getSourceDataAtCell(1, 'b')).toEqual(5);
+    expect(getSourceDataAtCell(2, 'a')).toEqual(7);
+    expect(getSourceDataAtCell(2, 'b')).toEqual(777);
+  });
+});


### PR DESCRIPTION
### Context
As:
1. `setDataAtRowProp` uses both validation and physical indexing (in terms of columns - it uses props)
2. validation utilizes `getCellMeta`
3. `getCellMeta` operates on visual indexes

`setDataAtRowProp` did not work correctly.

This PR makes validation use the top-level table meta as cell meta to retrieve validation-related settings if the requested cell was a part of a trimmed-out column.

### How has this been tested?
1. Added some tests for `setDataAtRowProp`
2. Added a test for the trimmed-out column logic

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#834

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
