### PR TITLE
add paths filter for docs related workflows

### DIFF
--- a/.github/workflows/docs-examples.yml
+++ b/.github/workflows/docs-examples.yml
@@ -2,6 +2,8 @@ name: Check docs examples (JS version vs TS version)
 
 on:
   pull_request:
+    paths:
+      - 'docs/**'
     types: [opened, synchronize, reopened]
 
 env:

--- a/.github/workflows/docs-linter.yml
+++ b/.github/workflows/docs-linter.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - 'docs/**'
   pull_request:
+    paths:
+      - 'docs/**'
     types: [ opened, synchronize, reopened ]
 
 env:


### PR DESCRIPTION
[skip changelog]

### Context
We only want to run docs related workflows only when something has changed inside `/docs` folder 

### How has this been tested?

Docs checks should not run on this PR

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
