### PR TITLE
Include 'none' and 'date-*' condition strings in the ConditionName

### DIFF
--- a/handsontable/types/plugins/filters/conditionCollection.d.ts
+++ b/handsontable/types/plugins/filters/conditionCollection.d.ts
@@ -5,9 +5,10 @@ import {
   ColumnConditions,
 } from './filters';
 
-export type ConditionName = 'begins_with' | 'between' | 'by_value' | 'contains' | 'empty' | 'ends_with' |
-                            'eq' | 'gt' | 'gte' | 'lt' | 'lte' | 'not_between' | 'not_contains' |
-                            'not_empty' | 'neq';
+export type ConditionName = 'begins_with' | 'between' | 'by_value' | 'contains' |
+                            'date_after' | 'date_before' | 'date_today' | 'date_tomorrow' | 'date_yesterday' |
+                            'empty' | 'ends_with' | 'eq' | 'gt' | 'gte' | 'lt' | 'lte' |
+                            'not_between' | 'not_contains' | 'not_empty' | 'neq' | 'none';
 
 export interface Condition {
   name: ConditionName;


### PR DESCRIPTION
### Context
Adds missing condition strings values to the ConditionName type

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.https://github.com/handsontable/dev-handsontable/issues/1832

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]
