### PR TITLE
Remove -ms fix from css

### DIFF
--- a/.changelogs/11055.json
+++ b/.changelogs/11055.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Remove -ms fix from css",
+  "type": "removed",
+  "issueOrPR": 11055,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/css/handsontable.scss
+++ b/handsontable/src/css/handsontable.scss
@@ -144,23 +144,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  /* Fix for IE9 to spread the ":before" pseudo element to 100% height of the parent element */
-  bottom: -100%\9;
   background: #005eff;
-}
-
-/* Fix for IE10 and IE11 to spread the ":before" pseudo element to 100% height of the parent element */
-@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .handsontable td.area:before,
-  .handsontable td.area-1:before,
-  .handsontable td.area-2:before,
-  .handsontable td.area-3:before,
-  .handsontable td.area-4:before,
-  .handsontable td.area-5:before,
-  .handsontable td.area-6:before,
-  .handsontable td.area-7:before {
-    bottom: -100%;
-  }
 }
 
 .handsontable td.area:before {


### PR DESCRIPTION
### Context
This PR includes changes in HOT scss file

### How has this been tested?
Locally

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/1958
2. https://github.com/handsontable/handsontable/issues/11055

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [ ] Remove -ms-high-contrast
- [ ] Remove unnecessary fix for IE9
