### PR TITLE
Fix missing (incorrect) render call after dataset change

### DIFF
--- a/.changelogs/11529.json
+++ b/.changelogs/11529.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed missing (incorrect) render call after dataset change",
+  "type": "fixed",
+  "issueOrPR": 11529,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/__tests__/tableView.spec.js
+++ b/handsontable/src/__tests__/tableView.spec.js
@@ -515,4 +515,164 @@ describe('TableView', () => {
       expect(hot.view._wt.wtViewport.getWorkspaceOffset).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('render()', () => {
+    it('should draw a table as fast render when the dataset size is not changed', () => {
+      const hot = handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      spyOn(hot.view._wt, 'draw').and.callThrough();
+      hot.view.render();
+
+      expect(hot.view._wt.draw).toHaveBeenCalledWith(true);
+    });
+
+    it('should draw a table as slow render when the `forceFullRender` flag is set and the dataset size is not changed', () => {
+      const hot = handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      spyOn(hot.view._wt, 'draw').and.callThrough();
+      hot.forceFullRender = true;
+      hot.view.render();
+
+      expect(hot.view._wt.draw).toHaveBeenCalledWith(false);
+      expect(hot.forceFullRender).toBe(false);
+    });
+
+    it('should draw a table as slow render when the dataset size is changed (number of rows is changed)', () => {
+      const hot = handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      spyOn(hot.view._wt, 'draw').and.callThrough();
+      loadData(createSpreadsheetData(10, 5));
+
+      expect(hot.view._wt.draw).toHaveBeenCalledWith(false);
+    });
+
+    it('should draw a table as slow render when the dataset size is changed (number of columns is changed)', () => {
+      const hot = handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      spyOn(hot.view._wt, 'draw').and.callThrough();
+      loadData(createSpreadsheetData(5, 10));
+
+      expect(hot.view._wt.draw).toHaveBeenCalledWith(false);
+    });
+
+    it('should draw a table as slow render when the number of visible rows was changed (hiding)', () => {
+      const hot = handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      rowIndexMapper()
+        .createAndRegisterIndexMap('my-hiding-map', 'hiding')
+        .setValueAtIndex(2, true);
+
+      spyOn(hot.view._wt, 'draw').and.callThrough();
+      hot.view.render();
+
+      expect(hot.view._wt.draw).toHaveBeenCalledWith(false);
+    });
+
+    it('should draw a table as slow render when the number of visible columns was changed (hiding)', () => {
+      const hot = handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      columnIndexMapper()
+        .createAndRegisterIndexMap('my-hiding-map', 'hiding')
+        .setValueAtIndex(2, true);
+
+      spyOn(hot.view._wt, 'draw').and.callThrough();
+      hot.view.render();
+
+      expect(hot.view._wt.draw).toHaveBeenCalledWith(false);
+    });
+
+    it('should draw a table as slow render when the number of visible rows was changed (trimming)', () => {
+      const hot = handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      rowIndexMapper()
+        .createAndRegisterIndexMap('my-hiding-map', 'trimming')
+        .setValueAtIndex(2, true);
+
+      spyOn(hot.view._wt, 'draw').and.callThrough();
+      hot.view.render();
+
+      expect(hot.view._wt.draw).toHaveBeenCalledWith(false);
+    });
+
+    it('should draw a table as slow render when the number of visible columns was changed (trimming)', () => {
+      const hot = handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      columnIndexMapper()
+        .createAndRegisterIndexMap('my-hiding-map', 'trimming')
+        .setValueAtIndex(2, true);
+
+      spyOn(hot.view._wt, 'draw').and.callThrough();
+      hot.view.render();
+
+      expect(hot.view._wt.draw).toHaveBeenCalledWith(false);
+    });
+
+    it('should draw a table as slow render when the rows order changed', () => {
+      const hot = handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      rowIndexMapper().moveIndexes(0, 2);
+
+      spyOn(hot.view._wt, 'draw').and.callThrough();
+      hot.view.render();
+
+      expect(hot.view._wt.draw).toHaveBeenCalledWith(false);
+    });
+
+    it('should draw a table as slow render when the columns order changed', () => {
+      const hot = handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      columnIndexMapper().moveIndexes(0, 2);
+
+      spyOn(hot.view._wt, 'draw').and.callThrough();
+      hot.view.render();
+
+      expect(hot.view._wt.draw).toHaveBeenCalledWith(false);
+    });
+
+    it('should draw a table as slow render when index sequence for rows was changed', () => {
+      const hot = handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      rowIndexMapper().setIndexesSequence([1, 0, 2, 3, 4]);
+
+      spyOn(hot.view._wt, 'draw').and.callThrough();
+      hot.view.render();
+
+      expect(hot.view._wt.draw).toHaveBeenCalledWith(false);
+    });
+
+    it('should draw a table as slow render when index sequence for columns was changed', () => {
+      const hot = handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      columnIndexMapper().setIndexesSequence([1, 0, 2, 3, 4]);
+
+      spyOn(hot.view._wt, 'draw').and.callThrough();
+      hot.view.render();
+
+      expect(hot.view._wt.draw).toHaveBeenCalledWith(false);
+    });
+  });
 });

