### PR TITLE
Make the Context Menu/Dropdown Menu container resize to the size of its content.

### DIFF
--- a/handsontable/src/plugins/contextMenu/contextMenu.js
+++ b/handsontable/src/plugins/contextMenu/contextMenu.js
@@ -254,6 +254,15 @@ export class ContextMenu extends BasePlugin {
     this.prepareMenuItems();
     this.menu.open();
 
+    const themeHasTableBorder = this.menu.tableBorderWidth > 0;
+
+    if (!themeHasTableBorder) {
+      offset.below += 1;
+      offset.right += 1;
+      offset.above -= 1;
+      offset.left -= 1;
+    }
+
     objectEach(offset, (value, key) => {
       this.menu.setOffset(key, value);
     });

--- a/handsontable/src/plugins/contextMenu/menu/menu.js
+++ b/handsontable/src/plugins/contextMenu/menu/menu.js
@@ -17,9 +17,11 @@ import { isWindowsOS, isMobileBrowser, isIpadOS } from '../../../helpers/browser
 import {
   addClass,
   isChildOf,
+  getComputedStyle,
   getParentWindow,
   hasClass,
   setAttribute,
+  outerHeight,
 } from '../../../helpers/dom/element';
 import { isRightClick } from '../../../helpers/dom/event';
 import { debounce, isFunction } from '../../../helpers/function';
@@ -117,6 +119,26 @@ export class Menu {
    * @type {KeyboardShortcutsMenuController}
    */
   #shortcutsCtrl;
+  /**
+   * The border width of the table used in the menu.
+   *
+   * @type {number}
+   */
+  #tableBorderWidth;
+
+  /**
+   * Getter for the table border width.
+   * This getter retrieves the border width of the table used in the menu.
+   *
+   * @returns {number} The border width of the table in pixels.
+   */
+  get tableBorderWidth() {
+    if (this.#tableBorderWidth === undefined && this.hotMenu) {
+      this.#tableBorderWidth = parseInt(getComputedStyle(this.hotMenu.view._wt.wtTable.TABLE).borderWidth, 10);
+    }
+
+    return this.#tableBorderWidth;
+  }
 
   /**
    * @param {Core} hotInstance Handsontable instance.
@@ -289,7 +311,7 @@ export class Menu {
           this.openSubMenu(coords.row);
         }
       },
-      rowHeights: row => (filteredItems[row].name === SEPARATOR ? 1 : 23),
+      rowHeights: row => (filteredItems[row].name === SEPARATOR ? 1 : undefined),
       afterOnCellContextMenu: (event) => {
         event.preventDefault();
 
@@ -592,6 +614,32 @@ export class Menu {
   }
 
   /**
+   * Updates the dimensions of the menu based on its content.
+   * This method calculates the real height of the menu by summing up the heights of its items,
+   * and adjusts the width and height of the menu's holder and hider elements accordingly.
+   */
+  updateMenuDimensions() {
+    const { wtTable } = this.hotMenu.view._wt;
+    const data = this.hotMenu.getSettings().data;
+    const hiderStyle = wtTable.hider.style;
+    const holderStyle = wtTable.holder.style;
+    const currentHiderWidth = parseInt(hiderStyle.width, 10);
+
+    const realHeight = arrayReduce(data,
+      (accumulator, value, index) => {
+        const itemCell = this.hotMenu.getCell(index, 0);
+        const currentRowHeight = itemCell ? outerHeight(this.hotMenu.getCell(index, 0)) : 0;
+
+        return accumulator + (value.name === SEPARATOR ? 1 : currentRowHeight);
+      }, 0);
+
+    // Additional 3px to menu's size because of additional border around its `table.htCore`.
+    holderStyle.width = `${currentHiderWidth + 3}px`;
+    holderStyle.height = `${realHeight + 3}px`;
+    hiderStyle.height = holderStyle.height;
+  }
+
+  /**
    * Create container/wrapper for handsontable.
    *
    * @private
@@ -642,18 +690,7 @@ export class Menu {
    * @private
    */
   onAfterInit() {
-    const { wtTable } = this.hotMenu.view._wt;
-    const data = this.hotMenu.getSettings().data;
-    const hiderStyle = wtTable.hider.style;
-    const holderStyle = wtTable.holder.style;
-    const currentHiderWidth = parseInt(hiderStyle.width, 10);
-
-    const realHeight = arrayReduce(data, (accumulator, value) => accumulator + (value.name === SEPARATOR ? 1 : 26), 0);
-
-    // Additional 3px to menu's size because of additional border around its `table.htCore`.
-    holderStyle.width = `${currentHiderWidth + 3}px`;
-    holderStyle.height = `${realHeight + 3}px`;
-    hiderStyle.height = holderStyle.height;
+    this.updateMenuDimensions();
 
     // Replace the default accessibility tags with the context menu's
     if (this.hot.getSettings().ariaTags) {

--- a/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
@@ -106,7 +106,7 @@ describe('Filters UI', () => {
 
       const rect = document.querySelector('.htFiltersConditionsMenu.handsontable table').getBoundingClientRect();
 
-      expect(window.scrollY + rect.top).toBe(914);
+      expect(window.scrollY + rect.top).toBe(757);
       hot.rootElement.style.marginTop = '';
     });
 

--- a/handsontable/src/plugins/filters/filters.js
+++ b/handsontable/src/plugins/filters/filters.js
@@ -665,7 +665,11 @@ export class Filters extends BasePlugin {
    * After dropdown menu show listener.
    */
   #onAfterDropdownMenuShow() {
+    const menu = this.dropdownMenuPlugin.menu;
+
     this.restoreComponents(Array.from(this.components.values()));
+
+    menu.updateMenuDimensions();
   }
 
   /**


### PR DESCRIPTION
### Context
This PR:
- Makes the Context Menu/Dropdown Menu container resize to the size of its content. Before this change, it was calculated by assuming every item in the menu is `26px` tall, which is no longer true in other themes.
- Moves the Context Menu/Dropdown Menu away from the cursor/button by `1px` if the menu doesn't have a border. This problem emerged while working on the first bullet point - basically, opening the Context Menu would result in auto-clicking the first item.
- Modifies one of the Filters test cases. Before this change, the Dropdown Menu container was too short for the Filters' items, and one of the test cases reflected that wrong (IMO) behavior.

### How has this been tested?
Tested manually with the current styles and a new prototype theme.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#2049

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
