### PR TITLE
Prevent deselecting cells when clicking on the Comments' editor element + other fixes.

### DIFF
--- a/.changelogs/11446.json
+++ b/.changelogs/11446.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed a problem, where clicking on the Comments' editor element deselected the currently selected cells.",
+  "type": "fixed",
+  "issueOrPR": 11446,
+  "breaking": false,
+  "framework": "none"
+}

--- a/docs/content/guides/navigation/keyboard-shortcuts/keyboard-shortcuts.md
+++ b/docs/content/guides/navigation/keyboard-shortcuts/keyboard-shortcuts.md
@@ -222,11 +222,13 @@ These keyboard shortcuts work with the [column filter](@/guides/columns/column-f
 
 These keyboard shortcuts work with [comments](@/guides/cell-features/comments/comments.md). To activate them, enable the [`Comments`](@/api/comments.md) plugin.
 
-| Windows                                                 | macOS                                                      | Action                                  |  Excel  | Sheets  |
-| ------------------------------------------------------- | ---------------------------------------------------------- | --------------------------------------- | :-----: | :-----: |
-| <kbd>**Ctrl**</kbd>+<kbd>**Alt**</kbd>+<kbd>**M**</kbd> | <kbd>**Ctrl**</kbd>+<kbd>**Option**</kbd>+<kbd>**M**</kbd> | Add or edit a comment                   | &cross; | &check; |
-| <kbd>**Ctrl**</kbd>+<kbd>**Enter**</kbd>                | <kbd>**Cmd**</kbd>+<kbd>**Enter**</kbd>                    | Save and exit the current comment       | &cross; | &check; |
-| <kbd>**Escape**</kbd>                                   | <kbd>**Escape**</kbd>                                      | Exit the current comment without saving | &cross; | &cross; |
+| Windows                                                 | macOS                                                      | Action                                                                     |  Excel  | Sheets  |
+|---------------------------------------------------------|------------------------------------------------------------|----------------------------------------------------------------------------| :-----: | :-----: |
+| <kbd>**Ctrl**</kbd>+<kbd>**Alt**</kbd>+<kbd>**M**</kbd> | <kbd>**Ctrl**</kbd>+<kbd>**Option**</kbd>+<kbd>**M**</kbd> | Add or edit a comment                                                      | &cross; | &check; |
+| <kbd>**Ctrl**</kbd>+<kbd>**Enter**</kbd>                | <kbd>**Cmd**</kbd>+<kbd>**Enter**</kbd>                    | Save and exit the current comment                                          | &cross; | &check; |
+| <kbd>**Escape**</kbd>                                   | <kbd>**Escape**</kbd>                                      | Exit the current comment without saving                                    | &cross; | &cross; |
+| <kbd>**Tab**</kbd>                                      | <kbd>**Tab**</kbd>                                         | Save and exit the current comment, move the selection to the next cell     | &cross; | &cross; |
+| <kbd>**Shift + Tab**</kbd>                              | <kbd>**Shift + Tab**</kbd>                                 | Save and exit the current comment, move the selection to the previous cell | &cross; | &cross; |
 
 
 ## API reference

--- a/handsontable/src/plugins/comments/__tests__/comments.spec.js
+++ b/handsontable/src/plugins/comments/__tests__/comments.spec.js
@@ -851,6 +851,38 @@ describe('Comments', () => {
     expect(getActiveEditor().isOpened()).toBe(true);
   });
 
+  it('should not deselect the currently selected cell after clicking on the Comments\' editor element', async() => {
+    handsontable({
+      data: createSpreadsheetData(4, 4),
+      rowHeaders: true,
+      colHeaders: true,
+      comments: {
+        displayDelay: 10
+      },
+      cell: [
+        { row: 1, col: 1, comment: { value: 'Hello world!' } }
+      ],
+    });
+
+    selectCell(1, 1);
+    $(getCell(1, 1)).simulate('mouseover', {
+      clientX: Handsontable.dom.offset(getCell(1, 1)).left + 5,
+      clientY: Handsontable.dom.offset(getCell(1, 1)).top + 5,
+    });
+
+    await sleep(50);
+
+    $(getPlugin('comments').getEditorInputElement())
+      .simulate('mousedown')
+      .simulate('mouseup')
+      .simulate('click');
+    getPlugin('comments').getEditorInputElement().focus();
+
+    await sleep(50);
+
+    expect(getSelected()).toEqual([[1, 1, 1, 1]]);
+  });
+
   describe('Using the Context Menu', () => {
     it('should open the comment editor when clicking the "Add comment" entry', () => {
       const hot = handsontable({

--- a/handsontable/src/plugins/comments/__tests__/keyboardShortcuts.spec.js
+++ b/handsontable/src/plugins/comments/__tests__/keyboardShortcuts.spec.js
@@ -327,7 +327,7 @@ describe('Comments keyboard shortcut', () => {
   });
 
   describe('"TAB"', () => {
-    it('should close the comment without saving the value and move the selection to the next cell (grid default for TAB)',
+    it('should close the comment, save the value and move the selection to the next cell (grid default for TAB)',
       async() => {
         handsontable({
           data: createSpreadsheetData(4, 4),
@@ -351,7 +351,7 @@ describe('Comments keyboard shortcut', () => {
 
         await sleep(50);
 
-        expect(getCellMeta(1, 1).comment).toEqual({ value: '' });
+        expect(getCellMeta(1, 1).comment).toEqual({ value: 'Test comment' });
         expect(commentsInput.parentNode.style.display).toEqual('none');
         expect(getSelectedLast()).toEqual([1, 2, 1, 2]);
         expect(document.activeElement).toBe(getCell(1, 2));
@@ -359,7 +359,7 @@ describe('Comments keyboard shortcut', () => {
   });
 
   describe('"Shift + TAB"', () => {
-    it('should close the comment without saving the value and move the selection to the next cell (grid default for TAB)',
+    it('should close the comment, save the value and move the selection to the next cell (grid default for TAB)',
       async() => {
         handsontable({
           data: createSpreadsheetData(4, 4),
@@ -383,7 +383,7 @@ describe('Comments keyboard shortcut', () => {
 
         await sleep(50);
 
-        expect(getCellMeta(1, 1).comment).toEqual({ value: '' });
+        expect(getCellMeta(1, 1).comment).toEqual({ value: 'Test comment' });
         expect(commentsInput.parentNode.style.display).toEqual('none');
         expect(getSelectedLast()).toEqual([1, 0, 1, 0]);
         expect(document.activeElement).toBe(getCell(1, 0));

--- a/handsontable/src/plugins/comments/comments.js
+++ b/handsontable/src/plugins/comments/comments.js
@@ -299,7 +299,7 @@ export class Comments extends BasePlugin {
       keys: [['Shift', 'Tab'], ['Tab']],
       forwardToContext: manager.getContext('grid'),
       callback: () => {
-        this.#editor.setValue(this.#commentValueBeforeSave);
+        this.#editor.setValue(this.#editor.getValue());
         this.hide();
         manager.setActiveContextName('grid');
       },
@@ -332,6 +332,12 @@ export class Comments extends BasePlugin {
     this.eventManager.addEventListener(rootDocument, 'mouseup', () => this.#onMouseUp());
     this.eventManager.addEventListener(editorElement, 'focus', () => this.#onEditorFocus());
     this.eventManager.addEventListener(editorElement, 'blur', () => this.#onEditorBlur());
+
+    this.eventManager.addEventListener(
+      this.getEditorInputElement(),
+      'mousedown',
+      event => this.#onInputElementMouseDown(event)
+    );
   }
 
   /**
@@ -678,6 +684,15 @@ export class Comments extends BasePlugin {
         this.hide();
       }
     }
+  }
+
+  /**
+   * Prevent recognizing clicking on the comment editor as clicking outside of table.
+   *
+   * @param {MouseEvent} event The `mousedown` event.
+   */
+  #onInputElementMouseDown(event) {
+    event.stopPropagation();
   }
 
   /**


### PR DESCRIPTION
### Context
This PR:

1. Prevents deselecting cells when clicking on the Comments' editor element.
2. Makes `TAB` and `Shift+TAB` save the comment value
3. Adds test cases for both `1` and `2`
4. Add a docs entry about the keyboard shortcuts

Note: This PR should be cherry-picked to the `15.1.0` release branch, as it fixed a problem with a change included in that version.

### How has this been tested?
Tested manually + added test cases.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [s] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#2152

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
