### PR TITLE
[themes] Make Handsontable react to theme class names being added to the root elements' parents.

### DIFF
--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -1117,7 +1117,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
 
     this.view = new TableView(this);
 
-    const themeName = tableMeta.themeName || getThemeClassName(instance.rootElement.className);
+    const themeName = tableMeta.themeName || getThemeClassName(instance.rootElement);
 
     // Use the theme defined as a root element class or in the settings (in that order).
     instance.useTheme(themeName);
@@ -2598,7 +2598,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
 
         const themeName =
           (themeNameOptionExists && settings.themeName) ||
-          getThemeClassName(instance.rootElement.className);
+          getThemeClassName(instance.rootElement);
 
         // Use the theme defined as a root element class or in the settings (in that order).
         instance.useTheme(themeName);

--- a/handsontable/src/editors/dateEditor/__tests__/themes/themes.spec.js
+++ b/handsontable/src/editors/dateEditor/__tests__/themes/themes.spec.js
@@ -1,0 +1,46 @@
+describe('Theme handling', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should have the same theme as the parent Handsontable instance (if originally passed as a config option)', async() => {
+    handsontable({
+      columns: [{ type: 'date' }],
+      themeName: 'ht-theme-sth',
+    });
+
+    selectCell(0, 0);
+    keyDownUp('enter');
+
+    await sleep(50);
+
+    const $editor = $(getActiveEditor().datePicker);
+
+    expect($editor.hasClass('ht-theme-sth')).toBe(true);
+  });
+
+  it('should have the same theme as the parent Handsontable instance (if originally passed as a container class)', async() => {
+    spec().$container.addClass('ht-theme-sth-else');
+    handsontable({
+      columns: [{ type: 'date' }],
+    });
+
+    selectCell(0, 0);
+    keyDownUp('enter');
+
+    await sleep(50);
+
+    const $editor = $(getActiveEditor().datePicker);
+
+    expect($editor.hasClass('ht-theme-sth-else')).toBe(true);
+  });
+});

