### PR TITLE
Extend the 16.0 migration guide with the information about the switch to pnpm.

### DIFF
--- a/docs/content/guides/upgrade-and-migration/migrating-from-15.3-to-16.0/migrating-from-15.3-to-16.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-15.3-to-16.0/migrating-from-15.3-to-16.0.md
@@ -18,7 +18,7 @@ category: Upgrade and migration
 
 # Migrate from 15.3 to 16.0
 
-Migrate from Handsontable 15.3 to Handsontable 16.0, released on [TODO].
+Migrate from Handsontable 15.3 to Handsontable 16.0, released on 09/07/2025.
 
 [[toc]]
 
@@ -70,7 +70,7 @@ body
 In Handsontable 16.0, we've made significant improvements to our CSS variables system to adjust themes colors, variable order and provide better customization options. Here are the key changes:
 
 ### New CSS variables
-We've introduced new variables that allow for easier customization: 
+We've introduced new variables that allow for easier customization:
 
  - `--ht-letter-spacing`: Controls letter spacing for improved readability and visual appearance.
  - `--ht-radio-*`: Enables more accurate styling of radio inputs.
@@ -78,7 +78,7 @@ We've introduced new variables that allow for easier customization:
  - `--ht-checkbox-indeterminate`: Lets you style the indeterminate state of checkboxes.
 
 ### Renamed CSS variables
-We've renamed a few variables to ensure more consistent naming: 
+We've renamed a few variables to ensure more consistent naming:
 
 | Old variable name                                | New variable name                                |
 |--------------------------------------------------|--------------------------------------------------|
@@ -128,7 +128,7 @@ npm uninstall @handsontable/angular
 npm install @handsontable/angular-wrapper
 ```
 
-### Step 2: Update component configuration 
+### Step 2: Update component configuration
 
 Move all configuration options to a `GridSettings` object in your component.
 
@@ -414,3 +414,28 @@ Ensure you're importing the correct CSS files for themes.
 - **Solution:** Convert your class-based editor to a component extending `HotCellEditorComponent`.
 
 This migration guide covers the major changes between the old and new Angular wrappers. The new wrapper provides better integration with modern Angular patterns, improved type safety, and a more maintainable codebase.
+
+## 5. Introducing `pnpm` as the repository package manager
+
+Starting on July 1st, 2025, we've switched to `pnpm` as the repository's main package manager.
+
+As the number of packages in the repository grew, so did the number of dependencies. This made it difficult to manage dependencies and install them in a consistent way. To address this, we've switched to `pnpm` as the main package manager.
+
+### Will this affect me?
+
+Unless you're not creating custom builds of Handsontable or any of the wrappers, this change will not affect you.
+
+If you are, however, you'll need to utilize `pnpm` to install the main repository dependencies.
+
+**Note**: The `examples` and `docs` packages are still managed with `npm`, and are not a part of the main `pnpm` workspace.
+
+### How to migrate?
+
+1. [Install `pnpm`](https://pnpm.io/installation) with a version corresponding to the one defined in the `packageManager` field of the root's `package.json`.
+2. If you worked on your clone of the repository before, you'll need to remove the `node_modules` directory, `package-lock.json` files etc.
+
+    You can do this by running `npm run clean:node_modules -- --keep-lockfiles`.
+3. Run `pnpm install` to install the dependencies.
+4. All the `npm` commands are still available, so you can build the packages as you did before, for example, by running `npm run build`.
+
+You can always find more information on the custom build process in the [Custom builds](https://handsontable.com/docs/custom-builds/) documentation page.


### PR DESCRIPTION
### Context
This PR extends the `16.0` migration guide with information on how to utilize `pnpm` in the build process.

[skip changelog]

**Note:** After merging to `develop`, this should be cherry-picked to `release/16.0`.
