### PR TITLE
Fix docs 16.2 build process

### DIFF
--- a/docs/.vuepress/plugins/dump-docs-data/canonicals.js
+++ b/docs/.vuepress/plugins/dump-docs-data/canonicals.js
@@ -24,7 +24,8 @@ async function generateCommonCanonicalURLs(currentCanonicals) {
     headers: fetchCommonHeaders
   });
   const docsData = await response.json();
-  const allDocsVersions = [...docsData.versions];
+  const allDocsVersions = [...docsData.versions].filter(version => version !== '17.0'); // TEMPORARY: exclude 17.0 version
+
   const latestDocsVersion = currentCanonicals.v === 'next' ? 'next' : docsData.latestVersion;
 
   if (!allDocsVersions.includes(currentCanonicals.v)) {


### PR DESCRIPTION
### Context
This PR includes temporary fix for documentation 16.2 build process

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, localized change to the docs build pipeline that only alters which documentation versions are considered when generating canonical URLs. Risk is mainly incorrect canonicals if excluding `17.0` is no longer desired.
> 
> **Overview**
> **Temporarily excludes `17.0`** from `docsData.versions` in `dump-docs-data/canonicals.js` when generating the common canonical URL map.
> 
> This prevents the build step from fetching/processing `17.0` canonicals while still ensuring the current docs version is included in the computed version list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b9333883d4907ddaa2c5f5bd4802fa55505750f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->