### PR TITLE
[docs] Correct the 16.1 migration guide.

### DIFF
--- a/docs/content/guides/upgrade-and-migration/migrating-from-16.0-to-16.1/migrating-from-16.0-to-16.1.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-16.0-to-16.1/migrating-from-16.0-to-16.1.md
@@ -18,7 +18,7 @@ category: Upgrade and migration
 
 # Migrate from 16.0 to 16.1
 
-Migrate from Handsontable 16.0 to Handsontable 16.1, released on TODO.
+Migrate from Handsontable 16.0 to Handsontable 16.1, released on September 15, 2025.
 
 More information about this release can be found in the [`16.1.0` release blog post](https://handsontable.com/blog/handsontable-16.1-row-pagination-loading-plugin-and-long-term-support-policy).
 


### PR DESCRIPTION
### Context
This PR corrects the 16.1 migration guide page in the docs.

Related to https://github.com/handsontable/handsontable/pull/11855

[skip changelog]