--- a/handsontable/src/dataMap/dataMap.js
+++ b/handsontable/src/dataMap/dataMap.js
@@ -397,7 +397,6 @@ class DataMap {
     }
 
     this.hot.runHooks('afterCreateRow', newVisualRowIndex, numberOfCreatedRows, source);
-    this.hot.forceFullRender = true; // used when data was changed
 
     return {
       delta: numberOfCreatedRows,
@@ -499,8 +498,6 @@ class DataMap {
     const newVisualColumnIndex = this.hot.toVisualColumn(startPhysicalIndex);
 
     this.hot.runHooks('afterCreateCol', newVisualColumnIndex, numberOfCreatedCols, source);
-    this.hot.forceFullRender = true; // used when data was changed
-
     this.refreshDuckSchema();
 
     return {
@@ -558,7 +555,6 @@ class DataMap {
     });
 
     this.hot.runHooks('afterRemoveRow', rowIndex, numberOfRemovedIndexes, removedPhysicalIndexes, source);
-    this.hot.forceFullRender = true; // used when data was changed
 
     return true;
   }
@@ -630,7 +626,6 @@ class DataMap {
     }
 
     this.hot.runHooks('afterRemoveCol', columnIndex, amount, removedPhysicalIndexes, source);
-    this.hot.forceFullRender = true; // used when data was changed
     this.refreshDuckSchema();
 
     return true;

--- a/handsontable/src/plugins/autoColumnSize/autoColumnSize.js
+++ b/handsontable/src/plugins/autoColumnSize/autoColumnSize.js
@@ -302,7 +302,7 @@ export class AutoColumnSize extends BasePlugin {
       return;
     }
 
-    const overwriteCache = this.hot.renderCall;
+    const overwriteCache = this.hot.forceFullRender;
 
     this.calculateColumnsWidth({ from: firstVisibleColumn, to: lastVisibleColumn }, undefined, overwriteCache);
   }

--- a/handsontable/src/plugins/autoRowSize/autoRowSize.js
+++ b/handsontable/src/plugins/autoRowSize/autoRowSize.js
@@ -282,7 +282,7 @@ export class AutoRowSize extends BasePlugin {
       return;
     }
 
-    const overwriteCache = this.hot.renderCall;
+    const overwriteCache = this.hot.forceFullRender;
 
     this.calculateRowsHeight({ from: firstVisibleRow, to: lastVisibleRow }, undefined, overwriteCache);
   }

--- a/handsontable/src/plugins/columnSorting/columnSorting.js
+++ b/handsontable/src/plugins/columnSorting/columnSorting.js
@@ -323,10 +323,6 @@ export class ColumnSorting extends BasePlugin {
 
     if (sortPossible) {
       this.hot.render();
-      // TODO: Workaround? This triggers fast redraw. One test won't pass after removal.
-      // It should be refactored / described.
-      this.hot.forceFullRender = false;
-      this.hot.view.render();
     }
   }
 

