### PR TITLE
Add a typo fix in the Angular documentation

### DIFF
--- a/docs/content/guides/getting-started/binding-to-data/binding-to-data.md
+++ b/docs/content/guides/getting-started/binding-to-data/binding-to-data.md
@@ -420,7 +420,7 @@ you). The easiest way to do it is by passing your data array as the value of `Ho
 ```ts
 import { GridSettings } from "@handsontable/angular-wrapper";
 
-data = newDatset,
+data = newDataset,
 gridSettings: GridSettings = {};
 ```
 


### PR DESCRIPTION
### Context
This PR includes fix for Angular documentation typo

### How has this been tested?
Locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2695

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

[skip changelog]
