### PR TITLE
Prevent an error from being thrown when re-enabling hidden columns containing a selection.

### DIFF
--- a/.changelogs/11508.json
+++ b/.changelogs/11508.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed a problem where re-enabling the Hidden Columns configuration caused an error to be thrown if a selection was a part of the hidden range.",
+  "type": "fixed",
+  "issueOrPR": 11508,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/hiddenColumns/__tests__/selection.spec.js
+++ b/handsontable/src/plugins/hiddenColumns/__tests__/selection.spec.js
@@ -778,6 +778,43 @@ describe('HiddenColumns', () => {
       | - ║   : 0 :   |
       `).toBeMatchToSelectionPattern();
     });
+
+    it('should regenerate the selection after hiding and showing columns it was in using `updateSettings`, ' +
+      'without throwing any errors (#dev-2293)', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        hiddenColumns: {
+          columns: []
+        },
+        rowHeaders: true,
+        colHeaders: true,
+      });
+
+      selectCell(0, 0);
+
+      let errorThrown = false;
+
+      try {
+        updateSettings({
+          hiddenColumns: {
+            columns: [0]
+          },
+        });
+
+        updateSettings({
+          hiddenColumns: {
+            columns: []
+          },
+        });
+
+      } catch (err) {
+        errorThrown = true;
+      }
+
+      expect(getSelected()).toEqual([[0, 0, 0, 0]]);
+      expect(getCell(0, 0, true)).toHaveClass('current');
+      expect(errorThrown).toBe(false);
+    });
   });
 
   describe('redrawing rendered selection when the selected range has been changed', () => {

--- a/handsontable/src/plugins/hiddenColumns/hiddenColumns.js
+++ b/handsontable/src/plugins/hiddenColumns/hiddenColumns.js
@@ -195,9 +195,9 @@ export class HiddenColumns extends BasePlugin {
    * Disables the plugin functionality for this Handsontable instance.
    */
   disablePlugin() {
-    this.hot.columnIndexMapper.unregisterMap(this.pluginName);
-
     super.disablePlugin();
+
+    this.hot.columnIndexMapper.unregisterMap(this.pluginName);
     this.resetCellsMeta();
   }
 

--- a/handsontable/src/plugins/hiddenRows/hiddenRows.js
+++ b/handsontable/src/plugins/hiddenRows/hiddenRows.js
@@ -195,9 +195,9 @@ export class HiddenRows extends BasePlugin {
    * Disables the plugin functionality for this Handsontable instance.
    */
   disablePlugin() {
-    this.hot.rowIndexMapper.unregisterMap(this.pluginName);
-
     super.disablePlugin();
+
+    this.hot.rowIndexMapper.unregisterMap(this.pluginName);
     this.resetCellsMeta();
   }
 


### PR DESCRIPTION
### Context
This PR:
- Prevents a situation where an error was thrown when re-enabling hidden columns if a cell was selected in the range of the hidden columns.
- Analogous change was done to the Hidden Rows plugin - it did not cause any errors, but I think it's a generally better solution.
- Added a test case for the error problem.

### How has this been tested?
Tested manually + added a test case.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#2293

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
