### PR TITLE
Dosc theme-switch logic

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -155,7 +155,8 @@ module.exports = {
       `
       (function(w, d) {
         const colorScheme = localStorage.getItem('handsontable/docs::color-scheme');
-        const preferredScheme = colorScheme ? colorScheme : 'light';
+        const systemPrefersDark = w.matchMedia && w.matchMedia('(prefers-color-scheme: dark)').matches;
+        const preferredScheme = colorScheme ? colorScheme : (systemPrefersDark ? 'dark' : 'light');
 
         if (preferredScheme === 'dark') {
           d.documentElement.classList.add('theme-dark');


### PR DESCRIPTION
### Context
This pull request updates the script for setting the color scheme preference to consider system settings when the user has not explicitly selected a preference.

- Added logic to check the user's system color scheme preference using matchMedia('(prefers-color-scheme: dark)').
- Modified the preferredScheme logic to default to the system's preference if no user preference is stored in localStorage.

[skip changelog]