### PR TITLE
Revert actionType class field for UndoRedo actions

### DIFF
--- a/.changelogs/11495.json
+++ b/.changelogs/11495.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Revert `actionType` class field for UndoRedo actions",
+  "type": "changed",
+  "issueOrPR": 11495,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/undoRedo/__tests__/actions/cellAlignment.spec.js
+++ b/handsontable/src/plugins/undoRedo/__tests__/actions/cellAlignment.spec.js
@@ -38,7 +38,7 @@ describe('UndoRedo -> CellAlignment action', () => {
         from: { row: 1, col: 1 },
         to: { row: 2, col: 2 },
       }],
-      stateBefore: { 1: [ null, null, null ], 2: [ null, null, null ] },
+      stateBefore: { 1: [null, null, null], 2: [null, null, null] },
       type: 'horizontal',
     });
   });

--- a/handsontable/src/plugins/undoRedo/__tests__/actions/cellAlignment.spec.js
+++ b/handsontable/src/plugins/undoRedo/__tests__/actions/cellAlignment.spec.js
@@ -30,7 +30,7 @@ describe('UndoRedo -> CellAlignment action', () => {
 
     getPlugin('undoRedo').undo();
 
-    expect(afterUndo).toHaveBeenCalledWith(jasmine.objectContaining({
+    expect(afterUndo).toHaveBeenCalledWith({
       actionType: 'cell_alignment',
       alignment: 'htRight',
       range: [{
@@ -38,7 +38,8 @@ describe('UndoRedo -> CellAlignment action', () => {
         from: { row: 1, col: 1 },
         to: { row: 2, col: 2 },
       }],
+      stateBefore: { 1: [ null, null, null ], 2: [ null, null, null ] },
       type: 'horizontal',
-    }));
+    });
   });
 });

--- a/handsontable/src/plugins/undoRedo/__tests__/actions/cellAlignment.spec.js
+++ b/handsontable/src/plugins/undoRedo/__tests__/actions/cellAlignment.spec.js
@@ -1,0 +1,44 @@
+describe('UndoRedo -> CellAlignment action', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should have defined correct action properties', async() => {
+    const afterUndo = jasmine.createSpy('afterUndo');
+
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+      rowHeaders: true,
+      colHeaders: true,
+      contextMenu: true,
+      afterUndo,
+    });
+
+    selectCells([[1, 1, 2, 2]]);
+    contextMenu();
+
+    await selectContextSubmenuOption('Alignment', 'Right');
+
+    getPlugin('undoRedo').undo();
+
+    expect(afterUndo).toHaveBeenCalledWith(jasmine.objectContaining({
+      actionType: 'cell_alignment',
+      alignment: 'htRight',
+      range: [{
+        highlight: { row: 1, col: 1 },
+        from: { row: 1, col: 1 },
+        to: { row: 2, col: 2 },
+      }],
+      type: 'horizontal',
+    }));
+  });
+});

--- a/handsontable/src/plugins/undoRedo/__tests__/actions/columnMove.spec.js
+++ b/handsontable/src/plugins/undoRedo/__tests__/actions/columnMove.spec.js
@@ -1,0 +1,35 @@
+describe('UndoRedo -> ColumnMove action', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should have defined correct action properties', async() => {
+    const afterUndo = jasmine.createSpy('afterUndo');
+
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+      rowHeaders: true,
+      colHeaders: true,
+      manualColumnMove: true,
+      afterUndo,
+    });
+
+    getPlugin('manualColumnMove').moveColumns([1, 2], 2);
+    getPlugin('undoRedo').undo();
+
+    expect(afterUndo).toHaveBeenCalledWith(jasmine.objectContaining({
+      actionType: 'col_move',
+      columns: [1, 2],
+      finalColumnIndex: 2,
+    }));
+  });
+});

--- a/handsontable/src/plugins/undoRedo/__tests__/actions/columnMove.spec.js
+++ b/handsontable/src/plugins/undoRedo/__tests__/actions/columnMove.spec.js
@@ -26,10 +26,10 @@ describe('UndoRedo -> ColumnMove action', () => {
     getPlugin('manualColumnMove').moveColumns([1, 2], 2);
     getPlugin('undoRedo').undo();
 
-    expect(afterUndo).toHaveBeenCalledWith(jasmine.objectContaining({
+    expect(afterUndo).toHaveBeenCalledWith({
       actionType: 'col_move',
       columns: [1, 2],
       finalColumnIndex: 2,
-    }));
+    });
   });
 });

