### PR TITLE
Fix settings object not being updated after new hooks

### DIFF
--- a/.changelogs/11566.json
+++ b/.changelogs/11566.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed settings object not being updated after new hooks",
+  "type": "fixed",
+  "issueOrPR": 11566,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/test/e2e/core/getSettings.spec.js
+++ b/handsontable/test/e2e/core/getSettings.spec.js
@@ -1,0 +1,54 @@
+describe('Core.getSettings', () => {
+  beforeEach(function() {
+    this.$container = $('<div id="testContainer"></div>').appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should be possible to retrieve core-specific as well custom-specific setting and hooks', () => {
+    const afterChanges = () => {};
+
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+      customOption: 'customValue',
+      rowHeaders: true,
+      colHeaders: false,
+      afterChanges,
+    });
+
+    expect(getSettings().customOption).toBe('customValue');
+    expect(getSettings().rowHeaders).toBe(true);
+    expect(getSettings().colHeaders).toBe(false);
+    expect(getSettings().afterChanges).toBe(afterChanges);
+  });
+
+  it('should reflect the new changes passed to `updateSettings` method', () => {
+    const afterChanges = () => {};
+    const afterChangesMod = () => {};
+
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+      customOption: 'customValue',
+      rowHeaders: true,
+      colHeaders: false,
+      afterChanges,
+    });
+
+    updateSettings({
+      customOption: 'updatedValue',
+      rowHeaders: false,
+      colHeaders: true,
+      afterChanges: afterChangesMod,
+    });
+
+    expect(getSettings().customOption).toBe('updatedValue');
+    expect(getSettings().rowHeaders).toBe(false);
+    expect(getSettings().colHeaders).toBe(true);
+    expect(getSettings().afterChanges).toBe(afterChangesMod);
+  });
+});


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes a bug where the settings object (results of the `getSettings` method) was not updated with new hooks added by the `updateSetting` method. The reason the bug occurred was that there were two problems
* On initialization, hooks were stored in the wrong meta layer (`globalMeta`). The correct layer for hooks is the `tableMeta` layer;
* When updating hooks, they were not stored at all - no meta was updated.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and I covered the fix with new tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/1837

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
