### PR TITLE
Add the Pricing page link to the documentation footer links

### DIFF
--- a/docs/.vuepress/theme/components/PageEdit.vue
+++ b/docs/.vuepress/theme/components/PageEdit.vue
@@ -27,8 +27,8 @@
         <a href="https://handsontable.com/terms-of-use">Terms of use</a>
         <a href="https://handsontable.com/team">Team</a>
         <a href="https://handsontable.com/contact?category=technical_support">Contact</a>
-
         <a href="https://handsontable.com/blog/">Blog</a>
+        <a href="https://handsontable.com/pricing">Pricing</a>
         <a href="https://status.handsontable.com/" target="_blank" class="status">Status</a>
       </div>
     </div>

--- a/docs/.vuepress/theme/styles/layout/footer.styl
+++ b/docs/.vuepress/theme/styles/layout/footer.styl
@@ -91,6 +91,10 @@
                 padding: 0 4px
                 border-radius: $radius-s
 
+                &.status {
+                    white-space: nowrap;
+                }
+
                 &.status:before {
                     content:''
                     margin: 2px 6px


### PR DESCRIPTION
### Context
This PR updates the documentation footer links by adding the Pricing page link

### How has this been tested?
Locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. https://app.clickup.com/t/9015210959/MRK-838

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

[skip changelog]
