### PR TITLE
Revert PR that improves the filters UX #10917

### DIFF
--- a/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
@@ -1058,85 +1058,6 @@ describe('Filters UI', () => {
       expect(byValueMultipleSelect().element.querySelector('.htCore td').textContent).toBe('(Blank cells)');
     });
 
-    it('should display all values after applying filters using search input method', async() => {
-      handsontable({
-        data: getDataForFilters().slice(0, 15),
-        columns: getColumnsForFilters(),
-        dropdownMenu: true,
-        filters: true,
-        width: 500,
-        height: 300
-      });
-
-      dropdownMenu(2);
-
-      await sleep(200);
-
-      byValueMultipleSelect().element.querySelector('input').focus();
-      document.activeElement.value = 'c';
-      keyUp('c');
-      document.activeElement.dispatchEvent(new Event('input', {
-        bubbles: true,
-        cancelable: true,
-      }));
-
-      $(dropdownMenuRootElement().querySelector('.htUIButton.htUIButtonOK input')).simulate('click');
-
-      dropdownMenu(2);
-
-      await sleep(200);
-
-      const valueBox = $(byValueBoxRootElement());
-
-      expect(valueBox.find('input[type=checkbox]').length).toBe(9);
-      expect(valueBox.find('input:checked').length).toBe(2);
-      expect(valueBox.find('input[type=checkbox]:checked').parent().toArray().map(a => a.innerText))
-        .toEqual(['Canby', 'Cascades']);
-    });
-
-    it('should be possible to restore the value list after changing the input in the search input', async() => {
-      handsontable({
-        data: getDataForFilters().slice(0, 15),
-        columns: getColumnsForFilters(),
-        dropdownMenu: true,
-        filters: true,
-        width: 500,
-        height: 300
-      });
-
-      dropdownMenu(2);
-
-      await sleep(200);
-
-      const valueBox = $(byValueBoxRootElement());
-
-      byValueMultipleSelect().element.querySelector('input').focus();
-      document.activeElement.value = 'c';
-      keyUp('c');
-      document.activeElement.dispatchEvent(new Event('input', {
-        bubbles: true,
-        cancelable: true,
-      }));
-
-      expect(valueBox.find('input:checked').length).toBe(2);
-
-      document.activeElement.value = '';
-      document.activeElement.dispatchEvent(new Event('input', {
-        bubbles: true,
-        cancelable: true,
-      }));
-
-      expect(valueBox.find('input:checked').length).toBe(9);
-
-      document.activeElement.value = 'usa';
-      document.activeElement.dispatchEvent(new Event('input', {
-        bubbles: true,
-        cancelable: true,
-      }));
-
-      expect(valueBox.find('input:checked').length).toBe(1);
-    });
-
     it('should utilize the `modifyFiltersMultiSelectValue` hook to display the cell value', () => {
       const columnsSetting = getColumnsForFilters();
 
@@ -2291,34 +2212,6 @@ describe('Filters UI', () => {
       expect(getData().length).toBe(10);
       expect(getDataAtCol(2).join())
         .toBe('Jenkinsville,Gardiner,Saranap,Soham,Needmore,Wakarusa,Yukon,Layhill,Henrietta,Wildwood');
-    });
-
-    it('should filter values using "by value" method (by typing in the search input)', async() => {
-      handsontable({
-        data: getDataForFilters().slice(0, 15),
-        columns: getColumnsForFilters(),
-        dropdownMenu: true,
-        filters: true,
-        width: 500,
-        height: 300
-      });
-
-      dropdownMenu(2);
-
-      await sleep(200);
-
-      byValueMultipleSelect().element.querySelector('input').focus();
-      document.activeElement.value = 'c';
-      keyUp('c');
-      document.activeElement.dispatchEvent(new Event('input', {
-        bubbles: true,
-        cancelable: true,
-      }));
-
-      $(dropdownMenuRootElement().querySelector('.htUIButton.htUIButtonOK input')).simulate('click');
-
-      expect(getData().length).toBe(2);
-      expect(getDataAtCol(2).join()).toBe('Cascades,Canby');
     });
 
     it('should overwrite condition filter when at specified column filter was already applied', async() => {

--- a/handsontable/src/plugins/filters/ui/multipleSelect.js
+++ b/handsontable/src/plugins/filters/ui/multipleSelect.js
@@ -239,7 +239,6 @@ export class MultipleSelectUI extends BaseUI {
 
           return width;
         },
-        hiddenRows: true,
         maxCols: 1,
         autoWrapCol: true,
         height: 110,
@@ -336,19 +335,16 @@ export class MultipleSelectUI extends BaseUI {
    */
   #onInput(event) {
     const value = event.target.value.toLocaleLowerCase(this.getLocale());
-    const hiddenRows = this.#itemsBox.getPlugin('hiddenRows');
+    let filteredItems;
 
-    hiddenRows.showRows(hiddenRows.getHiddenRows());
-    this.#items.forEach((item, index) => {
-      item.checked = `${item.value}`.toLocaleLowerCase(this.getLocale()).indexOf(value) >= 0;
+    if (value === '') {
+      filteredItems = [...this.#items];
+    } else {
+      filteredItems = this.#items
+        .filter(item => (`${item.value}`).toLocaleLowerCase(this.getLocale()).indexOf(value) >= 0);
+    }
 
-      if (!item.checked) {
-        hiddenRows.hideRow(index);
-      }
-    });
-
-    this.#itemsBox.view.adjustElementsSize();
-    this.#itemsBox.render();
+    this.#itemsBox.loadData(filteredItems);
   }
 
   /**

--- a/visual-tests/package.json
+++ b/visual-tests/package.json
@@ -9,7 +9,7 @@
     "build": "node ./scripts/build.mjs",
     "test": "node ./scripts/run-tests.mjs",
     "upload": "node ./scripts/upload.mjs",
-    "serve-example-preview": "npm --prefix ../examples/visual-tests/js/demo run serve -- --port=8085",
+    "serve-example-preview": "npm --prefix ../examples/next/visual-tests/js/demo run serve -- --port=8085",
     "install-system-dependencies": "npx --no playwright install --with-deps",
     "publish-package": "echo \"There is nothing to publish. Skipped.\"",
     "clean": "rimraf ./screenshots ./playwright-report"

--- a/visual-tests/src/page-helpers.ts
+++ b/visual-tests/src/page-helpers.ts
@@ -296,10 +296,11 @@ export async function setAdditionalColumnSorting(
  * @param {string} value Filter value.
  */
 export async function filterByValue(value: string) {
-  await getPageInstance().getByText('Clear', { exact: true }).click();
+  await getPageInstance().getByText('Clear', { exact: true }).click(); // deselect all checkboxes
   await getPageInstance()
     .getByPlaceholder('Search')
     .pressSequentially(value, { delay: 100 });
+  await getPageInstance().getByText('Select all', { exact: true }).click(); // select only that filtered one
   await getPageInstance().getByRole('button', { name: 'OK' }).click();
 }
 

--- a/visual-tests/tests/e2e/filter.spec.ts
+++ b/visual-tests/tests/e2e/filter.spec.ts
@@ -21,5 +21,4 @@ test(__filename, async({ tablePage }) => {
   await filterByCondition(FilterConditions.IsBetween, '01/01/2020', '30/06/2020');
 
   expect(await rowsCount()).toBe(3);
-
 });


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR reverts the changes from #10917.

_[skip changelog]_

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
