### PR TITLE
Add registerTheme on init option

### DIFF
--- a/docs/content/guides/styling/legacy-style/legacy-style.md
+++ b/docs/content/guides/styling/legacy-style/legacy-style.md
@@ -47,12 +47,10 @@ The Theme API allows you to import and register themes programmatically. This ap
 
 ```js
 import Handsontable from 'handsontable';
-import { classicTheme, registerTheme } from 'handsontable/themes';
-
-const theme = registerTheme(classicTheme);
+import { classicTheme } from 'handsontable/themes';
 
 const hot = new Handsontable(container, {
-  theme: theme,
+  theme: classicTheme,
   // ... other options
 });
 ```
@@ -63,14 +61,12 @@ const hot = new Handsontable(container, {
 
 ```jsx
 import { HotTable } from '@handsontable/react-wrapper';
-import { classicTheme, registerTheme } from 'handsontable/themes';
-
-const theme = registerTheme(classicTheme);
+import { classicTheme } from 'handsontable/themes';
 
 function App() {
   return (
     <HotTable
-      theme={theme}
+      theme={classicTheme}
       // ... other options
     />
   );
@@ -82,9 +78,7 @@ function App() {
 ::: only-for angular
 
 ```ts
-import { classicTheme, registerTheme } from 'handsontable/themes';
-
-const theme = registerTheme(classicTheme);
+import { classicTheme } from 'handsontable/themes';
 
 // In your component
 @Component({
@@ -92,7 +86,7 @@ const theme = registerTheme(classicTheme);
 })
 export class AppComponent {
   hotSettings = {
-    theme: theme,
+    theme: classicTheme,
     // ... other options
   };
 }

--- a/docs/content/guides/styling/themes/themes.md
+++ b/docs/content/guides/styling/themes/themes.md
@@ -229,39 +229,46 @@ There are two ways to apply a theme. The recommended approach is to use the Them
 
 The Theme API allows you to import and register themes programmatically. This approach provides runtime access to theme customization features.
 
-#### Step 1. Import the base styles
-
-```js
-```
-
-#### Step 2. Import and register the theme
+#### Import and use theme
 
 ::: only-for javascript
 
 ```js
 import Handsontable from 'handsontable';
-import { mainTheme, registerTheme } from 'handsontable/themes';
-
-const theme = registerTheme(mainTheme);
+import { classicTheme } from 'handsontable/themes';
 
 const hot = new Handsontable(container, {
-  theme: theme,
+  theme: classicTheme,
   // ... other options
 });
 ```
 
-You can also configure the theme at runtime using the builder pattern:
+You can configure the theme before creating the instance using the builder pattern:
 
 ```js
 import { mainTheme, registerTheme } from 'handsontable/themes';
 
 const theme = registerTheme(mainTheme)
-  .setColorScheme('auto')  // 'light', 'dark', or 'auto'
+  .setColorScheme('auto')   // 'light', 'dark', or 'auto'
   .setDensityType('comfortable');  // 'default', 'compact', or 'comfortable'
 
 const hot = new Handsontable(container, {
-  theme: theme,
+  theme,
 });
+```
+
+Or configure it after init by retrieving the registered theme with `getTheme()` (the theme is registered when you pass it to the config):
+
+```js
+import { mainTheme, getTheme } from 'handsontable/themes';
+
+const hot = new Handsontable(container, {
+  theme: mainTheme,
+});
+
+getTheme('main')
+  ?.setColorScheme('auto')
+  ?.setDensityType('comfortable');
 ```
 
 #### UMD build (script tags)

--- a/docs/content/guides/upgrade-and-migration/migrating-from-16.2-to-17.0/migrating-from-16.2-to-17.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-16.2-to-17.0/migrating-from-16.2-to-17.0.md
@@ -59,12 +59,10 @@ The Theme API allows you to register and configure themes programmatically with 
 
 ```js
 import Handsontable from 'handsontable';
-import { classicTheme, registerTheme } from 'handsontable/themes';
-
-const theme = registerTheme(classicTheme);
+import { classicTheme } from 'handsontable/themes';
 
 const hot = new Handsontable(container, {
-  theme: theme,
+  theme: classicTheme,
   // ... other options
 });
 ```
@@ -75,14 +73,12 @@ const hot = new Handsontable(container, {
 
 ```jsx
 import { HotTable } from '@handsontable/react-wrapper';
-import { classicTheme, registerTheme } from 'handsontable/themes';
-
-const theme = registerTheme(classicTheme);
+import { classicTheme } from 'handsontable/themes';
 
 function App() {
   return (
     <HotTable
-      theme={theme}
+      theme={classicTheme}
       // ... other options
     />
   );
@@ -94,16 +90,14 @@ function App() {
 ::: only-for angular
 
 ```ts
-import { classicTheme, registerTheme } from 'handsontable/themes';
-
-const theme = registerTheme(classicTheme);
+import { classicTheme } from 'handsontable/themes';
 
 @Component({
   template: `<hot-table [settings]="hotSettings"></hot-table>`
 })
 export class AppComponent {
   hotSettings = {
-    theme: theme,
+    theme: classicTheme,
     // ... other options
   };
 }

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -1383,6 +1383,8 @@ export default function Core(rootContainer, userSettings, rootInstanceSymbol = f
       }
 
       themeObject = getTheme('main');
+    } else if (typeof theme.getThemeConfig !== 'function') {
+      themeObject = registerTheme(theme);
     } else {
       themeObject = theme;
     }

--- a/handsontable/src/dataMap/metaManager/metaSchema.js
+++ b/handsontable/src/dataMap/metaManager/metaSchema.js
@@ -5500,6 +5500,7 @@ export default () => {
      * | ------------------------------------- | ------------------------------------------------------------------------------------- |
      * | `undefined` (default)                 | Don't apply any theme and use the default main theme                                  |
      * | A string (e.g., `'ht-theme-horizon'`) | Apply a registered theme by name (required to import CSS file)                        |
+     * | A plain theme config object           | Apply a theme with default settings (import and pass the config, e.g. `horizonTheme`) |
      * | A `ThemeBuilder` object               | Apply a theme with runtime configuration (recommended)                                |
      *
      * When using a `ThemeBuilder` object, you can configure the theme at runtime using these methods:
@@ -5522,25 +5523,38 @@ export default () => {
      *
      * @example
      * ```js
-     * // enable a theme by name (required to import CSS file)
+     * // Enable a theme by class name (requires loading the theme CSS)
      * theme: 'ht-theme-horizon',
+     * ```
+     * @example
+     * ```js
+     * // Pass a plain theme config object
+     * import { horizonTheme } from 'handsontable/themes';
      *
-     * // enable a theme using a ThemeBuilder object (recommended)
-     * const horizonTheme = registerTheme(horizonTheme);
+     * const hot = new Handsontable(container, {
+     *   theme: horizonTheme,
+     * });
+     * ```
      *
-     * // configure the theme settings at runtime
-     * horizonTheme.setColorScheme('dark');
-     * horizonTheme.setDensityType('compact');
-     * horizonTheme.params({
-     *  tokens: {
-     *    fontSize: '14px',
-     *    iconSize: 'size_5',
-     *    borderColor: ['colors.palette.100', 'colors.palette.800'],
-     *  },
-     * })
+     * @example
+     * ```js
+     * // Pass a ThemeBuilder object (for customization before initialization)
+     * import { horizonTheme, registerTheme } from 'handsontable/themes';
      *
-     * // use the configured theme
-     * theme: horizonTheme,
+     * const theme = registerTheme(horizonTheme)
+     *   .setColorScheme('dark')
+     *   .setDensityType('compact')
+     *   .params({
+     *     tokens: {
+     *       fontSize: '14px',
+     *       iconSize: 'size_5',
+     *       borderColor: ['colors.palette.100', 'colors.palette.800'],
+     *     },
+     *   });
+     *
+     * const hot = new Handsontable(container, {
+     *   theme,
+     * });
      * ```
      */
     theme: undefined,

--- a/handsontable/test/e2e/core/themeManager.spec.js
+++ b/handsontable/test/e2e/core/themeManager.spec.js
@@ -45,6 +45,46 @@ describe('Core.themeManager', () => {
       expect(hot.themeManager).toBeDefined();
     });
 
+    it('should initialize themeManager when a plain theme config object is passed (without prior registerTheme)', async() => {
+      const plainThemeConfig = createValidThemeConfig({ name: 'plain-config-theme' });
+
+      const hot = handsontable({
+        data: createSpreadsheetData(5, 5),
+        theme: plainThemeConfig,
+      }, true);
+
+      expect(hot.themeManager).not.toBeNull();
+      expect(hot.themeManager).toBeDefined();
+      expect(hot.themeManager.getClassName()).toBe('ht-theme-plain-config-theme');
+    });
+
+    it('should set the correct theme class when passing a plain theme config object', async() => {
+      const plainThemeConfig = createValidThemeConfig({ name: 'plain-class-theme' });
+
+      const hot = handsontable({
+        data: createSpreadsheetData(5, 5),
+        theme: plainThemeConfig,
+      }, true);
+
+      expect(hot.themeManager.getClassName()).toBe('ht-theme-plain-class-theme');
+      expect(getCurrentThemeName()).toBe('ht-theme-plain-class-theme');
+      expect($(hot.rootWrapperElement).hasClass('ht-theme-plain-class-theme')).toBe(true);
+    });
+
+    it('should inject theme styles when passing a plain theme config object', async() => {
+      const plainThemeConfig = createValidThemeConfig({ name: 'plain-styles-theme' });
+
+      const hot = handsontable({
+        data: createSpreadsheetData(5, 5),
+        theme: plainThemeConfig,
+      }, true);
+
+      const styleElement = hot.rootWrapperElement.querySelector('style');
+
+      expect(styleElement).not.toBeNull();
+      expect(styleElement.textContent).toContain('.ht-theme-plain-styles-theme');
+    });
+
     it('should set the correct theme class name based on the theme config', async() => {
       const testTheme = Handsontable.themes.registerTheme(createValidThemeConfig({
         name: 'my-custom-theme',
@@ -148,6 +188,27 @@ describe('Core.themeManager', () => {
 
       expect(hot.themeManager).not.toBeNull();
       expect(hot.themeManager.getClassName()).toBe('ht-theme-update-init-theme');
+    });
+
+    it('should initialize themeManager when plain theme config object is passed via updateSettings', async() => {
+      simulateModernThemeStylesheet(spec().$container);
+
+      const hot = handsontable({
+        themeName: 'ht-theme-sth',
+        data: createSpreadsheetData(5, 5),
+      }, true);
+
+      expect(hot.themeManager).toBeNull();
+
+      const plainThemeConfig = createValidThemeConfig({ name: 'update-plain-config-theme' });
+
+      await updateSettings({
+        theme: plainThemeConfig,
+      });
+
+      expect(hot.themeManager).not.toBeNull();
+      expect(hot.themeManager.getClassName()).toBe('ht-theme-update-plain-config-theme');
+      expect(getCurrentThemeName()).toBe('ht-theme-update-plain-config-theme');
     });
 
     it('should update existing themeManager when new theme object is passed', async() => {

--- a/handsontable/types/settings.d.ts
+++ b/handsontable/types/settings.d.ts
@@ -45,7 +45,7 @@ import { Settings as DialogSettings } from './plugins/dialog';
 import { Settings as LoadingSettings } from './plugins/loading';
 import { Settings as EmptyDataStateSettings } from './plugins/emptyDataState';
 import { Settings as UndoRedoSettings } from './plugins/undoRedo';
-import { ThemeBuilder } from './themes';
+import { ThemeBuilder, BaseTheme } from './themes';
 import { EditorType, BaseEditor } from './editors';
 import { RendererType } from './renderers';
 import { BaseRenderer } from './renderers/base';
@@ -226,7 +226,7 @@ export interface GridSettings extends Events {
   tableClassName?: string | string[];
   tabMoves?: CellCoords | SimpleCellCoords | ((event: KeyboardEvent) => CellCoords | SimpleCellCoords);
   textEllipsis?: boolean;
-  theme?: ThemeBuilder | string;
+  theme?: ThemeBuilder | BaseTheme | string;
   themeName?: string;
   title?: string;
   trimDropdown?: boolean;


### PR DESCRIPTION
### Context
This PR improves the developer experience of the Theme API by removing the requirement to explicitly call `registerTheme` and allowing a plain configuration object to be passed directly as the `theme` option value.

### How has this been tested?
Locally and new e2e tests

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/3067

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]