### PR TITLE
Fix input width calculation for password cell type

### DIFF
--- a/.changelogs/11283.json
+++ b/.changelogs/11283.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed input width calculation for password cell type",
+  "type": "fixed",
+  "issueOrPR": 11283,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/editors/passwordEditor/__tests__/passwordEditor.spec.js
+++ b/handsontable/src/editors/passwordEditor/__tests__/passwordEditor.spec.js
@@ -308,6 +308,28 @@ describe('PasswordEditor', () => {
 
   });
 
+  it('should correctly calculate the input width based on typed values', async() => {
+    handsontable({
+      columns: [
+        {
+          editor: 'password'
+        }
+      ]
+    });
+
+    selectCell(0, 0);
+    keyDownUp('enter');
+
+    const editor = getActiveEditor().TEXTAREA;
+
+    editor.value = 'wwwwwwwwwwwwwwwwww'; // "w" is wider than password dots
+    keyDownUp('w'); // trigger editor autoresize
+
+    await sleep(10);
+
+    expect(editor.style.width).toBe('84px');
+  });
+
   it('should set passwordEditor using \'password\' alias', () => {
     handsontable({
       data: [

--- a/handsontable/src/editors/passwordEditor/passwordEditor.js
+++ b/handsontable/src/editors/passwordEditor/passwordEditor.js
@@ -1,4 +1,5 @@
 import { TextEditor } from '../textEditor';
+import { createInputElementResizer } from '../../utils/autoResize';
 import { empty } from '../../helpers/dom/element';
 
 export const EDITOR_TYPE = 'password';
@@ -8,6 +9,17 @@ export const EDITOR_TYPE = 'password';
  * @class PasswordEditor
  */
 export class PasswordEditor extends TextEditor {
+  /**
+   * Autoresize instance for resizing the editor to the size of the entered text. Its overwrites the default
+   * resizer of the TextEditor.
+   *
+   * @private
+   * @type {Function}
+   */
+  autoResize = createInputElementResizer(this.hot.rootDocument, {
+    textContent: element => '•'.repeat(element.value.length)
+  });
+
   static get EDITOR_TYPE() {
     return EDITOR_TYPE;
   }

--- a/handsontable/src/utils/autoResize.js
+++ b/handsontable/src/utils/autoResize.js
@@ -44,6 +44,7 @@ function getComputedStyle(element) {
  * @property {number} maxWidth The maximum width of the element.
  * @property {number} minHeight The minimum height of the element.
  * @property {number} maxHeight The maximum height of the element.
+ * @property {function(HTMLElement): string} textContent The function that returns the text content to measure.
  */
 /**
  * @typedef InputElementResizer
@@ -55,14 +56,17 @@ function getComputedStyle(element) {
  * Creates an input element resizer.
  *
  * @param {Document} ownerDocument The document to create the resizer for.
+ * @param {InputElementResizerConfig} initialOptions The configuration to extend the defaults with.
  * @returns {InputElementResizer}
  */
-export function createInputElementResizer(ownerDocument) {
+export function createInputElementResizer(ownerDocument, initialOptions = {}) {
   const defaults = {
     minHeight: 200,
     maxHeight: 300,
     minWidth: 100,
     maxWidth: 300,
+    textContent: element => element.value,
+    ...initialOptions,
   };
   const body = ownerDocument.body;
   const textHolder = ownerDocument.createTextNode('');
@@ -73,7 +77,7 @@ export function createInputElementResizer(ownerDocument) {
    * Resizes the element.
    */
   function resize() {
-    textHolder.textContent = observedElement.value;
+    textHolder.textContent = defaults.textContent(observedElement);
     // Won't expand the element size for displaying body as for example, `grid`, `inline-grid` or `flex` with
     // `flex-direction` set as `column`.
     textContainer.style.position = 'absolute';


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the editor's input width calculation for password cell types. 

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and I covered the fix with a new test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/2097

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
