### PR TITLE
[hotfix] Fix autocomplete editor size

### DIFF
--- a/handsontable/src/editors/autocompleteEditor/__tests__/autocompleteEditor.spec.js
+++ b/handsontable/src/editors/autocompleteEditor/__tests__/autocompleteEditor.spec.js
@@ -1,10 +1,10 @@
 describe('AutocompleteEditor', () => {
-  const id = 'testContainer';
   const choices = ['yellow', 'red', 'orange', 'green', 'blue', 'gray', 'black',
     'white', 'purple', 'lime', 'olive', 'cyan'];
 
   beforeEach(function() {
-    this.$container = $(`<div id="${id}" style="width: 300px; height: 200px; overflow: auto"></div>`).appendTo('body');
+    this.$container = $('<div id="testContainer" style="width: 300px; height: 200px; overflow: auto"></div>')
+      .appendTo('body');
   });
 
   afterEach(function() {
@@ -394,6 +394,30 @@ describe('AutocompleteEditor', () => {
       expect(container.clientHeight).toBe(118);
     });
 
+    it('should open editor with the correct size when there is no scrollbar on the list (trimDropdown: false)', async() => {
+      handsontable({
+        colWidths: 120,
+        columns: [
+          {
+            editor: 'autocomplete',
+            source: choices.slice(0, 5),
+            visibleRows: 5,
+            trimDropdown: false,
+          }
+        ]
+      });
+
+      selectCell(0, 0);
+      keyDownUp('enter');
+
+      await sleep(100);
+
+      const container = getActiveEditor().htContainer;
+
+      expect(container.clientWidth).toBe(52);
+      expect(container.clientHeight).toBe(118);
+    });
+
     it('should open editor with the correct size when there is scrollbar on the list', async() => {
       handsontable({
         colWidths: 120,
@@ -414,6 +438,30 @@ describe('AutocompleteEditor', () => {
       const container = getActiveEditor().htContainer;
 
       expect(container.clientWidth).toBe(120 + Handsontable.dom.getScrollbarWidth());
+      expect(container.clientHeight).toBe(72);
+    });
+
+    it('should open editor with the correct size when there is scrollbar on the list (trimDropdown: false)', async() => {
+      handsontable({
+        colWidths: 120,
+        columns: [
+          {
+            editor: 'autocomplete',
+            source: choices,
+            visibleRows: 3,
+            trimDropdown: false,
+          }
+        ]
+      });
+
+      selectCell(0, 0);
+      keyDownUp('enter');
+
+      await sleep(100);
+
+      const container = getActiveEditor().htContainer;
+
+      expect(container.clientWidth).toBe(52 + Handsontable.dom.getScrollbarWidth());
       expect(container.clientHeight).toBe(72);
     });
   });

--- a/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
+++ b/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
@@ -439,18 +439,14 @@ export class AutocompleteEditor extends HandsontableEditor {
    * @private
    */
   updateDropdownDimensions() {
-    const trimDropdown = this.cellProperties.trimDropdown;
-    const width = trimDropdown ? this.getWidth() : undefined;
-    const height = this.getHeight();
-
     this.htEditor.updateSettings({
-      width,
-      height,
+      width: this.getWidth(),
+      height: this.getHeight(),
     });
 
-    if (trimDropdown && this.htEditor.view.hasVerticalScroll()) {
+    if (this.htEditor.view.hasVerticalScroll()) {
       this.htEditor.updateSettings({
-        width: width + getScrollbarWidth(this.hot.rootDocument),
+        width: this.htEditor.getSettings().width + getScrollbarWidth(this.hot.rootDocument),
       });
     }
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR is a hotfix for #11201 mentioned in https://github.com/handsontable/dev-handsontable/issues/2070#issuecomment-2388304730 and fixes an issue where the editor size was incorrectly calculated when the `trimDropdown` option was disabled.
 
_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and I added missing tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/2070

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
