### PR TITLE
Fix docs themes page

### DIFF
--- a/docs/content/guides/styling/themes/themes.md
+++ b/docs/content/guides/styling/themes/themes.md
@@ -72,10 +72,8 @@ Keep in mind that starting from version `15.0`, importing a theme is required.
 ::: only-for angular
 
 ::: example #example1 :angular --ts 1 --html 2
-
 @[code](@/content/guides/styling/themes/angular/example1.ts)
 @[code](@/content/guides/styling/themes/angular/example1.html)
-
 :::
 
 :::
@@ -219,6 +217,8 @@ When both a global theme and a local themeName are defined, the local setting ta
 - Global Setting: If no local theme is specified, the component falls back to the global configuration provided via the injection token or the configuration service.
 
 This hierarchy ensures that you can define a consistent default theme for your entire application while still allowing individual components to customize their appearance when needed.
+
+:::
 
 ## The classic theme
 


### PR DESCRIPTION
### Context
This PR includes hotfix for documentation themes page content.

### How has this been tested?
Loaclly

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]