### PR TITLE
Add PoC for grid-like demo

### DIFF
--- a/handsontable/src/3rdparty/walkontable/src/calculator/viewportColumns.js
+++ b/handsontable/src/3rdparty/walkontable/src/calculator/viewportColumns.js
@@ -84,12 +84,6 @@ export class ViewportColumnsCalculator extends ViewportBaseCalculator {
    * @returns {number}
    */
   getColumnWidth(column) {
-    const width = this.columnWidthFn(column);
-
-    if (isNaN(width)) {
-      return DEFAULT_WIDTH;
-    }
-
-    return width;
+    return this.columnWidthFn(column);
   }
 }

--- a/handsontable/src/3rdparty/walkontable/src/calculator/viewportRows.js
+++ b/handsontable/src/3rdparty/walkontable/src/calculator/viewportRows.js
@@ -86,12 +86,6 @@ export class ViewportRowsCalculator extends ViewportBaseCalculator {
    * @returns {number}
    */
   getRowHeight(row) {
-    const rowHeight = this.rowHeightFn(row);
-
-    if (isNaN(rowHeight)) {
-      return this.defaultHeight;
-    }
-
-    return rowHeight;
+    return this.rowHeightFn(row);
   }
 }

--- a/handsontable/src/3rdparty/walkontable/src/overlay/inlineStart.js
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/inlineStart.js
@@ -126,16 +126,7 @@ export class InlineStartOverlay extends Overlay {
    * @returns {number} Width sum.
    */
   sumCellSizes(from, to) {
-    const defaultColumnWidth = this.wtSettings.getSetting('defaultColumnWidth');
-    let column = from;
-    let sum = 0;
-
-    while (column < to) {
-      sum += this.wot.wtTable.getColumnWidth(column) || defaultColumnWidth;
-      column += 1;
-    }
-
-    return sum;
+    return (to - from) * 80;
   }
 
   /**

--- a/handsontable/src/3rdparty/walkontable/src/overlay/top.js
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/top.js
@@ -148,18 +148,7 @@ export class TopOverlay extends Overlay {
    * @returns {number} Height sum.
    */
   sumCellSizes(from, to) {
-    const defaultRowHeight = this.wot.stylesHandler.getDefaultRowHeight();
-    let row = from;
-    let sum = 0;
-
-    while (row < to) {
-      const height = this.wot.wtTable.getRowHeight(row);
-
-      sum += height === undefined ? defaultRowHeight : height;
-      row += 1;
-    }
-
-    return sum;
+    return (to - from) * 29;
   }
 
   /**

--- a/handsontable/src/3rdparty/walkontable/src/renderer/cells.js
+++ b/handsontable/src/3rdparty/walkontable/src/renderer/cells.js
@@ -83,7 +83,7 @@ export class CellsRenderer extends BaseRenderer {
       orderView
         .prependView(rowHeadersView)
         .setSize(columnsToRender)
-        .setOffset(0)
+        .setOffset(this.table.renderedColumnToSource(0))
         .start();
 
       for (let visibleColumnIndex = 0; visibleColumnIndex < columnsToRender; visibleColumnIndex++) {
@@ -91,6 +91,10 @@ export class CellsRenderer extends BaseRenderer {
 
         const sourceColumnIndex = this.table.renderedColumnToSource(visibleColumnIndex);
         const TD = orderView.getCurrentNode();
+
+        if (TD.innerHTML !== '') {
+          continue;
+        }
 
         if (!hasClass(TD, 'hide')) { // Workaround for hidden columns plugin
           TD.className = '';

--- a/handsontable/src/3rdparty/walkontable/src/renderer/columnHeaders.js
+++ b/handsontable/src/3rdparty/walkontable/src/renderer/columnHeaders.js
@@ -28,7 +28,7 @@ import {
  */
 export class ColumnHeadersRenderer extends BaseRenderer {
   constructor(rootNode) {
-    super(null, rootNode); // NodePool is not implemented for this renderer yet
+    super('TR', rootNode); // NodePool is not implemented for this renderer yet
   }
 
   /**
@@ -98,6 +98,10 @@ export class ColumnHeadersRenderer extends BaseRenderer {
       for (let renderedColumnIndex = (-1) * rowHeadersCount; renderedColumnIndex < columnsToRender; renderedColumnIndex += 1) { // eslint-disable-line max-len
         const sourceColumnIndex = this.table.renderedColumnToSource(renderedColumnIndex);
         const TH = TR.childNodes[renderedColumnIndex + rowHeadersCount];
+
+        if (TH.innerHTML !== '') {
+          continue;
+        }
 
         TH.className = '';
         TH.removeAttribute('style');

--- a/handsontable/src/3rdparty/walkontable/src/renderer/rowHeaders.js
+++ b/handsontable/src/3rdparty/walkontable/src/renderer/rowHeaders.js
@@ -87,6 +87,10 @@ export class RowHeadersRenderer extends BaseRenderer {
 
         const TH = orderView.getCurrentNode();
 
+        if (TH.innerHTML !== '') {
+          continue;
+        }
+
         TH.className = '';
         TH.removeAttribute('style');
 

--- a/handsontable/src/3rdparty/walkontable/src/utils/column.js
+++ b/handsontable/src/3rdparty/walkontable/src/utils/column.js
@@ -33,10 +33,7 @@ export default class ColumnUtils {
    * @returns {number}
    */
   getWidth(sourceIndex) {
-    const width = this.wtSettings.getSetting('columnWidth', sourceIndex)
-      || this.wtSettings.getSetting('defaultColumnWidth');
-
-    return width;
+    return this.wtSettings.getSetting('columnWidth', sourceIndex);
   }
 
   /**
@@ -46,14 +43,7 @@ export default class ColumnUtils {
    * @returns {number}
    */
   getHeaderHeight(level) {
-    let height = this.dataAccessObject.stylesHandler.getDefaultRowHeight();
-    const oversizedHeight = this.dataAccessObject.wtViewport.oversizedColumnHeaders[level];
-
-    if (oversizedHeight !== undefined) {
-      height = height ? Math.max(height, oversizedHeight) : oversizedHeight;
-    }
-
-    return height;
+    return this.dataAccessObject.stylesHandler.getDefaultRowHeight();
   }
 
   /**
@@ -63,30 +53,13 @@ export default class ColumnUtils {
    * @returns {number}
    */
   getHeaderWidth(sourceIndex) {
-    return this.headerWidths.get(this.dataAccessObject.wtTable.columnFilter.sourceToRendered(sourceIndex));
+    return 50;
   }
 
   /**
    * Calculates column header widths that can be retrieved from the cache.
    */
   calculateWidths() {
-    const { wtSettings } = this;
-    let rowHeaderWidthSetting = wtSettings.getSetting('rowHeaderWidth');
 
-    rowHeaderWidthSetting = wtSettings.getSetting('onModifyRowHeaderWidth', rowHeaderWidthSetting);
-
-    if (rowHeaderWidthSetting !== null && rowHeaderWidthSetting !== undefined) {
-      const rowHeadersCount = wtSettings.getSetting('rowHeaders').length;
-      const defaultColumnWidth = wtSettings.getSetting('defaultColumnWidth');
-
-      for (let visibleColumnIndex = 0; visibleColumnIndex < rowHeadersCount; visibleColumnIndex++) {
-        let width = Array.isArray(rowHeaderWidthSetting)
-          ? rowHeaderWidthSetting[visibleColumnIndex] : rowHeaderWidthSetting;
-
-        width = (width === null || width === undefined) ? defaultColumnWidth : width;
-
-        this.headerWidths.set(visibleColumnIndex, width);
-      }
-    }
   }
 }

--- a/handsontable/src/3rdparty/walkontable/src/utils/row.js
+++ b/handsontable/src/3rdparty/walkontable/src/utils/row.js
@@ -29,14 +29,7 @@ export default class RowUtils {
    * @returns {number}
    */
   getHeight(sourceIndex) {
-    let height = this.wtSettings.getSetting('rowHeight', sourceIndex);
-    const oversizedHeight = this.dataAccessObject.wtViewport.oversizedRows[sourceIndex];
-
-    if (oversizedHeight !== undefined) {
-      height = height === undefined ? oversizedHeight : Math.max(height, oversizedHeight);
-    }
-
-    return height;
+    return this.wtSettings.getSetting('rowHeight', sourceIndex);
   }
 
   /**
@@ -47,13 +40,6 @@ export default class RowUtils {
    * @returns {number}
    */
   getHeightByOverlayName(sourceIndex, overlayName) {
-    let height = this.wtSettings.getSetting('rowHeightByOverlayName', sourceIndex, overlayName);
-    const oversizedHeight = this.dataAccessObject.wtViewport.oversizedRows[sourceIndex];
-
-    if (oversizedHeight !== undefined) {
-      height = height === undefined ? oversizedHeight : Math.max(height, oversizedHeight);
-    }
-
-    return height;
+    return this.wtSettings.getSetting('rowHeight', sourceIndex);
   }
 }

--- a/handsontable/src/3rdparty/walkontable/src/viewport.js
+++ b/handsontable/src/3rdparty/walkontable/src/viewport.js
@@ -37,7 +37,6 @@ class Viewport {
     this.domBindings = domBindings;
     this.wtSettings = wtSettings;
     this.wtTable = wtTable;
-    this.oversizedRows = [];
     this.oversizedColumnHeaders = [];
     this.hasOversizedColumnHeadersMarked = {};
     this.clientHeight = 0;
@@ -218,59 +217,14 @@ class Viewport {
    * @returns {number}
    */
   getColumnHeaderHeight() {
-    const columnHeaders = this.wtSettings.getSetting('columnHeaders');
-
-    if (!columnHeaders.length) {
-      this.columnHeaderHeight = 0;
-    } else if (isNaN(this.columnHeaderHeight)) {
-      this.columnHeaderHeight = outerHeight(this.wtTable.THEAD);
-    }
-
-    return this.columnHeaderHeight;
+    return 59;
   }
 
   /**
    * @returns {number}
    */
   getRowHeaderWidth() {
-    const rowHeadersWidthSetting = this.wtSettings.getSetting('rowHeaderWidth');
-    const rowHeaders = this.wtSettings.getSetting('rowHeaders');
-
-    if (rowHeadersWidthSetting) {
-      this.rowHeaderWidth = 0;
-
-      for (let i = 0, len = rowHeaders.length; i < len; i++) {
-        this.rowHeaderWidth += rowHeadersWidthSetting[i] || rowHeadersWidthSetting;
-      }
-    }
-
-    if (isNaN(this.rowHeaderWidth)) {
-
-      if (rowHeaders.length) {
-        let TH = this.wtTable.TABLE.querySelector('TH');
-
-        this.rowHeaderWidth = 0;
-
-        for (let i = 0, len = rowHeaders.length; i < len; i++) {
-          if (TH) {
-            this.rowHeaderWidth += outerWidth(TH);
-            TH = TH.nextSibling;
-
-          } else {
-            // yes this is a cheat but it worked like that before, just taking assumption from CSS instead of measuring.
-            // TODO: proper fix
-            this.rowHeaderWidth += 50;
-          }
-        }
-      } else {
-        this.rowHeaderWidth = 0;
-      }
-    }
-
-    this.rowHeaderWidth = this.wtSettings
-      .getSetting('onModifyRowHeaderWidth', this.rowHeaderWidth) || this.rowHeaderWidth;
-
-    return this.rowHeaderWidth;
+    return 50;
   }
 
   /**

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -3800,7 +3800,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
    * @returns {number}
    */
   this._getColWidthFromSettings = function(col) {
-    return tableMeta.colWidths[col];
+    return tableMeta.colWidths;
   };
 
   /**

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -3800,37 +3800,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
    * @returns {number}
    */
   this._getColWidthFromSettings = function(col) {
-    let width;
-
-    // We currently don't support cell meta objects for headers (negative values)
-    if (col >= 0) {
-      const cellProperties = instance.getCellMeta(0, col);
-
-      width = cellProperties.width;
-    }
-
-    if (width === undefined || width === tableMeta.width) {
-      width = tableMeta.colWidths;
-    }
-
-    if (width !== undefined && width !== null) {
-      switch (typeof width) {
-        case 'object': // array
-          width = width[col];
-          break;
-
-        case 'function':
-          width = width(col);
-          break;
-        default:
-          break;
-      }
-      if (typeof width === 'string') {
-        width = parseInt(width, 10);
-      }
-    }
-
-    return width;
+    return tableMeta.colWidths[col];
   };
 
   /**
@@ -3844,15 +3814,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
    * @fires Hooks#modifyColWidth
    */
   this.getColWidth = function(column, source) {
-    let width = instance._getColWidthFromSettings(column);
-
-    width = instance.runHooks('modifyColWidth', width, column, source);
-
-    if (width === undefined) {
-      width = DEFAULT_COLUMN_WIDTH;
-    }
-
-    return width;
+    return instance._getColWidthFromSettings(column);
   };
 
   /**
@@ -3865,26 +3827,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
    * @returns {number}
    */
   this._getRowHeightFromSettings = function(row) {
-    let height = tableMeta.rowHeights;
-
-    if (height !== undefined && height !== null) {
-      switch (typeof height) {
-        case 'object': // array
-          height = height[row];
-          break;
-
-        case 'function':
-          height = height(row);
-          break;
-        default:
-          break;
-      }
-      if (typeof height === 'string') {
-        height = parseInt(height, 10);
-      }
-    }
-
-    return height;
+    return tableMeta.rowHeights;
   };
 
   /**
@@ -3915,11 +3858,7 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
    * @fires Hooks#modifyRowHeight
    */
   this.getRowHeight = function(row, source) {
-    let height = instance._getRowHeightFromSettings(row);
-
-    height = instance.runHooks('modifyRowHeight', height, row, source);
-
-    return height;
+    return instance._getRowHeightFromSettings(row);
   };
 
   /**

--- a/handsontable/src/renderers/textRenderer/textRenderer.js
+++ b/handsontable/src/renderers/textRenderer/textRenderer.js
@@ -30,8 +30,16 @@ export function textRenderer(hotInstance, TD, row, col, prop, value, cellPropert
     escaped = escaped.trim();
   }
 
-  // this is faster than innerHTML. See: https://github.com/handsontable/handsontable/wiki/JavaScript-&-DOM-performance-tips
-  fastInnerText(TD, escaped);
+  if (TD.firstChild) {
+    fastInnerText(TD.firstChild, escaped);
+  } else {
+    const div = hotInstance.rootDocument.createElement('div');
+
+    div.style.height = '20px';
+
+    TD.appendChild(div);
+    fastInnerText(div, escaped);
+  }
 }
 
 textRenderer.RENDERER_TYPE = RENDERER_TYPE;


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR shows PoC for demo that includes: 
 * grid-like dataset;
 * Add `div` to the cells;
 * Turn on eco renderers;
 * Disabling dynamic changes in cell sizes; 

_[skip changelog]_

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2221

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
