### PR TITLE
Fix `isListening` state after closing dropdown menu

### DIFF
--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -4830,10 +4830,10 @@ export default function Core(rootContainer, userSettings, rootInstanceSymbol = f
 
     if (isRootInstance(this)) {
       uninstallAccessibilityAnnouncer();
+      this.getFocusScopeManager().destroy();
     }
 
     this.getShortcutManager().destroy();
-    this.getFocusScopeManager().destroy();
     moduleRegisterer.clear();
     metaManager.clearCache();
     foreignHotInstances.delete(this.guid);
@@ -5443,7 +5443,7 @@ export default function Core(rootContainer, userSettings, rootInstanceSymbol = f
 
   focusGridManager = new FocusGridManager(instance);
 
-  const focusScopeManager = createFocusScopeManager(instance);
+  const focusScopeManager = isRootInstance(this) ? createFocusScopeManager(instance) : null;
 
   /**
    * Return the Focus Manager responsible for managing the browser's focus in the table.
@@ -5478,6 +5478,10 @@ export default function Core(rootContainer, userSettings, rootInstanceSymbol = f
    * ```
    */
   this.getFocusScopeManager = function() {
+    if (!isRootInstance(instance)) {
+      throw new Error('The FocusScopeManager is only available for the main Handsontable instance.');
+    }
+
     return focusScopeManager;
   };
 

--- a/handsontable/src/focusManager/scopeManager.js
+++ b/handsontable/src/focusManager/scopeManager.js
@@ -237,6 +237,10 @@ export function createFocusScopeManager(hotInstance) {
    * @param {'unknown' | 'click' | 'tab_from_above' | 'tab_from_below'} focusSource The source of the focus event.
    */
   function processScopes(target, focusSource) {
+    if (!target.isConnected) {
+      return;
+    }
+
     const allEnabledScopes = SCOPES.getValues().filter(scope => scope.runOnlyIf());
     let hasActiveScope = false;
 

--- a/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
@@ -1839,4 +1839,40 @@ describe('Filters UI', () => {
     expect(byValueScrollableElement.scrollTop).toBe(100);
     expect(byValueScrollableElement.scrollLeft).toBe(100);
   });
+
+  it('should return the focus to the grid after clicking "OK" button', async() => {
+    handsontable({
+      data: getDataForFilters(),
+      columns: getColumnsForFilters(),
+      filters: true,
+      dropdownMenu: true,
+      width: 500,
+      height: 300
+    });
+
+    await dropdownMenu(1);
+    await sleep(100);
+    await simulateClick(getFilterDropdownMenuOKButton());
+
+    expect(isListening()).toBe(true);
+    expect(getShortcutManager().getActiveContextName()).toBe('grid');
+  });
+
+  it('should return the focus to the grid after clicking "Cancel" button', async() => {
+    handsontable({
+      data: getDataForFilters(),
+      columns: getColumnsForFilters(),
+      filters: true,
+      dropdownMenu: true,
+      width: 500,
+      height: 300
+    });
+
+    await dropdownMenu(1);
+    await sleep(100);
+    await simulateClick(getFilterDropdownMenuCancelButton());
+
+    expect(isListening()).toBe(true);
+    expect(getShortcutManager().getActiveContextName()).toBe('grid');
+  });
 });

--- a/handsontable/src/plugins/filters/__tests__/helpers/utils.js
+++ b/handsontable/src/plugins/filters/__tests__/helpers/utils.js
@@ -113,3 +113,21 @@ export function conditionFactory(funcForCall) {
     };
   };
 }
+
+/**
+ * Returns the "OK" button element of the filter dropdown menu.
+ *
+ * @returns {HTMLElement}
+ */
+export function getFilterDropdownMenuOKButton() {
+  return dropdownMenuRootElement().querySelector('.htUIButton.htUIButtonOK input');
+}
+
+/**
+ * Returns the "Cancel" button element of the filter dropdown menu.
+ *
+ * @returns {HTMLElement}
+ */
+export function getFilterDropdownMenuCancelButton() {
+  return dropdownMenuRootElement().querySelector('.htUIButton.htUIButtonCancel input');
+}

--- a/handsontable/test/e2e/core/getFocusScopeManager.spec.js
+++ b/handsontable/test/e2e/core/getFocusScopeManager.spec.js
@@ -1,0 +1,39 @@
+describe('Core.getFocusScopeManager', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should return the focus scope manager instance', async() => {
+    handsontable({});
+
+    expect(getFocusScopeManager()).toBeDefined();
+    expect(getFocusScopeManager().registerScope).toBeDefined();
+    expect(getFocusScopeManager().unregisterScope).toBeDefined();
+    expect(getFocusScopeManager().activateScope).toBeDefined();
+    expect(getFocusScopeManager().deactivateScope).toBeDefined();
+    expect(getFocusScopeManager().getActiveScopeId).toBeDefined();
+  });
+
+  it('should throw an error if the method is called on a non-root instance', async() => {
+    handsontable({
+      contextMenu: true,
+    });
+
+    await contextMenu();
+
+    const hotMenu = getPlugin('contextMenu').menu.hotMenu;
+
+    expect(() => {
+      hotMenu.getFocusScopeManager();
+    }).toThrowError('The FocusScopeManager is only available for the main Handsontable instance.');
+  });
+});


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes a regression (that sits on the `develop` branch) introduced within _FocusScopeManager_ (https://github.com/handsontable/handsontable/pull/11804). The regression manifests itself in the table losing the `isListening` state after the dropdown menu is closed, after clicking the OK or Cancel buttons. The main cause of this bug was the fact that the focus manager reacted to a change of focus on a clicked element that was detached from the DOM.

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally and I covered the fix with tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/2949

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
