### PR TITLE
Fix problem with context menu opening on classic theme

### DIFF
--- a/.changelogs/11486.json
+++ b/.changelogs/11486.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed issue with context menu opening on classic theme",
+  "type": "fixed",
+  "issueOrPR": 11486,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/contextMenu/__tests__/contextMenu.spec.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/contextMenu.spec.js
@@ -102,7 +102,7 @@ describe('ContextMenu', () => {
 
       expect($menu.find('.wtHider').width()).toEqual(215);
       expect($menu.width()).forThemes(({ classic, main }) => {
-        classic.toEqual(215);
+        classic.toEqual(218);
         main.toEqual(217);
       });
     });

--- a/handsontable/src/plugins/contextMenu/__tests__/positioning.spec.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/positioning.spec.js
@@ -110,8 +110,7 @@ describe('ContextMenu', () => {
           main.toBeCloseTo(subMenuItemOffset.top - 9, 0);
         });
         expect(subMenuOffset.left).forThemes(({ classic, main }) => {
-          // 3px comes from borders
-          classic.toBeCloseTo(contextMenuOffset.left + contextMenuRoot.outerWidth() + 3, 0);
+          classic.toBeCloseTo(contextMenuOffset.left + contextMenuRoot.outerWidth(), 0);
 
           // https://github.com/handsontable/dev-handsontable/issues/2205#issuecomment-2612363401
           main.toBeCloseTo(contextMenuOffset.left + contextMenuRoot.outerWidth() - 1, 0);
@@ -143,7 +142,7 @@ describe('ContextMenu', () => {
           .toBeCloseTo(subMenuItemOffset.top - subMenuRoot.outerHeight() + subMenuItem.outerHeight() + 3, 0);
         // 3px comes from right borders
         expect(subMenuOffset.left)
-          .toBeCloseTo(contextMenuOffset.left + contextMenuRoot.outerWidth() + 3, 0);
+          .toBeCloseTo(contextMenuOffset.left + contextMenuRoot.outerWidth(), 0);
       });
 
       it.forTheme('main')('should open subMenu on the right-top of the main menu if on the left and ' +
@@ -340,7 +339,7 @@ describe('ContextMenu', () => {
       });
       expect(subMenuOffset.left).forThemes(({ classic, main }) => {
         // 3px comes from right borders
-        classic.toBeCloseTo(contextMenuOffset.left + contextMenuRoot.outerWidth() + 3, 0);
+        classic.toBeCloseTo(contextMenuOffset.left + contextMenuRoot.outerWidth(), 0);
         main.toBeCloseTo(contextMenuOffset.left + contextMenuRoot.outerWidth() - 1, 0);
       });
     });

--- a/handsontable/src/plugins/contextMenu/__tests__/rtl/positioning.spec.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/rtl/positioning.spec.js
@@ -48,8 +48,7 @@ describe('ContextMenu (RTL mode)', () => {
           main.toBeCloseTo(subMenuItemOffset.top - 9, 0);
         });
         expect(subMenuOffset.left).forThemes(({ classic, main }) => {
-          // 3px comes from borders
-          classic.toBeCloseTo(contextMenuOffset.left - contextMenuRoot.outerWidth() - 3, 0);
+          classic.toBeCloseTo(contextMenuOffset.left - contextMenuRoot.outerWidth(), 0);
 
           // https://github.com/handsontable/dev-handsontable/issues/2205#issuecomment-2612363401
           main.toBeCloseTo(contextMenuOffset.left - contextMenuRoot.outerWidth() + 1, 0);
@@ -79,9 +78,8 @@ describe('ContextMenu (RTL mode)', () => {
         // 3px comes from bottom borders
         expect(subMenuOffset.top)
           .toBeCloseTo(subMenuItemOffset.top - subMenuRoot.outerHeight() + subMenuItem.outerHeight() + 3, 0);
-        // 3px comes from borders
         expect(subMenuOffset.left)
-          .toBeCloseTo(contextMenuOffset.left - contextMenuRoot.outerWidth() - 3, 0);
+          .toBeCloseTo(contextMenuOffset.left - contextMenuRoot.outerWidth(), 0);
       });
 
       it.forTheme('main')('should open subMenu on the left-top of the main menu if on the right and ' +
@@ -256,8 +254,7 @@ describe('ContextMenu (RTL mode)', () => {
         main.toBeCloseTo(subMenuItemOffset.top - 9, 0);
       });
       expect(subMenuOffset.left).forThemes(({ classic, main }) => {
-        // 3px comes from borders
-        classic.toBeCloseTo(contextMenuOffset.left - contextMenuRoot.outerWidth() - 3, 0);
+        classic.toBeCloseTo(contextMenuOffset.left - contextMenuRoot.outerWidth(), 0);
 
         // https://github.com/handsontable/dev-handsontable/issues/2205#issuecomment-2612363401
         main.toBeCloseTo(contextMenuOffset.left - contextMenuRoot.outerWidth() + 1, 0);

--- a/handsontable/src/plugins/contextMenu/menu/menu.js
+++ b/handsontable/src/plugins/contextMenu/menu/menu.js
@@ -626,7 +626,7 @@ export class Menu {
    * and adjusts the width and height of the menu's holder and hider elements accordingly.
    */
   updateMenuDimensions() {
-    const stylesHandler = this.hot.view.getStylesHandler();
+    const stylesHandler = this.hotMenu.view.getStylesHandler();
     const { wtTable } = this.hotMenu.view._wt;
     const data = this.hotMenu.getSettings().data;
     const hiderStyle = wtTable.hider.style;

--- a/handsontable/src/plugins/contextMenu/menu/menu.js
+++ b/handsontable/src/plugins/contextMenu/menu/menu.js
@@ -626,6 +626,7 @@ export class Menu {
    * and adjusts the width and height of the menu's holder and hider elements accordingly.
    */
   updateMenuDimensions() {
+    const stylesHandler = this.hot.view.getStylesHandler();
     const { wtTable } = this.hotMenu.view._wt;
     const data = this.hotMenu.getSettings().data;
     const hiderStyle = wtTable.hider.style;
@@ -640,8 +641,15 @@ export class Menu {
         return accumulator + (value.name === SEPARATOR ? 1 : currentRowHeight);
       }, 0);
 
-    holderStyle.width = `${currentHiderWidth}px`;
-    holderStyle.height = `${realHeight}px`;
+    if (stylesHandler.isClassicTheme()) {
+      // Additional 3px to menu's size because of additional border around its `table.htCore`.
+      holderStyle.width = `${currentHiderWidth + 3}px`;
+      holderStyle.height = `${realHeight + 3}px`;
+    } else {
+      holderStyle.width = `${currentHiderWidth}px`;
+      holderStyle.height = `${realHeight}px`;
+    }
+
     hiderStyle.height = holderStyle.height;
   }
 

--- a/handsontable/src/plugins/dropdownMenu/__tests__/positioning.spec.js
+++ b/handsontable/src/plugins/dropdownMenu/__tests__/positioning.spec.js
@@ -49,8 +49,7 @@ describe('DropdownMenu', () => {
           main.toBeCloseTo(subMenuItemOffset.top - 9, 0);
         });
         expect(subMenuOffset.left).forThemes(({ classic, main }) => {
-          // 3px comes from borders
-          classic.toBeCloseTo(dropdownOffset.left + $dropdownMenu.outerWidth() + 3, 0);
+          classic.toBeCloseTo(dropdownOffset.left + $dropdownMenu.outerWidth(), 0);
 
           // https://github.com/handsontable/dev-handsontable/issues/2205#issuecomment-2612363401
           main.toBeCloseTo(dropdownOffset.left + $dropdownMenu.outerWidth() - 1, 0);
@@ -149,8 +148,7 @@ describe('DropdownMenu', () => {
         main.toBeCloseTo(subMenuItemOffset.top - 9, 0);
       });
       expect(subMenuOffset.left).forThemes(({ classic, main }) => {
-        // 3px comes from borders
-        classic.toBeCloseTo(dropdownOffset.left + $dropdownMenu.outerWidth() + 3, 0);
+        classic.toBeCloseTo(dropdownOffset.left + $dropdownMenu.outerWidth(), 0);
 
         // https://github.com/handsontable/dev-handsontable/issues/2205#issuecomment-2612363401
         main.toBeCloseTo(dropdownOffset.left + $dropdownMenu.outerWidth() - 1, 0);

--- a/handsontable/src/plugins/dropdownMenu/__tests__/rtl/positioning.spec.js
+++ b/handsontable/src/plugins/dropdownMenu/__tests__/rtl/positioning.spec.js
@@ -49,8 +49,7 @@ describe('DropdownMenu (RTL mode)', () => {
           main.toBeCloseTo(subMenuItemOffset.top - 9, 0);
         });
         expect(subMenuOffset.left).forThemes(({ classic, main }) => {
-          // 3px comes from borders
-          classic.toBe(Math.floor(dropdownOffset.left - subMenuWidth) - 3);
+          classic.toBe(Math.floor(dropdownOffset.left - subMenuWidth));
 
           // https://github.com/handsontable/dev-handsontable/issues/2205#issuecomment-2612363401
           main.toBe(Math.floor(dropdownOffset.left - subMenuWidth) + 1);
@@ -162,8 +161,7 @@ describe('DropdownMenu (RTL mode)', () => {
         main.toBeCloseTo(subMenuItemOffset.top - 9, 0);
       });
       expect(subMenuOffset.left).forThemes(({ classic, main }) => {
-        // 3px comes from borders
-        classic.toBe(Math.floor(dropdownOffset.left - subMenuWidth) - 3);
+        classic.toBe(Math.floor(dropdownOffset.left - subMenuWidth));
 
         // https://github.com/handsontable/dev-handsontable/issues/2205#issuecomment-2612363401
         main.toBe(Math.floor(dropdownOffset.left - subMenuWidth) + 1);

--- a/handsontable/src/plugins/filters/__tests__/component/conditional.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/component/conditional.spec.js
@@ -94,8 +94,7 @@ describe('Filters UI Conditional component', () => {
 
     const rect = document.querySelector('.htFiltersConditionsMenu.handsontable table').getBoundingClientRect();
 
-    // 3px comes from borders
-    expect(window.scrollY + rect.top - 3).forThemes(({ classic, main }) => {
+    expect(window.scrollY + rect.top).forThemes(({ classic, main }) => {
       classic.toBeAroundValue(755, 1);
       main.toBeAroundValue(715, 1);
     });

--- a/handsontable/src/plugins/filters/__tests__/component/conditional.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/component/conditional.spec.js
@@ -96,7 +96,7 @@ describe('Filters UI Conditional component', () => {
 
     expect(window.scrollY + rect.top).forThemes(({ classic, main }) => {
       classic.toBeAroundValue(755, 1);
-      main.toBeAroundValue(715, 1);
+      main.toBeAroundValue(718, 1);
     });
     hot.rootElement.style.marginTop = '';
   });


### PR DESCRIPTION
### Context
This PR includes fix for context menu size in the classic theme.

### How has this been tested?
Locally and updated tests

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2279

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
