### PR TITLE
Sync the `visual-test` demos between all frameworks and update the Angular wrapper config.

### DIFF
--- a/examples/next/visual-tests/angular/demo/src/data-grid/data-grid.component.html
+++ b/examples/next/visual-tests/angular/demo/src/data-grid/data-grid.component.html
@@ -14,7 +14,7 @@
     [multiColumnSorting]="true"
     [filters]="true"
     [afterOnCellMouseDown]="changeCheckboxCell"
-    headerClassName="htLeft"
+    [headerClassName]="headerClassNameValue"
     [afterGetRowHeader]="drawCheckboxInRowHeaders"
     [beforeRenderer]="addClassesToRows"
     [manualRowMove]="true"
@@ -40,6 +40,7 @@
       [renderer]="starsRenderer"
       [readOnly]="true"
       className="star htCenter"
+      headerClassName="htCenter"
     ></hot-column>
     <hot-column data="5"></hot-column>
     <hot-column data="2"></hot-column>

--- a/examples/next/visual-tests/angular/demo/src/data-grid/data-grid.component.ts
+++ b/examples/next/visual-tests/angular/demo/src/data-grid/data-grid.component.ts
@@ -36,5 +36,6 @@ export class DataGridComponent {
   hiddenColumns = {
     indicators: true
   };
+  headerClassNameValue = document.documentElement.getAttribute('dir') === 'rtl' ? 'htRight' : 'htLeft';
   licenseKey = "non-commercial-and-evaluation";
 }

--- a/examples/next/visual-tests/react/demo/src/DataGrid.tsx
+++ b/examples/next/visual-tests/react/demo/src/DataGrid.tsx
@@ -14,6 +14,8 @@ import {
 import "handsontable/dist/handsontable.css";
 
 const DataGrid = () => {
+  const isRtl = document.documentElement.getAttribute('dir') === 'rtl';
+
   return (
     <HotTable
       data={data}
@@ -38,7 +40,7 @@ const DataGrid = () => {
       multiColumnSorting={true}
       filters={true}
       rowHeaders={true}
-      headerClassName="htLeft"
+      headerClassName={isRtl ? "htRight" : "htLeft"}
       beforeRenderer={addClassesToRows}
       afterGetRowHeader={drawCheckboxInRowHeaders}
       afterOnCellMouseDown={changeCheckboxCell}

--- a/examples/next/visual-tests/vue/demo/src/components/DataGrid.vue
+++ b/examples/next/visual-tests/vue/demo/src/components/DataGrid.vue
@@ -20,6 +20,8 @@ import {
 export default {
   name: 'DataGrid',
   data: function() {
+    const isRtl = document.documentElement.getAttribute('dir') === 'rtl';
+
     return {
       hotSettings: {
         height: 450,
@@ -38,7 +40,7 @@ export default {
         comments: true,
         customBorders: true,
         afterOnCellMouseDown: changeCheckboxCell,
-        headerClassName: "htLeft",
+        headerClassName: isRtl ? "htRight" : "htLeft",
         afterGetRowHeader: drawCheckboxInRowHeaders,
         beforeRenderer: addClassesToRows,
         colWidths: [140, 192, 100, 90, 90, 110, 97, 100, 126],
@@ -83,6 +85,7 @@ export default {
             renderer: starsRenderer,
             readOnly: true,
             className: "star htCenter",
+            headerClassName: "htCenter",
           },
           { data: 5, type: "text" },
           { data: 2, type: "text" }

--- a/wrappers/angular/projects/hot-table/src/lib/hot-column.component.ts
+++ b/wrappers/angular/projects/hot-table/src/lib/hot-column.component.ts
@@ -30,6 +30,7 @@ export class HotColumnComponent implements OnInit, OnChanges, OnDestroy {
   @Input() defaultDate: Handsontable.ColumnSettings['defaultDate'];
   @Input() editor: Handsontable.ColumnSettings['editor'];
   @Input() filteringCaseSensitive: Handsontable.ColumnSettings['filteringCaseSensitive'];
+  @Input() headerClassName: Handsontable.GridSettings['headerClassName'];
   @Input() invalidCellClassName: Handsontable.ColumnSettings['invalidCellClassName'];
   @Input() label: Handsontable.ColumnSettings['label'];
   @Input() language: Handsontable.ColumnSettings['language'];


### PR DESCRIPTION
### Context
This PR:
- Synchronizes the `visual-test` demos between all of the frameworks.
- Adds `headerClassName` to the supported `hot-column` props in the Angular wrapper.

[skip changelog]

### How has this been tested?
Tested manually

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Affected project(s):
- [ ] `handsontable`
- [x] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`
