### PR TITLE
Add missing "name" attribute to the focus catcher

### DIFF
--- a/.changelogs/11256.json
+++ b/.changelogs/11256.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Added missing \"name\" attribute to the focus catcher",
+  "type": "fixed",
+  "issueOrPR": 11256,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/core/focusCatcher/__tests__/focusDetector.unit.js
+++ b/handsontable/src/core/focusCatcher/__tests__/focusDetector.unit.js
@@ -36,9 +36,11 @@ describe('focusDetector', () => {
     const inputTrapBottom = hot.rootElement.lastChild;
 
     expect(inputTrapTop.className).toBe('htFocusCatcher');
+    expect(inputTrapTop.name).toBe('__htFocusCatcher');
     expect(inputTrapTop.getAttribute('role')).toBe('presentation');
     expect(inputTrapTop.getAttribute('aria-hidden')).toBe('true');
     expect(inputTrapBottom.className).toBe('htFocusCatcher');
+    expect(inputTrapBottom.name).toBe('__htFocusCatcher');
     expect(inputTrapBottom.getAttribute('role')).toBe('presentation');
     expect(inputTrapBottom.getAttribute('aria-hidden')).toBe('true');
   });

--- a/handsontable/src/core/focusCatcher/focusDetector.js
+++ b/handsontable/src/core/focusCatcher/focusDetector.js
@@ -55,6 +55,7 @@ function createInputElement(hot) {
   const input = rootDocument.createElement('input');
 
   input.type = 'text';
+  input.name = '__htFocusCatcher';
   input.classList.add('htFocusCatcher');
 
   if (hot.getSettings().ariaTags) {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adds a missing "name" attribute to the focus catcher inputs.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally, and I covered the change with the updated test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/2095

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
