### PR TITLE
Fix docs `Cell renderer` guide text

### DIFF
--- a/docs/content/guides/cell-functions/cell-renderer/cell-renderer.md
+++ b/docs/content/guides/cell-functions/cell-renderer/cell-renderer.md
@@ -232,7 +232,7 @@ That's better.
 
 :::
 
-The final touch is to using the registered aliases, so that users can easily refer to it without the need to now the actual renderer function is.
+The final touch is to use registered aliases. That way users can easily refer to an alias without the need to know the name of the function.
 
 To sum up, a well prepared renderer function should look like this:
 


### PR DESCRIPTION
### Context
This PR includes fix for grammar mistake in the `Cell renderer` guide.

### How has this been tested?
Locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2397

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

[skip changelog]
