### PR TITLE
Fix a problem with the Comments editor not flipping direction when overlapping the window's scrollbars.

### DIFF
--- a/handsontable/src/helpers/dom/__tests__/element.spec.js
+++ b/handsontable/src/helpers/dom/__tests__/element.spec.js
@@ -111,4 +111,146 @@ describe('DOM helpers', () => {
       document.body.removeChild(wrapper);
     });
   });
+
+  describe('hasVerticalScrollbar', () => {
+    it('should return `true` if the provided HTML element has a vertical scrollbar', () => {
+      const element = document.createElement('div');
+
+      document.body.appendChild(element);
+
+      element.innerText = new Array(50)
+        .fill('Lorem ipsum dolor sit amet, consectetur adipiscing elit.').join(' ');
+
+      element.style.width = '100px';
+      element.style.height = '100px';
+      element.style.overflow = 'auto';
+
+      expect(Handsontable.dom.hasVerticalScrollbar(element)).toBe(true);
+
+      element.style.overflow = 'scroll';
+
+      expect(Handsontable.dom.hasVerticalScrollbar(element)).toBe(true);
+
+      element.style.overflow = '';
+      element.style.overflowY = 'auto';
+      element.style.overflowX = 'hidden';
+
+      expect(Handsontable.dom.hasVerticalScrollbar(element)).toBe(true);
+
+      document.body.removeChild(element);
+    });
+
+    it('should return `false` if the provided HTML element doesn\'t have a vertical scrollbar', () => {
+      const element = document.createElement('div');
+
+      document.body.appendChild(element);
+
+      element.innerText = new Array(50)
+        .fill('Lorem ipsum dolor sit amet, consectetur adipiscing elit.').join(' ');
+
+      element.style.width = '100px';
+      element.style.height = '100px';
+
+      element.style.overflowY = 'hidden';
+      element.style.overflowX = 'auto';
+
+      expect(Handsontable.dom.hasVerticalScrollbar(element)).toBe(false);
+
+      element.style.overflowY = '';
+      element.style.overflowX = '';
+      element.style.overflow = 'hidden';
+
+      expect(Handsontable.dom.hasVerticalScrollbar(element)).toBe(false);
+
+      document.body.removeChild(element);
+    });
+
+    it('should return `true` if the provided Window element has a vertical scrollbar', () => {
+      const element = document.createElement('div');
+
+      document.body.appendChild(element);
+
+      element.innerText = new Array(1000)
+        .fill('Lorem ipsum dolor sit amet, consectetur adipiscing elit.').join(' ');
+
+      expect(Handsontable.dom.hasVerticalScrollbar(window)).toBe(true);
+
+      document.body.removeChild(element);
+    });
+
+    it('should return `false` if the provided Window element doesn\'t have a vertical scrollbar', () => {
+      expect(Handsontable.dom.hasVerticalScrollbar(window)).toBe(false);
+    });
+  });
+
+  describe('hasHorizontalScrollbar', () => {
+    it('should return `true` if the provided HTML element has a vertical scrollbar', () => {
+      const element = document.createElement('div');
+
+      document.body.appendChild(element);
+
+      element.innerText = new Array(50)
+        .fill('Lorem ipsum dolor sit amet, consectetur adipiscing elit.').join(' ');
+
+      element.style.width = '100px';
+      element.style.height = '100px';
+
+      element.style.overflow = 'scroll';
+
+      expect(Handsontable.dom.hasHorizontalScrollbar(element)).toBe(true);
+
+      element.style.overflow = '';
+      element.style.overflowY = 'hidden';
+      element.style.overflowX = 'scroll';
+
+      expect(Handsontable.dom.hasHorizontalScrollbar(element)).toBe(true);
+
+      document.body.removeChild(element);
+    });
+
+    it('should return `false` if the provided HTML element doesn\'t have a vertical scrollbar', () => {
+      const element = document.createElement('div');
+
+      document.body.appendChild(element);
+
+      element.innerText = new Array(50)
+        .fill('Lorem ipsum dolor sit amet, consectetur adipiscing elit.').join(' ');
+
+      element.style.width = '100px';
+      element.style.height = '100px';
+
+      element.style.overflowY = 'auto';
+      element.style.overflowX = 'hidden';
+
+      expect(Handsontable.dom.hasHorizontalScrollbar(element)).toBe(false);
+
+      element.style.overflowY = '';
+      element.style.overflowX = '';
+      element.style.overflow = 'hidden';
+
+      expect(Handsontable.dom.hasHorizontalScrollbar(element)).toBe(false);
+
+      document.body.removeChild(element);
+    });
+
+    it('should return `true` if the provided Window element has a vertical scrollbar', () => {
+      const element = document.createElement('div');
+
+      element.style.height = '100%';
+      element.style.width = '500%';
+
+      document.body.appendChild(element);
+
+      element.innerText = new Array(1000)
+        .fill('Lorem ipsum dolor sit amet, consectetur adipiscing elit.').join(' ');
+
+      expect(Handsontable.dom.hasHorizontalScrollbar(window)).toBe(true);
+
+      document.body.removeChild(element);
+    });
+
+    it('should return `false` if the provided Window element doesn\'t have a vertical scrollbar', () => {
+      expect(Handsontable.dom.hasHorizontalScrollbar(window)).toBe(false);
+    });
+  });
 });

