### PR TITLE
Fix border radius for tables without height

### DIFF
--- a/handsontable/src/styles/base/_base.scss
+++ b/handsontable/src/styles/base/_base.scss
@@ -207,9 +207,9 @@
       }
 
       &.ht__active_highlight {
+        border-color: var(--ht-header-active-border-color) !important;
         color: var(--ht-header-active-foreground-color);
         background-color: var(--ht-header-active-background-color);
-        border-color: var(--ht-header-active-border-color);
         box-shadow: -1px 0 0 0 var(--ht-header-active-border-color);
       }
     }

--- a/handsontable/src/styles/base/_base.scss
+++ b/handsontable/src/styles/base/_base.scss
@@ -207,7 +207,7 @@
       }
 
       &.ht__active_highlight {
-        border-color: var(--ht-header-active-border-color) !important;
+        border-color: var(--ht-header-active-border-color);
         color: var(--ht-header-active-foreground-color);
         background-color: var(--ht-header-active-background-color);
         box-shadow: -1px 0 0 0 var(--ht-header-active-border-color);
@@ -431,6 +431,10 @@
       th,
       td {
         border-bottom-color: var(--ht-border-color);
+
+        &.ht__active_highlight {
+          border-bottom-color: var(--ht-header-active-border-color);
+        }
       }
     }
 

--- a/handsontable/src/styles/base/_border-radius.scss
+++ b/handsontable/src/styles/base/_border-radius.scss
@@ -5,6 +5,8 @@
     &.ht-wrapper {
       .ht_master {
         .htCore {
+          border-radius: var(--ht-wrapper-border-radius);
+
           thead tr:first-child th:first-child {
             border-start-start-radius: var(--ht-wrapper-border-radius);
           }
@@ -48,17 +50,15 @@
 
       .ht_clone_top_inline_start_corner {
         .htCore {
+          border-start-start-radius: var(--ht-wrapper-border-radius);
+
           thead tr:first-child th:first-child {
-            border-start-start-radius: var(
-              --ht-wrapper-border-radius
-            ) !important;
+            border-start-start-radius: var(--ht-wrapper-border-radius);
           }
 
           tbody tr:first-child td:first-child,
           tbody tr:first-child th:first-child {
-            border-start-start-radius: var(
-              --ht-wrapper-border-radius
-            ) !important;
+            border-start-start-radius: var(--ht-wrapper-border-radius);
           }
 
           &:has(thead tr th) {
@@ -72,13 +72,15 @@
 
       .ht_clone_bottom_inline_start_corner {
         .htCore {
+          border-end-start-radius: var(--ht-wrapper-border-radius);
+
           thead tr:last-child th:first-child {
-            border-end-start-radius: var(--ht-wrapper-border-radius) !important;
+            border-end-start-radius: var(--ht-wrapper-border-radius);
           }
 
           tbody tr:last-child td:first-child,
           tbody tr:last-child th:first-child {
-            border-end-start-radius: var(--ht-wrapper-border-radius) !important;
+            border-end-start-radius: var(--ht-wrapper-border-radius);
           }
 
           &:has(thead tr td) {
@@ -92,10 +94,13 @@
 
       .ht_clone_top {
         .htCore {
+          border-start-start-radius: var(--ht-wrapper-border-radius);
+          border-start-end-radius: var(--ht-wrapper-border-radius);
+
           thead tr:first-child th:first-child {
             border-start-start-radius: var(--ht-wrapper-border-radius);
           }
-          
+
           thead tr:first-child th:last-child {
             border-start-end-radius: var(--ht-wrapper-border-radius);
           }
@@ -122,6 +127,9 @@
 
       .ht_clone_inline_start {
         .htCore {
+          border-start-start-radius: var(--ht-wrapper-border-radius);
+          border-end-start-radius: var(--ht-wrapper-border-radius);
+
           thead tr:first-child th:first-child {
             border-start-start-radius: var(--ht-wrapper-border-radius);
           }
@@ -147,6 +155,9 @@
 
       .ht_clone_bottom {
         .htCore {
+          border-end-start-radius: var(--ht-wrapper-border-radius);
+          border-end-end-radius: var(--ht-wrapper-border-radius);
+
           thead tr:last-child th:first-child {
             border-end-start-radius: var(--ht-wrapper-border-radius);
           }
@@ -177,6 +188,9 @@
 
       &.htHasScrollX {
         .htCore {
+          border-end-start-radius: 0;
+          border-end-end-radius: 0;
+
           thead tr:last-child th:first-child,
           tbody tr:last-child td:first-child,
           tbody tr:last-child th:first-child {
@@ -193,6 +207,9 @@
 
       &.htHasScrollY {
         .htCore {
+          border-start-end-radius: 0;
+          border-end-end-radius: 0;
+
           thead tr:first-child th:last-child,
           tbody tr:first-child td:last-child,
           tbody tr:first-child th:last-child {


### PR DESCRIPTION
### Context
This PR includes fixes for border radius when table height is not set.

### How has this been tested?
Locally

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2137

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] Fix background overlap on table corner when table height is not set.

[skip changelog]
