### PR TITLE
Fix autocomplete highlight

### DIFF
--- a/.changelogs/11364.json
+++ b/.changelogs/11364.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fix autocomplete highlight",
+  "type": "fixed",
+  "issueOrPR": 11364,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/styles/components/editors/_dropdown-editor.scss
+++ b/handsontable/src/styles/components/editors/_dropdown-editor.scss
@@ -55,7 +55,7 @@
         }
 
         strong {
-          font-weight: var(--ht-font-weight);
+          font-weight: bold;
           color: inherit;
         }
 

--- a/visual-tests/tests/themes/themes.spec.ts
+++ b/visual-tests/tests/themes/themes.spec.ts
@@ -94,4 +94,20 @@ urls.forEach((url) => {
 
     await tablePage.screenshot({ path: helpers.screenshotMultiUrlPath(testFileName, themeName, '-rtl-dateEditor') });
   });
+
+  testCrossBrowser(`Highlight autocomplete in theme: ${themeName}`, async({ tablePage }) => {
+    await tablePage.goto(url);
+
+    const cell = await selectCell(4, 7);
+
+    await openEditor(cell);
+
+    const cellEditor = tablePage.locator(helpers.findCellEditor());
+
+    await cellEditor.waitFor();
+    await cellEditor.clear();
+    await cellEditor.type('to');
+
+    await tablePage.screenshot({ path: helpers.screenshotMultiUrlPath(testFileName, themeName, '-autoComplete') });
+  });
 });


### PR DESCRIPTION
### Context
This PR includes fix for autocomplete highlight in new themes

### How has this been tested?
Locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2164

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] Fix autocomplete highlight in new themes