### PR TITLE
Update a wrong blog post link for the `14.4.0` release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 For more information on Handsontable 14.4.0, see:
 
-- [Blog post (14.4.0)](https://handsontable.com/blog/handsontable-14.4.0-enhanced-navigation-and-bug-fixes)
+- [Blog post (14.4.0)](https://handsontable.com/blog/handsontable-14.4.0-improved-stability)
 - [Documentation (14.4)](https://handsontable.com/docs/14.4)
 - [Release notes (14.4.0)](https://handsontable.com/docs/release-notes/#_14-4-0)
 

--- a/docs/content/guides/upgrade-and-migration/release-notes/release-notes.md
+++ b/docs/content/guides/upgrade-and-migration/release-notes/release-notes.md
@@ -30,7 +30,7 @@ See the full history of changes made to Handsontable in each major, minor, and p
 Released on June 11, 2024
 
 For more information on this release, see:
-- [Blog post (14.4.0)](https://handsontable.com/blog/handsontable-14.4.0-enhanced-navigation-and-bug-fixes)
+- [Blog post (14.4.0)](https://handsontable.com/blog/handsontable-14.4.0-improved-stability)
 - [Documentation (14.4)](https://handsontable.com/docs/14.4)
 
 ### Added


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
This PR updates the 14.4.0 blog post link in the `CHANGELOG.md` file and the docs' release notes.

[skip changelog]