### PR TITLE
Fix the `setVersion` function for the rc releases.

### DIFF
--- a/scripts/utils/pre-release.mjs
+++ b/scripts/utils/pre-release.mjs
@@ -92,9 +92,16 @@ export function setVersion(version, packages = workspacePackages) {
 
         } else {
           const isPreRelease = version.includes('-next-');
-          const newVersion = isPreRelease ? version : `${semverPrefix}${semver.major(
-            semver.maxSatisfying([version, previousVersion], '*')
-          )}.0.0`;
+          const isMajorRC = !isPreRelease && /^\d+\.0\.0-/.test(version);
+          let newVersion;
+
+          if (isPreRelease) {
+            newVersion = version;
+          } else if (isMajorRC) {
+            newVersion = `^${semver.major(version)}.0.0`;
+          } else {
+            newVersion = `${semverPrefix}${semver.major(semver.maxSatisfying([version, previousVersion], '*'))}.0.0`;
+          }
 
           // Replace the `handsontable` dependency with the current major (or previous major, if it's a prerelease).
           return `"handsontable": "${newVersion}"`;


### PR DESCRIPTION
### Context
This PR fixes the `setVersion` script function to correctly set the dependency versions for `rc` releases. 
(needed for the new GH-based freeze/release flow)

[skip changelog]

### How has this been tested?
Tested locally.
