### PR TITLE
Add horizontal scroll to the Filter's by value component

### DIFF
--- a/.changelogs/11561.json
+++ b/.changelogs/11561.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Added horizontal scroll to the Filter's by value component",
+  "type": "added",
+  "issueOrPR": 11561,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
@@ -1834,7 +1834,7 @@ describe('Filters UI', () => {
     expect(countRows()).toBe(1);
   });
 
-  it('should be possible to scroll vertically and horizontally viewport of the by value component', () => {
+  it('should be possible to scroll the viewport of the 'by value' component in both directions', () => {
     const data = getDataForFilters();
 
     data[1].name = 'A very long name that should be visible in the component';

--- a/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
@@ -1834,7 +1834,7 @@ describe('Filters UI', () => {
     expect(countRows()).toBe(1);
   });
 
-  it('should be possible to scroll the viewport of the 'by value' component in both directions', () => {
+  it('should be possible to scroll the viewport of the "by value" component in both directions', () => {
     const data = getDataForFilters();
 
     data[1].name = 'A very long name that should be visible in the component';

--- a/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
@@ -1833,4 +1833,28 @@ describe('Filters UI', () => {
 
     expect(countRows()).toBe(1);
   });
+
+  it('should be possible to scroll vertically and horizontally viewport of the by value component', () => {
+    const data = getDataForFilters();
+
+    data[1].name = 'A very long name that should be visible in the component';
+
+    handsontable({
+      data,
+      columns: getColumnsForFilters(),
+      dropdownMenu: true,
+      filters: true,
+      width: 500,
+      height: 300
+    });
+
+    dropdownMenu(1);
+
+    const byValueScrollableElement = byValueBoxRootElement().querySelector('.ht_master .wtHolder');
+
+    byValueScrollableElement.scrollBy(100, 100);
+
+    expect(byValueScrollableElement.scrollTop).toBe(100);
+    expect(byValueScrollableElement.scrollLeft).toBe(100);
+  });
 });

--- a/handsontable/src/plugins/filters/ui/multipleSelect.js
+++ b/handsontable/src/plugins/filters/ui/multipleSelect.js
@@ -226,7 +226,15 @@ export class MultipleSelectUI extends BaseUI {
         beforeOnCellMouseUp: () => {
           this.#itemsBox.listen();
         },
-        colWidths: () => this.#itemsBox.container.scrollWidth - getScrollbarWidth(rootDocument),
+        modifyColWidth: (width) => {
+          const minWidth = this.#itemsBox.container.scrollWidth - getScrollbarWidth(rootDocument);
+
+          if (width !== undefined && width < minWidth) {
+            return minWidth;
+          }
+
+          return width;
+        },
         maxCols: 1,
         autoWrapCol: true,
         height: 110,

--- a/handsontable/src/styles/classic/handsontable.css
+++ b/handsontable/src/styles/classic/handsontable.css
@@ -1428,7 +1428,7 @@ textarea.HandsontableCopyPaste {
 }
 
 .htUIMultipleSelect .ht_master .wtHolder {
-  overflow-y: scroll;
+  overflow: auto;
 }
 
 .handsontable .htFiltersActive .changeType {

--- a/handsontable/src/styles/components/plugins/_filters.scss
+++ b/handsontable/src/styles/components/plugins/_filters.scss
@@ -135,7 +135,7 @@
 
     // SelectMultiple
     .htUIMultipleSelect .ht_master .wtHolder {
-      overflow-y: auto;
+      overflow: auto;
 
       .wtHider,
       .htCore,


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR improves the Filter's "by value" component by adding a horizontal scroll when the width of the values is wider than the component viewport size.

#### Before
![Kapture 2025-04-01 at 09 41 25](https://github.com/user-attachments/assets/fae19d5b-185d-460f-8240-aa274978747d)

#### After
![Kapture 2025-04-01 at 09 42 17](https://github.com/user-attachments/assets/a1495450-7a52-4ccb-8d02-53c2a4d4bb6d)

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally, and I covered the fix with updated tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1863

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
