### PR TITLE
Fix copy, cut an paste actions on tables with a selection ranging outside of the rendered viewport.

### DIFF
--- a/.changelogs/11504.json
+++ b/.changelogs/11504.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed copy, cut an paste actions on tables with a selection reaching outside of the rendered viewport.",
+  "type": "fixed",
+  "issueOrPR": 11504,
+  "breaking": false,
+  "framework": "none"
+}

--- a/examples/next/visual-tests/js/demo/src/demos/largeDataset/largeDatasetDemo.js
+++ b/examples/next/visual-tests/js/demo/src/demos/largeDataset/largeDatasetDemo.js
@@ -1,0 +1,25 @@
+import Handsontable from 'handsontable';
+import { getThemeNameFromURL } from '../../utils';
+
+const root = document.getElementById('root');
+
+const container = document.createElement('div');
+container.id = 'hot';
+
+root.appendChild(container);
+
+export function initializeLargeDatasetDemo() {
+  new Handsontable(container, {
+    data: Handsontable.helper.createSpreadsheetData(150, 150),
+    colHeaders: true,
+    rowHeaders: true,
+    themeName: getThemeNameFromURL(),
+    height: 500,
+    width: 500,
+    contextMenu: true,
+    licenseKey: 'non-commercial-and-evaluation',
+  });
+  console.log(
+    `Handsontable: v${Handsontable.version} (${Handsontable.buildDate})`
+  );
+}

--- a/examples/next/visual-tests/js/demo/src/index.js
+++ b/examples/next/visual-tests/js/demo/src/index.js
@@ -11,7 +11,8 @@ import { initializeMergedCellsDemo } from './demos/mergedCells/mergedCellsDemo';
 import { initializeNestedHeadersDemo } from './demos/nestedHeaders/nestedHeadersDemo';
 import { initializeNestedRowsDemo } from './demos/nestedRows/nestedRowsDemo';
 import { initializeComplexDemo } from './demos/complex/complexDemo';