--- a/handsontable/src/plugins/undoRedo/__tests__/actions/columnSort.spec.js
+++ b/handsontable/src/plugins/undoRedo/__tests__/actions/columnSort.spec.js
@@ -26,10 +26,10 @@ describe('UndoRedo -> ColumnSort action', () => {
     getPlugin('columnSorting').sort({ column: 1, sortOrder: 'asc' });
     getPlugin('undoRedo').undo();
 
-    expect(afterUndo).toHaveBeenCalledWith(jasmine.objectContaining({
+    expect(afterUndo).toHaveBeenCalledWith({
       actionType: 'col_sort',
       previousSortState: [],
       nextSortState: [{ column: 1, sortOrder: 'asc' }],
-    }));
+    });
   });
 });

--- a/handsontable/src/plugins/undoRedo/__tests__/actions/columnSort.spec.js
+++ b/handsontable/src/plugins/undoRedo/__tests__/actions/columnSort.spec.js
@@ -1,0 +1,35 @@
+describe('UndoRedo -> ColumnSort action', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should have defined correct action properties', async() => {
+    const afterUndo = jasmine.createSpy('afterUndo');
+
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+      rowHeaders: true,
+      colHeaders: true,
+      columnSorting: true,
+      afterUndo,
+    });
+
+    getPlugin('columnSorting').sort({ column: 1, sortOrder: 'asc' });
+    getPlugin('undoRedo').undo();
+
+    expect(afterUndo).toHaveBeenCalledWith(jasmine.objectContaining({
+      actionType: 'col_sort',
+      previousSortState: [],
+      nextSortState: [{ column: 1, sortOrder: 'asc' }],
+    }));
+  });
+});

--- a/handsontable/src/plugins/undoRedo/__tests__/actions/createColumn.spec.js
+++ b/handsontable/src/plugins/undoRedo/__tests__/actions/createColumn.spec.js
@@ -1,0 +1,44 @@
+describe('UndoRedo -> CreateColumn action', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should have defined correct action properties', async() => {
+    const afterUndo = jasmine.createSpy('afterUndo');
+
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+      rowHeaders: true,
+      colHeaders: true,
+      afterUndo,
+    });
+
+    alter('insert_col_start', 1, 2);
+    getPlugin('undoRedo').undo();
+
+    expect(afterUndo).toHaveBeenCalledWith(jasmine.objectContaining({
+      actionType: 'insert_col',
+      index: 1,
+      amount: 2,
+    }));
+
+    afterUndo.calls.reset();
+    alter('insert_col_end', 2, 3);
+    getPlugin('undoRedo').undo();
+
+    expect(afterUndo).toHaveBeenCalledWith(jasmine.objectContaining({
+      actionType: 'insert_col',
+      index: 3,
+      amount: 3,
+    }));
+  });
+});

--- a/handsontable/src/plugins/undoRedo/__tests__/actions/createColumn.spec.js
+++ b/handsontable/src/plugins/undoRedo/__tests__/actions/createColumn.spec.js
@@ -25,20 +25,20 @@ describe('UndoRedo -> CreateColumn action', () => {
     alter('insert_col_start', 1, 2);
     getPlugin('undoRedo').undo();
 
-    expect(afterUndo).toHaveBeenCalledWith(jasmine.objectContaining({
+    expect(afterUndo).toHaveBeenCalledWith({
       actionType: 'insert_col',
       index: 1,
       amount: 2,
-    }));
+    });
 
     afterUndo.calls.reset();
     alter('insert_col_end', 2, 3);
     getPlugin('undoRedo').undo();
 
-    expect(afterUndo).toHaveBeenCalledWith(jasmine.objectContaining({
+    expect(afterUndo).toHaveBeenCalledWith({
       actionType: 'insert_col',
       index: 3,
       amount: 3,
-    }));
+    });
   });
 });

