### PR TITLE
Fix table misalignment when new data is loaded

### DIFF
--- a/handsontable/src/dataMap/replaceData.js
+++ b/handsontable/src/dataMap/replaceData.js
@@ -120,6 +120,7 @@ function replaceData(data, setDataMapFunction, callbackFunction, config) {
   // TODO: rethink the way the `afterChange` hook is being run here in the core `init` method.
   if (!firstRun) {
     hotInstance.runHooks('afterChange', null, internalSource);
+    hotInstance.view.adjustElementsSize();
     hotInstance.render();
   }
 

--- a/handsontable/test/e2e/core/loadData.spec.js
+++ b/handsontable/test/e2e/core/loadData.spec.js
@@ -1,4 +1,4 @@
-describe('Core_loadData', () => {
+describe('Core.loadData', () => {
   const id = 'testContainer';
 
   beforeEach(function() {
@@ -1113,5 +1113,27 @@ describe('Core_loadData', () => {
     await loadData(arrayOfArrays(), 'testSource');
 
     expect(correctSourceCount).toEqual(2);
+  });
+
+  it('should adjust the container size after loading new data (loading more columns)', async() => {
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+    });
+
+    await loadData(createSpreadsheetData(5, 7));
+
+    expect(tableView().getTotalTableWidth()).toBe(getDefaultColumnWidth() * 7);
+    expect(tableView().getTotalTableHeight()).toBe((getDefaultRowHeight() * 5) + 1);
+  });
+
+  it('should adjust the container size after loading new data (loading more rows)', async() => {
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+    });
+
+    await loadData(createSpreadsheetData(7, 5));
+
+    expect(tableView().getTotalTableWidth()).toBe(getDefaultColumnWidth() * 5);
+    expect(tableView().getTotalTableHeight()).toBe((getDefaultRowHeight() * 7) + 1);
   });
 });


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes a bug where, in some cases, the table's container was not updated after loading new data, causing the table to misalign.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the change locally, and I covered the fix with 2 new tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/2841#event-19453601105

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
