### PR TITLE
Implement undo/redo for `columnSorting`/`multiColumnSorting` + other improvements.

### DIFF
--- a/.changelogs/11037.json
+++ b/.changelogs/11037.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Implemented the Undo/Redo logic for the ColumnSorting/ManualColumnSorting plugins and made some adjustments for it to work properly.",
+  "type": "added",
+  "issueOrPR": 11037,
+  "breaking": false,
+  "framework": "none"
+}

--- a/docs/content/guides/rows/rows-sorting/rows-sorting.md
+++ b/docs/content/guides/rows/rows-sorting/rows-sorting.md
@@ -340,8 +340,7 @@ const configurationOptions = {
 
 :::
 
-The [`columnSorting`](@/api/options.md#columnsorting) and [`multiColumnSorting`](@/api/options.md#multicolumnsorting) options override each other. If you use
-them both, the one defined later takes precedence.
+The [`columnSorting`](@/api/options.md#columnsorting) and [`multiColumnSorting`](@/api/options.md#multicolumnsorting) options are mutually exclusive, so don't enable them together. If you do so, [`columnSorting`](@/api/options.md#columnsorting) will be automatically disabled, as it's being overridden by [`multiColumnSorting`](@/api/options.md#multicolumnsorting).
 
 ## Set an initial sort order
 

--- a/handsontable/src/plugins/columnSorting/__tests__/columnSorting.spec.js
+++ b/handsontable/src/plugins/columnSorting/__tests__/columnSorting.spec.js
@@ -3019,6 +3019,68 @@ describe('ColumnSorting', () => {
     ]);
   });
 
+  describe('undo/redo', () => {
+    it('should be able to undo the sorting action', () => {
+      const hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(3, 3),
+        columnSorting: true
+      });
+
+      hot.getPlugin('columnSorting').sort({
+        column: 0,
+        sortOrder: 'desc'
+      });
+
+      expect(getData()).toEqual([
+        ['A3', 'B3', 'C3'],
+        ['A2', 'B2', 'C2'],
+        ['A1', 'B1', 'C1']
+      ]);
+
+      hot.undo();
+
+      expect(getData()).toEqual([
+        ['A1', 'B1', 'C1'],
+        ['A2', 'B2', 'C2'],
+        ['A3', 'B3', 'C3']
+      ]);
+    });
+
+    it('should be able to redo the sorting action', () => {
+      const hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(3, 3),
+        columnSorting: true
+      });
+
+      hot.getPlugin('columnSorting').sort({
+        column: 0,
+        sortOrder: 'desc'
+      });
+
+      expect(getData()).toEqual([
+        ['A3', 'B3', 'C3'],
+        ['A2', 'B2', 'C2'],
+        ['A1', 'B1', 'C1']
+      ]);
+
+      hot.undo();
+
+      expect(getData()).toEqual([
+        ['A1', 'B1', 'C1'],
+        ['A2', 'B2', 'C2'],
+        ['A3', 'B3', 'C3']
+      ]);
+
+      hot.redo();
+
+      expect(getData()).toEqual([
+        ['A3', 'B3', 'C3'],
+        ['A2', 'B2', 'C2'],
+        ['A1', 'B1', 'C1']
+      ]);
+    });
+  });
+
   describe('cooperation with alter actions', () => {
     it('should sort proper column after removing column right before the already sorted one', () => {
       handsontable({

--- a/handsontable/src/plugins/columnSorting/columnSorting.js
+++ b/handsontable/src/plugins/columnSorting/columnSorting.js
@@ -198,6 +198,8 @@ export class ColumnSorting extends BasePlugin {
       if (this.indexesSequenceCache !== null) {
         this.hot.rowIndexMapper.setIndexesSequence(this.indexesSequenceCache.getValues());
         this.hot.rowIndexMapper.unregisterMap(this.pluginKey);
+
+        this.indexesSequenceCache = null;
       }
     }, true);
 
@@ -617,9 +619,9 @@ export class ColumnSorting extends BasePlugin {
    * @private
    */
   sortByPresetSortStates(sortConfigs) {
-    if (sortConfigs.length === 0) {
-      this.hot.rowIndexMapper.setIndexesSequence(this.indexesSequenceCache.getValues());
+    this.hot.rowIndexMapper.setIndexesSequence(this.indexesSequenceCache.getValues());
 
+    if (sortConfigs.length === 0) {
       return;
     }
 

--- a/handsontable/src/plugins/multiColumnSorting/__tests__/multiColumnSorting.spec.js
+++ b/handsontable/src/plugins/multiColumnSorting/__tests__/multiColumnSorting.spec.js
@@ -71,6 +71,22 @@ describe('MultiColumnSorting', () => {
     expect(htCore.find('tbody tr:eq(0) td:eq(3)').text()).toEqual('5');
   });
 
+  it('should disable the `columnSorting` plugin and throw a warning when both `columnSorting` and `multiColumnSorting` are enabled', () => {
+    const warnSpy = spyOn(console, 'warn');
+
+    handsontable({
+      data: arrayOfObjects(),
+      colHeaders: true,
+      columnSorting: true,
+      multiColumnSorting: true
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith('Plugins `columnSorting` and `multiColumnSorting` should not be enabled ' +
+      'simultaneously. Only `multiColumnSorting` will work. The `columnSorting` plugin will be disabled.');
+
+    expect(getPlugin('columnSorting').enabled).toBe(false);
+  });
+
   it('should not change row indexes in the sorted table after using `disablePlugin` until next render is called', () => {
     handsontable({
       data: [
@@ -3524,5 +3540,130 @@ describe('MultiColumnSorting', () => {
 
     expect(window.getComputedStyle(sortedColumn1, ':before').getPropertyValue('background-image')).not.toMatch(/url/);
     expect(window.getComputedStyle(sortedColumn2, ':before').getPropertyValue('background-image')).toMatch(/url/);
+  });
+
+  describe('undo/redo', () => {
+    it('should be able to undo the sorting action', () => {
+      const hot = handsontable({
+        data: [
+          ['Alice', 'Smith', 'Eve'],
+          ['Bob', 'Johnson', 'Grace'],
+          ['Alice', 'Brown', 'Liam'],
+          ['Alice', 'Miller', 'Olivia'],
+          ['David', 'Lee', 'Sophia']
+        ],
+        multiColumnSorting: true,
+        colHeaders: true,
+      });
+
+      hot.getPlugin('multiColumnSorting').sort([{
+        column: 0,
+        sortOrder: 'desc'
+      }]);
+
+      expect(getData()).toEqual([
+        ['David', 'Lee', 'Sophia'],
+        ['Bob', 'Johnson', 'Grace'],
+        ['Alice', 'Smith', 'Eve'],
+        ['Alice', 'Brown', 'Liam'],
+        ['Alice', 'Miller', 'Olivia']
+      ]);
+
+      hot.getPlugin('multiColumnSorting').sort([{
+        column: 0,
+        sortOrder: 'desc'
+      }, {
+        column: 1,
+        sortOrder: 'desc'
+      }]);
+
+      expect(getData()).toEqual([
+        ['David', 'Lee', 'Sophia'],
+        ['Bob', 'Johnson', 'Grace'],
+        ['Alice', 'Smith', 'Eve'],
+        ['Alice', 'Miller', 'Olivia'],
+        ['Alice', 'Brown', 'Liam']
+      ]);
+
+      hot.undo();
+
+      expect(getData()).toEqual([
+        ['David', 'Lee', 'Sophia'],
+        ['Bob', 'Johnson', 'Grace'],
+        ['Alice', 'Smith', 'Eve'],
+        ['Alice', 'Brown', 'Liam'],
+        ['Alice', 'Miller', 'Olivia']
+      ]);
+
+      hot.undo();
+
+      expect(getData()).toEqual([
+        ['Alice', 'Smith', 'Eve'],
+        ['Bob', 'Johnson', 'Grace'],
+        ['Alice', 'Brown', 'Liam'],
+        ['Alice', 'Miller', 'Olivia'],
+        ['David', 'Lee', 'Sophia']
+      ]);
+    });
+
+    it('should be able to redo the sorting action', () => {
+      const hot = handsontable({
+        data: [
+          ['Alice', 'Smith', 'Eve'],
+          ['Bob', 'Johnson', 'Grace'],
+          ['Alice', 'Brown', 'Liam'],
+          ['Alice', 'Miller', 'Olivia'],
+          ['David', 'Lee', 'Sophia']
+        ],
+        multiColumnSorting: true,
+        colHeaders: true,
+      });
+
+      hot.getPlugin('multiColumnSorting').sort([
+        {
+          column: 0,
+          sortOrder: 'desc'
+        }]);
+
+      hot.getPlugin('multiColumnSorting').sort([
+        {
+          column: 0,
+          sortOrder: 'desc'
+        }, {
+          column: 1,
+          sortOrder: 'desc'
+        }]);
+
+      hot.undo();
+      hot.undo();
+
+      expect(getData()).toEqual([
+        ['Alice', 'Smith', 'Eve'],
+        ['Bob', 'Johnson', 'Grace'],
+        ['Alice', 'Brown', 'Liam'],
+        ['Alice', 'Miller', 'Olivia'],
+        ['David', 'Lee', 'Sophia']
+      ]);
+
+      hot.redo();
+
+      expect(getData()).toEqual([
+        ['David', 'Lee', 'Sophia'],
+        ['Bob', 'Johnson', 'Grace'],
+        ['Alice', 'Smith', 'Eve'],
+        ['Alice', 'Brown', 'Liam'],
+        ['Alice', 'Miller', 'Olivia']
+      ]);
+
+      hot.redo();
+
+      expect(getData()).toEqual([
+        ['David', 'Lee', 'Sophia'],
+        ['Bob', 'Johnson', 'Grace'],
+        ['Alice', 'Smith', 'Eve'],
+        ['Alice', 'Miller', 'Olivia'],
+        ['Alice', 'Brown', 'Liam']
+      ]);
+    });
   });
 });

--- a/handsontable/src/plugins/multiColumnSorting/multiColumnSorting.js
+++ b/handsontable/src/plugins/multiColumnSorting/multiColumnSorting.js
@@ -104,6 +104,8 @@ export class MultiColumnSorting extends ColumnSorting {
   enablePlugin() {
     if (!this.enabled && this.hot.getSettings()[this.pluginKey] && this.hot.getSettings()[CONFLICTED_PLUGIN_KEY]) {
       warnAboutPluginsConflict();
+
+      this.hot.getPlugin(CONFLICTED_PLUGIN_KEY).disablePlugin();
     }
 
     super.enablePlugin();

--- a/handsontable/src/plugins/multiColumnSorting/utils.js
+++ b/handsontable/src/plugins/multiColumnSorting/utils.js
@@ -6,5 +6,5 @@ import { toSingleLine } from '../../helpers/templateLiteralTag';
  */
 export function warnAboutPluginsConflict() {
   warn(toSingleLine`Plugins \`columnSorting\` and \`multiColumnSorting\` should not be enabled simultaneously. 
-    Only \`multiColumnSorting\` will work.`);
+    Only \`multiColumnSorting\` will work. The \`columnSorting\` plugin will be disabled.`);
 }

--- a/handsontable/src/plugins/undoRedo/undoRedo.js
+++ b/handsontable/src/plugins/undoRedo/undoRedo.js
@@ -207,6 +207,14 @@ function UndoRedo(instance) {
     plugin.done(() => new UndoRedo.UnmergeCellsAction(instance, cellRange));
   });
 
+  instance.addHook('beforeColumnSort', (currentSortConfig, destinationSortConfigs, sortPossible) => {
+    if (!sortPossible) {
+      return;
+    }
+
+    plugin.done(() => new UndoRedo.ColumnSortAction(currentSortConfig, destinationSortConfigs));
+  });
+
   // TODO: Why this callback is needed? One test doesn't pass after calling method right after plugin creation (outside the callback).
   instance.addHook('afterInit', () => {
     plugin.init();
@@ -973,6 +981,44 @@ UndoRedo.ColumnMoveAction.prototype.redo = function(instance, redoneCallback) {
 
   instance.deselectCell();
   instance.selectColumns(this.finalColumnIndex, this.finalColumnIndex + this.columns.length - 1);
+};
+
+/**
+ * ColumnSort action.
+ *
+ * @private
+ * @param {Array} currentSortState The current sort state.
+ * @param {Array} newSortState The new sort state.
+ */
+UndoRedo.ColumnSortAction = function(currentSortState, newSortState) {
+  this.previousSortState = currentSortState;
+  this.nextSortState = newSortState;
+};
+inherit(UndoRedo.ColumnSortAction, UndoRedo.Action);
+
+UndoRedo.ColumnSortAction.prototype.undo = function(instance, undoneCallback) {
+  const sortPlugin = instance.getPlugin('columnSorting');
+  const multiSortPlugin = instance.getPlugin('multiColumnSorting');
+  const enabledSortPlugin = multiSortPlugin.isEnabled() ? multiSortPlugin : sortPlugin;
+
+  if (this.previousSortState.length) {
+    enabledSortPlugin.sort(this.previousSortState);
+
+  } else {
+    enabledSortPlugin.clearSort();
+  }
+
+  undoneCallback();
+};
+
+UndoRedo.ColumnSortAction.prototype.redo = function(instance, redoneCallback) {
+  const sortPlugin = instance.getPlugin('columnSorting');
+  const multiSortPlugin = instance.getPlugin('multiColumnSorting');
+  const enabledSortPlugin = multiSortPlugin.isEnabled() ? multiSortPlugin : sortPlugin;
+
+  enabledSortPlugin.sort(this.nextSortState);
+
+  redoneCallback();
 };
 
 /**


### PR DESCRIPTION
### Context
This PR:

- Implements the Undo/Redo logic for `columnSorting`/`multiColumnSorting`
- Fixes a problem where removing one of the sort configs from `multiColumnSorting`'s array of configs did not reset the unsorted columns properly
- Modifies the `columnSorting`/`multiColumnSorting` conflict warning to be more precise
- Makes the `multiColumnSorting` plugin disable `columnSorting` plugin when there's a conflict between them (when both of them are enabled at the same time)
- Modifies the docs to reflect the actual state of `columnSorting`/`manualColumnSorting` better (basically, that they're conflicted with each other, and that the order of defining them does not matter)
- Adds test cases

### How has this been tested?
Added test cases.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#916

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
