### PR TITLE
Update deprecated warning for `intl-date` and `intl-time` cell types

### DIFF
--- a/handsontable/src/cellTypes/intlDateType/__tests__/intlDateType.spec.js
+++ b/handsontable/src/cellTypes/intlDateType/__tests__/intlDateType.spec.js
@@ -21,7 +21,7 @@ describe('IntlDateType', () => {
     });
 
     expect(warnSpy).toHaveBeenCalledWith('Source data warning (3 cells). ' +
-      'Invalid value for "intlDate" cell type.\n\n' +
+      'Invalid value for "intl-date" cell type.\n\n' +
       'Affected cells:\n' +
       '  - row 0, col 0, value: "0"\n' +
       '  - row 0, col 1, value: "test"\n' +
@@ -41,7 +41,7 @@ describe('IntlDateType', () => {
     await loadData([['2026-01']]);
 
     expect(warnSpy).toHaveBeenCalledWith('Source data warning (1 cell). ' +
-      'Invalid value for "intlDate" cell type.\n\n' +
+      'Invalid value for "intl-date" cell type.\n\n' +
       'Affected cells:\n' +
       '  - row 0, col 0, value: "2026-01"\n\n' +
       'Expected a value compatible with the ISO 8601 date format ("YYYY-MM-DD").'
@@ -59,7 +59,7 @@ describe('IntlDateType', () => {
     await updateData([['2026-01']]);
 
     expect(warnSpy).toHaveBeenCalledWith('Source data warning (1 cell). ' +
-      'Invalid value for "intlDate" cell type.\n\n' +
+      'Invalid value for "intl-date" cell type.\n\n' +
       'Affected cells:\n' +
       '  - row 0, col 0, value: "2026-01"\n\n' +
       'Expected a value compatible with the ISO 8601 date format ("YYYY-MM-DD").'

--- a/handsontable/src/cellTypes/intlTimeType/__tests__/intlTimeType.spec.js
+++ b/handsontable/src/cellTypes/intlTimeType/__tests__/intlTimeType.spec.js
@@ -21,7 +21,7 @@ describe('IntlTimeType', () => {
     });
 
     expect(warnSpy).toHaveBeenCalledWith('Source data warning (3 cells). ' +
-      'Invalid value for "intlTime" cell type.\n\n' +
+      'Invalid value for "intl-time" cell type.\n\n' +
       'Affected cells:\n' +
       '  - row 0, col 0, value: "0"\n' +
       '  - row 0, col 1, value: "test"\n' +
@@ -41,7 +41,7 @@ describe('IntlTimeType', () => {
     await loadData([['12:000']]);
 
     expect(warnSpy).toHaveBeenCalledWith('Source data warning (1 cell). ' +
-      'Invalid value for "intlTime" cell type.\n\n' +
+      'Invalid value for "intl-time" cell type.\n\n' +
       'Affected cells:\n' +
       '  - row 0, col 0, value: "12:000"\n\n' +
       'Expected a value compatible with the 24-hour time format ("HH:mm", "HH:mm:ss" or "HH:mm:ss.SSS").'
@@ -59,7 +59,7 @@ describe('IntlTimeType', () => {
     await updateData([['12:000']]);
 
     expect(warnSpy).toHaveBeenCalledWith('Source data warning (1 cell). ' +
-      'Invalid value for "intlTime" cell type.\n\n' +
+      'Invalid value for "intl-time" cell type.\n\n' +
       'Affected cells:\n' +
       '  - row 0, col 0, value: "12:000"\n\n' +
       'Expected a value compatible with the 24-hour time format ("HH:mm", "HH:mm:ss" or "HH:mm:ss.SSS").'

--- a/handsontable/src/dataMap/metaManager/metaSchema.js
+++ b/handsontable/src/dataMap/metaManager/metaSchema.js
@@ -1805,21 +1805,21 @@ export default () => {
     /**
      * Configures the time format for time cells. Accepts either a string (legacy, for [`time`](@/guides/cell-types/time-cell-type/time-cell-type.md)
      * cells) or an object of [`Intl.DateTimeFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat)
-     * options (for [`intlTime`](@/guides/cell-types/time-cell-type/time-cell-type.md) cells).
+     * options (for [`intl-time`](@/guides/cell-types/time-cell-type/time-cell-type.md) cells).
      *
      * ::: warning
      * The string form of `timeFormat` is deprecated and will be removed in the next major release.
-     * It is used only by the `time` cell type. Use the `intlTime` cell type with an `Intl.DateTimeFormat`
+     * It is used only by the `time` cell type. Use the `intl-time` cell type with an `Intl.DateTimeFormat`
      * options object instead.
      * :::
      *
      * **Object form (Intl.DateTimeFormat options):**
      *
-     * The object form is supported only when the cell type is `intlTime`. The locale is controlled separately
+     * The object form is supported only when the cell type is `intl-time`. The locale is controlled separately
      * via the [`locale`](@/api/options.md#locale) option.
      *
      * ::: tip Source data format
-     * For `intlTime` cells, source data must be in 24-hour time format (`HH:mm`, `HH:mm:ss`, or `HH:mm:ss.SSS`), matching
+     * For `intl-time` cells, source data must be in 24-hour time format (`HH:mm`, `HH:mm:ss`, or `HH:mm:ss.SSS`), matching
      * the HTML `input type="time"` value. Otherwise operations such as sorting and filtering can be unstable or unpredictable.
      * The `timeFormat` object affects only how times are displayed; the underlying value should remain in that format.
      * :::
@@ -1862,7 +1862,7 @@ export default () => {
      * **Deprecated: string form**
      *
      * Passing a string (e.g. `'h:mm:ss a'`) is deprecated and works only with the `time` cell type.
-     * Migrate to the `intlTime` cell type and pass an `Intl.DateTimeFormat` options object.
+     * Migrate to the `intl-time` cell type and pass an `Intl.DateTimeFormat` options object.
      *
      * **Migration example:**
      *
@@ -1893,7 +1893,7 @@ export default () => {
      *
      * @example
      * ```js
-     * // intlTime cell type with Intl options
+     * // intl-time cell type with Intl options
      * columns: [
      *   {
      *     type: 'intl-time',

--- a/handsontable/src/dataMap/metaManager/metaSchema.js
+++ b/handsontable/src/dataMap/metaManager/metaSchema.js
@@ -1682,21 +1682,21 @@ export default () => {
     /**
      * Configures the date format for date cells. Accepts either a string (legacy, for [`date`](@/guides/cell-types/date-cell-type/date-cell-type.md)
      * cells) or an object of [`Intl.DateTimeFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat)
-     * options (for [`intlDate`](@/guides/cell-types/date-cell-type/date-cell-type.md) cells).
+     * options (for [`intl-date`](@/guides/cell-types/date-cell-type/date-cell-type.md) cells).
      *
      * ::: warning
      * The string form of `dateFormat` is deprecated and will be removed in the next major release.
-     * It is used only by the `date` cell type (moment.js-based). Use the `intlDate` cell type
-     * with an `Intl.DateTimeFormat` options object instead. In the next major release, `intlDate`
-     * will become the default `date` cell type, and `intlDate` will be an alias for `date`.
+     * It is used only by the `date` cell type (moment.js-based). Use the `intl-date` cell type
+     * with an `Intl.DateTimeFormat` options object instead. In the next major release, `intl-date`
+     * will become the default `date` cell type, and `intl-date` will be an alias for `date`.
      * :::
      *
      * **Object form (Intl.DateTimeFormat options):**
      *
-     * The object form is supported only when the cell type is `intlDate`. The locale is controlled separately via the [`locale`](@/api/options.md#locale) option.
+     * The object form is supported only when the cell type is `intl-date`. The locale is controlled separately via the [`locale`](@/api/options.md#locale) option.
      *
      * ::: tip Source data format
-     * For `intlDate` cells, source data must be in an ISO 8601 date format (`YYYY-MM-DD`). Otherwise operations such
+     * For `intl-date` cells, source data must be in an ISO 8601 date format (`YYYY-MM-DD`). Otherwise operations such
      * as sorting and filtering can be unstable or unpredictable. The `dateFormat` object affects only how dates are
      * displayed; the underlying value should remain ISO.
      * :::
@@ -1747,7 +1747,7 @@ export default () => {
      * **Deprecated: string form**
      *
      * Passing a string (e.g. `'DD/MM/YYYY'`, `'YYYY-MM-DD'`) is deprecated and works only with the `date` cell type.
-     * Migrate to the `intlDate` cell type and pass an `Intl.DateTimeFormat` options object.
+     * Migrate to the `intl-date` cell type and pass an `Intl.DateTimeFormat` options object.
      *
      * **Migration example:**
      *
@@ -1777,7 +1777,7 @@ export default () => {
      *
      * @example
      * ```js
-     * // intlDate cell type with Intl options
+     * // intl-date cell type with Intl options
      * columns: [
      *   {
      *     type: 'intl-date',
@@ -4769,7 +4769,7 @@ export default () => {
      *
      * @example
      * ```js
-     * // parse editor string to ISO date (e.g. intlDate: display format => source format)
+     * // parse editor string to ISO date (e.g. intl-date: display format => source format)
      * valueParser(value, cellProperties) {
      *   if (value == null || value === '') {
      *     return null;

--- a/handsontable/src/plugins/columnSorting/utils.js
+++ b/handsontable/src/plugins/columnSorting/utils.js
@@ -231,7 +231,7 @@ export function createIntlDateCompareFunction(sortOrder, format, columnPluginSet
 }
 
 /**
- * Creates intlTime sorting compare function.
+ * Creates intl-time sorting compare function.
  *
  * @param {string} sortOrder Sort order (`asc` for ascending, `desc` for descending).
  * @param {string} format Date or time format.

--- a/handsontable/src/plugins/columnSorting/utils.js
+++ b/handsontable/src/plugins/columnSorting/utils.js
@@ -170,7 +170,7 @@ export function createDateTimeCompareFunction(sortOrder, format, columnPluginSet
 }
 
 /**
- * Creates intlDate sorting compare function.
+ * Creates intl-date sorting compare function.
  *
  * @param {string} sortOrder Sort order (`asc` for ascending, `desc` for descending).
  * @param {string} format Date or time format.

--- a/handsontable/src/renderers/dateRenderer/dateRenderer.js
+++ b/handsontable/src/renderers/dateRenderer/dateRenderer.js
@@ -22,8 +22,8 @@ export function dateRenderer(hotInstance, TD, row, col, prop, value, cellPropert
     deprecatedWarn(
       'The `date` cell type with string-based `dateFormat` (moment.js) is deprecated. ' +
       'In the next major release, `date` will accept only Intl.DateTimeFormat options (object). ' +
-      'To start migrating, use the `intlDate` cell type now; it will become the `date` cell type ' +
-      'after the next major release (the `intlDate` will become an alias for `date`).\n\n' +
+      'To start migrating, use the `intl-date` cell type now; it will become the `date` cell type ' +
+      'after the next major release (the `intl-date` will become an alias for `date`).\n\n' +
       'Migration guide: https://handsontable.com/docs/migration-from-16.2-to-17.0/\n' +
       '`date` cell type: https://handsontable.com/docs/date-cell-type/'
     );

--- a/handsontable/src/renderers/timeRenderer/timeRenderer.js
+++ b/handsontable/src/renderers/timeRenderer/timeRenderer.js
@@ -22,8 +22,8 @@ export function timeRenderer(hotInstance, TD, row, col, prop, value, cellPropert
     deprecatedWarn(
       'The `time` cell type with string-based `timeFormat` (moment.js) is deprecated. ' +
       'In the next major release, `time` will accept only Intl.DateTimeFormat options (object). ' +
-      'To start migrating, use the `intlTime` cell type now; it will become the `time` cell type ' +
-      'after the next major release (the `intlTime` will become an alias for `time`).\n\n' +
+      'To start migrating, use the `intl-time` cell type now; it will become the `time` cell type ' +
+      'after the next major release (the `intl-time` will become an alias for `time`).\n\n' +
       'Migration guide: https://handsontable.com/docs/migration-from-16.2-to-17.0/\n' +
       '`time` cell type: https://handsontable.com/docs/time-cell-type/'
     );

--- a/handsontable/src/validators/intlDateValidator/__tests__/allowEmpty.spec.js
+++ b/handsontable/src/validators/intlDateValidator/__tests__/allowEmpty.spec.js
@@ -38,7 +38,7 @@ describe('IntlDateType - allowEmpty', () => {
     await setSourceDataAtCell(0, 0, '');
 
     expect(warnSpy).toHaveBeenCalledWith('Source data warning (1 cell). ' +
-      'Invalid value for "intlDate" cell type.\n\n' +
+      'Invalid value for "intl-date" cell type.\n\n' +
       'Affected cells:\n' +
       '  - row 0, col 0, value: ""\n\n' +
       'Expected a value compatible with the ISO 8601 date format ("YYYY-MM-DD").'

--- a/handsontable/src/validators/intlDateValidator/__tests__/allowInvalid.spec.js
+++ b/handsontable/src/validators/intlDateValidator/__tests__/allowInvalid.spec.js
@@ -94,7 +94,7 @@ describe('IntlDateType - allowInvalid', () => {
     await setSourceDataAtCell(0, 0, '');
 
     expect(warnSpy).toHaveBeenCalledWith('Source data warning (1 cell). ' +
-      'Invalid value for "intlDate" cell type.\n\n' +
+      'Invalid value for "intl-date" cell type.\n\n' +
       'Affected cells:\n' +
       '  - row 0, col 0, value: ""\n\n' +
       'Expected a value compatible with the ISO 8601 date format ("YYYY-MM-DD").'
@@ -105,7 +105,7 @@ describe('IntlDateType - allowInvalid', () => {
     await setSourceDataAtCell(0, 0, '2026-01');
 
     expect(warnSpy).toHaveBeenCalledWith('Source data warning (1 cell). ' +
-      'Invalid value for "intlDate" cell type.\n\n' +
+      'Invalid value for "intl-date" cell type.\n\n' +
       'Affected cells:\n' +
       '  - row 0, col 0, value: "2026-01"\n\n' +
       'Expected a value compatible with the ISO 8601 date format ("YYYY-MM-DD").'

--- a/handsontable/src/validators/intlDateValidator/intlDateValidator.js
+++ b/handsontable/src/validators/intlDateValidator/intlDateValidator.js
@@ -3,7 +3,7 @@ import { isEmpty } from '../../helpers/mixed';
 
 export const VALIDATOR_TYPE = 'intl-date';
 export const SOURCE_DATA_WARNING_MESSAGE = 'Source data warning ([itemsCount]). ' +
-  'Invalid value for "intlDate" cell type.\n\n' +
+  'Invalid value for "intl-date" cell type.\n\n' +
   '[affectedCells]\n\n' +
   'Expected a value compatible with the ISO 8601 date format ("YYYY-MM-DD").';
 

--- a/handsontable/src/validators/intlTimeValidator/__tests__/allowEmpty.spec.js
+++ b/handsontable/src/validators/intlTimeValidator/__tests__/allowEmpty.spec.js
@@ -38,7 +38,7 @@ describe('IntlTimeType - allowEmpty', () => {
     await setSourceDataAtCell(0, 0, '');
 
     expect(warnSpy).toHaveBeenCalledWith('Source data warning (1 cell). ' +
-      'Invalid value for "intlTime" cell type.\n\n' +
+      'Invalid value for "intl-time" cell type.\n\n' +
       'Affected cells:\n' +
       '  - row 0, col 0, value: ""\n\n' +
       'Expected a value compatible with the 24-hour time format ("HH:mm", "HH:mm:ss" or "HH:mm:ss.SSS").'

--- a/handsontable/src/validators/intlTimeValidator/__tests__/allowInvalid.spec.js
+++ b/handsontable/src/validators/intlTimeValidator/__tests__/allowInvalid.spec.js
@@ -94,7 +94,7 @@ describe('IntlTimeType - allowInvalid', () => {
     await setSourceDataAtCell(0, 0, '');
 
     expect(warnSpy).toHaveBeenCalledWith('Source data warning (1 cell). ' +
-      'Invalid value for "intlTime" cell type.\n\n' +
+      'Invalid value for "intl-time" cell type.\n\n' +
       'Affected cells:\n' +
       '  - row 0, col 0, value: ""\n\n' +
       'Expected a value compatible with the 24-hour time format ("HH:mm", "HH:mm:ss" or "HH:mm:ss.SSS").'
@@ -105,7 +105,7 @@ describe('IntlTimeType - allowInvalid', () => {
     await setSourceDataAtCell(0, 0, '12:000');
 
     expect(warnSpy).toHaveBeenCalledWith('Source data warning (1 cell). ' +
-      'Invalid value for "intlTime" cell type.\n\n' +
+      'Invalid value for "intl-time" cell type.\n\n' +
       'Affected cells:\n' +
       '  - row 0, col 0, value: "12:000"\n\n' +
       'Expected a value compatible with the 24-hour time format ("HH:mm", "HH:mm:ss" or "HH:mm:ss.SSS").'

--- a/handsontable/src/validators/intlTimeValidator/intlTimeValidator.js
+++ b/handsontable/src/validators/intlTimeValidator/intlTimeValidator.js
@@ -3,7 +3,7 @@ import { isEmpty } from '../../helpers/mixed';
 
 export const VALIDATOR_TYPE = 'intl-time';
 export const SOURCE_DATA_WARNING_MESSAGE = 'Source data warning ([itemsCount]). ' +
-  'Invalid value for "intlTime" cell type.\n\n' +
+  'Invalid value for "intl-time" cell type.\n\n' +
   '[affectedCells]\n\n' +
   'Expected a value compatible with the 24-hour time format ("HH:mm", "HH:mm:ss" or "HH:mm:ss.SSS").';
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The PR updates the deprecation warnings for `intl-date` and `intl-time` cell types. In the https://github.com/handsontable/handsontable/pull/11999, there was a typo that showed the migration guide to `intlDate` and `intlTime` cell type, where names with hyphens are correct.

_[skip changelog]_

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/handsontable/pull/11999

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
