### PR TITLE
[docs] Update the changelog for `15.1.0` with a blog post link.

### DIFF
--- a/docs/content/guides/upgrade-and-migration/changelog/changelog.md
+++ b/docs/content/guides/upgrade-and-migration/changelog/changelog.md
@@ -30,7 +30,8 @@ See the full history of changes made to Handsontable in each major, minor, and p
 Released on February 20, 2025
 
 For more information about this release see:
-- [Documentation (15.0)](https://handsontable.com/docs/15.1)
+- [Blog post (15.1.0)](https://handsontable.com/blog/handsontable-15.1.0-performance-and-stability-improvements)
+- [Documentation (15.1)](https://handsontable.com/docs/15.1)
 
 #### Added
 - Added the `TAB` and `SHIFT + TAB` functionality to the Comments editor. [#11345](https://github.com/handsontable/handsontable/pull/11345)


### PR DESCRIPTION
### Context
This PR:
- Adds a blog post link to the docs' changelog.
- Corrects a typo in the changelog's documentation link.

This PR should be merged to `prod-docs/15.1` as well as `develop`.

[skip changelog]