### PR TITLE
Update div with theme class name in Readme files

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ You can also use [Yarn](https://yarnpkg.com/package/handsontable), [NuGet](https
       />
     </head>
     <body>
-      <div id="handsontable-grid" class="ht-theme-main"></div>
+      <div id="handsontable-grid" class="ht-theme-main-dark-auto"></div>
       <script src="https://cdn.jsdelivr.net/npm/handsontable/dist/handsontable.full.min.js"></script>
       <script>
         const element = document.getElementById("handsontable-grid");

--- a/handsontable/README.md
+++ b/handsontable/README.md
@@ -143,7 +143,7 @@ You can also use [Yarn](https://yarnpkg.com/package/handsontable), [NuGet](https
       />
     </head>
     <body>
-      <div id="handsontable-grid" class="ht-theme-main"></div>
+      <div id="handsontable-grid" class="ht-theme-main-dark-auto"></div>
       <script src="https://cdn.jsdelivr.net/npm/handsontable/dist/handsontable.full.min.js"></script>
       <script>
         const element = document.getElementById("handsontable-grid");

--- a/wrappers/angular/README.md
+++ b/wrappers/angular/README.md
@@ -130,19 +130,22 @@ export class AppComponent  {
 **Template**
 
 ```html
-<hot-table
-  [data]="data"
-  [rowHeaders]="true"
-  [colHeaders]="true"
-  [navigableHeaders]="true"
-  [tabNavigation]="true"
-  [multiColumnSorting]="true"
-  headerClassName="htLeft"
-  licenseKey="non-commercial-and-evaluation">
+<div class="ht-theme-main-dark-auto">
+  <hot-table
+    [data]="data"
+    [rowHeaders]="true"
+    [colHeaders]="true"
+    [navigableHeaders]="true"
+    [tabNavigation]="true"
+    [multiColumnSorting]="true"
+    headerClassName="htLeft"
+    licenseKey="non-commercial-and-evaluation"
+  >
     <hot-column title="Company" data="company" width=100></hot-column>
     <hot-column title="Country" data="country" width=170 type="dropdown" [source]="['United Kingdom', 'Japan', 'United States']"></hot-column>
     <hot-column title="Rating" data="rating" width=100 type="numeric"></hot-column>
-</hot-table>
+  </hot-table>
+</div>
 ```
 
 [![Static Badge](https://img.shields.io/badge/View%20live%20demo-1a42e8?style=for-the-badge)](https://handsontable.com/docs/javascript-data-grid/angular-basic-example/)

--- a/wrappers/react-wrapper/README.md
+++ b/wrappers/react-wrapper/README.md
@@ -104,24 +104,26 @@ registerAllModules();
 
 const ExampleComponent = () => {
   return (
-    <HotTable
-      data={[
-        { company: 'Tagcat', country: 'United Kingdom', rating: 4.4 },
-        { company: 'Zoomzone', country: 'Japan', rating: 4.5 },
-        { company: 'Meeveo', country: 'United States', rating: 4.6 },
-      ]}
-      rowHeaders={true}
-      colHeaders={true}
-      navigableHeaders={true}
-      tabNavigation={true}
-      multiColumnSorting={true}
-      headerClassName="htLeft"
-      licenseKey="non-commercial-and-evaluation"
-    >
-      <HotColumn title="Company" data="company" width="100"></HotColumn>
-      <HotColumn title="Country" data="country" width="170" type="dropdown" source={['United Kingdom', 'Japan', 'United States']}></HotColumn>
-      <HotColumn title="Rating" data="rating" width="100" type="numeric"></HotColumn>
-    </HotTable>
+    <div class="ht-theme-main-dark-auto">
+      <HotTable
+        data={[
+          { company: 'Tagcat', country: 'United Kingdom', rating: 4.4 },
+          { company: 'Zoomzone', country: 'Japan', rating: 4.5 },
+          { company: 'Meeveo', country: 'United States', rating: 4.6 },
+        ]}
+        rowHeaders={true}
+        colHeaders={true}
+        navigableHeaders={true}
+        tabNavigation={true}
+        multiColumnSorting={true}
+        headerClassName="htLeft"
+        licenseKey="non-commercial-and-evaluation"
+      >
+        <HotColumn title="Company" data="company" width="100"></HotColumn>
+        <HotColumn title="Country" data="country" width="170" type="dropdown" source={['United Kingdom', 'Japan', 'United States']}></HotColumn>
+        <HotColumn title="Rating" data="rating" width="100" type="numeric"></HotColumn>
+      </HotTable>
+    </div>
   );
 };
 ```

--- a/wrappers/react/README.md
+++ b/wrappers/react/README.md
@@ -110,24 +110,26 @@ registerAllModules();
 
 const ExampleComponent = () => {
   return (
-    <HotTable
-      data={[
-        { company: 'Tagcat', country: 'United Kingdom', rating: 4.4 },
-        { company: 'Zoomzone', country: 'Japan', rating: 4.5 },
-        { company: 'Meeveo', country: 'United States', rating: 4.6 },
-      ]}
-      rowHeaders={true}
-      colHeaders={true}
-      navigableHeaders={true}
-      tabNavigation={true}
-      multiColumnSorting={true}
-      headerClassName="htLeft"
-      licenseKey="non-commercial-and-evaluation"
-    >
-      <HotColumn title="Company" data="company" width="100"></HotColumn>
-      <HotColumn title="Country" data="country" width="170" type="dropdown" source={['United Kingdom', 'Japan', 'United States']}></HotColumn>
-      <HotColumn title="Rating" data="rating" width="100" type="numeric"></HotColumn>
-    </HotTable>
+    <div class="ht-theme-main-dark-auto">
+      <HotTable
+        data={[
+          { company: 'Tagcat', country: 'United Kingdom', rating: 4.4 },
+          { company: 'Zoomzone', country: 'Japan', rating: 4.5 },
+          { company: 'Meeveo', country: 'United States', rating: 4.6 },
+        ]}
+        rowHeaders={true}
+        colHeaders={true}
+        navigableHeaders={true}
+        tabNavigation={true}
+        multiColumnSorting={true}
+        headerClassName="htLeft"
+        licenseKey="non-commercial-and-evaluation"
+      >
+        <HotColumn title="Company" data="company" width="100"></HotColumn>
+        <HotColumn title="Country" data="country" width="170" type="dropdown" source={['United Kingdom', 'Japan', 'United States']}></HotColumn>
+        <HotColumn title="Rating" data="rating" width="100" type="numeric"></HotColumn>
+      </HotTable>
+    </div>
   );
 };
 ```

--- a/wrappers/vue/README.md
+++ b/wrappers/vue/README.md
@@ -99,20 +99,22 @@ Use this data grid as you would any other component in your application. [Option
 **Vue Component**
 ```vue
 <template>
-  <hot-table
-    :data="data"
-    :row-headers=true
-    :col-headers=true
-    :navigable-headers=true
-    :tab-navigation=true
-    :multi-column-sorting=true
-    header-class-name="htLeft"
-    license-key="non-commercial-and-evaluation"
-  >
-    <hot-column title="Company" data="company" width=100></hot-column>
-    <hot-column title="Country" data="country" width=170 type="dropdown" :source="['United Kingdom', 'Japan', 'United States']"></hot-column>
-    <hot-column title="Rating" data="rating" width=100 type="numeric"></hot-column>
-  </hot-table>
+  <div class="ht-theme-main-dark-auto">
+    <hot-table
+      :data="data"
+      :row-headers=true
+      :col-headers=true
+      :navigable-headers=true
+      :tab-navigation=true
+      :multi-column-sorting=true
+      header-class-name="htLeft"
+      license-key="non-commercial-and-evaluation"
+    >
+      <hot-column title="Company" data="company" width=100></hot-column>
+      <hot-column title="Country" data="country" width=170 type="dropdown" :source="['United Kingdom', 'Japan', 'United States']"></hot-column>
+      <hot-column title="Rating" data="rating" width=100 type="numeric"></hot-column>
+    </hot-table>
+  </div>
 </template>
 
 <script>

--- a/wrappers/vue3/README.md
+++ b/wrappers/vue3/README.md
@@ -96,20 +96,22 @@ Use this data grid as you would any other component in your application. [Option
 **Vue 3 Component**
 ```vue
 <template>
-  <hot-table
-    :data="data"
-    :row-headers=true
-    :col-headers=true
-    :navigable-headers=true
-    :tab-navigation=true
-    :multi-column-sorting=true
-    header-class-name="htLeft"
-    license-key="non-commercial-and-evaluation"
-  >
-    <hot-column title="Company" data="company" width=100></hot-column>
-    <hot-column title="Country" data="country" width=170 type="dropdown" :source="['United Kingdom', 'Japan', 'United States']"></hot-column>
-    <hot-column title="Rating" data="rating" width=100 type="numeric"></hot-column>
-  </hot-table>
+  <div class="ht-theme-main-dark-auto">
+    <hot-table
+      :data="data"
+      :row-headers=true
+      :col-headers=true
+      :navigable-headers=true
+      :tab-navigation=true
+      :multi-column-sorting=true
+      header-class-name="htLeft"
+      license-key="non-commercial-and-evaluation"
+    >
+      <hot-column title="Company" data="company" width=100></hot-column>
+      <hot-column title="Country" data="country" width=170 type="dropdown" :source="['United Kingdom', 'Japan', 'United States']"></hot-column>
+      <hot-column title="Rating" data="rating" width=100 type="numeric"></hot-column>
+    </hot-table>
+  </div>
 </template>
 
 <script>


### PR DESCRIPTION
### Context
This PR includes changes for class name in Readme file and missing div in frameworks Readme files

### How has this been tested?
Locally

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2179

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] Update class name in readme file from `ht-theme-main` to `ht-theme-main-dark-auto`
- [x] Add missing divs with theme class name to framework Readme files

[skip changelog]