### PR TITLE
Fix golden screenshoots for wrappers

### DIFF
--- a/visual-tests/scripts/run-tests.mjs
+++ b/visual-tests/scripts/run-tests.mjs
@@ -107,8 +107,10 @@ if (isReferenceBranch()) {
   // so we need to make sure the paths are the same
   for (let i = 0; i < WRAPPERS.length; ++i) {
     fse.copySync(
-      path.resolve(`${dirs.screenshots}/${REFERENCE_FRAMEWORK}`),
-      path.resolve(`${dirs.screenshots}/${WRAPPERS[i]}`),
+      path.resolve(`${dirs.screenshots}/${REFERENCE_FRAMEWORK}/chromium`),
+      path.resolve(`${dirs.screenshots}/${WRAPPERS[i]}/chromium`),
       { overwrite: true });
+    // complex demo is skipped for wrappers so remove the directory from golden snapshots
+    fse.removeSync(path.resolve(`${dirs.screenshots}/${WRAPPERS[i]}/chromium/complex-demo`));
   }
 }


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR is a hotfix for https://github.com/handsontable/handsontable/pull/11356, where on the develop branch, wrong screenshots were copied for wrappers, leading to a broken golden snapshot.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
