### PR TITLE
Allow running the tests workflow from other workflows.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
       test-visual: ${{ steps.path-filter.outputs.test-visual }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # https://github.com/actions/checkout/releases/tag/v4.1.1
-        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' }}
       - uses: dorny/paths-filter@ebc4d7e9ebcb0b1eb21480bb8f43113e996ac77a # https://github.com/dorny/paths-filter/releases/tag/v3.0.1
         id: path-filter
         with:


### PR DESCRIPTION
### Context
This PR fixes a problem, where the Tests workflow cannot be run by other workflows (needed for the new GH-based freeze flow).

[skip changelog]

