### PR TITLE
Fix column header misalignment when nestedRow is enabled

### DIFF
--- a/.changelogs/12081.json
+++ b/.changelogs/12081.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed column header misalignment when nestedRow is enabled",
+  "type": "fixed",
+  "issueOrPR": 12081,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/nestedRows/nestedRows.js
+++ b/handsontable/src/plugins/nestedRows/nestedRows.js
@@ -69,6 +69,12 @@ export class NestedRows extends BasePlugin {
    * @type {boolean}
    */
   #skipCoreAPIModifiers = false;
+  /**
+   * State of the first render.
+   *
+   * @type {boolean}
+   */
+  #isFirstRender = true;
 
   /**
    * Checks if the plugin is enabled in the handsontable settings. This method is executed in {@link Hooks#beforeInit}
@@ -89,6 +95,7 @@ export class NestedRows extends BasePlugin {
     }
 
     this.collapsedRowsMap = this.hot.rowIndexMapper.registerMap('nestedRows', new TrimmingMap());
+    this.#isFirstRender = true;
 
     this.dataManager = new DataManager(this, this.hot);
     this.collapsingUI = new CollapsingUI(this, this.hot);
@@ -97,6 +104,7 @@ export class NestedRows extends BasePlugin {
     this.rowMoveController = new RowMoveController(this);
 
     this.addHook('afterInit', (...args) => this.#onAfterInit(...args));
+    this.addHook('afterRender', (...args) => this.#onAfterRender(...args));
     this.addHook('beforeViewRender', (...args) => this.#onBeforeViewRender(...args));
     this.addHook('modifyRowData', (...args) => this.onModifyRowData(...args));
     this.addHook('modifySourceLength', (...args) => this.onModifySourceLength(...args));
@@ -446,6 +454,22 @@ export class NestedRows extends BasePlugin {
    */
   #onAfterInit() {
     this.headersUI.updateRowHeaderWidth();
+  }
+
+  /**
+   * `afterRender` hook callback.
+   * Recalculates table dimensions after the first render. Fixes the wtHider size being too small on initial display.
+   */
+  #onAfterRender() {
+    if (this.#isFirstRender && this.hot.view) {
+      this.#isFirstRender = false;
+
+      this.hot.rootWindow.requestAnimationFrame(() => {
+        if (this.hot && this.hot.view && !this.hot.isDestroyed) {
+          this.hot.view.adjustElementsSize(true);
+        }
+      });
+    }
   }
 
   /**

--- a/handsontable/test/e2e/Core_view.spec.js
+++ b/handsontable/test/e2e/Core_view.spec.js
@@ -968,4 +968,53 @@ describe('Core_view', () => {
         .toEqual(rowHeight);
     });
   });
+
+  it('should have correct wtHider size on first render when nestedRows is enabled', async() => {
+    const nestedData = [
+      {
+        id: 1,
+        name: 'father 1',
+        __children: [
+          {
+            id: 2,
+            name: 'Child 1.1',
+            __children: [
+              {
+                id: 3,
+                name: 'Child 1.1.1',
+                __children: [
+                  {
+                    id: 4,
+                    name: 'Child 1.1.1.1'
+                  }
+                ]
+              },
+            ]
+          },
+        ]
+      },
+    ];
+
+    handsontable({
+      data: nestedData,
+      colHeaders: ['ID', 'Name'],
+      columns: [
+        { data: 'id', type: 'numeric' },
+        { data: 'name', type: 'text' }
+      ],
+      nestedRows: true,
+      rowHeaders: true,
+      contextMenu: true
+    });
+
+    await sleep(100);
+
+    const $htCore = spec().$container.find('.ht_master .wtHolder .wtHider .wtSpreader .htCore');
+    const $wtHider = spec().$container.find('.ht_master .wtHolder .wtHider');
+
+    const htCoreWidth = $htCore.width();
+    const wtHiderWidth = $wtHider.width();
+
+    expect(wtHiderWidth).toEqual(htCoreWidth);
+  });
 });


### PR DESCRIPTION
### Context
This PR resolves column header alignment issues that occur when `nestedRow` is enabled.

### How has this been tested?
Locally and e2e test case

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/3010

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches render lifecycle behavior by forcing an extra size recalculation after first paint, which could have subtle performance or timing side effects across themes/browsers; guarded to run only once and checks for destroyed instances.
> 
> **Overview**
> Fixes an initial render sizing bug when `nestedRows` is enabled by adding a one-time `afterRender` hook that schedules `view.adjustElementsSize(true)` on the next animation frame, preventing the `.wtHider` (and related overlays/headers) from being too small on first paint.
> 
> Adds an e2e regression test asserting the `.wtHider` width matches the `.htCore` width on the first render with `nestedRows` enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 456eb146369cda8dad7fa07d27f45dfb093c4ec2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->