### PR TITLE
Add visual tests for themes

### DIFF
--- a/examples/next/visual-tests/angular/demo/angular.json
+++ b/examples/next/visual-tests/angular/demo/angular.json
@@ -26,14 +26,26 @@
             "polyfills": ["zone.js"],
             "tsConfig": "tsconfig.app.json",
             "aot": true,
-            "styles": [
-              "../node_modules/handsontable/dist/handsontable.full.css"
-            ],
+            "styles": [],
             "scripts": [],
             "preserveSymlinks": true,
             "allowedCommonJsDependencies": [
               "core-js",
               "@handsontable/pikaday"
+            ],
+            "assets": [
+              "src/favicon.ico",
+              "src/assets",
+              {
+                "glob": "*.css",
+                "input": "node_modules/handsontable/dist/",
+                "output": "/assets/handsontable/dist/"
+              },
+              {
+                "glob": "*.css",
+                "input": "node_modules/handsontable/styles/",
+                "output": "/assets/handsontable/styles/"
+              }
             ]
           },
           "configurations": {

--- a/examples/next/visual-tests/angular/demo/src/data-grid/data-grid.component.html
+++ b/examples/next/visual-tests/angular/demo/src/data-grid/data-grid.component.html
@@ -4,7 +4,7 @@
     id="root"
     [data]="dataset"
     height="450"
-    [colWidths]="[140, 192, 100, 90, 90, 110, 97, 100, 126]"
+    [colWidths]="[140, 210, 135, 100, 90, 110, 120, 115, 140]"
     [colHeaders]="colHeaders"
     [rowHeaders]="true"
     [dropdownMenu]="true"
@@ -22,6 +22,7 @@
     [comments]="true"
     [manualColumnMove]="true"
     [customBorders]="true"
+    [themeName]="themeName"
     licenseKey="non-commercial-and-evaluation"
   >
     <hot-column data="1"></hot-column>

--- a/examples/next/visual-tests/angular/demo/src/data-grid/data-grid.component.ts
+++ b/examples/next/visual-tests/angular/demo/src/data-grid/data-grid.component.ts
@@ -1,5 +1,6 @@
 import { Component, ViewEncapsulation, CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
-import { HotTableModule } from '@handsontable/angular';
+import { ActivatedRoute } from "@angular/router";
+import { HotTableModule } from "@handsontable/angular";
 import { getData } from "./utils/constants";
 import { starsRenderer } from "./renderers/stars";
 import { progressBarRenderer } from "./renderers/progressBar";
@@ -40,6 +41,17 @@ export class DataGridComponent {
   hiddenColumns = {
     indicators: true
   };
-  headerClassNameValue = document.documentElement.getAttribute('dir') === 'rtl' ? 'htRight' : 'htLeft';
+  headerClassNameValue = document.documentElement.getAttribute("dir") === "rtl" ? "htRight" : "htLeft";
   licenseKey = "non-commercial-and-evaluation";
+  themeName: string | undefined = undefined;
+
+  constructor(private route: ActivatedRoute) {}
+
+  ngOnInit() {
+    this.route.queryParams.subscribe(params => {
+      if (params["theme"]) {
+        this.themeName = `ht-theme-${params["theme"]}`;
+      }
+    });
+  }
 }

--- a/examples/next/visual-tests/angular/demo/src/data-grid/data-grid.scss
+++ b/examples/next/visual-tests/angular/demo/src/data-grid/data-grid.scss
@@ -1,14 +1,11 @@
-/*
-  A stylesheet customizing app (custom renderers)
-*/
+.handsontable {
+  font-size: 13px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+  'Ubuntu', 'Helvetica Neue', Arial, sans-serif;
+  font-weight: 400;
 
-table.htCore {
-  tr.odd td {
-    background: #fafbff;
-  }
-
-  tr.selected td {
-    background: #edf3fd;
+  .collapsibleIndicator {
+    text-align: center;
   }
 
   td .progressBar {
@@ -19,19 +16,20 @@ table.htCore {
   td.star {
     color: #fcb515;
   }
+
+  table.htCore tr.selected td {
+    background: #edf3fd;
+  }
 }
 
-/*
-  A stylesheet customizing Handsontable style
-*/
+.handsontable.ht-theme-main-dark {
+  table.htCore tr.selected td {
+    background: #081b3d;
+  }
+}
 
-.handsontable {
-  font-size: 13px;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-  'Ubuntu', 'Helvetica Neue', Arial, sans-serif;
-  font-weight: 400;
-
-  .collapsibleIndicator {
-    text-align: center;
+.handsontable.ht-theme-horizon-dark {
+  table.htCore tr.selected td {
+    background: #3a2901;
   }
 }

--- a/examples/next/visual-tests/angular/demo/src/data-grid/utils/hooks-callbacks.ts
+++ b/examples/next/visual-tests/angular/demo/src/data-grid/utils/hooks-callbacks.ts
@@ -61,6 +61,7 @@ export const drawCheckboxInRowHeaders: DrawCheckboxInRowHeaders = function drawC
 
   input.type = "checkbox";
   input.tabIndex = -1;
+  input.classList.add("htCheckboxRendererInput");
 
   if (row >= 0 && this.getDataAtRowProp(row, "0")) {
     input.checked = true;

--- a/examples/next/visual-tests/angular/demo/src/index.html
+++ b/examples/next/visual-tests/angular/demo/src/index.html
@@ -5,7 +5,35 @@
   <title>Handsontable for Angular example</title>
   <base href=".">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <script>
+    (function () {
+      const urlParams = new URLSearchParams(window.location.search);
+      const theme = urlParams.get('theme');
+      const baseLink = document.createElement('link');
+      const themeLink = document.createElement('link');
 
+      baseLink.rel = 'stylesheet';
+      themeLink.rel = 'stylesheet';
+
+      if (theme === 'main' || theme === 'main-dark') {
+        baseLink.href = `/assets/handsontable/styles/handsontable.css`;
+        themeLink.href = `/assets/handsontable/styles/ht-theme-main.css`;
+
+      } else if (theme === 'horizon' || theme === 'horizon-dark') {
+        baseLink.href = `/assets/handsontable/styles/handsontable.css`;
+        themeLink.href = `/assets/handsontable/styles/ht-theme-horizon.css`;
+
+      } else {
+        baseLink.href = `/assets/handsontable/dist/handsontable.full.css`;
+      }
+
+      [baseLink, themeLink].forEach((link) => {
+        if (link.href) {
+          document.head.appendChild(link);
+        }
+      });
+    })();
+  </script>
 </head>
 <body>
   <app-root></app-root>


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR extends the current visual tests to test the same tests but also with themes (horizon, horizon-dark, main, main-dark). 

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2177

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
