### PR TITLE
Modify the README entries for `/handsontable` and the root directory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ You can also use [Yarn](https://yarnpkg.com/package/handsontable), [NuGet](https
     </head>
     <body>
       <div id="handsontable-grid" class="ht-theme-main"></div>
-      <script src="https://cdn.jsdelivr.net/gh/handsontable/handsontable/dist/handsontable.full.min.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/handsontable/dist/handsontable.full.min.js"></script>
       <script>
         const element = document.getElementById("handsontable-grid");
   

--- a/handsontable/README.md
+++ b/handsontable/README.md
@@ -144,7 +144,7 @@ You can also use [Yarn](https://yarnpkg.com/package/handsontable), [NuGet](https
     </head>
     <body>
       <div id="handsontable-grid" class="ht-theme-main"></div>
-      <script src="https://cdn.jsdelivr.net/gh/handsontable/handsontable/dist/handsontable.full.min.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/handsontable/dist/handsontable.full.min.js"></script>
       <script>
         const element = document.getElementById("handsontable-grid");
   


### PR DESCRIPTION
### Context
This PR fixes the handsontable URL in the "CDN-based" section of `README.md` and `/handsontable/README.md`.

[skip changelog]