--- a/handsontable/src/plugins/undoRedo/__tests__/actions/createRow.spec.js
+++ b/handsontable/src/plugins/undoRedo/__tests__/actions/createRow.spec.js
@@ -25,20 +25,20 @@ describe('UndoRedo -> CreateRow action', () => {
     alter('insert_row_above', 1, 2);
     getPlugin('undoRedo').undo();
 
-    expect(afterUndo).toHaveBeenCalledWith(jasmine.objectContaining({
+    expect(afterUndo).toHaveBeenCalledWith({
       actionType: 'insert_row',
       index: 1,
       amount: 2,
-    }));
+    });
 
     afterUndo.calls.reset();
     alter('insert_row_below', 2, 3);
     getPlugin('undoRedo').undo();
 
-    expect(afterUndo).toHaveBeenCalledWith(jasmine.objectContaining({
+    expect(afterUndo).toHaveBeenCalledWith({
       actionType: 'insert_row',
       index: 3,
       amount: 3,
-    }));
+    });
   });
 });

--- a/handsontable/src/plugins/undoRedo/__tests__/actions/createRow.spec.js
+++ b/handsontable/src/plugins/undoRedo/__tests__/actions/createRow.spec.js
@@ -1,0 +1,44 @@
+describe('UndoRedo -> CreateRow action', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should have defined correct action properties', async() => {
+    const afterUndo = jasmine.createSpy('afterUndo');
+
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+      rowHeaders: true,
+      colHeaders: true,
+      afterUndo,
+    });
+
+    alter('insert_row_above', 1, 2);
+    getPlugin('undoRedo').undo();
+
+    expect(afterUndo).toHaveBeenCalledWith(jasmine.objectContaining({
+      actionType: 'insert_row',
+      index: 1,
+      amount: 2,
+    }));
+
+    afterUndo.calls.reset();
+    alter('insert_row_below', 2, 3);
+    getPlugin('undoRedo').undo();
+
+    expect(afterUndo).toHaveBeenCalledWith(jasmine.objectContaining({
+      actionType: 'insert_row',
+      index: 3,
+      amount: 3,
+    }));
+  });
+});

--- a/handsontable/src/plugins/undoRedo/__tests__/actions/dataChange.spec.js
+++ b/handsontable/src/plugins/undoRedo/__tests__/actions/dataChange.spec.js
@@ -25,12 +25,12 @@ describe('UndoRedo -> DataChange action', () => {
     setDataAtCell(1, 2, 'test');
     getPlugin('undoRedo').undo();
 
-    expect(afterUndo).toHaveBeenCalledWith(jasmine.objectContaining({
+    expect(afterUndo).toHaveBeenCalledWith({
       actionType: 'change',
       changes: [[1, 2, 'C2', 'test']],
       selected: [[1, 2]],
       countCols: 5,
       countRows: 5,
-    }));
+    });
   });
 });

--- a/handsontable/src/plugins/undoRedo/__tests__/actions/dataChange.spec.js
+++ b/handsontable/src/plugins/undoRedo/__tests__/actions/dataChange.spec.js
@@ -1,0 +1,36 @@
+describe('UndoRedo -> DataChange action', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should have defined correct action properties', async() => {
+    const afterUndo = jasmine.createSpy('afterUndo');
+
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+      rowHeaders: true,
+      colHeaders: true,
+      afterUndo,
+    });
+
+    setDataAtCell(1, 2, 'test');
+    getPlugin('undoRedo').undo();
+
+    expect(afterUndo).toHaveBeenCalledWith(jasmine.objectContaining({
+      actionType: 'change',
+      changes: [[1, 2, 'C2', 'test']],
+      selected: [[1, 2]],
+      countCols: 5,
+      countRows: 5,
+    }));
+  });
+});

--- a/handsontable/src/plugins/undoRedo/__tests__/actions/filters.spec.js
+++ b/handsontable/src/plugins/undoRedo/__tests__/actions/filters.spec.js
@@ -1,0 +1,43 @@
+describe('UndoRedo -> Filters action', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should have defined correct action properties', async() => {
+    const afterUndo = jasmine.createSpy('afterUndo');
+
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+      rowHeaders: true,
+      colHeaders: true,
+      filters: true,
+      afterUndo,
+    });
+
+    getPlugin('filters').addCondition(1, 'begins_with', ['c']);
+    getPlugin('filters').filter();
+    getPlugin('undoRedo').undo();
+
+    expect(afterUndo).toHaveBeenCalledWith(jasmine.objectContaining({
+      actionType: 'filter',
+      conditionsStack: [{
+        column: 1,
+        operation: 'conjunction',
+        conditions: [{
+          name: 'begins_with',
+          args: ['c']
+        }]
+      }],
+      previousConditionsStack: [],
+    }));
+  });
+});

