### PR TITLE
Fix remove row when physical and visual rows indexes don't match

### DIFF
--- a/handsontable/src/dataMap/dataMap.js
+++ b/handsontable/src/dataMap/dataMap.js
@@ -867,18 +867,18 @@ class DataMap {
    * @returns {number}
    */
   visualRowsToPhysical(index, amount) {
-    const totalRows = this.hot.countSourceRows();
+    const totalRows = this.hot.countRows();
     const logicRows = [];
-    let physicRow = (totalRows + index) % totalRows;
+    let visualRow = (totalRows + index) % totalRows;
     let rowsToRemove = amount;
     let row;
 
-    while (physicRow < totalRows && rowsToRemove) {
-      row = this.hot.toPhysicalRow(physicRow);
+    while (visualRow < totalRows && rowsToRemove) {
+      row = this.hot.toPhysicalRow(visualRow);
       logicRows.push(row);
 
       rowsToRemove -= 1;
-      physicRow += 1;
+      visualRow += 1;
     }
 
     return logicRows;


### PR DESCRIPTION

### Context
`core.alter('remove_row')` doesn't correctly handle cases where the visual and physical row counts don't match (eg. the table has trimmed rows)

Row removal is eventually handled by `DataMap.removeRow(index, amount, source)` which uses `DataMap.visualRowsToPhysical(visualRowIndex, amount)` to convert the passed range of visual rows to an array of physical row indexes.  

`visualRowsToPhysical()` attempts to:

1. Normalize the passed `index` and `amount` parameters based on the size of the table
2. iterate over each visual row within the normalized visual row index and visual row count
3. convert the visual row index to its physical equivalent
4. return array of physical row indexes

The existing logic for step 1 is incorrectly normalizing the passed arguments using the physical number of rows in the columns instead of the visual number of rows.  This pull request fixes the normalization to use `countRows()` instead of `countSourceRows()`.  It also renames the incorrectly named `physicRow` variable to `visualRow` since it contains the current visual row index during loop iteration.

### How has this been tested?
This has been tested by using verifying the behavior demonstrated by the codesandbox provided with #11643 works as expected regardless of whether the table contains trimmed rows or not.

It is also worth nothing that the fixed normalization logic in `visualRowsToPhysical()` is now consistent with `visualColumnsToPhysical()` which provides the same functionality but for columns (although, it too suffers from an incorrectly named `physicalCol` variable).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.  #11643 

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
