### PR TITLE
Speed up the rendering performance 

### DIFF
--- a/.changelogs/11443.json
+++ b/.changelogs/11443.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Speed up the rendering performance for themes",
+  "type": "changed",
+  "issueOrPR": 11443,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/nestedHeaders/__tests__/generalFunctionality.spec.js
+++ b/handsontable/src/plugins/nestedHeaders/__tests__/generalFunctionality.spec.js
@@ -20,6 +20,19 @@ describe('NestedHeaders', () => {
   });
 
   describe('general functionality', () => {
+    it('should add `htColumnHeaders` to the table when nested headers are defined', () => {
+      const hot = handsontable({
+        data: createSpreadsheetData(10, 10),
+        colHeaders: true,
+        nestedHeaders: [
+          ['a', 'b', 'c', 'd'],
+          ['a', 'b', 'c', 'd']
+        ]
+      });
+
+      expect(hot.rootElement.className).toContain('htColumnHeaders');
+    });
+
     it('should add as many header levels as the \'colHeaders\' property suggests', () => {
       const hot = handsontable({
         data: Handsontable.helper.createSpreadsheetData(10, 10),

--- a/handsontable/src/plugins/nestedHeaders/__tests__/hidingColumns.spec.js
+++ b/handsontable/src/plugins/nestedHeaders/__tests__/hidingColumns.spec.js
@@ -36,6 +36,15 @@ describe('NestedHeaders', () => {
 
       expect(extractDOMStructure(getTopClone(), getMaster())).toMatchHTML(`
         <thead>
+        <tr>
+          <th class=""></th>
+          <th class=""></th>
+          <th class=""></th>
+          <th class=""></th>
+          <th class=""></th>
+          <th class=""></th>
+          <th class=""></th>
+        </tr>
         </thead>
         <tbody>
           <tr class="ht__row_odd">

--- a/handsontable/src/plugins/nestedHeaders/__tests__/initialization.spec.js
+++ b/handsontable/src/plugins/nestedHeaders/__tests__/initialization.spec.js
@@ -362,7 +362,15 @@ describe('NestedHeaders', () => {
       expect(warnSpy).toHaveBeenCalledWith('Your Nested Headers plugin setup contains overlapping headers. ' +
                                            'This kind of configuration is currently not supported.');
       expect(extractDOMStructure(getTopClone(), getMaster())).toMatchHTML(`
-        <thead></thead>
+        <thead>
+          <tr>
+            <th class=""></th>
+            <th class=""></th>
+            <th class=""></th>
+            <th class=""></th>
+            <th class=""></th>
+          </tr>
+        </thead>
         <tbody>
           <tr class="ht__row_odd">
             <td class="">A1</td>
@@ -374,7 +382,15 @@ describe('NestedHeaders', () => {
         </tbody>
         `);
       expect(extractDOMStructure(getMaster(), getMaster())).toMatchHTML(`
-        <thead></thead>
+        <thead>
+          <tr>
+            <th class=""></th>
+            <th class=""></th>
+            <th class=""></th>
+            <th class=""></th>
+            <th class=""></th>
+          </tr>
+        </thead>
         <tbody>
           <tr class="ht__row_odd">
             <td class="">A1</td>
@@ -407,7 +423,18 @@ describe('NestedHeaders', () => {
       expect(warnSpy).toHaveBeenCalledWith(expectedWarn);
       expect(extractDOMStructure(getTopClone(), getMaster())).toMatchHTML(`
         <thead>
-          <tr></tr>
+          <tr>
+            <th class=""></th>
+            <th class=""></th>
+            <th class=""></th>
+            <th class=""></th>
+            <th class=""></th>
+            <th class=""></th>
+            <th class=""></th>
+            <th class=""></th>
+            <th class=""></th>
+            <th class=""></th>
+          </tr>
         </thead>
         <tbody>
           <tr class="ht__row_odd">
@@ -432,7 +459,18 @@ describe('NestedHeaders', () => {
       expect(warnSpy).toHaveBeenCalledWith(expectedWarn);
       expect(extractDOMStructure(getTopClone(), getMaster())).toMatchHTML(`
         <thead>
-          <tr></tr>
+          <tr>
+            <th class=""></th>
+            <th class=""></th>
+            <th class=""></th>
+            <th class=""></th>
+            <th class=""></th>
+            <th class=""></th>
+            <th class=""></th>
+            <th class=""></th>
+            <th class=""></th>
+            <th class=""></th>
+          </tr>
         </thead>
         <tbody>
           <tr class="ht__row_odd">
@@ -457,7 +495,18 @@ describe('NestedHeaders', () => {
       expect(warnSpy).toHaveBeenCalledWith(expectedWarn);
       expect(extractDOMStructure(getTopClone(), getMaster())).toMatchHTML(`
         <thead>
-          <tr></tr>
+          <tr>
+            <th class=""></th>
+            <th class=""></th>
+            <th class=""></th>
+            <th class=""></th>
+            <th class=""></th>
+            <th class=""></th>
+            <th class=""></th>
+            <th class=""></th>
+            <th class=""></th>
+            <th class=""></th>
+          </tr>
         </thead>
         <tbody>
           <tr class="ht__row_odd">

--- a/handsontable/src/plugins/nestedHeaders/__tests__/showingColumns.spec.js
+++ b/handsontable/src/plugins/nestedHeaders/__tests__/showingColumns.spec.js
@@ -36,6 +36,11 @@ describe('NestedHeaders', () => {
 
       expect(extractDOMStructure(getTopClone(), getMaster())).toMatchHTML(`
         <thead>
+          <tr>
+          <th class=""></th>
+          <th class=""></th>
+          <th class=""></th>
+        </tr>
         </thead>
         <tbody>
           <tr class="ht__row_odd">

--- a/handsontable/src/plugins/nestedHeaders/nestedHeaders.js
+++ b/handsontable/src/plugins/nestedHeaders/nestedHeaders.js
@@ -860,10 +860,12 @@ export class NestedHeaders extends BasePlugin {
    * @param {Array} renderersArray Array of renderers.
    */
   #onAfterGetColumnHeaderRenderers(renderersArray) {
-    renderersArray.length = 0;
+    if (this.#stateManager.getLayersCount() > 0) {
+      renderersArray.length = 0;
 
-    for (let headerLayer = 0; headerLayer < this.#stateManager.getLayersCount(); headerLayer++) {
-      renderersArray.push(this.headerRendererFactory(headerLayer));
+      for (let headerLayer = 0; headerLayer < this.#stateManager.getLayersCount(); headerLayer++) {
+        renderersArray.push(this.headerRendererFactory(headerLayer));
+      }
     }
   }
 

--- a/handsontable/src/styles/base/_base.scss
+++ b/handsontable/src/styles/base/_base.scss
@@ -210,22 +210,12 @@
       &.ht__highlight {
         color: var(--ht-header-highlighted-foreground-color);
         background-color: var(--ht-header-highlighted-background-color);
-
-        .relative {
-          &::after {
-            @include mixins.pseudo;
-
-            position: absolute;
-            background-color: var(--ht-accent-color);
-          }
-        }
       }
 
       &.ht__active_highlight {
         border-color: var(--ht-header-active-border-color);
         color: var(--ht-header-active-foreground-color);
         background-color: var(--ht-header-active-background-color);
-        box-shadow: -1px 0 0 0 var(--ht-header-active-border-color);
       }
     }
 
@@ -254,21 +244,14 @@
           color: var(--ht-header-row-foreground-color);
           background-color: var(--ht-header-row-background-color);
 
+          &.ht__active_highlight {
+            box-shadow: 0 -1px 0 0 var(--ht-header-active-border-color);
+          }
+
           .relative {
             padding: var(--ht-cell-vertical-padding)
               var(--ht-cell-horizontal-padding);
             height: 100%;
-
-            &::after {
-              top: -1px;
-              right: -1px;
-              bottom: -1px;
-              width: var(--ht-header-highlighted-shadow-size);
-            }
-          }
-
-          &.ht__active_highlight {
-            box-shadow: 0 -1px 0 0 var(--ht-header-active-border-color);
           }
         }
 
@@ -287,29 +270,16 @@
     // Header in Col
     thead {
       tr {
-        &:only-of-type {
-          th {
-            .relative {
-              &::after {
-                bottom: 0;
-              }
-            }
-          }
-        }
-
         th {
           padding: 0;
+
+          &.ht__active_highlight {
+            box-shadow: -1px 0 0 0 var(--ht-header-active-border-color);
+          }
 
           .relative {
             padding: var(--ht-cell-vertical-padding)
               var(--ht-cell-horizontal-padding);
-
-            &::after {
-              left: -1px;
-              right: -1px;
-              bottom: -1px;
-              height: var(--ht-header-highlighted-shadow-size);
-            }
 
             .colHeader {
               text-overflow: ellipsis;
@@ -349,6 +319,53 @@
 
         &.ht__active_highlight {
           border-bottom-color: var(--ht-header-active-border-color);
+        }
+      }
+    }
+
+    // header highlight line
+    div[class^="ht_clone"] {
+      thead {
+        .ht__highlight {
+          .relative {
+            &::after {
+              @include mixins.pseudo();
+
+              position: absolute;
+              left: -1px;
+              right: -1px;
+              bottom: -1px;
+              height: var(--ht-header-highlighted-shadow-size);
+              background-color: var(--ht-accent-color);
+            }
+          }
+        }
+
+        tr:only-of-type {
+          .ht__highlight {
+            .relative {
+              &::after {
+                bottom: 0;
+              }
+            }
+          }
+        }
+      }
+
+      tbody {
+        .ht__highlight {
+          .relative {
+            &::after {
+              @include mixins.pseudo();
+
+              position: absolute;
+              top: -1px;
+              right: -1px;
+              bottom: -1px;
+              width: var(--ht-header-highlighted-shadow-size);
+              background-color: var(--ht-accent-color);
+            }
+          }
         }
       }
     }
@@ -531,16 +548,13 @@
             border-inline-start-color: var(--ht-border-color);
           }
         }
-
-        th {
-          .relative {
-            &::after {
-              right: auto;
-              left: -1px;
-            }
-          }
-        }
       }
+    }
+
+    // header highlight line rtl fix
+    div[class^="ht_clone"] tbody .ht__highlight .relative::after {
+      right: auto;
+      left: -1px;
     }
   }
 }

--- a/handsontable/src/styles/base/_base.scss
+++ b/handsontable/src/styles/base/_base.scss
@@ -213,7 +213,8 @@
 
         .relative {
           &::after {
-            display: block;
+            @include mixins.pseudo;
+
             position: absolute;
             background-color: var(--ht-accent-color);
           }

--- a/handsontable/src/styles/base/_base.scss
+++ b/handsontable/src/styles/base/_base.scss
@@ -93,6 +93,7 @@
       .ht_master {
         .wtHolder {
           background-color: var(--ht-background-color);
+          border-radius: var(--ht-wrapper-border-radius, 0);
         }
       }
     }

--- a/handsontable/src/styles/base/_base.scss
+++ b/handsontable/src/styles/base/_base.scss
@@ -213,8 +213,7 @@
 
         .relative {
           &::after {
-            @include mixins.pseudo;
-
+            display: block;
             position: absolute;
             background-color: var(--ht-accent-color);
           }

--- a/handsontable/src/styles/base/_border-radius.scss
+++ b/handsontable/src/styles/base/_border-radius.scss
@@ -87,6 +87,8 @@
 
       .ht_master {
         .htCore {
+          border-radius: var(--ht-wrapper-border-radius);
+
           thead {
             tr {
               &:first-child {
@@ -135,6 +137,8 @@
 
       .ht_clone_top_inline_start_corner {
         .htCore {
+          border-start-start-radius: var(--ht-wrapper-border-radius);
+
           thead {
             tr {
               &:first-child {
@@ -151,6 +155,9 @@
 
       .ht_clone_top {
         .htCore {
+          border-start-start-radius: var(--ht-wrapper-border-radius);
+          border-start-end-radius: var(--ht-wrapper-border-radius);
+
           thead {
             tr {
               &:first-child {
@@ -171,6 +178,9 @@
 
       .ht_clone_inline_start {
         .htCore {
+          border-start-start-radius: var(--ht-wrapper-border-radius);
+          border-end-start-radius: var(--ht-wrapper-border-radius);
+
           thead {
             tr {
               &:first-child {
@@ -200,6 +210,8 @@
 
       .ht_clone_bottom_inline_start_corner {
         .htCore {
+          border-end-start-radius: var(--ht-wrapper-border-radius);
+
           tr {
             &:last-child {
               th,
@@ -215,6 +227,9 @@
 
       .ht_clone_bottom {
         .htCore {
+          border-end-start-radius: var(--ht-wrapper-border-radius);
+          border-end-end-radius: var(--ht-wrapper-border-radius);
+          
           tr {
             &:last-child {
               th,

--- a/handsontable/src/styles/base/_border-radius.scss
+++ b/handsontable/src/styles/base/_border-radius.scss
@@ -14,6 +14,7 @@
                         --ht-wrapper-border-radius
                       );
                     }
+
                     &:last-child {
                       border-start-end-radius: var(--ht-wrapper-border-radius);
                     }
@@ -23,6 +24,7 @@
             }
           }
         }
+
         .ht_clone_top_inline_start_corner {
           .htCore {
             tbody {
@@ -40,6 +42,7 @@
             }
           }
         }
+
         .ht_clone_top {
           .htCore {
             tbody {
@@ -51,6 +54,7 @@
                         --ht-wrapper-border-radius
                       );
                     }
+
                     &:last-child {
                       border-start-end-radius: var(--ht-wrapper-border-radius);
                     }
@@ -60,6 +64,7 @@
             }
           }
         }
+
         .ht_clone_inline_start {
           .htCore {
             tbody {
@@ -79,6 +84,7 @@
           }
         }
       }
+
       .ht_master {
         .htCore {
           thead {
@@ -88,16 +94,19 @@
                   &:first-child {
                     border-start-start-radius: var(--ht-wrapper-border-radius);
                   }
+
                   &:last-child {
                     border-start-end-radius: var(--ht-wrapper-border-radius);
                   }
                 }
               }
+
               &:last-child {
                 th {
                   &:first-child {
                     border-end-start-radius: var(--ht-wrapper-border-radius);
                   }
+
                   &:last-child {
                     border-end-end-radius: var(--ht-wrapper-border-radius);
                   }
@@ -105,6 +114,7 @@
               }
             }
           }
+
           tbody {
             tr {
               &:last-child {
@@ -112,6 +122,7 @@
                   &:first-child {
                     border-end-start-radius: var(--ht-wrapper-border-radius);
                   }
+
                   &:last-child {
                     border-end-end-radius: var(--ht-wrapper-border-radius);
                   }
@@ -121,6 +132,7 @@
           }
         }
       }
+
       .ht_clone_top_inline_start_corner {
         .htCore {
           thead {
@@ -136,6 +148,7 @@
           }
         }
       }
+
       .ht_clone_top {
         .htCore {
           thead {
@@ -145,6 +158,7 @@
                   &:first-child {
                     border-start-start-radius: var(--ht-wrapper-border-radius);
                   }
+
                   &:last-child {
                     border-start-end-radius: var(--ht-wrapper-border-radius);
                   }
@@ -154,6 +168,7 @@
           }
         }
       }
+
       .ht_clone_inline_start {
         .htCore {
           thead {
@@ -167,6 +182,7 @@
               }
             }
           }
+
           tbody {
             tr {
               &:last-child {
@@ -181,6 +197,7 @@
           }
         }
       }
+
       .ht_clone_bottom_inline_start_corner {
         .htCore {
           tr {
@@ -195,6 +212,7 @@
           }
         }
       }
+
       .ht_clone_bottom {
         .htCore {
           tr {
@@ -204,6 +222,7 @@
                 &:first-child {
                   border-end-start-radius: var(--ht-wrapper-border-radius);
                 }
+
                 &:last-child {
                   border-end-end-radius: var(--ht-wrapper-border-radius);
                 }
@@ -212,15 +231,18 @@
           }
         }
       }
+
       &.htHasScrollX {
         .htCore {
           border-end-start-radius: 0;
           border-end-end-radius: 0;
+
           thead tr:last-child th:first-child,
           tbody tr:last-child td:first-child,
           tbody tr:last-child th:first-child {
             border-end-start-radius: 0 !important;
           }
+
           thead tr:last-child th:last-child,
           tbody tr:last-child td:last-child,
           tbody tr:last-child th:last-child {
@@ -228,15 +250,18 @@
           }
         }
       }
+
       &.htHasScrollY {
         .htCore {
           border-start-end-radius: 0;
           border-end-end-radius: 0;
+
           thead tr:first-child th:last-child,
           tbody tr:first-child td:last-child,
           tbody tr:first-child th:last-child {
             border-start-end-radius: 0 !important;
           }
+
           thead tr:last-child th:last-child,
           tbody tr:last-child td:last-child,
           tbody tr:last-child th:last-child {

--- a/handsontable/src/styles/base/_border-radius.scss
+++ b/handsontable/src/styles/base/_border-radius.scss
@@ -1,225 +1,246 @@
 // Table Border Radius
-
 @mixin output {
   .handsontable {
     &.ht-wrapper {
-      .ht_master {
-        .htCore {
-          border-radius: var(--ht-wrapper-border-radius);
-
-          thead tr:first-child th:first-child {
-            border-start-start-radius: var(--ht-wrapper-border-radius);
-          }
-
-          thead tr:first-child th:last-child {
-            border-start-end-radius: var(--ht-wrapper-border-radius);
-          }
-
-          tbody tr:first-child td:first-child {
-            border-start-start-radius: var(--ht-wrapper-border-radius);
-          }
-
-          tbody tr:first-child td:last-child {
-            border-start-end-radius: var(--ht-wrapper-border-radius);
-          }
-
-          tbody tr:last-child td:first-child {
-            border-end-start-radius: var(--ht-wrapper-border-radius);
-          }
-
-          tbody tr:last-child td:last-child {
-            border-end-end-radius: var(--ht-wrapper-border-radius);
-          }
-        }
-      }
-
-      &:has(.ht_clone_top thead tr th),
-      &:has(.ht_clone_top tbody tr td) {
+      &:not(.htColumnHeaders) {
         .ht_master {
           .htCore {
-            tbody tr:first-child td:first-child {
-              border-start-start-radius: 0;
+            tbody {
+              tr {
+                &:first-child {
+                  td {
+                    &:first-child {
+                      border-start-start-radius: var(
+                        --ht-wrapper-border-radius
+                      );
+                    }
+                    &:last-child {
+                      border-start-end-radius: var(--ht-wrapper-border-radius);
+                    }
+                  }
+                }
+              }
             }
-
-            tbody tr:first-child td:last-child {
-              border-start-end-radius: 0;
+          }
+        }
+        .ht_clone_top_inline_start_corner {
+          .htCore {
+            tbody {
+              tr {
+                &:first-child {
+                  td {
+                    &:first-child {
+                      border-start-start-radius: var(
+                        --ht-wrapper-border-radius
+                      );
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        .ht_clone_top {
+          .htCore {
+            tbody {
+              tr {
+                &:first-child {
+                  td {
+                    &:first-child {
+                      border-start-start-radius: var(
+                        --ht-wrapper-border-radius
+                      );
+                    }
+                    &:last-child {
+                      border-start-end-radius: var(--ht-wrapper-border-radius);
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        .ht_clone_inline_start {
+          .htCore {
+            tbody {
+              tr {
+                &:first-child {
+                  th,
+                  td {
+                    &:first-child {
+                      border-start-start-radius: var(
+                        --ht-wrapper-border-radius
+                      );
+                    }
+                  }
+                }
+              }
             }
           }
         }
       }
-
+      .ht_master {
+        .htCore {
+          thead {
+            tr {
+              &:first-child {
+                th {
+                  &:first-child {
+                    border-start-start-radius: var(--ht-wrapper-border-radius);
+                  }
+                  &:last-child {
+                    border-start-end-radius: var(--ht-wrapper-border-radius);
+                  }
+                }
+              }
+              &:last-child {
+                th {
+                  &:first-child {
+                    border-end-start-radius: var(--ht-wrapper-border-radius);
+                  }
+                  &:last-child {
+                    border-end-end-radius: var(--ht-wrapper-border-radius);
+                  }
+                }
+              }
+            }
+          }
+          tbody {
+            tr {
+              &:last-child {
+                td {
+                  &:first-child {
+                    border-end-start-radius: var(--ht-wrapper-border-radius);
+                  }
+                  &:last-child {
+                    border-end-end-radius: var(--ht-wrapper-border-radius);
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
       .ht_clone_top_inline_start_corner {
         .htCore {
-          border-start-start-radius: var(--ht-wrapper-border-radius);
-
-          thead tr:first-child th:first-child {
-            border-start-start-radius: var(--ht-wrapper-border-radius);
-          }
-
-          tbody tr:first-child td:first-child,
-          tbody tr:first-child th:first-child {
-            border-start-start-radius: var(--ht-wrapper-border-radius);
-          }
-
-          &:has(thead tr th) {
-            tbody tr:first-child td:first-child,
-            tbody tr:first-child th:first-child {
-              border-start-start-radius: 0 !important;
+          thead {
+            tr {
+              &:first-child {
+                th {
+                  &:first-child {
+                    border-start-start-radius: var(--ht-wrapper-border-radius);
+                  }
+                }
+              }
             }
           }
         }
       }
-
-      .ht_clone_bottom_inline_start_corner {
-        .htCore {
-          border-end-start-radius: var(--ht-wrapper-border-radius);
-
-          thead tr:last-child th:first-child {
-            border-end-start-radius: var(--ht-wrapper-border-radius);
-          }
-
-          tbody tr:last-child td:first-child,
-          tbody tr:last-child th:first-child {
-            border-end-start-radius: var(--ht-wrapper-border-radius);
-          }
-
-          &:has(thead tr td) {
-            tbody tr:last-child td:first-child,
-            tbody tr:last-child th:first-child {
-              border-end-start-radius: 0 !important;
-            }
-          }
-        }
-      }
-
       .ht_clone_top {
         .htCore {
-          border-start-start-radius: var(--ht-wrapper-border-radius);
-          border-start-end-radius: var(--ht-wrapper-border-radius);
-
-          thead tr:first-child th:first-child {
-            border-start-start-radius: var(--ht-wrapper-border-radius);
-          }
-
-          thead tr:first-child th:last-child {
-            border-start-end-radius: var(--ht-wrapper-border-radius);
-          }
-
-          tbody tr:first-child td:first-child {
-            border-start-start-radius: var(--ht-wrapper-border-radius);
-          }
-
-          tbody tr:first-child td:last-child {
-            border-start-end-radius: var(--ht-wrapper-border-radius);
-          }
-
-          &:has(thead tr th) {
-            tbody tr:first-child td:first-child {
-              border-start-start-radius: 0;
-            }
-
-            tbody tr:first-child td:last-child {
-              border-start-end-radius: 0;
+          thead {
+            tr {
+              &:first-child {
+                th {
+                  &:first-child {
+                    border-start-start-radius: var(--ht-wrapper-border-radius);
+                  }
+                  &:last-child {
+                    border-start-end-radius: var(--ht-wrapper-border-radius);
+                  }
+                }
+              }
             }
           }
         }
       }
-
       .ht_clone_inline_start {
         .htCore {
-          border-start-start-radius: var(--ht-wrapper-border-radius);
-          border-end-start-radius: var(--ht-wrapper-border-radius);
-
-          thead tr:first-child th:first-child {
-            border-start-start-radius: var(--ht-wrapper-border-radius);
+          thead {
+            tr {
+              &:first-child {
+                th {
+                  &:first-child {
+                    border-start-start-radius: var(--ht-wrapper-border-radius);
+                  }
+                }
+              }
+            }
           }
-
-          tbody tr:first-child td:first-child,
-          tbody tr:first-child th:first-child {
-            border-start-start-radius: var(--ht-wrapper-border-radius);
-          }
-
-          tbody tr:last-child td:first-child,
-          tbody tr:last-child th:first-child {
-            border-end-start-radius: var(--ht-wrapper-border-radius);
-          }
-
-          &:has(thead tr th) {
-            tbody tr:first-child td:first-child,
-            tbody tr:first-child th:first-child {
-              border-start-start-radius: 0;
+          tbody {
+            tr {
+              &:last-child {
+                th,
+                td {
+                  &:first-child {
+                    border-end-start-radius: var(--ht-wrapper-border-radius);
+                  }
+                }
+              }
             }
           }
         }
       }
-
+      .ht_clone_bottom_inline_start_corner {
+        .htCore {
+          tr {
+            &:last-child {
+              th,
+              td {
+                &:first-child {
+                  border-end-start-radius: var(--ht-wrapper-border-radius);
+                }
+              }
+            }
+          }
+        }
+      }
       .ht_clone_bottom {
         .htCore {
-          border-end-start-radius: var(--ht-wrapper-border-radius);
-          border-end-end-radius: var(--ht-wrapper-border-radius);
-
-          thead tr:last-child th:first-child {
-            border-end-start-radius: var(--ht-wrapper-border-radius);
-          }
-
-          thead tr:last-child th:last-child {
-            border-end-end-radius: var(--ht-wrapper-border-radius);
-          }
-
-          tbody tr:last-child td:first-child {
-            border-end-start-radius: var(--ht-wrapper-border-radius);
-          }
-
-          tbody tr:last-child td:last-child {
-            border-end-end-radius: var(--ht-wrapper-border-radius);
-          }
-
-          &:has(thead tr th) {
-            tbody tr:last-child td:first-child {
-              border-end-start-radius: 0;
-            }
-
-            tbody tr:last-child td:last-child {
-              border-end-end-radius: 0;
+          tr {
+            &:last-child {
+              th,
+              td {
+                &:first-child {
+                  border-end-start-radius: var(--ht-wrapper-border-radius);
+                }
+                &:last-child {
+                  border-end-end-radius: var(--ht-wrapper-border-radius);
+                }
+              }
             }
           }
         }
       }
-
       &.htHasScrollX {
         .htCore {
           border-end-start-radius: 0;
           border-end-end-radius: 0;
-
           thead tr:last-child th:first-child,
           tbody tr:last-child td:first-child,
           tbody tr:last-child th:first-child {
-            border-end-start-radius: 0;
+            border-end-start-radius: 0 !important;
           }
-
           thead tr:last-child th:last-child,
           tbody tr:last-child td:last-child,
           tbody tr:last-child th:last-child {
-            border-end-end-radius: 0;
+            border-end-end-radius: 0 !important;
           }
         }
       }
-
       &.htHasScrollY {
         .htCore {
           border-start-end-radius: 0;
           border-end-end-radius: 0;
-
           thead tr:first-child th:last-child,
           tbody tr:first-child td:last-child,
           tbody tr:first-child th:last-child {
-            border-start-end-radius: 0;
+            border-start-end-radius: 0 !important;
           }
-
           thead tr:last-child th:last-child,
           tbody tr:last-child td:last-child,
           tbody tr:last-child th:last-child {
-            border-end-end-radius: 0;
+            border-end-end-radius: 0 !important;
           }
         }
       }


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR includes fixes:
 * Optimize the table selectors responsible for border-radius (thanks, @adrianspdev, for help);
 * Fix missing `htColumnHeaders` class for nested headers;
 * Optimize the selectors responsible for selection header borders (thanks, @adrianspdev, for help);

All those optimizations result in rendering the table almost twice as fast.

#### Navigation by arrow down from the topmost viewport:
![image](https://github.com/user-attachments/assets/c09fb0d9-67ee-4253-9160-9f4a5236c181)

Faster ~90% in fast render and 100% in slow render phase.

#### Navigation by arrow right from the middle of the viewport:
![image](https://github.com/user-attachments/assets/04c05d68-46ac-464c-8218-540f3124298c)

Faster ~70% in fast render and 40% in slow render phase.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2234

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
