### PR TITLE
Prevent clearing of the applied theme after calling `updateSettings` with `themeName` set to the currently applied theme name.

### DIFF
--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -2592,7 +2592,11 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
         const currentThemeName = instance.getCurrentThemeName();
         const themeNameOptionExists = hasOwnProperty(settings, 'themeName');
 
-        if (currentThemeName && themeNameOptionExists) {
+        if (
+          currentThemeName &&
+          themeNameOptionExists &&
+          currentThemeName !== settings.themeName
+        ) {
           instance.view.getStylesHandler().removeClassNames();
           instance.view.removeClassNameFromLicenseElement(currentThemeName);
         }

--- a/handsontable/test/e2e/Core_update.spec.js
+++ b/handsontable/test/e2e/Core_update.spec.js
@@ -681,6 +681,15 @@ describe('Core_updateSettings', () => {
       expect(hot.getCurrentThemeName()).toBe('ht-theme-sth');
       expect(spec().$container.hasClass('ht-theme-sth')).toBe(true);
 
+      // `updateSettings` calls with the theme name provided as the same that's currently applied should not change the theme
+      hot.updateSettings({
+        themeName: 'ht-theme-sth'
+      });
+
+      expect(hot.view.getStylesHandler().isClassicTheme()).toBe(false);
+      expect(hot.getCurrentThemeName()).toBe('ht-theme-sth');
+      expect(spec().$container.hasClass('ht-theme-sth')).toBe(true);
+
       // Calling `updateSettings` with `themeName` defined to `undefined` or `false` should
       // switch HOT back to the classic theme.
       hot.updateSettings({


### PR DESCRIPTION
### Context
In `15.0.0`, calling `updateSettings` with `themeName` set to the currently applied `themeName` clears the theme class from the root element, thus, in some scenarios. removing the theme from the table.

This is most noticeable in `@handsontable/react-wrapper` with the strict mode during development (the effect hooks are called twice then).

This PR prevents removing the theme class names from the root elements if the updated theme names is the same as the one that's currently applied.

### How has this been tested?
Tested manually + extended a test case.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#2167

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [x] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
