### PR TITLE
Update docs logo link to handsontable main page

### DIFF
--- a/docs/.vuepress/theme/components/Navbar.vue
+++ b/docs/.vuepress/theme/components/Navbar.vue
@@ -1,13 +1,13 @@
 <template>
   <header class="navbar">
     <div class="navbar-wrapper">
-      <RouterLink
-          :to="frameworkUrlPrefix"
-          class="home-link"
-          aria-label="Docs Homepage Link"
+      <a
+        href="/"
+        class="home-link"
+        aria-label="Handsontable Main Page"
       >
         <Logo />
-      </RouterLink>
+    </a>
 
       <div class="top-bar">
         <div class="top-bar_left">
@@ -83,9 +83,6 @@ export default {
     },
     isAlgoliaSearch() {
       return this.algolia && this.algolia.apiKey && this.algolia.indexName;
-    },
-    frameworkUrlPrefix() {
-      return `/${this.$page.currentFramework}${this.$page.frameworkSuffix}/`;
     }
   },
   methods: {


### PR DESCRIPTION
### Context
This PR updates the docs logo link to direct users to the Handsontable main page.

### How has this been tested?
Locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2425

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

[skip changelog]
