### PR TITLE
Replace `ReactDOM.render` with `createRoot` in the repo.

### DIFF
--- a/docs/.vuepress/containers/examples/add-code-for-preset.js
+++ b/docs/.vuepress/containers/examples/add-code-for-preset.js
@@ -19,7 +19,7 @@ const addCodeForPreset = (code, preset, id) => {
 
   const renderCreatePart = () => {
     if (/react(-.*)?/.test(preset)) {
-      return `ReactDOM.render(<${exportId} />, document.getElementById("${id}"));`;
+      return `ReactDOM.createRoot(document.getElementById("${id}")).render(<${exportId} />);`;
     } else if (/vue3(-.*)?/.test(preset)) {
       return `const app = createApp(${exportId});
 app.mount('#${id}');`;

--- a/examples/next/docs/react-wrapper/basic-example/src/index.js
+++ b/examples/next/docs/react-wrapper/basic-example/src/index.js
@@ -1,9 +1,8 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App';
 
-ReactDOM.render(
-  <App />,
-  document.getElementById('root')
+createRoot(document.getElementById('root')).render(
+  <App />
 );

--- a/examples/next/docs/react-wrapper/demo/src/index.tsx
+++ b/examples/next/docs/react-wrapper/demo/src/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 import "@handsontable/pikaday/css/pikaday.css";
 import "./styles.css";
 import Handsontable from 'handsontable';
@@ -50,6 +50,7 @@ const App = () => {
 };
 
 const rootElement = document.getElementById("root");
-ReactDOM.render(<App />, rootElement);
+
+createRoot(rootElement as HTMLElement).render(<App />);
 
 console.log(`Handsontable: v${Handsontable.version} (${Handsontable.buildDate}) Wrapper: v${HotTable.version} React: v${React.version}`);

--- a/examples/next/docs/react/basic-example/src/index.js
+++ b/examples/next/docs/react/basic-example/src/index.js
@@ -1,9 +1,8 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App';
 
-ReactDOM.render(
-  <App />,
-  document.getElementById('root')
+createRoot(document.getElementById('root')).render(
+  <App />
 );

--- a/examples/next/docs/react/demo/src/index.tsx
+++ b/examples/next/docs/react/demo/src/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 import "@handsontable/pikaday/css/pikaday.css";
 import "./styles.css";
 import Handsontable from 'handsontable';
@@ -50,6 +50,7 @@ const App = () => {
 };
 
 const rootElement = document.getElementById("root");
-ReactDOM.render(<App />, rootElement);
+
+createRoot(rootElement as HTMLElement).render(<App />);
 
 console.log(`Handsontable: v${Handsontable.version} (${Handsontable.buildDate}) Wrapper: v${HotTable.version} React: v${React.version}`);

--- a/examples/next/visual-tests/react-wrapper/basic-example/src/index.js
+++ b/examples/next/visual-tests/react-wrapper/basic-example/src/index.js
@@ -1,9 +1,8 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App';
 
-ReactDOM.render(
-  <App />,
-  document.getElementById('root')
+createRoot(document.getElementById('root')).render(
+  <App />
 );

--- a/examples/next/visual-tests/react-wrapper/demo/src/index.tsx
+++ b/examples/next/visual-tests/react-wrapper/demo/src/index.tsx
@@ -1,4 +1,4 @@
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 import "./styles.css";
 import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 import DataGrid from "./DataGrid";
@@ -15,4 +15,4 @@ const App = () => {
   );
 }
 
-ReactDOM.render(<App />, document.getElementById("root"));
+createRoot(document.getElementById("root") as HTMLElement).render(<App />);

--- a/examples/next/visual-tests/react/basic-example/src/index.js
+++ b/examples/next/visual-tests/react/basic-example/src/index.js
@@ -1,9 +1,8 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App';
 
-ReactDOM.render(
-  <App />,
-  document.getElementById('root')
+createRoot(document.getElementById('root')).render(
+  <App />
 );

--- a/examples/next/visual-tests/react/demo/src/index.tsx
+++ b/examples/next/visual-tests/react/demo/src/index.tsx
@@ -1,4 +1,4 @@
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 import "./styles.css";
 import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 import DataGrid from "./DataGrid";
@@ -15,4 +15,4 @@ const App = () => {
   );
 }
 
-ReactDOM.render(<App />, document.getElementById("root"));
+createRoot(document.getElementById("root") as HTMLElement).render(<App />);

--- a/examples/templates/react-wrapper/src/index.js
+++ b/examples/templates/react-wrapper/src/index.js
@@ -1,9 +1,8 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App';
 
-ReactDOM.render(
-  <App />,
-  document.getElementById('root')
+createRoot(document.getElementById('root')).render(
+  <App />
 );

--- a/examples/templates/react/src/index.js
+++ b/examples/templates/react/src/index.js
@@ -1,9 +1,8 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App';
 
-ReactDOM.render(
-  <App />,
-  document.getElementById('root')
+createRoot(document.getElementById('root')).render(
+  <App />
 );


### PR DESCRIPTION
### Context
This PR replaces the deprecated `ReactDOM.render` with the `createRoot` approach.

[skip changelog]

### How has this been tested?
Tested the docs manually + ran tests for the examples.

### Related issue(s):
1. handsontable/dev-handsontable#2249

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
