### PR TITLE
Fix problem with Angular theme switcher on Themes documentation page

### DIFF
--- a/docs/.vuepress/handsontable-manager/theme-manager.js
+++ b/docs/.vuepress/handsontable-manager/theme-manager.js
@@ -15,10 +15,7 @@ const ensureCorrectHotThemes = () => {
   if (typeof Handsontable !== 'undefined') {
     // eslint-disable-next-line no-undef
     Handsontable.hooks.add('afterSetTheme', function() {
-      if (
-        this.rootContainer.classList.contains('disable-auto-theme') ||
-        this.rootContainer?.parentNode.classList.contains('disable-auto-theme')
-      ) {
+      if (this.rootContainer.closest('.disable-auto-theme')) {
         return;
       }
 
@@ -33,10 +30,7 @@ const ensureCorrectHotThemes = () => {
 
 const switchExamplesTheme = (hotInstances) => {
   hotInstances.forEach((hotInstance) => {
-    if (
-      hotInstance.rootContainer.classList.contains('disable-auto-theme') ||
-      hotInstance.rootContainer?.parentNode.classList.contains('disable-auto-theme')
-    ) {
+    if (hotInstance.rootContainer.closest('.disable-auto-theme')) {
       return;
     }
 

--- a/docs/content/guides/styling/themes/angular/example1.html
+++ b/docs/content/guides/styling/themes/angular/example1.html
@@ -1,3 +1,3 @@
-<div>
+<div class="disable-auto-theme">
   <app-example1></app-example1>
 </div>

--- a/docs/content/guides/styling/themes/themes.md
+++ b/docs/content/guides/styling/themes/themes.md
@@ -49,7 +49,7 @@ Keep in mind that starting from version `15.0`, importing a theme is required.
 
 ::: only-for javascript
 
-::: example #exampleTheme .disable-auto-theme --html 1 --js 2 --ts 3 --css 4
+::: example #exampleTheme --html 1 --js 2 --ts 3 --css 4
 @[code](@/content/guides/styling/themes/javascript/exampleTheme.html)
 @[code](@/content/guides/styling/themes/javascript/exampleTheme.js)
 @[code](@/content/guides/styling/themes/javascript/exampleTheme.ts)


### PR DESCRIPTION
### Context
This PR includes fix for theme switcher problem on Themes documentation page

### How has this been tested?
Locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2634

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

[skip changelog]
