### PR TITLE
Remove `devDependencies` field from prod package.json file

### DIFF
--- a/handsontable/package.json
+++ b/handsontable/package.json
@@ -265,7 +265,6 @@
       "unpkg",
       "keywords",
       "dependencies",
-      "devDependencies",
       "optionalDependencies",
       "license",
       "typings",


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR removes the `devDependencies` field from the production `package.json` file.

Before:
https://www.npmjs.com/package/handsontable/v/16.2.0?activeTab=dependencies

After
https://www.npmjs.com/package/handsontable/v/0.0.0-next-f9bbea4-20260218?activeTab=dependencies

_[skip changelog]_

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/3070

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
