### PR TITLE
Fix a problem with multiple row header levels being rendered in reverse order.

### DIFF
--- a/.changelogs/11533.json
+++ b/.changelogs/11533.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed a problem with multiple row header levels being rendered in reverse order.",
+  "type": "fixed",
+  "issueOrPR": 11533,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/src/renderer/rowHeaders.js
+++ b/handsontable/src/3rdparty/walkontable/src/renderer/rowHeaders.js
@@ -82,7 +82,9 @@ export class RowHeadersRenderer extends BaseRenderer {
         .setOffset(0)
         .start();
 
-      for (let visibleColumnIndex = 0; visibleColumnIndex < rowHeadersCount; visibleColumnIndex++) {
+      // Reading the row header renderers in reverse because of how the Eco Renderers handle rendering
+      // (prepending the nodes when rendering row headers).
+      for (let visibleColumnIndex = rowHeadersCount - 1; visibleColumnIndex >= 0; visibleColumnIndex--) {
         orderView.render();
 
         const TH = orderView.getCurrentNode();

--- a/handsontable/src/3rdparty/walkontable/test/spec/renderer/rowHeaders.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/renderer/rowHeaders.spec.js
@@ -205,4 +205,43 @@ describe('Walkontable.Renderer.RowHeadersRenderer', () => {
     expect(rootNode.childNodes[0].childNodes[0]).toBe(TR1.childNodes[0]);
     expect(rootNode.childNodes[1].childNodes[0]).toBe(TR2.childNodes[0]);
   });
+
+  it('should render multi-level row headers in the correct order', () => {
+    const { rowHeadersRenderer, rowsRenderer, cellsRenderer, tableMock, rootNode } = createRenderer();
+
+    const headerRenderer1 = (_, TH) => { TH.innerHTML = 'HeaderOne' };
+    const headerRenderer2 = (_, TH) => { TH.innerHTML = 'HeaderTwo' };
+    const cellRenderer = () => {};
+
+    tableMock.rowsToRender = 2;
+    tableMock.columnsToRender = 2;
+    tableMock.rowHeadersCount = 2;
+    tableMock.rowHeaderFunctions = [headerRenderer1, headerRenderer2];
+    tableMock.cellRenderer = cellRenderer;
+
+    rowsRenderer.adjust();
+    rowHeadersRenderer.adjust();
+    cellsRenderer.adjust();
+
+    rowsRenderer.render();
+    rowHeadersRenderer.render();
+    cellsRenderer.render();
+
+    expect(rootNode.outerHTML).toMatchHTML(`
+      <tbody>
+        <tr>
+          <th>HeaderOne</th>
+          <th>HeaderTwo</th>
+          <td></td>
+          <td></td>
+        </tr>
+        <tr>
+          <th>HeaderOne</th>
+          <th>HeaderTwo</th>
+          <td></td>
+          <td></td>
+        </tr>
+      </tbody>
+      `);
+  });
 });

--- a/handsontable/src/3rdparty/walkontable/test/spec/renderer/rowHeaders.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/renderer/rowHeaders.spec.js
@@ -209,8 +209,8 @@ describe('Walkontable.Renderer.RowHeadersRenderer', () => {
   it('should render multi-level row headers in the correct order', () => {
     const { rowHeadersRenderer, rowsRenderer, cellsRenderer, tableMock, rootNode } = createRenderer();
 
-    const headerRenderer1 = (_, TH) => { TH.innerHTML = 'HeaderOne' };
-    const headerRenderer2 = (_, TH) => { TH.innerHTML = 'HeaderTwo' };
+    const headerRenderer1 = (_, TH) => { TH.innerHTML = 'HeaderOne'; };
+    const headerRenderer2 = (_, TH) => { TH.innerHTML = 'HeaderTwo'; };
     const cellRenderer = () => {};
 
     tableMock.rowsToRender = 2;


### PR DESCRIPTION
### Context
This PR:
- Modifies the order in which row header renderers are called to prevent an issue with the row headers being rendered in reverse order.
- Adds a test case.

An alternative solution would be to modify the `ViewDiffer` module to allow an "append" action at the end of the row header section, but I figured this solution requires less calculations and therefore should be faster.

### How has this been tested?
Added a test case.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#2294

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
