### PR TITLE
Disable `autoRowSize` for the autocomplete editor.

### DIFF
--- a/.changelogs/11552.json
+++ b/.changelogs/11552.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed a problem with the autocomplete editor rendering very slowly when provided with a long list of choices.",
+  "type": "fixed",
+  "issueOrPR": 11552,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/editors/autocompleteEditor/__tests__/autocompleteEditor.spec.js
+++ b/handsontable/src/editors/autocompleteEditor/__tests__/autocompleteEditor.spec.js
@@ -667,6 +667,40 @@ describe('AutocompleteEditor', () => {
         horizon.toBe(112);
       });
     });
+
+    it('should not take excessive time to open the editor if the choice list is very long', async() => {
+      const choices = new Array(50000).fill().map((i) => Math.random());
+      let startTime;
+      let endTime;
+
+      handsontable({
+        data: [[], [], [], [], []],
+        columns: [
+          {
+            type: 'autocomplete',
+            source: choices,
+          },
+        ],
+        afterBeginEditing: function() {
+          startTime = performance.now();
+
+          this.getActiveEditor().htEditor.addHookOnce('afterRender', () => {
+            endTime = performance.now();
+          });
+        },
+      });
+
+      selectCell(0, 0);
+
+      keyDownUp('enter');
+
+      await sleep(10);
+
+      const $editor = $('.autocompleteEditor').eq(0);
+
+      expect(endTime - startTime).toBeLessThan(300);
+      expect($editor.find('.ht_master tbody tr').size()).toBeGreaterThan(0);
+    });
   });
 
   describe('choices', () => {

--- a/handsontable/src/editors/autocompleteEditor/__tests__/autocompleteEditor.spec.js
+++ b/handsontable/src/editors/autocompleteEditor/__tests__/autocompleteEditor.spec.js
@@ -669,7 +669,7 @@ describe('AutocompleteEditor', () => {
     });
 
     it('should not take excessive time to open the editor if the choice list is very long', async() => {
-      const choices = new Array(50000).fill().map((i) => Math.random());
+      const options = new Array(50000).fill().map(() => Math.random());
       let startTime;
       let endTime;
 
@@ -678,10 +678,10 @@ describe('AutocompleteEditor', () => {
         columns: [
           {
             type: 'autocomplete',
-            source: choices,
+            source: options,
           },
         ],
-        afterBeginEditing: function() {
+        afterBeginEditing() {
           startTime = performance.now();
 
           this.getActiveEditor().htEditor.addHookOnce('afterRender', () => {

--- a/handsontable/src/editors/autocompleteEditor/__tests__/autocompleteEditor.spec.js
+++ b/handsontable/src/editors/autocompleteEditor/__tests__/autocompleteEditor.spec.js
@@ -668,7 +668,7 @@ describe('AutocompleteEditor', () => {
       });
     });
 
-    it('should not take excessive time to open the editor if the choice list is very long', async() => {
+    it('should not take excessive time to open the editor if the choice list is very long (dev-handsontable#2313)', async() => {
       const options = new Array(50000).fill().map(() => Math.random());
       let startTime;
       let endTime;

--- a/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
+++ b/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
@@ -154,7 +154,6 @@ export class AutocompleteEditor extends HandsontableEditor {
     this.htEditor.updateSettings({
       colWidths: trimDropdown ? [outerWidth(this.TEXTAREA) - 2] : undefined,
       autoColumnSize: true,
-      autoRowSize: true,
       renderer: (hotInstance, TD, row, col, prop, value, cellProperties) => {
         textRenderer(hotInstance, TD, row, col, prop, value, cellProperties);
 
@@ -501,7 +500,11 @@ export class AutocompleteEditor extends HandsontableEditor {
       parseInt(containerStyle.borderBottomWidth, 10);
     const maxItems = Math.min(this.cellProperties.visibleRows, this.strippedChoices.length);
     const height = Array.from({ length: maxItems }, (_, i) => i)
-      .reduce((h, index) => h + this.htEditor.getRowHeight(index), 0);
+      .reduce((totalHeight, index) => {
+        const rowHeight = this.htEditor.getRowHeight(index) || this.htEditor.view.getDefaultRowHeight();
+
+        return totalHeight + rowHeight;
+      }, 0);
 
     return height + borderVerticalCompensation + 1;
   }


### PR DESCRIPTION
### Context
This PR disables `autoRowSize` for the Autocomplete Editor, as it took a long time to calculate on cells with large choice lists.
As the entries in the dropdown rarely span more than one line, I don't think it's required.

### How has this been tested?
Tested locally + added a test case.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#2313

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
