### PR TITLE
Make the `autoRowSize` plugin not change the size of the rows if their content doesn't require the plugin to do so.

### DIFF
--- a/handsontable/src/styles/base/_base.scss
+++ b/handsontable/src/styles/base/_base.scss
@@ -65,6 +65,26 @@
       }
     }
 
+    // Force the ghost table to ignore the additional 1px border for the first rows in the table
+    &.htGhostTable {
+      table {
+        thead {
+          th {
+            border-bottom-width: 0;
+          }
+        }
+
+        tbody {
+          tr {
+            td,
+            th {
+              border-top-width: 0;
+            }
+          }
+        }
+      }
+    }
+
     // Background
     &.htHasScrollX,
     &.htHasScrollY {

--- a/handsontable/src/styles/legacy/handsontable.css
+++ b/handsontable/src/styles/legacy/handsontable.css
@@ -937,6 +937,16 @@ CheckboxRenderer
   padding-right: 20px;
 }
 
+/* Force the ghost table to ignore the additional upper border 1px for the first row in the table */
+.handsontable.htGhostTable table thead th {
+  border-bottom-width: 0;
+}
+
+.handsontable.htGhostTable table tbody tr th,
+.handsontable.htGhostTable table tbody tr td {
+  border-top-width: 0;
+}
+
 .handsontable .htCommentCell {
   position: relative;
 }

--- a/handsontable/src/utils/ghostTable.js
+++ b/handsontable/src/utils/ghostTable.js
@@ -462,21 +462,12 @@ class GhostTable {
     const { rootDocument } = this.hot;
     const fragment = rootDocument.createDocumentFragment();
 
-
-
-    // const temp = rootDocument.createElement('div');
-    // rootDocument.body.appendChild(temp);
-    // const fragment = temp;
-
-
-
-
     const container = rootDocument.createElement('div');
     const containerClassName = `htGhostTable htAutoSize ${className.trim()}`;
 
     addClass(container, containerClassName);
     fragment.appendChild(container);
-// debugger;
+
     return { fragment, container };
   }
 

--- a/handsontable/src/utils/ghostTable.js
+++ b/handsontable/src/utils/ghostTable.js
@@ -461,7 +461,6 @@ class GhostTable {
   createContainer(className = '') {
     const { rootDocument } = this.hot;
     const fragment = rootDocument.createDocumentFragment();
-
     const container = rootDocument.createElement('div');
     const containerClassName = `htGhostTable htAutoSize ${className.trim()}`;
 

--- a/handsontable/src/utils/ghostTable.js
+++ b/handsontable/src/utils/ghostTable.js
@@ -150,17 +150,13 @@ class GhostTable {
       this.injectTable();
     }
 
-    const isBorderBoxSizing = this.hot.view.getStylesHandler().areCellsBorderBox();
-    const borderCompensation = isBorderBoxSizing ? 0 : 1;
-
     arrayEach(this.rows, (row) => {
       // In cases when the cell's content produces the height with a decimal point, the height
       // needs to be rounded up to make sure that there will be a space for the cell's content.
       // The `.offsetHeight` always returns the rounded number (floored), so it's not suitable for this case.
       const { height } = row.table.getBoundingClientRect();
 
-      // -1 <- reduce border-top from table (if box-sizing is not border-box)
-      callback(row.row, Math.ceil(height) - borderCompensation);
+      callback(row.row, Math.ceil(height));
     });
   }
 
@@ -465,12 +461,22 @@ class GhostTable {
   createContainer(className = '') {
     const { rootDocument } = this.hot;
     const fragment = rootDocument.createDocumentFragment();
+
+
+
+    // const temp = rootDocument.createElement('div');
+    // rootDocument.body.appendChild(temp);
+    // const fragment = temp;
+
+
+
+
     const container = rootDocument.createElement('div');
     const containerClassName = `htGhostTable htAutoSize ${className.trim()}`;
 
     addClass(container, containerClassName);
     fragment.appendChild(container);
-
+// debugger;
     return { fragment, container };
   }
 


### PR DESCRIPTION
### Context
Before this change, using the `autoRowSize` plugin on regular-sized rows, with the new themes enabled, resulted in the rows being higher (by 1px) than before enabling the plugin.

This PR removes the compensation logic from GhostTable, replacing it with forcing the ghost table to not have some of the borders from the actual table.

[skip changelog]

### How has this been tested?
Tested manually

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
