### PR TITLE
Fix problem with focus on password editor

### DIFF
--- a/handsontable/src/editors/passwordEditor/__tests__/passwordEditor.spec.js
+++ b/handsontable/src/editors/passwordEditor/__tests__/passwordEditor.spec.js
@@ -522,6 +522,19 @@ describe('PasswordEditor', () => {
     expect(editableElement.getAttribute('dir')).toBeNull();
   });
 
+  it('should render an editable editor\'s element with "tabindex" attribute set to "-1"', async() => {
+    handsontable({
+      data: createSpreadsheetData(2, 5),
+      editor: 'password',
+    });
+
+    await selectCell(0, 0);
+
+    const editableElement = getActiveEditor().TEXTAREA;
+
+    expect(editableElement.getAttribute('tabindex')).toBe('-1');
+  });
+
   describe('IME support', () => {
     it('should focus editable element after a timeout when selecting the cell if `imeFastEdit` is enabled', async() => {
       handsontable({

--- a/handsontable/src/editors/passwordEditor/passwordEditor.js
+++ b/handsontable/src/editors/passwordEditor/passwordEditor.js
@@ -1,6 +1,7 @@
 import { TextEditor } from '../textEditor';
 import { createInputElementResizer } from '../../utils/autoResize';
 import { empty } from '../../helpers/dom/element';
+import { A11Y_TABINDEX } from '../../helpers/a11y';
 
 export const EDITOR_TYPE = 'password';
 
@@ -36,6 +37,7 @@ export class PasswordEditor extends TextEditor {
     this.textareaStyle.height = 0;
 
     empty(this.TEXTAREA_PARENT);
+    this.TEXTAREA.setAttribute(...A11Y_TABINDEX(-1));
     this.TEXTAREA_PARENT.appendChild(this.TEXTAREA);
   }
 }


### PR DESCRIPTION
### Context
This PR includes a fix for a focus issue when a password-type field is in the table.

### How has this been tested?
Locally and test case

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2625

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

[skip changelog]
