### PR TITLE
Revert back introduction page examples

### DIFF
--- a/docs/content/guides/getting-started/introduction/introduction.md
+++ b/docs/content/guides/getting-started/introduction/introduction.md
@@ -39,6 +39,31 @@ Use Handsontable with plain JavaScript, TypeScript, or your favorite framework. 
 [Vue 2](@/guides/integrate-with-vue/vue-installation/vue-installation.md)
 - <i class="ico i-vue"></i> 
 [Vue 3](@/guides/integrate-with-vue3/vue3-installation/vue3-installation.md)
+s
+
+</div>
+
+## Examples 
+
+<div class="boxes-list gray col3">
+
+- [Angular](https://handsontable.com/stackblitz?example-dir=angular&handsontable-version={{$currentVersion}})
+- [Vanilla JS](https://handsontable.com/stackblitz?example-dir=javascript&handsontable-version={{$currentVersion}})
+- [React TS](https://handsontable.com/stackblitz?example-dir=react&handsontable-version={{$currentVersion}})
+- [React JS](https://handsontable.com/codesandbox?example-dir=react-js&handsontable-version={{$currentVersion}})
+- [TypeScript](https://handsontable.com/stackblitz?example-dir=typescript&handsontable-version={{$currentVersion}})
+- [Vue 3](https://handsontable.com/stackblitz?example-dir=vue&handsontable-version={{$currentVersion}})
+
+</div>
+
+Examples with SSR (Server Side Rendering): 
+
+<div class="boxes-list gray col3">
+
+- [Next.js](https://handsontable.com/stackblitz?example-dir=next.js&handsontable-version={{$currentVersion}})
+- [Astro](https://handsontable.com/stackblitz?example-dir=astro&handsontable-version={{$currentVersion}}) 
+- [Remix](https://handsontable.com/stackblitz?example-dir=remix&handsontable-version={{$currentVersion}})
+- [Nuxt](https://handsontable.com/stackblitz?example-dir=nuxt&handsontable-version={{$currentVersion}})
 
 </div>
 

--- a/docs/content/guides/getting-started/introduction/introduction.md
+++ b/docs/content/guides/getting-started/introduction/introduction.md
@@ -39,7 +39,6 @@ Use Handsontable with plain JavaScript, TypeScript, or your favorite framework. 
 [Vue 2](@/guides/integrate-with-vue/vue-installation/vue-installation.md)
 - <i class="ico i-vue"></i> 
 [Vue 3](@/guides/integrate-with-vue3/vue3-installation/vue3-installation.md)
-s
 
 </div>
 

--- a/docs/content/guides/getting-started/introduction/introduction.md
+++ b/docs/content/guides/getting-started/introduction/introduction.md
@@ -46,12 +46,12 @@ Use Handsontable with plain JavaScript, TypeScript, or your favorite framework. 
 
 <div class="boxes-list gray col3">
 
-- [Angular](https://handsontable.com/stackblitz?example-dir=angular&handsontable-version={{$currentVersion}})
-- [Vanilla JS](https://handsontable.com/stackblitz?example-dir=javascript&handsontable-version={{$currentVersion}})
-- [React TS](https://handsontable.com/stackblitz?example-dir=react&handsontable-version={{$currentVersion}})
-- [React JS](https://handsontable.com/codesandbox?example-dir=react-js&handsontable-version={{$currentVersion}})
-- [TypeScript](https://handsontable.com/stackblitz?example-dir=typescript&handsontable-version={{$currentVersion}})
-- [Vue 3](https://handsontable.com/stackblitz?example-dir=vue&handsontable-version={{$currentVersion}})
+- [Angular](https://handsontable.com/codesandbox-vm?example-dir=angular&handsontable-version={{$currentVersion}})
+- [Vanilla JS](https://handsontable.com/codesandbox-browser?example-dir=javascript&handsontable-version={{$currentVersion}})
+- [React TS](https://handsontable.com/codesandbox-browser?example-dir=react&handsontable-version={{$currentVersion}})
+- [React JS](https://handsontable.com/codesandbox-browser?example-dir=react-js&handsontable-version={{$currentVersion}})
+- [TypeScript](https://handsontable.com/codesandbox-browser?example-dir=typescript&handsontable-version={{$currentVersion}})
+- [Vue 3](https://handsontable.com/codesandbox-vm?example-dir=vue&handsontable-version={{$currentVersion}})
 
 </div>
 
@@ -59,10 +59,10 @@ Examples with SSR (Server Side Rendering):
 
 <div class="boxes-list gray col3">
 
-- [Next.js](https://handsontable.com/stackblitz?example-dir=next.js&handsontable-version={{$currentVersion}})
-- [Astro](https://handsontable.com/stackblitz?example-dir=astro&handsontable-version={{$currentVersion}}) 
-- [Remix](https://handsontable.com/stackblitz?example-dir=remix&handsontable-version={{$currentVersion}})
-- [Nuxt](https://handsontable.com/stackblitz?example-dir=nuxt&handsontable-version={{$currentVersion}})
+- [Next.js](https://handsontable.com/codesandbox-vm?example-dir=next.js&handsontable-version={{$currentVersion}})
+- [Astro](https://handsontable.com/codesandbox-vm?example-dir=astro&handsontable-version={{$currentVersion}}) 
+- [Remix](https://handsontable.com/codesandbox-vm?example-dir=remix&handsontable-version={{$currentVersion}})
+- [Nuxt](https://handsontable.com/codesandbox-vm?example-dir=nuxt&handsontable-version={{$currentVersion}})
 
 </div>
 


### PR DESCRIPTION
### Context
This PR revert the examples section on the Docs Introduction page.

### How has this been tested?
Locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/handsontable/pull/11988

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

[skip changelog]
