### PR TITLE
Make angular-wrapper always import Handsontable from '/base'

### DIFF
--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/base-editor-adapter.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/base-editor-adapter.ts
@@ -1,4 +1,4 @@
-import Handsontable from 'handsontable';
+import Handsontable from 'handsontable/base';
 import {
   ComponentRef,
   createComponent,

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/models/column-settings.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/models/column-settings.ts
@@ -1,5 +1,5 @@
 import { ComponentRef, EnvironmentInjector, Type, TemplateRef } from '@angular/core';
-import Handsontable from 'handsontable';
+import Handsontable from 'handsontable/base';
 import { HotCellRendererComponent } from '../renderer/hot-cell-renderer.component';
 import { HotCellEditorComponent } from '../editor/hot-cell-editor.component';
 

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/models/grid-settings.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/models/grid-settings.ts
@@ -1,4 +1,4 @@
-import Handsontable from 'handsontable';
+import Handsontable from 'handsontable/base';
 import { ColumnSettings, ColumnSettingsInternal } from './column-settings';
 
 export interface GridSettings extends Omit<Handsontable.GridSettings, 'columns' | 'data'> {

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/renderer/hot-dynamic-renderer-component.service.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/renderer/hot-dynamic-renderer-component.service.ts
@@ -3,8 +3,8 @@ import {
   EmbeddedViewRef, EnvironmentInjector, Injectable,
   TemplateRef, Type
 } from '@angular/core';
-import {BaseRenderer} from 'handsontable/renderers';
-import Handsontable from 'handsontable';
+import {baseRenderer, BaseRenderer} from 'handsontable/renderers';
+import Handsontable from 'handsontable/base';
 import {HotCellRendererComponent} from './hot-cell-renderer.component';
 
 type BaseRendererParameters = Parameters<BaseRenderer>;
@@ -101,7 +101,7 @@ export class DynamicComponentService {
         instance, td, row, col, prop, value, cellProperties
       ];
 
-      Handsontable.renderers.BaseRenderer.apply(this, rendererParameters);
+      baseRenderer.apply(this, rendererParameters);
 
       td.innerHTML = '';
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
