### PR TITLE
[docs] Update docs' changelog with a link to the `15.3.0` blog post.

### DIFF
--- a/docs/content/guides/upgrade-and-migration/changelog/changelog.md
+++ b/docs/content/guides/upgrade-and-migration/changelog/changelog.md
@@ -30,6 +30,7 @@ See the full history of changes made to Handsontable in each major, minor, and p
 Released on April 29, 2025
 
 For more information about this release see:
+- [Blog post (15.3.0)](https://handsontable.com/blog/handsontable-15.3.0-csv-sanitization-accessibility-updates-and-30-fixes)
 - [Documentation (15.3)](https://handsontable.com/docs/15.3)
 
 #### Added


### PR DESCRIPTION
### Context
This PR updates docs' changelog with a link to the `15.3.0` blog post.

This needs to be cherry-picked to `prod-docs/15.3`.

[skip changelog]
