### PR TITLE
[themes] Fix a problem where assigning the theme class without importing the correct CSS files would block the table from being edited.

### DIFF
--- a/handsontable/src/3rdparty/walkontable/src/utils/stylesHandler.js
+++ b/handsontable/src/3rdparty/walkontable/src/utils/stylesHandler.js
@@ -125,7 +125,7 @@ export class StylesHandler {
 
     const cssVarRowHeightValue = this.getCSSVariableValue('row-height');
 
-    if (!this.#isClassicTheme && !cssVarRowHeightValue) {
+    if (!cssVarRowHeightValue) {
       warn(`The "${this.#themeName}" theme is enabled, but its stylesheets are missing. \
 Import the correct CSS files in order to use that theme.`);
 
@@ -135,7 +135,7 @@ Import the correct CSS files in order to use that theme.`);
       return CLASSIC_THEME_DEFAULT_HEIGHT;
     }
 
-    return this.getCSSVariableValue('row-height');
+    return cssVarRowHeightValue;
   }
 
   /**

--- a/handsontable/src/3rdparty/walkontable/src/utils/stylesHandler.js
+++ b/handsontable/src/3rdparty/walkontable/src/utils/stylesHandler.js
@@ -119,6 +119,10 @@ export class StylesHandler {
    * @returns {number} The calculated row height.
    */
   getDefaultRowHeight() {
+    if (this.#isClassicTheme) {
+      return CLASSIC_THEME_DEFAULT_HEIGHT;
+    }
+
     const cssVarRowHeightValue = this.getCSSVariableValue('row-height');
 
     if (!this.#isClassicTheme && !cssVarRowHeightValue) {
@@ -128,10 +132,6 @@ Import the correct CSS files in order to use that theme.`);
       this.#isClassicTheme = true;
       this.useTheme();
 
-      return CLASSIC_THEME_DEFAULT_HEIGHT;
-    }
-
-    if (this.#isClassicTheme) {
       return CLASSIC_THEME_DEFAULT_HEIGHT;
     }
 

--- a/handsontable/src/3rdparty/walkontable/src/utils/stylesHandler.js
+++ b/handsontable/src/3rdparty/walkontable/src/utils/stylesHandler.js
@@ -1,4 +1,5 @@
 import { addClass, hasClass, removeClass } from '../../../../helpers/dom/element';
+import { warn } from '../../../../helpers/console';
 
 const CLASSIC_THEME_DEFAULT_HEIGHT = 23;
 
@@ -118,6 +119,18 @@ export class StylesHandler {
    * @returns {number} The calculated row height.
    */
   getDefaultRowHeight() {
+    const cssVarRowHeightValue = this.getCSSVariableValue('row-height');
+
+    if (!this.#isClassicTheme && !cssVarRowHeightValue) {
+      warn(`The "${this.#themeName}" theme is enabled, but its stylesheets are missing. \
+Import the correct CSS files in order to use that theme.`);
+
+      this.#isClassicTheme = true;
+      this.useTheme();
+
+      return CLASSIC_THEME_DEFAULT_HEIGHT;
+    }
+
     if (this.#isClassicTheme) {
       return CLASSIC_THEME_DEFAULT_HEIGHT;
     }

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -4968,7 +4968,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
    * @memberof Core#
    * @function useTheme
    * @since 15.0.0
-   * @param {string|undefined} themeName The name of the theme to use.
+   * @param {string|boolean|undefined} themeName The name of the theme to use.
    */
   this.useTheme = (themeName) => {
     this.view.getStylesHandler().useTheme(themeName);

--- a/handsontable/src/dataMap/metaManager/metaSchema.js
+++ b/handsontable/src/dataMap/metaManager/metaSchema.js
@@ -3951,8 +3951,8 @@ export default () => {
     /**
      * The `rowHeights` option sets rows' heights, in pixels.
      *
-     * In the rendering process, the default row height is 23 px (22 px + 1 px of the row's bottom border).
-     * You can change it to equal or greater than 23px, by setting the `rowHeights` option to one of the following:
+     * In the rendering process, the default row height is 23 px (in the classic theme: 22 px + 1 px of the row's bottom border) or what's defined as `--ht-row-height` in the used theme.
+     * You can change it to equal or greater than the defautl value, by setting the `rowHeights` option to one of the following:
      *
      * | Setting     | Description                                                                                         | Example                                                      |
      * | ----------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
@@ -3984,7 +3984,7 @@ export default () => {
      * // set the first (by visual index) row's height to 100
      * // set the second (by visual index) row's height to 120
      * // set the third (by visual index) row's height to `undefined`
-     * // set any other row's height to the default 23px
+     * // set any other row's height to the default height value
      * rowHeights: [100, 120, undefined],
      *
      * // set each row's height individually, using a function
@@ -4435,19 +4435,22 @@ export default () => {
      */
     tableClassName: undefined,
 
-    // TODO: add themeName description
     /**
-     * The `themeName` option lets you add CSS class names
+     * The `themeName` option allows enabling a theme by that name.
+     *
+     * If no `themeName` is provided, the table will use the classic theme (if the correct CSS files are imported).
+     *
+     * Read more:
+     * - [Themes](@/guides/styling/themes/themes.md)
      *
      * @memberof Options#
-     * @type {string|string[]}
+     * @type {string}
      * @default undefined
      * @category Core
+     * @since 15.0.0
      *
      * @example
      * ```js
-     * // add a `ht-theme-name` CSS class name
-     * // to every Handsontable instance inside the `container` element
      * themeName: 'ht-theme-name',
      * ```
      */

--- a/handsontable/src/dataMap/metaManager/metaSchema.js
+++ b/handsontable/src/dataMap/metaManager/metaSchema.js
@@ -4444,7 +4444,7 @@ export default () => {
      * - [Themes](@/guides/styling/themes/themes.md)
      *
      * @memberof Options#
-     * @type {string}
+     * @type {string|boolean|undefined}
      * @default undefined
      * @category Core
      * @since 15.0.0

--- a/handsontable/src/editors/dateEditor/__tests__/themes/themes.spec.js
+++ b/handsontable/src/editors/dateEditor/__tests__/themes/themes.spec.js
@@ -1,4 +1,4 @@
-describe('Theme handling', () => {
+describe('Date editor theme handling', () => {
   const id = 'testContainer';
 
   beforeEach(function() {
@@ -13,6 +13,7 @@ describe('Theme handling', () => {
   });
 
   it('should have the same theme as the parent Handsontable instance (if originally passed as a config option)', async() => {
+    simulateModernThemeStylesheet(spec().$container);
     handsontable({
       columns: [{ type: 'date' }],
       themeName: 'ht-theme-sth',
@@ -29,6 +30,7 @@ describe('Theme handling', () => {
   });
 
   it('should have the same theme as the parent Handsontable instance (if originally passed as a container class)', async() => {
+    simulateModernThemeStylesheet(spec().$container);
     spec().$container.addClass('ht-theme-sth-else');
     handsontable({
       columns: [{ type: 'date' }],

--- a/handsontable/src/editors/handsontableEditor/__tests__/themes/themes.spec.js
+++ b/handsontable/src/editors/handsontableEditor/__tests__/themes/themes.spec.js
@@ -1,4 +1,4 @@
-describe('Theme handling', () => {
+describe('Handsontable editor theme handling', () => {
   const id = 'testContainer';
 
   function getManufacturerData() {
@@ -24,6 +24,7 @@ describe('Theme handling', () => {
   });
 
   it('should have the same theme as the parent Handsontable instance (if originally passed as a config option)', async() => {
+    simulateModernThemeStylesheet(spec().$container);
     handsontable({
       columns: [
         {
@@ -47,6 +48,7 @@ describe('Theme handling', () => {
   });
 
   it('should have the same theme as the parent Handsontable instance (if originally passed as a container class)', async() => {
+    simulateModernThemeStylesheet(spec().$container);
     spec().$container.addClass('ht-theme-sth-else');
     handsontable({
       columns: [

--- a/handsontable/src/plugins/comments/__tests__/themes/themes.spec.js
+++ b/handsontable/src/plugins/comments/__tests__/themes/themes.spec.js
@@ -1,4 +1,4 @@
-describe('Theme handling', () => {
+describe('Comments theme handling', () => {
   const id = 'testContainer';
 
   beforeEach(function() {
@@ -13,6 +13,7 @@ describe('Theme handling', () => {
   });
 
   it('should have the same theme as the parent Handsontable instance (if originally passed as a config option)', () => {
+    simulateModernThemeStylesheet(spec().$container);
     handsontable({
       data: createSpreadsheetData(4, 4),
       comments: true,
@@ -29,6 +30,7 @@ describe('Theme handling', () => {
   });
 
   it('should have the same theme as the parent Handsontable instance (if originally passed as a container class)', () => {
+    simulateModernThemeStylesheet(spec().$container);
     spec().$container.addClass('ht-theme-sth-else');
     handsontable({
       comments: true,

--- a/handsontable/src/plugins/contextMenu/__tests__/themes/themes.spec.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/themes/themes.spec.js
@@ -1,4 +1,4 @@
-describe('Theme handling', () => {
+describe('Context menu theme handling', () => {
   const id = 'testContainer';
 
   beforeEach(function() {
@@ -13,6 +13,7 @@ describe('Theme handling', () => {
   });
 
   it('should have the same theme as the parent Handsontable instance (if originally passed as a config option)', async() => {
+    simulateModernThemeStylesheet(spec().$container.parent());
     handsontable({
       contextMenu: true,
       themeName: 'ht-theme-sth',
@@ -24,9 +25,12 @@ describe('Theme handling', () => {
 
     expect($(getPlugin('contextMenu').menu.container).hasClass('ht-theme-sth')).toBe(true);
     expect(getPlugin('contextMenu').menu.hotMenu.getCurrentThemeName()).toBe('ht-theme-sth');
+
+    clearModernThemeStylesheetMock(spec().$container.parent());
   });
 
   it('should have the same theme as the parent Handsontable instance (if originally passed as a container class)', async() => {
+    simulateModernThemeStylesheet(spec().$container.parent());
     spec().$container.addClass('ht-theme-sth-else');
     handsontable({
       contextMenu: true,
@@ -38,5 +42,7 @@ describe('Theme handling', () => {
 
     expect($(getPlugin('contextMenu').menu.container).hasClass('ht-theme-sth-else')).toBe(true);
     expect(getPlugin('contextMenu').menu.hotMenu.getCurrentThemeName()).toBe('ht-theme-sth-else');
+
+    clearModernThemeStylesheetMock(spec().$container.parent());
   });
 });

--- a/handsontable/test/e2e/Core_init.spec.js
+++ b/handsontable/test/e2e/Core_init.spec.js
@@ -218,6 +218,7 @@ describe('Core_init', () => {
 
   describe('theme initialization', () => {
     it('should enable a theme when a theme class name was added to the root element', () => {
+      simulateModernThemeStylesheet(spec().$container);
       spec().$container.addClass('ht-theme-sth');
 
       const hot = handsontable({
@@ -229,6 +230,7 @@ describe('Core_init', () => {
     });
 
     it('should enable a theme when a theme class name was added to a parent of the root element', () => {
+      simulateModernThemeStylesheet(spec().$container);
       spec().$parentContainer.addClass('ht-theme-sth');
 
       const hot = handsontable({

--- a/handsontable/test/e2e/Core_update.spec.js
+++ b/handsontable/test/e2e/Core_update.spec.js
@@ -665,6 +665,7 @@ describe('Core_updateSettings', () => {
       expect(hot.view.getStylesHandler().isClassicTheme()).toBe(true);
       expect(hot.getCurrentThemeName()).toBe(undefined);
 
+      simulateModernThemeStylesheet(spec().$container);
       hot.updateSettings({
         themeName: 'ht-theme-sth'
       });
@@ -703,6 +704,7 @@ describe('Core_updateSettings', () => {
     });
 
     it('should update the theme based on the `themeName` option, even if a theme class is already applied to the container', () => {
+      simulateModernThemeStylesheet(spec().$container);
       spec().$container.addClass('ht-theme-sth');
       const hot = handsontable({
         data: Handsontable.helper.createSpreadsheetData(15, 15),
@@ -723,6 +725,7 @@ describe('Core_updateSettings', () => {
     });
 
     it('should be possible to disable a "modern" theme by setting the `themeName` to `false` or `undefined`', () => {
+      simulateModernThemeStylesheet(spec().$container);
       spec().$container.addClass('ht-theme-sth');
 
       const hot = handsontable({

--- a/handsontable/test/helpers/common.js
+++ b/handsontable/test/helpers/common.js
@@ -1079,6 +1079,28 @@ export function simulateTouch(target) {
 }
 
 /**
+ * Simulates the application of modern theme styles to a Handsontable context.
+ *
+ * @param {HTMLElement|jQuery} container - The container element to which the styles will be applied.
+ */
+export function simulateModernThemeStylesheet(container) {
+  const element = container instanceof $ ? container.get(0) : container;
+
+  element.style.setProperty('--ht-row-height', '28px');
+}
+
+/**
+ * Clears the modern theme styles simulation applied using the `simulateModernThemeStylesheet` method.
+ *
+ * @param {HTMLElement|jQuery} container - The container element.
+ */
+export function clearModernThemeStylesheetMock(container) {
+  const element = container instanceof $ ? container.get(0) : container;
+
+  element.style.removeProperty('--ht-row-height');
+}
+
+/**
  * Creates spreadsheet data as an array of arrays filled with spreadsheet-like label
  * values (e.q "A1", "A2"...).
  *


### PR DESCRIPTION
### Context
This PR:
1. In a case where the theme class name was applied to the Handsontable container (or any of its parents), but the classic CSS files were imported instead of the "modern" ones:
    1. Makes it switch back to the "classic" theme internally.
    2. Displays a warning in the console.
2. Modifies the test cases for the new logic.
3. Documents the `themeName` option.
4. Modifies the JSDocs of other options, where the obsolete mentions of `23px` being the default height were still present. 

This branch is meant to be merged to `feature/dev-issue-1291`.
[skip changelog]
