### PR TITLE
Hotfix: sed pattern support for the clean prod-docs branch name

### DIFF
--- a/.github/workflows/docs-production-netlify-cli.yml
+++ b/.github/workflows/docs-production-netlify-cli.yml
@@ -51,7 +51,7 @@ jobs:
         id: check-branch
         run: |
           echo "The current branch: $GITHUB_REF_NAME"
-          GITHUB_REF_VERSION_ONLY=$(echo $GITHUB_REF_NAME | sed 's|^.*/prod-docs/||')
+          GITHUB_REF_VERSION_ONLY=$(echo $GITHUB_REF_NAME | sed 's|prod-docs/||'
           echo "The current version: $GITHUB_REF_VERSION_ONLY"
           if [[ "$GITHUB_REF_VERSION_ONLY" != "$DOCS_LATEST_VERSION" ]]; then
             echo "The current branch is not the latest version and will not be deployed to Netlify"


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
"Improved sed pattern to correctly handle and clean prod-docs branch names."

### How has this been tested?
Locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #11267 
2. #11266 
3. #11268 
4. #11174 

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]
