### PR TITLE
Add Formulas integration with Vue3 example to docs

### DIFF
--- a/docs/content/guides/integrate-with-vue3/vue3-formulas-example/vue/example1.html
+++ b/docs/content/guides/integrate-with-vue3/vue3-formulas-example/vue/example1.html
@@ -1,0 +1,3 @@
+<div id="example1">
+  <hot-table :settings="hotSettings"></hot-table>
+</div>

--- a/docs/content/guides/integrate-with-vue3/vue3-formulas-example/vue/example1.js
+++ b/docs/content/guides/integrate-with-vue3/vue3-formulas-example/vue/example1.js
@@ -1,0 +1,47 @@
+import { defineComponent, markRaw } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import { HyperFormula } from 'hyperformula';
+import 'handsontable/styles/handsontable.css';
+import 'handsontable/styles/ht-theme-main.css';
+
+// register Handsontable's modules
+registerAllModules();
+
+// mark the HyperFormula instance as raw to avoid Vue from proxying it
+const hfRaw = markRaw(
+  HyperFormula.buildEmpty({
+    licenseKey: 'internal-use-in-handsontable',
+  })
+);
+
+const ExampleComponent = defineComponent({
+  data() {
+    return {
+      hotSettings: {
+        themeName: 'ht-theme-main',
+        data: [
+          ['4', '=IF(A1>4, "TRUE", "FALSE")', 'C1'],
+          ['2', 'B2', '=A1+A2'],
+          ['3', 'B3', 'C3'],
+          ['4', 'B4', 'C4'],
+          ['5', 'B5', 'C5'],
+          ['6', 'B6', 'C6'],
+        ],
+        colHeaders: true,
+        height: 'auto',
+        autoWrapRow: true,
+        autoWrapCol: true,
+        licenseKey: 'non-commercial-and-evaluation',
+        formulas: {
+          engine: hfRaw,
+        },
+      },
+    };
+  },
+  components: {
+    HotTable,
+  },
+});
+
+export default ExampleComponent;

--- a/docs/content/guides/integrate-with-vue3/vue3-formulas-example/vue3-formulas-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-formulas-example/vue3-formulas-example.md
@@ -1,0 +1,75 @@
+---
+id: o47p9rb3
+title: Formulas integration in Vue 3
+metaTitle: Formulas integration in Vue 3 - Vue 3 Data Grid | Handsontable
+description: Integrate the Formulas plugin with your Vue 3 data grid.
+permalink: /vue3-formulas-example
+canonicalUrl: /vue3-formulas-example
+react:
+  id: b711n01r
+  metaTitle: Formulas integration in Vue 3 - Vue 3 Data Grid | Handsontable
+angular:
+  id: 4h37k7c4
+  metaTitle: Formulas integration in Vue 3 - Vue 3 Data Grid | Handsontable
+searchCategory: Guides
+category: Integrate with Vue 3
+---
+
+# Formulas integration in Vue 3
+
+Integrate the Formulas plugin with your Vue 3 data grid.
+
+[[toc]]
+
+## Overview
+
+You can use the Formulas plugin to perform Excel-like calculations in your business applications. It does it by an integration with our other product, [HyperFormula](https://hyperformula.handsontable.com/), which is a powerful calculation engine with an extensive number of features.
+
+[Find out more about the Formulas plugin](@/guides/formulas/formula-calculation/formula-calculation.md)
+
+## Example - Using the Formulas plugin
+
+When using HyperFormula with Vue 3, never let Vue make the HyperFormula instance reactive.
+Vue's proxying interferes with the internal state of the engine and leads to subtle bugs and performance issues.
+
+Wrap the instance with `markRaw()`:
+```js
+import { markRaw } from 'vue';
+import { HyperFormula } from 'hyperformula';
+
+const hfInstance = markRaw(HyperFormula.buildEmpty());
+```
+This keeps the engine untouched and ensures it behaves exactly as intended.
+
+::: example #example1 :vue3 --html 1 --js 2
+
+@[code](@/content/guides/integrate-with-vue3/vue3-formulas-example/vue/example1.html)
+@[code](@/content/guides/integrate-with-vue3/vue3-formulas-example/vue/example1.js)
+
+:::
+
+## Related articles
+
+### Related guides
+
+<div class="boxes-list gray">
+
+- [Formula calculation](@/guides/formulas/formula-calculation/formula-calculation.md)
+
+</div>
+
+### Related API reference
+
+- Configuration options:
+  - [`formulas`](@/api/options.md#formulas)
+- Core methods:
+  - [`getPlugin()`](@/api/core.md#getplugin)
+- Hooks:
+  - [`afterFormulasValuesUpdate`](@/api/hooks.md#afterformulasvaluesupdate)
+  - [`afterNamedExpressionAdded`](@/api/hooks.md#afternamedexpressionadded)
+  - [`afterNamedExpressionRemoved`](@/api/hooks.md#afternamedexpressionremoved)
+  - [`afterSheetAdded`](@/api/hooks.md#aftersheetadded)
+  - [`afterSheetRemoved`](@/api/hooks.md#aftersheetremoved)
+  - [`afterSheetRenamed`](@/api/hooks.md#aftersheetrenamed)
+- Plugins:
+  - [`Formulas`](@/api/formulas.md)

--- a/docs/content/guides/sidebar.js
+++ b/docs/content/guides/sidebar.js
@@ -48,6 +48,7 @@ const integrateWithVue3Items = [
   { path: 'guides/integrate-with-vue3/vue3-language-change-example/vue3-language-change-example' },
   { path: 'guides/integrate-with-vue3/vue3-vuex-example/vue3-vuex-example' },
   { path: 'guides/integrate-with-vue3/vue3-hot-reference/vue3-hot-reference' },
+  { path: 'guides/integrate-with-vue3/vue3-formulas-example/vue3-formulas-example' },
 ];
 
 const columnsItems = [


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR adds the Formulas integration with Vue3 example to Docs.

A new page to review: https://dev-handsontable-feature-dev-issue-2902.netlify.app/docs/javascript-data-grid/vue3-formulas-example/

_[skip changelog]_

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/2902

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
