### PR TITLE
Updated Serbian translation for new context menu labels (PR-10115-fix)

### DIFF
--- a/.changelogs/11437.json
+++ b/.changelogs/11437.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Updated Serbian translation for new context menu labels (PR-10115-fix)",
+  "type": "added",
+  "issueOrPR": 11437,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/i18n/languages/sr-SP.js
+++ b/handsontable/src/i18n/languages/sr-SP.js
@@ -49,6 +49,9 @@ const dictionary = {
   [C.CONTEXTMENU_ITEMS_UNMERGE_CELLS]: 'Odvoji ćelije',
 
   [C.CONTEXTMENU_ITEMS_COPY]: 'Kopiraj',
+  [C.CONTEXTMENU_ITEMS_COPY_WITH_COLUMN_HEADERS]: ['Kopiraj sa zaglavljem', 'Kopiraj sa zaglavljima'],
+  [C.CONTEXTMENU_ITEMS_COPY_WITH_COLUMN_GROUP_HEADERS]: ['Kopiraj sa zaglavljem grupe', 'Kopiraj sa zaglavljima grupe'],
+  [C.CONTEXTMENU_ITEMS_COPY_COLUMN_HEADERS_ONLY]: ['Kopiraj samo zaglavlje', 'Kopiraj samo zaglavlja'],
   [C.CONTEXTMENU_ITEMS_CUT]: 'Iseci',
 
   [C.CONTEXTMENU_ITEMS_NESTED_ROWS_INSERT_CHILD]: 'Unesi ugnježdeni red',


### PR DESCRIPTION
### Context
This PR includes fix from PR-10115

### How has this been tested?
Locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2232
2. https://github.com/handsontable/handsontable/pull/10115

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
