### PR TITLE
Remove allowInvalid from documentation demos

### DIFF
--- a/docs/content/guides/accessibility/accessibility/angular/example1.ts
+++ b/docs/content/guides/accessibility/accessibility/angular/example1.ts
@@ -511,7 +511,6 @@ export class AppComponent implements OnInit {
           data: 'sellDate',
           type: 'date',
           dateFormat: 'DD/MM/YYYY',
-          allowInvalid: false,
         },
         {
           data: 'inStock',

--- a/docs/content/guides/accessibility/accessibility/javascript/example1.js
+++ b/docs/content/guides/accessibility/accessibility/javascript/example1.js
@@ -495,7 +495,6 @@ const hotOptions = {
       data: 'sellDate',
       type: 'date',
       dateFormat: 'DD/MM/YYYY',
-      allowInvalid: false,
     },
     {
       data: 'inStock',

--- a/docs/content/guides/accessibility/accessibility/javascript/example1.ts
+++ b/docs/content/guides/accessibility/accessibility/javascript/example1.ts
@@ -508,7 +508,6 @@ const hotOptions: Handsontable.GridSettings = {
       data: 'sellDate',
       type: 'date',
       dateFormat: 'DD/MM/YYYY',
-      allowInvalid: false,
     },
     {
       data: 'inStock',

--- a/docs/content/guides/accessibility/accessibility/react/example2.jsx
+++ b/docs/content/guides/accessibility/accessibility/react/example2.jsx
@@ -529,7 +529,7 @@ const ExampleComponent = () => {
         {/* Define HotColumns for the data */}
         <HotColumn data="companyName" type="text" />
         <HotColumn data="productName" type="text" />
-        <HotColumn data="sellDate" dateFormat="DD/MM/YYYY" correctFormat type="date" allowInvalid={false} />
+        <HotColumn data="sellDate" dateFormat="DD/MM/YYYY" correctFormat type="date" />
         <HotColumn data="inStock" type="checkbox" className="htCenter" headerClassName="htCenter" />
         <HotColumn data="qty" type="numeric" headerClassName="htRight" />
         <HotColumn data="orderId" type="text" />

--- a/docs/content/guides/accessibility/accessibility/react/example2.tsx
+++ b/docs/content/guides/accessibility/accessibility/react/example2.tsx
@@ -552,7 +552,7 @@ const ExampleComponent = () => {
         {/* Define HotColumns for the data */}
         <HotColumn data="companyName" type="text" />
         <HotColumn data="productName" type="text" />
-        <HotColumn data="sellDate" dateFormat="DD/MM/YYYY" correctFormat type="date" allowInvalid={false} />
+        <HotColumn data="sellDate" dateFormat="DD/MM/YYYY" correctFormat type="date" />
         <HotColumn data="inStock" type="checkbox" className="htCenter" headerClassName="htCenter" />
         <HotColumn data="qty" type="numeric" headerClassName="htRight" />
         <HotColumn data="orderId" type="text" />

--- a/docs/content/guides/cell-functions/cell-validator/angular/example1.ts
+++ b/docs/content/guides/cell-functions/cell-validator/angular/example1.ts
@@ -147,7 +147,7 @@ export class AppComponent implements OnInit {
         { data: 'name.first' },
         { data: 'name.last' },
         { data: 'ip', validator: ipValidatorRegexp, allowInvalid: true },
-        { data: 'email', validator: emailValidator, allowInvalid: false },
+        { data: 'email', validator: emailValidator },
       ],
       autoWrapRow: true,
       autoWrapCol: true,

--- a/docs/content/guides/cell-functions/cell-validator/javascript/example1.js
+++ b/docs/content/guides/cell-functions/cell-validator/javascript/example1.js
@@ -130,7 +130,7 @@ new Handsontable(container, {
     { data: 'name.first' },
     { data: 'name.last' },
     { data: 'ip', validator: ipValidatorRegexp, allowInvalid: true },
-    { data: 'email', validator: emailValidator, allowInvalid: false },
+    { data: 'email', validator: emailValidator },
   ],
   autoWrapRow: true,
   autoWrapCol: true,

--- a/docs/content/guides/cell-functions/cell-validator/javascript/example1.ts
+++ b/docs/content/guides/cell-functions/cell-validator/javascript/example1.ts
@@ -131,7 +131,7 @@ new Handsontable(container, {
     { data: 'name.first' },
     { data: 'name.last' },
     { data: 'ip', validator: ipValidatorRegexp, allowInvalid: true },
-    { data: 'email', validator: emailValidator, allowInvalid: false },
+    { data: 'email', validator: emailValidator },
   ],
   autoWrapRow: true,
   autoWrapCol: true,

--- a/docs/content/guides/cell-functions/cell-validator/react/example1.jsx
+++ b/docs/content/guides/cell-functions/cell-validator/react/example1.jsx
@@ -134,7 +134,7 @@ const ExampleComponent = () => {
           { data: 'name.first' },
           { data: 'name.last' },
           { data: 'ip', validator: ipValidatorRegexp, allowInvalid: true },
-          { data: 'email', validator: emailValidator, allowInvalid: false },
+          { data: 'email', validator: emailValidator },
         ]}
       />
     </>

--- a/docs/content/guides/cell-functions/cell-validator/react/example1.tsx
+++ b/docs/content/guides/cell-functions/cell-validator/react/example1.tsx
@@ -136,7 +136,7 @@ const ExampleComponent = () => {
           { data: 'name.first' },
           { data: 'name.last' },
           { data: 'ip', validator: ipValidatorRegexp, allowInvalid: true },
-          { data: 'email', validator: emailValidator, allowInvalid: false },
+          { data: 'email', validator: emailValidator },
         ]}
       />
     </>

--- a/docs/content/guides/cell-types/autocomplete-cell-type/angular/example2.ts
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/angular/example2.ts
@@ -38,7 +38,7 @@ export class Example2AutocompleteCellTypeComponent {
     colHeaders: [
       'Car<br>(allowInvalid true)',
       'Year',
-      'Chassis color<br>(allowInvalid false)',
+      'Chassis color',
       'Bumper color<br>(allowInvalid true)',
     ],
     autoWrapRow: true,
@@ -54,7 +54,6 @@ export class Example2AutocompleteCellTypeComponent {
         type: 'autocomplete',
         source: colors,
         strict: true,
-        allowInvalid: false,
       },
       {
         type: 'autocomplete',

--- a/docs/content/guides/cell-types/autocomplete-cell-type/javascript/example2.js
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/javascript/example2.js
@@ -33,12 +33,7 @@ new Handsontable(container, {
     ['Chrysler', 2019, 'yellow', 'black'],
     ['Volvo', 2020, 'white', 'gray'],
   ],
-  colHeaders: [
-    'Car<br>(allowInvalid true)',
-    'Year',
-    'Chassis color<br>(allowInvalid false)',
-    'Bumper color<br>(allowInvalid true)',
-  ],
+  colHeaders: ['Car<br>(allowInvalid true)', 'Year', 'Chassis color', 'Bumper color<br>(allowInvalid true)'],
   columns: [
     {
       type: 'autocomplete',
@@ -51,7 +46,6 @@ new Handsontable(container, {
       type: 'autocomplete',
       source: colors,
       strict: true,
-      allowInvalid: false,
     },
     {
       type: 'autocomplete',

--- a/docs/content/guides/cell-types/autocomplete-cell-type/javascript/example2.ts
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/javascript/example2.ts
@@ -34,12 +34,7 @@ new Handsontable(container, {
     ['Chrysler', 2019, 'yellow', 'black'],
     ['Volvo', 2020, 'white', 'gray'],
   ],
-  colHeaders: [
-    'Car<br>(allowInvalid true)',
-    'Year',
-    'Chassis color<br>(allowInvalid false)',
-    'Bumper color<br>(allowInvalid true)',
-  ],
+  colHeaders: ['Car<br>(allowInvalid true)', 'Year', 'Chassis color', 'Bumper color<br>(allowInvalid true)'],
   columns: [
     {
       type: 'autocomplete',
@@ -52,7 +47,6 @@ new Handsontable(container, {
       type: 'autocomplete',
       source: colors,
       strict: true,
-      allowInvalid: false,
     },
     {
       type: 'autocomplete',

--- a/docs/content/guides/cell-types/autocomplete-cell-type/react/example2.jsx
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/react/example2.jsx
@@ -36,12 +36,7 @@ const ExampleComponent = () => {
         ['Chrysler', 2019, 'yellow', 'black'],
         ['Volvo', 2020, 'white', 'gray'],
       ]}
-      colHeaders={[
-        'Car<br>(allowInvalid true)',
-        'Year',
-        'Chassis color<br>(allowInvalid false)',
-        'Bumper color<br>(allowInvalid true)',
-      ]}
+      colHeaders={['Car<br>(allowInvalid true)', 'Year', 'Chassis color', 'Bumper color<br>(allowInvalid true)']}
       columns={[
         {
           type: 'autocomplete',
@@ -54,7 +49,6 @@ const ExampleComponent = () => {
           type: 'autocomplete',
           source: colors,
           strict: true,
-          allowInvalid: false,
         },
         {
           type: 'autocomplete',

--- a/docs/content/guides/cell-types/autocomplete-cell-type/react/example2.tsx
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/react/example2.tsx
@@ -36,12 +36,7 @@ const ExampleComponent = () => {
         ['Chrysler', 2019, 'yellow', 'black'],
         ['Volvo', 2020, 'white', 'gray'],
       ]}
-      colHeaders={[
-        'Car<br>(allowInvalid true)',
-        'Year',
-        'Chassis color<br>(allowInvalid false)',
-        'Bumper color<br>(allowInvalid true)',
-      ]}
+      colHeaders={['Car<br>(allowInvalid true)', 'Year', 'Chassis color', 'Bumper color<br>(allowInvalid true)']}
       columns={[
         {
           type: 'autocomplete',
@@ -54,7 +49,6 @@ const ExampleComponent = () => {
           type: 'autocomplete',
           source: colors,
           strict: true,
-          allowInvalid: false,
         },
         {
           type: 'autocomplete',

--- a/docs/content/guides/getting-started/demo/angular/example1.ts
+++ b/docs/content/guides/getting-started/demo/angular/example1.ts
@@ -1296,7 +1296,7 @@ export class Example1DemoComponent {
     columns: [
       { data: 1 },
       { data: 3 },
-      { data: 4, type: 'date', allowInvalid: false },
+      { data: 4, type: 'date' },
       { data: 6, type: 'checkbox', className: 'htCenter' },
       { data: 7, type: 'numeric' },
       { data: 5 },

--- a/docs/content/guides/getting-started/demo/javascript/example.js
+++ b/docs/content/guides/getting-started/demo/javascript/example.js
@@ -165,7 +165,6 @@ new Handsontable(example, {
     {
       data: 4,
       type: 'date',
-      allowInvalid: false,
       dateFormat: 'DD/MM/YYYY',
     },
     {

--- a/docs/content/guides/getting-started/demo/javascript/example.ts
+++ b/docs/content/guides/getting-started/demo/javascript/example.ts
@@ -174,7 +174,6 @@ new Handsontable(example, {
     {
       data: 4,
       type: 'date',
-      allowInvalid: false,
       dateFormat: 'DD/MM/YYYY',
     },
     {

--- a/docs/content/guides/getting-started/demo/react/example2.jsx
+++ b/docs/content/guides/getting-started/demo/react/example2.jsx
@@ -183,7 +183,7 @@ const App = () => {
     >
       <HotColumn data={1} />
       <HotColumn data={3} />
-      <HotColumn data={4} type="date" allowInvalid={false} />
+      <HotColumn data={4} type="date" />
       <HotColumn data={6} type="checkbox" className="htCenter" />
       <HotColumn data={7} type="numeric" />
       <HotColumn data={5} />

--- a/docs/content/guides/getting-started/demo/react/example2.tsx
+++ b/docs/content/guides/getting-started/demo/react/example2.tsx
@@ -191,7 +191,7 @@ const App = () => {
     >
       <HotColumn data={1} />
       <HotColumn data={3} />
-      <HotColumn data={4} type="date" allowInvalid={false} />
+      <HotColumn data={4} type="date" />
       <HotColumn data={6} type="checkbox" className="htCenter" />
       <HotColumn data={7} type="numeric" />
       <HotColumn data={5} />

--- a/docs/content/guides/styling/themes/angular/example1.ts
+++ b/docs/content/guides/styling/themes/angular/example1.ts
@@ -1341,7 +1341,6 @@ export class AppComponent implements OnInit, AfterViewInit {
         {
           data: 4,
           type: 'date',
-          allowInvalid: false,
           dateFormat: 'DD/MM/YYYY',
           headerClassName: 'htLeft',
         },

--- a/docs/content/guides/styling/themes/javascript/exampleTheme.js
+++ b/docs/content/guides/styling/themes/javascript/exampleTheme.js
@@ -144,7 +144,6 @@ const hotInstance = new Handsontable(example, {
     {
       data: 4,
       type: 'date',
-      allowInvalid: false,
       dateFormat: 'DD/MM/YYYY',
       headerClassName: 'htLeft',
     },

--- a/docs/content/guides/styling/themes/javascript/exampleTheme.ts
+++ b/docs/content/guides/styling/themes/javascript/exampleTheme.ts
@@ -147,7 +147,6 @@ const hotInstance = new Handsontable(example, {
     {
       data: 4,
       type: 'date',
-      allowInvalid: false,
       dateFormat: 'DD/MM/YYYY',
       headerClassName: 'htLeft',
     },

--- a/docs/content/guides/styling/themes/react/exampleTheme.jsx
+++ b/docs/content/guides/styling/themes/react/exampleTheme.jsx
@@ -188,7 +188,7 @@ const ExampleComponent = () => {
       >
         <HotColumn data={1} />
         <HotColumn data={3} />
-        <HotColumn data={4} type="date" allowInvalid={false} />
+        <HotColumn data={4} type="date" />
         <HotColumn data={6} type="checkbox" className="htCenter" />
         <HotColumn data={7} type="numeric" />
         <HotColumn data={5} />

--- a/docs/content/guides/styling/themes/react/exampleTheme.tsx
+++ b/docs/content/guides/styling/themes/react/exampleTheme.tsx
@@ -188,7 +188,7 @@ const ExampleComponent = () => {
       >
         <HotColumn data={1} />
         <HotColumn data={3} />
-        <HotColumn data={4} type="date" allowInvalid={false} />
+        <HotColumn data={4} type="date" />
         <HotColumn data={6} type="checkbox" className="htCenter" />
         <HotColumn data={7} type="numeric" />
         <HotColumn data={5} />


### PR DESCRIPTION
### Context
This PR removes the allowInvalid option from all documentation demos 

### How has this been tested?
Locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2646

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

[skip changelog]
