### PR TITLE
Add missing theme class name to docs installation pages and fix angular stackblitz angular examples

### DIFF
--- a/docs/.vuepress/code-structure-builder/buildAngularBody.js
+++ b/docs/.vuepress/code-structure-builder/buildAngularBody.js
@@ -82,7 +82,8 @@ const buildAngularBody = ({ html, js, version, hyperformulaVersion }) => {
             "polyfills": ["zone.js"],
             "tsConfig": "tsconfig.app.json",
             "styles": [
-              "node_modules/handsontable/dist/handsontable.full.css"
+              "node_modules/handsontable/styles/handsontable.min.css",
+              "node_modules/handsontable/styles/ht-theme-main.min.css"
             ],
             "scripts": [],
             "preserveSymlinks": true,

--- a/docs/content/guides/getting-started/installation/installation.md
+++ b/docs/content/guides/getting-started/installation/installation.md
@@ -133,7 +133,7 @@ You can also import Handsontable's CSS using a link tag:
 In your HTML, add an empty `div`, which serves as a container for your Handsontable instance.
 
 ```html
-<div id="example"></div>
+<div id="example" class="ht-theme-main-dark-auto"></div>
 ```
 
 ## Initialize your grid
@@ -233,20 +233,22 @@ import { HotTable } from '@handsontable/react-wrapper';
 To set Handsontable's [configuration options](@/guides/getting-started/configuration-options/configuration-options.md), use `HotTable`'s props. For example:
 
 ```jsx
-<HotTable
-  data={[
-    ['', 'Tesla', 'Volvo', 'Toyota', 'Ford'],
-    ['2019', 10, 11, 12, 13],
-    ['2020', 20, 11, 14, 13],
-    ['2021', 30, 15, 12, 13]
-  ]}
-  rowHeaders={true}
-  colHeaders={true}
-  height="auto"
-  autoWrapRow={true}
-  autoWrapCol={true}
-  licenseKey="non-commercial-and-evaluation" // for non-commercial use only
-/>
+<div class="ht-theme-main-dark-auto">
+  <HotTable
+    data={[
+      ['', 'Tesla', 'Volvo', 'Toyota', 'Ford'],
+      ['2019', 10, 11, 12, 13],
+      ['2020', 20, 11, 14, 13],
+      ['2021', 30, 15, 12, 13]
+    ]}
+    rowHeaders={true}
+    colHeaders={true}
+    height="auto"
+    autoWrapRow={true}
+    autoWrapCol={true}
+    licenseKey="non-commercial-and-evaluation" // for non-commercial use only
+  />
+</div>
 ```
 
 ::: tip

--- a/docs/content/guides/integrate-with-angular/angular-installation/angular-installation.md
+++ b/docs/content/guides/integrate-with-angular/angular-installation/angular-installation.md
@@ -71,13 +71,15 @@ You can reduce the size of your bundle by importing and registering only the
 Now, you can use the Handsontable component in your HTML files.
 
 ```html
-<hot-table
-  [colHeaders]="true"
-  [rowHeaders]="true"
-  autoWrapRow={true}
-  autoWrapCol={true}
-  licenseKey="non-commercial-and-evaluation">
-</hot-table>
+<div class="ht-theme-main-dark-auto">
+  <hot-table
+    [colHeaders]="true"
+    [rowHeaders]="true"
+    autoWrapRow={true}
+    autoWrapCol={true}
+    licenseKey="non-commercial-and-evaluation">
+  </hot-table>
+</div>
 ```
 
 ## Related API reference

--- a/docs/content/guides/integrate-with-angular/angular-simple-example/angular/example1.js
+++ b/docs/content/guides/integrate-with-angular/angular-simple-example/angular/example1.js
@@ -8,7 +8,6 @@ import { Component } from '@angular/core';
       <hot-table
         [data]="dataset"
         [colHeaders]="true"
-        [rowHeaders]="true"
         height="auto"
         [autoWrapRow]="true"
         [autoWrapCol]="true"

--- a/docs/content/guides/integrate-with-vue/vue-installation/vue-installation.md
+++ b/docs/content/guides/integrate-with-vue/vue-installation/vue-installation.md
@@ -30,7 +30,9 @@ npm install handsontable @handsontable/vue
 
 ```js
 <template>
-  <hot-table :data="data" :rowHeaders="true" :colHeaders="true"></hot-table>
+  <div class="ht-theme-main-dark-auto">
+    <hot-table :data="data" :rowHeaders="true" :colHeaders="true"></hot-table>
+  </div>
 </template>
 
 <script>

--- a/docs/content/guides/integrate-with-vue3/vue3-installation/vue3-installation.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-installation/vue3-installation.md
@@ -39,7 +39,9 @@ npm install handsontable @handsontable/vue3
 
 ```js
 <template>
-  <hot-table :data="data" :rowHeaders="true" :colHeaders="true"></hot-table>
+  <div class="ht-theme-main-dark-auto">
+    <hot-table :data="data" :rowHeaders="true" :colHeaders="true"></hot-table>
+  </div>
 </template>
 
 <script>


### PR DESCRIPTION
### Context
This PR includes fixes for missing theme wrappers in documentation installation pages and fixes for css imports in stackblitz angular examples

### How has this been tested?
Locally

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2186

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] Add missing theme wrappers in documentation installation pages
- [x] Fix angular examples css imports 

[skip changelog]
