### PR TITLE
Fix filter buttons focus outline in documentation demos

### DIFF
--- a/docs/.vuepress/theme/styles/components/handsontable.styl
+++ b/docs/.vuepress/theme/styles/components/handsontable.styl
@@ -6,6 +6,14 @@
   font-size: 13px;
   color #222222;
 
+  *:not(a) { 
+    outline: blue solid 0 !important
+  }
+
+  *:not(a):focus-visible {
+    outline: blue solid 0 !important
+  }
+
   img {
     border-radius: 0 !important
   }


### PR DESCRIPTION
### Context
This PR includes fix for outline size for filer buttons

### How has this been tested?
Locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2183

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

[skip changelog]
