### PR TITLE
Fix mouse wheel zoom problem on Windows

### DIFF
--- a/.changelogs/11680.json
+++ b/.changelogs/11680.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed an issue with mouse wheel zooming on Windows",
+  "type": "fixed",
+  "issueOrPR": 11680,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/src/overlays.js
+++ b/handsontable/src/3rdparty/walkontable/src/overlays.js
@@ -423,6 +423,11 @@ class Overlays {
    * @param {boolean} preventDefault If `true`, the `preventDefault` will be called on event object.
    */
   onCloneWheel(event, preventDefault) {
+    // Fix for Windows OS, where the ctrl key is used to zoom the page (issue #2405).
+    if (event.ctrlKey) {
+      return;
+    }
+
     const { rootWindow } = this.domBindings;
 
     // There was if statement which controlled flow of this function. It avoided the execution of the next lines

--- a/handsontable/src/3rdparty/walkontable/src/overlays.js
+++ b/handsontable/src/3rdparty/walkontable/src/overlays.js
@@ -423,7 +423,7 @@ class Overlays {
    * @param {boolean} preventDefault If `true`, the `preventDefault` will be called on event object.
    */
   onCloneWheel(event, preventDefault) {
-    // Fix for Windows OS, where the ctrl key is used to zoom the page (issue #2405).
+    // Fix for Windows OS, where the ctrl key is used to zoom the page (issue #dev-2405).
     if (event.ctrlKey) {
       return;
     }

--- a/handsontable/src/3rdparty/walkontable/test/spec/overlay.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/overlay.spec.js
@@ -988,4 +988,28 @@ describe('WalkontableOverlay', () => {
     expect(inlineStartOverlay().getScrollPosition()).toBe(250);
     expect(topOverlay().getScrollPosition()).toBe(300);
   });
+
+  it('should not scroll the table when the ctrl key is pressed on Windows OS (#2405)', async() => {
+    const wt = walkontable({
+      data: getData,
+      totalRows: getTotalRows,
+      totalColumns: getTotalColumns,
+      fixedColumnsStart: 0,
+      fixedRowsTop: 0,
+      fixedRowsBottom: 0,
+    });
+
+    wt.draw();
+
+    inlineStartOverlay().clone.wtTable.holder
+      .dispatchEvent(new WheelEvent('wheel', {
+        deltaX: 50,
+        deltaY: 60,
+        ctrlKey: true,
+      }));
+
+    expect(isWindowsOS()).toBe(true);
+    expect(inlineStartOverlay().getScrollPosition()).toBe(0);
+    expect(topOverlay().getScrollPosition()).toBe(0);
+  });
 });

--- a/handsontable/src/3rdparty/walkontable/test/spec/overlay.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/overlay.spec.js
@@ -1008,7 +1008,6 @@ describe('WalkontableOverlay', () => {
         ctrlKey: true,
       }));
 
-    expect(isWindowsOS()).toBe(true);
     expect(inlineStartOverlay().getScrollPosition()).toBe(0);
     expect(topOverlay().getScrollPosition()).toBe(0);
   });

--- a/handsontable/src/3rdparty/walkontable/test/spec/overlay.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/overlay.spec.js
@@ -989,7 +989,7 @@ describe('WalkontableOverlay', () => {
     expect(topOverlay().getScrollPosition()).toBe(300);
   });
 
-  it('should not scroll the table when the ctrl key is pressed on Windows OS (#2405)', async() => {
+  it('should not scroll the table when the ctrl key is pressed on Windows OS (#dev-2405)', async() => {
     const wt = walkontable({
       data: getData,
       totalRows: getTotalRows,


### PR DESCRIPTION
### Context
This PR includes a fix for a zooming issue on Windows when a user uses the mouse wheel over a table and ctrl key is pressed.

### How has this been tested?
Locally and new test case

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2405

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
