### PR TITLE
Make the exportConditions visible in docs

### DIFF
--- a/handsontable/src/plugins/filters/filters.js
+++ b/handsontable/src/plugins/filters/filters.js
@@ -553,10 +553,10 @@ export class Filters extends BasePlugin {
    *
    * @returns {Array}
    */
-  /* eslint-enable jsdoc/require-description-complete-sentence */
   exportConditions() {
     return this.conditionCollection.exportAllConditions();
   }
+  /* eslint-enable jsdoc/require-description-complete-sentence */
 
   /**
    * Filters data based on added filter conditions.


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR makes the recently added _Filter_'s `exportConditions` method visible in Docs.

_[skip changelog]_

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
