### PR TITLE
[docs] Correct a typo in the docs' example.

### DIFF
--- a/docs/content/guides/cell-types/autocomplete-cell-type/javascript/example5.js
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/javascript/example5.js
@@ -6,7 +6,7 @@ import 'handsontable/styles/ht-theme-main.css';
 // Register all Handsontable's modules.
 registerAllModules();
 
-const container = document.querySelector('#example4');
+const container = document.querySelector('#example5');
 const shipmentKVData = [
   ['Electronics and Gadgets', { key: 'LAX', value: 'Los Angeles International Airport' }],
   ['Medical Supplies', { key: 'JFK', value: 'John F. Kennedy International Airport' }],

--- a/docs/content/guides/cell-types/autocomplete-cell-type/javascript/example5.ts
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/javascript/example5.ts
@@ -6,7 +6,7 @@ import 'handsontable/styles/ht-theme-main.css';
 // Register all Handsontable's modules.
 registerAllModules();
 
-const container = document.querySelector('#example4')!;
+const container = document.querySelector('#example5')!;
 
 const shipmentKVData = [
   ['Electronics and Gadgets', { key: 'LAX', value: 'Los Angeles International Airport' }],


### PR DESCRIPTION
### Context
This PR should correct the placement of the Autocomplete example in the docs by correcting a typo in its config.

[skip changelog]

### How has this been tested?
Tested locally.

### Related issue(s):
1. handsontable/dev-handsontable#2882

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
