### PR TITLE
Improve DX of `useHotEditor`

### DIFF
--- a/.changelogs/11152.json
+++ b/.changelogs/11152.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Improve DX of useHotEditor",
+  "type": "added",
+  "issueOrPR": 11152,
+  "breaking": false,
+  "framework": "react"
+}

--- a/wrappers/react/src/hotEditor.tsx
+++ b/wrappers/react/src/hotEditor.tsx
@@ -1,17 +1,26 @@
-import React from 'react';
-import Handsontable from 'handsontable/base';
-import { HotEditorHooks, UseHotEditorImpl } from './types';
+import React from "react";
+import Handsontable from "handsontable/base";
+import { HotEditorHooks, UseHotEditorImpl } from "./types";
 
-type HookPropName = (keyof Handsontable.editors.BaseEditor) | 'constructor';
+type HookPropName = keyof Handsontable.editors.BaseEditor | "constructor";
 
-const AbstractMethods: (keyof Handsontable.editors.BaseEditor)[] = ['close', 'focus', 'open'];
-const ExcludedMethods: (keyof Handsontable.editors.BaseEditor)[] = ['getValue', 'setValue'];
+const AbstractMethods: (keyof Handsontable.editors.BaseEditor)[] = [
+  "close",
+  "focus",
+  "open",
+];
+const ExcludedMethods: (keyof Handsontable.editors.BaseEditor)[] = [
+  "getValue",
+  "setValue",
+];
 
