### PR TITLE
[docs] Copy the theme class to the html layout of the stackblitz examples.

### DIFF
--- a/docs/.vuepress/code-structure-builder/buildReactBody.js
+++ b/docs/.vuepress/code-structure-builder/buildReactBody.js
@@ -1,4 +1,4 @@
-const buildReactBody = ({ js, css, version, hyperformulaVersion, preset, sandbox, lang }) => {
+const buildReactBody = ({ js, css, version, hyperformulaVersion, themeName, preset, sandbox, lang }) => {
   const addReduxDependencies = preset.includes('redux')
     ? `
     "redux": "^4.0.0",
@@ -85,7 +85,7 @@ const buildReactBody = ({ js, css, version, hyperformulaVersion, preset, sandbox
 
   <body>
     <noscript> You need to enable JavaScript to run this app. </noscript>
-    <div id="root"></div>
+    <div id="root" class="${themeName}"></div>
   </body>
 </html>
 `
@@ -170,7 +170,7 @@ ${js}`
 
   <body>
     <noscript> You need to enable JavaScript to run this app. </noscript>
-    <div id="root"></div>
+    <div id="root" class="${themeName}"></div>
   </body>
 </html>
 `

--- a/docs/.vuepress/code-structure-builder/getBody.js
+++ b/docs/.vuepress/code-structure-builder/getBody.js
@@ -8,7 +8,7 @@ const { buildVueBody } = require('./buildVueBody');
 const getBody = ({ id, html, js, css, docsVersion, preset, sandbox, lang }) => {
   const version = formatVersion(docsVersion);
   const hyperformulaVersion = '^2.4.0';
-  const themeName = html.match(/(ht-theme-([a-zA-Z])*)/)?.[0] || '';
+  const themeName = html.match(/class="[^"]*(ht-theme-[^"\s]*)[^"]*"/)?.[1] || '';
 
   if (/hot(-.*)?/.test(preset)) {
     return buildJavascriptBody({

--- a/docs/.vuepress/code-structure-builder/getBody.js
+++ b/docs/.vuepress/code-structure-builder/getBody.js
@@ -8,6 +8,7 @@ const { buildVueBody } = require('./buildVueBody');
 const getBody = ({ id, html, js, css, docsVersion, preset, sandbox, lang }) => {
   const version = formatVersion(docsVersion);
   const hyperformulaVersion = '^2.4.0';
+  const themeName = html.match(/(ht-theme-([a-zA-Z])*)/)?.[0] || '';
 
   if (/hot(-.*)?/.test(preset)) {
     return buildJavascriptBody({
@@ -26,6 +27,7 @@ const getBody = ({ id, html, js, css, docsVersion, preset, sandbox, lang }) => {
       css,
       version,
       hyperformulaVersion,
+      themeName,
       preset,
       sandbox,
       lang: lang === 'JavaScript' ? 'jsx' : 'tsx'


### PR DESCRIPTION
### Context
This PR serves as a continuation of handsontable/dev-handsontable#2167.

- It copies the themes class name used in the JSFiddle examples to the Stackblitz examples' HTML layout
- Can be deployed on the current (`15.0`) docs instead of the [previous workaround](https://github.com/handsontable/handsontable/pull/11340). As it uses a class name method of applying the theme, React's strict mode should not impact the result negatively.

[skip changelog]

### How has this been tested?
Tested locally.

### Related issue(s):
1. handsontable/dev-handsontable#2167
