### PR TITLE
[docs] Bump the Hyperformula version to `^3.0.0` for the Stackblitz examples and update the SSR demos.

### DIFF
--- a/docs/.vuepress/code-structure-builder/getBody.js
+++ b/docs/.vuepress/code-structure-builder/getBody.js
@@ -7,7 +7,7 @@ const { buildVueBody } = require('./buildVueBody');
 
 const getBody = ({ id, html, js, css, docsVersion, preset, sandbox, lang }) => {
   const version = formatVersion(docsVersion);
-  const hyperformulaVersion = '^2.4.0';
+  const hyperformulaVersion = '^3.0.0';
   const themeName = html.match(/class="[^"]*(ht-theme-[^"\s]*)[^"]*"/)?.[1] || '';
 
   if (/hot(-.*)?/.test(preset)) {

--- a/docs/content/guides/getting-started/introduction/introduction.md
+++ b/docs/content/guides/getting-started/introduction/introduction.md
@@ -43,10 +43,10 @@ Use Handsontable with plain JavaScript, TypeScript, or your favorite framework. 
 
 <div class="boxes-list gray col3">
 
-- [Next.js](https://stackblitz.com/edit/stackblitz-starters-btdkan?file=README.md)
-- [Astro](https://stackblitz.com/edit/withastro-astro-xrzgch?file=README.md) 
-- [Remix](https://stackblitz.com/edit/remix-run-remix-q5kqz6?file=README.md)
-- [Nuxt](https://stackblitz.com/edit/nuxt-starter-uy1zw3?file=README.md)
+- [Next.js](https://stackblitz.com/edit/stackblitz-starters-wp9wzrnb?file=README.md)
+- [Astro](https://stackblitz.com/edit/withastro-astro-nabzqba4?file=README.md) 
+- [Remix](https://stackblitz.com/edit/remix-run-remix-owyjdkt5?file=README.md)
+- [Nuxt](https://stackblitz.com/edit/nuxt-starter-ljnxhaxa?file=README.md)
 
 </div>
 


### PR DESCRIPTION
### Context
This PR:
1. Bumps the Hyperformula version to `^3.0.0` for the docs' Stackblitz examples.
2. Updates the Handsontable version to `15.1.0` in the SSR demos (by linking clones of the current SSR examples).

Note: The new SSR demos will start being function after the `15.1.0` release - currently they'll return the _"No matching version found for handsontable@15.1.0."_ error.

[skip changelog]

### How has this been tested?
Tested locally.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
