### PR TITLE
Fix the header selection with `nestedHeaders` enabled not working on mobile devices.

### DIFF
--- a/.changelogs/11051.json
+++ b/.changelogs/11051.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed the header selection with `nestedHeaders` enabled not working on mobile devices.",
+  "type": "fixed",
+  "issueOrPR": 11051,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/helpers/dom/__tests__/dom.types.ts
+++ b/handsontable/src/helpers/dom/__tests__/dom.types.ts
@@ -55,6 +55,7 @@ Handsontable.dom.isInput(domElement);
 Handsontable.dom.isLeftClick(domEvent);
 Handsontable.dom.isOutsideInput(domElement);
 Handsontable.dom.isRightClick(domEvent);
+Handsontable.dom.isTouchEvent(domEvent);
 Handsontable.dom.isVisible(domElement);
 Handsontable.dom.matchesCSSRules(domElement, cssRule);
 Handsontable.dom.offset(domElement);

--- a/handsontable/src/helpers/dom/__tests__/event.unit.js
+++ b/handsontable/src/helpers/dom/__tests__/event.unit.js
@@ -1,4 +1,4 @@
-import { isLeftClick, isRightClick } from 'handsontable/helpers/dom/event';
+import { isLeftClick, isRightClick, isTouchEvent } from 'handsontable/helpers/dom/event';
 
 describe('DomEvent helper', () => {
   //
@@ -35,6 +35,19 @@ describe('DomEvent helper', () => {
       expect(isRightClick({ button: null })).toBe(false);
       expect(isRightClick({ button: undefined })).toBe(false);
       expect(isRightClick({})).toBe(false);
+    });
+  });
+
+  //
+  // Handsontable.dom.isTouchEvent
+  //
+  describe('isTouchEvent', () => {
+    it('should return true for valid touch events', () => {
+      expect(isTouchEvent(new TouchEvent('touchstart'))).toBe(true);
+    });
+
+    it('should return false for invalid touch events', () => {
+      expect(isTouchEvent(new MouseEvent('mousedown'))).toBe(false);
     });
   });
 });

--- a/handsontable/src/helpers/dom/event.js
+++ b/handsontable/src/helpers/dom/event.js
@@ -39,6 +39,16 @@ export function isLeftClick(event) {
 }
 
 /**
+ * Check if the provided event is a touch event.
+ *
+ * @param {Event} event The event object.
+ * @returns {boolean}
+ */
+export function isTouchEvent(event) {
+  return event instanceof TouchEvent;
+}
+
+/**
  * Calculates the event offset until reaching the element defined by `relativeElement` argument.
  *
  * @param {Event} event The mouse event object.

--- a/handsontable/src/plugins/nestedHeaders/__tests__/mobile/selection.spec.js
+++ b/handsontable/src/plugins/nestedHeaders/__tests__/mobile/selection.spec.js
@@ -1,0 +1,54 @@
+describe('Mobile selection', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should allow selecting columns by tapping on the column headers', () => {
+    handsontable({
+      data: Handsontable.helper.createSpreadsheetData(10, 10),
+      colHeaders: true,
+      rowHeaders: true,
+      nestedHeaders: [
+        ['A', { label: 'B', colspan: 8 }, 'C'],
+        ['D', { label: 'E', colspan: 4 }, { label: 'F', colspan: 4 }, 'G'],
+        [
+          'H', { label: 'I', colspan: 2 },
+          { label: 'J', colspan: 2 },
+          { label: 'K', colspan: 2 },
+          { label: 'L', colspan: 2 },
+          'M'
+        ],
+        ['N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W'],
+      ],
+      width: 400,
+      height: 200,
+    });
+
+    let $colHeader = spec().$container.find('.ht_clone_top thead tr:nth-child(4) th').get(2);
+
+    simulateTouch($colHeader);
+
+    expect(getSelected()).toEqual([[-1, 1, 9, 1]]);
+
+    $colHeader = spec().$container.find('.ht_clone_top thead tr:nth-child(3) th').get(2);
+
+    simulateTouch($colHeader);
+
+    expect(getSelected()).toEqual([[-2, 1, 9, 2]]);
+
+    $colHeader = spec().$container.find('.ht_clone_top thead tr:nth-child(2) th').get(2);
+
+    simulateTouch($colHeader);
+
+    expect(getSelected()).toEqual([[-3, 1, 9, 4]]);
+  });
+});

--- a/handsontable/src/plugins/nestedHeaders/nestedHeaders.js
+++ b/handsontable/src/plugins/nestedHeaders/nestedHeaders.js
@@ -4,7 +4,7 @@ import {
 } from '../../helpers/dom/element';
 import { isNumeric, clamp } from '../../helpers/number';
 import { toSingleLine } from '../../helpers/templateLiteralTag';
-import { isLeftClick, isRightClick } from '../../helpers/dom/event';
+import { isLeftClick, isRightClick, isTouchEvent } from '../../helpers/dom/event';
 import { warn } from '../../helpers/console';
 import {
   ACTIVE_HEADER_TYPE,
@@ -606,7 +606,7 @@ export class NestedHeaders extends BasePlugin {
         columnsToSelect.push(columnIndex, columnIndex + origColspan - 1, coords.row);
       }
 
-    } else if (isLeftClick(event) || (isRightClick(event) && allowRightClickSelection)) {
+    } else if (isLeftClick(event) || (isRightClick(event) && allowRightClickSelection) || isTouchEvent(event)) {
       columnsToSelect.push(columnIndex, columnIndex + origColspan - 1, coords.row);
     }
 

--- a/handsontable/types/helpers/dom/event.d.ts
+++ b/handsontable/types/helpers/dom/event.d.ts
@@ -2,4 +2,5 @@ export function stopImmediatePropagation(event: Event): void;
 export function isImmediatePropagationStopped(event: Event): boolean;
 export function isRightClick(event: Event): boolean;
 export function isLeftClick(event: Event): boolean;
+export function isTouchEvent(event: Event): boolean;
 export function offsetRelativeTo(event: Event, untilElement: HTMLElement | undefined): { x: number, y: number };


### PR DESCRIPTION
### Context
This PR:
- Extends the `nestedHeaders` logic with allowing the mobile devices to select nested headers
- Adds a mobile test case

### How has this been tested?
Tested manually and added a mobile test case

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#1901

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
