### PR TITLE
Fix docs export to csv link in the description

### DIFF
--- a/docs/content/guides/accessories-and-menus/export-to-csv/export-to-csv.md
+++ b/docs/content/guides/accessories-and-menus/export-to-csv/export-to-csv.md
@@ -243,7 +243,7 @@ Default value: `'text/csv'`
 Controls the value sanitization during the CSV export
 
 - when `sanitizeValues` is `false`, `ExportPlugin` doesn't sanitize the values
-- when `sanitizeValues` is `true`, `ExportPlugin` sanitizes values according to OWASP recommendations: https://owasp.org/www-community/attacks/CSV_Injection
+- when `sanitizeValues` is `true`, `ExportPlugin` sanitizes values according to [OWASP recommendations](https://owasp.org/www-community/attacks/CSV_Injection).
 - when `sanitizeValues` is a regexp, `ExportPlugin` escapes values that match the regexp
 - when `sanitizeValues` is a function, `ExportPlugin` replaces values with the return value of the function
 


### PR DESCRIPTION
### Context
This PR includes fixed to the content on the [csv page](https://handsontable.com/docs/javascript-data-grid/export-to-csv/#sanitizevalues-boolean-regexp-function)

### How has this been tested?
Locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2484

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

[skip changelog]
