### PR TITLE
Fix a bug related to not clearing the dataset correctly for formulas

### DIFF
--- a/handsontable/src/plugins/formulas/__tests__/featureIntegration.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/featureIntegration.spec.js
@@ -1,10 +1,8 @@
 import HyperFormula from 'hyperformula';
 
 describe('Formulas: Integration with other features', () => {
-  const id = 'testContainer';
-
   beforeEach(function() {
-    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+    this.$container = $('<div id="testContainer"></div>').appendTo('body');
   });
 
   afterEach(function() {

--- a/handsontable/src/plugins/formulas/__tests__/formulas.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/formulas.spec.js
@@ -13,10 +13,9 @@ const autofill = (endRow, endCol) => {
 
 describe('Formulas general', () => {
   const debug = false;
-  const id = 'testContainer';
 
   beforeEach(function() {
-    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+    this.$container = $('<div id="testContainer"></div>').appendTo('body');
   });
 
   afterEach(function() {
@@ -717,6 +716,24 @@ describe('Formulas general', () => {
       expect(hot.getDataAtRow(3)).toEqual([2012, 6033, 8049, '#REF!', 12, '=SUM(E5)']);
     });
 
+    it('should correctly remove rows with bigger index than 10 (#dev-1841)', () => {
+      handsontable({
+        data: createSpreadsheetData(20, 5),
+        formulas: {
+          engine: HyperFormula,
+        },
+      });
+
+      const engine = getPlugin('formulas').engine;
+
+      spyOn(engine, 'removeRows').and.callThrough();
+      alter('remove_row', 9, 3);
+
+      expect(engine.removeRows.calls.argsFor(0)).toEqual([0, [11, 1]]);
+      expect(engine.removeRows.calls.argsFor(1)).toEqual([0, [10, 1]]);
+      expect(engine.removeRows.calls.argsFor(2)).toEqual([0, [9, 1]]);
+    });
+
     it('should not throw an error after removing all rows', () => {
       expect(() => {
         handsontable({
@@ -885,6 +902,24 @@ describe('Formulas general', () => {
       expect(hot.getDataAtRow(2)).toEqual([2010, 2905, 2867, 2016, '#REF!']);
       expect(hot.getDataAtRow(3)).toEqual([2011, 2517, 4822, 552, 6127]);
       expect(hot.getDataAtRow(4)).toEqual([2012, '#REF!', '#REF!', 12, '=SUM(E5)']);
+    });
+
+    it('should correctly remove columns with bigger index than 10 (#dev-1841)', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 20),
+        formulas: {
+          engine: HyperFormula,
+        },
+      });
+
+      const engine = getPlugin('formulas').engine;
+
+      spyOn(engine, 'removeColumns').and.callThrough();
+      alter('remove_col', 9, 3);
+
+      expect(engine.removeColumns.calls.argsFor(0)).toEqual([0, [11, 1]]);
+      expect(engine.removeColumns.calls.argsFor(1)).toEqual([0, [10, 1]]);
+      expect(engine.removeColumns.calls.argsFor(2)).toEqual([0, [9, 1]]);
     });
 
     it('should recalculate table and replace coordinates in formula expressions into #REF! ' +

--- a/handsontable/src/plugins/formulas/__tests__/hfApi.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/hfApi.spec.js
@@ -2,10 +2,9 @@ import HyperFormula from 'hyperformula';
 
 describe('Formulas general', () => {
   const debug = false;
-  const id = 'testContainer';
 
   beforeEach(function() {
-    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+    this.$container = $('<div id="testContainer"></div>').appendTo('body');
   });
 
   afterEach(function() {

--- a/handsontable/src/plugins/formulas/__tests__/hooks.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/hooks.spec.js
@@ -1,11 +1,8 @@
 import HyperFormula from 'hyperformula';
 
 describe('Formulas general', () => {
-  const id = 'testContainer';
-
   beforeEach(function() {
-    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
-
+    this.$container = $('<div id="testContainer"></div>').appendTo('body');
     this.hfInstance = HyperFormula.buildEmpty({ licenseKey: 'internal-use-in-handsontable' });
   });
 

--- a/handsontable/src/plugins/formulas/__tests__/initialization.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/initialization.spec.js
@@ -5,12 +5,11 @@ import plPL from 'hyperformula/es/i18n/languages/plPL';
 
 describe('Formulas general', () => {
   const debug = false;
-  const id = 'testContainer';
 
   beforeEach(function() {
-    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
-    this.$container2 = $(`<div id="${id}-2"></div>`).appendTo('body');
-    this.$container3 = $(`<div id="${id}-3"></div>`).appendTo('body');
+    this.$container = $('<div id="testContainer"></div>').appendTo('body');
+    this.$container2 = $('<div id="testContainer-2"></div>').appendTo('body');
+    this.$container3 = $('<div id="testContainer-3"></div>').appendTo('body');
   });
 
   afterEach(function() {

--- a/handsontable/src/plugins/formulas/__tests__/memoryLeak.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/memoryLeak.spec.js
@@ -2,11 +2,10 @@ import HyperFormula from 'hyperformula';
 
 describe('Formulas memory leak check', () => {
   const debug = false;
-  const id = 'testContainer';
 
   beforeEach(function() {
-    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
-    this.$container2 = $(`<div id="${id}-2"></div>`).appendTo('body');
+    this.$container = $('<div id="testContainer"></div>').appendTo('body');
+    this.$container2 = $('<div id="testContainer-2"></div>').appendTo('body');
   });
 
   afterEach(function() {

--- a/handsontable/src/plugins/formulas/__tests__/plugins/autofill.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/plugins/autofill.spec.js
@@ -1,10 +1,8 @@
 import HyperFormula from 'hyperformula';
 
 describe('Formulas', () => {
-  const id = 'testContainer';
-
   beforeEach(function() {
-    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+    this.$container = $('<div id="testContainer"></div>').appendTo('body');
   });
 
   afterEach(function() {

--- a/handsontable/src/plugins/formulas/__tests__/plugins/copyPaste.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/plugins/copyPaste.spec.js
@@ -1,10 +1,8 @@
 import HyperFormula from 'hyperformula';
 
 describe('Formulas', () => {
-  const id = 'testContainer';
-
   beforeEach(function() {
-    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+    this.$container = $('<div id="testContainer"></div>').appendTo('body');
   });
 
   afterEach(function() {

--- a/handsontable/src/plugins/formulas/__tests__/plugins/manualColumnFreeze.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/plugins/manualColumnFreeze.spec.js
@@ -1,10 +1,8 @@
 import HyperFormula from 'hyperformula';
 
 describe('Formulas', () => {
-  const id = 'testContainer';
-
   beforeEach(function() {
-    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+    this.$container = $('<div id="testContainer"></div>').appendTo('body');
   });
 
   afterEach(function() {

--- a/handsontable/src/plugins/formulas/__tests__/plugins/manualColumnMove.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/plugins/manualColumnMove.spec.js
@@ -1,18 +1,16 @@
 import HyperFormula from 'hyperformula';
 
-const dataset = [
-  [1, '=A1+10', '=B1+100', '=C1+1000', '=D1+1000000'],
-  [2, '=A2+10', '=B2+100', '=C2+1000', '=D2+1000000'],
-  [3, '=A3+10', '=B3+100', '=C3+1000', '=D3+1000000'],
-  [4, '=A4+10', '=B4+100', '=C4+1000', '=D4+1000000'],
-  [5, '=A5+10', '=B5+100', '=C5+1000', '=D5+1000000'],
-];
-
 describe('Formulas', () => {
-  const id = 'testContainer';
+  const dataset = [
+    [1, '=A1+10', '=B1+100', '=C1+1000', '=D1+1000000'],
+    [2, '=A2+10', '=B2+100', '=C2+1000', '=D2+1000000'],
+    [3, '=A3+10', '=B3+100', '=C3+1000', '=D3+1000000'],
+    [4, '=A4+10', '=B4+100', '=C4+1000', '=D4+1000000'],
+    [5, '=A5+10', '=B5+100', '=C5+1000', '=D5+1000000'],
+  ];
 
   beforeEach(function() {
-    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+    this.$container = $('<div id="testContainer"></div>').appendTo('body');
   });
 
   afterEach(function() {

--- a/handsontable/src/plugins/formulas/__tests__/plugins/manualRowMove.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/plugins/manualRowMove.spec.js
@@ -1,18 +1,16 @@
 import HyperFormula from 'hyperformula';
 
-const dataset = [
-  [1, 2, 3, 4, 5],
-  ['=A1+10', '=B1+10', '=C1+10', '=D1+10', '=E1+10'],
-  ['=A2+100', '=B2+100', '=C2+100', '=D2+100', '=E2+100'],
-  ['=A3+1000', '=B3+1000', '=C3+1000', '=D3+1000', '=E3+1000'],
-  ['=A4+1000000', '=B4+1000000', '=C4+1000000', '=D4+1000000', '=E4+1000000'],
-];
-
 describe('Formulas', () => {
-  const id = 'testContainer';
+  const dataset = [
+    [1, 2, 3, 4, 5],
+    ['=A1+10', '=B1+10', '=C1+10', '=D1+10', '=E1+10'],
+    ['=A2+100', '=B2+100', '=C2+100', '=D2+100', '=E2+100'],
+    ['=A3+1000', '=B3+1000', '=C3+1000', '=D3+1000', '=E3+1000'],
+    ['=A4+1000000', '=B4+1000000', '=C4+1000000', '=D4+1000000', '=E4+1000000'],
+  ];
 
   beforeEach(function() {
-    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+    this.$container = $('<div id="testContainer"></div>').appendTo('body');
   });
 
   afterEach(function() {

--- a/handsontable/src/plugins/formulas/__tests__/plugins/nestedRows.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/plugins/nestedRows.spec.js
@@ -1,10 +1,8 @@
 import HyperFormula from 'hyperformula';
 
 describe('Formulas', () => {
-  const id = 'testContainer';
-
   beforeEach(function() {
-    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+    this.$container = $('<div id="testContainer"></div>').appendTo('body');
   });
 
   afterEach(function() {

--- a/handsontable/src/plugins/formulas/__tests__/publicAPI.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/publicAPI.spec.js
@@ -2,10 +2,9 @@ import HyperFormula from 'hyperformula';
 
 describe('Formulas public API', () => {
   const debug = false;
-  const id = 'testContainer';
 
   beforeEach(function() {
-    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+    this.$container = $('<div id="testContainer"></div>').appendTo('body');
   });
 
   afterEach(function() {

--- a/handsontable/src/plugins/formulas/__tests__/validation.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/validation.spec.js
@@ -2,11 +2,10 @@ import HyperFormula from 'hyperformula';
 
 describe('Formulas general', () => {
   const debug = false;
-  const id = 'testContainer';
 
   beforeEach(function() {
-    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
-    this.$container2 = $(`<div id="${id}-2"></div>`).appendTo('body');
+    this.$container = $('<div id="testContainer"></div>').appendTo('body');
+    this.$container2 = $('<div id="testContainer-2"></div>').appendTo('body');
   });
 
   afterEach(function() {

--- a/handsontable/src/plugins/formulas/formulas.js
+++ b/handsontable/src/plugins/formulas/formulas.js
@@ -1150,7 +1150,10 @@ export class Formulas extends BasePlugin {
       return;
     }
 
-    const descendingHfRows = this.rowAxisSyncer.getRemovedHfIndexes().sort().reverse();
+    const descendingHfRows = this.rowAxisSyncer
+      .getRemovedHfIndexes()
+      .sort((a, b) => b - a); // sort numeric values descending
+
     const changes = this.engine.batch(() => {
       descendingHfRows.forEach((hfRow) => {
         this.engine.removeRows(this.sheetId, [hfRow, 1]);
@@ -1174,7 +1177,9 @@ export class Formulas extends BasePlugin {
       return;
     }
 
-    const descendingHfColumns = this.columnAxisSyncer.getRemovedHfIndexes().sort().reverse();
+    const descendingHfColumns = this.columnAxisSyncer
+      .getRemovedHfIndexes()
+      .sort((a, b) => b - a); // sort numeric values descending
 
     const changes = this.engine.batch(() => {
       descendingHfColumns.forEach((hfColumn) => {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes a bug related to not clearing the dataset correctly when Formulas is enabled. The unorder indexes passed to the HF API cause the issue.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and I covered the fix with tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1841

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
