### PR TITLE
fix: add missing common lib export from package.json

### DIFF
--- a/.changelogs/11247.json
+++ b/.changelogs/11247.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed an issue with export of common lib in package.json",
+  "type": "fixed",
+  "issueOrPR": 11247,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/package.json
+++ b/handsontable/package.json
@@ -204,6 +204,13 @@
         }
       },
       {
+        "./common": {
+          "types": "./common.d.ts",
+          "import": "./common.mjs",
+          "require": "./common.js"
+        }
+      },
+      {
         "./languages/all": {
           "import": "./languages/index.mjs",
           "require": "./languages/all.js"

--- a/handsontable/package.json
+++ b/handsontable/package.json
@@ -205,9 +205,7 @@
       },
       {
         "./common": {
-          "types": "./common.d.ts",
-          "import": "./common.mjs",
-          "require": "./common.js"
+          "types": "./common.d.ts"
         }
       },
       {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->

`handsontable/common` export is missing from exports in `package.json`. It causes typescript to incorrectly infer types and throw `TS2307: Cannot find module handsontable/ common or its corresponding type declarations` if `moduleResolution` in `tsconfig.json` is set to other than `node` and as per TypeScript [documentation](https://www.typescriptlang.org/tsconfig/#moduleResolution)  they don't recommend using it. 

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

I've checked if build has exported `handsontable/common` lib.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #10415 

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
