### PR TITLE
[Docs] add initialState explanation to react guides

### DIFF
--- a/docs/content/guides/getting-started/configuration-options/configuration-options.md
+++ b/docs/content/guides/getting-started/configuration-options/configuration-options.md
@@ -1005,6 +1005,55 @@ In the example below, some cells are read-only, and some cells are editable:
 
 :::
 
+
+
+
+::: only-for react
+
+## Non-Idempotent Options
+
+A non-idempotent option is one that produces different results when applied multiple times. In the context of Handsontable and `<HotTable/>` component, options like `manualColumnMove=[1, 0]` will swap columns every time they're applied - first application swaps columns, second application swaps them back, third swaps again, and so on.
+
+### Problem 
+
+Non-idempotent options like `manualColumnMove` and `manualRowMove` cause unwanted visual changes on every React re-render because they operate on visual indexes.
+
+```jsx
+// Problem: Columns swap on EVERY re-render
+const ExampleComponent = () => {
+  const [state, setState] = React.useState(0);
+  return (
+    <>
+      <button onClick={() => setState(state + 1)}>{state}</button>
+      <HotTable
+        manualColumnMove={[1, 0]}  // Columns keep swapping!
+        data={[['A', 'B'], [0, 1]]}
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </>
+  );
+};
+```
+
+### Solution
+
+Use [`initialState`](@/api/options.md#initialstate) to apply these options only during initialization:
+
+```jsx
+<HotTable
+  initialState={{ 
+    manualColumnMove: [1, 0]  // Applied only once
+  }}
+  data={[['A', 'B'], [0, 1]]}
+  rowHeaders={true}
+  colHeaders={true}
+  licenseKey="non-commercial-and-evaluation"
+/>
+```
+
+:::
+
+
 ::: only-for angular
 
 ::: example #example6 :angular --ts 1 --html 2


### PR DESCRIPTION
### Context

Adding `initialState` examples in getting started react documentations 

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/1305
2.
3.

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]
