### PR TITLE
Update grid size documentation page

### DIFF
--- a/docs/content/guides/getting-started/grid-size/grid-size.md
+++ b/docs/content/guides/getting-started/grid-size/grid-size.md
@@ -141,7 +141,7 @@ Changes called in [`updateSettings()`](@/api/core.md#updatesettings) will re-ren
 
 ### Troubleshooting with 100% height
 
-Assuming you're creating an Handsontable instance that has `100% height` and container is element with id `#example`. 
+When the `height` option is set to 100%, there are three ways to define the container’s height. Assuming you're creating an Handsontable instance that has `100% height` and container is element with id `#example`. 
 
 ```js
 const container = document.querySelector('#example');


### PR DESCRIPTION
### Context
This PR updates grid size documentation page

### How has this been tested?
Locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2942#issuecomment-3520988787

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

[skip changelog]
