### PR TITLE
Refactor error handling in useHandsontable to throw AbortError and log callback errors

### DIFF
--- a/docs/.vuepress/handsontable-manager/use-handsontable.js
+++ b/docs/.vuepress/handsontable-manager/use-handsontable.js
@@ -110,7 +110,7 @@ const useHandsontable = (version, callback = () => {}, preset = 'hot', buildMode
       const dep = dependencies[i];
 
       if (abortSignal?.aborted) {
-        break;
+        throw new AbortError();
       }
 
       // Ensure that `fixer.js` is not loaded while injecting new dependencies (with an exception for `react-colorful`).
@@ -121,8 +121,13 @@ const useHandsontable = (version, callback = () => {}, preset = 'hot', buildMode
 
         if (fixerScript) {
           fixerScript.remove();
-          delete window.require;
-          delete window.exports;
+          try {
+            delete window.require;
+            delete window.exports;
+          } catch (error) {
+            // eslint-disable-next-line no-console
+            console.error('Error deleting require and exports', error);
+          }
         }
       }
 
@@ -135,11 +140,21 @@ const useHandsontable = (version, callback = () => {}, preset = 'hot', buildMode
   const currentPresetPromise = globalLoadingChain.then(async() => {
     try {
       await loadPreset();
-      callback();
     } catch (err) {
       if (!(err instanceof AbortError)) {
         throw err;
       }
+
+      return;
+    }
+
+    // Execute callback separately - errors from example code should not break
+    // the loading chain for other examples on the page
+    try {
+      callback();
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('Example callback error:', err);
     }
   });
 


### PR DESCRIPTION
### Context
This PR includes fix for error handling.

### How has this been tested?
Locall

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://app.clickup.com/t/9015210959/PRO-1043

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Limited to the docs `useHandsontable` loader and primarily changes error handling; risk is mainly that abort/callback behavior changes could affect how examples initialize on the docs site.
> 
> **Overview**
> **Improves error handling in the docs `useHandsontable` preset loader.** Aborted loads now explicitly throw `AbortError` (instead of silently breaking), preventing partial preset loads from continuing.
> 
> Global cleanup of `window.require`/`window.exports` is wrapped in `try/catch` with logging, and the example `callback()` is executed in a separate guarded block so errors in example code are logged without breaking the shared preset-loading promise chain.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43414c537b99507be22e63ff77215adb4df69a30. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->