### PR TITLE
[Docs] Optional chaining for accesing abort signal in Handsontable Manager

### DIFF
--- a/docs/.vuepress/handsontable-manager/register.js
+++ b/docs/.vuepress/handsontable-manager/register.js
@@ -137,7 +137,7 @@ function createRegister() {
   const getAbortSignal = () => {
     const controllers = Array.from(abortControllers);
 
-    return controllers[controllers.length - 1].signal;
+    return controllers[controllers.length - 1]?.signal;
   };
 
   const getAllHotInstances =

--- a/docs/.vuepress/handsontable-manager/use-handsontable.js
+++ b/docs/.vuepress/handsontable-manager/use-handsontable.js
@@ -21,11 +21,11 @@ const useHandsontable = (version, callback = () => {}, preset = 'hot', buildMode
       reject(new AbortError());
     };
 
-    if (abortSignal.aborted) {
+    if (abortSignal?.aborted) {
       reject(abortHandler());
     }
 
-    abortSignal.addEventListener('abort', abortHandler);
+    abortSignal?.addEventListener('abort', abortHandler);
 
     const getId = depName => `dependency-reloader_${depName}`;
     const [jsUrl, dependentVars = [], cssUrl = undefined, globalVarSharedDependency] = getDependency(dep);


### PR DESCRIPTION
### Context

There are hundreds of errors for hundreds of users caught by Sentry 

There is possibility that in docs `handsontable-manager` either controllers array is empty of does not contain a controller https://github.com/handsontable/handsontable/blob/develop/docs/.vuepress/handsontable-manager/register.js#L140

```js
  const getAbortSignal = () => {
    const controllers = Array.from(abortControllers);

    return controllers[controllers.length - 1].signal;
  };
```

should be fixed 

```js
  const getAbortSignal = () => {
    const controllers = Array.from(abortControllers);

    return controllers[controllers.length - 1]?.signal;
  };
```


### How has this been tested?
locally 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2759
2.
3.

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [] My change requires a change to the documentation.

[skip changelog] 