### PR TITLE
replacing docs example from stackblizt to codesanbox

### DIFF
--- a/docs/content/guides/getting-started/introduction/introduction.md
+++ b/docs/content/guides/getting-started/introduction/introduction.md
@@ -50,7 +50,7 @@ Use Handsontable with plain JavaScript, TypeScript, or your favorite framework. 
 - [Angular](https://handsontable.com/stackblitz?example-dir=angular&handsontable-version={{$currentVersion}})
 - [Vanilla JS](https://handsontable.com/stackblitz?example-dir=javascript&handsontable-version={{$currentVersion}})
 - [React TS](https://handsontable.com/stackblitz?example-dir=react&handsontable-version={{$currentVersion}})
-- [React JS](https://handsontable.com/stackblitz?example-dir=react-js&handsontable-version={{$currentVersion}})
+- [React JS](https://handsontable.com/codesandbox?example-dir=react-js&handsontable-version={{$currentVersion}})
 - [TypeScript](https://handsontable.com/stackblitz?example-dir=typescript&handsontable-version={{$currentVersion}})
 - [Vue 3](https://handsontable.com/stackblitz?example-dir=vue&handsontable-version={{$currentVersion}})
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->

https://handsontable.com/codesandbox?example-dir=react generates working exmaple much faster than 
https://handsontable.com/stackblitz?example-dir=react


### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]