### PR TITLE
Fix table background problem

### DIFF
--- a/.changelogs/12063.json
+++ b/.changelogs/12063.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed and issue with table backround overflow",
+  "type": "fixed",
+  "issueOrPR": 12063,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/styles/base/_base.scss
+++ b/handsontable/src/styles/base/_base.scss
@@ -153,8 +153,10 @@
     }
 
     &.htPagination,
-    &.htHasScrollX:not(.htHorizontallyScrollableByWindow),
-    &.htHasScrollY:not(.htVerticallyScrollableByWindow) {
+    &.htHasScrollX,
+    &.htHasScrollY,
+    &:not(.htHorizontallyScrollableByWindow),
+    &:not(.htVerticallyScrollableByWindow) {
       .ht_master {
         .wtHolder {
           background-color: var(--ht-background-color);

--- a/handsontable/src/styles/base/_base.scss
+++ b/handsontable/src/styles/base/_base.scss
@@ -146,11 +146,11 @@
       }
     }
 
-    &.htPagination,
-    &.htHasScrollX,
-    &.htHasScrollY {
-      &:not(.htHorizontallyScrollableByWindow),
-      &:not(.htVerticallyScrollableByWindow) {
+    &:not(.htHorizontallyScrollableByWindow),
+    &:not(.htVerticallyScrollableByWindow) {
+      &.htPagination,
+      &.htHasScrollX,
+      &.htHasScrollY {
         .ht_master {
           .wtHolder {
             background-color: var(--ht-background-color);

--- a/handsontable/src/styles/base/_base.scss
+++ b/handsontable/src/styles/base/_base.scss
@@ -3,7 +3,6 @@
 // Handsontable Base Row and Col
 
 @mixin output {
-
   // Root wrapper
   .ht-root-wrapper {
     @include mixins.font-family;
@@ -100,8 +99,7 @@
 
         position: absolute;
         inset: 0;
-        border: var(--ht-wrapper-border-width) solid
-          var(--ht-wrapper-border-color);
+        border: var(--ht-wrapper-border-width) solid var(--ht-wrapper-border-color);
         border-radius: var(--ht-wrapper-border-radius, 0);
         z-index: 999;
         pointer-events: none;
@@ -124,9 +122,7 @@
               th,
               td {
                 &:first-child {
-                  height: calc(
-                    var(--ht-cell-vertical-padding) * 2 + var(--ht-line-height) + 1px
-                  )
+                  height: calc(var(--ht-cell-vertical-padding) * 2 + var(--ht-line-height) + 1px);
                 }
               }
             }
@@ -134,9 +130,7 @@
             th,
             td {
               border-top-width: 0;
-              height: calc(
-                var(--ht-cell-vertical-padding) * 2 + var(--ht-line-height) + 1px
-              )
+              height: calc(var(--ht-cell-vertical-padding) * 2 + var(--ht-line-height) + 1px);
             }
           }
         }
@@ -154,12 +148,13 @@
 
     &.htPagination,
     &.htHasScrollX,
-    &.htHasScrollY,
-    &:not(.htHorizontallyScrollableByWindow),
-    &:not(.htVerticallyScrollableByWindow) {
-      .ht_master {
-        .wtHolder {
-          background-color: var(--ht-background-color);
+    &.htHasScrollY {
+      &:not(.htHorizontallyScrollableByWindow),
+      &:not(.htVerticallyScrollableByWindow) {
+        .ht_master {
+          .wtHolder {
+            background-color: var(--ht-background-color);
+          }
         }
       }
     }
@@ -190,9 +185,7 @@
     // Cell and Header
     th,
     td {
-      height: calc(
-        var(--ht-cell-vertical-padding) * 2 + var(--ht-line-height) + 1px
-      );
+      height: calc(var(--ht-cell-vertical-padding) * 2 + var(--ht-line-height) + 1px);
       padding: var(--ht-cell-vertical-padding) var(--ht-cell-horizontal-padding);
       vertical-align: top;
       border-top-width: 0;
@@ -287,9 +280,7 @@
           th {
             &.ht__highlight {
               color: var(--ht-header-row-highlighted-foreground-color);
-              background-color: var(
-                --ht-header-row-highlighted-background-color
-              );
+              background-color: var(--ht-header-row-highlighted-background-color);
             }
 
             &.ht__active_highlight {
@@ -322,8 +313,7 @@
           }
 
           .relative {
-            padding: var(--ht-cell-vertical-padding)
-              var(--ht-cell-horizontal-padding);
+            padding: var(--ht-cell-vertical-padding) var(--ht-cell-horizontal-padding);
             min-height: 100%;
           }
         }
@@ -351,8 +341,7 @@
           }
 
           .relative {
-            padding: var(--ht-cell-vertical-padding)
-              var(--ht-cell-horizontal-padding);
+            padding: var(--ht-cell-vertical-padding) var(--ht-cell-horizontal-padding);
 
             .colHeader {
               text-overflow: ellipsis;
@@ -364,9 +353,7 @@
             // compensates the icon + gap + 1px border size
             &:has(.collapsibleIndicator, .changeType) {
               .colHeader {
-                max-width: calc(
-                  100% - (var(--ht-icon-size) + var(--ht-gap-size)) - 1px
-                );
+                max-width: calc(100% - (var(--ht-icon-size) + var(--ht-gap-size)) - 1px);
               }
             }
           }
@@ -569,10 +556,7 @@
       tbody tr th,
       thead tr th:first-child,
       ~ .handsontable:not(.htGhostTable) tbody tr th,
-      ~ .handsontable:not(.ht_clone_top):not(.htGhostTable)
-        thead
-        tr
-        th:first-child {
+      ~ .handsontable:not(.ht_clone_top):not(.htGhostTable) thead tr th:first-child {
         border-inline-end-width: 0;
         border-inline-start-width: 1px;
       }

--- a/handsontable/src/styles/base/_base.scss
+++ b/handsontable/src/styles/base/_base.scss
@@ -152,8 +152,9 @@
       }
     }
 
-    &:not(.htHorizontallyScrollableByWindow),
-    &:not(.htVerticallyScrollableByWindow) {
+    &.htPagination,
+    &.htHasScrollX:not(.htHorizontallyScrollableByWindow),
+    &.htHasScrollY:not(.htVerticallyScrollableByWindow) {
       .ht_master {
         .wtHolder {
           background-color: var(--ht-background-color);


### PR DESCRIPTION
### Context
This PR includes fix for table background overflow when table don't have any scroll or pagination

### How has this been tested?
This PR includes a fix for the table background when the table does not have any scrolling or pagination.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/3037

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CSS selector changes alter when `wtHolder` receives the table background color, which could impact rendering across different scroll/pagination configurations.
> 
> **Overview**
> Fixes a visual issue where the table background could overflow when the table has **no scrolling and no pagination** by tightening the conditions under which `.ht_master .wtHolder` gets `background-color`.
> 
> Also includes minor SCSS formatting/selector cleanups and adds a changelog entry for issue/PR `12063`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2400753eb2cab8c9e83bdb1bd3ad3766c4fbaca4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->