### PR TITLE
Fix docs saving data page example styles

### DIFF
--- a/docs/content/guides/getting-started/saving-data/angular/example1.html
+++ b/docs/content/guides/getting-started/saving-data/angular/example1.html
@@ -2,6 +2,7 @@
   <style>
     .controls {
       display: flex;
+      align-items: center;
       flex-wrap: wrap;
     }
   </style>

--- a/docs/content/guides/getting-started/saving-data/angular/example1.html
+++ b/docs/content/guides/getting-started/saving-data/angular/example1.html
@@ -1,3 +1,9 @@
 <div>
+  <style>
+    .controls {
+      display: flex;
+      flex-wrap: wrap;
+    }
+  </style>
   <example1-saving-data></example1-saving-data>
 </div>

--- a/docs/content/guides/getting-started/saving-data/angular/example1.ts
+++ b/docs/content/guides/getting-started/saving-data/angular/example1.ts
@@ -14,7 +14,7 @@ import Handsontable from 'handsontable';
           (click)="loadClickCallback($event)"
         >
           Load data
-        </button>&nbsp;
+        </button>
         <button
           id="save"
           class="button button--primary button--blue"

--- a/docs/content/guides/getting-started/saving-data/javascript/example1.css
+++ b/docs/content/guides/getting-started/saving-data/javascript/example1.css
@@ -1,4 +1,5 @@
 .controls {
     display: flex;
+    align-items: center;
     flex-wrap: wrap;
 }

--- a/docs/content/guides/getting-started/saving-data/javascript/example1.css
+++ b/docs/content/guides/getting-started/saving-data/javascript/example1.css
@@ -1,0 +1,4 @@
+.controls {
+    display: flex;
+    flex-wrap: wrap;
+}

--- a/docs/content/guides/getting-started/saving-data/javascript/example1.html
+++ b/docs/content/guides/getting-started/saving-data/javascript/example1.html
@@ -1,6 +1,6 @@
 <div class="example-controls-container">
   <div class="controls">
-    <button id="load" class="button button--primary button--blue">Load data</button>&nbsp;
+    <button id="load" class="button button--primary button--blue">Load data</button>
     <button id="save" class="button button--primary button--blue">Save data</button>
     <label>
       <input type="checkbox" name="autosave" id="autosave"/>

--- a/docs/content/guides/getting-started/saving-data/react/example1.css
+++ b/docs/content/guides/getting-started/saving-data/react/example1.css
@@ -1,4 +1,5 @@
 .controls {
     display: flex;
+    align-items: center;
     flex-wrap: wrap;
 }

--- a/docs/content/guides/getting-started/saving-data/react/example1.css
+++ b/docs/content/guides/getting-started/saving-data/react/example1.css
@@ -1,0 +1,4 @@
+.controls {
+    display: flex;
+    flex-wrap: wrap;
+}

--- a/docs/content/guides/getting-started/saving-data/react/example1.jsx
+++ b/docs/content/guides/getting-started/saving-data/react/example1.jsx
@@ -59,7 +59,6 @@ const ExampleComponent = () => {
           <button id="load" className="button button--primary button--blue" onClick={loadClickCallback}>
             Load data
           </button>
-          &nbsp;
           <button id="save" className="button button--primary button--blue" onClick={saveClickCallback}>
             Save data
           </button>

--- a/docs/content/guides/getting-started/saving-data/react/example1.tsx
+++ b/docs/content/guides/getting-started/saving-data/react/example1.tsx
@@ -62,7 +62,6 @@ const ExampleComponent: React.FC = () => {
           <button id="load" className="button button--primary button--blue" onClick={loadClickCallback}>
             Load data
           </button>
-          &nbsp;
           <button id="save" className="button button--primary button--blue" onClick={saveClickCallback}>
             Save data
           </button>

--- a/docs/content/guides/getting-started/saving-data/saving-data.md
+++ b/docs/content/guides/getting-started/saving-data/saving-data.md
@@ -33,9 +33,10 @@ The example below handles data by using `fetch`. Note that this is just a mockup
 
 ::: only-for javascript
 
-::: example #example1 --html 1 --js 2 --ts 3
+::: example #example1 --html 1 --css 2 --js 3 --ts 4
 
 @[code](@/content/guides/getting-started/saving-data/javascript/example1.html)
+@[code](@/content/guides/getting-started/saving-data/javascript/example1.css)
 @[code](@/content/guides/getting-started/saving-data/javascript/example1.js)
 @[code](@/content/guides/getting-started/saving-data/javascript/example1.ts)
 
@@ -45,8 +46,9 @@ The example below handles data by using `fetch`. Note that this is just a mockup
 
 ::: only-for react
 
-::: example #example1 :react --js 1 --ts 2
+::: example #example1 :react --css 1 --js 2 --ts 3
 
+@[code](@/content/guides/getting-started/saving-data/react/example1.css)
 @[code](@/content/guides/getting-started/saving-data/react/example1.jsx)
 @[code](@/content/guides/getting-started/saving-data/react/example1.tsx)
 


### PR DESCRIPTION
### Context
This PR includes fix for /saving-data documentation page example styles.

### How has this been tested?
Locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2478

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

[skip changelog]
