### PR TITLE
Remove CodeSandbox for react docs demos

### DIFF
--- a/docs/.vuepress/containers/examples/examples.js
+++ b/docs/.vuepress/containers/examples/examples.js
@@ -168,9 +168,11 @@ module.exports = function(docsVersion, base) {
         const isRTL = /layoutDirection(.*)'rtl'/.test(codeToCompile) || /dir="rtl"/.test(htmlContent);
         const isActive = `$parent.$parent.isScriptLoaderActivated('${id}')`;
         const selectedLang = '$parent.$parent.selectedLang';
+        const isJavaScript = preset.includes('hot');
         const isReact = preset.includes('react');
         const isAngular = preset.includes('angular');
-        const isReactOrJavaScript = preset.includes('hot') || preset.includes('react');
+        const isReactOrJavaScript = isJavaScript || isReact;
+        const isAngularOrReact = isAngular || isReact;
 
         return `
           <div class="example-container">
@@ -198,7 +200,7 @@ module.exports = function(docsVersion, base) {
       'JavaScript'
     )
     : ''}
-                  ${!noEdit && !isAngular
+                  ${!noEdit && !isAngularOrReact
     ? codesandbox(
       id,
       htmlContent,
@@ -233,7 +235,7 @@ module.exports = function(docsVersion, base) {
       'TypeScript'
     )
     : ''}
-                  ${!noEdit
+                  ${!noEdit && !isReact
     ? codesandbox(
       id,
       htmlContent,


### PR DESCRIPTION
### Context
This PR includes changes for docs examples sandboxes buttons

### How has this been tested?
Locally

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2014

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] Remove CodeSandbox for react docs demos

[skip changelog]