### PR TITLE
Allow focus navigation between multiple selection layers

### DIFF
--- a/handsontable/src/selection/transformation/_base.js
+++ b/handsontable/src/selection/transformation/_base.js
@@ -1,11 +1,11 @@
-import { mixin, createObjectPropListener } from '../helpers/object';
-import localHooks from './../mixins/localHooks';
+import { mixin, createObjectPropListener } from '../../helpers/object';
+import localHooks from '../../mixins/localHooks';
 
 /**
- * The Transformation class implements algorithms for transforming coordinates based on current settings
+ * The BaseTransformation class implements algorithms for transforming coordinates based on current settings
  * passed to the Handsontable. The class performs the calculations based on the renderable indexes.
  *
- * Transformation is always applied relative to the current selection.
+ * Transformation is always applied relative to the currently active selection layer.
  *
  * The class operates on a table size defined by the renderable indexes. If the `navigableHeaders`
  * option is enabled, the table size is increased by the number of row and/or column headers.
@@ -13,10 +13,10 @@ import localHooks from './../mixins/localHooks';
  * the algorithm can be written as simply as possible (without new if's that distinguish the headers
  * logic).
  *
- * @class Transformation
- * @util
+ * @class BaseTransformation
+ * @private
  */
-class Transformation {
+export class BaseTransformation {
   /**
    * Instance of the SelectionRange, holder for visual coordinates applied to the table.
    *
@@ -24,12 +24,11 @@ class Transformation {
    */
   #range;
   /**
-   * Additional options which define the state of the settings which can infer transformation and
-   * give the possibility to translate indexes.
+   * Index of the currently active selection layer.
    *
-   * @type {object}
+   * @type {number}
    */
-  #options;
+  #activeLayerIndex = 0;
   /**
    * Increases the table size by applying the offsets. The option is used by the `navigableHeaders`
    * option.
@@ -37,10 +36,36 @@ class Transformation {
    * @type {{ x: number, y: number }}
    */
   #offset = { x: 0, y: 0 };
+  /**
+   * Additional options which define the state of the settings which can infer transformation and
+   * give the possibility to translate indexes.
+   *
+   * @type {object}
+   */
+  _options;
 
   constructor(range, options) {
     this.#range = range;
-    this.#options = options;
+    this._options = options;
+  }
+
+  /**
+   * Sets the currently active selection layer index.
+   *
+   * @param {number} layerIndex The layer index to set as active.
+   */
+  setActiveLayerIndex(layerIndex) {
+    this.#activeLayerIndex = layerIndex;
+    this.#offset = this.calculateOffset();
+  }
+
+  /**
+   * Gets the currently active selection layer range.
+   *
+   * @returns {CellRange}
+   */
+  getCurrentSelection() {
+    return this.#range.peekByIndex(this.#activeLayerIndex);
   }
 
   /**
@@ -50,27 +75,28 @@ class Transformation {
    * @param {number} colDelta Columns number to move, value can be passed as negative number.
    * @param {boolean} [createMissingRecords=false] If `true` the new rows/columns will be created if necessary. Otherwise, row/column will
    *                        be created according to `minSpareRows/minSpareCols` settings of Handsontable.
-   * @returns {CellCoords} Visual coordinates after transformation.
+   * @returns {{selectionLayer: number, visualCoords: CellCoords}} Visual coordinates with selection layer after transformation.
    */
   transformStart(rowDelta, colDelta, createMissingRecords = false) {
-    const delta = this.#options.createCellCoords(rowDelta, colDelta);
-    let visualCoords = this.#range.current().highlight;
-    const highlightRenderableCoords = this.#options.visualToRenderableCoords(visualCoords);
+    const delta = this._options.createCellCoords(rowDelta, colDelta);
+    let visualCoords = this.getCurrentSelection().highlight;
+    const highlightRenderableCoords = this._options.visualToRenderableCoords(visualCoords);
     let rowTransformDir = 0;
     let colTransformDir = 0;
 
     this.runLocalHooks('beforeTransformStart', delta);
 
     if (highlightRenderableCoords.row !== null && highlightRenderableCoords.col !== null) {
-      const { width, height } = this.#getTableSize();
+      let { width, height } = this.#getTableSize();
       const { row, col } = this.#visualToZeroBasedCoords(visualCoords);
-      const fixedRowsBottom = this.#options.fixedRowsBottom();
-      const minSpareRows = this.#options.minSpareRows();
-      const minSpareCols = this.#options.minSpareCols();
-      const autoWrapRow = this.#options.autoWrapRow();
-      const autoWrapCol = this.#options.autoWrapCol();
 
-      const zeroBasedCoords = this.#options.createCellCoords(
+      const fixedRowsBottom = this._options.fixedRowsBottom();
+      const minSpareRows = this._options.minSpareRows();
+      const minSpareCols = this._options.minSpareCols();
+      const autoWrapRow = this._options.autoWrapRow();
+      const autoWrapCol = this._options.autoWrapCol();
+
+      const zeroBasedCoords = this._options.createCellCoords(
         row + delta.row,
         col + delta.col,
       );
@@ -80,52 +106,74 @@ class Transformation {
           createMissingRecords && minSpareRows > 0 && fixedRowsBottom === 0
         );
         const nextColumn = zeroBasedCoords.col + 1;
-        const newCoords = this.#options.createCellCoords(
+        const isColumnOutOfRange = nextColumn >= width;
+        const newCoords = this._options.createCellCoords(
           zeroBasedCoords.row - height,
-          nextColumn >= width ? nextColumn - width : nextColumn,
+          isColumnOutOfRange ? nextColumn - width : nextColumn,
         );
 
         this.runLocalHooks(
           'beforeColumnWrap',
           isActionInterrupted,
           this.#zeroBasedToVisualCoords(newCoords),
-          nextColumn >= width,
+          isColumnOutOfRange,
         );
 
         if (isActionInterrupted.value) {
-          this.runLocalHooks('insertRowRequire', this.#options.countRenderableRows());
+          this.runLocalHooks('insertRowRequire', this.countRenderableRows());
 
         } else if (autoWrapCol) {
+          if (isColumnOutOfRange) {
+            this.#chooseNextSelectionLayer();
+
+            const topStartCoords = this.getCurrentSelection().getTopStartCorner();
+
+            newCoords.assign(this.#visualToZeroBasedCoords(topStartCoords));
+          }
+
           zeroBasedCoords.assign(newCoords);
         }
 
       } else if (zeroBasedCoords.row < 0) {
         const isActionInterrupted = createObjectPropListener(autoWrapCol);
         const previousColumn = zeroBasedCoords.col - 1;
-        const newCoords = this.#options.createCellCoords(
+        const isColumnOutOfRange = previousColumn < 0;
+        const newCoords = this._options.createCellCoords(
           height + zeroBasedCoords.row,
-          previousColumn < 0 ? width + previousColumn : previousColumn,
+          isColumnOutOfRange ? width + previousColumn : previousColumn,
         );
 
         this.runLocalHooks(
           'beforeColumnWrap',
           isActionInterrupted,
           this.#zeroBasedToVisualCoords(newCoords),
-          previousColumn < 0,
+          isColumnOutOfRange,
         );
 
         if (autoWrapCol) {
+          if (isColumnOutOfRange) {
+            this.#choosePreviousSelectionLayer();
+
+            const bottomEndCoords = this.getCurrentSelection().getBottomEndCorner();
+
+            newCoords.assign(this.#visualToZeroBasedCoords(bottomEndCoords));
+          }
+
           zeroBasedCoords.assign(newCoords);
         }
       }
+
+      // the range size may be changed after the column wrap, so we need to recalculate it for row wrap
+      ({ width, height } = this.#getTableSize());
 
       if (zeroBasedCoords.col >= width) {
         const isActionInterrupted = createObjectPropListener(
           createMissingRecords && minSpareCols > 0
         );
         const nextRow = zeroBasedCoords.row + 1;
-        const newCoords = this.#options.createCellCoords(
-          nextRow >= height ? nextRow - height : nextRow,
+        const isRowOutOfRange = nextRow >= height;
+        const newCoords = this._options.createCellCoords(
+          isRowOutOfRange ? nextRow - height : nextRow,
           zeroBasedCoords.col - width,
         );
 
@@ -133,21 +181,30 @@ class Transformation {
           'beforeRowWrap',
           isActionInterrupted,
           this.#zeroBasedToVisualCoords(newCoords),
-          nextRow >= height,
+          isRowOutOfRange,
         );
 
         if (isActionInterrupted.value) {
-          this.runLocalHooks('insertColRequire', this.#options.countRenderableColumns());
+          this.runLocalHooks('insertColRequire', this.countRenderableColumns());
 
         } else if (autoWrapRow) {
+          if (isRowOutOfRange) {
+            this.#chooseNextSelectionLayer();
+
+            const topStartCoords = this.getCurrentSelection().getTopStartCorner();
+
+            newCoords.assign(this.#visualToZeroBasedCoords(topStartCoords));
+          }
+
           zeroBasedCoords.assign(newCoords);
         }
 
       } else if (zeroBasedCoords.col < 0) {
         const isActionInterrupted = createObjectPropListener(autoWrapRow);
         const previousRow = zeroBasedCoords.row - 1;
-        const newCoords = this.#options.createCellCoords(
-          previousRow < 0 ? height + previousRow : previousRow,
+        const isRowOutOfRange = previousRow < 0;
+        const newCoords = this._options.createCellCoords(
+          isRowOutOfRange ? height + previousRow : previousRow,
           width + zeroBasedCoords.col,
         );
 
@@ -155,10 +212,18 @@ class Transformation {
           'beforeRowWrap',
           isActionInterrupted,
           this.#zeroBasedToVisualCoords(newCoords),
-          previousRow < 0,
+          isRowOutOfRange,
         );
 
         if (autoWrapRow) {
+          if (isRowOutOfRange) {
+            this.#choosePreviousSelectionLayer();
+
+            const bottomEndCoords = this.getCurrentSelection().getBottomEndCorner();
+
+            newCoords.assign(this.#visualToZeroBasedCoords(bottomEndCoords));
+          }
+
           zeroBasedCoords.assign(newCoords);
         }
       }
@@ -172,7 +237,10 @@ class Transformation {
 
     this.runLocalHooks('afterTransformStart', visualCoords, rowTransformDir, colTransformDir);
 
-    return visualCoords;
+    return {
+      selectionLayer: this.#activeLayerIndex,
+      visualCoords,
+    };
   }
 
   /**
@@ -180,12 +248,12 @@ class Transformation {
    *
    * @param {number} rowDelta Rows number to move, value can be passed as negative number.
    * @param {number} colDelta Columns number to move, value can be passed as negative number.
-   * @returns {CellCoords} Visual coordinates after transformation.
+   * @returns {{selectionLayer: number, visualCoords: CellCoords}} Visual coordinates with selection layer after transformation.
    */
   transformEnd(rowDelta, colDelta) {
-    const delta = this.#options.createCellCoords(rowDelta, colDelta);
-    const cellRange = this.#range.current();
-    const highlightRenderableCoords = this.#options.visualToRenderableCoords(cellRange.highlight);
+    const delta = this._options.createCellCoords(rowDelta, colDelta);
+    const cellRange = this.getCurrentSelection();
+    const highlightRenderableCoords = this._options.visualToRenderableCoords(cellRange.highlight);
     const toRow = this.#findFirstNonHiddenZeroBasedRow(cellRange.to.row, cellRange.from.row);
     const toColumn = this.#findFirstNonHiddenZeroBasedColumn(cellRange.to.col, cellRange.from.col);
     const visualCoords = cellRange.to.clone();
@@ -202,7 +270,7 @@ class Transformation {
         row: highlightRow,
         col: highlightColumn,
       } = this.#visualToZeroBasedCoords(cellRange.highlight);
-      const coords = this.#options.createCellCoords(toRow + delta.row, toColumn + delta.col);
+      const coords = this._options.createCellCoords(toRow + delta.row, toColumn + delta.col);
       const topStartCorner = cellRange.getTopStartCorner();
       const topEndCorner = cellRange.getTopEndCorner();
       const bottomEndCorner = cellRange.getBottomEndCorner();
@@ -252,27 +320,60 @@ class Transformation {
 
     this.runLocalHooks('afterTransformEnd', visualCoords, rowTransformDir, colTransformDir);
 
-    return visualCoords;
-  }
-
-  /**
-   * Sets the additional offset in table size that may occur when the `navigableHeaders` option
-   * is enabled.
-   *
-   * @param {{x: number, y: number}} offset Offset as x and y properties.
-   */
-  setOffsetSize({ x, y }) {
-    this.#offset = { x, y };
-  }
-
-  /**
-   * Resets the offset size to the default values.
-   */
-  resetOffsetSize() {
-    this.#offset = {
-      x: 0,
-      y: 0
+    return {
+      selectionLayer: this.#activeLayerIndex,
+      visualCoords,
     };
+  }
+
+  /**
+   * Abstract method that child classes must implement to calculate offset coordinates based on
+   * the current processed selection layer.
+   */
+  calculateOffset() {
+    throw new Error('`calculateOffset` is not implemented');
+  }
+
+  /**
+   * Abstract method that child classes must implement to provide the count of renderable rows
+   * based on their specific transformation logic.
+   */
+  countRenderableRows() {
+    throw new Error('`countRenderableRows` is not implemented');
+  }
+
+  /**
+   * Abstract method that child classes must implement to provide the count of renderable columns
+   * based on their specific transformation logic.
+   */
+  countRenderableColumns() {
+    throw new Error('`countRenderableColumns` is not implemented');
+  }
+
+  /**
+   * Chooses the next selection layer as active one.
+   */
+  #chooseNextSelectionLayer() {
+    let layerIndex = this.#activeLayerIndex + 1;
+
+    if (layerIndex >= this.#range.size()) {
+      layerIndex = 0;
+    }
+
+    this.setActiveLayerIndex(layerIndex);
+  }
+
+  /**
+   * Chooses the previous selection layer as active one.
+   */
+  #choosePreviousSelectionLayer() {
+    let layerIndex = this.#activeLayerIndex - 1;
+
+    if (layerIndex < 0) {
+      layerIndex = this.#range.size() - 1;
+    }
+
+    this.setActiveLayerIndex(layerIndex);
   }
 
   /**
@@ -315,8 +416,8 @@ class Transformation {
    */
   #getTableSize() {
     return {
-      width: this.#offset.x + this.#options.countRenderableColumns(),
-      height: this.#offset.y + this.#options.countRenderableRows(),
+      width: this.#offset.x + this.countRenderableColumns(),
+      height: this.#offset.y + this.countRenderableRows(),
     };
   }
 
@@ -328,7 +429,7 @@ class Transformation {
    * @returns {number | null}
    */
   #findFirstNonHiddenZeroBasedRow(visualRowFrom, visualRowTo) {
-    const row = this.#options.findFirstNonHiddenRenderableRow(visualRowFrom, visualRowTo);
+    const row = this._options.findFirstNonHiddenRenderableRow(visualRowFrom, visualRowTo);
 
     if (row === null) {
       return null;
@@ -345,7 +446,7 @@ class Transformation {
    * @returns {number | null}
    */
   #findFirstNonHiddenZeroBasedColumn(visualColumnFrom, visualColumnTo) {
-    const column = this.#options.findFirstNonHiddenRenderableColumn(visualColumnFrom, visualColumnTo);
+    const column = this._options.findFirstNonHiddenRenderableColumn(visualColumnFrom, visualColumnTo);
 
     if (column === null) {
       return null;
@@ -361,13 +462,13 @@ class Transformation {
    * @returns {CellCoords}
    */
   #visualToZeroBasedCoords(visualCoords) {
-    const { row, col } = this.#options.visualToRenderableCoords(visualCoords);
+    const { row, col } = this._options.visualToRenderableCoords(visualCoords);
 
     if (row === null || col === null) {
       throw new Error('Renderable coords are not visible.');
     }
 
-    return this.#options.createCellCoords(this.#offset.y + row, this.#offset.x + col);
+    return this._options.createCellCoords(this.#offset.y + row, this.#offset.x + col);
   }
 
   /**
@@ -382,10 +483,8 @@ class Transformation {
     coords.col = zeroBasedCoords.col - this.#offset.x;
     coords.row = zeroBasedCoords.row - this.#offset.y;
 
-    return this.#options.renderableToVisualCoords(coords);
+    return this._options.renderableToVisualCoords(coords);
   }
 }
 
-mixin(Transformation, localHooks);
-
-export default Transformation;
+mixin(BaseTransformation, localHooks);

--- a/handsontable/src/selection/transformation/extender.js
+++ b/handsontable/src/selection/transformation/extender.js
@@ -1,0 +1,42 @@
+import { BaseTransformation } from './_base';
+
+/**
+ * The ExtenderTransformation class implements algorithms for transforming coordinates while the
+ * selection is being extended or shrunk. Table size defines the bounds for the selection extent.
+ *
+ * @class ExtenderTransformation
+ * @private
+ */
+export class ExtenderTransformation extends BaseTransformation {
+  /**
+   * Calculates offset coordinates for extender selection.
+   *
+   * @returns {{x: number, y: number}}
+   */
+  calculateOffset() {
+    return {
+      x: this._options.navigableHeaders ? this._options.countRowHeaders() : 0,
+      y: this._options.navigableHeaders ? this._options.countColHeaders() : 0,
+    };
+  }
+
+  /**
+   * Gets the count of renderable rows for extender transformation.
+   * Extender transformation operates on the full table size.
+   *
+   * @returns {number}
+   */
+  countRenderableRows() {
+    return this._options.countRenderableRows();
+  }
+
+  /**
+   * Gets the count of renderable columns for extender transformation.
+   * Extender transformation operates on the full table size.
+   *
+   * @returns {number}
+   */
+  countRenderableColumns() {
+    return this._options.countRenderableColumns();
+  }
+}

--- a/handsontable/src/selection/transformation/focus.js
+++ b/handsontable/src/selection/transformation/focus.js
@@ -1,0 +1,63 @@
+import { BaseTransformation } from './_base';
+
+/**
+ * The FocusTransformation class implements algorithms for transforming coordinates while the
+ * focus is being moved. The currently selection layer range defines the bounds for the focus movement.
+ *
+ * @class FocusTransformation
+ * @private
+ */
+export class FocusTransformation extends BaseTransformation {
+  /**
+   * Calculates offset coordinates for focus selection based on the current selection state.
+   * For header focus selection, calculates offset including headers.
+   * For cell focus selection, calculates offset only for selected cells.
+   *
+   * @returns {{x: number, y: number}}
+   */
+  calculateOffset() {
+    const range = this.getCurrentSelection();
+    const { row, col } = range.getOuterTopStartCorner();
+    const columnsInRange = this._options.countRenderableColumnsInRange(0, col - 1);
+    const rowsInRange = this._options.countRenderableRowsInRange(0, row - 1);
+    const isHeaderSelection = range.highlight.isHeader();
+    const headerX = isHeaderSelection ? Math.abs(col) : 0;
+    const headerY = isHeaderSelection ? Math.abs(row) : 0;
+
+    return {
+      x: col < 0 ? headerX : -columnsInRange,
+      y: row < 0 ? headerY : -rowsInRange
+    };
+  }
+
+  /**
+   * Gets the count of renderable rows for focus transformation.
+   * Focus transformation operates on the current selection range.
+   *
+   * @returns {number}
+   */
+  countRenderableRows() {
+    const range = this.getCurrentSelection();
+
+    return this._options.countRenderableRowsInRange(0, range.getOuterBottomEndCorner().row);
+  }
+
+  /**
+   * Gets the count of renderable columns for focus transformation.
+   * Focus transformation operates on the current selection range.
+   *
+   * @returns {number}
+   */
+  countRenderableColumns() {
+    const range = this.getCurrentSelection();
+
+    return this._options.countRenderableColumnsInRange(0, range.getOuterBottomEndCorner().col);
+  }
+
+  /**
+   * Throws an error because focus transformation doesn't support `transformEnd`.
+   */
+  transformEnd() {
+    throw new Error('`transformEnd` is not valid for focus selection use `transformStart` instead');
+  }
+}

--- a/handsontable/src/selection/transformation/index.js
+++ b/handsontable/src/selection/transformation/index.js
@@ -1,0 +1,2 @@
+export { ExtenderTransformation } from './extender';
+export { FocusTransformation } from './focus';

--- a/handsontable/src/shortcutContexts/commands/editor/open.js
+++ b/handsontable/src/shortcutContexts/commands/editor/open.js
@@ -9,7 +9,7 @@ export const command = {
 
     // supports for navigating with enter key when multiple cells are selected
     if (
-      hot.selection.isMultiple() &&
+      // hot.selection.isMultiple() &&
       !selectedRange.isHeader() &&
       hot.countRenderedCols() > 0 &&
       hot.countRenderedRows() > 0

--- a/handsontable/src/shortcutContexts/commands/moveCellSelection/inlineEnd.js
+++ b/handsontable/src/shortcutContexts/commands/moveCellSelection/inlineEnd.js
@@ -11,7 +11,7 @@ export const command = {
     selection.markSource('keyboard');
 
     if (
-      selection.isMultiple() &&
+      // selection.isMultiple() &&
       !selectedRange.isHeader() &&
       hot.countRenderedCols() > 0 &&
       hot.countRenderedRows() > 0

--- a/handsontable/src/shortcutContexts/commands/moveCellSelection/inlineStart.js
+++ b/handsontable/src/shortcutContexts/commands/moveCellSelection/inlineStart.js
@@ -11,7 +11,7 @@ export const command = {
     selection.markSource('keyboard');
 
     if (
-      selection.isMultiple() &&
+      // selection.isMultiple() &&
       !selectedRange.isHeader() &&
       hot.countRenderedCols() > 0 &&
       hot.countRenderedRows() > 0


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR improves the UI by allowing the change of focus selection for multiple layers.



### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/2627

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
