### PR TITLE
Fix class name assignment in component-based renderer in Vue 2 wrapper

### DIFF
--- a/.changelogs/11499.json
+++ b/.changelogs/11499.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed an issue with class name assignment in component-based renderer in Vue 2 wrapper",
+  "type": "fixed",
+  "issueOrPR": 11499,
+  "breaking": false,
+  "framework": "vue"
+}

--- a/wrappers/vue/src/HotTable.vue
+++ b/wrappers/vue/src/HotTable.vue
@@ -269,7 +269,13 @@
               cachedEntry.lastUsedTD = TD;
             }
           }
+          
+          const className = cellProperties?.className;
 
+          if (className !== void 0 && TD) {
+            TD.classList.add(className)
+          }
+          
           return TD;
         };
       },


### PR DESCRIPTION
### Context
This PR incudes fix for assigning class name in component-based renderer in Vue 2 wrapper

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/1204

### Affected project(s):
- [x] `@handsontable/vue`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
