### PR TITLE
[themes] Add the theme class name to the Nested Headers' ghost table helper element.

### DIFF
--- a/.changelogs/11410.json
+++ b/.changelogs/11410.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed a problem with header widths when using Nested Headers with the new themes.",
+  "type": "fixed",
+  "issueOrPR": 11410,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/nestedHeaders/utils/ghostTable.js
+++ b/handsontable/src/plugins/nestedHeaders/utils/ghostTable.js
@@ -78,8 +78,15 @@ class GhostTable {
    * Build cache of the headers widths.
    */
   buildWidthsMap() {
+    const currentThemeName = this.hot.getCurrentThemeName();
+
     this.container = this.hot.rootDocument.createElement('div');
     this.container.classList.add('handsontable', 'htGhostTable', 'htAutoSize');
+
+    if (currentThemeName) {
+      this.container.classList.add(currentThemeName);
+    }
+
     this._buildGhostTable(this.container);
     this.hot.rootDocument.body.appendChild(this.container);
 


### PR DESCRIPTION
### Context
This PR should fix a problem with the header widths when using Nested Headers with the new themes.

The headers after this change:
<img width="820" alt="image" src="https://github.com/user-attachments/assets/5becec72-52fb-4653-9808-873b6566195c" />


### How has this been tested?
Tested manually.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#2213

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
