### PR TITLE
Add language directory building to the ES part of the testing workflow.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -176,6 +176,8 @@ jobs:
           npm run build:es
           npm run build:commonjs
           npm run build:languages.es
+          npm run build:languages
+          npm run build:languages.min
           npm run postbuild
       - run: tar -zcf tmp.tar.gz ./handsontable/tmp
 


### PR DESCRIPTION
### Context
This PR adds a full `language` directory building to the Tests workflow (ES+CJS build job).
Needed update after removing the `languages` directory from being tracked by git.

[skip changelog]

### How has this been tested?
Tested locally.
