### PR TITLE
Fix date cell type documentation demo

### DIFF
--- a/docs/content/guides/cell-types/date-cell-type/angular/example1.ts
+++ b/docs/content/guides/cell-types/date-cell-type/angular/example1.ts
@@ -64,7 +64,7 @@ interface CarData {
             <option value="ja-JP">Japanese (Japan)</option>
             <option value="ko-KR">Korean (Korea)</option>
             <option value="lv-LV">Latvian (Latvia)</option>
-            <option value="nb-NO">Norwegian Bokmål (Norway)</option>
+            <option value="nb-NO">Norwegian Bokmal (Norway)</option>
             <option value="nl-NL">Dutch (Netherlands)</option>
             <option value="pl-PL">Polish (Poland)</option>
             <option value="pt-BR">Portuguese (Brazil)</option>

--- a/docs/content/guides/cell-types/date-cell-type/javascript/example1.html
+++ b/docs/content/guides/cell-types/date-cell-type/javascript/example1.html
@@ -16,7 +16,7 @@
         <option value="ja-JP">Japanese (Japan)</option>
         <option value="ko-KR">Korean (Korea)</option>
         <option value="lv-LV">Latvian (Latvia)</option>
-        <option value="nb-NO">Norwegian Bokmål (Norway)</option>
+        <option value="nb-NO">Norwegian Bokmal (Norway)</option>
         <option value="nl-NL">Dutch (Netherlands)</option>
         <option value="pl-PL">Polish (Poland)</option>
         <option value="pt-BR">Portuguese (Brazil)</option>

--- a/docs/content/guides/cell-types/date-cell-type/react/example1.jsx
+++ b/docs/content/guides/cell-types/date-cell-type/react/example1.jsx
@@ -64,7 +64,7 @@ const ExampleComponent = () => {
               <option value="ja-JP">Japanese (Japan)</option>
               <option value="ko-KR">Korean (Korea)</option>
               <option value="lv-LV">Latvian (Latvia)</option>
-              <option value="nb-NO">Norwegian Bokmål (Norway)</option>
+              <option value="nb-NO">Norwegian Bokmal (Norway)</option>
               <option value="nl-NL">Dutch (Netherlands)</option>
               <option value="pl-PL">Polish (Poland)</option>
               <option value="pt-BR">Portuguese (Brazil)</option>

--- a/docs/content/guides/cell-types/date-cell-type/react/example1.tsx
+++ b/docs/content/guides/cell-types/date-cell-type/react/example1.tsx
@@ -65,7 +65,7 @@ const ExampleComponent = () => {
               <option value="ja-JP">Japanese (Japan)</option>
               <option value="ko-KR">Korean (Korea)</option>
               <option value="lv-LV">Latvian (Latvia)</option>
-              <option value="nb-NO">Norwegian Bokmål (Norway)</option>
+              <option value="nb-NO">Norwegian Bokmal (Norway)</option>
               <option value="nl-NL">Dutch (Netherlands)</option>
               <option value="pl-PL">Polish (Poland)</option>
               <option value="pt-BR">Portuguese (Brazil)</option>

--- a/docs/content/guides/cell-types/numeric-cell-type/angular/example1.ts
+++ b/docs/content/guides/cell-types/numeric-cell-type/angular/example1.ts
@@ -68,7 +68,7 @@ interface CarData {
             <option value="ja-JP">Japanese (Japan)</option>
             <option value="ko-KR">Korean (Korea)</option>
             <option value="lv-LV">Latvian (Latvia)</option>
-            <option value="nb-NO">Norwegian Bokmål (Norway)</option>
+            <option value="nb-NO">Norwegian Bokmal (Norway)</option>
             <option value="nl-NL">Dutch (Netherlands)</option>
             <option value="pl-PL">Polish (Poland)</option>
             <option value="pt-BR">Portuguese (Brazil)</option>

--- a/docs/content/guides/cell-types/numeric-cell-type/javascript/example1.html
+++ b/docs/content/guides/cell-types/numeric-cell-type/javascript/example1.html
@@ -16,7 +16,7 @@
         <option value="ja-JP">Japanese (Japan)</option>
         <option value="ko-KR">Korean (Korea)</option>
         <option value="lv-LV">Latvian (Latvia)</option>
-        <option value="nb-NO">Norwegian Bokmål (Norway)</option>
+        <option value="nb-NO">Norwegian Bokmal (Norway)</option>
         <option value="nl-NL">Dutch (Netherlands)</option>
         <option value="pl-PL">Polish (Poland)</option>
         <option value="pt-BR">Portuguese (Brazil)</option>

--- a/docs/content/guides/cell-types/numeric-cell-type/react/example1.jsx
+++ b/docs/content/guides/cell-types/numeric-cell-type/react/example1.jsx
@@ -85,7 +85,7 @@ const ExampleComponent = () => {
               <option value="ja-JP">Japanese (Japan)</option>
               <option value="ko-KR">Korean (Korea)</option>
               <option value="lv-LV">Latvian (Latvia)</option>
-              <option value="nb-NO">Norwegian Bokmål (Norway)</option>
+              <option value="nb-NO">Norwegian Bokmal (Norway)</option>
               <option value="nl-NL">Dutch (Netherlands)</option>
               <option value="pl-PL">Polish (Poland)</option>
               <option value="pt-BR">Portuguese (Brazil)</option>

--- a/docs/content/guides/cell-types/numeric-cell-type/react/example1.tsx
+++ b/docs/content/guides/cell-types/numeric-cell-type/react/example1.tsx
@@ -97,7 +97,7 @@ const ExampleComponent = () => {
               <option value="ja-JP">Japanese (Japan)</option>
               <option value="ko-KR">Korean (Korea)</option>
               <option value="lv-LV">Latvian (Latvia)</option>
-              <option value="nb-NO">Norwegian Bokmål (Norway)</option>
+              <option value="nb-NO">Norwegian Bokmal (Norway)</option>
               <option value="nl-NL">Dutch (Netherlands)</option>
               <option value="pl-PL">Polish (Poland)</option>
               <option value="pt-BR">Portuguese (Brazil)</option>

--- a/docs/content/guides/cell-types/time-cell-type/angular/example1.ts
+++ b/docs/content/guides/cell-types/time-cell-type/angular/example1.ts
@@ -64,7 +64,7 @@ interface CarData {
             <option value="ja-JP">Japanese (Japan)</option>
             <option value="ko-KR">Korean (Korea)</option>
             <option value="lv-LV">Latvian (Latvia)</option>
-            <option value="nb-NO">Norwegian Bokmål (Norway)</option>
+            <option value="nb-NO">Norwegian Bokmal (Norway)</option>
             <option value="nl-NL">Dutch (Netherlands)</option>
             <option value="pl-PL">Polish (Poland)</option>
             <option value="pt-BR">Portuguese (Brazil)</option>

--- a/docs/content/guides/cell-types/time-cell-type/javascript/example1.html
+++ b/docs/content/guides/cell-types/time-cell-type/javascript/example1.html
@@ -16,7 +16,7 @@
         <option value="ja-JP">Japanese (Japan)</option>
         <option value="ko-KR">Korean (Korea)</option>
         <option value="lv-LV">Latvian (Latvia)</option>
-        <option value="nb-NO">Norwegian Bokmål (Norway)</option>
+        <option value="nb-NO">Norwegian Bokmal (Norway)</option>
         <option value="nl-NL">Dutch (Netherlands)</option>
         <option value="pl-PL">Polish (Poland)</option>
         <option value="pt-BR">Portuguese (Brazil)</option>

--- a/docs/content/guides/cell-types/time-cell-type/react/example1.jsx
+++ b/docs/content/guides/cell-types/time-cell-type/react/example1.jsx
@@ -39,7 +39,7 @@ const ExampleComponent = () => {
               <option value="ja-JP">Japanese (Japan)</option>
               <option value="ko-KR">Korean (Korea)</option>
               <option value="lv-LV">Latvian (Latvia)</option>
-              <option value="nb-NO">Norwegian Bokmål (Norway)</option>
+              <option value="nb-NO">Norwegian Bokmal (Norway)</option>
               <option value="nl-NL">Dutch (Netherlands)</option>
               <option value="pl-PL">Polish (Poland)</option>
               <option value="pt-BR">Portuguese (Brazil)</option>

--- a/docs/content/guides/cell-types/time-cell-type/react/example1.tsx
+++ b/docs/content/guides/cell-types/time-cell-type/react/example1.tsx
@@ -40,7 +40,7 @@ const ExampleComponent = () => {
               <option value="ja-JP">Japanese (Japan)</option>
               <option value="ko-KR">Korean (Korea)</option>
               <option value="lv-LV">Latvian (Latvia)</option>
-              <option value="nb-NO">Norwegian Bokmål (Norway)</option>
+              <option value="nb-NO">Norwegian Bokmal (Norway)</option>
               <option value="nl-NL">Dutch (Netherlands)</option>
               <option value="pl-PL">Polish (Poland)</option>
               <option value="pt-BR">Portuguese (Brazil)</option>


### PR DESCRIPTION
### Context
This PR fixes the 500 error occurring in the JSFiddle example for the Date cell type documentation.

### How has this been tested?
Locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/3096

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 0d1265e82ebd8444131f2ba92edd0e6703cba814. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->