### PR TITLE
Fix merged cell height calculation in the new themes

### DIFF
--- a/.changelogs/11418.json
+++ b/.changelogs/11418.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fix merged cell height calculation in the new themes",
+  "type": "fixed",
+  "issueOrPR": 11418,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/styles/base/_base.scss
+++ b/handsontable/src/styles/base/_base.scss
@@ -71,6 +71,7 @@
         thead {
           th {
             border-bottom-width: 0;
+            line-height: var(--ht-line-height);
           }
         }
 
@@ -79,6 +80,7 @@
             td,
             th {
               border-top-width: 0;
+              line-height: var(--ht-line-height);
             }
           }
         }


### PR DESCRIPTION
### Context
This PR includes fix for ghost table cell height calculation

### How has this been tested?
Locally

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2218

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] Fix merged cell height calculation in the new themes
