### PR TITLE
Add info about copyPaste problem in chrome version 133

### DIFF
--- a/handsontable/src/plugins/copyPaste/copyPaste.js
+++ b/handsontable/src/plugins/copyPaste/copyPaste.js
@@ -41,6 +41,11 @@ const META_HEAD = [
 /* eslint-disable jsdoc/require-description-complete-sentence */
 /**
  * @description
+ * ::: tip
+ *
+ * In Chrome version 133, this functionality is currently non-operational. To restore it, we recommend reverting to Handsontable version 14.5.0. The issue will be addressed and resolved in version 15.1.0, scheduled for release on February 12, 2025.
+ *
+ * :::
  * Copy, cut, and paste data by using the `CopyPaste` plugin.
  *
  * Control the `CopyPaste` plugin programmatically through its [API methods](#methods).


### PR DESCRIPTION
### Context
This PR includes info about copyPaste problem in chrome version 133 on CopyPaste documentation page.

### How has this been tested?
Locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2226

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] Add info about copyPaste problem in chrome version 133 on CopyPaste documentation page.

[skip changelog]
