### PR TITLE
Update docs configuration options `setCellMeta` example

### DIFF
--- a/docs/content/guides/getting-started/configuration-options/configuration-options.md
+++ b/docs/content/guides/getting-started/configuration-options/configuration-options.md
@@ -546,25 +546,12 @@ const hot = new Handsontable(container, {
   height: 'auto',
   rowHeaders: true,
   colHeaders: true,
-  // in the top-level grid options, all cells are read-only
-  readOnly: false,
-  cell: [
-    {
-      // bottom-level cell options overwrite the top-level grid options
-      // apply only to a cell with coordinates (1, 1)
-      row: 1,
-      col: 1,
-      readOnly: true,
-    }
-  ]
 });
 
-// for cell (0, 0), the `readOnly` option is the default (`false`)
-// returns `false`
-hot.getCellMeta(0, 0).readOnly;
+// changes the `readOnly` option of cell (1, 1) back to `false`
+hot.setCellMeta(1, 1, 'readOnly', false);
 
-// for cell (1, 1), the `cell` option overwrote the default `readOnly` value
-// returns `true`
+// returns `false`
 hot.getCellMeta(1, 1).readOnly;
 ```
 


### PR DESCRIPTION
### Context
This PR includes update for documentation [setCellMeta](https://handsontable.com/docs/javascript-data-grid/configuration-options/#change-cell-options) example 

### How has this been tested?
Locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2236

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

[skip changelog]
