### PR TITLE
Tag new in sidebar

### DIFF
--- a/docs/.vuepress/theme/components/Sidebar.vue
+++ b/docs/.vuepress/theme/components/Sidebar.vue
@@ -64,6 +64,24 @@ export default {
   },
   mounted() {
     this.scrollToActiveElement(this.$route.path);
+    // THIS IS hack but it works
+    const newLinks = [
+      '/deprecation-policy/',
+      '/versioning-policy/'
+    ];
+
+    document.querySelectorAll('aside.sidebar .sidebar-links a').forEach((a) => {
+      if (newLinks.some(link => a.href.endsWith(link))) {
+        if (a.querySelector('span.new-link') === null) {
+          const span = document.createElement('span');
+
+          span.textContent = 'New';
+          span.classList.add('tag-new');
+          a.appendChild(span);
+        }
+      }
+    });
+
   },
   watch: {
     $route(to, from) {


### PR DESCRIPTION
### Context
Insert tag into sidebar in case of:
* content update
* new page in docs

<img width="720" height="557" alt="image" src="https://github.com/user-attachments/assets/61cec47b-85d2-4928-a2e1-09e7d3f5aab1" />


It's very hacky but i tried to extend vue press 1 sidebar component and failed 

### How has this been tested?

locally 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
[skip changelog]
