### PR TITLE
Feature filter items ordering hook

### DIFF
--- a/handsontable/src/__tests__/core/settings.types.ts
+++ b/handsontable/src/__tests__/core/settings.types.ts
@@ -551,6 +551,7 @@ const allSettings: Required<Handsontable.GridSettings> = {
   beforeDropdownMenuSetItems: (menuItems) => {},
   beforeDropdownMenuShow: (instance) => {},
   beforeFilter: (conditionsStack) => { conditionsStack[0].conditions[0].name === 'begins_with'; },
+  beforeFilterValueOptionsShow: (items) => {},
   beforeGetCellMeta: (row, col, cellProperties) => {},
   beforeHideColumns: (currentHideConfig, destinationHideConfig, actionPossible) => {},
   beforeHideRows: (currentHideConfig, destinationHideConfig, actionPossible) => {},

--- a/handsontable/src/pluginHooks.js
+++ b/handsontable/src/pluginHooks.js
@@ -2085,6 +2085,15 @@ const REGISTERED_HOOKS = [
    */
   'beforeStretchingColumnWidth',
 
+    /**
+   * Fired before showing filter dropdown.
+   *
+   * @event Hooks#beforeFilterValueOptionsShow
+   * @param {object[]} items an array of items to show on the dropdown menu.
+   * @returns {undefined}
+   */
+    'beforeFilterValueOptionsShow',
+
   /**
    * Fired by the [`Filters`](@/api/filters.md) plugin,
    * before a [column filter](@/guides/columns/column-filter/column-filter.md) gets applied.

--- a/handsontable/src/pluginHooks.js
+++ b/handsontable/src/pluginHooks.js
@@ -2085,14 +2085,14 @@ const REGISTERED_HOOKS = [
    */
   'beforeStretchingColumnWidth',
 
-    /**
+  /**
    * Fired before showing filter dropdown.
    *
    * @event Hooks#beforeFilterValueOptionsShow
    * @param {object[]} items an array of items to show on the dropdown menu.
    * @returns {undefined}
    */
-    'beforeFilterValueOptionsShow',
+  'beforeFilterValueOptionsShow',
 
   /**
    * Fired by the [`Filters`](@/api/filters.md) plugin,

--- a/handsontable/src/plugins/filters/component/value.js
+++ b/handsontable/src/plugins/filters/component/value.js
@@ -225,6 +225,7 @@ export class ValueComponent extends BaseComponent {
     const rowValues = rowEntries.map(entry => entry.value);
     const rowMetaMap = new Map(rowEntries.map(row => [row.value, row.meta]));
     const values = unifyColumnValues(rowValues);
+    this.hot.runHooks('beforeFilterValueOptionsShow', values);
     const items = intersectValues(values, values, defaultBlankCellValue, (item) => {
       this.#triggerModifyMultipleSelectionValueHook(item, rowMetaMap);
     });

--- a/handsontable/src/plugins/filters/component/value.js
+++ b/handsontable/src/plugins/filters/component/value.js
@@ -225,7 +225,9 @@ export class ValueComponent extends BaseComponent {
     const rowValues = rowEntries.map(entry => entry.value);
     const rowMetaMap = new Map(rowEntries.map(row => [row.value, row.meta]));
     const values = unifyColumnValues(rowValues);
+
     this.hot.runHooks('beforeFilterValueOptionsShow', values);
+
     const items = intersectValues(values, values, defaultBlankCellValue, (item) => {
       this.#triggerModifyMultipleSelectionValueHook(item, rowMetaMap);
     });

--- a/handsontable/types/pluginHooks.d.ts
+++ b/handsontable/types/pluginHooks.d.ts
@@ -181,6 +181,7 @@ export interface Events {
   beforeDropdownMenuSetItems?: (menuItems: ContextMenuMenuItemConfig[]) => void;
   beforeDropdownMenuShow?: (instance: DropdownMenu) => void;
   beforeFilter?: (conditionsStack: FiltersColumnConditions[]) => void | boolean;
+  beforeFilterValueOptionsShow?: (items: object[]) => void; 
   beforeGetCellMeta?: (row: number, column: number, cellProperties: CellProperties) => void;
   beforeHideColumns?: (currentHideConfig: number[], destinationHideConfig: number[], actionPossible: boolean) => void | boolean;
   beforeHideRows?: (currentHideConfig: number[], destinationHideConfig: number[], actionPossible: boolean) => void | boolean;

--- a/wrappers/angular/projects/hot-table/src/lib/hot-table.component.ts
+++ b/wrappers/angular/projects/hot-table/src/lib/hot-table.component.ts
@@ -288,6 +288,7 @@ export class HotTableComponent implements AfterViewInit, OnChanges, OnDestroy {
   @Input() beforeDropdownMenuSetItems: Handsontable.GridSettings['beforeDropdownMenuSetItems'];
   @Input() beforeDropdownMenuShow: Handsontable.GridSettings['beforeDropdownMenuShow'];
   @Input() beforeFilter: Handsontable.GridSettings['beforeFilter'];
+  @Input() beforeFilterValueOptionsShow: Handsontable.GridSettings['beforeFilterValueOptionsShow'];
   @Input() beforeGetCellMeta: Handsontable.GridSettings['beforeGetCellMeta'];
   @Input() beforeHideColumns: Handsontable.GridSettings['beforeHideColumns'];
   @Input() beforeHideRows: Handsontable.GridSettings['beforeHideRows'];


### PR DESCRIPTION
### Context
This can be useful in ordering in items to be on the filter view. The usual behaviour of the filter menu is to show Blank items on top and remaining items in lexicographical order. This hook can help in giving flexibility to provide the custom ordering.

### How has this been tested?
Local

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.