### PR TITLE
Improve Handsontable editor types positioning

### DIFF
--- a/.changelogs/11593.json
+++ b/.changelogs/11593.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Improve Handsontable editor types positioning",
+  "type": "added",
+  "issueOrPR": 11593,
+  "breaking": false,
+  "framework": "none"
+}

--- a/examples/next/visual-tests/js/demo/src/demos/editors/index.js
+++ b/examples/next/visual-tests/js/demo/src/demos/editors/index.js
@@ -1,0 +1,59 @@
+import Handsontable from "handsontable/base";
+import { registerAllModules } from "handsontable/registry";
+import { getDirectionFromURL, getThemeNameFromURL, getFromURL } from "../../utils";
+import { registerLanguageDictionary, arAR } from "handsontable/i18n";
+
+registerAllModules();
+registerLanguageDictionary(arAR);
+
+const root = document.getElementById('root');
+const example = document.createElement('div');
+
+root.appendChild(example);
+
+export function init() {
+  const sizeSettings = {};
+
+  if (getFromURL('hasDefinedSize')) {
+    sizeSettings.height = 700;
+  }
+
+  const cellType = getFromURL('cellType', 'text');
+  const editorSettings = {
+    type: cellType,
+  };
+
+  if (cellType === 'handsontable') {
+    Object.assign(editorSettings, {
+      handsontable: {
+        colHeaders: ['Marque', 'Country', 'Parent company'],
+        autoColumnSize: true,
+        data: [
+          {name: 'BMW', country: 'Germany', owner: 'Bayerische Motoren Werke AG'},
+          {name: 'Chrysler', country: 'USA', owner: 'Chrysler Group LLC'},
+          {name: 'Nissan', country: 'Japan', owner: 'Nissan Motor Company Ltd'},
+          {name: 'Suzuki', country: 'Japan', owner: 'Suzuki Motor Corporation'},
+          {name: 'Toyota', country: 'Japan', owner: 'Toyota Motor Corporation'},
+          {name: 'Volvo', country: 'Sweden', owner: 'Zhejiang Geely Holding Group'},
+        ],
+      },
+    });
+  }
+
+  new Handsontable(example, {
+    data: Handsontable.helper.createEmptySpreadsheetData(100, 50),
+    layoutDirection: getDirectionFromURL(),
+    language: getDirectionFromURL() === "rtl" ? arAR.languageCode : "en-US",
+    themeName: getThemeNameFromURL(),
+    colWidths: 100,
+    rowHeaders: true,
+    colHeaders: true,
+    navigableHeaders: true,
+    contextMenu: true,
+    licenseKey: "non-commercial-and-evaluation",
+    ...editorSettings,
+    ...sizeSettings,
+  });
+
+  console.log(`Handsontable: v${Handsontable.version} (${Handsontable.buildDate})`);
+}

--- a/examples/next/visual-tests/js/demo/src/index.js
+++ b/examples/next/visual-tests/js/demo/src/index.js
@@ -16,6 +16,7 @@ import { init as initContextMenuDemo } from "./demos/contextMenu";
 import { init as initDropdownMenuDemo } from "./demos/dropdownMenu";
 import { init as initLargeDatasetDemo } from './demos/largeDataset';
 import { init as initWebComponentDemo } from './demos/webComponent';
+import { init as initEditorsDemo } from './demos/editors';
 
 // Function to dynamically load CSS
 function loadCSS(href) {
@@ -215,6 +216,15 @@ router
         loadThemeCSS(),
       ]).then(() => {
         initWebComponentDemo();
+      });
+    },
+    '/editors-demo': function () {
+      removeCSS();
+
+      Promise.all([
+        loadThemeCSS(),
+      ]).then(() => {
+        initEditorsDemo();
       });
     },
   })

--- a/examples/next/visual-tests/js/demo/src/utils.js
+++ b/examples/next/visual-tests/js/demo/src/utils.js
@@ -28,16 +28,18 @@ function generateArabicData() {
   ]);
 }
 
