### PR TITLE
[docs] Change the MultiSelect's examples config to make it render correctly.

### DIFF
--- a/docs/content/guides/cell-types/multiselect-cell-type/javascript/example1.js
+++ b/docs/content/guides/cell-types/multiselect-cell-type/javascript/example1.js
@@ -24,6 +24,12 @@ const data = [
   ['Charles de Gaulle Airport', ['Textiles', 'Industrial Equipment']],
   ['Tokyo Haneda Airport', ['Pharmaceuticals', 'Consumer Goods']],
   ['Singapore Changi Airport', ['Machine Parts', 'Food Products']],
+  ['Luton Airport', ['Electronics and Gadgets', 'Pharmaceuticals']],
+  ['Frankfurt Airport', ['Industrial Equipment', 'Auto Parts', 'Consumer Goods']],
+  ['Sydney Kingsford Smith Airport', ['Fresh Produce', 'Food Products']],
+  ['Toronto Pearson International Airport', ['Medical Supplies', 'Textiles']],
+  ['Hong Kong International Airport', ['Machine Parts', 'Electronics and Gadgets', 'Industrial Equipment']],
+  ['Heathrow Airport', ['Textiles', 'Consumer Goods']],
 ];
 
 new Handsontable(container, {
@@ -41,6 +47,7 @@ new Handsontable(container, {
   ],
   autoWrapRow: true,
   autoWrapCol: true,
-  preventOverflow: 'horizontal',
-  colWidths: 300,
+  height: 'auto',
+  stretchH: 'last',
+  width: '100%',
 });

--- a/docs/content/guides/cell-types/multiselect-cell-type/javascript/example1.ts
+++ b/docs/content/guides/cell-types/multiselect-cell-type/javascript/example1.ts
@@ -25,6 +25,12 @@ const data = [
   ['Charles de Gaulle Airport', ['Textiles', 'Industrial Equipment']],
   ['Tokyo Haneda Airport', ['Pharmaceuticals', 'Consumer Goods']],
   ['Singapore Changi Airport', ['Machine Parts', 'Food Products']],
+  ['Luton Airport', ['Electronics and Gadgets', 'Pharmaceuticals']],
+  ['Frankfurt Airport', ['Industrial Equipment', 'Auto Parts', 'Consumer Goods']],
+  ['Sydney Kingsford Smith Airport', ['Fresh Produce', 'Food Products']],
+  ['Toronto Pearson International Airport', ['Medical Supplies', 'Textiles']],
+  ['Hong Kong International Airport', ['Machine Parts', 'Electronics and Gadgets', 'Industrial Equipment']],
+  ['Heathrow Airport', ['Textiles', 'Consumer Goods']],
 ];
 
 new Handsontable(container, {
@@ -42,6 +48,7 @@ new Handsontable(container, {
   ],
   autoWrapRow: true,
   autoWrapCol: true,
-  preventOverflow: 'horizontal',
-  colWidths: 300,
+  height: 'auto',
+  stretchH: 'last',
+  width: '100%',
 });

--- a/docs/content/guides/cell-types/multiselect-cell-type/javascript/example2.js
+++ b/docs/content/guides/cell-types/multiselect-cell-type/javascript/example2.js
@@ -54,6 +54,50 @@ const data = [
       { key: 'food', value: 'Food Products' },
     ],
   ],
+  [
+    'Luton Airport',
+    [
+      { key: 'electronics', value: 'Electronics and Gadgets' },
+      { key: 'pharmaceuticals', value: 'Pharmaceuticals' },
+    ],
+  ],
+  [
+    'Frankfurt Airport',
+    [
+      { key: 'industrial', value: 'Industrial Equipment' },
+      { key: 'auto-parts', value: 'Auto Parts' },
+      { key: 'consumer', value: 'Consumer Goods' },
+    ],
+  ],
+  [
+    'Sydney Kingsford Smith Airport',
+    [
+      { key: 'fresh-produce', value: 'Fresh Produce' },
+      { key: 'food', value: 'Food Products' },
+    ],
+  ],
+  [
+    'Toronto Pearson International Airport',
+    [
+      { key: 'medical', value: 'Medical Supplies' },
+      { key: 'textiles', value: 'Textiles' },
+    ],
+  ],
+  [
+    'Hong Kong International Airport',
+    [
+      { key: 'machine-parts', value: 'Machine Parts' },
+      { key: 'electronics', value: 'Electronics and Gadgets' },
+      { key: 'industrial', value: 'Industrial Equipment' },
+    ],
+  ],
+  [
+    'Heathrow Airport',
+    [
+      { key: 'textiles', value: 'Textiles' },
+      { key: 'consumer', value: 'Consumer Goods' },
+    ],
+  ],
 ];
 
 new Handsontable(container, {
@@ -71,6 +115,7 @@ new Handsontable(container, {
   ],
   autoWrapRow: true,
   autoWrapCol: true,
-  preventOverflow: 'horizontal',
-  colWidths: 300,
+  height: 'auto',
+  stretchH: 'last',
+  width: '100%',
 });

--- a/docs/content/guides/cell-types/multiselect-cell-type/javascript/example2.ts
+++ b/docs/content/guides/cell-types/multiselect-cell-type/javascript/example2.ts
@@ -40,6 +40,32 @@ const data = [
     { key: 'machine-parts', value: 'Machine Parts' },
     { key: 'food', value: 'Food Products' },
   ]],
