### PR TITLE
Fix an issue with publishing npm package files using a relative path.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -298,7 +298,7 @@ jobs:
           echo "Publishing packages from _tmp_packs/ with tag: rc"
           for TARBALL in _tmp_packs/*.tgz; do
             echo "Publishing: $(basename "$TARBALL")"
-            npm publish "$TARBALL" --tag rc
+            npm publish "./$TARBALL" --tag rc
           done
           echo "All packages published successfully."
 
@@ -569,7 +569,7 @@ jobs:
           echo "Publishing packages from _tmp_packs/ with tag: rc"
           for TARBALL in _tmp_packs/*.tgz; do
             echo "Publishing: $(basename "$TARBALL")"
-            npm publish "$TARBALL" --tag rc
+            npm publish "./$TARBALL" --tag rc
           done
           echo "All packages published successfully."
 
@@ -915,7 +915,7 @@ jobs:
           echo "Publishing packages from _tmp_packs/ with tag: latest"
           for TARBALL in _tmp_packs/*.tgz; do
             echo "Publishing: $(basename "$TARBALL")"
-            npm publish "$TARBALL" --tag latest
+            npm publish "./$TARBALL" --tag latest
           done
           echo "All packages published successfully."
 


### PR DESCRIPTION
### Context
This PR should fix a problem when trying to publish a npm package file to npm by providing it's relative path.
Ref: https://github.com/npm/cli/issues/3010.

