### PR TITLE
Change updateDropdownHeight to the updateDropdownDimensions in types

### DIFF
--- a/handsontable/src/editors/autocompleteEditor/__tests__/autocompleteEditor.types.ts
+++ b/handsontable/src/editors/autocompleteEditor/__tests__/autocompleteEditor.types.ts
@@ -1,0 +1,18 @@
+import Handsontable from 'handsontable';
+
+const element = document.createElement('div');
+const hot = new Handsontable(element, {});
+const editor = new Handsontable.editors.AutocompleteEditor(hot);
+
+editor.queryChoices('test');
+editor.updateChoicesList(['a', 'b', 'c']);
+editor.limitDropdownIfNeeded(100, 20);
+editor.flipDropdown(100);
+editor.unflipDropdown();
+editor.updateDropdownDimensions();
+editor.setDropdownHeight(100);
+editor.highlightBestMatchingChoice(1);
+
+const value: string = editor.getValue();
+const isFlipped: boolean = editor.flipDropdownIfNeeded();
+const dropdownHeight: number = editor.getDropdownHeight();

--- a/handsontable/types/editors/autocompleteEditor/autocompleteEditor.d.ts
+++ b/handsontable/types/editors/autocompleteEditor/autocompleteEditor.d.ts
@@ -17,7 +17,7 @@ export class AutocompleteEditor extends HandsontableEditor {
   limitDropdownIfNeeded(spaceAvailable: number, dropdownHeight: number): void;
   flipDropdown(dropdownHeight: number): void;
   unflipDropdown(): void;
-  updateDropdownHeight(): void;
+  updateDropdownDimensions(): void;
   setDropdownHeight(height: number): void;
   highlightBestMatchingChoice(index?: number): void;
   getDropdownHeight(): number;


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
- changes `updateDropdownHeight` to the `updateDropdownDimensions` in the `autocompleteEditor.d.ts`

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/1962
2. https://github.com/handsontable/dev-handsontable/issues/1892

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]