### PR TITLE
Markdown fix that broke hooks page

### DIFF
--- a/handsontable/src/core/hooks/constants.js
+++ b/handsontable/src/core/hooks/constants.js
@@ -1250,6 +1250,7 @@ export const REGISTERED_HOOKS = [
    * />
    * ```
    * :::
+   * 
    * ::: only-for angular
    *```ts
    * // To alter a single change, overwrite the desired value with `changes[i][3]`


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->

There is an error on hooks page that disable some functionalities of documentation like search and other plugins 

<img width="874" height="897" alt="image" src="https://github.com/user-attachments/assets/cea90b97-ddc2-47a8-87bd-713f026f408d" />


### How has this been tested?

Manualny on my machine 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog] 