### PR TITLE
Temporarily remove `StrictMode` and add a div with a theme class name to the React's Stackblitz examples.

### DIFF
--- a/docs/.vuepress/code-structure-builder/buildReactBody.js
+++ b/docs/.vuepress/code-structure-builder/buildReactBody.js
@@ -103,9 +103,9 @@ const rootElement = document.getElementById("root");
 const root = createRoot(rootElement);
 
 root.render(
-  <StrictMode>
+  <div class="ht-theme-main">
     <ExampleComponent />
-  </StrictMode>
+  </div>
 );`
         },
         [`src/ExampleComponent.${lang}`]: {

--- a/docs/.vuepress/code-structure-builder/buildReactBody.js
+++ b/docs/.vuepress/code-structure-builder/buildReactBody.js
@@ -103,7 +103,7 @@ const rootElement = document.getElementById("root");
 const root = createRoot(rootElement);
 
 root.render(
-  <div class="ht-theme-main">
+  <div class="ht-theme-main-dark-auto">
     <ExampleComponent />
   </div>
 );`


### PR DESCRIPTION
### Context
As reported in https://github.com/handsontable/dev-handsontable/issues/2167, currently the React's Stackblitz examples from the docs don't assign the themes correctly.

As it seems to be caused by the React dev mode's double effect triggering, as a temporary measure, this PR removes the `<StrictMode>` tag from them, replacing it with a `div` with a theme-based class name.

I don't think this should be merged to `develop` as hopefully by the time `15.1` is released, this workaround should no longer be needed (and should be replaced by whatever's at `develop`).

 [skip changelog]

### How has this been tested?
Tested locally.

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2167
