### PR TITLE
Reset cells states after no data change

### DIFF
--- a/.changelogs/11035.json
+++ b/.changelogs/11035.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed invalid cells states after data population that was canceled in the `beforeChange` hook.",
+  "type": "fixed",
+  "issueOrPR": 11035,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/test/e2e/Core_render.spec.js
+++ b/handsontable/test/e2e/Core_render.spec.js
@@ -79,6 +79,27 @@ describe('Core_render', () => {
     expect(afterRender).toHaveBeenCalledTimes(2); // 1 from load and 1 from populateFromArray
   });
 
+  it('should render the table when there is no changes in the dataset', () => {
+    const afterRender = jasmine.createSpy('afterRender');
+
+    handsontable({
+      data: [
+        ['Joe Red']
+      ],
+      beforeChange(changes) {
+        changes.length = 0;
+      },
+      afterRender,
+    });
+
+    afterRender.calls.reset();
+    setDataAtCell(0, 0, 'Test');
+
+    // even though the changes are canceled, the table should be rendered to reset
+    // the cells states (e.g. validation CSS classes)
+    expect(afterRender).toHaveBeenCalledTimes(1);
+  });
+
   it('should run afterRenderer hook', () => {
     let lastCellProperties;
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes an issue where the cell states were not updated after the table was updated with new data that was cleared/unset in the `beforeChange` hook (or in the validator). Previously, the table skipped its render when no changes were detected, which caused the cells to appear in the previous state. Now, the render always occurs whether the data was passed or not.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and I covered the fix with a new test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/774

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
