### PR TITLE
Fix autoRowSize height calculation

### DIFF
--- a/handsontable/src/plugins/autoRowSize/__tests__/autoRowSize.spec.js
+++ b/handsontable/src/plugins/autoRowSize/__tests__/autoRowSize.spec.js
@@ -478,13 +478,13 @@ describe('AutoRowSize', () => {
     });
     expect(parseInt(getCell(1, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
       classic.toBe(22); // -1px of cell border
-      main.toBe(30);
-      horizon.toBe(38);
+      main.toBe(29);
+      horizon.toBe(37);
     });
     expect(parseInt(getCell(2, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
       classic.toBe(22); // -1px of cell border
-      main.toBe(30);
-      horizon.toBe(38);
+      main.toBe(29);
+      horizon.toBe(37);
     });
 
     await resizeColumn(1, 90);
@@ -538,8 +538,8 @@ describe('AutoRowSize', () => {
     });
     expect(parseInt(getCell(1, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
       classic.toBe(22);
-      main.toBe(30);
-      horizon.toBe(38);
+      main.toBe(29);
+      horizon.toBe(37);
     });
     expect(parseInt(getCell(2, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
       classic.toBe(22);
@@ -572,8 +572,8 @@ describe('AutoRowSize', () => {
     });
     expect(parseInt(getCell(2, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
       classic.toBeInArray([22, 42]); // -1px of cell border
-      main.toBeInArray([30, 49]);
-      horizon.toBeInArray([38, 63]);
+      main.toBeInArray([29, 49]);
+      horizon.toBeInArray([37, 63]);
     });
 
     plugin.moveColumn(0, 1);
@@ -619,8 +619,8 @@ describe('AutoRowSize', () => {
     });
     expect(parseInt(getCell(2, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
       classic.toBeInArray([22, 42]); // -1px of cell border
-      main.toBeInArray([30, 49]);
-      horizon.toBeInArray([38, 63]);
+      main.toBeInArray([29, 49]);
+      horizon.toBeInArray([37, 63]);
     });
 
     await setDataAtCell(1, 0, 'A\nB\nC\nD\nE');
@@ -637,8 +637,8 @@ describe('AutoRowSize', () => {
     });
     expect(parseInt(getCell(2, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
       classic.toBeInArray([22, 42]);
-      main.toBeInArray([30, 49]);
-      horizon.toBeInArray([38, 63]);
+      main.toBeInArray([29, 49]);
+      horizon.toBeInArray([37, 63]);
     });
   });
 
@@ -665,8 +665,8 @@ describe('AutoRowSize', () => {
     });
     expect(parseInt(getCell(2, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
       classic.toBeInArray([22, 42]); // -1px of cell border
-      main.toBeInArray([30, 49]);
-      horizon.toBeInArray([38, 63]);
+      main.toBeInArray([29, 49]);
+      horizon.toBeInArray([37, 63]);
     });
 
     const plugin = getPlugin('manualRowMove');
@@ -682,13 +682,13 @@ describe('AutoRowSize', () => {
     });
     expect(parseInt(getCell(1, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
       classic.toBe(22);
-      main.toBe(30);
-      horizon.toBe(38);
+      main.toBe(29);
+      horizon.toBe(37);
     });
     expect(parseInt(getCell(2, -1).style.height, 10)).forThemes(({ classic, main, horizon }) => {
       classic.toBeInArray([22, 42]); // -1px of cell border
-      main.toBeInArray([30, 49]);
-      horizon.toBeInArray([38, 63]);
+      main.toBeInArray([29, 49]);
+      horizon.toBeInArray([37, 63]);
     });
   });
 
@@ -773,13 +773,13 @@ describe('AutoRowSize', () => {
     });
     expect(getRowHeight(1)).forThemes(({ classic, main, horizon }) => {
       classic.toBe(23);
-      main.toBe(30);
-      horizon.toBe(38);
+      main.toBe(29);
+      horizon.toBe(37);
     });
     expect(getRowHeight(2)).forThemes(({ classic, main, horizon }) => {
       classic.toBe(23);
-      main.toBe(30);
-      horizon.toBe(38);
+      main.toBe(29);
+      horizon.toBe(37);
     });
   });
 
@@ -854,8 +854,8 @@ describe('AutoRowSize', () => {
 
     expect(topOverlay().getScrollPosition()).forThemes(({ classic, main, horizon }) => {
       classic.toBe(833);
-      main.toBe(1185);
-      horizon.toBe(1593);
+      main.toBe(1136);
+      horizon.toBe(1544);
     });
 
     await listen();
@@ -864,8 +864,8 @@ describe('AutoRowSize', () => {
 
     expect(topOverlay().getScrollPosition()).forThemes(({ classic, main, horizon }) => {
       classic.toBe(833);
-      main.toBe(1185);
-      horizon.toBe(1593);
+      main.toBe(1136);
+      horizon.toBe(1544);
     });
   });
 

--- a/handsontable/src/plugins/autoRowSize/__tests__/mergeCells.spec.js
+++ b/handsontable/src/plugins/autoRowSize/__tests__/mergeCells.spec.js
@@ -36,8 +36,8 @@ describe('MergeCells', () => {
     });
     expect(getRowHeight(1)).forThemes(({ classic, main, horizon }) => {
       classic.toBe(23);
-      main.toBe(30);
-      horizon.toBe(38);
+      main.toBe(29);
+      horizon.toBe(37);
     });
   });
 });

--- a/handsontable/src/plugins/hiddenRows/__tests__/plugins/autoRowSize.spec.js
+++ b/handsontable/src/plugins/hiddenRows/__tests__/plugins/autoRowSize.spec.js
@@ -116,8 +116,8 @@ describe('HiddenRows', () => {
       expect(getRowHeight(1)).toBe(0);
       expect(getRowHeight(2)).forThemes(({ classic, main, horizon }) => {
         classic.toBe(23);
-        main.toBe(30);
-        horizon.toBe(38);
+        main.toBe(29);
+        horizon.toBe(37);
       });
     });
 
@@ -148,8 +148,8 @@ describe('HiddenRows', () => {
       expect(getRowHeight(1)).toBe(0);
       expect(getRowHeight(2)).forThemes(({ classic, main, horizon }) => {
         classic.toBe(23);
-        main.toBe(30);
-        horizon.toBe(38);
+        main.toBe(29);
+        horizon.toBe(37);
       });
     });
 

--- a/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
+++ b/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
@@ -724,8 +724,8 @@ describe('manualRowResize', () => {
 
     expect(afterRowResizeCallback.calls.count()).toEqual(1);
     expect(afterRowResizeCallback.calls.argsFor(0)[1]).toEqual(2);
-    expect(afterRowResizeCallback.calls.argsFor(0)[0]).toEqual(themeDefaultRowHeight + 1);
-    expect(rowHeight(spec().$container, 2)).toEqual(themeDefaultRowHeight + 1);
+    expect(afterRowResizeCallback.calls.argsFor(0)[0]).toEqual(themeDefaultRowHeight);
+    expect(rowHeight(spec().$container, 2)).toEqual(themeDefaultRowHeight);
   });
 
   it.forTheme('horizon')('should trigger an afterRowResize after row size changes, after double click', async() => {
@@ -754,8 +754,8 @@ describe('manualRowResize', () => {
 
     expect(afterRowResizeCallback.calls.count()).toEqual(1);
     expect(afterRowResizeCallback.calls.argsFor(0)[1]).toEqual(2);
-    expect(afterRowResizeCallback.calls.argsFor(0)[0]).toEqual(themeDefaultRowHeight + 1);
-    expect(rowHeight(spec().$container, 2)).toEqual(themeDefaultRowHeight + 1);
+    expect(afterRowResizeCallback.calls.argsFor(0)[0]).toEqual(themeDefaultRowHeight);
+    expect(rowHeight(spec().$container, 2)).toEqual(themeDefaultRowHeight);
   });
 
   it('should resize appropriate rows to calculated autoRowSize height after double click on row handler after ' +

--- a/handsontable/src/plugins/mergeCells/__tests__/mergeCells.spec.js
+++ b/handsontable/src/plugins/mergeCells/__tests__/mergeCells.spec.js
@@ -1611,13 +1611,13 @@ describe('MergeCells', () => {
 
     expect(getTopInlineStartClone().height()).forThemes(({ classic, main, horizon }) => {
       classic.toBe(111);
-      main.toBe(130);
-      horizon.toBe(154);
+      main.toBe(129);
+      horizon.toBe(153);
     });
     expect(getTopClone().height()).forThemes(({ classic, main, horizon }) => {
       classic.toBe(111);
-      main.toBe(130);
-      horizon.toBe(154);
+      main.toBe(129);
+      horizon.toBe(153);
     });
     expect(getInlineStartClone().height()).toBe(400);
   });

--- a/handsontable/src/styles/base/_base.scss
+++ b/handsontable/src/styles/base/_base.scss
@@ -115,13 +115,23 @@
 
         tbody {
           tr {
+            &:first-of-type {
+              th,
+              td {
+                &:first-child {
+                  height: calc(
+                    var(--ht-cell-vertical-padding) * 2 + var(--ht-line-height) + 1px
+                  )
+                }
+              }
+            }
+
             th,
             td {
               border-top-width: 0;
               height: calc(
-                var(--ht-cell-vertical-padding) * 2 + var(--ht-line-height) +
-                  1px
-              );
+                var(--ht-cell-vertical-padding) * 2 + var(--ht-line-height) + 1px
+              )
             }
           }
         }


### PR DESCRIPTION
### Context
This PR includes a fixes for ghost table row sizes when autoRowSize is enabled

### How has this been tested?
Updated test cases

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

[skip changelog]