### PR TITLE
Fix the manual row move guide backlight offset in the new themes

### DIFF
--- a/.changelogs/11401.json
+++ b/.changelogs/11401.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fix the manual row move guide backlight offset in the new themes",
+  "type": "fixed",
+  "issueOrPR": 11401,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/manualRowMove/manualRowMove.js
+++ b/handsontable/src/plugins/manualRowMove/manualRowMove.js
@@ -538,7 +538,7 @@ export class ManualRowMove extends BasePlugin {
       this.#rowsToMove = this.prepareRowsToMoving();
 
       const leftPos = wtTable.holder.scrollLeft + wtViewport.getRowHeaderWidth();
-      const topOffset = this.getRowsHeight(start, coords.row - 1) + event.offsetY;
+      const topOffset = this.getRowsHeight(start, coords.row - 1) + (event.clientY - TD.getBoundingClientRect().top);
 
       this.#backlight.setPosition(null, leftPos);
       this.#backlight.setSize(wtTable.hider.offsetWidth - leftPos, this.getRowsHeight(start, end));


### PR DESCRIPTION
### Context
This PR includes fix for the manual row move guide backlight offset.

### How has this been tested?
Locally

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2207

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] Fix the manual row move guide backlight offset.
