### PR TITLE
Update information regarding the use of mergeCells in the documentation

### DIFF
--- a/docs/content/guides/cell-features/merge-cells/merge-cells.md
+++ b/docs/content/guides/cell-features/merge-cells/merge-cells.md
@@ -27,8 +27,6 @@ By merging, you can combine two or more adjacent cells into a single cell that s
 
 Handsontable merges cells in the same way as Microsoft Excel: keeps only the upper-left value of the selected range and clears other values.
 
-Cell merging happens on Handsontable's visual layer and doesn't affect your source data structure.
-
 ## How to merge cells
 
 To enable the merge cells feature, set the [`mergeCells`](@/api/options.md#mergecells) option to  `true` or to an array.


### PR DESCRIPTION
### Context
This PR includes changes for documentation merge cells page. The paragraph with incorrect information was removed.

### How has this been tested?
Locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2536

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

[skip changelog]
