### PR TITLE
Add Enter key handler to trigger filters

### DIFF
--- a/handsontable/src/dataMap/metaManager/metaSchema.js
+++ b/handsontable/src/dataMap/metaManager/metaSchema.js
@@ -2309,6 +2309,13 @@ export default () => {
      * | ------- | ------------------------------------------------ |
      * | `false` | Disable the [`Filters`](@/api/filters.md) plugin |
      * | `true`  | Enable the [`Filters`](@/api/filters.md) plugin  |
+     * | `object`| Enable the [`Filters`](@/api/filters.md) plugin with custom settings |
+     *
+     * If you set the `filters` option to an object, you can configure the following settings:
+     *
+     * | Property                 | Possible values   | Description              |
+     * | ------------------------ | ----------------- | ------------------------ |
+     * | `uncheckFilteredQueries` | `true` \| `false` | Uncheck filtered queries |
      *
      * Read more:
      * - [Column filter](@/guides/columns/column-filter/column-filter.md)

--- a/handsontable/src/plugins/filters/component/value.js
+++ b/handsontable/src/plugins/filters/component/value.js
@@ -84,15 +84,29 @@ export class ValueComponent extends BaseComponent {
   /**
    * Export state of the component (get selected filter and filter arguments).
    *
+   * @param {boolean} uncheckFilteredQueries Whether to uncheck filtered queries.
    * @returns {object} Returns object where `command` key keeps used condition filter and `args` key its arguments.
    */
-  getState() {
+  getState(uncheckFilteredQueries) {
     const select = this.getMultipleSelectElement();
     const availableItems = select.getItems();
+    const values = uncheckFilteredQueries ? select.getFilteredItemsValue() : select.getValue();
+
+    if (uncheckFilteredQueries) {
+      availableItems.forEach((item) => {
+        if (values.includes(item.value)) {
+          item.checked = true;
+
+          return;
+        }
+
+        item.checked = false;
+      });
+    }
 
     return {
       command: { key: select.isSelectedAllValues() || !availableItems.length ? CONDITION_NONE : CONDITION_BY_VALUE },
-      args: [select.getValue()],
+      args: [values],
       itemsSnapshot: availableItems
     };
   }
@@ -252,6 +266,11 @@ export class ValueComponent extends BaseComponent {
   #onInputKeyDown(event) {
     if (isKey(event.keyCode, 'ESCAPE')) {
       this.runLocalHooks('cancel');
+      stopImmediatePropagation(event);
+    }
+
+    if (isKey(event.keyCode, 'ENTER')) {
+      this.runLocalHooks('accept', true);
       stopImmediatePropagation(event);
     }
   }

--- a/handsontable/src/plugins/filters/filters.js
+++ b/handsontable/src/plugins/filters/filters.js
@@ -188,8 +188,13 @@ export class Filters extends BasePlugin {
 
     const dropdownSettings = this.hot.getSettings().dropdownMenu;
     const menuContainer = (dropdownSettings && dropdownSettings.uiContainer) || this.hot.rootPortalElement;
+
+    const pluginSettings = this.hot.getSettings()[PLUGIN_KEY];
+    const uncheckFilteredQueriesSetting = pluginSettings?.uncheckFilteredQueries;
+
     const addConfirmationHooks = (component) => {
-      component.addLocalHook('accept', () => this.#onActionBarSubmit('accept'));
+      component.addLocalHook('accept', uncheckFilteredQueries =>
+        this.#onActionBarSubmit('accept', uncheckFilteredQueriesSetting || uncheckFilteredQueries));
       component.addLocalHook('cancel', () => this.#onActionBarSubmit('cancel'));
       component.addLocalHook('change', command => this.#onComponentChange(component, command));
 
@@ -871,8 +876,9 @@ export class Filters extends BasePlugin {
    *
    * @private
    * @param {string} submitType The submit type.
+   * @param {boolean} uncheckFilteredQueries Whether to uncheck filtered queries.
    */
-  #onActionBarSubmit(submitType) {
+  #onActionBarSubmit(submitType, uncheckFilteredQueries) {
     if (submitType === 'accept') {
       const selectedColumn = this.getSelectedColumn();
 
@@ -885,7 +891,7 @@ export class Filters extends BasePlugin {
       const { physicalIndex } = selectedColumn;
       const byConditionState1 = this.components.get('filter_by_condition').getState();
       const byConditionState2 = this.components.get('filter_by_condition2').getState();
-      const byValueState = this.components.get('filter_by_value').getState();
+      const byValueState = this.components.get('filter_by_value').getState(uncheckFilteredQueries);
 
       const operation = this.getOperationBasedOnArguments(
         this.components.get('filter_operators').getActiveOperationId(),

--- a/handsontable/src/plugins/filters/ui/multipleSelect.js
+++ b/handsontable/src/plugins/filters/ui/multipleSelect.js
@@ -90,6 +90,15 @@ export class MultipleSelectUI extends BaseUI {
   }
 
   /**
+   * Get filtered items value.
+   *
+   * @returns {Array} Array of selected values.
+   */
+  getFilteredItemsValue() {
+    return itemsToValue(this.#itemsBox.getSourceData(), true);
+  }
+
+  /**
    * Register all necessary hooks.
    */
   registerHooks() {
@@ -421,13 +430,14 @@ function valueToItems(availableItems, selectedValue) {
  * Convert all checked items into flat array.
  *
  * @param {Array} availableItems Base collection.
+ * @param {boolean} notChecked Whether to include not checked items.
  * @returns {Array}
  */
-function itemsToValue(availableItems) {
+function itemsToValue(availableItems, notChecked = false) {
   const items = [];
 
   availableItems.forEach((item) => {
-    if (item.checked) {
+    if (item.checked || notChecked) {
       items.push(item.value);
     }
   });


### PR DESCRIPTION
### Context
Implemented an event handler that listens for the Enter key press when input is focused to automatically submit the filters.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2883

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
