### PR TITLE
Fix MultiSelect editor label clicks affecting wrong Handsontable instance.

### DIFF
--- a/handsontable/src/editors/multiSelectEditor/__tests__/multiSelectEditor.spec.js
+++ b/handsontable/src/editors/multiSelectEditor/__tests__/multiSelectEditor.spec.js
@@ -984,7 +984,7 @@ describe('MultiSelectEditor', () => {
       });
 
       it('should toggle selection when clicking on the label', async() => {
-        handsontable({
+        const hot = handsontable({
           data: [
             [[]],
           ],
@@ -996,13 +996,15 @@ describe('MultiSelectEditor', () => {
           ],
         });
 
+        const instanceId = hot.guid;
+
         await selectCell(0, 0);
         await keyDownUp('enter');
         await sleep(10);
 
         const $dropdown = $('.ht-multi-select-editor');
         const $checkbox = $dropdown.find('input[type="checkbox"][data-value="yellow"]');
-        const $label = $dropdown.find('label[for="ht-multi-select-editor-item-0"]');
+        const $label = $dropdown.find(`label[for="${instanceId}-ht-multi-select-editor-item-0"]`);
 
         expect($checkbox.prop('checked')).toBe(false);
         expect($dropdown.find('li.ht-multi-select-editor-item-selected').length).toBe(0);
@@ -1207,6 +1209,50 @@ describe('MultiSelectEditor', () => {
         expect($checkedCheckboxes.eq(0).data('value')).toBe('yellow');
         expect($checkedCheckboxes.eq(1).data('value')).toBe('red');
         expect($checkedCheckboxes.eq(2).data('value')).toBe('orange');
+      });
+    });
+
+    describe('multiple Handsontable instances on the same page', () => {
+      it('should save the selection to the currently edited instance when clicking a label, ' +
+        'not to a cell from a previously edited instance', async() => {
+        handsontable({
+          data: [[[]]],
+          columns: [{ type: 'multiselect', source: choices }],
+        });
+
+        const $container2 = $('<div style="width: 300px; height: 300px;"></div>').appendTo('body');
+        const hot2 = new Handsontable($container2[0], {
+          data: [[[]]],
+          columns: [{ type: 'multiselect', source: choices }],
+        });
+
+        // Open the editor on instance 1 then close it without selecting anything
+        await selectCell(0, 0);
+        await keyDownUp('enter');
+        await sleep(10);
+        await keyDownUp('escape');
+        await sleep(10);
+
+        // Open the editor on instance 2
+        hot2.selectCell(0, 0);
+        await keyDownUp('enter');
+        await sleep(10);
+
+        // Click the label of the first checkbox in instance 2's dropdown
+        const $dropdown2 = $(hot2.rootElement).find('.ht-multi-select-editor');
+        const $label2 = $dropdown2.find('label').first();
+
+        await simulateClick($label2);
+        await sleep(10);
+
+        // The value should be saved to instance 2's cell
+        expect(hot2.getSourceDataAtCell(0, 0)).toEqual([choices[0]]);
+
+        // Instance 1's cell should remain unchanged
+        expect(getSourceDataAtCell(0, 0)).toEqual([]);
+
+        hot2.destroy();
+        $container2.remove();
       });
     });
   });

--- a/handsontable/src/editors/multiSelectEditor/controllers/dropdownController.js
+++ b/handsontable/src/editors/multiSelectEditor/controllers/dropdownController.js
@@ -29,6 +29,11 @@ import {
  */
 export class DropdownController {
   /**
+   * Handsontable instance id.
+   */
+  #instanceId = null;
+
+  /**
    * Element that wraps the dropdown list inside the editor UI.
    *
    * @private
@@ -112,10 +117,12 @@ export class DropdownController {
    * Creates a dropdown renderer attached to the provided container.
    *
    * @param {HTMLDivElement} containerElement Host element created by the editor.
+   * @param {string} instanceId Handsontable instance id.
    */
-  constructor(containerElement) {
+  constructor(containerElement, instanceId) {
     this.#containerElement = containerElement;
     this.#rootDocument = this.#containerElement.ownerDocument;
+    this.#instanceId = instanceId;
 
     this.init();
   }
@@ -195,7 +202,7 @@ export class DropdownController {
 
     entries.forEach((elem, indexWithinList) => {
       this.#addDropdownItem({
-        rootElement: this.#rootDocument,
+        rootDocument: this.#rootDocument,
         itemKey: elem?.key,
         itemValue: elem?.value ?? elem,
         indexWithinList,
@@ -488,16 +495,17 @@ export class DropdownController {
    * Adds a single row to the dropdown and optionally marks it as checked.
    *
    * @param {object} options Options object.
-   * @param {Document} options.rootElement Root document element.
+   * @param {Document} options.rootDocument Root document element.
    * @param {string} options.itemKey Key stored in the associated checkbox dataset.
    * @param {string} options.itemValue Text content rendered next to the checkbox.
    * @param {number} options.indexWithinList Index of the item within the list.
    * @param {boolean} [options.checked=false] Flag indicating whether the checkbox starts selected.
    * @param {boolean} [options.disabled=false] Flag indicating whether the checkbox starts disabled.
    */
-  #addDropdownItem({ rootElement, itemKey, itemValue, indexWithinList, checked = false, disabled = false }) {
+  #addDropdownItem({ rootDocument, itemKey, itemValue, indexWithinList, checked = false, disabled = false }) {
     const itemElement = createListItemElement({
-      rootElement,
+      rootDocument,
+      instanceId: this.#instanceId,
       itemKey,
       itemValue,
       indexWithinList,

--- a/handsontable/src/editors/multiSelectEditor/controllers/utils.js
+++ b/handsontable/src/editors/multiSelectEditor/controllers/utils.js
@@ -214,7 +214,8 @@ export function enableAllCheckboxes({ dropdownListElement }) {
  * Creates a single dropdown row with a checkbox and label.
  *
  * @param {object} options Options object.
- * @param {Document} options.rootElement Root document element.
+ * @param {Document} options.rootDocument Root document element.
+ * @param {string} options.instanceId Handsontable instance id.
  * @param {string} options.itemKey Key stored in the associated checkbox dataset.
  * @param {string} options.itemValue Text shown next to the checkbox.
  * @param {number} options.indexWithinList Index of the item within the list.
@@ -223,19 +224,20 @@ export function enableAllCheckboxes({ dropdownListElement }) {
  * @returns {HTMLLIElement}
  */
 export function createListItemElement({
-  rootElement,
+  rootDocument,
+  instanceId,
   itemKey,
   itemValue,
   indexWithinList,
   checked = false,
   disabled = false,
 }) {
-  const itemElement = rootElement.createElement('li');
-  const innerContainer = rootElement.createElement('div');
-  const checkboxElement = rootElement.createElement('input');
-  const labelElement = rootElement.createElement('label');
+  const itemElement = rootDocument.createElement('li');
+  const innerContainer = rootDocument.createElement('div');
+  const checkboxElement = rootDocument.createElement('input');
+  const labelElement = rootDocument.createElement('label');
 
-  checkboxElement.id = `${CHECKBOX_ID_PREFIX}${indexWithinList}`;
+  checkboxElement.id = `${instanceId}-${CHECKBOX_ID_PREFIX}${indexWithinList}`;
   checkboxElement.type = 'checkbox';
   checkboxElement.dataset.value = itemValue;
   checkboxElement.dataset.index = indexWithinList;

--- a/handsontable/src/editors/multiSelectEditor/multiSelectEditor.js
+++ b/handsontable/src/editors/multiSelectEditor/multiSelectEditor.js
@@ -104,7 +104,7 @@ export class MultiSelectEditor extends BaseEditor {
     this.#editorContainer.appendChild(this.dropdownContainerElement);
     this.hot.rootElement.appendChild(this.#editorContainer);
 
-    this.dropdownController = new DropdownController(this.dropdownContainerElement);
+    this.dropdownController = new DropdownController(this.dropdownContainerElement, this.hot.guid);
   }
 
   /**

--- a/handsontable/src/styles/components/editors/_multi-select-editor.scss
+++ b/handsontable/src/styles/components/editors/_multi-select-editor.scss
@@ -103,6 +103,11 @@
           background: var(--ht-background-color);
           padding: var(--ht-menu-item-vertical-padding) var(--ht-menu-item-horizontal-padding);
           user-select: none;
+          cursor: pointer;
+
+          * {
+            cursor: pointer;
+          }
 
           &.ht-multi-select-editor-item-selected {
             background: color-mix(in srgb, var(--ht-menu-item-active-color) var(--ht-menu-item-active-color-opacity, 100%), transparent);


### PR DESCRIPTION
### Context
When two Handsontable instances existed on the same page, clicking a checkbox **label** in the MultiSelect editor of the second instance would incorrectly save the value to the previously edited cell of the first instance. 
  Clicking the checkbox directly worked correctly - only label clicks were affected.                                                                                                                                             
                                                                                                                                                                                                                                 
  The root cause was non-unique checkbox IDs across instances, causing the browser's `label[for]` resolution to target the wrong instance's checkbox.                                                                            

  Also sets `cursor: pointer` on MultiSelect dropdown list items and their children.

**Note: this PR needs to be cherry-picked to `release/17.0.0` after merging to `develop`**

[skip changelog]
<sup>unreleased feature</sup>

### How has this been tested?
Added a new test case covering the two-instance scenario, and updated an existing label-click test to reflect the fix.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. handsontable/dev-handsontable#3078

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
