### PR TITLE
Typescript sandboxes for Codesandbox, Stackblitz and JSFiddle

### DIFF
--- a/docs/.vuepress/code-structure-builder/buildTypescriptBody.js
+++ b/docs/.vuepress/code-structure-builder/buildTypescriptBody.js
@@ -1,0 +1,91 @@
+const buildTypescriptBody = ({ id, html, ts, css, version, hyperformulaVersion, sandbox }) => {
+  if (sandbox === 'stackblitz') {
+    return {
+      files: {
+        'package.json': {
+          content: `{
+    "name": "handsontable",
+    "version": "1.0.0",
+    "description": "",
+    "dependencies": {
+      "hyperformula": "${hyperformulaVersion}",
+      "handsontable": "${version}"
+    }
+  }`
+        },
+        'index.html': {
+          content: `<!DOCTYPE html>
+  <html>
+    <head>
+      <meta charset="utf-8" />
+      <title>Handsontable</title>
+    </head>
+  
+    <body>
+      ${html || `<div id="${id}"></div>`}
+    </body>
+  </html>`
+        },
+        'styles.css': {
+          content: css
+        },
+        'index.ts': {
+          content: `import './styles.css'
+${ts}`
+        },
+      }
+    };
+  }
+
+  return {
+    files: {
+      'package.json': {
+        content: `{
+  "name": "handsontable",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.html",
+  "scripts": {
+    "start": "parcel --no-source-maps index.html --open",
+    "build": "parcel build index.html"
+  },
+  "dependencies": {
+    "hyperformula": "${hyperformulaVersion}",
+    "handsontable": "${version}",
+    "typescript": "latest"
+  },
+  "devDependencies": {
+    "@babel/core": "7.2.0",
+    "parcel-bundler": "^1.6.1"
+  }
+}`
+      },
+      'index.html': {
+        content: `<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Handsontable</title>
+    <link rel="stylesheet" href="src/styles.css" />
+    ${ts.includes('from \'hyperformula\'')
+    ? '<script src="https://cdn.jsdelivr.net/npm/hyperformula/dist/hyperformula.full.min.js"></script>'
+    : ''}
+  </head>
+
+  <body>
+    ${html || `<div id="${id}"></div>`}
+    <script src="src/index.ts"></script>
+  </body>
+</html>`
+      },
+      'src/styles.css': {
+        content: css
+      },
+      'src/index.ts': {
+        content: ts.replace('import { HyperFormula } from \'hyperformula\';', '')
+      }
+    }
+  };
+};
+
+module.exports = { buildTypescriptBody };

--- a/docs/.vuepress/code-structure-builder/getBody.js
+++ b/docs/.vuepress/code-structure-builder/getBody.js
@@ -1,6 +1,7 @@
 const { formatVersion } = require('../handsontable-manager/dependencies');
 const { buildAngularBody } = require('./buildAngularBody');
 const { buildJavascriptBody } = require('./buildJavascriptBody');
+const { buildTypescriptBody } = require('./buildTypescriptBody');
 const { buildReactBody } = require('./buildReactBody');
 const { buildVue3Body } = require('./buildVue3Body');
 const { buildVueBody } = require('./buildVueBody');
@@ -11,6 +12,8 @@ const getBody = (id, html, js, css, docsVersion, preset, sandbox) => {
 
   if (/hot(-.*)?/.test(preset)) {
     return buildJavascriptBody({ id, html, js, css, version, hyperformulaVersion, sandbox });
+  } else if(/ts(-.*)?/.test(preset)) {
+    return buildTypescriptBody({ id, html, ts: js, css, version, hyperformulaVersion, sandbox });
   } else if (/react(-.*)?/.test(preset)) {
     return buildReactBody({ js, css, version, hyperformulaVersion, preset, sandbox });
   } else if (/vue3(-.*)?/.test(preset)) {

--- a/docs/.vuepress/containers/examples/examples.js
+++ b/docs/.vuepress/containers/examples/examples.js
@@ -125,7 +125,7 @@ module.exports = function(docsVersion, base) {
 
         // Parse code
         const codeToCompile = parseCode(jsToken.content);
-        const codeToCompileSandbox = parseCodeSandbox(jsToken.content);
+        const codeToCompileSandbox = parseCodeSandbox(tsToken.content);
         const codeToPreview = parsePreview(jsToken.content, base);
         const tsCodeToPreview = parsePreview(tsToken?.content, base);
 
@@ -181,8 +181,8 @@ module.exports = function(docsVersion, base) {
                 <i class="ico i-code"></i>Source code
               </button>
               <div class="example-controls">
-                ${!noEdit ? stackblitz(id, htmlContent, codeToCompileSandbox, cssContent, docsVersion, preset) : ''}
-                ${!noEdit ? codesandbox(id, htmlContent, codeToCompileSandbox, cssContent, docsVersion, preset) : ''}
+                ${!noEdit ? stackblitz(id, htmlContent, codeToCompileSandbox, cssContent, docsVersion, 'ts') : ''}
+                ${!noEdit ? codesandbox(id, htmlContent, codeToCompileSandbox, cssContent, docsVersion, 'ts') : ''}
                 ${displayJsFiddle ? jsfiddle(id, htmlContent, codeForPreset, cssContent, docsVersion, preset) : ''}
                 <button 
                   aria-label="Reset the demo" 

--- a/docs/.vuepress/containers/examples/stackblitz.js
+++ b/docs/.vuepress/containers/examples/stackblitz.js
@@ -16,6 +16,8 @@ const stackblitz = (id, html, js, css, docsVersion, preset) => {
   const getTemplate = () => {
     if (preset.includes('react')) return 'create-react-app';
 
+    if (preset.includes('ts')) return 'typescript';
+
     if (preset.includes('hot')) return 'javascript';
 
     return 'node';


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->

This pull request adds the Codesandbox, Stackblitz and JSFiddle previews for the typescript version of the docs examples.

The Codesandbox button will work as follows:
- if the user is looking at the JS version of the code, it will open the JS Codesandbox preview
- otherwise, it will open the TS Codesandbox preview (if its available)

The Stackblitz and JSFiddle buttons will work analogically 

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

To be provided

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
https://github.com/handsontable/dev-handsontable/issues/1905

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
