### PR TITLE
Fix column width calculation for collapsed columns

### DIFF
--- a/.changelogs/12059.json
+++ b/.changelogs/12059.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed column width calculation for collapsed columns",
+  "type": "fixed",
+  "issueOrPR": 12059,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/collapsibleColumns/__tests__/collapsibleColumns.spec.js
+++ b/handsontable/src/plugins/collapsibleColumns/__tests__/collapsibleColumns.spec.js
@@ -2251,7 +2251,7 @@ describe('CollapsibleColumns', () => {
 
       expect(getColWidth(1)).forThemes(({ classic, main, horizon }) => {
         classic.toBe(90);
-        main.toBe(90);
+        main.toBe(99);
         horizon.toBe(107);
       });
 

--- a/handsontable/src/plugins/collapsibleColumns/__tests__/collapsibleColumns.spec.js
+++ b/handsontable/src/plugins/collapsibleColumns/__tests__/collapsibleColumns.spec.js
@@ -2244,19 +2244,27 @@ describe('CollapsibleColumns', () => {
           ['A1', { label: 'Very long header text', colspan: 4 }, 'F1', 'G1', 'H1', 'I1', 'J1'],
           ['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2', 'H2', 'I2', 'J2'],
         ],
-        collapsibleColumns: true
+        collapsibleColumns: true,
       });
 
       await setDataAtCell(0, 1, 'Longer value');
 
-      expect(getColWidth(1)).toBe(99);
+      expect(getColWidth(1)).forThemes(({ classic, main, horizon }) => {
+        classic.toBe(90);
+        main.toBe(90);
+        horizon.toBe(107);
+      });
 
       $(getCell(-2, 1).querySelector('.collapsibleIndicator')) // header "B1"
         .simulate('mousedown')
         .simulate('mouseup')
         .simulate('click');
 
-      expect(getColWidth(1)).toBe(99);
+      expect(getColWidth(1)).forThemes(({ classic, main, horizon }) => {
+        classic.toBe(90);
+        main.toBe(99);
+        horizon.toBe(107);
+      });
     });
   });
 

--- a/handsontable/src/plugins/collapsibleColumns/__tests__/collapsibleColumns.spec.js
+++ b/handsontable/src/plugins/collapsibleColumns/__tests__/collapsibleColumns.spec.js
@@ -2236,6 +2236,28 @@ describe('CollapsibleColumns', () => {
         </tbody>
         `);
     });
+
+    it('should calculate the column width on the longest cell value, not the header text size (#dev-2151)', async() => {
+      handsontable({
+        data: createSpreadsheetData(10, 10),
+        nestedHeaders: [
+          ['A1', { label: 'Very long header text', colspan: 4 }, 'F1', 'G1', 'H1', 'I1', 'J1'],
+          ['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2', 'H2', 'I2', 'J2'],
+        ],
+        collapsibleColumns: true
+      });
+
+      await setDataAtCell(0, 1, 'Longer value');
+
+      expect(getColWidth(1)).toBe(99);
+
+      $(getCell(-2, 1).querySelector('.collapsibleIndicator')) // header "B1"
+        .simulate('mousedown')
+        .simulate('mouseup')
+        .simulate('click');
+
+      expect(getColWidth(1)).toBe(99);
+    });
   });
 
   describe('expanding headers functionality', () => {

--- a/handsontable/src/plugins/nestedHeaders/utils/ghostTable.js
+++ b/handsontable/src/plugins/nestedHeaders/utils/ghostTable.js
@@ -132,7 +132,13 @@ class GhostTable {
         const th = rootDocument.createElement('th');
         const headerSettings = this.nestedHeaderSettingsGetter(row, visualColumnsIndex);
 
-        if (headerSettings && (!headerSettings.isPlaceholder || headerSettings.isHidden)) {
+        if (
+          headerSettings &&
+          (
+            (!headerSettings.isPlaceholder && !headerSettings.isCollapsed) ||
+            headerSettings.isHidden
+          )
+        ) {
           let label = headerSettings.label;
 
           if (isDropdownEnabled) {


### PR DESCRIPTION
### Context
The _NestedHeaders_ ghost table now correctly skips rendering text for collapsed columns. This prevents hidden header labels from inflating column widths, ensuring that widths are accurately based on the actual cell content.

### How has this been tested?
I tested the changes locally and I covered the fix with new tests.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/2151

### Affected project(s):
- [x] `handsontable`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
