### PR TITLE
Update migration guide: Replace TODO placeholder with published release blog URL

### DIFF
--- a/docs/content/guides/upgrade-and-migration/migrating-from-16.0-to-16.1/migrating-from-16.0-to-16.1.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-16.0-to-16.1/migrating-from-16.0-to-16.1.md
@@ -20,7 +20,7 @@ category: Upgrade and migration
 
 Migrate from Handsontable 16.0 to Handsontable 16.1, released on TODO.
 
-More information about this release can be found in the [`16.1.0` release blog post](TODO_URL]).
+More information about this release can be found in the [`16.1.0` release blog post](https://handsontable.com/blog/handsontable-16.1-row-pagination-loading-plugin-and-long-term-support-policy).
 
 [[toc]]
 


### PR DESCRIPTION
Updated the blog post link for Handsontable 16.1 migration.

### Context
The migration guide contained a TODO placeholder for the Handsontable 16.1 release blog URL. This PR replaces the placeholder with the actual published blog post URL to provide users with the correct reference link.

### How has this been tested?
- Verified that the new URL is accessible and points to the correct blog post
- Confirmed that the link renders properly in the documentation

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. N/A

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.