### PR TITLE
Fix failing React wrapper test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -563,7 +563,6 @@ jobs:
           name: handsontable-build-es-cjs
           path: ./
       - run: tar -zxf tmp.tar.gz ./handsontable/tmp && rm tmp.tar.gz
-      - run: cd handsontable
       - run: npm run in angular-wrapper build
       - run: tar --exclude='node_modules' -zcf angular-wrapper.tar.gz ./wrappers/angular-wrapper
 
@@ -602,7 +601,6 @@ jobs:
           name: handsontable-build-es-cjs
           path: ./
       - run: tar -zxf tmp.tar.gz ./handsontable/tmp && rm tmp.tar.gz
-      - run: cd handsontable
       - run: npm run in react-wrapper build
       - run: tar --exclude='node_modules' -zcf react-wrapper.tar.gz ./wrappers/react-wrapper
 
@@ -640,7 +638,6 @@ jobs:
           name: handsontable-build-es-cjs
           path: ./
       - run: tar -zxf tmp.tar.gz ./handsontable/tmp && rm tmp.tar.gz
-      - run: cd handsontable
       - run: npm run in vue3 build
       - run: tar --exclude='node_modules' -zcf vue3.tar.gz ./wrappers/vue3
 

--- a/wrappers/react-wrapper/test/undoRedo.spec.tsx
+++ b/wrappers/react-wrapper/test/undoRedo.spec.tsx
@@ -29,6 +29,7 @@ describe('UndoRedo plugin in React wrapper', () => {
       ));
 
       const hotInstance = hotTableRef.hotInstance!;
+
       expect(hotInstance).not.toBe(null);
       expect(hotInstance.getDataAtCell(0, 0)).toBe(0);
 
@@ -51,7 +52,7 @@ describe('UndoRedo plugin in React wrapper', () => {
       const firstAction = undoRedoPlugin.doneActions[0];
       const secondAction = undoRedoPlugin.doneActions[1];
 
-      expect(firstAction.changes[0][2]).toBe(0); 
+      expect(firstAction.changes[0][2]).toBe(0);
       expect(firstAction.changes[0][3]).toBe(2);
 
       expect(secondAction.changes[0][2]).toBe(2);

--- a/wrappers/react-wrapper/test/undoRedo.spec.tsx
+++ b/wrappers/react-wrapper/test/undoRedo.spec.tsx
@@ -10,6 +10,8 @@ import {
 
 registerAllModules();
 
+jest.setTimeout(10000);
+
 describe('UndoRedo plugin in React wrapper', () => {
   describe('beforeChange hook execution order', () => {
     it('should record the modified value in UndoRedo when beforeChange modifies the change', async () => {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Fix failing React wrapper test after merging https://github.com/handsontable/handsontable/pull/12001.

_[skip changelog]_

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Affected project(s):
- [x] `@handsontable/react-wrapper`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
