### PR TITLE
Add missing predefined menu item key types for menu config

### DIFF
--- a/.changelogs/10984.json
+++ b/.changelogs/10984.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Improved typings for the ContextMenu plugin.",
+  "type": "fixed",
+  "issueOrPR": 10984,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/__tests__/core/settings.types.ts
+++ b/handsontable/src/__tests__/core/settings.types.ts
@@ -14,6 +14,8 @@ enum SortDirection { asc = 'asc', desc = 'desc' }
 const contextMenuDemo: Handsontable.plugins.ContextMenu.Settings = {
   callback(key, selection, clickEvent) { },
   items: {
+    sep1: '---------',
+    row_above: 'row_above',
     item: {
       name() {
         return '';

--- a/handsontable/types/plugins/contextMenu/contextMenu.d.ts
+++ b/handsontable/types/plugins/contextMenu/contextMenu.d.ts
@@ -21,7 +21,7 @@ export interface Selection {
 }
 
 export interface MenuConfig {
-  [key: string]: MenuItemConfig;
+  [key: string]: MenuItemConfig | PredefinedMenuItemKey;
 }
 
 export interface MenuItemConfig {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR improves typings for the _ContextMenu_ plugin.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and I covered the fix with an updated test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1903

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