--- a/handsontable/src/plugins/undoRedo/__tests__/actions/filters.spec.js
+++ b/handsontable/src/plugins/undoRedo/__tests__/actions/filters.spec.js
@@ -27,7 +27,7 @@ describe('UndoRedo -> Filters action', () => {
     getPlugin('filters').filter();
     getPlugin('undoRedo').undo();
 
-    expect(afterUndo).toHaveBeenCalledWith(jasmine.objectContaining({
+    expect(afterUndo).toHaveBeenCalledWith({
       actionType: 'filter',
       conditionsStack: [{
         column: 1,
@@ -38,6 +38,6 @@ describe('UndoRedo -> Filters action', () => {
         }]
       }],
       previousConditionsStack: [],
-    }));
+    });
   });
 });

--- a/handsontable/src/plugins/undoRedo/__tests__/actions/mergeCells.spec.js
+++ b/handsontable/src/plugins/undoRedo/__tests__/actions/mergeCells.spec.js
@@ -1,0 +1,43 @@
+describe('UndoRedo -> MergeCells action', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should have defined correct action properties', async() => {
+    const afterUndo = jasmine.createSpy('afterUndo');
+
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+      rowHeaders: true,
+      colHeaders: true,
+      mergeCells: true,
+      afterUndo,
+    });
+
+    getPlugin('mergeCells').merge(1, 1, 3, 3);
+    getPlugin('undoRedo').undo();
+
+    expect(afterUndo).toHaveBeenCalledWith(jasmine.objectContaining({
+      actionType: 'merge_cells',
+      cellRange: {
+        highlight: { row: 1, col: 1 },
+        from: { row: 1, col: 1 },
+        to: { row: 3, col: 3 },
+      },
+      data: [
+        ['B2', 'C2', 'D2'],
+        ['B3', 'C3', 'D3'],
+        ['B4', 'C4', 'D4'],
+      ],
+    }));
+  });
+});

--- a/handsontable/src/plugins/undoRedo/__tests__/actions/mergeCells.spec.js
+++ b/handsontable/src/plugins/undoRedo/__tests__/actions/mergeCells.spec.js
@@ -26,7 +26,7 @@ describe('UndoRedo -> MergeCells action', () => {
     getPlugin('mergeCells').merge(1, 1, 3, 3);
     getPlugin('undoRedo').undo();
 
-    expect(afterUndo).toHaveBeenCalledWith(jasmine.objectContaining({
+    expect(afterUndo).toHaveBeenCalledWith({
       actionType: 'merge_cells',
       cellRange: {
         highlight: { row: 1, col: 1 },
@@ -38,6 +38,6 @@ describe('UndoRedo -> MergeCells action', () => {
         ['B3', 'C3', 'D3'],
         ['B4', 'C4', 'D4'],
       ],
-    }));
+    });
   });
 });

--- a/handsontable/src/plugins/undoRedo/__tests__/actions/removeColumn.spec.js
+++ b/handsontable/src/plugins/undoRedo/__tests__/actions/removeColumn.spec.js
@@ -25,7 +25,7 @@ describe('UndoRedo -> RemoveColumn action', () => {
     alter('remove_col', 1, 2);
     getPlugin('undoRedo').undo();
 
-    expect(afterUndo).toHaveBeenCalledWith(jasmine.objectContaining({
+    expect(afterUndo).toHaveBeenCalledWith({
       actionType: 'remove_col',
       index: 1,
       indexes: [1, 2],
@@ -42,6 +42,6 @@ describe('UndoRedo -> RemoveColumn action', () => {
       rowPositions: [0, 1, 2, 3, 4],
       fixedColumnsStart: 0,
       removedCellMetas: [],
-    }));
+    });
   });
 });

