### PR TITLE
Add null checks for getCoords

### DIFF
--- a/handsontable/src/3rdparty/walkontable/src/table.js
+++ b/handsontable/src/3rdparty/walkontable/src/table.js
@@ -715,7 +715,7 @@ class Table {
     } else if (CONTAINER === this.THEAD) {
       row = this.rowFilter.visibleColHeadedRowToSourceRow(row);
 
-    } else {
+    } else if (this.rowFilter) {
       row = this.rowFilter.renderedToSource(row);
     }
 
@@ -724,7 +724,7 @@ class Table {
       || overlayContainsElement(CLONE_BOTTOM_INLINE_START_CORNER, cellElement, this.wtRootElement)) {
       col = this.columnFilter.offsettedTH(col);
 
-    } else {
+    } else if (this.columnFilter) {
       col = this.columnFilter.visibleRowHeadedColumnToSourceColumn(col);
     }
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->

In specific cases where Handsontable has been embedded inside of a SAPUI5 app, errors will occur in the getCoords method due to the rowFilter and columnFilter properties of walkontable being undefined.  We have been unable to reproduce this in a standalone Handsontable instance, or in our wrapper library by itself outside of the app context, but it occurs fairly consistently in the app.

The error occurs because there is no null check for the rowFilter and columnFilter, which results in errors when the final else condition is executed.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Tested in the app that was having issues with multiple users and confirmed that issue appears resolved.

 * Automated tests with `npm run test:walkontable` complete successfully.
 * Automated tests with `npm run test:production` are unsuccessful on the original develop branch and fail with same errors in the fork; failing tests are related to dropdown menu, dates, and hyperformula so appear unrelated to the change.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. [Error in getCoords method in "walkontable" this.rowFilter is not defined #11466](https://github.com/handsontable/handsontable/issues/11466)

### Affected project(s):
- [X] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [X] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
