### PR TITLE
Add background color to wtHolder

### DIFF
--- a/.changelogs/11797.json
+++ b/.changelogs/11797.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Added background color to holder element (`wtHolder`)",
+  "type": "changed",
+  "issueOrPR": 11797,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/styles/base/_base.scss
+++ b/handsontable/src/styles/base/_base.scss
@@ -163,12 +163,20 @@
       }
     }
 
-    // Background
     &.htHasScrollX:not(.htHorizontallyScrollableByWindow),
     &.htHasScrollY:not(.htVerticallyScrollableByWindow) {
       .ht_master {
         .wtHolder {
           border-radius: var(--ht-wrapper-border-radius, 0);
+        }
+      }
+    }
+
+    &:not(.htHorizontallyScrollableByWindow),
+    &:not(.htVerticallyScrollableByWindow) {
+      .ht_master {
+        .wtHolder {
+          background-color: var(--ht-background-color);
         }
       }
     }
@@ -637,7 +645,6 @@
   }
 
   .ht_master .wtHolder {
-    background-color: var(--ht-background-color);
     overflow: auto;
   }
 

--- a/handsontable/src/styles/base/_base.scss
+++ b/handsontable/src/styles/base/_base.scss
@@ -168,7 +168,6 @@
     &.htHasScrollY:not(.htVerticallyScrollableByWindow) {
       .ht_master {
         .wtHolder {
-          background-color: var(--ht-background-color);
           border-radius: var(--ht-wrapper-border-radius, 0);
         }
       }
@@ -638,6 +637,7 @@
   }
 
   .ht_master .wtHolder {
+    background-color: var(--ht-background-color);
     overflow: auto;
   }
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adds missing background color to the holder element (`wtHolder`).

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and the change is reflected in the visual tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/2796

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
