### PR TITLE
Remove check marks from alignment submenu

### DIFF
--- a/.changelogs/11278.json
+++ b/.changelogs/11278.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Removed check marks from alignment submenu.",
+  "type": "removed",
+  "issueOrPR": 11278,
+  "breaking": true,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/contextMenu/predefinedItems/alignment.js
+++ b/handsontable/src/plugins/contextMenu/predefinedItems/alignment.js
@@ -1,8 +1,6 @@
 import {
   align,
   getAlignmentClasses,
-  markLabelAsSelected,
-  hasSelectionAClass
 } from '../utils';
 import { KEY as SEPARATOR } from './separator';
 import * as C from '../../../i18n/constants';
@@ -39,21 +37,8 @@ export default function alignmentItem() {
       items: [
         {
           key: `${KEY}:left`,
-          checkable: true,
-          ariaLabel() {
-            return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_ALIGNMENT_LEFT);
-          },
-          ariaChecked() {
-            return hasSelectionAClass(this, 'htLeft');
-          },
           name() {
-            let label = this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_ALIGNMENT_LEFT);
-
-            if (hasSelectionAClass(this, 'htLeft')) {
-              label = markLabelAsSelected(label);
-            }
-
-            return label;
+            return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_ALIGNMENT_LEFT);
           },
           callback() {
             const selectedRange = this.getSelectedRange();
@@ -70,21 +55,8 @@ export default function alignmentItem() {
         },
         {
           key: `${KEY}:center`,
-          checkable: true,
-          ariaLabel() {
-            return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_ALIGNMENT_CENTER);
-          },
-          ariaChecked() {
-            return hasSelectionAClass(this, 'htCenter');
-          },
           name() {
-            let label = this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_ALIGNMENT_CENTER);
-
-            if (hasSelectionAClass(this, 'htCenter')) {
-              label = markLabelAsSelected(label);
-            }
-
-            return label;
+            return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_ALIGNMENT_CENTER);
           },
           callback() {
             const selectedRange = this.getSelectedRange();
@@ -101,21 +73,8 @@ export default function alignmentItem() {
         },
         {
           key: `${KEY}:right`,
-          checkable: true,
-          ariaLabel() {
-            return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_ALIGNMENT_RIGHT);
-          },
-          ariaChecked() {
-            return hasSelectionAClass(this, 'htRight');
-          },
           name() {
-            let label = this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_ALIGNMENT_RIGHT);
-
-            if (hasSelectionAClass(this, 'htRight')) {
-              label = markLabelAsSelected(label);
-            }
-
-            return label;
+            return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_ALIGNMENT_RIGHT);
           },
           callback() {
             const selectedRange = this.getSelectedRange();
@@ -132,21 +91,8 @@ export default function alignmentItem() {
         },
         {
           key: `${KEY}:justify`,
-          checkable: true,
-          ariaLabel() {
-            return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_ALIGNMENT_JUSTIFY);
-          },
-          ariaChecked() {
-            return hasSelectionAClass(this, 'htJustify');
-          },
           name() {
-            let label = this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_ALIGNMENT_JUSTIFY);
-
-            if (hasSelectionAClass(this, 'htJustify')) {
-              label = markLabelAsSelected(label);
-            }
-
-            return label;
+            return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_ALIGNMENT_JUSTIFY);
           },
           callback() {
             const selectedRange = this.getSelectedRange();
@@ -166,21 +112,8 @@ export default function alignmentItem() {
         },
         {
           key: `${KEY}:top`,
-          checkable: true,
-          ariaLabel() {
-            return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_ALIGNMENT_TOP);
-          },
-          ariaChecked() {
-            return hasSelectionAClass(this, 'htTop');
-          },
           name() {
-            let label = this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_ALIGNMENT_TOP);
-
-            if (hasSelectionAClass(this, 'htTop')) {
-              label = markLabelAsSelected(label);
-            }
-
-            return label;
+            return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_ALIGNMENT_TOP);
           },
           callback() {
             const selectedRange = this.getSelectedRange();
@@ -197,21 +130,8 @@ export default function alignmentItem() {
         },
         {
           key: `${KEY}:middle`,
-          checkable: true,
-          ariaLabel() {
-            return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_ALIGNMENT_MIDDLE);
-          },
-          ariaChecked() {
-            return hasSelectionAClass(this, 'htMiddle');
-          },
           name() {
-            let label = this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_ALIGNMENT_MIDDLE);
-
-            if (hasSelectionAClass(this, 'htMiddle')) {
-              label = markLabelAsSelected(label);
-            }
-
-            return label;
+            return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_ALIGNMENT_MIDDLE);
           },
           callback() {
             const selectedRange = this.getSelectedRange();
@@ -228,21 +148,8 @@ export default function alignmentItem() {
         },
         {
           key: `${KEY}:bottom`,
-          checkable: true,
-          ariaLabel() {
-            return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_ALIGNMENT_BOTTOM);
-          },
-          ariaChecked() {
-            return hasSelectionAClass(this, 'htBottom');
-          },
           name() {
-            let label = this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_ALIGNMENT_BOTTOM);
-
-            if (hasSelectionAClass(this, 'htBottom')) {
-              label = markLabelAsSelected(label);
-            }
-
-            return label;
+            return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_ALIGNMENT_BOTTOM);
           },
           callback() {
             const selectedRange = this.getSelectedRange();

--- a/handsontable/src/plugins/contextMenu/utils.js
+++ b/handsontable/src/plugins/contextMenu/utils.js
@@ -175,15 +175,3 @@ export function getAlignmentComparatorByClass(htClassName) {
     return (className && className.indexOf(htClassName) !== -1);
   };
 }
-
-/**
- * @param {object} hot Handsontable instance.
- * @param {string} htClassName The class name to check.
- * @returns {boolean} Returns true if at least one cell has the provided class name.
- */
-export function hasSelectionAClass(hot, htClassName) {
-  return checkSelectionConsistency(
-    hot.getSelectedRange(),
-    getAlignmentComparatorByClass(htClassName).bind(hot)
-  );
-}


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR removes the check marks for the Alignment submenu.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and I updated tests according to new changes.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/2128

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
