### PR TITLE
Allow to change the selection after filter is applied

### DIFF
--- a/handsontable/src/plugins/filters/__tests__/component/conditional.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/component/conditional.spec.js
@@ -95,7 +95,7 @@ describe('Filters UI Conditional component', () => {
     const rect = document.querySelector('.htFiltersConditionsMenu.handsontable table').getBoundingClientRect();
 
     expect(window.scrollY + rect.top).forThemes(({ classic, main, horizon }) => {
-      classic.toBeAroundValue(756, 1);
+      classic.toBeAroundValue(755, 1);
       main.toBeAroundValue(718, 1);
       horizon.toBeAroundValue(676, 1);
     });

--- a/handsontable/src/plugins/filters/__tests__/hooks/afterFilter.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/hooks/afterFilter.spec.js
@@ -80,4 +80,27 @@ describe('`afterFilter` hook', () => {
     expect(plugin.exportConditions()).toEqual([]);
     expect(getData(0, 0, 0, 5)).toEqual([[1, 'Nannie Patel', 'Jenkinsville', '2014-01-29', 'green', 1261.6]]);
   });
+
+  it('should be possible to change the default selection after filter is applied', () => {
+    handsontable({
+      data: getDataForFilters(),
+      columns: getColumnsForFilters(),
+      dropdownMenu: true,
+      filters: true,
+      width: 500,
+      height: 300,
+      afterFilter() {
+        selectCells([[2, 2, 5, 5]]);
+      },
+    });
+
+    const plugin = getPlugin('filters');
+
+    plugin.addCondition(0, 'gt', [12]);
+    plugin.filter();
+
+    expect(getSelectedRange()).toEqualCellRange([
+      'highlight: 2,2 from: 2,2 to: 5,5',
+    ]);
+  });
 });

--- a/handsontable/src/plugins/filters/filters.js
+++ b/handsontable/src/plugins/filters/filters.js
@@ -607,9 +607,6 @@ export class Filters extends BasePlugin {
       }
 
       this.#previousConditionStack = this.exportConditions();
-      this.hot.runHooks('afterFilter', conditions);
-      this.hot.view.adjustElementsSize();
-      this.hot.render();
 
     } else {
       this.importConditions(this.#previousConditionStack);
@@ -620,6 +617,12 @@ export class Filters extends BasePlugin {
         navigableHeaders ? -1 : 0,
         this.hot.getSelectedRangeLast().highlight.col,
       );
+    }
+
+    if (allowFiltering !== false) {
+      this.hot.runHooks('afterFilter', conditions);
+      this.hot.view.adjustElementsSize();
+      this.hot.render();
     }
   }
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes a bug where the custom selection was ignored in the `afterFilter` hook.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and I covered the fix with a new test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1572

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