--- a/handsontable/src/editors/dateEditor/dateEditor.js
+++ b/handsontable/src/editors/dateEditor/dateEditor.js
@@ -40,7 +40,9 @@ export class DateEditor extends TextEditor {
     if (typeof Pikaday !== 'function') {
       throw new Error('You need to include Pikaday to your project.');
     }
+
     super.init();
+
     this.hot.addHook('afterDestroy', () => {
       this.parentDestroyed = true;
       this.destroyElements();
@@ -62,7 +64,7 @@ export class DateEditor extends TextEditor {
 
     this.datePicker.setAttribute('dir', this.hot.isRtl() ? 'rtl' : 'ltr');
 
-    const themeClassName = this.hot.getSettings().themeName;
+    const themeClassName = this.hot.getCurrentThemeName();
 
     addClass(this.datePicker, 'htDatepickerHolder');
     addClass(this.datePicker, themeClassName);

--- a/handsontable/src/helpers/dom/__tests__/element.unit.js
+++ b/handsontable/src/helpers/dom/__tests__/element.unit.js
@@ -11,6 +11,7 @@ import {
   setAttribute,
   fastInnerHTML,
   isVisible,
+  findFirstParentWithClass,
 } from 'handsontable/helpers/dom/element';
 
 describe('DomElement helper', () => {
@@ -136,6 +137,79 @@ describe('DomElement helper', () => {
 
         expect(closest(element, nodes, until)).toBe(null);
       });
+    });
+  });
+
+  //
+  // Handsontable.helper.closestDown
+  //
+  describe('findFirstParentWithClass', () => {
+    const test1 = '<div class="wrapper1"><table><tbody><tr class="ht-test-sth">' +
+      '<td>test1</td></tr></tbody></table></div>';
+    const test2 = `<div><table class="test2 test2-2"><tbody class="ht-test-sth ht-test-sth2"><tr>' +
+      '<td>test2${test1}</td></tr></tbody></table></div>`;
+
+    it('should return the closest parent with the provided class', () => {
+      const wrapper1 = document.createElement('div');
+      const wrapper2 = document.createElement('div');
+
+      wrapper1.innerHTML = test1;
+      wrapper2.innerHTML = test2;
+
+      const td1 = wrapper1.querySelector('td');
+      const td2 = wrapper2.querySelector('td');
+
+      expect(findFirstParentWithClass(td1, 'ht-test-sth').element).toBe(wrapper1.querySelector('.ht-test-sth'));
+      expect(findFirstParentWithClass(td1, 'ht-test-sth').classNames).toEqual(['ht-test-sth']);
+      expect(findFirstParentWithClass(td1, 'wrapper1').element).toBe(wrapper1.querySelector('.wrapper1'));
+      expect(findFirstParentWithClass(td1, 'wrapper1').classNames).toEqual(['wrapper1']);
+
+      expect(findFirstParentWithClass(td2, 'ht-test-sth').element).toBe(wrapper2.querySelector('.ht-test-sth'));
+      expect(findFirstParentWithClass(td2, 'ht-test-sth').classNames).toEqual(['ht-test-sth']);
+      expect(findFirstParentWithClass(td2, 'test2').element).toBe(wrapper2.querySelector('.test2'));
+      expect(findFirstParentWithClass(td2, 'test2').classNames).toEqual(['test2']);
+    });
+
+    it('should return the closest parent with a class that matches the provided regex', () => {
+      const wrapper1 = document.createElement('div');
+      const wrapper2 = document.createElement('div');
+
+      wrapper1.innerHTML = test1;
+      wrapper2.innerHTML = test2;
+
+      const td1 = wrapper1.querySelector('td');
+      const td2 = wrapper2.querySelector('td');
+
+      expect(findFirstParentWithClass(td1, /xt-test-(.*)/).element).toBe(undefined);
+      expect(findFirstParentWithClass(td1, /xt-test-(.*)/).classNames).toEqual([]);
+      expect(findFirstParentWithClass(td1, /vrapper(.*)/).element).toBe(undefined);
+      expect(findFirstParentWithClass(td1, /vrapper(.*)/).classNames).toEqual([]);
+
+      expect(findFirstParentWithClass(td2, /xt-test-(.*)/).element).toBe(undefined);
+      expect(findFirstParentWithClass(td2, /xt-test-(.*)/).classNames).toEqual([]);
+      expect(findFirstParentWithClass(td2, /xtest2(.*)/).element).toBe(undefined);
+      expect(findFirstParentWithClass(td2, /xtest2(.*)/).classNames).toEqual([]);
+    });
+
+    it('should return `undefined` as the element and an empty array as the class list array if no elements were found', () => {
+      const wrapper1 = document.createElement('div');
+      const wrapper2 = document.createElement('div');
+
+      wrapper1.innerHTML = test1;
+      wrapper2.innerHTML = test2;
+
+      const td1 = wrapper1.querySelector('td');
+      const td2 = wrapper2.querySelector('td');
+
+      expect(findFirstParentWithClass(td1, /ht-test-(.*)/).element).toBe(wrapper1.querySelector('.ht-test-sth'));
+      expect(findFirstParentWithClass(td1, /ht-test-(.*)/).classNames).toEqual(['ht-test-sth']);
+      expect(findFirstParentWithClass(td1, /wrapper(.*)/).element).toBe(wrapper1.querySelector('.wrapper1'));
+      expect(findFirstParentWithClass(td1, /wrapper(.*)/).classNames).toEqual(['wrapper1']);
+
+      expect(findFirstParentWithClass(td2, /ht-test-(.*)/).element).toBe(wrapper2.querySelector('.ht-test-sth'));
+      expect(findFirstParentWithClass(td2, /ht-test-(.*)/).classNames).toEqual(['ht-test-sth', 'ht-test-sth2']);
+      expect(findFirstParentWithClass(td2, /test2(.*)/).element).toBe(wrapper2.querySelector('.test2'));
+      expect(findFirstParentWithClass(td2, /test2(.*)/).classNames).toEqual(['test2', 'test2-2']);
     });
   });
 

--- a/handsontable/src/helpers/dom/element.js
+++ b/handsontable/src/helpers/dom/element.js
@@ -144,6 +144,43 @@ export function closestDown(element, nodes, until) {
 }
 
 /**
+ * Traverses up the DOM tree from the given element and finds parent elements that have a specified class name
+ * or match a provided class name regular expression.
+ *
+ * @param {HTMLElement} element - The element from which to start traversing.
+ * @param {string|RegExp} className - The class name or class name regular expression to check.
+ * @returns {{element: HTMLElement, classNames: string[]}} - Returns an object containing the matched parent element and an array of matched class names.
+ */
+export function findFirstParentWithClass(element, className) {
+  const matched = {
+    element: undefined,
+    classNames: []
+  };
+  let elementToCheck = element;
+
+  while (elementToCheck !== null && elementToCheck !== element.ownerDocument.documentElement && !matched.element) {
+    if (typeof className === 'string' && elementToCheck.classList.contains(className)) {
+
+      matched.element = elementToCheck;
+      matched.classNames.push(className);
+
+    } else if (className instanceof RegExp) {
+      const matchingClasses = Array.from(elementToCheck.classList).filter(cls => className.test(cls));
+
+      if (matchingClasses.length) {
+
+        matched.element = elementToCheck;
+        matched.classNames.push(...matchingClasses);
+      }
+    }
+
+    elementToCheck = elementToCheck.parentElement;
+  }
+
+  return matched;
+}
+
+/**
  * Goes up the DOM tree and checks if element is child of another element.
  *
  * @param {HTMLElement} child Child element An element to check.

--- a/handsontable/src/helpers/themes.js
+++ b/handsontable/src/helpers/themes.js
@@ -1,15 +1,13 @@
+import { findFirstParentWithClass } from './dom/element';
+
 /**
- * Get theme class name from rootElement class.
+ * Retrieves the theme class name from the closest parent element that matches the specified regex pattern.
  *
- * @param {string} className Class names.
- * @returns {string}
+ * @param {HTMLElement} rootElement - The root element from which to start searching for the theme class.
+ * @returns {string} - The theme class name regex.
  */
-export function getThemeClassName(className) {
-  if (!className || typeof className !== 'string') {
-    return false;
-  }
+export function getThemeClassName(rootElement) {
+  const { classNames } = findFirstParentWithClass(rootElement, /ht-theme-[a-zA-Z0-9_-]+/);
 
-  const [match] = className.match(/ht-theme-[a-zA-Z0-9_-]+/) || [];
-
-  return match;
+  return classNames.pop();
 }

--- a/handsontable/src/plugins/comments/__tests__/themes/themes.spec.js
+++ b/handsontable/src/plugins/comments/__tests__/themes/themes.spec.js
@@ -1,0 +1,45 @@
+describe('Theme handling', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should have the same theme as the parent Handsontable instance (if originally passed as a config option)', () => {
+    handsontable({
+      data: createSpreadsheetData(4, 4),
+      comments: true,
+      cell: [
+        { row: 1, col: 1, comment: { value: 'Test comment' } }
+      ],
+      themeName: 'ht-theme-sth',
+    });
+
+    selectCell(1, 1);
+    const $editorElement = $(getPlugin('comments').getEditorInputElement().parentElement);
+
+    expect($editorElement.hasClass('ht-theme-sth')).toBe(true);
+  });
+
+  it('should have the same theme as the parent Handsontable instance (if originally passed as a container class)', () => {
+    spec().$container.addClass('ht-theme-sth-else');
+    handsontable({
+      comments: true,
+      cell: [
+        { row: 1, col: 1, comment: { value: 'Test comment' } }
+      ],
+    });
+
+    selectCell(1, 1);
+    const $editorElement = $(getPlugin('comments').getEditorInputElement().parentElement);
+
+    expect($editorElement.hasClass('ht-theme-sth-else')).toBe(true);
+  });
+});

