### PR TITLE
Revert the Docs scroll behavior

### DIFF
--- a/docs/.vuepress/enhanceApp.js
+++ b/docs/.vuepress/enhanceApp.js
@@ -1,5 +1,4 @@
 /* global GA_ID, ga */
-
 const { applyToWindow, instanceRegister } = require('./handsontable-manager');
 
 applyToWindow();
@@ -42,6 +41,7 @@ const buildRegisterCleaner = register => (to, from) => {
  * route changes, the event is triggered manually.
  */
 let isFirstPageGALoaded = true;
+let isPageLoaded = false;
 
 export default async({ router, siteData, isServer }) => {
   if (isServer) {
@@ -78,46 +78,50 @@ export default async({ router, siteData, isServer }) => {
     page.versionsWithPatches = new Map(docsData.versionsWithPatches);
   });
 
-  let scrollbarPosition = null;
-
-  // AfterEach Hook
-  router.afterEach((to) => {
-    if (scrollbarPosition) {
-      window.scrollTo(scrollbarPosition.left, scrollbarPosition.top);
-      scrollbarPosition = null; // Reset after use
-
-      return;
+  router.options.scrollBehavior = function(to, from, savedPosition) {
+    if (this.app.$vuepress.$get('disableScrollBehavior')) {
+      return false;
     }
 
-    // Check if the route has a hash
-    if (to.hash) {
-      const element = document.querySelector(to.hash);
+    let scrollPosition = { x: 0, y: 0 }; // page without hash
 
-      if (element) {
-        element.scrollIntoView({
-          behavior: 'smooth', // Smooth scrolling
-          block: 'start', // Align the element at the start of the viewport
-        });
-
-        if (!window.location.hash || window.location.hash !== to.hash) {
-          router.push({ hash: to.hash }).catch(() => {}); // Avoid duplicate navigation error
-        }
-      }
-
-      return;
-    }
-    window.scrollTo(0, 75);
-  });
-
-  // ScrollBehavior Function
-  router.options.scrollBehavior = async(to, from, savedPosition) => {
     if (savedPosition) {
-      scrollbarPosition = savedPosition; // Save position for back/forward navigation
-    } else {
-      scrollbarPosition = null; // Reset for new navigation
+      scrollPosition = savedPosition; // page from the browser navigation (back/forward)
     }
 
-    return false; // Disable Vue Router's default scroll behavior
+    if (from.hash) {
+      scrollPosition = { x: 0, y: 0 };
+    }
+
+    if (to.hash) {
+      scrollPosition = {
+        selector: to.hash,
+        // top offset that matches to the "scroll-padding-top" (.vuepress/theme/styles/index.styl@34)
+        // mostly it's the height of the top header plus some margin
+        offset: { x: 0, y: 75 }
+      };
+    }
+
+    let scrollResolver;
+
+    const scrollPromise = new Promise((resolve) => {
+      scrollResolver = resolve;
+    });
+
+    if (isPageLoaded) {
+      if (to.path === from.path) {
+        scrollResolver(scrollPosition);
+      } else {
+        setTimeout(() => scrollResolver(scrollPosition));
+      }
+    } else {
+      window.onload = () => {
+        isPageLoaded = true;
+        scrollResolver(scrollPosition);
+      };
+    }
+
+    return scrollPromise;
   };
 
   if (typeof window.ga === 'function') {

--- a/docs/content/guides/cell-features/merge-cells/javascript/example2.ts
+++ b/docs/content/guides/cell-features/merge-cells/javascript/example2.ts
@@ -21,9 +21,7 @@ new Handsontable(container, {
   contextMenu: true,
   mergeCells: {
     virtualized: true,
-    cells: [
-      { row: 1, col: 1, rowspan: 3, colspan: 498 },
-    ],
+    cells: [{ row: 1, col: 1, rowspan: 3, colspan: 498 }],
   },
   viewportColumnRenderingOffset: 15,
   viewportColumnRenderingThreshold: 5,

--- a/docs/content/guides/cell-features/merge-cells/react/example2.tsx
+++ b/docs/content/guides/cell-features/merge-cells/react/example2.tsx
@@ -25,9 +25,7 @@ const ExampleComponent = () => {
       contextMenu={true}
       mergeCells={{
         virtualized: true,
-        cells: [
-          { row: 1, col: 1, rowspan: 3, colspan: 498 },
-        ],
+        cells: [{ row: 1, col: 1, rowspan: 3, colspan: 498 }],
       }}
       viewportColumnRenderingOffset={15}
       viewportColumnRenderingThreshold={5}


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR reverts the Docs scroll behavior to the previous state.

_[skip changelog]_

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

