### PR TITLE
Remove unused Babel packages

### DIFF
--- a/docs/.eslintrc.js
+++ b/docs/.eslintrc.js
@@ -2,7 +2,7 @@ module.exports = {
   extends: ['../.eslintrc.js'],
   parser: 'vue-eslint-parser',
   parserOptions: {
-    parser: 'babel-eslint',
+    parser: '@babel/eslint-parser',
     sourceType: 'module'
   },
   ignorePatterns: [

--- a/handsontable/package.json
+++ b/handsontable/package.json
@@ -101,8 +101,6 @@
     "@babel/runtime": "^7.11.2",
     "@babel/types": "^7.12.12",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
-    "babel-core": "7.0.0-bridge.0",
-    "babel-eslint": "^11.0.0-beta.2",
     "babel-jest": "^26.6.3",
     "babel-loader": "^8.0.4",
     "babel-plugin-forbidden-imports": "^0.1.2",
@@ -151,7 +149,7 @@
   },
   "license": "SEE LICENSE IN LICENSE.txt",
   "resolutions": {
-    "babel-core": "7.0.0-bridge.0"
+    "@babel/core": "^7.11.4"
   },
   "typings": "./index.d.ts",
   "handsontable": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,8 +28,6 @@
         "@babel/register": "^7.8.3",
         "@babel/runtime": "^7.11.2",
         "@babel/types": "^7.12.12",
-        "babel-core": "7.0.0-bridge.0",
-        "babel-eslint": "^11.0.0-beta.2",
         "babel-plugin-forbidden-imports": "^0.1.2",
         "babel-plugin-transform-inline-environment-variables": "^0.4.3",
         "babel-plugin-transform-require-ignore": "^0.1.1",
@@ -78,8 +76,6 @@
         "@babel/runtime": "^7.11.2",
         "@babel/types": "^7.12.12",
         "@typescript-eslint/eslint-plugin": "^4.33.0",
-        "babel-core": "7.0.0-bridge.0",
-        "babel-eslint": "^11.0.0-beta.2",
         "babel-jest": "^26.6.3",
         "babel-loader": "^8.0.4",
         "babel-plugin-forbidden-imports": "^0.1.2",
@@ -9885,74 +9881,6 @@
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.6.tgz",
       "integrity": "sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg==",
       "dev": true
-    },
-    "node_modules/babel-core": {
-      "version": "7.0.0-bridge.0",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
-      "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
-      "dev": true,
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/babel-eslint": {
-      "version": "11.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-11.0.0-beta.2.tgz",
-      "integrity": "sha512-D2tunrOu04XloEdU2XVUminUu25FILlGruZmffqH5OSnLDhCheKNvUoM1ihrexdUvhizlix8bjqRnsss4V/UIQ==",
-      "deprecated": "babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.",
-      "dev": true,
-      "dependencies": {
-        "eslint-scope": "5.0.0",
-        "eslint-visitor-keys": "^1.1.0",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "peerDependencies": {
-        "@babel/core": ">=7.2.0",
-        "eslint": ">= 6.0.0"
-      }
-    },
-    "node_modules/babel-eslint/node_modules/eslint-scope": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
-      "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
-      "dev": true,
-      "dependencies": {
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/babel-eslint/node_modules/eslint-visitor-keys": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/babel-eslint/node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/babel-eslint/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
     },
     "node_modules/babel-jest": {
       "version": "26.6.3",
@@ -36955,7 +36883,6 @@
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
         "@types/react-redux": "^7.1.7",
-        "babel-core": "^7.0.0-bridge.0",
         "cross-env": "^7.0.3",
         "handsontable": "^14.0.0",
         "jest": "^29.7.0",
@@ -36994,7 +36921,6 @@
         "@rollup/plugin-replace": "^5.0.5",
         "@rollup/plugin-terser": "0.4.4",
         "@vue/test-utils": "^1.0.3",
-        "babel-core": "^7.0.0-bridge.0",
         "cross-env": "^7.0.3",
         "css-loader": "^6.10.0",
         "handsontable": "^14.0.0",
@@ -38250,7 +38176,6 @@
         "@vue/compiler-sfc": "^3.2.12",
         "@vue/eslint-config-typescript": "^9.0.1",
         "@vue/test-utils": "2.0.0-rc.16",
-        "babel-core": "^7.0.0-bridge.0",
         "cross-env": "^7.0.3",
         "eslint-plugin-vue": "^8.0.3",
         "handsontable": "^14.0.0",

--- a/package.json
+++ b/package.json
@@ -50,8 +50,6 @@
     "@babel/register": "^7.8.3",
     "@babel/runtime": "^7.11.2",
     "@babel/types": "^7.12.12",
-    "babel-core": "7.0.0-bridge.0",
-    "babel-eslint": "^11.0.0-beta.2",
     "babel-plugin-forbidden-imports": "^0.1.2",
     "babel-plugin-transform-inline-environment-variables": "^0.4.3",
     "babel-plugin-transform-require-ignore": "^0.1.1",
@@ -80,7 +78,7 @@
   },
   "license": "SEE LICENSE IN LICENSE.txt",
   "resolutions": {
-    "babel-core": "7.0.0-bridge.0"
+    "@babel/core": "^7.11.4"
   },
   "workspaces": [
     "handsontable",

--- a/wrappers/react/package.json
+++ b/wrappers/react/package.json
@@ -71,7 +71,6 @@
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@types/react-redux": "^7.1.7",
-    "babel-core": "^7.0.0-bridge.0",
     "cross-env": "^7.0.3",
     "handsontable": "^14.0.0",
     "jest": "^29.7.0",

--- a/wrappers/vue/package.json
+++ b/wrappers/vue/package.json
@@ -71,7 +71,6 @@
     "@rollup/plugin-replace": "^5.0.5",
     "@rollup/plugin-babel": "6.0.4",
     "@vue/test-utils": "^1.0.3",
-    "babel-core": "^7.0.0-bridge.0",
     "cross-env": "^7.0.3",
     "css-loader": "^6.10.0",
     "handsontable": "^14.0.0",

--- a/wrappers/vue3/package.json
+++ b/wrappers/vue3/package.json
@@ -75,7 +75,6 @@
     "@vue/compiler-sfc": "^3.2.12",
     "@vue/eslint-config-typescript": "^9.0.1",
     "@vue/test-utils": "2.0.0-rc.16",
-    "babel-core": "^7.0.0-bridge.0",
     "cross-env": "^7.0.3",
     "eslint-plugin-vue": "^8.0.3",
     "handsontable": "^14.0.0",


### PR DESCRIPTION
### Context
This PR includes Babel packages cleanup

### How has this been tested?
Locally

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/1955

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] Remove unused Babel packages 

[skip changelog]
