### PR TITLE
Fix the docs' Accessibility page demo being shifted up after navigating over it with the `TAB` key.

### DIFF
--- a/docs/.vuepress/theme/styles/components/tabs.styl
+++ b/docs/.vuepress/theme/styles/components/tabs.styl
@@ -27,9 +27,9 @@
         min-height: 32px
         border-radius: 0 0 $radius $radius !important
 
-        pre { 
+        pre {
             margin: -16px -16px -40px
-            border-radius: 0 
+            border-radius: 0
             border-radius: 0 0 $radius $radius !important
         }
 
@@ -40,7 +40,7 @@
 
     ul.tabs-component-tabs  {
         background: $editorHeadColor
-        padding: 8px 
+        padding: 8px
         border-bottom: none
         box-sizing: border-box;
         border-radius: $radius $radius 0 0 !important
@@ -48,7 +48,7 @@
         gap: 8px
 
         li.tabs-component-tab  {
-            &:first-child:last-child { 
+            &:first-child:last-child {
             //    visibility: hidden
             }
 
@@ -66,16 +66,16 @@
                 border: 1px solid $onsurfaceColor
 
                 @media (hover: hover) {
-                    &:hover { 
+                    &:hover {
                         color: $textColor
                     }
                 }
             }
 
-            &.is-active { 
+            &.is-active {
                 font-weight: 400
                 border-bottom:0
-                
+
                 a {
                     color: $textColor
                     background: white
@@ -104,19 +104,19 @@
     .controls {
         padding-bottom: 16px
 
-        > button { 
+        > button {
             margin-right: 8px
         }
     }
-    .example-controls-container .controls { 
-        padding-bottom: 0 
+    .example-controls-container .controls {
+        padding-bottom: 0
     }
 
     .checkbox-container {
         margin: 16px 0
         display: block
 
-        .checkbox-group > div { 
+        .checkbox-group > div {
             display: flex
             font-size: $font-size-xs
             line-height: 32px
@@ -131,7 +131,7 @@
                 }
             }
 
-            > a { 
+            > a {
                 //margin-left: auto
                 margin-right: 0
             }
@@ -158,7 +158,7 @@
     }
 
     .tabs-button-list {
-        display: flex 
+        display: flex
         gap: 8px
         background: $editorColor
         border-radius: $radius
@@ -174,7 +174,7 @@
                 //border: 1px solid $accentColor !important
             }
 
-            + .example-container-code { 
+            + .example-container-code {
                 visibility visible
                 opacity 1
                 max-height: 100vh
@@ -198,7 +198,7 @@
             }
         }
 
-        .example-controls { 
+        .example-controls {
             display: flex
             height: 36px
 
@@ -209,7 +209,7 @@
                 width: 36px
                 position: relative
 
-                i, svg { 
+                i, svg {
                     opacity: .7
                     transition: all $ts ease-in-out
                 }
@@ -228,8 +228,8 @@
 
                 @media (hover: hover) {
                     &:hover {
-                        i, svg { 
-                            opacity 1 
+                        i, svg {
+                            opacity 1
                         }
                     }
                 }
@@ -281,11 +281,11 @@
     margin-bottom: 0;
     padding: 8px 8px 0 0;
 
-    br { 
+    br {
         display: none
     }
 
-    .handsontable br { 
+    .handsontable br {
         display: block
     }
 
@@ -293,7 +293,11 @@
         margin: 4px
     }
 
-    #mainInput, select:not(.htSelectEditor), input[type=text], input[type=search], .placeholder-input {
+    #mainInput,
+    select:not(.htSelectEditor),
+    input[type=text]:not(.htFocusCatcher),
+    input[type=search],
+    .placeholder-input {
         padding: 8px 16px;
         font-size: $font-size-xs
         line-height: $line-height-xs
@@ -310,12 +314,12 @@
     }
 
     &.select-language {
-        label { 
+        label {
             display: block
         }
     }
-    
-    &:last-child { 
+
+    &:last-child {
         margin-bottom:0
     }
 }


### PR DESCRIPTION
### Context
This PR:
- Excludes the Handsontable's focus catcher input from being styled by the docs' stylesheet.

[skip changelog]

### How has this been tested?
Tested manually

### Related issue(s):
1. handsontable/dev-handsontable#1941

