### PR TITLE
Improve table UI behavior after removing all rows/columns

### DIFF
--- a/handsontable/src/plugins/contextMenu/__tests__/predefinedItems/removeColumn.spec.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/predefinedItems/removeColumn.spec.js
@@ -130,10 +130,15 @@ describe('ContextMenu', () => {
       const item = selectContextMenuOption('Remove column');
 
       expect(item.hasClass('htDisabled')).toBe(false);
-      expect(getData()).toEqual([]);
+      expect(getData()).toEqual([[null], [null], [null], [null], [null]]);
       expect(`
         |   |
         |===|
+        |   |
+        |   |
+        |   |
+        |   |
+        |   |
         `).toBeMatchToSelectionPattern();
     });
 

--- a/handsontable/src/plugins/contextMenu/__tests__/predefinedItems/removeRow.spec.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/predefinedItems/removeRow.spec.js
@@ -122,8 +122,8 @@ describe('ContextMenu', () => {
       expect(item.hasClass('htDisabled')).toBe(false);
       expect(getData()).toEqual([]);
       expect(`
-        |   |
-        |===|
+        |   ║   :   :   :   :   |
+        |===:===:===:===:===:===|
         `).toBeMatchToSelectionPattern();
     });
 

--- a/handsontable/test/e2e/core/alter/removeCol.spec.js
+++ b/handsontable/test/e2e/core/alter/removeCol.spec.js
@@ -103,25 +103,27 @@ describe('Core.alter', () => {
         expect(getData()[0].length).toBe(5);
       });
 
-      it('should not display rows when every column have been removed (row header enabled)', () => {
+      it('should display rows when every column have been removed (row header enabled, column header disabled)', () => {
         handsontable({
-          data: Handsontable.helper.createSpreadsheetData(5, 5),
-          rowHeaders: true
+          data: createSpreadsheetData(5, 5),
+          rowHeaders: true,
+          colHeaders: false,
         });
 
         alter('remove_col', 0, 5);
 
-        expect(countRows()).toBe(0);
-        expect(getData()).toEqual([]);
+        expect(countRows()).toBe(5);
+        expect(getData()).toEqual([[null], [null], [null], [null], [null]]);
         expect($('.ht_master .htCore td').length).toBe(0);
-        expect($('.ht_master .htCore tbody th').length).toBe(0);
+        expect($('.ht_master .htCore tbody th').length).toBe(5);
         expect($('.ht_master .htCore thead th').length).toBe(0);
         expect($('.ht_master .htCore .cornerHeader').length).toBe(0);
       });
 
-      it('should not display rows when every column have been removed (column header enabled)', () => {
+      it('should not display rows when every column have been removed (row header disabled, column header enabled)', () => {
         handsontable({
-          data: Handsontable.helper.createSpreadsheetData(5, 5),
+          data: createSpreadsheetData(5, 5),
+          rowHeaders: false,
           colHeaders: true
         });
 
@@ -135,19 +137,36 @@ describe('Core.alter', () => {
         expect($('.ht_master .htCore .cornerHeader').length).toBe(0);
       });
 
-      it('should not display rows when every column have been removed (both headers enabled)', () => {
+      it('should not display rows when every column have been removed (both headers disabled)', () => {
         handsontable({
-          data: Handsontable.helper.createSpreadsheetData(5, 5),
+          data: createSpreadsheetData(5, 5),
+          rowHeaders: false,
+          colHeaders: false,
+        });
+
+        alter('remove_col', 0, 5);
+
+        expect(countRows()).toBe(0);
+        expect(getData()).toEqual([]);
+        expect($('.ht_master .htCore td').length).toBe(0);
+        expect($('.ht_master .htCore tbody th').length).toBe(0);
+        expect($('.ht_master .htCore thead th').length).toBe(0);
+        expect($('.ht_master .htCore .cornerHeader').length).toBe(0);
+      });
+
+      it('should display rows when every column have been removed (both headers enabled)', () => {
+        handsontable({
+          data: createSpreadsheetData(5, 5),
           rowHeaders: true,
           colHeaders: true
         });
 
         alter('remove_col', 0, 5);
 
-        expect(countRows()).toBe(0);
-        expect(getData()).toEqual([]);
+        expect(countRows()).toBe(5);
+        expect(getData()).toEqual([[null], [null], [null], [null], [null]]);
         expect($('.ht_master .htCore td').length).toBe(0);
-        expect($('.ht_master .htCore tbody th').length).toBe(0);
+        expect($('.ht_master .htCore tbody th').length).toBe(5);
         expect($('.ht_master .htCore thead th').length).toBe(1);
         expect($('.ht_master .htCore .cornerHeader').length).toBe(1); // Corner visible.
       });

--- a/handsontable/test/e2e/core/alter/removeRow.spec.js
+++ b/handsontable/test/e2e/core/alter/removeRow.spec.js
@@ -123,10 +123,11 @@ describe('Core.alter', () => {
         expect(getData().length).toBe(5);
       });
 
-      it('should not display columns when every row have been removed (row header enabled)', () => {
+      it('should not display columns when every row have been removed (row header enabled, column header disabled)', () => {
         handsontable({
-          data: Handsontable.helper.createSpreadsheetData(5, 5),
-          rowHeaders: true
+          data: createSpreadsheetData(5, 5),
+          rowHeaders: true,
+          colHeaders: false,
         });
 
         alter('remove_row', 0, 5);
@@ -138,10 +139,28 @@ describe('Core.alter', () => {
         expect($('.ht_master .htCore .cornerHeader').length).toBe(0);
       });
 
-      it('should not display columns when every row have been removed (column header enabled)', () => {
+      it('should display columns when every row have been removed (row header disabled, column header enabled)', () => {
         handsontable({
-          data: Handsontable.helper.createSpreadsheetData(5, 5),
-          colHeaders: true
+          data: createSpreadsheetData(5, 5),
+          rowHeaders: false,
+          colHeaders: true,
+        });
+
+        alter('remove_row', 0, 5);
+
+        expect(countCols()).toBe(5);
+        expect(getData()).toEqual([]);
+        expect($('.ht_master .htCore td').length).toBe(0);
+        expect($('.ht_master .htCore tbody th').length).toBe(0);
+        expect($('.ht_master .htCore thead th').length).toBe(5);
+        expect($('.ht_master .htCore .cornerHeader').length).toBe(0);
+      });
+
+      it('should display columns when every row have been removed (both headers disabled)', () => {
+        handsontable({
+          data: createSpreadsheetData(5, 5),
+          rowHeaders: false,
+          colHeaders: false,
         });
 
         alter('remove_row', 0, 5);
@@ -156,18 +175,18 @@ describe('Core.alter', () => {
 
       it('should not display columns when every row have been removed (both headers enabled)', () => {
         handsontable({
-          data: Handsontable.helper.createSpreadsheetData(5, 5),
+          data: createSpreadsheetData(5, 5),
           rowHeaders: true,
-          colHeaders: true
+          colHeaders: true,
         });
 
         alter('remove_row', 0, 5);
 
-        expect(countCols()).toBe(0);
+        expect(countCols()).toBe(5);
         expect(getData()).toEqual([]);
         expect($('.ht_master .htCore td').length).toBe(0);
         expect($('.ht_master .htCore tbody th').length).toBe(0);
-        expect($('.ht_master .htCore thead th').length).toBe(1);
+        expect($('.ht_master .htCore thead th').length).toBe(6); // 5 + corner
         expect($('.ht_master .htCore .cornerHeader').length).toBe(1); // Corner visible.
       });
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR improves the table UI behavior after removing all rows and/or columns.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/2240

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
