### PR TITLE
[themes] Allow switching between dark and light themes in the documentation.

### DIFF
--- a/docs/.vuepress/containers/examples/examples.js
+++ b/docs/.vuepress/containers/examples/examples.js
@@ -104,15 +104,14 @@ module.exports = function(docsVersion, base) {
         preset = preset ? preset.substring(1) : 'hot';
         args = args || '';
 
-        const themeClassName = '$parent.$parent.themeClassName';
         const htmlPos = args.match(/--html (\d*)/)?.[1];
         const htmlIndex = htmlPos ? index + Number.parseInt(htmlPos, 10) : 0;
         const htmlToken = htmlPos ? tokens[htmlIndex] : undefined;
         const htmlContent = htmlToken
           ? htmlToken.content
-          : `<div id="${id}" :class="['hot', '${klass}', ${themeClassName}]"></div>`;
-        const htmlContentExternal = `<div id="${id}" class="hot ${klass} ht-theme-main-dark-auto"></div>`;
-        const htmlContentRoot = `<div data-preset-type="${preset}" data-example-id="${id}">${htmlContent}</div>`;
+          : `<div id="${id}" class="hot ${klass}"></div>`;
+        // eslint-disable-next-line max-len
+        const htmlContentRoot = `<div data-preset-type="${preset}" data-example-id="${id}" class="ht-theme-main-dark-auto">${htmlContent}</div>`;
 
         const cssPos = args.match(/--css (\d*)/)?.[1];
         const cssIndex = cssPos ? index + Number.parseInt(cssPos, 10) : 0;
@@ -177,7 +176,7 @@ module.exports = function(docsVersion, base) {
           <div class="example-container">
             <template v-if="${isActive}">
               <style v-pre>${cssContent}</style>
-              <div>${htmlContentRoot}</div>
+              <div v-pre>${htmlContentRoot}</div>
               <ScriptLoader code="${encodedCode}"></ScriptLoader>
             </template>
           </div>
@@ -191,7 +190,7 @@ module.exports = function(docsVersion, base) {
                   ${!noEdit
     ? stackblitz(
       id,
-      htmlContentExternal,
+      htmlContent,
       codeToCompileSandbox,
       cssContent,
       docsVersion,
@@ -202,7 +201,7 @@ module.exports = function(docsVersion, base) {
                   ${!noEdit
     ? jsfiddle(
       id,
-      htmlContentExternal,
+      htmlContent,
       codeForPreset,
       cssContent,
       docsVersion,
@@ -215,7 +214,7 @@ module.exports = function(docsVersion, base) {
                   ${!noEdit
     ? stackblitz(
       id,
-      htmlContentExternal,
+      htmlContent,
       tsCodeToCompileSandbox,
       cssContent,
       docsVersion,
@@ -226,7 +225,7 @@ module.exports = function(docsVersion, base) {
                   ${!noEdit && !isReact
     ? jsfiddle(
       id,
-      htmlContentExternal,
+      htmlContent,
       tsCodeForPreset,
       cssContent,
       docsVersion,

--- a/docs/.vuepress/containers/examples/examples.js
+++ b/docs/.vuepress/containers/examples/examples.js
@@ -104,14 +104,15 @@ module.exports = function(docsVersion, base) {
         preset = preset ? preset.substring(1) : 'hot';
         args = args || '';
 
+        const themeClassName = '$parent.$parent.themeClassName';
         const htmlPos = args.match(/--html (\d*)/)?.[1];
         const htmlIndex = htmlPos ? index + Number.parseInt(htmlPos, 10) : 0;
         const htmlToken = htmlPos ? tokens[htmlIndex] : undefined;
         const htmlContent = htmlToken
           ? htmlToken.content
-          : `<div id="${id}" class="hot ${klass}"></div>`;
-        // eslint-disable-next-line max-len
-        const htmlContentRoot = `<div data-preset-type="${preset}" data-example-id="${id}" class="ht-theme-main-dark-auto">${htmlContent}</div>`;
+          : `<div id="${id}" :class="['hot', '${klass}', ${themeClassName}]"></div>`;
+        const htmlContentExternal = `<div id="${id}" class="hot ${klass} ht-theme-main-dark-auto"></div>`;
+        const htmlContentRoot = `<div data-preset-type="${preset}" data-example-id="${id}">${htmlContent}</div>`;
 
         const cssPos = args.match(/--css (\d*)/)?.[1];
         const cssIndex = cssPos ? index + Number.parseInt(cssPos, 10) : 0;
@@ -176,7 +177,7 @@ module.exports = function(docsVersion, base) {
           <div class="example-container">
             <template v-if="${isActive}">
               <style v-pre>${cssContent}</style>
-              <div v-pre>${htmlContentRoot}</div>
+              <div>${htmlContentRoot}</div>
               <ScriptLoader code="${encodedCode}"></ScriptLoader>
             </template>
           </div>
@@ -190,7 +191,7 @@ module.exports = function(docsVersion, base) {
                   ${!noEdit
     ? stackblitz(
       id,
-      htmlContent,
+      htmlContentExternal,
       codeToCompileSandbox,
       cssContent,
       docsVersion,
@@ -201,7 +202,7 @@ module.exports = function(docsVersion, base) {
                   ${!noEdit
     ? jsfiddle(
       id,
-      htmlContent,
+      htmlContentExternal,
       codeForPreset,
       cssContent,
       docsVersion,
@@ -214,7 +215,7 @@ module.exports = function(docsVersion, base) {
                   ${!noEdit
     ? stackblitz(
       id,
-      htmlContent,
+      htmlContentExternal,
       tsCodeToCompileSandbox,
       cssContent,
       docsVersion,
@@ -225,7 +226,7 @@ module.exports = function(docsVersion, base) {
                   ${!noEdit && !isReact
     ? jsfiddle(
       id,
-      htmlContent,
+      htmlContentExternal,
       tsCodeForPreset,
       cssContent,
       docsVersion,

--- a/docs/.vuepress/handsontable-manager/index.js
+++ b/docs/.vuepress/handsontable-manager/index.js
@@ -1,6 +1,7 @@
 const { useHandsontable } = require('./use-handsontable');
 const { getDependencies } = require('./dependencies');
 const { register } = require('./register');
+const { themeManager } = require('./theme-manager');
 
 if (module) {
   module.exports = {
@@ -12,6 +13,7 @@ if (module) {
       if ((typeof window !== 'undefined')) {
         window.useHandsontable = useHandsontable;
         window.instanceRegister = register;
+        window.hotThemeManager = themeManager;
       }
       /* eslint-enable no-restricted-globals */
     }

--- a/docs/.vuepress/handsontable-manager/register.js
+++ b/docs/.vuepress/handsontable-manager/register.js
@@ -10,23 +10,30 @@
  */
 function createDestroyableResource(presetType, { rootExampleElement, hotInstance }) {
   return () => {
-    if (presetType.startsWith('vue3')) {
-      rootExampleElement.firstChild.__vue_app__.unmount();
+    const resource = {
+      destroy: () => {
+        if (presetType.startsWith('vue3')) {
+          rootExampleElement.firstChild.__vue_app__.unmount();
 
-    } else if (presetType.startsWith('vue')) {
-      rootExampleElement.firstChild.__vue__.$root.$destroy();
+        } else if (presetType.startsWith('vue')) {
+          rootExampleElement.firstChild.__vue__.$root.$destroy();
 
-    } else if (presetType.startsWith('react')) {
-      ReactDOM.unmountComponentAtNode(rootExampleElement.firstChild);
+        } else if (presetType.startsWith('react')) {
+          ReactDOM.unmountComponentAtNode(rootExampleElement.firstChild);
 
-    } else if (presetType.startsWith('angular')) {
-      ng.core.getPlatform().destroy();
+        } else if (presetType.startsWith('angular')) {
+          ng.core.getPlatform().destroy();
 
-    } else if (!hotInstance.isDestroyed) {
-      // Skip internal HoT-based components (e.g. context menu, dropdown menu). They
-      // are managed by the HoT itself.
-      hotInstance.destroy();
-    }
+        } else if (!hotInstance.isDestroyed) {
+          // Skip internal HoT-based components (e.g. context menu, dropdown menu). They
+          // are managed by the HoT itself.
+          hotInstance.destroy();
+        }
+      },
+      hotInstance
+    };
+
+    return resource;
   };
 }
 
@@ -78,10 +85,15 @@ function createRegister() {
           if (rootExampleElement) {
             const examplePresetType = rootExampleElement.getAttribute('data-preset-type');
             const exampleId = rootExampleElement.getAttribute('data-example-id');
+            const currentEntry = register.get(exampleId);
+            const currentHotInstance =
+              typeof currentEntry === 'function' ?
+                register.get(exampleId)()?.hotInstance :
+                null;
 
             register.set(exampleId, createDestroyableResource(examplePresetType, {
               rootExampleElement,
-              hotInstance: this,
+              hotInstance: currentHotInstance || this,
             }));
           }
         });
@@ -93,13 +105,13 @@ function createRegister() {
   };
 
   const destroyAll = () => {
-    register.forEach(destroyableResource => destroyableResource());
+    register.forEach(instanceResource => instanceResource().destroy());
     register.clear();
   };
 
   const destroyExample = (exampleId) => {
     if (register.has(exampleId)) {
-      register.get(exampleId)();
+      register.get(exampleId)().destroy();
       register.delete(exampleId);
     }
   };
@@ -111,6 +123,31 @@ function createRegister() {
     abortControllers.add(new AbortController());
 
     destroyAll();
+  };
+
+  const switchExamplesTheme = () => {
+    const version = localStorage.getItem('handsontable/docs::color-scheme');
+
+    register.forEach((instanceResource) => {
+      const instanceRes = instanceResource();
+      const currentThemeName = instanceRes.hotInstance.getCurrentThemeName();
+
+      // Remove the '-auto' suffix from the theme name.
+      const newThemeName = currentThemeName.replace('-auto', '');
+      const isCurrentlyDark = newThemeName.includes('dark');
+
+      switch (version) {
+        case 'dark':
+          instanceRes.hotInstance.useTheme(isCurrentlyDark ? newThemeName : `${newThemeName}-dark`);
+          break;
+        case 'light':
+          instanceRes.hotInstance.useTheme(isCurrentlyDark ? newThemeName.replace('-dark', '') : newThemeName);
+          break;
+        default:
+      }
+
+      instanceRes.hotInstance.render();
+    });
   };
 
   const getAbortSignal = () => {
@@ -125,6 +162,7 @@ function createRegister() {
     destroyAll,
     destroyExample,
     getAbortSignal,
+    switchExamplesTheme,
   };
 }
 

--- a/docs/.vuepress/handsontable-manager/register.js
+++ b/docs/.vuepress/handsontable-manager/register.js
@@ -125,36 +125,15 @@ function createRegister() {
     destroyAll();
   };
 
-  const switchExamplesTheme = () => {
-    const version = localStorage.getItem('handsontable/docs::color-scheme');
-
-    register.forEach((instanceResource) => {
-      const instanceRes = instanceResource();
-      const currentThemeName = instanceRes.hotInstance.getCurrentThemeName();
-
-      // Remove the '-auto' suffix from the theme name.
-      const newThemeName = currentThemeName.replace('-auto', '');
-      const isCurrentlyDark = newThemeName.includes('dark');
-
-      switch (version) {
-        case 'dark':
-          instanceRes.hotInstance.useTheme(isCurrentlyDark ? newThemeName : `${newThemeName}-dark`);
-          break;
-        case 'light':
-          instanceRes.hotInstance.useTheme(isCurrentlyDark ? newThemeName.replace('-dark', '') : newThemeName);
-          break;
-        default:
-      }
-
-      instanceRes.hotInstance.render();
-    });
-  };
-
   const getAbortSignal = () => {
     const controllers = Array.from(abortControllers);
 
     return controllers[controllers.length - 1].signal;
   };
+
+  const getAllHotInstances =
+    () =>
+      Array.from(register.values()).map(instanceResource => instanceResource().hotInstance);
 
   return {
     initPage,
@@ -162,7 +141,7 @@ function createRegister() {
     destroyAll,
     destroyExample,
     getAbortSignal,
-    switchExamplesTheme,
+    getAllHotInstances,
   };
 }
 

--- a/docs/.vuepress/handsontable-manager/theme-manager.js
+++ b/docs/.vuepress/handsontable-manager/theme-manager.js
@@ -1,0 +1,58 @@
+const getThemeClassName = (colorScheme) => {
+  switch (colorScheme) {
+    case 'dark':
+      return 'ht-theme-main-dark';
+    case 'light':
+      return 'ht-theme-main';
+    default:
+      return 'ht-theme-main-dark-auto';
+  }
+};
+
+const ensureCorrectHotThemes = () => {
+  if (typeof Handsontable !== 'undefined') {
+    const themeName = getThemeClassName(localStorage?.getItem('handsontable/docs::color-scheme'));
+
+    if (themeName) {
+      // eslint-disable-next-line no-undef
+      Handsontable.hooks.add('afterInit', function() {
+        if (this.getCurrentThemeName() !== themeName) {
+          this.useTheme(themeName);
+          this.render();
+        }
+      });
+    }
+  }
+};
+
+const switchExamplesTheme = (hotInstances) => {
+  const version = localStorage.getItem('handsontable/docs::color-scheme');
+
+  hotInstances.forEach((hotInstance) => {
+    const currentThemeName = hotInstance.getCurrentThemeName();
+
+    // Remove the '-auto' suffix from the theme name.
+    const newThemeName = currentThemeName.replace('-auto', '');
+    const isCurrentlyDark = newThemeName.includes('dark');
+
+    switch (version) {
+      case 'dark':
+        hotInstance.useTheme(isCurrentlyDark ? newThemeName : `${newThemeName}-dark`);
+        break;
+      case 'light':
+        hotInstance.useTheme(isCurrentlyDark ? newThemeName.replace('-dark', '') : newThemeName);
+        break;
+      default:
+    }
+
+    hotInstance.render();
+  });
+};
+
+module.exports = {
+  themeManager: {
+    ensureCorrectHotThemes,
+    switchExamplesTheme,
+    getThemeClassName,
+  }
+};

--- a/docs/.vuepress/handsontable-manager/use-handsontable.js
+++ b/docs/.vuepress/handsontable-manager/use-handsontable.js
@@ -1,4 +1,5 @@
 const { register } = require('./register');
+const { themeManager } = require('./theme-manager');
 const {
   buildDependencyGetter,
   presetMap,
@@ -86,12 +87,14 @@ const useHandsontable = (version, callback = () => {}, preset = 'hot', buildMode
       setTimeout(() => {
         abortSignal.removeEventListener('abort', abortHandler);
         register.listen();
+        themeManager.ensureCorrectHotThemes();
         resolve();
       });
     } else {
       script.addEventListener('load', () => {
         abortSignal.removeEventListener('abort', abortHandler);
         register.listen();
+        themeManager.ensureCorrectHotThemes();
         resolve();
       });
     }

--- a/docs/.vuepress/theme/components/Page.vue
+++ b/docs/.vuepress/theme/components/Page.vue
@@ -11,7 +11,7 @@
 </template>
 
 <script>
-/* global instanceRegister */
+/* global instanceRegister, hotThemeManager */
 import PageEdit from '@theme/components/PageEdit.vue';
 import Breadcrumbs from '@theme/components/Breadcrumbs.vue';
 
@@ -176,16 +176,6 @@ export default {
         '_blank'
       );
     },
-    getThemeClassName(colorScheme) {
-      switch (colorScheme) {
-        case 'dark':
-          return 'ht-theme-main-dark';
-        case 'light':
-          return 'ht-theme-main';
-        default:
-          return 'ht-theme-main-dark-auto';
-      }
-    },
     detectClickOutsideButton(e) {
       const buttons = document.querySelectorAll('.select-type-button');
 
@@ -198,7 +188,7 @@ export default {
   },
   mounted() {
     this.selectedLang = localStorage?.getItem('selected_lang') ?? 'JavaScript';
-    this.themeClassName = this.getThemeClassName(localStorage.getItem('handsontable/docs::color-scheme'));
+    this.themeClassName = hotThemeManager.getThemeClassName(localStorage.getItem('handsontable/docs::color-scheme'));
 
     this.checkSectionInView();
     window.addEventListener('click', this.detectClickOutsideButton);
@@ -210,7 +200,7 @@ export default {
   },
   watch: {
     $route() {
-      this.themeClassName = this.getThemeClassName(localStorage.getItem('handsontable/docs::color-scheme'));
+      this.themeClassName = hotThemeManager.getThemeClassName(localStorage.getItem('handsontable/docs::color-scheme'));
     }
   }
 };

--- a/docs/.vuepress/theme/components/Page.vue
+++ b/docs/.vuepress/theme/components/Page.vue
@@ -25,7 +25,8 @@ export default {
     return {
       inActiveElementId: '',
       isButtonInactive: false,
-      selectedLang: 'JavaScript'
+      selectedLang: 'JavaScript',
+      themeClassName: null,
     };
   },
   computed: {
@@ -175,6 +176,16 @@ export default {
         '_blank'
       );
     },
+    getThemeClassName(colorScheme) {
+      switch (colorScheme) {
+        case 'dark':
+          return 'ht-theme-main-dark';
+        case 'light':
+          return 'ht-theme-main';
+        default:
+          return 'ht-theme-main-dark-auto';
+      }
+    },
     detectClickOutsideButton(e) {
       const buttons = document.querySelectorAll('.select-type-button');
 
@@ -187,6 +198,8 @@ export default {
   },
   mounted() {
     this.selectedLang = localStorage?.getItem('selected_lang') ?? 'JavaScript';
+    this.themeClassName = this.getThemeClassName(localStorage?.getItem('handsontable/docs::color-scheme'));
+
     this.checkSectionInView();
     window.addEventListener('click', this.detectClickOutsideButton);
     window.addEventListener('scroll', this.checkSectionInView);
@@ -194,6 +207,11 @@ export default {
   unmounted() {
     window.removeEventListener('scroll', this.checkSectionInView);
     window.removeEventListener('click', this.detectClickOutsideButton);
+  },
+  watch: {
+    $route() {
+      this.themeClassName = this.getThemeClassName(localStorage?.getItem('handsontable/docs::color-scheme'));
+    }
   }
 };
 </script>

--- a/docs/.vuepress/theme/components/ThemeSwitcher.vue
+++ b/docs/.vuepress/theme/components/ThemeSwitcher.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script>
-/* global instanceRegister */
+/* global instanceRegister, hotThemeManager */
 const CLASS_THEME_DARK = 'theme-dark';
 const STORAGE_KEY = 'handsontable/docs::color-scheme';
 // The "SELECTED_COLOR_SCHEME" const is defined in the script that is injected in the VuePress config.js file.
@@ -33,7 +33,7 @@ export default {
         document.documentElement.setAttribute('data-theme', 'light');
       }
 
-      instanceRegister.switchExamplesTheme();
+      hotThemeManager.switchExamplesTheme(instanceRegister.getAllHotInstances());
     },
   },
   data() {

--- a/docs/.vuepress/theme/components/ThemeSwitcher.vue
+++ b/docs/.vuepress/theme/components/ThemeSwitcher.vue
@@ -9,6 +9,7 @@
 </template>
 
 <script>
+/* global instanceRegister */
 const CLASS_THEME_DARK = 'theme-dark';
 const STORAGE_KEY = 'handsontable/docs::color-scheme';
 // The "SELECTED_COLOR_SCHEME" const is defined in the script that is injected in the VuePress config.js file.

--- a/docs/.vuepress/theme/components/ThemeSwitcher.vue
+++ b/docs/.vuepress/theme/components/ThemeSwitcher.vue
@@ -31,6 +31,8 @@ export default {
         document.documentElement.classList.remove(CLASS_THEME_DARK);
         document.documentElement.setAttribute('data-theme', 'light');
       }
+
+      instanceRegister.switchExamplesTheme();
     },
   },
   data() {

--- a/handsontable/src/3rdparty/walkontable/src/utils/stylesHandler.js
+++ b/handsontable/src/3rdparty/walkontable/src/utils/stylesHandler.js
@@ -197,9 +197,9 @@ Import the correct CSS files in order to use that theme.`);
    * Applies the necessary class names to the root element.
    */
   #applyClassNames() {
-    if (!hasClass(this.#rootElement, this.#themeName)) {
-      addClass(this.#rootElement, this.#themeName);
-    }
+    removeClass(this.#rootElement, /ht-theme-.*/g);
+
+    addClass(this.#rootElement, this.#themeName);
   }
 
   /**

--- a/handsontable/src/__tests__/core/settings.types.ts
+++ b/handsontable/src/__tests__/core/settings.types.ts
@@ -507,6 +507,7 @@ const allSettings: Required<Handsontable.GridSettings> = {
   afterSetDataAtCell: (changes, source) => {},
   afterSetDataAtRowProp: (changes, source) => {},
   afterSetSourceDataAtCell: (changes, source) => {},
+  afterSetTheme: (themeName) => {},
   afterSheetAdded: (addedSheetDisplayName) => {},
   afterSheetRemoved: (removedSheetDisplayName, changes) => {},
   afterSheetRenamed: (oldDisplayName, newDisplayName) => {},

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -4972,6 +4972,8 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
    */
   this.useTheme = (themeName) => {
     this.view.getStylesHandler().useTheme(themeName);
+
+    this.runHooks('afterSetTheme', themeName);
   };
 
   /**

--- a/handsontable/src/core/hooks/constants.js
+++ b/handsontable/src/core/hooks/constants.js
@@ -923,6 +923,15 @@ export const REGISTERED_HOOKS = [
   'afterSetSourceDataAtCell',
 
   /**
+   * Fired after a theme is enabled.
+   *
+   * @since 15.0.0
+   * @event Hooks#afterSetTheme
+   * @param {string|boolean|undefined} themeName The theme name.
+   */
+  'afterSetTheme',
+
+  /**
    * Fired after calling the [`updateSettings`](@/api/core.md#updatesettings) method.
    *
    * @event Hooks#afterUpdateSettings

--- a/handsontable/src/editors/dateEditor/dateEditor.js
+++ b/handsontable/src/editors/dateEditor/dateEditor.js
@@ -2,7 +2,7 @@ import moment from 'moment';
 import Pikaday from '@handsontable/pikaday';
 import { EDITOR_STATE } from '../baseEditor';
 import { TextEditor } from '../textEditor';
-import { addClass, hasClass, outerHeight, outerWidth } from '../../helpers/dom/element';
+import { addClass, removeClass, hasClass, outerHeight, outerWidth } from '../../helpers/dom/element';
 import { deepExtend } from '../../helpers/object';
 import { isFunctionKey } from '../../helpers/unicode';
 
@@ -47,6 +47,12 @@ export class DateEditor extends TextEditor {
       this.parentDestroyed = true;
       this.destroyElements();
     });
+
+    this.hot.addHook('afterSetTheme', (themeName) => {
+      removeClass(this.datePicker, /ht-theme-.*/g);
+
+      addClass(this.datePicker, themeName);
+    });
   }
 
   /**
@@ -64,10 +70,13 @@ export class DateEditor extends TextEditor {
 
     this.datePicker.setAttribute('dir', this.hot.isRtl() ? 'rtl' : 'ltr');
 
+    addClass(this.datePicker, 'htDatepickerHolder');
+
     const themeClassName = this.hot.getCurrentThemeName();
 
-    addClass(this.datePicker, 'htDatepickerHolder');
+    removeClass(this.datePicker, /ht-theme-.*/g);
     addClass(this.datePicker, themeClassName);
+
     this.hot.rootDocument.body.appendChild(this.datePicker);
 
     /**

--- a/handsontable/src/editors/handsontableEditor/handsontableEditor.js
+++ b/handsontable/src/editors/handsontableEditor/handsontableEditor.js
@@ -198,6 +198,10 @@ export class HandsontableEditor extends TextEditor {
         this.htEditor.destroy();
       }
     });
+
+    this.hot.addHook('afterSetTheme', (themeName) => {
+      this.htEditor.useTheme(themeName);
+    });
   }
 
   /**

--- a/handsontable/src/helpers/dom/element.js
+++ b/handsontable/src/helpers/dom/element.js
@@ -329,7 +329,7 @@ export function addClass(element, className) {
  * Remove class name from an element.
  *
  * @param {HTMLElement} element An element to process.
- * @param {string|Array<string|RegExp>} className Class name as string or array of strings.
+ * @param {string|RegExp|Array<string|RegExp>} className Class name as string or array of strings.
  */
 export function removeClass(element, className) {
   if (typeof className === 'string') {

--- a/handsontable/src/plugins/comments/comments.js
+++ b/handsontable/src/plugins/comments/comments.js
@@ -1,9 +1,10 @@
 import {
   addClass,
+  removeClass,
   closest,
   isChildOf,
   hasClass,
-  outerHeight
+  outerHeight,
 } from '../../helpers/dom/element';
 import { stopImmediatePropagation } from '../../helpers/dom/event';
 import { deepClone, deepExtend } from '../../helpers/object';
@@ -212,8 +213,7 @@ export class Comments extends BasePlugin {
     this.addHook('afterScroll', () => this.#onAfterScroll());
     this.addHook('afterBeginEditing', () => this.hide());
     this.addHook('afterDocumentKeyDown', event => this.#onAfterDocumentKeyDown(event));
-    this.addHook('afterInit', () => this.#updateEditorThemeClassName());
-    this.addHook('afterUpdateSettings', () => this.#updateEditorThemeClassName());
+    this.addHook('afterSetTheme', () => this.#updateEditorThemeClassName());
 
     this.#displaySwitch.addLocalHook('hide', () => this.hide());
     this.#displaySwitch.addLocalHook('show', (row, col) => this.showAtCell(row, col));
@@ -770,7 +770,10 @@ export class Comments extends BasePlugin {
    * Updates the editor theme class name.
    */
   #updateEditorThemeClassName() {
-    addClass(this.#editor.getEditorElement(), this.hot.getCurrentThemeName());
+    const editorElement = this.#editor.getEditorElement();
+
+    removeClass(editorElement, /ht-theme-.*/g);
+    addClass(editorElement, this.hot.getCurrentThemeName());
   }
 
   /**

--- a/handsontable/src/plugins/contextMenu/menu/menu.js
+++ b/handsontable/src/plugins/contextMenu/menu/menu.js
@@ -165,6 +165,12 @@ export class Menu {
       this.addLocalHook('afterSelectionChange',
         (...args) => this.parentMenu.runLocalHooks('afterSelectionChange', ...args));
     }
+
+    this.hot.addHook('afterSetTheme', (themeName) => {
+      if (this.hotMenu) {
+        this.hotMenu.useTheme(themeName);
+      }
+    });
   }
 
   /**

--- a/handsontable/test/e2e/hooks/afterSetTheme.spec.js
+++ b/handsontable/test/e2e/hooks/afterSetTheme.spec.js
@@ -1,0 +1,46 @@
+describe('Hook', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}" class="ht-theme-sth"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  describe('afterSetTheme', () => {
+    it('should be fired every time the theme is modified', () => {
+      const afterSetThemeSpy = jasmine.createSpy('afterSetTheme');
+
+      handsontable({
+        data: createSpreadsheetData(2, 2),
+        afterSetTheme: afterSetThemeSpy,
+      });
+
+      // Initial theme setup.
+      expect(afterSetThemeSpy.calls.count()).toBe(1);
+      expect(afterSetThemeSpy.calls.mostRecent().args).toEqual(['ht-theme-sth']);
+
+      useTheme('ht-theme-sth2');
+
+      expect(afterSetThemeSpy.calls.count()).toBe(2);
+      expect(afterSetThemeSpy.calls.mostRecent().args).toEqual(['ht-theme-sth2']);
+
+      useTheme();
+
+      expect(afterSetThemeSpy.calls.count()).toBe(3);
+      expect(afterSetThemeSpy.calls.mostRecent().args).toEqual([]);
+
+      updateSettings({
+        themeName: 'ht-theme-sth3',
+      });
+
+      expect(afterSetThemeSpy.calls.count()).toBe(4);
+      expect(afterSetThemeSpy.calls.mostRecent().args).toEqual(['ht-theme-sth3']);
+    });
+  });
+});

--- a/handsontable/types/core/hooks/index.d.ts
+++ b/handsontable/types/core/hooks/index.d.ts
@@ -134,6 +134,7 @@ export interface Events {
   afterSetDataAtCell?: (changes: CellChange[], source?: ChangeSource) => void;
   afterSetDataAtRowProp?: (changes: CellChange[], source?: ChangeSource) => void;
   afterSetSourceDataAtCell?: (changes: CellChange[], source?: ChangeSource) => void;
+  afterSetTheme?: (themeName: string|boolean|undefined) => void;
   afterSheetAdded?: (addedSheetDisplayName: string) => void;
   afterSheetRemoved?: (removedSheetDisplayName: string, changes: ExportedChange[]) => void;
   afterSheetRenamed?: (oldDisplayName: string, newDisplayName: string) => void;

--- a/wrappers/angular/projects/hot-table/src/lib/hot-table.component.ts
+++ b/wrappers/angular/projects/hot-table/src/lib/hot-table.component.ts
@@ -246,6 +246,7 @@ export class HotTableComponent implements AfterViewInit, OnChanges, OnDestroy {
   @Input() afterSetDataAtCell: Handsontable.GridSettings['afterSetDataAtCell'];
   @Input() afterSetDataAtRowProp: Handsontable.GridSettings['afterSetDataAtRowProp'];
   @Input() afterSetSourceDataAtCell: Handsontable.GridSettings['afterSetSourceDataAtCell'];
+  @Input() afterSetTheme: Handsontable.GridSettings['afterSetTheme'];
   @Input() afterSheetAdded: Handsontable.GridSettings['afterSheetAdded'];
   @Input() afterSheetRenamed: Handsontable.GridSettings['afterSheetRenamed'];
   @Input() afterSheetRemoved: Handsontable.GridSettings['afterSheetRemoved'];


### PR DESCRIPTION
### Context
This PR:

- Implements a new `afterSetTheme` hook to be used internally to notify plugins that a theme had been set.
- Updates the styles handler and the plugins with the new logic.
- Updates the docs to allow changing the theme of the examples on the fly.

[skip changelog]
This PR is meant to be merged to `feature/dev-issue-1291`.
