### PR TITLE
Remove filters active class name from parent elements in the nestedHeaders

### DIFF
--- a/.changelogs/11381.json
+++ b/.changelogs/11381.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Remove filters active class name from parent elements in the nestedHeaders",
+  "type": "fixed",
+  "issueOrPR": 11381,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/filters/filters.js
+++ b/handsontable/src/plugins/filters/filters.js
@@ -138,7 +138,7 @@ export class Filters extends BasePlugin {
   constructor(hotInstance) {
     super(hotInstance);
     // One listener for the enable/disable functionality
-    this.hot.addHook('afterGetColHeader', (col, TH) => this.#onAfterGetColHeader(col, TH));
+    this.hot.addHook('afterGetColHeader', (col, TH, headerLevel) => this.#onAfterGetColHeader(col, TH, headerLevel));
   }
 
   /**
@@ -857,14 +857,17 @@ export class Filters extends BasePlugin {
    *
    * @param {number} col Visual column index.
    * @param {HTMLTableCellElement} TH Header's TH element.
+   * @param {number} headerLevel The index of header level counting from the top (positive
+   *                             values counting from 0 to N).
+   *
    */
-  #onAfterGetColHeader(col, TH) {
+  #onAfterGetColHeader(col, TH, headerLevel) {
     const physicalColumn = this.hot.toPhysicalColumn(col);
 
     if (
       this.enabled
       && this.conditionCollection.hasConditions(physicalColumn)
-      && TH.querySelector('.changeType')
+      && headerLevel === (this.hot.getSettings().nestedHeaders?.length || 1) - 1
     ) {
       addClass(TH, 'htFiltersActive');
     } else {

--- a/handsontable/src/plugins/filters/filters.js
+++ b/handsontable/src/plugins/filters/filters.js
@@ -138,7 +138,7 @@ export class Filters extends BasePlugin {
   constructor(hotInstance) {
     super(hotInstance);
     // One listener for the enable/disable functionality
-    this.hot.addHook('afterGetColHeader', (col, TH, headerLevel) => this.#onAfterGetColHeader(col, TH, headerLevel));
+    this.hot.addHook('afterGetColHeader', (...args) => this.#onAfterGetColHeader(...args));
   }
 
   /**

--- a/handsontable/src/plugins/filters/filters.js
+++ b/handsontable/src/plugins/filters/filters.js
@@ -861,7 +861,11 @@ export class Filters extends BasePlugin {
   #onAfterGetColHeader(col, TH) {
     const physicalColumn = this.hot.toPhysicalColumn(col);
 
-    if (this.enabled && this.conditionCollection.hasConditions(physicalColumn)) {
+    if (
+      this.enabled
+      && this.conditionCollection.hasConditions(physicalColumn)
+      && TH.querySelector('.changeType')
+    ) {
       addClass(TH, 'htFiltersActive');
     } else {
       removeClass(TH, 'htFiltersActive');

--- a/handsontable/src/plugins/filters/filters.js
+++ b/handsontable/src/plugins/filters/filters.js
@@ -867,7 +867,7 @@ export class Filters extends BasePlugin {
     if (
       this.enabled
       && this.conditionCollection.hasConditions(physicalColumn)
-      && headerLevel === (this.hot.getSettings().nestedHeaders?.length || 1) - 1
+      && headerLevel === this.hot.view.getColumnHeadersCount() - 1
     ) {
       addClass(TH, 'htFiltersActive');
     } else {

--- a/visual-tests/tests/multi-frameworks/filters/apply-active-class-name-header.spec.ts
+++ b/visual-tests/tests/multi-frameworks/filters/apply-active-class-name-header.spec.ts
@@ -1,0 +1,29 @@
+import { test } from '../../../src/test-runner';
+import { helpers } from '../../../src/helpers';
+import { selectCell } from '../../../src/page-helpers';
+
+/**
+ * Checks if active class is applied on the filtered column header.
+ */
+test(__filename, async({ tablePage }) => {
+  const cell = await selectCell(0, 2);
+
+  await cell.click();
+  await tablePage.keyboard.press('Alt+Shift+ArrowDown'); // trigger the dropdown menu to show up
+  await tablePage.keyboard.press('Tab');
+  await tablePage.keyboard.press('Enter'); // open the filter
+  await tablePage.keyboard.press('ArrowDown');
+  await tablePage.keyboard.press('ArrowDown');
+  await tablePage.keyboard.press('Enter'); // select the filter
+  await tablePage.keyboard.press('Tab');
+  await tablePage.keyboard.press('Tab');
+  await tablePage.keyboard.press('Tab');
+  await tablePage.keyboard.press('Tab');
+  await tablePage.keyboard.press('Tab');
+  await tablePage.keyboard.press('Tab');
+  await tablePage.keyboard.press('Tab');
+  await tablePage.keyboard.press('Enter'); // apply the filter
+
+  // take a screenshot of the dropdown menu
+  await tablePage.screenshot({ path: helpers.screenshotPath() });
+});

--- a/visual-tests/tests/multi-frameworks/filters/apply-active-class-name-nested-header.spec.ts
+++ b/visual-tests/tests/multi-frameworks/filters/apply-active-class-name-nested-header.spec.ts
@@ -5,7 +5,7 @@ import { selectCell } from '../../../src/page-helpers';
 /**
  * Checks if active class is applied on the filtered column header with nested headers.
  */
-test(__filename, async({ tablePage, goto }) => {
+test(__filename, async({ goto, tablePage }) => {
   await goto(
     helpers
       .setBaseUrl('/nested-headers-demo')

--- a/visual-tests/tests/multi-frameworks/filters/apply-active-class-name-nested-header.spec.ts
+++ b/visual-tests/tests/multi-frameworks/filters/apply-active-class-name-nested-header.spec.ts
@@ -2,6 +2,12 @@ import { test } from '../../../src/test-runner';
 import { helpers } from '../../../src/helpers';
 import { selectCell } from '../../../src/page-helpers';
 
+test.beforeEach(async({ page }) => {
+  await page.setViewportSize({ width: 1920, height: 1080 });
+});
+
+test.skip(helpers.hotWrapper !== 'js', 'This test case is only for JavaScript framework');
+
 /**
  * Checks if active class is applied on the filtered column header with nested headers.
  */

--- a/visual-tests/tests/multi-frameworks/filters/apply-active-class-name-nested-header.spec.ts
+++ b/visual-tests/tests/multi-frameworks/filters/apply-active-class-name-nested-header.spec.ts
@@ -1,0 +1,35 @@
+import { test } from '../../../src/test-runner';
+import { helpers } from '../../../src/helpers';
+import { selectCell } from '../../../src/page-helpers';
+
+/**
+ * Checks if active class is applied on the filtered column header with nested headers.
+ */
+test(__filename, async({ tablePage, goto }) => {
+  await goto(
+    helpers
+      .setBaseUrl('/nested-headers-demo')
+      .getFullUrl()
+  );
+
+  const cell = await selectCell(0, 2);
+
+  await cell.click();
+  await tablePage.keyboard.press('Alt+Shift+ArrowDown'); // trigger the dropdown menu to show up
+  await tablePage.keyboard.press('Tab');
+  await tablePage.keyboard.press('Enter'); // open the filter
+  await tablePage.keyboard.press('ArrowDown');
+  await tablePage.keyboard.press('ArrowDown');
+  await tablePage.keyboard.press('Enter'); // select the filter
+  await tablePage.keyboard.press('Tab');
+  await tablePage.keyboard.press('Tab');
+  await tablePage.keyboard.press('Tab');
+  await tablePage.keyboard.press('Tab');
+  await tablePage.keyboard.press('Tab');
+  await tablePage.keyboard.press('Tab');
+  await tablePage.keyboard.press('Tab');
+  await tablePage.keyboard.press('Enter'); // apply the filter
+
+  // take a screenshot of the dropdown menu
+  await tablePage.screenshot({ path: helpers.screenshotPath() });
+});


### PR DESCRIPTION
### Context
This PR includes fix for `htFiltersActive` class name placement in headers

### How has this been tested?
Locally

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2147

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] Remove `htFiltersActive` class name from nestedHeaders parents