### PR TITLE
Remove `getComputedStyle` function declaration from types

### DIFF
--- a/.changelogs/11421.json
+++ b/.changelogs/11421.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Removed `getComputedStyle` function declaration from types",
+  "type": "removed",
+  "issueOrPR": 11421,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/types/helpers/dom/element.d.ts
+++ b/handsontable/types/helpers/dom/element.d.ts
@@ -24,7 +24,6 @@ export function getScrollableElement(element: HTMLElement): HTMLElement;
 export function getTrimmingContainer(base: HTMLElement): HTMLElement;
 export function getStyle(element: HTMLElement, prop: string, rootWindow?: Window): string;
 export function matchesCSSRules(element: Element, rule: CSSRule): boolean;
-export function getComputedStyle(element: HTMLElement, rootWindow?: Window): any;
 export function outerWidth(element: HTMLElement): number;
 export function outerHeight(element: HTMLElement): number;
 export function innerHeight(element: HTMLElement): number;


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR removes the `getComputedStyle` function declaration from types. The function does not exist in the code anymore.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/2206

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
