### PR TITLE
In the Tests workflow, skip the "path-filter" step when "test-all" is set to true.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,7 @@ jobs:
           endsWith(github.ref, '/master') ||
           endsWith(github.ref, '/develop') ||
           contains(github.ref, '/release/') ||
-          (github.event_name == 'workflow_dispatch' && inputs.test-all == true) ||
-          (github.event_name == 'workflow_call' && inputs.test-all == true)
+          inputs['test-all'] == true
         }}
       build-handsontable-es-cjs: ${{ steps.path-filter.outputs.build-handsontable-es-cjs }}
       build-handsontable-umd: ${{ steps.path-filter.outputs.build-handsontable-umd }}
@@ -52,9 +51,10 @@ jobs:
       test-visual: ${{ steps.path-filter.outputs.test-visual }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # https://github.com/actions/checkout/releases/tag/v4.1.1
-        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' }}
+        if: ${{ inputs['test-all'] != true }}
       - uses: dorny/paths-filter@ebc4d7e9ebcb0b1eb21480bb8f43113e996ac77a # https://github.com/dorny/paths-filter/releases/tag/v3.0.1
         id: path-filter
+        if: ${{ inputs['test-all'] != true }}
         with:
           filters: |
             config-files: &config-files


### PR DESCRIPTION
### Context
This PR skips the changed file path recognition in the Tests workflow, when "test-all" is set as "true".

[skip changelog]
