### PR TITLE
Add a note to the AutoRowSize docs.

### DIFF
--- a/handsontable/src/plugins/autoRowSize/autoRowSize.js
+++ b/handsontable/src/plugins/autoRowSize/autoRowSize.js
@@ -47,6 +47,11 @@ const FIRST_COLUMN_NOT_RENDERED_CLASS_NAME = 'htFirstDatasetColumnNotRendered';
  * You can also use the `allowSampleDuplicates` option to allow sampling duplicate values when calculating the row
  * height. __Note__, that this might have a negative impact on performance.
  *
+ * ::: tip
+ * Note: Updating some of the table's settings can cause the row heights to change (e.g. `wordWrap`, `textEllipsis`, renderers etc.).
+ * In those cases, to ensure that the row heights are properly recalculated, you need to call the {@link AutoRowSize#recalculateAllRowsHeight} method after calling {@link Core#updateSettings}.
+ * :::
+ *
  * To configure this plugin see {@link Options#autoRowSize}.
  *
  * @example


### PR DESCRIPTION
### Context
The AutoRowSize plugin does not automatically recalculate row heights after calling `updateSettings`, despite some of the options (`wordWrap`, `textEllipsis`, renderers, etc) having impact on the row heights.

Unfortunately, there's no bullet-proof way to recognize if those options were changed, as they can be set globally, per-column, or even per-cell, using a `cells` function. Triggering the recalculation after every `updateSettings` call is out of the question as well at this point, because of the potential performance drops.

Because of that, I suggest adding a note to the current AutoRowSize API page.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
