### PR TITLE
Provide default time format for `timeFormat`

### DIFF
--- a/handsontable/src/dataMap/metaManager/metaSchema.js
+++ b/handsontable/src/dataMap/metaManager/metaSchema.js
@@ -1682,6 +1682,36 @@ export default () => {
     dateFormat: 'DD/MM/YYYY',
 
     /**
+     * The `timeFormat` option configures the time format accepted by [`time`](@/guides/cell-types/time-cell-type/time-cell-type.md) cells.
+     *
+     * You can set the `timeFormat` option to a string with a proper time format. The default value is: `'h:mm:ss a'`.
+     *
+     * To automatically correct times whose format doesn't match the `timeFormat` setting, use the [`correctFormat`](#correctFormat) option.
+     *
+     * Read more:
+     * - [Time cell type](@/guides/cell-types/time-cell-type/time-cell-type.md)
+     * - [`correctFormat`](#correctFormat)
+     *
+     * @memberof Options#
+     * @type {string}
+     * @default 'h:mm:ss a'
+     * @category Core
+     *
+     * @example
+     * ```js
+     * columns: [
+     *   {
+     *   // set the `type` of each cell in this column to `time`
+     *   type: 'time',
+     *   // for every `time` cell of this column, set the time format to `h:mm:ss a`
+     *   timeFormat: 'h:mm:ss a',
+     *   },
+     * ],
+     * ```
+     */
+    timeFormat: 'h:mm:ss a',
+
+    /**
      * The `datePickerConfig` option configures the `date` [cell editor](@/guides/cell-functions/cell-editor/cell-editor.md)'s date picker, which uses an external dependency: [Pikaday](https://github.com/Pikaday/Pikaday/tree/1.8.2).
      *
      * You can set the `datePickerConfig` option to an object with any of the available [Pikaday options](https://github.com/Pikaday/Pikaday/tree/1.8.2#configuration),

--- a/handsontable/test/e2e/settings/timeFormat.spec.js
+++ b/handsontable/test/e2e/settings/timeFormat.spec.js
@@ -1,0 +1,24 @@
+describe('settings', () => {
+  describe('timeFormat', () => {
+    const id = 'testContainer';
+
+    beforeEach(function() {
+      this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+    });
+
+    afterEach(function() {
+      if (this.$container) {
+        destroy();
+        this.$container.remove();
+      }
+    });
+
+    it('should have defined default value', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      expect(getCellMeta(0, 0).timeFormat).toBe('h:mm:ss a');
+    });
+  });
+});


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR is a hotfix for https://github.com/handsontable/handsontable/pull/10956 where the sorting did not work without providing the `timeFormat` value. 

Additionally, the PR makes the option visible in the Docs.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes localy.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1920

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
