### PR TITLE
Fix a bug where the pasted value cannot be changed

### DIFF
--- a/.changelogs/11989.json
+++ b/.changelogs/11989.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed a bug where the pasted value cannot be changed",
+  "type": "fixed",
+  "issueOrPR": 11989,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .idea
 .vscode
 .cache
+.cursor
 dev*.html
 dev*.js
 npm-debug.log

--- a/handsontable/src/plugins/copyPaste/__tests__/hooks/beforePaste.spec.js
+++ b/handsontable/src/plugins/copyPaste/__tests__/hooks/beforePaste.spec.js
@@ -34,5 +34,60 @@ describe('CopyPaste', () => {
 
       expect(getDataAtCol(1)).toEqual(['B1', 'B2', 'B3', 'B4', 'B5']);
     });
+
+    it('should be possible to modify the pasted data in beforePaste hook (scalar values)', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        copyPaste: true,
+        beforePaste(pastedData) {
+          for (let r = 0; r < pastedData.length; r++) {
+            for (let c = 0; c < pastedData[r].length; c++) {
+              pastedData[r][c] = 'test';
+            }
+          }
+        },
+      });
+
+      const plugin = getPlugin('CopyPaste');
+
+      await selectCell(1, 1);
+
+      plugin.paste('a\na\na\na');
+
+      expect(getDataAtCol(1)).toEqual(['B1', 'test', 'test', 'test', 'test']);
+    });
+
+    it('should be possible to modify the pasted data in beforePaste hook (object values)', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5).map(row => row.map(() => ({ name: 'test', code: '0' }))),
+        renderer(hot, td, row, col, prop, value) {
+          td.textContent = `${value.name}: ${value.code}`;
+        },
+        colHeaders: true,
+        copyPaste: true,
+        beforePaste(pastedData) {
+          for (let r = 0; r < pastedData.length; r++) {
+            for (let c = 0; c < pastedData[r].length; c++) {
+              pastedData[r][c] = { name: 'test', code: 'test' };
+            }
+          }
+        },
+      });
+
+      const plugin = getPlugin('CopyPaste');
+
+      await selectCell(1, 1);
+
+      plugin.paste('a\na\na\na');
+
+      expect(getDataAtCol(1)).toEqual([
+        { name: 'test', code: '0' },
+        { name: 'test', code: 'test' },
+        { name: 'test', code: 'test' },
+        { name: 'test', code: 'test' },
+        { name: 'test', code: 'test' },
+      ]);
+    });
   });
 });

--- a/handsontable/src/plugins/copyPaste/copyPaste.js
+++ b/handsontable/src/plugins/copyPaste/copyPaste.js
@@ -3,7 +3,7 @@ import { Hooks } from '../../core/hooks';
 import { stringify, parse } from '../../3rdparty/SheetClip';
 import { arrayEach } from '../../helpers/array';
 import { sanitize, isJSON } from '../../helpers/string';
-import { isObject } from '../../helpers/object';
+import { isObject, deepClone } from '../../helpers/object';
 import {
   removeContentEditableFromElementAndDeselect,
   runWithSelectedContendEditableElement,
@@ -532,18 +532,20 @@ export class CopyPaste extends BasePlugin {
    * Prepares new values to populate them into datasource.
    *
    * @private
-   * @param {Array} inputArray An array of the data to populate.
-   * @param {Array} sourceInputArray An array of the source data to populate.
-   * @param {Array} [selection] The selection which indicates from what position the data will be populated.
-   * @returns {Array} Range coordinates after populate data.
+   * @param {object} pasteData An object with the data to populate.
+   * @param {object} pasteData.plainData The plain data to populate.
+   * @param {object} pasteData.sourceData The source data to populate.
+   * @param {object} pasteData.originalPlainData The original plain data before user modifications in beforePaste.
+   * @returns {number[]} Range coordinates after populate data.
    */
-  populateValues(inputArray, sourceInputArray, selection = this.hot.getSelectedRangeActive()) {
-    if (!inputArray.length) {
+  populateValues({ plainData, originalPlainData, sourceData }) {
+    if (!plainData.length) {
       return [null, null, null, null];
     }
 
-    const populatedRowsLength = inputArray.length;
-    const populatedColumnsLength = inputArray[0].length;
+    const selection = this.hot.getSelectedRangeActive();
+    const populatedRowsLength = plainData.length;
+    const populatedColumnsLength = plainData[0].length;
     const newRows = [];
 
     const { row: startRow, col: startColumn } = selection.getTopStartCorner();
@@ -590,10 +592,11 @@ export class CopyPaste extends BasePlugin {
 
         lastVisualColumn = visualCol;
 
-        const sourceCellValue = sourceInputArray?.[insertedRow]?.[insertedColumn];
-        let cellValue = inputArray[insertedRow][insertedColumn];
+        const sourceCellValue = sourceData?.[insertedRow]?.[insertedColumn];
+        const originalCellValue = originalPlainData?.[insertedRow]?.[insertedColumn];
+        let cellValue = plainData[insertedRow][insertedColumn];
 
-        if (sourceInputArray && isJSON(sourceCellValue)) {
+        if (sourceData && isJSON(sourceCellValue) && cellValue === originalCellValue) {
           const parsedCellValue = JSON.parse(sourceCellValue);
 
           if (isObject(sourceDataAtTarget) || sourceDataAtTarget === null) {
@@ -801,11 +804,19 @@ export class CopyPaste extends BasePlugin {
       return;
     }
 
+    // Store a copy of the original pasted data before user can modify it in beforePaste hook.
+    // This is needed to detect if user modified values and respect their modifications over source data.
+    const originalPastedData = deepClone(pastedData);
+
     if (this.hot.runHooks('beforePaste', pastedData, this.copyableRanges) === false) {
       return;
     }
 
-    const [startRow, startColumn, endRow, endColumn] = this.populateValues(pastedData, pastedSourceData);
+    const [startRow, startColumn, endRow, endColumn] = this.populateValues({
+      plainData: pastedData,
+      sourceData: pastedSourceData,
+      originalPlainData: originalPastedData,
+    });
 
     if (startRow !== null && startColumn !== null) {
       this.hot.selectCell(


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR fixes a bug in the _CopyPaste_ plugin where values modified in the `beforePaste` hook were being overwritten by source data when pasting JSON/object values.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally, and I covered the fix with a test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/3024

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
