### PR TITLE
Fix rows height calculations for merged cells on Safari

### DIFF
--- a/.changelogs/11517.json
+++ b/.changelogs/11517.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed rows height calculations for merged cells on Safari",
+  "type": "fixed",
+  "issueOrPR": 11517,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/mergeCells/__tests__/mergeCells.spec.js
+++ b/handsontable/src/plugins/mergeCells/__tests__/mergeCells.spec.js
@@ -1770,7 +1770,11 @@ describe('MergeCells', () => {
     });
 
     expect(getCell(0, 0).offsetHeight).toBe(201);
-    expect(getCell(0, 1).offsetHeight).toBe(52);
+    expect(getCell(0, 1).offsetHeight).forThemes(({ classic, main, horizon }) => {
+      classic.toBe(52);
+      main.toBe(52);
+      horizon.toBe(51);
+    });
     expect(getCell(1, 1).offsetHeight).toBe(50);
     expect(getCell(2, 1).offsetHeight).toBe(50);
     expect(getCell(3, 1).offsetHeight).toBe(50);

--- a/handsontable/src/plugins/mergeCells/__tests__/mergeCells.spec.js
+++ b/handsontable/src/plugins/mergeCells/__tests__/mergeCells.spec.js
@@ -1761,6 +1761,21 @@ describe('MergeCells', () => {
     });
   });
 
+  it('should proportionally calculate the height of the cells on the right of the merged cell (#dev-2302)', () => {
+    handsontable({
+      data: createSpreadsheetData(4, 3),
+      rowHeaders: false,
+      rowHeights: 50,
+      mergeCells: [{ row: 0, col: 0, rowspan: 4, colspan: 1 }],
+    });
+
+    expect(getCell(0, 0).offsetHeight).toBe(201);
+    expect(getCell(0, 1).offsetHeight).toBe(52);
+    expect(getCell(1, 1).offsetHeight).toBe(50);
+    expect(getCell(2, 1).offsetHeight).toBe(50);
+    expect(getCell(3, 1).offsetHeight).toBe(50);
+  });
+
   it.forTheme('classic')('should display properly high merged cell', () => {
     handsontable({
       data: createSpreadsheetData(50, 3),

--- a/handsontable/src/plugins/mergeCells/mergeCells.js
+++ b/handsontable/src/plugins/mergeCells/mergeCells.js
@@ -13,6 +13,7 @@ import { getStyle } from '../../helpers/dom/element';
 import { isChrome } from '../../helpers/browser';
 import { FocusOrder } from './focusOrder';
 import { createMergeCellRenderer } from './renderer';
+import { sumCellsHeights } from './utils';
 
 Hooks.getSingleton().register('beforeMergeCells');
 Hooks.getSingleton().register('afterMergeCells');
@@ -1490,34 +1491,8 @@ export class MergeCells extends BasePlugin {
         rowspanAfterCorrection = rowspan - rowspanCorrection;
       }
 
-      height = Math.max(height ?? 0, this.#sumCellsHeights(row, rowspanAfterCorrection));
+      height = Math.max(height ?? 0, sumCellsHeights(this.hot, row, rowspanAfterCorrection));
     });
-
-    return height;
-  }
-
-  /**
-   * Sums the heights of the all cells that the merge cell consists of.
-   *
-   * @param {number} row The visual row index of the merged cell.
-   * @param {number} rowspan The rowspan value of the merged cell.
-   * @returns {number}
-   */
-  #sumCellsHeights(row, rowspan) {
-    const { view, rowIndexMapper } = this.hot;
-    const stylesHandler = view.getStylesHandler();
-    const defaultHeight = view.getDefaultRowHeight();
-    let height = 0;
-
-    for (let i = row; i < row + rowspan; i++) {
-      if (!rowIndexMapper.isHidden(i)) {
-        height += this.hot.getRowHeight(i) ?? defaultHeight;
-
-        if (i === 0 && !stylesHandler.isClassicTheme()) {
-          height += 1; // border-top-width
-        }
-      }
-    }
 
     return height;
   }

--- a/handsontable/src/plugins/mergeCells/utils.js
+++ b/handsontable/src/plugins/mergeCells/utils.js
@@ -1,0 +1,26 @@
+/**
+ * Calculates the total height of the merged cell.
+ *
+ * @param {Core} hotInstance The Handsontable instance.
+ * @param {*} row The merged cell's row index.
+ * @param {*} rowspan The merged cell height.
+ * @returns {number}
+ */
+export function sumCellsHeights(hotInstance, row, rowspan) {
+  const { view, rowIndexMapper } = hotInstance;
+  const stylesHandler = view.getStylesHandler();
+  const defaultHeight = view.getDefaultRowHeight();
+  let height = 0;
+
+  for (let i = row; i < row + rowspan; i++) {
+    if (!rowIndexMapper.isHidden(i)) {
+      height += hotInstance.getRowHeight(i) ?? defaultHeight;
+
+      if (i === 0 && !stylesHandler.isClassicTheme()) {
+        height += 1; // border-top-width
+      }
+    }
+  }
+
+  return height;
+}


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes a bug where the cells on the right of the merged cells were not shrunk proportionally to the merged cell height. This is a known bug of Safari, and the PR emulates the default behavior that can be seen in other browsers (Chrome, FF).

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally, and I covered the fix with a new test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/2302

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
