### PR TITLE
Fix the deprecation warning shown when the plugin is loaded

### DIFF
--- a/handsontable/src/plugins/dialog/dialog.js
+++ b/handsontable/src/plugins/dialog/dialog.js
@@ -4,7 +4,7 @@ import { installFocusDetector } from '../../utils/focusDetector';
 import { isObject } from '../../helpers/object';
 
 export const PLUGIN_KEY = 'dialog';
-export const PLUGIN_PRIORITY = 340;
+export const PLUGIN_PRIORITY = 360;
 const SHORTCUTS_GROUP = PLUGIN_KEY;
 const SHORTCUTS_CONTEXT_NAME = `plugin:${PLUGIN_KEY}`;
 

--- a/handsontable/src/plugins/loading/__tests__/loading.spec.js
+++ b/handsontable/src/plugins/loading/__tests__/loading.spec.js
@@ -112,4 +112,20 @@ describe('Loading', () => {
     expect(plugin.isVisible()).toBe(false);
     expect(plugin.enabled).toBe(false);
   });
+
+  it('should not shown Deprecated warning when loading plugin is enabled and theme is not classic (legacy)', async() => {
+    const warnSpy = spyOn(console, 'warn');
+
+    const hot = handsontable({
+      data: createSpreadsheetData(10, 10),
+      loading: true,
+    });
+
+    if (hot.stylesHandler.isClassicTheme()) {
+      // eslint-disable-next-line max-len
+      expect(warnSpy).toHaveBeenCalledWith('Deprecated: Handsontable classic theme is a legacy theme and will be removed in version 17.0. Please update your theme settings to ensure compatibility with future versions.');
+    } else {
+      expect(warnSpy).not.toHaveBeenCalled();
+    }
+  });
 });

--- a/handsontable/src/plugins/loading/loading.js
+++ b/handsontable/src/plugins/loading/loading.js
@@ -152,9 +152,7 @@ export class Loading extends BasePlugin {
       this.#dialogPlugin = this.hot.getPlugin('dialog');
 
       if (!this.#dialogPlugin?.isEnabled()) {
-        this.hot.updateSettings({
-          dialog: true,
-        });
+        this.hot.getSettings().dialog = true;
       }
 
       this.hot.addHook('afterDialogFocus', () => this.#onAfterDialogFocus());


### PR DESCRIPTION
### Context
This PR includes fix for Loading plugin deprecation warning shown when the plugin is loaded for non classic (legacy) themes.

### How has this been tested?
New test case

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2850

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
