### PR TITLE
Fix docs loading page examples

### DIFF
--- a/docs/content/guides/dialog/loading/javascript/example2.js
+++ b/docs/content/guides/dialog/loading/javascript/example2.js
@@ -87,7 +87,8 @@ const hot = new Handsontable(container, {
   height: 300,
   stretchH: 'all',
   loading: {
-    title: 'Processing Data',
+    icon: '<svg class="ht-loading__icon-svg" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16"><path stroke="currentColor" stroke-width="2" d="M15 8a7 7 0 1 1-3.5-6.062"></path></svg>',
+    title: 'Processing Data...',
     description: 'Please wait while we load your inventory data...',
   },
   licenseKey: 'non-commercial-and-evaluation',

--- a/docs/content/guides/dialog/loading/javascript/example3.js
+++ b/docs/content/guides/dialog/loading/javascript/example3.js
@@ -69,11 +69,13 @@ const hot = new Handsontable(container, {
 
 // Get loading plugin instance
 const loadingPlugin = hot.getPlugin('loading');
+const loadDataButton = document.getElementById('loadData');
 
 // Simulate data loading
 async function loadData() {
   // Show loading dialog
   loadingPlugin.show();
+  loadDataButton.disabled = true;
 
   try {
     // Simulate API call delay
@@ -93,24 +95,20 @@ async function loadData() {
       { model: 'Windbreaker Jacket', price: 919.09, sellDate: 'Jul 16, 2025', sellTime: '07:11 PM', inStock: true },
     ];
 
-    // Update loading message
-    loadingPlugin.update({
-      title: 'Processing Data',
-      description: 'Formatting and validating data...',
-    });
-    // Simulate additional processing time
-    await new Promise((resolve) => setTimeout(resolve, 1500));
     // Load data into the table
     hot.loadData(data);
     // Hide loading dialog
     loadingPlugin.hide();
+    loadDataButton.disabled = false;
+    loadDataButton.innerHTML = 'Reload Data';
   } catch (error) {
     // Handle error
     setTimeout(() => {
       loadingPlugin.hide();
+      loadDataButton.disabled = false;
+      loadDataButton.innerHTML = 'Load Data';
     }, 2000);
   }
 }
 
-// Start loading data when page loads
-loadData();
+loadDataButton.addEventListener('click', loadData);

--- a/docs/content/guides/dialog/loading/javascript/example3.ts
+++ b/docs/content/guides/dialog/loading/javascript/example3.ts
@@ -71,10 +71,13 @@ const hot = new Handsontable(container, {
 // Get loading plugin instance
 const loadingPlugin = hot.getPlugin('loading');
 
+const loadDataButton = document.getElementById('loadData') as HTMLButtonElement;
+
 // Simulate data loading
 async function loadData(): Promise<void> {
   // Show loading dialog
   loadingPlugin.show();
+  loadDataButton.disabled = true;
 
   try {
     // Simulate API call delay
@@ -93,28 +96,22 @@ async function loadData(): Promise<void> {
       { model: 'Aero Bottle', price: 1571.13, sellDate: 'May 24, 2025', sellTime: '12:24 AM', inStock: true },
       { model: 'Windbreaker Jacket', price: 919.09, sellDate: 'Jul 16, 2025', sellTime: '07:11 PM', inStock: true },
     ];
-
-    // Update loading message
-    loadingPlugin.update({
-      title: 'Processing Data',
-      description: 'Formatting and validating data...',
-    });
-
-    // Simulate additional processing time
-    await new Promise((resolve) => setTimeout(resolve, 1500));
-
+  
     // Load data into the table
     hot.loadData(data);
 
     // Hide loading dialog
     loadingPlugin.hide();
+    loadDataButton.disabled = false;
+    loadDataButton.innerHTML = 'Reload Data';
   } catch (error) {
     // Handle error
     setTimeout(() => {
       loadingPlugin.hide();
+      loadDataButton.disabled = false;
+      loadDataButton.innerHTML = 'Load Data';
     }, 2000);
   }
 }
 
-// Start loading data when page loads
-loadData();
+loadDataButton.addEventListener('click', loadData);

--- a/docs/content/guides/dialog/loading/loading.md
+++ b/docs/content/guides/dialog/loading/loading.md
@@ -30,9 +30,9 @@ Display loading indicators and progress feedback in your data grid application u
 
 ## Overview
 
-The Loading plugin provides a loading overlay system for Handsontable using the [Dialog](@/api/dialog.md) plugin. It displays a loading indicator with customizable title, icon, and description. This is useful for showing progress feedback during data operations, API calls, or any other time-consuming tasks.
+The Loading plugin provides a loading overlay for Handsontable using the [Dialog](@/api/dialog.md) plugin. It displays a loading indicator with a customizable title, icon, and description. This is useful for showing progress feedback during data operations, API calls, or any other time-consuming tasks.
 
-The loading system is designed to be simple and effective, providing a consistent user experience with customizable appearance and behavior. It requires the [Dialog](@/api/dialog.md) plugin to be enabled to function properly.
+With simplicity and effectiveness in mind, the loading plugin was designed to provide a consistent user experience with customizable appearance and behavior. It requires the [Dialog](@/api/dialog.md) plugin to be enabled to function properly.
 
 ## Basic configuration
 


### PR DESCRIPTION
### Context
This PR includes fixes for documentation Loading page examples.

### How has this been tested?
Locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]