### PR TITLE
Fix merge cells height calculation, and revert line-height style changes

### DIFF
--- a/.changelogs/11423.json
+++ b/.changelogs/11423.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fix merge cells height calculation, and revert line-height style changes",
+  "type": "fixed",
+  "issueOrPR": 11423,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/mergeCells/mergeCells.js
+++ b/handsontable/src/plugins/mergeCells/mergeCells.js
@@ -1504,6 +1504,7 @@ export class MergeCells extends BasePlugin {
    * @returns {number}
    */
   #sumCellsHeights(row, rowspan) {
+    const stylesHandler = this.hot.view.getStylesHandler();
     const defaultHeight = this.hot.view.getDefaultRowHeight();
     const autoRowSizePlugin = this.hot.getPlugin('autoRowSize');
     let height = 0;
@@ -1511,6 +1512,10 @@ export class MergeCells extends BasePlugin {
     for (let i = row; i < row + rowspan; i++) {
       if (!this.hot.rowIndexMapper.isHidden(i)) {
         height += autoRowSizePlugin?.getRowHeight(i) ?? defaultHeight;
+
+        if (i === 0 && !stylesHandler.isClassicTheme()) {
+          height += 1; // border-top-width
+        }
       }
     }
 

--- a/handsontable/src/styles/base/_base.scss
+++ b/handsontable/src/styles/base/_base.scss
@@ -71,7 +71,6 @@
         thead {
           th {
             border-bottom-width: 0;
-            line-height: var(--ht-line-height);
           }
         }
 
@@ -80,7 +79,6 @@
             td,
             th {
               border-top-width: 0;
-              line-height: var(--ht-line-height);
             }
           }
         }
@@ -291,7 +289,7 @@
           th {
             .relative {
               &::after {
-                bottom: -2px;
+                bottom: 0;
               }
             }
           }
@@ -335,15 +333,6 @@
       td {
         border-top-color: var(--ht-border-color);
         border-top-width: 1px;
-        line-height: calc(var(--ht-line-height) - 2px);
-
-        .rowHeader, .colHeader {
-          line-height: calc(var(--ht-line-height) - 2px);
-        }
-        
-        .colHeader {
-          margin-top: 1px;
-        }
 
         &.ht__active_highlight {
           border-top-color: var(--ht-header-active-border-color);


### PR DESCRIPTION
### Context
This PR includes fixes for merge cells plugin row height calculation, problem with gap between the selected cell at the edge of the viewport and misaligned when editing a cell in the first row.

### How has this been tested?
Locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2219
2. https://github.com/handsontable/dev-handsontable/issues/2220
3. https://github.com/handsontable/dev-handsontable/issues/2208

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] Fix for problem with gap between the selected cell at the edge of the viewport 
- [x] Fix for misaligned when editing a cell in the first row
- [x] Fix for merge cell row height calculation
