### PR TITLE
Wrong version in breadcrumbs in previous versions

### DIFF
--- a/docs/.vuepress/theme/components/Breadcrumbs.vue
+++ b/docs/.vuepress/theme/components/Breadcrumbs.vue
@@ -20,6 +20,14 @@ export default {
         ? [...this.$page.versionsWithPatches]
         : [];
 
+      if (window.DOCS_VERSION && window.DOCS_VERSION !== 'next') {
+        const findVersion = versions.find(version => version[0] === window.DOCS_VERSION);
+
+        if (findVersion) {
+          return findVersion[1][0];
+        }
+      }
+
       if (versions.length && versions[0].length >= 2 && versions[0][1].length) {
         return `${versions[0][1][0]}`;
       }


### PR DESCRIPTION
### Context

Previous versions of docs eg https://handsontable.com/docs/15.2/javascript-data-grid/ are showing always latest version in breadcrums 

### How has this been tested?

Locally 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]
