### PR TITLE
Extract languages files for ESM and CJS tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       run-all: ${{
-          true ||
           endsWith(github.ref, '/master') ||
           endsWith(github.ref, '/develop') ||
           contains(github.ref, '/release/') ||
@@ -491,7 +490,7 @@ jobs:
         with:
           name: handsontable-build-umd
           path: ./
-      - run: tar -zxf dist.tar.gz --overwrite --wildcards '*.css' 'handsontable/dist/languages/*' && rm dist.tar.gz
+      - run: tar -zxf dist.tar.gz --overwrite --wildcards --no-anchored '*.css' 'handsontable/dist/languages/*.js' && rm dist.tar.gz
 
       - name: Build UMD from ESM
         run: |
@@ -532,7 +531,6 @@ jobs:
         with:
           name: handsontable-build-umd
           path: ./
-      - run: tar -tvf dist.tar.gz
       - run: tar -zxf dist.tar.gz --overwrite --wildcards --no-anchored '*.css' 'handsontable/dist/languages/*.js' && rm dist.tar.gz
 
       - name: Build UMD from CJS


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes a bug where the test workflows that test the ESM and CJS build failed due to missing (not rebuilt) language files. Also, the PR extends the workflow by adding the ability to manually trigger all tests within the file, for debugging purposes.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