--- a/handsontable/src/plugins/comments/commentEditor.js
+++ b/handsontable/src/plugins/comments/commentEditor.js
@@ -55,15 +55,9 @@ class CommentEditor {
    */
   #resizeObserver = new EditorResizeObserver();
 
-  /**
-   * @type {string}
-   */
-  #themeClassName;
-
-  constructor(rootDocument, isRtl, themeClassName) {
+  constructor(rootDocument, isRtl) {
     this.#rootDocument = rootDocument;
     this.#isRtl = isRtl;
-    this.#themeClassName = themeClassName;
     this.#editor = this.createEditor();
     this.#editorStyle = this.#editor.style;
     this.#resizeObserver.setObservedElement(this.getInputElement());
@@ -219,7 +213,6 @@ class CommentEditor {
     this.#container.setAttribute('dir', this.#isRtl ? 'rtl' : 'ltr');
 
     addClass(this.#container, CommentEditor.CLASS_EDITOR_CONTAINER);
-    addClass(this.#container, this.#themeClassName);
 
     this.#rootDocument.body.appendChild(this.#container);
 
@@ -240,6 +233,15 @@ class CommentEditor {
    */
   getInputElement() {
     return this.#editor.querySelector(`.${CommentEditor.CLASS_INPUT}`);
+  }
+
+  /**
+   * Get the editor element.
+   *
+   * @returns {HTMLElement} The editor element.
+   */
+  getEditorElement() {
+    return this.#editor;
   }
 
   /**

--- a/handsontable/src/plugins/comments/comments.js
+++ b/handsontable/src/plugins/comments/comments.js
@@ -198,7 +198,7 @@ export class Comments extends BasePlugin {
     }
 
     if (!this.#editor) {
-      this.#editor = new CommentEditor(this.hot.rootDocument, this.hot.isRtl(), this.hot.getSettings().themeName);
+      this.#editor = new CommentEditor(this.hot.rootDocument, this.hot.isRtl());
       this.#editor.addLocalHook('resize', (...args) => this.#onEditorResize(...args));
     }
 
@@ -212,6 +212,8 @@ export class Comments extends BasePlugin {
     this.addHook('afterScroll', () => this.#onAfterScroll());
     this.addHook('afterBeginEditing', () => this.hide());
     this.addHook('afterDocumentKeyDown', event => this.#onAfterDocumentKeyDown(event));
+    this.addHook('afterInit', () => this.#updateEditorThemeClassName());
+    this.addHook('afterUpdateSettings', () => this.#updateEditorThemeClassName());
 
     this.#displaySwitch.addLocalHook('hide', () => this.hide());
     this.#displaySwitch.addLocalHook('show', (row, col) => this.showAtCell(row, col));
@@ -762,6 +764,13 @@ export class Comments extends BasePlugin {
     if (!this.#preventEditorHiding) {
       this.hide();
     }
+  }
+
+  /**
+   * Updates the editor theme class name.
+   */
+  #updateEditorThemeClassName() {
+    addClass(this.#editor.getEditorElement(), this.hot.getCurrentThemeName());
   }
 
   /**

--- a/handsontable/src/plugins/contextMenu/menu/menu.js
+++ b/handsontable/src/plugins/contextMenu/menu/menu.js
@@ -670,12 +670,9 @@ export class Menu {
     }
 
     if (!container) {
-      const themeClassName = this.hot.getSettings().themeName;
-
       container = doc.createElement('div');
 
       addClass(container, `htMenu ${this.options.className}`);
-      addClass(container, themeClassName);
 
       if (className) {
         addClass(container, className);

--- a/handsontable/test/e2e/Core_init.spec.js
+++ b/handsontable/test/e2e/Core_init.spec.js
@@ -2,7 +2,8 @@ describe('Core_init', () => {
   const id = 'testContainer';
 
   beforeEach(function() {
-    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+    this.$parentContainer = $(`<div id="${id}"></div>`).appendTo('body');
+    this.$container = $(`<div id="${id}"></div>`).appendTo(this.$parentContainer);
   });
 
   afterEach(function() {
@@ -10,6 +11,8 @@ describe('Core_init', () => {
       destroy();
       this.$container.remove();
     }
+
+    this.$parentContainer.remove();
   });
 
   it('should respect startRows and startCols when no data is provided', () => {
@@ -223,6 +226,18 @@ describe('Core_init', () => {
 
       expect(hot.view.getStylesHandler().isClassicTheme()).toBe(false);
       expect(hot.getCurrentThemeName()).toBe('ht-theme-sth');
+    });
+
+    it('should enable a theme when a theme class name was added to a parent of the root element', () => {
+      spec().$parentContainer.addClass('ht-theme-sth');
+
+      const hot = handsontable({
+        data: Handsontable.helper.createSpreadsheetData(15, 15),
+      });
+
+      expect(hot.view.getStylesHandler().isClassicTheme()).toBe(false);
+      expect(hot.getCurrentThemeName()).toBe('ht-theme-sth');
+      expect($(hot.rootElement).hasClass('ht-theme-sth')).toBe(true);
     });
   });
 });


### PR DESCRIPTION
### Context
This PR:
- Makes Handsontable react to theme class names being added to the root elements' parents.
- Corrects the theme class names not being added to the date and comment editors.
- Adds additional test cases.

**This PR is meant to be merged into `feature/dev-issue-1291`**
[skip changelog]

### How has this been tested?
Tested manually + added additional test cases.

### Related issue(s):
1. https://github.com/handsontable/handsontable/pull/11144