### PR TITLE
Prevent viewport scroll after loadData/updateData call

### DIFF
--- a/.changelogs/11985.json
+++ b/.changelogs/11985.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed an issue with viewport scroll after loadData/updateData method call",
+  "type": "fixed",
+  "issueOrPR": 11985,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -561,8 +561,12 @@ export default function Core(rootContainer, userSettings, rootInstanceSymbol = f
       selectionLayerLevel
     );
 
+    const selectionSource = selection.getSelectionSource();
+    const ignoreScrollSources = ['loadData', 'updateData'];
+
     if (
       isLastSelectionLayer &&
+      !ignoreScrollSources.includes(selectionSource) &&
       (!preventScrolling.isTouched() || preventScrolling.isTouched() && !preventScrolling.value)
     ) {
       viewportScroller.scrollTo(cellCoords);
@@ -589,11 +593,11 @@ export default function Core(rootContainer, userSettings, rootInstanceSymbol = f
       removeClass(this.rootElement, ['ht__selection--rows', 'ht__selection--columns']);
     }
 
-    if (!['shift', 'refresh'].includes(selection.getSelectionSource())) {
+    if (!['shift', 'refresh', 'loadData', 'updateData'].includes(selectionSource)) {
       editorManager.closeEditor(null);
     }
 
-    if (selection.getSelectionSource() !== 'refresh') {
+    if (!['refresh', 'loadData', 'updateData'].includes(selectionSource)) {
       instance.view.render();
       editorManager.prepareEditor();
     }
@@ -2463,7 +2467,9 @@ export default function Core(rootContainer, userSettings, rootInstanceSymbol = f
         instance.rowIndexMapper.fitToLength(this.countSourceRows());
 
         grid.adjustRowsAndCols();
+        selection.markSource('updateData');
         selection.refresh();
+        selection.markEndSource();
       }, {
         hotInstance: instance,
         dataMap: datamap,
@@ -2507,7 +2513,9 @@ export default function Core(rootContainer, userSettings, rootInstanceSymbol = f
         metaManager.clearCellsCache();
         instance.initIndexMappers();
         grid.adjustRowsAndCols();
+        selection.markSource('loadData');
         selection.refresh();
+        selection.markEndSource();
 
         if (firstRun) {
           firstRun = [null, 'loadData'];

--- a/handsontable/src/selection/__tests__/selection/refresh.spec.js
+++ b/handsontable/src/selection/__tests__/selection/refresh.spec.js
@@ -154,5 +154,63 @@ describe('Selection', () => {
         | - ║   :   :   :   :   : 0 :   :   |
         `).toBeMatchToSelectionPattern();
     });
+
+    it('should mark the source as "refresh" by default', async() => {
+      let selectionSource = null;
+
+      handsontable({
+        data: createSpreadsheetData(8, 8),
+        rowHeaders: true,
+        colHeaders: true,
+        afterSelection() {
+          selectionSource = selection().getSelectionSource();
+        },
+      });
+
+      await selectCell(1, 1, 3, 3);
+
+      selection().refresh();
+
+      expect(selectionSource).toBe('refresh');
+    });
+
+    it('should be possible to change the source of the refresh call', async() => {
+      let selectionSource = null;
+
+      handsontable({
+        data: createSpreadsheetData(8, 8),
+        rowHeaders: true,
+        colHeaders: true,
+        afterSelection() {
+          selectionSource = selection().getSelectionSource();
+        },
+      });
+
+      await selectCell(1, 1, 3, 3);
+
+      selection().markSource('test');
+      selection().refresh();
+
+      expect(selectionSource).toBe('test');
+    });
+
+    it('should scroll the viewport to the focused cell after refresh call with default source', async() => {
+      handsontable({
+        data: createSpreadsheetData(20, 20),
+        width: 200,
+        height: 200,
+      });
+
+      await selectCell(0, 0);
+      await scrollViewportTo({
+        row: 19,
+        col: 19,
+      });
+
+      selection().refresh();
+
+      expect(inlineStartOverlay().getScrollPosition()).toBe(0);
+      expect(topOverlay().getScrollPosition()).toBe(0);
+    });
   });
 });

--- a/handsontable/src/selection/selection.js
+++ b/handsontable/src/selection/selection.js
@@ -1315,8 +1315,11 @@ class Selection {
     }
 
     const ranges = this.selectedRange.ranges.map(range => range.clone());
+    const selectionSource = this.getSelectionSource();
 
-    this.markSource('refresh');
+    if (selectionSource === 'unknown') {
+      this.markSource('refresh');
+    }
 
     const selectedByRowHeader = new Set(this.selectedByRowHeader);
     const selectedByColumnHeader = new Set(this.selectedByColumnHeader);

--- a/handsontable/test/e2e/core/loadData.spec.js
+++ b/handsontable/test/e2e/core/loadData.spec.js
@@ -1136,4 +1136,26 @@ describe('Core.loadData', () => {
     expect(tableView().getTotalTableWidth()).toBe(getDefaultColumnWidth() * 5);
     expect(tableView().getTotalTableHeight()).toBe((getDefaultRowHeight() * 7) + 1);
   });
+
+  it('should not scroll the viewport to the focused cell after loading new data', async() => {
+    handsontable({
+      data: createSpreadsheetData(20, 20),
+      width: 200,
+      height: 200,
+    });
+
+    await selectCell(0, 0);
+    await scrollViewportTo({
+      row: 19,
+      col: 19,
+    });
+
+    const inlineStartPosition = inlineStartOverlay().getScrollPosition();
+    const topPosition = topOverlay().getScrollPosition();
+
+    await loadData(createSpreadsheetData(20, 20));
+
+    expect(inlineStartOverlay().getScrollPosition()).toBe(inlineStartPosition);
+    expect(topOverlay().getScrollPosition()).toBe(topPosition);
+  });
 });

--- a/handsontable/test/e2e/core/updateData.spec.js
+++ b/handsontable/test/e2e/core/updateData.spec.js
@@ -1,4 +1,4 @@
-describe('Core_updateData', () => {
+describe('Core.updateData', () => {
   const id = 'testContainer';
 
   beforeEach(function() {
@@ -69,14 +69,6 @@ describe('Core_updateData', () => {
     ['<b>H&M</b>']
   ];
 
-  it('should allow array of arrays', async() => {
-    handsontable();
-
-    await updateData(arrayOfArrays());
-
-    expect(getDataAtCell(0, 2)).toEqual('Nissan');
-  });
-
   it('should load data properly when it is defined as an array of objects #4204', async() => {
     handsontable({});
 
@@ -96,6 +88,14 @@ describe('Core_updateData', () => {
     ]);
   });
 
+  it('should allow array of arrays', async() => {
+    handsontable();
+
+    await updateData(arrayOfArrays());
+
+    expect(getDataAtCell(0, 2)).toEqual('Nissan');
+  });
+
   it('should allow array of objects', async() => {
     handsontable({
       columns: [
@@ -104,6 +104,7 @@ describe('Core_updateData', () => {
         { data: 'name' }
       ]
     });
+
     await updateData(arrayOfObjects());
 
     expect(getDataAtCell(0, 2)).toEqual('Ted');
@@ -186,10 +187,11 @@ describe('Core_updateData', () => {
     });
 
     await updateData(arrayOfNestedObjects());
+
     expect(getDataAtCell(0, 2)).toEqual('Right');
   });
 
-  it('should trigger onChange callback when loaded array of arrays', async() => {
+  it('should trigger afterChange callback when loaded array of arrays', async() => {
     let called = false;
 
     handsontable({
@@ -205,7 +207,7 @@ describe('Core_updateData', () => {
     expect(called).toEqual(true);
   });
 
-  it('should trigger onChange callback when loaded array of objects', async() => {
+  it('should trigger afterChange callback when loaded array of objects', async() => {
     let called = false;
 
     handsontable({
@@ -221,7 +223,7 @@ describe('Core_updateData', () => {
     expect(called).toEqual(true);
   });
 
-  it('should trigger onChange callback when loaded array of nested objects', async() => {
+  it('should trigger afterChange callback when loaded array of nested objects', async() => {
     let called = false;
 
     handsontable({
@@ -243,6 +245,7 @@ describe('Core_updateData', () => {
     });
 
     await updateData(arrayOfArrays());
+
     expect(countRows()).toEqual(20); // TODO why this must be checked after render?
   });
 
@@ -252,6 +255,7 @@ describe('Core_updateData', () => {
     });
 
     await updateData(arrayOfNestedObjects());
+
     expect(countRows()).toEqual(20); // TODO why this must be checked after render?
   });
 
@@ -269,6 +273,7 @@ describe('Core_updateData', () => {
     });
 
     await updateData(arrayOfObjects());
+
     expect(getCell(9, 1).innerHTML).toEqual('Eve');
   });
 
@@ -335,9 +340,7 @@ describe('Core_updateData', () => {
     });
 
     await updateData(data1);
-
     await selectCell(7, 0);
-
     await updateData(data2);
 
     expect(countRows()).toBe(data2.length);
@@ -371,9 +374,7 @@ describe('Core_updateData', () => {
     });
 
     await updateData(data1);
-
     await selectCell(8, 0);
-
     await updateData(data2);
 
     expect(countRows()).toBe(6); // +1 because of minSpareRows
@@ -400,9 +401,7 @@ describe('Core_updateData', () => {
     });
 
     await updateData(data1);
-
     await selectCell(7, 0);
-
     await updateData(data2);
 
     expect(countRows()).toBe(0);
@@ -602,8 +601,9 @@ describe('Core_updateData', () => {
     expect(countRows()).toBe(3);
   });
 
-  it('should NOT clear cell properties after updateData', async() => {
+  it('should not clear cell properties after updateData', async() => {
     handsontable();
+
     await updateData(arrayOfArrays());
 
     getCellMeta(0, 0).foo = 'bar';
@@ -613,6 +613,22 @@ describe('Core_updateData', () => {
     await updateData(arrayOfArrays());
 
     expect(getCellMeta(0, 0).foo).toEqual('bar');
+  });
+
+  it('should not clear cell properties after updateData, but before rendering new data', async() => {
+    handsontable();
+
+    await updateData(arrayOfArrays());
+
+    getCellMeta(0, 0).valid = false;
+
+    await render();
+
+    expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').hasClass('htInvalid')).toEqual(true);
+
+    await updateData(arrayOfArrays());
+
+    expect(spec().$container.find('tbody tr:eq(0) td:eq(0)').hasClass('htInvalid')).toEqual(true);
   });
 
   it('should not reinitialize index mappers after calling updateData', async() => {
@@ -658,15 +674,20 @@ describe('Core_updateData', () => {
     });
 
     await updateData(objectData);
-
     await mouseDoubleClick(getCell(1, 1));
+
     document.activeElement.value = 'Harry';
+
     await deselectCell();
+
     expect(objectData[1].user.name.first).toEqual('Harry');
 
     await mouseDoubleClick(getCell(2, 1));
+
     document.activeElement.value = 'Barry';
+
     await deselectCell();
+
     expect(objectData[2].user.name.first).toEqual('Barry');
   });
 
@@ -697,19 +718,24 @@ describe('Core_updateData', () => {
     });
 
     await updateData(objectData);
-
     await mouseDoubleClick(getCell(1, 1));
+
     document.activeElement.value = 'Harry';
+
     await deselectCell();
+
     expect(objectData[1].user.name.first).toEqual('Harry');
 
     await mouseDoubleClick(getCell(2, 1));
+
     document.activeElement.value = 'Barry';
+
     await deselectCell();
+
     expect(objectData[2].user.name.first).toEqual('Barry');
   });
 
-  it('should create new data schema after loading data', async() => {
+  it('should create new data schema after updating data', async() => {
     handsontable({
     });
 
@@ -718,6 +744,28 @@ describe('Core_updateData', () => {
 
     expect(getSourceData()).toEqual(arrayOfArrays());
     expect(getData()).toEqual(arrayOfArrays());
+  });
+
+  it('should pass the `source` argument to the `beforeUpdateData` and `afterUpdateData` hooks', async() => {
+    let correctSourceCount = 0;
+
+    handsontable({
+      data: arrayOfObjects(),
+      beforeUpdateData: (data, firstRun, source) => {
+        if (source === 'testSource') {
+          correctSourceCount += 1;
+        }
+      },
+      afterUpdateData: (data, firstRun, source) => {
+        if (source === 'testSource') {
+          correctSourceCount += 1;
+        }
+      }
+    });
+
+    await updateData(arrayOfArrays(), 'testSource');
+
+    expect(correctSourceCount).toEqual(2);
   });
 
   it('should pass the `source` argument to the `beforeUpdateData` and `afterUpdateData` hooks', async() => {
@@ -737,9 +785,52 @@ describe('Core_updateData', () => {
     });
 
     await updateData(arrayOfObjects());
-
     await updateData(arrayOfArrays(), 'testSource');
 
     expect(correctSourceCount).toEqual(2);
+  });
+
+  it('should adjust the container size after loading new data (loading more columns)', async() => {
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+    });
+
+    await updateData(createSpreadsheetData(5, 7));
+
+    expect(tableView().getTotalTableWidth()).toBe(getDefaultColumnWidth() * 7);
+    expect(tableView().getTotalTableHeight()).toBe((getDefaultRowHeight() * 5) + 1);
+  });
+
+  it('should adjust the container size after loading new data (loading more rows)', async() => {
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+    });
+
+    await updateData(createSpreadsheetData(7, 5));
+
+    expect(tableView().getTotalTableWidth()).toBe(getDefaultColumnWidth() * 5);
+    expect(tableView().getTotalTableHeight()).toBe((getDefaultRowHeight() * 7) + 1);
+  });
+
+  it('should not scroll the viewport to the focused cell after updating new data', async() => {
+    handsontable({
+      data: createSpreadsheetData(20, 20),
+      width: 200,
+      height: 200,
+    });
+
+    await selectCell(0, 0);
+    await scrollViewportTo({
+      row: 19,
+      col: 19,
+    });
+
+    const inlineStartPosition = inlineStartOverlay().getScrollPosition();
+    const topPosition = topOverlay().getScrollPosition();
+
+    await updateData(createSpreadsheetData(20, 20));
+
+    expect(inlineStartOverlay().getScrollPosition()).toBe(inlineStartPosition);
+    expect(topOverlay().getScrollPosition()).toBe(topPosition);
   });
 });


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes an issue where the viewport would unexpectedly scroll back to the focused cell after calling `loadData()` or `updateData()`. Now the viewport maintains its scroll position after these operations. 

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally, and I covered the fix with new tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/3026

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
