### PR TITLE
Fix column sorting styles

### DIFF
--- a/.changelogs/12058.json
+++ b/.changelogs/12058.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed and issue with column headers styles",
+  "type": "fixed",
+  "issueOrPR": 12058,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/styles/components/plugins/_column-sorting.scss
+++ b/handsontable/src/styles/components/plugins/_column-sorting.scss
@@ -36,6 +36,11 @@
     .htRight {
       .columnSorting {
         &.sortAction {
+          &.ascending, &.descending {
+            padding-inline-start: calc(var(--ht-icon-size, 16px) + 2px);
+            padding-inline-end: 0;
+          }
+
           &::before {
             left: 2px;
             right: auto;
@@ -58,9 +63,25 @@
         }
       }
 
+      .htRight {
+        .columnSorting {
+          &.sortAction {
+            &.ascending, &.descending {
+              padding-inline-start: 0;
+              padding-inline-end: calc(var(--ht-icon-size, 16px) + 2px);
+            }
+          }
+        }
+      }
+
       .htLeft {
         .columnSorting {
           &.sortAction {
+            &.ascending, &.descending {
+              padding-inline-start: calc(var(--ht-icon-size, 16px) + 2px);
+              padding-inline-end: 0;
+            }
+
             &::before {
               left: auto;
               right: 2px;

--- a/handsontable/src/styles/components/plugins/_column-sorting.scss
+++ b/handsontable/src/styles/components/plugins/_column-sorting.scss
@@ -8,10 +8,12 @@
       position: relative;
 
       &.sortAction {
-        padding-inline-start: calc(var(--ht-icon-size, 16px) + 2px);
-        padding-inline-end: calc(var(--ht-icon-size, 16px) + 2px);
         min-width: calc(var(--ht-icon-size, 16px) + 8px);
-        max-width: calc(100% - calc(var(--ht-icon-size, 16px) * 2) - 5px) !important;
+
+        &.ascending, &.descending {
+          padding-inline-end: calc(var(--ht-icon-size, 16px) + 2px);
+          max-width: calc(100% - calc(var(--ht-icon-size, 16px) * 2 + var(--ht-gap-size, 4px) + 3px)) !important;
+        }
 
         &:hover {
           text-decoration: none;
@@ -31,20 +33,9 @@
       }
     }
 
-    .htLeft {
-      .columnSorting {
-        &.sortAction {
-          padding-inline-start: 0;
-        }
-      }
-    }
-
     .htRight {
       .columnSorting {
         &.sortAction {
-          padding-inline-start: var(--ht-icon-size, 16px);
-          padding-inline-end: var(--ht-gap-size, 4px);
-
           &::before {
             left: 2px;
             right: auto;
@@ -67,21 +58,9 @@
         }
       }
 
-      .htRight {
-        .columnSorting {
-          &.sortAction {
-            padding-inline-start: var(--ht-gap-size, 4px);
-            padding-inline-end: var(--ht-icon-size, 16px);
-          }
-        }
-      }
-
       .htLeft {
         .columnSorting {
           &.sortAction {
-            padding-inline-start: var(--ht-icon-size, 16px);
-            padding-inline-end: var(--ht-gap-size, 4px);
-
             &::before {
               left: auto;
               right: 2px;
@@ -102,6 +81,6 @@
 
     /* The multi-line header and header with longer text need more padding to not hide arrow,
         we make header wider in `GhostTable` to make some space for arrow which is positioned absolutely in the main table */
-    padding-right: 20px;
+    padding-inline-end: calc(var(--ht-icon-size, 16px) + 2px);
   }
 }


### PR DESCRIPTION
### Context
This PR includes a fix for an issue with column header styles when sorting is enabled.

### How has this been tested?
Locally and updated visual tests results

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/3006

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only adjustments to column sorting header padding/width in LTR/RTL and fixed columns; low risk but may affect header layout/overflow in edge cases.
> 
> **Overview**
> Fixes column header styling when column sorting is active by scoping padding/max-width adjustments to the `ascending`/`descending` states and updating LTR/RTL + `htRight`/`htLeft` alignment rules so sort indicators don’t overlap header text.
> 
> Updates ghost table header spacing to use `padding-inline-end` tied to the icon size, and adds a changelog entry for the fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit effd9286bd6c1ea569e12b50662522abd4b2cca8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->