--- a/handsontable/src/plugins/undoRedo/__tests__/actions/removeColumn.spec.js
+++ b/handsontable/src/plugins/undoRedo/__tests__/actions/removeColumn.spec.js
@@ -1,0 +1,47 @@
+describe('UndoRedo -> RemoveColumn action', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should have defined correct action properties', async() => {
+    const afterUndo = jasmine.createSpy('afterUndo');
+
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+      rowHeaders: true,
+      colHeaders: true,
+      afterUndo,
+    });
+
+    alter('remove_col', 1, 2);
+    getPlugin('undoRedo').undo();
+
+    expect(afterUndo).toHaveBeenCalledWith(jasmine.objectContaining({
+      actionType: 'remove_col',
+      index: 1,
+      indexes: [1, 2],
+      data: [
+        ['B1', 'C1'],
+        ['B2', 'C2'],
+        ['B3', 'C3'],
+        ['B4', 'C4'],
+        ['B5', 'C5'],
+      ],
+      amount: 2,
+      headers: [],
+      columnPositions: [0, 1, 2, 3, 4],
+      rowPositions: [0, 1, 2, 3, 4],
+      fixedColumnsStart: 0,
+      removedCellMetas: [],
+    }));
+  });
+});

--- a/handsontable/src/plugins/undoRedo/__tests__/actions/removeRow.spec.js
+++ b/handsontable/src/plugins/undoRedo/__tests__/actions/removeRow.spec.js
@@ -1,0 +1,41 @@
+describe('UndoRedo -> RemoveRow action', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should have defined correct action properties', async() => {
+    const afterUndo = jasmine.createSpy('afterUndo');
+
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+      rowHeaders: true,
+      colHeaders: true,
+      afterUndo,
+    });
+
+    alter('remove_row', 1, 2);
+    getPlugin('undoRedo').undo();
+
+    expect(afterUndo).toHaveBeenCalledWith(jasmine.objectContaining({
+      actionType: 'remove_row',
+      index: 1,
+      data: [
+        ['A2', 'B2', 'C2', 'D2', 'E2'],
+        ['A3', 'B3', 'C3', 'D3', 'E3']
+      ],
+      rowIndexesSequence: [0, 1, 2, 3, 4],
+      fixedRowsTop: 0,
+      fixedRowsBottom: 0,
+      removedCellMetas: [],
+    }));
+  });
+});

--- a/handsontable/src/plugins/undoRedo/__tests__/actions/removeRow.spec.js
+++ b/handsontable/src/plugins/undoRedo/__tests__/actions/removeRow.spec.js
@@ -25,7 +25,7 @@ describe('UndoRedo -> RemoveRow action', () => {
     alter('remove_row', 1, 2);
     getPlugin('undoRedo').undo();
 
-    expect(afterUndo).toHaveBeenCalledWith(jasmine.objectContaining({
+    expect(afterUndo).toHaveBeenCalledWith({
       actionType: 'remove_row',
       index: 1,
       data: [
@@ -36,6 +36,6 @@ describe('UndoRedo -> RemoveRow action', () => {
       fixedRowsTop: 0,
       fixedRowsBottom: 0,
       removedCellMetas: [],
-    }));
+    });
   });
 });

--- a/handsontable/src/plugins/undoRedo/__tests__/actions/rowMove.spec.js
+++ b/handsontable/src/plugins/undoRedo/__tests__/actions/rowMove.spec.js
@@ -1,0 +1,35 @@
+describe('UndoRedo -> RowMove action', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should have defined correct action properties', async() => {
+    const afterUndo = jasmine.createSpy('afterUndo');
+
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+      rowHeaders: true,
+      colHeaders: true,
+      manualRowMove: true,
+      afterUndo,
+    });
+
+    getPlugin('manualRowMove').moveRows([1, 2], 2);
+    getPlugin('undoRedo').undo();
+
+    expect(afterUndo).toHaveBeenCalledWith(jasmine.objectContaining({
+      actionType: 'row_move',
+      rows: [1, 2],
+      finalRowIndex: 2,
+    }));
+  });
+});

