### PR TITLE
Remove temporary fix for documentation version

### DIFF
--- a/docs/.vuepress/plugins/dump-docs-data/canonicals.js
+++ b/docs/.vuepress/plugins/dump-docs-data/canonicals.js
@@ -24,7 +24,7 @@ async function generateCommonCanonicalURLs(currentCanonicals) {
     headers: fetchCommonHeaders
   });
   const docsData = await response.json();
-  const allDocsVersions = [...docsData.versions].filter(version => version !== '17.0'); // TEMPORARY: exclude 17.0 version
+  const allDocsVersions = [...docsData.versions];
 
   const latestDocsVersion = currentCanonicals.v === 'next' ? 'next' : docsData.latestVersion;
 


### PR DESCRIPTION
### Context
This PR removes the temporary workaround that was introduced to handle documentation versioning.

### How has this been tested?
Locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a hardcoded version filter so canonical URL aggregation once again considers all docs versions; impact is limited to docs metadata output and could only affect canonical mapping for previously excluded versions.
> 
> **Overview**
> Removes the temporary workaround that excluded docs version `17.0` from the version list used to build the shared canonical URL map.
> 
> Canonical URL generation now iterates over *all* versions returned by `common.json`, potentially changing which version is recorded as the latest owner for a given canonical path when `17.0` is present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9bf2ff311f2bbc3f99dd50d4704d1bf040d5c5f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->