### PR TITLE
Fix TypeError after undo opertation

### DIFF
--- a/handsontable/src/plugins/nestedRows/__tests__/integration/undoRedo.spec.js
+++ b/handsontable/src/plugins/nestedRows/__tests__/integration/undoRedo.spec.js
@@ -29,5 +29,30 @@ describe('NestedRows', () => {
 
       expect(getDataAtCell(1, 0)).toBe('A1.1');
     });
+
+    it('should not throw an error when removing a parent row', async() => {
+      const onErrorSpy = spyOn(window, 'onerror').and.returnValue(true);
+
+      handsontable({
+        rowHeaders: true,
+        colHeaders: true,
+        contextMenu: true,
+        data: [
+          {
+            col1: 'A1',
+            __children: [{ col1: 'A1.1' }],
+          },
+        ],
+        nestedRows: true,
+      });
+
+      await alter('remove_row', 0);
+
+      getPlugin('undoRedo').undo();
+
+      await sleep(50);
+
+      expect(onErrorSpy).not.toHaveBeenCalled();
+    });
   });
 });

--- a/handsontable/src/plugins/nestedRows/ui/headers.js
+++ b/handsontable/src/plugins/nestedRows/ui/headers.js
@@ -66,8 +66,13 @@ class HeadersUI extends BaseUI {
    */
   appendLevelIndicators(row, TH) {
     const rowIndex = this.hot.toPhysicalRow(row);
-    const rowLevel = this.dataManager.getRowLevel(rowIndex);
     const rowObject = this.dataManager.getDataObject(rowIndex);
+
+    if (!rowObject) {
+      return;
+    }
+
+    const rowLevel = this.dataManager.getRowLevel(rowIndex);
     const innerDiv = TH.getElementsByTagName('DIV')[0];
     const innerSpan = innerDiv.querySelector('span.rowHeader');
     const previousIndicators = innerDiv.querySelectorAll('[class^="ht_nesting"]');


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes a TypeError that could have been thrown during the `undo` operation on the nested rows data structure.

@Wojciech-Swiderski, the PR fixes the error, but not the Undo/Redo functionality.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and I covered the change with a test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/2770
2.
3.

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
