### PR TITLE
Fix filter dropdown focus in docs examples

### DIFF
--- a/docs/.vuepress/theme/styles/components/handsontable.styl
+++ b/docs/.vuepress/theme/styles/components/handsontable.styl
@@ -6,13 +6,6 @@
   font-size: 13px;
   color #222222;
 
-  * { 
-    outline: blue solid 0 !important
-  }
-  *:focus-visible {
-    outline: blue solid 0 !important
-  }
-
   img {
     border-radius: 0 !important
   }


### PR DESCRIPTION
### Context
This PR includes improvements to the focus behavior in dropdown buttons within the documentation examples.

### How has this been tested?
Locally

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2183

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] Fix filter dropdown focus in docs examples

[skip changelog]