+  ['Luton Airport', [
+    { key: 'electronics', value: 'Electronics and Gadgets' },
+    { key: 'pharmaceuticals', value: 'Pharmaceuticals' },
+  ]],
+  ['Frankfurt Airport', [
+    { key: 'industrial', value: 'Industrial Equipment' },
+    { key: 'auto-parts', value: 'Auto Parts' },
+    { key: 'consumer', value: 'Consumer Goods' },
+  ]],
+  ['Sydney Kingsford Smith Airport', [
+    { key: 'fresh-produce', value: 'Fresh Produce' },
+    { key: 'food', value: 'Food Products' },
+  ]],
+  ['Toronto Pearson International Airport', [
+    { key: 'medical', value: 'Medical Supplies' },
+    { key: 'textiles', value: 'Textiles' },
+  ]],
+  ['Hong Kong International Airport', [
+    { key: 'machine-parts', value: 'Machine Parts' },
+    { key: 'electronics', value: 'Electronics and Gadgets' },
+    { key: 'industrial', value: 'Industrial Equipment' },
+  ]],
+  ['Heathrow Airport', [
+    { key: 'textiles', value: 'Textiles' },
+    { key: 'consumer', value: 'Consumer Goods' },
+  ]],
 ];
 
 new Handsontable(container, {
@@ -57,6 +83,7 @@ new Handsontable(container, {
   ],
   autoWrapRow: true,
   autoWrapCol: true,
-  preventOverflow: 'horizontal',
-  colWidths: 300,
+  height: 'auto',
+  stretchH: 'last',
+  width: '100%',
 });

--- a/docs/content/guides/cell-types/multiselect-cell-type/javascript/example3.js
+++ b/docs/content/guides/cell-types/multiselect-cell-type/javascript/example3.js
@@ -14,6 +14,15 @@ const data = [
   [['Phone', 'Keys'], ['First aid kit', 'Snacks', 'Umbrella'], ['Nature']],
   [['Wallet', 'Phone'], [], ['Food', 'Shopping']],
   [['Passport', 'Tickets'], ['Book'], ['Art', 'History']],
+  [['Phone', 'Keys'], ['First aid kit', 'Snacks', 'Umbrella'], ['Nature']],
+  [['Wallet', 'Phone'], [], ['Food', 'Shopping']],
+  [['Passport', 'Tickets'], ['Book'], ['Art', 'History']],
+  [['Phone', 'Keys'], ['First aid kit', 'Snacks', 'Umbrella'], ['Nature']],
+  [['Wallet', 'Phone'], [], ['Food', 'Shopping']],
+  [['Passport', 'Tickets'], ['Book'], ['Art', 'History']],
+  [['Phone', 'Keys'], ['First aid kit', 'Snacks', 'Umbrella'], ['Nature']],
+  [['Wallet', 'Phone'], [], ['Food', 'Shopping']],
+  [['Passport', 'Tickets'], ['Book'], ['Art', 'History']],
 ];
 
 new Handsontable(container, {
@@ -46,6 +55,7 @@ new Handsontable(container, {
   ],
   autoWrapRow: true,
   autoWrapCol: true,
-  preventOverflow: 'horizontal',
-  colWidths: 200,
+  height: 'auto',
+  stretchH: 'last',
+  width: '100%',
 });

--- a/docs/content/guides/cell-types/multiselect-cell-type/javascript/example3.ts
+++ b/docs/content/guides/cell-types/multiselect-cell-type/javascript/example3.ts
@@ -16,6 +16,15 @@ const data = [
   [['Phone', 'Keys'], ['First aid kit', 'Snacks', 'Umbrella'], ['Nature']],
   [['Wallet', 'Phone'], [], ['Food', 'Shopping']],
   [['Passport', 'Tickets'], ['Book'], ['Art', 'History']],
+  [['Phone', 'Keys'], ['First aid kit', 'Snacks', 'Umbrella'], ['Nature']],
+  [['Wallet', 'Phone'], [], ['Food', 'Shopping']],
+  [['Passport', 'Tickets'], ['Book'], ['Art', 'History']],
+  [['Phone', 'Keys'], ['First aid kit', 'Snacks', 'Umbrella'], ['Nature']],
+  [['Wallet', 'Phone'], [], ['Food', 'Shopping']],
+  [['Passport', 'Tickets'], ['Book'], ['Art', 'History']],
+  [['Phone', 'Keys'], ['First aid kit', 'Snacks', 'Umbrella'], ['Nature']],
+  [['Wallet', 'Phone'], [], ['Food', 'Shopping']],
+  [['Passport', 'Tickets'], ['Book'], ['Art', 'History']],
 ];
 
 new Handsontable(container, {
@@ -48,6 +57,7 @@ new Handsontable(container, {
   ],
   autoWrapRow: true,
   autoWrapCol: true,
-  preventOverflow: 'horizontal',
-  colWidths: 200,
+  height: 'auto',
+  stretchH: 'last',
+  width: '100%',
 });

--- a/docs/content/guides/cell-types/multiselect-cell-type/multiselect-cell-type.md
+++ b/docs/content/guides/cell-types/multiselect-cell-type/multiselect-cell-type.md
@@ -43,7 +43,7 @@ The `source` option can be provided in two formats:
 You can provide the `source` option as an array of values that will be used as the MultiSelect options.
 
 ::: only-for javascript
-::: example #example1 .docs-height-small --js 1 --ts 2
+::: example #example1 --js 1 --ts 2
 
 @[code](@/content/guides/cell-types/multiselect-cell-type/javascript/example1.js)
 
@@ -53,7 +53,7 @@ You can provide the `source` option as an array of values that will be used as t
 :::
 
 ::: only-for react
-::: example #example1 .docs-height-small :react --js 1 --ts 2
+::: example #example1 :react --js 1 --ts 2
 
 @[code](@/content/guides/cell-types/multiselect-cell-type/react/example1.jsx)
 
@@ -63,7 +63,7 @@ You can provide the `source` option as an array of values that will be used as t
 :::
 
 ::: only-for angular
-::: example #example1 .docs-height-small :angular --ts 1 --html 2
+::: example #example1 :angular --ts 1 --html 2
 
 @[code](@/content/guides/cell-types/multiselect-cell-type/angular/example1.ts)
 
@@ -77,7 +77,7 @@ You can provide the `source` option as an array of values that will be used as t
 You can provide the `source` option as an array of objects with `key` and `value` properties. The `value` property will be used as the MultiSelect's option label, while the entire object will be used as the value saved to the cell's source data.
 
 ::: only-for javascript
-::: example #example2 .docs-height-small --js 1 --ts 2
+::: example #example2 --js 1 --ts 2
 
 @[code](@/content/guides/cell-types/multiselect-cell-type/javascript/example2.js)
 
@@ -87,7 +87,7 @@ You can provide the `source` option as an array of objects with `key` and `value
 :::
 
 ::: only-for react
-::: example #example2 .docs-height-small :react --js 1 --ts 2
+::: example #example2 :react --js 1 --ts 2
 
 @[code](@/content/guides/cell-types/multiselect-cell-type/react/example2.jsx)
 
@@ -98,7 +98,7 @@ You can provide the `source` option as an array of objects with `key` and `value
 
 
 ::: only-for angular
-::: example #example2 .docs-height-small :angular --ts 1 --html 2
+::: example #example2 :angular --ts 1 --html 2
 
 @[code](@/content/guides/cell-types/multiselect-cell-type/angular/example2.ts)
 
@@ -138,7 +138,7 @@ These options allow you to modify the MultiSelect cell type's appearance, usabil
 The demo below showcases some the options in an interactive example.
 
 ::: only-for javascript
-::: example #example3 .docs-height-small --js 1 --ts 2
+::: example #example3 --js 1 --ts 2
 
 @[code](@/content/guides/cell-types/multiselect-cell-type/javascript/example3.js)
 
@@ -148,7 +148,7 @@ The demo below showcases some the options in an interactive example.
 :::
 
 ::: only-for react
-::: example #example3 .docs-height-small :react --js 1 --ts 2
+::: example #example3 :react --js 1 --ts 2
 
 @[code](@/content/guides/cell-types/multiselect-cell-type/react/example3.jsx)
 
@@ -158,7 +158,7 @@ The demo below showcases some the options in an interactive example.
 :::
 
 ::: only-for angular
-::: example #example3 .docs-height-small :angular --ts 1 --html 2
+::: example #example3 :angular --ts 1 --html 2
 
 @[code](@/content/guides/cell-types/multiselect-cell-type/angular/example3.ts)
 


### PR DESCRIPTION
### Context
  The multiselect cell type doc examples were using `preventOverflow: 'horizontal'` and `colWidths` which caused column header misalignment. Replaced with `height: 'auto'`, `stretchH: 'last'`, and `width: '100%'` to render   
  correctly. Also removed the `.docs-height-small` class from all example blocks and added more data rows to better showcase the cell type.                                             
                                                                                                                                                                                                                                 
  > [!IMPORTANT]                                                                                                                                                                                                               
  > After merging this PR to `develop`, it needs to be cherry-picked to the `release/17.0.0` branch.     

[skip changelog]

### How has this been tested?
  Verified visually in the docs preview.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit d44c461de13eedc7a4d71ace5f6e6d7783f6da7b. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->