### PR TITLE
Fix a problem with the dropdown editor having a horizontal scrollbar on Windows with fractional scaling applied.

### DIFF
--- a/.changelogs/11613.json
+++ b/.changelogs/11613.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed a problem with the dropdown editor having a horizontal scrollbar on Windows with fractional scaling applied.",
+  "type": "fixed",
+  "issueOrPR": 11613,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.github/workflows/docs-staging.yml
+++ b/.github/workflows/docs-staging.yml
@@ -19,7 +19,7 @@ defaults:
     working-directory: ./docs/
 
 jobs:
-  preview-on-pull-request: 
+  preview-on-pull-request:
     environment:
       name: approvers
     if: ${{ github.event_name == 'pull_request' }}
@@ -49,35 +49,35 @@ jobs:
               repo: context.repo.repo,
               pull_number: context.issue.number ||  ${{ steps.pr-finder.outputs.pr }}
             });
-            
+
             console.log(`PR #${context.issue.number} details fetched`);
             console.log(`Source branch: ${pullRequest.head.ref}`);
             console.log(`Target branch: ${pullRequest.base.ref}`);
-            
+
             // Set outputs to use in subsequent steps
             core.setOutput('source_branch', pullRequest.head.ref);
             core.setOutput('target_branch', pullRequest.base.ref);
             core.setOutput('pr_owner', pullRequest.head.repo.owner.login);
             core.setOutput('pr_repo', pullRequest.head.repo.name);
-            
+
             return pullRequest;
           result-encoding: string
 
       - name: Install Netlify dependencies
         run: |
-           cd netlify 
-           npm i 
+           cd netlify
+           npm i
            npm install netlify-cli -g
 
       - name: Run the create or get Netlify Page proccess. Save the Netlify vars in a file
-        run: | 
-          cd netlify  
-          node createOrGet.mjs  
-          cat NETLIFY_VARS >> $GITHUB_ENV 
+        run: |
+          cd netlify
+          node createOrGet.mjs
+          cat NETLIFY_VARS >> $GITHUB_ENV
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_PREVIEW_AUTH_TOKEN }}
           BRANCH_NAME_PREFIX: dev-handsontable-
-          BRANCH_NAME: ${{ steps.get-pr.outputs.source_branch }}     
+          BRANCH_NAME: ${{ steps.get-pr.outputs.source_branch }}
 
       - name: Publish sticky comment in PR. Docs are being built
         uses: marocchino/sticky-pull-request-comment@adca94abcaf73c10466a71cc83ae561fd66d1a56 # https://github.com/marocchino/sticky-pull-request-comment/tree/v2.3.0
@@ -107,22 +107,22 @@ jobs:
 
       - name: Build and deploy the preview to Netlify
         run: |
-          cd netlify  
+          cd netlify
           mkdir -p docs/docs
           mv ../.vuepress/dist/docs docs
-          
+
           ./build_previous_versions.sh
           echo "Building the documentation..." >> docs/index.html
           cp _redirects docs/_redirects
-          cp docs/docs/404.html docs/404.html    
+          cp docs/docs/404.html docs/404.html
 
       - name: Publish preview to Netlify
         run: |
-          cd netlify  
+          cd netlify
           netlify deploy --prod --build --context production
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_PREVIEW_AUTH_TOKEN }}
-          NETLIFY_SITE_ID: ${{ env.NETLIFY_SITE_ID }}    
+          NETLIFY_SITE_ID: ${{ env.NETLIFY_SITE_ID }}
 
       - name: Publish sticky comment in PR
         uses: marocchino/sticky-pull-request-comment@adca94abcaf73c10466a71cc83ae561fd66d1a56 # https://github.com/marocchino/sticky-pull-request-comment/tree/v2.3.0
@@ -135,7 +135,7 @@ jobs:
   preview-on-push-or-workflow-dispatch:
     name: Build and push Preview to Netlify (on push or workflow dispatch)
     #if: ${{ github.ref != 'refs/heads/prod-docs/latest' }} # Exclude the prod-docs-latest branch from triggering the workflow
-    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch'}}
 
     runs-on: ubuntu-latest
     steps:
