### PR TITLE
fix TOC (right hand menu) urls

### DIFF
--- a/docs/patches/markdown-it-table-of-contents+0.4.4.patch
+++ b/docs/patches/markdown-it-table-of-contents+0.4.4.patch
@@ -1,0 +1,15 @@
+diff --git a/node_modules/markdown-it-table-of-contents/index.js b/node_modules/markdown-it-table-of-contents/index.js
+index 92c5b62..fd91396 100644
+--- a/node_modules/markdown-it-table-of-contents/index.js
++++ b/node_modules/markdown-it-table-of-contents/index.js
+@@ -143,8 +143,8 @@ module.exports = (md, o) => {
+           headings.push(buffer);
+         }
+       }
+-      var slugifiedContent = options.slugify(heading.content);
+-      var link = "#"+slugifiedContent;
++      var linkToken = heading.children.find(element => element.type === 'link_open');
++      var link = linkToken ? linkToken.attrGet('href') : "#" + options.slugify(heading.content);
+       if (options.transformLink) {
+           link = options.transformLink(link);
+       }


### PR DESCRIPTION
### Context
This PR includes fix for right hand menu URLs

### How has this been tested?
Locally

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/1881

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] Fix TOC anchor URLs


[skip changelog]

