### PR TITLE
Add migration guide from 15.3 to 16.0 to the documentation

### DIFF
--- a/docs/content/guides/sidebar.js
+++ b/docs/content/guides/sidebar.js
@@ -167,6 +167,7 @@ const technicalSpecificationItems = [
 const upgradeAndMigrationItems = [
   { path: 'guides/upgrade-and-migration/changelog/changelog' },
   { path: 'guides/upgrade-and-migration/versioning-policy/versioning-policy' },
+  { path: 'guides/upgrade-and-migration/migrating-from-15.3-to-16.0/migrating-from-15.3-to-16.0' },
   { path: 'guides/upgrade-and-migration/migrating-from-14.6-to-15.0/migrating-from-14.6-to-15.0' },
   { path: 'guides/upgrade-and-migration/migrating-from-13.1-to-14.0/migrating-from-13.1-to-14.0' },
   { path: 'guides/upgrade-and-migration/migrating-from-12.4-to-13.0/migrating-from-12.4-to-13.0' },

--- a/docs/content/guides/upgrade-and-migration/migrating-from-15.3-to-16.0/migrating-from-15.3-to-16.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-15.3-to-16.0/migrating-from-15.3-to-16.0.md
@@ -1,0 +1,23 @@
+---
+id: migrating-15.3-to-16.0
+title: Migrating from 15.3 to 16.0
+metaTitle: Migrating from 15.3 to 16.0 - JavaScript Data Grid | Handsontable
+description: Migrate from Handsontable 15.3 to Handsontable 16.0, released on [].
+permalink: /migration-from-15.3-to-16.0
+canonicalUrl: /migration-from-15.3-to-16.0
+pageClass: migration-guide
+react:
+  id: migrating-15.3-to-16.0-react
+  metaTitle: Migrate from 15.3 to 16.0 - React Data Grid | Handsontable
+angular:
+  id: migrating-15.3-to-16.0-angular
+  metaTitle: Migrate from 15.3 to 16.0 - Angular Data Grid | Handsontable
+searchCategory: Guides
+category: Upgrade and migration
+---
+
+# Migrate from 15.3 to 16.0
+
+Migrate from Handsontable 15.3 to Handsontable 16.0, released on [TODO].
+
+[[toc]]

--- a/docs/content/guides/upgrade-and-migration/migrating-from-15.3-to-16.0/migrating-from-15.3-to-16.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-15.3-to-16.0/migrating-from-15.3-to-16.0.md
@@ -73,11 +73,11 @@ In Handsontable 16.0, we've made significant improvements to our CSS variables s
 We've introduced new variables that allow for easier customization: 
 
 - `--ht-letter-spacing`: controls the spacing between letters for better readability and visual appearance
- - `--ht-radio-[]`: style radio inputs more accurate
- - `--ht-cell-read-only-background-color`: better adjust readonly cells.
+ - `--ht-radio-[]`: style radio input more accurate
+ - `--ht-cell-read-only-background-color`: better adjust readonly cells
  - `--ht-checkbox-indeterminate`: customize checkbox indeterminate state
 
-### Changed css variables
+### Renamed CSS variables
 We've renamed a few variables to ensure more consistent naming: 
 
 | Old variable name | New variable name |
@@ -89,17 +89,10 @@ We've renamed a few variables to ensure more consistent naming:
 | `--ht-icon-active-button-hover-background-color` | `--ht-icon-button-active-hover-background-color` |
 | `--ht-icon-active-button-hover-icon-color` | `--ht-icon-button-active-hover-icon-color` |
 
-### Accessibility improvements
-Checkbox variables have been added to support better accessibility:
-
-- `--hot-focus-outline-color`: Controls the color of focus indicators
-- `--hot-contrast-ratio`: Helps maintain proper contrast ratios for better readability
-
 ### Migration notes
 If you were using custom CSS variables in version 15.3, you'll need to:
 
 1. Review your custom variable names against the new naming convention
-2. Update any deprecated variable references to their new counterparts
-3. Take advantage of the new theme-specific variables for more granular control
+2. Update variable references to the new radio input (only if checkbox variables were changed)
+3. Take advantage of the new variables for more granular control
 
-For a complete list of new and changed CSS variables, please refer to our [CSS Customization](/guides/customize-theme/css-variables) guide.

--- a/docs/content/guides/upgrade-and-migration/migrating-from-15.3-to-16.0/migrating-from-15.3-to-16.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-15.3-to-16.0/migrating-from-15.3-to-16.0.md
@@ -21,3 +21,85 @@ category: Upgrade and migration
 Migrate from Handsontable 15.3 to Handsontable 16.0, released on [TODO].
 
 [[toc]]
+
+## 1. Introducing the new DOM structure
+
+In Handsontable 16.0, we updated the DOM structure. The main change is how the table is mounted. Previously, the container `<div>` you provided became the root element of the table. In the new approach, that `<div>` is now just the element into which the Handsontable instance is injected.
+
+Here is a comparison of the old and new DOM structures:
+
+Old DOM structure:
+
+```
+body
+├── #example.ht-wrapper.handsontable
+│   ├── Focus catcher (top)
+│   ├── Personal details table/grid content
+│   └── Focus catcher (bottom)
+├── License key notification bar
+└── Context menus, dropdowns, pop-ups, sidebars
+    (absolutely positioned elements)
+```
+
+New DOM structure:
+
+```
+body
+└── #example
+    └── .ht-root-wrapper
+        ├── Focus catcher (top)
+        ├── .ht-wrapper.handsontable
+        │   ├── Personal details table/grid content
+        │   ├── License key notification bar
+        │   ├── Future: Status bar
+        │   └── Future: Pagination bar
+        ├── Focus catcher (bottom)
+        └── .ht-portal
+            └── Context menus, dropdowns, pop-ups, sidebars
+                (absolutely positioned elements)
+```
+
+### Key changes
+- Root Wrapper: User-provided div is now used as a container for the new DOM structure
+- Focus Catcher Relocation: Input elements used as focus catchers have been moved outside of the treegrid element for accessibility compliance
+- Portal Element: New div.ht-portal with ht-theme class for absolutely positioned elements
+- Root Element: rootElement is now created internally by Handsontable instead of using the user-provided container directly
+
+## 2. Update the css variables
+
+In Handsontable 16.0, we've made significant improvements to our CSS variables system to adjust themes colors, variable order and provide better customization options. Here are the key changes:
+
+### New css variables
+We've introduced new variables that allow for easier customization: 
+
+- `--ht-letter-spacing`: controls the spacing between letters for better readability and visual appearance
+ - `--ht-radio-[]`: style radio inputs more accurate
+ - `--ht-cell-read-only-background-color`: better adjust readonly cells.
+ - `--ht-checkbox-indeterminate`: customize checkbox indeterminate state
+
+### Changed css variables
+We've renamed a few variables to ensure more consistent naming: 
+
+| Old variable name | New variable name |
+|------------------|-------------------|
+| `--ht-icon-active-button-border-color` | `--ht-icon-button-active-border-color` |
+| `--ht-icon-active-button-background-color` | `--ht-icon-button-active-background-color` |
+| `--ht-icon-active-button-icon-color` | `--ht-icon-button-active-icon-color` |
+| `--ht-icon-active-button-hover-border-color` | `--ht-icon-button-active-hover-border-color` |
+| `--ht-icon-active-button-hover-background-color` | `--ht-icon-button-active-hover-background-color` |
+| `--ht-icon-active-button-hover-icon-color` | `--ht-icon-button-active-hover-icon-color` |
+
+### Accessibility improvements
+Checkbox variables have been added to support better accessibility:
+
+- `--hot-focus-outline-color`: Controls the color of focus indicators
+- `--hot-contrast-ratio`: Helps maintain proper contrast ratios for better readability
+
+### Migration notes
+If you were using custom CSS variables in version 15.3, you'll need to:
+
+1. Review your custom variable names against the new naming convention
+2. Update any deprecated variable references to their new counterparts
+3. Take advantage of the new theme-specific variables for more granular control
+
+For a complete list of new and changed CSS variables, please refer to our [CSS Customization](/guides/customize-theme/css-variables) guide.


### PR DESCRIPTION
### Context
This PR includes new migration guide and describe how to migrate from Handsontable 15.3 to Handsontable 16.0

### How has this been tested?
Locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2591

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

[skip changelog]
