### PR TITLE
[docs] Make the docs symlink the `tmp` directory instead of `dist`.

### DIFF
--- a/docs/.vuepress/handsontable-manager/dependencies.js
+++ b/docs/.vuepress/handsontable-manager/dependencies.js
@@ -15,7 +15,7 @@ const formatVersion = version => (/^\d+\.\d+$/.test(version) ? version : 'latest
 const getPackageUrls = (packageName, version, fileSelection) => {
   const subDirs = {
     handsontable: {
-      js: 'handsontable.full.min.js',
+      js: 'dist/handsontable.full.min.js',
       css: [
         'styles/handsontable.min.css',
         'styles/ht-theme-main.css',

--- a/docs/.vuepress/tools/link-assets.mjs
+++ b/docs/.vuepress/tools/link-assets.mjs
@@ -8,8 +8,7 @@ const { logger } = utils;
 const docsBasePath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 
 const SYMLINK_PATHS = [
-  { source: '../handsontable/dist/', target: './.vuepress/public/handsontable/' },
-  { source: '../handsontable/styles/', target: './.vuepress/public/handsontable/styles/' },
+  { source: '../handsontable/tmp/', target: './.vuepress/public/handsontable/' },
   { source: '../wrappers/react/dist/', target: './.vuepress/public/@handsontable/react/' },
   { source: '../wrappers/react-wrapper/dist/', target: './.vuepress/public/@handsontable/react-wrapper/' },
   { source: '../wrappers/angular/dist/hot-table/fesm2022', target: './.vuepress/public/@handsontable/angular/' },

--- a/handsontable/.config/themes-development.js
+++ b/handsontable/.config/themes-development.js
@@ -1,7 +1,7 @@
 const configFactory = require('./base');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const RemoveEmptyScriptsPlugin = require('webpack-remove-empty-scripts');
-const glob = require("glob");
+const glob = require('glob');
 const path = require('path');
 
 module.exports.create = function create(envArgs) {

--- a/handsontable/dist/styles
+++ b/handsontable/dist/styles
@@ -1,1 +1,0 @@
-/Users/krzysztofspilka/WebstormProjects/handsontable-repo-new/handsontable/styles


### PR DESCRIPTION
### Context
As with `15.0.0` not all the CSS files are stored inside the `dist` directory, the docs need to symlink more than just the `dist`.
This PR makes the docs symlink the entire local `tmp` directory, so both the `js` and `css` files of the local build can be loaded.

---
This PR is meant to be merged to `feature/dev-issue-2137-new-base`.

[skip changelog]

### How has this been tested?
Tested locally.

### Related issue(s):
1. handsontable/dev-handsontable#2139
