### PR TITLE
Fix double border for row/column headers

### DIFF
--- a/handsontable/src/3rdparty/walkontable/src/overlay/inlineStart.js
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/inlineStart.js
@@ -356,10 +356,12 @@ export class InlineStartOverlay extends Overlay {
    * @returns {boolean}
    */
   adjustHeaderBordersPosition(position) {
+    const { wtSettings } = this;
     const masterParent = this.wot.wtTable.holder.parentNode;
-    const rowHeaders = this.wtSettings.getSetting('rowHeaders');
-    const fixedColumnsStart = this.wtSettings.getSetting('fixedColumnsStart');
-    const totalRows = this.wtSettings.getSetting('totalRows');
+    const rowHeaders = wtSettings.getSetting('rowHeaders');
+    const fixedColumnsStart = wtSettings.getSetting('fixedColumnsStart');
+    const totalRows = wtSettings.getSetting('totalRows');
+    const preventVerticalOverflow = wtSettings.getSetting('preventOverflow') === 'vertical';
 
     if (totalRows) {
       removeClass(masterParent, 'emptyRows');
@@ -369,19 +371,21 @@ export class InlineStartOverlay extends Overlay {
 
     let positionChanged = false;
 
-    if (fixedColumnsStart && !rowHeaders.length) {
-      // "innerBorderLeft" is for backward compatibility
-      addClass(masterParent, 'innerBorderLeft innerBorderInlineStart');
-
-    } else if (!fixedColumnsStart && rowHeaders.length) {
-      const previousState = hasClass(masterParent, 'innerBorderInlineStart');
-
-      if (position) {
+    if (!preventVerticalOverflow) {
+      if (fixedColumnsStart && !rowHeaders.length) {
+        // "innerBorderLeft" is for backward compatibility
         addClass(masterParent, 'innerBorderLeft innerBorderInlineStart');
-        positionChanged = !previousState;
-      } else {
-        removeClass(masterParent, 'innerBorderLeft innerBorderInlineStart');
-        positionChanged = previousState;
+
+      } else if (!fixedColumnsStart && rowHeaders.length) {
+        const previousState = hasClass(masterParent, 'innerBorderInlineStart');
+
+        if (position) {
+          addClass(masterParent, 'innerBorderLeft innerBorderInlineStart');
+          positionChanged = !previousState;
+        } else {
+          removeClass(masterParent, 'innerBorderLeft innerBorderInlineStart');
+          positionChanged = previousState;
+        }
       }
     }
 

--- a/handsontable/src/3rdparty/walkontable/src/overlay/top.js
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/top.js
@@ -381,8 +381,10 @@ export class TopOverlay extends Overlay {
    * @returns {boolean}
    */
   adjustHeaderBordersPosition(position, skipInnerBorderAdjusting = false) {
+    const { wtSettings } = this;
     const masterParent = this.wot.wtTable.holder.parentNode;
-    const totalColumns = this.wtSettings.getSetting('totalColumns');
+    const totalColumns = wtSettings.getSetting('totalColumns');
+    const preventHorizontalOverflow = wtSettings.getSetting('preventOverflow') === 'horizontal';
 
     if (totalColumns) {
       removeClass(masterParent, 'emptyColumns');
@@ -392,17 +394,17 @@ export class TopOverlay extends Overlay {
 
     let positionChanged = false;
 
-    if (!skipInnerBorderAdjusting) {
-      const fixedRowsTop = this.wtSettings.getSetting('fixedRowsTop');
+    if (!skipInnerBorderAdjusting && !preventHorizontalOverflow) {
+      const fixedRowsTop = wtSettings.getSetting('fixedRowsTop');
       const areFixedRowsTopChanged = this.cachedFixedRowsTop !== fixedRowsTop;
-      const columnHeaders = this.wtSettings.getSetting('columnHeaders');
+      const columnHeaders = wtSettings.getSetting('columnHeaders');
 
       if ((areFixedRowsTopChanged || fixedRowsTop === 0) && columnHeaders.length > 0) {
         const previousState = hasClass(masterParent, 'innerBorderTop');
 
-        this.cachedFixedRowsTop = this.wtSettings.getSetting('fixedRowsTop');
+        this.cachedFixedRowsTop = wtSettings.getSetting('fixedRowsTop');
 
-        if (position || this.wtSettings.getSetting('totalRows') === 0) {
+        if (position || wtSettings.getSetting('totalRows') === 0) {
           addClass(masterParent, 'innerBorderTop');
           positionChanged = !previousState;
         } else {

--- a/handsontable/src/3rdparty/walkontable/test/helpers/common.js
+++ b/handsontable/src/3rdparty/walkontable/test/helpers/common.js
@@ -1,3 +1,28 @@
+/**
+ * Test context object.
+ *
+ * @type {object}
+ */
+const specContext = {};
+
+beforeEach(function() {
+  specContext.spec = this;
+});
+
+afterEach(() => {
+  specContext.spec = null;
+  window.scrollTo(0, 0);
+});
+
+beforeAll(() => {
+  // Make the test more predictable by hiding the test suite dots
+  $('.jasmine_html-reporter').hide();
+});
+afterAll(() => {
+  // After the test are finished show the test suite dots
+  $('.jasmine_html-reporter').show();
+});
+
 /* eslint-disable jsdoc/require-description-complete-sentence */
 /**
  * The function allows you to run the test suites based on different parameters (object configuration, datasets etc).
@@ -45,13 +70,6 @@ export function sleep(delay = 100) {
     }
   });
 }
-
-/**
- * Test context object.
- *
- * @type {object}
- */
-const specContext = {};
 
 /**
  * Get the test case context.
@@ -154,24 +172,6 @@ export function getTotalColumns() {
 export function wheelOnElement(elem, deltaX = 0, deltaY = 0) {
   elem.dispatchEvent(new WheelEvent('wheel', { deltaX, deltaY }));
 }
-
-beforeEach(function() {
-  specContext.spec = this;
-});
-
-afterEach(() => {
-  specContext.spec = null;
-  window.scrollTo(0, 0);
-});
-
-beforeAll(() => {
-  // Make the test more predictable by hiding the test suite dots
-  $('.jasmine_html-reporter').hide();
-});
-afterAll(() => {
-  // After the test are finished show the test suite dots
-  $('.jasmine_html-reporter').show();
-});
 
 /**
  * Returns the table width.

--- a/handsontable/test/e2e/settings/preventOverflow.spec.js
+++ b/handsontable/test/e2e/settings/preventOverflow.spec.js
@@ -1,0 +1,61 @@
+describe('settings', () => {
+  describe('preventOverflow', () => {
+    const id = 'testContainer';
+
+    beforeEach(function() {
+      this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+    });
+
+    afterEach(function() {
+      if (this.$container) {
+        destroy();
+        this.$container.remove();
+      }
+    });
+
+    it('should not render column double border on the bottom when `horizontal` option is used and the viewport is scrolled', async() => {
+      const origMarginTop = document.body.style.marginTop;
+
+      document.body.style.marginTop = '2000px';
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        width: 400,
+        height: 300,
+        preventOverflow: 'horizontal',
+      });
+
+      window.scrollTo(0, 100);
+
+      await sleep(50);
+
+      expect(getMaster().hasClass('innerBorderTop')).toBe(false);
+
+      document.body.style.marginTop = origMarginTop;
+    });
+
+    it('should not render row double border on the right when `vertical` option is used and the viewport is scrolled', async() => {
+      const origMarginLeft = document.body.style.marginLeft;
+
+      document.body.style.marginLeft = '2000px';
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        width: 400,
+        height: 300,
+        preventOverflow: 'vertical',
+      });
+
+      window.scrollTo(100, 0);
+
+      await sleep(50);
+
+      expect(getMaster().hasClass('innerBorderInlineStart')).toBe(false);
+      expect(getMaster().hasClass('innerBorderLeft')).toBe(false);
+
+      document.body.style.marginLeft = origMarginLeft;
+    });
+  });
+});

--- a/handsontable/test/helpers/common.js
+++ b/handsontable/test/helpers/common.js
@@ -1,3 +1,25 @@
+const specContext = {};
+
+beforeEach(function() {
+  specContext.spec = this;
+});
+afterEach(() => {
+  specContext.spec = null;
+});
+
+beforeAll(() => {
+  // Make the test more predictable by hiding the test suite dots (skip it on unit tests)
+  if (!process.env.JEST_WORKER_ID) {
+    $('.jasmine_html-reporter').hide();
+  }
+});
+afterAll(() => {
+  // After the test are finished show the test suite dots
+  if (!process.env.JEST_WORKER_ID) {
+    $('.jasmine_html-reporter').show();
+  }
+});
+
 /**
  * @param {number} [delay=100] The delay in ms after which the Promise is resolved.
  * @returns {Promise}
@@ -139,28 +161,6 @@ export const updateSettings = handsontableMethodFactory('updateSettings');
 export const validateCell = handsontableMethodFactory('validateCell');
 export const validateCells = handsontableMethodFactory('validateCells');
 export const unlisten = handsontableMethodFactory('unlisten');
-
-const specContext = {};
-
-beforeEach(function() {
-  specContext.spec = this;
-});
-afterEach(() => {
-  specContext.spec = null;
-});
-
-beforeAll(() => {
-  // Make the test more predictable by hiding the test suite dots (skip it on unit tests)
-  if (!process.env.JEST_WORKER_ID) {
-    $('.jasmine_html-reporter').hide();
-  }
-});
-afterAll(() => {
-  // After the test are finished show the test suite dots
-  if (!process.env.JEST_WORKER_ID) {
-    $('.jasmine_html-reporter').show();
-  }
-});
 
 /**
  * @returns {object} Returns the spec object for currently running test.


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes an issue where the table was rendered with double borders of column headers when the `preventOverflow` was set as `'horizontal'` or double borders of the row headers when the `'vertical'` value was used. 

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and I covered the fix with new tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1900

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
