### PR TITLE
Docs: Add framework icons to navbar dropdown

### DIFF
--- a/docs/.vuepress/theme/components/FrameworksDropdown.vue
+++ b/docs/.vuepress/theme/components/FrameworksDropdown.vue
@@ -82,6 +82,7 @@ export default {
             link: this.getLink(id),
             target: '_self',
             isHtmlLink: true,
+            icon: `i-${id}`,
           };
         }
       );

--- a/docs/.vuepress/theme/components/NavLink.vue
+++ b/docs/.vuepress/theme/components/NavLink.vue
@@ -30,7 +30,7 @@
     </section>
 
     <template v-else>
-      {{ item.text }}
+      <i v-if="item.icon" class="ico" :class="item.icon"></i>{{ item.text }}
     </template>
     <OutboundLink v-if="isBlankTarget" />
   </a>

--- a/docs/.vuepress/theme/styles/layout/navbar.styl
+++ b/docs/.vuepress/theme/styles/layout/navbar.styl
@@ -280,10 +280,10 @@
                     transition all $ts ease
                     display: flex;
                     align-items: center;
-                    justify-content: space-between;
-                    z-index 1
-                    border-radius: $radius
-
+                    justify-content: start;
+                    gap: 10px;
+                    z-index: 1;
+                    border-radius: $radius;
 
                     &:before { 
                         content: ''


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->

Adding icons for JS, React and Angular to the select-documentation-version dropdown.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

local docs build

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
https://github.com/handsontable/dev-handsontable/issues/2466

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]