### PR TITLE
Bump Hyperformula to v3

### DIFF
--- a/.changelogs/11373.json
+++ b/.changelogs/11373.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Bump Hyperformula to v3",
+  "type": "changed",
+  "issueOrPR": 11373,
+  "breaking": false,
+  "framework": "none"
+}

--- a/docs/content/guides/formulas/formula-calculation/formula-calculation.md
+++ b/docs/content/guides/formulas/formula-calculation/formula-calculation.md
@@ -493,15 +493,15 @@ To find out which HyperFormula version to use, see the table below:
 
 | Handsontable version                                                                    | HyperFormula version                                                        |
 |-----------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
-| [`8.x.x`](https://github.com/handsontable/handsontable/releases/tag/8.0.0) and lower    | No HyperFormula support                                                     
+| [`8.x.x`](https://github.com/handsontable/handsontable/releases/tag/8.0.0) and lower    | No HyperFormula support
 | [`9.x.x`](https://github.com/handsontable/handsontable/releases/tag/9.0.0)              | [`0.6.2`](https://github.com/handsontable/hyperformula/releases/tag/0.6.2)  |
 | [`10.x.x`](https://github.com/handsontable/handsontable/releases/tag/10.0.0)            | [`^1.2.0`](https://github.com/handsontable/hyperformula/releases/tag/1.2.0) |
 | [`11.x.x`](https://github.com/handsontable/handsontable/releases/tag/11.0.0)            | [`^1.2.0`](https://github.com/handsontable/hyperformula/releases/tag/1.2.0) |
 | [`12.x.x`](https://github.com/handsontable/handsontable/releases/tag/12.0.0)            | [`^2.0.0`](https://github.com/handsontable/hyperformula/releases/tag/2.0.0) |
 | [`13.x.x`](https://github.com/handsontable/handsontable/releases/tag/13.0.0)            | [`^2.4.0`](https://github.com/handsontable/hyperformula/releases/tag/2.4.0) |
 | [`14.x.x`](https://github.com/handsontable/handsontable/releases/tag/14.0.0)            | [`^2.4.0`](https://github.com/handsontable/hyperformula/releases/tag/2.4.0) |
-| [`14.3.x - 14.6.x`](https://github.com/handsontable/handsontable/releases/tag/14.3.0)   | [`^2.6.2`](https://github.com/handsontable/hyperformula/releases/tag/2.6.2) |
-| [`15.x.x`](https://github.com/handsontable/handsontable/releases/tag/15.0.0) and higher | [`^2.6.2`](https://github.com/handsontable/hyperformula/releases/tag/2.6.2) |
+| [`14.3.x - 15.0.x`](https://github.com/handsontable/handsontable/releases/tag/14.3.0)   | [`^2.6.2`](https://github.com/handsontable/hyperformula/releases/tag/2.6.2) |
+| [`15.1.x`](https://github.com/handsontable/handsontable/releases/tag/15.1.0) and higher | [`^3.0.0`](https://github.com/handsontable/hyperformula/releases/tag/3.0.0) |
 
 ::: tip
 

--- a/handsontable/.config/development.js
+++ b/handsontable/.config/development.js
@@ -105,12 +105,12 @@ module.exports.create = function create(envArgs) {
       test: /hyperformula/,
       use: [
         {
-          loader: path.resolve(__dirname, 'loader/exports-to-window-loader.js'),
+          loader: path.resolve(__dirname, 'loader/exports-to-window-loader-esm.js'),
           options: {
             globals: {
-              HyperFormula: 'hyperformula',
-            },
-            defaultExport: true
+              moduleToExport: 'HyperFormula',
+              moduleName: 'hyperformula',
+            }
           }
         }
       ]

--- a/handsontable/.config/loader/exports-to-window-loader-esm.js
+++ b/handsontable/.config/loader/exports-to-window-loader-esm.js
@@ -1,0 +1,26 @@
+const loaderUtils = require('loader-utils');
+const FOOTER = '/*** EXPORTS FROM exports-to-window-loader-esm ***/\n';
+const alreadyExported = {};
+
+module.exports = function(content, sourceMap) {
+  if (this.cacheable) {
+    this.cacheable();
+  }
+
+  const query = loaderUtils.getOptions(this) || {};
+  const moduleToExport = query.globals.moduleToExport;
+  const moduleName = query.globals.moduleName;
+
+  if (!alreadyExported[moduleName]) {
+    alreadyExported[moduleName] = true;
+
+    const exports = `
+      import { ${moduleToExport} as moduleToExport } from '${moduleName}';
+
+      window['${moduleToExport}'] = moduleToExport;
+    `;
+    content += `\n\n${FOOTER}${exports}`;
+  }
+
+  return content;
+};

--- a/handsontable/package.json
+++ b/handsontable/package.json
@@ -90,7 +90,7 @@
     "numbro": "2.5.0"
   },
   "optionalDependencies": {
-    "hyperformula": "^2.6.2"
+    "hyperformula": "^3.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -124,7 +124,7 @@
         "webpack-remove-empty-scripts": "^1.0.4"
       },
       "optionalDependencies": {
-        "hyperformula": "^2.6.2"
+        "hyperformula": "^3.0.0"
       }
     },
     "handsontable/.config/plugin/eslint": {
@@ -3190,9 +3190,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
-      "version": "7.26.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.26.5.tgz",
-      "integrity": "sha512-OHqczNm4NTQlW1ghrVY43FPoiRzbmzNVbcgVnMKZN/RQYezHUSdjACjaX50CD3B7UIAjv39+MlsrVDb3v741FA==",
+      "version": "7.26.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.26.6.tgz",
+      "integrity": "sha512-CKW8Vu+uUZneQCPtXmSBUC6NCAUdya26hWCElAWh5mVSlSRsmiCPUUDKb3Z0szng1hiAJa098Hkhg9o4SE35Qw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8534,13 +8534,13 @@
       }
     },
     "node_modules/@sigstore/protobuf-specs": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.3.2.tgz",
-      "integrity": "sha512-c6B0ehIWxMI8wiS/bj6rHMPqeFvngFV7cDU/MY+B16P9Z3Mp9k8L93eYZ7BYzSickzuqAQqAq0V956b3Ju6mLw==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.3.3.tgz",
+      "integrity": "sha512-RpacQhBlwpBWd7KEJsRKcBQalbV28fvkxwTOJIqhIuDysMMaJW47V4OqW30iJB9uRpqOSxxEAQFdr8tTattReQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/@sigstore/sign": {
@@ -9175,9 +9175,9 @@
       "license": "MIT"
     },
     "node_modules/@types/qs": {
-      "version": "6.9.17",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.17.tgz",
-      "integrity": "sha512-rX4/bPcfmvxHDv0XjfJELTTr+iB+tn032nPILqHm5wbthUUUuVtNGGqzhya9XUxjTP8Fpr0qYgSZZKxGY++svQ==",
+      "version": "6.9.18",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.18.tgz",
+      "integrity": "sha512-kK7dgTYDyGqS+e2Q4aK9X3D7q234CIZ1Bv0q/7Z5IwRDoADNU81xXJK/YVyLbLTZCoIwUoDoffFeF+p/eIklAA==",
       "dev": true,
       "license": "MIT"
     },
@@ -11363,6 +11363,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bare-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/bare-buffer/-/bare-buffer-3.0.1.tgz",
+      "integrity": "sha512-QuDV/Wv5k1xsevh24zQwEjlQJuRvt3tUC39VFai6PoJiDIwmISEoc76ZTae4yVcacRBw0HBArrHssV1o3TEKhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "bare": ">=1.13.0"
+      }
+    },
     "node_modules/bare-events": {
       "version": "2.5.4",
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.4.tgz",
@@ -11404,14 +11416,18 @@
       }
     },
     "node_modules/bare-stream": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.6.1.tgz",
-      "integrity": "sha512-eVZbtKM+4uehzrsj49KtCy3Pbg7kO1pJ3SKZ1SFrIH/0pnj9scuGGgUlNDf/7qS8WKtGdiJY5Kyhs/ivYPTB/g==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.6.3.tgz",
+      "integrity": "sha512-AiqV593yTkEU3Lka0Sn+UT8X8U5hZ713RHa5Dg88GtJRite8TeD0oBOESNY6LnaBXTK0LjAW82OVhws+7L4JGA==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "streamx": "^2.21.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-events": "*"
       }
     },
     "node_modules/base": {
@@ -15067,9 +15083,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.80",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.80.tgz",
-      "integrity": "sha512-LTrKpW0AqIuHwmlVNV+cjFYTnXtM9K37OGhpe0ZI10ScPSxqVSryZHIY3WnCS5NSYbBODRTZyhRMS2h5FAEqAw==",
+      "version": "1.5.81",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.81.tgz",
+      "integrity": "sha512-SFsAz1hoR+u1eAWjofSPQnx0InE1QHGUAQ92pqYJPT8GARzmyP1zcEBDBxFFC6okJk2E94Ryfmib4DB8Sc6LBw==",
       "dev": true,
       "license": "ISC"
     },
@@ -15549,9 +15565,9 @@
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
-      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.1.tgz",
+      "integrity": "sha512-BPOBuyUF9QIVhuNLhbToCLHP6+0MHwZ7xLBkPPCZqK4JmpJgGnv10035STzzQwFpqdzNFMB3irvDI63IagvDwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18446,9 +18462,9 @@
       }
     },
     "node_modules/hyperformula": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/hyperformula/-/hyperformula-2.7.1.tgz",
-      "integrity": "sha512-mpVF5zOyNpksZzgTaCQyRAzdC/X43+taz5x1n7zNbs/PUUv0AuLmsy2yfihCr+vihUzN/pk+gXBbOfNpXKOpgA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hyperformula/-/hyperformula-3.0.0.tgz",
+      "integrity": "sha512-fAmwxQnbo405llUZiLcnrQTWA26kmbWZk+Cn58PJrANJ/xHBk7ls0ilcNJRIJdti5Z6AqPVi0hZSKvHLbTYtyQ==",
       "license": "GPL-3.0-only",
       "optional": true,
       "dependencies": {
@@ -28530,9 +28546,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.49",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
-      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.1.tgz",
+      "integrity": "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==",
       "dev": true,
       "funding": [
         {
@@ -28550,7 +28566,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.7",
+        "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -31823,9 +31839,9 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.83.1",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.83.1.tgz",
-      "integrity": "sha512-EVJbDaEs4Rr3F0glJzFSOvtg2/oy2V/YrGFPqPY24UqcLDWcI9ZY5sN+qyO3c/QCZwzgfirvhXvINiJCE/OLcA==",
+      "version": "1.83.4",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.83.4.tgz",
+      "integrity": "sha512-B1bozCeNQiOgDcLd33e2Cs2U60wZwjUUXzh900ZyQF5qUasvMdDZYbQ566LJu7cqR+sAHlAfO6RMkaID5s6qpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -33787,9 +33803,9 @@
       }
     },
     "node_modules/stylelint": {
-      "version": "16.13.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.13.0.tgz",
-      "integrity": "sha512-muxVjMhZB8BrDFSKNva0dmvD2tM0o/szrvuZuXYcAnN9a8nQmbGLqNUOemSgumaCMCPQ+0USYyG3hA5vJjUC1Q==",
+      "version": "16.13.2",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.13.2.tgz",
+      "integrity": "sha512-wDlgh0mRO9RtSa3TdidqHd0nOG8MmUyVKl+dxA6C1j8aZRzpNeEgdhFmU5y4sZx4Fc6r46p0fI7p1vR5O2DZqA==",
       "dev": true,
       "funding": [
         {
@@ -33821,7 +33837,7 @@
         "globby": "^11.1.0",
         "globjoin": "^0.1.4",
         "html-tags": "^3.3.1",
-        "ignore": "^7.0.0",
+        "ignore": "^7.0.1",
         "imurmurhash": "^0.1.4",
         "is-plain-object": "^5.0.0",
         "known-css-properties": "^0.35.0",
@@ -34069,9 +34085,9 @@
       }
     },
     "node_modules/stylelint/node_modules/ignore": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.0.tgz",
-      "integrity": "sha512-lcX8PNQygAa22u/0BysEY8VhaFRzlOkvdlKczDPnJvrkJD1EuqzEky5VYYKM2iySIuaVIDv9N190DfSreSLw2A==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.3.tgz",
+      "integrity": "sha512-bAH5jbK/F3T3Jls4I0SO1hmPR0dKU0a7+SY6n1yzRtG54FLO8d6w/nxLFX2Nb7dBu6cCWXPaAME6cYqFUMmuCA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -37592,9 +37608,9 @@
       }
     },
     "wrappers/angular/node_modules/@angular-devkit/build-angular/node_modules/@types/node": {
-      "version": "22.10.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
-      "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
+      "version": "22.10.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.6.tgz",
+      "integrity": "sha512-qNiuwC4ZDAUNcY47xgaSuS92cjf8JbSUoaKS77bmLG1rU7MlATVSiw/IlrjtIyyskXBZ8KkNfjK/P5na7rgXbQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR bumps Hyperformula to the latest stable version (3.x.x).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/2191

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
