### PR TITLE
Update copyright year to 2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,4 +258,4 @@ Created and maintained by the [Handsontable Team](https://handsontable.com/team)
 
 ---
 
-© 2012 - 2024 Handsoncode
+© 2012 - 2025 Handsoncode

--- a/handsontable/README.md
+++ b/handsontable/README.md
@@ -256,4 +256,4 @@ Created and maintained by the [Handsontable Team](https://handsontable.com/team)
 
 ---
 
-© 2012 - 2024 Handsoncode
+© 2012 - 2025 Handsoncode

--- a/wrappers/angular/README.md
+++ b/wrappers/angular/README.md
@@ -230,4 +230,4 @@ Created and maintained by the [Handsontable Team](https://handsontable.com/team)
 
 ---
 
-© 2012 - 2024 Handsoncode
+© 2012 - 2025 Handsoncode

--- a/wrappers/react-wrapper/README.md
+++ b/wrappers/react-wrapper/README.md
@@ -211,4 +211,4 @@ Created and maintained by the [Handsontable Team](https://handsontable.com/team)
 
 ---
 
-© 2012 - 2024 Handsoncode
+© 2012 - 2025 Handsoncode

--- a/wrappers/react/README.md
+++ b/wrappers/react/README.md
@@ -217,4 +217,4 @@ Created and maintained by the [Handsontable Team](https://handsontable.com/team)
 
 ---
 
-© 2012 - 2024 Handsoncode
+© 2012 - 2025 Handsoncode

--- a/wrappers/vue/README.md
+++ b/wrappers/vue/README.md
@@ -227,4 +227,4 @@ Created and maintained by the [Handsontable Team](https://handsontable.com/team)
 
 ---
 
-© 2012 - 2024 Handsoncode
+© 2012 - 2025 Handsoncode

--- a/wrappers/vue3/README.md
+++ b/wrappers/vue3/README.md
@@ -227,4 +227,4 @@ Created and maintained by the [Handsontable Team](https://handsontable.com/team)
 
 ---
 
-© 2012 - 2024 Handsoncode
+© 2012 - 2025 Handsoncode


### PR DESCRIPTION
### Context
This PR includes update for copyright year

### How has this been tested?
Locally

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2176

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] Update copyright year to 2025]

[skip changelog]