### PR TITLE
Fix the data source for non-string values in the `name` property

### DIFF
--- a/.changelogs/11565.json
+++ b/.changelogs/11565.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed an issue with data source for non-string values in the `name` property",
+  "type": "fixed",
+  "issueOrPR": 11565,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/helpers/__tests__/object.unit.js
+++ b/handsontable/src/helpers/__tests__/object.unit.js
@@ -396,5 +396,19 @@ describe('Object helper', () => {
       setProperty(testObject2, 'prop1.subprop1', 'value1');
       expect(testObject2.prop1.subprop1).toEqual('value1');
     });
+
+    it('should not set object if name is not a string', () => {
+      const testObject = { prop1: 0 };
+
+      setProperty(
+        testObject,
+        (row, value) => {
+          return row.attr(attr, value);
+        },
+        'value1'
+      );
+
+      expect(testObject).toEqual({ prop1: 0 });
+    });
   });
 });

--- a/handsontable/src/helpers/object.js
+++ b/handsontable/src/helpers/object.js
@@ -285,6 +285,10 @@ export function getProperty(object, name) {
  * @param {*} value Value to be assigned at the provided property.
  */
 export function setProperty(object, name, value) {
+  if (typeof name !== 'string') {
+    return;
+  }
+
   const names = name.split('.');
   let workingObject = object;
 


### PR DESCRIPTION
### Context
This PR includes fix for throwing an error after remove row when data source is defined as a non-string value.

### How has this been tested?
Locally and covered with unit test

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/1878

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
