### PR TITLE
Update fill handle styles

### DIFF
--- a/.changelogs/11663.json
+++ b/.changelogs/11663.json
@@ -3,6 +3,6 @@
   "title": "Updated an fill handle styles",
   "type": "changed",
   "issueOrPR": 11663,
-  "breaking": false,
+  "breaking": true,
   "framework": "none"
 }

--- a/.changelogs/11663.json
+++ b/.changelogs/11663.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Updated an fill handle styles",
+  "type": "changed",
+  "issueOrPR": 11663,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/src/selection/border/border.js
+++ b/handsontable/src/3rdparty/walkontable/src/selection/border/border.js
@@ -48,8 +48,14 @@ class Border {
     this.endStyle = null;
 
     this.cornerDefaultStyle = getCornerStyle(this.instance);
+
     // Offset to moving the corner to be centered relative to the grid.
-    this.cornerCenterPointOffset = -Math.ceil((parseInt(this.cornerDefaultStyle.width, 10) / 2));
+    if (this.wot.wtSettings.getSetting('stylesHandler').isClassicTheme()) {
+      this.cornerCenterPointOffset = -Math.ceil((parseInt(this.cornerDefaultStyle.width, 10) / 2));
+    } else {
+      this.cornerCenterPointOffset = -parseInt(this.cornerDefaultStyle.width, 10);
+    }
+
     this.corner = null;
     this.cornerStyle = null;
 
@@ -619,9 +625,6 @@ class Border {
             // styles for classic theme
             this.cornerStyle.top = `${cornerTopPosition}px`;
             this.cornerStyle.borderBottomWidth = 0;
-          } else {
-            // styles for ht-theme
-            this.cornerStyle.top = `${cornerTopPosition - 1}px`;
           }
         }
       }