--- a/handsontable/src/plugins/undoRedo/__tests__/actions/rowMove.spec.js
+++ b/handsontable/src/plugins/undoRedo/__tests__/actions/rowMove.spec.js
@@ -26,10 +26,10 @@ describe('UndoRedo -> RowMove action', () => {
     getPlugin('manualRowMove').moveRows([1, 2], 2);
     getPlugin('undoRedo').undo();
 
-    expect(afterUndo).toHaveBeenCalledWith(jasmine.objectContaining({
+    expect(afterUndo).toHaveBeenCalledWith({
       actionType: 'row_move',
       rows: [1, 2],
       finalRowIndex: 2,
-    }));
+    });
   });
 });

--- a/handsontable/src/plugins/undoRedo/__tests__/actions/unmergeCells.spec.js
+++ b/handsontable/src/plugins/undoRedo/__tests__/actions/unmergeCells.spec.js
@@ -1,0 +1,38 @@
+describe('UndoRedo -> UnmergeCells action', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should have defined correct action properties', async() => {
+    const afterUndo = jasmine.createSpy('afterUndo');
+
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+      rowHeaders: true,
+      colHeaders: true,
+      mergeCells: [{ row: 1, col: 1, rowspan: 3, colspan: 3 }],
+      afterUndo,
+    });
+
+    getPlugin('mergeCells').unmerge(1, 1, 3, 3);
+    getPlugin('undoRedo').undo();
+
+    expect(afterUndo).toHaveBeenCalledWith(jasmine.objectContaining({
+      actionType: 'unmerge_cells',
+      cellRange: {
+        highlight: { row: 1, col: 1 },
+        from: { row: 1, col: 1 },
+        to: { row: 3, col: 3 },
+      },
+    }));
+  });
+});

--- a/handsontable/src/plugins/undoRedo/__tests__/actions/unmergeCells.spec.js
+++ b/handsontable/src/plugins/undoRedo/__tests__/actions/unmergeCells.spec.js
@@ -26,13 +26,13 @@ describe('UndoRedo -> UnmergeCells action', () => {
     getPlugin('mergeCells').unmerge(1, 1, 3, 3);
     getPlugin('undoRedo').undo();
 
-    expect(afterUndo).toHaveBeenCalledWith(jasmine.objectContaining({
+    expect(afterUndo).toHaveBeenCalledWith({
       actionType: 'unmerge_cells',
       cellRange: {
         highlight: { row: 1, col: 1 },
         from: { row: 1, col: 1 },
         to: { row: 3, col: 3 },
       },
-    }));
+    });
   });
 });

--- a/handsontable/src/plugins/undoRedo/__tests__/undoRedo.types.ts
+++ b/handsontable/src/plugins/undoRedo/__tests__/undoRedo.types.ts
@@ -1,7 +1,20 @@
 import Handsontable from 'handsontable';
+import { Action } from 'handsontable/plugins/undoRedo';
 
 const hot = new Handsontable(document.createElement('div'), {
   undo: true,
+  beforeUndo(action) {
+    const _action: Action = action;
+  },
+  beforeRedo(action) {
+    const _action: Action = action;
+  },
+  afterUndo(action) {
+    const _action: Action = action;
+  },
+  afterRedo(action) {
+    const _action: Action = action;
+  },
 });
 const plugin = hot.getPlugin('undoRedo');
 

