### PR TITLE
Docs: change release-notes to the changelog

### DIFF
--- a/.changelogs/11074.json
+++ b/.changelogs/11074.json
@@ -1,0 +1,9 @@
+{
+    "issuesOrigin": "private",
+    "title": "Update Release Notes URL/Page name and add redirect",
+    "type": "fixed",
+    "issueOrPR": 11074,
+    "breaking": true,
+    "framework": "none"
+  }
+  

--- a/.changelogs/11074.json
+++ b/.changelogs/11074.json
@@ -1,9 +1,0 @@
-{
-    "issuesOrigin": "private",
-    "title": "Update Release Notes URL/Page name and add redirect",
-    "type": "fixed",
-    "issueOrPR": 11074,
-    "breaking": true,
-    "framework": "none"
-  }
-  

--- a/docs/.vuepress/public/scripts/canonicals-for-legacy-docs.js
+++ b/docs/.vuepress/public/scripts/canonicals-for-legacy-docs.js
@@ -31,6 +31,7 @@
     [/\/docs\/\d+\.\d+\.\d+\/tutorial-testing.html$/, '/docs/testing/'],
     [/\/docs\/\d+\.\d+\.\d+\/tutorial-migration-guide.html$/, '/docs/migration-from-7.4-to-8.0/'],
     [/\/docs\/\d+\.\d+\.\d+\/tutorial-performance-tips.html$/, '/docs/performance/'],
+    [/\/docs\/\d+\.\d+\.\d+\/tutorial-release-notes.html$/, '/docs/changelog/'],
     [/\/docs\/\d+\.\d+\.\d+\/tutorial-changelog.html$/, '/docs/changelog/'],
     [/\/docs\/\d+\.\d+\.\d+\/tutorial-principles.html$/, '/docs/6.2.2/tutorial-principles.html'],
     [/\/docs\/\d+\.\d+\.\d+\/tutorial-good-practices.html$/, '/docs/6.2.2/tutorial-good-practices.html'],

--- a/docs/.vuepress/public/scripts/canonicals-for-legacy-docs.js
+++ b/docs/.vuepress/public/scripts/canonicals-for-legacy-docs.js
@@ -31,7 +31,7 @@
     [/\/docs\/\d+\.\d+\.\d+\/tutorial-testing.html$/, '/docs/testing/'],
     [/\/docs\/\d+\.\d+\.\d+\/tutorial-migration-guide.html$/, '/docs/migration-from-7.4-to-8.0/'],
     [/\/docs\/\d+\.\d+\.\d+\/tutorial-performance-tips.html$/, '/docs/performance/'],
-    [/\/docs\/\d+\.\d+\.\d+\/tutorial-release-notes.html$/, '/docs/release-notes/'],
+    [/\/docs\/\d+\.\d+\.\d+\/tutorial-changelog.html$/, '/docs/changelog/'],
     [/\/docs\/\d+\.\d+\.\d+\/tutorial-principles.html$/, '/docs/6.2.2/tutorial-principles.html'],
     [/\/docs\/\d+\.\d+\.\d+\/tutorial-good-practices.html$/, '/docs/6.2.2/tutorial-good-practices.html'],
     [/\/docs\/\d+\.\d+\.\d+\/tutorial-known-limitations.html$/, '/docs/7.2.2/tutorial-known-limitations.html'],

--- a/docs/.vuepress/theme/components/InfoBox.vue
+++ b/docs/.vuepress/theme/components/InfoBox.vue
@@ -49,7 +49,7 @@ export default {
     },
     getVersionUrl() {
       // eslint-disable-next-line max-len
-      return `/${this.$page.currentFramework}${this.$page.frameworkSuffix}/release-notes/#_${this.getVersion.replaceAll('.', '-')}`;
+      return `/${this.$page.currentFramework}${this.$page.frameworkSuffix}/changelog/#_${this.getVersion.replaceAll('.', '-')}`;
     },
   },
   mounted() {

--- a/docs/.vuepress/theme/components/NavLinks.vue
+++ b/docs/.vuepress/theme/components/NavLinks.vue
@@ -40,12 +40,12 @@ export default {
     },
     changelogLink() {
       return {
-        link: `${this.frameworkUrlPrefix}/release-notes/`,
+        link: `${this.frameworkUrlPrefix}/changelog/`,
         text: 'Changelog'
       };
     },
     isChangelogLinkActive() {
-      return this.$route.path.includes('/release-notes');
+      return this.$route.path.includes('/changelog');
     }
   }
 };

