### PR TITLE
Fix focus catcher accessibility problem

### DIFF
--- a/.changelogs/11553.json
+++ b/.changelogs/11553.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed an issue with focus catcher accessibility",
+  "type": "fixed",
+  "issueOrPR": 11553,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/core/focusCatcher/__tests__/focusDetector.unit.js
+++ b/handsontable/src/core/focusCatcher/__tests__/focusDetector.unit.js
@@ -37,12 +37,10 @@ describe('focusDetector', () => {
 
     expect(inputTrapTop.className).toBe('htFocusCatcher');
     expect(inputTrapTop.name).toBe('__htFocusCatcher');
-    expect(inputTrapTop.getAttribute('role')).toBe('presentation');
-    expect(inputTrapTop.getAttribute('aria-hidden')).toBe('true');
+    expect(inputTrapTop.getAttribute('aria-label')).toBe('Focus catcher');
     expect(inputTrapBottom.className).toBe('htFocusCatcher');
     expect(inputTrapBottom.name).toBe('__htFocusCatcher');
-    expect(inputTrapBottom.getAttribute('role')).toBe('presentation');
-    expect(inputTrapBottom.getAttribute('aria-hidden')).toBe('true');
+    expect(inputTrapTop.getAttribute('aria-label')).toBe('Focus catcher');
   });
 
   // More tests around the focusCatcher module you'll find here ./handsontable/test/e2e/keyboardShortcuts/tabNavigation.spec.js

--- a/handsontable/src/core/focusCatcher/focusDetector.js
+++ b/handsontable/src/core/focusCatcher/focusDetector.js
@@ -1,5 +1,5 @@
 import { setAttribute } from '../../helpers/dom/element';
-import { A11Y_PRESENTATION, A11Y_HIDDEN } from '../../helpers/a11y';
+import { A11Y_LABEL } from '../../helpers/a11y';
 
 /**
  * Installs a focus detector module. The module appends two input elements into the DOM side by side.
@@ -60,8 +60,7 @@ function createInputElement(hot) {
 
   if (hot.getSettings().ariaTags) {
     setAttribute(input, [
-      A11Y_PRESENTATION(),
-      A11Y_HIDDEN(),
+      A11Y_LABEL('Focus catcher'),
     ]);
   }
 


### PR DESCRIPTION
### Context
This PR includes fixes for focus catcher aria tags

### How has this been tested?
Locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2331

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
