### PR TITLE
Add more info about IME in different parts of docs

### DIFF
--- a/docs/content/guides/cell-functions/cell-editor/cell-editor.md
+++ b/docs/content/guides/cell-functions/cell-editor/cell-editor.md
@@ -221,6 +221,12 @@ When editor is prepared the [`EditorManager`](@/api/baseEditor.md) waits for use
 
 If any of those events is triggered, [`EditorManager`](@/api/baseEditor.md) calls editor's [`beginEditing()`](@/api/baseEditor.md#beginediting) method, which should display the editor.
 
+::: tip
+
+**IME support:** When using languages that require IME (Input Method Editor), such as Chinese, Japanese, or Korean, the editor opens through the standard edit mode (pressing Enter, F2, or double-clicking). To enable immediate typing into a selected cell without explicitly opening the editor, enable the [`imeFastEdit`](@/api/options.md#imefastedit) option. For more information, see the [IME support](@/guides/internationalization/ime-support/ime-support.md) guide.
+
+:::
+
 ##### Close editor
 
 When editor is opened the [`EditorManager`](@/api/baseEditor.md) waits for user event that should end cell edition. Those events are:
@@ -1275,6 +1281,7 @@ From now on, you can use `CustomEditor` like so:
 - Configuration options:
   - [`editor`](@/api/options.md#editor)
   - [`enterBeginsEditing`](@/api/options.md#enterbeginsediting)
+  - [`imeFastEdit`](@/api/options.md#imefastedit)
 - Core methods:
   - [`destroyEditor()`](@/api/core.md#destroyeditor)
   - [`getActiveEditor()`](@/api/core.md#getactiveeditor)

--- a/docs/content/guides/internationalization/language/language.md
+++ b/docs/content/guides/internationalization/language/language.md
@@ -229,8 +229,16 @@ Below is a list of features which can be translated:
 - Freezing
 - Merge cells
 - Read-only
+- Pagination
+- Dialogs (including Loading indicator)
 
 ## List of available languages
+
+::: tip
+
+When using languages that require IME (Input Method Editor), such as Chinese, Japanese, or Korean, consider enabling the [`imeFastEdit`](@/api/options.md#imefastedit) option to improve editing experience. For more information, see the [IME support](@/guides/internationalization/ime-support/ime-support.md) guide.
+
+:::
 
 By default, Handsontable uses the **English - United States** language-country set (`en-US` code) for creating the text of UI elements. However, it can be used like every extra, "non-standard" language file, thus the `en-US.js` file can be found in `/dist/languages`, `/languages` and `/src/languages` folders. Currently, we also distribute extra language-country files:
 
@@ -243,8 +251,8 @@ By default, Handsontable uses the **English - United States** language-country s
 - `fr-FR.js` for **French - France** (`fr-FR` code).
 - `hr-HR.js` for **Croatian - Croatia** (`hr-HR` code).
 - `it-IT.js` for **Italian - Italy** (`it-IT` code).
-- `ja-JP.js` for **Japanese - Japan** (`ja-JP` code).
-- `ko-KR.js` for **Korean - Korea** (`ko-KR` code).
+- `ja-JP.js` for **Japanese - Japan** (`ja-JP` code)**\***.
+- `ko-KR.js` for **Korean - Korea** (`ko-KR` code)**\***.
 - `lv-LV.js` for **Latvian - Latvia** (`lv-LV` code).
 - `nb-NO.js` for **Norwegian (Bokmål) - Norway** (`nb-NO` code).
 - `nl-NL.js` for **Dutch - Netherlands** (`nl-NL` code).
@@ -252,8 +260,10 @@ By default, Handsontable uses the **English - United States** language-country s
 - `pt-BR.js` for **Portuguese - Brazil** (`pt-BR` code).
 - `ru-RU.js` for **Russian - Russia** (`ru-RU` code).
 - `sr-SP.js` for **Serbian (Latin) - Serbia** (`sr-SP` code).
-- `zh-CN.js` for **Chinese - China** (`zh-CN` code).
-- `zh-TW.js` for **Chinese - Taiwan** (`zh-TW` code).
+- `zh-CN.js` for **Chinese - China** (`zh-CN` code)**\***.
+- `zh-TW.js` for **Chinese - Taiwan** (`zh-TW` code)**\***.
+
+**\*** Consider enabling the [`imeFastEdit`](@/api/options.md#imefastedit) option for better editing experience.
 
 ### Create custom languages
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR improves docs about IME.

_[skip changelog]_

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/2703

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
