### PR TITLE
Fix the merge cells selection highlight

### DIFF
--- a/handsontable/src/styles/components/plugins/_merge-cells.scss
+++ b/handsontable/src/styles/components/plugins/_merge-cells.scss
@@ -3,6 +3,14 @@
 // Handsontable Merge Cells
 
 @mixin output {
+  .handsontable tbody td[rowspan][class*=area][class*=highlight]:not([class*=fullySelectedMergedCell])::before {
+    opacity: 0;
+  }
+  
+  .handsontable tbody td[rowspan][class*=area][class*=highlight][class*=fullySelectedMergedCell-multiple]::before {
+    opacity: 0.14;
+  }
+
   @for $i from 0 through 7 {
     @include mixins.selection-opacity($i);
   }


### PR DESCRIPTION
### Context
This PR includes fix for the merge cells selection highlight in new themes

### How has this been tested?
Locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2209

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] Fix the merge cells selection highlight in new themes
