### PR TITLE
Fix data source modification for row values as a string

### DIFF
--- a/handsontable/src/dataMap/dataSource.js
+++ b/handsontable/src/dataMap/dataSource.js
@@ -207,8 +207,8 @@ class DataSource {
       }
     }
 
-    if (!Number.isInteger(row)) {
-      // invalid row number
+    if (['__proto__', 'constructor', 'prototype'].includes(row)) {
+      // prevent prototype pollution
       return;
     }
 

--- a/handsontable/test/e2e/Core_modifySourceData.spec.js
+++ b/handsontable/test/e2e/Core_modifySourceData.spec.js
@@ -177,6 +177,56 @@ describe('Core_modifySourceData', () => {
           expect(getSourceDataArray(0, 0, 1, 2)[rowIndex][columnIndex]).toEqual(modifiedSourceCellValue);
         });
       });
+
+      it('should replace the source value for a cell using the `valueHolder` object of the hook callback for row values as a string', () => {
+        const changesList = [
+          ['0', '0', 'a'], ['0', '1', 'b'], ['0', '2', 'c'],
+          ['1', '0', 'd'], ['1', '1', 'e'], ['1', '2', 'f'],
+        ];
+
+        handsontable({
+          data: Handsontable.helper.createEmptySpreadsheetData(2, 3),
+          modifySourceData: (row, column, valueHolder, mode) => {
+            if (mode === 'set') {
+              valueHolder.value += `->${row}-${column}-${mode}`;
+            }
+          }
+        });
+
+        setSourceDataAtCell(changesList);
+
+        changesList.forEach((change) => {
+          const [rowIndex, columnIndex, dataCellValue] = change;
+          const modifiedSourceCellValue = `${dataCellValue}->${rowIndex}-${columnIndex}-set`;
+
+          expect(getDataAtCell(rowIndex, columnIndex)).toEqual(modifiedSourceCellValue);
+          expect(getDataAtRow(rowIndex)[columnIndex]).toEqual(modifiedSourceCellValue);
+          expect(getData()[rowIndex][columnIndex]).toEqual(modifiedSourceCellValue);
+
+          // Check for multiple API endpoints
+          expect(getSourceDataAtCell(rowIndex, columnIndex)).toEqual(modifiedSourceCellValue);
+          expect(getSourceDataAtRow(rowIndex)[columnIndex]).toEqual(modifiedSourceCellValue);
+          expect(getSourceDataAtCol(columnIndex)[rowIndex]).toEqual(modifiedSourceCellValue);
+          expect(getSourceData()[rowIndex][columnIndex]).toEqual(modifiedSourceCellValue);
+          expect(getSourceData(0, 0, 1, 2)[rowIndex][columnIndex]).toEqual(modifiedSourceCellValue);
+          expect(getSourceDataArray()[rowIndex][columnIndex]).toEqual(modifiedSourceCellValue);
+          expect(getSourceDataArray(0, 0, 1, 2)[rowIndex][columnIndex]).toEqual(modifiedSourceCellValue);
+        });
+      });
+
+      it('should not replace the source value for row values as a `__proto__`, `constructor`, `prototype`', () => {
+        const changesList = [
+          ['__proto__', '0', 'a'], ['constructor', '1', 'b'], ['prototype', '2', 'c'],
+        ];
+
+        const hot = handsontable({
+          data: Handsontable.helper.createEmptySpreadsheetData(1, 3)
+        });
+
+        setSourceDataAtCell(changesList);
+
+        expect(hot.getData()[0]).toEqual(['', '', '']);
+      });
     });
 
     describe('array of objects datasource', () => {


### PR DESCRIPTION
### Context
This PR includes a fix for dataSource the `setAtCell` function, in the case where someone passes row as a string.

### How has this been tested?
Locally and covered the fix with new tests

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2283

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
