### PR TITLE
Fix focus scopes documentation examples

### DIFF
--- a/docs/content/guides/navigation/focus-scopes/javascript/example1.js
+++ b/docs/content/guides/navigation/focus-scopes/javascript/example1.js
@@ -172,15 +172,19 @@ const hot = new Handsontable(container, {
   licenseKey: 'non-commercial-and-evaluation',
 });
 
-function updateDebugInformation() {
+const debugIntervalId = setInterval(function updateDebugInformation() {
   const examplesContainer = document.getElementById('example1container');
+  if (!examplesContainer || hot.isDestroyed) {
+    clearInterval(debugIntervalId);
+    return;
+  }
   const isListeningElement = examplesContainer.querySelector('.isListening');
   const focusScopeElement = examplesContainer.querySelector('.focusScope');
   const shortcutsContextElement = examplesContainer.querySelector('.shortcutsContext');
 
-  isListeningElement.textContent = `${hot.isListening()}`;
-  focusScopeElement.textContent = `${hot.getFocusScopeManager().getActiveScopeId()}`;
-  shortcutsContextElement.textContent = `${hot.getShortcutManager().getActiveContextName()}`;
-}
-
-setInterval(updateDebugInformation, 200);
+  if (isListeningElement && focusScopeElement && shortcutsContextElement) {
+    isListeningElement.textContent = `${hot.isListening()}`;
+    focusScopeElement.textContent = `${hot.getFocusScopeManager().getActiveScopeId()}`;
+    shortcutsContextElement.textContent = `${hot.getShortcutManager().getActiveContextName()}`;
+  }
+}, 200);

