### PR TITLE
Add missing API Docs about merge cells virtualization mode

### DIFF
--- a/handsontable/src/dataMap/metaManager/metaSchema.js
+++ b/handsontable/src/dataMap/metaManager/metaSchema.js
@@ -3075,11 +3075,13 @@ export default () => {
      *
      * You can set the `mergeCells` option to one of the following:
      *
-     * | Setting             | Description                                                                                         |
-     * | ------------------- | --------------------------------------------------------------------------------------------------- |
-     * | `true`              | Enable the [`MergeCells`](@/api/mergeCells.md) plugin                                               |
-     * | `false`             | Disable the [`MergeCells`](@/api/mergeCells.md) plugin                                              |
-     * | An array of objects | - Enable the [`MergeCells`](@/api/mergeCells.md) plugin<br>- Merge specific cells at initialization |
+     * | Setting               | Description                                                                                         |
+     * | --------------------- | --------------------------------------------------------------------------------------------------- |
+     * | `true`                | Enable the [`MergeCells`](@/api/mergeCells.md) plugin                                               |
+     * | `false`               | Disable the [`MergeCells`](@/api/mergeCells.md) plugin                                              |
+     * | An array of objects   | - Enable the [`MergeCells`](@/api/mergeCells.md) plugin<br>- Merge specific cells at initialization |
+     * | { virtualized: true } | Enable the [`MergeCells`](@/api/mergeCells.md) plugin with enabled virtualization mode              |
+     *
      *
      * To merge specific cells at Handsontable's initialization,
      * set the `mergeCells` option to an array of objects, with the following properties:
@@ -3114,6 +3116,20 @@ export default () => {
      *   // merge cells from cell (5,6) to cell (3,3)
      *   {row: 5, col: 6, rowspan: 3, colspan: 3}
      * ],
+     *
+     * // enable the `MergeCells` plugin with enabled virtualization mode
+     * // and merge specific cells at initialization
+     * mergeCells: {
+     *   virtualized: true,
+     *   cells: [
+     *     // merge cells from cell (1,1) to cell (3,3)
+     *     {row: 1, col: 1, rowspan: 3, colspan: 3},
+     *     // merge cells from cell (3,4) to cell (2,2)
+     *     {row: 3, col: 4, rowspan: 2, colspan: 2},
+     *     // merge cells from cell (5,6) to cell (3,3)
+     *     {row: 5, col: 6, rowspan: 3, colspan: 3}
+     *   ],
+     * },
      * ```
      */
     mergeCells: false,


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR extends the description of the `mergeCells` option for recently released virtualization mode.

_[skip changelog]_

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/2155

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
