### PR TITLE
Fix `hasVerticalScroll` and `hasHorizontalScroll` methods

### DIFF
--- a/.changelogs/11455.json
+++ b/.changelogs/11455.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed `hasVerticalScroll` and `hasHorizontalScroll` methods",
+  "type": "fixed",
+  "issueOrPR": 11455,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/src/viewport.js
+++ b/handsontable/src/3rdparty/walkontable/src/viewport.js
@@ -160,7 +160,21 @@ class Viewport {
    * @returns {boolean}
    */
   hasVerticalScroll() {
-    return this.wtTable.hider.offsetHeight > this.getWorkspaceHeight();
+    if (this.isVerticallyScrollableByWindow()) {
+      const documentElement = this.domBindings.rootDocument.documentElement;
+
+      return documentElement.scrollHeight > documentElement.clientHeight;
+    }
+
+    const { holder, hider } = this.wtTable;
+    const holderHeight = holder.clientHeight;
+    const hiderOffsetHeight = hider.offsetHeight;
+
+    if (holderHeight < hiderOffsetHeight) {
+      return true;
+    }
+
+    return hiderOffsetHeight > this.getWorkspaceHeight();
   }
 
   /**
@@ -169,7 +183,21 @@ class Viewport {
    * @returns {boolean}
    */
   hasHorizontalScroll() {
-    return this.wtTable.hider.offsetWidth > this.getWorkspaceWidth();
+    if (this.isVerticallyScrollableByWindow()) {
+      const documentElement = this.domBindings.rootDocument.documentElement;
+
+      return documentElement.scrollWidth > documentElement.clientWidth;
+    }
+
+    const { holder, hider } = this.wtTable;
+    const holderWidth = holder.clientWidth;
+    const hiderOffsetWidth = hider.offsetWidth;
+
+    if (holderWidth < hiderOffsetWidth) {
+      return true;
+    }
+
+    return hiderOffsetWidth > this.getWorkspaceWidth();
   }
 
   /**

--- a/handsontable/src/3rdparty/walkontable/test/spec/viewport.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/viewport.spec.js
@@ -270,6 +270,22 @@ describe('WalkontableViewport', () => {
 
       expect(wt.wtViewport.hasVerticalScroll()).toBe(true);
     });
+
+    it('should return `true` when the viewport height is the same as total height of all rows (#dev-2248)', () => {
+      createDataArray(13, 15);
+
+      spec().$wrapper.width(500).height(300);
+
+      const wt = walkontable({
+        data: getData,
+        totalRows: getTotalRows,
+        totalColumns: getTotalColumns,
+      });
+
+      wt.draw();
+
+      expect(wt.wtViewport.hasVerticalScroll()).toBe(true);
+    });
   });
 
   describe('hasHorizontalScroll()', () => {
@@ -302,6 +318,22 @@ describe('WalkontableViewport', () => {
         totalColumns: getTotalColumns,
         fixedRowsTop: 2,
         fixedRowsBottom: 2,
+      });
+
+      wt.draw();
+
+      expect(wt.wtViewport.hasHorizontalScroll()).toBe(true);
+    });
+
+    it('should return `true` when the viewport width is the same as total width of all columns (#dev-2248)', () => {
+      createDataArray(50, 10);
+
+      spec().$wrapper.width(500).height(300);
+
+      const wt = walkontable({
+        data: getData,
+        totalRows: getTotalRows,
+        totalColumns: getTotalColumns,
       });
 
       wt.draw();


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the `hasVerticalScroll` and `hasHorizontalScroll` methods, affecting the overlays to have a wrong size. From now on, the updated logic supports both renderings. In the window (window as a scrollable element) and the element (table with a defined size).

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally, and I covered the fix with new tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/2248

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
