### PR TITLE
Set visual tests playwright workers to 5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,8 +53,8 @@ jobs:
               - './package-lock.json'
               - './handsontable/hot.config.js'
               - './handsontable/babel.config.js'
-              - '.visual-tests/playwright.config.ts'
-              - '.visual-tests/playwright-cross-browser.config.ts'
+              - './visual-tests/playwright.config.ts'
+              - './visual-tests/playwright-cross-browser.config.ts'
             hot-definition-files: &hot-definition-files
               - './handsontable/base.d.ts'
               - './handsontable/handsontable.d.ts'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,6 +107,8 @@ jobs:
             test-visual:
               - './examples/next/visual-tests/**'
               - './visual-tests/**'
+              - '.visual-tests/playwright.config.ts'
+              - '.visual-tests/playwright-cross-browser.config.ts'
 
   build-handsontable-umd:
     name: "[BUILD] Handsontable: UMD"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,8 @@ jobs:
               - './package-lock.json'
               - './handsontable/hot.config.js'
               - './handsontable/babel.config.js'
+              - '.visual-tests/playwright.config.ts'
+              - '.visual-tests/playwright-cross-browser.config.ts'
             hot-definition-files: &hot-definition-files
               - './handsontable/base.d.ts'
               - './handsontable/handsontable.d.ts'
@@ -107,8 +109,6 @@ jobs:
             test-visual:
               - './examples/next/visual-tests/**'
               - './visual-tests/**'
-              - '.visual-tests/playwright.config.ts'
-              - '.visual-tests/playwright-cross-browser.config.ts'
 
   build-handsontable-umd:
     name: "[BUILD] Handsontable: UMD"

--- a/visual-tests/playwright-cross-browser.config.ts
+++ b/visual-tests/playwright-cross-browser.config.ts
@@ -27,7 +27,7 @@ const config: PlaywrightTestConfig = {
   /* Retry on CI only */
   retries: process.env.CI ? 1 : 0,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  workers: process.env.CI ? 5 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/visual-tests/playwright.config.ts
+++ b/visual-tests/playwright.config.ts
@@ -27,7 +27,7 @@ const config: PlaywrightTestConfig = {
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 2,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  workers: process.env.CI ? 5 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */


### PR DESCRIPTION
### Context
This PR includes changes for visual tests playwright workers ammount

### How has this been tested?
Locally

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2190

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] Set visual tests playwright to use 5 workers

[skip changelog]