### PR TITLE
Extend the `beforeFilter` hook with a second argument to allow correct Undo/Redo functionality.

### DIFF
--- a/.changelogs/11170.json
+++ b/.changelogs/11170.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Extended the `beforeFilter` hook with a second argument to allow correct Undo/Redo functionality.",
+  "type": "added",
+  "issueOrPR": 11170,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/__tests__/core/settings.types.ts
+++ b/handsontable/src/__tests__/core/settings.types.ts
@@ -550,7 +550,7 @@ const allSettings: Required<Handsontable.GridSettings> = {
   beforeDrawBorders: (corners, borderClassName) => {},
   beforeDropdownMenuSetItems: (menuItems) => {},
   beforeDropdownMenuShow: (instance) => {},
-  beforeFilter: (conditionsStack) => { conditionsStack[0].conditions[0].name === 'begins_with'; },
+  beforeFilter: (conditionsStack, previousConditionStack) => { conditionsStack[0].conditions[0].name === 'begins_with'; },
   beforeGetCellMeta: (row, col, cellProperties) => {},
   beforeHideColumns: (currentHideConfig, destinationHideConfig, actionPossible) => {},
   beforeHideRows: (currentHideConfig, destinationHideConfig, actionPossible) => {},

--- a/handsontable/src/pluginHooks.js
+++ b/handsontable/src/pluginHooks.js
@@ -2139,6 +2139,7 @@ const REGISTERED_HOOKS = [
    *
    * @event Hooks#beforeFilter
    * @param {object[]} conditionsStack An array of objects with your [column filters](@/api/filters.md#addcondition).
+   * @param {object[]|null} previousConditionsStack An array of objects with your previous [column filters](@/api/filters.md#addcondition).
    * @returns {boolean} To perform server-side filtering (i.e., to not apply filtering to Handsontable's UI), return `false`.
    */
   'beforeFilter',

--- a/handsontable/src/pluginHooks.js
+++ b/handsontable/src/pluginHooks.js
@@ -2139,7 +2139,7 @@ const REGISTERED_HOOKS = [
    *
    * @event Hooks#beforeFilter
    * @param {object[]} conditionsStack An array of objects with your [column filters](@/api/filters.md#addcondition).
-   * @param {object[]|null} previousConditionsStack An array of objects with your previous [column filters](@/api/filters.md#addcondition).
+   * @param {object[]|null} previousConditionsStack An array of objects with your previous [column filters](@/api/filters.md#addcondition). It can also be `null` if there was no previous filters applied or the conditions did not change between performing the `filter` action.
    * @returns {boolean} To perform server-side filtering (i.e., to not apply filtering to Handsontable's UI), return `false`.
    */
   'beforeFilter',

--- a/handsontable/src/plugins/filters/__tests__/conditionCollection.unit.js
+++ b/handsontable/src/plugins/filters/__tests__/conditionCollection.unit.js
@@ -8,6 +8,7 @@ const hotMock = {
   toVisualColumn: column => column,
   columnIndexMapper: new IndexMapper(),
   getCellMeta: () => ({}),
+  addHook: () => {},
 };
 
 // Mocking that table have 5 columns.

--- a/handsontable/src/plugins/filters/__tests__/filters.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/filters.spec.js
@@ -773,23 +773,23 @@ describe('Filters', () => {
       expect(getDataAtCell(33, 1).includes('!')).toBe(true);
 
       hot.undo();
-      
+
       expect(getData().length).toEqual(2);
       expect(getDataAtCell(0, 1).includes('!')).toBe(true);
       expect(getDataAtCell(1, 1).includes('!')).toBe(true);
 
       hot.undo();
-      
+
       expect(getDataAtCell(0, 1).includes('!')).toBe(true);
       expect(getDataAtCell(1, 1).includes('!')).toBe(false);
 
       hot.undo();
-      
+
       expect(getDataAtCell(0, 1).includes('!')).toBe(false);
       expect(getDataAtCell(1, 1).includes('!')).toBe(false);
 
       hot.undo();
-      
+
       expect(getData().length).toEqual(39);
       expect(getDataAtCell(0, 1).includes('!')).toBe(false);
       expect(getDataAtCell(1, 1).includes('!')).toBe(false);

--- a/handsontable/src/plugins/filters/__tests__/filters.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/filters.spec.js
@@ -727,6 +727,71 @@ describe('Filters', () => {
 
       expect(getData().length).toEqual(2);
     });
+
+    it('should undo multiple steps of filtering performed with the Filters\' UI', async() => {
+      const hot = handsontable({
+        data: getDataForFilters(),
+        columns: getColumnsForFilters(),
+        dropdownMenu: true,
+        filters: true,
+        width: 500,
+        height: 300
+      });
+
+      dropdownMenu(1);
+      openDropdownByConditionMenu();
+      selectDropdownByConditionMenuOption('Begins with');
+
+      await sleep(20);
+      document.activeElement.value = 'R';
+      keyUp('R');
+
+      $(dropdownMenuRootElement().querySelector('.htUIButton.htUIButtonOK input')).simulate('click');
+
+      expect(getData().length).toEqual(2);
+
+      setDataAtCell(0, 1, `${getDataAtCell(0, 1)}!`);
+      setDataAtCell(1, 1, `${getDataAtCell(1, 1)}!`);
+
+      expect(getDataAtCell(0, 1).includes('!')).toBe(true);
+      expect(getDataAtCell(1, 1).includes('!')).toBe(true);
+
+      dropdownMenu(1);
+      openDropdownByConditionMenu();
+      selectDropdownByConditionMenuOption('Begins with');
+
+      await sleep(20);
+      document.activeElement.value = '';
+      keyUp('Backspace');
+
+      $(dropdownMenuRootElement().querySelector('.htUIButton.htUIButtonOK input')).simulate('click');
+
+      expect(getData().length).toEqual(39);
+      expect(getDataAtCell(0, 1).includes('!')).toBe(false);
+      expect(getDataAtCell(1, 1).includes('!')).toBe(false);
+      expect(getDataAtCell(4, 1).includes('!')).toBe(true);
+      expect(getDataAtCell(33, 1).includes('!')).toBe(true);
+
+      hot.undo();
+      expect(getData().length).toEqual(2);
+      expect(getDataAtCell(0, 1).includes('!')).toBe(true);
+      expect(getDataAtCell(1, 1).includes('!')).toBe(true);
+
+      hot.undo();
+      expect(getDataAtCell(0, 1).includes('!')).toBe(true);
+      expect(getDataAtCell(1, 1).includes('!')).toBe(false);
+
+      hot.undo();
+      expect(getDataAtCell(0, 1).includes('!')).toBe(false);
+      expect(getDataAtCell(1, 1).includes('!')).toBe(false);
+
+      hot.undo();
+      expect(getData().length).toEqual(39);
+      expect(getDataAtCell(0, 1).includes('!')).toBe(false);
+      expect(getDataAtCell(1, 1).includes('!')).toBe(false);
+      expect(getDataAtCell(4, 1).includes('!')).toBe(false);
+      expect(getDataAtCell(33, 1).includes('!')).toBe(false);
+    });
   });
 
   describe('Hooks', () => {

--- a/handsontable/src/plugins/filters/__tests__/filters.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/filters.spec.js
@@ -773,19 +773,23 @@ describe('Filters', () => {
       expect(getDataAtCell(33, 1).includes('!')).toBe(true);
 
       hot.undo();
+      
       expect(getData().length).toEqual(2);
       expect(getDataAtCell(0, 1).includes('!')).toBe(true);
       expect(getDataAtCell(1, 1).includes('!')).toBe(true);
 
       hot.undo();
+      
       expect(getDataAtCell(0, 1).includes('!')).toBe(true);
       expect(getDataAtCell(1, 1).includes('!')).toBe(false);
 
       hot.undo();
+      
       expect(getDataAtCell(0, 1).includes('!')).toBe(false);
       expect(getDataAtCell(1, 1).includes('!')).toBe(false);
 
       hot.undo();
+      
       expect(getData().length).toEqual(39);
       expect(getDataAtCell(0, 1).includes('!')).toBe(false);
       expect(getDataAtCell(1, 1).includes('!')).toBe(false);

--- a/handsontable/src/plugins/filters/conditionCollection.js
+++ b/handsontable/src/plugins/filters/conditionCollection.js
@@ -53,8 +53,6 @@ class ConditionCollection {
     } else {
       this.filteringStates.init(this.hot.columnIndexMapper.getNumberOfIndexes());
     }
-
-    this.hot.addHook('afterFilter', () => this.#onAfterFilter());
   }
 
   /**
@@ -300,15 +298,6 @@ class ConditionCollection {
 
     this.filteringStates = null;
     this.clearLocalHooks();
-  }
-
-  /**
-   * Callback for the `afterFilter` hook.
-   *
-   * @private
-   */
-  #onAfterFilter() {
-    this.setPreviousConditionStack(null);
   }
 }
 

--- a/handsontable/src/plugins/filters/filters.js
+++ b/handsontable/src/plugins/filters/filters.js
@@ -515,7 +515,11 @@ export class Filters extends BasePlugin {
     let visibleVisualRows = [];
 
     const conditions = this.conditionCollection.exportAllConditions();
-    const allowFiltering = this.hot.runHooks('beforeFilter', conditions, this.conditionCollection.previousConditionStack);
+    const allowFiltering = this.hot.runHooks(
+      'beforeFilter',
+      conditions,
+      this.conditionCollection.previousConditionStack
+    );
 
     if (allowFiltering !== false) {
       if (needToFilter) {

--- a/handsontable/src/plugins/filters/filters.js
+++ b/handsontable/src/plugins/filters/filters.js
@@ -515,7 +515,7 @@ export class Filters extends BasePlugin {
     let visibleVisualRows = [];
 
     const conditions = this.conditionCollection.exportAllConditions();
-    const allowFiltering = this.hot.runHooks('beforeFilter', conditions);
+    const allowFiltering = this.hot.runHooks('beforeFilter', conditions, this.conditionCollection.previousConditionStack);
 
     if (allowFiltering !== false) {
       if (needToFilter) {

--- a/handsontable/src/plugins/filters/filters.js
+++ b/handsontable/src/plugins/filters/filters.js
@@ -553,6 +553,8 @@ export class Filters extends BasePlugin {
 
     this.hot.runHooks('afterFilter', conditions);
 
+    this.conditionCollection.setPreviousConditionStack(null);
+
     this.hot.view.adjustElementsSize();
     this.hot.render();
 

--- a/handsontable/src/plugins/undoRedo/undoRedo.js
+++ b/handsontable/src/plugins/undoRedo/undoRedo.js
@@ -801,12 +801,13 @@ inherit(UndoRedo.FiltersAction, UndoRedo.Action);
 
 UndoRedo.FiltersAction.prototype.undo = function(instance, undoneCallback) {
   const filters = instance.getPlugin('filters');
+  const previousStack =
+    this.previousConditionsStack ||
+    this.conditionsStack.slice(0, this.conditionsStack.length - 1);
 
   instance.addHookOnce('afterViewRender', undoneCallback);
 
-  if (this.previousConditionsStack) {
-    filters.conditionCollection.importAllConditions(this.previousConditionsStack);
-  }
+  filters.conditionCollection.importAllConditions(previousStack);
 
   filters.filter();
 };

--- a/handsontable/src/plugins/undoRedo/undoRedo.js
+++ b/handsontable/src/plugins/undoRedo/undoRedo.js
@@ -804,7 +804,9 @@ UndoRedo.FiltersAction.prototype.undo = function(instance, undoneCallback) {
 
   instance.addHookOnce('afterViewRender', undoneCallback);
 
-  filters.conditionCollection.importAllConditions(this.previousConditionsStack);
+  if (this.previousConditionsStack) {
+    filters.conditionCollection.importAllConditions(this.previousConditionsStack);
+  }
 
   filters.filter();
 };

--- a/handsontable/src/plugins/undoRedo/undoRedo.js
+++ b/handsontable/src/plugins/undoRedo/undoRedo.js
@@ -801,13 +801,12 @@ inherit(UndoRedo.FiltersAction, UndoRedo.Action);
 
 UndoRedo.FiltersAction.prototype.undo = function(instance, undoneCallback) {
   const filters = instance.getPlugin('filters');
-  const previousStack =
-    this.previousConditionsStack ||
-    this.conditionsStack.slice(0, this.conditionsStack.length - 1);
 
   instance.addHookOnce('afterViewRender', undoneCallback);
 
-  filters.conditionCollection.importAllConditions(previousStack);
+  if (this.previousConditionsStack) {
+    filters.conditionCollection.importAllConditions(this.previousConditionsStack);
+  }
 
   filters.filter();
 };

--- a/handsontable/src/plugins/undoRedo/undoRedo.js
+++ b/handsontable/src/plugins/undoRedo/undoRedo.js
@@ -171,8 +171,8 @@ function UndoRedo(instance) {
     plugin.done(() => new UndoRedo.CellAlignmentAction(stateBefore, range, type, alignment));
   });
 
-  instance.addHook('beforeFilter', (conditionsStack) => {
-    plugin.done(() => new UndoRedo.FiltersAction(conditionsStack));
+  instance.addHook('beforeFilter', (conditionsStack, previousConditionsStack) => {
+    plugin.done(() => new UndoRedo.FiltersAction(conditionsStack, previousConditionsStack));
   });
 
   instance.addHook('beforeRowMove', (rows, finalIndex) => {
@@ -789,9 +789,11 @@ UndoRedo.CellAlignmentAction.prototype.redo = function(instance, undoneCallback)
  * Filters action.
  *
  * @private
- * @param {Array} conditionsStack An array of the filter condition.
+ * @param {Array} conditionsStack An array of the filter conditions.
+ * @param {Array} previousConditionsStack An array of the previous filter conditions.
  */
-UndoRedo.FiltersAction = function(conditionsStack) {
+UndoRedo.FiltersAction = function(conditionsStack, previousConditionsStack) {
+  this.previousConditionsStack = previousConditionsStack;
   this.conditionsStack = conditionsStack;
   this.actionType = 'filter';
 };
@@ -802,7 +804,8 @@ UndoRedo.FiltersAction.prototype.undo = function(instance, undoneCallback) {
 
   instance.addHookOnce('afterViewRender', undoneCallback);
 
-  filters.conditionCollection.importAllConditions(this.conditionsStack.slice(0, this.conditionsStack.length - 1));
+  filters.conditionCollection.importAllConditions(this.previousConditionsStack);
+
   filters.filter();
 };
 UndoRedo.FiltersAction.prototype.redo = function(instance, redoneCallback) {

--- a/handsontable/types/pluginHooks.d.ts
+++ b/handsontable/types/pluginHooks.d.ts
@@ -180,7 +180,7 @@ export interface Events {
   beforeDrawBorders?: (corners: number[], borderClassName: 'current' | 'area' | 'highlight' | undefined) => void;
   beforeDropdownMenuSetItems?: (menuItems: ContextMenuMenuItemConfig[]) => void;
   beforeDropdownMenuShow?: (instance: DropdownMenu) => void;
-  beforeFilter?: (conditionsStack: FiltersColumnConditions[]) => void | boolean;
+  beforeFilter?: (conditionsStack: FiltersColumnConditions[], previousConditionsStack: FiltersColumnConditions[]) => void | boolean;
   beforeGetCellMeta?: (row: number, column: number, cellProperties: CellProperties) => void;
   beforeHideColumns?: (currentHideConfig: number[], destinationHideConfig: number[], actionPossible: boolean) => void | boolean;
   beforeHideRows?: (currentHideConfig: number[], destinationHideConfig: number[], actionPossible: boolean) => void | boolean;


### PR DESCRIPTION
### Context
This PR:
- Extends the `beforeFilter` hook with a second argument, `previousConditionStack`, containing the condition stack from before the new Filters are applied. This allows the UndoRedo plugin to record the filters change and undo/redo it properly. Currently it doesn't work right in some cases.
- Extends the UndoRedo logic for filters to utilize the new argument.
- Adds tests covering the case from handsontable/dev-handsontable#910.

### How has this been tested?
Added a test case.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#910

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
