### PR TITLE
Fix an error for cases where the `key` value is `undefined`

### DIFF
--- a/.changelogs/11281.json
+++ b/.changelogs/11281.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed an error for cases where the keyboard event was triggered with `key` as `undefined`.",
+  "type": "fixed",
+  "issueOrPR": 11281,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/shortcuts/__tests__/shortcutManager.spec.js
+++ b/handsontable/src/shortcuts/__tests__/shortcutManager.spec.js
@@ -167,6 +167,22 @@ describe('shortcutManager', () => {
     expect(callback.calls.count()).toBe(1);
   });
 
+  it('should not trigger a callback when the `key` is undefined (#dev-2096)', () => {
+    const afterDocumentKeyDown = jasmine.createSpy();
+    const hot = handsontable({
+      afterDocumentKeyDown,
+    });
+
+    hot.listen();
+
+    keyTriggerFactory('keydown', undefined, {
+      extend: {},
+      target: document.activeElement,
+    });
+
+    expect(afterDocumentKeyDown).not.toHaveBeenCalled();
+  });
+
   it('should run action for specified Command/Control modifier key depending on the operating system the table runs on', () => {
     const hot = handsontable();
     const shortcutManager = hot.getShortcutManager();

--- a/handsontable/src/shortcuts/recorder.js
+++ b/handsontable/src/shortcuts/recorder.js
@@ -87,7 +87,12 @@ export function useRecorder(ownerWindow, handleEvent, beforeKeyDown, afterKeyDow
     // keyCode 229 aka 'uninitialized' doesn't take into account with editors. This key code is
     // produced when unfinished character is entering using the IME editor. It is fired on macOS,
     // Windows and linux (ubuntu) with installed ibus-pinyin package.
-    if (event.keyCode === 229 || result === false || isImmediatePropagationStopped(event)) {
+    if (
+      result === false ||
+      event.keyCode === 229 ||
+      typeof event.key !== 'string' ||
+      isImmediatePropagationStopped(event)
+    ) {
       return;
     }
 
@@ -117,7 +122,7 @@ export function useRecorder(ownerWindow, handleEvent, beforeKeyDown, afterKeyDow
    * @param {KeyboardEvent} event The event object
    */
   const onkeydownForModKeys = (event) => {
-    if (event.key) {
+    if (typeof event.key === 'string') {
       const pressedKey = normalizeEventKey(event);
 
       if (isModifierKey(pressedKey)) {
@@ -133,7 +138,7 @@ export function useRecorder(ownerWindow, handleEvent, beforeKeyDown, afterKeyDow
    * @param {KeyboardEvent} event The event object
    */
   const onkeyupForModKeys = (event) => {
-    if (event.key) {
+    if (typeof event.key === 'string') {
       const pressedKey = normalizeEventKey(event);
 
       if (isModifierKey(pressedKey)) {

--- a/handsontable/test/helpers/keyboardEvents.js
+++ b/handsontable/test/helpers/keyboardEvents.js
@@ -92,10 +92,13 @@ export function keyTriggerFactory(type, key, { extend, target, ime }) {
   const ev = {};
 
   if (ime) {
-    // emulates the event that happens while using IME
-    ev.keyCode = 229;
-  } else {
-    ev.keyCode = KEY_CODES_MAP.has(key) ? KEY_CODES_MAP.get(key) : key.codePointAt(0);
+    ev.keyCode = 229; // emulates the event that happens while using IME
+
+  } else if (KEY_CODES_MAP.has(key)) {
+    ev.keyCode = KEY_CODES_MAP.get(key);
+
+  } else if (typeof key === 'string') {
+    ev.keyCode = key.codePointAt(0);
   }
 
   ev.key = key;


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes an error that could happen when the keyboard event was triggered with a `key` property as `undefined`. That could happen when the event was emulated by the 3rd party developer's app or IME.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and I covered the fix with a new test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/2096

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