--- a/handsontable/src/helpers/dom/element.js
+++ b/handsontable/src/helpers/dom/element.js
@@ -1006,20 +1006,28 @@ export function getScrollbarWidth(rootDocument = document) {
 /**
  * Checks if the provided element has a vertical scrollbar.
  *
- * @param {HTMLElement} element An element to check.
+ * @param {HTMLElement|Window} element An element to check.
  * @returns {boolean}
  */
 export function hasVerticalScrollbar(element) {
+  if (element instanceof Window) {
+    return element.document.body.scrollHeight > element.innerHeight;
+  }
+
   return element.offsetWidth !== element.clientWidth;
 }
 
 /**
  * Checks if the provided element has a vertical scrollbar.
  *
- * @param {HTMLElement} element An element to check.
+ * @param {HTMLElement|Window} element An element to check.
  * @returns {boolean}
  */
 export function hasHorizontalScrollbar(element) {
+  if (element instanceof Window) {
+    return element.document.body.scrollWidth > element.innerWidth;
+  }
+
   return element.offsetHeight !== element.clientHeight;
 }
 

--- a/handsontable/src/plugins/comments/comments.js
+++ b/handsontable/src/plugins/comments/comments.js
@@ -1,10 +1,13 @@
 import {
   addClass,
-  removeClass,
   closest,
-  isChildOf,
+  getScrollbarWidth,
   hasClass,
+  hasVerticalScrollbar,
+  hasHorizontalScrollbar,
+  isChildOf,
   outerHeight,
+  removeClass,
 } from '../../helpers/dom/element';
 import { stopImmediatePropagation } from '../../helpers/dom/event';
 import { deepClone, deepExtend } from '../../helpers/object';
@@ -591,6 +594,9 @@ export class Comments extends BasePlugin {
 
     const { innerWidth, innerHeight } = this.hot.rootWindow;
     const documentElement = this.hot.rootDocument.documentElement;
+    const scrollbarWidth = getScrollbarWidth(this.hot.rootDocument);
+    const verticalScrollbarWidth = hasVerticalScrollbar(this.hot.rootWindow) ? scrollbarWidth : 0;
+    const horizontalScrollbarWidth = hasHorizontalScrollbar(this.hot.rootWindow) ? scrollbarWidth : 0;
     let x = left + rootWindow.scrollX + lastColWidth;
     let y = top + rootWindow.scrollY + lastRowHeight;
 
@@ -599,14 +605,14 @@ export class Comments extends BasePlugin {
     }
 
     // flip to the right or left the comments editor position when it goes out of browser viewport
-    if (this.hot.isLtr() && left + cellWidth + editorWidth > innerWidth) {
+    if (this.hot.isLtr() && left + cellWidth + editorWidth > innerWidth - verticalScrollbarWidth) {
       x = left + rootWindow.scrollX - editorWidth - 1;
 
     } else if (this.hot.isRtl() && x < -(documentElement.scrollWidth - documentElement.clientWidth)) {
       x = left + rootWindow.scrollX + lastColWidth + 1;
     }
 
-    if (top + editorHeight > innerHeight) {
+    if (top + editorHeight > innerHeight - horizontalScrollbarWidth) {
       y -= (editorHeight - cellHeight + 1);
     }
 


### PR DESCRIPTION
### Context
This PR:

- Fixes a problem with the Comments editor not flipping direction when overlapping the window's scrollbars.
- Adds test cases to cover that situation.
- Adds test cases for the `hasVerticalScrollbar` and `hasHorizontalScrollbar` helpers.


### How has this been tested?
Tested manually and with an extended test case.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#2261

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
