### PR TITLE
Add border radius to documentation table wrapper

### DIFF
--- a/docs/.vuepress/theme/styles/layout/page.styl
+++ b/docs/.vuepress/theme/styles/layout/page.styl
@@ -310,6 +310,7 @@
         margin: 32px 0
         box-shadow: 0 0 0 1px $borderColor 
         padding: 0 !important
+        border-radius: $radius
     }
     
     table:not(.htCore) { 


### PR DESCRIPTION
### Context
This PR includes fix for missing border radius in documentation pages table

### How has this been tested?
Locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2271

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

[skip changelog]
