### PR TITLE
feat: link to changelog/release notes instead of roadmap

### DIFF
--- a/docs/.vuepress/theme/components/NavLinks.vue
+++ b/docs/.vuepress/theme/components/NavLinks.vue
@@ -1,14 +1,14 @@
 <template>
   <nav class="nav-links">
     <!-- user links -->
-    <div :class="{'nav-item': true, 'no-active': isRoadmapLinkActive}">
+    <div :class="{'nav-item': true, 'no-active': isChangelogLinkActive}">
       <NavLink :item="guideLink"/>
     </div>
     <div class="nav-item">
       <NavLink :item="apiLink"/>
     </div>
-    <div class="nav-item roadmap">
-      <NavLink :item="roadmapLink"/>
+    <div class="nav-item changelog">
+      <NavLink :item="changelogLink"/>
     </div>
   </nav>
 </template>
@@ -38,14 +38,14 @@ export default {
         text: 'API'
       };
     },
-    roadmapLink() {
+    changelogLink() {
       return {
-        link: `${this.frameworkUrlPrefix}/roadmap/`,
-        text: 'Roadmap'
+        link: `${this.frameworkUrlPrefix}/release-notes/`,
+        text: 'Changelog'
       };
     },
-    isRoadmapLinkActive() {
-      return this.$route.path.includes('/roadmap');
+    isChangelogLinkActive() {
+      return this.$route.path.includes('/release-notes');
     }
   }
 };

--- a/docs/.vuepress/theme/styles/layout/sidebar.styl
+++ b/docs/.vuepress/theme/styles/layout/sidebar.styl
@@ -611,7 +611,7 @@
     }
 
     .nav-links {
-        .roadmap { 
+        .changelog { 
             display: none
         }
 

--- a/docs/content/guides/sidebar.js
+++ b/docs/content/guides/sidebar.js
@@ -175,7 +175,6 @@ const technicalSpecificationItems = [
 const upgradeAndMigrationItems = [
   { path: 'guides/upgrade-and-migration/release-notes/release-notes' },
   { path: 'guides/upgrade-and-migration/versioning-policy/versioning-policy' },
-  { path: 'guides/upgrade-and-migration/roadmap/roadmap' },
   { path: 'guides/upgrade-and-migration/migrating-from-7.4-to-8.0/migrating-from-7.4-to-8.0' },
   { path: 'guides/upgrade-and-migration/migrating-from-8.4-to-9.0/migrating-from-8.4-to-9.0' },
   { path: 'guides/upgrade-and-migration/migrating-from-9.0-to-10.0/migrating-from-9.0-to-10.0' },


### PR DESCRIPTION
### Context
Replace roadmap navbar link with "Changelog" and link to the release notes page

### How has this been tested?
Locally

[skip changelog]