### PR TITLE
Fix wrong scrollbar width calculation

### DIFF
--- a/.changelogs/12035.json
+++ b/.changelogs/12035.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed wrong scrollbar with calculation for scaled environments",
+  "type": "fixed",
+  "issueOrPR": 12035,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/12035.json
+++ b/.changelogs/12035.json
@@ -1,6 +1,6 @@
 {
   "issuesOrigin": "private",
-  "title": "Fixed wrong scrollbar with calculation for scaled environments",
+  "title": "Fixed wrong scrollbar width calculation for scaled environments",
   "type": "fixed",
   "issueOrPR": 12035,
   "breaking": false,

--- a/handsontable/src/helpers/dom/__tests__/element.unit.js
+++ b/handsontable/src/helpers/dom/__tests__/element.unit.js
@@ -3,6 +3,7 @@ import {
   closest,
   closestDown,
   getParent,
+  getScrollbarWidth,
   getFractionalScalingCompensation,
   hasClass,
   isInput,
@@ -948,6 +949,19 @@ describe('DomElement helper', () => {
       setPlatformMeta({ platform: 'Win32' });
 
       expect(getFractionalScalingCompensation(mockDocument)).toBe(2);
+    });
+  });
+
+  //
+  // Handsontable.helper.getScrollbarWidth
+  //
+  describe('getScrollbarWidth', () => {
+    it('should not use the `getBoundingClientRect` method to calculate the scrollbar width', () => {
+      const spy = spyOn(Element.prototype, 'getBoundingClientRect');
+
+      getScrollbarWidth();
+
+      expect(spy).not.toHaveBeenCalled();
     });
   });
 });

--- a/handsontable/src/helpers/dom/element.js
+++ b/handsontable/src/helpers/dom/element.js
@@ -984,8 +984,6 @@ export function setCaretPosition(element, pos, endPos) {
   }
 }
 
-let cachedScrollbarWidth;
-
 /**
  * Returns the fractional scaling compensation for scrollbar width calculation.
  *
@@ -1008,7 +1006,7 @@ export function getFractionalScalingCompensation(rootDocument = document) {
  * Source: https://stackoverflow.com/questions/986937/how-can-i-get-the-browsers-scrollbar-sizes.
  *
  * @private
- * @param {Document} rootDocument The onwer of the document.
+ * @param {Document} rootDocument The owner of the document.
  * @returns {number}
  */
 // eslint-disable-next-line no-restricted-globals
@@ -1035,25 +1033,30 @@ function walkontableCalculateScrollbarWidth(rootDocument = document) {
   outer.style.visibility = 'hidden';
   outer.appendChild(inner);
 
-  (rootDocument.body || rootDocument.documentElement).appendChild(outer);
-  const w1 = inner.getBoundingClientRect().width;
+  rootDocument.body.appendChild(outer);
+
+  const w1 = inner.offsetWidth;
 
   outer.style.overflow = 'scroll';
-  let w2 = inner.getBoundingClientRect().width;
+
+  let w2 = inner.offsetWidth;
 
   if (w1 === w2) {
     w2 = outer.clientWidth;
   }
-  (rootDocument.body || rootDocument.documentElement).removeChild(outer);
 
-  return parseFloat((w1 - w2).toFixed(3));
+  rootDocument.body.removeChild(outer);
+
+  return w1 - w2;
 }
+
+let cachedScrollbarWidth;
 
 /**
  * Returns the computed width of the native browser scroll bar.
  *
  * @param {Document} [rootDocument] The owner of the document.
- * @returns {number} Width.
+ * @returns {number} The computed width of the native browser scroll bar.
  */
 // eslint-disable-next-line no-restricted-globals
 export function getScrollbarWidth(rootDocument = document) {


### PR DESCRIPTION
### Context
The PR fixes the wrong scrollbar width calculation. Scrollbar width was measured with `getBoundingClientRect().width`, which can be fractional (e.g. 15.2px at 125% scale). Viewport and overlay logic use integer layout values (`offsetWidth`, `clientWidth`, `getWorkspaceWidth()` etc.), so the comparison in `hasHorizontalScroll()` and overlay sizing broke when the scrollbar width was fractional.

Additionally, I have removed some fallbacks for non-supported browsers.

### How has this been tested?
I tested the changes locally and added new tests to cover the fix.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/2955

### Affected project(s):
- [x] `handsontable`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
