### PR TITLE
Upload screenshots as artifact

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,9 @@ jobs:
               - './package-lock.json'
               - './handsontable/hot.config.js'
               - './handsontable/babel.config.js'
+              - './.github/workflows/test.yml'
+              - './visual-tests/playwright.config.ts'
+              - './visual-tests/playwright-cross-browser.config.ts'
             hot-definition-files: &hot-definition-files
               - './handsontable/base.d.ts'
               - './handsontable/handsontable.d.ts'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -633,6 +633,14 @@ jobs:
       - name: Run visual cross-browser tests
         run: npm run in visual-tests test:cross-browser
 
+      - run: tar -zcf screenshots.tar.gz ./visual-tests/screenshots
+
+      - name: Upload the test results artifact
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # https://github.com/actions/upload-artifact/releases/tag/v4.3.1
+        with:
+          name: visual-tests-screenshots
+          path: screenshots.tar.gz
+
       - name: Upload the screenshot to Argos CI
         env:
           ARGOS_TOKEN: ${{ secrets.ARGOS_TOKEN }}


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR for debug purposes (and not only) uploads the results of the visual tests as artifacts.

_[skip changelog]_

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
