### PR TITLE
Fix hyperformula link

### DIFF
--- a/docs/content/guides/formulas/formula-calculation/formula-calculation.md
+++ b/docs/content/guides/formulas/formula-calculation/formula-calculation.md
@@ -395,7 +395,7 @@ For the list of available settings and methods, visit the [API reference](@/api/
 
 This plugin inherits the calculation powers from _HyperFormula_. The complete functions reference
 can be found in the
-[HyperFormula documentation](https://handsontable.github.io/hyperformula/guide/built-in-functions.html).
+[HyperFormula documentation](https://hyperformula.handsontable.com/guide/cell-references.html#relative-references).
 
 ## [`afterFormulasValuesUpdate`](@/api/hooks.md#afterformulasvaluesupdate) hook
 


### PR DESCRIPTION
### Context
This PR includes hyperformula link change

### How has this been tested?
Locally

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/1480

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] Change hyperformula link

[skip changelog]
