### PR TITLE
Update docs READMEs to reflect GitHub Actions-based release process.

### DIFF
--- a/docs/README-EDITING.md
+++ b/docs/README-EDITING.md
@@ -134,8 +134,7 @@ To deploy the documentation locally at a `[COMMIT_HASH]` commit:
 
 ## Documentation versioning
 
-New documentation is created automatically after the Handsontable is released. The `./scripts/release.mjs`
-takes care to create a Documentation production branch, generate API content from source code, commit, and deploy the Docs image to the production.
+New documentation is created automatically after the Handsontable is released. The `stable-publish` job in `.github/workflows/publish.yml` creates or updates the documentation production branch, generates API content from source code, commits, and pushes — which then triggers the Netlify deployment.
 
 ## Markdown links
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -126,14 +126,14 @@ docs                            # All documentation files
 
 Each documentation version has its own production branch from which the deployment is happening. The documentation branches are created using the following pattern `prod-docs/<MAJOR.MINOR>`. The `prod-docs/latest` branch contains all files necessary for Netlify deployment.
 
-The documentation branches are created automatically once the Handsontable release script finishes its job. Depending on the Handsontable release version, two scenarios may happen:
+The documentation branches are created and updated automatically by the `stable-publish` job in `.github/workflows/publish.yml`. Depending on the Handsontable release version, two scenarios may happen:
 1. Patch release:
-    * Checkout to the existing branch;
-    * Regenerate Docs content for the API by executing `npm run docs:api`;
+    * Check out the existing `prod-docs/<MAJOR.MINOR>` branch;
+    * Update the docs changelog and regenerate API content via `npm run docs:api`;
     * Commit and push the changes to the origin;
 2. Major or Minor release:
-    * Create a new Docs branch, e.g. `prod-docs/13.0` from the `develop` branch (after the release branch is merged to the `develop` branch);
-    * Generate Docs content for the API by executing `npm run docs:api`;
+    * Create a new Docs branch, e.g. `prod-docs/13.0`, from the version tag (after the release branch is merged to `master`);
+    * Update the docs changelog and generate API content via `npm run docs:api`;
     * Commit and push the changes to the origin;
 
 The prod-docs/latest branch is automatically recreated by the CI/CD pipeline whenever a patch or release update is applied to the latest documentation version. This branch triggers a GitHub workflow that initiates a rebuild and deploys to Netlify on each push or when a new branch `prod-docs/<MAJOR.MINOR>` is created.


### PR DESCRIPTION
### Context                                                                                                                                                                                                                    
  Updates the docs' internal READMEs to reflect that the release process is now automated via GitHub Actions (`publish.yml`) rather than the old `./scripts/release.mjs` script. Also corrects the description of how and from    
  where the docs production branches are created.                                                                                                                                                                                
                                                                                                                                                                                                                                 
  - `README-EDITING.md`: replaced reference to `./scripts/release.mjs` with the `stable-publish` job in `publish.yml`                                                                                                            
  - `README.md`: replaced "release script" language with `stable-publish`; corrected that new docs branches are created from the version tag (post-merge `master`), not from `develop`; added mention of the docs changelog      
  update step in both patch and major/minor scenarios                                                                                                                                                                          
                                                                                                                                                                                                                                 
  > [!IMPORTANT]                                                                                                                                                                                                                 
  > After merging this PR to `develop`, it needs to be cherry-picked to the `release/17.0.0` branch.                                                                                                                             
                                                                                                                                                                                                                                 
  [skip changelog]            

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only updates; no runtime or deployment logic is changed.
> 
> **Overview**
> Docs-only update to align `docs/README.md` and `docs/README-EDITING.md` with the new GitHub Actions release process.
> 
> Replaces references to the old `./scripts/release.mjs` flow with the `stable-publish` job in `.github/workflows/publish.yml`, and clarifies branch/update behavior: patch releases update an existing `prod-docs/<MAJOR.MINOR>` (including changelog + `npm run docs:api`), while major/minor releases create a new `prod-docs/<MAJOR.MINOR>` from the version tag before generating/committing docs (triggering Netlify via push).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1b4a4bd2f1cd54a15f0052f8dd1fd7836cb35cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->