### PR TITLE
Correct the changelog for `16.1.0`.

### DIFF
--- a/.changelogs/11790.json
+++ b/.changelogs/11790.json
@@ -1,8 +1,0 @@
-{
-  "issuesOrigin": "private",
-  "title": "Added a new \"classic\" theme and deprecated the legacy classic styles.",
-  "type": "added",
-  "issueOrPR": 11790,
-  "breaking": false,
-  "framework": "none"
-}

--- a/.changelogs/11819.json
+++ b/.changelogs/11819.json
@@ -1,8 +1,0 @@
-{
-  "issuesOrigin": "private",
-  "title": "Fixed and issue with deprecation warning shown when the plugin is loaded",
-  "type": "fixed",
-  "issueOrPR": 11819,
-  "breaking": false,
-  "framework": "none"
-}

--- a/.changelogs/11820.json
+++ b/.changelogs/11820.json
@@ -1,8 +1,0 @@
-{
-  "issuesOrigin": "private",
-  "title": "Updated CSS variable for pagination styles",
-  "type": "changed",
-  "issueOrPR": 11820,
-  "breaking": false,
-  "framework": "none"
-}

--- a/.changelogs/11821.json
+++ b/.changelogs/11821.json
@@ -1,8 +1,0 @@
-{
-  "issuesOrigin": "private",
-  "title": "Fixed an issue with classic (legacy) theme deprecation warning in non root instances",
-  "type": "fixed",
-  "issueOrPR": 11821,
-  "breaking": false,
-  "framework": "none"
-}

--- a/.changelogs/11825.json
+++ b/.changelogs/11825.json
@@ -1,8 +1,0 @@
-{
-  "issuesOrigin": "private",
-  "title": "Fixed an issue with the table not rendering correctly when scrolling into extremely tall rows.",
-  "type": "fixed",
-  "issueOrPR": 11825,
-  "breaking": false,
-  "framework": "none"
-}

--- a/.changelogs/11835.json
+++ b/.changelogs/11835.json
@@ -1,8 +1,0 @@
-{
-  "issuesOrigin": "private",
-  "title": "Deprecated the PersistentState plugin (to be removed in version `17.0.0`).",
-  "type": "deprecated",
-  "issueOrPR": 11835,
-  "breaking": false,
-  "framework": "none"
-}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Deprecated
 - Deprecated the legacy style (to be removed in version `17.0.0`). [#11790](https://github.com/handsontable/handsontable/pull/11790)
 - Deprecated the PersistentState plugin (to be removed in version `17.0.0`). [#11835](https://github.com/handsontable/handsontable/pull/11835)
+- Deprecated the `@handsontable/vue` wrapper. [#11839](https://github.com/handsontable/handsontable/pull/11839)
 
 ## [16.0.1] - 2025-07-10
 

--- a/docs/content/guides/upgrade-and-migration/changelog/changelog.md
+++ b/docs/content/guides/upgrade-and-migration/changelog/changelog.md
@@ -73,6 +73,7 @@ For more information about this release see:
 #### Deprecated
 - Deprecated the legacy style (to be removed in version `17.0.0`). [#11790](https://github.com/handsontable/handsontable/pull/11790)
 - Deprecated the PersistentState plugin (to be removed in version `17.0.0`). [#11835](https://github.com/handsontable/handsontable/pull/11835)
+- Deprecated the `@handsontable/vue` wrapper. [#11839](https://github.com/handsontable/handsontable/pull/11839)
 
 
 ## 16.0.1


### PR DESCRIPTION
### Context
This PR:
- Adds information on deprecating the `@handsontable/vue` wrapper to the changelog
- Removes the changelog entry files for the tasks already released in `16.1.0` (leftovers after cherry-picking to the release branch).

This change needs to be cherry-picked to `prod-docs/16.1`

[skip changelog]

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
