### PR TITLE
Fix broken scroll on overlays when `batch` is used

### DIFF
--- a/.changelogs/11328.json
+++ b/.changelogs/11328.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed broken scroll on overlays when batch is used",
+  "type": "fixed",
+  "issueOrPR": 11328,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/src/overlays.js
+++ b/handsontable/src/3rdparty/walkontable/src/overlays.js
@@ -364,16 +364,12 @@ class Overlays {
     ];
 
     overlays.forEach((overlay) => {
-      if (overlay && overlay.needFullRender) {
-        const { holder } = overlay.clone.wtTable; // todo rethink, maybe: overlay.getHolder()
-
-        this.eventManager.addEventListener(
-          holder,
-          'wheel',
-          event => this.onCloneWheel(event, preventWheel),
-          wheelEventOptions
-        );
-      }
+      this.eventManager.addEventListener(
+        overlay.clone.wtTable.holder,
+        'wheel',
+        event => this.onCloneWheel(event, preventWheel),
+        wheelEventOptions
+      );
     });
 
     let resizeTimeout;
@@ -393,13 +389,6 @@ class Overlays {
     if (!isScrollOnWindow) {
       this.resizeObserver.observe(this.wtTable.wtRootElement.parentElement);
     }
-  }
-
-  /**
-   * Deregister all previously registered listeners.
-   */
-  deregisterListeners() {
-    this.eventManager.clearEvents(true);
   }
 
   /**
@@ -594,36 +583,12 @@ class Overlays {
   }
 
   /**
-   * Update the main scrollable elements for all the overlays.
-   */
-  updateMainScrollableElements() {
-    this.deregisterListeners();
-
-    this.inlineStartOverlay.updateMainScrollableElement();
-    this.topOverlay.updateMainScrollableElement();
-
-    if (this.bottomOverlay.needFullRender) {
-      this.bottomOverlay.updateMainScrollableElement();
-    }
-    const { wtTable } = this;
-    const { rootWindow } = this.domBindings;
-
-    if (rootWindow.getComputedStyle(wtTable.wtRootElement.parentNode).getPropertyValue('overflow') === 'hidden') {
-      this.scrollableElement = wtTable.holder;
-    } else {
-      this.scrollableElement = getScrollableElement(wtTable.TABLE);
-    }
-
-    this.registerListeners();
-  }
-
-  /**
    *
    */
   destroy() {
     this.resizeObserver.disconnect();
     this.eventManager.destroy();
-    // todo, probably all below `destory` calls has no sense. To analyze
+    // todo, probably all below `destroy` calls has no sense. To analyze
     this.topOverlay.destroy();
 
     if (this.bottomOverlay.clone) {

--- a/handsontable/src/3rdparty/walkontable/test/helpers/common.js
+++ b/handsontable/src/3rdparty/walkontable/test/helpers/common.js
@@ -113,6 +113,41 @@ export function walkontable(options, table) {
 }
 
 /**
+ * @returns {Overlay} Returns the table's overlay instance.
+ */
+export function topOverlay() {
+  return wot().wtOverlays.topOverlay;
+}
+
+/**
+ * @returns {Overlay} Returns the table's overlay instance.
+ */
+export function bottomOverlay() {
+  return wot().wtOverlays.bottomOverlay;
+}
+
+/**
+ * @returns {Overlay} Returns the table's overlay instance.
+ */
+export function topInlineStartCornerOverlay() {
+  return wot().wtOverlays.topInlineStartCornerOverlay;
+}
+
+/**
+ * @returns {Overlay} Returns the table's overlay instance.
+ */
+export function inlineStartOverlay() {
+  return wot().wtOverlays.inlineStartOverlay;
+}
+
+/**
+ * @returns {Overlay} Returns the table's overlay instance.
+ */
+export function bottomInlineStartCornerOverlay() {
+  return wot().wtOverlays.bottomInlineStartCornerOverlay;
+}
+
+/**
  * Creates the new data into an object returned by "spec()" function.
  *
  * @param {number} [rows=100] The number of rows to generate.

--- a/handsontable/src/3rdparty/walkontable/test/spec/overlay.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/overlay.spec.js
@@ -930,4 +930,62 @@ describe('WalkontableOverlay', () => {
       wtOverlaysRef.wtTable
     ]);
   });
+
+  it('should attach the `wheel` event to each overlay even if they are disabled (#dev-512)', () => {
+    const wt = walkontable({
+      data: getData,
+      totalRows: getTotalRows,
+      totalColumns: getTotalColumns,
+      fixedColumnsStart: 0,
+      fixedRowsTop: 0,
+      fixedRowsBottom: 0,
+    });
+
+    wt.draw();
+
+    inlineStartOverlay().clone.wtTable.holder
+      .dispatchEvent(new WheelEvent('wheel', {
+        deltaX: 50,
+        deltaY: 60,
+      }));
+
+    expect(inlineStartOverlay().getScrollPosition()).toBe(50);
+    expect(topOverlay().getScrollPosition()).toBe(60);
+
+    topInlineStartCornerOverlay().clone.wtTable.holder
+      .dispatchEvent(new WheelEvent('wheel', {
+        deltaX: 50,
+        deltaY: 60,
+      }));
+
+    expect(inlineStartOverlay().getScrollPosition()).toBe(100);
+    expect(topOverlay().getScrollPosition()).toBe(120);
+
+    topOverlay().clone.wtTable.holder
+      .dispatchEvent(new WheelEvent('wheel', {
+        deltaX: 50,
+        deltaY: 60,
+      }));
+
+    expect(inlineStartOverlay().getScrollPosition()).toBe(150);
+    expect(topOverlay().getScrollPosition()).toBe(180);
+
+    bottomInlineStartCornerOverlay().clone.wtTable.holder
+      .dispatchEvent(new WheelEvent('wheel', {
+        deltaX: 50,
+        deltaY: 60,
+      }));
+
+    expect(inlineStartOverlay().getScrollPosition()).toBe(200);
+    expect(topOverlay().getScrollPosition()).toBe(240);
+
+    bottomOverlay().clone.wtTable.holder
+      .dispatchEvent(new WheelEvent('wheel', {
+        deltaX: 50,
+        deltaY: 60,
+      }));
+
+    expect(inlineStartOverlay().getScrollPosition()).toBe(250);
+    expect(topOverlay().getScrollPosition()).toBe(300);
+  });
 });

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -2618,11 +2618,6 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
       instance.view.render();
       instance.view._wt.wtOverlays.adjustElementsSize();
     }
-
-    if (!init && instance.view && (currentHeight === '' || height === '' || height === undefined) &&
-        currentHeight !== height) {
-      instance.view._wt.wtOverlays.updateMainScrollableElements();
-    }
   };
 
   /**

--- a/handsontable/test/e2e/core/batch.spec.js
+++ b/handsontable/test/e2e/core/batch.spec.js
@@ -14,7 +14,7 @@ describe('Core.batch', () => {
 
   it('should batch multi-line operations into one render and execution call', async() => {
     const hot = handsontable({
-      data: Handsontable.helper.createSpreadsheetData(5, 5),
+      data: createSpreadsheetData(5, 5),
       autoColumnSize: false,
       autoRowSize: false,
     });
@@ -76,7 +76,7 @@ describe('Core.batch', () => {
 
   it('should batch showing/hiding headers correctly', () => {
     const hot = handsontable({
-      data: Handsontable.helper.createSpreadsheetData(5, 5),
+      data: createSpreadsheetData(5, 5),
       colHeaders: false,
       rowHeaders: false,
     });
@@ -119,7 +119,7 @@ describe('Core.batch', () => {
 
   it('should batch adjusting fixed headers correctly', () => {
     const hot = handsontable({
-      data: Handsontable.helper.createSpreadsheetData(5, 5),
+      data: createSpreadsheetData(5, 5),
       fixedRowsTop: 0,
       fixedColumnsStart: 0,
       fixedRowsBottom: 0,


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the overlay scroll event that was not attached when the `updateSettings` was called in the `batch`.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and I covered the fix with a new test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/512

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
