### PR TITLE
Add missing type for `namedExpressions`

### DIFF
--- a/.changelogs/10986.json
+++ b/.changelogs/10986.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Added missing type for `namedExpressions`",
+  "type": "fixed",
+  "issueOrPR": 10986,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/formulas/__tests__/formulas.types.ts
+++ b/handsontable/src/plugins/formulas/__tests__/formulas.types.ts
@@ -15,6 +15,28 @@ new Handsontable(document.createElement('div'), {
   formulas: {
     engine: Hyperformula,
     sheetName: 'sheet1',
+    namedExpressions: [
+      {
+        name: 'ADDITIONAL_COST',
+        expression: 100,
+      },
+    ],
+  },
+});
+new Handsontable(document.createElement('div'), {
+  formulas: {
+    engine: Hyperformula,
+    sheetName: 'sheet1',
+    namedExpressions: [
+      {
+        name: 'ADDITIONAL_COST',
+        expression: 100,
+        scope: 0,
+        options: {
+          volatile: true,
+        },
+      },
+    ],
   },
 });
 const hot = new Handsontable(document.createElement('div'), {});

--- a/handsontable/types/plugins/formulas/formulas.d.ts
+++ b/handsontable/types/plugins/formulas/formulas.d.ts
@@ -2,10 +2,19 @@ import {
   CellType as HyperFormulaCellType,
   ConfigParams,
   HyperFormula,
+  RawCellContent,
+  NamedExpressionOptions,
 } from 'hyperformula';
 import Core from '../../core';
 import { CellValue } from '../../common';
 import { BasePlugin } from '../base';
+
+type NamedExpressions = {
+  name: string;
+  expression: RawCellContent;
+  scope?: number;
+  options?: NamedExpressionOptions;
+}
 
 export interface HyperFormulaSettings extends Partial<ConfigParams> {
   hyperformula: typeof HyperFormula | HyperFormula;
@@ -13,6 +22,7 @@ export interface HyperFormulaSettings extends Partial<ConfigParams> {
 export interface DetailedSettings {
   engine: typeof HyperFormula | HyperFormula | HyperFormulaSettings;
   sheetName?: string;
+  namedExpressions?: NamedExpressions[],
 }
 
 export type Settings = DetailedSettings;


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adds missing type for the `namedExpressions` option of the _Formulas_ plugin.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally, and I covered the fix with the updated test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1904

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
