### PR TITLE
Fix viewport shifting after render call

### DIFF
--- a/.changelogs/11352.json
+++ b/.changelogs/11352.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed columns shifting after render call for new themes",
+  "type": "fixed",
+  "issueOrPR": 11352,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/styles/base/_base.scss
+++ b/handsontable/src/styles/base/_base.scss
@@ -281,7 +281,7 @@
             }
           }
         }
-        
+
         th {
           padding: 0;
 
@@ -452,9 +452,11 @@
       }
     }
 
-    .ht_master:not(.innerBorderInlineStart):not(.emptyColumns) ~ .handsontable {
+    .ht_master:not(.innerBorderInlineStart):not(.emptyColumns) {
       tbody tr th,
-      &:not(.ht_clone_top) thead tr th:first-child {
+      thead tr th:first-child,
+      ~ .handsontable:not(.htGhostTable) tbody tr th,
+      ~ .handsontable:not(.ht_clone_top):not(.htGhostTable) thead tr th:first-child {
         border-inline-end-width: 0;
         border-inline-start-width: 1px;
       }


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR copies the CSS rules from the classic stylesheet to the new one that removes the 1px border after the horizontal scroll is !== 0. Missing that part caused the unintentional viewport shifting after the render call.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/2142

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
