### PR TITLE
Make the instance not render when it's placed in a hidden container.

### DIFF
--- a/handsontable/src/3rdparty/walkontable/src/calculator/viewportRows.js
+++ b/handsontable/src/3rdparty/walkontable/src/calculator/viewportRows.js
@@ -85,6 +85,10 @@ export class ViewportRowsCalculator {
     } = this.#options;
     const zeroBasedScrollOffset = Math.max(this.#options.scrollOffset, 0);
     const horizontalScrollbarHeight = this.#options.horizontalScrollbarHeight || 0;
+    const innerViewportHeight =
+      zeroBasedScrollOffset +
+      viewportHeight -
+      horizontalScrollbarHeight;
     let sum = 0;
     let needReverse = true;
     const startPositions = [];
@@ -105,7 +109,10 @@ export class ViewportRowsCalculator {
         firstVisibleRowHeight = rowHeight;
       }
 
-      if (sum >= zeroBasedScrollOffset && sum + (calculationType === FULLY_VISIBLE_TYPE ? rowHeight : 0) <= zeroBasedScrollOffset + viewportHeight - horizontalScrollbarHeight) { // eslint-disable-line max-len
+      if (
+        sum >= zeroBasedScrollOffset &&
+        sum + (calculationType === FULLY_VISIBLE_TYPE ? rowHeight : 0) <= innerViewportHeight
+      ) {
         if (this.startRow === null) {
           this.startRow = i;
 
@@ -121,7 +128,7 @@ export class ViewportRowsCalculator {
       if (calculationType !== FULLY_VISIBLE_TYPE) {
         this.endRow = i;
       }
-      if (sum >= zeroBasedScrollOffset + viewportHeight - horizontalScrollbarHeight) {
+      if (sum >= innerViewportHeight) {
         needReverse = false;
         break;
       }

--- a/handsontable/src/3rdparty/walkontable/src/core/_base.js
+++ b/handsontable/src/3rdparty/walkontable/src/core/_base.js
@@ -115,7 +115,7 @@ export default class CoreAbstract {
   draw(fastDraw = false) {
     this.drawInterrupted = false;
 
-    if (!fastDraw && !this.wtTable.isVisible()) {
+    if (!this.wtTable.isVisible()) {
       // draw interrupted because TABLE is not visible
       this.drawInterrupted = true;
     } else {

--- a/handsontable/src/3rdparty/walkontable/test/spec/table.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/table.spec.js
@@ -577,4 +577,24 @@ describe('WalkontableTable', () => {
     expect($('.ht_clone_inline_start')[0]).toHaveClass('ht_clone_left');
     expect($('.ht_clone_bottom_inline_start_corner')[0]).toHaveClass('ht_clone_bottom_left_corner');
   });
+
+  it('should not re-render the full table when the table has `display: none` declared', () => {
+    const cellRenderer = jasmine.createSpy('cellRenderer');
+    const wt = walkontable({
+      data: getData,
+      totalRows: getTotalRows,
+      totalColumns: getTotalColumns,
+      cellRenderer
+    });
+
+    wt.draw();
+
+    expect(cellRenderer).toHaveBeenCalledTimes(18);
+
+    spec().$wrapper.css('display', 'none');
+
+    wt.draw();
+
+    expect(cellRenderer).toHaveBeenCalledTimes(18);
+  });
 });

--- a/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
+++ b/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
@@ -403,7 +403,8 @@ export class AutocompleteEditor extends HandsontableEditor {
       height = tempHeight - lastRowHeight;
 
       if (this.htEditor.flipped) {
-        this.htEditor.rootElement.style.top = `${parseInt(this.htEditor.rootElement.style.top, 10) + dropdownHeight - height}px`; // eslint-disable-line max-len
+        this.htEditor.rootElement.style.top =
+        `${parseInt(this.htEditor.rootElement.style.top, 10) + dropdownHeight - height}px`;
       }
 
       this.setDropdownHeight(tempHeight - lastRowHeight);

--- a/handsontable/test/e2e/settings/outsideClickDeselects.spec.js
+++ b/handsontable/test/e2e/settings/outsideClickDeselects.spec.js
@@ -341,5 +341,36 @@ describe('settings', () => {
 
       textarea.remove();
     });
+
+    it('should not re-render all the rows when outsideClickDeselects is set as false and the user toggles the visibility' +
+    'of the table with an outside button (dev-handsontable#1610)', () => {
+      const onAfterRenderer = jasmine.createSpy('onAfterRenderer');
+      const $externalButton = $('<button>test</button>').prependTo('body');
+      const hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(50, 1),
+        rowHeaders: true,
+        colHeaders: true,
+        outsideClickDeselects: false,
+        width: 600,
+        height: 300
+      });
+
+      $externalButton.on('click', () => {
+        spec().$container.toggle();
+      });
+
+      hot.selectCell(0, 0);
+
+      $externalButton.simulate('click');
+
+      hot.addHook('afterRenderer', onAfterRenderer);
+
+      $externalButton.simulate('mousedown');
+      $externalButton.simulate('mouseup');
+
+      expect(onAfterRenderer).toHaveBeenCalledTimes(0);
+
+      $externalButton.remove();
+    });
   });
 });


### PR DESCRIPTION
### Context
The problem described in handsontable/dev-handsontable#1610 was caused by logic that made _all the rows_ re-render when trying to render the table if it was placed in a hidden (`display: none`) container.

Initially, I wanted to tackle just this issue, but ended up disabling the ability to render the table when it's hidden.
Personally, I can't think of a scenario where this would be needed, but if I'm missing something, just let me know.

### How has this been tested?
- Added a test case for disabling the rendering for the hidden instances
- Added a test case specifically for handsontable/dev-handsontable#1610

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#1610

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
