### PR TITLE
Remove already released changelog entries

### DIFF
--- a/.changelogs/11849.json
+++ b/.changelogs/11849.json
@@ -1,8 +1,0 @@
-{
-  "issuesOrigin": "private",
-  "title": "Fixed a problem where setting `manualRowResize` on an instance with `autoRowSize` enabled led to row misalignment.",
-  "type": "fixed",
-  "issueOrPR": 11849,
-  "breaking": false,
-  "framework": "none"
-}

--- a/.changelogs/11852.json
+++ b/.changelogs/11852.json
@@ -1,8 +1,0 @@
-{
-  "issuesOrigin": "private",
-  "title": "Reverted the foreground color change for the \"main\" theme.",
-  "type": "fixed",
-  "issueOrPR": 11852,
-  "breaking": false,
-  "framework": "none"
-}

--- a/.changelogs/11853.json
+++ b/.changelogs/11853.json
@@ -1,8 +1,0 @@
-{
-  "issuesOrigin": "private",
-  "title": "Fixed a problem when using autocomplete-typed cells with key/value sources alongside formulas caused the table to throw an error.",
-  "type": "fixed",
-  "issueOrPR": 11853,
-  "breaking": false,
-  "framework": "none"
-}


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR removes already released (in 16.1.1) changelog entries from the `develop` branch.

_[skip changelog]_

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
