### PR TITLE
Fix theme switcher on Themes documentation page

### DIFF
--- a/docs/.vuepress/handsontable-manager/theme-manager.js
+++ b/docs/.vuepress/handsontable-manager/theme-manager.js
@@ -16,8 +16,8 @@ const ensureCorrectHotThemes = () => {
     // eslint-disable-next-line no-undef
     Handsontable.hooks.add('afterSetTheme', function() {
       if (
-        this.rootElement.classList.contains('disable-auto-theme') ||
-        this.rootElement?.parentNode.classList.contains('disable-auto-theme')
+        this.rootContainer.classList.contains('disable-auto-theme') ||
+        this.rootContainer?.parentNode.classList.contains('disable-auto-theme')
       ) {
         return;
       }
@@ -34,8 +34,8 @@ const ensureCorrectHotThemes = () => {
 const switchExamplesTheme = (hotInstances) => {
   hotInstances.forEach((hotInstance) => {
     if (
-      hotInstance.rootElement.classList.contains('disable-auto-theme') ||
-      hotInstance.rootElement?.parentNode.classList.contains('disable-auto-theme')
+      hotInstance.rootContainer.classList.contains('disable-auto-theme') ||
+      hotInstance.rootContainer?.parentNode.classList.contains('disable-auto-theme')
     ) {
       return;
     }


### PR DESCRIPTION
### Context
This PR includes fix to the The theme switcher on the [Themes documentation page](https://dev.handsontable.com/docs/javascript-data-grid/themes/) 

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2606

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

[skip changelog]
