### PR TITLE
Fix `allowInvalid` (both `true` and `false`) for the Dropdown Editor.

### DIFF
--- a/.changelogs/11587.json
+++ b/.changelogs/11587.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed the `allowInvalid` option (both `true` and `false`) for the Dropdown Editor. ",
+  "type": "fixed",
+  "issueOrPR": 11587,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/editors/autocompleteEditor/__tests__/autocompleteEditor.spec.js
+++ b/handsontable/src/editors/autocompleteEditor/__tests__/autocompleteEditor.spec.js
@@ -2562,8 +2562,7 @@ describe('AutocompleteEditor', () => {
       expect(autocompleteList.find('td:eq(1)').html()).toEqual('Female');
     });
 
-    // TODO: Test added/refactored by Piotr should be checked.
-    xit('should allow any value if filter === false and allowInvalid === true', async() => {
+    it('should allow any value if filter === false and allowInvalid === true', async() => {
       spyOn(Handsontable.editors.AutocompleteEditor.prototype, 'queryChoices').and.callThrough();
       const queryChoices = Handsontable.editors.AutocompleteEditor.prototype.queryChoices;
 
@@ -2586,14 +2585,14 @@ describe('AutocompleteEditor', () => {
 
       keyDownUp('f');
 
-      await sleep(200);
+      await sleep(10);
 
       queryChoices.calls.reset();
       editorInput.val('foobar');
 
       keyDownUp('r');
 
-      await sleep(200);
+      await sleep(10);
 
       keyDownUp('enter');
 

--- a/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
+++ b/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
@@ -294,7 +294,9 @@ export class AutocompleteEditor extends HandsontableEditor {
     const orderByRelevanceLength = Array.isArray(orderByRelevance) ? orderByRelevance.length : 0;
 
     if (filterSetting === false) {
-      highlightIndex = orderByRelevanceLength > 0 ? orderByRelevance[0] : 0;
+      if (orderByRelevanceLength) {
+        highlightIndex = orderByRelevance[0];
+      }
 
     } else {
       const sorted = [];


### PR DESCRIPTION
### Context
This PR:

- Revert a change done in #11314 that broke the dropdown editor's behavior. I don't think it breaks the initial fix, as all the test cases implemented in it still pass.
- Un-xit a test that checks the broken scenario.

### How has this been tested?
Tested locally + uncommented a preexisting test case.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#2394

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