@@ -149,19 +149,19 @@ jobs:
 
       - name: Install Netlify dependencies
         run: |
-           cd netlify 
-           npm i 
+           cd netlify
+           npm i
            npm install netlify-cli -g
 
       - name: Run the create or get Netlify Page proccess. Save the Netlify vars in a file
-        run: | 
-          cd netlify  
-          node createOrGet.mjs  
-          cat NETLIFY_VARS >> $GITHUB_ENV 
+        run: |
+          cd netlify
+          node createOrGet.mjs
+          cat NETLIFY_VARS >> $GITHUB_ENV
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_PREVIEW_AUTH_TOKEN }}
           BRANCH_NAME_PREFIX: dev-handsontable-
-          BRANCH_NAME: ${{ github.ref_name }}     
+          BRANCH_NAME: ${{ github.ref_name }}
 
       - name: Install the documentation dependencies
         run: |
@@ -183,22 +183,22 @@ jobs:
 
       - name: Build and deploy the preview to Netlify
         run: |
-          cd netlify  
+          cd netlify
           mkdir -p docs/docs
           mv ../.vuepress/dist/docs docs
-          
+
           ./build_previous_versions.sh
           echo "Building the documentation..." >> docs/index.html
           cp _redirects docs/_redirects
-          cp docs/docs/404.html docs/404.html    
+          cp docs/docs/404.html docs/404.html
 
       - name: Publish preview to Netlify
         run: |
-          cd netlify  
+          cd netlify
           netlify deploy --prod --build --context production
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_PREVIEW_AUTH_TOKEN }}
-          NETLIFY_SITE_ID: ${{ env.NETLIFY_SITE_ID }}    
+          NETLIFY_SITE_ID: ${{ env.NETLIFY_SITE_ID }}
 
 
-      
+

--- a/handsontable/src/helpers/dom/__tests__/dom.types.ts
+++ b/handsontable/src/helpers/dom/__tests__/dom.types.ts
@@ -27,6 +27,8 @@ Handsontable.dom.getScrollLeft(domElement, window);
 Handsontable.dom.getScrollTop(domElement);
 Handsontable.dom.getScrollTop(domElement, window);
 Handsontable.dom.getScrollableElement(domElement);
+Handsontable.dom.getScrollbarFractionalScalingCompensation();
+Handsontable.dom.getScrollbarFractionalScalingCompensation(document);
 Handsontable.dom.getScrollbarWidth();
 Handsontable.dom.getScrollbarWidth(document);
 Handsontable.dom.getSelectionEndPosition(domElement);

--- a/handsontable/src/helpers/dom/__tests__/element.unit.js
+++ b/handsontable/src/helpers/dom/__tests__/element.unit.js
@@ -3,6 +3,7 @@ import {
   closest,
   closestDown,
   getParent,
+  getScrollbarFractionalScalingCompensation,
   hasClass,
   isInput,
   removeAttribute,
@@ -832,6 +833,50 @@ describe('DomElement helper', () => {
       const element = document.createElement('div');
 
       expect(isHTMLElement(element)).toBe(true);
+    });
+  });
+
+  //
+  // Handsontable.helper.getScrollbarFractionalScalingCompensation
+  //
+  describe('getScrollbarFractionalScalingCompensation', () => {
+    it('should return 0 for non-Windows platforms', () => {
+      const mockDocument = {
+        defaultView: {
+          navigator: {
+            userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)'
+          },
+          devicePixelRatio: 1.5
+        }
+      };
+
+      expect(getScrollbarFractionalScalingCompensation(mockDocument)).toBe(0);
+    });
+
+    it('should return 0 for Windows with integer devicePixelRatio', () => {
+      const mockDocument = {
+        defaultView: {
+          navigator: {
+            userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
+          },
+          devicePixelRatio: 2
+        }
+      };
+
+      expect(getScrollbarFractionalScalingCompensation(mockDocument)).toBe(0);
+    });
+
+    it('should return 2 for Windows with fractional devicePixelRatio', () => {
+      const mockDocument = {
+        defaultView: {
+          navigator: {
+            userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
+          },
+          devicePixelRatio: 1.5
+        }
+      };
+
+      expect(getScrollbarFractionalScalingCompensation(mockDocument)).toBe(2);
     });
   });
 });

