### PR TITLE
Add the missing changelog entry for #11790.

### DIFF
--- a/.changelogs/11790.json
+++ b/.changelogs/11790.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Added a new \"classic\" theme and deprecated the legacy classic styles.",
+  "type": "added",
+  "issueOrPR": 11790,
+  "breaking": false,
+  "framework": "none"
+}


### PR DESCRIPTION
### Context
This PR adds a missing changelog entry to #11790.

**Note:** When generating the release changelog, this entry needs to be split into two entries for better clarity:
- Adding a new theme (in the `Added` section)
- Deprecating the classic/legacy styles (in the `Deprecated` section)

### Related issue(s):
1. #11790 

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
