### PR TITLE
Sync the docs' changelog with the docs branch.

### DIFF
--- a/docs/content/guides/upgrade-and-migration/changelog/changelog.md
+++ b/docs/content/guides/upgrade-and-migration/changelog/changelog.md
@@ -28,9 +28,9 @@ See the full history of changes made to Handsontable in each major, minor, and p
 
 [[toc]]
 
-## 17.0.0-rc15
+## 17.0.0
 
-Released on March 5th, 2026
+Released on March 9th, 2026
 
 For more information about this release, see:
 - [Documentation (17.0)](https://handsontable.com/docs/17.0)


### PR DESCRIPTION
### Context
The release process updated the docs' changelog on the docs branch, but not on develop. This PR corrects it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change that updates a version label and release date; no product code or runtime behavior is affected.
> 
> **Overview**
> Updates the docs `Changelog` page to reflect the final `17.0.0` release instead of `17.0.0-rc15`, including updating the release date to March 9th, 2026.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d64353a44136cf1c1dd0d2915710efac94530c9c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->