### PR TITLE
Fix Angular wrapper builds by updating the examples' tsconfigs and removing `handsontable/core` import from the angular wrapper.

### DIFF
--- a/.changelogs/12091.json
+++ b/.changelogs/12091.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed a problem with the Angular wrapper that broke builds done with a disabled `skipLibCheck`.",
+  "type": "fixed",
+  "issueOrPR": 12091,
+  "breaking": false,
+  "framework": "angular"
+}

--- a/examples/next/docs/angular-wrapper/basic-example/tsconfig.json
+++ b/examples/next/docs/angular-wrapper/basic-example/tsconfig.json
@@ -14,7 +14,7 @@
     "declaration": false,
     "downlevelIteration": true,
     "experimentalDecorators": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "importHelpers": true,
     "target": "ES2022",
     "module": "ES2022",
@@ -23,7 +23,6 @@
       "ES2022",
       "dom"
     ],
-    "skipLibCheck": true
   },
   "angularCompilerOptions": {
     "disableTypeScriptVersionCheck": true,

--- a/examples/next/docs/angular-wrapper/demo/tsconfig.json
+++ b/examples/next/docs/angular-wrapper/demo/tsconfig.json
@@ -11,12 +11,11 @@
     "declaration": false,
     "downlevelIteration": true,
     "experimentalDecorators": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "importHelpers": true,
     "target": "ES2022",
     "module": "ES2022",
-    "lib": ["ES2022", "dom"],
-    "skipLibCheck": true
+    "lib": ["ES2022", "dom"]
   },
   "angularCompilerOptions": {
     "strictInjectionParameters": true,

--- a/examples/next/visual-tests/angular-wrapper/basic-example/tsconfig.json
+++ b/examples/next/visual-tests/angular-wrapper/basic-example/tsconfig.json
@@ -14,7 +14,7 @@
     "declaration": false,
     "downlevelIteration": true,
     "experimentalDecorators": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "importHelpers": true,
     "target": "ES2022",
     "module": "ES2022",
@@ -23,7 +23,6 @@
       "ES2022",
       "dom"
     ],
-    "skipLibCheck": true
   },
   "angularCompilerOptions": {
     "disableTypeScriptVersionCheck": true,

--- a/examples/next/visual-tests/angular-wrapper/demo/tsconfig.json
+++ b/examples/next/visual-tests/angular-wrapper/demo/tsconfig.json
@@ -11,12 +11,11 @@
     "declaration": false,
     "downlevelIteration": true,
     "experimentalDecorators": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "importHelpers": true,
     "target": "ES2022",
     "module": "ES2022",
     "lib": ["ES2022", "dom"],
-    "skipLibCheck": true
   },
   "angularCompilerOptions": {
     "strictInjectionParameters": true,

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/models/column-settings.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/models/column-settings.ts
@@ -2,12 +2,10 @@ import { ComponentRef, EnvironmentInjector, Type, TemplateRef } from '@angular/c
 import Handsontable from 'handsontable/base';
 import { ExtendedEditor } from 'handsontable/editors/factory';
 import { CellProperties } from 'handsontable/settings';
-import Core from 'handsontable/core';
 import { HotCellRendererComponent } from '../renderer/hot-cell-renderer.component';
 import { HotCellEditorComponent } from '../editor/hot-cell-editor.component';
 import { HotCellRendererAdvancedComponent } from '../renderer/hot-cell-renderer-advanced.component';
 import { HotCellEditorAdvancedComponent } from '../editor/hot-cell-editor-advanced.component';
-
 export type CustomValidatorFn<T> = (value: T) => boolean;
 
 export type ColumnSettings =
@@ -22,7 +20,7 @@ export type ColumnSettings =
         TemplateRef<any> |
         Handsontable.ColumnSettings['renderer'] |
         (
-          (instance: Core,
+          (instance: Handsontable,
             td: HTMLTableCellElement,
             row: number, column: number,
             prop: string | number,


### PR DESCRIPTION
### Context
  Two fixes to make `@handsontable/angular-wrapper` builds work without `skipLibCheck`:

  - **`column-settings.ts`**: Removed the `import Core from 'handsontable/core'` import, which is not exposed in Handsontable's package exports. Since `Core` was only used as a type for the custom renderer function signature,
   it's replaced with `Handsontable` (imported from `handsontable/base`), which refers to the same class.
  - **Angular examples `tsconfig.json` files**: Changed `moduleResolution` from `"node"` to `"bundler"` and removed `skipLibCheck: true` in all four Angular demo/visual-test configs. Angular 19+ uses package subpath exports (e.g.
  `@angular/core/primitives/di`), which require a module resolution strategy that understands the `exports` field in `package.json`. The `"node"` strategy predates this.

  > [!IMPORTANT]
  > After merging this PR to `develop`, it needs to be cherry-picked to the `release/17.0.0` branch.

  ### How has this been tested?
  Verified the `@handsontable/angular-wrapper` demo builds successfully with `npm run build`.

  ### Types of changes
  - [x] Bug fix (non-breaking change which fixes an issue)

  ### Related issue(s):
  1.

  ### Affected project(s):
  - [x] `@handsontable/angular-wrapper`

  ### Checklist:
  - [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
  - [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
  - [ ] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly TypeScript config and type-only changes; low behavioral risk, with the main risk being unexpected TS resolution differences in the Angular example builds.
> 
> **Overview**
> Fixes Angular wrapper builds with `skipLibCheck` disabled by removing the non-exported `handsontable/core` type import and updating the custom renderer signature in `column-settings.ts` to use `Handsontable` from `handsontable/base`.
> 
> Updates the Angular wrapper Next.js examples/visual-tests `tsconfig.json` files to use `moduleResolution: "bundler"` and drops `skipLibCheck: true`, ensuring TypeScript correctly resolves modern package `exports` (notably Angular 19+ subpath exports). Adds a changelog entry for the fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9769eeeaa0c6218cc066ac166b937711b8dbf70f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->