### PR TITLE
Add prerelease filter to docs versions

### DIFF
--- a/docs/.vuepress/plugins/dump-docs-data/docs-versions.js
+++ b/docs/.vuepress/plugins/dump-docs-data/docs-versions.js
@@ -49,6 +49,7 @@ async function readFromGitHub() {
 
   releases.data
     .map(item => item.tag_name)
+    .filter(tag => !semver.prerelease(tag))
     .sort((a, b) => semver.rcompare(a, b))
     .forEach((tag) => {
       const minorVersion = `${semver.parse(tag).major}.${semver.parse(tag).minor}`;


### PR DESCRIPTION
### Context
This PR includes fix for documentation versions

### How has this been tested?
Locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small change to docs build metadata that only filters out prerelease GitHub release tags; potential impact is limited to which versions appear in generated docs data.
> 
> **Overview**
> Docs version generation now **excludes prerelease GitHub release tags** when building the list of available documentation versions.
> 
> This prevents `-alpha`/`-beta`/`-rc` releases from being included in `versions`/`versionsWithPatches` derived from `repos.listReleases`, making the published versions list stable-only.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5152f0bac8824b50266519860610cf4d0f5f4d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->