### PR TITLE
Fix selection expanding for merged cells

### DIFF
--- a/.changelogs/11010.json
+++ b/.changelogs/11010.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed selection expanding for merged cells.",
+  "type": "fixed",
+  "issueOrPR": 11010,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/mergeCells/__tests__/keyboardShortcuts/shiftArrowDown.spec.js
+++ b/handsontable/src/plugins/mergeCells/__tests__/keyboardShortcuts/shiftArrowDown.spec.js
@@ -79,6 +79,22 @@ describe('MergeCells keyboard shortcut', () => {
       expect(getSelectedRange()).toEqualCellRange(['highlight: 1,1 from: 1,2 to: 9,1']);
     });
 
+    it('should correctly extend the cells selection down by one cell when merged cell is selected (#11010)', () => {
+      handsontable({
+        data: createSpreadsheetData(10, 10),
+        rowHeaders: true,
+        colHeaders: true,
+        mergeCells: [
+          { row: 1, col: 1, rowspan: 3, colspan: 3 },
+        ],
+      });
+
+      selectCells([[3, 3, 1, 1]]);
+      keyDownUp(['shift', 'arrowdown']);
+
+      expect(getSelectedRange()).toEqualCellRange(['highlight: 1,1 from: 1,3 to: 4,1']);
+    });
+
     it('should expand the cells selection down keeping the internal current focus position when some rows are hidden', () => {
       handsontable({
         data: createSpreadsheetData(6, 5),

--- a/handsontable/src/plugins/mergeCells/__tests__/keyboardShortcuts/shiftArrowRight.spec.js
+++ b/handsontable/src/plugins/mergeCells/__tests__/keyboardShortcuts/shiftArrowRight.spec.js
@@ -51,7 +51,7 @@ describe('MergeCells keyboard shortcut', () => {
       expect(getSelectedRange()).toEqualCellRange(['highlight: 3,0 from: 1,0 to: 3,4']);
     });
 
-    it('should extend the cells selection down when focus is moved within a range', () => {
+    it('should extend the cells selection right when focus is moved within a range', () => {
       handsontable({
         data: createSpreadsheetData(10, 10),
         rowHeaders: true,
@@ -77,6 +77,22 @@ describe('MergeCells keyboard shortcut', () => {
       keyDownUp(['shift', 'arrowright']);
 
       expect(getSelectedRange()).toEqualCellRange(['highlight: 1,1 from: 1,1 to: 2,9']);
+    });
+
+    it('should correctly extend the cells selection right by one cell when merged cell is selected (#11010)', () => {
+      handsontable({
+        data: createSpreadsheetData(10, 10),
+        rowHeaders: true,
+        colHeaders: true,
+        mergeCells: [
+          { row: 1, col: 1, rowspan: 3, colspan: 3 },
+        ],
+      });
+
+      selectCells([[1, 3, 3, 1]]);
+      keyDownUp(['shift', 'arrowright']);
+
+      expect(getSelectedRange()).toEqualCellRange(['highlight: 1,1 from: 1,1 to: 3,4']);
     });
 
     it('should expand the cells selection right keeping the internal current focus position when some columns are hidden', () => {

--- a/handsontable/src/selection/transformation.js
+++ b/handsontable/src/selection/transformation.js
@@ -206,31 +206,29 @@ class Transformation {
       const topStartCorner = cellRange.getTopStartCorner();
       const topEndCorner = cellRange.getTopEndCorner();
       const bottomEndCorner = cellRange.getBottomEndCorner();
-      const restDelta = {
-        row: coords.row - highlightRow,
-        col: coords.col - highlightColumn,
-      };
 
-      if (delta.col < 0) {
-        if (toColumn >= highlightColumn && coords.col < highlightColumn) {
-          coords.col = this.#findFirstNonHiddenZeroBasedColumn(topStartCorner.col, topEndCorner.col) + restDelta.col;
-        }
+      if (delta.col < 0 && toColumn >= highlightColumn && coords.col < highlightColumn) {
+        const columnRestDelta = coords.col - highlightColumn;
 
-      } else if (delta.col > 0) {
-        if (toColumn <= highlightColumn && coords.col > highlightColumn) {
-          coords.col = this.#findFirstNonHiddenZeroBasedColumn(topEndCorner.col, topStartCorner.col) + restDelta.col;
-        }
+        coords.col = this.#findFirstNonHiddenZeroBasedColumn(topStartCorner.col, topEndCorner.col) + columnRestDelta;
+
+      } else if (delta.col > 0 && toColumn <= highlightColumn && coords.col > highlightColumn) {
+        const endColumnIndex = this.#findFirstNonHiddenZeroBasedColumn(topEndCorner.col, topStartCorner.col);
+        const columnRestDelta = Math.max(coords.col - endColumnIndex, 1);
+
+        coords.col = endColumnIndex + columnRestDelta;
       }
 
-      if (delta.row < 0) {
-        if (toRow >= highlightRow && coords.row < highlightRow) {
-          coords.row = this.#findFirstNonHiddenZeroBasedRow(topStartCorner.row, bottomEndCorner.row) + restDelta.row;
-        }
+      if (delta.row < 0 && toRow >= highlightRow && coords.row < highlightRow) {
+        const rowRestDelta = coords.row - highlightRow;
 
-      } else if (delta.row > 0) {
-        if (toRow <= highlightRow && coords.row > highlightRow) {
-          coords.row = this.#findFirstNonHiddenZeroBasedRow(bottomEndCorner.row, topStartCorner.row) + restDelta.row;
-        }
+        coords.row = this.#findFirstNonHiddenZeroBasedRow(topStartCorner.row, bottomEndCorner.row) + rowRestDelta;
+
+      } else if (delta.row > 0 && toRow <= highlightRow && coords.row > highlightRow) {
+        const bottomRowIndex = this.#findFirstNonHiddenZeroBasedRow(bottomEndCorner.row, topStartCorner.row);
+        const rowRestDelta = Math.max(coords.row - bottomRowIndex, 1);
+
+        coords.row = bottomRowIndex + rowRestDelta;
       }
 
       const { rowDir, colDir } = this.#clampCoords(coords);


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the selection expansion that, in some cases, may cause the selection to be expanded for a wrong number of cells. The issue occurred only when the _MergeCells_ plugin was enabled.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and I covered the fix with new tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1927

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
