### PR TITLE
[docs] Fix the resource urls in JSFiddle for netlify.

### DIFF
--- a/docs/.vuepress/handsontable-manager/dependencies.js
+++ b/docs/.vuepress/handsontable-manager/dependencies.js
@@ -105,8 +105,9 @@ const getPrebuiltUmdUrl = (scriptName) => {
 
   // eslint-disable-next-line global-require
   const { getDocsBaseFullUrl } = require('../helpers');
+  const docsBaseFullUrl = getDocsBaseFullUrl();
 
-  return `${getDocsBaseFullUrl()}/scripts/prebuilt-umd/${scriptName}`;
+  return `${docsBaseFullUrl}${docsBaseFullUrl.endsWith('/') ? '' : '/'}scripts/prebuilt-umd/${scriptName}`;
 };
 
 /**

--- a/docs/.vuepress/helpers.js
+++ b/docs/.vuepress/helpers.js
@@ -269,7 +269,7 @@ function getDocsBase() {
 function getDocsBaseFullUrl() {
 
   if (process.env.BUILD_MODE === 'preview') {
-    return '/docs/';
+    return `${process.env.NETLIFY_SITE_URL || ''}/docs/`;
   }
 
   return `${getDocsHostname()}${getDocsBase()}`;

--- a/docs/.vuepress/tools/angular-umd-builder/package.json
+++ b/docs/.vuepress/tools/angular-umd-builder/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "scripts": {
-    "umd-builder:install": "echo \"Installing up the Angular UMD Builder dependencies...\n\" && npm i --no-audit",
+    "umd-builder:install": "echo \"Installing the Angular UMD Builder dependencies...\n\" && npm i --no-audit",
     "umd-builder:build-umd": "webpack --config angular-webpack.config.js",
     "umd-builder:clean": "echo \"Cleaning up the Angular UMD Builder...\n\" && rimraf ./node_modules/ && rimraf package-lock.json",
     "umd-builder:full-build": "npm run umd-builder:install && npm run umd-builder:build-umd && npm run umd-builder:clean"


### PR DESCRIPTION
### Context
This PR:
- Utilizes the netlify url when generating the resource urls for JSFiddle, when built in "preview" mode.

**Note: The stackblitz links are still not functional!**
They use `"latest"` as a version of `@handsontable/angular-wrapper`, which is _not_ actually the latest build - it's the initial published. That's going to change after the official release.
After changing it to `next` (automatically assigned to each new pre-release), the table seems to render correclty.

[skip changelog]

### How has this been tested?
Tested locally

### Related issue(s):
1. handsontable/dev-handsontable#2479

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
