### PR TITLE
Make the build scripts of `@handsontable/react-wrapper` place the TS type definitions in the configured directory.

### DIFF
--- a/.changelogs/11296.json
+++ b/.changelogs/11296.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Madee the build scripts of `@handsontable/react-wrapper` place the TS type definitions in the configured directory.",
+  "type": "fixed",
+  "issueOrPR": 11296,
+  "breaking": false,
+  "framework": "react"
+}

--- a/wrappers/react-wrapper/.config/base.js
+++ b/wrappers/react-wrapper/.config/base.js
@@ -6,7 +6,8 @@ import commonjs from '@rollup/plugin-commonjs';
 
 export const plugins = {
   typescript: typescript({
-    clean: true
+    clean: true,
+    useTsconfigDeclarationDir: true,
   }),
   babel: babel({
     babelHelpers: 'bundled',


### PR DESCRIPTION
### Context
Before this change, the `commonjs` and `umd` scripts generated the `.d.ts` files into `dist/src` and `commonjs/src` directories, which was not needed, as the types would be eventually be generated with the `es` script into the `types` directory, and then moved to the root.

After this change, every build script generate the type definitions into the same directory (which is then moved to the root).

---

This change needs to be cherry-picked to the `release/15.0.0` branch.

### How has this been tested?
Tested lodally.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#2138

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [x] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