-import { initializeBasicTwoTablesDemo } from "./demos/basicTwoTables/basicTwoTables";
+import { initializeBasicTwoTablesDemo } from './demos/basicTwoTables/basicTwoTables';
+import { initializeLargeDatasetDemo } from './demos/largeDataset/largeDatasetDemo';
 
 // Function to dynamically load CSS
 function loadCSS(href) {
@@ -127,6 +128,15 @@ router
         loadThemeCSS(),
       ]).then(() => {
         initializeCustomStyleDemo();
+      });
+    },
+    '/large-dataset-demo': function () {
+      removeCSS();
+
+      Promise.all([
+        loadThemeCSS(),
+      ]).then(() => {
+        initializeLargeDatasetDemo();
       });
     },
     '/merged-cells-demo': function () {

--- a/handsontable/src/editors/textEditor/textEditor.js
+++ b/handsontable/src/editors/textEditor/textEditor.js
@@ -3,7 +3,7 @@ import EventManager from '../../eventManager';
 import { isEdge, isIOS } from '../../helpers/browser';
 import {
   addClass,
-  isThisHotChild,
+  isInternalElement,
   setCaretPosition,
   hasClass,
   removeClass,
@@ -129,7 +129,7 @@ export class TextEditor extends BaseEditor {
   close() {
     this.autoResize.unObserve();
 
-    if (isThisHotChild(this.hot.rootDocument.activeElement, this.hot.rootElement)) {
+    if (isInternalElement(this.hot.rootDocument.activeElement, this.hot.rootElement)) {
       this.hot.listen(); // don't refocus the table if user focused some cell outside of HT on purpose
     }
 

--- a/handsontable/src/helpers/dom/__tests__/element.spec.js
+++ b/handsontable/src/helpers/dom/__tests__/element.spec.js
@@ -23,7 +23,7 @@ describe('DOM helpers', () => {
     });
   });
 
-  describe('isThisHotChild', () => {
+  describe('isInternalElement', () => {
     it('should recognize if the provided element is a child of the container of the Handsontable container provided' +
       ' as the second argument', () => {
       const createDivWithId = (id) => {
@@ -45,7 +45,7 @@ describe('DOM helpers', () => {
         fixedColumnsStart: 3
       });
       const { rootElement } = hot;
-      const isThisHotChild = Handsontable.dom.isThisHotChild;
+      const isInternalElement = Handsontable.dom.isInternalElement;
 
       hot.selectCell(0, 0);
 
@@ -57,30 +57,30 @@ describe('DOM helpers', () => {
       // Overlay elements
       const topOverlayTableElement = hot.view._wt.wtOverlays.topOverlay.clone.wtTable.TABLE;
 
-      expect(isThisHotChild(topOverlayTableElement, rootElement)).toBe(true);
-      expect(isThisHotChild(topOverlayTableElement.parentNode, rootElement)).toBe(true);
-      expect(isThisHotChild(topOverlayTableElement.parentNode.parentNode, rootElement)).toBe(true);
-      expect(isThisHotChild(topOverlayTableElement.parentNode.parentNode.parentNode, rootElement)).toBe(true);
+      expect(isInternalElement(topOverlayTableElement, rootElement)).toBe(true);
+      expect(isInternalElement(topOverlayTableElement.parentNode, rootElement)).toBe(true);
+      expect(isInternalElement(topOverlayTableElement.parentNode.parentNode, rootElement)).toBe(true);
+      expect(isInternalElement(topOverlayTableElement.parentNode.parentNode.parentNode, rootElement)).toBe(true);
 
       const mainOverlayTableElement = hot.view._wt.wtOverlays.wtTable.TABLE;
 
-      expect(isThisHotChild(mainOverlayTableElement, rootElement)).toBe(true);
-      expect(isThisHotChild(mainOverlayTableElement.parentNode, rootElement)).toBe(true);
-      expect(isThisHotChild(mainOverlayTableElement.parentNode.parentNode, rootElement)).toBe(true);
-      expect(isThisHotChild(mainOverlayTableElement.parentNode.parentNode.parentNode, rootElement)).toBe(true);
+      expect(isInternalElement(mainOverlayTableElement, rootElement)).toBe(true);
+      expect(isInternalElement(mainOverlayTableElement.parentNode, rootElement)).toBe(true);
+      expect(isInternalElement(mainOverlayTableElement.parentNode.parentNode, rootElement)).toBe(true);
+      expect(isInternalElement(mainOverlayTableElement.parentNode.parentNode.parentNode, rootElement)).toBe(true);
 
       // Cell elements
-      expect(isThisHotChild(hot.getCell(0, 0, true), rootElement)).toBe(true);
-      expect(isThisHotChild(hot.getCell(3, 3, true), rootElement)).toBe(true);
-      expect(isThisHotChild(hot.getCell(9, 9, true), rootElement)).toBe(true);
+      expect(isInternalElement(hot.getCell(0, 0, true), rootElement)).toBe(true);
+      expect(isInternalElement(hot.getCell(3, 3, true), rootElement)).toBe(true);
+      expect(isInternalElement(hot.getCell(9, 9, true), rootElement)).toBe(true);
 
       // Misc
-      expect(isThisHotChild(document.querySelector('.htFocusCatcher'), rootElement)).toBe(true);
-      expect(isThisHotChild(document.querySelector('.handsontableInputHolder'), rootElement)).toBe(true);
-      expect(isThisHotChild(document.querySelector('#rootChild'), rootElement)).toBe(true);
+      expect(isInternalElement(document.querySelector('.htFocusCatcher'), rootElement)).toBe(true);
+      expect(isInternalElement(document.querySelector('.handsontableInputHolder'), rootElement)).toBe(true);
+      expect(isInternalElement(document.querySelector('#rootChild'), rootElement)).toBe(true);
 
-      expect(isThisHotChild(document.querySelector('#rootSibling'), rootElement)).toBe(false);
-      expect(isThisHotChild(document.body, rootElement)).toBe(false);
+      expect(isInternalElement(document.querySelector('#rootSibling'), rootElement)).toBe(false);
+      expect(isInternalElement(document.body, rootElement)).toBe(false);
 
       hot.destroy();
       document.body.removeChild(document.querySelector('#rootSibling'));

--- a/handsontable/src/helpers/dom/element.js
+++ b/handsontable/src/helpers/dom/element.js
@@ -38,7 +38,7 @@ export function getParent(element, level = 0) {
  * @param {HTMLElement} thisHotContainer The Handsontable container.
  * @returns {boolean}
  */
-export function isThisHotChild(element, thisHotContainer) {
+export function isInternalElement(element, thisHotContainer) {
   const closestHandsontableContainer = element.closest('.handsontable');
 
   return !!closestHandsontableContainer &&

--- a/handsontable/src/plugins/copyPaste/__tests__/copy.spec.js
+++ b/handsontable/src/plugins/copyPaste/__tests__/copy.spec.js
@@ -309,7 +309,7 @@ describe('CopyPaste', () => {
       expect(copyEvent.preventDefault).toHaveBeenCalled();
     });
 
-    it('should skip processing the event when the target element has not the "data-hot-input" attribute and it\'s not a BODY element', () => {
+    it('should skip processing the event when the target element does not have the "data-hot-input" attribute and it\'s not a BODY element', () => {
       handsontable({
         data: createSpreadsheetData(5, 5),
       });
@@ -326,7 +326,7 @@ describe('CopyPaste', () => {
       expect(copyEvent.preventDefault).not.toHaveBeenCalled();
     });
 
-    it('should not skip processing the event when the target element has not the "data-hot-input" attribute and it\'s a BODY element', () => {
+    it('should not skip processing the event when the target element does not have the "data-hot-input" attribute and it\'s a BODY element', () => {
       handsontable({
         data: createSpreadsheetData(5, 5),
       });
@@ -343,7 +343,7 @@ describe('CopyPaste', () => {
       expect(copyEvent.preventDefault).toHaveBeenCalled();
     });
 
-    it('should not skip processing the event when the target element has not the "data-hot-input" attribute and it\'s a TD element (#dev-2225)', () => {
+    it('should not skip processing the event when the target element does not have the "data-hot-input" attribute and it\'s a TD element (#dev-2225)', () => {
       handsontable({
         data: createSpreadsheetData(5, 5),
       });
@@ -358,6 +358,27 @@ describe('CopyPaste', () => {
       plugin.onCopy(copyEvent); // trigger the plugin's method that is normally triggered by the native "copy" event
 
       expect(copyEvent.preventDefault).toHaveBeenCalled();
+    });
+
+    it('should be possible to copy the content that starts outside of the rendered viewport (#dev-2298)', async() => {
+      handsontable({
+        data: createSpreadsheetData(1, 50),
+        width: 100,
+        height: 50,
+      });
+
+      const copyEvent = getClipboardEvent();
+      const plugin = getPlugin('CopyPaste');
+      const expectedResult = getDataAtRow(0).join('\t');
+
+      selectCells([[0, 0, 0, 49]]);
+
+      await sleep(10);
+
+      copyEvent.target = document.activeElement;
+      plugin.onCopy(copyEvent); // emulate native "copy" event
+
+      expect(copyEvent.clipboardData.getData('text/plain')).toBe(expectedResult);
     });
   });
 });

--- a/handsontable/src/plugins/copyPaste/__tests__/cut.spec.js
+++ b/handsontable/src/plugins/copyPaste/__tests__/cut.spec.js
@@ -126,7 +126,7 @@ describe('CopyPaste', () => {
       expect(copyEvent.preventDefault).toHaveBeenCalled();
     });
 
-    it('should skip processing the event when the target element has not the "data-hot-input" attribute and it\'s not a BODY element', () => {
+    it('should skip processing the event when the target element does not have the "data-hot-input" attribute and it\'s not a BODY element', () => {
       handsontable({
         data: createSpreadsheetData(5, 5),
       });
@@ -143,7 +143,7 @@ describe('CopyPaste', () => {
       expect(copyEvent.preventDefault).not.toHaveBeenCalled();
     });
 
-    it('should not skip processing the event when the target element has not the "data-hot-input" attribute and it\'s a BODY element', () => {
+    it('should not skip processing the event when the target element does not have the "data-hot-input" attribute and it\'s a BODY element', () => {
       handsontable({
         data: createSpreadsheetData(5, 5),
       });
@@ -160,7 +160,7 @@ describe('CopyPaste', () => {
       expect(copyEvent.preventDefault).toHaveBeenCalled();
     });
 
-    it('should not skip processing the event when the target element has not the "data-hot-input" attribute and it\'s a TD element (#dev-2225)', () => {
+    it('should not skip processing the event when the target element does not have the "data-hot-input" attribute and it\'s a TD element (#dev-2225)', () => {
       handsontable({
         data: createSpreadsheetData(5, 5),
       });
@@ -175,6 +175,27 @@ describe('CopyPaste', () => {
       plugin.onCut(copyEvent); // trigger the plugin's method that is normally triggered by the native "cut" event
 
       expect(copyEvent.preventDefault).toHaveBeenCalled();
+    });
+
+    it('should be possible to cut the content that starts outside of the rendered viewport (#dev-2298)', async() => {
+      handsontable({
+        data: createSpreadsheetData(1, 50),
+        width: 100,
+        height: 50,
+      });
+
+      const cutEvent = getClipboardEvent();
+      const plugin = getPlugin('CopyPaste');
+      const expectedResult = getDataAtRow(0).join('\t');
+
+      selectCells([[0, 0, 0, 49]]);
+
+      await sleep(10);
+
+      cutEvent.target = document.activeElement;
+      plugin.onCut(cutEvent); // emulate native "cut" event
+
+      expect(cutEvent.clipboardData.getData('text/plain')).toBe(expectedResult);
     });
   });
 });

--- a/handsontable/src/plugins/copyPaste/__tests__/paste.spec.js
+++ b/handsontable/src/plugins/copyPaste/__tests__/paste.spec.js
@@ -656,7 +656,7 @@ describe('CopyPaste', () => {
       expect(copyEvent.preventDefault).toHaveBeenCalled();
     });
 
-    it('should skip processing the event when the target element has not the "data-hot-input" attribute and it\'s not a BODY element', () => {
+    it('should skip processing the event when the target element does not have the "data-hot-input" attribute and it\'s not a BODY element', () => {
       handsontable({
         data: createSpreadsheetData(5, 5),
       });
@@ -673,7 +673,7 @@ describe('CopyPaste', () => {
       expect(copyEvent.preventDefault).not.toHaveBeenCalled();
     });
 
-    it('should not skip processing the event when the target element has not the "data-hot-input" attribute and it\'s a BODY element', () => {
+    it('should not skip processing the event when the target element does not have the "data-hot-input" attribute and it\'s a BODY element', () => {
       handsontable({
         data: createSpreadsheetData(5, 5),
       });
@@ -690,7 +690,7 @@ describe('CopyPaste', () => {
       expect(copyEvent.preventDefault).toHaveBeenCalled();
     });
 
-    it('should not skip processing the event when the target element has not the "data-hot-input" attribute and it\'s a TD element (#dev-2225)', () => {
+    it('should not skip processing the event when the target element does not have the "data-hot-input" attribute and it\'s a TD element (#dev-2225)', () => {
       handsontable({
         data: createSpreadsheetData(5, 5),
       });
@@ -705,6 +705,28 @@ describe('CopyPaste', () => {
       plugin.onPaste(copyEvent); // trigger the plugin's method that is normally triggered by the native "paste" event
 
       expect(copyEvent.preventDefault).toHaveBeenCalled();
+    });
+
+    it('should be possible to paste data having selected a range that reaches outside of the rendered viewport (#dev-2298)', async() => {
+      handsontable({
+        data: createSpreadsheetData(1, 50),
+        width: 100,
+        height: 50,
+      });
+
+      const pasteEvent = getClipboardEvent();
+      const plugin = getPlugin('CopyPaste');
+
+      spyOn(pasteEvent, 'preventDefault');
+
+      selectCells([[0, 0, 0, 49]]);
+
+      await sleep(10);
+
+      pasteEvent.target = document.activeElement;
+      plugin.onPaste(pasteEvent); // emulate native "paste" event
+
+      expect(pasteEvent.preventDefault).toHaveBeenCalled();
     });
   });
 });

--- a/handsontable/src/plugins/copyPaste/copyPaste.js
+++ b/handsontable/src/plugins/copyPaste/copyPaste.js
@@ -7,7 +7,8 @@ import {
   removeContentEditableFromElementAndDeselect,
   runWithSelectedContendEditableElement,
   makeElementContentEditableAndSelectItsContent,
-  isHTMLElement
+  isHTMLElement,
+  isInternalElement,
 } from '../../helpers/dom/element';
 import { isSafari } from '../../helpers/browser';
 import copyItem from './contextMenuItem/copy';
@@ -627,15 +628,16 @@ export class CopyPaste extends BasePlugin {
   onCopy(event) {
     const focusedElement = this.hot.getFocusManager().getRefocusElement();
     const isHotInput = event.target?.hasAttribute('data-hot-input');
-    const selectedCell = this.hot.getSelectedRangeLast()?.highlight;
-    const TD = selectedCell ? this.hot.getCell(selectedCell.row, selectedCell.col, true) : null;
 
     if (
       !this.hot.isListening() && !this.#isTriggeredByCopy ||
       this.isEditorOpened() ||
       isHTMLElement(event.target) && (
-        isHotInput && event.target !== focusedElement ||
-        !isHotInput && event.target !== this.hot.rootDocument.body && TD !== event.target
+        (isHotInput && event.target !== focusedElement) ||
+        (
+          !isHotInput && event.target !== this.hot.rootDocument.body &&
+          !isInternalElement(event.target, this.hot.rootElement)
+        )
       )
     ) {
       return;
@@ -677,15 +679,16 @@ export class CopyPaste extends BasePlugin {
   onCut(event) {
     const focusedElement = this.hot.getFocusManager().getRefocusElement();
     const isHotInput = event.target?.hasAttribute('data-hot-input');
-    const selectedCell = this.hot.getSelectedRangeLast()?.highlight;
-    const TD = selectedCell ? this.hot.getCell(selectedCell.row, selectedCell.col, true) : null;
 
     if (
       !this.hot.isListening() && !this.#isTriggeredByCut ||
       this.isEditorOpened() ||
       isHTMLElement(event.target) && (
-        isHotInput && event.target !== focusedElement ||
-        !isHotInput && event.target !== this.hot.rootDocument.body && TD !== event.target
+        (isHotInput && event.target !== focusedElement) ||
+        (
+          !isHotInput && event.target !== this.hot.rootDocument.body &&
+          !isInternalElement(event.target, this.hot.rootElement)
+        )
       )
     ) {
       return;
@@ -725,16 +728,17 @@ export class CopyPaste extends BasePlugin {
   onPaste(event) {
     const focusedElement = this.hot.getFocusManager().getRefocusElement();
     const isHotInput = event.target?.hasAttribute('data-hot-input');
-    const selectedCell = this.hot.getSelectedRangeLast()?.highlight;
-    const TD = selectedCell ? this.hot.getCell(selectedCell.row, selectedCell.col, true) : null;
 
     if (
       !this.hot.isListening() ||
       this.isEditorOpened() ||
       !this.hot.getSelected() ||
       isHTMLElement(event.target) && (
-        isHotInput && event.target !== focusedElement ||
-        !isHotInput && event.target !== this.hot.rootDocument.body && TD !== event.target
+        (isHotInput && event.target !== focusedElement) ||
+        (
+          !isHotInput && event.target !== this.hot.rootDocument.body &&
+          !isInternalElement(event.target, this.hot.rootElement)
+        )
       )
     ) {
       return;

--- a/visual-tests/src/helpers.ts
+++ b/visual-tests/src/helpers.ts
@@ -44,7 +44,7 @@ export const helpers = {
   testedPageUrl: '',
 
   cssPath(file: string) {
-    return `./tests-css/${file}`;
+    return path.resolve(__dirname, '../tests-css', file);
   },
 
   init() {

--- a/visual-tests/tests/cross-browser/copy-paste.spec.ts
+++ b/visual-tests/tests/cross-browser/copy-paste.spec.ts
@@ -60,3 +60,92 @@ test('Copy inside table', async({ goto, tablePage, browserName }) => {
 
   expect(await targetCell.innerText()).toBe(copiedText);
 });
+
+test('Copy and paste data in a scrolled table', async({ goto, tablePage, browserName }) => {
+  test.skip(browserName !== 'chromium', 'This test runs only on Chrome');
+
+  await goto('/large-dataset-demo');
+
+  const table = tablePage.locator('#root > .handsontable');
+  const scrollableElement = table.locator('.ht_master .wtHolder');
+  const sourceCell = await selectCell(1, 1, table);
+
+  await tablePage.keyboard.down('Shift');
+  await sourceCell.click();
+
+  await scrollableElement.evaluate((element) => {
+    element.scrollTo(10000, 10000); // Large values to ensure scrolling to the end
+  });
+
+  await tablePage.waitForTimeout(20);
+
+  const endCell = table.locator('.ht_master table tr:last-of-type > td:last-of-type');
+
+  await endCell.click();
+  await tablePage.keyboard.up('Shift');
+
+  await tablePage.keyboard.press(`${helpers.modifier}+c`);
+
+  await scrollableElement.evaluate((element) => {
+    element.scrollTo(0, 0);
+  });
+
+  await tablePage.waitForTimeout(20);
+
+  const targetCell = await selectCell(0, 0, table);
+
+  await targetCell.click();
+
+  await tablePage.keyboard.press(`${helpers.modifier}+v`);
+
+  await tablePage.screenshot({ path: helpers.screenshotPath() });
+
+  expect(await targetCell.innerText()).toBe('B2');
+});
+
+test('Cut and paste data in a scrolled table', async({ goto, tablePage, browserName }) => {
+  test.skip(browserName !== 'chromium', 'This test runs only on Chrome');
+
+  await goto('/large-dataset-demo');
+
+  const table = tablePage.locator('#root > .handsontable');
+  const scrollableElement = table.locator('.ht_master .wtHolder');
+  let sourceCell = await selectCell(1, 1, table);
+
+  await tablePage.keyboard.down('Shift');
+  await sourceCell.click();
+
+  await scrollableElement.evaluate((element) => {
+    element.scrollTo(10000, 10000); // Large values to ensure scrolling to the end
+  });
+
+  await tablePage.waitForTimeout(20);
+
+  const endCell = table.locator('.ht_master table tr:last-of-type > td:last-of-type');
+
+  await endCell.click();
+  await tablePage.keyboard.up('Shift');
+
+  await tablePage.keyboard.press(`${helpers.modifier}+x`);
+
+  await scrollableElement.evaluate((element) => {
+    element.scrollTo(0, 0);
+  });
+
+  await tablePage.waitForTimeout(20);
+
+  await tablePage.screenshot({ path: helpers.screenshotPath() });
+
+  sourceCell = await selectCell(1, 1, table);
+  expect(await sourceCell.innerText()).toBe('');
+
+  const targetCell = await selectCell(0, 0, table);
+
+  await targetCell.click();
+
+  await tablePage.keyboard.press(`${helpers.modifier}+v`);
+
+  await tablePage.screenshot({ path: helpers.screenshotPath() });
+
+  expect(await targetCell.innerText()).toBe('B2');
+});


### PR DESCRIPTION
### Context
This PR:
- Prevents the clipboard event callbacks from being skipped when the selection reaches outside of the rendered viewport.
- Renames the `isThisHotChild` helper to `isInternalElement`
- Adds test cases.

### How has this been tested?
Tested manually and added test cases.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#2298

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
