### PR TITLE
Make the autocomplete editor show the choice list before loading the new choice data.

### DIFF
--- a/.changelogs/10977.json
+++ b/.changelogs/10977.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed a problem where the autocomplete dropdown was not displayed with the right dimensions after previously filtering out all the choices.",
+  "type": "fixed",
+  "issueOrPR": 10977,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/editors/autocompleteEditor/__tests__/autocompleteEditor.spec.js
+++ b/handsontable/src/editors/autocompleteEditor/__tests__/autocompleteEditor.spec.js
@@ -667,6 +667,41 @@ describe('AutocompleteEditor', () => {
       expect(editor.find('.autocompleteEditor .htCore td').width()).toBeGreaterThan(187);
     });
 
+    it('should display the autocomplete list with correct dimensions, after updating the choice list from no match' +
+    'to a match', async() => {
+      handsontable({
+        columns: [
+          {
+            type: 'autocomplete',
+            trimDropdown: false,
+            source: choices
+          }
+        ]
+      });
+
+      selectCell(0, 0);
+      keyDownUp('enter');
+
+      const autocompleteEditor = $('.autocompleteEditor');
+      const inputHolder = $('.handsontableInputHolder');
+
+      await sleep(50);
+
+      autocompleteEditor.siblings('textarea').first().val('ab');
+      keyDownUp('a');
+      keyDownUp('b');
+      await sleep(50);
+
+      autocompleteEditor.siblings('textarea').first().val('a');
+      keyDownUp('backspace');
+      await sleep(50);
+
+      expect(
+        inputHolder.find('.autocompleteEditor .ht_master').eq(0).width()
+      ).toBeGreaterThan(inputHolder.find('.handsontableInput').width());
+
+    });
+
     it('autocomplete list should have the suggestion table dimensions, when trimDropdown option is set to false', async() => {
       const syncSources = jasmine.createSpy('syncSources');
 

--- a/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
+++ b/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
@@ -320,15 +320,17 @@ export class AutocompleteEditor extends HandsontableEditor {
 
     this.strippedChoices = choices;
 
-    this.htEditor.loadData(pivot([choices]));
-
     if (choices.length === 0) {
       this.htEditor.rootElement.style.display = 'none';
 
     } else {
       this.htEditor.rootElement.style.display = '';
+    }
 
-      this.updateDropdownHeight();
+    this.htEditor.loadData(pivot([choices]));
+
+    if (choices.length > 0) {
+      this.updateDropdownDimensions();
       this.flipDropdownIfNeeded();
 
       if (this.cellProperties.strict === true) {
@@ -442,7 +444,7 @@ export class AutocompleteEditor extends HandsontableEditor {
    *
    * @private
    */
-  updateDropdownHeight() {
+  updateDropdownDimensions() {
     const currentDropdownWidth = this.htEditor.getColWidth(0) + getScrollbarWidth(this.hot.rootDocument) + 2;
     const trimDropdown = this.cellProperties.trimDropdown;
 


### PR DESCRIPTION
### Context
This PR moves around some logic for the autocomplete editor's dropdown to calculate its dimensions properly when moving from a "no match" to "match" situation.

### How has this been tested?
Added a test case.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#1892

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
