### PR TITLE
Fix rows virtualization for Filter's "by value" component

### DIFF
--- a/.changelogs/11351.json
+++ b/.changelogs/11351.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed rows virtualization for Filter's \"by value\" component",
+  "type": "fixed",
+  "issueOrPR": 11351,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/styles/components/plugins/_filters.scss
+++ b/handsontable/src/styles/components/plugins/_filters.scss
@@ -69,7 +69,7 @@
     }
 
     .htUIMultipleSelectHot {
-      --ht-cell-vertical-padding: calc(
+      --ht-cell-horizontal-padding: calc(
               var(--ht-menu-item-horizontal-padding, 2px) +
               var(--ht-gap-size, 2px) * 2);
 
@@ -105,7 +105,7 @@
 
         td {
           height: auto;
-          padding: 4px var(--ht-cell-vertical-padding);
+          padding: 4px var(--ht-cell-horizontal-padding);
         }
       }
     }


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes a typo in the CSS variable name that causes the virtualization not to work properly.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/2161

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
