### PR TITLE
Fix header font size

### DIFF
--- a/handsontable/src/styles/base/_base.scss
+++ b/handsontable/src/styles/base/_base.scss
@@ -131,8 +131,8 @@
       border-inline-end-width: 1px;
       border-bottom-width: 1px;
       border-style: solid;
-      font-size: var(--ht-font-size, 14px);
-      line-height: var(--ht-line-height, 20px);
+      font-size: var(--ht-font-size);
+      line-height: var(--ht-line-height);
       white-space: pre-wrap;
       overflow: hidden;
       outline: none;
@@ -387,9 +387,13 @@
       }
     }
 
-    span.colHeader {
-      display: inline-block;
-      line-height: var(--ht-line-height, 20px);
+    span {
+      &.colHeader,
+      &.rowHeader {
+        display: inline-block;
+        font-size: var(--ht-font-size);
+        line-height: var(--ht-line-height);
+      }
     }
 
     tr.hidden {


### PR DESCRIPTION
### Context
This PR includes override for header font size and line height

### How has this been tested?
Locally

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2137

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] Override colHeader and rowHeader font size and line height

[skip changelog]
