### PR TITLE
Fix copy paste for chrome version 133

### DIFF
--- a/.changelogs/11428.json
+++ b/.changelogs/11428.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fix copy paste for chrome version 133",
+  "type": "fixed",
+  "issueOrPR": 11428,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/copyPaste/__tests__/copy.spec.js
+++ b/handsontable/src/plugins/copyPaste/__tests__/copy.spec.js
@@ -342,5 +342,22 @@ describe('CopyPaste', () => {
 
       expect(copyEvent.preventDefault).toHaveBeenCalled();
     });
+
+    it('should not skip processing the event when the target element has not the "data-hot-input" attribute and it\'s a TD element (#dev-2225)', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      const copyEvent = getClipboardEvent();
+      const plugin = getPlugin('CopyPaste');
+
+      spyOn(copyEvent, 'preventDefault');
+
+      selectCell(1, 1);
+      copyEvent.target = getCell(1, 1);
+      plugin.onCopy(copyEvent); // trigger the plugin's method that is normally triggered by the native "copy" event
+
+      expect(copyEvent.preventDefault).toHaveBeenCalled();
+    });
   });
 });

--- a/handsontable/src/plugins/copyPaste/__tests__/cut.spec.js
+++ b/handsontable/src/plugins/copyPaste/__tests__/cut.spec.js
@@ -159,5 +159,22 @@ describe('CopyPaste', () => {
 
       expect(copyEvent.preventDefault).toHaveBeenCalled();
     });
+
+    it('should not skip processing the event when the target element has not the "data-hot-input" attribute and it\'s a TD element (#dev-2225)', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      const copyEvent = getClipboardEvent();
+      const plugin = getPlugin('CopyPaste');
+
+      spyOn(copyEvent, 'preventDefault');
+
+      selectCell(1, 1);
+      copyEvent.target = getCell(1, 1);
+      plugin.onCut(copyEvent); // trigger the plugin's method that is normally triggered by the native "cut" event
+
+      expect(copyEvent.preventDefault).toHaveBeenCalled();
+    });
   });
 });

--- a/handsontable/src/plugins/copyPaste/__tests__/paste.spec.js
+++ b/handsontable/src/plugins/copyPaste/__tests__/paste.spec.js
@@ -668,5 +668,22 @@ describe('CopyPaste', () => {
 
       expect(copyEvent.preventDefault).toHaveBeenCalled();
     });
+
+    it('should not skip processing the event when the target element has not the "data-hot-input" attribute and it\'s a TD element (#dev-2225)', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      const copyEvent = getClipboardEvent();
+      const plugin = getPlugin('CopyPaste');
+
+      spyOn(copyEvent, 'preventDefault');
+
+      selectCell(1, 1);
+      copyEvent.target = getCell(1, 1);
+      plugin.onPaste(copyEvent); // trigger the plugin's method that is normally triggered by the native "paste" event
+
+      expect(copyEvent.preventDefault).toHaveBeenCalled();
+    });
   });
 });

