### PR TITLE
Prevent the table from scrolling after inserting a new row above an existing selection.

### DIFF
--- a/.changelogs/10965.json
+++ b/.changelogs/10965.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed a problem where the table scrolled all the way right after inserting a new row over a table-wide selection.",
+  "type": "fixed",
+  "issueOrPR": 10965,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -577,6 +577,11 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
               // Remove from the stack the last added selection as that selection below will be
               // replaced by new transformed selection.
               selection.getSelectedRange().pop();
+
+              instance.addHookOnce('afterSelection', (...[,,,, preventScrolling]) => {
+                preventScrolling.value = true;
+              });
+
               // I can't use transforms as they don't work in negative indexes.
               selection.setRangeStartOnly(instance
                 ._createCellCoords(currentFromRow + rowDelta, currentFromColumn), true);

--- a/handsontable/test/e2e/core/alter/insertRowAbove.spec.js
+++ b/handsontable/test/e2e/core/alter/insertRowAbove.spec.js
@@ -462,6 +462,27 @@ describe('Core.alter', () => {
       `).toBeMatchToSelectionPattern();
     });
 
+    it('should not scroll the table after shifting the selection down', async() => {
+      const onAfterScroll = jasmine.createSpy('onAfterScroll');
+
+      handsontable({
+        data: createSpreadsheetData(5, 30),
+        width: 300,
+        height: 300,
+        rowHeaders: true,
+        colHeaders: true,
+        afterScroll: onAfterScroll,
+      });
+
+      selectRows(2);
+
+      alter('insert_row_above', 2, 1);
+
+      await sleep(20);
+
+      expect(onAfterScroll).not.toHaveBeenCalled();
+    });
+
     it('should not shift down the selected row when the new row is inserted below that selection', () => {
       handsontable({
         data: createSpreadsheetData(5, 5),


### PR DESCRIPTION
### Context
This PR prevents the table from scrolling after shifting the selection down when a new row has been added above it.

### How has this been tested?
Added a test case.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#1814

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
