### PR TITLE
Precise calculating the first row height

### DIFF
--- a/.changelogs/11557.json
+++ b/.changelogs/11557.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed calculating the first row height",
+  "type": "fixed",
+  "issueOrPR": 11557,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/autoRowSize/__tests__/autoRowSize.spec.js
+++ b/handsontable/src/plugins/autoRowSize/__tests__/autoRowSize.spec.js
@@ -316,13 +316,13 @@ describe('AutoRowSize', () => {
 
     expect(getInlineStartClone().find('.wtHolder').scrollTop()).forThemes(({ classic, main, horizon }) => {
       classic.toBe(90);
-      main.toBe(216);
-      horizon.toBe(264);
+      main.toBe(217);
+      horizon.toBe(265);
     });
     expect(getMaster().find('.wtHolder').scrollTop()).forThemes(({ classic, main, horizon }) => {
       classic.toBe(90);
-      main.toBe(216);
-      horizon.toBe(264);
+      main.toBe(217);
+      horizon.toBe(265);
     });
   });
 
@@ -459,7 +459,7 @@ describe('AutoRowSize', () => {
   });
 
   it('should recalculate heights after column resize', function() {
-    const hot = handsontable({
+    handsontable({
       data: arrayOfObjects2(),
       colWidths: 250,
       manualColumnResize: true,
@@ -468,17 +468,17 @@ describe('AutoRowSize', () => {
       colHeaders: true
     });
 
-    expect(parseInt(hot.getCell(0, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
+    expect(parseInt(getCell(0, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
+      classic.toBe(22); // -1px of cell border
+      main.toBe(30);
+      horizon.toBe(38);
+    });
+    expect(parseInt(getCell(1, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
       classic.toBe(22); // -1px of cell border
       main.toBe(29);
       horizon.toBe(37);
     });
-    expect(parseInt(hot.getCell(1, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
-      classic.toBe(22); // -1px of cell border
-      main.toBe(29);
-      horizon.toBe(37);
-    });
-    expect(parseInt(hot.getCell(2, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
+    expect(parseInt(getCell(2, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
       classic.toBe(22); // -1px of cell border
       main.toBe(29);
       horizon.toBe(37);
@@ -486,17 +486,17 @@ describe('AutoRowSize', () => {
 
     resizeColumn.call(this, 1, 90);
 
-    expect(parseInt(hot.getCell(0, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
+    expect(parseInt(getCell(0, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
       classic.toBe(22);
-      main.toBe(29);
-      horizon.toBe(37);
+      main.toBe(30);
+      horizon.toBe(38);
     });
-    expect(parseInt(hot.getCell(1, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
+    expect(parseInt(getCell(1, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
       classic.toBe(42);
       main.toBe(49);
       horizon.toBe(57);
     });
-    expect(parseInt(hot.getCell(2, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
+    expect(parseInt(getCell(2, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
       classic.toBe(63);
       main.toBe(89);
       horizon.toBe(97);
@@ -504,17 +504,17 @@ describe('AutoRowSize', () => {
 
     resizeColumn.call(this, 1, 50);
 
-    expect(parseInt(hot.getCell(0, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
+    expect(parseInt(getCell(0, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
       classic.toBe(22);
-      main.toBe(29);
-      horizon.toBe(37);
+      main.toBe(30);
+      horizon.toBe(38);
     });
-    expect(parseInt(hot.getCell(1, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
+    expect(parseInt(getCell(1, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
       classic.toBe(42);
       main.toBe(49);
       horizon.toBe(57);
     });
-    expect(parseInt(hot.getCell(2, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
+    expect(parseInt(getCell(2, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
       classic.toBe(126);
       main.toBe(129);
       horizon.toBe(137);
@@ -522,17 +522,17 @@ describe('AutoRowSize', () => {
 
     resizeColumn.call(this, 1, 200);
 
-    expect(parseInt(hot.getCell(0, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
+    expect(parseInt(getCell(0, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
+      classic.toBe(22);
+      main.toBe(30);
+      horizon.toBe(38);
+    });
+    expect(parseInt(getCell(1, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
       classic.toBe(22);
       main.toBe(29);
       horizon.toBe(37);
     });
-    expect(parseInt(hot.getCell(1, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
-      classic.toBe(22);
-      main.toBe(29);
-      horizon.toBe(37);
-    });
-    expect(parseInt(hot.getCell(2, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
+    expect(parseInt(getCell(2, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
       classic.toBe(22);
       main.toBe(49);
       horizon.toBe(57);
@@ -540,7 +540,7 @@ describe('AutoRowSize', () => {
   });
 
   it('should recalculate heights after column moved', () => {
-    const hot = handsontable({
+    handsontable({
       data: arrayOfObjects2(),
       colWidths: [250, 50],
       manualColumnMove: true,
@@ -549,38 +549,38 @@ describe('AutoRowSize', () => {
       colHeaders: true
     });
 
-    const plugin = hot.getPlugin('manualColumnMove');
+    const plugin = getPlugin('manualColumnMove');
 
-    expect(parseInt(hot.getCell(0, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
+    expect(parseInt(getCell(0, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
       classic.toBe(42); // -1px of cell border
-      main.toBe(49);
-      horizon.toBe(57);
+      main.toBe(50);
+      horizon.toBe(58);
     });
-    expect(parseInt(hot.getCell(1, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
+    expect(parseInt(getCell(1, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
       classic.toBe(105); // -1px of cell border
       main.toBe(109);
       horizon.toBe(117);
     });
-    expect(parseInt(hot.getCell(2, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
+    expect(parseInt(getCell(2, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
       classic.toBeInArray([22, 42]); // -1px of cell border
       main.toBeInArray([29, 49]);
       horizon.toBeInArray([37, 63]);
     });
 
     plugin.moveColumn(0, 1);
-    hot.render();
+    render();
 
-    expect(parseInt(hot.getCell(0, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
+    expect(parseInt(getCell(0, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
       classic.toBe(22);
-      main.toBe(29);
-      horizon.toBe(37);
+      main.toBe(30);
+      horizon.toBe(38);
     });
-    expect(parseInt(hot.getCell(1, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
+    expect(parseInt(getCell(1, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
       classic.toBe(42);
       main.toBe(49);
       horizon.toBe(57);
     });
-    expect(parseInt(hot.getCell(2, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
+    expect(parseInt(getCell(2, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
       classic.toBe(126);
       main.toBe(129);
       horizon.toBe(137);
@@ -588,7 +588,7 @@ describe('AutoRowSize', () => {
   });
 
   it('should recalculate heights with manualRowResize when changing text to multiline', () => {
-    const hot = handsontable({
+    handsontable({
       data: arrayOfObjects2(),
       colWidths: 250,
       manualRowResize: [23, 50],
@@ -597,35 +597,35 @@ describe('AutoRowSize', () => {
       colHeaders: true
     });
 
-    expect(parseInt(hot.getCell(0, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
+    expect(parseInt(getCell(0, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
       classic.toBe(22); // -1px of cell border
-      main.toBe(29);
-      horizon.toBe(37);
+      main.toBe(30);
+      horizon.toBe(38);
     });
-    expect(parseInt(hot.getCell(1, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
+    expect(parseInt(getCell(1, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
       classic.toBe(49); // -1px of cell border
       main.toBe(50);
       horizon.toBe(50);
     });
-    expect(parseInt(hot.getCell(2, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
+    expect(parseInt(getCell(2, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
       classic.toBeInArray([22, 42]); // -1px of cell border
       main.toBeInArray([29, 49]);
       horizon.toBeInArray([37, 63]);
     });
 
-    hot.setDataAtCell(1, 0, 'A\nB\nC\nD\nE');
+    setDataAtCell(1, 0, 'A\nB\nC\nD\nE');
 
-    expect(parseInt(hot.getCell(0, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
+    expect(parseInt(getCell(0, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
       classic.toBe(22);
-      main.toBe(29);
-      horizon.toBe(37);
+      main.toBe(30);
+      horizon.toBe(38);
     });
-    expect(parseInt(hot.getCell(1, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
+    expect(parseInt(getCell(1, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
       classic.toBe(105);
       main.toBe(109);
       horizon.toBe(117);
     });
-    expect(parseInt(hot.getCell(2, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
+    expect(parseInt(getCell(2, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
       classic.toBeInArray([22, 42]);
       main.toBeInArray([29, 49]);
       horizon.toBeInArray([37, 63]);
@@ -633,7 +633,7 @@ describe('AutoRowSize', () => {
   });
 
   it('should recalculate heights after moved row', () => {
-    const hot = handsontable({
+    handsontable({
       data: arrayOfObjects2(),
       colWidths: 250,
       manualRowResize: [23, 50],
@@ -643,38 +643,38 @@ describe('AutoRowSize', () => {
       colHeaders: true
     });
 
-    expect(parseInt(hot.getCell(0, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
+    expect(parseInt(getCell(0, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
       classic.toBe(22); // -1px of cell border
-      main.toBe(29);
-      horizon.toBe(37);
+      main.toBe(30);
+      horizon.toBe(38);
     });
-    expect(parseInt(hot.getCell(1, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
+    expect(parseInt(getCell(1, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
       classic.toBe(49); // -1px of cell border
       main.toBe(50);
       horizon.toBe(50);
     });
-    expect(parseInt(hot.getCell(2, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
+    expect(parseInt(getCell(2, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
       classic.toBeInArray([22, 42]); // -1px of cell border
       main.toBeInArray([29, 49]);
       horizon.toBeInArray([37, 63]);
     });
 
-    const plugin = hot.getPlugin('manualRowMove');
+    const plugin = getPlugin('manualRowMove');
 
     plugin.moveRow(1, 0);
-    hot.render();
+    render();
 
-    expect(parseInt(hot.getCell(0, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
+    expect(parseInt(getCell(0, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
       classic.toBe(49);
       main.toBe(50);
       horizon.toBe(50);
     });
-    expect(parseInt(hot.getCell(1, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
+    expect(parseInt(getCell(1, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
       classic.toBe(22);
       main.toBe(29);
       horizon.toBe(37);
     });
-    expect(parseInt(hot.getCell(2, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
+    expect(parseInt(getCell(2, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
       classic.toBeInArray([22, 42]); // -1px of cell border
       main.toBeInArray([29, 49]);
       horizon.toBeInArray([37, 63]);
@@ -718,8 +718,8 @@ describe('AutoRowSize', () => {
 
     expect(cloneLeft.height()).forThemes(({ classic, main, horizon }) => {
       classic.toEqual(70);
-      main.toEqual(79);
-      horizon.toEqual(95);
+      main.toEqual(80);
+      horizon.toEqual(96);
     });
   });
 
@@ -756,8 +756,8 @@ describe('AutoRowSize', () => {
 
     expect(getRowHeight(0)).forThemes(({ classic, main, horizon }) => {
       classic.toBe(23);
-      main.toBe(29);
-      horizon.toBe(37);
+      main.toBe(30);
+      horizon.toBe(38);
     });
     expect(getRowHeight(1)).forThemes(({ classic, main, horizon }) => {
       classic.toBe(23);
@@ -792,8 +792,8 @@ describe('AutoRowSize', () => {
 
     expect(getRowHeight(0)).forThemes(({ classic, main, horizon }) => {
       classic.toBe(23);
-      main.toBe(29);
-      horizon.toBe(37);
+      main.toBe(30);
+      horizon.toBe(38);
     });
   });
 
@@ -841,8 +841,8 @@ describe('AutoRowSize', () => {
 
     expect(topOverlay().getScrollPosition()).forThemes(({ classic, main, horizon }) => {
       classic.toBe(833);
-      main.toBe(1135);
-      horizon.toBe(1543);
+      main.toBe(1136);
+      horizon.toBe(1544);
     });
 
     selectColumns(2, 2);
@@ -851,8 +851,8 @@ describe('AutoRowSize', () => {
 
     expect(topOverlay().getScrollPosition()).forThemes(({ classic, main, horizon }) => {
       classic.toBe(833);
-      main.toBe(1135);
-      horizon.toBe(1543);
+      main.toBe(1136);
+      horizon.toBe(1544);
     });
   });
 
@@ -895,8 +895,8 @@ describe('AutoRowSize', () => {
 
     expect(getRowHeight(0)).forThemes(({ classic, main, horizon }) => {
       classic.toBe(26);
-      main.toBe(34);
-      horizon.toBe(42);
+      main.toBe(35);
+      horizon.toBe(43);
     });
     expect(getRowHeight(4)).forThemes(({ classic, main, horizon }) => {
       classic.toBe(26);

--- a/handsontable/src/plugins/autoRowSize/__tests__/mergeCells.spec.js
+++ b/handsontable/src/plugins/autoRowSize/__tests__/mergeCells.spec.js
@@ -31,8 +31,8 @@ describe('MergeCells', () => {
 
     expect(getRowHeight(0)).forThemes(({ classic, main, horizon }) => {
       classic.toBe(23);
-      main.toBe(29);
-      horizon.toBe(37);
+      main.toBe(30);
+      horizon.toBe(38);
     });
     expect(getRowHeight(1)).forThemes(({ classic, main, horizon }) => {
       classic.toBe(23);

--- a/handsontable/src/plugins/mergeCells/__tests__/mergeCells.spec.js
+++ b/handsontable/src/plugins/mergeCells/__tests__/mergeCells.spec.js
@@ -1606,13 +1606,13 @@ describe('MergeCells', () => {
 
     expect(getTopInlineStartClone().height()).forThemes(({ classic, main, horizon }) => {
       classic.toBe(111);
-      main.toBe(128);
-      horizon.toBe(152);
+      main.toBe(129);
+      horizon.toBe(153);
     });
     expect(getTopClone().height()).forThemes(({ classic, main, horizon }) => {
       classic.toBe(111);
-      main.toBe(128);
-      horizon.toBe(152);
+      main.toBe(129);
+      horizon.toBe(153);
     });
     expect(getInlineStartClone().height()).toBe(400);
   });

--- a/handsontable/src/styles/base/_base.scss
+++ b/handsontable/src/styles/base/_base.scss
@@ -78,19 +78,24 @@
 
         tbody {
           tr {
-            td,
-            th {
+            th,
+            td {
               border-top-width: 0;
+              height: calc(
+                var(--ht-cell-vertical-padding) * 2 + var(--ht-line-height) + 1px
+              );
             }
+          }
+        }
 
-            &:first-of-type {
-              th,
-              td {
-                height: calc(
-                  var(--ht-cell-vertical-padding) * 2 + var(--ht-line-height) +
-                    1px
-                );
-              }
+        &.htGhostTableFirstRow tbody {
+          tr {
+            th,
+            td {
+              border-top-width: 1px;
+              height: calc(
+                var(--ht-cell-vertical-padding) * 2 + var(--ht-line-height) + 2px
+              );
             }
           }
         }

--- a/handsontable/src/utils/__tests__/ghostTable.spec.js
+++ b/handsontable/src/utils/__tests__/ghostTable.spec.js
@@ -76,7 +76,7 @@ describe('GhostTable', () => {
 
       expect(gt.rows.length).toBe(1);
       expect(gt.rows[0].row).toBe(0);
-      expect(gt.rows[0].table.className).toBe('htCore');
+      expect(gt.rows[0].table.className).toBe('htCore htGhostTableFirstRow');
       expect(gt.rows[0].table.nodeName).toBe('TABLE');
       expect(gt.rows[0].table.querySelectorAll('colgroup > col').length).toBe(2);
       expect(gt.rows[0].table.querySelector('tbody > tr > td').innerHTML).toBe('Foo');
@@ -121,8 +121,8 @@ describe('GhostTable', () => {
       expect(heightSpy.calls.argsFor(0)[0]).toBe(0);
       expect(heightSpy.calls.argsFor(0)[1]).forThemes(({ classic, main, horizon }) => {
         classic.toBe(23);
-        main.toBe(29);
-        horizon.toBe(37);
+        main.toBe(30);
+        horizon.toBe(38);
       });
       expect(heightSpy.calls.argsFor(1)[0]).toBe(1);
       expect(heightSpy.calls.argsFor(1)[1]).forThemes(({ classic, main, horizon }) => {

--- a/handsontable/src/utils/ghostTable.js
+++ b/handsontable/src/utils/ghostTable.js
@@ -77,6 +77,11 @@ class GhostTable {
     this.table = this.createTable(this.hot.table.className);
     this.table.colGroup.appendChild(this.createColGroupsCol(row));
     this.table.tr.appendChild(this.createRow(row));
+
+    if (row === 0) {
+      addClass(this.table.table, 'htGhostTableFirstRow');
+    }
+
     this.container.container.appendChild(this.table.fragment);
 
     rowObject.table = this.table.table;


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR improves the height calculation for the first row for themes. I think the PR's changes are a continuation of the https://github.com/handsontable/handsontable/pull/11458, where the initial CSS compensations were added. The same height compensation needs to be added to the `.htGhostTable`.

#### Before
The physical element height is `30`, but the `getRowHeight` method returns `29`.
![image](https://github.com/user-attachments/assets/6a043c28-27c4-44bf-b4f5-17301df9e0c1)

#### After
![image](https://github.com/user-attachments/assets/63196544-cd1a-4c8d-a30a-4ffc62e21c79)


### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and I updated the tests according to new values.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/2327

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
