### PR TITLE
Add even and odd class names to the `TR` elements.

### DIFF
--- a/.changelogs/11183.json
+++ b/.changelogs/11183.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Added even and odd class names to the TR elements.",
+  "type": "added",
+  "issueOrPR": 11183,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/src/renderer/rows.js
+++ b/handsontable/src/3rdparty/walkontable/src/renderer/rows.js
@@ -2,7 +2,7 @@ import BaseRenderer from './_base';
 import { warn } from './../../../../helpers/console';
 import { toSingleLine } from './../../../../helpers/templateLiteralTag';
 import { OrderView } from './../utils/orderView';
-import { setAttribute } from '../../../../helpers/dom/element';
+import { addClass, removeClass, setAttribute } from '../../../../helpers/dom/element';
 import {
   A11Y_ROW,
   A11Y_ROWGROUP,
@@ -87,6 +87,15 @@ export default class RowsRenderer extends BaseRenderer {
           // `aria-rowindex` is incremented by both tbody and thead rows.
           A11Y_ROWINDEX(sourceRowIndex + (this.table.rowUtils?.dataAccessObject?.columnHeaders.length ?? 0) + 1),
         ]);
+      }
+
+      removeClass(TR, ['ht__row_odd', 'ht__row_even']);
+
+      if ((sourceRowIndex + 1) % 2 === 0) {
+        addClass(TR, 'ht__row_even');
+
+      } else {
+        addClass(TR, 'ht__row_odd');
       }
     }
 

--- a/handsontable/src/3rdparty/walkontable/src/renderer/rows.js
+++ b/handsontable/src/3rdparty/walkontable/src/renderer/rows.js
@@ -2,13 +2,21 @@ import BaseRenderer from './_base';
 import { warn } from './../../../../helpers/console';
 import { toSingleLine } from './../../../../helpers/templateLiteralTag';
 import { OrderView } from './../utils/orderView';
-import { addClass, removeClass, setAttribute } from '../../../../helpers/dom/element';
+import {
+  addClass,
+  removeClass,
+  setAttribute
+} from '../../../../helpers/dom/element';
 import {
   A11Y_ROW,
   A11Y_ROWGROUP,
   A11Y_ROWINDEX
 } from '../../../../helpers/a11y';
 