-const MethodsMap: Partial<Record<keyof Handsontable.editors.BaseEditor, keyof HotEditorHooks>> = {
-  open: 'onOpen',
-  close: 'onClose',
-  prepare: 'onPrepare',
-  focus: 'onFocus',
+const MethodsMap: Partial<
+  Record<keyof Handsontable.editors.BaseEditor, keyof HotEditorHooks>
+> = {
+  open: "onOpen",
+  close: "onClose",
+  prepare: "onPrepare",
+  focus: "onFocus",
 };
 
 /**
@@ -21,29 +30,48 @@ const MethodsMap: Partial<Record<keyof Handsontable.editors.BaseEditor, keyof Ho
  * @param {React.RefObject} instanceRef Reference to Handsontable-native custom editor class instance.
  * @returns {Function} A class to be passed to the Handsontable editor settings.
  */
-export function makeEditorClass(hooksRef: React.MutableRefObject<HotEditorHooks | null>, instanceRef: React.MutableRefObject<Handsontable.editors.BaseEditor | null>): typeof Handsontable.editors.BaseEditor {
-  return class CustomEditor extends Handsontable.editors.BaseEditor implements Handsontable.editors.BaseEditor {
+export function makeEditorClass(
+  hooksRef: React.MutableRefObject<HotEditorHooks | null>,
+  instanceRef: React.MutableRefObject<Handsontable.editors.BaseEditor | null>
+): typeof Handsontable.editors.BaseEditor {
+  return class CustomEditor
+    extends Handsontable.editors.BaseEditor
+    implements Handsontable.editors.BaseEditor
+  {
     private value: any;
 
     constructor(hotInstance: Handsontable.Core) {
       super(hotInstance);
       instanceRef.current = this;
 
-      (Object.getOwnPropertyNames(Handsontable.editors.BaseEditor.prototype) as HookPropName[]).forEach((propName) => {
-        if (propName === 'constructor' || ExcludedMethods.includes(propName)) {
+      (
+        Object.getOwnPropertyNames(
+          Handsontable.editors.BaseEditor.prototype
+        ) as HookPropName[]
+      ).forEach((propName) => {
+        if (propName === "constructor" || ExcludedMethods.includes(propName)) {
           return;
         }
 
         const baseMethod = Handsontable.editors.BaseEditor.prototype[propName];
-        (CustomEditor.prototype as any)[propName] = function (this: CustomEditor, ...args: any[]) {
+        (CustomEditor.prototype as any)[propName] = function (
+          this: CustomEditor,
+          ...args: any[]
+        ) {
           let result;
 
           if (!AbstractMethods.includes(propName)) {
             result = baseMethod.call(this, ...args); // call super
           }
 
-          if (MethodsMap[propName] && hooksRef.current?.[MethodsMap[propName]!]) {
-            result = (hooksRef.current[MethodsMap[propName]!] as any).call(this, ...args);
+          if (
+            MethodsMap[propName] &&
+            hooksRef.current?.[MethodsMap[propName]!]
+          ) {
+            result = (hooksRef.current[MethodsMap[propName]!] as any).call(
+              this,
+              ...args
+            );
           }
 
           return result;
@@ -51,8 +79,7 @@ export function makeEditorClass(hooksRef: React.MutableRefObject<HotEditorHooks 
       });
     }
 
-    focus() {
-    }
+    focus() {}
 
     getValue() {
       return this.value;
@@ -62,28 +89,28 @@ export function makeEditorClass(hooksRef: React.MutableRefObject<HotEditorHooks 
       this.value = newValue;
     }
 
-    open() {
-    }
+    open() {}
 
-    close() {
-    }
-  }
+    close() {}
+  };
 }
 
 interface EditorContextType {
-  hooksRef: React.Ref<HotEditorHooks>
-  hotCustomEditorInstanceRef: React.RefObject<Handsontable.editors.BaseEditor>
+  hooksRef: React.Ref<HotEditorHooks>;
+  hotCustomEditorInstanceRef: React.RefObject<Handsontable.editors.BaseEditor>;
 }
 
 /**
  * Context to provide Handsontable-native custom editor class instance to overridden hooks object.
  */
-const EditorContext = React.createContext<EditorContextType | undefined>(undefined);
+const EditorContext = React.createContext<EditorContextType | undefined>(
+  undefined
+);
 
 interface EditorContextProviderProps {
-  hooksRef: React.Ref<HotEditorHooks>
-  hotCustomEditorInstanceRef: React.RefObject<Handsontable.editors.BaseEditor>
-  children: React.ReactNode
+  hooksRef: React.Ref<HotEditorHooks>;
+  hotCustomEditorInstanceRef: React.RefObject<Handsontable.editors.BaseEditor>;
+  children: React.ReactNode;
 }
 
 /**
@@ -93,11 +120,17 @@ interface EditorContextProviderProps {
  * @param {React.Ref} hooksRef Reference for component-based editor overridden hooks object.
  * @param {React.RefObject} hotCustomEditorInstanceRef  Reference to Handsontable-native editor instance.
  */
-export const EditorContextProvider: React.FC<EditorContextProviderProps> = ({ hooksRef, hotCustomEditorInstanceRef, children }) => {
-  return <EditorContext.Provider value={{ hooksRef, hotCustomEditorInstanceRef }}>
-    {children}
-  </EditorContext.Provider>
-}
+export const EditorContextProvider: React.FC<EditorContextProviderProps> = ({
+  hooksRef,
+  hotCustomEditorInstanceRef,
+  children,
+}) => {
+  return (
+    <EditorContext.Provider value={{ hooksRef, hotCustomEditorInstanceRef }}>
+      {children}
+    </EditorContext.Provider>
+  );
+};
 
 /**
  * Hook that allows encapsulating custom behaviours of component-based editor by customizing passed ref with overridden hooks object.
@@ -106,36 +139,51 @@ export const EditorContextProvider: React.FC<EditorContextProviderProps> = ({ ho
  * @param {React.DependencyList} deps Overridden hooks object React dependency list.
  * @returns {UseHotEditorImpl} Editor API methods
  */
-export function useHotEditor(overriddenHooks?: HotEditorHooks, deps?: React.DependencyList): UseHotEditorImpl {
-  const { hooksRef, hotCustomEditorInstanceRef } = React.useContext(EditorContext)!;
-  const [rerenderTrigger, setRerenderTrigger] = React.useState(0);
+export function useHotEditor<T>(
+  overriddenHooks?: HotEditorHooks,
+  deps?: React.DependencyList
+): UseHotEditorImpl<T> {
+  const { hooksRef, hotCustomEditorInstanceRef } =
+    React.useContext(EditorContext)!;
+  const [rerenderTrigger, setRerenderTrigger] = React.useState();
+  const [editorValue, setEditorValue] = React.useState<T>();
 
-  React.useImperativeHandle(hooksRef, () => ({
-    ...overriddenHooks,
-    onOpen() {
-      overriddenHooks?.onOpen?.();
-      setRerenderTrigger((t) => t + 1);
-    },
-  }), deps);
+  React.useImperativeHandle(
+    hooksRef,
+    () => ({
+      ...overriddenHooks,
+      onOpen() {
+        // console.log("onOpen", hotCustomEditorInstanceRef.current?.getValue());
+        setEditorValue(hotCustomEditorInstanceRef.current?.getValue());
+        overriddenHooks?.onOpen?.();
+        setRerenderTrigger((t) => t + 1);
+      },
+    }),
+    deps
+  );
 
-  return React.useMemo(() => ({
-    get value() {
-      return hotCustomEditorInstanceRef.current?.getValue();
-    },
-    setValue(newValue) {
-      hotCustomEditorInstanceRef.current?.setValue(newValue);
-    },
-    get isOpen() {
-      return hotCustomEditorInstanceRef.current?.isOpened() ?? false;
-    },
-    finishEditing() {
-      hotCustomEditorInstanceRef.current?.finishEditing();
-    },
-    get row() {
-      return hotCustomEditorInstanceRef.current?.row;
-    },
-    get col() {
-      return hotCustomEditorInstanceRef.current?.col;
-    }
-  }), [rerenderTrigger, hotCustomEditorInstanceRef]);
+  return React.useMemo(
+    () => ({
+      get value(): T | undefined {
+        return editorValue;
+      },
+      setValue(newValue) {
+        setEditorValue(newValue);
+        hotCustomEditorInstanceRef.current?.setValue(newValue);
+      },
+      get isOpen() {
+        return hotCustomEditorInstanceRef.current?.isOpened() ?? false;
+      },
+      finishEditing() {
+        hotCustomEditorInstanceRef.current?.finishEditing();
+      },
+      get row() {
+        return hotCustomEditorInstanceRef.current?.row;
+      },
+      get col() {
+        return hotCustomEditorInstanceRef.current?.col;
+      },
+    }),
+    [rerenderTrigger, hotCustomEditorInstanceRef, editorValue]
+  );
 }

--- a/wrappers/react/src/hotEditor.tsx
+++ b/wrappers/react/src/hotEditor.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useDeferredValue } from "react";
 import Handsontable from "handsontable/base";
 import { HotEditorHooks, UseHotEditorImpl } from "./types";
 
@@ -148,6 +148,9 @@ export function useHotEditor<T>(
   const [rerenderTrigger, setRerenderTrigger] = React.useState();
   const [editorValue, setEditorValue] = React.useState<T>();
 
+  // return a deferred value that allows for optimizing performance by delaying the update of a value until the next render.
+  const deferredValue = useDeferredValue(editorValue);
+
   React.useImperativeHandle(
     hooksRef,
     () => ({
@@ -165,7 +168,7 @@ export function useHotEditor<T>(
   return React.useMemo(
     () => ({
       get value(): T | undefined {
-        return editorValue;
+        return deferredValue;
       },
       setValue(newValue) {
         setEditorValue(newValue);
@@ -184,6 +187,6 @@ export function useHotEditor<T>(
         return hotCustomEditorInstanceRef.current?.col;
       },
     }),
-    [rerenderTrigger, hotCustomEditorInstanceRef, editorValue]
+    [rerenderTrigger, hotCustomEditorInstanceRef, deferredValue]
   );
 }

--- a/wrappers/react/src/hotEditor.tsx
+++ b/wrappers/react/src/hotEditor.tsx
@@ -145,7 +145,7 @@ export function useHotEditor<T>(
 ): UseHotEditorImpl<T> {
   const { hooksRef, hotCustomEditorInstanceRef } =
     React.useContext(EditorContext)!;
-  const [rerenderTrigger, setRerenderTrigger] = React.useState();
+  const [rerenderTrigger, setRerenderTrigger] = React.useState(0);
   const [editorValue, setEditorValue] = React.useState<T>();
 
   // return a deferred value that allows for optimizing performance by delaying the update of a value until the next render.
@@ -156,7 +156,6 @@ export function useHotEditor<T>(
     () => ({
       ...overriddenHooks,
       onOpen() {
-        // console.log("onOpen", hotCustomEditorInstanceRef.current?.getValue());
         setEditorValue(hotCustomEditorInstanceRef.current?.getValue());
         overriddenHooks?.onOpen?.();
         setRerenderTrigger((t) => t + 1);

--- a/wrappers/react/src/types.tsx
+++ b/wrappers/react/src/types.tsx
@@ -32,9 +32,9 @@ export interface HotEditorHooks {
 /**
  * Interface for custom component-based editor API exposed by useHotEditor
  */
-export interface UseHotEditorImpl {
-  value?: any
-  setValue: React.Dispatch<any>
+export interface UseHotEditorImpl<T> {
+  value?: T
+  setValue: React.Dispatch<T>
   isOpen: boolean
   finishEditing: React.DispatchWithoutAction
   row?: number


### PR DESCRIPTION
As a React user, one would expect `value` and `setValue` returned by `useHotEditor` to allow seamless integration for controlled inputs, as demonstrated below:

```jsx
// note example has some unrelated code ommited
import { useHotEditor } from "@handsontable/react";

const Example = () => {
  const { value, setValue } = useHotEditor<number>();
  return (
    <input
      className="w-full"
      type="range"
      id="progress"
      name="progress"
      min="0"
      max="100"
      value={value ?? 0}
      onChange={(event) => setValue(event.target.valueAsNumber)}
    />
  );
};
```

**Problem Before This Update:**

Before this update, attempting to implement controlled inputs like the example above wouldn’t work correctly. Specifically, the input change would not be reflected because React wouldn’t receive the updated value. This introduces unnecessary complexity and potential points of failure for developers using Handsontable.

**Without This Update:**
Without this improvement, developers are forced to write more boilerplate code to achieve the same functionality, as shown in the following example:
```jsx

// note example has some unrelated code ommited
import { useHotEditor } from '@handsontable/react';
import { useEffect, useState } from 'react';

const Example = () => {
  const [progress, setProgress] = useState(0);
  const { value, setValue, finishEditing } = useHotEditor();

  useEffect(() => {
    if (value !== undefined) {
      setProgress(value);
    }
  }, [value]);

  const handleFinish = () => {
    setValue(progress);
    finishEditing();
  };

  return (
    <input
      className="w-full"
      type="range"
      id="progress"
      name="progress"
      min="0"
      max="100"
      value={progress}
      onChange={(event) => setProgress(event.target.valueAsNumber)}
    />
  );
};
```

In this example, the user has to manually manage state using `useState` and `useEffect`, complicating what should be a straightforward task.


**Key Enhancements in This Pull Request:**
- **Simplified API:** The most notable change is the removal of the need for useState within the user's implementation. This shifts the responsibility from the user to the library, ensuring the input works out-of-the-box.
- **Deffering values:** Additionally, I introduced `useDeferredValue` as a micro-optimization after adding state management to the useHotEditor hook. This change helps optimize performance without requiring any additional effort from the user.
- **Type Safety:** This update also introduces a generic `useHotEditor<T>`, allowing users to specify the type, as seen in the first example above. This enhances type safety and improves the developer experience.

By making these changes, the complexity for developers using Handsontable in React projects is significantly reduced, allowing them to focus more on building great things with fewer hurdles

### How has this been tested?
Locally and tests being run

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [X] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [X] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
