### PR TITLE
Fix a problem with the `initOnly` options and the component re-rendering in the new React wrapper.

### DIFF
--- a/wrappers/react-wrapper/src/settingsMapper.ts
+++ b/wrappers/react-wrapper/src/settingsMapper.ts
@@ -32,7 +32,11 @@ export class SettingsMapper {
     let newSettings: Handsontable.GridSettings = {};
 
     for (const key in properties) {
-      if (key !== 'children' && properties.hasOwnProperty(key)) {
+      if (
+        key !== 'children' &&
+        !shouldSkipProp(key as keyof Handsontable.GridSettings) &&
+        properties.hasOwnProperty(key)
+      ) {
         (newSettings as any)[key] = properties[key as keyof HotTableProps];
       }
     }

--- a/wrappers/react-wrapper/test/hotTable.spec.tsx
+++ b/wrappers/react-wrapper/test/hotTable.spec.tsx
@@ -10,6 +10,7 @@ import {
   sleep,
   simulateKeyboardEvent,
   simulateMouseEvent,
+  mountComponent,
   mountComponentWithRef,
   customNativeRenderer,
   CustomNativeEditor,

--- a/wrappers/react/src/settingsMapper.ts
+++ b/wrappers/react/src/settingsMapper.ts
@@ -3,7 +3,7 @@ import { HotTableProps } from './types';
 
 export class SettingsMapper {
   /**
-   * Parse component settings into Handosntable-compatible settings.
+   * Parse component settings into Handsontable-compatible settings.
    *
    * @param {Object} properties Object containing properties from the HotTable object.
    * @param {Object} additionalSettings Additional settings.


### PR DESCRIPTION
### Context
This PR fixes a problem with the `init-only` options (like `renderAllRows`) crashing the wrapper in strict mode, when the component is re-rendered on init.

After the review, it should be merged to the [feature/new-react-wrapper](https://github.com/handsontable/handsontable/tree/feature/new-react-wrapper) branch.

[skip changelog]

### How has this been tested?
Tested manually and made sure the tests pass locally.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [x] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
