### PR TITLE
Fix the `getCellsMeta` method results

### DIFF
--- a/.changelogs/11350.json
+++ b/.changelogs/11350.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed the `getCellsMeta` method results ",
+  "type": "fixed",
+  "issueOrPR": 11350,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/dataMap/metaManager/__tests__/lazyFactoryMap.unit.js
+++ b/handsontable/src/dataMap/metaManager/__tests__/lazyFactoryMap.unit.js
@@ -313,6 +313,21 @@ describe('LazyFactoryMap', () => {
       expect(iterator.next()).toEqual({ done: false, value: 13 });
       expect(iterator.next()).toEqual({ done: true, value: undefined });
     });
+
+    it('should return all values in the collection except that not-obtained yet (non-undefined)', () => {
+      const map = createLazyFactoryMap(index => index / 2);
+
+      map.obtain(10);
+      map.obtain(11);
+
+      map.insert();
+
+      const iterator = map.values();
+
+      expect(iterator.next()).toEqual({ done: false, value: 5 });
+      expect(iterator.next()).toEqual({ done: false, value: 5.5 });
+      expect(iterator.next()).toEqual({ done: true, value: undefined });
+    });
   });
 
   describe('entries()', () => {
@@ -353,6 +368,21 @@ describe('LazyFactoryMap', () => {
       expect(iterator.next()).toEqual({ done: false, value: [11, 6.5] });
       expect(iterator.next()).toEqual({ done: true, value: undefined });
     });
+
+    it('should return all values in the collection except that not-obtained yet (non-undefined)', () => {
+      const map = createLazyFactoryMap(index => index / 2);
+
+      map.obtain(10);
+      map.obtain(11);
+
+      map.insert();
+
+      const iterator = map.entries();
+
+      expect(iterator.next()).toEqual({ done: false, value: [10, 5] });
+      expect(iterator.next()).toEqual({ done: false, value: [11, 5.5] });
+      expect(iterator.next()).toEqual({ done: true, value: undefined });
+    });
   });
 
   describe('Iterator protocol', () => {
@@ -382,6 +412,17 @@ describe('LazyFactoryMap', () => {
 
       // Proof that physical index was changed but data value is still intact.
       expect(Array.from(map)).toEqual([[10, 6], [11, 6.5]]);
+    });
+
+    it('should return all values in the collection except that not-obtained yet (non-undefined)', () => {
+      const map = createLazyFactoryMap(index => index / 2);
+
+      map.obtain(10);
+      map.obtain(11);
+
+      map.insert();
+
+      expect(Array.from(map)).toEqual([[10, 5], [11, 5.5]]);
     });
   });
 });

--- a/handsontable/src/dataMap/metaManager/lazyFactoryMap.js
+++ b/handsontable/src/dataMap/metaManager/lazyFactoryMap.js
@@ -1,4 +1,3 @@
-import { arrayFilter } from '../../helpers/array';
 import { assert, isUnsignedNumber, isNullish } from './utils';
 
 /* eslint-disable jsdoc/require-description-complete-sentence */
@@ -201,7 +200,7 @@ export default class LazyFactoryMap {
    * new data.
    *
    * @param {number} key The key as volatile zero-based index at which to begin inserting space for new data.
-   * @param {number} [amount=1] Ammount of data to insert.
+   * @param {number} [amount=1] Amount of data to insert.
    */
   insert(key, amount = 1) {
     assert(() => (isUnsignedNumber(key) || isNullish(key)), 'Expecting an unsigned number or null/undefined argument.');
@@ -223,7 +222,7 @@ export default class LazyFactoryMap {
    * Removes (soft remove) data from "index" and according to the amount of data.
    *
    * @param {number} key The key as volatile zero-based index at which to begin removing the data.
-   * @param {number} [amount=1] Ammount data to remove.
+   * @param {number} [amount=1] Amount data to remove.
    */
   remove(key, amount = 1) {
     assert(() => (isUnsignedNumber(key) || isNullish(key)), 'Expecting an unsigned number or null/undefined argument.');
@@ -254,7 +253,9 @@ export default class LazyFactoryMap {
    * @returns {Iterator}
    */
   values() {
-    return arrayFilter(this.data, (_, index) => !this.holes.has(index))[Symbol.iterator]();
+    return this.data.filter((meta, index) => {
+      return meta !== undefined && !this.holes.has(index);
+    })[Symbol.iterator]();
   }
 
   /**
@@ -268,7 +269,7 @@ export default class LazyFactoryMap {
     for (let i = 0; i < this.data.length; i++) {
       const keyIndex = this._getKeyByStorageIndex(i);
 
-      if (keyIndex !== -1) {
+      if (keyIndex !== -1 && this.data[i] !== undefined) {
         validEntries.push([keyIndex, this.data[i]]);
       }
     }

--- a/handsontable/src/plugins/hiddenColumns/hiddenColumns.js
+++ b/handsontable/src/plugins/hiddenColumns/hiddenColumns.js
@@ -345,9 +345,7 @@ export class HiddenColumns extends BasePlugin {
    */
   resetCellsMeta() {
     arrayEach(this.hot.getCellsMeta(), (meta) => {
-      if (meta) {
-        meta.skipColumnOnPaste = false;
-      }
+      meta.skipColumnOnPaste = false;
     });
   }
 

--- a/handsontable/src/plugins/hiddenRows/hiddenRows.js
+++ b/handsontable/src/plugins/hiddenRows/hiddenRows.js
@@ -340,9 +340,7 @@ export class HiddenRows extends BasePlugin {
    */
   resetCellsMeta() {
     arrayEach(this.hot.getCellsMeta(), (meta) => {
-      if (meta) {
-        meta.skipRowOnPaste = false;
-      }
+      meta.skipRowOnPaste = false;
     });
   }
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes an issue with the `getCellsMeta` method that, in some cases, could return a meta collection with `undefined` values.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and I covered the fix with new unit tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/2034

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
