### PR TITLE
Fix arrow left/right shortcuts for menu (RTL)

### DIFF
--- a/.changelogs/11562.json
+++ b/.changelogs/11562.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed arrow left/right shortcuts for menu when the table was configured as `layoutDirection: rtl`.",
+  "type": "fixed",
+  "issueOrPR": 11562,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/contextMenu/__tests__/keyboardShortcuts/arrowLeft.spec.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/keyboardShortcuts/arrowLeft.spec.js
@@ -10,28 +10,10 @@ describe('ContextMenu keyboard shortcut', () => {
     }
   });
 
-  describe('"ArrowRight"', () => {
-    it('should open subMenu and highlight the first item', async() => {
+  describe('"ArrowLeft"', () => {
+    it('should open subMenu and highlight the first item when configured as `layoutDirection: rtl`', async() => {
       handsontable({
         data: createSpreadsheetData(4, 4),
-        contextMenu: ['alignment'],
-        height: 100
-      });
-
-      contextMenu();
-      keyDownUp('arrowdown');
-      keyDownUp('arrowright');
-
-      await sleep(300);
-
-      expect(getPlugin('contextMenu').menu.hotSubMenus.alignment.hotMenu.getSelected()).toEqual([
-        [0, 0, 0, 0]
-      ]);
-    });
-
-    it('should hide already opened subMenu when configured as `layoutDirection: rtl`', async() => {
-      handsontable({
-        data: createSpreadsheetData(5, 5),
         contextMenu: ['alignment'],
         height: 100,
         layoutDirection: 'rtl',
@@ -43,9 +25,27 @@ describe('ContextMenu keyboard shortcut', () => {
 
       await sleep(300);
 
+      expect(getPlugin('contextMenu').menu.hotSubMenus.alignment.hotMenu.getSelected()).toEqual([
+        [0, 0, 0, 0]
+      ]);
+    });
+
+    it('should hide already opened subMenu', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        contextMenu: ['alignment'],
+        height: 100,
+      });
+
+      contextMenu();
+      keyDownUp('arrowdown');
+      keyDownUp('arrowright');
+
+      await sleep(300);
+
       expect($('.htContextMenuSub_Alignment').is(':visible')).toBe(true);
 
-      keyDownUp('arrowright');
+      keyDownUp('arrowleft');
 
       expect($('.htContextMenuSub_Alignment').is(':visible')).toBe(false);
     });

--- a/handsontable/src/plugins/contextMenu/menu/defaultShortcutsList.js
+++ b/handsontable/src/plugins/contextMenu/menu/defaultShortcutsList.js
@@ -37,7 +37,7 @@ export function createDefaultShortcutsList(menu) {
     keys: [['ArrowUp']],
     callback: () => menu.getNavigator().toPreviousItem(),
   }, {
-    keys: [['ArrowRight']],
+    keys: [[hot.isRtl() ? 'ArrowLeft' : 'ArrowRight']],
     callback: () => {
       const selection = hotMenu.getSelectedLast();
 
@@ -50,7 +50,7 @@ export function createDefaultShortcutsList(menu) {
       }
     }
   }, {
-    keys: [['ArrowLeft']],
+    keys: [[hot.isRtl() ? 'ArrowRight' : 'ArrowLeft']],
     callback: () => {
       const selection = hotMenu.getSelectedLast();
 

--- a/visual-tests/tests/js-only/context-menu/rtl/menus-position-scrolled-viewport.spec.ts
+++ b/visual-tests/tests/js-only/context-menu/rtl/menus-position-scrolled-viewport.spec.ts
@@ -24,7 +24,7 @@ test(__filename, async({ goto, tablePage }) => {
   await tablePage.keyboard.press('ArrowUp');
   await tablePage.keyboard.press('ArrowUp');
   await tablePage.keyboard.press('ArrowUp'); // selects "Alignment" submenu option
-  await tablePage.keyboard.press('ArrowRight'); // selects "Left" submenu option
+  await tablePage.keyboard.press('ArrowLeft'); // selects "Left" submenu option
   await tablePage.screenshot({ path: helpers.screenshotPath() });
 
   await closeTheMenu();
@@ -33,7 +33,7 @@ test(__filename, async({ goto, tablePage }) => {
   await tablePage.keyboard.press('ArrowUp');
   await tablePage.keyboard.press('ArrowUp');
   await tablePage.keyboard.press('ArrowUp'); // selects "Alignment" submenu option
-  await tablePage.keyboard.press('ArrowRight'); // selects "Left" submenu option
+  await tablePage.keyboard.press('ArrowLeft'); // selects "Left" submenu option
   await tablePage.screenshot({ path: helpers.screenshotPath() });
 
   await closeTheMenu();
@@ -42,7 +42,7 @@ test(__filename, async({ goto, tablePage }) => {
   await tablePage.keyboard.press('ArrowUp');
   await tablePage.keyboard.press('ArrowUp');
   await tablePage.keyboard.press('ArrowUp'); // selects "Alignment" submenu option
-  await tablePage.keyboard.press('ArrowRight');
+  await tablePage.keyboard.press('ArrowLeft');
   await tablePage.keyboard.press('ArrowUp'); // selects "Left" submenu option
   await tablePage.screenshot({ path: helpers.screenshotPath() });
 
@@ -52,7 +52,7 @@ test(__filename, async({ goto, tablePage }) => {
   await tablePage.keyboard.press('ArrowUp');
   await tablePage.keyboard.press('ArrowUp');
   await tablePage.keyboard.press('ArrowUp'); // selects "Alignment" submenu option
-  await tablePage.keyboard.press('ArrowRight');
+  await tablePage.keyboard.press('ArrowLeft');
   await tablePage.keyboard.press('ArrowUp'); // selects "Left" submenu option
   await tablePage.screenshot({ path: helpers.screenshotPath() });
 });

--- a/visual-tests/tests/js-only/context-menu/rtl/menus-position.spec.ts
+++ b/visual-tests/tests/js-only/context-menu/rtl/menus-position.spec.ts
@@ -19,7 +19,7 @@ test(__filename, async({ goto, tablePage }) => {
   await tablePage.keyboard.press('ArrowUp');
   await tablePage.keyboard.press('ArrowUp');
   await tablePage.keyboard.press('ArrowUp'); // selects "Alignment" submenu option
-  await tablePage.keyboard.press('ArrowRight'); // selects "Left" submenu option
+  await tablePage.keyboard.press('ArrowLeft'); // selects "Left" submenu option
   await tablePage.screenshot({ path: helpers.screenshotPath() });
 
   await closeTheMenu();
@@ -28,7 +28,7 @@ test(__filename, async({ goto, tablePage }) => {
   await tablePage.keyboard.press('ArrowUp');
   await tablePage.keyboard.press('ArrowUp');
   await tablePage.keyboard.press('ArrowUp'); // selects "Alignment" submenu option
-  await tablePage.keyboard.press('ArrowRight'); // selects "Left" submenu option
+  await tablePage.keyboard.press('ArrowLeft'); // selects "Left" submenu option
   await tablePage.screenshot({ path: helpers.screenshotPath() });
 
   await closeTheMenu();
@@ -37,7 +37,7 @@ test(__filename, async({ goto, tablePage }) => {
   await tablePage.keyboard.press('ArrowUp');
   await tablePage.keyboard.press('ArrowUp');
   await tablePage.keyboard.press('ArrowUp'); // selects "Alignment" submenu option
-  await tablePage.keyboard.press('ArrowRight');
+  await tablePage.keyboard.press('ArrowLeft');
   await tablePage.keyboard.press('ArrowUp'); // selects "Left" submenu option
   await tablePage.screenshot({ path: helpers.screenshotPath() });
 
@@ -47,7 +47,7 @@ test(__filename, async({ goto, tablePage }) => {
   await tablePage.keyboard.press('ArrowUp');
   await tablePage.keyboard.press('ArrowUp');
   await tablePage.keyboard.press('ArrowUp'); // selects "Alignment" submenu option
-  await tablePage.keyboard.press('ArrowRight');
+  await tablePage.keyboard.press('ArrowLeft');
   await tablePage.keyboard.press('ArrowUp'); // selects "Left" submenu option
   await tablePage.screenshot({ path: helpers.screenshotPath() });
 });

--- a/visual-tests/tests/js-only/dropdown-menu/rtl/submenu-position-scrolled-viewport.spec.ts
+++ b/visual-tests/tests/js-only/dropdown-menu/rtl/submenu-position-scrolled-viewport.spec.ts
@@ -22,13 +22,13 @@ test(__filename, async({ goto, tablePage }) => {
 
   await openHeaderDropdownMenu('AM');
   await tablePage.keyboard.press('ArrowUp');
-  await tablePage.keyboard.press('ArrowRight'); // selects "Left" submenu option
+  await tablePage.keyboard.press('ArrowLeft'); // selects "Left" submenu option
   await tablePage.screenshot({ path: helpers.screenshotPath() });
 
   await closeTheMenu();
 
   await openHeaderDropdownMenu('AX');
   await tablePage.keyboard.press('ArrowUp');
-  await tablePage.keyboard.press('ArrowRight'); // selects "Left" submenu option
+  await tablePage.keyboard.press('ArrowLeft'); // selects "Left" submenu option
   await tablePage.screenshot({ path: helpers.screenshotPath() });
 });

--- a/visual-tests/tests/js-only/dropdown-menu/rtl/submenu-position.spec.ts
+++ b/visual-tests/tests/js-only/dropdown-menu/rtl/submenu-position.spec.ts
@@ -17,13 +17,13 @@ test(__filename, async({ goto, tablePage }) => {
 
   await openHeaderDropdownMenu('A');
   await tablePage.keyboard.press('ArrowUp');
-  await tablePage.keyboard.press('ArrowRight'); // selects "Left" submenu option
+  await tablePage.keyboard.press('ArrowLeft'); // selects "Left" submenu option
   await tablePage.screenshot({ path: helpers.screenshotPath() });
 
   await closeTheMenu();
 
   await openHeaderDropdownMenu('L');
   await tablePage.keyboard.press('ArrowUp');
-  await tablePage.keyboard.press('ArrowRight'); // selects "Left" submenu option
+  await tablePage.keyboard.press('ArrowLeft'); // selects "Left" submenu option
   await tablePage.screenshot({ path: helpers.screenshotPath() });
 });


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes a bug where the <kbd>ArrowRight</kbd> and <kbd>ArrowLeft</kbd> keyboard shortcut functionalities were reversed while navigating in the context or dropdown menu when the table was run as RTL layout direction.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and I covered the fix with new tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1558

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
