### PR TITLE
[Docs] Skip sending handsontable error to sentry as it's making to much noise

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -123,6 +123,18 @@ module.exports = {
       `
       window.sentryOnLoad = function () {
         Sentry.init({
+          beforeSend(event, hint) {
+            const error = hint.originalException;
+            if (error) {
+              if (error.cause?.handsontable) {
+                return null;
+              }
+              if (error.message.match(/ColumnSummary plugin: cell at/i)) {
+                return null;
+              }
+            }
+            return event;
+          },
           environment: '${buildMode || 'testing'}',
           tracesSampleRate: 0,
           profilesSampleRate: 0,


### PR DESCRIPTION
### Context
There are too many obsolete errors in Sentry, which shoud not be sent from docs to sentry. 

There is a way to filter them by using [beforeSent](https://docs.sentry.io/platforms/javascript/configuration/filtering/#using-hints) Sentry SDK 

1. errors that are from Handsontable [will have a `cause` property  ](https://github.com/handsontable/handsontable/pull/11780)
2. errors filtered by message text (to skip those errors before PR above is merged and released) 

### How has this been tested?

locally 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/pull/11780
2. https://github.com/handsontable/dev-handsontable/issues/2577
3.

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
[skip changelog] 