### PR TITLE
Skip downloading puppeteer binaries

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -134,6 +134,8 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
       - run: pnpm install && pnpm -r rebuild
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: "true"
 
       - name: Build
         run: |
@@ -169,6 +171,8 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
       - run: pnpm install && pnpm -r rebuild
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: "true"
 
       - name: Build
         run: |
@@ -206,6 +210,8 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
       - run: pnpm install && pnpm -r rebuild
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: "true"
 
       - name: Test
         run: |
@@ -231,6 +237,8 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
       - run: pnpm install && pnpm -r rebuild
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: "true"
 
       - name: Test
         run: |


### PR DESCRIPTION
### Context

The PR improves the CI cost and speed by avoiding unnecessary Puppeteer Chromium downloads. Puppeteer (used for e2e and Walkontable tests) downloads Chromium when its install script runs. Workflows that use only `pnpm install` do not need `PUPPETEER_SKIP_DOWNLOAD`: pnpm does not run lifecycle scripts by default, so Chromium is never downloaded there. The change sets `PUPPETEER_SKIP_DOWNLOAD=true` only in workflows that run `pnpm -r rebuild` (which does run scripts) but do not run Puppeteer, so those jobs skip the download. Jobs that run Puppeteer (e2e, visual tests) are unchanged and still get the browser.

_[skip changelog]_

fixes https://github.com/handsontable/dev-handsontable/issues/2948

### How has this been tested?
I tested the changes locally.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Affected project(s):
- [x] `handsontable`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that avoids downloading Puppeteer Chromium during dependency rebuilds; the main risk is unexpected test failures if any of these jobs implicitly require a browser binary.
> 
> **Overview**
> Speeds up and reduces cost of the GitHub Actions test workflow by setting `PUPPETEER_SKIP_DOWNLOAD=true` for the Handsontable build jobs and the unit/types test jobs when running `pnpm install && pnpm -r rebuild`.
> 
> Puppeteer-based jobs (e2e/visual) are left unchanged, so they still download and use Chromium as needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 434d4c563c992ed13dfc0539e37fa59900254aab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->