### PR TITLE
Fix grid-size demo for angular

### DIFF
--- a/docs/content/guides/getting-started/grid-size/angular/example.html
+++ b/docs/content/guides/getting-started/grid-size/angular/example.html
@@ -1,3 +1,11 @@
 <div>
+  <style>
+    .table-container hot-table > div {
+      height: 100%;
+    }
+    .table-container hot-table > div > div {
+      height: 100%;
+    }
+  </style>
   <example-grid-size></example-grid-size>
 </div>

--- a/docs/content/guides/getting-started/grid-size/angular/example.ts
+++ b/docs/content/guides/getting-started/grid-size/angular/example.ts
@@ -14,7 +14,7 @@ import { GridSettings, HotTableComponent } from '@handsontable/angular-wrapper';
         {{ isContainerExpanded ? 'Collapse container' : 'Expand container' }}
       </button>
     </div>
-    <div [style.height.px]="currentHeight">
+    <div class="table-container" [style.height.px]="currentHeight">
       <hot-table [data]="data" [settings]="gridSettings"></hot-table>
     </div>`,
 })


### PR DESCRIPTION
### Context
This PR includes fix for angular `/grid-size` demo

### How has this been tested?
Locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2632

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

[skip changelog]
