### PR TITLE
Fix problem with horizontal scroll in autocomplete editor dropdown when table overflow is hidden

### DIFF
--- a/.changelogs/11473.json
+++ b/.changelogs/11473.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed problem with horizontal scroll in autocomplete dropdown",
+  "type": "fixed",
+  "issueOrPR": 11473,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/editors/autocompleteEditor/__tests__/autocompleteEditor.spec.js
+++ b/handsontable/src/editors/autocompleteEditor/__tests__/autocompleteEditor.spec.js
@@ -529,6 +529,36 @@ describe('AutocompleteEditor', () => {
       });
     });
 
+    it('should open editor with the correct size when there is scrollbar on the list and table overflow is hidden', async() => {
+      handsontable({
+        colWidths: 120,
+        columns: [
+          {
+            editor: 'autocomplete',
+            source: choices,
+            visibleRows: choices.length,
+          }
+        ],
+        height: 'auto'
+      });
+
+      selectCell(0, 0);
+      keyDownUp('enter');
+
+      await sleep(100);
+
+      const container = getActiveEditor().htContainer;
+
+      expect(container.clientWidth).forThemes(({ classic, main }) => {
+        classic.toBe(120 + Handsontable.dom.getScrollbarWidth());
+        main.toBe(118 + Handsontable.dom.getScrollbarWidth());
+      });
+      expect(container.clientHeight).forThemes(({ classic, main }) => {
+        classic.toBe(69);
+        main.toBe(87);
+      });
+    });
+
     it('should open editor with the correct size when there is scrollbar on the list (trimDropdown: false)', async() => {
       handsontable({
         colWidths: 120,

--- a/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
+++ b/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
@@ -323,7 +323,6 @@ export class AutocompleteEditor extends HandsontableEditor {
     if (choices.length > 0) {
       this.updateDropdownDimensions();
       this.flipDropdownIfNeeded();
-      this.updateDropdownWidth();
 
       if (this.cellProperties.strict === true) {
         this.highlightBestMatchingChoice(highlightIndex);
@@ -433,6 +432,17 @@ export class AutocompleteEditor extends HandsontableEditor {
   }
 
   /**
+   * Fix width of the internal Handsontable's instance when editor has vertical scroll.
+   */
+  #fixDropdownWidth() {
+    if (this.htEditor.view.hasVerticalScroll()) {
+      this.htEditor.updateSettings({
+        width: this.htEditor.getSettings().width + getScrollbarWidth(this.hot.rootDocument),
+      });
+    }
+  }
+
+  /**
    * Updates width and height of the internal Handsontable's instance.
    *
    * @private
@@ -443,22 +453,9 @@ export class AutocompleteEditor extends HandsontableEditor {
       height: this.getHeight(),
     });
 
+    this.#fixDropdownWidth();
+
     this.htEditor.view._wt.wtTable.alignOverlaysWithTrimmingContainer();
-  }
-
-  /**
-   * Updates width of the internal Handsontable's instance when editor has vertical scroll.
-   *
-   * @private
-   */
-  updateDropdownWidth() {
-    if (this.htEditor.view.hasVerticalScroll()) {
-      this.htEditor.updateSettings({
-        width: this.htEditor.getSettings().width + getScrollbarWidth(this.hot.rootDocument),
-      });
-
-      this.htEditor.view._wt.wtTable.alignOverlaysWithTrimmingContainer();
-    }
   }
 
   /**
@@ -471,6 +468,10 @@ export class AutocompleteEditor extends HandsontableEditor {
     this.htEditor.updateSettings({
       height
     });
+
+    this.#fixDropdownWidth();
+
+    this.htEditor.view._wt.wtTable.alignOverlaysWithTrimmingContainer();
   }
 
   /**

--- a/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
+++ b/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
@@ -323,6 +323,7 @@ export class AutocompleteEditor extends HandsontableEditor {
     if (choices.length > 0) {
       this.updateDropdownDimensions();
       this.flipDropdownIfNeeded();
+      this.updateDropdownWidth();
 
       if (this.cellProperties.strict === true) {
         this.highlightBestMatchingChoice(highlightIndex);
@@ -442,13 +443,22 @@ export class AutocompleteEditor extends HandsontableEditor {
       height: this.getHeight(),
     });
 
+    this.htEditor.view._wt.wtTable.alignOverlaysWithTrimmingContainer();
+  }
+
+  /**
+   * Updates width of the internal Handsontable's instance when editor has vertical scroll.
+   *
+   * @private
+   */
+  updateDropdownWidth() {
     if (this.htEditor.view.hasVerticalScroll()) {
       this.htEditor.updateSettings({
         width: this.htEditor.getSettings().width + getScrollbarWidth(this.hot.rootDocument),
       });
-    }
 
-    this.htEditor.view._wt.wtTable.alignOverlaysWithTrimmingContainer();
+      this.htEditor.view._wt.wtTable.alignOverlaysWithTrimmingContainer();
+    }
   }
 
   /**


### PR DESCRIPTION
### Context
This PR includes fixes for horizontal scroll in autocomplete editor list when `overflow: hidden` is applied to the `wrapper` element.

### How has this been tested?
Locally and covered the fix with new tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2258

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
