### PR TITLE
Fix autocomplete caret position after using scroll on a list of choices and dropdown width fixer

### DIFF
--- a/.changelogs/11503.json
+++ b/.changelogs/11503.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed an issue with autocomplete caret position after using scroll on a list of choices and dropdown width fixer",
+  "type": "fixed",
+  "issueOrPR": 11503,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
+++ b/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
@@ -30,6 +30,7 @@ import {
   A11Y_SETSIZE,
   A11Y_TEXT
 } from '../../helpers/a11y';
+import { debounce } from '../../helpers/function';
 
 export const EDITOR_TYPE = 'autocomplete';
 
@@ -87,6 +88,13 @@ export class AutocompleteEditor extends HandsontableEditor {
   }
 
   /**
+   * Runs focus method after debounce.
+   */
+  #focusDebounced = debounce(() => {
+    this.focus();
+  }, 100);
+
+  /**
    * Creates an editor's elements and adds necessary CSS classnames.
    */
   createElements() {
@@ -141,6 +149,7 @@ export class AutocompleteEditor extends HandsontableEditor {
     this.showEditableElement();
     this.focus();
     this.addHook('beforeKeyDown', event => this.onBeforeKeyDown(event));
+    this.htEditor.addHook('afterScroll', this.#focusDebounced);
 
     this.htEditor.updateSettings({
       colWidths: trimDropdown ? [outerWidth(this.TEXTAREA) - 2] : undefined,
@@ -429,7 +438,7 @@ export class AutocompleteEditor extends HandsontableEditor {
   #fixDropdownWidth() {
     if (this.htEditor.view.hasVerticalScroll()) {
       this.htEditor.updateSettings({
-        width: this.htEditor.getSettings().width + getScrollbarWidth(this.hot.rootDocument),
+        width: this.getWidth() + getScrollbarWidth(this.hot.rootDocument),
       });
     }
   }

--- a/handsontable/src/editors/dropdownEditor/__tests__/dropdownEditor.spec.js
+++ b/handsontable/src/editors/dropdownEditor/__tests__/dropdownEditor.spec.js
@@ -675,9 +675,7 @@ describe('DropdownEditor', () => {
 
       await sleep(100);
 
-      const $editorInput = $('.handsontableInput');
-
-      expect(Handsontable.dom.getCaretPosition($editorInput[0])).toEqual(6);
+      expect(Handsontable.dom.getCaretPosition(getActiveEditor().TEXTAREA)).toBe(6);
     });
   });
 

--- a/handsontable/src/editors/dropdownEditor/__tests__/dropdownEditor.spec.js
+++ b/handsontable/src/editors/dropdownEditor/__tests__/dropdownEditor.spec.js
@@ -598,6 +598,87 @@ describe('DropdownEditor', () => {
         horizon.toBe(112);
       });
     });
+
+    it('should open editor with the correct size when there is scrollbar on the list and table', async() => {
+      handsontable({
+        colWidths: 120,
+        height: 100,
+        columns: [
+          {
+            editor: 'dropdown',
+            source: choices,
+            visibleRows: 3,
+          }
+        ]
+      });
+
+      selectCell(0, 0);
+      keyDownUp('enter');
+
+      await sleep(100);
+
+      const container = getActiveEditor().htContainer;
+
+      expect(container.clientWidth).forThemes(({ classic, main, horizon }) => {
+        classic.toBe(120 + Handsontable.dom.getScrollbarWidth());
+        main.toBe(118 + Handsontable.dom.getScrollbarWidth());
+        horizon.toBe(118 + Handsontable.dom.getScrollbarWidth());
+      });
+      expect(container.clientHeight).forThemes(({ classic, main, horizon }) => {
+        classic.toBe(72);
+        main.toBe(58);
+        horizon.toBe(37);
+      });
+    });
+
+    it('should set textarea caret position at the end of the input, after moving scrollbar', async() => {
+      const hot = handsontable({
+        data: [
+          ['yellow'],
+          ['red'],
+          ['orange'],
+          ['green'],
+          ['blue'],
+          ['gray'],
+          ['black'],
+          ['white'],
+          ['purple'],
+          ['lime'],
+          ['olive'],
+          ['cyan'],
+        ],
+        colWidths: 120,
+        columns: [
+          {
+            editor: 'dropdown',
+            source: choices,
+            visibleRows: 3,
+          }
+        ]
+      });
+
+      selectCell(0, 0);
+      keyDownUp('enter');
+
+      const editor = hot.getActiveEditor();
+      const htContainer = editor.htContainer;
+
+      await sleep(50);
+
+      simulateClick(htContainer.querySelector('.wtHolder'));
+      htContainer.querySelector('.wtHolder').scrollTo(0, 40);
+
+      await sleep(50);
+
+      keyDownUp('a');
+      keyDownUp('a');
+
+      await sleep(50);
+
+      const $editorInput = $('.handsontableInput');
+
+      expect(Handsontable.dom.getCaretPosition($editorInput[0])).toEqual(6);
+    });
   });
 
   describe('closing the editor', () => {

--- a/handsontable/src/editors/dropdownEditor/__tests__/dropdownEditor.spec.js
+++ b/handsontable/src/editors/dropdownEditor/__tests__/dropdownEditor.spec.js
@@ -663,17 +663,17 @@ describe('DropdownEditor', () => {
       const editor = hot.getActiveEditor();
       const htContainer = editor.htContainer;
 
-      await sleep(50);
+      await sleep(100);
 
       simulateClick(htContainer.querySelector('.wtHolder'));
       htContainer.querySelector('.wtHolder').scrollTo(0, 40);
 
-      await sleep(50);
+      await sleep(100);
 
       keyDownUp('a');
       keyDownUp('a');
 
-      await sleep(50);
+      await sleep(100);
 
       const $editorInput = $('.handsontableInput');
 


### PR DESCRIPTION
### Context
This PR includes fixes for caret position inside autocomplete `textarea` after move srollbar via mouse and and back to typing text, and fix for dropdown width when vertical scroll is visible.

### How has this been tested?
Locally and covered by new e2e test cases

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/50

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
