### PR TITLE
Remove getComputedStyle from element dom helper type definitions, add breaking change entry to changelog

### DIFF
--- a/docs/content/guides/upgrade-and-migration/changelog/changelog.md
+++ b/docs/content/guides/upgrade-and-migration/changelog/changelog.md
@@ -47,6 +47,7 @@ For more information about this release see:
 
 #### Removed
 - **Breaking change**: Removed check marks from the Context Menu's alignment submenu. [#11278](https://github.com/handsontable/handsontable/pull/11278)
+- **Breaking change**: Removed getComputedStyle from element dom helper. [#11201](https://github.com/handsontable/handsontable/pull/11201)
 - Removed `aria-hidden` from TextEditor's and PasswordEditor's `TEXTAREA` elements.  [#11218](https://github.com/handsontable/handsontable/pull/11218)
 
 #### Fixed

--- a/handsontable/types/helpers/dom/element.d.ts
+++ b/handsontable/types/helpers/dom/element.d.ts
@@ -24,7 +24,6 @@ export function getScrollableElement(element: HTMLElement): HTMLElement;
 export function getTrimmingContainer(base: HTMLElement): HTMLElement;
 export function getStyle(element: HTMLElement, prop: string, rootWindow?: Window): string;
 export function matchesCSSRules(element: Element, rule: CSSRule): boolean;
-export function getComputedStyle(element: HTMLElement, rootWindow?: Window): any;
 export function outerWidth(element: HTMLElement): number;
 export function outerHeight(element: HTMLElement): number;
 export function innerHeight(element: HTMLElement): number;


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Handsontable v15 removed the implementation of getComputedStyle from element dom helper file, causing errors when `Handsontable.dom.getComputedStyle` is being used. This fix is to remove the method from element dom helper type definition file, also add the breaking change to changelog to highlight this.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
`npm run test` all passed

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/11394
2.
3.

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
