### PR TITLE
[docs] Add information about the Angular version compatibility.

### DIFF
--- a/docs/content/guides/getting-started/installation/installation.md
+++ b/docs/content/guides/getting-started/installation/installation.md
@@ -176,14 +176,6 @@ export class HotTableWrapperComponent {
 }
 ```
 
-::: tip
-
-`@handsontable/angular-wrapper` requires at least Angular@16. If you use a lower version of Angular, you can use the `@handsontable/angular` package instead.
-
-For more information on `@handsontable/angular`, see the [15.3 documentation](https://handsontable.com/docs/15.3/javascript-data-grid/angular-installation/).
-
-:::
-
 ### Preview the result
 
 ::: example :angular --ts 1 --html 2
@@ -192,6 +184,19 @@ For more information on `@handsontable/angular`, see the [15.3 documentation](ht
 @[code](@/content/guides/getting-started/installation/angular/example1.html)
 
 :::
+
+## Supported versions of Angular
+`@handsontable/angular-wrapper` requires at least Angular@16. If you use a lower version of Angular, you can use the `@handsontable/angular` package instead.
+
+For more information on `@handsontable/angular`, see the [15.3 documentation](https://handsontable.com/docs/15.3/javascript-data-grid/angular-installation/).
+
+| Angular version | Handsontable wrapper                              |
+| ---------------- | ------------------------------------------------ |
+| Older than 16   | [@handsontable/angular](https://www.npmjs.com/package/@handsontable/angular) (deprecated)   |
+| 16 and newer    | [@handsontable/angular-wrapper](https://www.npmjs.com/package/@handsontable/angular-wrapper)        |
+
+### Troubleshooting
+If you're using Angular 21 or newer, please note that older versions of `@handsontable/angular-wrapper` are incompatible due to recent breaking changes in Angular. To ensure smooth integration, upgrade to `@handsontable/angular-wrapper@16.2` or later.
 
 :::
 


### PR DESCRIPTION
### Context
This PR adds information about the compatible Angular versions + information about Angular's `v21` breaking change.

[skip changelog]

### How has this been tested?
Tested locally

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
