### PR TITLE
Fix the scrolling issue that occurs when `preventOverflow` is enabled

### DIFF
--- a/.changelogs/12086.json
+++ b/.changelogs/12086.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed an issue with scrolling issue that occurs when preventOverflow is enabled",
+  "type": "fixed",
+  "issueOrPR": 12086,
+  "breaking": false,
+  "framework": "none"
+}

--- a/examples/next/visual-tests/js/demo/src/demos/wrapper/index.js
+++ b/examples/next/visual-tests/js/demo/src/demos/wrapper/index.js
@@ -1,7 +1,7 @@
 
 import Handsontable from "handsontable/base";
 import { registerAllModules } from "handsontable/registry";
-import { getDirectionFromURL, getThemeNameFromURL } from "../../utils";
+import { getDirectionFromURL, getFromURL, getThemeNameFromURL } from "../../utils";
 import { registerLanguageDictionary, arAR } from "handsontable/i18n";
 
 export function init() {
@@ -11,24 +11,41 @@ export function init() {
     const root = document.getElementById('root');
     const example = document.createElement('div');
 
-    example.style.width = '500px';
-    example.style.height = '400px';
-
     root.appendChild(example);
 
-    new Handsontable(example, {
-        data: Handsontable.helper.createSpreadsheetData(20, 20),
-        layoutDirection: getDirectionFromURL(),
-        language: getDirectionFromURL() === "rtl" ? arAR.languageCode : "en-US",
-        themeName: getThemeNameFromURL(),
-        width: '100%',
-        height: '100%',
-        colWidths: 100,
-        rowHeaders: true,
-        colHeaders: true,
-        navigableHeaders: true,
-        licenseKey: "non-commercial-and-evaluation"
-    });
+    const preventOverflow = getFromURL('preventOverflow', false);
+
+    if (preventOverflow) {
+        new Handsontable(example, {
+            columns: [
+                {
+                title: 'TEST LONGER HEADER',
+                },
+                {
+                title: 'TEST NO:2 LONG HEADER',
+                },
+            ],
+            preventOverflow: 'horizontal',
+            licenseKey: 'non-commercial-and-evaluation',
+        });
+    } else {
+        example.style.width = '500px';
+        example.style.height = '400px';
+
+        new Handsontable(example, {
+            data: Handsontable.helper.createSpreadsheetData(20, 20),
+            layoutDirection: getDirectionFromURL(),
+            language: getDirectionFromURL() === "rtl" ? arAR.languageCode : "en-US",
+            themeName: getThemeNameFromURL(),
+            width: '100%',
+            height: '100%',
+            colWidths: 100,
+            rowHeaders: true,
+            colHeaders: true,
+            navigableHeaders: true,
+            licenseKey: "non-commercial-and-evaluation"
+        });
+    }
 
     console.log(`Handsontable: v${Handsontable.version} (${Handsontable.buildDate})`);
 }

--- a/handsontable/src/3rdparty/walkontable/src/overlays.js
+++ b/handsontable/src/3rdparty/walkontable/src/overlays.js
@@ -538,15 +538,16 @@ class Overlays {
 
     const topHolder = this.topOverlay.clone.wtTable.holder; // todo rethink
     const leftHolder = this.inlineStartOverlay.clone.wtTable.holder; // todo rethink
+    const preventOverflow = this.wtSettings.getSetting('preventOverflow');
 
     let scrollX = this.scrollableElement.scrollLeft;
     let scrollY = this.scrollableElement.scrollTop;
 
-    if (this.wot.wtViewport.isHorizontallyScrollableByWindow()) {
+    if (this.wot.wtViewport.isHorizontallyScrollableByWindow() && preventOverflow !== 'horizontal') {
       scrollX = this.scrollableElement.scrollX;
     }
 
-    if (this.wot.wtViewport.isVerticallyScrollableByWindow()) {
+    if (this.wot.wtViewport.isVerticallyScrollableByWindow() && preventOverflow !== 'vertical') {
       scrollY = this.scrollableElement.scrollY;
     }
 

--- a/handsontable/src/3rdparty/walkontable/src/overlays.js
+++ b/handsontable/src/3rdparty/walkontable/src/overlays.js
@@ -543,11 +543,17 @@ class Overlays {
     let scrollX = this.scrollableElement.scrollLeft;
     let scrollY = this.scrollableElement.scrollTop;
 
-    if (this.wot.wtViewport.isHorizontallyScrollableByWindow() && preventOverflow !== 'horizontal') {
+    if (
+      this.wot.wtViewport.isHorizontallyScrollableByWindow()
+      && ((typeof preventOverflow === 'boolean' && preventOverflow) || preventOverflow !== 'horizontal')
+    ) {
       scrollX = this.scrollableElement.scrollX;
     }
 
-    if (this.wot.wtViewport.isVerticallyScrollableByWindow() && preventOverflow !== 'vertical') {
+    if (
+      this.wot.wtViewport.isVerticallyScrollableByWindow()
+      && ((typeof preventOverflow === 'boolean' && preventOverflow) || preventOverflow !== 'vertical')
+    ) {
       scrollY = this.scrollableElement.scrollY;
     }
 

--- a/visual-tests/tests/js-only/wrapper/wrapper-preventOverflow.spec.ts
+++ b/visual-tests/tests/js-only/wrapper/wrapper-preventOverflow.spec.ts
@@ -1,0 +1,22 @@
+import { test } from '../../../src/test-runner';
+import { helpers } from '../../../src/helpers';
+
+test.skip(helpers.hotWrapper !== 'js', 'This test case is only for JavaScript framework');
+
+test(__filename, async({ page, goto, tablePage }) => {
+
+  await page.setViewportSize({ width: 200, height: 400 });
+
+  await goto(
+    helpers
+      .setBaseUrl('/wrapper-demo')
+      .setPageParams({ preventOverflow: true })
+      .getFullUrl()
+  );
+
+  await tablePage.mouse.move(50, 50);
+  await tablePage.mouse.wheel(100, 0);
+  await tablePage.waitForTimeout(500);
+
+  await tablePage.screenshot({ path: helpers.screenshotPath() });
+});


### PR DESCRIPTION
### Context
This PR includes fix for table top overlay scrolling problem when `preventOverflow` is enabled.

### How has this been tested?
Locally and new visual test

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/3097

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit a5f46c73b787f351769b7ccec62e5c9384b21eb3. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->