### PR TITLE
Utilize the `valueGetter `when retrieving object-based values to be used in formula calculations.

### DIFF
--- a/handsontable/src/plugins/formulas/__tests__/featureIntegration.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/featureIntegration.spec.js
@@ -470,4 +470,59 @@ describe('Formulas: Integration with other features', () => {
       ]);
     });
   });
+
+  describe('Integration with the Autocomplete cell type with object-based key/value source', () => {
+    it('should utilize the visible values of the object-based, key/value autocomplete cells in the formulas engine', async() => {
+      const errorSpy = jasmine.createSpyObj('error', ['test']);
+      const prevError = window.onerror;
+      const airportKVData = [
+        { key: 'LAX', value: 'Los Angeles International Airport' },
+        { key: 'JFK', value: 'John F. Kennedy International Airport' },
+        { key: 'ORD', value: 'Chicago O\'Hare International Airport' },
+        { key: 'LHR', value: 'London Heathrow Airport' },
+      ];
+      const nestedAirportObjectKVData = [
+        {
+          key: 'LAX',
+          value: { key: 'LAX', value: 'Los Angeles International Airport' },
+          formulas: '=CONCATENATE(B1, B2)',
+        },
+        {
+          key: 'JFK',
+          value: { key: 'JFK', value: 'John F. Kennedy International Airport' },
+          formulas: null,
+        },
+      ];
+
+      window.onerror = errorSpy.test;
+
+      handsontable({
+        data: nestedAirportObjectKVData,
+        rowHeaders: true,
+        colHeaders: true,
+        formulas: {
+          engine: HyperFormula,
+          sheetName: 'Sheet1'
+        },
+        columns: [
+          {
+            data: 'key',
+          },
+          {
+            data: 'value',
+            type: 'autocomplete',
+            source: airportKVData,
+          },
+          {
+            data: 'formulas',
+            type: 'text',
+          }],
+      });
+
+      expect(getDataAtCell(0, 2)).toEqual('Los Angeles International AirportJohn F. Kennedy International Airport');
+      expect(errorSpy.test).not.toHaveBeenCalled();
+
+      window.onerror = prevError;
+    });
+  });
 });


### PR DESCRIPTION
### Context
This PR makes the Formulas plugin utilize the `valueGetter`s when retrieving object-based cell content to be used within the formula calculations.

### How has this been tested?
Added a test case.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#2881

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
