### PR TITLE
Change the size of the manual row and column resize guide line

### DIFF
--- a/.changelogs/11507.json
+++ b/.changelogs/11507.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Changed the size of the manual row resize guide line",
+  "type": "changed",
+  "issueOrPR": 11507,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/11507.json
+++ b/.changelogs/11507.json
@@ -1,6 +1,6 @@
 {
   "issuesOrigin": "private",
-  "title": "Changed the size of the manual row resize guide line",
+  "title": "Changed the size of the manual row and row resize guide line",
   "type": "changed",
   "issueOrPR": 11507,
   "breaking": false,

--- a/handsontable/src/plugins/manualColumnResize/__tests__/manualColumnResize.spec.js
+++ b/handsontable/src/plugins/manualColumnResize/__tests__/manualColumnResize.spec.js
@@ -1495,6 +1495,32 @@ describe('manualColumnResize', () => {
 
         expect($handle.css('z-index')).toBeGreaterThan(getTopClone().css('z-index'));
       });
+
+      it('should display the resize guide in the correct size', async() => {
+        const hot = handsontable({
+          layoutDirection,
+          data: Handsontable.helper.createSpreadsheetData(10, 10),
+          colHeaders: true,
+          manualColumnResize: true,
+          height: 'auto',
+          width: 200
+        });
+        const tableHeight = parseInt(hot.view.getTableHeight(), 10);
+        const $headerTH = getTopClone().find('thead tr:eq(0) th:eq(1)');
+
+        $headerTH.simulate('mouseover');
+
+        const $resizer = spec().$container.find('.manualColumnResizer');
+        const resizerPosition = $resizer.position();
+
+        $resizer.simulate('mousedown', { clientY: resizerPosition.top });
+
+        const $guide = spec().$container.find('.manualColumnResizerGuide');
+
+        $resizer.simulate('mouseup');
+
+        expect($guide.height()).toBeCloseTo(tableHeight - $resizer.height(), 0);
+      });
     });
 
     it.forTheme('classic')('should remove resize handler when user clicks RMB', async() => {

--- a/handsontable/src/plugins/manualColumnResize/manualColumnResize.js
+++ b/handsontable/src/plugins/manualColumnResize/manualColumnResize.js
@@ -353,14 +353,14 @@ export class ManualColumnResize extends BasePlugin {
   setupGuidePosition() {
     const handleHeight = parseInt(outerHeight(this.#handle), 10);
     const handleBottomPosition = parseInt(this.#handle.style.top, 10) + handleHeight;
-    const maximumVisibleElementHeight = parseInt(this.hot.view.maximumVisibleElementHeight(0), 10);
+    const tableHeight = this.hot.view.getTableHeight();
 
     addClass(this.#handle, 'active');
     addClass(this.#guide, 'active');
 
     this.#guide.style.top = `${handleBottomPosition}px`;
     this.refreshGuidePosition();
-    this.#guide.style.height = `${maximumVisibleElementHeight - handleHeight}px`;
+    this.#guide.style.height = `${tableHeight - handleHeight}px`;
     this.hot.rootElement.appendChild(this.#guide);
   }
 

--- a/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
+++ b/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
@@ -1821,6 +1821,32 @@ describe('manualRowResize', () => {
         expect($rowHeader.offset().left).toBeCloseTo($handle.offset().left, 0);
         expect($rowHeader.offset().top + $rowHeader.height() - 5).toBeCloseTo($handle.offset().top, 0);
       });
+
+      it('should display the resize guide in the correct size', async() => {
+        const hot = handsontable({
+          layoutDirection,
+          data: Handsontable.helper.createSpreadsheetData(20, 20),
+          rowHeaders: true,
+          manualRowResize: true,
+          height: 100,
+          width: 200
+        });
+        const tableWidth = parseInt(hot.view.getTableWidth(), 10);
+        const $rowHeader = getInlineStartClone().find('tbody tr:eq(2) th:eq(0)');
+
+        $rowHeader.simulate('mouseover');
+
+        const $resizer = spec().$container.find('.manualRowResizer');
+        const resizerPosition = $resizer.position();
+
+        $resizer.simulate('mousedown', { clientY: resizerPosition.top });
+
+        const $guide = spec().$container.find('.manualRowResizerGuide');
+
+        $resizer.simulate('mouseup');
+
+        expect($guide.width()).toBeCloseTo(tableWidth - $resizer.width(), 0);
+      });
     });
 
     it.forTheme('classic')('should remove resize handler when user clicks RMB', async() => {

--- a/handsontable/src/plugins/manualRowResize/manualRowResize.js
+++ b/handsontable/src/plugins/manualRowResize/manualRowResize.js
@@ -321,14 +321,14 @@ export class ManualRowResize extends BasePlugin {
   setupGuidePosition() {
     const handleWidth = parseInt(outerWidth(this.#handle), 10);
     const handleEndPosition = parseInt(this.#handle.style[this.inlineDir], 10) + handleWidth;
-    const maximumVisibleElementWidth = parseInt(this.hot.view.maximumVisibleElementWidth(0), 10);
+    const tableWidth = parseInt(this.hot.view.getTableWidth(), 10);
 
     addClass(this.#handle, 'active');
     addClass(this.#guide, 'active');
 
     this.#guide.style.top = this.#handle.style.top;
     this.#guide.style[this.inlineDir] = `${handleEndPosition}px`;
-    this.#guide.style.width = `${maximumVisibleElementWidth - handleWidth}px`;
+    this.#guide.style.width = `${tableWidth - handleWidth}px`;
     this.hot.rootElement.appendChild(this.#guide);
   }
 

--- a/handsontable/src/plugins/manualRowResize/manualRowResize.js
+++ b/handsontable/src/plugins/manualRowResize/manualRowResize.js
@@ -321,7 +321,7 @@ export class ManualRowResize extends BasePlugin {
   setupGuidePosition() {
     const handleWidth = parseInt(outerWidth(this.#handle), 10);
     const handleEndPosition = parseInt(this.#handle.style[this.inlineDir], 10) + handleWidth;
-    const tableWidth = parseInt(this.hot.view.getTableWidth(), 10);
+    const tableWidth = this.hot.view.getTableWidth();
 
     addClass(this.#handle, 'active');
     addClass(this.#guide, 'active');


### PR DESCRIPTION
### Context
This PR includes changes for the manual row and column resize guide. The guide line will now match the size of the table.

### How has this been tested?
Locally and covered by new test case

### Types of changes
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2296

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