--- a/handsontable/src/plugins/copyPaste/copyPaste.js
+++ b/handsontable/src/plugins/copyPaste/copyPaste.js
@@ -725,7 +725,7 @@ export class CopyPaste extends BasePlugin {
     const focusedElement = this.hot.getFocusManager().getRefocusElement();
     const isHotInput = event.target?.hasAttribute('data-hot-input');
     const selectedCell = this.hot.getSelectedRangeLast()?.highlight;
-    const TD = selectedCell ? this.hot.getCell(selectedCell.row, selectedCell.col) : null;
+    const TD = selectedCell ? this.hot.getCell(selectedCell.row, selectedCell.col, true) : null;
 
     if (
       !this.hot.isListening() ||

--- a/handsontable/src/plugins/copyPaste/copyPaste.js
+++ b/handsontable/src/plugins/copyPaste/copyPaste.js
@@ -627,7 +627,7 @@ export class CopyPaste extends BasePlugin {
     const focusedElement = this.hot.getFocusManager().getRefocusElement();
     const isHotInput = event.target?.hasAttribute('data-hot-input');
     const selectedCell = this.hot.getSelectedRangeLast()?.highlight;
-    const TD = selectedCell ? this.hot.getCell(selectedCell.row, selectedCell.col) : null;
+    const TD = selectedCell ? this.hot.getCell(selectedCell.row, selectedCell.col, true) : null;
 
     if (
       !this.hot.isListening() && !this.#isTriggeredByCopy ||

--- a/handsontable/src/plugins/copyPaste/copyPaste.js
+++ b/handsontable/src/plugins/copyPaste/copyPaste.js
@@ -722,8 +722,8 @@ export class CopyPaste extends BasePlugin {
   onPaste(event) {
     const focusedElement = this.hot.getFocusManager().getRefocusElement();
     const isHotInput = event.target?.hasAttribute('data-hot-input');
-    const selected = this.hot.getSelected();
-    const TD = selected ? this.hot.getCell(selected[0][0], selected[0][1]) : null;
+    const selectedCell = this.hot.getSelectedRangeLast()?.highlight;
+    const TD = selectedCell ? this.hot.getCell(selectedCell.row, selectedCell.col) : null;
 
     if (
       !this.hot.isListening() ||

--- a/handsontable/src/plugins/copyPaste/copyPaste.js
+++ b/handsontable/src/plugins/copyPaste/copyPaste.js
@@ -626,13 +626,15 @@ export class CopyPaste extends BasePlugin {
   onCopy(event) {
     const focusedElement = this.hot.getFocusManager().getRefocusElement();
     const isHotInput = event.target?.hasAttribute('data-hot-input');
+    const selected = this.hot.getSelected();
+    const TD = selected ? this.hot.getCell(selected[0][0], selected[0][1]) : null;
 
     if (
       !this.hot.isListening() && !this.#isTriggeredByCopy ||
       this.isEditorOpened() ||
       event.target instanceof HTMLElement && (
         isHotInput && event.target !== focusedElement ||
-        !isHotInput && event.target !== this.hot.rootDocument.body
+        !isHotInput && event.target !== this.hot.rootDocument.body && TD !== event.target
       )
     ) {
       return;
@@ -720,6 +722,8 @@ export class CopyPaste extends BasePlugin {
   onPaste(event) {
     const focusedElement = this.hot.getFocusManager().getRefocusElement();
     const isHotInput = event.target?.hasAttribute('data-hot-input');
+    const selected = this.hot.getSelected();
+    const TD = selected ? this.hot.getCell(selected[0][0], selected[0][1]) : null;
 
     if (
       !this.hot.isListening() ||
@@ -727,7 +731,7 @@ export class CopyPaste extends BasePlugin {
       !this.hot.getSelected() ||
       event.target instanceof HTMLElement && (
         isHotInput && event.target !== focusedElement ||
-        !isHotInput && event.target !== this.hot.rootDocument.body
+        !isHotInput && event.target !== this.hot.rootDocument.body && TD !== event.target
       )
     ) {
       return;

--- a/handsontable/src/plugins/copyPaste/copyPaste.js
+++ b/handsontable/src/plugins/copyPaste/copyPaste.js
@@ -626,8 +626,8 @@ export class CopyPaste extends BasePlugin {
   onCopy(event) {
     const focusedElement = this.hot.getFocusManager().getRefocusElement();
     const isHotInput = event.target?.hasAttribute('data-hot-input');
-    const selected = this.hot.getSelected();
-    const TD = selected ? this.hot.getCell(selected[0][0], selected[0][1]) : null;
+    const selectedCell = this.hot.getSelectedRangeLast()?.highlight;
+    const TD = selectedCell ? this.hot.getCell(selectedCell.row, selectedCell.col) : null;
 
     if (
       !this.hot.isListening() && !this.#isTriggeredByCopy ||

--- a/handsontable/src/plugins/copyPaste/copyPaste.js
+++ b/handsontable/src/plugins/copyPaste/copyPaste.js
@@ -676,13 +676,15 @@ export class CopyPaste extends BasePlugin {
   onCut(event) {
     const focusedElement = this.hot.getFocusManager().getRefocusElement();
     const isHotInput = event.target?.hasAttribute('data-hot-input');
+    const selectedCell = this.hot.getSelectedRangeLast()?.highlight;
+    const TD = selectedCell ? this.hot.getCell(selectedCell.row, selectedCell.col, true) : null;
 
     if (
       !this.hot.isListening() && !this.#isTriggeredByCut ||
       this.isEditorOpened() ||
       event.target instanceof HTMLElement && (
         isHotInput && event.target !== focusedElement ||
-        !isHotInput && event.target !== this.hot.rootDocument.body
+        !isHotInput && event.target !== this.hot.rootDocument.body && TD !== event.target
       )
     ) {
       return;

--- a/visual-tests/src/page-helpers.ts
+++ b/visual-tests/src/page-helpers.ts
@@ -494,9 +494,9 @@ export async function redo() {
   const isMac = process.platform === 'darwin';
 
   if (isMac) {
-    await getPageInstance().keyboard.press('Meta+X');
+    await getPageInstance().keyboard.press('Meta+Y');
   } else {
-    await getPageInstance().keyboard.press('Control+X');
+    await getPageInstance().keyboard.press('Control+Y');
   }
 }
 


### PR DESCRIPTION
### Context
This PR incudes fixes for copyPaste plugin in chrome version 133

### How has this been tested?
Locally

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2225

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] Fix copyPaste plugin in chrome version 133