--- a/docs/content/guides/navigation/focus-scopes/javascript/example1.js
+++ b/docs/content/guides/navigation/focus-scopes/javascript/example1.js
@@ -174,10 +174,13 @@ const hot = new Handsontable(container, {
 
 const debugIntervalId = setInterval(function updateDebugInformation() {
   const examplesContainer = document.getElementById('example1container');
+
   if (!examplesContainer || hot.isDestroyed) {
     clearInterval(debugIntervalId);
+
     return;
   }
+
   const isListeningElement = examplesContainer.querySelector('.isListening');
   const focusScopeElement = examplesContainer.querySelector('.focusScope');
   const shortcutsContextElement = examplesContainer.querySelector('.shortcutsContext');

--- a/docs/content/guides/navigation/focus-scopes/javascript/example1.ts
+++ b/docs/content/guides/navigation/focus-scopes/javascript/example1.ts
@@ -172,15 +172,19 @@ const hot = new Handsontable(container, {
   licenseKey: 'non-commercial-and-evaluation',
 });
 
-function updateDebugInformation() {
+const debugIntervalId = setInterval(function updateDebugInformation() {
   const examplesContainer = document.getElementById('example1container');
-  const isListeningElement = examplesContainer!.querySelector('.isListening');
-  const focusScopeElement = examplesContainer!.querySelector('.focusScope');
-  const shortcutsContextElement = examplesContainer!.querySelector('.shortcutsContext');
+  if (!examplesContainer || hot.isDestroyed) {
+    clearInterval(debugIntervalId);
+    return;
+  }
+  const isListeningElement = examplesContainer.querySelector('.isListening');
+  const focusScopeElement = examplesContainer.querySelector('.focusScope');
+  const shortcutsContextElement = examplesContainer.querySelector('.shortcutsContext');
 
-  isListeningElement!.textContent = `${hot.isListening()}`;
-  focusScopeElement!.textContent = `${hot.getFocusScopeManager().getActiveScopeId()}`;
-  shortcutsContextElement!.textContent = `${hot.getShortcutManager().getActiveContextName()}`;
-}
-
-setInterval(updateDebugInformation, 200);
+  if (isListeningElement && focusScopeElement && shortcutsContextElement) {
+    isListeningElement.textContent = `${hot.isListening()}`;
+    focusScopeElement.textContent = `${hot.getFocusScopeManager().getActiveScopeId()}`;
+    shortcutsContextElement.textContent = `${hot.getShortcutManager().getActiveContextName()}`;
+  }
+}, 200);

--- a/docs/content/guides/navigation/focus-scopes/javascript/example2.js
+++ b/docs/content/guides/navigation/focus-scopes/javascript/example2.js
@@ -183,10 +183,13 @@ dialogPlugin.show();
 
 const debugIntervalId = setInterval(function updateDebugInformation() {
   const examplesContainer = document.getElementById('example2container');
+
   if (!examplesContainer || hot.isDestroyed) {
     clearInterval(debugIntervalId);
+
     return;
   }
+
   const isListeningElement = examplesContainer.querySelector('.isListening');
   const focusScopeElement = examplesContainer.querySelector('.focusScope');
   const shortcutsContextElement = examplesContainer.querySelector('.shortcutsContext');

--- a/docs/content/guides/navigation/focus-scopes/javascript/example2.js
+++ b/docs/content/guides/navigation/focus-scopes/javascript/example2.js
@@ -181,15 +181,19 @@ const dialogPlugin = hot.getPlugin('dialog');
 
 dialogPlugin.show();
 
-function updateDebugInformation() {
+const debugIntervalId = setInterval(function updateDebugInformation() {
   const examplesContainer = document.getElementById('example2container');
+  if (!examplesContainer || hot.isDestroyed) {
+    clearInterval(debugIntervalId);
+    return;
+  }
   const isListeningElement = examplesContainer.querySelector('.isListening');
   const focusScopeElement = examplesContainer.querySelector('.focusScope');
   const shortcutsContextElement = examplesContainer.querySelector('.shortcutsContext');
 
-  isListeningElement.textContent = `${hot.isListening()}`;
-  focusScopeElement.textContent = `${hot.getFocusScopeManager().getActiveScopeId()}`;
-  shortcutsContextElement.textContent = `${hot.getShortcutManager().getActiveContextName()}`;
-}
-
-setInterval(updateDebugInformation, 200);
+  if (isListeningElement && focusScopeElement && shortcutsContextElement) {
+    isListeningElement.textContent = `${hot.isListening()}`;
+    focusScopeElement.textContent = `${hot.getFocusScopeManager().getActiveScopeId()}`;
+    shortcutsContextElement.textContent = `${hot.getShortcutManager().getActiveContextName()}`;
+  }
+}, 200);

--- a/docs/content/guides/navigation/focus-scopes/javascript/example2.ts
+++ b/docs/content/guides/navigation/focus-scopes/javascript/example2.ts
@@ -181,15 +181,19 @@ const dialogPlugin = hot.getPlugin('dialog');
 
 dialogPlugin.show();
 
-function updateDebugInformation() {
+const debugIntervalId = setInterval(function updateDebugInformation() {
   const examplesContainer = document.getElementById('example2container');
-  const isListeningElement = examplesContainer!.querySelector('.isListening');
-  const focusScopeElement = examplesContainer!.querySelector('.focusScope');
-  const shortcutsContextElement = examplesContainer!.querySelector('.shortcutsContext');
+  if (!examplesContainer || hot.isDestroyed) {
+    clearInterval(debugIntervalId);
+    return;
+  }
+  const isListeningElement = examplesContainer.querySelector('.isListening');
+  const focusScopeElement = examplesContainer.querySelector('.focusScope');
+  const shortcutsContextElement = examplesContainer.querySelector('.shortcutsContext');
 
-  isListeningElement!.textContent = `${hot.isListening()}`;
-  focusScopeElement!.textContent = `${hot.getFocusScopeManager().getActiveScopeId()}`;
-  shortcutsContextElement!.textContent = `${hot.getShortcutManager().getActiveContextName()}`;
-}
-
-setInterval(updateDebugInformation, 200);
+  if (isListeningElement && focusScopeElement && shortcutsContextElement) {
+    isListeningElement.textContent = `${hot.isListening()}`;
+    focusScopeElement.textContent = `${hot.getFocusScopeManager().getActiveScopeId()}`;
+    shortcutsContextElement.textContent = `${hot.getShortcutManager().getActiveContextName()}`;
+  }
+}, 200);


### PR DESCRIPTION
### Context
This PR inlcudes fix for documentation focus scopes page

### How has this been tested?
Locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/3001

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only JavaScript/TypeScript example tweaks that add null/teardown guards to prevent runtime errors and leaking intervals when the demo is destroyed or missing DOM elements.
> 
> **Overview**
> Improves the focus-scopes documentation examples by making the debug info updater resilient to demo teardown and missing DOM nodes.
> 
> The `setInterval` loop is now stored in `debugIntervalId` and self-clears when the container is absent or `hot.isDestroyed`, and it only updates `.isListening`/`.focusScope`/`.shortcutsContext` when all elements are present (removing TypeScript non-null assertions).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01c2251ce8a4ee66a8b4718d5bf23063bfc9875d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->