### PR TITLE
Update the `17.0.0` changelog + sync the release branch with some of the changes from `develop`.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1023,12 +1023,12 @@ jobs:
         run: node .github/scripts/purge-jsdelivr-cache.mjs '${{ needs.stable-build.outputs.version }}'
 
       - name: Download NuGet package artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # https://github.com/actions/download-artifact/releases/tag/v4.3.0
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # https://github.com/actions/download-artifact/releases/tag/v8.0.0
         with:
           name: nuget_pack_${{ needs.stable-build.outputs.version }}
 
       - name: NuGet login (OIDC trusted publishing)
-        uses: NuGet/login@d22cc5f58ff5b88bf9bd452535b4335137e24544 # https://github.com/NuGet/login/releases/tag/v1
+        uses: NuGet/login@d22cc5f58ff5b88bf9bd452535b4335137e24544 # https://github.com/NuGet/login/releases/tag/v1.0.0
         id: nuget-login
         with:
           user: ${{ secrets.NUGET_USER }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -860,7 +860,7 @@ jobs:
         run: node .github/scripts/generate-nuget-package.mjs
 
       - name: Upload NuGet package artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # https://github.com/actions/upload-artifact/releases/tag/v4.6.2
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # https://github.com/actions/upload-artifact/releases/tag/v7.0.0
         with:
           name: nuget_pack_${{ steps.version.outputs.version }}
           path: Handsontable.*.nupkg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Changed the element type for focus catchers. [#12032](https://github.com/handsontable/handsontable/pull/12032)
 - Fixed incorrect scrollbar width calculation for scaled environments. [#12035](https://github.com/handsontable/handsontable/pull/12035)
 
+### Deprecated
+- Deprecated **numbro.js** for numeric formatting. Copy it to your project or replace it with the `Intl.NumberFormat` API. [Migration guide](https://handsontable.com/docs/javascript-data-grid/migration-from-16.2-to-17.0#_3-migrate-from-numbro-format-to-intl-numberformat)
+- Deprecated **Pikaday** for date picking. Switch to native date input. [Migration guide](https://handsontable.com/docs/javascript-data-grid/recipes/cell-types/pikaday)
+- Deprecated **moment.js** for date parsing and display. Replace it with the `Intl.DateTimeFormat` API. [Migration guide](https://handsontable.com/docs/javascript-data-grid/migration-from-16.2-to-17.0#_4-migrate-from-moment-js-format-to-intl-datetimeformat)
+- Deprecated **DOMPurify** as a built-in XSS sanitizer. Use the new `sanitizer` option or convert content to plain text. [Migration guide](https://handsontable.com/docs/javascript-data-grid/migration-from-16.2-to-17.0#_5-migrate-from-built-in-dompurify-to-the-sanitizer-option)
+- Deprecated **core-js** polyfills for ECMAScript features. [Migration guide](https://handsontable.com/docs/javascript-data-grid/migration-from-16.2-to-17.0#_6-core-js-dependency-removed)
+- Deprecated bundling **HyperFormula** as a Handsontable dependency. Starting from version 18.0, install and import it separately, then pass it to the Formulas plugin with `licenseKey: 'internal-use'`. [Formula calculation](https://handsontable.com/docs/javascript-data-grid/formula-calculation)
+
 ## [16.2.0] - 2025-11-25
 
 ### Added

--- a/docs/.vuepress/plugins/dump-docs-data/docs-versions.js
+++ b/docs/.vuepress/plugins/dump-docs-data/docs-versions.js
@@ -49,6 +49,7 @@ async function readFromGitHub() {
 
   releases.data
     .map(item => item.tag_name)
+    .filter(tag => !semver.prerelease(tag))
     .sort((a, b) => semver.rcompare(a, b))
     .forEach((tag) => {
       const minorVersion = `${semver.parse(tag).major}.${semver.parse(tag).minor}`;

--- a/docs/README-EDITING.md
+++ b/docs/README-EDITING.md
@@ -134,8 +134,7 @@ To deploy the documentation locally at a `[COMMIT_HASH]` commit:
 
 ## Documentation versioning
 
-New documentation is created automatically after the Handsontable is released. The `./scripts/release.mjs`
-takes care to create a Documentation production branch, generate API content from source code, commit, and deploy the Docs image to the production.
+New documentation is created automatically after the Handsontable is released. The `stable-publish` job in `.github/workflows/publish.yml` creates or updates the documentation production branch, generates API content from source code, commits, and pushes — which then triggers the Netlify deployment.
 
 ## Markdown links
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -126,14 +126,14 @@ docs                            # All documentation files
 
 Each documentation version has its own production branch from which the deployment is happening. The documentation branches are created using the following pattern `prod-docs/<MAJOR.MINOR>`. The `prod-docs/latest` branch contains all files necessary for Netlify deployment.
 
-The documentation branches are created automatically once the Handsontable release script finishes its job. Depending on the Handsontable release version, two scenarios may happen:
+The documentation branches are created and updated automatically by the `stable-publish` job in `.github/workflows/publish.yml`. Depending on the Handsontable release version, two scenarios may happen:
 1. Patch release:
-    * Checkout to the existing branch;
-    * Regenerate Docs content for the API by executing `npm run docs:api`;
+    * Check out the existing `prod-docs/<MAJOR.MINOR>` branch;
+    * Update the docs changelog and regenerate API content via `npm run docs:api`;
     * Commit and push the changes to the origin;
 2. Major or Minor release:
-    * Create a new Docs branch, e.g. `prod-docs/13.0` from the `develop` branch (after the release branch is merged to the `develop` branch);
-    * Generate Docs content for the API by executing `npm run docs:api`;
+    * Create a new Docs branch, e.g. `prod-docs/13.0`, from the version tag (after the release branch is merged to `master`);
+    * Update the docs changelog and generate API content via `npm run docs:api`;
     * Commit and push the changes to the origin;
 
 The prod-docs/latest branch is automatically recreated by the CI/CD pipeline whenever a patch or release update is applied to the latest documentation version. This branch triggers a GitHub workflow that initiates a rebuild and deploys to Netlify on each push or when a new branch `prod-docs/<MAJOR.MINOR>` is created.

--- a/docs/content/guides/upgrade-and-migration/deprecation-policy/deprecation-policy.md
+++ b/docs/content/guides/upgrade-and-migration/deprecation-policy/deprecation-policy.md
@@ -56,6 +56,6 @@ Below is a list of current deprecations that are planned to be removed in the ne
 | **moment.js** | Parses, validates and displays dates. Needed for Excel compat. | [Migrate from 16.2 to 17.0 → Date/Time](@/guides/upgrade-and-migration/migrating-from-16.2-to-17.0/migrating-from-16.2-to-17.0.md#_4-migrate-from-moment-js-format-to-intl-datetimeformat) |
 | **DOMPurify** | An XSS sanitizer for HTML. Use the `sanitizer` option to keep a sanitizer, or convert content to plain text. | [Migrate from 16.2 to 17.0 → DOMPurify](@/guides/upgrade-and-migration/migrating-from-16.2-to-17.0/migrating-from-16.2-to-17.0.md#_5-migrate-from-built-in-dompurify-to-the-sanitizer-option) |
 | **core-js** | Polyfills for ECMAScript 5, ECMAScript 6, promises, symbols, collections. | [Migrate from 16.2 to 17.0 → core-js](@/guides/upgrade-and-migration/migrating-from-16.2-to-17.0/migrating-from-16.2-to-17.0.md#_6-core-js-dependency-removed) |
-
+| **Built-in HyperFormula** | The Formulas plugin engine. Will be removed from package.json in 18.0. Import HyperFormula yourself and pass it to the Formulas plugin with `licenseKey: 'internal-use'`. | [Formula calculation](@/guides/formulas/formula-calculation/formula-calculation.md) |
 
 


### PR DESCRIPTION
### Context                                                                                                                                                                                                                    
  In this PR:
  - It extends the 17.0.0 changelog with a new **Deprecated** section listing all third-party dependencies being deprecated in this release: numbro.js, Pikaday, moment.js, DOMPurify, core-js, and built-in HyperFormula. Also adds  
  HyperFormula to the deprecation policy table in the docs.
- Cherry-picked from `develop`:
    - ([0aae594](https://github.com/handsontable/handsontable/commit/0aae594a41)): updates `docs/README.md` and `docs/README-EDITING.md` to reflect the new GitHub Actions-based release process —      
  replacing references to the old `release.mjs` script with the `stable-publish` job in `.github/workflows/publish.yml`.  
  - (https://github.com/handsontable/handsontable/commit/770a7fb233d3fd31fdfcbed6ad9d46ae22bc05dc): filters out prerelease versions (e.g. 17.0.0-rc10) from the docs version switcher, so only stable
  releases appear in the list.
- Bumps GH Actions versions in the publishing workflow to prevent merge conflicts when merging `release/17.0.0` back into `develop`:                                                                                             
  - `actions/upload-artifact`: v4.6.2 → v7.0.0                                                                                                                                                                                   
  - `actions/download-artifact`: v4.3.0 → v8.0.0                                                                                                                                                                                 
  - `NuGet/login`: v1 → v1.0.0 (explicit version pin)  
 
                                                                                                                                                                                                                                
[skip changelog]



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly documentation/changelog edits plus small CI workflow action-version bumps; low runtime/product risk but could affect release pipeline behavior if the updated actions introduce incompatibilities.
> 
> **Overview**
> Extends the `17.0.0` changelog with a new **Deprecated** section covering several third‑party dependencies (including the planned removal of bundled HyperFormula).
> 
> Updates documentation to reflect the GitHub Actions-based docs release process (`stable-publish` job) and adds **Built-in HyperFormula** to the deprecation policy table.
> 
> Tweaks docs version generation to filter out prerelease tags from the version switcher, and bumps GitHub Actions artifact steps in `publish.yml` (`upload-artifact` to v7, `download-artifact` to v8) for NuGet packaging/publishing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27b9fa41bceb5f29b8146f2f4c530fcd7c32b5ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->