### PR TITLE
Hotfix: update sed matcher to remove prod-docs prefix

### DIFF
--- a/.github/workflows/docs-production-netlify-cli.yml
+++ b/.github/workflows/docs-production-netlify-cli.yml
@@ -50,7 +50,7 @@ jobs:
         id: check-branch
         run: |
           echo "The current branch: $GITHUB_REF_NAME"
-          GITHUB_REF_VERSION_ONLY=$(echo $GITHUB_REF_NAME | sed 's|.*/prod-docs/||')
+          GITHUB_REF_VERSION_ONLY=$(echo $GITHUB_REF_NAME | sed 's|^.*/prod-docs/||')
           echo "The current version: $GITHUB_REF_VERSION_ONLY"
           if [[ "$GITHUB_REF_VERSION_ONLY" != "$DOCS_LATEST_VERSION" ]]; then
             echo "The current branch is not the latest version and will not be deployed to Netlify"

--- a/.github/workflows/docs-production-netlify-cli.yml
+++ b/.github/workflows/docs-production-netlify-cli.yml
@@ -21,7 +21,9 @@ defaults:
 jobs:
   check-version:
     name: Check Docs Version and Branch
-    if: ${{ github.ref != 'refs/heads/prod-docs/latest' }} # Exclude the prod-docs-latest branch from triggering the workflow
+    # Exclude the prod-docs-latest branch from triggering the workflow.
+    # "The prod-docs/ prefix must be validated within the workflow itself, as on: create does not support branch filtering."
+    if: startsWith(github.ref, 'refs/heads/prod-docs/') && github.ref != 'refs/heads/prod-docs/latest'
     runs-on: ubuntu-latest
     outputs:
       continue: ${{ steps.check-branch.outputs.continue }}

--- a/.github/workflows/docs-production-netlify-cli.yml
+++ b/.github/workflows/docs-production-netlify-cli.yml
@@ -6,9 +6,8 @@ env:
   DOCSEARCH_APP_ID: ${{ secrets.DOCSEARCH_APP_ID }}
 
 on:
+  # Branch filtering is not supported with `on: create`.
   create:
-    branches:
-      - 'prod-docs/**'
   push:
     branches:
       - 'prod-docs/**'
@@ -22,7 +21,7 @@ jobs:
   check-version:
     name: Check Docs Version and Branch
     # Exclude the prod-docs-latest branch from triggering the workflow.
-    # "The prod-docs/ prefix must be validated within the workflow itself, as on: create does not support branch filtering."
+    # The prod-docs/ prefix must be validated within the workflow itself, as on: create does not support branch filtering.
     if: startsWith(github.ref, 'refs/heads/prod-docs/') && github.ref != 'refs/heads/prod-docs/latest'
     runs-on: ubuntu-latest
     outputs:
@@ -78,7 +77,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # https://github.com/actions/checkout/releases/tag/v4.1.1
 
       - name: Remove local branch if it exists
-        run: |
+            run: |
           git branch -D prod-docs/latest || true
 
       - name: Recreate the docs latest branch

--- a/.github/workflows/docs-production-netlify-cli.yml
+++ b/.github/workflows/docs-production-netlify-cli.yml
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # https://github.com/actions/checkout/releases/tag/v4.1.1
 
       - name: Remove local branch if it exists
-            run: |
+        run: |
           git branch -D prod-docs/latest || true
 
       - name: Recreate the docs latest branch


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->

Adds an `if` condition to the `on: create` trigger to prevent it from running for all branches, as branch filtering is not supported with `on: create`.
Fixes issue with `sed` stripping incorrect portions of the string.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #11267 
2. #11266 
3. #11268 
4. #11174 

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]
