### PR TITLE
[Docs] Feature/algolia docsearch previous versions and disable on staging 

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -411,7 +411,7 @@ module.exports = {
     },
     searchPlaceholder: 'Search...',
     algolia: {
-      indexName: 'handsontable',
+      indexName: 'handsontable', // or 'handsontable-with-versions'
       apiKey: 'c2430302c91e0162df988d4b383c9d8b',
       appId: 'MMN6OTJMGX'
     }

--- a/docs/.vuepress/theme/components/AlgoliaSearch.vue
+++ b/docs/.vuepress/theme/components/AlgoliaSearch.vue
@@ -19,9 +19,8 @@ export default {
         // Disable search for next version as it's not crawled by Algolia
         return;
       }
-
-      const latestReleasedVersion = this.$page.versions.find(version => !isNaN(parseInt(version, 10)));
-      const isLatestReleasedVersion = latestReleasedVersion === this.$page.currentVersion;
+      
+      const isLatestReleasedVersion = this.$page.currentVersion === this.$page.latestVersion
 
       docsearch({
         container: '#algolia-search',

--- a/docs/.vuepress/theme/components/AlgoliaSearch.vue
+++ b/docs/.vuepress/theme/components/AlgoliaSearch.vue
@@ -10,13 +10,32 @@ export default {
   name: 'AlgoliaSearch',
   props: ['options'],
   mounted() {
+    // this.options = {
+    //   indexName: 'handsontable-with-versions',
+    //   apiKey: 'c2430302c91e0162df988d4b383c9d8b',
+    //   appId: 'MMN6OTJMGX',
+    //   searchParameters: {
+    //     facetFilters: [`version:15.3`]
+    //   },
+    // }
     this.initialize(this.options, this.$lang);
   },
   methods: {
     initialize(userOptions, lang) {
+
+      if (this.$page.currentVersion === 'next') {
+        // Disable search for next version as it's not crawled by Algolia
+        return;
+      }
+
+      const latestReleasedVersion = this.$page.versions.find(version => !isNaN(parseInt(version)));
+      const isLatestReleasedVersion = latestReleasedVersion === this.$page.currentVersion;
+
       docsearch({
         container: '#algolia-search',
         ...userOptions,
+        indexName: isLatestReleasedVersion ? 'handsontable' : 'handsontable-with-versions',
+
         placeholder: this.$site.themeConfig.searchPlaceholder || 'Search',
         translations: {
           button: {
@@ -26,7 +45,7 @@ export default {
           },
         },
         searchParameters: {
-          facetFilters: [`lang:${lang}`, `tags:${this.$page.currentFramework}`],
+          facetFilters: isLatestReleasedVersion ? [`lang:${lang}`, `tags:${this.$page.currentFramework}`] : [`lang:${lang}`, `tags:${this.$page.currentFramework}`, `version:${this.$page.currentVersion}`],
         },
       });
     },

--- a/docs/.vuepress/theme/components/AlgoliaSearch.vue
+++ b/docs/.vuepress/theme/components/AlgoliaSearch.vue
@@ -10,14 +10,6 @@ export default {
   name: 'AlgoliaSearch',
   props: ['options'],
   mounted() {
-    // this.options = {
-    //   indexName: 'handsontable-with-versions',
-    //   apiKey: 'c2430302c91e0162df988d4b383c9d8b',
-    //   appId: 'MMN6OTJMGX',
-    //   searchParameters: {
-    //     facetFilters: [`version:15.3`]
-    //   },
-    // }
     this.initialize(this.options, this.$lang);
   },
   methods: {

--- a/docs/.vuepress/theme/components/AlgoliaSearch.vue
+++ b/docs/.vuepress/theme/components/AlgoliaSearch.vue
@@ -28,7 +28,7 @@ export default {
         return;
       }
 
-      const latestReleasedVersion = this.$page.versions.find(version => !isNaN(parseInt(version)));
+      const latestReleasedVersion = this.$page.versions.find(version => !isNaN(parseInt(version, 10)));
       const isLatestReleasedVersion = latestReleasedVersion === this.$page.currentVersion;
 
       docsearch({
@@ -45,6 +45,7 @@ export default {
           },
         },
         searchParameters: {
+          // eslint-disable-next-line max-len
           facetFilters: isLatestReleasedVersion ? [`lang:${lang}`, `tags:${this.$page.currentFramework}`] : [`lang:${lang}`, `tags:${this.$page.currentFramework}`, `version:${this.$page.currentVersion}`],
         },
       });

--- a/docs/.vuepress/theme/components/AlgoliaSearch.vue
+++ b/docs/.vuepress/theme/components/AlgoliaSearch.vue
@@ -19,8 +19,8 @@ export default {
         // Disable search for next version as it's not crawled by Algolia
         return;
       }
-      
-      const isLatestReleasedVersion = this.$page.currentVersion === this.$page.latestVersion
+
+      const isLatestReleasedVersion = this.$page.currentVersion === this.$page.latestVersion;
 
       docsearch({
         container: '#algolia-search',


### PR DESCRIPTION
### Context

Our documentation site has multiple framework versions accessible via different URL paths (e.g., /docs/15.3, /docs/14.2, etc.), but Algolia DocSearch is not properly crawling and indexing each version separately

There are two Algolia crawlers 
* for latest environment https://dashboard.algolia.com/apps/MMN6OTJMGX/explorer/browse/handsontable is triggered on schedule and will be [triggered automatically ](https://github.com/handsontable/dev-handsontable/issues/2675)
* for all enviroments including previous versions - this one needs to be trigged every time a new version is included (so previous version is availabe in the address - eg realsing 16.1 would create a new versions docs/16.0 etc 
* list of versions is hardcoded in [crawrler setup ](https://dashboard.algolia.com/apps/MMN6OTJMGX/crawler/crawler/eda11bc1-04e4-406a-bf0f-9a0bf29c9c38/editor?tab=url-tester)
* on staging evironment algolia should not be displayed 

<img width="761" height="862" alt="image" src="https://github.com/user-attachments/assets/a76b44bb-b83a-4a71-8eb9-b514b44c1546" />


<img width="796" height="331" alt="image" src="https://github.com/user-attachments/assets/f9afafbe-c954-410e-bb42-7efc6dd9eb64" />

### How has this been tested?
* locally 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2772
2. https://github.com/handsontable/dev-handsontable/issues/2681
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]
