### PR TITLE
Date validator: Add support for strict format checking

### DIFF
--- a/docs/content/guides/cell-types/date-cell-type/date-cell-type.md
+++ b/docs/content/guides/cell-types/date-cell-type/date-cell-type.md
@@ -92,6 +92,31 @@ correctFormat={false}
 correctFormat={true}
 ```
 
+Also, you can set `isCorrectFormatStrict` to `true` to make the date validation stricter when trying to correct the input format.
+For more information check [Moment.js documentation](https://momentjs.com/guides/#/parsing/strict-mode/).
+
+```js
+dateFormat: 'D/M/YY',
+
+// default behavior
+// date entered as `01/02/2023` will be formatted as `1/2/20` which is incorrect
+isCorrectFormatStrict={false}
+
+// date entered as `01/02/2023` will be formatted as `1/2/23` which is correct
+isCorrectFormatStrict={true}
+```
+
+```jsx
+dateFormat={'D/M/YY'}
+
+// default behavior
+// date entered as `01-02-2023` will be formatted as `1-2-20` which is incorrect
+isCorrectFormatStrict={false}
+
+// date entered as `01-02-2023` will be formatted as `1-2-23` which is correct
+isCorrectFormatStrict={true}
+```
+
 :::
 
 ## Basic example

--- a/handsontable/src/validators/dateValidator/__tests__/dateValidator.spec.js
+++ b/handsontable/src/validators/dateValidator/__tests__/dateValidator.spec.js
@@ -388,6 +388,51 @@ describe('dateValidator', () => {
 
       expect(countRows()).toBe(6);
     });
+
+    it('should validate strings strictly when `strict` parameter is set to `true`', async() => {
+      const { validators } = Handsontable;
+
+      handsontable({
+        data: arrayOfObjects(),
+        columns: [
+          { data: 'date',
+            type: 'date',
+            dateFormat: 'MMM D, YYYY',
+            validator: (
+              value,
+              callback,
+            ) => {
+              return validators.dateValidator.call(
+                this,
+                value,
+                callback,
+                (val, format) => validators.correctFormat(val, format, true)
+              );
+            }
+          },
+          { data: 'name' },
+          { data: 'lastName' }
+        ],
+      });
+
+      setDataAtCell(1, 0, '01-01-2015');
+
+      await sleep(100);
+
+      expect(getDataAtCell(1, 0)).toEqual('01/01/2015');
+
+      setDataAtCell(1, 0, '01-01-15');
+      await sleep(100);
+      expect(getDataAtCell(1, 0)).toEqual('01/01/2015');
+
+      setDataAtCell(1, 0, '01/01/2015');
+      await sleep(100);
+      expect(getDataAtCell(1, 0)).toEqual('01/01/2015');
+
+      setDataAtCell(1, 0, '01/01/15');
+      await sleep(100);
+      expect(getDataAtCell(1, 0)).toEqual('01/01/2015');
+    });
   });
 
   describe('Date formats', () => {

--- a/handsontable/src/validators/dateValidator/__tests__/dateValidator.spec.js
+++ b/handsontable/src/validators/dateValidator/__tests__/dateValidator.spec.js
@@ -388,51 +388,6 @@ describe('dateValidator', () => {
 
       expect(countRows()).toBe(6);
     });
-
-    it('should validate strings strictly when `strict` parameter is set to `true`', async() => {
-      const { validators } = Handsontable;
-
-      handsontable({
-        data: arrayOfObjects(),
-        columns: [
-          { data: 'date',
-            type: 'date',
-            dateFormat: 'MMM D, YYYY',
-            validator: (
-              value,
-              callback,
-            ) => {
-              return validators.dateValidator.call(
-                this,
-                value,
-                callback,
-                (val, format) => validators.correctFormat(val, format, true)
-              );
-            }
-          },
-          { data: 'name' },
-          { data: 'lastName' }
-        ],
-      });
-
-      setDataAtCell(1, 0, '01-01-2015');
-
-      await sleep(100);
-
-      expect(getDataAtCell(1, 0)).toEqual('01/01/2015');
-
-      setDataAtCell(1, 0, '01-01-15');
-      await sleep(100);
-      expect(getDataAtCell(1, 0)).toEqual('01/01/2015');
-
-      setDataAtCell(1, 0, '01/01/2015');
-      await sleep(100);
-      expect(getDataAtCell(1, 0)).toEqual('01/01/2015');
-
-      setDataAtCell(1, 0, '01/01/15');
-      await sleep(100);
-      expect(getDataAtCell(1, 0)).toEqual('01/01/2015');
-    });
   });
 
   describe('Date formats', () => {
@@ -507,27 +462,36 @@ describe('dateValidator', () => {
 
     describe('with `correctFormat` enabled', () => {
       using('data set', [
-        { value: '01/02/2023', dateFormat: 'DD/MM/YYYY' },
-        { value: '01/02/23', dateFormat: 'DD/MM/YY' },
-        { value: '1/2/23', dateFormat: 'D/M/YY' },
-        { value: '01/02/23', dateFormat: 'D/M/YY' }, // ?
-        { value: '01-02-2023', dateFormat: 'DD-MM-YYYY' },
-        { value: '1-2-23', dateFormat: 'D-M-YY' },
-        { value: '1-12-23', dateFormat: 'D-M-YY' },
-        { value: '1.2.23', dateFormat: 'D.M.YY' },
-        { value: '2023 February 2nd', dateFormat: 'YYYY MMMM Do' },
-        { value: 'Feb 2nd \'23', dateFormat: 'MMM Do \'YY' },
-        { value: 'The 2nd of February \'23', dateFormat: '[The] Do [of] MMMM \'YY' },
-        { value: 'Day: 2, Month: 2, Year: 2023', dateFormat: '[Day:] D, [Month:] M, [Year:] YYYY' },
-        { value: '01/02/23', dateFormat: 'DD/MM/YYYY' },
-        { value: '1/2/23', dateFormat: 'DD/MM/YY' },
-        { value: '01/02/2023', dateFormat: 'D/M/YY' },
-        { value: '1-2-23', dateFormat: 'DD-MM-YYYY' },
-        { value: '01/02/2023', dateFormat: 'DD-MM-YYYY' },
-        { value: '01-02-2023', dateFormat: 'DD.MM.YYYY' },
-        { value: '1-2-2023', dateFormat: 'D-M-YY' },
-        { value: '1.2.2023', dateFormat: 'D.M.YY' },
-      ], ({ value, dateFormat }) => {
+        { value: '01/02/2023', dateFormat: 'DD/MM/YYYY', formattedValue: '01/02/2023' },
+        { value: '01/02/23', dateFormat: 'DD/MM/YY', formattedValue: '01/02/23' },
+        { value: '1/2/23', dateFormat: 'D/M/YY', formattedValue: '1/2/23' },
+        { value: '01/02/23', dateFormat: 'D/M/YY', formattedValue: '1/2/23' },
+        { value: '01-02-2023', dateFormat: 'DD-MM-YYYY', formattedValue: '01-02-2023' },
+        { value: '1-2-23', dateFormat: 'D-M-YY', formattedValue: '1-2-23' },
+        { value: '1-12-23', dateFormat: 'D-M-YY', formattedValue: '1-12-23' },
+        { value: '1.2.23', dateFormat: 'D.M.YY', formattedValue: '1.2.23' },
+        { value: '2023 February 2nd', dateFormat: 'YYYY MMMM Do', formattedValue: '2023 February 2nd' },
+        { value: 'Feb 2nd \'23', dateFormat: 'MMM Do \'YY', formattedValue: 'Feb 2nd \'23' },
+        { value: 'The 2nd of February \'23',
+          dateFormat: '[The] Do [of] MMMM \'YY',
+          formattedValue: 'The 2nd of February \'23'
+        },
+        { value: 'Day: 2, Month: 2, Year: 2023',
+          dateFormat: '[Day:] D, [Month:] M, [Year:] YYYY',
+          formattedValue: 'Day: 2, Month: 2, Year: 2023'
+        },
+        { value: '01/02/23', dateFormat: 'DD/MM/YYYY', formattedValue: '01/02/2023' },
+        { value: '1/2/23', dateFormat: 'DD/MM/YY', formattedValue: '01/02/23' },
+        { value: '1-2-23', dateFormat: 'DD-MM-YYYY', formattedValue: '01-02-2023' },
+        { value: '01/02/2023', dateFormat: 'DD-MM-YYYY', formattedValue: '01-02-2023' },
+        { value: '01-02-2023', dateFormat: 'DD.MM.YYYY', formattedValue: '01.02.2023' },
+        // The following are formatted in a wrong way because isCorrectFormatStrict is set to false
+        // and Moment is in forgiving mode.
+        { value: '01/02/2023', dateFormat: 'D/M/YY', formattedValue: '1/2/20' },
+        { value: '1-2-2023', dateFormat: 'D-M-YY', formattedValue: '1-2-20' },
+        { value: '1.2.2023', dateFormat: 'D.M.YY', formattedValue: '1.2.20' },
+        { value: '2024-01-01', dateFormat: 'MMM D, YYYY', formattedValue: 'Jan 20, 2024' },
+      ], ({ value, dateFormat, formattedValue }) => {
         it('should validate positively', async() => {
           const onAfterValidateSpy = jasmine.createSpy('onAfterValidate');
 
@@ -543,6 +507,7 @@ describe('dateValidator', () => {
 
           await sleep(50);
 
+          expect(getDataAtCell(0, 0)).toEqual(formattedValue);
           expect(onAfterValidateSpy).toHaveBeenCalledWith(true, value, 0, 0);
         });
       });
@@ -569,6 +534,59 @@ describe('dateValidator', () => {
 
           await sleep(50);
 
+          expect(onAfterValidateSpy).toHaveBeenCalledWith(false, value, 0, 0);
+        });
+      });
+    });
+
+    describe('with `correctFormat` enabled and `isCorrectFormatStrict` enabled', () => {
+      using('data set', [
+        { value: '01/02/2023', dateFormat: 'D/M/YY', formattedValue: '1/2/23' },
+        { value: '1-2-2023', dateFormat: 'D-M-YY', formattedValue: '1-2-23' },
+        { value: '1.2.2023', dateFormat: 'D.M.YY', formattedValue: '1.2.23' },
+        { value: '2024-01-01', dateFormat: 'MMM D, YYYY', formattedValue: 'Jan 01, 2024' },
+      ], ({ value, formattedValue, dateFormat }) => {
+        const onAfterValidateSpy = jasmine.createSpy('onAfterValidate');
+
+        it('should validate positively and should transform', async() => {
+          handsontable({
+            data: [],
+            columns: [
+              { type: 'date', dateFormat, correctFormat: true, isCorrectFormatStrict: true },
+            ],
+            afterValidate: onAfterValidateSpy
+          });
+
+          setDataAtCell(0, 0, value);
+
+          await sleep(50);
+
+          expect(getDataAtCell(0, 0)).toEqual(formattedValue);
+          expect(onAfterValidateSpy).toHaveBeenCalledWith(true, value, 0, 0);
+        });
+      });
+      using('data set', [
+        { value: '2023 February 2nd' },
+        { value: 'Feb 2nd \'23' },
+        { value: 'The 2nd of February \'23' },
+        { value: '100110/09/2015' }
+      ], ({ value }) => {
+        const onAfterValidateSpy = jasmine.createSpy('onAfterValidate');
+
+        it('should validate negatively', async() => {
+          handsontable({
+            data: [],
+            columns: [
+              { type: 'date', dateFormat: 'MMM D, YYYY', correctFormat: true, isCorrectFormatStrict: true },
+            ],
+            afterValidate: onAfterValidateSpy
+          });
+
+          setDataAtCell(0, 0, value);
+
+          await sleep(50);
+
+          expect(getDataAtCell(0, 0)).toEqual(value);
           expect(onAfterValidateSpy).toHaveBeenCalledWith(false, value, 0, 0);
         });
       });

--- a/handsontable/src/validators/dateValidator/dateValidator.js
+++ b/handsontable/src/validators/dateValidator/dateValidator.js
@@ -1,6 +1,6 @@
 import moment from 'moment';
-import { getEditorInstance } from '../../editors/registry';
 import { EDITOR_TYPE as DATE_EDITOR_TYPE } from '../../editors/dateEditor';
+import { getEditorInstance } from '../../editors/registry';
 import { getNormalizedDate } from '../../helpers/date';
 
 export const VALIDATOR_TYPE = 'date';
@@ -11,8 +11,9 @@ export const VALIDATOR_TYPE = 'date';
  * @private
  * @param {*} value Value of edited cell.
  * @param {Function} callback Callback called with validation result.
+ * @param {Function} correctFormatFn Function to correct the format of the input date.
  */
-export function dateValidator(value, callback) {
+export function dateValidator(value, callback, correctFormatFn = correctFormat) {
   const dateEditor = getEditorInstance(DATE_EDITOR_TYPE, this.instance);
   let valueToValidate = value;
   let valid = true;
@@ -37,7 +38,7 @@ export function dateValidator(value, callback) {
 
   if (isValidDate && !isValidFormat) {
     if (this.correctFormat === true) { // if format correction is enabled
-      const correctedValue = correctFormat(valueToValidate, this.dateFormat);
+      const correctedValue = correctFormatFn(valueToValidate, this.dateFormat);
 
       this.instance.setDataAtCell(this.visualRow, this.visualCol, correctedValue, 'dateValidator');
       valid = true;
@@ -56,11 +57,12 @@ dateValidator.VALIDATOR_TYPE = VALIDATOR_TYPE;
  *
  * @param {string} value The value to format.
  * @param {string} dateFormat The date pattern to format to.
+ * @param {boolean} strictFormat If true, moment will try to format the date string strictly. Defaults to false.
  * @returns {string}
  */
-export function correctFormat(value, dateFormat) {
+export function correctFormat(value, dateFormat, strictFormat = false) {
   const dateFromDate = moment(getNormalizedDate(value));
-  const dateFromMoment = moment(value, dateFormat);
+  const dateFromMoment = moment(value, dateFormat, strictFormat);
   const isAlphanumeric = value.search(/[A-z]/g) > -1;
   let date;
 

--- a/handsontable/src/validators/dateValidator/dateValidator.js
+++ b/handsontable/src/validators/dateValidator/dateValidator.js
@@ -11,9 +11,8 @@ export const VALIDATOR_TYPE = 'date';
  * @private
  * @param {*} value Value of edited cell.
  * @param {Function} callback Callback called with validation result.
- * @param {Function} correctFormatFn Function to correct the format of the input date.
  */
-export function dateValidator(value, callback, correctFormatFn = correctFormat) {
+export function dateValidator(value, callback) {
   const dateEditor = getEditorInstance(DATE_EDITOR_TYPE, this.instance);
   let valueToValidate = value;
   let valid = true;
@@ -38,7 +37,7 @@ export function dateValidator(value, callback, correctFormatFn = correctFormat) 
 
   if (isValidDate && !isValidFormat) {
     if (this.correctFormat === true) { // if format correction is enabled
-      const correctedValue = correctFormatFn(valueToValidate, this.dateFormat);
+      const correctedValue = correctFormat(valueToValidate, this.dateFormat, this.isCorrectFormatStrict);
 
       this.instance.setDataAtCell(this.visualRow, this.visualCol, correctedValue, 'dateValidator');
       valid = true;

--- a/handsontable/test/scripts/run-puppeteer.mjs
+++ b/handsontable/test/scripts/run-puppeteer.mjs
@@ -1,8 +1,8 @@
-import puppeteer, { JSHandle } from 'puppeteer';
-import path from 'path';
-import { fileURLToPath } from 'url';
 import { createServer } from 'http-server';
 import JasmineReporter from 'jasmine-terminal-reporter';
+import path from 'path';
+import puppeteer, { JSHandle } from 'puppeteer';
+import { fileURLToPath } from 'url';
 
 const PORT = 8086;
 const IS_CI = process.env.CI;

--- a/handsontable/types/settings.d.ts
+++ b/handsontable/types/settings.d.ts
@@ -128,6 +128,7 @@ export interface GridSettings extends Events {
   copyable?: boolean;
   copyPaste?: CopyPasteSettings;
   correctFormat?: boolean;
+  isCorrectFormatStrict?: boolean;
   currentColClassName?: string;
   currentHeaderClassName?: string;
   currentRowClassName?: string;


### PR DESCRIPTION
### Context
Currently, `correctFormat` function is used to correct the format of the input date but it does not do a strict format check while trying to parse the date with MomentJS, which can lead to unexpected results.

Moment.js recommends to use strict format checking when parsing dates if possible.

[MomentJS Docs](https://momentjs.com/guides/#/parsing/strict-mode/)

- Add `strict` parameter to the `correctFormat` function to allow strict format checking.
- Add  optional`isCorrectFormatStrict` parameter to `GridSettings`. Defaults to `false`

### How has this been tested?
I added some e2e tests with the corresponding explanation, mainly for some wrong scenarios with the old approach.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

### Affected project(s):
- [x] `handsontable`
- [] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
