### PR TITLE
Improve performance of the horizontal scrolling

### DIFF
--- a/.changelogs/11412.json
+++ b/.changelogs/11412.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Improved performance of the horizontal scrolling",
+  "type": "changed",
+  "issueOrPR": 11412,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/src/renderer/cells.js
+++ b/handsontable/src/3rdparty/walkontable/src/renderer/cells.js
@@ -83,7 +83,7 @@ export class CellsRenderer extends BaseRenderer {
       orderView
         .prependView(rowHeadersView)
         .setSize(columnsToRender)
-        .setOffset(this.table.renderedColumnToSource(0))
+        .setOffset(0)
         .start();
 
       for (let visibleColumnIndex = 0; visibleColumnIndex < columnsToRender; visibleColumnIndex++) {

--- a/handsontable/src/3rdparty/walkontable/src/renderer/rowHeaders.js
+++ b/handsontable/src/3rdparty/walkontable/src/renderer/rowHeaders.js
@@ -79,7 +79,7 @@ export class RowHeadersRenderer extends BaseRenderer {
       orderView
         .appendView(cellsView)
         .setSize(rowHeadersCount)
-        .setOffset(this.table.renderedColumnToSource(0))
+        .setOffset(0)
         .start();
 
       for (let visibleColumnIndex = 0; visibleColumnIndex < rowHeadersCount; visibleColumnIndex++) {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR improves horizontal (columns) rendering by limiting the node pool size. The tests show that limiting the node pool size to the viewport size, not the dataset size, speeds up rendering time by up to 25%.

![image](https://github.com/user-attachments/assets/2ade347b-7830-4667-90b8-ac49ec41423b)

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/2215

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
