### PR TITLE
Fix overlay's misalignment that contain merge cells

### DIFF
--- a/.changelogs/11458.json
+++ b/.changelogs/11458.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed the wrong height of the first row",
+  "type": "fixed",
+  "issueOrPR": 11458,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/editors/textEditor/__tests__/textEditor.spec.js
+++ b/handsontable/src/editors/textEditor/__tests__/textEditor.spec.js
@@ -650,7 +650,7 @@ describe('TextEditor', () => {
 
     expect(hot.getActiveEditor().TEXTAREA.style.height).forThemes(({ classic, main }) => {
       classic.toBe('24px');
-      main.toBe('29px');
+      main.toBe('30px');
     });
     expect(hot.getActiveEditor().TEXTAREA.style.width).toBe('50px');
   });
@@ -1959,7 +1959,7 @@ describe('TextEditor', () => {
 
     expect($editorInput.height()).forThemes(({ classic, main }) => {
       classic.toBe(83);
-      main.toBe(95);
+      main.toBe(94);
     });
   });
 

--- a/handsontable/src/plugins/contextMenu/__tests__/positioning.spec.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/positioning.spec.js
@@ -301,7 +301,7 @@ describe('ContextMenu', () => {
 
       expect(tickItemOffset.top).forThemes(({ classic, main }) => {
         classic.toBe(216);
-        main.toBe(247);
+        main.toBe(248);
       });
       expect(tickItemOffset.left).forThemes(({ classic, main }) => {
         classic.toBe(contextMenuOffset.left + 4);

--- a/handsontable/src/plugins/contextMenu/__tests__/rtl/positioning.spec.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/rtl/positioning.spec.js
@@ -221,7 +221,7 @@ describe('ContextMenu (RTL mode)', () => {
 
       expect(tickItemOffset.top).forThemes(({ classic, main }) => {
         classic.toBe(216);
-        main.toBe(247);
+        main.toBe(248);
       });
       expect(tickItemOffset.left).forThemes(({ classic, main }) => {
         classic.toBe(contextMenuOffset.left + $contextMenuRoot.outerWidth() - 4);

--- a/handsontable/src/plugins/dropdownMenu/__tests__/positioning.spec.js
+++ b/handsontable/src/plugins/dropdownMenu/__tests__/positioning.spec.js
@@ -110,7 +110,7 @@ describe('DropdownMenu', () => {
 
       expect(tickItemOffset.top).forThemes(({ classic, main }) => {
         classic.toBe(135);
-        main.toBe(155);
+        main.toBe(156);
       });
       expect(tickItemOffset.left).forThemes(({ classic, main }) => {
         classic.toBe(dropdownMenuOffset.left + 4);

--- a/handsontable/src/plugins/dropdownMenu/__tests__/rtl/positioning.spec.js
+++ b/handsontable/src/plugins/dropdownMenu/__tests__/rtl/positioning.spec.js
@@ -130,7 +130,7 @@ describe('DropdownMenu (RTL mode)', () => {
       const $dropdownMenuRoot = $('.htDropdownMenu');
       const dropdownMenuOffset = $dropdownMenuRoot.offset();
 
-      expect(tickItemOffset.top).toBe(155);
+      expect(tickItemOffset.top).toBe(156);
       expect(tickItemOffset.left).toBe(dropdownMenuOffset.left + 1);
     });
   });

--- a/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
+++ b/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
@@ -71,9 +71,9 @@ describe('manualRowResize', () => {
       manualRowResize: true
     });
 
-    expect(rowHeight(spec().$container, 0)).toEqual(themeDefaultRowHeight); // + Double border
-    expect(rowHeight(spec().$container, 1)).toEqual(themeDefaultRowHeight); // + Single border
-    expect(rowHeight(spec().$container, 2)).toEqual(themeDefaultRowHeight); // + Single border
+    expect(rowHeight(spec().$container, 0)).toEqual(themeDefaultRowHeight + 1); // + Single border
+    expect(rowHeight(spec().$container, 1)).toEqual(themeDefaultRowHeight);
+    expect(rowHeight(spec().$container, 2)).toEqual(themeDefaultRowHeight);
 
     updateSettings({
       manualRowResize: [60, 50, 80]
@@ -165,7 +165,7 @@ describe('manualRowResize', () => {
       manualRowResize: undefined
     });
 
-    expect(rowHeight(spec().$container, 0)).toEqual(themeDefaultRowHeight);
+    expect(rowHeight(spec().$container, 0)).toEqual(themeDefaultRowHeight + 1); // + Single border
     expect(rowHeight(spec().$container, 1)).toEqual(themeDefaultRowHeight);
     expect(rowHeight(spec().$container, 2)).toEqual(themeDefaultRowHeight);
   });
@@ -195,7 +195,7 @@ describe('manualRowResize', () => {
       manualRowResize: true
     });
 
-    expect(rowHeight(spec().$container, 0)).toEqual(themeDefaultRowHeight);
+    expect(rowHeight(spec().$container, 0)).toEqual(themeDefaultRowHeight + 1); // + Single border
     expect(rowHeight(spec().$container, 1)).toEqual(themeDefaultRowHeight);
     expect(rowHeight(spec().$container, 2)).toEqual(themeDefaultRowHeight);
 
@@ -203,7 +203,7 @@ describe('manualRowResize', () => {
       manualRowResize: true
     });
 
-    expect(rowHeight(spec().$container, 0)).toEqual(themeDefaultRowHeight);
+    expect(rowHeight(spec().$container, 0)).toEqual(themeDefaultRowHeight + 1); // + Single border
     expect(rowHeight(spec().$container, 1)).toEqual(themeDefaultRowHeight);
     expect(rowHeight(spec().$container, 2)).toEqual(themeDefaultRowHeight);
   });
@@ -233,14 +233,14 @@ describe('manualRowResize', () => {
       manualRowResize: [undefined, undefined, 120]
     });
 
-    expect(rowHeight(spec().$container, 0)).toBe(themeDefaultRowHeight);
+    expect(rowHeight(spec().$container, 0)).toBe(themeDefaultRowHeight + 1); // + Single border
     expect(rowHeight(spec().$container, 1)).toBe(themeDefaultRowHeight);
     expect(rowHeight(spec().$container, 2)).toBe(120);
     expect(rowHeight(spec().$container, 3)).toBe(themeDefaultRowHeight);
 
     alter('insert_row_above', 0);
 
-    expect(rowHeight(spec().$container, 0)).toBe(themeDefaultRowHeight);
+    expect(rowHeight(spec().$container, 0)).toBe(themeDefaultRowHeight + 1); // + Single border
     expect(rowHeight(spec().$container, 1)).toBe(themeDefaultRowHeight);
     expect(rowHeight(spec().$container, 2)).toBe(themeDefaultRowHeight);
     expect(rowHeight(spec().$container, 3)).toBe(120);
@@ -271,14 +271,14 @@ describe('manualRowResize', () => {
       manualRowResize: [undefined, undefined, 120]
     });
 
-    expect(rowHeight(spec().$container, 0)).toBe(themeDefaultRowHeight);
+    expect(rowHeight(spec().$container, 0)).toBe(themeDefaultRowHeight + 1); // + Single border
     expect(rowHeight(spec().$container, 1)).toBe(themeDefaultRowHeight);
     expect(rowHeight(spec().$container, 2)).toBe(120);
     expect(rowHeight(spec().$container, 3)).toBe(themeDefaultRowHeight);
 
     alter('remove_row', 0);
 
-    expect(rowHeight(spec().$container, 0)).toBe(themeDefaultRowHeight);
+    expect(rowHeight(spec().$container, 0)).toBe(themeDefaultRowHeight + 1); // + Single border
     expect(rowHeight(spec().$container, 1)).toBe(120);
     expect(rowHeight(spec().$container, 2)).toBe(themeDefaultRowHeight);
     expect(rowHeight(spec().$container, 3)).toBe(themeDefaultRowHeight);

--- a/handsontable/src/plugins/mergeCells/mergeCells.js
+++ b/handsontable/src/plugins/mergeCells/mergeCells.js
@@ -1504,13 +1504,19 @@ export class MergeCells extends BasePlugin {
    * @returns {number}
    */
   #sumCellsHeights(row, rowspan) {
-    const defaultHeight = this.hot.view.getDefaultRowHeight();
+    const { view, rowIndexMapper } = this.hot;
+    const stylesHandler = view.getStylesHandler();
+    const defaultHeight = view.getDefaultRowHeight();
     const autoRowSizePlugin = this.hot.getPlugin('autoRowSize');
     let height = 0;
 
     for (let i = row; i < row + rowspan; i++) {
-      if (!this.hot.rowIndexMapper.isHidden(i)) {
+      if (!rowIndexMapper.isHidden(i)) {
         height += autoRowSizePlugin?.getRowHeight(i) ?? defaultHeight;
+
+        if (i === 0 && !stylesHandler.isClassicTheme()) {
+          height += 1; // border-top-width
+        }
       }
     }
 

--- a/handsontable/src/plugins/mergeCells/mergeCells.js
+++ b/handsontable/src/plugins/mergeCells/mergeCells.js
@@ -1504,7 +1504,6 @@ export class MergeCells extends BasePlugin {
    * @returns {number}
    */
   #sumCellsHeights(row, rowspan) {
-    const stylesHandler = this.hot.view.getStylesHandler();
     const defaultHeight = this.hot.view.getDefaultRowHeight();
     const autoRowSizePlugin = this.hot.getPlugin('autoRowSize');
     let height = 0;
@@ -1512,10 +1511,6 @@ export class MergeCells extends BasePlugin {
     for (let i = row; i < row + rowspan; i++) {
       if (!this.hot.rowIndexMapper.isHidden(i)) {
         height += autoRowSizePlugin?.getRowHeight(i) ?? defaultHeight;
-
-        if (i === 0 && !stylesHandler.isClassicTheme()) {
-          height += 1; // border-top-width
-        }
       }
     }
 

--- a/handsontable/src/styles/base/_base.scss
+++ b/handsontable/src/styles/base/_base.scss
@@ -83,6 +83,12 @@
               border-top-width: 0;
             }
           }
+
+          &:first-of-type td {
+            height: calc(
+              var(--ht-cell-vertical-padding) * 2 + var(--ht-line-height) + 1px
+            );
+          }
         }
       }
     }
@@ -155,6 +161,13 @@
           background: transparent;
         }
       }
+    }
+
+    // compensates the top border width of the first row
+    tr:first-of-type td {
+      height: calc(
+        var(--ht-cell-vertical-padding) * 2 + var(--ht-line-height) + 2px
+      );
     }
 
     // Cell


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the overlay's misalignment for overlays that contain merge cells. The reason for the misalignment was the incorrect height of the first row, which is the only one that receives the border-width attribute of 1px for the top, which causes the content in the cells to be pushed by 1px (as the box-sizing is set as border-box). The fix compensates for that 1px in CSS.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally, and I updated the tests according to the changes.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/2252

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
