### PR TITLE
Use Netlify https for stating to allow fetching from rewriten stage

### DIFF
--- a/docs/netlify/createOrGet.mjs
+++ b/docs/netlify/createOrGet.mjs
@@ -33,7 +33,7 @@ await writeFileSync(
   'NETLIFY_VARS',
   site
     ? `NETLIFY_SITE_ID=${site.id}
-NETLIFY_SITE_URL=${site.url}`
+NETLIFY_SITE_URL=${site.ssl_url || site.url}`
     : '',
   { encoding: 'utf-8' }
 );


### PR DESCRIPTION
### Context
<img width="728" alt="Screenshot 2025-06-09 at 11 22 04" src="https://github.com/user-attachments/assets/20c5cf0b-f390-4546-be92-d88176931514" />

https://dev.handsontable.com/docs/javascript-data-grid/angular-basic-example/ is trying to fetch resources from netlifyy http (not https) URL which is blocked by default brower security setup eg https://dev.handsontable.com/docs/angular-data-grid/demo/

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
