### PR TITLE
[docs] Ensure that `fixer.js` is not loaded while injecting the docs' page dependencies and is loaded last.

### DIFF
--- a/docs/.vuepress/handsontable-manager/dependencies.js
+++ b/docs/.vuepress/handsontable-manager/dependencies.js
@@ -174,7 +174,7 @@ const presetMap = {
   'react-languages': ['hot', 'languages', 'react', 'react-dom', 'hot-react', 'fixer'],
   'react-numbro': ['hot', 'numbro', 'react', 'react-dom', 'hot-react', 'fixer'],
   'react-redux': ['hot', 'react', 'react-dom', 'redux', 'react-redux', 'hot-react', 'fixer'],
-  'react-advanced': ['hot', 'react', 'react-dom', 'redux', 'react-redux', 'hot-react', 'fixer', 'react-colorful', 'react-star-rating-component'],
+  'react-advanced': ['hot', 'react', 'react-dom', 'redux', 'react-redux', 'hot-react', 'react-colorful', 'react-star-rating-component', 'fixer'],
   angular: ['hot', 'rxjs', 'core-js', 'zone', 'angular-core-primitives-signals', 'angular-compiler', 'angular-core', 'angular-common', 'angular-forms', 'angular-platform-browser', 'angular-platform-browser-dynamic', 'hot-angular', 'fixer'],
   'angular-languages': ['hot', 'languages', 'rxjs', 'core-js', 'zone', 'angular-core-primitives-signals', 'angular-compiler', 'angular-core', 'angular-common', 'angular-forms', 'angular-platform-browser', 'angular-platform-browser-dynamic', 'hot-angular', 'fixer'],
   'angular-numbro': ['hot', 'numbro', 'rxjs', 'core-js', 'zone', 'angular-core-primitives-signals', 'angular-compiler', 'angular-core', 'angular-common', 'angular-forms', 'angular-platform-browser', 'angular-platform-browser-dynamic', 'hot-angular', 'fixer'],

--- a/docs/.vuepress/handsontable-manager/use-handsontable.js
+++ b/docs/.vuepress/handsontable-manager/use-handsontable.js
@@ -31,6 +31,18 @@ const useHandsontable = (version, callback = () => {}, preset = 'hot', buildMode
     const _document = document; // eslint-disable-line no-restricted-globals
     let script = null;
 
+    // Ensure that `fixer.js` is not loaded while injecting new dependencies.
+    if (dep !== 'fixer') {
+      const fixerScript = _document.getElementById(`script-${getId('fixer')}`);
+
+      if (fixerScript) {
+        fixerScript.remove();
+
+        delete window.require;
+        delete window.exports;
+      }
+    }
+
     // As the documentation uses multiple versions of Vue (which reuse the same global variable - `Vue`), every
     // time the Vue dependency is loaded, the previously used version should be removed.
     if (globalVarSharedDependency) {


### PR DESCRIPTION
### Context
`fixer.js` needs to be loaded as a last dependency and not be present while injecting other dependencies.

This became a problem with the new Angular UMD builds, where angular did not recognize its own modules when `fixer` overwritten the `require` method and `exports` object.

This change needs to be cherry-picked to `prod-docs/15.3`.

[skip changelog]

### How has this been tested?
Tested locally.

### Related issue(s):
1. handsontable/dev-handsontable#2488