### PR TITLE
Mark internal modules as `private`

### DIFF
--- a/handsontable/src/plugins/mergeCells/renderer.js
+++ b/handsontable/src/plugins/mergeCells/renderer.js
@@ -17,8 +17,9 @@ export function createMergeCellRenderer(plugin) {
   } = hot;
 
   /**
-   * @private
    * Runs before the cell is rendered.
+   *
+   * @private
    */
   function before() {}
 

--- a/handsontable/src/plugins/mergeCells/renderer.js
+++ b/handsontable/src/plugins/mergeCells/renderer.js
@@ -3,6 +3,7 @@ import { isObject } from '../../helpers/object';
 /**
  * Creates a renderer object for the `MergeCells` plugin.
  *
+ * @private
  * @param {MergeCells} plugin The `MergeCells` plugin instance.
  * @returns {{before: Function, after: Function}}
  */
@@ -16,6 +17,7 @@ export function createMergeCellRenderer(plugin) {
   } = hot;
 
   /**
+   * @private
    * Runs before the cell is rendered.
    */
   function before() {}
@@ -23,6 +25,7 @@ export function createMergeCellRenderer(plugin) {
   /**
    * Runs after the cell is rendered.
    *
+   * @private
    * @param {HTMLElement} TD The cell to be modified.
    * @param {number} row Row index.
    * @param {number} col Visual column index.


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR marks the internal _MergeCells_ plugin module as internal.

_[skip changelog]_

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