--- a/handsontable/src/3rdparty/walkontable/src/selection/border/border.js
+++ b/handsontable/src/3rdparty/walkontable/src/selection/border/border.js
@@ -53,7 +53,8 @@ class Border {
     if (this.wot.wtSettings.getSetting('stylesHandler').isClassicTheme()) {
       this.cornerCenterPointOffset = -Math.ceil((parseInt(this.cornerDefaultStyle.width, 10) / 2));
     } else {
-      this.cornerCenterPointOffset = -parseInt(this.cornerDefaultStyle.width, 10);
+      // -1 was initially removed from the base position to compensate the lack of a corner border.
+      this.cornerCenterPointOffset = -(parseInt(this.cornerDefaultStyle.width, 10) - 1);
     }
 
     this.corner = null;
@@ -577,12 +578,13 @@ class Border {
 
       let trimmingContainer = getTrimmingContainer(wtTable.TABLE);
       const trimToWindow = trimmingContainer === rootWindow;
+      const isClassicTheme = this.wot.wtSettings.getSetting('stylesHandler').isClassicTheme();
 
       if (trimToWindow) {
         trimmingContainer = rootDocument.documentElement;
       }
 
-      // -1 was initially removed from the base position to compansate for the table border. We need to exclude it from
+      // -1 was initially removed from the base position to compensate for the table border. We need to exclude it from
       // the corner width.
       const cornerBorderCompensation = parseInt(this.cornerDefaultStyle.borderWidth, 10) - 1;
       const cornerHalfWidth = Math.ceil(parseInt(this.cornerDefaultStyle.width, 10) / 2);
@@ -603,9 +605,18 @@ class Border {
         }
 
         if (cornerOverlappingContainer) {
-          this.cornerStyle[inlinePosProperty] = `${Math.floor(
-            inlineStartPos + width + this.cornerCenterPointOffset - cornerHalfWidth - cornerBorderCompensation
-          )}px`;
+          if (isClassicTheme) {
+            // styles for classic theme
+            this.cornerStyle[inlinePosProperty] = `${Math.floor(
+              inlineStartPos + width + this.cornerCenterPointOffset - cornerHalfWidth - cornerBorderCompensation
+            )}px`;
+          } else {
+            // styles for modern themes
+            this.cornerStyle[inlinePosProperty] = `${Math.floor(
+              inlineStartPos + width + this.cornerCenterPointOffset - cornerHalfWidth - cornerBorderCompensation + 2
+            )}px`;
+          }
+
           this.cornerStyle[isRtl ? 'borderLeftWidth' : 'borderRightWidth'] = 0;
         }
       }
@@ -614,7 +625,6 @@ class Border {
         const toTdOffsetTop = trimToWindow ? toTD.getBoundingClientRect().top : toTD.offsetTop;
         const cornerBottomEdge = toTdOffsetTop + outerHeight(toTD) + (parseInt(this.cornerDefaultStyle.height, 10) / 2);
         const cornerOverlappingContainer = cornerBottomEdge >= innerHeight(trimmingContainer);
-        const isClassicTheme = this.wot.wtSettings.getSetting('stylesHandler').isClassicTheme();
 
         if (cornerOverlappingContainer) {
           const cornerTopPosition = Math.floor(

--- a/handsontable/src/3rdparty/walkontable/src/selection/border/border.js
+++ b/handsontable/src/3rdparty/walkontable/src/selection/border/border.js
@@ -605,19 +605,15 @@ class Border {
         }
 
         if (cornerOverlappingContainer) {
+          const cornerEndPosition = Math.floor(
+            inlineStartPos + width + this.cornerCenterPointOffset - cornerHalfWidth - cornerBorderCompensation
+          );
+
           if (isClassicTheme) {
             // styles for classic theme
-            this.cornerStyle[inlinePosProperty] = `${Math.floor(
-              inlineStartPos + width + this.cornerCenterPointOffset - cornerHalfWidth - cornerBorderCompensation
-            )}px`;
-          } else {
-            // styles for modern themes
-            this.cornerStyle[inlinePosProperty] = `${Math.floor(
-              inlineStartPos + width + this.cornerCenterPointOffset - cornerHalfWidth - cornerBorderCompensation + 2
-            )}px`;
+            this.cornerStyle[inlinePosProperty] = `${Math.floor(cornerEndPosition)}px`;
+            this.cornerStyle[isRtl ? 'borderLeftWidth' : 'borderRightWidth'] = 0;
           }
-
-          this.cornerStyle[isRtl ? 'borderLeftWidth' : 'borderRightWidth'] = 0;
         }
       }
 

--- a/handsontable/src/3rdparty/walkontable/src/selection/border/border.js
+++ b/handsontable/src/3rdparty/walkontable/src/selection/border/border.js
@@ -51,7 +51,7 @@ class Border {
 
     // Offset to moving the corner to be centered relative to the grid.
     if (this.wot.wtSettings.getSetting('stylesHandler').isClassicTheme()) {
-      this.cornerCenterPointOffset = -Math.ceil((parseInt(this.cornerDefaultStyle.width, 10) / 2));
+      this.cornerCenterPointOffset = -Math.ceil(parseInt(this.cornerDefaultStyle.width, 10) / 2);
     } else {
       // -1 was initially removed from the base position to compensate the lack of a corner border.
       this.cornerCenterPointOffset = -(parseInt(this.cornerDefaultStyle.width, 10) - 1);

--- a/handsontable/src/3rdparty/walkontable/src/selection/border/utils.js
+++ b/handsontable/src/3rdparty/walkontable/src/selection/border/utils.js
@@ -12,14 +12,12 @@ export const getCornerStyle = (wot) => {
   }
 
   const cornerSizeFromVar = stylesHandler.getCSSVariableValue('cell-autofill-size');
-  const cornerBorderWidthFromVar = stylesHandler.getCSSVariableValue('cell-autofill-border-width');
-  const cornerColorFromVar = stylesHandler.getCSSVariableValue('cell-autofill-border-color');
 
   return Object.freeze({
     width: cornerSizeFromVar,
     height: cornerSizeFromVar,
-    borderWidth: cornerBorderWidthFromVar,
+    borderWidth: 0,
     borderStyle: 'solid',
-    borderColor: cornerColorFromVar,
+    borderColor: 'transparent',
   });
 };

--- a/handsontable/src/3rdparty/walkontable/test/spec/selection/themes/corner.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/selection/themes/corner.spec.js
@@ -13,8 +13,6 @@ describe('WalkontableBorder corner (modern themes)', () => {
     this.$wrapper[0].style.setProperty('--ht-line-height', '22px');
     this.$wrapper[0].style.setProperty('--ht-cell-vertical-padding', '0px');
     this.$wrapper[0].style.setProperty('--ht-cell-autofill-size', '10px');
-    this.$wrapper[0].style.setProperty('--ht-cell-autofill-border-width', '4px');
-    this.$wrapper[0].style.setProperty('--ht-cell-autofill-border-color', '#FF0000');
 
     createDataArray();
   });

--- a/handsontable/src/styles/components/core/_selection.scss
+++ b/handsontable/src/styles/components/core/_selection.scss
@@ -65,12 +65,10 @@
 
       // Fill handle
       &.corner {
-        border-radius: var(--ht-cell-autofill-border-radius) !important;
         background-color: var(
           --ht-cell-autofill-background-color,
           #1a42e8
         ) !important;
-        border-color: var(--ht-cell-autofill-border-color) !important;;
         font-size: 0;
         cursor: crosshair;
         z-index: 10;

--- a/handsontable/src/styles/themes/horizon.scss
+++ b/handsontable/src/styles/themes/horizon.scss
@@ -39,9 +39,6 @@
   --ht-cell-selection-border-color: #37bc6c;
   --ht-cell-selection-background-color: #37bc6c;
   --ht-cell-autofill-size: 8px;
-  --ht-cell-autofill-border-width: 1px;
-  --ht-cell-autofill-border-radius: 4px;
-  --ht-cell-autofill-border-color: #ffffff;
   --ht-cell-autofill-background-color: #37bc6c;
   --ht-cell-autofill-fill-border-color: #353535;
   --ht-cell-mobile-handle-size: 12px;
@@ -252,7 +249,6 @@
   --ht-cell-read-only-background-color: rgba(209, 209, 212, 0.04);
   --ht-cell-selection-border-color: #f1b93e;
   --ht-cell-selection-background-color: #f1b93e;
-  --ht-cell-autofill-border-color: #070604;
   --ht-cell-autofill-background-color: #f1b93e;
   --ht-cell-autofill-fill-border-color: #b5b5b9;
   --ht-cell-mobile-handle-border-color: #f1b93e;

--- a/handsontable/src/styles/themes/horizon.scss
+++ b/handsontable/src/styles/themes/horizon.scss
@@ -38,7 +38,7 @@
   --ht-cell-read-only-background-color: rgba(35, 35, 38, 0.04);
   --ht-cell-selection-border-color: #37bc6c;
   --ht-cell-selection-background-color: #37bc6c;
-  --ht-cell-autofill-size: 8px;
+  --ht-cell-autofill-size: 6px;
   --ht-cell-autofill-background-color: #37bc6c;
   --ht-cell-autofill-fill-border-color: #353535;
   --ht-cell-mobile-handle-size: 12px;

--- a/handsontable/src/styles/themes/main.scss
+++ b/handsontable/src/styles/themes/main.scss
@@ -38,7 +38,7 @@
   --ht-cell-read-only-background-color: rgba(34, 34, 34, 0.04);
   --ht-cell-selection-border-color: #1a42e8;
   --ht-cell-selection-background-color: #5371ee;
-  --ht-cell-autofill-size: 8px;
+  --ht-cell-autofill-size: 6px;
   --ht-cell-autofill-background-color: #1a42e8;
   --ht-cell-autofill-fill-border-color: #222222;
   --ht-cell-mobile-handle-size: 12px;

--- a/handsontable/src/styles/themes/main.scss
+++ b/handsontable/src/styles/themes/main.scss
@@ -39,9 +39,6 @@
   --ht-cell-selection-border-color: #1a42e8;
   --ht-cell-selection-background-color: #5371ee;
   --ht-cell-autofill-size: 8px;
-  --ht-cell-autofill-border-width: 1px;
-  --ht-cell-autofill-border-radius: 4px;
-  --ht-cell-autofill-border-color: #ffffff;
   --ht-cell-autofill-background-color: #1a42e8;
   --ht-cell-autofill-fill-border-color: #222222;
   --ht-cell-mobile-handle-size: 12px;
@@ -252,7 +249,6 @@
   --ht-cell-read-only-background-color: rgba(199, 199, 199, 0.12);
   --ht-cell-selection-border-color: #476af7;
   --ht-cell-selection-background-color: #2e56fc;
-  --ht-cell-autofill-border-color: #050506;
   --ht-cell-autofill-background-color: #476af7;
   --ht-cell-autofill-fill-border-color: #c7c7c7;
   --ht-cell-mobile-handle-border-color: #476af7;


### PR DESCRIPTION
### Context
This PR includes changes to the fill handle styles. After these changes, it should have a different shape and positioning.

Before:
![image](https://github.com/user-attachments/assets/19f22ff5-38b7-41b4-b762-24f718aabf2b)

After:
![image](https://github.com/user-attachments/assets/0399d560-b15b-467f-923a-b21e9e52fd35)


### How has this been tested?
Locally and updated visual tests results

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2522

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
