### PR TITLE
Fix a problem with the first column not having the left border in some scenarios.

### DIFF
--- a/examples/next/visual-tests/js/demo/src/demos/largeDatasetFixedCells/index.js
+++ b/examples/next/visual-tests/js/demo/src/demos/largeDatasetFixedCells/index.js
@@ -1,0 +1,29 @@
+import Handsontable from 'handsontable';
+import { getThemeNameFromURL } from '../../utils';
+
+export function init() {
+  const root = document.getElementById('root');
+
+  const container = document.createElement('div');
+  container.id = 'hot';
+
+  root.appendChild(container);
+
+  new Handsontable(container, {
+    data: Handsontable.helper.createSpreadsheetData(150, 150),
+    colHeaders: true,
+    rowHeaders: true,
+    fixedColumnsStart: 2,
+    fixedRowsTop: 2,
+    fixedRowsBottom: 2,
+    themeName: getThemeNameFromURL(),
+    height: 500,
+    width: 500,
+    autoRowSize: true,
+    contextMenu: true,
+    licenseKey: 'non-commercial-and-evaluation',
+  });
+  console.log(
+    `Handsontable: v${Handsontable.version} (${Handsontable.buildDate})`
+  );
+}

--- a/examples/next/visual-tests/js/demo/src/index.js
+++ b/examples/next/visual-tests/js/demo/src/index.js
@@ -16,6 +16,7 @@ import { init as initBasicTwoTablesDemo } from "./demos/basicTwoTables";
 import { init as initContextMenuDemo } from "./demos/contextMenu";
 import { init as initDropdownMenuDemo } from "./demos/dropdownMenu";
 import { init as initLargeDatasetDemo } from './demos/largeDataset';
+import { init as initLargeDatasetFixedCellsDemo } from './demos/largeDatasetFixedCells';
 import { init as initCustomBordersDemo } from './demos/customBorders';
 import { init as initWebComponentDemo } from './demos/webComponent';
 import { init as initEditorsDemo } from './demos/editors';
@@ -146,6 +147,15 @@ router
         loadThemeCSS(),
       ]).then(() => {
         initLargeDatasetDemo();
+      });
+    },
+    '/large-dataset-fixed-cells-demo': function () {
+      removeCSS();
+
+      Promise.all([
+        loadThemeCSS(),
+      ]).then(() => {
+        initLargeDatasetFixedCellsDemo();
       });
     },
     '/merged-cells-demo': function () {

--- a/handsontable/src/styles/classic/handsontable.css
+++ b/handsontable/src/styles/classic/handsontable.css
@@ -172,6 +172,9 @@
 }
 
 .handsontable th:first-child,
+.handsontable .ht_clone_inline_start td:first-of-type,
+.handsontable .ht_clone_top_inline_start_corner td:first-of-type,
+.handsontable .ht_clone_bottom_inline_start_corner td:first-of-type,
 .handsontable.ht-wrapper:not(.htFirstDatasetColumnNotRendered) td:first-of-type {
   border-left: 1px solid #ccc;
 }

--- a/visual-tests/tests/cross-browser/scroll.spec.ts
+++ b/visual-tests/tests/cross-browser/scroll.spec.ts
@@ -9,6 +9,7 @@ const urls = [
   '/merged-cells-demo',
   '/nested-headers-demo',
   '/nested-rows-demo',
+  '/large-dataset-fixed-cells-demo',
 ];
 
 urls.forEach((url) => {


### PR DESCRIPTION
### Context
This PR fixes a problem with the first column not having the left border on the `classic` theme with `autoRowSize` and `fixedColumnStart` defined.
It's a follow-up to handsontable/dev-handsontable#2512.

[skip changelog] (fix described in the original PR)

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Added a visual test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#2512

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
