### PR TITLE
Change the element type for focus catchers

### DIFF
--- a/.changelogs/12032.json
+++ b/.changelogs/12032.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Change the element type for focus catchers",
+  "type": "fixed",
+  "issueOrPR": 12032,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/focusManager/__tests__/focusDetector.spec.js
+++ b/handsontable/src/focusManager/__tests__/focusDetector.spec.js
@@ -12,46 +12,42 @@ describe('ScopeManager', () => {
     }
   });
 
-  it('should add input traps with correct attributes to the wrapper element', async() => {
+  it('should add catcher traps with correct attributes to the wrapper element', async() => {
     const hot = handsontable({
       data: createSpreadsheetData(10, 10),
     });
 
-    const inputTrapTop = hot.rootGridElement.firstChild;
-    const inputTrapBottom = hot.rootGridElement.lastChild;
+    const catcherTop = hot.rootGridElement.firstChild;
+    const catcherBottom = hot.rootGridElement.lastChild;
 
-    expect(inputTrapTop.className).toBe('htFocusCatcher');
-    expect(inputTrapTop.name).toBe('htFocusCatcher');
-    expect(inputTrapTop.getAttribute('aria-label')).toBe('Focus catcher');
-    expect(inputTrapTop.dataset.htFocusSource).toBe('tab_from_above');
-    expect(inputTrapBottom.className).toBe('htFocusCatcher');
-    expect(inputTrapBottom.name).toBe('htFocusCatcher');
-    expect(inputTrapBottom.getAttribute('aria-label')).toBe('Focus catcher');
-    expect(inputTrapBottom.dataset.htFocusSource).toBe('tab_from_below');
+    expect(catcherTop.className).toBe('htFocusCatcher');
+    expect(catcherTop.dataset.htFocusSource).toBe('tab_from_above');
+    expect(catcherBottom.className).toBe('htFocusCatcher');
+    expect(catcherBottom.dataset.htFocusSource).toBe('tab_from_below');
 
-    const inputTrapTopStyle = window.getComputedStyle(inputTrapTop);
+    const catcherTopStyle = window.getComputedStyle(catcherTop);
 
-    expect(inputTrapTopStyle.position).toBe('absolute');
-    expect(inputTrapTopStyle.width).toBe('0px');
-    expect(inputTrapTopStyle.height).toBe('0px');
-    expect(inputTrapTopStyle.opacity).toBe('0');
-    expect(inputTrapTopStyle.zIndex).toBe('-1');
-    expect(inputTrapTopStyle.borderWidth).toBe('0px');
-    expect(inputTrapTopStyle.outlineWidth).toBe('0px');
-    expect(inputTrapTopStyle.padding).toBe('0px');
-    expect(inputTrapTopStyle.margin).toBe('0px');
+    expect(catcherTopStyle.position).toBe('absolute');
+    expect(catcherTopStyle.width).toBe('0px');
+    expect(catcherTopStyle.height).toBe('0px');
+    expect(catcherTopStyle.opacity).toBe('0');
+    expect(catcherTopStyle.zIndex).toBe('-1');
+    expect(catcherTopStyle.borderWidth).toBe('0px');
+    expect(catcherTopStyle.outlineWidth).toBe('0px');
+    expect(catcherTopStyle.padding).toBe('0px');
+    expect(catcherTopStyle.margin).toBe('0px');
 
-    const inputTrapBottomStyle = window.getComputedStyle(inputTrapBottom);
+    const catcherBottomStyle = window.getComputedStyle(catcherBottom);
 
-    expect(inputTrapBottomStyle.position).toBe('absolute');
-    expect(inputTrapBottomStyle.width).toBe('0px');
-    expect(inputTrapBottomStyle.height).toBe('0px');
-    expect(inputTrapBottomStyle.opacity).toBe('0');
-    expect(inputTrapBottomStyle.zIndex).toBe('-1');
-    expect(inputTrapBottomStyle.borderWidth).toBe('0px');
-    expect(inputTrapBottomStyle.outlineWidth).toBe('0px');
-    expect(inputTrapBottomStyle.padding).toBe('0px');
-    expect(inputTrapBottomStyle.margin).toBe('0px');
+    expect(catcherBottomStyle.position).toBe('absolute');
+    expect(catcherBottomStyle.width).toBe('0px');
+    expect(catcherBottomStyle.height).toBe('0px');
+    expect(catcherBottomStyle.opacity).toBe('0');
+    expect(catcherBottomStyle.zIndex).toBe('-1');
+    expect(catcherBottomStyle.borderWidth).toBe('0px');
+    expect(catcherBottomStyle.outlineWidth).toBe('0px');
+    expect(catcherBottomStyle.padding).toBe('0px');
+    expect(catcherBottomStyle.margin).toBe('0px');
   });
 
   // More tests around the focusCatcher module you'll find here ./handsontable/test/e2e/keyboardShortcuts/tabNavigation.spec.js

--- a/handsontable/src/focusManager/utils/focusDetector.js
+++ b/handsontable/src/focusManager/utils/focusDetector.js
@@ -1,5 +1,3 @@
-import { setAttribute } from '../../helpers/dom/element';
-import { A11Y_LABEL } from '../../helpers/a11y';
 import { FOCUS_SOURCES } from '../constants';
 
 /**
@@ -59,19 +57,11 @@ export function installFocusDetector(hot, wrapperElement) {
  */
 function createInputElement(hot, focusSource) {
   const rootDocument = hot.rootDocument;
-  const input = rootDocument.createElement('input');
+  const catcher = rootDocument.createElement('div');
 
-  input.type = 'text';
-  input.name = 'htFocusCatcher';
-  input.style.display = 'none';
-  input.classList.add('htFocusCatcher');
-  input.dataset.htFocusSource = focusSource;
+  catcher.style.display = 'none';
+  catcher.classList.add('htFocusCatcher');
+  catcher.dataset.htFocusSource = focusSource;
 
-  if (hot.getSettings().ariaTags) {
-    setAttribute(input, [
-      A11Y_LABEL('Focus catcher')
-    ]);
-  }
-
-  return input;
+  return catcher;
 }


### PR DESCRIPTION
### Context
Focus detector used `<input>` elements as focus catchers at the top and bottom of the table. Those inputs could be exposed to assistive tech or affect form behavior. This change switches focus catchers to non-interactive `<div>` elements with the same `tabIndex` behavior.

### How has this been tested?
I tested the changes locally and I covered the fix with new tests.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://app.clickup.com/t/9015210959/IT-440

### Affected project(s):
- [x] `handsontable`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
