### PR TITLE
Fix the Autocomplete and Dropdown editor's container size counting

### DIFF
--- a/.changelogs/11201.json
+++ b/.changelogs/11201.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed the Autocomplete and Dropdown editor's container size counting",
+  "type": "fixed",
+  "issueOrPR": 11201,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/src/selection/border/border.js
+++ b/handsontable/src/3rdparty/walkontable/src/selection/border/border.js
@@ -2,7 +2,6 @@ import {
   addClass,
   hasClass,
   removeClass,
-  getComputedStyle,
   getTrimmingContainer,
   innerWidth,
   innerHeight,
@@ -497,7 +496,7 @@ class Border {
       }
     }
 
-    const style = getComputedStyle(fromTD, rootWindow);
+    const style = rootWindow.getComputedStyle(fromTD);
 
     if (parseInt(style.borderTopWidth, 10) > 0) {
       top += 1;

--- a/handsontable/src/3rdparty/walkontable/src/table/master.js
+++ b/handsontable/src/3rdparty/walkontable/src/table/master.js
@@ -1,6 +1,5 @@
 import {
   getStyle,
-  getComputedStyle,
   getTrimmingContainer,
   isVisible,
 } from './../../../../helpers/dom/element';
@@ -64,7 +63,7 @@ class MasterTable extends Table {
           trimmingElementParent.appendChild(cloneNode);
         }
 
-        const cloneHeight = parseInt(getComputedStyle(cloneNode, rootWindow).height, 10);
+        const cloneHeight = parseInt(rootWindow.getComputedStyle(cloneNode).height, 10);
 
         trimmingElementParent.removeChild(cloneNode);
 

--- a/handsontable/src/__tests__/tableView.spec.js
+++ b/handsontable/src/__tests__/tableView.spec.js
@@ -416,4 +416,26 @@ describe('TableView', () => {
       expect(hot.view._wt.wtViewport.getWorkspaceHeight).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('hasVerticalScroll()', () => {
+    it('should internally call `hasVerticalScroll` method of the Viewport module of the Walkontable', () => {
+      const hot = handsontable({});
+
+      spyOn(hot.view._wt.wtViewport, 'hasVerticalScroll').and.returnValue(100);
+
+      expect(hot.view.hasVerticalScroll()).toBe(100);
+      expect(hot.view._wt.wtViewport.hasVerticalScroll).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('hasHorizontalScroll()', () => {
+    it('should internally call `hasHorizontalScroll` method of the Viewport module of the Walkontable', () => {
+      const hot = handsontable({});
+
+      spyOn(hot.view._wt.wtViewport, 'hasHorizontalScroll').and.returnValue(100);
+
+      expect(hot.view.hasHorizontalScroll()).toBe(100);
+      expect(hot.view._wt.wtViewport.hasHorizontalScroll).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/handsontable/src/__tests__/tableView.spec.js
+++ b/handsontable/src/__tests__/tableView.spec.js
@@ -438,4 +438,26 @@ describe('TableView', () => {
       expect(hot.view._wt.wtViewport.hasHorizontalScroll).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('getTableWidth()', () => {
+    it('should internally call `getTableWidth` method of the Table module of the Walkontable', () => {
+      const hot = handsontable({});
+
+      spyOn(hot.view._wt.wtTable, 'getWidth').and.returnValue(100);
+
+      expect(hot.view.getTableWidth()).toBe(100);
+      expect(hot.view._wt.wtTable.getWidth).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getTableHeight()', () => {
+    it('should internally call `getTableHeight` method of the Table module of the Walkontable', () => {
+      const hot = handsontable({});
+
+      spyOn(hot.view._wt.wtTable, 'getHeight').and.returnValue(100);
+
+      expect(hot.view.getTableHeight()).toBe(100);
+      expect(hot.view._wt.wtTable.getHeight).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/handsontable/src/editors/autocompleteEditor/__tests__/autocompleteEditor.spec.js
+++ b/handsontable/src/editors/autocompleteEditor/__tests__/autocompleteEditor.spec.js
@@ -371,29 +371,50 @@ describe('AutocompleteEditor', () => {
       window.onerror = prevError;
     });
 
-    it('should open editor with the proper width of the autocomplete list', async() => {
+    it('should open editor with the correct size when there is no scrollbar on the list', async() => {
       handsontable({
-        colWidths: 50,
+        colWidths: 120,
         columns: [
           {
             editor: 'autocomplete',
-            source: choices,
-            visibleRows: 2,
+            source: choices.slice(0, 5),
+            visibleRows: 5,
           }
         ]
       });
-      const scrollbarWidth = Handsontable.dom.getScrollbarWidth();
-      const expectedWidth = 50 + (scrollbarWidth === 0 ? 15 : scrollbarWidth);
 
       selectCell(0, 0);
-
-      const editor = $('.autocompleteEditor');
-
       keyDownUp('enter');
 
       await sleep(100);
 
-      expect(editor.find('.ht_master .wtHolder').width()).toBe(expectedWidth);
+      const container = getActiveEditor().htContainer;
+
+      expect(container.clientWidth).toBe(120);
+      expect(container.clientHeight).toBe(118);
+    });
+
+    it('should open editor with the correct size when there is scrollbar on the list', async() => {
+      handsontable({
+        colWidths: 120,
+        columns: [
+          {
+            editor: 'autocomplete',
+            source: choices,
+            visibleRows: 3,
+          }
+        ]
+      });
+
+      selectCell(0, 0);
+      keyDownUp('enter');
+
+      await sleep(100);
+
+      const container = getActiveEditor().htContainer;
+
+      expect(container.clientWidth).toBe(120 + Handsontable.dom.getScrollbarWidth());
+      expect(container.clientHeight).toBe(72);
     });
   });
 

--- a/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
+++ b/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
@@ -15,7 +15,6 @@ import {
 import { isDefined, stringify } from '../../helpers/mixed';
 import { stripTags } from '../../helpers/string';
 import { KEY_CODES, isPrintableChar } from '../../helpers/unicode';
-import { isMacOS } from '../../helpers/browser';
 import { textRenderer } from '../../renderers/textRenderer';
 import {
   A11Y_ACTIVEDESCENDANT,
@@ -144,18 +143,14 @@ export class AutocompleteEditor extends HandsontableEditor {
 
     this.showEditableElement();
     this.focus();
-    let scrollbarWidth = getScrollbarWidth();
-
-    if (scrollbarWidth === 0 && isMacOS()) {
-      scrollbarWidth += 15; // default scroll bar width if scroll bars are visible only when scrolling
-    }
-
     this.addHook('beforeKeyDown', event => this.onBeforeKeyDown(event));
 
     this.htEditor.updateSettings({
       colWidths: trimDropdown ? [outerWidth(this.TEXTAREA) - 2] : undefined,
-      width: trimDropdown ? outerWidth(this.TEXTAREA) + scrollbarWidth : undefined,
+      width: this.getDropdownWidth(),
+      height: this.getDropdownHeight(),
       autoColumnSize: true,
+      autoRowSize: true,
       renderer: (hotInstance, TD, row, col, prop, value, cellProperties) => {
         textRenderer(hotInstance, TD, row, col, prop, value, cellProperties);
 
@@ -446,13 +441,20 @@ export class AutocompleteEditor extends HandsontableEditor {
    * @private
    */
   updateDropdownDimensions() {
-    const currentDropdownWidth = this.htEditor.getColWidth(0) + getScrollbarWidth(this.hot.rootDocument) + 2;
     const trimDropdown = this.cellProperties.trimDropdown;
+    const width = trimDropdown ? this.getDropdownWidth() : undefined;
+    const height = this.getDropdownHeight();
 
     this.htEditor.updateSettings({
-      height: this.getDropdownHeight(),
-      width: trimDropdown ? undefined : currentDropdownWidth
+      width,
+      height,
     });
+
+    if (trimDropdown && this.htEditor.view.hasVerticalScroll()) {
+      this.htEditor.updateSettings({
+        width: width + getScrollbarWidth(this.hot.rootDocument),
+      });
+    }
 
     this.htEditor.view._wt.wtTable.alignOverlaysWithTrimmingContainer();
   }
@@ -490,10 +492,28 @@ export class AutocompleteEditor extends HandsontableEditor {
    * @returns {number}
    */
   getDropdownHeight() {
-    const firstRowHeight = this.htEditor.getRowHeight(0) || 23;
-    const visibleRows = this.cellProperties.visibleRows;
+    const containerStyle = this.hot.rootWindow.getComputedStyle(this.htContainer.querySelector('.htCore'));
+    const borderVerticalCompensation = parseInt(containerStyle.borderTopWidth, 10) +
+      parseInt(containerStyle.borderBottomWidth, 10);
+    const maxItems = Math.min(this.cellProperties.visibleRows, this.strippedChoices.length);
+    const height = Array.from({ length: maxItems }, (_, i) => i)
+      .reduce((h, index) => h + this.htEditor.getRowHeight(index), 0);
 
-    return this.strippedChoices.length >= visibleRows ? (visibleRows * firstRowHeight) : (this.strippedChoices.length * firstRowHeight) + 8; // eslint-disable-line max-len
+    return height + borderVerticalCompensation + 1;
+  }
+
+  /**
+   * Calculates and return the internal Handsontable's width.
+   *
+   * @private
+   * @returns {number}
+   */
+  getDropdownWidth() {
+    const containerStyle = this.hot.rootWindow.getComputedStyle(this.htContainer.querySelector('.htCore'));
+    const borderHorizontalCompensation = parseInt(containerStyle.borderInlineStartWidth, 10) +
+      parseInt(containerStyle.borderInlineEndWidth, 10);
+
+    return this.htEditor.getColWidth(0) + borderHorizontalCompensation;
   }
 
   /**

--- a/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
+++ b/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
@@ -147,8 +147,6 @@ export class AutocompleteEditor extends HandsontableEditor {
 
     this.htEditor.updateSettings({
       colWidths: trimDropdown ? [outerWidth(this.TEXTAREA) - 2] : undefined,
-      width: this.getDropdownWidth(),
-      height: this.getDropdownHeight(),
       autoColumnSize: true,
       autoRowSize: true,
       renderer: (hotInstance, TD, row, col, prop, value, cellProperties) => {
@@ -356,7 +354,7 @@ export class AutocompleteEditor extends HandsontableEditor {
 
     const textareaOffset = offset(this.TEXTAREA);
     const textareaHeight = outerHeight(this.TEXTAREA);
-    const dropdownHeight = this.getDropdownHeight();
+    const dropdownHeight = this.getHeight();
     const trimmingContainerScrollTop = trimmingContainer.scrollTop;
     const headersHeight = outerHeight(this.hot.view._wt.wtTable.THEAD);
     const containerOffset = offset(trimmingContainer);
@@ -442,8 +440,8 @@ export class AutocompleteEditor extends HandsontableEditor {
    */
   updateDropdownDimensions() {
     const trimDropdown = this.cellProperties.trimDropdown;
-    const width = trimDropdown ? this.getDropdownWidth() : undefined;
-    const height = this.getDropdownHeight();
+    const width = trimDropdown ? this.getWidth() : undefined;
+    const height = this.getHeight();
 
     this.htEditor.updateSettings({
       width,
@@ -491,7 +489,7 @@ export class AutocompleteEditor extends HandsontableEditor {
    * @private
    * @returns {number}
    */
-  getDropdownHeight() {
+  getHeight() {
     const containerStyle = this.hot.rootWindow.getComputedStyle(this.htContainer.querySelector('.htCore'));
     const borderVerticalCompensation = parseInt(containerStyle.borderTopWidth, 10) +
       parseInt(containerStyle.borderBottomWidth, 10);
@@ -508,7 +506,7 @@ export class AutocompleteEditor extends HandsontableEditor {
    * @private
    * @returns {number}
    */
-  getDropdownWidth() {
+  getWidth() {
     const containerStyle = this.hot.rootWindow.getComputedStyle(this.htContainer.querySelector('.htCore'));
     const borderHorizontalCompensation = parseInt(containerStyle.borderInlineStartWidth, 10) +
       parseInt(containerStyle.borderInlineEndWidth, 10);

--- a/handsontable/src/editors/baseEditor/baseEditor.js
+++ b/handsontable/src/editors/baseEditor/baseEditor.js
@@ -8,7 +8,6 @@ import {
   hasHorizontalScrollbar,
   outerWidth,
   outerHeight,
-  getComputedStyle,
 } from '../../helpers/dom/element';
 
 export const EDITOR_TYPE = 'base';
@@ -517,7 +516,7 @@ export class BaseEditor {
       cellStartOffset += firstColumnOffset - horizontalScrollPosition;
     }
 
-    const cellComputedStyle = getComputedStyle(this.TD, this.hot.rootWindow);
+    const cellComputedStyle = rootWindow.getComputedStyle(this.TD);
     const borderPhysicalWidthProp = this.hot.isRtl() ? 'borderRightWidth' : 'borderLeftWidth';
     const inlineStartBorderCompensation = parseInt(cellComputedStyle[borderPhysicalWidthProp], 10) > 0 ? 0 : 1;
     const topBorderCompensation = parseInt(cellComputedStyle.borderTopWidth, 10) > 0 ? 0 : 1;

--- a/handsontable/src/editors/dropdownEditor/__tests__/dropdownEditor.spec.js
+++ b/handsontable/src/editors/dropdownEditor/__tests__/dropdownEditor.spec.js
@@ -356,6 +356,52 @@ describe('DropdownEditor', () => {
 
       window.onerror = prevError;
     });
+
+    it('should open editor with the correct size when there is no scrollbar on the list', async() => {
+      handsontable({
+        colWidths: 120,
+        columns: [
+          {
+            editor: 'dropdown',
+            source: choices.slice(0, 5),
+            visibleRows: 5,
+          }
+        ]
+      });
+
+      selectCell(0, 0);
+      keyDownUp('enter');
+
+      await sleep(100);
+
+      const container = getActiveEditor().htContainer;
+
+      expect(container.clientWidth).toBe(120);
+      expect(container.clientHeight).toBe(118);
+    });
+
+    it('should open editor with the correct size when there is scrollbar on the list', async() => {
+      handsontable({
+        colWidths: 120,
+        columns: [
+          {
+            editor: 'dropdown',
+            source: choices,
+            visibleRows: 3,
+          }
+        ]
+      });
+
+      selectCell(0, 0);
+      keyDownUp('enter');
+
+      await sleep(100);
+
+      const container = getActiveEditor().htContainer;
+
+      expect(container.clientWidth).toBe(120 + Handsontable.dom.getScrollbarWidth());
+      expect(container.clientHeight).toBe(72);
+    });
   });
 
   describe('closing the editor', () => {

--- a/handsontable/src/editors/handsontableEditor/__tests__/handsontableEditor.spec.js
+++ b/handsontable/src/editors/handsontableEditor/__tests__/handsontableEditor.spec.js
@@ -1,8 +1,6 @@
 describe('HandsontableEditor', () => {
-  const id = 'testContainer';
-
   beforeEach(function() {
-    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+    this.$container = $('<div id="testContainer"></div>').appendTo('body');
   });
 
   afterEach(function() {
@@ -831,5 +829,31 @@ describe('HandsontableEditor', () => {
     keyDownUp('arrowdown');
 
     expect(getSelected()).toEqual([[1, 2, 1, 2]]);
+  });
+
+  it('should open editor with the correct size', async() => {
+    handsontable({
+      colWidths: 120,
+      columns: [
+        {
+          type: 'handsontable',
+          handsontable: {
+            colHeaders: ['Marque', 'Country', 'Parent company'],
+            data: getManufacturerData(),
+            autoColumnSize: true,
+          }
+        }
+      ]
+    });
+
+    selectCell(0, 0);
+    keyDownUp('enter');
+
+    await sleep(100);
+
+    const container = getActiveEditor().htContainer;
+
+    expect(container.clientWidth).toBe(290);
+    expect(container.clientHeight).toBe(167);
   });
 });

--- a/handsontable/src/editors/handsontableEditor/handsontableEditor.js
+++ b/handsontable/src/editors/handsontableEditor/handsontableEditor.js
@@ -46,6 +46,11 @@ export class HandsontableEditor extends TextEditor {
 
     setCaretPosition(this.TEXTAREA, 0, this.TEXTAREA.value.length);
     this.refreshDimensions();
+
+    this.htEditor.updateSettings({
+      width: this.getWidth(),
+      height: this.getHeight(),
+    });
   }
 
   /**
@@ -159,6 +164,26 @@ export class HandsontableEditor extends TextEditor {
     }
 
     super.finishEditing(restoreOriginalValue, ctrlDown, callback);
+  }
+
+  /**
+   * Calculates and return the internal Handsontable's height.
+   *
+   * @private
+   * @returns {number}
+   */
+  getHeight() {
+    return this.htEditor.view.getTableHeight();
+  }
+
+  /**
+   * Calculates and return the internal Handsontable's width.
+   *
+   * @private
+   * @returns {number}
+   */
+  getWidth() {
+    return this.htEditor.view.getTableWidth();
   }
 
   /**

--- a/handsontable/src/editors/textEditor/textEditor.js
+++ b/handsontable/src/editors/textEditor/textEditor.js
@@ -3,7 +3,6 @@ import EventManager from '../../eventManager';
 import { isEdge, isIOS } from '../../helpers/browser';
 import {
   addClass,
-  getComputedStyle,
   isThisHotChild,
   setCaretPosition,
   hasClass,
@@ -353,13 +352,13 @@ export class TextEditor extends BaseEditor {
     this.textareaParentStyle[this.hot.isRtl() ? 'right' : 'left'] = `${start}px`;
     this.showEditableElement();
 
-    const cellComputedStyle = getComputedStyle(this.TD, this.hot.rootWindow);
+    const cellComputedStyle = this.hot.rootWindow.getComputedStyle(this.TD);
 
     this.TEXTAREA.style.fontSize = cellComputedStyle.fontSize;
     this.TEXTAREA.style.fontFamily = cellComputedStyle.fontFamily;
     this.TEXTAREA.style.backgroundColor = this.TD.style.backgroundColor;
 
-    const textareaComputedStyle = getComputedStyle(this.TEXTAREA);
+    const textareaComputedStyle = this.hot.rootWindow.getComputedStyle(this.TEXTAREA);
 
     const horizontalPadding = parseInt(textareaComputedStyle.paddingLeft, 10) +
       parseInt(textareaComputedStyle.paddingRight, 10);

--- a/handsontable/src/helpers/dom/__tests__/dom.types.ts
+++ b/handsontable/src/helpers/dom/__tests__/dom.types.ts
@@ -18,8 +18,6 @@ Handsontable.dom.empty(domElement);
 Handsontable.dom.fastInnerHTML(domElement, 'foo');
 Handsontable.dom.fastInnerText(domElement, 'foo');
 Handsontable.dom.getCaretPosition(domElement);
-Handsontable.dom.getComputedStyle(domElement);
-Handsontable.dom.getComputedStyle(domElement, window);
 Handsontable.dom.getCssTransform(domElement);
 Handsontable.dom.getFrameElement(window);
 Handsontable.dom.getParent(domElement, 1);

--- a/handsontable/src/helpers/dom/element.js
+++ b/handsontable/src/helpers/dom/element.js
@@ -459,6 +459,7 @@ export function fastInnerText(element, content) {
  */
 export function isVisible(element) {
   const documentElement = element.ownerDocument.documentElement;
+  const windowElement = element.ownerDocument.defaultView;
   let next = element;
 
   while (next !== documentElement) { // until <html> reached
@@ -481,7 +482,7 @@ export function isVisible(element) {
         return false; // this is a node detached from document in IE8
       }
 
-    } else if (getComputedStyle(next).display === 'none') {
+    } else if (windowElement.getComputedStyle(next).display === 'none') {
       return false;
     }
 
@@ -676,7 +677,7 @@ export function getTrimmingContainer(base) {
       return el;
     }
 
-    const computedStyle = getComputedStyle(el, rootWindow);
+    const computedStyle = rootWindow.getComputedStyle(el);
     const allowedProperties = ['scroll', 'hidden', 'auto'];
     const property = computedStyle.getPropertyValue('overflow');
     const propertyY = computedStyle.getPropertyValue('overflow-y');
@@ -724,7 +725,7 @@ export function getStyle(element, prop, rootWindow = window) {
     return styleProp;
   }
 
-  const computedStyle = getComputedStyle(element, rootWindow);
+  const computedStyle = rootWindow.getComputedStyle(element);
 
   if (computedStyle[prop] !== '' && computedStyle[prop] !== undefined) {
     return computedStyle[prop];
@@ -752,18 +753,6 @@ export function matchesCSSRules(element, rule) {
   }
 
   return result;
-}
-
-/**
- * Returns a computed style object for the provided element. (Needed if style is declared in external stylesheet).
- *
- * @param {HTMLElement} element An element to get style from.
- * @param {Window} [rootWindow] The document window owner.
- * @returns {IEElementStyle|CssStyle} Elements computed style object.
- */
-// eslint-disable-next-line no-restricted-globals
-export function getComputedStyle(element, rootWindow = window) {
-  return element.currentStyle || rootWindow.getComputedStyle(element);
 }
 
 /**

--- a/handsontable/src/plugins/autofill/__tests__/autofill.spec.js
+++ b/handsontable/src/plugins/autofill/__tests__/autofill.spec.js
@@ -44,11 +44,11 @@ describe('AutoFill', () => {
 
     hot.selectCell(1, 1, 2, 2);
 
-    expect(Handsontable.dom.getComputedStyle(hot.rootElement.querySelector('.ht_master .htBorders .current')).zIndex)
+    expect(getComputedStyle(hot.rootElement.querySelector('.ht_master .htBorders .current')).zIndex)
       .toBe('10');
-    expect(Handsontable.dom.getComputedStyle(hot.rootElement.querySelector('.ht_master .htBorders .area')).zIndex)
+    expect(getComputedStyle(hot.rootElement.querySelector('.ht_master .htBorders .area')).zIndex)
       .toBe('8');
-    expect(Handsontable.dom.getComputedStyle(hot.rootElement.querySelector('.ht_master .htBorders .fill')).zIndex)
+    expect(getComputedStyle(hot.rootElement.querySelector('.ht_master .htBorders .fill')).zIndex)
       .toBe('6');
   });
 

--- a/handsontable/src/plugins/contextMenu/menu/menu.js
+++ b/handsontable/src/plugins/contextMenu/menu/menu.js
@@ -17,7 +17,6 @@ import { isWindowsOS, isMobileBrowser, isIpadOS } from '../../../helpers/browser
 import {
   addClass,
   isChildOf,
-  getComputedStyle,
   getParentWindow,
   hasClass,
   setAttribute,
@@ -134,7 +133,8 @@ export class Menu {
    */
   get tableBorderWidth() {
     if (this.#tableBorderWidth === undefined && this.hotMenu) {
-      this.#tableBorderWidth = parseInt(getComputedStyle(this.hotMenu.view._wt.wtTable.TABLE).borderWidth, 10);
+      this.#tableBorderWidth = parseInt(this.hotMenu.rootWindow
+        .getComputedStyle(this.hotMenu.view._wt.wtTable.TABLE).borderWidth, 10);
     }
 
     return this.#tableBorderWidth;

--- a/handsontable/src/plugins/contextMenu/menu/positioner.js
+++ b/handsontable/src/plugins/contextMenu/menu/positioner.js
@@ -166,7 +166,8 @@ export class Positioner {
     let left = this.#cursor.left;
 
     if (this.#parentContainer) {
-      const borderRightWidth = Number.parseInt(getComputedStyle(this.#parentContainer
+      const rootWindow = this.#parentContainer.ownerDocument.defaultView;
+      const borderRightWidth = Number.parseInt(rootWindow.getComputedStyle(this.#parentContainer
         .querySelector('.htCore')).borderRightWidth, 10);
 
       left += this.#cursor.cellWidth + borderRightWidth;
@@ -184,7 +185,8 @@ export class Positioner {
     let left = this.#offset.left + this.#cursor.left - this.#container.offsetWidth;
 
     if (this.#parentContainer) {
-      const borderLeftWidth = Number.parseInt(getComputedStyle(this.#parentContainer
+      const rootWindow = this.#parentContainer.ownerDocument.defaultView;
+      const borderLeftWidth = Number.parseInt(rootWindow.getComputedStyle(this.#parentContainer
         .querySelector('.htCore')).borderLeftWidth, 10);
 
       left -= borderLeftWidth;

--- a/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
@@ -4026,13 +4026,13 @@ describe('Filters UI', () => {
     dropdownMenu(0);
 
     const htItemWrapper = document.querySelector('.htItemWrapper');
-    const compStyleHtItemWrapper = Handsontable.dom.getComputedStyle(htItemWrapper);
+    const compStyleHtItemWrapper = getComputedStyle(htItemWrapper);
 
     const htFiltersMenuLabel = document.querySelector('.htFiltersMenuLabel');
-    const compStyleHtFiltersMenuLabel = Handsontable.dom.getComputedStyle(htFiltersMenuLabel);
+    const compStyleHtFiltersMenuLabel = getComputedStyle(htFiltersMenuLabel);
 
     const htUISelectCaption = document.querySelector('.htUISelectCaption');
-    const compStyleHtUISelectCaption = Handsontable.dom.getComputedStyle(htUISelectCaption);
+    const compStyleHtUISelectCaption = getComputedStyle(htUISelectCaption);
 
     expect(compStyleHtItemWrapper.fontFamily).not.toBe('Helvetica');
     expect(compStyleHtFiltersMenuLabel.fontFamily).not.toBe('Helvetica');

--- a/handsontable/src/selection/__tests__/general.spec.js
+++ b/handsontable/src/selection/__tests__/general.spec.js
@@ -139,9 +139,9 @@ describe('Selection', () => {
 
     hot.selectCell(1, 1, 2, 2);
 
-    expect(Handsontable.dom.getComputedStyle(hot.rootElement.querySelector('.ht_master .htBorders .current')).zIndex)
+    expect(getComputedStyle(hot.rootElement.querySelector('.ht_master .htBorders .current')).zIndex)
       .toBe('10');
-    expect(Handsontable.dom.getComputedStyle(hot.rootElement.querySelector('.ht_master .htBorders .area')).zIndex)
+    expect(getComputedStyle(hot.rootElement.querySelector('.ht_master .htBorders .area')).zIndex)
       .toBe('8');
   });
 

--- a/handsontable/src/tableView.js
+++ b/handsontable/src/tableView.js
@@ -1674,6 +1674,24 @@ class TableView {
   }
 
   /**
+   * Checks if the table has a horizontal scrollbar.
+   *
+   * @returns {boolean}
+   */
+  hasVerticalScroll() {
+    return this._wt.wtViewport.hasVerticalScroll();
+  }
+
+  /**
+   * Checks if the table has a vertical scrollbar.
+   *
+   * @returns {boolean}
+   */
+  hasHorizontalScroll() {
+    return this._wt.wtViewport.hasHorizontalScroll();
+  }
+
+  /**
    * Return the value of the `aria-colcount` attribute.
    *
    * @returns {number} The value of the `aria-colcount` attribute.

--- a/handsontable/src/tableView.js
+++ b/handsontable/src/tableView.js
@@ -1692,6 +1692,24 @@ class TableView {
   }
 
   /**
+   * Gets the table's width.
+   *
+   * @returns {boolean}
+   */
+  getTableWidth() {
+    return this._wt.wtTable.getWidth();
+  }
+
+  /**
+   * Gets the table's height.
+   *
+   * @returns {boolean}
+   */
+  getTableHeight() {
+    return this._wt.wtTable.getHeight();
+  }
+
+  /**
    * Return the value of the `aria-colcount` attribute.
    *
    * @returns {number} The value of the `aria-colcount` attribute.

--- a/handsontable/test/e2e/Dom.spec.js
+++ b/handsontable/test/e2e/Dom.spec.js
@@ -209,7 +209,7 @@ describe('Handsontable.Dom', () => {
       .appendTo('body');
 
     const span = document.getElementById('testable');
-    const compStyle = Handsontable.dom.getComputedStyle(span);
+    const compStyle = getComputedStyle(span);
 
     expect(compStyle.fontSize).toBe('12px');
 
@@ -221,7 +221,7 @@ describe('Handsontable.Dom', () => {
       .appendTo('body');
 
     const div = document.getElementById('testable');
-    const compStyle = Handsontable.dom.getComputedStyle(div);
+    const compStyle = getComputedStyle(div);
 
     expect(compStyle.borderTopWidth).toBe('10px');
 

--- a/handsontable/test/e2e/publicAPI.spec.js
+++ b/handsontable/test/e2e/publicAPI.spec.js
@@ -190,7 +190,6 @@ describe('Public API', () => {
       expect(Handsontable.dom.fastInnerHTML).toBeFunction();
       expect(Handsontable.dom.fastInnerText).toBeFunction();
       expect(Handsontable.dom.getCaretPosition).toBeFunction();
-      expect(Handsontable.dom.getComputedStyle).toBeFunction();
       expect(Handsontable.dom.getCssTransform).toBeFunction();
       expect(Handsontable.dom.getParent).toBeFunction();
       expect(Handsontable.dom.getScrollLeft).toBeFunction();


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR improves the calculation of the container size for the `autocomplete`, `dropdown` and `handsontable` editors. Previously, the container size was incorrect, resulting in much more challenging (or impossible) styling the editor, e.g., adding a shadow, borders, or more.

Additionally, the PR removes the `getComputedStyle` helper as the API is supported in all browsers supported by the Handsontable.

#### 14.5
![Kapture 2024-09-25 at 14 06 05](https://github.com/user-attachments/assets/d47aebf3-50dd-4fc8-ab5d-098a4a3bfbf8)

#### After the changes
![Kapture 2024-09-25 at 14 07 15](https://github.com/user-attachments/assets/f1d9dfe9-2a4c-4891-a377-b8f5c61f99b9)

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and I covered the fix with new tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/2070

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
