### PR TITLE
Expand the publishing workflow with syncing the changelog with new changes and updating the docs' changelog page.

### DIFF
--- a/.github/scripts/update-docs-changelog.mjs
+++ b/.github/scripts/update-docs-changelog.mjs
@@ -1,0 +1,122 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// Usage: node prepend-docs-changelog.mjs <version> [docs-path]
+//
+// Changelog content is read from the CHANGELOG_CONTENT environment variable.
+//
+// If CHANGELOG_CONTENT is set:
+//   - Same base version at top → replace the entire section
+//   - Different base version   → prepend a new section after [[toc]]
+// If CHANGELOG_CONTENT is unset (stable promotion of an RC entry):
+//   - Updates the version header and release date in place
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const DEFAULT_DOCS = path.join(REPO_ROOT, 'docs/content/guides/upgrade-and-migration/changelog/changelog.md');
+
+const [version, docsPath = DEFAULT_DOCS] = process.argv.slice(2);
+
+if (!version) {
+  process.stderr.write('Usage: node prepend-docs-changelog.mjs <version> [docs-path]\n');
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+
+function parseVersion(ver) {
+  const m = ver.match(/^(\d+)\.(\d+)\.\d+(-rc\d+)?$/);
+
+  if (!m) {
+    process.stderr.write(`Error: invalid version "${ver}" — expected X.Y.Z or X.Y.Z-rcN\n`);
+    process.exit(1);
+  }
+
+  return { base: `${m[1]}.${m[2]}.${ver.split('.')[2].replace(/-rc\d+$/, '')}`, majorMinor: `${m[1]}.${m[2]}` };
+}
+
+function formatDate() {
+  const d = new Date();
+  const day = d.getDate();
+  const suffix = { one: 'st', two: 'nd', few: 'rd', other: 'th' }[new Intl.PluralRules('en-US', { type: 'ordinal' }).select(day)];
+
+  return `${d.toLocaleString('en-US', { month: 'long' })} ${day}${suffix}, ${d.getFullYear()}`;
+}
+
+function buildEntry(ver, content, majorMinor) {
+  return [
+    `## ${ver}`,
+    '',
+    `Released on ${formatDate()}`,
+    '',
+    'For more information about this release, see:',
+    `- [Documentation (${majorMinor})](https://handsontable.com/docs/${majorMinor})`,
+    '',
+    content.trim().replace(/^### /gm, '#### '),
+    '',
+  ].join('\n');
+}
+
+// ---------------------------------------------------------------------------
+
+const { base, majorMinor } = parseVersion(version);
+const trimmedContent = process.env.CHANGELOG_CONTENT?.trim();
+const lines = fs.readFileSync(docsPath, 'utf8').split('\n');
+
+// Find the topmost ## section header
+const topIdx = lines.findIndex(l => /^## /.test(l));
+
+// Does it belong to the same base version? (e.g. 16.0.0, 16.0.0-rc1, 16.0.0-rc2 all share base 16.0.0)
+const escapedBase = base.replace(/\./g, '\\.');
+const sameBase = topIdx !== -1 && new RegExp(`^## ${escapedBase}(-rc\\d+)?\\s*$`).test(lines[topIdx]);
+
+if (sameBase && !trimmedContent) {
+  // Stable promotion: just fix the header and date, leave content untouched
+  lines[topIdx] = `## ${version}`;
+
+  for (let i = topIdx + 1; i < lines.length && !/^## /.test(lines[i]); i++) {
+    if (lines[i].startsWith('Released on ')) {
+      lines[i] = `Released on ${formatDate()}`;
+      break;
+    }
+  }
+
+  fs.writeFileSync(docsPath, lines.join('\n'), 'utf8');
+  process.stdout.write(`Promoted to stable ${version}.\n`);
+
+} else if (sameBase && trimmedContent) {
+  // Replace the existing section entirely
+  let end = lines.length;
+
+  for (let i = topIdx + 1; i < lines.length; i++) {
+    if (/^## /.test(lines[i])) { end = i; break; }
+  }
+
+  const updated = [...lines.slice(0, topIdx), ...buildEntry(version, trimmedContent, majorMinor).split('\n'), ...lines.slice(end)];
+
+  fs.writeFileSync(docsPath, updated.join('\n'), 'utf8');
+  process.stdout.write(`Replaced docs changelog entry for ${version}.\n`);
+
+} else {
+  // New base version: prepend after [[toc]]
+  if (!trimmedContent) {
+    process.stderr.write(`Error: no changelog content provided for new version ${version}.\n`);
+    process.exit(1);
+  }
+
+  const tocIdx = lines.findIndex(l => l.trim() === '[[toc]]');
+
+  if (tocIdx === -1) {
+    process.stderr.write('Error: [[toc]] marker not found in docs changelog.\n');
+    process.exit(1);
+  }
+
+  let insertAt = tocIdx + 1;
+
+  while (insertAt < lines.length && lines[insertAt].trim() === '') insertAt++;
+
+  const updated = [...lines.slice(0, insertAt), ...buildEntry(version, trimmedContent, majorMinor).split('\n'), ...lines.slice(insertAt)];
+
+  fs.writeFileSync(docsPath, updated.join('\n'), 'utf8');
+  process.stdout.write(`Prepended docs changelog entry for ${version}.\n`);
+}

--- a/.github/scripts/update-docs-changelog.mjs
+++ b/.github/scripts/update-docs-changelog.mjs
@@ -67,7 +67,7 @@ const lines = fs.readFileSync(docsPath, 'utf8').split('\n');
 const topIdx = lines.findIndex(l => /^## /.test(l));
 
 // Does it belong to the same base version? (e.g. 16.0.0, 16.0.0-rc1, 16.0.0-rc2 all share base 16.0.0)
-const escapedBase = base.replace(/\./g, '\\.');
+const escapedBase = base.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 const sameBase = topIdx !== -1 && new RegExp(`^## ${escapedBase}(-rc\\d+)?\\s*$`).test(lines[topIdx]);
 
 if (sameBase && !trimmedContent) {

--- a/.github/scripts/update-docs-changelog.mjs
+++ b/.github/scripts/update-docs-changelog.mjs
@@ -100,6 +100,18 @@ if (sameBase && !trimmedContent) {
 } else {
   // New base version: prepend after [[toc]]
   if (!trimmedContent) {
+    // Patch release on an existing docs branch: the top entry belongs to the same
+    // major.minor line but a different patch (e.g. promoting 16.2.1 when 16.2.0 is
+    // already at the top). There is no RC-sourced content to prepend, so skip.
+    const escapedMajorMinor = majorMinor.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const sameMajorMinor = topIdx !== -1 &&
+      new RegExp(`^## ${escapedMajorMinor}\\.`).test(lines[topIdx]);
+
+    if (sameMajorMinor) {
+      process.stdout.write(`Patch release ${version} — docs branch already on ${majorMinor}.x, skipping changelog prepend.\n`);
+      process.exit(0);
+    }
+
     process.stderr.write(`Error: no changelog content provided for new version ${version}.\n`);
     process.exit(1);
   }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -865,9 +865,6 @@ jobs:
           name: nuget_pack_${{ steps.version.outputs.version }}
           path: Handsontable.*.nupkg
 
-      - name: Update docs changelog
-        run: node .github/scripts/update-docs-changelog.mjs '${{ steps.version.outputs.version }}'
-
       - name: Update changelog release date
         run: |
           VERSION='${{ steps.version.outputs.version }}'
@@ -1100,6 +1097,9 @@ jobs:
               exit 1
             fi
           fi
+
+      - name: Update docs changelog
+        run: node .github/scripts/update-docs-changelog.mjs '${{ needs.stable-build.outputs.version }}'
 
       - name: Regenerate docs API and legacy versions
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1077,7 +1077,7 @@ jobs:
           gh api repos/${{ github.repository }}/git/refs/tags/${VERSION} \
             -X PATCH \
             -f sha="$NEW_SHA" \
-            -f force=true
+            -F force=true
 
           echo "Tag ${VERSION} updated to ${NEW_SHA} (post-merge master)"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -213,6 +213,11 @@ jobs:
             echo "EOF"
           } >> $GITHUB_OUTPUT
 
+      - name: Update docs changelog
+        env:
+          CHANGELOG_CONTENT: ${{ steps.changelog.outputs.content }}
+        run: node .github/scripts/update-docs-changelog.mjs '${{ steps.version.outputs.rc-version }}'
+
       - name: Commit and push
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -393,6 +398,7 @@ jobs:
     if: github.event_name == 'push'
     outputs:
       rc-version: ${{ steps.rc-version.outputs.rc-version }}
+      changelog-synced: ${{ steps.sync-changelog.outputs.synced }}
     steps:
       - name: Extract version from branch name
         id: version
@@ -504,6 +510,33 @@ jobs:
           sed -i "s/${PATTERN}/## [${RC_VERSION}] - ${TODAY}/" CHANGELOG.md
           echo "Updated CHANGELOG.md: ## [${RC_VERSION}] - ${TODAY}"
 
+      - name: Sync pending changelog entries
+        id: sync-changelog
+        run: |
+          if ls .changelogs/*.json 2>/dev/null | grep -q .; then
+            npm run changelog sync < /dev/null
+            echo "synced=true" >> $GITHUB_OUTPUT
+          else
+            echo "No pending changelog entries to sync."
+            echo "synced=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Extract changelog for this version
+        id: changelog
+        run: |
+          RC_VERSION='${{ steps.rc-version.outputs.rc-version }}'
+          CONTENT=$(node .github/scripts/extract-changelog.mjs "$RC_VERSION")
+          {
+            echo "content<<EOF"
+            printf '%s\n' "$CONTENT"
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+
+      - name: Update docs changelog
+        env:
+          CHANGELOG_CONTENT: ${{ steps.changelog.outputs.content }}
+        run: node .github/scripts/update-docs-changelog.mjs '${{ steps.rc-version.outputs.rc-version }}'
+
       - name: Commit and push
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -522,17 +555,6 @@ jobs:
           gh api repos/${{ github.repository }}/git/refs \
             -f ref="refs/tags/${RC_VERSION}" \
             -f sha="$(git rev-parse HEAD)"
-
-      - name: Extract changelog for this version
-        id: changelog
-        run: |
-          RC_VERSION='${{ steps.rc-version.outputs.rc-version }}'
-          CONTENT=$(node .github/scripts/extract-changelog.mjs "$RC_VERSION")
-          {
-            echo "content<<EOF"
-            printf '%s\n' "$CONTENT"
-            echo "EOF"
-          } >> $GITHUB_OUTPUT
 
       - name: Update GitHub release
         env:
@@ -655,14 +677,17 @@ jobs:
             COMMITS_TEXT="No commits found since \`${PREV_TAG}\`."
           fi
 
+          CHANGELOG_SYNCED='${{ needs.rc-build.outputs.changelog-synced }}'
+
           jq -n \
-            --arg status     "$STATUS_FIELD" \
-            --arg version    "${RC_VERSION}" \
-            --arg branch     "${BRANCH}" \
-            --arg repo_url   "${REPO_URL}" \
-            --arg prev_tag   "${PREV_TAG}" \
-            --arg commits    "$COMMITS_TEXT" \
-            --arg run_url    "${RUN_URL}" \
+            --arg status            "$STATUS_FIELD" \
+            --arg version           "${RC_VERSION}" \
+            --arg branch            "${BRANCH}" \
+            --arg repo_url          "${REPO_URL}" \
+            --arg prev_tag          "${PREV_TAG}" \
+            --arg commits           "$COMMITS_TEXT" \
+            --arg run_url           "${RUN_URL}" \
+            --arg changelog_synced  "${CHANGELOG_SYNCED}" \
           '{
             text: ("🚀 Pre-release " + $version + " generated – " + $status),
             blocks: [
@@ -684,6 +709,12 @@ jobs:
                 type: "section",
                 text: { type: "mrkdwn", text: ("*📋 Commits since `" + $prev_tag + "`*\n" + $commits) }
               },
+              if $changelog_synced == "true" then
+                {
+                  type: "context",
+                  elements: [{ type: "mrkdwn", text: "❗ *Changelog extended with new entries!*" }]
+                }
+              else empty end,
               { type: "divider" },
               {
                 type: "section",
@@ -833,6 +864,9 @@ jobs:
         with:
           name: nuget_pack_${{ steps.version.outputs.version }}
           path: Handsontable.*.nupkg
+
+      - name: Update docs changelog
+        run: node .github/scripts/update-docs-changelog.mjs '${{ steps.version.outputs.version }}'
 
       - name: Update changelog release date
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -230,7 +230,7 @@ jobs:
 
           git commit -m "${RC_VERSION}" || echo "No changes to commit"
           git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
-          git push -u origin "${RELEASE_BRANCH}" --tags
+          git push -u origin "${RELEASE_BRANCH}"
 
           # Create tag via GitHub API so it's automatically verified
           gh api repos/${{ github.repository }}/git/refs \
@@ -853,7 +853,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y mono-complete
-          curl -o /tmp/nuget.exe https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
+          curl -o /tmp/nuget.exe https://dist.nuget.org/win-x86-commandline/v7.3.0/nuget.exe
           sudo bash -c 'echo "#!/bin/bash" > /usr/local/bin/nuget && echo "exec mono /tmp/nuget.exe \"$@\"" >> /usr/local/bin/nuget && chmod +x /usr/local/bin/nuget'
 
       - name: Generate NuGet package
@@ -1028,7 +1028,7 @@ jobs:
           name: nuget_pack_${{ needs.stable-build.outputs.version }}
 
       - name: NuGet login (OIDC trusted publishing)
-        uses: NuGet/login@v1
+        uses: NuGet/login@d22cc5f58ff5b88bf9bd452535b4335137e24544 # https://github.com/NuGet/login/releases/tag/v1
         id: nuget-login
         with:
           user: ${{ secrets.NUGET_USER }}
@@ -1066,6 +1066,20 @@ jobs:
 
           echo "Deleting release branch ${RELEASE_BRANCH}..."
           git push origin --delete ${RELEASE_BRANCH}
+
+      - name: Move version tag to post-merge master commit
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION='${{ needs.stable-build.outputs.version }}'
+          NEW_SHA=$(git rev-parse HEAD) # HEAD is master after the merge step
+
+          gh api repos/${{ github.repository }}/git/refs/tags/${VERSION} \
+            -X PATCH \
+            -f sha="$NEW_SHA" \
+            -f force=true
+
+          echo "Tag ${VERSION} updated to ${NEW_SHA} (post-merge master)"
 
       - name: Create or update docs production branch
         env:
@@ -1143,17 +1157,15 @@ jobs:
         env:
           JOB_STATUS: ${{ job.status }}
           VERSION: ${{ needs.stable-build.outputs.version }}
-          RELEASE_BRANCH: ${{ needs.stable-build.outputs.release-branch }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           REPO_URL: ${{ github.server_url }}/${{ github.repository }}
         run: |
           if [ "$JOB_STATUS" = "success" ]; then STATUS_FIELD=":white_check_mark: Success"; else STATUS_FIELD=":x: Failed"; fi
-          CHANGELOG_URL="${REPO_URL}/blob/${RELEASE_BRANCH}/CHANGELOG.md"
+          CHANGELOG_URL="${REPO_URL}/blob/master/CHANGELOG.md"
 
           jq -n \
             --arg status        "$STATUS_FIELD" \
             --arg version       "${VERSION}" \
-            --arg branch        "${RELEASE_BRANCH}" \
             --arg repo_url      "${REPO_URL}" \
             --arg changelog_url "$CHANGELOG_URL" \
             --arg run_url       "${RUN_URL}" \
@@ -1170,7 +1182,7 @@ jobs:
                   { type: "mrkdwn", text: ("*Status*\n" + $status) },
                   { type: "mrkdwn", text: "*Type*\n📦 Stable Release" },
                   { type: "mrkdwn", text: ("*Version*\n<https://www.npmjs.com/package/handsontable/v/" + $version + "|" + $version + ">") },
-                  { type: "mrkdwn", text: ("*Branch*\n<" + $repo_url + "/tree/" + $branch + "|" + $branch + ">") }
+                  { type: "mrkdwn", text: ("*Branch*\n<" + $repo_url + "/tree/master|master>") }
                 ]
               },
               { type: "divider" },

--- a/bin/changelog
+++ b/bin/changelog
@@ -307,15 +307,19 @@ ${chalk.yellow.italic(compiled)}
 
 const syncCommand = async(args) => {
   const { dryRun } = args;
-  let text = await fs.readFile(changelogPath, 'utf8');
+  const text = await fs.readFile(changelogPath, 'utf8');
 
   const version = args.version || text.match(/^## \[([^\]]+)\]/m)?.[1];
 
-  if (!version) throw new Error('No versioned sections found in CHANGELOG.md');
+  if (!version) {
+    throw new Error('No versioned sections found in CHANGELOG.md');
+  }
 
   const start = text.indexOf(`## [${version}]`);
 
-  if (start === -1) throw new Error(`Version ${version} not found in CHANGELOG.md`);
+  if (start === -1) {
+    throw new Error(`Version ${version} not found in CHANGELOG.md`);
+  }
 
   const nextStart = text.indexOf('\n## [', start + 1);
   const end = nextStart === -1 ? text.length : nextStart;
@@ -325,7 +329,7 @@ const syncCommand = async(args) => {
   const buckets = {};
   let curType = null;
 
-  for (const line of section.split('\n')) {
+  section.split('\n').forEach((line) => {
     const m = line.match(/^### (\w+)/);
 
     if (m) {
@@ -334,10 +338,13 @@ const syncCommand = async(args) => {
     } else if (curType && line.startsWith('- ')) {
       buckets[curType].push(line);
     }
-  }
+  });
 
   // Load entries, skipping ones already present in this section
-  const entryFiles = await glob('*.json', { absolute: true, cwd: path.join(__dirname, '..', changelogsDirectoryName) });
+  const entryFiles = await glob('*.json', {
+    absolute: true,
+    cwd: path.join(__dirname, '..', changelogsDirectoryName)
+  });
 
   if (!entryFiles.length) {
     console.log('No changelog entries found in the .changelogs directory.');
@@ -355,7 +362,9 @@ const syncCommand = async(args) => {
     return;
   }
 
-  console.log(chalk.dim(`\nSyncing into [${version}] in ${chalk.reset.blue.underline(path.basename(changelogPath))}:\n`));
+  console.log(chalk.dim(
+    `\nSyncing into [${version}] in ${chalk.reset.blue.underline(path.basename(changelogPath))}:\n`
+  ));
   newEntries.forEach(e => console.log(chalk.yellow.italic(`  - ${stringifyChangelogEntryObject(e)}`)));
   console.log();
 
@@ -368,16 +377,17 @@ const syncCommand = async(args) => {
   await askToProceedOrExit(`Write the new ${path.basename(changelogPath)} and delete the changelog entry .json files?`);
 
   // Merge entries into buckets
-  for (const e of newEntries) {
+  newEntries.forEach((e) => {
     (buckets[e.type] = buckets[e.type] || []).push(`- ${stringifyChangelogEntryObject(e)}`);
-  }
+  });
 
   // Re-serialize the version section
-  const newSection = section.split('\n')[0] + '\n' +
+  const newSection = `${section.split('\n')[0]}\n${
     changelogEntryTypes
       .filter(t => buckets[t]?.length)
       .map(t => `\n### ${uppercaseFirstLetter(t)}\n${buckets[t].join('\n')}\n`)
-      .join('');
+      .join('')
+  }`;
 
   console.log();
   console.log(chalk.dim('Writing the new changelog...'));
@@ -407,9 +417,12 @@ yargs(hideBin(process.argv))
       .option('date', { type: 'string' })
       .option('dry-run', { type: 'boolean' });
   }, argv => consumeCommand(argv))
-  .command('sync [version]', `sync all \`${changelogsDirectoryName}/*.json\` entries into an existing version section`, (y) => {
-    return y.option('dry-run', { type: 'boolean' });
-  }, argv => syncCommand(argv))
+  .command(
+    'sync [version]',
+    `sync all \`${changelogsDirectoryName}/*.json\` entries into an existing version section`,
+    y => y.option('dry-run', { type: 'boolean' }),
+    argv => syncCommand(argv)
+  )
   .help()
   .demandCommand()
   .version(false)

--- a/bin/changelog
+++ b/bin/changelog
@@ -305,6 +305,94 @@ ${chalk.yellow.italic(compiled)}
   } to undo.`);
 };
 
+const syncCommand = async(args) => {
+  const { dryRun } = args;
+  let text = await fs.readFile(changelogPath, 'utf8');
+
+  const version = args.version || text.match(/^## \[([^\]]+)\]/m)?.[1];
+
+  if (!version) throw new Error('No versioned sections found in CHANGELOG.md');
+
+  const start = text.indexOf(`## [${version}]`);
+
+  if (start === -1) throw new Error(`Version ${version} not found in CHANGELOG.md`);
+
+  const nextStart = text.indexOf('\n## [', start + 1);
+  const end = nextStart === -1 ? text.length : nextStart;
+  const section = text.slice(start, end);
+
+  // Parse the section into type buckets
+  const buckets = {};
+  let curType = null;
+
+  for (const line of section.split('\n')) {
+    const m = line.match(/^### (\w+)/);
+
+    if (m) {
+      curType = m[1].toLowerCase();
+      buckets[curType] = buckets[curType] || [];
+    } else if (curType && line.startsWith('- ')) {
+      buckets[curType].push(line);
+    }
+  }
+
+  // Load entries, skipping ones already present in this section
+  const entryFiles = await glob('*.json', { absolute: true, cwd: path.join(__dirname, '..', changelogsDirectoryName) });
+
+  if (!entryFiles.length) {
+    console.log('No changelog entries found in the .changelogs directory.');
+
+    return;
+  }
+
+  const newEntries = (await Promise.all(entryFiles.map(p => fs.readFile(p, 'utf8'))))
+    .map(c => assertChangelogEntryFormat(JSON.parse(c)))
+    .filter(e => !section.includes(`/${e.issueOrPR})`));
+
+  if (!newEntries.length) {
+    console.log(`All changelog entries are already present in version ${version}.`);
+
+    return;
+  }
+
+  console.log(chalk.dim(`\nSyncing into [${version}] in ${chalk.reset.blue.underline(path.basename(changelogPath))}:\n`));
+  newEntries.forEach(e => console.log(chalk.yellow.italic(`  - ${stringifyChangelogEntryObject(e)}`)));
+  console.log();
+
+  if (dryRun) {
+    console.log('Dry run, skipping write.');
+
+    process.exit(0);
+  }
+
+  await askToProceedOrExit(`Write the new ${path.basename(changelogPath)} and delete the changelog entry .json files?`);
+
+  // Merge entries into buckets
+  for (const e of newEntries) {
+    (buckets[e.type] = buckets[e.type] || []).push(`- ${stringifyChangelogEntryObject(e)}`);
+  }
+
+  // Re-serialize the version section
+  const newSection = section.split('\n')[0] + '\n' +
+    changelogEntryTypes
+      .filter(t => buckets[t]?.length)
+      .map(t => `\n### ${uppercaseFirstLetter(t)}\n${buckets[t].join('\n')}\n`)
+      .join('');
+
+  console.log();
+  console.log(chalk.dim('Writing the new changelog...'));
+  await fs.writeFile(changelogPath, text.slice(0, start) + newSection + text.slice(end));
+
+  console.log(chalk.dim('Deleting changelog entries...'));
+  await Promise.all(entryFiles.map(p => fs.unlink(p)));
+
+  console.log();
+  console.log(`Changelog updated! Run ${
+    chalk.blackBright(`\`git checkout ${path.relative(process.cwd(), changelogPath)
+    } ${path.relative(process.cwd(), path.join(__dirname, '..', changelogsDirectoryName))}\``)
+  } to undo.`);
+};
+
 // eslint-disable-next-line no-unused-expressions
 yargs(hideBin(process.argv))
   .command('entry [title..]', 'create a new changelog entry', (y) => {
@@ -319,6 +407,9 @@ yargs(hideBin(process.argv))
       .option('date', { type: 'string' })
       .option('dry-run', { type: 'boolean' });
   }, argv => consumeCommand(argv))
+  .command('sync [version]', `sync all \`${changelogsDirectoryName}/*.json\` entries into an existing version section`, (y) => {
+    return y.option('dry-run', { type: 'boolean' });
+  }, argv => syncCommand(argv))
   .help()
   .demandCommand()
   .version(false)

--- a/bin/changelog
+++ b/bin/changelog
@@ -359,6 +359,10 @@ const syncCommand = async(args) => {
   if (!newEntries.length) {
     console.log(`All changelog entries are already present in version ${version}.`);
 
+    if (!dryRun) {
+      await Promise.all(entryFiles.map(p => fs.unlink(p)));
+    }
+
     return;
   }
 


### PR DESCRIPTION
### Context
Two improvements to the changelog tooling and publish workflow:                                                                                                                                                              
                                                                                                                                                                                                                                 
  - **`bin/changelog sync [version]`** — new command that reads pending `.changelogs/*.json` entries and merges them into an existing version section in `CHANGELOG.md`, then deletes the entry files. Useful for adding         
  fixes/entries to a version that has already been started (e.g. mid-RC cycle). Supports `--dry-run`. Defaults to the latest versioned section when no `version` argument is given.                                              
  - **RC build workflow** — the `rc-build` job now runs `changelog sync` automatically before extracting the changelog, so any pending entries in `.changelogs/` are picked up without manual intervention. The `rc-publish`     
  Slack notification flags when this sync happened.                                                                                                                                                                              
  - **Docs changelog update** — `update-docs-changelog.mjs` is wired into all three publish scenarios (first RC, subsequent RC, stable release) to keep the docs changelog page in sync automatically. 
   - **Pin `NuGet/login` to a commit SHA** instead of the mutable `@v1` tag.
    All other actions in the workflow were already pinned; this was the only
    exception and a supply chain risk since it runs with full secrets access.

  - **Pin NuGet CLI to v7.3.0** instead of `latest`. Downloading `latest`
    on every run is unpredictable — a new NuGet release could silently change
    behavior or break the build.

  - **Move the version tag to the post-merge master commit.** GitHub creates
    the tag automatically when a release is published, but that tag points to
    the last RC commit on the release branch — before `stable-build` bumps
    the version, updates the changelog date, and before the branch is merged
    back. The tag should point to what was actually published, which is the
    post-merge master commit.

  - **Remove `--tags` from `first-rc-build`'s `git push`.** The RC tag is
    created explicitly via the GitHub API on the next line. `--tags` would
    push all local tags indiscriminately, not just the intended one.

  - **Fix the stable Slack message linking to a deleted branch.** The
    release branch is deleted during `stable-publish` as part of the
    merge-back step. The Slack notification was still linking to it, producing
    a 404. Now links to `master`, which is the permanent home of the code
    after the release.

  - **Handle patch releases gracefully in `update-docs-changelog.mjs`.**
    When promoting a patch release (e.g. `16.2.1`) on a docs branch that
    already has a `16.2.x` entry at the top, the script would crash with
    "no changelog content provided". Patch releases on an existing major.minor
    docs branch don't need a new entry prepended, so the script now exits
    cleanly with a log message instead.
  - **Pin `NuGet/login` to a commit SHA** instead of the mutable `@v1` tag.
    All other actions in the workflow were already pinned; this was the only
    exception and a supply chain risk since it runs with full secrets access.

  - **Pin NuGet CLI to v7.3.0** instead of `latest`. Downloading `latest`
    on every run is unpredictable — a new NuGet release could silently change
    behavior or break the build.

  - **Move the version tag to the post-merge master commit.** GitHub creates
    the tag automatically when a release is published, but that tag points to
    the last RC commit on the release branch — before `stable-build` bumps
    the version, updates the changelog date, and before the branch is merged
    back. The tag should point to what was actually published, which is the
    post-merge master commit.

  - **Remove `--tags` from `first-rc-build`'s `git push`.** The RC tag is
    created explicitly via the GitHub API on the next line. `--tags` would
    push all local tags indiscriminately, not just the intended one.

  - **Fix the stable Slack message linking to a deleted branch.** The
    release branch is deleted during `stable-publish` as part of the
    merge-back step. The Slack notification was still linking to it, producing
    a 404. Now links to `master`, which is the permanent home of the code
    after the release.

  - **Handle patch releases gracefully in `update-docs-changelog.mjs`.**
    When promoting a patch release (e.g. `16.2.1`) on a docs branch that
    already has a `16.2.x` entry at the top, the script would crash with
    "no changelog content provided". Patch releases on an existing major.minor
    docs branch don't need a new entry prepended, so the script now exits
    cleanly with a log message instead.

> [!IMPORTANT]  
> These PR should be cherry-picked to `release/17.0.0` after being merged to `develop`.

[skip changelog]

### How has this been tested?
Manually tested the `sync` command and docs' changelog updating script locally against the actual `CHANGELOG.md`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies the release/publish GitHub Actions workflow and changelog tooling, which can affect automated tagging, branch updates, and release notes generation if misconfigured.
> 
> **Overview**
> Automates changelog maintenance during releases by adding `bin/changelog sync` to merge pending `.changelogs/*.json` entries into an existing `CHANGELOG.md` version section (with `--dry-run`) and wiring it into the RC build so new entries are picked up automatically.
> 
> Adds `.github/scripts/update-docs-changelog.mjs` and runs it for first RC, subsequent RCs, and stable releases to keep the docs changelog page in sync (prepend/replace entries or promote RC to stable by updating header/date).
> 
> Tweaks release workflow behavior: pushes release branches without `--tags`, pins NuGet tooling versions, emits a Slack flag when changelog sync occurred, updates stable-release Slack links to `master`, and force-moves the `${VERSION}` tag to the post-merge `master` commit.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd51bb37add084d8568c57115e2b80df80e5b2f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->