### PR TITLE
Move `themeName` input to wrapper settings

### DIFF
--- a/docs/content/guides/tools-and-building/modules/modules.md
+++ b/docs/content/guides/tools-and-building/modules/modules.md
@@ -252,8 +252,8 @@ registerCellType(NumericCellType);
 @Component({
   standalone: true,
   imports: [HotTableModule],
-  template: ` <div>
-    <hot-table themeName="ht-theme-main" [settings]="gridSettings" />
+  template: `<div>
+    <hot-table [settings]="gridSettings" />
   </div>`,
 })
 export class ExampleComponent {
@@ -261,6 +261,7 @@ export class ExampleComponent {
   readonly hotTable!: HotTableComponent;
 
   readonly gridSettings = <GridSettings>{
+    themeName: "ht-theme-main",
     columns: [
       {
         type: "numeric",
@@ -367,8 +368,8 @@ registerValidator(numericValidator);
 @Component({
   standalone: true,
   imports: [HotTableModule],
-  template: ` <div>
-    <hot-table themeName="ht-theme-main" [settings]="gridSettings" />
+  template: `<div>
+    <hot-table [settings]="gridSettings" />
   </div>`,
 })
 export class ExampleComponent {
@@ -376,13 +377,13 @@ export class ExampleComponent {
   readonly hotTable!: HotTableComponent;
 
   readonly gridSettings = <GridSettings>{
+    themeName: "ht-theme-main",
     columns: [
       {
         renderer: "numeric",
         editor: "numeric",
         validator: "numeric",
         dataType: "number",
-        type: "numeric",
       },
     ],
   };


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Update Angular Docs examples by moving the `themeName` input to wrapper options.

_[skip changelog]_

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/2698

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
