### PR TITLE
Add Plugin prefix to documentation api page

### DIFF
--- a/docs/.vuepress/tools/jsdoc-convert/renderer/seo.mjs
+++ b/docs/.vuepress/tools/jsdoc-convert/renderer/seo.mjs
@@ -42,7 +42,7 @@ export const buildHeaderWriter = ({ seo, urlPrefix }) => {
 ${toYaml(pageMeta)}
 ---
 
-# ${pageMeta.title}
+# Plugin: ${pageMeta.title}
 
 [[toc]]
 `;


### PR DESCRIPTION
### Context
This PR updates the documentation API page by adding the "Plugin" prefix to relevant sections and headings. This change improves clarity and consistency, helping AI quickly identify plugin-related API information.

### How has this been tested?
Locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2517

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]