+const ROW_CLASSNAMES = {
+  rowEven: 'ht__row_even',
+  rowOdd: 'ht__row_odd',
+};
 let performanceWarningAppeared = false;
 
 /**
@@ -89,13 +97,13 @@ export default class RowsRenderer extends BaseRenderer {
         ]);
       }
 
-      removeClass(TR, ['ht__row_odd', 'ht__row_even']);
+      removeClass(TR, [ROW_CLASSNAMES.rowEven, ROW_CLASSNAMES.rowOdd]);
 
       if ((sourceRowIndex + 1) % 2 === 0) {
-        addClass(TR, 'ht__row_even');
+        addClass(TR, ROW_CLASSNAMES.rowEven);
 
       } else {
-        addClass(TR, 'ht__row_odd');
+        addClass(TR, ROW_CLASSNAMES.rowOdd);
       }
     }
 

--- a/handsontable/src/3rdparty/walkontable/test/spec/renderer/cells.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/renderer/cells.spec.js
@@ -38,7 +38,7 @@ describe('Walkontable.Renderer.CellsRenderer', () => {
     // Matchers configuration.
     this.matchersConfig = {
       toMatchHTML: {
-        keepAttributes: ['class', 'dir', 'style']
+        keepAttributes: ['dir', 'style']
       }
     };
   });
@@ -92,14 +92,14 @@ describe('Walkontable.Renderer.CellsRenderer', () => {
     expect(rootNode.outerHTML).toMatchHTML(`
       <tbody>
         <tr>
-          <th class=""></th>
-          <td class=""></td>
-          <td class=""></td>
+          <th></th>
+          <td></td>
+          <td></td>
         </tr>
         <tr>
-          <th class=""></th>
-          <td class=""></td>
-          <td class=""></td>
+          <th></th>
+          <td></td>
+          <td></td>
         </tr>
       </tbody>
       `);
@@ -132,14 +132,14 @@ describe('Walkontable.Renderer.CellsRenderer', () => {
     expect(rootNode.outerHTML).toMatchHTML(`
       <tbody>
         <tr>
-          <td class="" dir="rtl" style="width: 60px;"></td>
-          <td class="" dir="rtl" style="width: 60px;"></td>
-          <td class="" dir="rtl" style="width: 60px;"></td>
+          <td dir="rtl" style="width: 60px;"></td>
+          <td dir="rtl" style="width: 60px;"></td>
+          <td dir="rtl" style="width: 60px;"></td>
         </tr>
         <tr>
-          <td class="" dir="rtl" style="width: 60px;"></td>
-          <td class="" dir="rtl" style="width: 60px;"></td>
-          <td class="" dir="rtl" style="width: 60px;"></td>
+          <td dir="rtl" style="width: 60px;"></td>
+          <td dir="rtl" style="width: 60px;"></td>
+          <td dir="rtl" style="width: 60px;"></td>
         </tr>
       </tbody>
       `);
@@ -157,14 +157,14 @@ describe('Walkontable.Renderer.CellsRenderer', () => {
     expect(rootNode.outerHTML).toMatchHTML(`
       <tbody>
         <tr>
-          <td class=""></td>
-          <td class=""></td>
-          <td class=""></td>
+          <td></td>
+          <td></td>
+          <td></td>
         </tr>
         <tr>
-          <td class=""></td>
-          <td class=""></td>
-          <td class=""></td>
+          <td></td>
+          <td></td>
+          <td></td>
         </tr>
       </tbody>
       `);
@@ -208,14 +208,14 @@ describe('Walkontable.Renderer.CellsRenderer', () => {
     expect(rootNode.outerHTML).toMatchHTML(`
       <tbody>
         <tr>
-          <td class=""></td>
-          <td class=""></td>
-          <td class=""></td>
+          <td></td>
+          <td></td>
+          <td></td>
         </tr>
         <tr>
-          <td class=""></td>
-          <td class=""></td>
-          <td class=""></td>
+          <td></td>
+          <td></td>
+          <td></td>
         </tr>
       </tbody>
       `);
@@ -243,14 +243,14 @@ describe('Walkontable.Renderer.CellsRenderer', () => {
     expect(rootNode.outerHTML).toMatchHTML(`
       <tbody>
         <tr>
-          <td class=""></td>
-          <td class=""></td>
-          <td class=""></td>
+          <td></td>
+          <td></td>
+          <td></td>
         </tr>
         <tr>
-          <td class=""></td>
-          <td class=""></td>
-          <td class=""></td>
+          <td></td>
+          <td></td>
+          <td></td>
         </tr>
       </tbody>
       `);

--- a/handsontable/src/3rdparty/walkontable/test/spec/renderer/rowHeaders.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/renderer/rowHeaders.spec.js
@@ -32,15 +32,6 @@ describe('Walkontable.Renderer.RowHeadersRenderer', () => {
     return { rowHeadersRenderer, rowsRenderer, cellsRenderer, tableMock, rootNode };
   }
 
-  beforeEach(function() {
-    // Matchers configuration.
-    this.matchersConfig = {
-      toMatchHTML: {
-        keepAttributes: ['class']
-      }
-    };
-  });
-
   it('should not generate any row headers', () => {
     const { rowHeadersRenderer, rowsRenderer, cellsRenderer, tableMock, rootNode } = createRenderer();
 
@@ -91,14 +82,14 @@ describe('Walkontable.Renderer.RowHeadersRenderer', () => {
     expect(rootNode.outerHTML).toMatchHTML(`
       <tbody>
         <tr>
-          <th class=""></th>
-          <td class=""></td>
-          <td class=""></td>
+          <th></th>
+          <td></td>
+          <td></td>
         </tr>
         <tr>
-          <th class=""></th>
-          <td class=""></td>
-          <td class=""></td>
+          <th></th>
+          <td></td>
+          <td></td>
         </tr>
       </tbody>
       `);
@@ -150,14 +141,14 @@ describe('Walkontable.Renderer.RowHeadersRenderer', () => {
     expect(rootNode.outerHTML).toMatchHTML(`
       <tbody>
         <tr>
-          <th class=""></th>
-          <td class=""></td>
-          <td class=""></td>
+          <th></th>
+          <td></td>
+          <td></td>
         </tr>
         <tr>
-          <th class=""></th>
-          <td class=""></td>
-          <td class=""></td>
+          <th></th>
+          <td></td>
+          <td></td>
         </tr>
       </tbody>
       `);
@@ -188,14 +179,14 @@ describe('Walkontable.Renderer.RowHeadersRenderer', () => {
     expect(rootNode.outerHTML).toMatchHTML(`
       <tbody>
         <tr>
-          <th class=""></th>
-          <td class=""></td>
-          <td class=""></td>
+          <th></th>
+          <td></td>
+          <td></td>
         </tr>
         <tr>
-          <th class=""></th>
-          <td class=""></td>
-          <td class=""></td>
+          <th></th>
+          <td></td>
+          <td></td>
         </tr>
       </tbody>
       `);

--- a/handsontable/src/3rdparty/walkontable/test/spec/renderer/rows.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/renderer/rows.spec.js
@@ -74,6 +74,31 @@ describe('Walkontable.Renderer.RowsRenderer', () => {
       `);
   });
 
+  it('should add the `ht__rows_odd` and `ht__rows_even` classes to the appropriate rows', () => {
+    const { renderer, tableMock, rootNode } = createRenderer();
+
+    spec().matchersConfig = {
+      toMatchHTML: {
+        keepAttributes: ['class']
+      }
+    };
+
+    tableMock.rowsToRender = 5;
+
+    renderer.adjust();
+    renderer.render();
+
+    expect(rootNode.outerHTML).toMatchHTML(`
+      <tbody>
+        <tr class="ht__row_odd"></tr>
+        <tr class="ht__row_even"></tr>
+        <tr class="ht__row_odd"></tr>
+        <tr class="ht__row_even"></tr>
+        <tr class="ht__row_odd"></tr>
+      </tbody>
+      `);
+  });
+
   it('should reuse previously created elements on next render cycle', () => {
     const { renderer, tableMock, rootNode } = createRenderer();
 

--- a/handsontable/src/plugins/collapsibleColumns/__tests__/API.spec.js
+++ b/handsontable/src/plugins/collapsibleColumns/__tests__/API.spec.js
@@ -268,7 +268,7 @@ describe('CollapsibleColumns API', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -366,7 +366,7 @@ describe('CollapsibleColumns API', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">J1</td>
@@ -514,7 +514,7 @@ describe('CollapsibleColumns API', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">B1</td>
             <td class="">J1</td>
             <td class="">K1</td>
@@ -645,7 +645,7 @@ describe('CollapsibleColumns API', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -794,7 +794,7 @@ describe('CollapsibleColumns API', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">D1</td>
@@ -897,7 +897,7 @@ describe('CollapsibleColumns API', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>

--- a/handsontable/src/plugins/collapsibleColumns/__tests__/collapsibleColumns.spec.js
+++ b/handsontable/src/plugins/collapsibleColumns/__tests__/collapsibleColumns.spec.js
@@ -141,7 +141,7 @@ describe('CollapsibleColumns', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -187,7 +187,7 @@ describe('CollapsibleColumns', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -248,7 +248,7 @@ describe('CollapsibleColumns', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -305,7 +305,7 @@ describe('CollapsibleColumns', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -365,7 +365,7 @@ describe('CollapsibleColumns', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -423,7 +423,7 @@ describe('CollapsibleColumns', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -485,7 +485,7 @@ describe('CollapsibleColumns', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -534,7 +534,7 @@ describe('CollapsibleColumns', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -581,7 +581,7 @@ describe('CollapsibleColumns', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -636,7 +636,7 @@ describe('CollapsibleColumns', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -687,7 +687,7 @@ describe('CollapsibleColumns', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -739,7 +739,7 @@ describe('CollapsibleColumns', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -781,7 +781,7 @@ describe('CollapsibleColumns', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">F1</td>
@@ -832,7 +832,7 @@ describe('CollapsibleColumns', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -878,7 +878,7 @@ describe('CollapsibleColumns', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">D1</td>
@@ -986,7 +986,7 @@ describe('CollapsibleColumns', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -1083,7 +1083,7 @@ describe('CollapsibleColumns', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">D1</td>
@@ -1169,7 +1169,7 @@ describe('CollapsibleColumns', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">F1</td>
@@ -1243,7 +1243,7 @@ describe('CollapsibleColumns', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">F1</td>
@@ -1305,7 +1305,7 @@ describe('CollapsibleColumns', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">J1</td>
@@ -1360,7 +1360,7 @@ describe('CollapsibleColumns', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">J1</td>
@@ -1409,7 +1409,7 @@ describe('CollapsibleColumns', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">J1</td>
@@ -1477,7 +1477,7 @@ describe('CollapsibleColumns', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -1532,7 +1532,7 @@ describe('CollapsibleColumns', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -1581,7 +1581,7 @@ describe('CollapsibleColumns', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -1624,7 +1624,7 @@ describe('CollapsibleColumns', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">D1</td>
@@ -1765,7 +1765,7 @@ describe('CollapsibleColumns', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">AC1</td>
             <td class="">AD1</td>
             <td class="">AE1</td>
@@ -1908,7 +1908,7 @@ describe('CollapsibleColumns', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">N1</td>
             <td class="">O1</td>
             <td class="">P1</td>
@@ -1971,7 +1971,7 @@ describe('CollapsibleColumns', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">F1</td>
@@ -2016,7 +2016,7 @@ describe('CollapsibleColumns', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -2068,7 +2068,7 @@ describe('CollapsibleColumns', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">F1</td>
@@ -2109,7 +2109,7 @@ describe('CollapsibleColumns', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -2175,7 +2175,7 @@ describe('CollapsibleColumns', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">J1</td>
@@ -2228,7 +2228,7 @@ describe('CollapsibleColumns', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -2292,7 +2292,7 @@ describe('CollapsibleColumns', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -2378,7 +2378,7 @@ describe('CollapsibleColumns', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -2478,7 +2478,7 @@ describe('CollapsibleColumns', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -2640,7 +2640,7 @@ describe('CollapsibleColumns', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">AC1</td>
             <td class="">AD1</td>
             <td class="">AE1</td>

--- a/handsontable/src/plugins/collapsibleColumns/__tests__/hooks.spec.js
+++ b/handsontable/src/plugins/collapsibleColumns/__tests__/hooks.spec.js
@@ -211,7 +211,7 @@ describe('CollapsibleColumns Hooks', () => {
         </tr>
       </thead>
       <tbody>
-        <tr>
+        <tr class="ht__row_odd">
           <td class="">A1</td>
           <td class="">B1</td>
           <td class="">C1</td>
@@ -270,7 +270,7 @@ describe('CollapsibleColumns Hooks', () => {
         </tr>
       </thead>
       <tbody>
-        <tr>
+        <tr class="ht__row_odd">
           <td class="">A1</td>
           <td class="">B1</td>
           <td class="">F1</td>
@@ -326,7 +326,7 @@ describe('CollapsibleColumns Hooks', () => {
         </tr>
       </thead>
       <tbody>
-        <tr>
+        <tr class="ht__row_odd">
           <td class="">A1</td>
           <td class="">B1</td>
           <td class="">C1</td>
@@ -366,7 +366,7 @@ describe('CollapsibleColumns Hooks', () => {
         </tr>
       </thead>
       <tbody>
-        <tr>
+        <tr class="ht__row_odd">
           <td class="">A1</td>
           <td class="">B1</td>
           <td class="">C1</td>
@@ -426,7 +426,7 @@ describe('CollapsibleColumns Hooks', () => {
         </tr>
       </thead>
       <tbody>
-        <tr>
+        <tr class="ht__row_odd">
           <td class="">A1</td>
           <td class="">B1</td>
           <td class="">C1</td>
@@ -469,7 +469,7 @@ describe('CollapsibleColumns Hooks', () => {
         </tr>
       </thead>
       <tbody>
-        <tr>
+        <tr class="ht__row_odd">
           <td class="">A1</td>
           <td class="">B1</td>
           <td class="">C1</td>

--- a/handsontable/src/plugins/hiddenRows/__tests__/plugins/manualRowMove.spec.js
+++ b/handsontable/src/plugins/hiddenRows/__tests__/plugins/manualRowMove.spec.js
@@ -59,22 +59,22 @@ describe('HiddenRows', () => {
       expect(getPlugin('hiddenRows').isHidden(3)).toBeTruthy();
       expect(extractDOMStructure(getMaster())).toMatchHTML(`
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <th class="">1</th>
             <td class="">A3</td>
             <td class="">B3</td>
           </tr>
-          <tr>
+          <tr class="ht__row_even">
             <th class="">2</th>
             <td class="">A4</td>
             <td class="">B4</td>
           </tr>
-          <tr>
+          <tr class="ht__row_odd">
             <th class="${CSS_CLASS_BEFORE_HIDDEN_ROW}">3</th>
             <td class="">A5</td>
             <td class="">B5</td>
           </tr>
-          <tr>
+          <tr class="ht__row_even">
             <th class="${CSS_CLASS_AFTER_HIDDEN_ROW}">5</th>
             <td class="${CSS_CLASS_AFTER_HIDDEN_ROW}">A2</td>
             <td class="${CSS_CLASS_AFTER_HIDDEN_ROW}">B2</td>
@@ -108,22 +108,22 @@ describe('HiddenRows', () => {
       expect(getPlugin('hiddenRows').isHidden(1)).toBeTruthy();
       expect(extractDOMStructure(getMaster())).toMatchHTML(`
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <th class="${CSS_CLASS_BEFORE_HIDDEN_ROW}">1</th>
             <td class="">A4</td>
             <td class="">B4</td>
           </tr>
-          <tr>
+          <tr class="ht__row_even">
             <th class="${CSS_CLASS_AFTER_HIDDEN_ROW}">3</th>
             <td class="${CSS_CLASS_AFTER_HIDDEN_ROW}">A1</td>
             <td class="${CSS_CLASS_AFTER_HIDDEN_ROW}">B1</td>
           </tr>
-          <tr>
+          <tr class="ht__row_odd">
             <th class="">4</th>
             <td class="">A2</td>
             <td class="">B2</td>
           </tr>
-          <tr>
+          <tr class="ht__row_even">
             <th class="">5</th>
             <td class="">A3</td>
             <td class="">B3</td>
@@ -157,22 +157,22 @@ describe('HiddenRows', () => {
       expect(getPlugin('hiddenRows').isHidden(1)).toBeTruthy();
       expect(extractDOMStructure(getMaster())).toMatchHTML(`
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <th class="${CSS_CLASS_BEFORE_HIDDEN_ROW}">1</th>
             <td class="">A1</td>
             <td class="">B1</td>
           </tr>
-          <tr>
+          <tr class="ht__row_even">
             <th class="${CSS_CLASS_AFTER_HIDDEN_ROW}">3</th>
             <td class="${CSS_CLASS_AFTER_HIDDEN_ROW}">A2</td>
             <td class="${CSS_CLASS_AFTER_HIDDEN_ROW}">B2</td>
           </tr>
-          <tr>
+          <tr class="ht__row_odd">
             <th class="">4</th>
             <td class="">A3</td>
             <td class="">B3</td>
           </tr>
-          <tr>
+          <tr class="ht__row_even">
             <th class="">5</th>
             <td class="">A4</td>
             <td class="">B4</td>
@@ -206,22 +206,22 @@ describe('HiddenRows', () => {
       expect(getPlugin('hiddenRows').isHidden(2)).toBeTruthy();
       expect(extractDOMStructure(getMaster())).toMatchHTML(`
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <th class="">1</th>
             <td class="">A1</td>
             <td class="">B1</td>
           </tr>
-          <tr>
+          <tr class="ht__row_even">
             <th class="${CSS_CLASS_BEFORE_HIDDEN_ROW}">2</th>
             <td class="">A3</td>
             <td class="">B3</td>
           </tr>
-          <tr>
+          <tr class="ht__row_odd">
             <th class="${CSS_CLASS_AFTER_HIDDEN_ROW}">4</th>
             <td class="${CSS_CLASS_AFTER_HIDDEN_ROW}">A5</td>
             <td class="${CSS_CLASS_AFTER_HIDDEN_ROW}">B5</td>
           </tr>
-          <tr>
+          <tr class="ht__row_even">
             <th class="">5</th>
             <td class="">A2</td>
             <td class="">B2</td>
@@ -259,12 +259,12 @@ describe('HiddenRows', () => {
       expect(getPlugin('hiddenRows').isHidden(3)).toBeTruthy();
       expect(extractDOMStructure(getMaster())).toMatchHTML(`
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <th class="${CSS_CLASS_BEFORE_HIDDEN_ROW}">1</th>
             <td class="">A1</td>
             <td class="">B1</td>
           </tr>
-          <tr>
+          <tr class="ht__row_even">
             <th class="${CSS_CLASS_AFTER_HIDDEN_ROW}">5</th>
             <td class="${CSS_CLASS_AFTER_HIDDEN_ROW}">A5</td>
             <td class="${CSS_CLASS_AFTER_HIDDEN_ROW}">B5</td>
@@ -302,12 +302,12 @@ describe('HiddenRows', () => {
       expect(getPlugin('hiddenRows').isHidden(3)).toBeTruthy();
       expect(extractDOMStructure(getMaster())).toMatchHTML(`
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <th class="${CSS_CLASS_AFTER_HIDDEN_ROW} ${CSS_CLASS_BEFORE_HIDDEN_ROW}">3</th>
             <td class="${CSS_CLASS_AFTER_HIDDEN_ROW}">A1</td>
             <td class="${CSS_CLASS_AFTER_HIDDEN_ROW}">B1</td>
           </tr>
-          <tr>
+          <tr class="ht__row_even">
             <th class="${CSS_CLASS_AFTER_HIDDEN_ROW}">5</th>
             <td class="${CSS_CLASS_AFTER_HIDDEN_ROW}">A3</td>
             <td class="${CSS_CLASS_AFTER_HIDDEN_ROW}">B3</td>

--- a/handsontable/src/plugins/hiddenRows/__tests__/settings/fixedRowsBottom.spec.js
+++ b/handsontable/src/plugins/hiddenRows/__tests__/settings/fixedRowsBottom.spec.js
@@ -46,11 +46,11 @@ describe('HiddenRows', () => {
       expect(getBottomClone().find('tbody tr').length).toBe(2);
       expect(extractDOMStructure(getBottomClone())).toMatchHTML(`
         <tbody>
-          <tr>
+          <tr class="ht__row_even">
             <th class="${CSS_CLASS_AFTER_HIDDEN_ROW}">9</th>
             <td class="${CSS_CLASS_AFTER_HIDDEN_ROW}">A9</td>
           </tr>
-          <tr>
+          <tr class="ht__row_odd">
             <th class="">10</th>
             <td class="">A10</td>
           </tr>
@@ -72,11 +72,11 @@ describe('HiddenRows', () => {
       expect(getBottomClone().find('tbody tr').length).toBe(2);
       expect(extractDOMStructure(getBottomClone())).toMatchHTML(`
         <tbody>
-          <tr>
+          <tr class="ht__row_even">
             <th class="${CSS_CLASS_BEFORE_HIDDEN_ROW}">8</th>
             <td class="">A8</td>
           </tr>
-          <tr>
+          <tr class="ht__row_odd">
             <th class="${CSS_CLASS_AFTER_HIDDEN_ROW}">10</th>
             <td class="${CSS_CLASS_AFTER_HIDDEN_ROW}">A10</td>
           </tr>
@@ -98,7 +98,7 @@ describe('HiddenRows', () => {
       expect(getBottomClone().find('tbody tr').length).toBe(1);
       expect(extractDOMStructure(getBottomClone())).toMatchHTML(`
         <tbody>
-          <tr>
+          <tr class="ht__row_even">
             <th class="${CSS_CLASS_BEFORE_HIDDEN_ROW}">8</th>
             <td class="">A8</td>
           </tr>
@@ -121,7 +121,7 @@ describe('HiddenRows', () => {
       expect(getBottomClone().find('tbody tr').length).toBe(1);
       expect(extractDOMStructure(getBottomClone())).toMatchHTML(`
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <th class="${CSS_CLASS_AFTER_HIDDEN_ROW} ${CSS_CLASS_BEFORE_HIDDEN_ROW}">9</th>
             <td class="${CSS_CLASS_AFTER_HIDDEN_ROW}">A9</td>
           </tr>

--- a/handsontable/src/plugins/hiddenRows/__tests__/settings/fixedRowsTop.spec.js
+++ b/handsontable/src/plugins/hiddenRows/__tests__/settings/fixedRowsTop.spec.js
@@ -46,11 +46,11 @@ describe('HiddenRows', () => {
       expect(getTopClone().find('tbody tr').length).toBe(2);
       expect(extractDOMStructure(getTopClone())).toMatchHTML(`
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <th class="${CSS_CLASS_AFTER_HIDDEN_ROW}">2</th>
             <td class="${CSS_CLASS_AFTER_HIDDEN_ROW}">A2</td>
           </tr>
-          <tr>
+          <tr class="ht__row_even">
             <th class="">3</th>
             <td class="">A3</td>
           </tr>
@@ -72,11 +72,11 @@ describe('HiddenRows', () => {
       expect(getTopClone().find('tbody tr').length).toBe(2);
       expect(extractDOMStructure(getTopClone())).toMatchHTML(`
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <th class="${CSS_CLASS_BEFORE_HIDDEN_ROW}">1</th>
             <td class="">A1</td>
           </tr>
-          <tr>
+          <tr class="ht__row_even">
             <th class="${CSS_CLASS_AFTER_HIDDEN_ROW}">3</th>
             <td class="${CSS_CLASS_AFTER_HIDDEN_ROW}">A3</td>
           </tr>
@@ -98,7 +98,7 @@ describe('HiddenRows', () => {
       expect(getTopClone().find('tbody tr').length).toBe(1);
       expect(extractDOMStructure(getTopClone())).toMatchHTML(`
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <th class="${CSS_CLASS_BEFORE_HIDDEN_ROW}">1</th>
             <td class="">A1</td>
           </tr>
@@ -121,7 +121,7 @@ describe('HiddenRows', () => {
       expect(getTopClone().find('tbody tr').length).toBe(1);
       expect(extractDOMStructure(getTopClone())).toMatchHTML(`
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <th class="${CSS_CLASS_AFTER_HIDDEN_ROW} ${CSS_CLASS_BEFORE_HIDDEN_ROW}">2</th>
             <td class="${CSS_CLASS_AFTER_HIDDEN_ROW}">A2</td>
           </tr>

--- a/handsontable/src/plugins/nestedHeaders/__tests__/generalFunctionality.spec.js
+++ b/handsontable/src/plugins/nestedHeaders/__tests__/generalFunctionality.spec.js
@@ -110,7 +110,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -159,7 +159,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -191,7 +191,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
           </tr>
@@ -236,7 +236,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -284,7 +284,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -332,7 +332,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class=""></td>
             <td class=""></td>
             <td class=""></td>
@@ -370,7 +370,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class=""></td>
             <td class=""></td>
             <td class=""></td>
@@ -403,7 +403,7 @@ describe('NestedHeaders', () => {
             </tr>
           </thead>
           <tbody>
-            <tr>
+            <tr class="ht__row_odd">
               <td class="">A1</td>
               <td class="">B1</td>
             </tr>
@@ -431,7 +431,7 @@ describe('NestedHeaders', () => {
             </tr>
           </thead>
           <tbody>
-            <tr>
+            <tr class="ht__row_odd">
               <td class="">A1</td>
               <td class="">B1</td>
               <td class="">C1</td>
@@ -466,7 +466,7 @@ describe('NestedHeaders', () => {
             </tr>
           </thead>
           <tbody>
-            <tr>
+            <tr class="ht__row_odd">
               <td class="">A1</td>
               <td class="">B1</td>
               <td class="">C1</td>
@@ -582,7 +582,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -680,7 +680,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">AK1</td>
             <td class="">AL1</td>
             <td class="">AM1</td>

--- a/handsontable/src/plugins/nestedHeaders/__tests__/hidingColumns.spec.js
+++ b/handsontable/src/plugins/nestedHeaders/__tests__/hidingColumns.spec.js
@@ -38,7 +38,7 @@ describe('NestedHeaders', () => {
         <thead>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">C1</td>
             <td class="">D1</td>
@@ -81,7 +81,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">C1</td>
             <td class="">D1</td>
@@ -123,7 +123,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">C1</td>
             <td class="">D1</td>
@@ -148,7 +148,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">C1</td>
             <td class="">F1</td>
@@ -171,7 +171,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">F1</td>
             <td class="">G1</td>
@@ -190,7 +190,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">F1</td>
           </tr>
         </tbody>
@@ -205,7 +205,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
           </tr>
         </tbody>
         `);
@@ -242,7 +242,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">C1</td>
             <td class="">D1</td>
@@ -269,7 +269,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">C1</td>
             <td class="">D1</td>
             <td class="">F1</td>
@@ -341,7 +341,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">C1</td>
             <td class="">E1</td>
@@ -391,7 +391,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">C1</td>
             <td class="">E1</td>
@@ -438,7 +438,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">C1</td>
             <td class="">E1</td>
@@ -479,7 +479,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">C1</td>
             <td class="">F1</td>
@@ -512,7 +512,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">F1</td>
             <td class="">I1</td>
           </tr>
@@ -538,7 +538,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">I1</td>
           </tr>
         </tbody>
@@ -559,7 +559,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
           </tr>
         </tbody>
         `);
@@ -640,7 +640,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">B1</td>
             <td class="">C1</td>
             <td class="">E1</td>
@@ -705,7 +705,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">B1</td>
             <td class="">C1</td>
             <td class="">E1</td>
@@ -758,7 +758,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">B1</td>
             <td class="">E1</td>
             <td class="">F1</td>
@@ -801,7 +801,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">B1</td>
             <td class="">F1</td>
             <td class="">G1</td>
@@ -834,7 +834,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">F1</td>
             <td class="">G1</td>
           </tr>
@@ -860,7 +860,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">G1</td>
           </tr>
         </tbody>
@@ -881,7 +881,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
           </tr>
         </tbody>
         `);
@@ -936,7 +936,7 @@ describe('NestedHeaders', () => {
             </tr>
           </thead>
           <tbody>
-            <tr>
+            <tr class="ht__row_odd">
               <td class="">B1</td>
               <td class="">C1</td>
               <td class="">E1</td>
@@ -977,7 +977,7 @@ describe('NestedHeaders', () => {
             </tr>
           </thead>
           <tbody>
-            <tr>
+            <tr class="ht__row_odd">
               <td class="">B1</td>
               <td class="">C1</td>
               <td class="">F1</td>
@@ -1013,7 +1013,7 @@ describe('NestedHeaders', () => {
             </tr>
           </thead>
           <tbody>
-            <tr>
+            <tr class="ht__row_odd">
               <td class="">C1</td>
               <td class="">F1</td>
             </tr>
@@ -1044,7 +1044,7 @@ describe('NestedHeaders', () => {
             </tr>
           </thead>
           <tbody>
-            <tr>
+            <tr class="ht__row_odd">
               <td class="">F1</td>
             </tr>
           </tbody>
@@ -1072,7 +1072,7 @@ describe('NestedHeaders', () => {
             </tr>
           </thead>
           <tbody>
-            <tr>
+            <tr class="ht__row_odd">
             </tr>
           </tbody>
           `;
@@ -1162,7 +1162,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">AL1</td>
             <td class="">AM1</td>
             <td class="">AN1</td>
@@ -1271,7 +1271,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">AU1</td>
             <td class="">AV1</td>
             <td class="">AW1</td>
@@ -1359,7 +1359,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -1411,7 +1411,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">E1</td>
             <td class="">F1</td>
@@ -1453,7 +1453,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">E1</td>
             <td class="">H1</td>
             <td class="">I1</td>
@@ -1529,7 +1529,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">E1</td>
             <td class="">H1</td>
             <td class="">I1</td>
@@ -1572,7 +1572,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">E1</td>
             <td class="">F1</td>
@@ -1630,7 +1630,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -1698,7 +1698,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -1823,7 +1823,7 @@ describe('NestedHeaders', () => {
             </tr>
           </thead>
           <tbody>
-            <tr>
+            <tr class="ht__row_odd">
               <td class="">A1</td>
               <td class="afterHiddenColumn">C1</td>
               <td class="">D1</td>
@@ -1865,7 +1865,7 @@ describe('NestedHeaders', () => {
             </tr>
           </thead>
           <tbody>
-            <tr>
+            <tr class="ht__row_odd">
               <td class="">A1</td>
               <td class="afterHiddenColumn">C1</td>
               <td class="">D1</td>
@@ -1892,7 +1892,7 @@ describe('NestedHeaders', () => {
             </tr>
           </thead>
           <tbody>
-            <tr>
+            <tr class="ht__row_odd">
               <td class="afterHiddenColumn">D1</td>
               <td class="afterHiddenColumn">F1</td>
               <td class="afterHiddenColumn">H1</td>
@@ -1913,7 +1913,7 @@ describe('NestedHeaders', () => {
             </tr>
           </thead>
           <tbody>
-            <tr>
+            <tr class="ht__row_odd">
               <td class="afterHiddenColumn">D1</td>
               <td class="afterHiddenColumn">F1</td>
               <td class="afterHiddenColumn">H1</td>

--- a/handsontable/src/plugins/nestedHeaders/__tests__/initialization.spec.js
+++ b/handsontable/src/plugins/nestedHeaders/__tests__/initialization.spec.js
@@ -46,7 +46,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -93,7 +93,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -154,7 +154,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -211,7 +211,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -257,7 +257,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -331,7 +331,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -364,7 +364,7 @@ describe('NestedHeaders', () => {
       expect(extractDOMStructure(getTopClone(), getMaster())).toMatchHTML(`
         <thead></thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -376,7 +376,7 @@ describe('NestedHeaders', () => {
       expect(extractDOMStructure(getMaster(), getMaster())).toMatchHTML(`
         <thead></thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -410,7 +410,7 @@ describe('NestedHeaders', () => {
           <tr></tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -435,7 +435,7 @@ describe('NestedHeaders', () => {
           <tr></tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -460,7 +460,7 @@ describe('NestedHeaders', () => {
           <tr></tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -496,7 +496,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>

--- a/handsontable/src/plugins/nestedHeaders/__tests__/showingColumns.spec.js
+++ b/handsontable/src/plugins/nestedHeaders/__tests__/showingColumns.spec.js
@@ -38,7 +38,7 @@ describe('NestedHeaders', () => {
         <thead>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">B1</td>
             <td class="">E1</td>
             <td class="">I1</td>
@@ -73,7 +73,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">B1</td>
             <td class="">E1</td>
             <td class="">I1</td>
@@ -105,7 +105,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">C1</td>
             <td class="">G1</td>
           </tr>
@@ -126,7 +126,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">C1</td>
             <td class="">E1</td>
             <td class="">F1</td>
@@ -153,7 +153,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">C1</td>
             <td class="">D1</td>
@@ -186,7 +186,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -227,7 +227,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">C1</td>
             <td class="">D1</td>
             <td class="">G1</td>
@@ -246,7 +246,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">C1</td>
             <td class="">D1</td>
             <td class="">G1</td>
@@ -293,7 +293,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">D1</td>
             <td class="">H1</td>
           </tr>
@@ -337,7 +337,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">C1</td>
             <td class="">D1</td>
             <td class="">H1</td>
@@ -391,7 +391,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">C1</td>
             <td class="">D1</td>
@@ -460,7 +460,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -520,7 +520,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">J1</td>
             <td class="">K1</td>
@@ -569,7 +569,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">E1</td>
             <td class="">G1</td>
@@ -633,7 +633,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">C1</td>
             <td class="">E1</td>
@@ -707,7 +707,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -791,7 +791,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">A1</td>
             <td class="">B1</td>
             <td class="">C1</td>
@@ -846,7 +846,7 @@ describe('NestedHeaders', () => {
             </tr>
           </thead>
           <tbody>
-            <tr>
+            <tr class="ht__row_odd">
               <td class="">E1</td>
             </tr>
           </tbody>
@@ -885,7 +885,7 @@ describe('NestedHeaders', () => {
             </tr>
           </thead>
           <tbody>
-            <tr>
+            <tr class="ht__row_odd">
               <td class="">C1</td>
               <td class="">D1</td>
               <td class="">E1</td>
@@ -929,7 +929,7 @@ describe('NestedHeaders', () => {
             </tr>
           </thead>
           <tbody>
-            <tr>
+            <tr class="ht__row_odd">
               <td class="">A1</td>
               <td class="">C1</td>
               <td class="">D1</td>
@@ -983,7 +983,7 @@ describe('NestedHeaders', () => {
             </tr>
           </thead>
           <tbody>
-            <tr>
+            <tr class="ht__row_odd">
               <td class="">A1</td>
               <td class="">B1</td>
               <td class="">C1</td>
@@ -1099,7 +1099,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">K1</td>
             <td class="">M1</td>
             <td class="">O1</td>
@@ -1233,7 +1233,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">U1</td>
             <td class="">W1</td>
             <td class="">Y1</td>
@@ -1312,7 +1312,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">D1</td>
             <td class="">G1</td>
             <td class="">J1</td>
@@ -1379,7 +1379,7 @@ describe('NestedHeaders', () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="ht__row_odd">
             <td class="">C1</td>
             <td class="">D1</td>
             <td class="">F1</td>
@@ -1409,7 +1409,7 @@ describe('NestedHeaders', () => {
             <tr></tr>
           </thead>
           <tbody>
-            <tr>
+            <tr class="ht__row_odd">
             </tr>
           </tbody>
           `);
@@ -1430,7 +1430,7 @@ describe('NestedHeaders', () => {
             </tr>
           </thead>
           <tbody>
-            <tr>
+            <tr class="ht__row_odd">
               <td class="">A1</td>
               <td class="">B1</td>
               <td class="afterHiddenColumn">E1</td>
@@ -1459,7 +1459,7 @@ describe('NestedHeaders', () => {
             </tr>
           </thead>
           <tbody>
-            <tr>
+            <tr class="ht__row_odd">
               <td class="">A1</td>
               <td class="">B1</td>
               <td class="afterHiddenColumn">D1</td>
@@ -1488,7 +1488,7 @@ describe('NestedHeaders', () => {
             </tr>
           </thead>
           <tbody>
-            <tr>
+            <tr class="ht__row_odd">
               <td class="">A1</td>
               <td class="">B1</td>
               <td class="afterHiddenColumn">D1</td>

--- a/handsontable/src/plugins/trimRows/__tests__/settings/fixedColumnsStart.spec.js
+++ b/handsontable/src/plugins/trimRows/__tests__/settings/fixedColumnsStart.spec.js
@@ -16,13 +16,6 @@ describe('TrimRows', () => {
 
   beforeEach(function() {
     this.$container = $(`<div id="${id}"></div>`).appendTo('body');
-
-    // Matchers configuration.
-    this.matchersConfig = {
-      toMatchHTML: {
-        keepAttributes: ['class']
-      }
-    };
   });
 
   afterEach(function() {
@@ -46,26 +39,26 @@ describe('TrimRows', () => {
       expect(extractDOMStructure(getInlineStartClone())).toMatchHTML(`
         <thead>
           <tr>
-            <th class="">A</th>
-            <th class="">B</th>
+            <th>A</th>
+            <th>B</th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td class="">A1</td>
-            <td class="">B1</td>
+            <td>A1</td>
+            <td>B1</td>
           </tr>
           <tr>
-            <td class="">A2</td>
-            <td class="">B2</td>
+            <td>A2</td>
+            <td>B2</td>
           </tr>
         </tbody>
         `);
       expect(extractDOMStructure(getTopInlineStartClone())).toMatchHTML(`
         <thead>
           <tr>
-            <th class="">A</th>
-            <th class="">B</th>
+            <th>A</th>
+            <th>B</th>
           </tr>
         </thead>
         <tbody></tbody>
@@ -83,22 +76,22 @@ describe('TrimRows', () => {
       expect(extractDOMStructure(getInlineStartClone())).toMatchHTML(`
         <thead>
           <tr>
-            <th class="">A</th>
+            <th>A</th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td class="">A1</td>
+            <td>A1</td>
           </tr>
           <tr>
-            <td class="">A2</td>
+            <td>A2</td>
           </tr>
         </tbody>
         `);
       expect(extractDOMStructure(getTopInlineStartClone())).toMatchHTML(`
         <thead>
           <tr>
-            <th class="">A</th>
+            <th>A</th>
           </tr>
         </thead>
         <tbody></tbody>

--- a/handsontable/src/plugins/trimRows/__tests__/settings/fixedRowsBottom.spec.js
+++ b/handsontable/src/plugins/trimRows/__tests__/settings/fixedRowsBottom.spec.js
@@ -15,13 +15,6 @@ describe('TrimRows', () => {
 
   beforeEach(function() {
     this.$container = $(`<div id="${id}"></div>`).appendTo('body');
-
-    // Matchers configuration.
-    this.matchersConfig = {
-      toMatchHTML: {
-        keepAttributes: ['class']
-      }
-    };
   });
 
   afterEach(function() {
@@ -45,24 +38,24 @@ describe('TrimRows', () => {
       expect(extractDOMStructure(getBottomClone())).toMatchHTML(`
         <tbody>
           <tr>
-            <th class="">1</th>
-            <td class="">A4</td>
-            <td class="">B4</td>
+            <th>1</th>
+            <td>A4</td>
+            <td>B4</td>
           </tr>
           <tr>
-            <th class="">2</th>
-            <td class="">A5</td>
-            <td class="">B5</td>
+            <th>2</th>
+            <td>A5</td>
+            <td>B5</td>
           </tr>
         </tbody>
         `);
       expect(extractDOMStructure(getBottomInlineStartClone())).toMatchHTML(`
         <tbody>
           <tr>
-            <th class="">1</th>
+            <th>1</th>
           </tr>
           <tr>
-            <th class="">2</th>
+            <th>2</th>
           </tr>
         </tbody>
         `);
@@ -79,16 +72,16 @@ describe('TrimRows', () => {
       expect(extractDOMStructure(getBottomClone())).toMatchHTML(`
         <tbody>
           <tr>
-            <th class="">1</th>
-            <td class="">A5</td>
-            <td class="">B5</td>
+            <th>1</th>
+            <td>A5</td>
+            <td>B5</td>
           </tr>
         </tbody>
         `);
       expect(extractDOMStructure(getBottomInlineStartClone())).toMatchHTML(`
         <tbody>
           <tr>
-            <th class="">1</th>
+            <th>1</th>
           </tr>
         </tbody>
         `);

--- a/handsontable/src/plugins/trimRows/__tests__/settings/fixedRowsTop.spec.js
+++ b/handsontable/src/plugins/trimRows/__tests__/settings/fixedRowsTop.spec.js
@@ -15,13 +15,6 @@ describe('TrimRows', () => {
 
   beforeEach(function() {
     this.$container = $(`<div id="${id}"></div>`).appendTo('body');
-
-    // Matchers configuration.
-    this.matchersConfig = {
-      toMatchHTML: {
-        keepAttributes: ['class']
-      }
-    };
   });
 
   afterEach(function() {
@@ -45,24 +38,24 @@ describe('TrimRows', () => {
       expect(extractDOMStructure(getTopClone())).toMatchHTML(`
         <tbody>
           <tr>
-            <th class="">1</th>
-            <td class="">A4</td>
-            <td class="">B4</td>
+            <th>1</th>
+            <td>A4</td>
+            <td>B4</td>
           </tr>
           <tr>
-            <th class="">2</th>
-            <td class="">A5</td>
-            <td class="">B5</td>
+            <th>2</th>
+            <td>A5</td>
+            <td>B5</td>
           </tr>
         </tbody>
         `);
       expect(extractDOMStructure(getTopInlineStartClone())).toMatchHTML(`
         <tbody>
           <tr>
-            <th class="">1</th>
+            <th>1</th>
           </tr>
           <tr>
-            <th class="">2</th>
+            <th>2</th>
           </tr>
         </tbody>
         `);
@@ -79,16 +72,16 @@ describe('TrimRows', () => {
       expect(extractDOMStructure(getTopClone())).toMatchHTML(`
         <tbody>
           <tr>
-            <th class="">1</th>
-            <td class="">A5</td>
-            <td class="">B5</td>
+            <th>1</th>
+            <td>A5</td>
+            <td>B5</td>
           </tr>
         </tbody>
         `);
       expect(extractDOMStructure(getTopInlineStartClone())).toMatchHTML(`
         <tbody>
           <tr>
-            <th class="">1</th>
+            <th>1</th>
           </tr>
         </tbody>
         `);


### PR DESCRIPTION
### Context
This PR:
- Adds `ht__row_odd` and `ht__row_even` classes to the odd and even `TR` elements. The convention is inspired by the [class names already present in Handsontable.](https://handsontable.com/docs/javascript-data-grid/api/options/#activeheaderclassname)
- Add a test case.
- Clean up some of the walkontable tests.

I implemented it as the first row is _odd_ (so as if it was indexed as `1`, not `0`). It's analogous to the native CSS solutions.

#### CSS: 
```css 
table tr:nth-child(even) {
  background: #f0f0f0;
}
```
<img width="289" alt="image" src="https://github.com/user-attachments/assets/4bc3082d-e5fb-42c9-933d-a2a99eb2b67d">

#### Handsontable:
```css 
table tr.ht__row_even td {
  background: #f0f0f0;
}
```
<img width="211" alt="image" src="https://github.com/user-attachments/assets/7d8d149f-8252-4459-901e-3f5c8ed8be68">


### How has this been tested?
Tested manually and added a Walkontable test case.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#2050

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