--- a/handsontable/src/plugins/undoRedo/actions/_base.js
+++ b/handsontable/src/plugins/undoRedo/actions/_base.js
@@ -5,6 +5,15 @@
  * @private
  */
 export class BaseAction {
+  /**
+   * @param {string} actionType The action type.
+   */
+  actionType = '';
+
+  constructor(actionType) {
+    this.actionType = actionType;
+  }
+
   undo() {
     throw new Error('Not implemented');
   }

--- a/handsontable/src/plugins/undoRedo/actions/cellAlignment.js
+++ b/handsontable/src/plugins/undoRedo/actions/cellAlignment.js
@@ -26,7 +26,7 @@ export class CellAlignmentAction extends BaseAction {
   alignment;
 
   constructor({ stateBefore, range, type, alignment }) {
-    super();
+    super('cell_alignment');
     this.stateBefore = stateBefore;
     this.range = range;
     this.type = type;

--- a/handsontable/src/plugins/undoRedo/actions/columnMove.js
+++ b/handsontable/src/plugins/undoRedo/actions/columnMove.js
@@ -18,7 +18,7 @@ export class ColumnMoveAction extends BaseAction {
   finalColumnIndex;
 
   constructor({ columns, finalIndex }) {
-    super();
+    super('col_move');
     this.columns = columns.slice();
     this.finalColumnIndex = finalIndex;
   }

--- a/handsontable/src/plugins/undoRedo/actions/columnSort.js
+++ b/handsontable/src/plugins/undoRedo/actions/columnSort.js
@@ -17,7 +17,7 @@ export class ColumnSortAction extends BaseAction {
   nextSortState;
 
   constructor({ currentSortState, newSortState }) {
-    super();
+    super('col_sort');
     this.previousSortState = currentSortState;
     this.nextSortState = newSortState;
   }

--- a/handsontable/src/plugins/undoRedo/actions/createColumn.js
+++ b/handsontable/src/plugins/undoRedo/actions/createColumn.js
@@ -17,7 +17,7 @@ export class CreateColumnAction extends BaseAction {
   amount;
 
   constructor({ index, amount }) {
-    super();
+    super('insert_col');
     this.index = index;
     this.amount = amount;
   }

--- a/handsontable/src/plugins/undoRedo/actions/createRow.js
+++ b/handsontable/src/plugins/undoRedo/actions/createRow.js
@@ -17,7 +17,7 @@ export class CreateRowAction extends BaseAction {
   amount;
 
   constructor({ index, amount }) {
-    super();
+    super('insert_row');
     this.index = index;
     this.amount = amount;
   }

--- a/handsontable/src/plugins/undoRedo/actions/dataChange.js
+++ b/handsontable/src/plugins/undoRedo/actions/dataChange.js
@@ -26,7 +26,7 @@ export class DataChangeAction extends BaseAction {
   countRows;
 
   constructor({ changes, selected, countCols, countRows }) {
-    super();
+    super('change');
     this.changes = changes;
     this.selected = selected;
     this.countCols = countCols;

--- a/handsontable/src/plugins/undoRedo/actions/filters.js
+++ b/handsontable/src/plugins/undoRedo/actions/filters.js
@@ -17,7 +17,7 @@ export class FiltersAction extends BaseAction {
   previousConditionsStack;
 
   constructor({ conditionsStack, previousConditionsStack }) {
-    super();
+    super('filter');
     this.conditionsStack = conditionsStack;
     this.previousConditionsStack = previousConditionsStack;
   }

--- a/handsontable/src/plugins/undoRedo/actions/mergeCells.js
+++ b/handsontable/src/plugins/undoRedo/actions/mergeCells.js
@@ -7,10 +7,13 @@ import { BaseAction } from './_base';
  * @private
  */
 export class MergeCellsAction extends BaseAction {
+  /**
+   * @param {CellRange} cellRange The merged cell range.
+   */
   cellRange;
 
   constructor({ data, cellRange }) {
-    super();
+    super('merge_cells');
     this.cellRange = cellRange;
     this.data = data;
   }

--- a/handsontable/src/plugins/undoRedo/actions/removeColumn.js
+++ b/handsontable/src/plugins/undoRedo/actions/removeColumn.js
@@ -58,7 +58,7 @@ export class RemoveColumnAction extends BaseAction {
     fixedColumnsStart,
     removedCellMetas
   }) {
-    super();
+    super('remove_col');
     this.index = index;
     this.indexes = indexes;
     this.data = data;

--- a/handsontable/src/plugins/undoRedo/actions/removeRow.js
+++ b/handsontable/src/plugins/undoRedo/actions/removeRow.js
@@ -42,7 +42,7 @@ export class RemoveRowAction extends BaseAction {
     rowIndexesSequence,
     removedCellMetas
   }) {
-    super();
+    super('remove_row');
     this.index = index;
     this.data = data;
     this.fixedRowsBottom = fixedRowsBottom;

--- a/handsontable/src/plugins/undoRedo/actions/rowMove.js
+++ b/handsontable/src/plugins/undoRedo/actions/rowMove.js
@@ -18,7 +18,7 @@ export class RowMoveAction extends BaseAction {
   finalRowIndex;
 
   constructor({ rows, finalIndex }) {
-    super();
+    super('row_move');
     this.rows = rows.slice();
     this.finalRowIndex = finalIndex;
   }

--- a/handsontable/src/plugins/undoRedo/actions/unmergeCells.js
+++ b/handsontable/src/plugins/undoRedo/actions/unmergeCells.js
@@ -7,10 +7,13 @@ import { BaseAction } from './_base';
  * @private
  */
 export class UnmergeCellsAction extends BaseAction {
+  /**
+   * @param {CellRange} cellRange The merged cell range.
+   */
   cellRange;
 
   constructor({ cellRange }) {
-    super();
+    super('unmerge_cells');
     this.cellRange = cellRange;
   }
 

--- a/handsontable/types/plugins/undoRedo/undoRedo.d.ts
+++ b/handsontable/types/plugins/undoRedo/undoRedo.d.ts
@@ -1,29 +1,58 @@
+import CellRange from '../../3rdparty/walkontable/src/cell/range';
 import Core from '../../core';
 import { CellValue, CellChange } from '../../common';
 import { ColumnConditions } from '../filters';
 import { BasePlugin } from '../base';
+import { Config as ColumnSortingConfig } from '../columnSorting';
 
 export type Settings = boolean;
 
-export interface ChangeAction {
-  actionType: 'change';
-  changes: CellChange[];
-  selected: Array<[number, number]>;
+export interface CellAlignmentAction {
+  actionType: 'cell_alignment';
+  stateBefore: { [row: number]: string[] };
+  range: CellRange[];
+  type: 'horizontal' | 'vertical';
+  alignment: 'htLeft' | 'htCenter' | 'htRight' | 'htJustify' | 'htTop' | 'htMiddle' | 'htBottom';
+}
+export interface ColumnMoveAction {
+  actionType: 'col_move';
+  columns: number[];
+  finalColumnIndex: number;
+}
+export interface ColumnSortAction {
+  actionType: 'col_sort';
+  previousSortState: ColumnSortingConfig[];
+  nextSortState: ColumnSortingConfig[];
+}
+export interface InsertColAction {
+  actionType: 'insert_col';
+  amount: number;
+  index: number;
 }
 export interface InsertRowAction {
   actionType: 'insert_row';
   amount: number;
   index: number;
 }
-export interface RemoveRowAction {
-  actionType: 'remove_row';
-  index: number;
-  data: CellValue[][];
+export interface ChangeAction {
+  actionType: 'change';
+  changes: CellChange[];
+  selected: Array<[number, number]>;
+  countCols: number;
+  countRows: number;
 }
-export interface InsertColAction {
-  actionType: 'insert_col';
-  amount: number;
-  index: number;
+export interface FilterAction {
+  actionType: 'filter';
+  conditionsStack: ColumnConditions[];
+  previousConditionsStack: ColumnConditions[];
+}
+export interface MergeAction {
+  actionType: 'merge_cells';
+  cellRange: CellRange[];
+}
+export interface UnmergeAction {
+  actionType: 'unmerge_cells';
+  cellRange: CellRange[];
 }
 export interface RemoveColAction {
   actionType: 'remove_col';
@@ -34,13 +63,15 @@ export interface RemoveColAction {
   headers: string[];
   data: CellValue[][];
 }
-export interface FilterAction {
-  actionType: 'filter';
-  conditionsStack: ColumnConditions[];
+export interface RemoveRowAction {
+  actionType: 'remove_row';
+  index: number;
+  data: CellValue[][];
 }
 
-export type Action = ChangeAction | InsertRowAction | RemoveRowAction | InsertColAction |
-                     RemoveColAction | FilterAction;
+export type Action = CellAlignmentAction | ColumnMoveAction | ColumnSortAction |
+  InsertColAction | InsertRowAction | ChangeAction | FilterAction | MergeAction |
+  UnmergeAction | RemoveColAction | RemoveRowAction;
 
 export class UndoRedo extends BasePlugin {
   constructor(hotInstance: Core);


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR reverts the `actionType` class field from the _UndoRedo_ plugin actions/events. The field was mistakenly removed in 15.0. Moreover, the PR improves the typings for those actions by updating some of them and adding missing ones.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I covered the changes with new tests that cover all action types.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/2292

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
