### PR TITLE
Fix docs boxes styles

### DIFF
--- a/docs/.vuepress/theme/styles/components/boxes.styl
+++ b/docs/.vuepress/theme/styles/components/boxes.styl
@@ -4,7 +4,7 @@
         padding: 0
     }
     #introduction ~ .boxes-list,
-    #open-source-software-components ~ .boxes-list
+    #open-source-software-components ~ .boxes-list,
     #handsontable-api-reference  ~ .boxes-list  {
         padding: 0
 
@@ -149,7 +149,7 @@
         }
     }
 
-    #open-source-software-components ~ .boxes-list
+    #open-source-software-components ~ .boxes-list,
     #handsontable-api-reference  ~ .boxes-list  {
         ul {
             grid-template-columns: repeat(2, 1fr);

--- a/docs/.vuepress/theme/styles/components/boxes.styl
+++ b/docs/.vuepress/theme/styles/components/boxes.styl
@@ -165,6 +165,10 @@
                     line-height: 22px;
                 }
             }
+
+            @media (max-width: $medium) {
+                grid-template-columns: repeat(1, 1fr);
+            }
         }
     }
 

--- a/docs/.vuepress/theme/styles/components/boxes.styl
+++ b/docs/.vuepress/theme/styles/components/boxes.styl
@@ -149,6 +149,25 @@
         }
     }
 
+    #open-source-software-components ~ .boxes-list
+    #handsontable-api-reference  ~ .boxes-list  {
+        ul {
+            grid-template-columns: repeat(2, 1fr);
+
+            li {
+                flex-direction: column;
+                align-items: stretch;
+                font-size: 14px;
+                line-height: 22px;
+
+                p {
+                    font-size: 14px;
+                    line-height: 22px;
+                }
+            }
+        }
+    }
+
     .icons-only {
         ul {
             margin-top: 16px


### PR DESCRIPTION
### Context
This PR includes fix for docs boxes styles

### How has this been tested?
Lcoally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/3075

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only Stylus/CSS changes for docs box list layouts, with no runtime logic or data handling impact; potential risk is limited to visual regressions on the targeted docs sections.
> 
> **Overview**
> Fixes docs "boxes" styling by correcting the selector list so `#open-source-software-components` and `#handsontable-api-reference` boxes lists consistently receive the shared base styles.
> 
> Adds section-specific layout overrides for those two pages: switches the boxes grid to 2 columns (1 on smaller screens) and adjusts list item typography and alignment for a stacked/column layout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3743f504158fd94e9ee0c72a637079ac56b82c08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->