### PR TITLE
Utilize the 'currentVersion' variable in the docs' links.

### DIFF
--- a/docs/content/guides/getting-started/demo/demo.md
+++ b/docs/content/guides/getting-started/demo/demo.md
@@ -42,11 +42,11 @@ Play around with a demo of Handsontable, in your favorite framework.
 
 <div class="boxes-list gray">
 
-- [JavaScript demo app](https://github.com/handsontable/handsontable/tree/prod-docs/14.4/examples/next/docs/js/demo/)
-- [TypeScript demo app](https://github.com/handsontable/handsontable/tree/prod-docs/14.4/examples/next/docs/ts/demo/)
-- [Angular demo app](https://github.com/handsontable/handsontable/tree/prod-docs/14.4/examples/next/docs/angular/demo/)
-- [React demo app](https://github.com/handsontable/handsontable/tree/prod-docs/14.4/examples/next/docs/react/demo/)
-- [Vue demo app](https://github.com/handsontable/handsontable/tree/prod-docs/14.4/examples/next/docs/vue/demo/)
+- <Link :href="`https://github.com/handsontable/handsontable/tree/prod-docs/${$page.currentVersion}/examples/next/docs/js/demo/`">JavaScript demo app</Link>
+- <Link :href="`https://github.com/handsontable/handsontable/tree/prod-docs/${$page.currentVersion}/examples/next/docs/ts/demo/`">TypeScript demo app</Link>
+- <Link :href="`https://github.com/handsontable/handsontable/tree/prod-docs/${$page.currentVersion}/examples/next/docs/angular/demo/`">Angular demo app</Link>
+- <Link :href="`https://github.com/handsontable/handsontable/tree/prod-docs/${$page.currentVersion}/examples/next/docs/react/demo/`">React demo app</Link>
+- <Link :href="`https://github.com/handsontable/handsontable/tree/prod-docs/${$page.currentVersion}/examples/next/docs/vue/demo/`">Vue demo app</Link>
 
 </div>
 


### PR DESCRIPTION
### Context
This PR makes the docs use the `currentVersion` variable in the "Find the code on GitHub" section of the docs.

[skip changelog]

