### PR TITLE
[Doc] Framework redirect indroduces in 12.1 not 12.0 fix

### DIFF
--- a/docs/netlify/netlify/edge-functions/rewrite_cookie_docs_x_x.mts
+++ b/docs/netlify/netlify/edge-functions/rewrite_cookie_docs_x_x.mts
@@ -1,12 +1,13 @@
 /* eslint-disable no-unused-vars */
-import { Config, Context } from '@netlify/edge-functions';
-import { getFrameworkFromCookie } from '../cookieHelper.mts';
+import { Config, Context } from "@netlify/edge-functions";
+import { getFrameworkFromCookie } from "../cookieHelper.mts";
 
-export default async(req: Request, context: Context) => {
-
-  const major = parseInt(context.params['0'], 10);
-  const framework = getFrameworkFromCookie(context.cookies.get('docs_fw'));
-  const version = `${context.params['0']}.${context.params['1']}`;
+export default async (req: Request, context: Context) => {
+  const major = parseInt(context.params["0"], 10);
+  const minor = parseInt(context.params["1"], 10);
+  const framework = getFrameworkFromCookie(context.cookies.get("docs_fw"));
+  const version = `${context.params["0"]}.${context.params["1"]}`;
+  const isFrameworkVersion = (major === 12 && minor >= 1) || major >= 13;
 
   if (major < 12) {
     // Get the page content
@@ -16,14 +17,11 @@ export default async(req: Request, context: Context) => {
     return new Response(page, response);
   }
 
-  const url = new URL(
-    major >= 12 ? `/docs/${version}/${framework}` : `/docs/${version}`,
-    req.url
-  );
+  const url = new URL(isFrameworkVersion ? `/docs/${version}/${framework}` : `/docs/${version}`, req.url);
 
   return Response.redirect(url);
 };
 
 export const config: Config = {
-  path: '/docs/(\\d+).(\\d+){/}?',
+  path: "/docs/(\\d+).(\\d+){/}?",
 };

--- a/docs/netlify/netlify/edge-functions/rewrite_cookie_docs_x_x_html.mts
+++ b/docs/netlify/netlify/edge-functions/rewrite_cookie_docs_x_x_html.mts
@@ -224,6 +224,8 @@ const redirectsMapfor12up = {
 export default async(req: Request, context: Context) => {
 
   const major = parseInt(context.params['0'], 10);
+  const minor = parseInt(context.params['2'], 10);
+  const isFrameworkVersion = (major === 12 && minor >= 1) || major >= 13;
   let framework = getFrameworkFromCookie(context.cookies.get('docs_fw'));
   const version = `${context.params[0]}.${context.params[1]}`;
   const page = context.params[2];
@@ -242,7 +244,7 @@ export default async(req: Request, context: Context) => {
     framework = 'javascript-data-grid';
   }
   const url = new URL(
-    major >= 12
+    isFrameworkVersion
       ? `/docs/${version}/${framework}/${redirectPath}`
       : `/docs/${version}/${redirectPath}`,
     req.url


### PR DESCRIPTION
### Context
Framework redirect indroduces in 12.1 not 12.0 fix

After migration to production version uptime bot found out that 12.0 has wrong redirects 

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]
