### PR TITLE
Add checkbox input visibility for the no-theme variant

### DIFF
--- a/.changelogs/11427.json
+++ b/.changelogs/11427.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Add checkbox input visibility for the no-theme variant",
+  "type": "fixed",
+  "issueOrPR": 11427,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/styles/base/_base.scss
+++ b/handsontable/src/styles/base/_base.scss
@@ -5,6 +5,8 @@
 @mixin output {
   // Required variables for bare theme
   .ht-wrapper:not([class*="ht-theme"]) {
+    --ht-gap-size: 4px;
+    --ht-checkbox-size: 16px;
     --ht-cell-horizontal-padding: 8px;
     --ht-cell-vertical-padding: 4px;
     --ht-font-size: 14px;

--- a/handsontable/src/styles/components/renderers/_checkbox-renderer.scss
+++ b/handsontable/src/styles/components/renderers/_checkbox-renderer.scss
@@ -12,7 +12,6 @@
       margin: 0;
       vertical-align: middle;
       cursor: pointer;
-      appearance: none;
       margin-top: -2px;
 
       &:first-child {

--- a/handsontable/src/styles/utils/_icons.scss
+++ b/handsontable/src/styles/utils/_icons.scss
@@ -49,6 +49,10 @@
     @include icon($icons, "check");
   }
 
+  .htCheckboxRendererInput {
+    appearance: none;
+  }
+
   .htCheckboxRendererInput::after {
     @include icon($icons, "checkbox");
   }


### PR DESCRIPTION
### Context
This PR includes changes to enable checkbox input visibility for the no-theme variant

### How has this been tested?
Locally

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2222

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] Add checkbox input visibility for the no-theme variant
