### PR TITLE
[docs] Add Angular entries to the page configs + frontmatter.

### DIFF
--- a/docs/.vuepress/plugins/dump-redirect-page-ids/index.js
+++ b/docs/.vuepress/plugins/dump-redirect-page-ids/index.js
@@ -24,8 +24,7 @@ module.exports = (options, context) => {
       }
 
       if (pageIdsMap.has(pageId)) {
-        // TODO temporary solution to avoid the error
-        // throw new Error(`The pageId (${pageId}) is already taken!`);
+        throw new Error(`The pageId (${pageId}) is already taken!`);
       }
 
       pageIdsMap.set(pageId, `/${$page.frontmatter.permalink}/`.replace(/(\/)+/g, '$1'));

--- a/docs/.vuepress/tools/jsdoc-convert/configuration.mjs
+++ b/docs/.vuepress/tools/jsdoc-convert/configuration.mjs
@@ -13,6 +13,10 @@ export default {
         id: '6kcorabp',
         metaTitle: 'Core methods API reference - React Data Grid | Handsontable',
       },
+      angular: {
+        id: 'a8m3k9xz',
+        metaTitle: 'Core methods API reference - Angular Data Grid | Handsontable',
+      },
     },
     'Hooks.md': {
       id: 'js126u0h',
@@ -22,6 +26,10 @@ export default {
       react: {
         id: 'u5rih2o2',
         metaTitle: 'Hooks API reference - React Data Grid | Handsontable',
+      },
+      angular: {
+        id: 'b7n4p2qw',
+        metaTitle: 'Hooks API reference - Angular Data Grid | Handsontable',
       },
     },
     'Options.md': {
@@ -33,6 +41,10 @@ export default {
         id: 'oga06iva',
         metaTitle: 'Options API reference - React Data Grid | Handsontable',
       },
+      angular: {
+        id: 'c9r5t8yx',
+        metaTitle: 'Options API reference - Angular Data Grid | Handsontable',
+      },
     },
     'AutoColumnSize.md': {
       id: 'hjr7zdxy',
@@ -41,6 +53,10 @@ export default {
       react: {
         id: '11f3lp0s',
         metaTitle: 'AutoColumnSize - React Data Grid | Handsontable',
+      },
+      angular: {
+        id: 'd6w1v4zu',
+        metaTitle: 'AutoColumnSize - Angular Data Grid | Handsontable',
       },
     },
     'AutoRowSize.md': {
@@ -51,6 +67,10 @@ export default {
         id: '8bcocfq1',
         metaTitle: 'AutoRowSize - React Data Grid | Handsontable',
       },
+      angular: {
+        id: 'e3x7s0ab',
+        metaTitle: 'AutoRowSize - Angular Data Grid | Handsontable',
+      },
     },
     'Autofill.md': {
       id: 'gybdfu49',
@@ -59,6 +79,10 @@ export default {
       react: {
         id: 'het268ia',
         metaTitle: 'Autofill - React Data Grid | Handsontable',
+      },
+      angular: {
+        id: 'f2y8u6cd',
+        metaTitle: 'Autofill - Angular Data Grid | Handsontable',
       },
     },
     'BindRowsWithHeaders.md': {
@@ -69,6 +93,10 @@ export default {
         id: '2mdpwy50',
         metaTitle: 'BindRowsWithHeaders - React Data Grid | Handsontable',
       },
+      angular: {
+        id: 'g1z9i5ef',
+        metaTitle: 'BindRowsWithHeaders - Angular Data Grid | Handsontable',
+      },
     },
     'CollapsibleColumns.md': {
       id: 'edkch5e6',
@@ -77,6 +105,10 @@ export default {
       react: {
         id: '6f5n1j47',
         metaTitle: 'CollapsibleColumns - React Data Grid | Handsontable',
+      },
+      angular: {
+        id: 'h4a0j7gh',
+        metaTitle: 'CollapsibleColumns - Angular Data Grid | Handsontable',
       },
     },
     'ColumnSorting.md': {
@@ -87,6 +119,10 @@ export default {
         id: 'lpx62nle',
         metaTitle: 'ColumnSorting - React Data Grid | Handsontable',
       },
+      angular: {
+        id: 'i3b8k4ij',
+        metaTitle: 'ColumnSorting - Angular Data Grid | Handsontable',
+      },
     },
     'ColumnSummary.md': {
       id: 'wrwu7s6c',
@@ -95,6 +131,10 @@ export default {
       react: {
         id: '0iw5v2b5',
         metaTitle: 'ColumnSummary - React Data Grid | Handsontable',
+      },
+      angular: {
+        id: 'j2c9l6kl',
+        metaTitle: 'ColumnSummary - Angular Data Grid | Handsontable',
       },
     },
     'Comments.md': {
@@ -105,6 +145,10 @@ export default {
         id: '3g0bkzza',
         metaTitle: 'Comments - React Data Grid | Handsontable',
       },
+      angular: {
+        id: 'k5d0m8mn',
+        metaTitle: 'Comments - Angular Data Grid | Handsontable',
+      },
     },
     'ContextMenu.md': {
       id: 'pczrlicw',
@@ -113,6 +157,10 @@ export default {
       react: {
         id: 'kx1mawmf',
         metaTitle: 'ContextMenu - React Data Grid | Handsontable',
+      },
+      angular: {
+        id: 'l4e1n9op',
+        metaTitle: 'ContextMenu - Angular Data Grid | Handsontable',
       },
     },
     'CopyPaste.md': {
@@ -123,6 +171,10 @@ export default {
         id: 'g6fi2a6i',
         metaTitle: 'CopyPaste - React Data Grid | Handsontable',
       },
+      angular: {
+        id: 'm3f2o0qr',
+        metaTitle: 'CopyPaste - Angular Data Grid | Handsontable',
+      },
     },
     'CustomBorders.md': {
       id: 'gxm1a98b',
@@ -131,6 +183,10 @@ export default {
       react: {
         id: '93acldzf',
         metaTitle: 'CustomBorders - React Data Grid | Handsontable',
+      },
+      angular: {
+        id: 'n6g3p2st',
+        metaTitle: 'CustomBorders - Angular Data Grid | Handsontable',
       },
     },
     'DragToScroll.md': {
@@ -141,6 +197,10 @@ export default {
         id: 'uawwix9r',
         metaTitle: 'DragToScroll - React Data Grid | Handsontable',
       },
+      angular: {
+        id: 'o5h4q1uv',
+        metaTitle: 'DragToScroll - Angular Data Grid | Handsontable',
+      },
     },
     'DropdownMenu.md': {
       id: 'snqjcwml',
@@ -149,6 +209,10 @@ export default {
       react: {
         id: 'zj3aru0b',
         metaTitle: 'DropdownMenu - React Data Grid | Handsontable',
+      },
+      angular: {
+        id: 'p4i5r3wx',
+        metaTitle: 'DropdownMenu - Angular Data Grid | Handsontable',
       },
     },
     'ExportFile.md': {
@@ -159,6 +223,10 @@ export default {
         id: 'qsmpym52',
         metaTitle: 'ExportFile - React Data Grid | Handsontable',
       },
+      angular: {
+        id: 'q3j6s4yz',
+        metaTitle: 'ExportFile - Angular Data Grid | Handsontable',
+      },
     },
     'Filters.md': {
       id: '3alr8j85',
@@ -167,6 +235,10 @@ export default {
       react: {
         id: 'vxwvhi0e',
         metaTitle: 'Filters - React Data Grid | Handsontable',
+      },
+      angular: {
+        id: 'r2k7t5ab',
+        metaTitle: 'Filters - Angular Data Grid | Handsontable',
       },
     },
     'Formulas.md': {
@@ -177,6 +249,10 @@ export default {
         id: 'of6l92wv',
         metaTitle: 'Formulas - React Data Grid | Handsontable',
       },
+      angular: {
+        id: 's1l8u6cd',
+        metaTitle: 'Formulas - Angular Data Grid | Handsontable',
+      },
     },
     'HiddenRows.md': {
       id: 'linbgjey',
@@ -185,6 +261,10 @@ export default {
       react: {
         id: 'ztxn1ekz',
         metaTitle: 'HiddenRows - React Data Grid | Handsontable',
+      },
+      angular: {
+        id: 't0m9v7ef',
+        metaTitle: 'HiddenRows - Angular Data Grid | Handsontable',
       },
     },
     'HiddenColumns.md': {
@@ -195,6 +275,10 @@ export default {
         id: 'crwccrpj',
         metaTitle: 'HiddenColumns - React Data Grid | Handsontable',
       },
+      angular: {
+        id: 'u9n0w8gh',
+        metaTitle: 'HiddenColumns - Angular Data Grid | Handsontable',
+      },
     },
     'ManualColumnFreeze.md': {
       id: 'xn65u35f',
@@ -203,6 +287,10 @@ export default {
       react: {
         id: '5y6obv03',
         metaTitle: 'ManualColumnFreeze - React Data Grid | Handsontable',
+      },
+      angular: {
+        id: 'v8o1x9ij',
+        metaTitle: 'ManualColumnFreeze - Angular Data Grid | Handsontable',
       },
     },
     'ManualColumnMove.md': {
@@ -213,6 +301,10 @@ export default {
         id: '41x190ra',
         metaTitle: 'ManualColumnMove - React Data Grid | Handsontable',
       },
+      angular: {
+        id: 'w7p2y0kl',
+        metaTitle: 'ManualColumnMove - Angular Data Grid | Handsontable',
+      },
     },
     'ManualColumnResize.md': {
       id: '4zjgoamn',
@@ -221,6 +313,10 @@ export default {
       react: {
         id: 'lszzwc0i',
         metaTitle: 'ManualColumnResize - React Data Grid | Handsontable',
+      },
+      angular: {
+        id: 'x6q3z1mn',
+        metaTitle: 'ManualColumnResize - Angular Data Grid | Handsontable',
       },
     },
     'ManualRowMove.md': {
@@ -231,6 +327,10 @@ export default {
         id: '87xdqwwb',
         metaTitle: 'ManualRowMove - React Data Grid | Handsontable',
       },
+      angular: {
+        id: 'y5r4a2op',
+        metaTitle: 'ManualRowMove - Angular Data Grid | Handsontable',
+      },
     },
     'ManualRowResize.md': {
       id: 'la7wo1xh',
@@ -239,6 +339,10 @@ export default {
       react: {
         id: '7chricz2',
         metaTitle: 'ManualRowResize - React Data Grid | Handsontable',
+      },
+      angular: {
+        id: 'z4s5b3qr',
+        metaTitle: 'ManualRowResize - Angular Data Grid | Handsontable',
       },
     },
     'MergeCells.md': {
@@ -249,6 +353,10 @@ export default {
         id: '62cv5ecx',
         metaTitle: 'MergeCells - React Data Grid | Handsontable',
       },
+      angular: {
+        id: 'a3t6c4st',
+        metaTitle: 'MergeCells - Angular Data Grid | Handsontable',
+      },
     },
     'MultiColumnSorting.md': {
       id: 'ypo7x8k9',
@@ -257,6 +365,10 @@ export default {
       react: {
         id: '8gqtvsrl',
         metaTitle: 'MultiColumnSorting - React Data Grid | Handsontable',
+      },
+      angular: {
+        id: 'b2u7d5uv',
+        metaTitle: 'MultiColumnSorting - Angular Data Grid | Handsontable',
       },
     },
     'NestedHeaders.md': {
@@ -267,6 +379,10 @@ export default {
         id: '8qwzxi9i',
         metaTitle: 'NestedHeaders - React Data Grid | Handsontable',
       },
+      angular: {
+        id: 'c1v8e6wx',
+        metaTitle: 'NestedHeaders - Angular Data Grid | Handsontable',
+      },
     },
     'NestedRows.md': {
       id: 'iadurw6z',
@@ -275,6 +391,10 @@ export default {
       react: {
         id: 'fvo6cybt',
         metaTitle: 'NestedRows - React Data Grid | Handsontable',
+      },
+      angular: {
+        id: 'd0w9f7yz',
+        metaTitle: 'NestedRows - Angular Data Grid | Handsontable',
       },
     },
     'PersistentState.md': {
@@ -285,6 +405,10 @@ export default {
         id: '8he28jcj',
         metaTitle: 'PersistentState - React Data Grid | Handsontable',
       },
+      angular: {
+        id: 'e9x0g8ab',
+        metaTitle: 'PersistentState - Angular Data Grid | Handsontable',
+      },
     },
     'Search.md': {
       id: '4r6t4j1z',
@@ -293,6 +417,10 @@ export default {
       react: {
         id: 'acamkuxd',
         metaTitle: 'Search - React Data Grid | Handsontable',
+      },
+      angular: {
+        id: 'f8y1h9cd',
+        metaTitle: 'Search - Angular Data Grid | Handsontable',
       },
     },
     'StretchColumns.md': {
@@ -303,6 +431,10 @@ export default {
         id: 'a2b7ku2p',
         metaTitle: 'StretchColumns - React Data Grid | Handsontable',
       },
+      angular: {
+        id: 'g7z2i0ef',
+        metaTitle: 'StretchColumns - Angular Data Grid | Handsontable',
+      },
     },
     'TrimRows.md': {
       id: 'ks06q7cq',
@@ -311,6 +443,10 @@ export default {
       react: {
         id: 'ysqsy1ec',
         metaTitle: 'TrimRows - React Data Grid | Handsontable',
+      },
+      angular: {
+        id: 'h6a3j1gh',
+        metaTitle: 'TrimRows - Angular Data Grid | Handsontable',
       },
     },
     'UndoRedo.md': {
@@ -321,6 +457,10 @@ export default {
         id: 't5lpzjly',
         metaTitle: 'UndoRedo - React Data Grid | Handsontable',
       },
+      angular: {
+        id: 'i5b4k2ij',
+        metaTitle: 'UndoRedo - Angular Data Grid | Handsontable',
+      },
     },
     'BaseEditor.md': {
       id: 'l025jsly',
@@ -329,6 +469,10 @@ export default {
       react: {
         id: 'snc3axwd',
         metaTitle: 'BaseEditor - React Data Grid | Handsontable',
+      },
+      angular: {
+        id: 'j4c5l3kl',
+        metaTitle: 'BaseEditor - Angular Data Grid | Handsontable',
       },
     },
     'BasePlugin.md': {
@@ -339,6 +483,10 @@ export default {
         id: 'wi27fiwz',
         metaTitle: 'BasePlugin - React Data Grid | Handsontable',
       },
+      angular: {
+        id: 'k3d6m4mn',
+        metaTitle: 'BasePlugin - Angular Data Grid | Handsontable',
+      },
     },
     'CellCoords.md': {
       id: 'qthfdrss',
@@ -347,6 +495,10 @@ export default {
       react: {
         id: 'ufhe1gsm',
         metaTitle: 'CellCoords - React Data Grid | Handsontable',
+      },
+      angular: {
+        id: 'l2e7n5op',
+        metaTitle: 'CellCoords - Angular Data Grid | Handsontable',
       },
     },
     'CellRange.md': {
@@ -357,6 +509,10 @@ export default {
         id: 'mpqwzjpm',
         metaTitle: 'CellRange - React Data Grid | Handsontable',
       },
+      angular: {
+        id: 'm1f8o6qr',
+        metaTitle: 'CellRange - Angular Data Grid | Handsontable',
+      },
     },
     'ChangesObserver.md': {
       id: 'n1d2orqc',
@@ -365,6 +521,10 @@ export default {
       react: {
         id: 'v5k5tou4',
         metaTitle: 'ChangesObserver - React Data Grid | Handsontable',
+      },
+      angular: {
+        id: 'n0g9p7st',
+        metaTitle: 'ChangesObserver - Angular Data Grid | Handsontable',
       },
     },
     'createShortcutManager.md': {
@@ -375,6 +535,10 @@ export default {
         id: 'smdsdtby',
         metaTitle: 'CreateShortcutManager - React Data Grid | Handsontable',
       },
+      angular: {
+        id: 'o9h0q8uv',
+        metaTitle: 'CreateShortcutManager - Angular Data Grid | Handsontable',
+      },
     },
     'ShortcutManager.md': {
       id: 'qos98msl',
@@ -383,6 +547,10 @@ export default {
       react: {
         id: 'doot085y',
         metaTitle: 'ShortcutManager - React Data Grid | Handsontable',
+      },
+      angular: {
+        id: 'p8i1r9wx',
+        metaTitle: 'ShortcutManager - Angular Data Grid | Handsontable',
       },
     },
     'DataMap.md': {
@@ -393,6 +561,10 @@ export default {
         id: 'a2342zyo',
         metaTitle: 'DataMap - React Data Grid | Handsontable',
       },
+      angular: {
+        id: 'q7j2s0yz',
+        metaTitle: 'DataMap - Angular Data Grid | Handsontable',
+      },
     },
     'GhostTable.md': {
       id: '1i74gjp4',
@@ -401,6 +573,10 @@ export default {
       react: {
         id: 'bbq83v9b',
         metaTitle: 'GhostTable - React Data Grid | Handsontable',
+      },
+      angular: {
+        id: 'r6k3t1ab',
+        metaTitle: 'GhostTable - Angular Data Grid | Handsontable',
       },
     },
     'HidingMap.md': {
@@ -411,6 +587,10 @@ export default {
         id: '9k5ucjxx',
         metaTitle: 'HidingMap - React Data Grid | Handsontable',
       },
+      angular: {
+        id: 's5l4u2cd',
+        metaTitle: 'HidingMap - Angular Data Grid | Handsontable',
+      },
     },
     'IndexMap.md': {
       id: '8b008itj',
@@ -419,6 +599,10 @@ export default {
       react: {
         id: 'nwnemipo',
         metaTitle: 'IndexMap - React Data Grid | Handsontable',
+      },
+      angular: {
+        id: 't4m5v3ef',
+        metaTitle: 'IndexMap - Angular Data Grid | Handsontable',
       },
     },
     'IndexMapper.md': {
@@ -429,6 +613,10 @@ export default {
         id: 'sbs3825t',
         metaTitle: 'IndexMapper - React Data Grid | Handsontable',
       },
+      angular: {
+        id: 'u3n6w4gh',
+        metaTitle: 'IndexMapper - Angular Data Grid | Handsontable',
+      },
     },
     'IndexesSequence.md': {
       id: 'huuybcbn',
@@ -437,6 +625,10 @@ export default {
       react: {
         id: '5nrvua89',
         metaTitle: 'IndexesSequence - React Data Grid | Handsontable',
+      },
+      angular: {
+        id: 'v2o7x5ij',
+        metaTitle: 'IndexesSequence - Angular Data Grid | Handsontable',
       },
     },
     'LinkedPhysicalIndexToValueMap.md': {
@@ -447,6 +639,10 @@ export default {
         id: 'h10c2au0',
         metaTitle: 'LinkedPhysicalIndexToValueMap - React Data Grid | Handsontable',
       },
+      angular: {
+        id: 'w1p8y6kl',
+        metaTitle: 'LinkedPhysicalIndexToValueMap - Angular Data Grid | Handsontable',
+      },
     },
     'Menu.md': {
       id: '6a7q8pb9',
@@ -455,6 +651,10 @@ export default {
       react: {
         id: '2eifxhv3',
         metaTitle: 'Menu - React Data Grid | Handsontable',
+      },
+      angular: {
+        id: 'x0q9z7mn',
+        metaTitle: 'Menu - Angular Data Grid | Handsontable',
       },
     },
     'PhysicalIndexToValueMap.md': {
@@ -465,6 +665,10 @@ export default {
         id: '8f31lcaa',
         metaTitle: 'PhysicalIndexToValueMap - React Data Grid | Handsontable',
       },
+      angular: {
+        id: 'y9r0a8op',
+        metaTitle: 'PhysicalIndexToValueMap - Angular Data Grid | Handsontable',
+      },
     },
     'SamplesGenerator.md': {
       id: 'n9lf8vn4',
@@ -473,6 +677,10 @@ export default {
       react: {
         id: 'gh3nicnu',
         metaTitle: 'SamplesGenerator - React Data Grid | Handsontable',
+      },
+      angular: {
+        id: 'z8s1b9qr',
+        metaTitle: 'SamplesGenerator - Angular Data Grid | Handsontable',
       },
     },
     'ShortcutContext.md': {
@@ -483,6 +691,10 @@ export default {
         id: 'qhf0cz5d',
         metaTitle: 'ShortcutContext - React Data Grid | Handsontable',
       },
+      angular: {
+        id: 'a7t2c0st',
+        metaTitle: 'ShortcutContext - Angular Data Grid | Handsontable',
+      },
     },
     'TrimmingMap.md': {
       id: '8wnfx6b9',
@@ -492,6 +704,10 @@ export default {
         id: 'l3n89gff',
         metaTitle: 'TrimmingMap - React Data Grid | Handsontable',
       },
+      angular: {
+        id: 'b6u3d1uv',
+        metaTitle: 'TrimmingMap - Angular Data Grid | Handsontable',
+      },
     },
     'EventManager.md': {
       id: '3k9p5r7t',
@@ -500,6 +716,10 @@ export default {
       react: {
         id: '5j7d9k2r',
         metaTitle: 'EventManager - React Data Grid | Handsontable',
+      },
+      angular: {
+        id: 'c5v4e2wx',
+        metaTitle: 'EventManager - Angular Data Grid | Handsontable',
       },
     },
   }

--- a/docs/content/api/introduction.md
+++ b/docs/content/api/introduction.md
@@ -9,6 +9,9 @@ searchCategory: API Reference
 react:
   id: 45svfigt
   metaTitle: API reference - React Data Grid | Handsontable
+angular:
+  id: 48gjbys8
+  metaTitle: API reference - Angular Data Grid | Handsontable
 ---
 
 # Handsontable API reference
@@ -33,11 +36,11 @@ The API enables you to control the data grid programmatically. With this API, yo
 
 - [Core](@/api/core.md)
 The `Handsontable` class controls the essential aspects of the data grid.
-- [Hooks](@/api/hooks.md) 
+- [Hooks](@/api/hooks.md)
 Handsontable hooks are events that fire whenever a specific action occurs within the instance of Handsontable.
-- [Options](@/api/options.md) 
+- [Options](@/api/options.md)
 These are the settings available to be registered for the `Core` features, in addition to those provided by plugins.
-- [Plugins](@/api/plugins.md) 
+- [Plugins](@/api/plugins.md)
 The plugins extend the capabilities of Handsontable.
 
 </div>

--- a/docs/content/api/plugins.md
+++ b/docs/content/api/plugins.md
@@ -9,6 +9,9 @@ searchCategory: API Reference
 react:
   id: iauj1mv1
   metaTitle: 'API reference: Plugins - React Data Grid | Handsontable'
+angular:
+  id: gueng7dm
+  metaTitle: 'API reference: Plugins - Angular Data Grid | Handsontable'
 ---
 
 # Available plugins

--- a/docs/content/guides/accessibility/accessibility/accessibility.md
+++ b/docs/content/guides/accessibility/accessibility/accessibility.md
@@ -20,6 +20,9 @@ tags:
 react:
   id: x82phf34
   metaTitle: Accessibility - React Data Grid | Handsontable
+angular:
+  id: 99l3uae8
+  metaTitle: Accessibility - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Accessibility
 ---

--- a/docs/content/guides/accessories-and-menus/context-menu/context-menu.md
+++ b/docs/content/guides/accessories-and-menus/context-menu/context-menu.md
@@ -13,6 +13,9 @@ tags:
 react:
   id: r2x6mh6h
   metaTitle: Context menu - React Data Grid | Handsontable
+angular:
+  id: 3xspgb3u
+  metaTitle: Context menu - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Accessories and menus
 ---

--- a/docs/content/guides/accessories-and-menus/export-to-csv/export-to-csv.md
+++ b/docs/content/guides/accessories-and-menus/export-to-csv/export-to-csv.md
@@ -11,6 +11,9 @@ tags:
 react:
   id: sfxo3g54
   metaTitle: Export to CSV - React Data Grid | Handsontable
+angular:
+  id: hwhzgoir
+  metaTitle: Export to CSV - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Accessories and menus
 ---

--- a/docs/content/guides/accessories-and-menus/icon-pack/icon-pack.md
+++ b/docs/content/guides/accessories-and-menus/icon-pack/icon-pack.md
@@ -11,6 +11,9 @@ tags:
 react:
   id: 24wgu6o9
   metaTitle: Icon pack - React Data Grid | Handsontable
+angular:
+  id: 5qu8t28e
+  metaTitle: Icon pack - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Accessories and menus
 ---

--- a/docs/content/guides/accessories-and-menus/undo-redo/undo-redo.md
+++ b/docs/content/guides/accessories-and-menus/undo-redo/undo-redo.md
@@ -16,6 +16,9 @@ tags:
 react:
   id: me8uxp3w
   metaTitle: Undo and redo - React Data Grid | Handsontable
+angular:
+  id: o21k5bjr
+  metaTitle: Undo and redo - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Accessories and menus
 ---

--- a/docs/content/guides/cell-features/autofill-values/autofill-values.md
+++ b/docs/content/guides/cell-features/autofill-values/autofill-values.md
@@ -16,6 +16,9 @@ tags:
 react:
   id: m4x3zpiw
   metaTitle: Autofill values - React Data Grid | Handsontable
+angular:
+  id: 8tftfxgq
+  metaTitle: Autofill values - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Cell features
 ---

--- a/docs/content/guides/cell-features/clipboard/clipboard.md
+++ b/docs/content/guides/cell-features/clipboard/clipboard.md
@@ -12,6 +12,9 @@ tags:
 react:
   id: mlctr1ri
   metaTitle: Clipboard - React Data Grid | Handsontable
+angular:
+  id: q473yaal
+  metaTitle: Clipboard - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Cell features
 ---

--- a/docs/content/guides/cell-features/comments/comments.md
+++ b/docs/content/guides/cell-features/comments/comments.md
@@ -10,6 +10,9 @@ tags:
 react:
   id: lxw2632u
   metaTitle: Comments - React Data Grid | Handsontable
+angular:
+  id: o4jcn137
+  metaTitle: Comments - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Cell features
 ---

--- a/docs/content/guides/cell-features/conditional-formatting/conditional-formatting.md
+++ b/docs/content/guides/cell-features/conditional-formatting/conditional-formatting.md
@@ -8,6 +8,9 @@ canonicalUrl: /conditional-formatting
 react:
   id: eyatgywe
   metaTitle: Conditional formatting - React Data Grid | Handsontable
+angular:
+  id: uz3qc620
+  metaTitle: Conditional formatting - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Cell features
 ---

--- a/docs/content/guides/cell-features/disabled-cells/disabled-cells.md
+++ b/docs/content/guides/cell-features/disabled-cells/disabled-cells.md
@@ -14,6 +14,9 @@ tags:
 react:
   id: zhv7fs29
   metaTitle: Disabled cells - React Data Grid | Handsontable
+angular:
+  id: 2epog9e1
+  metaTitle: Disabled cells - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Cell features
 ---

--- a/docs/content/guides/cell-features/formatting-cells/formatting-cells.md
+++ b/docs/content/guides/cell-features/formatting-cells/formatting-cells.md
@@ -8,6 +8,9 @@ canonicalUrl: /formatting-cells
 react:
   id: qywqgovy
   metaTitle: Formatting cells - React Data Grid | Handsontable
+angular:
+  id: 0eswjne7
+  metaTitle: Formatting cells - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Cell features
 ---

--- a/docs/content/guides/cell-features/merge-cells/merge-cells.md
+++ b/docs/content/guides/cell-features/merge-cells/merge-cells.md
@@ -8,6 +8,9 @@ canonicalUrl: /merge-cells
 react:
   id: ulndkavi
   metaTitle: Merge cells - React Data Grid | Handsontable
+angular:
+  id: pbcdsao1
+  metaTitle: Merge cells - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Cell features
 ---

--- a/docs/content/guides/cell-features/selection/selection.md
+++ b/docs/content/guides/cell-features/selection/selection.md
@@ -11,6 +11,9 @@ tags:
 react:
   id: k88lznt8
   metaTitle: Selection - React Data Grid | Handsontable
+angular:
+  id: 8l4fmyur
+  metaTitle: Selection - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Cell features
 ---

--- a/docs/content/guides/cell-features/text-alignment/text-alignment.md
+++ b/docs/content/guides/cell-features/text-alignment/text-alignment.md
@@ -8,6 +8,9 @@ canonicalUrl: /text-alignment
 react:
   id: 959g5cbf
   metaTitle: Text alignment - React Data Grid | Handsontable
+angular:
+  id: h6sbjq1g
+  metaTitle: Text alignment - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Cell features
 ---

--- a/docs/content/guides/cell-functions/cell-function/cell-function.md
+++ b/docs/content/guides/cell-functions/cell-function/cell-function.md
@@ -8,6 +8,9 @@ canonicalUrl: /cell-function
 react:
   id: i2sqtwh6
   metaTitle: Cell functions - React Data Grid | Handsontable
+angular:
+  id: 377lnttu
+  metaTitle: Cell functions - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Cell functions
 ---

--- a/docs/content/guides/cell-functions/cell-renderer/cell-renderer.md
+++ b/docs/content/guides/cell-functions/cell-renderer/cell-renderer.md
@@ -8,6 +8,9 @@ canonicalUrl: /cell-renderer
 react:
   id: 2ej30mcg
   metaTitle: Cell renderer - React Data Grid | Handsontable
+angular:
+  id: 36rymylj
+  metaTitle: Cell renderer - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Cell functions
 ---

--- a/docs/content/guides/cell-functions/cell-validator/cell-validator.md
+++ b/docs/content/guides/cell-functions/cell-validator/cell-validator.md
@@ -8,6 +8,9 @@ canonicalUrl: /cell-validator
 react:
   id: fvou30a5
   metaTitle: Cell validator - React Data Grid | Handsontable
+angular:
+  id: ut7amcaz
+  metaTitle: Cell validator - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Cell functions
 ---

--- a/docs/content/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md
@@ -8,6 +8,9 @@ canonicalUrl: /autocomplete-cell-type
 react:
   id: vnnvp396
   metaTitle: Autocomplete cell type - React Data Grid | Handsontable
+angular:
+  id: md3vhixm
+  metaTitle: Autocomplete cell type - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types
 ---

--- a/docs/content/guides/cell-types/cell-type/cell-type.md
+++ b/docs/content/guides/cell-types/cell-type/cell-type.md
@@ -8,6 +8,9 @@ canonicalUrl: /cell-type
 react:
   id: m60w87tn
   metaTitle: Cell type - React Data Grid | Handsontable
+angular:
+  id: aho23taw
+  metaTitle: Cell type - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types
 ---

--- a/docs/content/guides/cell-types/checkbox-cell-type/checkbox-cell-type.md
+++ b/docs/content/guides/cell-types/checkbox-cell-type/checkbox-cell-type.md
@@ -8,6 +8,9 @@ canonicalUrl: /checkbox-cell-type
 react:
   id: tfr1gisf
   metaTitle: Checkbox cell type - React Data Grid | Handsontable
+angular:
+  id: 4cn9mp6z
+  metaTitle: Checkbox cell type - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types
 ---

--- a/docs/content/guides/cell-types/date-cell-type/date-cell-type.md
+++ b/docs/content/guides/cell-types/date-cell-type/date-cell-type.md
@@ -8,6 +8,9 @@ canonicalUrl: /date-cell-type
 react:
   id: u7t2rn0n
   metaTitle: Date cell type - React Data Grid | Handsontable
+angular:
+  id: 9vvupwbx
+  metaTitle: Date cell type - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types
 ---

--- a/docs/content/guides/cell-types/dropdown-cell-type/dropdown-cell-type.md
+++ b/docs/content/guides/cell-types/dropdown-cell-type/dropdown-cell-type.md
@@ -8,6 +8,9 @@ canonicalUrl: /dropdown-cell-type
 react:
   id: 5i86kjqu
   metaTitle: Dropdown cell type - React Data Grid | Handsontable
+angular:
+  id: yatyane1
+  metaTitle: Dropdown cell type - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types
 ---

--- a/docs/content/guides/cell-types/handsontable-cell-type/handsontable-cell-type.md
+++ b/docs/content/guides/cell-types/handsontable-cell-type/handsontable-cell-type.md
@@ -8,6 +8,9 @@ canonicalUrl: /handsontable-cell-type
 react:
   id: fcxtj167
   metaTitle: Handsontable cell type - React Data Grid | Handsontable
+angular:
+  id: cewiknc8
+  metaTitle: Handsontable cell type - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types
 ---

--- a/docs/content/guides/cell-types/numeric-cell-type/numeric-cell-type.md
+++ b/docs/content/guides/cell-types/numeric-cell-type/numeric-cell-type.md
@@ -8,6 +8,9 @@ canonicalUrl: /numeric-cell-type
 react:
   id: e6zmmawj
   metaTitle: Numeric cell type - React Data Grid | Handsontable
+angular:
+  id: odhu846f
+  metaTitle: Numeric cell type - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types
 ---

--- a/docs/content/guides/cell-types/password-cell-type/password-cell-type.md
+++ b/docs/content/guides/cell-types/password-cell-type/password-cell-type.md
@@ -8,6 +8,9 @@ canonicalUrl: /password-cell-type
 react:
   id: gydne13d
   metaTitle: Password cell type - React Data Grid | Handsontable
+angular:
+  id: 2x5025ww
+  metaTitle: Password cell type - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types
 ---

--- a/docs/content/guides/cell-types/select-cell-type/select-cell-type.md
+++ b/docs/content/guides/cell-types/select-cell-type/select-cell-type.md
@@ -8,6 +8,9 @@ canonicalUrl: /select-cell-type
 react:
   id: xmdreeu3
   metaTitle: Select cell type - React Data Grid | Handsontable
+angular:
+  id: dtzqxytv
+  metaTitle: Select cell type - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types
 ---

--- a/docs/content/guides/cell-types/time-cell-type/time-cell-type.md
+++ b/docs/content/guides/cell-types/time-cell-type/time-cell-type.md
@@ -8,6 +8,9 @@ canonicalUrl: /time-cell-type
 react:
   id: 34n5nwja
   metaTitle: Time cell type - React Data Grid | Handsontable
+angular:
+  id: fu9fqphw
+  metaTitle: Time cell type - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types
 ---

--- a/docs/content/guides/columns/column-filter/column-filter.md
+++ b/docs/content/guides/columns/column-filter/column-filter.md
@@ -21,6 +21,9 @@ tags:
 react:
   id: vz7ct2bv
   metaTitle: Column filter - React Data Grid | Handsontable
+angular:
+  id: woyi876m
+  metaTitle: Column filter - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Columns
 ---

--- a/docs/content/guides/columns/column-freezing/column-freezing.md
+++ b/docs/content/guides/columns/column-freezing/column-freezing.md
@@ -13,6 +13,9 @@ tags:
 react:
   id: otumcpty
   metaTitle: Column freezing - React Data Grid | Handsontable
+angular:
+  id: i85vqeao
+  metaTitle: Column freezing - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Columns
 ---

--- a/docs/content/guides/columns/column-groups/column-groups.md
+++ b/docs/content/guides/columns/column-groups/column-groups.md
@@ -13,6 +13,9 @@ tags:
 react:
   id: 2ei1omu0
   metaTitle: Column groups - React Data Grid | Handsontable
+angular:
+  id: 2k8cam98
+  metaTitle: Column groups - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Columns
 ---

--- a/docs/content/guides/columns/column-header/column-header.md
+++ b/docs/content/guides/columns/column-header/column-header.md
@@ -8,6 +8,9 @@ canonicalUrl: /column-header
 react:
   id: 5e0tnexi
   metaTitle: Column headers - React Data Grid | Handsontable
+angular:
+  id: owl7h4t1
+  metaTitle: Column headers - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Columns
 ---

--- a/docs/content/guides/columns/column-hiding/column-hiding.md
+++ b/docs/content/guides/columns/column-hiding/column-hiding.md
@@ -10,6 +10,9 @@ canonicalUrl: /column-hiding
 react:
   id: u1aw329h
   metaTitle: Column hiding - React Data Grid | Handsontable
+angular:
+  id: 69k5r1oh
+  metaTitle: Column hiding - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Columns
 ---

--- a/docs/content/guides/columns/column-menu/column-menu.md
+++ b/docs/content/guides/columns/column-menu/column-menu.md
@@ -10,6 +10,9 @@ tags:
 react:
   id: uc7w8gu1
   metaTitle: Column menu - React Data Grid | Handsontable
+angular:
+  id: zclxcsij
+  metaTitle: Column menu - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Columns
 ---

--- a/docs/content/guides/columns/column-moving/column-moving.md
+++ b/docs/content/guides/columns/column-moving/column-moving.md
@@ -8,6 +8,9 @@ canonicalUrl: /column-moving
 react:
   id: zhlikwwh
   metaTitle: Column moving - React Data Grid | Handsontable
+angular:
+  id: fsfvsoi3
+  metaTitle: Column moving - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Columns
 ---

--- a/docs/content/guides/columns/column-summary/column-summary.md
+++ b/docs/content/guides/columns/column-summary/column-summary.md
@@ -16,6 +16,9 @@ tags:
 react:
   id: r3x4l0gp
   metaTitle: Column summary - React Data Grid | Handsontable
+angular:
+  id: 1rptt5bu
+  metaTitle: Column summary - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Columns
 ---

--- a/docs/content/guides/columns/column-virtualization/column-virtualization.md
+++ b/docs/content/guides/columns/column-virtualization/column-virtualization.md
@@ -12,6 +12,9 @@ tags:
 react:
   id: 24n21dwi
   metaTitle: Column virtualization - React Data Grid | Handsontable
+angular:
+  id: qhqjtdsr
+  metaTitle: Column virtualization - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Columns
 ---

--- a/docs/content/guides/columns/column-width/column-width.md
+++ b/docs/content/guides/columns/column-width/column-width.md
@@ -17,6 +17,9 @@ tags:
 react:
   id: gr6w8qsy
   metaTitle: Column widths - React Data Grid | Handsontable
+angular:
+  id: eourt93b
+  metaTitle: Column widths - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Columns
 ---

--- a/docs/content/guides/formulas/formula-calculation/formula-calculation.md
+++ b/docs/content/guides/formulas/formula-calculation/formula-calculation.md
@@ -18,6 +18,9 @@ tags:
 react:
   id: 05z3cjez
   metaTitle: Formula calculation - React Data Grid | Handsontable
+angular:
+  id: hqzll0fz
+  metaTitle: Formula calculation - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Formulas
 ---

--- a/docs/content/guides/getting-started/binding-to-data/binding-to-data.md
+++ b/docs/content/guides/getting-started/binding-to-data/binding-to-data.md
@@ -12,6 +12,9 @@ tags:
 react:
   id: umdq9b9j
   metaTitle: Binding to data - React Data Grid | Handsontable
+angular:
+  id: xnqn2zg9
+  metaTitle: Binding to data - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Getting started
 ---

--- a/docs/content/guides/getting-started/configuration-options/configuration-options.md
+++ b/docs/content/guides/getting-started/configuration-options/configuration-options.md
@@ -12,6 +12,9 @@ tags:
 react:
   id: gmpbmisy
   metaTitle: Configuration options - React Data Grid | Handsontable
+angular:
+  id: 16bofyho
+  metaTitle: Configuration options - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Getting started
 ---

--- a/docs/content/guides/getting-started/demo/demo.md
+++ b/docs/content/guides/getting-started/demo/demo.md
@@ -12,6 +12,10 @@ react:
   id: ccqbm8hn
   metaTitle: Demo - React Data Grid | Handsontable
   description: Play around with a demo of Handsontable in React.
+angular:
+  id: i2n378hh
+  metaTitle: Demo - Angular Data Grid | Handsontable
+  description: Play around with a demo of Handsontable in Angular.
 searchCategory: Guides
 category: Getting started
 ---

--- a/docs/content/guides/getting-started/events-and-hooks/events-and-hooks.md
+++ b/docs/content/guides/getting-started/events-and-hooks/events-and-hooks.md
@@ -18,6 +18,9 @@ tags:
 react:
   id: d966se98
   metaTitle: Events and hooks - React Data Grid | Handsontable
+angular:
+  id: iifvbgu0
+  metaTitle: Events and hooks - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Getting started
 ---

--- a/docs/content/guides/getting-started/grid-size/grid-size.md
+++ b/docs/content/guides/getting-started/grid-size/grid-size.md
@@ -13,6 +13,9 @@ tags:
 react:
   id: cifepxzs
   metaTitle: Grid size - React Data Grid | Handsontable
+angular:
+  id: w6lvb55f
+  metaTitle: Grid size - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Getting started
 ---

--- a/docs/content/guides/getting-started/installation/installation.md
+++ b/docs/content/guides/getting-started/installation/installation.md
@@ -10,6 +10,9 @@ tags:
 react:
   id: zqk2jjw3
   metaTitle: Installation - React Data Grid | Handsontable
+angular:
+  id: y52wtu7t
+  metaTitle: Installation - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Getting started
 ---

--- a/docs/content/guides/getting-started/introduction/introduction.md
+++ b/docs/content/guides/getting-started/introduction/introduction.md
@@ -8,6 +8,9 @@ canonicalUrl: /
 react:
   id: fexwrrj2
   metaTitle: React Data Grid - Documentation | Handsontable
+angular:
+  id: igd8lqh8
+  metaTitle: Angular Data Grid - Documentation | Handsontable
 searchCategory: Guides
 category: Getting started
 ---

--- a/docs/content/guides/getting-started/license-key/license-key.md
+++ b/docs/content/guides/getting-started/license-key/license-key.md
@@ -8,6 +8,9 @@ canonicalUrl: /license-key
 react:
   id: vyfski60
   metaTitle: License key - React Data Grid | Handsontable
+angular:
+  id: bcvwr25r
+  metaTitle: License key - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Getting started
 ---

--- a/docs/content/guides/getting-started/react-methods/react-methods.md
+++ b/docs/content/guides/getting-started/react-methods/react-methods.md
@@ -13,6 +13,9 @@ tags:
   - methods
 react:
   metaTitle: Instance methods - React Data Grid | Handsontable
+angular:
+  id: 7a8puryp
+  metaTitle: Instance methods - Angular Data Grid | Handsontable
 searchCategory: Guides
 onlyFor: react
 category: Getting started

--- a/docs/content/guides/getting-started/saving-data/saving-data.md
+++ b/docs/content/guides/getting-started/saving-data/saving-data.md
@@ -12,6 +12,9 @@ tags:
 react:
   id: rib1rhmf
   metaTitle: Saving data - React Data Grid | Handsontable
+angular:
+  id: uny2nvqk
+  metaTitle: Saving data - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Getting started
 ---

--- a/docs/content/guides/integrate-with-vue/vue-custom-context-menu-example/vue-custom-context-menu-example.md
+++ b/docs/content/guides/integrate-with-vue/vue-custom-context-menu-example/vue-custom-context-menu-example.md
@@ -8,6 +8,9 @@ canonicalUrl: /vue-custom-context-menu-example
 react:
   id: 6218j2a1
   metaTitle: Custom context menu - Vue 2 Data Grid | Handsontable
+angular:
+  id: zl92lu7v
+  metaTitle: Custom context menu - Vue 2 Data Grid | Handsontable
 searchCategory: Guides
 category: Integrate with Vue 2
 ---

--- a/docs/content/guides/integrate-with-vue/vue-custom-editor-example/vue-custom-editor-example.md
+++ b/docs/content/guides/integrate-with-vue/vue-custom-editor-example/vue-custom-editor-example.md
@@ -8,6 +8,9 @@ canonicalUrl: /vue-custom-editor-example
 react:
   id: 54b3cgid
   metaTitle: Custom cell editor - Vue 2 Data Grid | Handsontable
+angular:
+  id: gymsg1xk
+  metaTitle: Custom cell editor - Vue 2 Data Grid | Handsontable
 searchCategory: Guides
 category: Integrate with Vue 2
 ---

--- a/docs/content/guides/integrate-with-vue/vue-custom-id-class-style/vue-custom-id-class-style.md
+++ b/docs/content/guides/integrate-with-vue/vue-custom-id-class-style/vue-custom-id-class-style.md
@@ -8,6 +8,9 @@ canonicalUrl: /vue-custom-id-class-style
 react:
   id: neeell9r
   metaTitle: Custom ID, class, and style - Vue 2 Data Grid | Handsontable
+angular:
+  id: 66xx8lni
+  metaTitle: Custom ID, class, and style - Vue 2 Data Grid | Handsontable
 searchCategory: Guides
 category: Integrate with Vue 2
 ---

--- a/docs/content/guides/integrate-with-vue/vue-custom-renderer-example/vue-custom-renderer-example.md
+++ b/docs/content/guides/integrate-with-vue/vue-custom-renderer-example/vue-custom-renderer-example.md
@@ -8,6 +8,9 @@ canonicalUrl: /vue-custom-renderer-example
 react:
   id: rv0aqgfe
   metaTitle: Custom cell renderer - Vue 2 Data Grid | Handsontable
+angular:
+  id: x05s59nc
+  metaTitle: Custom cell renderer - Vue 2 Data Grid | Handsontable
 searchCategory: Guides
 category: Integrate with Vue 2
 ---

--- a/docs/content/guides/integrate-with-vue/vue-hot-column/vue-hot-column.md
+++ b/docs/content/guides/integrate-with-vue/vue-hot-column/vue-hot-column.md
@@ -8,6 +8,9 @@ canonicalUrl: /vue-hot-column
 react:
   id: 0lip32oe
   metaTitle: HotColumn component - Vue 2 Data Grid | Handsontable
+angular:
+  id: pw27m953
+  metaTitle: HotColumn component - Vue 2 Data Grid | Handsontable
 searchCategory: Guides
 category: Integrate with Vue 2
 ---

--- a/docs/content/guides/integrate-with-vue/vue-hot-reference/vue-hot-reference.md
+++ b/docs/content/guides/integrate-with-vue/vue-hot-reference/vue-hot-reference.md
@@ -8,6 +8,9 @@ canonicalUrl: /vue-hot-reference
 react:
   id: xk0bot46
   metaTitle: Referencing Handsontable - Vue 2 Data Grid | Handsontable
+angular:
+  id: ofn3kq3s
+  metaTitle: Referencing Handsontable - Vue 2 Data Grid | Handsontable
 searchCategory: Guides
 category: Integrate with Vue 2
 ---

--- a/docs/content/guides/integrate-with-vue/vue-installation/vue-installation.md
+++ b/docs/content/guides/integrate-with-vue/vue-installation/vue-installation.md
@@ -8,6 +8,9 @@ canonicalUrl: /vue-installation
 react:
   id: psozke11
   metaTitle: Installation - Vue 2 Data Grid | Handsontable
+angular:
+  id: 1yl06ihk
+  metaTitle: Installation - Vue 2 Data Grid | Handsontable
 searchCategory: Guides
 category: Integrate with Vue 2
 ---

--- a/docs/content/guides/integrate-with-vue/vue-language-change-example/vue-language-change-example.md
+++ b/docs/content/guides/integrate-with-vue/vue-language-change-example/vue-language-change-example.md
@@ -8,6 +8,9 @@ canonicalUrl: /vue-language-change-example
 react:
   id: kyfo402o
   metaTitle: Language change - Vue 2 Data Grid | Handsontable
+angular:
+  id: lqvafqid
+  metaTitle: Language change - Vue 2 Data Grid | Handsontable
 searchCategory: Guides
 category: Integrate with Vue 2
 ---

--- a/docs/content/guides/integrate-with-vue/vue-modules/vue-modules.md
+++ b/docs/content/guides/integrate-with-vue/vue-modules/vue-modules.md
@@ -8,6 +8,9 @@ canonicalUrl: /vue-modules
 react:
   id: ijlm2nkx
   metaTitle: Modules - Vue 2 Data Grid | Handsontable
+angular:
+  id: nwf12mbz
+  metaTitle: Modules - Vue 2 Data Grid | Handsontable
 searchCategory: Guides
 category: Integrate with Vue 2
 ---

--- a/docs/content/guides/integrate-with-vue/vue-setting-up-a-language/vue-setting-up-a-language.md
+++ b/docs/content/guides/integrate-with-vue/vue-setting-up-a-language/vue-setting-up-a-language.md
@@ -8,6 +8,9 @@ canonicalUrl: /vue-setting-up-a-translation
 react:
   id: dt7dct4e
   metaTitle: Setting up a translation - Vue 2 Data Grid | Handsontable
+angular:
+  id: ctozuyy9
+  metaTitle: Setting up a translation - Vue 2 Data Grid | Handsontable
 searchCategory: Guides
 category: Integrate with Vue 2
 ---

--- a/docs/content/guides/integrate-with-vue/vue-simple-example/vue-simple-example.md
+++ b/docs/content/guides/integrate-with-vue/vue-simple-example/vue-simple-example.md
@@ -8,6 +8,9 @@ canonicalUrl: /vue-basic-example
 react:
   id: sd36i6vo
   metaTitle: Basic example - Vue 2 Data Grid | Handsontable
+angular:
+  id: ixwxjdo3
+  metaTitle: Basic example - Vue 2 Data Grid | Handsontable
 searchCategory: Guides
 category: Integrate with Vue 2
 ---

--- a/docs/content/guides/integrate-with-vue/vue-vuex-example/vue-vuex-example.md
+++ b/docs/content/guides/integrate-with-vue/vue-vuex-example/vue-vuex-example.md
@@ -8,6 +8,9 @@ canonicalUrl: /vue-vuex-example
 react:
   id: fdtaa1rw
   metaTitle: Integration with Vuex - Vue 2 Data Grid - Handsontable
+angular:
+  id: xlr8qatx
+  metaTitle: Integration with Vuex - Vue 2 Data Grid - Handsontable
 searchCategory: Guides
 category: Integrate with Vue 2
 ---

--- a/docs/content/guides/integrate-with-vue3/vue3-custom-context-menu-example/vue3-custom-context-menu-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-custom-context-menu-example/vue3-custom-context-menu-example.md
@@ -8,6 +8,9 @@ canonicalUrl: /vue3-custom-context-menu-example
 react:
   id: rw3lzobe
   metaTitle: Custom context menu - Vue 3 Data Grid | Handsontable
+angular:
+  id: fp49yb44
+  metaTitle: Custom context menu - Vue 3 Data Grid | Handsontable
 searchCategory: Guides
 category: Integrate with Vue 3
 ---

--- a/docs/content/guides/integrate-with-vue3/vue3-custom-editor-example/vue3-custom-editor-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-custom-editor-example/vue3-custom-editor-example.md
@@ -8,6 +8,9 @@ canonicalUrl: /vue3-custom-editor-example
 react:
   id: vm94urge
   metaTitle: Custom cell editor - Vue 3 Data Grid | Handsontable
+angular:
+  id: nmw9ha36
+  metaTitle: Custom cell editor - Vue 3 Data Grid | Handsontable
 searchCategory: Guides
 category: Integrate with Vue 3
 ---

--- a/docs/content/guides/integrate-with-vue3/vue3-custom-id-class-style/vue3-custom-id-class-style.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-custom-id-class-style/vue3-custom-id-class-style.md
@@ -8,6 +8,9 @@ canonicalUrl: /vue3-custom-id-class-style
 react:
   id: jeuzzosp
   metaTitle: Custom ID, class, and style - Vue 3 Data Grid | Handsontable
+angular:
+  id: 9zzwqp3r
+  metaTitle: Custom ID, class, and style - Vue 3 Data Grid | Handsontable
 searchCategory: Guides
 category: Integrate with Vue 3
 ---

--- a/docs/content/guides/integrate-with-vue3/vue3-custom-renderer-example/vue3-custom-renderer-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-custom-renderer-example/vue3-custom-renderer-example.md
@@ -8,6 +8,9 @@ canonicalUrl: /vue3-custom-renderer-example
 react:
   id: ijm6kk3v
   metaTitle: Custom cell renderer - Vue 3 Data Grid | Handsontable
+angular:
+  id: karjf4av
+  metaTitle: Custom cell renderer - Vue 3 Data Grid | Handsontable
 searchCategory: Guides
 category: Integrate with Vue 3
 ---

--- a/docs/content/guides/integrate-with-vue3/vue3-hot-column/vue3-hot-column.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-hot-column/vue3-hot-column.md
@@ -8,6 +8,9 @@ canonicalUrl: /vue3-hot-column
 react:
   id: vevcltww
   metaTitle: HotColumn component - Vue 3 Data Grid | Handsontable
+angular:
+  id: 65dx0xyo
+  metaTitle: HotColumn component - Vue 3 Data Grid | Handsontable
 searchCategory: Guides
 category: Integrate with Vue 3
 ---

--- a/docs/content/guides/integrate-with-vue3/vue3-hot-reference/vue3-hot-reference.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-hot-reference/vue3-hot-reference.md
@@ -8,6 +8,9 @@ canonicalUrl: /vue3-hot-reference
 react:
   id: h1s6hk2m
   metaTitle: Referencing Handsontable - Vue 3 Data Grid | Handsontable
+angular:
+  id: 7d76fp5u
+  metaTitle: Referencing Handsontable - Vue 3 Data Grid | Handsontable
 searchCategory: Guides
 category: Integrate with Vue 3
 ---

--- a/docs/content/guides/integrate-with-vue3/vue3-installation/vue3-installation.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-installation/vue3-installation.md
@@ -8,6 +8,9 @@ canonicalUrl: /vue3-installation
 react:
   id: fsggsowh
   metaTitle: Installation - Vue 3 Data Grid | Handsontable
+angular:
+  id: od7j5cpt
+  metaTitle: Installation - Vue 3 Data Grid | Handsontable
 searchCategory: Guides
 category: Integrate with Vue 3
 ---

--- a/docs/content/guides/integrate-with-vue3/vue3-language-change-example/vue3-language-change-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-language-change-example/vue3-language-change-example.md
@@ -8,6 +8,9 @@ canonicalUrl: /vue3-language-change-example
 react:
   id: sxkgoryi
   metaTitle: Language change - Vue 3 Data Grid | Handsontable
+angular:
+  id: zjy408sj
+  metaTitle: Language change - Vue 3 Data Grid | Handsontable
 searchCategory: Guides
 category: Integrate with Vue 3
 ---

--- a/docs/content/guides/integrate-with-vue3/vue3-modules/vue3-modules.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-modules/vue3-modules.md
@@ -8,6 +8,9 @@ canonicalUrl: /vue3-modules
 react:
   id: q4l7029o
   metaTitle: Modules - Vue 3 Data Grid | Handsontable
+angular:
+  id: p3omli89
+  metaTitle: Modules - Vue 3 Data Grid | Handsontable
 searchCategory: Guides
 category: Integrate with Vue 3
 ---

--- a/docs/content/guides/integrate-with-vue3/vue3-setting-up-a-language/vue3-setting-up-a-language.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-setting-up-a-language/vue3-setting-up-a-language.md
@@ -8,6 +8,9 @@ canonicalUrl: /vue3-setting-up-a-translation
 react:
   id: 5sootj6b
   metaTitle: Setting up a translation - Vue 3 Data Grid | Handsontable
+angular:
+  id: wangjjlr
+  metaTitle: Setting up a translation - Vue 3 Data Grid | Handsontable
 searchCategory: Guides
 category: Integrate with Vue 3
 ---

--- a/docs/content/guides/integrate-with-vue3/vue3-simple-example/vue3-simple-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-simple-example/vue3-simple-example.md
@@ -8,6 +8,9 @@ canonicalUrl: /vue3-basic-example
 react:
   id: 8nvt7139
   metaTitle: Basic example - Vue 3 Data Grid | Handsontable
+angular:
+  id: kojv7mkj
+  metaTitle: Basic example - Vue 3 Data Grid | Handsontable
 searchCategory: Guides
 category: Integrate with Vue 3
 ---

--- a/docs/content/guides/integrate-with-vue3/vue3-vuex-example/vue3-vuex-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-vuex-example/vue3-vuex-example.md
@@ -8,6 +8,9 @@ canonicalUrl: /vue3-vuex-example
 react:
   id: z78880e4
   metaTitle: Integration with Vuex - Vue 3 Data Grid - Handsontable
+angular:
+  id: b16i0n4r
+  metaTitle: Integration with Vuex - Vue 3 Data Grid - Handsontable
 searchCategory: Guides
 category: Integrate with Vue 3
 ---

--- a/docs/content/guides/internationalization/ime-support/ime-support.md
+++ b/docs/content/guides/internationalization/ime-support/ime-support.md
@@ -14,6 +14,9 @@ tags:
 react:
   id: 8pqhhu5r
   metaTitle: IME support - React Data Grid | Handsontable
+angular:
+  id: 7u4izjbt
+  metaTitle: IME support - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Internationalization
 ---

--- a/docs/content/guides/internationalization/language/language.md
+++ b/docs/content/guides/internationalization/language/language.md
@@ -14,6 +14,9 @@ tags:
 react:
   id: qz0qgi9f
   metaTitle: Language - React Data Grid | Handsontable
+angular:
+  id: eujz2e6s
+  metaTitle: Language - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Internationalization
 ---

--- a/docs/content/guides/internationalization/layout-direction/layout-direction.md
+++ b/docs/content/guides/internationalization/layout-direction/layout-direction.md
@@ -19,6 +19,9 @@ tags:
 react:
   id: g4mu790t
   metaTitle: Layout direction - React Data Grid | Handsontable
+angular:
+  id: orgwjmih
+  metaTitle: Layout direction - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Internationalization
 ---

--- a/docs/content/guides/internationalization/locale/locale.md
+++ b/docs/content/guides/internationalization/locale/locale.md
@@ -13,6 +13,9 @@ tags:
 react:
   id: 1ueuuazs
   metaTitle: Locale - React Data Grid | Handsontable
+angular:
+  id: arpg1wyq
+  metaTitle: Locale - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Internationalization
 ---

--- a/docs/content/guides/navigation/custom-shortcuts/custom-shortcuts.md
+++ b/docs/content/guides/navigation/custom-shortcuts/custom-shortcuts.md
@@ -19,6 +19,9 @@ tags:
 react:
   id: d5ay8gj1
   metaTitle: Custom shortcuts - React Data Grid | Handsontable
+angular:
+  id: lqk5kuws
+  metaTitle: Custom shortcuts - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Navigation
 ---

--- a/docs/content/guides/navigation/keyboard-shortcuts/keyboard-shortcuts.md
+++ b/docs/content/guides/navigation/keyboard-shortcuts/keyboard-shortcuts.md
@@ -18,6 +18,9 @@ tags:
 react:
   id: ddjw4zt88
   metaTitle: Keyboard shortcuts - React Data Grid | Handsontable
+angular:
+  id: v7sq2x22
+  metaTitle: Keyboard shortcuts - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Navigation
 ---

--- a/docs/content/guides/navigation/searching-values/searching-values.md
+++ b/docs/content/guides/navigation/searching-values/searching-values.md
@@ -12,6 +12,9 @@ tags:
 react:
   id: 48lhnrbd
   metaTitle: Searching values - React Data Grid | Handsontable
+angular:
+  id: q7wwbzzr
+  metaTitle: Searching values - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Navigation
 ---

--- a/docs/content/guides/optimization/batch-operations/batch-operations.md
+++ b/docs/content/guides/optimization/batch-operations/batch-operations.md
@@ -12,6 +12,9 @@ tags:
 react:
   id: 3xqdvk3u
   metaTitle: Batch operations - React Data Grid | Handsontable
+angular:
+  id: tnvv2pjr
+  metaTitle: Batch operations - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Optimization
 ---

--- a/docs/content/guides/optimization/bundle-size/bundle-size.md
+++ b/docs/content/guides/optimization/bundle-size/bundle-size.md
@@ -10,6 +10,9 @@ tags:
 react:
   id: c8onyes4
   metaTitle: Bundle size - React Data Grid | Handsontable
+angular:
+  id: qdq3dmts
+  metaTitle: Bundle size - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Optimization
 ---

--- a/docs/content/guides/optimization/performance/performance.md
+++ b/docs/content/guides/optimization/performance/performance.md
@@ -10,6 +10,9 @@ tags:
 react:
   id: gbdbrlc8
   metaTitle: Performance - React Data Grid | Handsontable
+angular:
+  id: 34wyxzpj
+  metaTitle: Performance - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Optimization
 ---

--- a/docs/content/guides/rows/row-freezing/row-freezing.md
+++ b/docs/content/guides/rows/row-freezing/row-freezing.md
@@ -12,6 +12,9 @@ tags:
 react:
   id: y5wx1mrk
   metaTitle: Row freezing - React Data Grid | Handsontable
+angular:
+  id: mskor25j
+  metaTitle: Row freezing - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Rows
 ---

--- a/docs/content/guides/rows/row-header/row-header.md
+++ b/docs/content/guides/rows/row-header/row-header.md
@@ -12,6 +12,9 @@ tags:
 react:
   id: prlcpqk8
   metaTitle: Row headers - React Data Grid | Handsontable
+angular:
+  id: jtqk0t2p
+  metaTitle: Row headers - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Rows
 ---

--- a/docs/content/guides/rows/row-height/row-height.md
+++ b/docs/content/guides/rows/row-height/row-height.md
@@ -19,6 +19,9 @@ tags:
 react:
   id: 87ulwfs2
   metaTitle: Row heights - React Data Grid | Handsontable
+angular:
+  id: h42skmvo
+  metaTitle: Row heights - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Rows
 ---

--- a/docs/content/guides/rows/row-hiding/row-hiding.md
+++ b/docs/content/guides/rows/row-hiding/row-hiding.md
@@ -8,6 +8,9 @@ canonicalUrl: /row-hiding
 react:
   id: al1djb6l
   metaTitle: Row hiding - React Data Grid | Handsontable
+angular:
+  id: 2dxb42jh
+  metaTitle: Row hiding - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Rows
 ---

--- a/docs/content/guides/rows/row-moving/row-moving.md
+++ b/docs/content/guides/rows/row-moving/row-moving.md
@@ -8,6 +8,9 @@ canonicalUrl: /row-moving
 react:
   id: g5mksyu1
   metaTitle: Row moving - React Data Grid | Handsontable
+angular:
+  id: ntz1a9ns
+  metaTitle: Row moving - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Rows
 ---

--- a/docs/content/guides/rows/row-parent-child/row-parent-child.md
+++ b/docs/content/guides/rows/row-parent-child/row-parent-child.md
@@ -17,6 +17,9 @@ tags:
 react:
   id: vo8uukt2
   metaTitle: Row parent-child - React Data Grid | Handsontable
+angular:
+  id: ojdl5nkd
+  metaTitle: Row parent-child - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Rows
 ---

--- a/docs/content/guides/rows/row-prepopulating/row-prepopulating.md
+++ b/docs/content/guides/rows/row-prepopulating/row-prepopulating.md
@@ -13,6 +13,9 @@ tags:
 react:
   id: kmqhr00y
   metaTitle: Row pre-populating - React Data Grid | Handsontable
+angular:
+  id: me99ozqr
+  metaTitle: Row pre-populating - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Rows
 ---

--- a/docs/content/guides/rows/row-trimming/row-trimming.md
+++ b/docs/content/guides/rows/row-trimming/row-trimming.md
@@ -8,6 +8,9 @@ canonicalUrl: /row-trimming
 react:
   id: fkcjw0q1
   metaTitle: Row trimming - React Data Grid | Handsontable
+angular:
+  id: fhh1b0n6
+  metaTitle: Row trimming - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Rows
 ---

--- a/docs/content/guides/rows/row-virtualization/row-virtualization.md
+++ b/docs/content/guides/rows/row-virtualization/row-virtualization.md
@@ -12,6 +12,9 @@ tags:
 react:
   id: kjsl63sh
   metaTitle: Row virtualization - React Data Grid | Handsontable
+angular:
+  id: 2imqjvmp
+  metaTitle: Row virtualization - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Rows
 ---

--- a/docs/content/guides/rows/rows-sorting/rows-sorting.md
+++ b/docs/content/guides/rows/rows-sorting/rows-sorting.md
@@ -27,6 +27,9 @@ tags:
 react:
   id: h4jfevxj
   metaTitle: Rows sorting - React Data Grid | Handsontable
+angular:
+  id: kzkj37v5
+  metaTitle: Rows sorting - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Rows
 ---

--- a/docs/content/guides/security/security/security.md
+++ b/docs/content/guides/security/security/security.md
@@ -8,6 +8,9 @@ canonicalUrl: /security
 react:
   id: h8zg4ign
   metaTitle: Security - React Data Grid | Handsontable
+angular:
+  id: 25m4fmia
+  metaTitle: Security - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Security
 ---

--- a/docs/content/guides/styling/design-system/design-system.md
+++ b/docs/content/guides/styling/design-system/design-system.md
@@ -19,6 +19,9 @@ tags:
 react:
   id: 0mz9id0l
   metaTitle: Design System / UI Kit - React Data Grid | Handsontable
+angular:
+  id: vru7jook
+  metaTitle: Design System / UI Kit - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Styling
 ---

--- a/docs/content/guides/styling/themes/themes.md
+++ b/docs/content/guides/styling/themes/themes.md
@@ -22,6 +22,9 @@ tags:
 react:
   id: jn2po47i
   metaTitle: Themes - React Data Grid | Handsontable
+angular:
+  id: 1sco6djp
+  metaTitle: Themes - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Styling
 ---

--- a/docs/content/guides/technical-specification/documentation-license/documentation-license.md
+++ b/docs/content/guides/technical-specification/documentation-license/documentation-license.md
@@ -8,6 +8,9 @@ canonicalUrl: /documentation-license
 react:
   id: u3lvnmzh
   metaTitle: Documentation license - React Data Grid | Handsontable
+angular:
+  id: g9ytiw67
+  metaTitle: Documentation license - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Technical specification
 ---

--- a/docs/content/guides/technical-specification/software-license/software-license.md
+++ b/docs/content/guides/technical-specification/software-license/software-license.md
@@ -8,6 +8,9 @@ canonicalUrl: /software-license
 react:
   id: ea206i3o
   metaTitle: Software license - React Data Grid | Handsontable
+angular:
+  id: fe9wliki
+  metaTitle: Software license - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Technical specification
 ---

--- a/docs/content/guides/technical-specification/supported-browsers/supported-browsers.md
+++ b/docs/content/guides/technical-specification/supported-browsers/supported-browsers.md
@@ -10,6 +10,9 @@ tags:
 react:
   id: 1e7f39og
   metaTitle: Supported browsers - React Data Grid | Handsontable
+angular:
+  id: a7fpjwud
+  metaTitle: Supported browsers - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Technical specification
 ---

--- a/docs/content/guides/technical-specification/third-party-licenses/third-party-licenses.md
+++ b/docs/content/guides/technical-specification/third-party-licenses/third-party-licenses.md
@@ -8,6 +8,9 @@ canonicalUrl: /third-party-licenses
 react:
   id: 5rt8dyg9
   metaTitle: Third-party licenses - React Data Grid | Handsontable
+angular:
+  id: kc0urkyj
+  metaTitle: Third-party licenses - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Technical specification
 ---

--- a/docs/content/guides/tools-and-building/custom-builds/custom-builds.md
+++ b/docs/content/guides/tools-and-building/custom-builds/custom-builds.md
@@ -12,6 +12,9 @@ tags:
 react:
   id: pcflnieu
   metaTitle: Custom builds - React Data Grid | Handsontable
+angular:
+  id: 098p9wiw
+  metaTitle: Custom builds - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Tools and building
 ---

--- a/docs/content/guides/tools-and-building/custom-plugins/custom-plugins.md
+++ b/docs/content/guides/tools-and-building/custom-plugins/custom-plugins.md
@@ -12,6 +12,9 @@ tags:
 react:
   id: y66k6b2h
   metaTitle: Custom plugins - React Data Grid | Handsontable
+angular:
+  id: ompl9j5i
+  metaTitle: Custom plugins - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Tools and building
 ---

--- a/docs/content/guides/tools-and-building/modules/modules.md
+++ b/docs/content/guides/tools-and-building/modules/modules.md
@@ -10,6 +10,9 @@ tags:
 react:
   id: weudz1vh
   metaTitle: Modules - React Data Grid | Handsontable
+angular:
+  id: 9i62e6cn
+  metaTitle: Modules - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Tools and building
 ---

--- a/docs/content/guides/tools-and-building/testing/testing.md
+++ b/docs/content/guides/tools-and-building/testing/testing.md
@@ -15,6 +15,9 @@ tags:
 react:
   id: y3wp74jh
   metaTitle: Testing - React Data Grid | Handsontable
+angular:
+  id: zggveqea
+  metaTitle: Testing - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Tools and building
 ---

--- a/docs/content/guides/upgrade-and-migration/changelog/changelog.md
+++ b/docs/content/guides/upgrade-and-migration/changelog/changelog.md
@@ -15,6 +15,9 @@ tags:
 react:
   id: 7y9fco03
   metaTitle: Changelog - React Data Grid | Handsontable
+angular:
+  id: um6ros3a
+  metaTitle: Changelog - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/migrating-from-10.0-to-11.0/migrating-from-10.0-to-11.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-10.0-to-11.0/migrating-from-10.0-to-11.0.md
@@ -9,6 +9,9 @@ pageClass: migration-guide
 react:
   id: sney23fh
   metaTitle: Migrate from 10.0 to 11.0 - React Data Grid | Handsontable
+angular:
+  id: 1fc8toqq
+  metaTitle: Migrate from 10.0 to 11.0 - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/migrating-from-11.1-to-12.0/migrating-from-11.1-to-12.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-11.1-to-12.0/migrating-from-11.1-to-12.0.md
@@ -9,6 +9,9 @@ pageClass: migration-guide
 react:
   id: ncj9bstu
   metaTitle: Migrate from 11.1 to 12.0 - React Data Grid | Handsontable
+angular:
+  id: e9gbxrvk
+  metaTitle: Migrate from 11.1 to 12.0 - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/migrating-from-12.4-to-13.0/migrating-from-12.4-to-13.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-12.4-to-13.0/migrating-from-12.4-to-13.0.md
@@ -9,6 +9,9 @@ pageClass: migration-guide
 react:
   id: tvum3ibg
   metaTitle: Migrate from 12.4 to 13.0 - React Data Grid | Handsontable
+angular:
+  id: kgutwhxo
+  metaTitle: Migrate from 12.4 to 13.0 - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/migrating-from-13.1-to-14.0/migrating-from-13.1-to-14.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-13.1-to-14.0/migrating-from-13.1-to-14.0.md
@@ -9,6 +9,9 @@ pageClass: migration-guide
 react:
   id: migrating-13.1-to-14.0-react
   metaTitle: Migrate from 13.1 to 14.0 - React Data Grid | Handsontable
+angular:
+  id: rxlauyd8-13.1-to-14.0-react
+  metaTitle: Migrate from 13.1 to 14.0 - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/migrating-from-14.6-to-15.0/migrating-from-14.6-to-15.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-14.6-to-15.0/migrating-from-14.6-to-15.0.md
@@ -9,6 +9,9 @@ pageClass: migration-guide
 react:
   id: migrating-14.6-to-15.0-react
   metaTitle: Migrate from 14.6 to 15.0 - React Data Grid | Handsontable
+angular:
+  id: 7kr2r20j-14.6-to-15.0-react
+  metaTitle: Migrate from 14.6 to 15.0 - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/migrating-from-7.4-to-8.0/migrating-from-7.4-to-8.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-7.4-to-8.0/migrating-from-7.4-to-8.0.md
@@ -9,6 +9,9 @@ pageClass: migration-guide
 react:
   id: ivkac4xa
   metaTitle: Migrate from 7.4 to 8.0 - React Data Grid | Handsontable
+angular:
+  id: wo49dhyu
+  metaTitle: Migrate from 7.4 to 8.0 - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/migrating-from-8.4-to-9.0/migrating-from-8.4-to-9.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-8.4-to-9.0/migrating-from-8.4-to-9.0.md
@@ -9,6 +9,9 @@ pageClass: migration-guide
 react:
   id: yns5r79k
   metaTitle: Migrate from 8.4 to 9.0 - React Data Grid | Handsontable
+angular:
+  id: tulale8x
+  metaTitle: Migrate from 8.4 to 9.0 - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/migrating-from-9.0-to-10.0/migrating-from-9.0-to-10.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-9.0-to-10.0/migrating-from-9.0-to-10.0.md
@@ -9,6 +9,9 @@ pageClass: migration-guide
 react:
   id: oh5ffbjc
   metaTitle: Migrate from 9.0 to 10.0 - React Data Grid | Handsontable
+angular:
+  id: a1bu3jwp
+  metaTitle: Migrate from 9.0 to 10.0 - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/versioning-policy/versioning-policy.md
+++ b/docs/content/guides/upgrade-and-migration/versioning-policy/versioning-policy.md
@@ -8,6 +8,9 @@ canonicalUrl: /versioning-policy
 react:
   id: avrihx7w
   metaTitle: Versioning policy - React Data Grid | Handsontable
+angular:
+  id: 1q96vyfn
+  metaTitle: Versioning policy - Angular Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---


### PR DESCRIPTION
### Context
This PR adds the `angular` sections to the API page config and the frontmatter of the `md` files (including unique `id`s).

[skip changelog]

### How has this been tested?
Tested locally.

### Related issue(s):
1. handsontable/dev-handsontable#2506

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
