### PR TITLE
Stabilizes the visual tests

### DIFF
--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -78,7 +78,6 @@ const deprecationWarns = new Set();
  * by using React's `ref` feature (read more on the [Instance methods](@/guides/getting-started/react-methods/react-methods.md) page).
  * :::
  *
- *
  * ## How to call a method
  *
  * ::: only-for javascript

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -78,6 +78,7 @@ const deprecationWarns = new Set();
  * by using React's `ref` feature (read more on the [Instance methods](@/guides/getting-started/react-methods/react-methods.md) page).
  * :::
  *
+ *
  * ## How to call a method
  *
  * ::: only-for javascript

--- a/visual-tests/src/test-runner.ts
+++ b/visual-tests/src/test-runner.ts
@@ -47,6 +47,7 @@ const test = baseTest.extend<TestParams>({
       testedPageUrl: page.url(),
     });
 
+    // disable animations and transitions on all testing pages (for consistent screenshots)
     await page.addStyleTag({
       content: `
         *,

--- a/visual-tests/src/test-runner.ts
+++ b/visual-tests/src/test-runner.ts
@@ -47,6 +47,17 @@ const test = baseTest.extend<TestParams>({
       testedPageUrl: page.url(),
     });
 
+    await page.addStyleTag({
+      content: `
+        *,
+        *::before,
+        *::after {
+            animation: none !important;
+            transition: none !important;
+        }
+      `
+    });
+
     stylesToAdd.forEach(item => page.addStyleTag({ path: helpers.cssPath(item) }));
 
     const table = page.locator(helpers.selectors.anyTable).first();

--- a/visual-tests/tests/multi-frameworks/filters/tab-navigation-through-all-components.spec.ts
+++ b/visual-tests/tests/multi-frameworks/filters/tab-navigation-through-all-components.spec.ts
@@ -2,6 +2,10 @@ import { test } from '../../../src/test-runner';
 import { helpers } from '../../../src/helpers';
 import { selectCell, tryToEscapeFromTheComponentsFocus } from '../../../src/page-helpers';
 
+test.beforeEach(async({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 980 });
+});
+
 /**
  * Checks whether pressing the Tab moves the focus forward within the filter's components.
  */


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR stabilizes the visual tests by adjusting the viewport size for some tests - to make sure that the whole component is captured, and disables all transitions and animations for all tested demo pages.

Part of https://github.com/handsontable/dev-handsontable/issues/2193

_[skip changelog]_

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
