### PR TITLE
Add boolean type to the editor in the react wrapper

### DIFF
--- a/.changelogs/11514.json
+++ b/.changelogs/11514.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Added missing boolean type to the editor in the react wrapper",
+  "type": "added",
+  "issueOrPR": 11514,
+  "breaking": false,
+  "framework": "none"
+}

--- a/wrappers/react-wrapper/src/helpers.tsx
+++ b/wrappers/react-wrapper/src/helpers.tsx
@@ -139,8 +139,8 @@ function hasChildElementOfType(children: ReactNode, type: 'hot-renderer' | 'hot-
  * @param {ComponentType} Editor Editor component or render function.
  * @returns {ReactPortal} The portal for the editor.
  */
-export function createEditorPortal(doc: Document | null, Editor: HotTableProps['editor'] | undefined): ReactPortal | null {
-  if (!doc || !Editor) {
+export function createEditorPortal(doc: Document | null, Editor: HotTableProps['editor'] | undefined | boolean): ReactPortal | null {
+  if (!doc || !Editor || typeof Editor === 'boolean') {
     return null;
   }
 

--- a/wrappers/react-wrapper/src/types.tsx
+++ b/wrappers/react-wrapper/src/types.tsx
@@ -55,7 +55,7 @@ type ReplaceRenderersEditors<T extends Pick<Handsontable.GridSettings, 'renderer
   hotRenderer?: T['renderer'],
   renderer?: ComponentType<HotRendererProps>,
   hotEditor?: T['editor'],
-  editor?: ComponentType,
+  editor?: ComponentType | boolean,
 }
 
 /**


### PR DESCRIPTION
### Context
This PR includes missing  boolean type in the editor props.

### How has this been tested?
Locally

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2303

### Affected project(s):
- [x] `handsontable`
- [x] `@handsontable/react-wrapper`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
