### PR TITLE
Update Angular cell renderer documentation page

### DIFF
--- a/docs/content/guides/cell-functions/cell-renderer/angular/example2.ts
+++ b/docs/content/guides/cell-functions/cell-renderer/angular/example2.ts
@@ -9,14 +9,14 @@ import {GridSettings} from '@handsontable/angular-wrapper';
       [settings]="hotSettings!" [data]="hotData">
     </hot-table>
 
-    <ng-template #coverRenderer let-value>
+    <ng-template #myCellTpl let-value let-row="row" let-col="col">
       <img [src]="value" (mousedown)="$event.preventDefault()"/>
     </ng-template>
   `,
   standalone: false
 })
 export class AppComponent implements OnInit {
-  @ViewChild('coverRenderer', { static: true }) coverRendererTemplate!: TemplateRef<any>;
+  @ViewChild('myCellTpl', { static: true }) myCellTpl!: TemplateRef<any>;
 
   readonly hotData = [
     {
@@ -53,7 +53,7 @@ export class AppComponent implements OnInit {
       columns: [
         { data: 'title', renderer: 'html' },
         { data: 'description', renderer: 'html' },
-        { data: 'cover', renderer: this.coverRendererTemplate },
+        { data: 'cover', renderer: this.myCellTpl },
       ],
       autoWrapRow: true,
       autoWrapCol: true,

--- a/docs/content/guides/cell-functions/cell-renderer/cell-renderer.md
+++ b/docs/content/guides/cell-functions/cell-renderer/cell-renderer.md
@@ -290,6 +290,16 @@ If you'd like to register `asterixDecoratorRenderer` under alias `asterix` you h
 Handsontable.renderers.registerRenderer("asterix", asterixDecoratorRenderer);
 ```
 
+::: only-for angular
+
+::: tip
+
+When using `Handsontable.renderers.registerRenderer()`, remember to call it at startup (e.g. in `main.ts` or `AppModule`), not in the component constructor. This ensures the renderer is registered before the table is initialized.
+
+:::
+
+:::
+
 Choose aliases wisely. If you register your renderer under name that is already registered, the target function will be overwritten:
 
 ```js


### PR DESCRIPTION
### Context
This PR updates the Angular cell renderer documentation page to include additional information about `Handsontable.renderers.registerRenderer()`.

### How has this been tested?
Locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2697

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

[skip changelog]