### PR TITLE
Fix a bug that made it impossible to delete values from a key-value-based autocomplete/dropdown cells.

### DIFF
--- a/.changelogs/12010.json
+++ b/.changelogs/12010.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed a bug that made it impossible to delete values from a key/value-based autocomplete/dropdown cells.",
+  "type": "fixed",
+  "issueOrPR": 12010,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/editors/autocompleteEditor/__tests__/key-value/autocompleteKeyValue.spec.js
+++ b/handsontable/src/editors/autocompleteEditor/__tests__/key-value/autocompleteKeyValue.spec.js
@@ -120,6 +120,52 @@ describe('AutocompleteEditor key/value source', () => {
 
   });
 
+  describe('Clearing values with DELETE/BACKSPACE', () => {
+    it('should clear the cell value when selecting a key-value-based cell with: ' +
+      '`strict=true`, `allowInvalid=false` and `allowEmpty=true` and pressing DELETE', async() => {
+      handsontable({
+        data: airportKVChoices.map(item => [item]),
+        columns: [{
+          type: 'autocomplete',
+          source: airportKVChoices,
+          strict: true,
+          allowInvalid: false,
+          allowEmpty: true,
+        }],
+      });
+
+      expect(getDataAtCell(0, 0)).toEqual(airportKVChoices[0].value);
+
+      await selectCell(0, 0);
+      await keyDownUp('delete');
+      await sleep(10);
+
+      expect(getDataAtCell(0, 0)).toBeNull();
+    });
+
+    it('should clear the cell value when selecting a key-value-based cell with: ' +
+      '`strict=true`, `allowInvalid=false` and `allowEmpty=true` and pressing BACKSPACE', async() => {
+      handsontable({
+        data: airportKVChoices.map(item => [item]),
+        columns: [{
+          type: 'autocomplete',
+          source: airportKVChoices,
+          strict: true,
+          allowInvalid: false,
+          allowEmpty: true,
+        }],
+      });
+
+      expect(getDataAtCell(0, 0)).toEqual(airportKVChoices[0].value);
+
+      await selectCell(0, 0);
+      await keyDownUp('backspace');
+      await sleep(10);
+
+      expect(getDataAtCell(0, 0)).toBeNull();
+    });
+  });
+
   describe('Saving values', () => {
     it('should save entire entries from the source object when the data is an AoO with the `key/value` props', async() => {
       handsontable({

--- a/handsontable/src/editors/dropdownEditor/__tests__/key-value/dropdownKeyValue.spec.js
+++ b/handsontable/src/editors/dropdownEditor/__tests__/key-value/dropdownKeyValue.spec.js
@@ -119,6 +119,50 @@ describe('DropdownEditor key/value source', () => {
 
   });
 
+  describe('Clearing values with DELETE/BACKSPACE', () => {
+    it('should clear the cell value when selecting a key-value-based cell with `allowInvalid=false` and `allowEmpty=true` ' +
+      'and pressing DELETE', async() => {
+      handsontable({
+        data: airportKVChoices.map(item => [item]),
+        columns: [{
+          type: 'dropdown',
+          source: airportKVChoices,
+          allowInvalid: false,
+          allowEmpty: true,
+        }],
+      });
+
+      expect(getDataAtCell(0, 0)).toEqual(airportKVChoices[0].value);
+
+      await selectCell(0, 0);
+      await keyDownUp('delete');
+      await sleep(10);
+
+      expect(getDataAtCell(0, 0)).toBeNull();
+    });
+
+    it('should clear the cell value when selecting a key-value-based cell with `allowInvalid=false` and `allowEmpty=true` ' +
+      'and pressing BACKSPACE', async() => {
+      handsontable({
+        data: airportKVChoices.map(item => [item]),
+        columns: [{
+          type: 'dropdown',
+          source: airportKVChoices,
+          allowInvalid: false,
+          allowEmpty: true,
+        }],
+      });
+
+      expect(getDataAtCell(0, 0)).toEqual(airportKVChoices[0].value);
+
+      await selectCell(0, 0);
+      await keyDownUp('backspace');
+      await sleep(10);
+
+      expect(getDataAtCell(0, 0)).toBeNull();
+    });
+  });
+
   describe('Saving values', () => {
     it('should save entire entries from the source object when the data is an AoO with the `key/value` props', async() => {
       handsontable({

--- a/handsontable/src/validators/autocompleteValidator/autocompleteValidator.js
+++ b/handsontable/src/validators/autocompleteValidator/autocompleteValidator.js
@@ -1,4 +1,5 @@
-import { isObjectEqual } from '../../helpers/object';
+import { isObjectEqual, isObject } from '../../helpers/object';
+import { isDefined } from '../../helpers/mixed';
 
 export const VALIDATOR_TYPE = 'autocomplete';
 
@@ -10,9 +11,17 @@ export const VALIDATOR_TYPE = 'autocomplete';
  * @param {Function} callback Callback called with validation result.
  */
 export function autocompleteValidator(value, callback) {
+  const isKeyValueObject = obj => isObject(obj) && isDefined(obj.key) && isDefined(obj.value);
+  const isNullOrUndefined = (val) => {
+    if (isKeyValueObject(val)) {
+      return isNullOrUndefined(val.key) && isNullOrUndefined(val.value);
+    }
+
+    return val === null || val === undefined;
+  };
   let valueToValidate = value;
 
-  if (valueToValidate === null || valueToValidate === undefined) {
+  if (isNullOrUndefined(valueToValidate)) {
     valueToValidate = '';
   }
 


### PR DESCRIPTION
### Context
When using `key/value` objects on an `autocomplete`/`dropdown`-typed cells, pressing <kbd>DELETE</kbd>/<kbd>BACKSPACE</kbd> did not remove the cell value.

This PR should fix this problem.

### How has this been tested?
Tested manually + added new test cases.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#2983

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
