### PR TITLE
Block the wheel -> `scrollTop`/`scrollLeft` assignment when `window` is the instance's scrollable container.

### DIFF
--- a/.changelogs/10996.json
+++ b/.changelogs/10996.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed a problem where clicking and dragging on cells on a window-controlled scrolled instances would end up in unpredictable results.",
+  "type": "fixed",
+  "issueOrPR": 10996,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/src/overlays.js
+++ b/handsontable/src/3rdparty/walkontable/src/overlays.js
@@ -413,7 +413,11 @@ class Overlays {
     const shouldNotWheelHorizontally = masterHorizontal !== rootWindow &&
       target !== rootWindow && !target.contains(masterHorizontal);
 
-    if (this.keyPressed && (shouldNotWheelVertically || shouldNotWheelHorizontally)) {
+    if (
+      (this.keyPressed && (shouldNotWheelVertically || shouldNotWheelHorizontally))
+       ||
+      this.scrollableElement === rootWindow
+    ) {
       return;
     }
 

--- a/handsontable/src/3rdparty/walkontable/test/spec/scroll.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/scroll.spec.js
@@ -1273,6 +1273,35 @@ describe('WalkontableScroll', () => {
         bottomHolder.removeEventListener('scroll', bottomCallback);
         leftHolder.removeEventListener('scroll', leftCallback);
       });
+
+      it('should not try to set the window\'s `scrollTop`/`scrollLeft` and `scrollY`/`scrollX` properties ' +
+      'when the window-scrolled table is scrolled', async() => {
+        spec().$wrapper.eq(0).css({ overflow: '', height: '', width: '' });
+
+        const wt = walkontable({
+          data: getData,
+          totalRows: getTotalRows,
+          totalColumns: getTotalColumns,
+        });
+
+        spyOn(wt.wtOverlays, 'scrollVertically').and.callThrough();
+        spyOn(wt.wtOverlays, 'scrollHorizontally').and.callThrough();
+
+        wt.draw();
+
+        const masterRootElement = wt.wtTable.wtRootElement;
+
+        wheelOnElement(masterRootElement, 400);
+        wt.draw();
+
+        await sleep(200);
+
+        expect(window.scrollTop).toEqual(undefined);
+        expect(window.scrollLeft).toEqual(undefined);
+
+        expect(wt.wtOverlays.scrollVertically).not.toHaveBeenCalled();
+        expect(wt.wtOverlays.scrollHorizontally).not.toHaveBeenCalled();
+      });
     });
 
     describe('horizontal scroll', () => {

--- a/handsontable/src/plugins/dragToScroll/dragToScroll.js
+++ b/handsontable/src/plugins/dragToScroll/dragToScroll.js
@@ -95,7 +95,7 @@ export class DragToScroll extends BasePlugin {
   }
 
   /**
-   * Sets the value of the visible element.
+   * Sets the boundaries/dimensions of the scrollable viewport.
    *
    * @param {DOMRect|{left: number, right: number, top: number, bottom: number}} [boundaries] An object with
    * coordinates. Contains the window boundaries by default. The object is compatible with DOMRect.


### PR DESCRIPTION
### Context
The problem in handsontable/dev-handsontable#1902 was caused by the `dragToScroll` logic reading `window`'s `scrollTop` property, which shouldn't be defined at all.

Before this PR, the `wheel` event was translated into deltas that were supposed to be assigned to the scrollable container's `scrollTop`/`scrollLeft` properties. In cases of window-scrolled instances, it resulted in the `window`'s `scrollTop`/`scrollLeft` properties having `NaN` as a value, which messed up the `dragToScroll` logic.

After this change, the logic remains the same for container-scrolled instances, but window-scrolled instances ignore that.

### How has this been tested?
Added a test case checking if triggering the `wheel` event on the instance results in attempts to assign `scrollTop`/`scrollLeft` properties of `window`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#1902

### Affected project(s):
- [X] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
