### PR TITLE
Correct the angular wrapper reference in the release script.

### DIFF
--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -128,7 +128,7 @@ displaySeparator();
       await execa.command(`cat ${docsPackageJsonPath}`, { shell: true }
       ).then(result => result.stdout));
 
-    docsPackageJson.devDependencies['@handsontable/angular'] = `~${releaseVersion}`;
+    docsPackageJson.devDependencies['@handsontable/angular-wrapper'] = `~${releaseVersion}`;
 
     // Write updated package.json back to file with proper formatting
     fs.writeFileSync(


### PR DESCRIPTION

### Context
The release script contains logic to update the Angular wrapper version for the docs.

This PR changes it from `@handsontable/angular` to `@handsontable/angular-wrapper`, which [is used in the docs](https://github.com/handsontable/handsontable/blob/f5fce9529727d34788b3e5ab47e4d71ad9363ed6/docs/package.json#L60).

[skip changelog]

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
