### PR TITLE
Fix unmerge cells action triggered form keyboard shortcut

### DIFF
--- a/.changelogs/11559.json
+++ b/.changelogs/11559.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed unmerge cells action triggered form keyboard shortcut",
+  "type": "fixed",
+  "issueOrPR": 11559,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/src/cell/range.js
+++ b/handsontable/src/3rdparty/walkontable/src/cell/range.js
@@ -100,9 +100,9 @@ class CellRange {
    * @returns {CellRange}
    */
   normalize() {
-    this.highlight = this.highlight.normalize();
-    this.from = this.from.normalize();
-    this.to = this.to.normalize();
+    this.highlight.normalize();
+    this.from.normalize();
+    this.to.normalize();
 
     return this;
   }

--- a/handsontable/src/3rdparty/walkontable/src/cell/range.js
+++ b/handsontable/src/3rdparty/walkontable/src/cell/range.js
@@ -93,6 +93,21 @@ class CellRange {
   }
 
   /**
+   * Normalizes the coordinates in your `CellRange` instance to the nearest valid position.
+   *
+   * Coordinates that point to headers (negative values) are normalized to `0`.
+   *
+   * @returns {CellRange}
+   */
+  normalize() {
+    this.highlight = this.highlight.normalize();
+    this.from = this.from.normalize();
+    this.to = this.to.normalize();
+
+    return this;
+  }
+
+  /**
    * Checks if the coordinates in your `CellRange` instance are valid
    * in the context of given table parameters.
    *

--- a/handsontable/src/3rdparty/walkontable/test/spec/cell/range.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/cell/range.spec.js
@@ -533,6 +533,22 @@ describe('Walkontable.CellRange', () => {
     });
   });
 
+  describe('normalize', () => {
+    it('should normalize all coords inside the range', () => {
+      const highlight = new Walkontable.CellCoords(-1, -2);
+      const from = new Walkontable.CellCoords(-1, 1);
+      const to = new Walkontable.CellCoords(2, -2);
+      const range = new Walkontable.CellRange(highlight, from, to);
+
+      const result = range.normalize();
+
+      expect(result).toBe(range);
+      expect(range.from).toEqual(new Walkontable.CellCoords(0, 1));
+      expect(range.to).toEqual(new Walkontable.CellCoords(2, 0));
+      expect(range.to).toEqual(new Walkontable.CellCoords(2, 0));
+    });
+  });
+
   describe('overlaps', () => {
     describe('positive', () => {
       /*

--- a/handsontable/src/plugins/mergeCells/__tests__/keyboardShortcuts/ctrlM.spec.js
+++ b/handsontable/src/plugins/mergeCells/__tests__/keyboardShortcuts/ctrlM.spec.js
@@ -13,76 +13,162 @@ describe('MergeCells keyboard shortcut', () => {
   });
 
   describe('"Control" + "M"', () => {
-    it('should toggle the cell when it points to the single cell', () => {
+    it('should not toggle the cell when it points to the single cell', () => {
       handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        data: createSpreadsheetData(5, 5),
         mergeCells: true,
         rowHeaders: true,
         colHeaders: true,
       });
-
-      spyOn(getPlugin('mergeCells'), 'toggleMerge');
 
       selectCell(1, 1);
       keyDownUp(['control', 'm']);
 
-      expect(getPlugin('mergeCells').toggleMerge).toHaveBeenCalledTimes(1);
+      const cell = getCell(1, 1);
+
+      expect(cell.rowSpan).toBe(1);
+      expect(cell.colSpan).toBe(1);
     });
 
-    it('should not toggle the cell when it points to the column header', () => {
+    it('should toggle the cells when it points to the whole column', () => {
       handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        data: createSpreadsheetData(5, 5),
+        mergeCells: true,
+        rowHeaders: true,
+        colHeaders: true,
+      });
+
+      selectColumns(1);
+      listen();
+      keyDownUp(['control', 'm']);
+
+      {
+        const cell = getCell(1, 1);
+
+        expect(cell.rowSpan).toBe(5);
+        expect(cell.colSpan).toBe(1);
+      }
+
+      keyDownUp(['control', 'm']);
+
+      {
+        const cell = getCell(1, 1);
+
+        expect(cell.rowSpan).toBe(1);
+        expect(cell.colSpan).toBe(1);
+      }
+    });
+
+    it('should toggle the cells when it points to the whole row', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        mergeCells: true,
+        rowHeaders: true,
+        colHeaders: true,
+      });
+
+      selectRows(1);
+      listen();
+      keyDownUp(['control', 'm']);
+
+      {
+        const cell = getCell(1, 1);
+
+        expect(cell.rowSpan).toBe(1);
+        expect(cell.colSpan).toBe(5);
+      }
+
+      keyDownUp(['control', 'm']);
+
+      {
+        const cell = getCell(1, 1);
+
+        expect(cell.rowSpan).toBe(1);
+        expect(cell.colSpan).toBe(1);
+      }
+    });
+
+    it('should not toggle the cell when it points to the column header only', () => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
         mergeCells: true,
         rowHeaders: true,
         colHeaders: true,
         navigableHeaders: true,
       });
-
-      spyOn(getPlugin('mergeCells'), 'toggleMerge');
 
       selectCell(-1, 1);
       keyDownUp(['control', 'm']);
 
-      expect(getPlugin('mergeCells').toggleMerge).toHaveBeenCalledTimes(0);
+      {
+        const cell = getCell(-1, 1);
+
+        expect(cell.rowSpan).toBe(1);
+        expect(cell.colSpan).toBe(1);
+      }
+      {
+        const cell = getCell(0, 1);
+
+        expect(cell.rowSpan).toBe(1);
+        expect(cell.colSpan).toBe(1);
+      }
     });
 
-    it('should not toggle the cell when it points to the row header', () => {
+    it('should not toggle the cell when it points to the row header only', () => {
       handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        data: createSpreadsheetData(5, 5),
         mergeCells: true,
         rowHeaders: true,
         colHeaders: true,
         navigableHeaders: true,
       });
-
-      spyOn(getPlugin('mergeCells'), 'toggleMerge');
 
       selectCell(1, -1);
       keyDownUp(['control', 'm']);
 
-      expect(getPlugin('mergeCells').toggleMerge).toHaveBeenCalledTimes(0);
+      {
+        const cell = getCell(1, -1);
+
+        expect(cell.rowSpan).toBe(1);
+        expect(cell.colSpan).toBe(1);
+      }
+      {
+        const cell = getCell(1, 0);
+
+        expect(cell.rowSpan).toBe(1);
+        expect(cell.colSpan).toBe(1);
+      }
     });
 
     it('should not toggle the cell when it points to the corner', () => {
       handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        data: createSpreadsheetData(5, 5),
         mergeCells: true,
         rowHeaders: true,
         colHeaders: true,
         navigableHeaders: true,
       });
 
-      spyOn(getPlugin('mergeCells'), 'toggleMerge');
-
       selectCell(-1, -1);
       keyDownUp(['control', 'm']);
 
-      expect(getPlugin('mergeCells').toggleMerge).toHaveBeenCalledTimes(0);
+      {
+        const cell = getCell(-1, -1);
+
+        expect(cell.rowSpan).toBe(1);
+        expect(cell.colSpan).toBe(1);
+      }
+      {
+        const cell = getCell(0, 0);
+
+        expect(cell.rowSpan).toBe(1);
+        expect(cell.colSpan).toBe(1);
+      }
     });
 
     it('should merge selected cells', () => {
       handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        data: createSpreadsheetData(5, 5),
         mergeCells: true,
       });
 
@@ -97,7 +183,7 @@ describe('MergeCells keyboard shortcut', () => {
 
     it('should toggle the selected cells to merged/unmerged/merged state', () => {
       handsontable({
-        data: Handsontable.helper.createSpreadsheetData(5, 5),
+        data: createSpreadsheetData(5, 5),
         mergeCells: true,
       });
 

--- a/handsontable/src/plugins/mergeCells/mergeCells.js
+++ b/handsontable/src/plugins/mergeCells/mergeCells.js
@@ -526,11 +526,12 @@ export class MergeCells extends BasePlugin {
    * @param {CellRange} cellRange The cell range to merge or unmerged.
    */
   toggleMerge(cellRange) {
-    const mergedCell = this.mergedCellsCollection.get(cellRange.from.row, cellRange.from.col);
-    const mergedCellCoversWholeRange = mergedCell.row === cellRange.from.row &&
-      mergedCell.col === cellRange.from.col &&
-      mergedCell.row + mergedCell.rowspan - 1 === cellRange.to.row &&
-      mergedCell.col + mergedCell.colspan - 1 === cellRange.to.col;
+    const { from, to } = cellRange.clone().normalize();
+    const mergedCell = this.mergedCellsCollection.get(from.row, from.col);
+    const mergedCellCoversWholeRange = mergedCell.row === from.row &&
+      mergedCell.col === from.col &&
+      mergedCell.row + mergedCell.rowspan - 1 === to.row &&
+      mergedCell.col + mergedCell.colspan - 1 === to.col;
 
     if (mergedCellCoversWholeRange) {
       this.unmergeRange(cellRange);


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes a bug where the <kbd>Ctrl</kbd>+<kbd>m</kbd> does not unmerge cells for selected rows/columns. Also, the PR adds a new `normalize` method to the `CellRange` class for easier coordinate normalizations.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and covered the fix with new tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1566

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
