### PR TITLE
Reset the internal offset values after disabling `navigableHeaders`

### DIFF
--- a/.changelogs/11043.json
+++ b/.changelogs/11043.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed a problem, where disabling `navigableHeaders` broke keyboard navigation in the first row, if the option was previously enabled and used.",
+  "type": "fixed",
+  "issueOrPR": 11043,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/selection/__tests__/keyboardShortcuts/arrowLeft.spec.js
+++ b/handsontable/src/selection/__tests__/keyboardShortcuts/arrowLeft.spec.js
@@ -130,6 +130,27 @@ describe('Selection navigation', () => {
         expect(getSelectedRange()).toEqualCellRange(['highlight: 0,4 from: 0,4 to: 0,4']);
       });
 
+      it('should move the cell selection to the last column of the row above, if the first column is already' +
+        ' selected (navigableHeaders: on -> navigableHeaders: off)', () => {
+        handsontable({
+          startRows: 5,
+          startCols: 5,
+          rowHeaders: true,
+          navigableHeaders: true,
+          autoWrapRow: true
+        });
+
+        selectCell(1, 0);
+        keyDownUp('arrowleft');
+
+        updateSettings({ navigableHeaders: false });
+
+        selectCell(1, 0);
+        keyDownUp('arrowleft');
+
+        expect(getSelectedRange()).toEqualCellRange(['highlight: 0,4 from: 0,4 to: 0,4']);
+      });
+
       it('should move the cell selection to the last column of the row above, if the first column is already selected (with headers)', () => {
         handsontable({
           startRows: 5,

--- a/handsontable/src/selection/__tests__/keyboardShortcuts/arrowUp.spec.js
+++ b/handsontable/src/selection/__tests__/keyboardShortcuts/arrowUp.spec.js
@@ -132,6 +132,27 @@ describe('Selection navigation', () => {
         expect(getSelectedRange()).toEqualCellRange(['highlight: 4,0 from: 4,0 to: 4,0']);
       });
 
+      it('should move the cell selection to the last row of the previous column, if the first row is already' +
+        ' selected (navigableHeaders: on -> navigableHeaders: off)', () => {
+        handsontable({
+          startRows: 5,
+          startCols: 5,
+          colHeaders: true,
+          navigableHeaders: true,
+          autoWrapCol: true
+        });
+
+        selectCell(0, 1);
+        keyDownUp('arrowup');
+
+        updateSettings({ navigableHeaders: false });
+
+        selectCell(0, 1);
+        keyDownUp('arrowup');
+
+        expect(getSelectedRange()).toEqualCellRange(['highlight: 4,0 from: 4,0 to: 4,0']);
+      });
+
       it('should move the cell selection to the last row of the previous column, if the first row is already selected (with headers)', () => {
         handsontable({
           startRows: 5,

--- a/handsontable/src/selection/selection.js
+++ b/handsontable/src/selection/selection.js
@@ -594,6 +594,9 @@ class Selection {
         x: this.tableProps.countRowHeaders(),
         y: this.tableProps.countColHeaders(),
       });
+
+    } else {
+      this.#transformation.resetOffsetSize();
     }
 
     this.setRangeStart(this.#transformation.transformStart(rowDelta, colDelta, createMissingRecords));
@@ -611,6 +614,9 @@ class Selection {
         x: this.tableProps.countRowHeaders(),
         y: this.tableProps.countColHeaders(),
       });
+
+    } else {
+      this.#transformation.resetOffsetSize();
     }
 
     this.setRangeEnd(this.#transformation.transformEnd(rowDelta, colDelta));

--- a/handsontable/src/selection/transformation.js
+++ b/handsontable/src/selection/transformation.js
@@ -266,6 +266,16 @@ class Transformation {
   }
 
   /**
+   * Resets the offset size to the default values.
+   */
+  resetOffsetSize() {
+    this.#offset = {
+      x: 0,
+      y: 0
+    };
+  }
+
+  /**
    * Clamps the coords to make sure they points to the cell (or header) in the table range.
    *
    * @param {CellCoords} zeroBasedCoords The coords object to clamp.


### PR DESCRIPTION
### Context
This PR:
- Resets the internal `offset` values of the `Transformation` class to `0` if `navigableHeaders` was disabled
- Adds test cases to cover the problem from handsontable/dev-handsontable#1942

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
- Added test cases to cover the problem from handsontable/dev-handsontable#1942

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#1942

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
