### PR TITLE
Make angular-wrapper handle situation when settings object is not provided

### DIFF
--- a/.changelogs/11719.json
+++ b/.changelogs/11719.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Make angular-wrapper handle situation when settings object is not provided",
+  "type": "fixed",
+  "issueOrPR": 11719,
+  "breaking": false,
+  "framework": "angular"
+}

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.spec.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.spec.ts
@@ -38,6 +38,15 @@ describe('HotTableComponent', () => {
     expect(fixture.componentInstance.hotInstance).toBeDefined();
   });
 
+  it(`should render 'hot-table' even when settings are not provided`, () => {
+    fixture = TestBed.createComponent(HotTableComponent);
+    fixture.detectChanges();
+
+    const elem = fixture.nativeElement;
+    expect(elem.querySelectorAll('.handsontable').length).toBeGreaterThan(0);
+    expect(fixture.componentInstance.hotInstance).toBeDefined();
+  });
+
   it(`should set data`, () => {
     fixture = TestBed.createComponent(HotTableComponent);
     fixture.componentInstance.settings = {};

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.ts
@@ -36,7 +36,7 @@ export class HotTableComponent implements AfterViewInit, OnChanges, OnDestroy {
   /** The data for the Handsontable instance. */
   @Input() data: Handsontable.GridSettings['data'] | null = null;
   /** The settings for the Handsontable instance. */
-  @Input() settings: GridSettings;
+  @Input() settings: GridSettings = {};
 
   /** The container element for the Handsontable instance. */
   @ViewChild('container', { static: false })


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->

Make angular-wrapper handle situation when settings object is not provided

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

- added unit test that reproduced the error

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
Fixes https://github.com/handsontable/dev-handsontable/issues/2618

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [x] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.