### PR TITLE
Change of color of the text in marquee of the custom for the 'Context…

### DIFF
--- a/docs/content/guides/accessories-and-menus/context-menu/angular/example3.ts
+++ b/docs/content/guides/accessories-and-menus/context-menu/angular/example3.ts
@@ -93,7 +93,7 @@ export class AppComponent implements OnInit {
           renderer() {
             const elem = document.createElement('marquee');
 
-            elem.style.cssText = 'background: lightgray;';
+            elem.style.cssText = 'background: lightgray; color: #222222;';
             elem.textContent = 'Brought to you by...';
 
             return elem;

--- a/docs/content/guides/accessories-and-menus/context-menu/javascript/example3.js
+++ b/docs/content/guides/accessories-and-menus/context-menu/javascript/example3.js
@@ -67,7 +67,7 @@ const contextMenuSettings = {
       renderer() {
         const elem = document.createElement('marquee');
 
-        elem.style.cssText = 'background: lightgray;';
+        elem.style.cssText = 'background: lightgray; color: #222222;';
         elem.textContent = 'Brought to you by...';
 
         return elem;

--- a/docs/content/guides/accessories-and-menus/context-menu/javascript/example3.ts
+++ b/docs/content/guides/accessories-and-menus/context-menu/javascript/example3.ts
@@ -68,7 +68,7 @@ const contextMenuSettings: DetailedSettings = {
       renderer() {
         const elem = document.createElement('marquee');
 
-        elem.style.cssText = 'background: lightgray;';
+        elem.style.cssText = 'background: lightgray; color: #222222;';
         elem.textContent = 'Brought to you by...';
 
         return elem;

--- a/docs/content/guides/accessories-and-menus/context-menu/react/example3.jsx
+++ b/docs/content/guides/accessories-and-menus/context-menu/react/example3.jsx
@@ -71,7 +71,7 @@ const contextMenuSettings = {
       renderer() {
         const elem = document.createElement('marquee');
 
-        elem.style.cssText = 'background: lightgray;';
+        elem.style.cssText = 'background: lightgray; color: #222222;';
         elem.textContent = 'Brought to you by...';
 
         return elem;

--- a/docs/content/guides/accessories-and-menus/context-menu/react/example3.tsx
+++ b/docs/content/guides/accessories-and-menus/context-menu/react/example3.tsx
@@ -72,7 +72,7 @@ const contextMenuSettings: DetailedSettings = {
       renderer() {
         const elem = document.createElement('marquee');
 
-        elem.style.cssText = 'background: lightgray;';
+        elem.style.cssText = 'background: lightgray; color: #222222;';
         elem.textContent = 'Brought to you by...';
 
         return elem;


### PR DESCRIPTION
… menu with a fully custom configuration' demo

### Context
<!--- Why is this change required? What problem does it solve? -->
In dark mode documentation in marquee text is not visible. By adding color to the marquee I ensured that contrast between background and foreground will be enough to see text inside the marquee
<img width="465" alt="image" src="https://github.com/user-attachments/assets/a11222f1-6a81-4000-bd31-6d6abcb35d8d" />
AFTER CHANGE:
<img width="676" alt="image" src="https://github.com/user-attachments/assets/5705c703-4842-4277-9b29-205f0b0d7c2a" />

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Locally for dark and light mode for Angular, javascript and react documentation
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
[skip changelog]