### PR TITLE
Fix merged cells height for custom defined row heights

### DIFF
--- a/handsontable/src/plugins/mergeCells/__tests__/mergeCells.spec.js
+++ b/handsontable/src/plugins/mergeCells/__tests__/mergeCells.spec.js
@@ -1691,6 +1691,59 @@ describe('MergeCells', () => {
     `).toBeMatchToSelectionPattern();
   });
 
+  it('should correctly calculate the height of the merged cell for custom defined height (the first column as merged cell, row headers enabled)', () => {
+    handsontable({
+      data: createSpreadsheetData(6, 3),
+      rowHeaders: true,
+      rowHeights: 50,
+      mergeCells: [{ row: 0, col: 0, rowspan: 6, colspan: 1 }],
+    });
+
+    expect(getCell(0, 0).offsetHeight).forThemes(({ classic, main }) => {
+      classic.toBe(301);
+      main.toBe(300);
+    });
+  });
+
+  it('should correctly calculate the height of the merged cell for custom defined height (the first column as merged cell, row headers disabled)', () => {
+    handsontable({
+      data: createSpreadsheetData(6, 3),
+      rowHeaders: false,
+      rowHeights: 50,
+      mergeCells: [{ row: 0, col: 0, rowspan: 6, colspan: 1 }],
+    });
+
+    expect(getCell(0, 0).offsetHeight).toBe(301);
+  });
+
+  it('should correctly calculate the height of the merged cell for custom defined height (the second column as merged cell)', () => {
+    handsontable({
+      data: createSpreadsheetData(6, 3),
+      rowHeaders: false,
+      rowHeights: 50,
+      mergeCells: [{ row: 0, col: 1, rowspan: 6, colspan: 1 }],
+    });
+
+    expect(getCell(0, 1).offsetHeight).forThemes(({ classic, main }) => {
+      classic.toBe(301);
+      main.toBe(300);
+    });
+  });
+
+  it('should correctly calculate the height of the merged cell for custom defined height (the second column as non-fully merged cell)', () => {
+    handsontable({
+      data: createSpreadsheetData(6, 3),
+      rowHeaders: false,
+      rowHeights: 50,
+      mergeCells: [{ row: 0, col: 1, rowspan: 4, colspan: 1 }],
+    });
+
+    expect(getCell(0, 1).offsetHeight).forThemes(({ classic, main }) => {
+      classic.toBe(201);
+      main.toBe(200);
+    });
+  });
+
   it.forTheme('classic')('should display properly high merged cell', () => {
     handsontable({
       data: createSpreadsheetData(50, 3),

--- a/handsontable/src/plugins/mergeCells/mergeCells.js
+++ b/handsontable/src/plugins/mergeCells/mergeCells.js
@@ -1507,12 +1507,11 @@ export class MergeCells extends BasePlugin {
     const { view, rowIndexMapper } = this.hot;
     const stylesHandler = view.getStylesHandler();
     const defaultHeight = view.getDefaultRowHeight();
-    const autoRowSizePlugin = this.hot.getPlugin('autoRowSize');
     let height = 0;
 
     for (let i = row; i < row + rowspan; i++) {
       if (!rowIndexMapper.isHidden(i)) {
-        height += autoRowSizePlugin?.getRowHeight(i) ?? defaultHeight;
+        height += this.hot.getRowHeight(i) ?? defaultHeight;
 
         if (i === 0 && !stylesHandler.isClassicTheme()) {
           height += 1; // border-top-width


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes an issue where the merged cells were rendered with the wrong height. The PR improves the height calculations of the merged cells and includes to them the custom-defined row height (`rowHeights`).

In the case of using `rowHeights: 50`, the merged cell height should be equal to `50 * 3` (row height * rowspan).

#### Before (👎)
![image](https://github.com/user-attachments/assets/176c9e71-3d4e-4549-8660-43476e0247a9)

#### After (👍)
![image](https://github.com/user-attachments/assets/49650424-bc5b-46b6-8754-38904a7da2f1)

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and I covered the fix with new tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/927

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
