### PR TITLE
Fix header text overlap in nested headers

### DIFF
--- a/handsontable/src/plugins/nestedHeaders/nestedHeaders.js
+++ b/handsontable/src/plugins/nestedHeaders/nestedHeaders.js
@@ -349,6 +349,7 @@ export class NestedHeaders extends BasePlugin {
 
       TH.removeAttribute('colspan');
       removeClass(TH, 'hiddenHeader');
+      removeClass(TH, 'hiddenHeaderText');
 
       const {
         colspan,
@@ -364,6 +365,11 @@ export class NestedHeaders extends BasePlugin {
         const { wtOverlays } = view._wt;
         const isTopInlineStartOverlay = wtOverlays.topInlineStartCornerOverlay?.clone.wtTable.THEAD.contains(TH);
         const isInlineStartOverlay = wtOverlays.inlineStartOverlay?.clone.wtTable.THEAD.contains(TH);
+        const isTopOverlay = wtOverlays.topOverlay?.clone.wtTable.THEAD.contains(TH);
+
+        if (isTopOverlay && visualColumnIndex < fixedColumnsStart) {
+          addClass(TH, 'hiddenHeaderText');
+        }
 
         // Check if there is a fixed column enabled, if so then reduce colspan to fixed column width.
         const correctedColspan = isTopInlineStartOverlay || isInlineStartOverlay ?

--- a/handsontable/src/styles/components/plugins/_nested-headers.scss
+++ b/handsontable/src/styles/components/plugins/_nested-headers.scss
@@ -5,5 +5,11 @@
     thead th.hiddenHeader:not(:first-of-type) {
       display: none;
     }
+
+    thead th.hiddenHeaderText {
+      .colHeader {
+        opacity: 0;
+      }
+    }
   }
 }


### PR DESCRIPTION
### Context
This PR addresses an issue where header text would overlap when the nested headers plugin is enabled and column is shrinking.

### How has this been tested?
Locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2108

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] Fix header text overlap in nested headers when column is shrinking
