### PR TITLE
Fix uncaught error for handsontable editor after changing the theme

### DIFF
--- a/.changelogs/11325.json
+++ b/.changelogs/11325.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed uncaught error for handsontable editor after changing the theme ",
+  "type": "fixed",
+  "issueOrPR": 11325,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/editors/handsontableEditor/__tests__/themes/themes.spec.js
+++ b/handsontable/src/editors/handsontableEditor/__tests__/themes/themes.spec.js
@@ -70,4 +70,25 @@ describe('Handsontable editor theme handling', () => {
     expect($(getActiveEditor().htEditor.rootElement).hasClass('ht-theme-sth-else')).toBe(true);
     expect(getActiveEditor().htEditor.getCurrentThemeName()).toBe('ht-theme-sth-else');
   });
+
+  it('should not throw an exception after changing a theme for non-fully-initialized editor (#dev-2157)', () => {
+    simulateModernThemeStylesheet(spec().$container);
+    handsontable({
+      columns: [
+        {
+          type: 'handsontable',
+          handsontable: {
+            colHeaders: ['Marque', 'Country', 'Parent company'],
+            data: getManufacturerData()
+          }
+        }
+      ],
+    });
+
+    selectCell(0, 0);
+
+    expect(() => {
+      updateSettings({ themeName: 'ht-theme-sth-else' });
+    }).not.toThrow();
+  });
 });

--- a/handsontable/src/editors/handsontableEditor/handsontableEditor.js
+++ b/handsontable/src/editors/handsontableEditor/handsontableEditor.js
@@ -200,14 +200,12 @@ export class HandsontableEditor extends TextEditor {
    */
   assignHooks() {
     this.hot.addHook('afterDestroy', () => {
-      if (this.htEditor) {
-        this.htEditor.destroy();
-      }
+      this.htEditor?.destroy();
     });
 
     this.hot.addHook('afterSetTheme', (themeName, firstRun) => {
       if (!firstRun) {
-        this.htEditor.useTheme(themeName);
+        this.htEditor?.useTheme(themeName);
       }
     });
   }


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes a bug with an uncaught error that could happen when the theme was changed when the Handsontable, Autocomplete, or Dropdown type editors were not fully initialized. The fix adds a null/undefined check.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the change locally and I covered the fix with a new test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/2157

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
