### PR TITLE
Fix issue with manualColumnResize and manualRowResize causing incorrect column or row resizing on mouse move after a double-click

### DIFF
--- a/.changelogs/11671.json
+++ b/.changelogs/11671.json
@@ -1,6 +1,6 @@
 {
   "issuesOrigin": "private",
-  "title": "Fixed an issue with incorrect column resizing that occurs when the user double-clicks a column separator to auto-size it and then moves the mouse",
+  "title": "Fixed an issue with incorrect row and column resizing that occurs when the user double-clicks a column or row separator to auto-size it and then moves the mouse",
   "type": "fixed",
   "issueOrPR": 11671,
   "breaking": false,

--- a/.changelogs/11671.json
+++ b/.changelogs/11671.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed an issue with incorrect column resizing that occurs when the user double-clicks a column separator to auto-size it and then moves the mouse",
+  "type": "fixed",
+  "issueOrPR": 11671,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/manualColumnResize/__tests__/manualColumnResize.spec.js
+++ b/handsontable/src/plugins/manualColumnResize/__tests__/manualColumnResize.spec.js
@@ -852,10 +852,7 @@ describe('manualColumnResize', () => {
     const resizerPosition = $resizer.position();
 
     await sleep(600);
-    $resizer.simulate('mousedown', { clientX: resizerPosition.left });
-    $resizer.simulate('mouseup', { clientX: resizerPosition.left });
-    $resizer.simulate('mousedown', { clientX: resizerPosition.left });
-    $resizer.simulate('mouseup', { clientX: resizerPosition.left });
+    await mouseDoubleClick($resizer, { clientX: resizerPosition.left });
     getTopClone().find('tr:eq(0) th:eq(2)').simulate('mouseover');
     await sleep(600);
 

--- a/handsontable/src/plugins/manualColumnResize/__tests__/manualColumnResize.spec.js
+++ b/handsontable/src/plugins/manualColumnResize/__tests__/manualColumnResize.spec.js
@@ -839,6 +839,33 @@ describe('manualColumnResize', () => {
     });
   });
 
+  it('should autosize selected columns after double click on handler and move mouse to the next column', async() => {
+    handsontable({
+      data: createSpreadsheetData(9, 9),
+      colHeaders: true,
+      manualColumnResize: true,
+    });
+
+    getTopClone().find('thead tr:eq(0) th:eq(1)').simulate('mouseover');
+
+    const $resizer = spec().$container.find('.manualColumnResizer');
+    const resizerPosition = $resizer.position();
+
+    await sleep(600);
+    $resizer.simulate('mousedown', { clientX: resizerPosition.left });
+    $resizer.simulate('mouseup', { clientX: resizerPosition.left });
+    $resizer.simulate('mousedown', { clientX: resizerPosition.left });
+    $resizer.simulate('mouseup', { clientX: resizerPosition.left });
+    getTopClone().find('tr:eq(0) th:eq(2)').simulate('mouseover');
+    await sleep(600);
+
+    expect(colWidth(spec().$container, 1)).forThemes(({ classic, main, horizon }) => {
+      classic.toBe(26);
+      main.toBe(36);
+      horizon.toBe(44);
+    });
+  });
+
   it.forTheme('classic')('should adjust resize handles position after table size changed', async() => {
     let maxed = false;
 

--- a/handsontable/src/plugins/manualColumnResize/manualColumnResize.js
+++ b/handsontable/src/plugins/manualColumnResize/manualColumnResize.js
@@ -261,7 +261,7 @@ export class ManualColumnResize extends BasePlugin {
    * @param {HTMLCellElement} TH TH HTML element.
    */
   setupHandlePosition(TH) {
-    if (!TH.parentNode) {
+    if (!TH.parentNode || this.#dblclick > 1) {
       return;
     }
 

--- a/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
+++ b/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
@@ -992,6 +992,32 @@ describe('manualRowResize', () => {
     });
   });
 
+  it('should autosize selected rows after double click on handler and move mouse to the next row', async() => {
+    handsontable({
+      data: createSpreadsheetData(9, 9),
+      rowHeaders: true,
+      manualRowResize: true,
+    });
+
+    await resizeRow(1, 100);
+
+    getInlineStartClone().find('tbody tr:eq(1) th:eq(0)').simulate('mouseover');
+
+    const $resizer = spec().$container.find('.manualRowResizer');
+    const resizerPosition = $resizer.position();
+
+    await sleep(600);
+    await mouseDoubleClick($resizer, { clientY: resizerPosition.top });
+    getInlineStartClone().find('tr:eq(2) th:eq(0)').simulate('mouseover');
+    await sleep(600);
+
+    expect(rowHeight(spec().$container, 1)).forThemes(({ classic, main, horizon }) => {
+      classic.toBeAroundValue(24);
+      main.toBeAroundValue(29);
+      horizon.toBeAroundValue(37);
+    });
+  });
+
   it('should resize (expanding and narrowing) selected rows', async() => {
     handsontable({
       data: createSpreadsheetData(10, 20),
@@ -1932,6 +1958,7 @@ describe('manualRowResize', () => {
       expect(beforeRowResizeCallback.calls.mostRecent().args).toEqual([300, 2, false]);
       expect(afterRowResizeCallback.calls.mostRecent().args).toEqual([300, 2, false]);
 
+      await sleep(500);
       await resizeRow(2, -10);
 
       expect(beforeRowResizeCallback.calls.mostRecent().args).forThemes(({ classic, main, horizon }) => {
@@ -1945,11 +1972,13 @@ describe('manualRowResize', () => {
         horizon.toEqual([37, 2, false]);
       });
 
+      await sleep(500);
       await resizeRow(2, 100);
 
       expect(beforeRowResizeCallback.calls.mostRecent().args).toEqual([100, 2, false]);
       expect(afterRowResizeCallback.calls.mostRecent().args).toEqual([100, 2, false]);
 
+      await sleep(500);
       await resizeRow(2, 5);
 
       expect(beforeRowResizeCallback.calls.mostRecent().args).forThemes(({ classic, main, horizon }) => {

--- a/handsontable/src/plugins/manualRowResize/manualRowResize.js
+++ b/handsontable/src/plugins/manualRowResize/manualRowResize.js
@@ -226,6 +226,10 @@ export class ManualRowResize extends BasePlugin {
    * @param {HTMLCellElement} TH TH HTML element.
    */
   setupHandlePosition(TH) {
+    if (this.#dblclick > 1) {
+      return;
+    }
+
     this.#currentTH = TH;
 
     const { view } = this.hot;


### PR DESCRIPTION
### Context
This PR includes a fix for the incorrect column or row resizing that occurs when the user double-clicks a column or row separator to auto-size it and then moves the mouse.

### How has this been tested?
Locally and new test case

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/749

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
