### PR TITLE
[docs] Remove a webkit-prefixed CSS property from the docs' sidebar.

### DIFF
--- a/docs/.vuepress/theme/styles/components/table-of-contents.styl
+++ b/docs/.vuepress/theme/styles/components/table-of-contents.styl
@@ -28,7 +28,6 @@
     }
 
     ul {
-        height: -webkit-fill-available;
         overflow: auto;
 
         li { 


### PR DESCRIPTION
### Context
This PR removes a CSS property that stretched the height of the TOC in the docs' sidebar.

[skip changelog]

### How has this been tested?
Tested locally.

### Related issue(s):
1. handsontable/dev-handsontable#2420


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
