### PR TITLE
Add the `TAB` and `SHIFT+TAB` functionality to the Comments editor.

### DIFF
--- a/.changelogs/11345.json
+++ b/.changelogs/11345.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Added the `TAB` and `SHIFT + TAB` functionality to the Comments editor.",
+  "type": "added",
+  "issueOrPR": 11345,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/comments/__tests__/keyboardShortcuts.spec.js
+++ b/handsontable/src/plugins/comments/__tests__/keyboardShortcuts.spec.js
@@ -322,4 +322,68 @@ describe('Comments keyboard shortcut', () => {
       expect(getCellMeta(1, 1).comment.value).toBe('Hello world!');
     });
   });
+
+  describe('"TAB"', () => {
+    it('should close the comment without saving the value and move the selection to the next cell (grid default for TAB)',
+      async() => {
+        handsontable({
+          data: createSpreadsheetData(4, 4),
+          rowHeaders: true,
+          colHeaders: true,
+          comments: true,
+        });
+
+        selectCell(1, 1);
+        keyDownUp(['control', 'alt', 'm']);
+
+        await sleep(50);
+
+        const plugin = getPlugin('comments');
+        const commentsInput = plugin.getEditorInputElement();
+
+        expect(commentsInput.parentNode.style.display).toEqual('block');
+        commentsInput.value = 'Test comment';
+
+        keyDownUp(['TAB']);
+
+        await sleep(50);
+
+        expect(getCellMeta(1, 1).comment).toEqual({ value: '' });
+        expect(commentsInput.parentNode.style.display).toEqual('none');
+        expect(getSelectedLast()).toEqual([1, 2, 1, 2]);
+        expect(document.activeElement).toBe(getCell(1, 2));
+      });
+  });
+
+  describe('"Shift + TAB"', () => {
+    it('should close the comment without saving the value and move the selection to the next cell (grid default for TAB)',
+      async() => {
+        handsontable({
+          data: createSpreadsheetData(4, 4),
+          rowHeaders: true,
+          colHeaders: true,
+          comments: true,
+        });
+
+        selectCell(1, 1);
+        keyDownUp(['control', 'alt', 'm']);
+
+        await sleep(50);
+
+        const plugin = getPlugin('comments');
+        const commentsInput = plugin.getEditorInputElement();
+
+        expect(commentsInput.parentNode.style.display).toEqual('block');
+        commentsInput.value = 'Test comment';
+
+        keyDownUp(['SHIFT', 'TAB']);
+
+        await sleep(50);
+
+        expect(getCellMeta(1, 1).comment).toEqual({ value: '' });
+        expect(commentsInput.parentNode.style.display).toEqual('none');
+        expect(getSelectedLast()).toEqual([1, 0, 1, 0]);
+        expect(document.activeElement).toBe(getCell(1, 0));
+      });
+  });
 });

--- a/handsontable/src/plugins/comments/comments.js
+++ b/handsontable/src/plugins/comments/comments.js
@@ -9,7 +9,6 @@ import {
 import { stopImmediatePropagation } from '../../helpers/dom/event';
 import { deepClone, deepExtend } from '../../helpers/object';
 import { BasePlugin } from '../base';
-import { GRID_GROUP } from '../../shortcutContexts';
 import CommentEditor from './commentEditor';
 import DisplaySwitch from './displaySwitch';
 import { SEPARATOR } from '../contextMenu/predefinedItems';

--- a/handsontable/src/plugins/comments/comments.js
+++ b/handsontable/src/plugins/comments/comments.js
@@ -301,6 +301,7 @@ export class Comments extends BasePlugin {
       callback: (_, keys) => {
         this.#editor.setValue(this.#commentValueBeforeSave);
         this.hide();
+
         manager.setActiveContextName('grid');
 
         // Use the grid's default callback.

--- a/handsontable/src/plugins/comments/comments.js
+++ b/handsontable/src/plugins/comments/comments.js
@@ -9,6 +9,7 @@ import {
 import { stopImmediatePropagation } from '../../helpers/dom/event';
 import { deepClone, deepExtend } from '../../helpers/object';
 import { BasePlugin } from '../base';
+import { GRID_GROUP } from '../../shortcutContexts';
 import CommentEditor from './commentEditor';
 import DisplaySwitch from './displaySwitch';
 import { SEPARATOR } from '../contextMenu/predefinedItems';
@@ -292,6 +293,23 @@ export class Comments extends BasePlugin {
         manager.setActiveContextName('grid');
       },
       runOnlyIf: () => this.#editor.isVisible() && this.#editor.isFocused(),
+      group: SHORTCUTS_GROUP,
+    });
+
+    pluginContext.addShortcut({
+      keys: [['SHIFT', 'TAB'], ['TAB']],
+      callback: (_, keys) => {
+        this.#editor.setValue(this.#commentValueBeforeSave);
+        this.hide();
+        manager.setActiveContextName('grid');
+
+        // Use the grid's default callback.
+        gridContext.getShortcuts(keys).filter(
+          shortcut => shortcut.group === GRID_GROUP,
+        ).forEach((shortcut) => {
+          shortcut.callback();
+        });
+      },
       group: SHORTCUTS_GROUP,
     });
   }

--- a/handsontable/src/plugins/comments/comments.js
+++ b/handsontable/src/plugins/comments/comments.js
@@ -297,19 +297,12 @@ export class Comments extends BasePlugin {
     });
 
     pluginContext.addShortcut({
-      keys: [['SHIFT', 'TAB'], ['TAB']],
-      callback: (_, keys) => {
+      keys: [['Shift', 'Tab'], ['Tab']],
+      forwardToContext: manager.getContext('grid'),
+      callback: () => {
         this.#editor.setValue(this.#commentValueBeforeSave);
         this.hide();
-
         manager.setActiveContextName('grid');
-
-        // Use the grid's default callback.
-        gridContext.getShortcuts(keys).filter(
-          shortcut => shortcut.group === GRID_GROUP,
-        ).forEach((shortcut) => {
-          shortcut.callback();
-        });
       },
       group: SHORTCUTS_GROUP,
     });


### PR DESCRIPTION
### Context
This PR adds a <kbd>TAB</kbd> and <Kbd>SHIFT</kbd>+<kbd>TAB</kbd> functionality to the Comments editor.
- <kbd>TAB</kbd> closes the Comments editor, discards the unsaved changes and moves the selection to the next cell
-  <Kbd>SHIFT</kbd>+<kbd>TAB</kbd> closes the Comments editor, discards the unsaved changes and moves the selection to the previous cell

I'm marking this as a feature, as I don't think it was ever present in the Comments plugin.

### How has this been tested?
Tested manually and added two additional test cases.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#2152

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