--- a/handsontable/src/helpers/dom/__tests__/element.unit.js
+++ b/handsontable/src/helpers/dom/__tests__/element.unit.js
@@ -15,6 +15,7 @@ import {
   findFirstParentWithClass,
   isHTMLElement,
 } from 'handsontable/helpers/dom/element';
+import { setPlatformMeta } from 'handsontable/helpers/browser';
 
 describe('DomElement helper', () => {
   //
@@ -843,12 +844,11 @@ describe('DomElement helper', () => {
     it('should return 0 for non-Windows platforms', () => {
       const mockDocument = {
         defaultView: {
-          navigator: {
-            userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)'
-          },
           devicePixelRatio: 1.5
         }
       };
+
+      setPlatformMeta({ platform: 'MacIntel' });
 
       expect(getScrollbarFractionalScalingCompensation(mockDocument)).toBe(0);
     });
@@ -856,12 +856,11 @@ describe('DomElement helper', () => {
     it('should return 0 for Windows with integer devicePixelRatio', () => {
       const mockDocument = {
         defaultView: {
-          navigator: {
-            userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
-          },
           devicePixelRatio: 2
         }
       };
+
+      setPlatformMeta({ platform: 'Win32' });
 
       expect(getScrollbarFractionalScalingCompensation(mockDocument)).toBe(0);
     });
@@ -869,12 +868,11 @@ describe('DomElement helper', () => {
     it('should return 2 for Windows with fractional devicePixelRatio', () => {
       const mockDocument = {
         defaultView: {
-          navigator: {
-            userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
-          },
           devicePixelRatio: 1.5
         }
       };
+
+      setPlatformMeta({ platform: 'Win32' });
 
       expect(getScrollbarFractionalScalingCompensation(mockDocument)).toBe(2);
     });

--- a/handsontable/src/helpers/dom/element.js
+++ b/handsontable/src/helpers/dom/element.js
@@ -976,7 +976,7 @@ let cachedScrollbarWidth;
  * @returns {number} The compensation for the scrollbar width, when the device pixel ratio is not an integer.
  */
 // eslint-disable-next-line no-restricted-globals
-function getScrollbarFractionalScalingCompensation(rootDocument = document) {
+export function getScrollbarFractionalScalingCompensation(rootDocument = document) {
   const rootWindow = rootDocument.defaultView;
   const isWindows = rootWindow.navigator.userAgent.toLowerCase().includes('windows');
 

--- a/handsontable/src/helpers/dom/element.js
+++ b/handsontable/src/helpers/dom/element.js
@@ -1,5 +1,6 @@
 import { sanitize } from '../string';
 import { A11Y_HIDDEN } from '../a11y';
+import { isWindowsOS } from '../browser';
 
 /**
  * Get the parent of the specified node in the DOM tree.
@@ -977,18 +978,13 @@ let cachedScrollbarWidth;
  */
 // eslint-disable-next-line no-restricted-globals
 export function getScrollbarFractionalScalingCompensation(rootDocument = document) {
-  const rootWindow = rootDocument.defaultView;
-  const isWindows = rootWindow.navigator.userAgent.toLowerCase().includes('windows');
-
-  if (!isWindows) {
+  if (!isWindowsOS()) {
     return 0;
   }
 
-  const devicePixelRatio = rootWindow.devicePixelRatio || 1;
-
   // On Windows, fractional scaling makes the scrollbar wider to compensate for the anti-aliasing.
   // This is a workaround to calculate the correct scrollbar width.
-  return Number.isInteger(devicePixelRatio) ? 0 : 2;
+  return Number.isInteger((rootDocument.defaultView.devicePixelRatio || 1)) ? 0 : 2;
 }
 
 /**

--- a/handsontable/src/helpers/dom/element.js
+++ b/handsontable/src/helpers/dom/element.js
@@ -970,6 +970,28 @@ export function setCaretPosition(element, pos, endPos) {
 let cachedScrollbarWidth;
 
 /**
+ * Returns the fractional scaling compensation for scrollbar width calculation.
+ *
+ * @param {Document} rootDocument The onwer of the document.
+ * @returns {number} The compensation for the scrollbar width, when the device pixel ratio is not an integer.
+ */
+// eslint-disable-next-line no-restricted-globals
+function getScrollbarFractionalScalingCompensation(rootDocument = document) {
+  const rootWindow = rootDocument.defaultView;
+  const isWindows = rootWindow.navigator.userAgent.toLowerCase().includes('windows');
+
+  if (!isWindows) {
+    return 0;
+  }
+
+  const devicePixelRatio = rootWindow.devicePixelRatio || 1;
+
+  // On Windows, fractional scaling makes the scrollbar wider to compensate for the anti-aliasing.
+  // This is a workaround to calculate the correct scrollbar width.
+  return Number.isInteger(devicePixelRatio) ? 0 : 2;
+}
+
+/**
  * Helper to calculate scrollbar width.
  * Source: https://stackoverflow.com/questions/986937/how-can-i-get-the-browsers-scrollbar-sizes.
  *
@@ -1007,7 +1029,7 @@ function walkontableCalculateScrollbarWidth(rootDocument = document) {
   }
   (rootDocument.body || rootDocument.documentElement).removeChild(outer);
 
-  return (w1 - w2);
+  return (w1 - w2) + getScrollbarFractionalScalingCompensation(rootDocument);
 }
 
 /**

--- a/handsontable/test/helpers/common.js
+++ b/handsontable/test/helpers/common.js
@@ -9,14 +9,14 @@ const DEBUG = false;
 const specContext = {};
 
 beforeEach(function() {
-  if (!DEBUG) {
-    window.scrollTo(0, 0);
-  }
-
   specContext.spec = this;
 
   if (!process.env.JEST_WORKER_ID) {
     this.loadedTheme = __ENV_ARGS__.HOT_THEME || 'classic';
+
+    if (!DEBUG) {
+      window.scrollTo(0, 0);
+    }
   }
 });
 

--- a/handsontable/types/helpers/dom/element.d.ts
+++ b/handsontable/types/helpers/dom/element.d.ts
@@ -1,6 +1,7 @@
 export function getParent(element: HTMLElement, level?: number): HTMLElement;
 export function getFrameElement(frame: Window): HTMLIFrameElement;
 export function getParentWindow(frame: Window): Window;
+export function getScrollbarFractionalScalingCompensation(rootDocument?: Document): number;
 export function hasAccessToParentWindow(frame: Window): boolean;
 export function closest(element: HTMLElement, nodes?: Array<string | HTMLElement>, until?: HTMLElement): HTMLElement;
 export function closestDown(element: HTMLElement, nodes: HTMLElement[], until?: HTMLElement): HTMLElement;


### PR DESCRIPTION
### Context
This PR should fix the problem with the dropdown editor having a horizontal scrollbar on Windows with fractional scaling applied.

What I found was that the scrollbar was wider by `2px` when the scaling was set to a fractional value (like `1.25` or `125%`) on Windows. The `2px` seem to be there because of the anti-aliasing Windows uses to render the UI elements in this scenario. Unfortunately, I wasn't able to confirm that's exactly what happens with any external sources.

**Scaling set to `100%`:**
<img width="215" alt="image" src="https://github.com/user-attachments/assets/71ce9780-0984-44db-945c-81cea238b136" />

**Scaling set to `125%`:**
<img width="208" alt="image" src="https://github.com/user-attachments/assets/fffb2394-fbb3-49de-b0ea-5234af2763f7" />

The problematic thing is that Windows sets the scaling to `125%` **by default** on some machines, which makes this issue a bigger problem.
I ran our E2E tests on a Windows laptop with the default scaling of `125%` and it ended with 500+ failing tests, so I assume there are more places where it can cause visual glitches. I think we should put some effort into investigating those potential issues. (CC: @qunabu)

----

This PR tries to work around that problem by compensating the scrollbar width by `2px` when used on Windows with a fractional `devicePixelRatio`.

Additionally, the changes include a fix for the unit tests silently throwing errors (what's currently happening on `develop`).

### How has this been tested?
- Tested locally on a Parallels machine with scaling and on a Windows laptop.
- Added a test case for the new logic.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#2427

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