-export function getDirectionFromURL() {
-  const urlParams = new URLSearchParams(location.search);
+export function getFromURL(paramName, defaultValue) {
+  return new URLSearchParams(location.search).get(paramName) ?? defaultValue;
+}
 
-  return urlParams.get("direction") ?? "ltr";
+export function getDirectionFromURL() {
+  return getFromURL("direction", "ltr");
 }
 
 export function getThemeNameFromURL() {
-  const urlParams = new URLSearchParams(location.search);
+  const theme = getFromURL("theme");
 
-  return urlParams.get("theme") ? `ht-theme-${urlParams.get("theme")}` : undefined;
+  return theme ? `ht-theme-${theme}` : undefined;
 }
 
 export function generateExampleData() {

--- a/handsontable/src/__tests__/core/methods.types.ts
+++ b/handsontable/src/__tests__/core/methods.types.ts
@@ -113,6 +113,8 @@ hot.getSourceDataAtCell(123, 123) === '';
 hot.getSourceDataAtCol(123)[0] === '';
 hot.getSourceDataAtRow(123) as any[];
 hot.getTranslatedPhrase('foo', 123)!.toLowerCase();
+const tableWidth: number = hot.getTableWidth();
+const tableHeight: number = hot.getTableHeight();
 hot.getValue() === '';
 
 const hasColHeaders: boolean = hot.hasColHeaders();

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -5034,6 +5034,30 @@ export default function Core(rootElement, userSettings, rootInstanceSymbol = fal
   };
 
   /**
+   * Gets the table's root container element height.
+   *
+   * @memberof Core#
+   * @function getTableHeight
+   * @since 16.0.0
+   * @returns {number}
+   */
+  this.getTableHeight = () => {
+    return this.rootElement.offsetHeight;
+  };
+
+  /**
+   * Gets the table's root container element width.
+   *
+   * @memberof Core#
+   * @function getTableWidth
+   * @since 16.0.0
+   * @returns {number}
+   */
+  this.getTableWidth = () => {
+    return this.rootElement.offsetWidth;
+  };
+
+  /**
    * Sets timeout. Purpose of this method is to clear all known timeouts when `destroy` method is called.
    *
    * @param {number|Function} handle Handler returned from setTimeout or function to execute (it will be automatically wraped

--- a/handsontable/src/editors/__tests__/editors.types.ts
+++ b/handsontable/src/editors/__tests__/editors.types.ts
@@ -32,8 +32,6 @@ autocomplete.saveValue();
 autocomplete.setValue('test');
 autocomplete.setValue();
 
-autocomplete.flipDropdown(100);
-
 const checkbox = new Handsontable.editors.CheckboxEditor(hot);
 
 checkbox.beginEditing('test');
@@ -124,9 +122,6 @@ dropdown.saveValue('test', true);
 dropdown.saveValue();
 dropdown.setValue('test');
 dropdown.setValue();
-
-dropdown.flipDropdownIfNeeded();
-dropdown.updateChoicesList([]);
 
 const hansontable = new Handsontable.editors.HandsontableEditor(hot);
 

--- a/handsontable/src/editors/autocompleteEditor/__tests__/autocompleteEditor.spec.js
+++ b/handsontable/src/editors/autocompleteEditor/__tests__/autocompleteEditor.spec.js
@@ -1327,7 +1327,7 @@ describe('AutocompleteEditor', () => {
 
       expect(container.offset()).forThemes(({ classic, main, horizon }) => {
         classic.toEqual({ top: 365, left: 0 });
-        main.toEqual({ top: 289, left: 0 });
+        main.toEqual({ top: 287, left: 0 });
         horizon.toEqual({ top: 184, left: 0 });
       });
     });
@@ -1360,7 +1360,7 @@ describe('AutocompleteEditor', () => {
 
       expect(container.offset()).forThemes(({ classic, main, horizon }) => {
         classic.toEqual({ top: 480, left: 0 });
-        main.toEqual({ top: 434, left: 0 });
+        main.toEqual({ top: 432, left: 0 });
         horizon.toEqual({ top: 369, left: 0 });
       });
 
@@ -1402,7 +1402,7 @@ describe('AutocompleteEditor', () => {
 
       expect(container.offset()).forThemes(({ classic, main, horizon }) => {
         classic.toEqual({ top: 2090, left: 0 });
-        main.toEqual({ top: 2638, left: 0 });
+        main.toEqual({ top: 2636, left: 0 });
         horizon.toEqual({ top: 3366, left: 0 });
       });
 

--- a/handsontable/src/editors/autocompleteEditor/__tests__/autocompleteEditor.types.ts
+++ b/handsontable/src/editors/autocompleteEditor/__tests__/autocompleteEditor.types.ts
@@ -13,36 +13,8 @@ editor.finishEditing();
 const value: string = editor.getValue();
 
 // editor specific ones
-{
-  const result: {
-    isFlipped: boolean;
-    spaceAbove: number;
-    spaceBelow: number;
-  } = editor.flipDropdownVerticallyIfNeeded();
-}
-editor.flipDropdownVertically();
-editor.unflipDropdownVertically();
-{
-  const result: {
-    isFlipped: boolean;
-    spaceInlineStart: number;
-    spaceInlineEnd: number;
-  } = editor.flipDropdownHorizontallyIfNeeded();
-}
-editor.flipDropdownHorizontally();
-editor.unflipDropdownHorizontally();
 editor.queryChoices('test');
-editor.updateChoicesList(['a', 'b', 'c']);
-editor.limitDropdownIfNeeded(100);
-editor.flipDropdown(100);
-editor.unflipDropdown();
-editor.updateDropdownDimensions();
-editor.setDropdownHeight(100);
-editor.highlightBestMatchingChoice(1);
-editor.stripValueIfNeeded('test');
-editor.stripValuesIfNeeded(['test1', 'test2']);
 
-const isFlipped: boolean = editor.flipDropdownIfNeeded();
 const dropdownHeight: number = editor.getDropdownHeight();
 const dropdownWidth: number = editor.getDropdownWidth();
 const targetDropdownWidth: number = editor.getTargetDropdownWidth();

--- a/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
+++ b/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
@@ -410,7 +410,7 @@ export class AutocompleteEditor extends HandsontableEditor {
   #fixDropdownWidth() {
     if (this.htEditor.view.hasVerticalScroll()) {
       this.htEditor.updateSettings({
-        width: this.getWidth() + getScrollbarWidth(this.hot.rootDocument),
+        width: this.getTargetEditorWidth() + getScrollbarWidth(this.hot.rootDocument),
       });
     }
   }
@@ -422,8 +422,8 @@ export class AutocompleteEditor extends HandsontableEditor {
    */
   updateDropdownDimensions() {
     this.htEditor.updateSettings({
-      width: this.calculateEditorWidth(),
-      height: this.calculateEditorHeight(),
+      width: this.getTargetEditorWidth(),
+      height: this.getTargetEditorHeight(),
     });
 
     this.#fixDropdownWidth();
@@ -465,26 +465,45 @@ export class AutocompleteEditor extends HandsontableEditor {
    * @private
    * @returns {number}
    */
-  calculateEditorHeight() {
+  getTargetEditorHeight() {
+    let borderVerticalCompensation = 0;
+
+    if (!this.hot.getCurrentThemeName()) {
+      const containerStyle = this.hot.rootWindow.getComputedStyle(this.htContainer.querySelector('.htCore'));
+
+      borderVerticalCompensation = parseInt(containerStyle.borderTopWidth, 10) +
+        parseInt(containerStyle.borderBottomWidth, 10);
+    }
+
     const maxItems = Math.min(this.cellProperties.visibleRows, this.strippedChoices.length);
     const height = Array.from({ length: maxItems }, (_, i) => i)
       .reduce((totalHeight, index) => {
+        // for the first row, we need to add 1px (border-top compensation)
         const rowHeight = this.htEditor.view.getDefaultRowHeight() + (index === 0 ? 1 : 0);
 
         return totalHeight + rowHeight;
       }, 0);
 
-    return height;
+    return height + borderVerticalCompensation;
   }
 
   /**
-   * Calculates and return the internal Handsontable's width.
+   * Calculates the proposed editor width that should be set once the editor is opened.
+   * The method may be overwritten in the child class to provide a custom logic.
    *
-   * @private
    * @returns {number}
    */
-  calculateEditorWidth() {
-    return this.htEditor.getColWidth(0);
+  getTargetEditorWidth() {
+    let borderHorizontalCompensation = 0;
+
+    if (!this.hot.getCurrentThemeName()) {
+      const containerStyle = this.hot.rootWindow.getComputedStyle(this.htContainer.querySelector('.htCore'));
+
+      borderHorizontalCompensation = parseInt(containerStyle.borderInlineStartWidth, 10) +
+        parseInt(containerStyle.borderInlineEndWidth, 10);
+    }
+
+    return this.htEditor.getColWidth(0) + borderHorizontalCompensation;
   }
 
   /**

--- a/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
+++ b/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
@@ -1,5 +1,6 @@
 import { HandsontableEditor } from '../handsontableEditor';
 import { arrayMap, pivot } from '../../helpers/array';
+import { warn } from '../../helpers/console';
 import {
   addClass,
   getCaretPosition,
@@ -260,7 +261,6 @@ export class AutocompleteEditor extends HandsontableEditor {
   /**
    * Prepares choices list based on applied argument.
    *
-   * @private
    * @param {string} query The query.
    */
   queryChoices(query) {
@@ -343,7 +343,7 @@ export class AutocompleteEditor extends HandsontableEditor {
 
     if (choices.length > 0) {
       this.updateDropdownDimensions();
-      this.flipEditorVerticallyIfNeeded();
+      this.flipDropdownVerticallyIfNeeded();
 
       if (this.cellProperties.strict === true) {
         this.highlightBestMatchingChoice(highlightIndex);
@@ -358,11 +358,46 @@ export class AutocompleteEditor extends HandsontableEditor {
   /**
    * Checks where is enough place to open editor.
    *
+   * @deprecated
+   * @private
+   * @returns {boolean}
+   */
+  flipDropdownIfNeeded() {
+    warn('The "flipDropdownIfNeeded" method is deprecated. Use "flipDropdownVerticallyIfNeeded" instead.');
+
+    return this.flipDropdownVerticallyIfNeeded().isFlipped;
+  }
+
+  /**
+   * Configures editor to open it at the top.
+   *
+   * @deprecated
+   * @private
+   */
+  flipDropdown() {
+    warn('The "flipDropdown" method is deprecated. Use "flipDropdownVertically" instead.');
+    this.flipDropdownVertically();
+  }
+
+  /**
+   * Configures editor to open it at the bottom.
+   *
+   * @deprecated
+   * @private
+   */
+  unflipDropdown() {
+    warn('The "unflipDropdown" method is deprecated. Use "unflipDropdownVertically" instead.');
+    this.unflipDropdownVertically();
+  }
+
+  /**
+   * Calculates the space above and below the editor and flips it vertically if needed.
+   *
    * @private
    * @returns {{ isFlipped: boolean, spaceAbove: number, spaceBelow: number}}
    */
-  flipEditorVerticallyIfNeeded() {
-    const result = super.flipEditorVerticallyIfNeeded();
+  flipDropdownVerticallyIfNeeded() {
+    const result = super.flipDropdownVerticallyIfNeeded();
     const {
       isFlipped,
       spaceAbove,
@@ -460,18 +495,18 @@ export class AutocompleteEditor extends HandsontableEditor {
   }
 
   /**
-   * Calculates and return the internal Handsontable's height.
+   * Calculates the proposed/target editor height that should be set once the editor is opened.
+   * The method may be overwritten in the child class to provide a custom size logic.
    *
-   * @private
    * @returns {number}
    */
   getTargetEditorHeight() {
-    let borderVerticalCompensation = 0;
+    let borderCompensation = 0;
 
     if (!this.hot.getCurrentThemeName()) {
       const containerStyle = this.hot.rootWindow.getComputedStyle(this.htContainer.querySelector('.htCore'));
 
-      borderVerticalCompensation = parseInt(containerStyle.borderTopWidth, 10) +
+      borderCompensation = parseInt(containerStyle.borderTopWidth, 10) +
         parseInt(containerStyle.borderBottomWidth, 10);
     }
 
@@ -484,26 +519,26 @@ export class AutocompleteEditor extends HandsontableEditor {
         return totalHeight + rowHeight;
       }, 0);
 
-    return height + borderVerticalCompensation;
+    return height + borderCompensation;
   }
 
   /**
-   * Calculates the proposed editor width that should be set once the editor is opened.
-   * The method may be overwritten in the child class to provide a custom logic.
+   * Calculates the proposed/target editor width that should be set once the editor is opened.
+   * The method may be overwritten in the child class to provide a custom size logic.
    *
    * @returns {number}
    */
   getTargetEditorWidth() {
-    let borderHorizontalCompensation = 0;
+    let borderCompensation = 0;
 
     if (!this.hot.getCurrentThemeName()) {
       const containerStyle = this.hot.rootWindow.getComputedStyle(this.htContainer.querySelector('.htCore'));
 
-      borderHorizontalCompensation = parseInt(containerStyle.borderInlineStartWidth, 10) +
+      borderCompensation = parseInt(containerStyle.borderInlineStartWidth, 10) +
         parseInt(containerStyle.borderInlineEndWidth, 10);
     }
 
-    return this.htEditor.getColWidth(0) + borderHorizontalCompensation;
+    return this.htEditor.getColWidth(0) + borderCompensation;
   }
 
   /**
@@ -636,7 +671,6 @@ export class AutocompleteEditor extends HandsontableEditor {
     }
 
     choicesRelevance.sort((a, b) => {
-
       if (b.index === -1) {
         return -1;
       }

--- a/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
+++ b/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
@@ -381,7 +381,7 @@ export class AutocompleteEditor extends HandsontableEditor {
    * @param {number} spaceAvailable The free space as height defined in px available for dropdown list.
    */
   limitDropdownIfNeeded(spaceAvailable) {
-    const dropdownHeight = this.getHeight();
+    const dropdownHeight = this.getDropdownHeight();
 
     if (dropdownHeight > spaceAvailable) {
       let tempHeight = 0;

--- a/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
+++ b/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
@@ -1,6 +1,5 @@
 import { HandsontableEditor } from '../handsontableEditor';
 import { arrayMap, pivot } from '../../helpers/array';
-import { warn } from '../../helpers/console';
 import {
   addClass,
   getCaretPosition,
@@ -353,41 +352,6 @@ export class AutocompleteEditor extends HandsontableEditor {
     this.hot.listen();
 
     setCaretPosition(this.TEXTAREA, pos, (pos === endPos ? undefined : endPos));
-  }
-
-  /**
-   * Checks where is enough place to open editor.
-   *
-   * @deprecated
-   * @private
-   * @returns {boolean}
-   */
-  flipDropdownIfNeeded() {
-    warn('The "flipDropdownIfNeeded" method is deprecated. Use "flipDropdownVerticallyIfNeeded" instead.');
-
-    return this.flipDropdownVerticallyIfNeeded().isFlipped;
-  }
-
-  /**
-   * Configures editor to open it at the top.
-   *
-   * @deprecated
-   * @private
-   */
-  flipDropdown() {
-    warn('The "flipDropdown" method is deprecated. Use "flipDropdownVertically" instead.');
-    this.flipDropdownVertically();
-  }
-
-  /**
-   * Configures editor to open it at the bottom.
-   *
-   * @deprecated
-   * @private
-   */
-  unflipDropdown() {
-    warn('The "unflipDropdown" method is deprecated. Use "unflipDropdownVertically" instead.');
-    this.unflipDropdownVertically();
   }
 
   /**

--- a/handsontable/src/editors/dropdownEditor/__tests__/dropdownEditor.types.ts
+++ b/handsontable/src/editors/dropdownEditor/__tests__/dropdownEditor.types.ts
@@ -2,7 +2,7 @@ import Handsontable from 'handsontable';
 
 const element = document.createElement('div');
 const hot = new Handsontable(element, {});
-const editor = new Handsontable.editors.AutocompleteEditor(hot);
+const editor = new Handsontable.editors.DropdownEditor(hot);
 
 // abstract ones
 editor.open();

--- a/handsontable/src/editors/dropdownEditor/__tests__/dropdownEditor.types.ts
+++ b/handsontable/src/editors/dropdownEditor/__tests__/dropdownEditor.types.ts
@@ -13,36 +13,8 @@ editor.finishEditing();
 const value: string = editor.getValue();
 
 // editor specific ones
-{
-  const result: {
-    isFlipped: boolean;
-    spaceAbove: number;
-    spaceBelow: number;
-  } = editor.flipDropdownVerticallyIfNeeded();
-}
-editor.flipDropdownVertically();
-editor.unflipDropdownVertically();
-{
-  const result: {
-    isFlipped: boolean;
-    spaceInlineStart: number;
-    spaceInlineEnd: number;
-  } = editor.flipDropdownHorizontallyIfNeeded();
-}
-editor.flipDropdownHorizontally();
-editor.unflipDropdownHorizontally();
 editor.queryChoices('test');
-editor.updateChoicesList(['a', 'b', 'c']);
-editor.limitDropdownIfNeeded(100);
-editor.flipDropdown(100);
-editor.unflipDropdown();
-editor.updateDropdownDimensions();
-editor.setDropdownHeight(100);
-editor.highlightBestMatchingChoice(1);
-editor.stripValueIfNeeded('test');
-editor.stripValuesIfNeeded(['test1', 'test2']);
 
-const isFlipped: boolean = editor.flipDropdownIfNeeded();
 const dropdownHeight: number = editor.getDropdownHeight();
 const dropdownWidth: number = editor.getDropdownWidth();
 const targetDropdownWidth: number = editor.getTargetDropdownWidth();

--- a/handsontable/src/editors/handsontableEditor/__tests__/handsontableEditor.spec.js
+++ b/handsontable/src/editors/handsontableEditor/__tests__/handsontableEditor.spec.js
@@ -21,6 +21,8 @@ describe('HandsontableEditor', () => {
     ];
   }
 
+  // all other E2E tests are moved to visual tests. See ./visual-tests/tests/js-only/editors/handsontable/
+
   it('should render an editor in specified position at cell 0, 0', async() => {
     handsontable({
       columns: [
@@ -338,26 +340,6 @@ describe('HandsontableEditor', () => {
     await keyDownUp('enter');
 
     expect(spec().$container.find('.handsontableEditor:visible').length).toEqual(1);
-  });
-
-  it('should create an editor directly below the textarea element', async() => {
-    handsontable({
-      columns: [
-        {
-          type: 'handsontable',
-          handsontable: {
-            colHeaders: ['Marque', 'Country', 'Parent company'],
-            data: getManufacturerData()
-          }
-        }
-      ]
-    });
-
-    await selectCell(2, 0);
-    await keyDownUp('enter');
-
-    expect(spec().$container.find('.handsontableEditor')[0].offsetTop)
-      .toEqual(spec().$container.find('.handsontableInput')[0].offsetHeight);
   });
 
   it('should prepare the editor only once per instance', async() => {

--- a/handsontable/src/editors/handsontableEditor/__tests__/handsontableEditor.spec.js
+++ b/handsontable/src/editors/handsontableEditor/__tests__/handsontableEditor.spec.js
@@ -21,8 +21,6 @@ describe('HandsontableEditor', () => {
     ];
   }
 
-  // all other E2E tests are moved to visual tests. See ./visual-tests/tests/js-only/editors/handsontable/
-
   it('should render an editor in specified position at cell 0, 0', async() => {
     handsontable({
       columns: [
@@ -836,12 +834,12 @@ describe('HandsontableEditor', () => {
     const container = getActiveEditor().htContainer;
 
     expect(container.clientWidth).forThemes(({ classic, main, horizon }) => {
-      classic.toBe(290);
+      classic.toBe(288);
       main.toBe(360);
       horizon.toBe(384);
     });
     expect(container.clientHeight).forThemes(({ classic, main, horizon }) => {
-      classic.toBe(168);
+      classic.toBe(166);
       main.toBe(212);
       horizon.toBe(260);
     });
@@ -877,12 +875,12 @@ describe('HandsontableEditor', () => {
     const container = getActiveEditor().htContainer;
 
     expect(container.clientWidth).forThemes(({ classic, main, horizon }) => {
-      classic.toBe(290);
+      classic.toBe(288);
       main.toBe(360);
       horizon.toBe(384);
     });
     expect(container.clientHeight).forThemes(({ classic, main, horizon }) => {
-      classic.toBe(168);
+      classic.toBe(166);
       main.toBe(212);
       horizon.toBe(260);
     });

--- a/handsontable/src/editors/handsontableEditor/__tests__/handsontableEditor.types.ts
+++ b/handsontable/src/editors/handsontableEditor/__tests__/handsontableEditor.types.ts
@@ -13,25 +13,8 @@ editor.finishEditing();
 const value: string = editor.getValue();
 
 // editor specific ones
-{
-  const result: {
-    isFlipped: boolean;
-    spaceAbove: number;
-    spaceBelow: number;
-  } = editor.flipDropdownVerticallyIfNeeded();
-}
-editor.flipDropdownVertically();
-editor.unflipDropdownVertically();
-{
-  const result: {
-    isFlipped: boolean;
-    spaceInlineStart: number;
-    spaceInlineEnd: number;
-  } = editor.flipDropdownHorizontallyIfNeeded();
-}
-editor.flipDropdownHorizontally();
-editor.unflipDropdownHorizontally();
-
+const isFlippedVertically: boolean = editor.isFlippedVertically;
+const isFlippedHorizontally: boolean = editor.isFlippedHorizontally;
 const dropdownHeight: number = editor.getDropdownHeight();
 const dropdownWidth: number = editor.getDropdownWidth();
 const targetDropdownWidth: number = editor.getTargetDropdownWidth();

--- a/handsontable/src/editors/handsontableEditor/__tests__/handsontableEditor.types.ts
+++ b/handsontable/src/editors/handsontableEditor/__tests__/handsontableEditor.types.ts
@@ -2,7 +2,7 @@ import Handsontable from 'handsontable';
 
 const element = document.createElement('div');
 const hot = new Handsontable(element, {});
-const editor = new Handsontable.editors.AutocompleteEditor(hot);
+const editor = new Handsontable.editors.HandsontableEditor(hot);
 
 // abstract ones
 editor.open();
@@ -31,18 +31,7 @@ editor.unflipDropdownVertically();
 }
 editor.flipDropdownHorizontally();
 editor.unflipDropdownHorizontally();
-editor.queryChoices('test');
-editor.updateChoicesList(['a', 'b', 'c']);
-editor.limitDropdownIfNeeded(100);
-editor.flipDropdown(100);
-editor.unflipDropdown();
-editor.updateDropdownDimensions();
-editor.setDropdownHeight(100);
-editor.highlightBestMatchingChoice(1);
-editor.stripValueIfNeeded('test');
-editor.stripValuesIfNeeded(['test1', 'test2']);
 
-const isFlipped: boolean = editor.flipDropdownIfNeeded();
 const dropdownHeight: number = editor.getDropdownHeight();
 const dropdownWidth: number = editor.getDropdownWidth();
 const targetDropdownWidth: number = editor.getTargetDropdownWidth();

--- a/handsontable/src/editors/handsontableEditor/__tests__/positioning.spec.js
+++ b/handsontable/src/editors/handsontableEditor/__tests__/positioning.spec.js
@@ -1,0 +1,154 @@
+describe('HandsontableEditor positioning', () => {
+  beforeEach(function() {
+    this.$container = $('<div id="testContainer"></div>').appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  function createEditorSettings() {
+    return {
+      type: 'handsontable',
+      handsontable: {
+        colHeaders: ['Marque', 'Country', 'Parent company'],
+        colWidths: [85, 85, 220],
+        data: [
+          { name: 'BMW', country: 'Germany', owner: 'Bayerische Motoren Werke AG' },
+          { name: 'Chrysler', country: 'USA', owner: 'Chrysler Group LLC' },
+          { name: 'Nissan', country: 'Japan', owner: 'Nissan Motor Company Ltd' },
+          { name: 'Suzuki', country: 'Japan', owner: 'Suzuki Motor Corporation' },
+          { name: 'Toyota', country: 'Japan', owner: 'Toyota Motor Corporation' },
+          { name: 'Volvo', country: 'Sweden', owner: 'Zhejiang Geely Holding Group' }
+        ],
+      }
+    };
+  }
+
+  // all other E2E tests are moved to visual tests. See ./visual-tests/tests/js-only/editors/handsontable/
+
+  it('should render the editors dropdown on the left edited cell when there is no space left on the right', async() => {
+    handsontable({
+      data: createSpreadsheetData(25, 25),
+      colWidths: 80,
+      rowHeights: 38,
+      width: 800,
+      height: 300,
+      ...createEditorSettings(),
+    });
+
+    const scrollEdgePositions = {
+      horizon: 149,
+      main: 151,
+      classic: 151,
+    };
+
+    const scrollPositionBase = scrollEdgePositions[spec().loadedTheme];
+
+    if (scrollPositionBase === undefined) {
+      throw new Error('Missing scroll position base for the current theme');
+    }
+
+    // scroll the viewport to the point where the editor may be rendered on the right (there is enough space)
+    await scrollViewportHorizontally(scrollPositionBase);
+
+    await selectCell(1, 7);
+    await keyDownUp('enter');
+
+    const relativeRect = getCell(2, 7).getBoundingClientRect();
+
+    {
+      const containerRect = getActiveEditor().htContainer.getBoundingClientRect();
+
+      expect({
+        top: containerRect.top,
+        left: containerRect.left,
+      }).toEqual({
+        top: relativeRect.top,
+        left: relativeRect.left - 1,
+      });
+    }
+
+    await keyDownUp('escape');
+    // scroll the viewport to the point where the editor may not be rendered on the right (there is not enough space)
+    // so it should be rendered on the left
+    await scrollViewportHorizontally(scrollPositionBase - 1);
+    await keyDownUp('enter');
+
+    {
+      const containerRect = getActiveEditor().htContainer.getBoundingClientRect();
+
+      expect({
+        top: containerRect.top,
+        right: containerRect.right,
+      }).toEqual({
+        top: relativeRect.top,
+        right: relativeRect.right + 1,
+      });
+    }
+  });
+
+  it('should render the editors dropdown above the cell when there is no space left below', async() => {
+    handsontable({
+      data: createSpreadsheetData(25, 25),
+      colWidths: 80,
+      rowHeights: 38,
+      width: 600,
+      height: 600,
+      ...createEditorSettings(),
+    });
+
+    const scrollEdgePositions = {
+      horizon: 116,
+      main: 70,
+      classic: 25,
+    };
+
+    const scrollPositionBase = scrollEdgePositions[spec().loadedTheme];
+
+    if (scrollPositionBase === undefined) {
+      throw new Error('Missing scroll position base for the current theme');
+    }
+
+    // scroll the viewport to the point where the editor may be rendered on the bottom (there is enough space)
+    await scrollViewportVertically(scrollPositionBase);
+
+    await selectCell(11, 1);
+    await keyDownUp('enter');
+
+    {
+      const relativeRect = getCell(12, 1).getBoundingClientRect();
+      const containerRect = getActiveEditor().htContainer.getBoundingClientRect();
+
+      expect({
+        top: containerRect.top,
+        left: containerRect.left,
+      }).toEqual({
+        top: relativeRect.top,
+        left: relativeRect.left - 1,
+      });
+    }
+
+    await keyDownUp('escape');
+    // scroll the viewport to the point where the editor may not be rendered on the bottom (there is not enough space)
+    // so it should be rendered above the edited cell
+    await scrollViewportVertically(scrollPositionBase - 1);
+    await keyDownUp('enter');
+
+    {
+      const relativeRect = getCell(11, 1).getBoundingClientRect();
+      const containerRect = getActiveEditor().htContainer.getBoundingClientRect();
+
+      expect({
+        top: containerRect.top,
+        left: containerRect.left,
+      }).toEqual({
+        top: relativeRect.top - containerRect.height - 1,
+        left: relativeRect.left - 1,
+      });
+    }
+  });
+});

--- a/handsontable/src/editors/handsontableEditor/__tests__/rtl/positioning.spec.js
+++ b/handsontable/src/editors/handsontableEditor/__tests__/rtl/positioning.spec.js
@@ -1,0 +1,103 @@
+describe('HandsontableEditor positioning (RTL mode)', () => {
+  function createEditorSettings() {
+    return {
+      type: 'handsontable',
+      handsontable: {
+        colHeaders: ['Marque', 'Country', 'Parent company'],
+        colWidths: [85, 85, 220],
+        data: [
+          { name: 'BMW', country: 'Germany', owner: 'Bayerische Motoren Werke AG' },
+          { name: 'Chrysler', country: 'USA', owner: 'Chrysler Group LLC' },
+          { name: 'Nissan', country: 'Japan', owner: 'Nissan Motor Company Ltd' },
+          { name: 'Suzuki', country: 'Japan', owner: 'Suzuki Motor Corporation' },
+          { name: 'Toyota', country: 'Japan', owner: 'Toyota Motor Corporation' },
+          { name: 'Volvo', country: 'Sweden', owner: 'Zhejiang Geely Holding Group' }
+        ],
+      }
+    };
+  }
+
+  using('configuration object', [
+    { htmlDir: 'rtl', layoutDirection: 'inherit' },
+    { htmlDir: 'ltr', layoutDirection: 'rtl' },
+  ], ({ htmlDir, layoutDirection }) => {
+
+    beforeEach(function() {
+      $('html').attr('dir', htmlDir);
+      this.$container = $('<div id="testContainer"></div>').appendTo('body');
+    });
+
+    afterEach(function() {
+      $('html').attr('dir', 'ltr');
+
+      if (this.$container) {
+        destroy();
+        this.$container.remove();
+      }
+    });
+
+    // all other E2E tests are moved to visual tests. See ./visual-tests/tests/js-only/editors/handsontable/
+
+    it('should render the editors dropdown on the right edited cell when there is no space left on the left', async() => {
+      handsontable({
+        data: createSpreadsheetData(25, 25),
+        layoutDirection,
+        colWidths: 80,
+        rowHeights: 38,
+        width: 800,
+        height: 300,
+        ...createEditorSettings(),
+      });
+
+      const scrollEdgePositions = {
+        horizon: 149,
+        main: 151,
+        classic: 151,
+      };
+
+      const scrollPositionBase = scrollEdgePositions[spec().loadedTheme];
+
+      if (scrollPositionBase === undefined) {
+        throw new Error('Missing scroll position base for the current theme');
+      }
+
+      // scroll the viewport to the point where the editor may be rendered on the right (there is enough space)
+      await scrollViewportHorizontally(scrollPositionBase);
+
+      await selectCell(1, 7);
+      await keyDownUp('enter');
+
+      const relativeRect = getCell(2, 7).getBoundingClientRect();
+
+      {
+        const containerRect = getActiveEditor().htContainer.getBoundingClientRect();
+
+        expect({
+          top: containerRect.top,
+          right: containerRect.right,
+        }).toEqual({
+          top: relativeRect.top,
+          right: relativeRect.right + 1,
+        });
+      }
+
+      await keyDownUp('escape');
+      // scroll the viewport to the point where the editor may not be rendered on the right (there is not enough space)
+      // so it should be rendered on the left
+      await scrollViewportHorizontally(scrollPositionBase - 1);
+      await keyDownUp('enter');
+
+      {
+        const containerRect = getActiveEditor().htContainer.getBoundingClientRect();
+
+        expect({
+          top: containerRect.top,
+          left: containerRect.left,
+        }).toEqual({
+          top: relativeRect.top,
+          left: relativeRect.left - 1,
+        });
+      }
+    });
+  });
+});

--- a/handsontable/src/editors/handsontableEditor/handsontableEditor.js
+++ b/handsontable/src/editors/handsontableEditor/handsontableEditor.js
@@ -20,6 +20,18 @@ export class HandsontableEditor extends TextEditor {
   }
 
   /**
+   * The editor container element.
+   *
+   * @type {HTMLElement}
+   */
+  htContainer = null;
+  /**
+   * The Handsontable editor instance.
+   *
+   * @type {Handsontable}
+   */
+  htEditor = null;
+  /**
    * The flag determining if the editor is flipped vertically (rendered on
    * the top of the edited cell) or not.
    *

--- a/handsontable/src/editors/handsontableEditor/handsontableEditor.js
+++ b/handsontable/src/editors/handsontableEditor/handsontableEditor.js
@@ -20,6 +20,21 @@ export class HandsontableEditor extends TextEditor {
   }
 
   /**
+   * The flag determining if the editor is flipped vertically (rendered on
+   * the top of the edited cell) or not.
+   *
+   * @type {boolean}
+   */
+  isFlippedVertically = false;
+  /**
+   * The flag determining if the editor is flipped horizontally (rendered on
+   * the inline start of the edited cell) or not.
+   *
+   * @type {boolean}
+   */
+  isFlippedHorizontally = false;
+
+  /**
    * Opens the editor and adjust its size.
    */
   open() {
@@ -52,11 +67,13 @@ export class HandsontableEditor extends TextEditor {
     setCaretPosition(this.TEXTAREA, 0, this.TEXTAREA.value.length);
 
     this.htEditor.updateSettings({
-      width: this.getWidth(),
-      height: this.getHeight(),
+      width: this.calculateEditorWidth(),
+      height: this.calculateEditorHeight(),
     });
 
     this.refreshDimensions();
+    this.flipEditorVerticallyIfNeeded();
+    this.flipEditorHorizontallyIfNeeded();
   }
 
   /**
@@ -174,23 +191,170 @@ export class HandsontableEditor extends TextEditor {
   }
 
   /**
-   * Calculates and return the internal Handsontable's height.
+   * Calculates the space above and below the editor and flips it vertically if needed.
    *
    * @private
-   * @returns {number}
+   * @returns {{ isFlipped: boolean, spaceAbove: number, spaceBelow: number}}
    */
-  getHeight() {
-    return this.htEditor.view.getTableHeight() + 1;
+  flipEditorVerticallyIfNeeded() {
+    const { view } = this.hot;
+    const cellRect = this.getEditedCellRect();
+    let spaceAbove = cellRect.top;
+
+    if (view.isVerticallyScrollableByWindow()) {
+      const topOffset = view.getTableOffset().top - this.hot.rootWindow.scrollY;
+
+      spaceAbove = Math.max(spaceAbove + topOffset, 0);
+    }
+
+    const workspaceHeight = view.getWorkspaceHeight();
+    const spaceBelow = workspaceHeight - spaceAbove - cellRect.height;
+    const flipNeeded = spaceBelow < this.getHeight() && spaceAbove > this.getHeight();
+
+    if (flipNeeded) {
+      this.flipEditorVertically();
+    } else {
+      this.unflipEditorVertically();
+    }
+
+    return {
+      isFlipped: flipNeeded,
+      spaceAbove,
+      spaceBelow,
+    };
   }
 
   /**
-   * Calculates and return the internal Handsontable's width.
+   * Adjusts the editor's container to flip vertically, positioning it from
+   * the bottom to the top of the edited cell.
    *
    * @private
+   */
+  flipEditorVertically() {
+    const dropdownStyle = this.htEditor.rootElement.style;
+
+    dropdownStyle.position = 'absolute';
+    dropdownStyle.top = `${-this.getHeight()}px`;
+
+    this.isFlippedVertically = true;
+  }
+
+  /**
+   * Adjusts the editor's container to unflip vertically, positioning it from
+   * the top to the bottom of the edited cell.
+   *
+   * @private
+   */
+  unflipEditorVertically() {
+    const dropdownStyle = this.htEditor.rootElement.style;
+
+    dropdownStyle.position = 'absolute';
+    dropdownStyle.top = '';
+
+    this.isFlippedVertically = false;
+  }
+
+  /**
+   * Calculates the space above and below the editor and flips it vertically if needed.
+   *
+   * @private
+   * @returns {{ isFlipped: boolean, spaceAbove: number, spaceBelow: number}}
+   */
+  flipEditorHorizontallyIfNeeded() {
+    const { view } = this.hot;
+    const cellRect = this.getEditedCellRect();
+    let spaceInlineStart = cellRect.start + cellRect.width;
+
+    if (view.isHorizontallyScrollableByWindow()) {
+      const inlineStartOffset = view.getTableOffset().left - this.hot.rootWindow.scrollX;
+
+      spaceInlineStart = Math.max(spaceInlineStart + inlineStartOffset, 0);
+    }
+
+    const workspaceWidth = view.getWorkspaceWidth();
+    const spaceInlineEnd = workspaceWidth - spaceInlineStart + cellRect.width;
+    const flipNeeded = spaceInlineEnd < this.getWidth() && spaceInlineStart > this.getWidth();
+
+    if (flipNeeded) {
+      this.flipEditorHorizontally();
+    } else {
+      this.unflipEditorHorizontally();
+    }
+
+    return {
+      isFlipped: flipNeeded,
+      spaceInlineStart,
+      spaceInlineEnd,
+    };
+  }
+
+  /**
+   * Adjusts the editor's container to flip horizontally, positioning it from
+   * the inline end (right) to the inline start (left) of the edited cell.
+   *
+   * @private
+   */
+  flipEditorHorizontally() {
+    const dropdownStyle = this.htEditor.rootElement.style;
+    const { width } = this.getEditedCellRect();
+
+    dropdownStyle.position = 'absolute';
+    dropdownStyle[this.hot.isRtl() ? 'right' : 'left'] = `${-(this.getWidth() - width)}px`;
+
+    this.isFlippedHorizontally = true;
+  }
+
+  /**
+   * Adjusts the editor's container to unflip horizontally, positioning it from
+   * the inline start (left) to the inline end (right) of the edited cell.
+   *
+   * @private
+   */
+  unflipEditorHorizontally() {
+    const dropdownStyle = this.htEditor.rootElement.style;
+
+    dropdownStyle.position = 'absolute';
+    dropdownStyle[this.hot.isRtl() ? 'right' : 'left'] = '';
+
+    this.isFlippedHorizontally = false;
+  }
+
+  /**
+   * Return the DOM height of the editor's container.
+   *
+   * @returns {number}
+   */
+  getHeight() {
+    return this.htEditor.getTableHeight();
+  }
+
+  /**
+   * Return the DOM width of the editor's container.
+   *
    * @returns {number}
    */
   getWidth() {
+    return this.htEditor.getTableWidth();
+  }
+
+  /**
+   * Calculates the proposed editor width that should be set once the editor is opened.
+   * The method may be overwritten in the child class to provide a custom logic.
+   *
+   * @returns {number}
+   */
+  calculateEditorWidth() {
     return this.htEditor.view.getTableWidth();
+  }
+
+  /**
+   * Calculates the proposed editor height that should be set once the editor is opened.
+   * The method may be overwritten in the child class to provide a custom logic.
+   *
+   * @returns {number}
+   */
+  calculateEditorHeight() {
+    return this.htEditor.view.getTableHeight() + 1;
   }
 
   /**
@@ -231,7 +395,7 @@ export class HandsontableEditor extends TextEditor {
       const innerHOT = this.htEditor;
 
       if (rowToSelect !== undefined) {
-        if (rowToSelect < 0 || (innerHOT.flipped && rowToSelect > innerHOT.countRows() - 1)) {
+        if (rowToSelect < 0 || (this.isFlippedVertically && rowToSelect > innerHOT.countRows() - 1)) {
           innerHOT.deselectCell();
         } else {
           innerHOT.selectCell(rowToSelect, 0);
@@ -255,11 +419,11 @@ export class HandsontableEditor extends TextEditor {
         let rowToSelect;
         let selectedRow;
 
-        if (!innerHOT.getSelectedLast() && innerHOT.flipped) {
+        if (!innerHOT.getSelectedLast() && this.isFlippedVertically) {
           rowToSelect = innerHOT.countRows() - 1;
 
         } else if (innerHOT.getSelectedLast()) {
-          if (innerHOT.flipped) {
+          if (this.isFlippedVertically) {
             selectedRow = innerHOT.getSelectedLast()[0];
             rowToSelect = Math.max(0, selectedRow - 1);
           } else {
@@ -278,14 +442,14 @@ export class HandsontableEditor extends TextEditor {
         let rowToSelect;
         let selectedRow;
 
-        if (!innerHOT.getSelectedLast() && !innerHOT.flipped) {
+        if (!innerHOT.getSelectedLast() && !this.isFlippedVertically) {
           rowToSelect = 0;
 
         } else if (innerHOT.getSelectedLast()) {
-          if (innerHOT.flipped) {
+          if (this.isFlippedVertically) {
             rowToSelect = innerHOT.getSelectedLast()[0] + 1;
 
-          } else if (!innerHOT.flipped) {
+          } else if (!this.isFlippedVertically) {
             const lastRow = innerHOT.countRows() - 1;
 
             selectedRow = innerHOT.getSelectedLast()[0];

--- a/handsontable/src/editors/handsontableEditor/handsontableEditor.js
+++ b/handsontable/src/editors/handsontableEditor/handsontableEditor.js
@@ -67,8 +67,8 @@ export class HandsontableEditor extends TextEditor {
     setCaretPosition(this.TEXTAREA, 0, this.TEXTAREA.value.length);
 
     this.htEditor.updateSettings({
-      width: this.getTargetEditorWidth(),
-      height: this.getTargetEditorHeight(),
+      width: this.getTargetDropdownWidth(),
+      height: this.getTargetDropdownHeight(),
     });
 
     this.refreshDimensions();
@@ -207,7 +207,7 @@ export class HandsontableEditor extends TextEditor {
       spaceAbove = Math.max(spaceAbove + topOffset, 0);
     }
 
-    const dropdownTargetHeight = this.getTargetEditorHeight();
+    const dropdownTargetHeight = this.getTargetDropdownHeight();
     const spaceBelow = view.getWorkspaceHeight() - spaceAbove - cellRect.height;
     const flipNeeded = dropdownTargetHeight > spaceBelow && spaceAbove > spaceBelow + cellRect.height;
 
@@ -234,7 +234,7 @@ export class HandsontableEditor extends TextEditor {
     const dropdownStyle = this.htEditor.rootElement.style;
 
     dropdownStyle.position = 'absolute';
-    dropdownStyle.top = `${-this.getHeight()}px`;
+    dropdownStyle.top = `${-this.getDropdownHeight()}px`;
 
     this.isFlippedVertically = true;
   }
@@ -271,7 +271,7 @@ export class HandsontableEditor extends TextEditor {
       spaceInlineStart = Math.max(spaceInlineStart + inlineStartOffset, 0);
     }
 
-    const dropdownTargetWidth = this.getTargetEditorWidth();
+    const dropdownTargetWidth = this.getTargetDropdownWidth();
     const spaceInlineEnd = view.getWorkspaceWidth() - spaceInlineStart + cellRect.width;
     const flipNeeded = dropdownTargetWidth > spaceInlineEnd && spaceInlineStart > spaceInlineEnd;
 
@@ -299,7 +299,7 @@ export class HandsontableEditor extends TextEditor {
     const { width } = this.getEditedCellRect();
 
     dropdownStyle.position = 'absolute';
-    dropdownStyle[this.hot.isRtl() ? 'right' : 'left'] = `${-(this.getWidth() - width)}px`;
+    dropdownStyle[this.hot.isRtl() ? 'right' : 'left'] = `${-(this.getDropdownWidth() - width)}px`;
 
     this.isFlippedHorizontally = true;
   }
@@ -324,7 +324,7 @@ export class HandsontableEditor extends TextEditor {
    *
    * @returns {number}
    */
-  getHeight() {
+  getDropdownHeight() {
     return this.htEditor.getTableHeight();
   }
 
@@ -333,7 +333,7 @@ export class HandsontableEditor extends TextEditor {
    *
    * @returns {number}
    */
-  getWidth() {
+  getDropdownWidth() {
     return this.htEditor.getTableWidth();
   }
 
@@ -343,7 +343,7 @@ export class HandsontableEditor extends TextEditor {
    *
    * @returns {number}
    */
-  getTargetEditorWidth() {
+  getTargetDropdownWidth() {
     return this.htEditor.view.getTableWidth();
   }
 
@@ -353,7 +353,7 @@ export class HandsontableEditor extends TextEditor {
    *
    * @returns {number}
    */
-  getTargetEditorHeight() {
+  getTargetDropdownHeight() {
     return this.htEditor.view.getTableHeight() + 1;
   }
 

--- a/handsontable/src/editors/handsontableEditor/handsontableEditor.js
+++ b/handsontable/src/editors/handsontableEditor/handsontableEditor.js
@@ -207,7 +207,7 @@ export class HandsontableEditor extends TextEditor {
       spaceAbove = Math.max(spaceAbove + topOffset, 0);
     }
 
-    const dropdownTargetHeight = this.getTargetDropdownHeight();
+    const dropdownTargetHeight = this.getDropdownHeight();
     const spaceBelow = view.getWorkspaceHeight() - spaceAbove - cellRect.height;
     const flipNeeded = dropdownTargetHeight > spaceBelow && spaceAbove > spaceBelow + cellRect.height;
 
@@ -271,14 +271,14 @@ export class HandsontableEditor extends TextEditor {
       spaceInlineStart = Math.max(spaceInlineStart + inlineStartOffset, 0);
     }
 
-    const dropdownTargetWidth = this.getTargetDropdownWidth();
+    const dropdownTargetWidth = this.getDropdownWidth();
     const spaceInlineEnd = view.getWorkspaceWidth() - spaceInlineStart + cellRect.width;
     const flipNeeded = dropdownTargetWidth > spaceInlineEnd && spaceInlineStart > spaceInlineEnd;
 
     if (flipNeeded) {
       this.flipDropdownHorizontally();
     } else {
-      this.unflipDropdpwnHorizontally();
+      this.unflipDropdownHorizontally();
     }
 
     return {
@@ -310,7 +310,7 @@ export class HandsontableEditor extends TextEditor {
    *
    * @private
    */
-  unflipDropdpwnHorizontally() {
+  unflipDropdownHorizontally() {
     const dropdownStyle = this.htEditor.rootElement.style;
 
     dropdownStyle.position = 'absolute';

--- a/handsontable/src/editors/handsontableEditor/handsontableEditor.js
+++ b/handsontable/src/editors/handsontableEditor/handsontableEditor.js
@@ -72,8 +72,8 @@ export class HandsontableEditor extends TextEditor {
     });
 
     this.refreshDimensions();
-    this.flipEditorVerticallyIfNeeded();
-    this.flipEditorHorizontallyIfNeeded();
+    this.flipDropdownVerticallyIfNeeded();
+    this.flipDropdownHorizontallyIfNeeded();
   }
 
   /**
@@ -196,7 +196,7 @@ export class HandsontableEditor extends TextEditor {
    * @private
    * @returns {{ isFlipped: boolean, spaceAbove: number, spaceBelow: number}}
    */
-  flipEditorVerticallyIfNeeded() {
+  flipDropdownVerticallyIfNeeded() {
     const { view } = this.hot;
     const cellRect = this.getEditedCellRect();
     let spaceAbove = cellRect.top;
@@ -212,9 +212,9 @@ export class HandsontableEditor extends TextEditor {
     const flipNeeded = dropdownTargetHeight > spaceBelow && spaceAbove > spaceBelow + cellRect.height;
 
     if (flipNeeded) {
-      this.flipEditorVertically();
+      this.flipDropdownVertically();
     } else {
-      this.unflipEditorVertically();
+      this.unflipDropdownVertically();
     }
 
     return {
@@ -230,7 +230,7 @@ export class HandsontableEditor extends TextEditor {
    *
    * @private
    */
-  flipEditorVertically() {
+  flipDropdownVertically() {
     const dropdownStyle = this.htEditor.rootElement.style;
 
     dropdownStyle.position = 'absolute';
@@ -245,7 +245,7 @@ export class HandsontableEditor extends TextEditor {
    *
    * @private
    */
-  unflipEditorVertically() {
+  unflipDropdownVertically() {
     const dropdownStyle = this.htEditor.rootElement.style;
 
     dropdownStyle.position = 'absolute';
@@ -258,9 +258,9 @@ export class HandsontableEditor extends TextEditor {
    * Calculates the space above and below the editor and flips it vertically if needed.
    *
    * @private
-   * @returns {{ isFlipped: boolean, spaceAbove: number, spaceBelow: number}}
+   * @returns {{ isFlipped: boolean, spaceInlineStart: number, spaceInlineEnd: number}}
    */
-  flipEditorHorizontallyIfNeeded() {
+  flipDropdownHorizontallyIfNeeded() {
     const { view } = this.hot;
     const cellRect = this.getEditedCellRect();
     let spaceInlineStart = cellRect.start + cellRect.width;
@@ -276,9 +276,9 @@ export class HandsontableEditor extends TextEditor {
     const flipNeeded = dropdownTargetWidth > spaceInlineEnd && spaceInlineStart > spaceInlineEnd;
 
     if (flipNeeded) {
-      this.flipEditorHorizontally();
+      this.flipDropdownHorizontally();
     } else {
-      this.unflipEditorHorizontally();
+      this.unflipDropdpwnHorizontally();
     }
 
     return {
@@ -294,7 +294,7 @@ export class HandsontableEditor extends TextEditor {
    *
    * @private
    */
-  flipEditorHorizontally() {
+  flipDropdownHorizontally() {
     const dropdownStyle = this.htEditor.rootElement.style;
     const { width } = this.getEditedCellRect();
 
@@ -310,7 +310,7 @@ export class HandsontableEditor extends TextEditor {
    *
    * @private
    */
-  unflipEditorHorizontally() {
+  unflipDropdpwnHorizontally() {
     const dropdownStyle = this.htEditor.rootElement.style;
 
     dropdownStyle.position = 'absolute';

--- a/handsontable/src/editors/handsontableEditor/handsontableEditor.js
+++ b/handsontable/src/editors/handsontableEditor/handsontableEditor.js
@@ -67,8 +67,8 @@ export class HandsontableEditor extends TextEditor {
     setCaretPosition(this.TEXTAREA, 0, this.TEXTAREA.value.length);
 
     this.htEditor.updateSettings({
-      width: this.calculateEditorWidth(),
-      height: this.calculateEditorHeight(),
+      width: this.getTargetEditorWidth(),
+      height: this.getTargetEditorHeight(),
     });
 
     this.refreshDimensions();
@@ -207,9 +207,9 @@ export class HandsontableEditor extends TextEditor {
       spaceAbove = Math.max(spaceAbove + topOffset, 0);
     }
 
-    const workspaceHeight = view.getWorkspaceHeight();
-    const spaceBelow = workspaceHeight - spaceAbove - cellRect.height;
-    const flipNeeded = spaceBelow < this.getHeight() && spaceAbove > this.getHeight();
+    const dropdownTargetHeight = this.getTargetEditorHeight();
+    const spaceBelow = view.getWorkspaceHeight() - spaceAbove - cellRect.height;
+    const flipNeeded = dropdownTargetHeight > spaceBelow && spaceAbove > spaceBelow + cellRect.height;
 
     if (flipNeeded) {
       this.flipEditorVertically();
@@ -271,9 +271,9 @@ export class HandsontableEditor extends TextEditor {
       spaceInlineStart = Math.max(spaceInlineStart + inlineStartOffset, 0);
     }
 
-    const workspaceWidth = view.getWorkspaceWidth();
-    const spaceInlineEnd = workspaceWidth - spaceInlineStart + cellRect.width;
-    const flipNeeded = spaceInlineEnd < this.getWidth() && spaceInlineStart > this.getWidth();
+    const dropdownTargetWidth = this.getTargetEditorWidth();
+    const spaceInlineEnd = view.getWorkspaceWidth() - spaceInlineStart + cellRect.width;
+    const flipNeeded = dropdownTargetWidth > spaceInlineEnd && spaceInlineStart > spaceInlineEnd;
 
     if (flipNeeded) {
       this.flipEditorHorizontally();
@@ -338,22 +338,22 @@ export class HandsontableEditor extends TextEditor {
   }
 
   /**
-   * Calculates the proposed editor width that should be set once the editor is opened.
-   * The method may be overwritten in the child class to provide a custom logic.
+   * Calculates the proposed/target editor width that should be set once the editor is opened.
+   * The method may be overwritten in the child class to provide a custom size logic.
    *
    * @returns {number}
    */
-  calculateEditorWidth() {
+  getTargetEditorWidth() {
     return this.htEditor.view.getTableWidth();
   }
 
   /**
-   * Calculates the proposed editor height that should be set once the editor is opened.
-   * The method may be overwritten in the child class to provide a custom logic.
+   * Calculates the proposed/target editor height that should be set once the editor is opened.
+   * The method may be overwritten in the child class to provide a custom size logic.
    *
    * @returns {number}
    */
-  calculateEditorHeight() {
+  getTargetEditorHeight() {
     return this.htEditor.view.getTableHeight() + 1;
   }
 

--- a/handsontable/src/editors/handsontableEditor/handsontableEditor.js
+++ b/handsontable/src/editors/handsontableEditor/handsontableEditor.js
@@ -20,18 +20,6 @@ export class HandsontableEditor extends TextEditor {
   }
 
   /**
-   * The editor container element.
-   *
-   * @type {HTMLElement}
-   */
-  htContainer = null;
-  /**
-   * The Handsontable editor instance.
-   *
-   * @type {Handsontable}
-   */
-  htEditor = null;
-  /**
    * The flag determining if the editor is flipped vertically (rendered on
    * the top of the edited cell) or not.
    *

--- a/handsontable/src/styles/classic/handsontable.css
+++ b/handsontable/src/styles/classic/handsontable.css
@@ -669,13 +669,23 @@ TextRenderer placeholder value
  * Handsontable listbox theme
  */
 .handsontable.listbox {
+  border: 1px solid #ccc;
   margin: 0;
 }
 
+.handsontable.listbox.autocompleteEditor,
+.handsontable.listbox.dropdownEditor {
+  border-width: 0;
+}
+
 .handsontable.listbox .ht_master table {
-  border: 1px solid #ccc;
   border-collapse: separate;
   background: white;
+}
+
+.handsontable.listbox.autocompleteEditor .ht_master table,
+.handsontable.listbox.dropdownEditor .ht_master table {
+  border: 1px solid #ccc;
 }
 
 .handsontable.listbox th,

--- a/handsontable/test/e2e/core/getTableHeight.spec.js
+++ b/handsontable/test/e2e/core/getTableHeight.spec.js
@@ -1,0 +1,30 @@
+describe('Core.getTableHeight', () => {
+  beforeEach(function() {
+    this.$container = $('<div id="testContainer"></div>').appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should return the height of the table container (not defined size)', async() => {
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+    });
+
+    expect(getTableHeight()).toBe((getDefaultRowHeight() * 5) + 1);
+  });
+
+  it('should return the height of the table container (defined size)', async() => {
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+      width: 500,
+      height: 500,
+    });
+
+    expect(getTableHeight()).toBe(500);
+  });
+});

--- a/handsontable/test/e2e/core/getTableWidth.spec.js
+++ b/handsontable/test/e2e/core/getTableWidth.spec.js
@@ -1,0 +1,30 @@
+describe('Core.getTableWidth', () => {
+  beforeEach(function() {
+    this.$container = $('<div id="testContainer"></div>').appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should return the width of the table container (not defined size)', async() => {
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+    });
+
+    expect(getTableWidth()).toBe(document.documentElement.clientWidth);
+  });
+
+  it('should return the width of the table container (defined size)', async() => {
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+      width: 500,
+      height: 500,
+    });
+
+    expect(getTableWidth()).toBe(500);
+  });
+});

--- a/handsontable/test/helpers/common.js
+++ b/handsontable/test/helpers/common.js
@@ -2,7 +2,8 @@ import { waitOnScroll } from './utils';
 
 /**
  * When `true` the test suite will not scroll to the top of the page before each test and
- * the spec will be not cleared.
+ * the spec will be not cleared which allows calling test helpers (`selectCell()` etc.) from
+ * the console.
  */
 const DEBUG = false;
 const specContext = {};
@@ -13,10 +14,7 @@ beforeEach(function() {
   }
 
   specContext.spec = this;
-
-  if (typeof __ENV_ARGS__ !== 'undefined') {
-    this.loadedTheme = __ENV_ARGS__.HOT_THEME;
-  }
+  this.loadedTheme = __ENV_ARGS__.HOT_THEME || 'classic';
 });
 
 afterEach(() => {
@@ -469,7 +467,7 @@ export function handsontable(options, explicitOptions = false, container = spec(
       loadedTheme &&
       loadedTheme !== 'classic'
     ) {
-      options.themeName = `ht-theme-${spec().loadedTheme}`;
+      options.themeName = `ht-theme-${loadedTheme}`;
     }
 
     options.licenseKey = 'non-commercial-and-evaluation';

--- a/handsontable/test/helpers/common.js
+++ b/handsontable/test/helpers/common.js
@@ -14,7 +14,10 @@ beforeEach(function() {
   }
 
   specContext.spec = this;
-  this.loadedTheme = __ENV_ARGS__.HOT_THEME || 'classic';
+
+  if (!process.env.JEST_WORKER_ID) {
+    this.loadedTheme = __ENV_ARGS__.HOT_THEME || 'classic';
+  }
 });
 
 afterEach(() => {

--- a/handsontable/test/helpers/common.js
+++ b/handsontable/test/helpers/common.js
@@ -1,9 +1,16 @@
 import { waitOnScroll } from './utils';
 
+/**
+ * When `true` the test suite will not scroll to the top of the page before each test and
+ * the spec will be not cleared.
+ */
+const DEBUG = false;
 const specContext = {};
 
 beforeEach(function() {
-  window.scrollTo(0, 0);
+  if (!DEBUG) {
+    window.scrollTo(0, 0);
+  }
 
   specContext.spec = this;
 
@@ -13,7 +20,9 @@ beforeEach(function() {
 });
 
 afterEach(() => {
-  specContext.spec = null;
+  if (!DEBUG) {
+    specContext.spec = null;
+  }
 });
 
 beforeAll(() => {
@@ -158,6 +167,8 @@ export const getSourceDataArray = handsontableMethodFactory('getSourceDataArray'
 export const getSourceDataAtCell = handsontableMethodFactory('getSourceDataAtCell');
 export const getSourceDataAtCol = handsontableMethodFactory('getSourceDataAtCol');
 export const getSourceDataAtRow = handsontableMethodFactory('getSourceDataAtRow');
+export const getTableHeight = handsontableMethodFactory('getTableHeight');
+export const getTableWidth = handsontableMethodFactory('getTableWidth');
 export const getValue = handsontableMethodFactory('getValue');
 export const hasHook = handsontableMethodFactory('hasHook');
 export const isExecutionSuspended = handsontableMethodFactory('isExecutionSuspended');

--- a/handsontable/types/core.d.ts
+++ b/handsontable/types/core.d.ts
@@ -113,6 +113,8 @@ export default class Core {
   getSourceDataAtCell(row: number, column: number): CellValue;
   getSourceDataAtCol(column: number): CellValue[];
   getSourceDataAtRow(row: number): CellValue[] | RowObject;
+  getTableWidth(): number;
+  getTableHeight(): number;
   getTranslatedPhrase(dictionaryKey: string, extraArguments: any): string | null;
   getValue(): CellValue;
   hasColHeaders(): boolean;

--- a/handsontable/types/editors/autocompleteEditor/autocompleteEditor.d.ts
+++ b/handsontable/types/editors/autocompleteEditor/autocompleteEditor.d.ts
@@ -10,11 +10,10 @@ export class AutocompleteEditor extends HandsontableEditor {
   strippedChoices: string[];
   rawChoices: string[];
 
-  getValue(): string;
   queryChoices(query: string): void;
   updateChoicesList(choicesList: string[]): void;
   flipDropdownIfNeeded(): boolean;
-  limitDropdownIfNeeded(spaceAvailable: number, dropdownHeight: number): void;
+  limitDropdownIfNeeded(spaceAvailable: number): void;
   flipDropdown(dropdownHeight: number): void;
   unflipDropdown(): void;
   updateDropdownDimensions(): void;

--- a/handsontable/types/editors/autocompleteEditor/autocompleteEditor.d.ts
+++ b/handsontable/types/editors/autocompleteEditor/autocompleteEditor.d.ts
@@ -11,17 +11,6 @@ export class AutocompleteEditor extends HandsontableEditor {
   rawChoices: string[];
 
   queryChoices(query: string): void;
-  updateChoicesList(choicesList: string[]): void;
-  flipDropdownIfNeeded(): boolean;
-  limitDropdownIfNeeded(spaceAvailable: number): void;
-  flipDropdown(dropdownHeight: number): void;
-  unflipDropdown(): void;
-  updateDropdownDimensions(): void;
-  setDropdownHeight(height: number): void;
-  highlightBestMatchingChoice(index?: number): void;
-  getDropdownHeight(): number;
-  stripValueIfNeeded(value: string): string;
-  stripValuesIfNeeded(values: string[]): string[];
 }
 export namespace AutocompleteEditor {
   export function sortByRelevance(value: any, choices: string[], caseSensitive: boolean): number[];

--- a/handsontable/types/editors/handsontableEditor/handsontableEditor.d.ts
+++ b/handsontable/types/editors/handsontableEditor/handsontableEditor.d.ts
@@ -7,4 +7,16 @@ export class HandsontableEditor extends TextEditor {
 
   htEditor: Core;
   htContainer: HTMLElement;
+
+  getValue(): string;
+  flipDropdownVerticallyIfNeeded(): { isFlipped: boolean, spaceAbove: number, spaceBelow: number};
+  flipDropdownVertically(): void;
+  unflipDropdownVertically(): void;
+  flipDropdownHorizontallyIfNeeded(): { isFlipped: boolean, spaceInlineStart: number, spaceInlineEnd: number};
+  flipDropdownHorizontally(): void;
+  unflipDropdownHorizontally(): void;
+  getDropdownHeight(): number;
+  getDropdownWidth(): number;
+  getTargetDropdownWidth(): number;
+  getTargetDropdownHeight(): number;
 }

--- a/handsontable/types/editors/handsontableEditor/handsontableEditor.d.ts
+++ b/handsontable/types/editors/handsontableEditor/handsontableEditor.d.ts
@@ -7,14 +7,10 @@ export class HandsontableEditor extends TextEditor {
 
   htEditor: Core;
   htContainer: HTMLElement;
+  isFlippedVertically: boolean;
+  isFlippedHorizontally: boolean;
 
   getValue(): string;
-  flipDropdownVerticallyIfNeeded(): { isFlipped: boolean, spaceAbove: number, spaceBelow: number};
-  flipDropdownVertically(): void;
-  unflipDropdownVertically(): void;
-  flipDropdownHorizontallyIfNeeded(): { isFlipped: boolean, spaceInlineStart: number, spaceInlineEnd: number};
-  flipDropdownHorizontally(): void;
-  unflipDropdownHorizontally(): void;
   getDropdownHeight(): number;
   getDropdownWidth(): number;
   getTargetDropdownWidth(): number;

--- a/visual-tests/src/page-helpers.ts
+++ b/visual-tests/src/page-helpers.ts
@@ -649,6 +649,27 @@ export async function scrollTableToTheInlineEnd() {
 }
 
 /**
+ * Scrolls the browser window to the specified coordinates.
+ *
+ * @param {number} x The x-coordinate to scroll to.
+ * @param {number} y The y-coordinate to scroll to.
+ */
+export async function scrollWindowTo(x: number, y: number) {
+  /* eslint-disable no-restricted-globals */
+  await getPageInstance().evaluate(([xPos, yPos]) => {
+    return new Promise((resolve) => {
+      const listener = () => {
+        window.removeEventListener('scroll', listener);
+        resolve([xPos, yPos]);
+      };
+
+      window.addEventListener('scroll', listener);
+      window.scrollTo(xPos, yPos);
+    });
+  }, [x, y]);
+}
+
+/**
  * Waits for the context submenu to appear on the page.
  *
  * @param {string} submenuName The name of the submenu.

--- a/visual-tests/tests/js-only/editors/handsontable/position-scrolled-viewport.spec.ts
+++ b/visual-tests/tests/js-only/editors/handsontable/position-scrolled-viewport.spec.ts
@@ -1,0 +1,46 @@
+import { test } from '../../../../src/test-runner';
+import { helpers } from '../../../../src/helpers';
+import {
+  clickRelativeToViewport,
+  scrollTableToTheInlineEnd,
+  scrollTableToTheBottom,
+} from '../../../../src/page-helpers';
+
+test.skip(helpers.hotWrapper !== 'js', 'This test case is only for JavaScript framework');
+
+test(__filename, async({ goto, tablePage }) => {
+  await goto(
+    helpers
+      .setBaseUrl('/editors-demo')
+      .setPageParams({
+        cellType: 'handsontable',
+        hasDefinedSize: '1',
+      })
+      .getFullUrl()
+  );
+
+  await scrollTableToTheInlineEnd();
+  await scrollTableToTheBottom();
+
+  await clickRelativeToViewport(80, 80); // top-left
+  await tablePage.keyboard.press('Enter');
+  await tablePage.screenshot({ path: helpers.screenshotPath() });
+
+  await tablePage.keyboard.press('Escape'); // closes the editor
+
+  await clickRelativeToViewport(-300, 80); // top-right
+  await tablePage.keyboard.press('Enter');
+  await tablePage.screenshot({ path: helpers.screenshotPath() });
+
+  await tablePage.keyboard.press('Escape'); // closes the editor
+
+  await clickRelativeToViewport(80, -195); // bottom-left
+  await tablePage.keyboard.press('Enter');
+  await tablePage.screenshot({ path: helpers.screenshotPath() });
+
+  await tablePage.keyboard.press('Escape'); // closes the editor
+
+  await clickRelativeToViewport(-300, -195); // bottom-right
+  await tablePage.keyboard.press('Enter');
+  await tablePage.screenshot({ path: helpers.screenshotPath() });
+});

--- a/visual-tests/tests/js-only/editors/handsontable/position-scrolled-window-viewport.spec.ts
+++ b/visual-tests/tests/js-only/editors/handsontable/position-scrolled-window-viewport.spec.ts
@@ -1,0 +1,48 @@
+import { test } from '../../../../src/test-runner';
+import { helpers } from '../../../../src/helpers';
+import {
+  clickRelativeToViewport,
+  scrollWindowTo,
+} from '../../../../src/page-helpers';
+
+test.skip(helpers.hotWrapper !== 'js', 'This test case is only for JavaScript framework');
+
+test(__filename, async({ goto, tablePage }) => {
+  await goto(
+    helpers
+      .setBaseUrl('/editors-demo')
+      .setPageParams({
+        cellType: 'handsontable',
+      })
+      .getFullUrl()
+  );
+
+  const [scrollWidth, scrollHeight] = await tablePage.evaluate(async() => {
+    // eslint-disable-next-line no-restricted-globals
+    return [document.body.scrollWidth, document.body.scrollHeight];
+  });
+
+  await scrollWindowTo(scrollWidth, scrollHeight);
+
+  await clickRelativeToViewport(120, 60); // top-left
+  await tablePage.keyboard.press('Enter');
+  await tablePage.screenshot({ path: helpers.screenshotPath() });
+
+  await tablePage.keyboard.press('Escape'); // closes the editor
+
+  await clickRelativeToViewport(-150, 60); // top-right
+  await tablePage.keyboard.press('Enter');
+  await tablePage.screenshot({ path: helpers.screenshotPath() });
+
+  await tablePage.keyboard.press('Escape'); // closes the editor
+
+  await clickRelativeToViewport(120, -165); // bottom-left
+  await tablePage.keyboard.press('Enter');
+  await tablePage.screenshot({ path: helpers.screenshotPath() });
+
+  await tablePage.keyboard.press('Escape'); // closes the editor
+
+  await clickRelativeToViewport(-150, -165); // bottom-right
+  await tablePage.keyboard.press('Enter');
+  await tablePage.screenshot({ path: helpers.screenshotPath() });
+});

--- a/visual-tests/tests/js-only/editors/handsontable/rtl/position-scrolled-viewport.spec.ts
+++ b/visual-tests/tests/js-only/editors/handsontable/rtl/position-scrolled-viewport.spec.ts
@@ -1,0 +1,47 @@
+import { test } from '../../../../../src/test-runner';
+import { helpers } from '../../../../../src/helpers';
+import {
+  clickRelativeToViewport,
+  scrollTableToTheInlineEnd,
+  scrollTableToTheBottom,
+} from '../../../../../src/page-helpers';
+
+test.skip(helpers.hotWrapper !== 'js', 'This test case is only for JavaScript framework');
+
+test(__filename, async({ goto, tablePage }) => {
+  await goto(
+    helpers
+      .setBaseUrl('/editors-demo')
+      .setPageParams({
+        direction: 'rtl',
+        cellType: 'handsontable',
+        hasDefinedSize: '1',
+      })
+      .getFullUrl()
+  );
+
+  await scrollTableToTheInlineEnd();
+  await scrollTableToTheBottom();
+
+  await clickRelativeToViewport(250, 80); // top-left
+  await tablePage.keyboard.press('Enter');
+  await tablePage.screenshot({ path: helpers.screenshotPath() });
+
+  await tablePage.keyboard.press('Escape'); // closes the editor
+
+  await clickRelativeToViewport(-120, 80); // top-right
+  await tablePage.keyboard.press('Enter');
+  await tablePage.screenshot({ path: helpers.screenshotPath() });
+
+  await tablePage.keyboard.press('Escape'); // closes the editor
+
+  await clickRelativeToViewport(250, -195); // bottom-left
+  await tablePage.keyboard.press('Enter');
+  await tablePage.screenshot({ path: helpers.screenshotPath() });
+
+  await tablePage.keyboard.press('Escape'); // closes the editor
+
+  await clickRelativeToViewport(-120, -195); // bottom-right
+  await tablePage.keyboard.press('Enter');
+  await tablePage.screenshot({ path: helpers.screenshotPath() });
+});


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR implements smart positioning for the `handsontable` editor type. When the editor does not fit into the space below or on the right, it will be repositioned in the opposite direction, the same as currently `dropdown` and `autocomplete` editors do.

Additionally, the PR adds two new methods (`getTableHeight` and `getTableWidth`) to the Core that allow getting a table container size more easly.

#### Before
![Kapture 2025-04-24 at 10 26 50](https://github.com/user-attachments/assets/483c3c7d-84d3-4288-bf4b-02f444c324c3)

#### After
![Kapture 2025-04-24 at 10 27 26](https://github.com/user-attachments/assets/1a9c0e03-81af-46c2-b9b8-ee1781ecdee0)

Also, the PR fixes an issue where the position of the `dropdown` and `autocomplete` dropdown was incorrect (top border of the cell was overlapped) when rendered above the edited cell.

#### Before
![Kapture 2025-04-24 at 10 34 32](https://github.com/user-attachments/assets/ca2176fb-9f32-4e8d-a4c5-c564a7698777)

#### After
![Kapture 2025-04-24 at 10 34 11](https://github.com/user-attachments/assets/50bd9c23-b585-4d1b-9207-c63c6e293715)

...and fixes the wrong `handsontable` cell type styling for the classic theme
#### Before
![Zrzut ekranu 2025-04-25 o 14 16 08](https://github.com/user-attachments/assets/345b3bbc-7276-48f1-affc-a43df05b794c)

#### After
![image](https://github.com/user-attachments/assets/cf5c3077-c058-444f-95e4-f2147a6f543f)

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and covered the fix by adding new E2E and visual tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/761
2. fixes https://github.com/handsontable/dev-handsontable/issues/707

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
