### PR TITLE
Fix TypeError for AutoRowSize plugin

### DIFF
--- a/.changelogs/11537.json
+++ b/.changelogs/11537.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed `TypeError` error for AutoRowSize plugin",
+  "type": "fixed",
+  "issueOrPR": 11537,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/autoRowSize/__tests__/autoRowSize.spec.js
+++ b/handsontable/src/plugins/autoRowSize/__tests__/autoRowSize.spec.js
@@ -814,6 +814,19 @@ describe('AutoRowSize', () => {
     expect(onErrorSpy).not.toHaveBeenCalled();
   });
 
+  it('should not throw an error when `syncLimit` is smaller than total rows count (#dev-2318)', async() => {
+    expect(() => {
+      handsontable({
+        data: createSpreadsheetData(10, 10),
+        rowHeaders: true,
+        colHeaders: true,
+        autoRowSize: {
+          syncLimit: 5
+        },
+      });
+    }).not.toThrow();
+  });
+
   it('should keep the viewport position unchanged after resetting all rows heights (#dev-1888)', () => {
     handsontable({
       data: createSpreadsheetData(50, 10),

--- a/handsontable/src/plugins/autoRowSize/autoRowSize.js
+++ b/handsontable/src/plugins/autoRowSize/autoRowSize.js
@@ -378,11 +378,6 @@ export class AutoRowSize extends BasePlugin {
 
         // @TODO Should call once per render cycle, currently fired separately in different plugins
         this.hot.view.adjustElementsSize();
-
-        // tmp
-        if (this.hot.view._wt.wtOverlays.inlineStartOverlay.needFullRender) {
-          this.hot.view._wt.wtOverlays.inlineStartOverlay.clone.draw();
-        }
       }
     };
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes the `TypeError` error that could happen in specific configuration setups. The error was caused by a custom code that triggers the left overlay render out of the common table render cycle. Removing that [10-year-old workaround](https://github.com/handsontable/handsontable/blame/17423faed1e9a6828bc58da79665a189aa1b4f78/handsontable/src/plugins/autoRowSize/autoRowSize.js#L291-L294) fixed the issue.  

I checked another similar plugin (_AutoColumnSize_), but I didn't find a similar bug to the one mentioned above.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and I covered the fix with a new test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/2318

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
