### PR TITLE
Update changelog and migration guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Deprecated **moment.js** for date parsing and display. Replace it with the `Intl.DateTimeFormat` API. [Migration guide](https://handsontable.com/docs/javascript-data-grid/migration-from-16.2-to-17.0#_4-migrate-from-moment-js-format-to-intl-datetimeformat)
 - Deprecated **DOMPurify** as a built-in XSS sanitizer. Use the new `sanitizer` option or convert content to plain text. [Migration guide](https://handsontable.com/docs/javascript-data-grid/migration-from-16.2-to-17.0#_5-migrate-from-built-in-dompurify-to-the-sanitizer-option)
 - Deprecated **core-js** polyfills for ECMAScript features. [Migration guide](https://handsontable.com/docs/javascript-data-grid/migration-from-16.2-to-17.0#_6-core-js-dependency-removed)
-- Deprecated bundling **HyperFormula** as a Handsontable dependency. Starting from version 18.0, install and import it separately, then pass it to the Formulas plugin with `licenseKey: 'internal-use'`. [Formula calculation](https://handsontable.com/docs/javascript-data-grid/formula-calculation)
+- Deprecated bundling **HyperFormula** as a Handsontable dependency. Starting from version 18.0, install and import it separately, then pass it to the Formulas plugin with `licenseKey: 'internal-use-in-handsontable'`. [Formula calculation](https://handsontable.com/docs/javascript-data-grid/formula-calculation)
 
 ### Removed
 - **Breaking change**: Removed deprecated wrapper packages for Angular, React, and Vue, the `PersistentState` plugin, and the legacy undo/redo methods. [#12015](https://github.com/handsontable/handsontable/pull/12015)

--- a/docs/content/guides/upgrade-and-migration/changelog/changelog.md
+++ b/docs/content/guides/upgrade-and-migration/changelog/changelog.md
@@ -60,7 +60,7 @@ For more information about this release, see:
 - Deprecated **moment.js** for date parsing and display. Replace it with the `Intl.DateTimeFormat` API. [Migration guide](https://handsontable.com/docs/javascript-data-grid/migration-from-16.2-to-17.0#_4-migrate-from-moment-js-format-to-intl-datetimeformat)
 - Deprecated **DOMPurify** as a built-in XSS sanitizer. Use the new `sanitizer` option or convert content to plain text. [Migration guide](https://handsontable.com/docs/javascript-data-grid/migration-from-16.2-to-17.0#_5-migrate-from-built-in-dompurify-to-the-sanitizer-option)
 - Deprecated **core-js** polyfills for ECMAScript features. [Migration guide](https://handsontable.com/docs/javascript-data-grid/migration-from-16.2-to-17.0#_6-core-js-dependency-removed)
-- Deprecated bundling **HyperFormula** as a Handsontable dependency. Starting from version 18.0, install and import it separately, then pass it to the Formulas plugin with `licenseKey: 'internal-use'`. [Formula calculation](https://handsontable.com/docs/javascript-data-grid/formula-calculation)
+- Deprecated bundling **HyperFormula** as a Handsontable dependency. Starting from version 18.0, install and import it separately, then pass it to the Formulas plugin with `licenseKey: 'internal-use-in-handsontable'`. [Formula calculation](https://handsontable.com/docs/javascript-data-grid/formula-calculation)
 
 #### Removed
 - **Breaking change**: Removed deprecated wrapper packages for Angular, React, and Vue, the `PersistentState` plugin, and the legacy undo/redo methods. [#12015](https://github.com/handsontable/handsontable/pull/12015)

--- a/docs/content/guides/upgrade-and-migration/changelog/changelog.md
+++ b/docs/content/guides/upgrade-and-migration/changelog/changelog.md
@@ -28,12 +28,14 @@ See the full history of changes made to Handsontable in each major, minor, and p
 
 [[toc]]
 
-## 17.0.0-rc15
+## 17.0.0
 
-Released on March 5th, 2026
+Released on March 9th, 2026
 
 For more information about this release, see:
+- [Blog post (17.0.0)](https://handsontable.com/blog/handsontable-17.0.0-multiselect-cell-type-simpler-custom-cells-and-a-new-themes-api)
 - [Documentation (17.0)](https://handsontable.com/docs/17.0)
+- [Migration guide (16.2 → 17.0)](@/guides/upgrade-and-migration/migrating-from-16.2-to-17.0/migrating-from-16.2-to-17.0.md)
 
 #### Added
 - **Breaking change**: Added the Theme API. [#11950](https://github.com/handsontable/handsontable/pull/11950)
@@ -85,6 +87,7 @@ For more information about this release, see:
 Released on November 25th, 2025
 
 For more information about this release see:
+- [Blog post (16.2.0)](https://handsontable.com/blog/handsontable-16.2.0-simplified-theming-and-advanced-user-notifications)
 - [Documentation (16.2)](https://handsontable.com/docs/16.2)
 
 #### Added
@@ -140,6 +143,7 @@ For more information about this release see:
 Released on September 15, 2025
 
 For more information about this release see:
+- [Blog post (16.1.0)](https://handsontable.com/blog/handsontable-16.1-row-pagination-loading-plugin-and-long-term-support-policy)
 - [Documentation (16.1)](https://handsontable.com/docs/16.1)
 - [Migration guide (16.0 → 16.1)](@/guides/upgrade-and-migration/migrating-from-16.0-to-16.1/migrating-from-16.0-to-16.1.md)
 

--- a/docs/content/guides/upgrade-and-migration/deprecation-policy/deprecation-policy.md
+++ b/docs/content/guides/upgrade-and-migration/deprecation-policy/deprecation-policy.md
@@ -56,6 +56,6 @@ Below is a list of current deprecations that are planned to be removed in the ne
 | **moment.js** | Parses, validates and displays dates. Needed for Excel compat. | [Migrate from 16.2 to 17.0 → Date/Time](@/guides/upgrade-and-migration/migrating-from-16.2-to-17.0/migrating-from-16.2-to-17.0.md#_4-migrate-from-moment-js-format-to-intl-datetimeformat) |
 | **DOMPurify** | An XSS sanitizer for HTML. Use the `sanitizer` option to keep a sanitizer, or convert content to plain text. | [Migrate from 16.2 to 17.0 → DOMPurify](@/guides/upgrade-and-migration/migrating-from-16.2-to-17.0/migrating-from-16.2-to-17.0.md#_5-migrate-from-built-in-dompurify-to-the-sanitizer-option) |
 | **core-js** | Polyfills for ECMAScript 5, ECMAScript 6, promises, symbols, collections. | [Migrate from 16.2 to 17.0 → core-js](@/guides/upgrade-and-migration/migrating-from-16.2-to-17.0/migrating-from-16.2-to-17.0.md#_6-core-js-dependency-removed) |
-| **Built-in HyperFormula** | The Formulas plugin engine. Will be removed from package.json in 18.0. Import HyperFormula yourself and pass it to the Formulas plugin with `licenseKey: 'internal-use'`. | [Formula calculation](@/guides/formulas/formula-calculation/formula-calculation.md) |
+| **Built-in HyperFormula** | The Formulas plugin engine. Will be removed from package.json in 18.0. Import HyperFormula yourself and pass it to the Formulas plugin with `licenseKey: 'internal-use-in-handsontable'`. | [Formula calculation](@/guides/formulas/formula-calculation/formula-calculation.md) |
 
 

--- a/docs/content/guides/upgrade-and-migration/migrating-from-14.6-to-15.0/migrating-from-14.6-to-15.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-14.6-to-15.0/migrating-from-14.6-to-15.0.md
@@ -2,7 +2,7 @@
 id: migrating-14.6-to-15.0
 title: Migrating from 14.6 to 15.0
 metaTitle: Migrating from 14.6 to 15.0 - JavaScript Data Grid | Handsontable
-description: Migrate from Handsontable 14.6 to Handsontable 15.0, released on [].
+description: Migrate from Handsontable 14.6 to Handsontable 15.0, released on December 16th, 2024.
 permalink: /migration-from-14.6-to-15.0
 canonicalUrl: /migration-from-14.6-to-15.0
 pageClass: migration-guide

--- a/docs/content/guides/upgrade-and-migration/migrating-from-15.3-to-16.0/migrating-from-15.3-to-16.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-15.3-to-16.0/migrating-from-15.3-to-16.0.md
@@ -2,7 +2,7 @@
 id: 1k7arh9z
 title: Migrating from 15.3 to 16.0
 metaTitle: Migrating from 15.3 to 16.0 - JavaScript Data Grid | Handsontable
-description: Migrate from Handsontable 15.3 to Handsontable 16.0, released on [09/07/2025].
+description: Migrate from Handsontable 15.3 to Handsontable 16.0, released on July 9, 2025.
 permalink: /migration-from-15.3-to-16.0
 canonicalUrl: /migration-from-15.3-to-16.0
 pageClass: migration-guide
@@ -18,7 +18,7 @@ category: Upgrade and migration
 
 # Migrate from 15.3 to 16.0
 
-Migrate from Handsontable 15.3 to Handsontable 16.0, released on 09/07/2025.
+Migrate from Handsontable 15.3 to Handsontable 16.0, released on July 9, 2025.
 
 More information about this release can be found in the [`16.0.0` release blog post](https://handsontable.com/blog/handsontable-16-new-angular-wrapper-and-core-improvements).<br/>
 For a detailed list of changes in this release, see the [Changelog](@/guides/upgrade-and-migration/changelog/changelog.md#_16-0-0).

--- a/docs/content/guides/upgrade-and-migration/migrating-from-16.0-to-16.1/migrating-from-16.0-to-16.1.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-16.0-to-16.1/migrating-from-16.0-to-16.1.md
@@ -2,7 +2,7 @@
 id: sf7vrh9z
 title: Migrating from 16.0 to 16.1
 metaTitle: Migrating from 16.0 to 16.1 - JavaScript Data Grid | Handsontable
-description: Migrate from Handsontable 16.0 to Handsontable 16.1, released on [TODO].
+description: Migrate from Handsontable 16.0 to Handsontable 16.1, released on September 15, 2025.
 permalink: /migration-from-16.0-to-16.1
 canonicalUrl: /migration-from-16.0-to-16.1
 pageClass: migration-guide

--- a/docs/content/guides/upgrade-and-migration/migrating-from-16.2-to-17.0/migrating-from-16.2-to-17.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-16.2-to-17.0/migrating-from-16.2-to-17.0.md
@@ -1100,12 +1100,12 @@ If you only target modern browsers and runtimes, no action is needed.
 
 The **Formulas** plugin uses [HyperFormula](https://hyperformula.handsontable.com/) as its calculation engine. Currently, HyperFormula is bundled with Handsontable. In **version 18.0**, it will be removed from `package.json`.
 
-### What to expect
+### What to Expect
 
 - **Version 17.x**: Built-in HyperFormula remains available, no change required yet.
 - **Version 18.0**: HyperFormula is removed from Handsontable dependencies. You must add it as your own dependency and configure the Formulas plugin to use your instance.
 
-### How to prepare
+### How to Prepare
 
 1. Install HyperFormula in your project (e.g. `npm install hyperformula`).
 2. Import HyperFormula and pass it to the Formulas plugin with `licenseKey: 'internal-use-in-handsontable'`.

--- a/docs/content/guides/upgrade-and-migration/migrating-from-16.2-to-17.0/migrating-from-16.2-to-17.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-16.2-to-17.0/migrating-from-16.2-to-17.0.md
@@ -1108,7 +1108,7 @@ The **Formulas** plugin uses [HyperFormula](https://hyperformula.handsontable.co
 ### How to prepare
 
 1. Install HyperFormula in your project (e.g. `npm install hyperformula`).
-2. Import HyperFormula and pass it to the Formulas plugin with `licenseKey: 'internal-use'`.
+2. Import HyperFormula and pass it to the Formulas plugin with `licenseKey: 'internal-use-in-handsontable'`.
 
 See the [Formula calculation](@/guides/formulas/formula-calculation/formula-calculation.md) guide for configuration details.
 
@@ -1120,7 +1120,7 @@ See the [Formula calculation](@/guides/formulas/formula-calculation/formula-calc
 | `handsontable.full.min.css` no longer available   | Use Theme API or import a theme CSS file (e.g. `ht-theme-classic.min.css`) |
 | CSS-based themes (optional migration)             | Consider migrating to Theme API for runtime features                       |
 | `core-js` dependency removed                      | Add `core-js` or other polyfills in your app if you support older environments |
-| Built-in HyperFormula (deprecation)               | In 18.0, import HyperFormula yourself and pass it to the Formulas plugin with `licenseKey: 'internal-use'` |
+| Built-in HyperFormula (deprecation)               | In 18.0, import HyperFormula yourself and pass it to the Formulas plugin with `licenseKey: 'internal-use-in-handsontable'` |
 
 ## Related resources
 

--- a/docs/content/guides/upgrade-and-migration/migrating-from-16.2-to-17.0/migrating-from-16.2-to-17.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-16.2-to-17.0/migrating-from-16.2-to-17.0.md
@@ -2,7 +2,7 @@
 id: 9w5zs3t2
 title: Migrating from 16.2 to 17.0
 metaTitle: Migrating from 16.2 to 17.0 - JavaScript Data Grid | Handsontable
-description: Migrate from Handsontable 16.2 to Handsontable 17.0, released on [TODO].
+description: Migrate from Handsontable 16.2 to Handsontable 17.0, released on released on March 09, 2025.
 permalink: /migration-from-16.2-to-17.0
 canonicalUrl: /migration-from-16.2-to-17.0
 pageClass: migration-guide
@@ -19,9 +19,9 @@ menuTag: new
 
 # Migrate from 16.2 to 17.0
 
-Migrate from Handsontable 16.2 to Handsontable 17.0, released on [TODO].
+Migrate from Handsontable 16.2 to Handsontable 17.0, released on March 09, 2025.
 
-More information about this release can be found in the [`17.0.0` release blog post](TODO).<br/>
+More information about this release can be found in the [`17.0.0` release blog post](https://handsontable.com/blog/handsontable-17.0.0-multiselect-cell-type-simpler-custom-cells-and-a-new-themes-api).<br/>
 For a detailed list of changes in this release, see the [Changelog](@/guides/upgrade-and-migration/changelog/changelog.md#_17-0-0).
 
 [[toc]]
@@ -1096,6 +1096,22 @@ If you only target modern browsers and runtimes, no action is needed.
 - [Browser support](@/guides/technical-specification/supported-browsers/supported-browsers.md) - Supported browsers and runtimes
 - [Third-party licenses](@/guides/technical-specification/third-party-licenses/third-party-licenses.md) - Dependencies and licenses
 
+## 7. Built-in HyperFormula (deprecation notice)
+
+The **Formulas** plugin uses [HyperFormula](https://hyperformula.handsontable.com/) as its calculation engine. Currently, HyperFormula is bundled with Handsontable. In **version 18.0**, it will be removed from `package.json`.
+
+### What to expect
+
+- **Version 17.x**: Built-in HyperFormula remains available, no change required yet.
+- **Version 18.0**: HyperFormula is removed from Handsontable dependencies. You must add it as your own dependency and configure the Formulas plugin to use your instance.
+
+### How to prepare
+
+1. Install HyperFormula in your project (e.g. `npm install hyperformula`).
+2. Import HyperFormula and pass it to the Formulas plugin with `licenseKey: 'internal-use'`.
+
+See the [Formula calculation](@/guides/formulas/formula-calculation/formula-calculation.md) guide for configuration details.
+
 ## Summary of breaking changes
 
 | Change                                            | Action Required                                                            |
@@ -1104,6 +1120,7 @@ If you only target modern browsers and runtimes, no action is needed.
 | `handsontable.full.min.css` no longer available   | Use Theme API or import a theme CSS file (e.g. `ht-theme-classic.min.css`) |
 | CSS-based themes (optional migration)             | Consider migrating to Theme API for runtime features                       |
 | `core-js` dependency removed                      | Add `core-js` or other polyfills in your app if you support older environments |
+| Built-in HyperFormula (deprecation)               | In 18.0, import HyperFormula yourself and pass it to the Formulas plugin with `licenseKey: 'internal-use'` |
 
 ## Related resources
 


### PR DESCRIPTION
### Context
This PR includes update for changelog and  migration guide after release.

### How has this been tested?
Locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/2978

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes (changelog/migration guides) with no runtime or API behavior impact; primary risk is misinformation if dates or the `licenseKey` string are incorrect.
> 
> **Overview**
> Updates release documentation for the 17.0.0 publication by adding missing links (blog post and `16.2 → 17.0` migration guide) and filling in previously placeholder release dates across several migration guide frontmatters.
> 
> Clarifies the upcoming HyperFormula unbundling in v18.0 by adding an explicit deprecation section to the `16.2 → 17.0` migration guide and updating related docs/changelog entries to reference the correct `licenseKey` value (`internal-use-in-handsontable`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9e9207e2bec1bd5f041f6f2fe6f121c851e3b76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->