### PR TITLE
Fix misalignment issues for CSS scale

### DIFF
--- a/.changelogs/11990.json
+++ b/.changelogs/11990.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed misalignment issues for CSS transform: scale()",
+  "type": "fixed",
+  "issueOrPR": 11990,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/helpers/dom/__tests__/element.unit.js
+++ b/handsontable/src/helpers/dom/__tests__/element.unit.js
@@ -14,6 +14,8 @@ import {
   isVisible,
   findFirstParentWithClass,
   isHTMLElement,
+  outerHeight,
+  outerWidth,
 } from 'handsontable/helpers/dom/element';
 import { setPlatformMeta } from 'handsontable/helpers/browser';
 
@@ -834,6 +836,40 @@ describe('DomElement helper', () => {
       const element = document.createElement('div');
 
       expect(isHTMLElement(element)).toBe(true);
+    });
+  });
+
+  //
+  // Handsontable.helper.outerHeight
+  //
+  describe('outerHeight', () => {
+    // Make sure that the value is returned from the element's offsetHeight property,
+    // not from getBoundingClientRect().height. The second returns a value after applying
+    // the CSS transform matrix, which when passed to element.style.height for example
+    // results in a different value, hence misalignments.
+    it('should return value from offsetHeight', () => {
+      const elementMock = {
+        offsetHeight: 100,
+      };
+
+      expect(outerHeight(elementMock)).toBe(100);
+    });
+  });
+
+  //
+  // Handsontable.helper.outerWidth
+  //
+  describe('outerWidth', () => {
+    // Make sure that the value is returned from the element's offsetHeight property,
+    // not from getBoundingClientRect().height. The second returns a value after applying
+    // the CSS transform matrix, which when passed to element.style.height for example
+    // results in a different value, hence misalignments.
+    it('should return value from offsetWidth', () => {
+      const elementMock = {
+        offsetWidth: 100,
+      };
+
+      expect(outerWidth(elementMock)).toBe(100);
     });
   });
 

--- a/handsontable/src/helpers/dom/element.js
+++ b/handsontable/src/helpers/dom/element.js
@@ -834,7 +834,7 @@ export function outerWidth(element) {
  * @returns {number} Element's outer height.
  */
 export function outerHeight(element) {
-  return element.getBoundingClientRect().height;
+  return element.offsetHeight;
 }
 
 /**


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Fixes `outerHeight()` helper to use `offsetHeight` instead of `getBoundingClientRect().height`, making it consistent with `outerWidth()`, which already uses `offsetWidth`.

When CSS `transform: scale()` is applied to elements (or their parents), `getBoundingClientRect()` returns the scaled dimensions, while `offsetHeight`/`offsetWidth` return the original dimensions before the transform is applied. Using scaled values for internal calculations and then applying them back to element styling (e.g., `element.style.height = offsetHeight()`) causes visual misalignments because the browser applies the transform again to the already-scaled value.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
I tested the changes locally, and I covered the fix with a new test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/2969

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
