### PR TITLE
Add missing typings for languages

### DIFF
--- a/.changelogs/11236.json
+++ b/.changelogs/11236.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Added missing typings for language files",
+  "type": "added",
+  "issueOrPR": 11236,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/i18n/__tests__/i18n.types.ts
+++ b/handsontable/src/i18n/__tests__/i18n.types.ts
@@ -1,10 +1,13 @@
 import {
   registerLanguageDictionary,
+  arAr,
+  csCZ,
   deCH,
   deDE,
   enUS,
   esMX,
   frFR,
+  hrHR,
   itIT,
   jaJP,
   koKR,
@@ -14,15 +17,40 @@ import {
   plPL,
   ptBR,
   ruRU,
+  srSP,
   zhCN,
   zhTW,
 } from 'handsontable/i18n';
 
+const arArCode: 'ar-AR' = arAr.languageCode;
+const csCZCode: 'cs-CZ' = csCZ.languageCode;
+const deCHCode: 'de-CH' = deCH.languageCode;
+const deDECode: 'de-DE' = deDE.languageCode;
+const enUSCode: 'en-US' = enUS.languageCode;
+const esMXCode: 'es-MX' = esMX.languageCode;
+const frFRCode: 'fr-FR' = frFR.languageCode;
+const hrHRCode: 'hr-HR' = hrHR.languageCode;
+const itITCode: 'it-IT' = itIT.languageCode;
+const jaJPCode: 'ja-JP' = jaJP.languageCode;
+const koKRCode: 'ko-KR' = koKR.languageCode;
+const lvLVCode: 'lv-LV' = lvLV.languageCode;
+const nbNOCode: 'nb-NO' = nbNO.languageCode;
+const nlNLCode: 'nl-NL' = nlNL.languageCode;
+const plPLCode: 'pl-PL' = plPL.languageCode;
+const ptBRCode: 'pt-BR' = ptBR.languageCode;
+const ruRUCode: 'ru-RU' = ruRU.languageCode;
+const srSPCode: 'sr-SP' = srSP.languageCode;
+const zhCNCode: 'zh-CN' = zhCN.languageCode;
+const zhTWCode: 'zh-TW' = zhTW.languageCode;
+
+registerLanguageDictionary(arAr);
+registerLanguageDictionary(csCZ);
 registerLanguageDictionary(deCH);
 registerLanguageDictionary(deDE);
 registerLanguageDictionary(enUS);
 registerLanguageDictionary(esMX);
 registerLanguageDictionary(frFR);
+registerLanguageDictionary(hrHR);
 registerLanguageDictionary(itIT);
 registerLanguageDictionary(jaJP);
 registerLanguageDictionary(koKR);
@@ -32,5 +60,6 @@ registerLanguageDictionary(nlNL);
 registerLanguageDictionary(plPL);
 registerLanguageDictionary(ptBR);
 registerLanguageDictionary(ruRU);
+registerLanguageDictionary(srSP);
 registerLanguageDictionary(zhCN);
 registerLanguageDictionary(zhTW);

--- a/handsontable/types/i18n/languages/index.d.ts
+++ b/handsontable/types/i18n/languages/index.d.ts
@@ -1,8 +1,11 @@
+import arAr from './ar-AR';
+import csCZ from './cs-CZ';
 import deCH from './de-CH';
 import deDE from './de-DE';
 import enUS from './en-US';
 import esMX from './es-MX';
 import frFR from './fr-FR';
+import hrHR from './hr-HR';
 import itIT from './it-IT';
 import jaJP from './ja-JP';
 import koKR from './ko-KR';
@@ -12,15 +15,19 @@ import nlNL from './nl-NL';
 import plPL from './pl-PL';
 import ptBR from './pt-BR';
 import ruRU from './ru-RU';
+import srSP from './sr-SP';
 import zhCN from './zh-CN';
 import zhTW from './zh-TW';
 
 export {
+  arAr,
+  csCZ,
   deCH,
   deDE,
   enUS,
   esMX,
   frFR,
+  hrHR,
   itIT,
   jaJP,
   koKR,
@@ -30,6 +37,7 @@ export {
   plPL,
   ptBR,
   ruRU,
+  srSP,
   zhCN,
   zhTW
 };

--- a/handsontable/types/i18n/languages/ja-JP.d.ts
+++ b/handsontable/types/i18n/languages/ja-JP.d.ts
@@ -1,5 +1,5 @@
 export default dictionary;
 declare const dictionary: {
   [x: string]: string | string[];
-  languageCode: 'js-JP';
+  languageCode: 'ja-JP';
 };


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adds missing TS typings for missing language files.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I covered the fix with extended tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/2080

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
