### PR TITLE
Add missing React demo for Customize column headers page

### DIFF
--- a/docs/content/guides/cell-types/autocomplete-cell-type/javascript/example4.ts
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/javascript/example4.ts
@@ -8,7 +8,7 @@ registerAllModules();
 
 const container = document.querySelector('#example4')!;
 const shipmentKVData = [
-  ['Electronics and Gadgets','Los Angeles International Airport'],
+  ['Electronics and Gadgets', 'Los Angeles International Airport'],
   ['Medical Supplies', 'John F. Kennedy International Airport'],
   ['Auto Parts', "Chicago O'Hare International Airport"],
   ['Fresh Produce', 'London Heathrow Airport'],
@@ -17,8 +17,9 @@ const shipmentKVData = [
   ['Pharmaceuticals', 'Tokyo Haneda Airport'],
   ['Consumer Goods', 'Beijing Capital International Airport'],
   ['Machine Parts', 'Singapore Changi Airport'],
-  ['Food Products', 'Amsterdam Airport Schiphol']
+  ['Food Products', 'Amsterdam Airport Schiphol'],
 ];
+
 const airportKVData = [
   'Los Angeles International Airport',
   'John F. Kennedy International Airport',
@@ -39,7 +40,7 @@ const airportKVData = [
   'Sydney Kingsford Smith Airport',
   'Barcelona-El Prat Airport',
   'Kuala Lumpur International Airport',
-  'Zurich Airport'
+  'Zurich Airport',
 ];
 
 new Handsontable(container, {

--- a/docs/content/guides/cell-types/autocomplete-cell-type/javascript/example5.ts
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/javascript/example5.ts
@@ -9,46 +9,16 @@ registerAllModules();
 const container = document.querySelector('#example4')!;
 
 const shipmentKVData = [
-  [
-    'Electronics and Gadgets',
-    { key: 'LAX', value: 'Los Angeles International Airport' },
-  ],
-  [
-    'Medical Supplies',
-    { key: 'JFK', value: 'John F. Kennedy International Airport' }
-  ],
-  [
-    'Auto Parts',
-    { key: 'ORD', value: "Chicago O'Hare International Airport" }
-  ],
-  [
-    'Fresh Produce',
-    { key: 'LHR', value: 'London Heathrow Airport' }
-  ],
-  [
-    'Textiles',
-    { key: 'CDG', value: 'Charles de Gaulle Airport' }
-  ],
-  [
-    'Industrial Equipment',
-    { key: 'DXB', value: 'Dubai International Airport' }
-  ],
-  [
-    'Pharmaceuticals',
-    { key: 'HND', value: 'Tokyo Haneda Airport' }
-  ],
-  [
-    'Consumer Goods',
-    { key: 'PEK', value: 'Beijing Capital International Airport' }
-  ],
-  [
-    'Machine Parts',
-    { key: 'SIN', value: 'Singapore Changi Airport' }
-  ],
-  [
-    'Food Products',
-    { key: 'AMS', value: 'Amsterdam Airport Schiphol' }
-  ]
+  ['Electronics and Gadgets', { key: 'LAX', value: 'Los Angeles International Airport' }],
+  ['Medical Supplies', { key: 'JFK', value: 'John F. Kennedy International Airport' }],
+  ['Auto Parts', { key: 'ORD', value: "Chicago O'Hare International Airport" }],
+  ['Fresh Produce', { key: 'LHR', value: 'London Heathrow Airport' }],
+  ['Textiles', { key: 'CDG', value: 'Charles de Gaulle Airport' }],
+  ['Industrial Equipment', { key: 'DXB', value: 'Dubai International Airport' }],
+  ['Pharmaceuticals', { key: 'HND', value: 'Tokyo Haneda Airport' }],
+  ['Consumer Goods', { key: 'PEK', value: 'Beijing Capital International Airport' }],
+  ['Machine Parts', { key: 'SIN', value: 'Singapore Changi Airport' }],
+  ['Food Products', { key: 'AMS', value: 'Amsterdam Airport Schiphol' }],
 ];
 
 const airportKVData = [
@@ -71,7 +41,7 @@ const airportKVData = [
   { key: 'SYD', value: 'Sydney Kingsford Smith Airport' },
   { key: 'BCN', value: 'Barcelona-El Prat Airport' },
   { key: 'KUL', value: 'Kuala Lumpur International Airport' },
-  { key: 'ZRH', value: 'Zurich Airport' }
+  { key: 'ZRH', value: 'Zurich Airport' },
 ];
 
 new Handsontable(container, {

--- a/docs/content/guides/cell-types/autocomplete-cell-type/react/example4.tsx
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/react/example4.tsx
@@ -8,7 +8,7 @@ registerAllModules();
 
 const ExampleComponent = () => {
   const shipmentKVData = [
-    ['Electronics and Gadgets','Los Angeles International Airport'],
+    ['Electronics and Gadgets', 'Los Angeles International Airport'],
     ['Medical Supplies', 'John F. Kennedy International Airport'],
     ['Auto Parts', "Chicago O'Hare International Airport"],
     ['Fresh Produce', 'London Heathrow Airport'],
@@ -17,8 +17,9 @@ const ExampleComponent = () => {
     ['Pharmaceuticals', 'Tokyo Haneda Airport'],
     ['Consumer Goods', 'Beijing Capital International Airport'],
     ['Machine Parts', 'Singapore Changi Airport'],
-    ['Food Products', 'Amsterdam Airport Schiphol']
+    ['Food Products', 'Amsterdam Airport Schiphol'],
   ];
+
   const airportKVData = [
     'Los Angeles International Airport',
     'John F. Kennedy International Airport',
@@ -39,7 +40,7 @@ const ExampleComponent = () => {
     'Sydney Kingsford Smith Airport',
     'Barcelona-El Prat Airport',
     'Kuala Lumpur International Airport',
-    'Zurich Airport'
+    'Zurich Airport',
   ];
 
   return (

--- a/docs/content/guides/cell-types/autocomplete-cell-type/react/example5.tsx
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/react/example5.tsx
@@ -8,46 +8,16 @@ registerAllModules();
 
 const ExampleComponent = () => {
   const shipmentKVData = [
-    [
-      'Electronics and Gadgets',
-      { key: 'LAX', value: 'Los Angeles International Airport' },
-    ],
-    [
-      'Medical Supplies',
-      { key: 'JFK', value: 'John F. Kennedy International Airport' }
-    ],
-    [
-      'Auto Parts',
-      { key: 'ORD', value: "Chicago O'Hare International Airport" }
-    ],
-    [
-      'Fresh Produce',
-      { key: 'LHR', value: 'London Heathrow Airport' }
-    ],
-    [
-      'Textiles',
-      { key: 'CDG', value: 'Charles de Gaulle Airport' }
-    ],
-    [
-      'Industrial Equipment',
-      { key: 'DXB', value: 'Dubai International Airport' }
-    ],
-    [
-      'Pharmaceuticals',
-      { key: 'HND', value: 'Tokyo Haneda Airport' }
-    ],
-    [
-      'Consumer Goods',
-      { key: 'PEK', value: 'Beijing Capital International Airport' }
-    ],
-    [
-      'Machine Parts',
-      { key: 'SIN', value: 'Singapore Changi Airport' }
-    ],
-    [
-      'Food Products',
-      { key: 'AMS', value: 'Amsterdam Airport Schiphol' }
-    ]
+    ['Electronics and Gadgets', { key: 'LAX', value: 'Los Angeles International Airport' }],
+    ['Medical Supplies', { key: 'JFK', value: 'John F. Kennedy International Airport' }],
+    ['Auto Parts', { key: 'ORD', value: "Chicago O'Hare International Airport" }],
+    ['Fresh Produce', { key: 'LHR', value: 'London Heathrow Airport' }],
+    ['Textiles', { key: 'CDG', value: 'Charles de Gaulle Airport' }],
+    ['Industrial Equipment', { key: 'DXB', value: 'Dubai International Airport' }],
+    ['Pharmaceuticals', { key: 'HND', value: 'Tokyo Haneda Airport' }],
+    ['Consumer Goods', { key: 'PEK', value: 'Beijing Capital International Airport' }],
+    ['Machine Parts', { key: 'SIN', value: 'Singapore Changi Airport' }],
+    ['Food Products', { key: 'AMS', value: 'Amsterdam Airport Schiphol' }],
   ];
 
   const airportKVData = [
@@ -70,7 +40,7 @@ const ExampleComponent = () => {
     { key: 'SYD', value: 'Sydney Kingsford Smith Airport' },
     { key: 'BCN', value: 'Barcelona-El Prat Airport' },
     { key: 'KUL', value: 'Kuala Lumpur International Airport' },
-    { key: 'ZRH', value: 'Zurich Airport' }
+    { key: 'ZRH', value: 'Zurich Airport' },
   ];
 
   return (

--- a/docs/content/guides/columns/column-header/react/example4.tsx
+++ b/docs/content/guides/columns/column-header/react/example4.tsx
@@ -18,18 +18,14 @@ const ExampleComponent = () => {
       rowHeaders={true}
       autoWrapRow={true}
       autoWrapCol={true}
-      height='auto'
-      headerClassName='htCenter'
-      licenseKey='non-commercial-and-evaluation'
+      height="auto"
+      headerClassName="htCenter"
+      licenseKey="non-commercial-and-evaluation"
     >
-      <HotColumn
-        headerClassName='htRight'
-      />
-      <HotColumn
-        headerClassName='htLeft'
-      />
-      <HotColumn/>
-      <HotColumn/>
+      <HotColumn headerClassName="htRight" />
+      <HotColumn headerClassName="htLeft" />
+      <HotColumn />
+      <HotColumn />
     </HotTable>
   );
 };

--- a/docs/content/guides/columns/column-header/react/example4.tsx
+++ b/docs/content/guides/columns/column-header/react/example4.tsx
@@ -18,14 +18,18 @@ const ExampleComponent = () => {
       rowHeaders={true}
       autoWrapRow={true}
       autoWrapCol={true}
-      height="auto"
-      headerClassName="htCenter"
-      licenseKey="non-commercial-and-evaluation"
+      height='auto'
+      headerClassName='htCenter'
+      licenseKey='non-commercial-and-evaluation'
     >
-      <HotColumn headerClassName="htRight" />
-      <HotColumn headerClassName="htLeft" />
-      <HotColumn />
-      <HotColumn />
+      <HotColumn
+        headerClassName='htRight'
+      />
+      <HotColumn
+        headerClassName='htLeft'
+      />
+      <HotColumn/>
+      <HotColumn/>
     </HotTable>
   );
 };


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adds a missing demo for the "Customize column headers" docs page. All examples are again reformatted using the `docs:code-examples:format-all-ts` script.

Fixed page: https://dev-handsontable-feature-dev-issue-2783.netlify.app/docs/react-data-grid/column-header/

_[skip changelog]_

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/2783

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
