### PR TITLE
Fix docs URL build error

### DIFF
--- a/docs/.vuepress/tools/jsdoc-convert/renderer/postProcessors/jsdocReturnsLinksFixer.mjs
+++ b/docs/.vuepress/tools/jsdoc-convert/renderer/postProcessors/jsdocReturnsLinksFixer.mjs
@@ -1,2 +1,2 @@
 export const jsdocReturnsLinksFixer = text => text
-  .replace(/\*\*Returns\*\*: `(Array<\[[^\]]+\]\([^\)]+\)>)`/g, '**Returns**: <code>$1</code>');
+  .replace(/\*\*Returns\*\*: `(Array<\[[^\]]+\]\([^\)]+\)>)`/g, '**Returns**: <code>$1</code>'); // eslint-disable-line no-useless-escape

--- a/docs/.vuepress/tools/jsdoc-convert/renderer/postProcessors/jsdocReturnsLinksFixer.mjs
+++ b/docs/.vuepress/tools/jsdoc-convert/renderer/postProcessors/jsdocReturnsLinksFixer.mjs
@@ -1,0 +1,2 @@
+export const jsdocReturnsLinksFixer = text => text
+  .replace(/\*\*Returns\*\*: `(Array<\[[^\]]+\]\([^\)]+\)>)`/g, '**Returns**: <code>$1</code>');

--- a/docs/.vuepress/tools/jsdoc-convert/renderer/renderer.mjs
+++ b/docs/.vuepress/tools/jsdoc-convert/renderer/renderer.mjs
@@ -13,6 +13,7 @@ import { jsdocLinksFixer } from './postProcessors/jsdocLinksFixer.mjs';
 import { isJsdocPlugin } from './predictors.mjs';
 import { buildHeaderWriter } from './seo.mjs';
 import { removeInternals } from './preProcessors/removeInternals.mjs';
+import { jsdocReturnsLinksFixer } from './postProcessors/jsdocReturnsLinksFixer.mjs';
 
 export const buildRenderer = ({ dist, generateMarkdown, configuration, logger }) =>
   (fileName, members, parsedTypes) => {
@@ -49,6 +50,7 @@ export const buildRenderer = ({ dist, generateMarkdown, configuration, logger })
       ...buildTypesLinkingFixers({ parsedTypes }),
       unescapeRedundant,
       jsdocLinksFixer,
+      jsdocReturnsLinksFixer,
     ]);
 
     const jsdocData = preProcessor(members);


### PR DESCRIPTION
### Context
This PR includes fix for docs URL build in the API "Returns:" part

### How has this been tested?
Locally

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2117

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] Fix getSelectedRange() URL build error

[skip changelog]
