### PR TITLE
Fix menu missing initial styles problem

### DIFF
--- a/.changelogs/11400.json
+++ b/.changelogs/11400.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fix menu missing initial styles problem",
+  "type": "fixed",
+  "issueOrPR": 11400,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/contextMenu/menu/menu.js
+++ b/handsontable/src/plugins/contextMenu/menu/menu.js
@@ -678,7 +678,7 @@ export class Menu {
     if (!container) {
       container = doc.createElement('div');
 
-      addClass(container, `htMenu ${this.options.className}`);
+      addClass(container, `htMenu handsontable ${this.options.className}`);
 
       if (className) {
         addClass(container, className);


### PR DESCRIPTION
### Context
This PR includes the missing `handsontable` class on the `htMenu` elements and resolves the issue with missing initial styles in the new themes.

### How has this been tested?
Locally

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2201
2. https://github.com/handsontable/dev-handsontable/issues/2202

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] Fix the menu missing initial styles in the new themes
