### PR TITLE
Fix table misalign after container size change

### DIFF
--- a/.changelogs/11324.json
+++ b/.changelogs/11324.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed table misalign after container size change",
+  "type": "fixed",
+  "issueOrPR": 11324,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -2160,7 +2160,8 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
       return;
     }
 
-    const { width: lastWidth, height: lastHeight } = instance.view.getLastSize();
+    const view = instance.view;
+    const { width: lastWidth, height: lastHeight } = view.getLastSize();
     const { width, height } = instance.rootElement.getBoundingClientRect();
     const isSizeChanged = width !== lastWidth || height !== lastHeight;
     const isResizeBlocked = instance.runHooks(
@@ -2174,9 +2175,10 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
       return;
     }
 
-    if (isSizeChanged || instance.view._wt.wtOverlays.scrollableElement === instance.rootWindow) {
-      instance.view.setLastSize(width, height);
+    if (isSizeChanged || view._wt.wtOverlays.scrollableElement === instance.rootWindow) {
+      view.setLastSize(width, height);
       instance.render();
+      view.adjustElementsSize();
     }
 
     instance.runHooks(

--- a/handsontable/test/e2e/core/refreshDimensions.spec.js
+++ b/handsontable/test/e2e/core/refreshDimensions.spec.js
@@ -1,0 +1,53 @@
+describe('Core.refreshDimensions', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should trigger `beforeRefreshDimensions` and `afterRefreshDimensions` hooks internally', () => {
+    const beforeRefreshDimensions = jasmine.createSpy('beforeRefreshDimensions');
+    const afterRefreshDimensions = jasmine.createSpy('afterRefreshDimensions');
+
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+      beforeRefreshDimensions,
+      afterRefreshDimensions,
+    });
+
+    refreshDimensions();
+
+    expect(beforeRefreshDimensions).toHaveBeenCalledOnceWith(
+      { width: 1265, height: 0 },
+      { width: 1265, height: 116 },
+      true,
+    );
+    expect(afterRefreshDimensions).toHaveBeenCalledOnceWith(
+      { width: 1265, height: 0 },
+      { width: 1265, height: 116 },
+      true,
+    );
+  });
+
+  it('should trigger `render` and `adjustElementsSize` methods internally (#dev-1876)', () => {
+    const hot = handsontable({
+      data: createSpreadsheetData(5, 5),
+    });
+
+    spyOn(hot, 'render');
+    spyOn(hot.view, 'adjustElementsSize');
+
+    refreshDimensions();
+
+    expect(hot.render).toHaveBeenCalledTimes(1);
+    expect(hot.render).toHaveBeenCalledBefore(hot.view.adjustElementsSize);
+    expect(hot.view.adjustElementsSize).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes misalign a bug that could occur after the window is resized. There was a missing internal `adjustElementsSize` method call in the `refreshDimensions` method.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and I covered the fix with new tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1876

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
