### PR TITLE
Fix checkbox switching in merged cell

### DIFF
--- a/.changelogs/11252.json
+++ b/.changelogs/11252.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed checkbox switching in merged cells",
+  "type": "fixed",
+  "issueOrPR": 11252,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/renderers/checkboxRenderer/__tests__/keyboardShortcuts/enter.spec.js
+++ b/handsontable/src/renderers/checkboxRenderer/__tests__/keyboardShortcuts/enter.spec.js
@@ -132,6 +132,50 @@ describe('CheckboxRenderer keyboard shortcut', () => {
         .toHaveBeenCalledWith([[0, 0, true, false]], 'edit');
     });
 
+    it('should change checkbox state from checked to unchecked for merged cell', () => {
+      handsontable({
+        data: [
+          [true, null, null],
+          [null, null, null],
+          [null, null, null],
+        ],
+        type: 'checkbox',
+        mergeCells: [
+          { row: 0, col: 0, rowspan: 3, colspan: 3 },
+        ],
+      });
+
+      const afterChangeCallback = jasmine.createSpy('afterChangeCallback');
+
+      addHook('afterChange', afterChangeCallback);
+
+      let checkboxes = spec().$container.find(':checkbox');
+
+      expect(checkboxes.eq(0).prop('checked')).toBe(true);
+      expect(checkboxes.eq(1).prop('checked')).toBe(true);
+      expect(checkboxes.eq(2).prop('checked')).toBe(true);
+      expect(getData()).toEqual([
+        [true, null, null],
+        [null, null, null],
+        [null, null, null],
+      ]);
+
+      selectCell(0, 0);
+      keyDownUp('enter');
+
+      checkboxes = spec().$container.find(':checkbox');
+
+      expect(checkboxes.eq(0).prop('checked')).toBe(false);
+      expect(getData()).toEqual([
+        [false, null, null],
+        [null, null, null],
+        [null, null, null],
+      ]);
+      expect(afterChangeCallback.calls.count()).toEqual(1);
+      expect(afterChangeCallback)
+        .toHaveBeenCalledWith([[0, 0, true, false]], 'edit');
+    });
+
     it('should move down without changing checkbox state when enterBeginsEditing equals false', () => {
       handsontable({
         enterBeginsEditing: false,

--- a/handsontable/src/renderers/checkboxRenderer/checkboxRenderer.js
+++ b/handsontable/src/renderers/checkboxRenderer/checkboxRenderer.js
@@ -192,7 +192,9 @@ export function checkboxRenderer(hotInstance, TD, row, col, prop, value, cellPro
       runOnlyIf: () => {
         const range = hotInstance.getSelectedRangeLast();
 
-        return hotInstance.getSettings().enterBeginsEditing && range?.isSingle() && range.highlight.isCell();
+        return hotInstance.getSettings().enterBeginsEditing &&
+          range?.highlight.isCell() &&
+          !hotInstance.selection.isMultiple();
       },
     }, {
       keys: [['delete'], ['backspace']],
@@ -229,6 +231,12 @@ export function checkboxRenderer(hotInstance, TD, row, col, prop, value, cellPro
       for (let visualRow = startRow; visualRow <= endRow; visualRow += 1) {
         for (let visualColumn = startColumn; visualColumn <= endColumn; visualColumn += 1) {
           const cachedCellProperties = hotInstance.getCellMeta(visualRow, visualColumn);
+
+          /* eslint-disable no-continue */
+          if (cachedCellProperties.hidden) {
+            continue;
+          }
+
           const templates = {
             checkedTemplate: cachedCellProperties.checkedTemplate,
             uncheckedTemplate: cachedCellProperties.uncheckedTemplate,


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes a bug where there was no reaction on <kbd>Enter</kbd> shortcut key on the `checkbox` cell type when the checkbox was rendered in the merged cell.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the change locally and I add a new test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/2104

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
