### PR TITLE
Fix problem with empty parentNode in the table getCords method

### DIFF
--- a/.changelogs/11509.json
+++ b/.changelogs/11509.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed an issue with empty parentNode in the table getCords method",
+  "type": "fixed",
+  "issueOrPR": 11509,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/src/table.js
+++ b/handsontable/src/3rdparty/walkontable/src/table.js
@@ -700,6 +700,11 @@ class Table {
     }
 
     const TR = cellElement.parentNode;
+
+    if (!TR) {
+      return null;
+    }
+
     const CONTAINER = TR.parentNode;
     let row = index(TR);
     let col = cellElement.cellIndex;

--- a/handsontable/src/3rdparty/walkontable/test/spec/table/getCoords.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/table/getCoords.spec.js
@@ -96,5 +96,21 @@ describe('WalkontableTable', () => {
 
       expect(wt.wtTable.getCoords($td2[0])).toEqual(new Walkontable.CellCoords(1, 1));
     });
+
+    it('should return `null` when the cell element doesn`t contain a parent node', () => {
+      const wt = walkontable({
+        data: getData,
+        totalRows: getTotalRows,
+        totalColumns: getTotalColumns
+      });
+
+      wt.draw();
+
+      const $td2 = spec().$table.find('tbody tr:eq(1) td:eq(1)');
+
+      $td2.remove();
+
+      expect(wt.wtTable.getCoords($td2[0])).toEqual(null);
+    });
   });
 });


### PR DESCRIPTION
### Context
This PR includes new exception inside the table `getCords` method to check if the cell element contains a `parentNode`.

### How has this been tested?
Locally

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2077

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
