### PR TITLE
Fix row resize line alignment and resize handle flickering

### DIFF
--- a/.changelogs/11500.json
+++ b/.changelogs/11500.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed an issue with row resize line alignment and resize handle flickering",
+  "type": "fixed",
+  "issueOrPR": 11500,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
+++ b/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
@@ -1865,14 +1865,14 @@ describe('manualRowResize', () => {
 
       $handle.simulate('mousedown', { clientY: resizerPosition.top });
 
-      // To watch whether color has changed.
-      expect(getComputedStyle($handle[0]).opacity).toBe('0');
+      // To watch whether opacity has changed.
+      expect(getComputedStyle($handle[0]).opacity).toBe('1');
 
       $handle.simulate('contextmenu');
 
       await sleep(0);
 
-      expect(getComputedStyle($handle[0]).opacity).not.toBe('0');
+      expect(getComputedStyle($handle[0]).opacity).not.toBe('1');
     });
 
     it.forTheme('horizon')('should remove resize handler when user clicks RMB', async() => {
@@ -1891,14 +1891,14 @@ describe('manualRowResize', () => {
 
       $handle.simulate('mousedown', { clientY: resizerPosition.top });
 
-      // To watch whether color has changed.
-      expect(getComputedStyle($handle[0]).opacity).toBe('0');
+      // To watch whether opacity has changed.
+      expect(getComputedStyle($handle[0]).opacity).toBe('1');
 
       $handle.simulate('contextmenu');
 
       await sleep(0);
 
-      expect(getComputedStyle($handle[0]).opacity).not.toBe('0');
+      expect(getComputedStyle($handle[0]).opacity).not.toBe('1');
     });
   });
 

--- a/handsontable/src/styles/components/plugins/_manual-row-resize.scss
+++ b/handsontable/src/styles/components/plugins/_manual-row-resize.scss
@@ -13,7 +13,6 @@
       cursor: row-resize;
       background: none;
       opacity: 0;
-      transition: opacity 0.2s ease-in-out;
 
       &::before,
       &::after {
@@ -46,7 +45,7 @@
       left: 0;
       bottom: 0;
       height: 0;
-      margin-top: 4px;
+      margin-top: 5px;
       display: none;
       border-bottom: 1px solid var(--ht-accent-color);
       border-top: none;

--- a/visual-tests/tests/js-only/complex-demo/manual-row-resize.spec.ts
+++ b/visual-tests/tests/js-only/complex-demo/manual-row-resize.spec.ts
@@ -1,0 +1,35 @@
+import { test } from '../../../src/test-runner';
+import { helpers } from '../../../src/helpers';
+import { selectCell } from '../../../src/page-helpers';
+
+test.beforeEach(async({ page }) => {
+  await page.setViewportSize({ width: 1920, height: 1080 });
+});
+
+test.skip(helpers.hotWrapper !== 'js', 'This test case is only for JavaScript framework');
+
+test(__filename, async({ goto, tablePage }) => {
+  await goto(
+    helpers
+      .setBaseUrl('/complex-demo')
+      .getFullUrl()
+  );
+  const table = await tablePage.locator(helpers.selectors.mainTable);
+
+  // get third row header position and size
+  const cell = await selectCell(2, 0, table, 'th');
+  const THboundingBox = await cell.boundingBox();
+
+  // hover over third row header bottom line
+  await tablePage.mouse.move(
+    THboundingBox!.x + (THboundingBox!.width / 2),
+    THboundingBox!.y + THboundingBox!.height - 3
+  );
+
+  await tablePage.screenshot({ path: helpers.screenshotPath() });
+
+  // click third row header bottom line
+  await tablePage.mouse.down();
+
+  await tablePage.screenshot({ path: helpers.screenshotPath() });
+});


### PR DESCRIPTION
### Context
This PR includes fixes for row resize line alignment and resize handle flickering

### How has this been tested?
Locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2290
2. https://github.com/handsontable/dev-handsontable/issues/2289

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