--- a/handsontable/src/plugins/manualColumnResize/manualColumnResize.js
+++ b/handsontable/src/plugins/manualColumnResize/manualColumnResize.js
@@ -462,8 +462,7 @@ export class ManualColumnResize extends BasePlugin {
    */
   afterMouseDownTimeout() {
     const render = () => {
-      this.hot.forceFullRender = true;
-      this.hot.view.render(); // updates all
+      this.hot.render();
       this.hot.view.adjustElementsSize();
     };
     const resize = (column, forceRender) => {
@@ -556,8 +555,7 @@ export class ManualColumnResize extends BasePlugin {
    */
   #onMouseUp() {
     const render = () => {
-      this.hot.forceFullRender = true;
-      this.hot.view.render(); // updates all
+      this.hot.render();
       this.hot.view.adjustElementsSize();
     };
     const resize = (column, forceRender) => {

--- a/handsontable/src/plugins/manualRowResize/manualRowResize.js
+++ b/handsontable/src/plugins/manualRowResize/manualRowResize.js
@@ -448,8 +448,7 @@ export class ManualRowResize extends BasePlugin {
    */
   afterMouseDownTimeout() {
     const render = () => {
-      this.hot.forceFullRender = true;
-      this.hot.view.render(); // updates all
+      this.hot.render();
       this.hot.view.adjustElementsSize();
     };
     const resize = (row, forceRender) => {
@@ -535,8 +534,7 @@ export class ManualRowResize extends BasePlugin {
    */
   #onMouseUp() {
     const render = () => {
-      this.hot.forceFullRender = true;
-      this.hot.view.render(); // updates all
+      this.hot.render();
       this.hot.view.adjustElementsSize();
     };
     const runHooks = (row, forceRender) => {

--- a/handsontable/src/styles/components/plugins/_column-sorting.scss
+++ b/handsontable/src/styles/components/plugins/_column-sorting.scss
@@ -4,7 +4,7 @@
 
 @mixin output {
   .handsontable {
-    .columnSorting {
+    .columnSorting:not(.indicatorDisabled) {
       position: relative;
 
       &.sortAction {

--- a/handsontable/src/tableView.js
+++ b/handsontable/src/tableView.js
@@ -156,7 +156,9 @@ class TableView {
    */
   render() {
     if (!this.hot.isRenderSuspended()) {
-      this.hot.runHooks('beforeRender', this.hot.forceFullRender);
+      const isFullRender = this.hot.forceFullRender;
+
+      this.hot.runHooks('beforeRender', isFullRender);
 
       if (this.postponedAdjustElementsSize) {
         this.postponedAdjustElementsSize = false;
@@ -164,13 +166,12 @@ class TableView {
         this.adjustElementsSize();
       }
 
-      this._wt.draw(!this.hot.forceFullRender);
+      this._wt.draw(!isFullRender);
 
       this.#updateScrollbarClassNames();
 
-      this.hot.runHooks('afterRender', this.hot.forceFullRender);
+      this.hot.runHooks('afterRender', isFullRender);
       this.hot.forceFullRender = false;
-      this.hot.renderCall = false;
     }
   }
 
@@ -1254,8 +1255,7 @@ class TableView {
     this.eventManager.addEventListener(this.hot.rootDocument.documentElement, 'click', () => {
       if (this.settings.observeDOMVisibility) {
         if (this._wt.drawInterrupted) {
-          this.hot.forceFullRender = true;
-          this.render();
+          this.hot.render();
         }
       }
     });
@@ -1330,7 +1330,6 @@ class TableView {
    */
   beforeRender(force, skipRender) {
     if (force) {
-      // this.hot.forceFullRender = did Handsontable request full render?
       this.hot.runHooks('beforeViewRender', this.hot.forceFullRender, skipRender);
     }
   }
@@ -1344,7 +1343,6 @@ class TableView {
    */
   afterRender(force) {
     if (force) {
-      // this.hot.forceFullRender = did Handsontable request full render?
       this.hot.runHooks('afterViewRender', this.hot.forceFullRender);
     }
   }

--- a/handsontable/test/e2e/core/suspendRender.spec.js
+++ b/handsontable/test/e2e/core/suspendRender.spec.js
@@ -38,7 +38,6 @@ describe('Core.suspendRender', () => {
     hot.render();
 
     expect(hot.renderSuspendedCounter).toBe(1);
-    expect(hot.renderCall).toBe(true);
     expect(hot.forceFullRender).toBe(true);
     expect(hot.view._wt.draw).not.toHaveBeenCalled();
     expect(hot.view._wt.wtOverlays.adjustElementsSize).not.toHaveBeenCalled();
@@ -72,7 +71,6 @@ describe('Core.suspendRender', () => {
     hot.selectCell(1, 1);
 
     expect(hot.renderSuspendedCounter).toBe(1);
-    expect(hot.renderCall).toBe(false);
     expect(hot.forceFullRender).toBe(false);
     expect(hot.view._wt.draw).not.toHaveBeenCalled();
     expect(hot.view._wt.wtOverlays.adjustElementsSize).not.toHaveBeenCalled();

--- a/handsontable/types/core.d.ts
+++ b/handsontable/types/core.d.ts
@@ -140,7 +140,6 @@ export default class Core {
   removeCellMeta(row: number, column: number, key: (keyof CellMeta) | string): void;
   removeHook<K extends keyof Events>(key: K, callback: Events[K]): void;
   render(): void;
-  renderCall: boolean;
   resumeExecution(): void;
   resumeRender(): void;
   rootDocument: Document;


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the `Uncaught TypeError` errors that can occur in situations when the table was rendered using fast mode after dataset change. The fix ensures that after the dataset length or order change, the next render cycle will be scheduled as slow render - all cell renderers are recalled.

Fixing the above bug exposed a problem with the _ColumnSorting_ plugin, which was also fixed (b4b2c4eba24fcc3e77ce2069793f7312ce086d96). This concerned incorrect column width calculations when the plugin was enabled without indicators. After the fix with render call [this test failed](https://github.com/handsontable/handsontable/blob/develop/handsontable/src/plugins/columnSorting/__tests__/columnSorting.spec.js#L3349), so no new one is needed.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally, and I covered the fix with new tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1270

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
