### PR TITLE
Development environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+Handsontable is a JavaScript/TypeScript data grid monorepo (pnpm workspace). It contains the core library plus React, Angular, and Vue 3 wrappers.
+
+### Workspace packages
+
+| Package | Directory | Purpose |
+|---|---|---|
+| `handsontable` | `handsontable/` | Core data grid (vanilla JS) |
+| `@handsontable/react-wrapper` | `wrappers/react-wrapper/` | React wrapper |
+| `@handsontable/angular-wrapper` | `wrappers/angular-wrapper/` | Angular wrapper |
+| `@handsontable/vue3` | `wrappers/vue3/` | Vue 3 wrapper |
+| `handsontable-visual-tests` | `visual-tests/` | Playwright visual regression tests |
+| `handsontable-examples-internal` | `examples/` | Code examples |
+| `handsontable-documentation` | `docs/` | VuePress docs site (requires Node 20) |
+
+### Prerequisites
+
+- **Node.js 22** (see `.nvmrc`)
+- **pnpm 10.30.2** (see `packageManager` in root `package.json`); activate via `corepack enable && corepack prepare pnpm@10.30.2 --activate`
+
+### Build, lint, test
+
+All commands below run from the workspace root (`/workspace`).
+
+- **Build core**: `pnpm --filter handsontable run build` (must be done before wrapper tests, since wrappers depend on the built `tmp/` output)
+- **Lint core**: `pnpm --filter handsontable run eslint` and `pnpm --filter handsontable run stylelint`
+- **Unit tests (core)**: `pnpm --filter handsontable run test:unit` (Jest, ~2200 tests)
+- **E2E tests (core)**: `pnpm --filter handsontable run test:e2e` (Puppeteer/Jasmine, headless Chrome)
+- **React tests**: `pnpm --filter @handsontable/react-wrapper run test`
+- **Vue3 tests**: `pnpm --filter @handsontable/vue3 run test`
+- **Angular tests**: `pnpm --filter @handsontable/angular-wrapper run test` (requires `--openssl-legacy-provider`; already handled via `cross-env` in `package.json` scripts)
+
+### Gotchas
+
+- The core build outputs to `handsontable/tmp/` (not `dist/` for wrappers' consumption). The UMD/minified builds go to `handsontable/dist/` and CSS to `handsontable/styles/`. Wrapper packages reference the `tmp/` build via workspace linking.
+- The Angular wrapper tests use `NODE_OPTIONS=--openssl-legacy-provider`; this is already wired into the `test` script.
+- The `pnpm-workspace.yaml` has `ignoredBuiltDependencies` and `onlyBuiltDependencies` lists. If pnpm warns about ignored build scripts (e.g., `less`), this is expected.
+- Root-level `npm run lint` and `npm run test` scripts use a custom `translate-to-native-npm.mjs` script to fan out across all workspace packages.
+- The docs site (`docs/`) uses Node 20 (its own `.nvmrc`) and is not needed for core library development.
+- No Docker, databases, or external services are required.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Context
This PR introduces `AGENTS.md`, a new documentation file to streamline the development environment setup for the Handsontable monorepo. It outlines the necessary steps for installation, building, linting, and testing, ensuring a consistent and verifiable setup for new contributors and automated agents.

### How has this been tested?
The development environment was set up from scratch, and all core and wrapper components were built and tested:
- `pnpm install` was executed to resolve dependencies.
- `handsontable` core was built using `pnpm --filter handsontable run build`.
- Linting was performed with `pnpm --filter handsontable run eslint` and `pnpm --filter handsontable run stylelint`.
- Unit tests were run for `handsontable` core, `@handsontable/react-wrapper`, `@handsontable/vue3`, and `@handsontable/angular-wrapper`. All tests passed.
- A temporary demo HTML page was created, served, and manually verified to confirm the functionality of the built Handsontable grid (cell editing, dropdown, context menu, sorting).

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. N/A

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

---
<p><a href="https://cursor.com/agents/bc-d6317785-cf5d-4d35-b789-aa847d14ffdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6317785-cf5d-4d35-b789-aa847d14ffdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->

[skip changelog]