### PR TITLE
Fix a problem with deleting content from a selection when it contains both `checkbox` and non-`checkbox` typed cells.

### DIFF
--- a/.changelogs/11182.json
+++ b/.changelogs/11182.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed a problem with deleting content from a selection when it contained both `checkbox` and non-`checkbox`-typed cells.",
+  "type": "fixed",
+  "issueOrPR": 11182,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/renderers/checkboxRenderer/__tests__/keyboardShortcuts/deleteOrBackspace.spec.js
+++ b/handsontable/src/renderers/checkboxRenderer/__tests__/keyboardShortcuts/deleteOrBackspace.spec.js
@@ -108,6 +108,23 @@ describe('CheckboxRenderer', () => {
       expect(getData()).toEqual([[true], [false], [true]]);
     });
 
+    it('should change the checkbox state to unchecked and clear the non-checkbox cells\' content when both the' +
+      ' checkbox-typed and non-checkbox-typed cells are selected', () => {
+      handsontable({
+        data: [['foo', true], ['bar', true]],
+        columns: [
+          { type: 'text' },
+          { type: 'checkbox' }
+        ]
+      });
+
+      selectCells([[0, 0, 1, 1]]);
+
+      keyDownUp(key);
+
+      expect(getData()).toEqual([[null, false], [null, false]]);
+    });
+
     it('should not steal the event when the column header is selected', () => {
       handsontable({
         data: [[true], [true], [true]],

--- a/handsontable/src/renderers/checkboxRenderer/checkboxRenderer.js
+++ b/handsontable/src/renderers/checkboxRenderer/checkboxRenderer.js
@@ -214,6 +214,7 @@ export function checkboxRenderer(hotInstance, TD, row, col, prop, value, cellPro
   function changeSelectedCheckboxesState(uncheckCheckbox = false) {
     const selRange = hotInstance.getSelectedRange();
     const changesPerSubSelection = [];
+    const nonCheckboxChanges = new Map();
     let changes = [];
     let changeCounter = 0;
 
@@ -233,8 +234,23 @@ export function checkboxRenderer(hotInstance, TD, row, col, prop, value, cellPro
             uncheckedTemplate: cachedCellProperties.uncheckedTemplate,
           };
 
+          // TODO: In the future it'd be better if non-checkbox changes were handled by the non-checkbox
+          //  `delete` keypress logic.
+          /* eslint-disable no-continue */
           if (cachedCellProperties.type !== 'checkbox') {
-            return;
+            if (uncheckCheckbox === true && !cachedCellProperties.readOnly) {
+              if (nonCheckboxChanges.has(changesPerSubSelection.length)) {
+                nonCheckboxChanges.set(changesPerSubSelection.length, [
+                  ...nonCheckboxChanges.get(changesPerSubSelection.length),
+                  [visualRow, visualColumn, null]
+                ]);
+
+              } else {
+                nonCheckboxChanges.set(changesPerSubSelection.length, [[visualRow, visualColumn, null]]);
+              }
+            }
+
+            continue;
           }
 
           /* eslint-disable no-continue */
@@ -282,8 +298,15 @@ export function checkboxRenderer(hotInstance, TD, row, col, prop, value, cellPro
     if (changes.length > 0) {
       // TODO: This is workaround for handsontable/dev-handsontable#1747 not being a breaking change.
       // Technically, the changes don't need to be split into chunks when sent to `setDataAtCell`.
-      changesPerSubSelection.forEach((changesCount) => {
-        const changesChunk = changes.splice(0, changesCount);
+      changesPerSubSelection.forEach((changesCount, sectionCount) => {
+        let changesChunk = changes.splice(0, changesCount);
+
+        if (nonCheckboxChanges.size && nonCheckboxChanges.has(sectionCount)) {
+          changesChunk = [
+            ...changesChunk,
+            ...nonCheckboxChanges.get(sectionCount)
+          ];
+        }
 
         hotInstance.setDataAtCell(changesChunk);
       });
@@ -310,10 +333,6 @@ export function checkboxRenderer(hotInstance, TD, row, col, prop, value, cellPro
       for (let visualRow = topLeft.row; visualRow <= bottomRight.row; visualRow++) {
         for (let visualColumn = topLeft.col; visualColumn <= bottomRight.col; visualColumn++) {
           const cachedCellProperties = hotInstance.getCellMeta(visualRow, visualColumn);
-
-          if (cachedCellProperties.type !== 'checkbox') {
-            return false;
-          }
 
           const cell = hotInstance.getCell(visualRow, visualColumn);
 


### PR DESCRIPTION
### Context
This PR:

- Adds a non-`checkbox` logic to the checkbox renderer for cases when deleting content from mixed-type cells. (With a `TODO` annotation to refactor it in a more structured way in the future. I think a better fix would involve refactoring the shortcuts logic to make the checkbox renderer handle just the checkbox-typed cells, but it might require significantly more time.)
- Add a test case for that situation.

### How has this been tested?
Tested manually and added a test case.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#482

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
