### PR TITLE
Fix scrollbar calculation on mobile devices

### DIFF
--- a/.changelogs/11683.json
+++ b/.changelogs/11683.json
@@ -1,8 +1,0 @@
-{
-  "issuesOrigin": "private",
-  "title": "Fixed an issue with scrollbar calculation on mobile devices",
-  "type": "fixed",
-  "issueOrPR": 11683,
-  "breaking": false,
-  "framework": "none"
-}

--- a/.changelogs/11683.json
+++ b/.changelogs/11683.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed an issue with scrollbar calculation on mobile devices",
+  "type": "fixed",
+  "issueOrPR": 11683,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/helpers/dom/element.js
+++ b/handsontable/src/helpers/dom/element.js
@@ -1,6 +1,6 @@
 import { sanitize } from '../string';
 import { A11Y_HIDDEN } from '../a11y';
-import { isWindowsOS, isSafari } from '../browser';
+import { isWindowsOS, isSafari, isMobileBrowser } from '../browser';
 /**
  * Get the parent of the specified node in the DOM tree.
  *
@@ -1004,7 +1004,7 @@ function walkontableCalculateScrollbarWidth(rootDocument = document) {
   const outer = rootDocument.createElement('div');
 
   // Fix for Safari custom scrollbar size
-  if (isSafari()) {
+  if (isSafari() && !isMobileBrowser()) {
     outer.classList.add('htScrollbarSafariTest');
   }
 


### PR DESCRIPTION
### Context
This PR includes fix for scrollbar calculation on mobile devices.

### How has this been tested?
Locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2613

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

[skip changelog]
