### PR TITLE
Fix a case with clicking outside of the table not restoring the Dropdown/Autocomplete Editor value.

### DIFF
--- a/handsontable/src/editors/autocompleteEditor/__tests__/autocompleteEditor.spec.js
+++ b/handsontable/src/editors/autocompleteEditor/__tests__/autocompleteEditor.spec.js
@@ -1852,6 +1852,34 @@ describe('AutocompleteEditor', () => {
       expect(getDataAtCell(0, 0)).toEqual(null);
     });
 
+    it('should not save the value in non strict mode, when closing the editor by clicking outside of the table', async() => {
+      const syncSources = jasmine.createSpy('syncSources');
+
+      syncSources.and.callFake((query, process) => {
+        process(choices);
+      });
+
+      handsontable({
+        columns: [
+          {
+            editor: 'autocomplete',
+            source: syncSources
+          }
+        ]
+      });
+
+      await selectCell(0, 0);
+      await keyDownUp('enter');
+      await sleep(50);
+
+      const editor = $('.handsontableInput');
+
+      editor.val('foo');
+      $('body').simulate('mousedown');
+
+      expect(getDataAtCell(0, 0)).toEqual(null);
+    });
+
     it('should save the value from textarea after hitting ENTER', async() => {
       const syncSources = jasmine.createSpy('syncSources');
 
@@ -2708,7 +2736,7 @@ describe('AutocompleteEditor', () => {
 
     spec().$container.simulate('mousedown');
 
-    expect(getDataAtCell(0, 0)).toEqual('');
+    expect(getDataAtCell(0, 0)).toEqual(null);
   });
 
   it('should be able to use empty value ("")', async() => {

--- a/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
+++ b/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
@@ -11,7 +11,7 @@ import {
   setAttribute,
   setCaretPosition,
 } from '../../helpers/dom/element';
-import { isDefined, stringify } from '../../helpers/mixed';
+import { isUndefined, isDefined, stringify } from '../../helpers/mixed';
 import { stripTags } from '../../helpers/string';
 import { KEY_CODES, isPrintableChar } from '../../helpers/unicode';
 import { textRenderer } from '../../renderers/textRenderer';
@@ -268,8 +268,14 @@ export class AutocompleteEditor extends HandsontableEditor {
     if (this.isOpened()) {
       const lastSelectedRange = this.hot.getSelectedRangeActive();
 
-      if (lastSelectedRange && !lastSelectedRange.includes(this.hot._createCellCoords(this.row, this.col))) {
-        // Method was triggered by selecting a different cell.
+      if (
+        isUndefined(lastSelectedRange) ||
+        (
+          isDefined(lastSelectedRange) &&
+          !lastSelectedRange.includes(this.hot._createCellCoords(this.row, this.col))
+        )
+      ) {
+        // Method was triggered by selecting a different cell or deselecting cells.
         restoreOriginalValue = true;
       }
     }

--- a/handsontable/src/editors/dropdownEditor/__tests__/dropdownEditor.spec.js
+++ b/handsontable/src/editors/dropdownEditor/__tests__/dropdownEditor.spec.js
@@ -695,7 +695,7 @@ describe('DropdownEditor', () => {
       expect($(dropdown).is(':visible')).toBe(true);
     });
 
-    it('should not save the value in non strict mode, when closing the editor by clicking on the table', async() => {
+    it('should not save the value, when closing the editor by clicking on the table', async() => {
       handsontable({
         columns: [
           {
@@ -721,6 +721,34 @@ describe('DropdownEditor', () => {
       await sleep(50);
 
       spec().$container.find('tbody tr:eq(1) td:eq(2)').simulate('mousedown');
+
+      expect(getDataAtCell(0, 0)).toEqual(null);
+    });
+
+    it('should not save the value, when closing the editor by clicking outside of the table', async() => {
+      const syncSources = jasmine.createSpy('syncSources');
+
+      syncSources.and.callFake((query, process) => {
+        process(choices);
+      });
+
+      handsontable({
+        columns: [
+          {
+            editor: 'dropdown',
+            source: syncSources
+          }
+        ]
+      });
+
+      await selectCell(0, 0);
+      await keyDownUp('enter');
+      await sleep(50);
+
+      const editor = $('.handsontableInput');
+
+      editor.val('foo');
+      $('body').simulate('mousedown');
 
       expect(getDataAtCell(0, 0)).toEqual(null);
     });


### PR DESCRIPTION
### Context
This PR is a continuation of #11873.

It focuses on a case of clicking outside of the table when closing the editor.

[skip changelog]
<sup>The changelog for #11873 is sufficient for the changelog.</sup>

### How has this been tested?
Tested locally + added test cases.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#2757
2. #11873

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
