### PR TITLE
Fix mobile select handles styles

### DIFF
--- a/.changelogs/12083.json
+++ b/.changelogs/12083.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed an issue with mobile select handles styles",
+  "type": "fixed",
+  "issueOrPR": 12083,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/src/selection/border/border.js
+++ b/handsontable/src/3rdparty/walkontable/src/selection/border/border.js
@@ -243,15 +243,8 @@ class Border {
    * Create multiple selector handler for mobile devices.
    */
   createMultipleSelectorHandles() {
-    const { rootDocument, wtSettings } = this.wot;
-    const stylesHandler = wtSettings.getSetting('stylesHandler');
-    const cellMobileHandleSize = stylesHandler.getCSSVariableValue('cell-mobile-handle-size');
-    const cellMobileHandleBorderRadius = stylesHandler.getCSSVariableValue('cell-mobile-handle-border-radius');
-    const cellMobileHandleBackgroundColor = stylesHandler.getCSSVariableValue('cell-mobile-handle-background-color');
-    const cellMobileHandleBackgroundOpacity =
-      stylesHandler.getCSSVariableValue('cell-mobile-handle-background-opacity');
-    const cellMobileHandleBorderWidth = stylesHandler.getCSSVariableValue('cell-mobile-handle-border-width');
-    const cellMobileHandleBorderColor = stylesHandler.getCSSVariableValue('cell-mobile-handle-border-color');
+    const hitAreaWidth = 40;
+    const { rootDocument } = this.wot;
 
     this.selectionHandles = {
       top: rootDocument.createElement('DIV'),
@@ -259,7 +252,6 @@ class Border {
       bottom: rootDocument.createElement('DIV'),
       bottomHitArea: rootDocument.createElement('DIV')
     };
-    const hitAreaWidth = 40;
 
     this.selectionHandles.top.className = 'topSelectionHandle topLeftSelectionHandle';
     this.selectionHandles.topHitArea.className = 'topSelectionHandle-HitArea topLeftSelectionHandle-HitArea';
@@ -285,13 +277,40 @@ class Border {
       this.selectionHandles.styles.topHitArea[key] = value;
     });
 
+    this.updateMultipleSelectorHandlesStyles();
+
+    this.main.appendChild(this.selectionHandles.top);
+    this.main.appendChild(this.selectionHandles.bottom);
+    this.main.appendChild(this.selectionHandles.topHitArea);
+    this.main.appendChild(this.selectionHandles.bottomHitArea);
+  }
+
+  /**
+   * Updates the multiple selector handle styles from the current theme after a theme change.
+   * Rereads CSS variables and applies them to existing handle elements.
+   */
+  updateMultipleSelectorHandlesStyles() {
+    if (!this.selectionHandles) {
+      return;
+    }
+
+    const wtSettings = this.wot.wtSettings;
+    const stylesHandler = wtSettings.getSetting('stylesHandler');
+    const cellMobileHandleSize = stylesHandler.getCSSVariableValue('cell-mobile-handle-size');
+    const cellMobileHandleBorderRadius = stylesHandler.getCSSVariableValue('cell-mobile-handle-border-radius');
+    const cellMobileHandleBackgroundColor = stylesHandler.getCSSVariableValue('cell-mobile-handle-background-color');
+    const cellMobileHandleBackgroundOpacity =
+      stylesHandler.getCSSVariableValue('cell-mobile-handle-background-opacity');
+    const cellMobileHandleBorderWidth = stylesHandler.getCSSVariableValue('cell-mobile-handle-border-width');
+    const cellMobileHandleBorderColor = stylesHandler.getCSSVariableValue('cell-mobile-handle-border-color');
+
     const handleStyle = {
       position: 'absolute',
       height: `${cellMobileHandleSize}px`,
       width: `${cellMobileHandleSize}px`,
       'border-radius': `${cellMobileHandleBorderRadius}px`,
       // eslint-disable-next-line max-len
-      background: `color-mix(in srgb, ${cellMobileHandleBackgroundColor} ${cellMobileHandleBackgroundOpacity}, transparent)`,
+      background: `color-mix(in srgb, ${cellMobileHandleBackgroundColor} ${cellMobileHandleBackgroundOpacity}%, transparent)`,
       border: `${cellMobileHandleBorderWidth}px solid ${cellMobileHandleBorderColor}`
     };
 
@@ -299,11 +318,6 @@ class Border {
       this.selectionHandles.styles.bottom[key] = value;
       this.selectionHandles.styles.top[key] = value;
     });
-
-    this.main.appendChild(this.selectionHandles.top);
-    this.main.appendChild(this.selectionHandles.bottom);
-    this.main.appendChild(this.selectionHandles.topHitArea);
-    this.main.appendChild(this.selectionHandles.bottomHitArea);
   }
 
   /**

--- a/handsontable/src/3rdparty/walkontable/src/selection/manager.js
+++ b/handsontable/src/3rdparty/walkontable/src/selection/manager.js
@@ -146,6 +146,17 @@ export class SelectionManager {
   }
 
   /**
+   * Refreshes the multiple selector handle styles on all border instances after a theme change.
+   */
+  refreshAllBorderHandleStyles() {
+    this.#selectionBorders.forEach((bordersMap) => {
+      bordersMap.forEach((border) => {
+        border.updateMultipleSelectorHandlesStyles?.();
+      });
+    });
+  }
+
+  /**
    * Renders all the selections (add CSS classes to cells and draw borders).
    *
    * @param {boolean} fastDraw Indicates the render cycle type (fast/slow).

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -368,6 +368,8 @@ export default function Core(rootContainer, userSettings, rootInstanceSymbol = f
               ' or not imported correctly. Import the correct CSS files in order to use that theme.');
           }
         }
+
+        this.view?._wt?.selectionManager?.refreshAllBorderHandleStyles();
       }
     },
     injectCoreCss: typeof userSettings?.injectCoreCss === 'boolean' ? userSettings.injectCoreCss : true,
@@ -2869,7 +2871,15 @@ export default function Core(rootContainer, userSettings, rootInstanceSymbol = f
           instance.useTheme(instance.themeManager.getClassName());
 
         } else {
-          instance.themeManager.update(settings.theme);
+          let themeObject;
+
+          if (typeof settings.theme.getThemeConfig !== 'function') {
+            themeObject = registerTheme(settings.theme);
+          } else {
+            themeObject = settings.theme;
+          }
+
+          instance.themeManager.update(themeObject);
           instance.useTheme(instance.themeManager.getClassName());
         }
       }

--- a/handsontable/test/e2e/core/themeManager.spec.js
+++ b/handsontable/test/e2e/core/themeManager.spec.js
@@ -239,6 +239,53 @@ describe('Core.themeManager', () => {
       expect($(hot.rootPortalElement).hasClass('ht-theme-update-theme-2')).toBe(true);
     });
 
+    it('should update existing themeManager with plain theme config (no getThemeConfig) via updateSettings', async() => {
+      const testTheme1 = Handsontable.themes.registerTheme(createValidThemeConfig({
+        name: 'update-registered-first',
+      }));
+
+      const hot = handsontable({
+        data: createSpreadsheetData(5, 5),
+        theme: testTheme1,
+      }, true);
+
+      expect(hot.themeManager.getClassName()).toBe('ht-theme-update-registered-first');
+
+      const plainThemeConfig = createValidThemeConfig({ name: 'update-plain-when-manager-exists' });
+
+      await updateSettings({
+        theme: plainThemeConfig,
+      });
+
+      expect(hot.themeManager.getClassName()).toBe('ht-theme-update-plain-when-manager-exists');
+      expect(getCurrentThemeName()).toBe('ht-theme-update-plain-when-manager-exists');
+      expect($(hot.rootWrapperElement).hasClass('ht-theme-update-plain-when-manager-exists')).toBe(true);
+    });
+
+    it('should use theme object directly when it has getThemeConfig (registered theme) on update', async() => {
+      const testTheme1 = Handsontable.themes.registerTheme(createValidThemeConfig({
+        name: 'getThemeConfig-theme-1',
+      }));
+
+      const hot = handsontable({
+        data: createSpreadsheetData(5, 5),
+        theme: testTheme1,
+      }, true);
+
+      const testTheme2 = Handsontable.themes.registerTheme(createValidThemeConfig({
+        name: 'getThemeConfig-theme-2',
+      }));
+
+      expect(typeof testTheme2.getThemeConfig).toBe('function');
+
+      await updateSettings({
+        theme: testTheme2,
+      });
+
+      expect(hot.themeManager.getClassName()).toBe('ht-theme-getThemeConfig-theme-2');
+      expect(getCurrentThemeName()).toBe('ht-theme-getThemeConfig-theme-2');
+    });
+
     it('should fire afterSetTheme hook on theme update with initial flag set to false', async() => {
       const afterSetThemeSpy = jasmine.createSpy('afterSetTheme');
       const testTheme1 = Handsontable.themes.registerTheme(createValidThemeConfig({
@@ -334,6 +381,31 @@ describe('Core.themeManager', () => {
       testTheme.setColorScheme('dark');
 
       expect(renderSpy).toHaveBeenCalled();
+    });
+
+    it('should refresh selection border handle styles when theme is changed', async() => {
+      const testTheme1 = Handsontable.themes.registerTheme(createValidThemeConfig({
+        name: 'border-handles-theme-1',
+      }));
+      const testTheme2 = Handsontable.themes.registerTheme(createValidThemeConfig({
+        name: 'border-handles-theme-2',
+      }));
+
+      const hot = handsontable({
+        data: createSpreadsheetData(5, 5),
+        theme: testTheme1,
+      }, true);
+
+      expect(hot.view).toBeDefined();
+      expect(hot.view._wt.selectionManager).toBeDefined();
+
+      const refreshSpy = spyOn(hot.view._wt.selectionManager, 'refreshAllBorderHandleStyles');
+
+      await updateSettings({
+        theme: testTheme2,
+      });
+
+      expect(refreshSpy).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
### Context
This PR fixes an issue with the styles of mobile selection handles.

### How has this been tested?
Locally and new e2e tests

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/3093

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit fcd8fdad4f3df8903308147ed9635485d2d34b00. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->