### PR TITLE
Fix problem with table on TAB navigation in docs

### DIFF
--- a/docs/.vuepress/theme/styles/components/handsontable.styl
+++ b/docs/.vuepress/theme/styles/components/handsontable.styl
@@ -21,6 +21,10 @@
   .handsontable tr {
     background: none;
   }
+  
+  .htFocusCatcher {
+    border: 0 !important;
+  }
 }
 
 table.htCore {


### PR DESCRIPTION
### Context
Fix problem with table jumping in the documentation when navigating using SHIFT + TAB.

### How has this been tested?
Locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2260

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

[skip changelog]
