### PR TITLE
[themes] Stop using the `--ht-row-height` CSS variable in the internal calculations.

### DIFF
--- a/handsontable/src/3rdparty/walkontable/src/table.js
+++ b/handsontable/src/3rdparty/walkontable/src/table.js
@@ -751,6 +751,7 @@ class Table {
     const borderBoxSizing = this.wot.stylesHandler.areCellsBorderBox();
     const rowHeightFn = borderBoxSizing ? outerHeight : innerHeight;
     const borderCompensation = borderBoxSizing ? 0 : 1;
+    const firstRowBorderCompensation = borderBoxSizing ? 1 : 0;
     let previousRowHeight;
     let rowCurrentHeight;
     let sourceRowIndex;
@@ -769,6 +770,8 @@ class Table {
       currentTr = this.getTrForRow(sourceRowIndex);
       rowHeader = currentTr.querySelector('th');
 
+      const topBorderCompensation = sourceRowIndex === 0 ? firstRowBorderCompensation : 0;
+
       if (rowHeader) {
         rowCurrentHeight = rowHeightFn(rowHeader);
 
@@ -776,8 +779,10 @@ class Table {
         rowCurrentHeight = rowHeightFn(currentTr) - borderCompensation;
       }
 
-      if (!previousRowHeight && this.dataAccessObject.stylesHandler.getDefaultRowHeight() < rowCurrentHeight ||
-          previousRowHeight < rowCurrentHeight
+      if (
+        !previousRowHeight &&
+        this.dataAccessObject.stylesHandler.getDefaultRowHeight() < rowCurrentHeight - topBorderCompensation ||
+        previousRowHeight < rowCurrentHeight
       ) {
         if (!borderBoxSizing) {
           rowCurrentHeight += 1;

--- a/handsontable/src/3rdparty/walkontable/test/spec/utils/stylesHandler.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/utils/stylesHandler.spec.js
@@ -91,7 +91,8 @@ describe('StylesHandler', () => {
     });
 
     it('should calculate the default row height for non-classic theme', () => {
-      spec().rootElement.style.setProperty('--ht-row-height', '31px');
+      spec().rootElement.style.setProperty('--ht-line-height', '20px');
+      spec().rootElement.style.setProperty('--ht-cell-vertical-padding', '5px');
 
       spec().wotInstance.destroy();
       walkontable({

--- a/handsontable/src/dataMap/metaManager/metaSchema.js
+++ b/handsontable/src/dataMap/metaManager/metaSchema.js
@@ -3951,7 +3951,7 @@ export default () => {
     /**
      * The `rowHeights` option sets rows' heights, in pixels.
      *
-     * In the rendering process, the default row height is 23 px (in the classic theme: 22 px + 1 px of the row's bottom border) or what's defined as `--ht-row-height` in the used theme.
+     * In the rendering process, the default row height is 23 px (in the classic theme: 22 px + 1 px of the row's bottom border) or whatever is defined in the used theme (based on the line height, vertical padding and cell borders).
      * You can change it to equal or greater than the defautl value, by setting the `rowHeights` option to one of the following:
      *
      * | Setting     | Description                                                                                         | Example                                                      |

--- a/handsontable/test/helpers/common.js
+++ b/handsontable/test/helpers/common.js
@@ -1086,7 +1086,8 @@ export function simulateTouch(target) {
 export function simulateModernThemeStylesheet(container) {
   const element = container instanceof $ ? container.get(0) : container;
 
-  element.style.setProperty('--ht-row-height', '28px');
+  element.style.setProperty('--ht-line-height', '17px');
+  element.style.setProperty('--ht-cell-vertical-padding', '5px');
 }
 
 /**
@@ -1097,7 +1098,8 @@ export function simulateModernThemeStylesheet(container) {
 export function clearModernThemeStylesheetMock(container) {
   const element = container instanceof $ ? container.get(0) : container;
 
-  element.style.removeProperty('--ht-row-height');
+  element.style.removeProperty('--ht-line-height');
+  element.style.removeProperty('--ht-cell-vertical-padding');
 }
 
 /**


### PR DESCRIPTION
### Context
This PR:
- Removed the usage of `--ht-row-height` CSS variable from the internal calculations and switched to calculating the default row height based on the line height, vertical padding and border sizes.

The side effect of this PR is fixing the row misalignment for the new themes on zoomed browser pages:

Before:
<img width="782" alt="image" src="https://github.com/user-attachments/assets/25fd255b-316e-4674-931a-664e5bc75b0d">

After:
<img width="803" alt="image" src="https://github.com/user-attachments/assets/65716496-b071-4413-88f5-a835c16a8fbb">

[skip changelog]
Note: This branch is meant to be merged to `feature/dev-issue-1291`.