### PR TITLE
Updated Italian translation for new context menu labels (PR-10117-fix)

### DIFF
--- a/.changelogs/11436.json
+++ b/.changelogs/11436.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Updated Italian translation for new context menu labels (PR-10117-fix)",
+  "type": "added",
+  "issueOrPR": 11436,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/i18n/languages/it-IT.js
+++ b/handsontable/src/i18n/languages/it-IT.js
@@ -48,6 +48,9 @@ const dictionary = {
   [C.CONTEXTMENU_ITEMS_UNMERGE_CELLS]: 'Separa celle',
 
   [C.CONTEXTMENU_ITEMS_COPY]: 'Copia',
+  [C.CONTEXTMENU_ITEMS_COPY_WITH_COLUMN_HEADERS]: ['Copia con intestazione', 'Copia con intestazioni'],
+  [C.CONTEXTMENU_ITEMS_COPY_WITH_COLUMN_GROUP_HEADERS]: 'Copia con intestazione completa',
+  [C.CONTEXTMENU_ITEMS_COPY_COLUMN_HEADERS_ONLY]: ['Copia solo intestazione', 'Copia solo intestazioni'],
   [C.CONTEXTMENU_ITEMS_CUT]: 'Taglia',
 
   [C.CONTEXTMENU_ITEMS_NESTED_ROWS_INSERT_CHILD]: 'Inserisci riga figlia',


### PR DESCRIPTION
### Context
This PR includes fix from PR-10117

### How has this been tested?
Locally

### Types of changes
- [x] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2231
2. https://github.com/handsontable/handsontable/pull/10117

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