--- a/docs/content/guides/getting-started/introduction/introduction.md
+++ b/docs/content/guides/getting-started/introduction/introduction.md
@@ -93,7 +93,7 @@ Implementing Handsontable requires a certain level of front-end development skil
 ## Stay in the loop
 
 - [Roadmap](@/guides/upgrade-and-migration/roadmap/roadmap.md)
-- [Release notes](@/guides/upgrade-and-migration/release-notes/release-notes.md)
+- [Release notes](@/guides/upgrade-and-migration/changelog/changelog.md)
 - [Blog](https://handsontable.com/blog)
 - [X](https://x.com/handsontable)
 - [LinkedIn](https://linkedin.com/company/handsontable)

--- a/docs/content/guides/getting-started/introduction/introduction.md
+++ b/docs/content/guides/getting-started/introduction/introduction.md
@@ -93,7 +93,7 @@ Implementing Handsontable requires a certain level of front-end development skil
 ## Stay in the loop
 
 - [Roadmap](@/guides/upgrade-and-migration/roadmap/roadmap.md)
-- [Release notes](@/guides/upgrade-and-migration/changelog/changelog.md)
+- [Changelog](@/guides/upgrade-and-migration/changelog/changelog.md)
 - [Blog](https://handsontable.com/blog)
 - [X](https://x.com/handsontable)
 - [LinkedIn](https://linkedin.com/company/handsontable)

--- a/docs/content/guides/sidebar.js
+++ b/docs/content/guides/sidebar.js
@@ -173,7 +173,7 @@ const technicalSpecificationItems = [
 ];
 
 const upgradeAndMigrationItems = [
-  { path: 'guides/upgrade-and-migration/release-notes/release-notes' },
+  { path: 'guides/upgrade-and-migration/changelog/changelog' },
   { path: 'guides/upgrade-and-migration/versioning-policy/versioning-policy' },
   { path: 'guides/upgrade-and-migration/migrating-from-7.4-to-8.0/migrating-from-7.4-to-8.0' },
   { path: 'guides/upgrade-and-migration/migrating-from-8.4-to-9.0/migrating-from-8.4-to-9.0' },

--- a/docs/content/guides/upgrade-and-migration/changelog/changelog.md
+++ b/docs/content/guides/upgrade-and-migration/changelog/changelog.md
@@ -1,11 +1,11 @@
 ---
 id: nbp8i3mk
-title: Release notes
-metaTitle: Release notes - JavaScript Data Grid | Handsontable
+title: Changelog
+metaTitle: Changelog - JavaScript Data Grid | Handsontable
 description:
   See the full history of changes made to Handsontable in each major, minor, and patch release.
-permalink: /release-notes
-canonicalUrl: /release-notes
+permalink: /changelog
+canonicalUrl: /changelog
 tags:
   - change log
   - changelog
@@ -14,12 +14,12 @@ tags:
   - breaking change
 react:
   id: 7y9fco03
-  metaTitle: Release notes - React Data Grid | Handsontable
+  metaTitle: Changelog - React Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---
 
-# Release notes
+# Changelog
 
 See the full history of changes made to Handsontable in each major, minor, and patch release.
 
@@ -2125,5 +2125,5 @@ For more information on this release, see:
 
 ## Older versions
 
-The release notes about older versions of Handsontable are
+The changelogs from older versions of Handsontable are
 [available on GitHub](https://github.com/handsontable/handsontable/releases).

--- a/docs/content/guides/upgrade-and-migration/migrating-from-12.4-to-13.0/migrating-from-12.4-to-13.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-12.4-to-13.0/migrating-from-12.4-to-13.0.md
@@ -37,7 +37,7 @@ If you're having any issues with Handsontable's [Angular wrapper](@/guides/integ
 ## Stop using the `beforeAutofillInsidePopulate` hook
 
 Handsontable 13.0 removes the [`beforeAutofillInsidePopulate`](https://handsontable.com/docs/12.4/javascript-data-grid/api/hooks/#beforeautofillinsidepopulate) hook,
-which has been marked as deprecated since Handsontable [9.0.0](@/guides/upgrade-and-migration/release-notes/release-notes.md#deprecated-3).
+which has been marked as deprecated since Handsontable [9.0.0](@/guides/upgrade-and-migration/changelog/changelog.md#deprecated-3).
 
 Make sure you're not using this hook.
 
@@ -50,7 +50,7 @@ don't pass these arguments to [`populateFromArray()`](@/api/core.md#populatefrom
 ## Change from `getFirstNotHiddenIndex()` to `getNearestNotHiddenIndex()`
 
 Handsontable 13.0 removes the [`getFirstNotHiddenIndex()`](https://handsontable.com/docs/12.4/javascript-data-grid/api/index-mapper/#getfirstnothiddenindex) method,
-which has been marked as deprecated since Handsontable [12.1.0](@/guides/upgrade-and-migration/release-notes/release-notes.md#deprecated-2). Instead , use the new
+which has been marked as deprecated since Handsontable [12.1.0](@/guides/upgrade-and-migration/changelog/changelog.md#deprecated-2). Instead , use the new
 [`getNearestNotHiddenIndex()`](@/api/indexMapper.md#getnearestnothiddenindex) method.
 
 For more details, see the API reference:
@@ -73,7 +73,7 @@ handsontableInstance.getNearestNotHiddenIndex(0, 1, true);
 ## Replace `'insert_row'` and `'insert_col'` in your `alter()` calls
 
 The [`alter()`](@/api/core.md#alter) method no longer accepts `'insert_row'` and `'insert_col'` arguments, which have been marked as deprecated since
-Handsontable [12.2.0](@/guides/upgrade-and-migration/release-notes/release-notes.md#deprecated).
+Handsontable [12.2.0](@/guides/upgrade-and-migration/changelog/changelog.md#deprecated).
 
 You can read more about this change on [our blog](https://handsontable.com/blog/handsontable-12.2.0).
 

--- a/docs/content/guides/upgrade-and-migration/migrating-from-7.4-to-8.0/migrating-from-7.4-to-8.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-7.4-to-8.0/migrating-from-7.4-to-8.0.md
@@ -33,7 +33,7 @@ Handsontable 8.0.0 introduces [`IndexMapper`](@/api/indexMapper.md), a new API t
 
 - Check if you use any of the features listed in the [Keywords](#keywords-alphabetically) section. You need to address them first after installing Handsontable 8.0.0.
 - To keep backward compatibility, test solutions proposed in this guide. If you experience any problems, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
-- You can also check the release notes for a complete list of all changes.
+- You can also check the changelog for a complete list of all changes.
 
 ## Keywords (alphabetically)
 

--- a/docs/content/guides/upgrade-and-migration/roadmap/roadmap.md
+++ b/docs/content/guides/upgrade-and-migration/roadmap/roadmap.md
@@ -22,7 +22,7 @@ Since the front-end world changes quickly, we might shuffle the order of project
 
 The roadmap below was last updated on `May 14th, 2024`.
 
-Curious about our progress? Check out the [Release Notes](@/guides/upgrade-and-migration/changelog/changelog.md).
+Curious about our progress? Check out the [Changelog](@/guides/upgrade-and-migration/changelog/changelog.md).
 <br><br>
 
 | Accepted 🎯 | In progress ✨ | Done 🏁 |

--- a/docs/content/guides/upgrade-and-migration/roadmap/roadmap.md
+++ b/docs/content/guides/upgrade-and-migration/roadmap/roadmap.md
@@ -22,7 +22,7 @@ Since the front-end world changes quickly, we might shuffle the order of project
 
 The roadmap below was last updated on `May 14th, 2024`.
 
-Curious about our progress? Check out the [Release Notes](@/guides/upgrade-and-migration/release-notes/release-notes.md).
+Curious about our progress? Check out the [Release Notes](@/guides/upgrade-and-migration/changelog/changelog.md).
 <br><br>
 
 | Accepted 🎯 | In progress ✨ | Done 🏁 |

--- a/docs/docker/redirects.conf
+++ b/docs/docker/redirects.conf
@@ -97,7 +97,8 @@ rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-cell-function/?$ /docs/$1$framework/c
 rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-suspend-rendering/?$ /docs/$1$framework/batch-operations/ permanent;
 rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-testing/?$ /docs/$1$framework/testing/ permanent;
 rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-performance-tips/?$ /docs/$1$framework/performance/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-release-notes/?$ /docs/$1$framework/release-notes/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-release-notes/?$ /docs/$1$framework/changelog/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-changelog/?$ /docs/$1$framework/release-notes/ permanent;
 rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-migration-guide/?$ /docs/$1$framework/migration-from-7.4-to-8.0/ permanent;
 rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-known-limitations/?$ /docs/$1$framework/third-party-licenses/ permanent;
 rewrite ^/docs/internationalization-i18n/?$ /docs/$framework/language/ permanent;

--- a/docs/docker/redirects.conf
+++ b/docs/docker/redirects.conf
@@ -32,6 +32,9 @@ if ($cookie_docs_fw = "react") {
 rewrite ^/docs/?$ /docs/$framework/ permanent;
 rewrite ^/docs/(\d+\.\d+|next)/?$ /docs/$1/$framework/ permanent;
 
+# --- redirect /release-notes/ to /changelog/ ---
+rewrite ^/docs/release-notes/?$ /docs/$framework/changelog/ permanent;
+
 # --- documentation links that come up in Handsontable's console logs ---
 rewrite ^/docs/i18n/missing-language-code /docs/$framework/language/#loading-the-prepared-language-files permanent;
 
@@ -98,7 +101,7 @@ rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-suspend-rendering/?$ /docs/$1$framewo
 rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-testing/?$ /docs/$1$framework/testing/ permanent;
 rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-performance-tips/?$ /docs/$1$framework/performance/ permanent;
 rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-release-notes/?$ /docs/$1$framework/changelog/ permanent;
-rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-changelog/?$ /docs/$1$framework/release-notes/ permanent;
+rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-changelog/?$ /docs/$1$framework/changelog/ permanent;
 rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-migration-guide/?$ /docs/$1$framework/migration-from-7.4-to-8.0/ permanent;
 rewrite ^/docs/((\d+\.\d+|next)/)?tutorial-known-limitations/?$ /docs/$1$framework/third-party-licenses/ permanent;
 rewrite ^/docs/internationalization-i18n/?$ /docs/$framework/language/ permanent;

--- a/docs/docker/redirects.conf
+++ b/docs/docker/redirects.conf
@@ -33,7 +33,7 @@ rewrite ^/docs/?$ /docs/$framework/ permanent;
 rewrite ^/docs/(\d+\.\d+|next)/?$ /docs/$1/$framework/ permanent;
 
 # --- redirect /release-notes/ to /changelog/ ---
-rewrite ^/docs/release-notes/?$ /docs/$framework/changelog/ permanent;
+rewrite ^/docs/$framework/release-notes/?$ /docs/$framework/changelog/ permanent;
 
 # --- documentation links that come up in Handsontable's console logs ---
 rewrite ^/docs/i18n/missing-language-code /docs/$framework/language/#loading-the-prepared-language-files permanent;

--- a/docs/docker/redirects.conf
+++ b/docs/docker/redirects.conf
@@ -32,9 +32,6 @@ if ($cookie_docs_fw = "react") {
 rewrite ^/docs/?$ /docs/$framework/ permanent;
 rewrite ^/docs/(\d+\.\d+|next)/?$ /docs/$1/$framework/ permanent;
 
-# --- redirect /release-notes/ to /changelog/ ---
-rewrite ^/docs/$framework/release-notes/?$ /docs/$framework/changelog/ permanent;
-
 # --- documentation links that come up in Handsontable's console logs ---
 rewrite ^/docs/i18n/missing-language-code /docs/$framework/language/#loading-the-prepared-language-files permanent;
 
@@ -122,6 +119,7 @@ rewrite ^/docs/row-sorting/?$ /docs/$framework/rows-sorting/ permanent;
 rewrite ^/docs/column-sorting/?$ /docs/$framework/rows-sorting/ permanent;
 rewrite ^/docs/(javascript|react)-data-grid/row-sorting/?$ /docs/$framework/rows-sorting/ permanent;
 rewrite ^/docs/(javascript|react)-data-grid/column-sorting/?$ /docs/$framework/rows-sorting/ permanent;
+rewrite ^/docs/(javascript|react)-data-grid/release-notes/?$ /docs/$framework/changelog/ permanent;
 
 # --- demos ---
 rewrite ^/docs/((\d+\.\d+|next)/)?demo-scrolling/?$ /docs/$1$framework/row-virtualization/ permanent;


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Changelogs are more suitable than release notes for developers seeking the details of specific change

### How has this been tested?
Locally, Staging

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/1956
### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]