### PR TITLE
Add mobile cell handle css variables to the themes

### DIFF
--- a/handsontable/src/3rdparty/walkontable/src/selection/border/border.js
+++ b/handsontable/src/3rdparty/walkontable/src/selection/border/border.js
@@ -223,7 +223,12 @@ class Border {
    * Create multiple selector handler for mobile devices.
    */
   createMultipleSelectorHandles() {
-    const { rootDocument } = this.wot;
+    const { rootDocument, stylesHandler } = this.wot;
+    const cellMobileHandleSize = stylesHandler.getCSSVariableValue('cell-mobile-handle-size');
+    const cellMobileHandleBorderRadius = stylesHandler.getCSSVariableValue('cell-mobile-handle-border-radius');
+    const cellMobileHandleBackgroundColor = stylesHandler.getCSSVariableValue('cell-mobile-handle-background-color');
+    const cellMobileHandleBorderWidth = stylesHandler.getCSSVariableValue('cell-mobile-handle-border-width');
+    const cellMobileHandleBorderColor = stylesHandler.getCSSVariableValue('cell-mobile-handle-border-color');
 
     this.selectionHandles = {
       top: rootDocument.createElement('DIV'),
@@ -258,13 +263,20 @@ class Border {
       this.selectionHandles.styles.topHitArea[key] = value;
     });
 
-    const handleStyle = {
+    const handleStyle = stylesHandler.isClassicTheme() ? {
       position: 'absolute',
       height: `${width}px`,
       width: `${width}px`,
       'border-radius': `${parseInt(width / 1.5, 10)}px`,
       background: '#F5F5FF',
       border: '1px solid #4285c8'
+    } : {
+      position: 'absolute',
+      height: `${cellMobileHandleSize}px`,
+      width: `${cellMobileHandleSize}px`,
+      'border-radius': `${cellMobileHandleBorderRadius}px`,
+      background: `${cellMobileHandleBackgroundColor}`,
+      border: `${cellMobileHandleBorderWidth}px solid ${cellMobileHandleBorderColor}`
     };
 
     objectEach(handleStyle, (value, key) => {

--- a/handsontable/src/styles/themes/horizon.scss
+++ b/handsontable/src/styles/themes/horizon.scss
@@ -43,6 +43,11 @@
   --ht-cell-autofill-border-color: #ffffff;
   --ht-cell-autofill-background-color: #37bc6c;
   --ht-cell-autofill-fill-border-color: #353535;
+  --ht-cell-mobile-handle-size: 12px;
+  --ht-cell-mobile-handle-border-width: 1px;
+  --ht-cell-mobile-handle-border-radius: 6px;
+  --ht-cell-mobile-handle-border-color: #37bc6c;
+  --ht-cell-mobile-handle-background-color: rgba(55, 188, 108, 0.40);
   --ht-resize-indicator-color: #727272;
   --ht-move-backlight-color: rgba(35, 35, 38, 0.06);
   --ht-move-indicator-color: #37bc6c;
@@ -248,6 +253,8 @@
   --ht-cell-autofill-border-color: #070604;
   --ht-cell-autofill-background-color: #f1b93e;
   --ht-cell-autofill-fill-border-color: #b5b5b9;
+  --ht-cell-mobile-handle-border-color: #f1b93e;
+  --ht-cell-mobile-handle-background-color: rgba(241, 185, 62, 0.40);
   --ht-resize-indicator-color: #aeaeae;
   --ht-move-backlight-color: rgba(209, 209, 212, 0.06);
   --ht-move-indicator-color: #f1b93e;

--- a/handsontable/src/styles/themes/main.scss
+++ b/handsontable/src/styles/themes/main.scss
@@ -43,6 +43,11 @@
   --ht-cell-autofill-border-color: #ffffff;
   --ht-cell-autofill-background-color: #1a42e8;
   --ht-cell-autofill-fill-border-color: #222222;
+  --ht-cell-mobile-handle-size: 12px;
+  --ht-cell-mobile-handle-border-width: 1px;
+  --ht-cell-mobile-handle-border-radius: 6px;
+  --ht-cell-mobile-handle-border-color: #1a42e8;
+  --ht-cell-mobile-handle-background-color: rgba(26, 66, 232, 0.40);
   --ht-resize-indicator-color: rgba(34, 34, 34, 0.40);
   --ht-move-backlight-color: rgba(34, 34, 34, 0.08);
   --ht-move-indicator-color: #1a42e8;
@@ -248,6 +253,8 @@
   --ht-cell-autofill-border-color: #0f0f10;
   --ht-cell-autofill-background-color: #476af7;
   --ht-cell-autofill-fill-border-color: #c7c7c7;
+  --ht-cell-mobile-handle-border-color: #476af7;
+  --ht-cell-mobile-handle-background-color: rgba(71, 106, 247, 0.40);
   --ht-resize-indicator-color: rgba(199, 199, 199, 0.40);
   --ht-move-backlight-color: rgba(199, 199, 199, 0.08);
   --ht-move-indicator-color: #476af7;


### PR DESCRIPTION
### Context
This PR includes new css variables to main and horizon themes.

### How has this been tested?
Locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2278

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
