### PR TITLE
Prevent the warning from being displayed when using Undo and Redo items from the Context Menu.

### DIFF
--- a/.changelogs/11588.json
+++ b/.changelogs/11588.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed a problem with a deprecation warnings being thrown when using Context Menu's Undo and Redo items.",
+  "type": "fixed",
+  "issueOrPR": 11588,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/contextMenu/__tests__/predefinedItems/redo.spec.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/predefinedItems/redo.spec.js
@@ -1,0 +1,40 @@
+describe('ContextMenu', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  describe('Redo', () => {
+    it('should redo the last action using the Context Menu option', () => {
+      handsontable({
+        data: [
+          ['']
+        ],
+        contextMenu: true
+      });
+
+      setDataAtCell(0, 0, 'test');
+
+      expect(getDataAtCell(0, 0)).toEqual('test');
+
+      getPlugin('undoRedo').undo();
+
+      contextMenu(getCell(0, 0, true));
+
+      const warnSpy = spyOn(console, 'warn');
+
+      selectContextMenuOption('Redo');
+
+      expect(getDataAtCell(0, 0)).toEqual('test');
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/handsontable/src/plugins/contextMenu/__tests__/predefinedItems/undo.spec.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/predefinedItems/undo.spec.js
@@ -1,0 +1,38 @@
+describe('ContextMenu', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  describe('Undo', () => {
+    it('should undo the last action using the Context Menu option', () => {
+      handsontable({
+        data: [
+          ['']
+        ],
+        contextMenu: true
+      });
+
+      setDataAtCell(0, 0, 'test');
+
+      expect(getDataAtCell(0, 0)).toEqual('test');
+
+      contextMenu(getCell(0, 0, true));
+
+      const warnSpy = spyOn(console, 'warn');
+
+      selectContextMenuOption('Undo');
+
+      expect(getDataAtCell(0, 0)).toEqual('');
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/handsontable/src/plugins/contextMenu/predefinedItems/redo.js
+++ b/handsontable/src/plugins/contextMenu/predefinedItems/redo.js
@@ -12,12 +12,12 @@ export default function redoItem() {
       return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_REDO);
     },
     callback() {
-      this.redo();
+      this.getPlugin('undoRedo').redo();
     },
     hidden() {
-      const undoRedo = this.getPlugin('undoRedo');
+      const undoRedoPlugin = this.getPlugin('undoRedo');
 
-      return !undoRedo || !undoRedo.isEnabled();
+      return !undoRedoPlugin || !undoRedoPlugin.isEnabled();
     },
     disabled() {
       return !this.getPlugin('undoRedo').isRedoAvailable();

--- a/handsontable/src/plugins/contextMenu/predefinedItems/undo.js
+++ b/handsontable/src/plugins/contextMenu/predefinedItems/undo.js
@@ -12,12 +12,12 @@ export default function undoItem() {
       return this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_UNDO);
     },
     callback() {
-      this.undo();
+      this.getPlugin('undoRedo').undo();
     },
     hidden() {
-      const undoRedo = this.getPlugin('undoRedo');
+      const undoRedoPlugin = this.getPlugin('undoRedo');
 
-      return !undoRedo || !undoRedo.isEnabled();
+      return !undoRedoPlugin || !undoRedoPlugin.isEnabled();
     },
     disabled() {
       return !this.getPlugin('undoRedo').isUndoAvailable();


### PR DESCRIPTION
### Context
This PR:

- Replaces the core calls with the UndoRedo plugin's methods in the Context Menu's predefined Undo and Redo items.
- Adds test cases.

### How has this been tested?
Tested manually + added test cases.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#2414

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
