### PR TITLE
Fix Angular demo image URLs in documentation

### DIFF
--- a/docs/content/guides/cell-functions/cell-renderer/angular/example1.ts
+++ b/docs/content/guides/cell-functions/cell-renderer/angular/example1.ts
@@ -31,21 +31,21 @@ export class AppComponent implements OnInit, AfterViewInit {
       description:
         'This <a href="https://bit.ly/sM1bDf">book</a> provides a developer-level introduction along with more advanced and useful features of <b>JavaScript</b>.',
       cover:
-        'https://handsontable.com/docs/15.0/img/examples/professional-javascript-developers-nicholas-zakas.jpg',
+        '{{$basePath}}/img/examples/professional-javascript-developers-nicholas-zakas.jpg',
     },
     {
       title:
         '<a href="https://shop.oreilly.com/product/9780596517748.do">JavaScript: The Good Parts</a>',
       description:
         'This book provides a developer-level introduction along with <b>more advanced</b> and useful features of JavaScript.',
-      cover: 'https://handsontable.com/docs/15.0/img/examples/javascript-the-good-parts.jpg',
+      cover: '{{$basePath}}/img/examples/javascript-the-good-parts.jpg',
     },
     {
       title:
         '<a href="https://shop.oreilly.com/product/9780596805531.do">JavaScript: The Definitive Guide</a>',
       description:
         '<em>JavaScript: The Definitive Guide</em> provides a thorough description of the core <b>JavaScript</b> language and both the legacy and standard DOMs implemented in web browsers.',
-      cover: 'https://handsontable.com/docs/15.0/img/examples/javascript-the-definitive-guide.jpg',
+      cover: '{{$basePath}}/img/examples/javascript-the-definitive-guide.jpg',
     },
   ];
 

--- a/docs/content/guides/cell-functions/cell-renderer/angular/example2.ts
+++ b/docs/content/guides/cell-functions/cell-renderer/angular/example2.ts
@@ -25,21 +25,21 @@ export class AppComponent implements OnInit {
       description:
         'This <a href="https://bit.ly/sM1bDf">book</a> provides a developer-level introduction along with more advanced and useful features of <b>JavaScript</b>.',
       cover:
-        'https://handsontable.com/docs/15.0/img/examples/professional-javascript-developers-nicholas-zakas.jpg',
+        '{{$basePath}}/img/examples/professional-javascript-developers-nicholas-zakas.jpg',
     },
     {
       title:
         '<a href="https://shop.oreilly.com/product/9780596517748.do">JavaScript: The Good Parts</a>',
       description:
         'This book provides a developer-level introduction along with <b>more advanced</b> and useful features of JavaScript.',
-      cover: 'https://handsontable.com/docs/15.0/img/examples/javascript-the-good-parts.jpg',
+      cover: '{{$basePath}}/img/examples/javascript-the-good-parts.jpg',
     },
     {
       title:
         '<a href="https://shop.oreilly.com/product/9780596805531.do">JavaScript: The Definitive Guide</a>',
       description:
         '<em>JavaScript: The Definitive Guide</em> provides a thorough description of the core <b>JavaScript</b> language and both the legacy and standard DOMs implemented in web browsers.',
-      cover: 'https://handsontable.com/docs/15.0/img/examples/javascript-the-definitive-guide.jpg',
+      cover: '{{$basePath}}/img/examples/javascript-the-definitive-guide.jpg',
     },
   ];
 

--- a/docs/content/guides/cell-functions/cell-renderer/angular/example4.ts
+++ b/docs/content/guides/cell-functions/cell-renderer/angular/example4.ts
@@ -34,21 +34,21 @@ export class AppComponent implements OnInit, AfterViewInit {
       description:
         'This <a href="https://bit.ly/sM1bDf">book</a> provides a developer-level introduction along with more advanced and useful features of <b>JavaScript</b>.',
       cover:
-        'https://handsontable.com/docs/15.0/img/examples/professional-javascript-developers-nicholas-zakas.jpg',
+        '{{$basePath}}/img/examples/professional-javascript-developers-nicholas-zakas.jpg',
     },
     {
       title:
         '<a href="https://shop.oreilly.com/product/9780596517748.do">JavaScript: The Good Parts</a>',
       description:
         'This book provides a developer-level introduction along with <b>more advanced</b> and useful features of JavaScript.',
-      cover: 'https://handsontable.com/docs/15.0/img/examples/javascript-the-good-parts.jpg',
+      cover: '{{$basePath}}/img/examples/javascript-the-good-parts.jpg',
     },
     {
       title:
         '<a href="https://shop.oreilly.com/product/9780596805531.do">JavaScript: The Definitive Guide</a>',
       description:
         '<em>JavaScript: The Definitive Guide</em> provides a thorough description of the core <b>JavaScript</b> language and both the legacy and standard DOMs implemented in web browsers.',
-      cover: 'https://handsontable.com/docs/15.0/img/examples/javascript-the-definitive-guide.jpg',
+      cover: '{{$basePath}}/img/examples/javascript-the-definitive-guide.jpg',
     },
   ];
 

--- a/docs/content/guides/cell-functions/cell-renderer/angular/example5.ts
+++ b/docs/content/guides/cell-functions/cell-renderer/angular/example5.ts
@@ -57,7 +57,7 @@ export class AppComponent implements AfterViewInit {
         'This <a href="https://bit.ly/sM1bDf">book</a> provides a developer-level introduction along with more advanced and useful features of <b>JavaScript</b>.',
       comments: 'I would rate it ★★★★☆',
       cover:
-        'http://localhost:8080/docs/img/examples/professional-javascript-developers-nicholas-zakas.jpg',
+        '{{$basePath}}/img/examples/professional-javascript-developers-nicholas-zakas.jpg',
     },
     {
       title:
@@ -65,7 +65,7 @@ export class AppComponent implements AfterViewInit {
       description:
         'This book provides a developer-level introduction along with <b>more advanced</b> and useful features of JavaScript.',
       comments: 'This is the book about JavaScript',
-      cover: 'http://localhost:8080/docs/img/examples/javascript-the-good-parts.jpg',
+      cover: '{{$basePath}}/img/examples/javascript-the-good-parts.jpg',
     },
     {
       title:
@@ -74,7 +74,7 @@ export class AppComponent implements AfterViewInit {
         '<em>JavaScript: The Definitive Guide</em> provides a thorough description of the core <b>JavaScript</b> language and both the legacy and standard DOMs implemented in web browsers.',
       comments:
         'I\'ve never actually read it, but the <a href="https://shop.oreilly.com/product/9780596805531.do">comments</a> are highly <strong>positive</strong>.',
-      cover: 'http://localhost:8080/docs/img/examples/javascript-the-definitive-guide.jpg',
+      cover: '{{$basePath}}/img/examples/javascript-the-definitive-guide.jpg',
     }
   ];
 


### PR DESCRIPTION
### Context
This PR includes fix for Angular version of Cell renderer demo image URLs.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2857

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

[skip changelog]
