### PR TITLE
Fix scrollable element size after table view size change

### DIFF
--- a/handsontable/src/3rdparty/walkontable/src/overlays.js
+++ b/handsontable/src/3rdparty/walkontable/src/overlays.js
@@ -583,6 +583,30 @@ class Overlays {
   }
 
   /**
+   * Update the main scrollable elements for all the overlays.
+   */
+  updateMainScrollableElements() {
+    this.eventManager.clearEvents(true);
+
+    this.inlineStartOverlay.updateMainScrollableElement();
+    this.topOverlay.updateMainScrollableElement();
+
+    if (this.bottomOverlay.needFullRender) {
+      this.bottomOverlay.updateMainScrollableElement();
+    }
+    const { wtTable } = this;
+    const { rootWindow } = this.domBindings;
+
+    if (rootWindow.getComputedStyle(wtTable.wtRootElement.parentNode).getPropertyValue('overflow') === 'hidden') {
+      this.scrollableElement = wtTable.holder;
+    } else {
+      this.scrollableElement = getScrollableElement(wtTable.TABLE);
+    }
+
+    this.registerListeners();
+  }
+
+  /**
    *
    */
   destroy() {

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -2632,6 +2632,11 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
       instance.view.render();
       instance.view._wt.wtOverlays.adjustElementsSize();
     }
+
+    if (!init && instance.view && (currentHeight === '' || height === '' || height === undefined) &&
+        currentHeight !== height) {
+      instance.view._wt.wtOverlays.updateMainScrollableElements();
+    }
   };
 
   /**

--- a/handsontable/test/e2e/Core_view.spec.js
+++ b/handsontable/test/e2e/Core_view.spec.js
@@ -666,6 +666,22 @@ describe('Core_view', () => {
     expect(getSelectedRange()).toEqualCellRange(['highlight: 1,2 from: 1,2 to: 1,2']);
   });
 
+  it('should update the `scrollableElement` value of the Overlays after changing the table view size settings', () => {
+    const hot = handsontable({
+      rowHeaders: true,
+      colHeaders: true,
+    });
+
+    expect(hot.view._wt.wtOverlays.scrollableElement).toBe(window);
+
+    updateSettings({
+      width: 200,
+      height: 200,
+    });
+
+    expect(hot.view._wt.wtOverlays.scrollableElement).toBe(hot.rootElement.querySelector('.wtHolder'));
+  });
+
   describe('scroll', () => {
     it('should call preventDefault in a wheel event on fixed overlay\'s element', async() => {
       spec().$container.css({


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR is a hotfix for a regression introduced in https://github.com/handsontable/handsontable/pull/11328. The fix reverts the code that was incorrectly identified as unnecessary/broken.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and I covered the regression with a test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
