### PR TITLE
Fix jsdoc type

### DIFF
--- a/handsontable/src/plugins/filters/filters.js
+++ b/handsontable/src/plugins/filters/filters.js
@@ -752,7 +752,7 @@ export class Filters extends BasePlugin {
    * are included.
    *
    * @param {number} physicalColumn The physical column index.
-   * @returns {{meta: CellProperties, value: any}[]} Array of objects with `meta` and `value`, one per source row.
+   * @returns {Array<{meta: CellProperties, value: any}>} Array of objects with `meta` and `value`, one per source row.
    */
   getDataMapAtColumn(physicalColumn) {
     const countSourceRows = this.hot.countSourceRows();


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Fix the jsdoc type to a valid one.

_[skip changelog]_

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/3072

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
