### PR TITLE
Fix UndoRedo crash when nullified changes

### DIFF
--- a/.changelogs/12000.json
+++ b/.changelogs/12000.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fix UndoRedo crash when nullified changes",
+  "type": "fixed",
+  "issueOrPR": 12000,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/undoRedo/__tests__/UndoRedo.spec.js
+++ b/handsontable/src/plugins/undoRedo/__tests__/UndoRedo.spec.js
@@ -2298,4 +2298,78 @@ describe('UndoRedo', () => {
 
     expect(getPlugin('undoRedo').isUndoAvailable()).toBe(true);
   });
+
+  it('should only record changes in undo stack that are not nullified by beforeChange hook', async() => {
+    handsontable({
+      data: createSpreadsheetData(2, 2),
+      beforeChange(changes) {
+        // Nullify changes made in the second column (index 1)
+        for (let i = 0; i < changes.length; i++) {
+          if (changes[i] && changes[i][1] === 1) {
+            changes[i] = null;
+          }
+        }
+      }
+    });
+
+    await setDataAtCell([
+      [0, 0, 'X1'],
+      [0, 1, 'Y1'], // Will be nullified
+      [1, 0, 'X2'],
+      [1, 1, 'Y2'], // Will be nullified
+    ]);
+
+    const undoPlugin = getPlugin('undoRedo');
+    const lastAction = undoPlugin.doneActions[undoPlugin.doneActions.length - 1];
+
+    expect(lastAction.changes.length).toBe(2);
+
+    expect(lastAction.changes.every(change => change[1] === 0)).toBe(true);
+  });
+
+  it('should undo only changes that are not nullified by beforeChange hook', async() => {
+    handsontable({
+      data: createSpreadsheetData(2, 2),
+      beforeChange(changes) {
+        // Nullify changes made in the second column (index 1)
+        for (let i = 0; i < changes.length; i++) {
+          if (changes[i] && changes[i][1] === 1) {
+            changes[i] = null;
+          }
+        }
+      }
+    });
+
+    await setDataAtCell(0, 0, 'X1');
+    await setDataAtCell(0, 1, 'Y1'); // Will be nullified
+
+    expect(getDataAtCell(0, 0)).toBe('X1');
+    expect(getDataAtCell(0, 1)).toBe('B1'); // Unchanged because nullified
+
+    expect(getPlugin('undoRedo').isUndoAvailable()).toBe(true);
+
+    getPlugin('undoRedo').undo();
+
+    expect(getDataAtCell(0, 0)).toBe('A1');
+    expect(getDataAtCell(0, 1)).toBe('B1');
+
+    expect(getPlugin('undoRedo').isUndoAvailable()).toBe(false);
+  });
+
+  it('should not add to undo stack when all changes are nullified by beforeChange hook', async() => {
+    handsontable({
+      data: createSpreadsheetData(2, 2),
+      beforeChange(changes) {
+        for (let i = 0; i < changes.length; i++) {
+          changes[i] = null;
+        }
+      }
+    });
+
+    await setDataAtCell(0, 0, 'X1');
+
+    expect(getDataAtCell(0, 0)).toBe('A1');
+
+    expect(getPlugin('undoRedo').isUndoAvailable()).toBe(false);
+  });
 });

--- a/handsontable/src/plugins/undoRedo/actions/dataChange.js
+++ b/handsontable/src/plugins/undoRedo/actions/dataChange.js
@@ -42,6 +42,10 @@ export class DataChangeAction extends BaseAction {
       }
 
       const hasDifferences = changes.find((change) => {
+        if (change === null) {
+          return false;
+        }
+
         const [, , oldValue, newValue] = change;
 
         return oldValue !== newValue;
@@ -53,10 +57,16 @@ export class DataChangeAction extends BaseAction {
 
       const wrappedAction = () => {
         const clonedChanges = changes.reduce((arr, change) => {
-          arr.push([...change]);
+          if (change !== null) {
+            arr.push([...change]);
+          }
 
           return arr;
         }, []);
+
+        if (clonedChanges.length === 0) {
+          return null;
+        }
 
         clonedChanges.forEach((change) => {
           change[1] = hot.propToCol(change[1]);

--- a/handsontable/src/plugins/undoRedo/undoRedo.js
+++ b/handsontable/src/plugins/undoRedo/undoRedo.js
@@ -179,7 +179,9 @@ export class UndoRedo extends BasePlugin {
     const newAction = wrappedAction();
     const undoneActionsCopy = this.undoneActions.slice();
 
-    this.doneActions.push(newAction);
+    if (newAction !== null) {
+      this.doneActions.push(newAction);
+    }
 
     this.hot.runHooks('afterUndoStackChange', doneActionsCopy, this.doneActions.slice());
     this.hot.runHooks('beforeRedoStackChange', undoneActionsCopy);


### PR DESCRIPTION
### Context

When using the `beforeChange` hook to reject changes by setting them to null (as documented in the the [beforeChange API](https://handsontable.com/docs/react-data-grid/api/hooks/#beforechange), the UndoRedo plugin crashes with a TypeError. 

> "To ignore a single change, set `changes[i]` to `null`"

This occurs because `DataChangeAction.startRegisteringEvents` attempts to destructure all changes without filtering out null entries first:

```typescript
const hasDifferences = changes.find((change) => {
  const [, , oldValue, newValue] = change; // TypeError: Cannot destructure null
  return oldValue !== newValue;
});
```

Reproduction:

```typescript
const hot = new Handsontable(container, {
  data: [['A1', 'B1'], ['A2', 'B2']],
  beforeChange(changes) {
    // Nullify change to reject it (documented API)
    changes[0] = null;
  }
});

hot.setDataAtCell(0, 0, 'X1'); // Crashes
```

Symptom:

```
Uncaught TypeError: change is not iterable
    at dataChange.mjs:55:41
    at Array.find (<anonymous>)
    at Core.<anonymous> (dataChange.mjs:54:38)
    at fastCall (function.mjs:293:17)
    at Hooks.run (index.mjs:246:23)
    at Core.runHooks (core.mjs:4827:33)
    at processChanges (core.mjs:1515:41)
    at Core.setDataAtCell (core.mjs:1578:30)
    at Object.populateFromArray (core.mjs:1145:20)
    at Core.populateFromArray (core.mjs:1707:17)
    at BaseEditor.saveValue (baseEditor.mjs:211:14)
    ...
```

Solution:

Filter out null entries before processing changes in the UndoRedo plugin's `beforeChange` handler, and return null from the action wrapper when all changes have been nullified to prevent adding empty actions to the undo stack.

### How has this been tested?

I tested the changes locally and covered the fix with E2E tests that verify:
 - Only non-nullified changes are recorded in the undo stack
 - Undo correctly reverts only the changes that were not nullified
 - No action is added to the undo stack when all changes are nullified

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

Could not find any reports on this.

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
