### PR TITLE
[docs] Reduce the number of duplicate `afterSetTheme` hook callbacks in the docs.

### DIFF
--- a/docs/.vuepress/handsontable-manager/theme-manager.js
+++ b/docs/.vuepress/handsontable-manager/theme-manager.js
@@ -27,6 +27,7 @@ const _afterSetThemeCallback = function() {
 
 const ensureCorrectHotThemes = () => {
   if (typeof Handsontable !== 'undefined') {
+    // eslint-disable-next-line no-undef
     Handsontable.hooks.add('afterSetTheme', _afterSetThemeCallback);
   }
 };


### PR DESCRIPTION
### Context
This PR:
- Reduces the number of duplicate `afterSetTheme` hooks in the docs.
- Adds optional chaining logic to the callback to prevent errors.

[skip changelog]

### How has this been tested?
Tested locally.

### Related issue(s):
1. handsontable/dev-handsontable#2940

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
