### PR TITLE
Fix header underline for single row header

### DIFF
--- a/handsontable/src/styles/base/_base.scss
+++ b/handsontable/src/styles/base/_base.scss
@@ -272,6 +272,16 @@
     // Header in Col
     thead {
       tr {
+        &:only-of-type {
+          th {
+            .relative {
+              &::after {
+                bottom: 0;
+              }
+            }
+          }
+        }
+        
         th {
           padding: 0;
 


### PR DESCRIPTION
### Context
This PR includes fixes for single row header underline

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2137

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] Fix heder undeline overlap

[skip changelog] 
