### PR TITLE
[docs] Remove the duplicated data from the React installation example.

### DIFF
--- a/docs/content/guides/getting-started/installation/react/example.jsx
+++ b/docs/content/guides/getting-started/installation/react/example.jsx
@@ -6,13 +6,6 @@ import 'handsontable/dist/handsontable.full.min.css';
 registerAllModules();
 
 const ExampleComponent = () => {
-  const data = [
-    ['', 'Tesla', 'Volvo', 'Toyota', 'Ford'],
-    ['2019', 10, 11, 12, 13],
-    ['2020', 20, 11, 14, 13],
-    ['2021', 30, 15, 12, 13],
-  ];
-
   return (
     <HotTable
       data={[

--- a/docs/content/guides/getting-started/installation/react/example.tsx
+++ b/docs/content/guides/getting-started/installation/react/example.tsx
@@ -8,13 +8,6 @@ import 'handsontable/dist/handsontable.full.min.css';
 registerAllModules();
 
 const ExampleComponent: FC = () => {
-  const data: Handsontable.CellValue[][] = [
-    ['', 'Tesla', 'Volvo', 'Toyota', 'Ford'],
-    ['2019', 10, 11, 12, 13],
-    ['2020', 20, 11, 14, 13],
-    ['2021', 30, 15, 12, 13],
-  ];
-
   return (
     <HotTable
       data={[


### PR DESCRIPTION
### Context
This PR removes the unneeded `data` variable from the docs' React installation example.

[skip changelog]