### PR TITLE
Fix a problem with a delayed `scroll` event making some of the test cases fail randomly.

### DIFF
--- a/handsontable/src/core/viewportScroll/__tests__/columnHeaderSelection.spec.js
+++ b/handsontable/src/core/viewportScroll/__tests__/columnHeaderSelection.spec.js
@@ -23,9 +23,7 @@ describe('Column header selection scroll', () => {
       });
 
       // make sure that the `F1` cell is partially visible on the right side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       simulateClick(getCell(-1, 5));
 
@@ -44,9 +42,7 @@ describe('Column header selection scroll', () => {
       });
 
       // make sure that the `F1` cell is partially visible on the right side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       simulateClick(getCell(-1, 4));
       keyDown('shift');
@@ -65,9 +61,7 @@ describe('Column header selection scroll', () => {
       });
 
       // make sure that the `F1` cell is partially visible on the right side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectColumns(4, 5);
 
@@ -84,9 +78,7 @@ describe('Column header selection scroll', () => {
       });
 
       // make sure that the `F1` cell is partially visible on the right side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectColumns(5, 4);
 
@@ -105,9 +97,7 @@ describe('Column header selection scroll', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the left side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       simulateClick(getCell(-1, 0));
 
@@ -126,9 +116,7 @@ describe('Column header selection scroll', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the left side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       simulateClick(getCell(-1, 1));
       keyDown('shift');
@@ -147,9 +135,7 @@ describe('Column header selection scroll', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the left side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectColumns(1, 0);
 
@@ -166,9 +152,7 @@ describe('Column header selection scroll', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the left side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectColumns(0, 1);
 

--- a/handsontable/src/core/viewportScroll/__tests__/cornerHeaderSelection.spec.js
+++ b/handsontable/src/core/viewportScroll/__tests__/cornerHeaderSelection.spec.js
@@ -21,10 +21,8 @@ describe('Corner selection scroll', () => {
       colHeaders: true,
     });
 
-    inlineStartOverlay().setScrollPosition(25);
-    topOverlay().setScrollPosition(50);
-
-    await sleep(10);
+    await scrollOverlay(inlineStartOverlay(), 25);
+    await scrollOverlay(topOverlay(), 50);
 
     simulateClick(getCell(-1, -1));
 

--- a/handsontable/src/core/viewportScroll/__tests__/generalHorizontalScroll.spec.js
+++ b/handsontable/src/core/viewportScroll/__tests__/generalHorizontalScroll.spec.js
@@ -25,9 +25,7 @@ describe('Horizontal scroll', () => {
     });
 
     // make sure that the `I` column is partially visible
-    inlineStartOverlay().setScrollPosition(415);
-
-    await sleep(10);
+    await scrollOverlay(inlineStartOverlay(), 415);
 
     // select the `I` column
     selectCell(0, 8);

--- a/handsontable/src/core/viewportScroll/__tests__/generalVerticalScroll.spec.js
+++ b/handsontable/src/core/viewportScroll/__tests__/generalVerticalScroll.spec.js
@@ -25,9 +25,7 @@ describe('Vertical scroll', () => {
     });
 
     // make sure that the `9` row is partially visible
-    topOverlay().setScrollPosition(195);
-
-    await sleep(10);
+    await scrollOverlay(topOverlay(), 195);
 
     // select the `9` row
     selectCell(8, 0);

--- a/handsontable/src/core/viewportScroll/__tests__/multipleSelection.spec.js
+++ b/handsontable/src/core/viewportScroll/__tests__/multipleSelection.spec.js
@@ -23,9 +23,7 @@ describe('Multiple selection scroll', () => {
       });
 
       // make sure that the `F1` cell is partially visible on the right side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       simulateClick(getCell(0, 4));
       keyDown('shift');
@@ -46,9 +44,7 @@ describe('Multiple selection scroll', () => {
       });
 
       // make sure that the `F1` cell is partially visible on the right side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectCell(0, 4);
       keyDownUp(['shift', 'arrowright']);
@@ -67,9 +63,7 @@ describe('Multiple selection scroll', () => {
       });
 
       // make sure that the `F1` cell is partially visible on the right side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectCell(-1, 4);
       keyDownUp(['shift', 'arrowright']);
@@ -87,9 +81,7 @@ describe('Multiple selection scroll', () => {
       });
 
       // make sure that the `F1` cell is partially visible on the right side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectCells([[0, 4, 0, 5]]);
 
@@ -106,9 +98,7 @@ describe('Multiple selection scroll', () => {
       });
 
       // make sure that the `F1` cell is partially visible on the right side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectCells([[0, 5, 0, 4]]);
 
@@ -127,9 +117,7 @@ describe('Multiple selection scroll', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the left side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       simulateClick(getCell(0, 1));
       keyDown('shift');
@@ -150,9 +138,7 @@ describe('Multiple selection scroll', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the left side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectCell(0, 1);
       keyDownUp(['shift', 'arrowleft']);
@@ -171,9 +157,7 @@ describe('Multiple selection scroll', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the left side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectCell(-1, 1);
       keyDownUp(['shift', 'arrowleft']);
@@ -191,9 +175,7 @@ describe('Multiple selection scroll', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the left side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectCells([[0, 1, 0, 0]]);
 
@@ -210,9 +192,7 @@ describe('Multiple selection scroll', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the left side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectCells([[0, 0, 0, 1]]);
 
@@ -231,9 +211,7 @@ describe('Multiple selection scroll', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the top side of the table
-      topOverlay().setScrollPosition(15);
-
-      await sleep(10);
+      await scrollOverlay(topOverlay(), 15);
 
       simulateClick(getCell(1, 0));
       keyDown('shift');
@@ -254,9 +232,7 @@ describe('Multiple selection scroll', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the top side of the table
-      topOverlay().setScrollPosition(15);
-
-      await sleep(10);
+      await scrollOverlay(topOverlay(), 15);
 
       selectCell(1, 0);
       keyDownUp(['shift', 'arrowup']);
@@ -275,9 +251,7 @@ describe('Multiple selection scroll', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the top side of the table
-      topOverlay().setScrollPosition(15);
-
-      await sleep(10);
+      await scrollOverlay(topOverlay(), 15);
 
       selectCell(1, -1);
       keyDownUp(['shift', 'arrowup']);
@@ -295,9 +269,7 @@ describe('Multiple selection scroll', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the top side of the table
-      topOverlay().setScrollPosition(15);
-
-      await sleep(10);
+      await scrollOverlay(topOverlay(), 15);
 
       selectCells([[1, 0, 0, 0]]);
 
@@ -316,9 +288,7 @@ describe('Multiple selection scroll', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the top side of the table
-      topOverlay().setScrollPosition(15);
-
-      await sleep(10);
+      await scrollOverlay(topOverlay(), 15);
 
       selectCells([[0, 0, 1, 0]]);
 
@@ -375,9 +345,7 @@ describe('Multiple selection scroll', () => {
       });
 
       // make sure that the `A12` cell is partially visible on the bottom side of the table
-      topOverlay().setScrollPosition(5);
-
-      await sleep(10);
+      await scrollOverlay(topOverlay(), 5);
 
       selectCell(10, -1);
       keyDownUp(['shift', 'arrowdown']);
@@ -417,9 +385,7 @@ describe('Multiple selection scroll', () => {
       });
 
       // make sure that the `A12` cell is partially visible on the bottom side of the table
-      topOverlay().setScrollPosition(5);
-
-      await sleep(10);
+      await scrollOverlay(topOverlay(), 5);
 
       selectCells([[11, 0, 10, 0]]);
 

--- a/handsontable/src/core/viewportScroll/__tests__/noncontiguousSelection.spec.js
+++ b/handsontable/src/core/viewportScroll/__tests__/noncontiguousSelection.spec.js
@@ -23,9 +23,7 @@ describe('Non-contiguous selection scroll', () => {
       });
 
       // make sure that the `F1` cell is partially visible on the right side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       simulateClick(getCell(0, 3));
       keyDown('control/meta');
@@ -46,9 +44,7 @@ describe('Non-contiguous selection scroll', () => {
       });
 
       // make sure that the `F1` cell is partially visible on the right side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectCells([[0, 3], [0, 5]]);
 
@@ -65,9 +61,7 @@ describe('Non-contiguous selection scroll', () => {
       });
 
       // make sure that the `F1` cell is partially visible on the right side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectCells([[0, 5], [0, 3]]);
 
@@ -86,9 +80,7 @@ describe('Non-contiguous selection scroll', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the left side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       simulateClick(getCell(0, 1));
       keyDown('control/meta');
@@ -109,9 +101,7 @@ describe('Non-contiguous selection scroll', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the left side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectCells([[0, 1], [0, 0]]);
 
@@ -128,9 +118,7 @@ describe('Non-contiguous selection scroll', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the left side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectCells([[0, 0], [0, 1]]);
 
@@ -149,9 +137,7 @@ describe('Non-contiguous selection scroll', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the top side of the table
-      topOverlay().setScrollPosition(15);
-
-      await sleep(10);
+      await scrollOverlay(topOverlay(), 15);
 
       simulateClick(getCell(1, 0));
       keyDown('control/meta');
@@ -172,9 +158,7 @@ describe('Non-contiguous selection scroll', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the top side of the table
-      topOverlay().setScrollPosition(15);
-
-      await sleep(10);
+      await scrollOverlay(topOverlay(), 15);
 
       selectCells([[1, 0], [0, 0]]);
 
@@ -193,9 +177,7 @@ describe('Non-contiguous selection scroll', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the top side of the table
-      topOverlay().setScrollPosition(15);
-
-      await sleep(10);
+      await scrollOverlay(topOverlay(), 15);
 
       selectCells([[0, 0], [1, 0]]);
 
@@ -254,9 +236,7 @@ describe('Non-contiguous selection scroll', () => {
       });
 
       // make sure that the `A12` cell is partially visible on the bottom side of the table
-      topOverlay().setScrollPosition(5);
-
-      await sleep(10);
+      await scrollOverlay(topOverlay(), 5);
 
       selectCells([[11, 0], [10, 0]]);
 

--- a/handsontable/src/core/viewportScroll/__tests__/rowHeaderSelection.spec.js
+++ b/handsontable/src/core/viewportScroll/__tests__/rowHeaderSelection.spec.js
@@ -23,9 +23,7 @@ describe('Row header selection scroll', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the top side of the table
-      topOverlay().setScrollPosition(15);
-
-      await sleep(10);
+      await scrollOverlay(topOverlay(), 15);
 
       simulateClick(getCell(0, -1));
 
@@ -44,9 +42,7 @@ describe('Row header selection scroll', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the top side of the table
-      topOverlay().setScrollPosition(15);
-
-      await sleep(10);
+      await scrollOverlay(topOverlay(), 15);
 
       simulateClick(getCell(1, -1));
       keyDown('shift');
@@ -65,9 +61,7 @@ describe('Row header selection scroll', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the top side of the table
-      topOverlay().setScrollPosition(15);
-
-      await sleep(10);
+      await scrollOverlay(topOverlay(), 15);
 
       selectRows(1, 0);
 
@@ -86,9 +80,7 @@ describe('Row header selection scroll', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the top side of the table
-      topOverlay().setScrollPosition(15);
-
-      await sleep(10);
+      await scrollOverlay(topOverlay(), 15);
 
       selectRows(0, 1);
 
@@ -161,9 +153,7 @@ describe('Row header selection scroll', () => {
       });
 
       // make sure that the `A12` cell is partially visible on the bottom side of the table
-      topOverlay().setScrollPosition(5);
-
-      await sleep(10);
+      await scrollOverlay(topOverlay(), 5);
 
       selectRows(11, 10);
 

--- a/handsontable/src/core/viewportScroll/__tests__/rtl/columnHeaderSelection.spec.js
+++ b/handsontable/src/core/viewportScroll/__tests__/rtl/columnHeaderSelection.spec.js
@@ -26,9 +26,7 @@ describe('Column header selection scroll (RTL mode)', () => {
       });
 
       // make sure that the `F1` cell is partially visible on the left side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       simulateClick(getCell(-1, 5));
 
@@ -47,9 +45,7 @@ describe('Column header selection scroll (RTL mode)', () => {
       });
 
       // make sure that the `F1` cell is partially visible on the left side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       simulateClick(getCell(-1, 4));
       keyDown('shift');
@@ -68,9 +64,7 @@ describe('Column header selection scroll (RTL mode)', () => {
       });
 
       // make sure that the `F1` cell is partially visible on the left side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectColumns(4, 5);
 
@@ -87,9 +81,7 @@ describe('Column header selection scroll (RTL mode)', () => {
       });
 
       // make sure that the `F1` cell is partially visible on the left side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectColumns(5, 4);
 
@@ -108,9 +100,7 @@ describe('Column header selection scroll (RTL mode)', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the right side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       simulateClick(getCell(-1, 0));
 
@@ -127,9 +117,7 @@ describe('Column header selection scroll (RTL mode)', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the right side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       simulateClick(getCell(-1, 1));
       keyDown('shift');
@@ -148,9 +136,7 @@ describe('Column header selection scroll (RTL mode)', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the right side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectColumns(1, 0);
 
@@ -169,9 +155,7 @@ describe('Column header selection scroll (RTL mode)', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the right side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectColumns(0, 1);
 

--- a/handsontable/src/core/viewportScroll/__tests__/rtl/multipleSelection.spec.js
+++ b/handsontable/src/core/viewportScroll/__tests__/rtl/multipleSelection.spec.js
@@ -26,9 +26,7 @@ describe('Multiple selection scroll (RTL mode)', () => {
       });
 
       // make sure that the `F1` cell is partially visible on the left side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       simulateClick(getCell(0, 4));
       keyDown('shift');
@@ -49,9 +47,7 @@ describe('Multiple selection scroll (RTL mode)', () => {
       });
 
       // make sure that the `F1` cell is partially visible on the left side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectCell(0, 4);
       keyDownUp(['shift', 'arrowleft']);
@@ -70,9 +66,7 @@ describe('Multiple selection scroll (RTL mode)', () => {
       });
 
       // make sure that the `F1` cell is partially visible on the left side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectCell(-1, 4);
       keyDownUp(['shift', 'arrowleft']);
@@ -90,15 +84,13 @@ describe('Multiple selection scroll (RTL mode)', () => {
       });
 
       // make sure that the `F1` cell is partially visible on the left side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectCells([[0, 4, 0, 5]]);
 
       expect(inlineStartOverlay().getScrollPosition()).toBe(51);
 
-      inlineStartOverlay().setScrollPosition(25);
+      await scrollOverlay(inlineStartOverlay(), 25);
     });
 
     it('should not scroll the viewport after using API (selecting partially visible column to fully visible column)', async() => {
@@ -111,9 +103,7 @@ describe('Multiple selection scroll (RTL mode)', () => {
       });
 
       // make sure that the `F1` cell is partially visible on the left side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectCells([[0, 5, 0, 4]]);
 
@@ -132,9 +122,7 @@ describe('Multiple selection scroll (RTL mode)', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the right side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       simulateClick(getCell(0, 1));
       keyDown('shift');
@@ -155,9 +143,7 @@ describe('Multiple selection scroll (RTL mode)', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the right side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectCell(0, 1);
       keyDownUp(['shift', 'arrowright']);
@@ -176,9 +162,7 @@ describe('Multiple selection scroll (RTL mode)', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the right side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectCell(-1, 1);
       keyDownUp(['shift', 'arrowright']);
@@ -196,9 +180,7 @@ describe('Multiple selection scroll (RTL mode)', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the right side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectCells([[0, 1, 0, 0]]);
 
@@ -215,9 +197,7 @@ describe('Multiple selection scroll (RTL mode)', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the right side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectCells([[0, 0, 0, 1]]);
 

--- a/handsontable/src/core/viewportScroll/__tests__/rtl/noncontiguousSelection.spec.js
+++ b/handsontable/src/core/viewportScroll/__tests__/rtl/noncontiguousSelection.spec.js
@@ -26,9 +26,7 @@ describe('Non-contiguous selection scroll (RTL mode)', () => {
       });
 
       // make sure that the `F1` cell is partially visible on the left side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       simulateClick(getCell(0, 3));
       keyDown('control/meta');
@@ -49,9 +47,7 @@ describe('Non-contiguous selection scroll (RTL mode)', () => {
       });
 
       // make sure that the `F1` cell is partially visible on the left side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectCells([[0, 3], [0, 5]]);
 
@@ -68,9 +64,7 @@ describe('Non-contiguous selection scroll (RTL mode)', () => {
       });
 
       // make sure that the `F1` cell is partially visible on the left side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectCells([[0, 5], [0, 3]]);
 
@@ -89,9 +83,7 @@ describe('Non-contiguous selection scroll (RTL mode)', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the right side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       simulateClick(getCell(0, 1));
       keyDown('control/meta');
@@ -112,9 +104,7 @@ describe('Non-contiguous selection scroll (RTL mode)', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the right side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectCells([[0, 1], [0, 0]]);
 
@@ -131,9 +121,7 @@ describe('Non-contiguous selection scroll (RTL mode)', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the right side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectCells([[0, 0], [0, 1]]);
 

--- a/handsontable/src/core/viewportScroll/__tests__/rtl/singleSelection.spec.js
+++ b/handsontable/src/core/viewportScroll/__tests__/rtl/singleSelection.spec.js
@@ -26,9 +26,7 @@ describe('Single selection scroll (RTL mode)', () => {
       });
 
       // make sure that the `F1` cell is partially visible on the left side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       simulateClick(getCell(0, 5));
 
@@ -45,9 +43,7 @@ describe('Single selection scroll (RTL mode)', () => {
       });
 
       // make sure that the `F1` cell is partially visible on the left side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       mouseDoubleClick(getCell(0, 5));
 
@@ -64,9 +60,7 @@ describe('Single selection scroll (RTL mode)', () => {
       });
 
       // make sure that the `F1` cell is partially visible on the left side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectCell(0, 4);
       keyDownUp('arrowleft');
@@ -85,9 +79,7 @@ describe('Single selection scroll (RTL mode)', () => {
       });
 
       // make sure that the `F1` cell is partially visible on the left side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectCell(-1, 4);
       keyDownUp('arrowleft');
@@ -105,9 +97,7 @@ describe('Single selection scroll (RTL mode)', () => {
       });
 
       // make sure that the `F1` cell is partially visible on the left side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectCell(0, 5);
 
@@ -126,9 +116,7 @@ describe('Single selection scroll (RTL mode)', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the right side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       simulateClick(getCell(0, 0));
 
@@ -147,9 +135,7 @@ describe('Single selection scroll (RTL mode)', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the right side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       mouseDoubleClick(getCell(0, 0));
 
@@ -166,9 +152,7 @@ describe('Single selection scroll (RTL mode)', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the right side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectCell(0, 1);
       keyDownUp('arrowright');
@@ -187,9 +171,7 @@ describe('Single selection scroll (RTL mode)', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the right side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectCell(-1, 1);
       keyDownUp('arrowright');
@@ -207,9 +189,7 @@ describe('Single selection scroll (RTL mode)', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the right side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectCell(0, 0);
 

--- a/handsontable/src/core/viewportScroll/__tests__/singleSelection.spec.js
+++ b/handsontable/src/core/viewportScroll/__tests__/singleSelection.spec.js
@@ -42,9 +42,7 @@ describe('Single selection scroll', () => {
       });
 
       // make sure that the `F1` cell is partially visible on the right side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       mouseDoubleClick(getCell(0, 5));
 
@@ -61,9 +59,7 @@ describe('Single selection scroll', () => {
       });
 
       // make sure that the `F1` cell is partially visible on the right side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectCell(0, 4);
       keyDownUp('arrowright');
@@ -82,9 +78,7 @@ describe('Single selection scroll', () => {
       });
 
       // make sure that the `F1` cell is partially visible on the right side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectCell(-1, 4);
       keyDownUp('arrowright');
@@ -102,9 +96,7 @@ describe('Single selection scroll', () => {
       });
 
       // make sure that the `F1` cell is partially visible on the right side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectCell(0, 5);
 
@@ -123,9 +115,7 @@ describe('Single selection scroll', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the left side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       simulateClick(getCell(0, 0));
 
@@ -144,9 +134,7 @@ describe('Single selection scroll', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the left side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       mouseDoubleClick(getCell(0, 0));
 
@@ -163,9 +151,7 @@ describe('Single selection scroll', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the left side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectCell(0, 1);
       keyDownUp('arrowleft');
@@ -184,9 +170,7 @@ describe('Single selection scroll', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the left side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectCell(-1, 1);
       keyDownUp('arrowleft');
@@ -204,9 +188,7 @@ describe('Single selection scroll', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the left side of the table
-      inlineStartOverlay().setScrollPosition(25);
-
-      await sleep(10);
+      await scrollOverlay(inlineStartOverlay(), 25);
 
       selectCell(0, 0);
 
@@ -225,9 +207,7 @@ describe('Single selection scroll', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the top side of the table
-      topOverlay().setScrollPosition(15);
-
-      await sleep(10);
+      await scrollOverlay(topOverlay(), 15);
 
       simulateClick(getCell(0, 0));
 
@@ -246,9 +226,7 @@ describe('Single selection scroll', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the top side of the table
-      topOverlay().setScrollPosition(15);
-
-      await sleep(10);
+      await scrollOverlay(topOverlay(), 15);
 
       mouseDoubleClick(getCell(0, 0));
 
@@ -265,9 +243,7 @@ describe('Single selection scroll', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the top side of the table
-      topOverlay().setScrollPosition(15);
-
-      await sleep(10);
+      await scrollOverlay(topOverlay(), 15);
 
       selectCell(1, 0);
       keyDownUp('arrowup');
@@ -286,9 +262,7 @@ describe('Single selection scroll', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the top side of the table
-      topOverlay().setScrollPosition(15);
-
-      await sleep(10);
+      await scrollOverlay(topOverlay(), 15);
 
       selectCell(1, -1);
       keyDownUp('arrowup');
@@ -306,9 +280,7 @@ describe('Single selection scroll', () => {
       });
 
       // make sure that the `A1` cell is partially visible on the top side of the table
-      topOverlay().setScrollPosition(15);
-
-      await sleep(10);
+      await scrollOverlay(topOverlay(), 15);
 
       selectCell(0, 0);
 

--- a/handsontable/src/plugins/comments/__tests__/comments.spec.js
+++ b/handsontable/src/plugins/comments/__tests__/comments.spec.js
@@ -164,7 +164,7 @@ describe('Comments', () => {
         const plugin = getPlugin('comments');
         const $editor = $(plugin.getEditorInputElement());
 
-        await sleep(10);
+        await sleep(30);
 
         plugin.showAtCell(countRows() - 10, countCols() - 10);
 
@@ -265,7 +265,7 @@ describe('Comments', () => {
         const plugin = getPlugin('comments');
         const $editor = $(plugin.getEditorInputElement());
 
-        await sleep(10);
+        await sleep(30);
 
         plugin.showAtCell(countRows() - 2, countCols() - 5);
 
@@ -296,7 +296,7 @@ describe('Comments', () => {
         const plugin = getPlugin('comments');
         const $editor = $(plugin.getEditorInputElement());
 
-        await sleep(10);
+        await sleep(30);
 
         plugin.showAtCell(countRows() - 2, countCols() - 8);
 
@@ -327,7 +327,7 @@ describe('Comments', () => {
         const plugin = getPlugin('comments');
         const $editor = $(plugin.getEditorInputElement());
 
-        await sleep(10);
+        await sleep(30);
 
         plugin.showAtCell(countRows() - 2, countCols() - 8);
 
@@ -361,7 +361,7 @@ describe('Comments', () => {
         const plugin = getPlugin('comments');
         const $editor = $(plugin.getEditorInputElement());
 
-        await sleep(10);
+        await sleep(30);
 
         plugin.showAtCell(countRows() - 5, countCols() - 2);
 
@@ -399,7 +399,7 @@ describe('Comments', () => {
           horizontalSnap: 'start',
         });
 
-        await sleep(10);
+        await sleep(30);
 
         const defaultRowHeight = getDefaultRowHeight();
         const plugin = getPlugin('comments');
@@ -520,7 +520,7 @@ describe('Comments', () => {
         const plugin = getPlugin('comments');
         const $editor = $(plugin.getEditorInputElement());
 
-        await sleep(10);
+        await sleep(30);
 
         plugin.showAtCell(countRows() - 1, 0);
 
@@ -637,7 +637,7 @@ describe('Comments', () => {
         clientY: cell.offset().top + 5,
       });
 
-      await sleep(10);
+      await sleep(30);
 
       const commentEditorOffset = $(hot.getPlugin('comments').getEditorInputElement()).offset();
 
@@ -679,7 +679,7 @@ describe('Comments', () => {
       horizontalSnap: 'start',
     });
 
-    await sleep(10);
+    await sleep(30);
 
     const plugin = hot.getPlugin('comments');
     const editor = plugin.getEditorInputElement();

--- a/handsontable/src/plugins/dragToScroll/__tests__/dragToScroll.spec.js
+++ b/handsontable/src/plugins/dragToScroll/__tests__/dragToScroll.spec.js
@@ -326,7 +326,7 @@ describe('DragToScroll', () => {
         horizontalSnap: 'start',
       });
 
-      await sleep(10);
+      await sleep(30);
 
       const $cell = $(getCell(0, 8));
       const $nextElement = $(document.body);

--- a/handsontable/src/plugins/manualColumnMove/__tests__/scrolling.spec.js
+++ b/handsontable/src/plugins/manualColumnMove/__tests__/scrolling.spec.js
@@ -97,7 +97,7 @@ describe('manualColumnMove', () => {
         horizontalSnap: 'start',
       });
 
-      await sleep(10);
+      await sleep(30);
 
       const columnHeader = $(getCell(-1, 8));
       const nextElement = $(document.body);

--- a/handsontable/test/helpers/common.js
+++ b/handsontable/test/helpers/common.js
@@ -1148,6 +1148,28 @@ export function clearModernThemeStylesheetMock(container) {
 }
 
 /**
+ * Scrolls the overlay to a specific position and waits for the scroll event to fire.
+ *
+ * @param {object} overlay The overlay object.
+ * @param {number} amount The amount to scroll.
+ * @returns {Promise} A promise that resolves when the scroll event fires.
+ */
+export async function scrollOverlay(overlay, amount) {
+  const scrollPromise = new Promise((resolve) => {
+    const scrollHandler = () => {
+      overlay.mainTableScrollableElement.removeEventListener('scroll', scrollHandler);
+      resolve();
+    };
+
+    overlay.mainTableScrollableElement.addEventListener('scroll', scrollHandler);
+  });
+
+  overlay.setScrollPosition(amount);
+
+  return scrollPromise;
+}
+
+/**
  * Creates spreadsheet data as an array of arrays filled with spreadsheet-like label
  * values (e.q "A1", "A2"...).
  *


### PR DESCRIPTION
### Context
To fix a problem with some of the test cases failing randomly in the local environment:

- As some of the test cases seem to have been failing randomly because of a delayed `scroll` event, I prepared a helper that waits until that event has been triggered before running the rest of the test.
- Extended the `sleep` times in test cases, which also had a tendency to fail randomly.

[skip changelog]

### How has this been tested?
Tested locally with `classic`, `main` and `horizon` themes, using Puppeteer and a live browser.

### Related issue(s):
1. handsontable/dev-handsontable#2297