### PR TITLE
Fix UndoRedo beforeChange order

### DIFF
--- a/.changelogs/12001.json
+++ b/.changelogs/12001.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fix UndoRedo beforeChange order",
+  "type": "fixed",
+  "issueOrPR": 12001,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/undoRedo/actions/dataChange.js
+++ b/handsontable/src/plugins/undoRedo/actions/dataChange.js
@@ -73,7 +73,7 @@ export class DataChangeAction extends BaseAction {
       };
 
       undoRedoPlugin.done(wrappedAction, source);
-    });
+    }, undoRedoPlugin.constructor.PLUGIN_PRIORITY);
   }
 
   /**

--- a/wrappers/react-wrapper/test/undoRedo.spec.tsx
+++ b/wrappers/react-wrapper/test/undoRedo.spec.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { act } from '@testing-library/react';
+import { registerAllModules } from 'handsontable/registry';
+import { HotTable } from '../src/hotTable';
+import { HotTableRef } from '../src/types';
+import {
+  mountComponentWithRef,
+  sleep,
+} from './_helpers';
+
+registerAllModules();
+
+describe('UndoRedo plugin in React wrapper', () => {
+  describe('beforeChange hook execution order', () => {
+    it('should record the modified value in UndoRedo when beforeChange modifies the change', async () => {
+      const hotTableRef = mountComponentWithRef<HotTableRef>((
+        <HotTable
+          id="test-hot"
+          data={[[0]]}
+          licenseKey="non-commercial-and-evaluation"
+          beforeChange={(changes) => {
+            for (let i = 0; i < changes!.length; i++) {
+              if (changes![i] && changes![i]![3] > 5) {
+                changes![i]![3] = 5; // Cap values at 5
+              }
+            }
+          }}
+        />
+      ));
+
+      const hotInstance = hotTableRef.hotInstance!;
+      expect(hotInstance).not.toBe(null);
+      expect(hotInstance.getDataAtCell(0, 0)).toBe(0);
+
+      await act(async () => {
+        hotInstance.setDataAtCell(0, 0, 2);
+      });
+
+      expect(hotInstance.getDataAtCell(0, 0)).toBe(2);
+
+      await act(async () => {
+        hotInstance.setDataAtCell(0, 0, 10); // Will be capped
+      });
+
+      expect(hotInstance.getDataAtCell(0, 0)).toBe(5);
+
+      const undoRedoPlugin = hotInstance.getPlugin('undoRedo') as any;
+
+      expect(undoRedoPlugin.doneActions.length).toBe(2);
+
+      const firstAction = undoRedoPlugin.doneActions[0];
+      const secondAction = undoRedoPlugin.doneActions[1];
+
+      expect(firstAction.changes[0][2]).toBe(0); 
+      expect(firstAction.changes[0][3]).toBe(2);
+
+      expect(secondAction.changes[0][2]).toBe(2);
+      expect(secondAction.changes[0][3]).toBe(5); // Capped
+
+      await act(async () => {
+        undoRedoPlugin.undo();
+      });
+      await sleep(50);
+
+      expect(hotInstance.getDataAtCell(0, 0)).toBe(2);
+
+      await act(async () => {
+        undoRedoPlugin.undo();
+      });
+      await sleep(50);
+
+      expect(hotInstance.getDataAtCell(0, 0)).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
### Context

When using the beforeChange hook in React wrapper to modify or nullify changes, the UndoRedo plugin may record the original values instead of the modified values. This happens because of hook execution order differences between vanilla Handsontable and the React wrapper.

The issue:

In vanilla Handsontable or when using `addHook`, hooks registered via config are typically processed in a predictable order. However, in the React wrapper, hooks passed as props are registered differently, which can cause the UndoRedo plugin's internal beforeChange hook to run after the user's hook has already modified the changes array.

This leads to incorrect undo behavior: undoing restores values that were never actually applied to the grid.

Example scenario:

```typescript
<HotTable
  beforeChange={(changes) => {
    if (changes[0][3] > 5) {
      changes[0][3] = 5;
    }
  }}
/>
```

When entering 10, the cell shows 5 (correctly capped), but UndoRedo records 10 as the new value. Undoing then incorrectly restores to 10 instead of the previous value.

Solution:

Pass the plugin's priority `PLUGIN_PRIORITY` as the orderIndex parameter when registering the UndoRedo plugin's beforeChange hook. This ensures the plugin's hook runs at the correct priority level relative to other hooks, capturing the final modified values.

```typescript
hot.addHook('beforeChange', callback, undoRedoPlugin.constructor.PLUGIN_PRIORITY);
```

Note: This issue does not typically manifest when using vanilla Handsontable or `addHook` directly, as the hook registration order is different in those cases.

Note2: Other plugins have seemingly random values on `orderIndex` when they are applied to the same lifecycle hooks (e.g. when `manualColumnResize` and `stretchColumns` use the `beforeColumnResize` with `orderIndex` 1 and 10 respectively. This PR uses `PLUGIN_PRIORITY` instead, which seemed easier to maintain.

### How has this been tested?

I tested the changes locally and added a test to the React wrapper that verifies:
1. When beforeChange modifies a value, UndoRedo records the modified value (not the original)
2. Undo correctly restores to the previous state based on the modified values


### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

Unable to find any.

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react`
- [x] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
