### PR TITLE
Apply the fix from #11736 to the modern themes (prevent row misalignment with AutoRowSize)

### DIFF
--- a/handsontable/src/plugins/autoRowSize/__tests__/autoRowSize.spec.js
+++ b/handsontable/src/plugins/autoRowSize/__tests__/autoRowSize.spec.js
@@ -962,6 +962,29 @@ describe('AutoRowSize', () => {
     expect(rowHeaderHeight).toBe(cellsHeight);
   });
 
+  it.forTheme('main')('should not cause a misalignment between the first column and the first row ' +
+    'header when scrolling horizontally (for the modern themes)', async() => {
+    handsontable({
+      data: [
+        // 3rd cell content has to be exactly 83px
+        ['test', 'test', 'xtv fvsxsvffkh', 'test', 'test', '', '', '', '', '', '', '', '', '', ''],
+      ],
+      colHeaders: true,
+      rowHeaders: true,
+      autoRowSize: true,
+      colWidths: 100,
+      wordWrap: true,
+      height: 500,
+      width: 300,
+      fixedColumnsStart: 1,
+      viewportColumnRenderingOffset: 0,
+    });
+
+    await scrollViewportTo(0, 2);
+
+    expect(getCell(0, 0, true).offsetHeight).toBe(getCell(0, 3, true).offsetHeight);
+  });
+
   it('should not cause a misalignment between the first column and the first row header when scrolling horizontally (with hidden columns) (dev-2512)', async() => {
     const data = Array(1).fill().map(() => Array(21).fill('test'));
 

--- a/handsontable/src/plugins/autoRowSize/autoRowSize.js
+++ b/handsontable/src/plugins/autoRowSize/autoRowSize.js
@@ -628,20 +628,18 @@ export class AutoRowSize extends BasePlugin {
    * @param {boolean} [forceState] Force the class to be added or removed (`true` to add, `false` to remove).
    */
   #toggleFirstDatasetColumnRenderedClassName(forceState) {
-    if (this.hot.stylesHandler.isClassicTheme()) {
-      const firstRenderedColumnVisualIndex = this.hot.getFirstRenderedVisibleColumn();
-      const firstRenderedColumnPhysicalIndex =
-        this.hot.columnIndexMapper.getPhysicalFromVisualIndex(firstRenderedColumnVisualIndex);
+    const firstRenderedColumnVisualIndex = this.hot.getFirstRenderedVisibleColumn();
+    const firstRenderedColumnPhysicalIndex =
+      this.hot.columnIndexMapper.getPhysicalFromVisualIndex(firstRenderedColumnVisualIndex);
 
-      if (
-        forceState === false ||
-        firstRenderedColumnPhysicalIndex === this.hot.columnIndexMapper.getPhysicalFromRenderableIndex(0)
-      ) {
-        removeClass(this.hot.rootElement, FIRST_COLUMN_NOT_RENDERED_CLASS_NAME);
+    if (
+      forceState === false ||
+      firstRenderedColumnPhysicalIndex === this.hot.columnIndexMapper.getPhysicalFromRenderableIndex(0)
+    ) {
+      removeClass(this.hot.rootElement, FIRST_COLUMN_NOT_RENDERED_CLASS_NAME);
 
-      } else {
-        addClass(this.hot.rootElement, FIRST_COLUMN_NOT_RENDERED_CLASS_NAME);
-      }
+    } else {
+      addClass(this.hot.rootElement, FIRST_COLUMN_NOT_RENDERED_CLASS_NAME);
     }
   }
 

--- a/handsontable/src/styles/base/_base.scss
+++ b/handsontable/src/styles/base/_base.scss
@@ -102,6 +102,14 @@
     &.ht-wrapper {
       border-radius: var(--ht-wrapper-border-radius, 0);
 
+      &:not(.htFirstDatasetColumnNotRendered) {
+        td {
+          &:first-of-type {
+            border-inline-start-width: 1px;
+          }
+        }
+      }
+
       &::before {
         @include mixins.pseudo();
 
@@ -237,13 +245,6 @@
         &::selection {
           background: transparent;
         }
-      }
-    }
-
-    // Cell
-    td {
-      &:first-of-type {
-        border-inline-start-width: 1px;
       }
     }
 
@@ -462,6 +463,13 @@
               background-color: var(--ht-accent-color);
             }
           }
+        }
+      }
+
+      // Cell
+      td {
+        &:first-of-type {
+          border-inline-start-width: 1px;
         }
       }
     }


### PR DESCRIPTION
### Context
This PR extends the fix from #11736 to the "modern" themes.

[skip changelog]
<sup>(the change was already described in #11736)</sup>

### How has this been tested?
Added a test case for the "main" theme.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#2863
2. handsontable/dev-handsontable#2512

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
