### PR TITLE
Fix an error being thrown on autocomplete-typed cells with a long list of choices rendered in a small container.

### DIFF
--- a/.changelogs/11589.json
+++ b/.changelogs/11589.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed an error being thrown when editing a Autocomplete-typed cells with a long list of choices rendered in a small container.",
+  "type": "fixed",
+  "issueOrPR": 11589,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/editors/autocompleteEditor/__tests__/a11y/attributes.spec.js
+++ b/handsontable/src/editors/autocompleteEditor/__tests__/a11y/attributes.spec.js
@@ -78,6 +78,35 @@ describe('a11y DOM attributes (ARIA tags)', () => {
     });
   });
 
+  it('should add a correct set of aria tags to the choice dropdown element (choice list being scrolled to the best choice)', async() => {
+    const hot = handsontable({
+      data: [['11'], [], []],
+      type: 'dropdown',
+      cells: () => {
+        return { type: 'dropdown', source: Array.from({ length: 100 }, (_, i) => i + 1) };
+      },
+      width: 200,
+      height: 'auto',
+    });
+
+    selectCell(0, 0);
+
+    keyDownUp('enter');
+
+    await sleep(50);
+
+    const editor = getActiveEditor();
+    const editorHot = editor.htEditor;
+    const choiceDropdownRoot = editorHot.rootElement;
+
+    expect(choiceDropdownRoot.getAttribute('role')).toEqual('listbox');
+    expect(choiceDropdownRoot.getAttribute('aria-live')).toEqual('polite');
+    expect(choiceDropdownRoot.getAttribute('aria-relevant')).toEqual('text');
+    expect(choiceDropdownRoot.getAttribute('id')).toEqual(`${hot.guid.slice(0, 9)}-listbox-0-0`);
+
+    expect(editorHot.getCell(...editorHot.getSelectedLast()).getAttribute('aria-selected')).toEqual('true');
+  });
+
   it('should should not add `aria-setsize` and `aria-posinset` if the source is a function`', async() => {
     const hot = handsontable({
       columns: [

--- a/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
+++ b/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
@@ -187,13 +187,27 @@ export class AutocompleteEditor extends HandsontableEditor {
       },
       afterSelectionEnd: (startRow, startCol) => {
         if (rootInstanceAriaTagsEnabled) {
+          const setA11yAttributes = (TD) => {
+            setAttribute(TD, [
+              A11Y_SELECTED(),
+            ]);
+
+            setAttribute(this.TEXTAREA, ...A11Y_ACTIVEDESCENDANT(TD.id));
+          };
           const TD = this.htEditor.getCell(startRow, startCol, true);
 
-          setAttribute(TD, [
-            A11Y_SELECTED(),
-          ]);
+          if (TD !== null) {
+            setA11yAttributes(TD);
 
-          setAttribute(this.TEXTAREA, ...A11Y_ACTIVEDESCENDANT(TD.id));
+          } else {
+            // If TD is null, it means that the cell is not (yet) in the viewport.
+            // Moving the logic to after it's been scrolled to the requested cell.
+            this.htEditor.addHookOnce('afterScrollVertically', () => {
+              const renderedTD = this.htEditor.getCell(startRow, startCol, true);
+
+              setA11yAttributes(renderedTD);
+            });
+          }
         }
       },
     });


### PR DESCRIPTION
### Context
This PR:
- Covers a scenario where the Autocomplete's choice list has to select an entry outside of the choice list's viewport. I was able to reproduce this problem only with `height` set to `auto` on the main table.
- Adds a test case for that scenario.

This should fix the second case from the original issue: https://github.com/handsontable/dev-handsontable/issues/2430#issuecomment-2804836585.

The first case (a gap in the choice list) seems to already be fixed on the current `develop`: https://jsfiddle.net/js_ziggle/1L54t2ho/.

### How has this been tested?
Tested manually + added a test case.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#2430

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
