### PR TITLE
Fix missing touchend entry handler

### DIFF
--- a/.changelogs/11729.json
+++ b/.changelogs/11729.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fix missing touchend entry handler that prevents editor to open on mobile devices",
+  "type": "fixed",
+  "issueOrPR": 11729,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/selection/mouseEventHandler.js
+++ b/handsontable/src/selection/mouseEventHandler.js
@@ -151,6 +151,7 @@ export function mouseUp({ isLeftClick, selection, cellRangeMapper }) {
 
 const handlers = new Map([
   ['touchstart', mouseDown],
+  ['touchend', mouseUp],
   ['mousedown', mouseDown],
   ['mouseover', mouseOver],
   ['mouseup', mouseUp],

--- a/handsontable/test/e2e/mobile/textEditor.spec.js
+++ b/handsontable/test/e2e/mobile/textEditor.spec.js
@@ -61,4 +61,19 @@ describe('Text Editor', () => {
 
     expect(compStyle.borderRadius).toBe('0px');
   });
+
+  it('should open an editor on double tap', async() => {
+    handsontable({});
+
+    await selectCell(0, 0);
+
+    const cell = getCell(0, 0);
+
+    await triggerTouchEvent('touchstart', cell);
+    await triggerTouchEvent('touchend', cell);
+    await triggerTouchEvent('touchstart', cell);
+    await triggerTouchEvent('touchend', cell);
+
+    expect(getActiveEditor().isOpened()).toBe(true);
+  });
 });


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes a bug where, on mobile devices, an editor can not be opened. Due to the missing `touched` handler, the error was thrown, which caused all the troubles.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and added a test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/2674

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
