### PR TITLE
Make the filters' dropdown resize to match its current content size.

### DIFF
--- a/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
@@ -1636,7 +1636,7 @@ describe('Filters UI', () => {
   });
 
   it('should inherit the actual layout direction option from the root Handsontable instance to the multiple ' +
-    'select component', async() => {
+    'select component', () => {
     handsontable({
       data: createSpreadsheetData(4, 4),
       colHeaders: true,
@@ -1668,4 +1668,33 @@ describe('Filters UI', () => {
 
     expect(onErrorSpy).not.toHaveBeenCalled();
   });
+
+  it('should adjust the dropdown height to the currently displayed content', async() => {
+    handsontable({
+      data: getDataForFilters(),
+      columns: getColumnsForFilters(),
+      dropdownMenu: true,
+      filters: true,
+      width: 500,
+      height: 300
+    });
+
+    dropdownMenu(0);
+
+    const initialDropdownHeight = dropdownMenuRootElement().offsetHeight;
+
+    simulateClick(dropdownMenuRootElement().querySelectorAll('.htUISelect')[0]);
+    selectDropdownByConditionMenuOption('Greater than');
+
+    await sleep(100);
+
+    expect(dropdownMenuRootElement().offsetHeight).toBeGreaterThan(initialDropdownHeight);
+
+    simulateClick(dropdownMenuRootElement().querySelectorAll('.htUISelect')[0]);
+    selectDropdownByConditionMenuOption('None');
+
+    await sleep(100);
+
+    expect(dropdownMenuRootElement().offsetHeight).toBe(initialDropdownHeight);
+  })
 });

--- a/handsontable/src/plugins/filters/filters.js
+++ b/handsontable/src/plugins/filters/filters.js
@@ -804,11 +804,15 @@ export class Filters extends BasePlugin {
    * @param {object} command Menu item object (command).
    */
   #onComponentChange(component, command) {
+    const menu = this.dropdownMenuPlugin.menu;
+
     this.updateDependentComponentsVisibility();
 
     if (component.constructor === ConditionComponent && !command.inputsCount) {
       this.setListeningDropdownMenu();
     }
+
+    menu.updateMenuDimensions();
   }
 
   /**


### PR DESCRIPTION
### Context
This PR:

- Makes the Filters' dropdown container resize whenever a new filtering component is shown/hidden.
- Adds a test case for that situation.

### How has this been tested?
- Tested manually + added a test case.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#2123

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
