### PR TITLE
Fix a problem with the `formulas` plugin using wrong indexes when performing autofill.

### DIFF
--- a/.changelogs/11038.json
+++ b/.changelogs/11038.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed a problem with the Formulas plugin using wrong indexes when performing autofill. ",
+  "type": "fixed",
+  "issueOrPR": 11038,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/formulas/__tests__/featureIntegration.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/featureIntegration.spec.js
@@ -184,18 +184,19 @@ describe('Formulas: Integration with other features', () => {
     it('should populate dates and formulas referencing to them properly', async() => {
       handsontable({
         data: [
-          ['28/02/1900', '28/02/1900', '28/02/1900'],
-          ['=A1', '=B1', '=C1'],
-          [null, null, null],
-          [null, null, null],
-          [null, null, null],
-          [null, null, null],
+          [null, null, null, null, null],
+          [null, null, '28/02/1900', '28/02/1900', '28/02/1900'],
+          [null, null, '=C2', '=D2', '=E2'],
+          [null, null, null, null, null],
+          [null, null, null, null, null],
+          [null, null, null, null, null],
+          [null, null, null, null, null],
         ],
         formulas: {
           engine: HyperFormula,
           sheetName: 'Sheet1'
         },
-        columns: [{
+        columns: [{}, {}, {
           type: 'date',
           dateFormat: 'MM/DD/YYYY'
         }, {
@@ -208,69 +209,73 @@ describe('Formulas: Integration with other features', () => {
         fillHandle: true,
       });
 
-      selectRows(0, 1);
+      selectCells([[1, 2, 2, 4]]);
 
       spec().$container.find('.wtBorder.current.corner').simulate('mousedown');
-      spec().$container.find('tr:last-child td:eq(0)').simulate('mouseover');
-      spec().$container.find('tr:last-child td:eq(2)').simulate('mouseup');
+      spec().$container.find('tr:last-child td:eq(2)').simulate('mouseover');
+      spec().$container.find('tr:last-child td:eq(4)').simulate('mouseup');
 
       const formulasPlugin = getPlugin('formulas');
 
       await sleep(300);
 
       expect(getData()).toEqual([
-        ['28/02/1900', '28/02/1900', '28/02/1900'],
-        ['28/02/1900', '28/02/1900', '28/02/1900'],
-        ['28/02/1900', '28/02/1900', '28/02/1900'],
-        ['28/02/1900', '28/02/1900', '28/02/1900'],
-        ['28/02/1900', '28/02/1900', '28/02/1900'],
-        ['28/02/1900', '28/02/1900', '28/02/1900'],
-        [null, null, null]
+        [null, null, null, null, null],
+        [null, null, '28/02/1900', '28/02/1900', '28/02/1900'],
+        [null, null, '28/02/1900', '28/02/1900', '28/02/1900'],
+        [null, null, '28/02/1900', '28/02/1900', '28/02/1900'],
+        [null, null, '28/02/1900', '28/02/1900', '28/02/1900'],
+        [null, null, '28/02/1900', '28/02/1900', '28/02/1900'],
+        [null, null, '28/02/1900', '28/02/1900', '28/02/1900'],
+        [null, null, null, null, null]
       ]);
 
       expect(getSourceData()).toEqual([
-        ['28/02/1900', '28/02/1900', '28/02/1900'],
-        ['=A1', '=B1', '=C1'],
-        ['28/02/1900', '28/02/1900', '28/02/1900'],
-        ['=A3', '=B3', '=C3'],
-        ['28/02/1900', '28/02/1900', '28/02/1900'],
-        ['=A5', '=B5', '=C5'],
-        [null, null, null]
+        [null, null, null, null, null],
+        [null, null, '28/02/1900', '28/02/1900', '28/02/1900'],
+        [null, null, '=C2', '=D2', '=E2'],
+        [null, null, '28/02/1900', '28/02/1900', '28/02/1900'],
+        [null, null, '=C4', '=D4', '=E4'],
+        [null, null, '28/02/1900', '28/02/1900', '28/02/1900'],
+        [null, null, '=C6', '=D6', '=E6'],
+        [null, null, null, null, null]
       ]);
 
       expect(formulasPlugin.engine.getSheetValues(0)).toEqual([
-        ['28/02/1900', 60, '28/02/1900'],
-        ['28/02/1900', 60, '28/02/1900'],
-        ['28/02/1900', 60, '28/02/1900'],
-        ['28/02/1900', 60, '28/02/1900'],
-        ['28/02/1900', 60, '28/02/1900'],
-        ['28/02/1900', 60, '28/02/1900'],
+        [],
+        [null, null, '28/02/1900', 60, '28/02/1900'],
+        [null, null, '28/02/1900', 60, '28/02/1900'],
+        [null, null, '28/02/1900', 60, '28/02/1900'],
+        [null, null, '28/02/1900', 60, '28/02/1900'],
+        [null, null, '28/02/1900', 60, '28/02/1900'],
+        [null, null, '28/02/1900', 60, '28/02/1900'],
       ]);
 
       expect(formulasPlugin.engine.getSheetSerialized(0)).toEqual([
-        ['\'28/02/1900', '28/02/1900', '\'28/02/1900'],
-        ['=A1', '=B1', '=C1'],
-        ['\'28/02/1900', '28/02/1900', '\'28/02/1900'],
-        ['=A3', '=B3', '=C3'],
-        ['\'28/02/1900', '28/02/1900', '\'28/02/1900'],
-        ['=A5', '=B5', '=C5'],
+        [],
+        [null, null, '\'28/02/1900', '28/02/1900', '\'28/02/1900'],
+        [null, null, '=C2', '=D2', '=E2'],
+        [null, null, '\'28/02/1900', '28/02/1900', '\'28/02/1900'],
+        [null, null, '=C4', '=D4', '=E4'],
+        [null, null, '\'28/02/1900', '28/02/1900', '\'28/02/1900'],
+        [null, null, '=C6', '=D6', '=E6'],
       ]);
 
-      expect(getCellMeta(2, 0).valid).toBe(false);
-      expect(getCellMeta(2, 1).valid).toBe(true);
-      expect(getCellMeta(2, 2).valid).toBe(false);
-
-      expect(getCellMeta(3, 0).valid).toBe(false);
-      expect(getCellMeta(3, 1).valid).toBe(true);
       expect(getCellMeta(3, 2).valid).toBe(false);
+      expect(getCellMeta(3, 3).valid).toBe(true);
+      expect(getCellMeta(3, 4).valid).toBe(false);
 
-      expect(getCellMeta(4, 0).valid).toBe(false);
-      expect(getCellMeta(4, 1).valid).toBe(true);
       expect(getCellMeta(4, 2).valid).toBe(false);
+      expect(getCellMeta(4, 3).valid).toBe(true);
+      expect(getCellMeta(4, 4).valid).toBe(false);
 
-      expect(getCellMeta(5, 0).valid).toBe(false);
-      expect(getCellMeta(5, 1).valid).toBe(true);
       expect(getCellMeta(5, 2).valid).toBe(false);
+      expect(getCellMeta(5, 3).valid).toBe(true);
+      expect(getCellMeta(5, 4).valid).toBe(false);
+
+      expect(getCellMeta(6, 2).valid).toBe(false);
+      expect(getCellMeta(6, 3).valid).toBe(true);
+      expect(getCellMeta(6, 4).valid).toBe(false);
     });
   });
 

--- a/handsontable/src/plugins/formulas/formulas.js
+++ b/handsontable/src/plugins/formulas/formulas.js
@@ -688,8 +688,8 @@ export class Formulas extends BasePlugin {
       for (let populatedColumnIndex = 0; populatedColumnIndex < fillRangeData[populatedRowIndex].length;
         populatedColumnIndex += 1) {
         const populatedValue = fillRangeData[populatedRowIndex][populatedColumnIndex];
-        const sourceRow = populatedRowIndex % populationRowLength;
-        const sourceColumn = populatedColumnIndex % populationColumnLength;
+        const sourceRow = sourceStartRow + (populatedRowIndex % populationRowLength);
+        const sourceColumn = sourceStartColumn + (populatedColumnIndex % populationColumnLength);
         const sourceCellMeta = this.hot.getCellMeta(sourceRow, sourceColumn);
 
         if (isDate(populatedValue, sourceCellMeta.type)) {


### PR DESCRIPTION
### Context
This PR:
- Corrects the row and column indexes being used in the Formulas plugin when performing autofill

### How has this been tested?
Modified an existing test case to check for this kind of problems.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#1889

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
