### PR TITLE
Fix problem with wrong documentation version in netlify

### DIFF
--- a/docs/netlify/getListOrPreviousVersions.mjs
+++ b/docs/netlify/getListOrPreviousVersions.mjs
@@ -32,6 +32,7 @@ async function readFromGitHub() {
 
   releases.data
     .map(item => item.tag_name)
+    .filter(tag => !semver.prerelease(tag))
     .sort((a, b) => semver.rcompare(a, b))
     .forEach((tag) => {
       const minorVersion = `${semver.parse(tag).major}.${


### PR DESCRIPTION
### Context
This PR fixes the documentation version used in the Netlify build process.

### How has this been tested?
Locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small change limited to the Netlify docs version selection script, affecting which release tags are considered for `LATEST_VERSION`/`PREVIOUS_VERSIONS`. Risk is mainly around accidentally excluding tags if release naming isn’t semver-compatible.
> 
> **Overview**
> Netlify’s docs build version selection now **ignores prerelease GitHub release tags** by filtering out `semver.prerelease(tag)` before sorting and deriving `LATEST_VERSION`/`PREVIOUS_VERSIONS`.
> 
> This prevents builds/redirects from targeting alpha/beta/rc tags as the “latest” documentation version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 332e059664d711bd1c94c5a001f4e5047fc56a7c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->