### PR TITLE
[Docs] Remove limit of max versions with patches as this is needed for breadcrumbs in each version

### DIFF
--- a/docs/.vuepress/plugins/dump-docs-data/docs-versions.js
+++ b/docs/.vuepress/plugins/dump-docs-data/docs-versions.js
@@ -12,10 +12,6 @@ const { logger } = require('@vuepress/shared-utils');
  * Min docs version that is used for creating canonicals.
  */
 const MIN_DOCS_VERSION = '9.0';
-/**
- * Max number of minors displayed in the drop-down.
- */
-const MAX_MINORS_COUNT = 6;
 
 /**
  * Reads the list of Docs versions from the latest Docs image.
@@ -73,7 +69,7 @@ async function readFromGitHub() {
   const tags = Array.from(tagsSet);
   const versions = tags.slice(0, tags.indexOf(MIN_DOCS_VERSION) + 1);
   // Converting the map, as it's later changed to JSON.
-  const versionsWithPatches = Array.from(minorsToPatches).slice(0, MAX_MINORS_COUNT);
+  const versionsWithPatches = Array.from(minorsToPatches);
 
   logger.info(`Fetched the following Docs versions: ${versions.join(', ')}`);
   logger.info(`GitHub API rate limits:


### PR DESCRIPTION
### Context
There was a problem with generating 14.4 Wrong version in breadcrumbs  


### How has this been tested?
locally 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2704
2.
3.

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog] 
