### PR TITLE
Remove border radius from dropdown

### DIFF
--- a/handsontable/src/styles/components/editors/_dropdown-editor.scss
+++ b/handsontable/src/styles/components/editors/_dropdown-editor.scss
@@ -13,13 +13,14 @@
 
       .ht_master {
         overflow: hidden;
+        background-color: var(--ht-background-color);
       }
 
       .wtHolder {
         overflow: auto;
       }
 
-      .wtHider {
+      .wtHider, .htCore {
         border-radius: 0 !important;
       }
 


### PR DESCRIPTION
### Context
This PR includes fixes for border radius in dropdown

### How has this been tested?
Locally

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2137

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] Remove border radius from dropdown

[skip changelog]
