### PR TITLE
Fix editor border radius on mobile devices

### DIFF
--- a/.changelogs/11457.json
+++ b/.changelogs/11457.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fix editor border radius on mobile devices",
+  "type": "fixed",
+  "issueOrPR": 11457,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/styles/components/editors/_select-editor.scss
+++ b/handsontable/src/styles/components/editors/_select-editor.scss
@@ -26,6 +26,7 @@
         0 0 var(--ht-cell-editor-shadow-blur-radius, 0) 0
           var(--ht-cell-editor-shadow-color, transparent);
       border: none;
+      border-radius: 0;
       box-sizing: border-box;
       -webkit-appearance: none !important;
 

--- a/handsontable/src/styles/components/editors/_text-editor.scss
+++ b/handsontable/src/styles/components/editors/_text-editor.scss
@@ -21,6 +21,7 @@
         0 0 var(--ht-cell-editor-shadow-blur-radius, 0) 0
           var(--ht-cell-editor-shadow-color, transparent);
       border: none;
+      border-radius: 0;
       -webkit-appearance: none !important;
       box-sizing: border-box;
       /* Miscellaneous */

--- a/handsontable/test/e2e/mobile/textEditor.spec.js
+++ b/handsontable/test/e2e/mobile/textEditor.spec.js
@@ -42,4 +42,25 @@ describe('Text Editor', () => {
 
     expect(cell.textContent).toBe('test');
   });
+
+  it('should have correct border radius value in editor textarea', async() => {
+    const hot = handsontable({
+      columns: [
+        {
+          type: 'text',
+        }
+      ]
+    });
+
+    hot.getCell(0, 0);
+
+    selectCell(0, 0);
+
+    keyDownUp('enter');
+
+    const editor = getActiveEditor();
+    const compStyle = getComputedStyle(editor.TEXTAREA);
+
+    expect(compStyle.borderRadius).toBe('0px');
+  });
 });


### PR DESCRIPTION
### Context
This PR includes fixes for problem with border radius in editor fields

### How has this been tested?
Locally on iOS emulator

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2255

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
