### PR TITLE
getCellMetaAtRow() returned cell metadata in an inconsistent order 

### DIFF
--- a/.changelogs/12109.json
+++ b/.changelogs/12109.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed `getCellMetaAtRow()` to always return cell metadata in physical column order.",
+  "type": "fixed",
+  "issueOrPR": 12109,
+  "breaking": false,
+  "framework": "none"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,3 +43,7 @@ All commands below run from the workspace root (`/workspace`).
 - Root-level `npm run lint` and `npm run test` scripts use a custom `translate-to-native-npm.mjs` script to fan out across all workspace packages.
 - The docs site (`docs/`) uses Node 20 (its own `.nvmrc`) and is not needed for core library development.
 - No Docker, databases, or external services are required.
+
+### Testing preference
+
+- For bug fixes in `handsontable/`, add both a focused unit test and a focused E2E regression test when practical.

--- a/handsontable/src/dataMap/metaManager/metaLayers/__tests__/cellMeta.unit.js
+++ b/handsontable/src/dataMap/metaManager/metaLayers/__tests__/cellMeta.unit.js
@@ -198,6 +198,19 @@ describe('ColumnMeta', () => {
       expect(meta.getMetasAtRow(10)).toEqual([{ _test: 'test' }]);
     });
 
+    it('should return metas sorted by physical column index', () => {
+      const globalMeta = new GlobalMeta();
+      const columnMeta = new ColumnMeta(globalMeta);
+      const meta = new CellMeta(columnMeta);
+
+      meta.getMeta(2, 3)._test = 'three';
+      meta.getMeta(2, 4)._test = 'four';
+      meta.getMeta(2, 0)._test = 'zero';
+      meta.getMeta(2, 1)._test = 'one';
+
+      expect(meta.getMetasAtRow(2).map(metaObject => metaObject._test)).toEqual(['zero', 'one', 'three', 'four']);
+    });
+
     it('should change cell meta by reference', () => {
       const globalMeta = new GlobalMeta();
       const columnMeta = new ColumnMeta(globalMeta);

--- a/handsontable/src/dataMap/metaManager/metaLayers/cellMeta.js
+++ b/handsontable/src/dataMap/metaManager/metaLayers/cellMeta.js
@@ -193,7 +193,13 @@ export default class CellMeta {
 
     const rowsMeta = new Map(this.metas);
 
-    return rowsMeta.has(physicalRow) ? Array.from(rowsMeta.get(physicalRow).values()) : [];
+    if (!rowsMeta.has(physicalRow)) {
+      return [];
+    }
+
+    return Array.from(rowsMeta.get(physicalRow))
+      .sort(([a], [b]) => a - b)
+      .map(([, meta]) => meta);
   }
 
   /**

--- a/handsontable/test/e2e/core/getCellMetaAtRow.spec.js
+++ b/handsontable/test/e2e/core/getCellMetaAtRow.spec.js
@@ -34,4 +34,33 @@ describe('Core.getCellMetaAtRow', () => {
     expect(rowOfMeta[3].prop).toBe(3);
     expect(rowOfMeta[4].prop).toBe(4);
   });
+
+  it('should return meta sorted by physical/visual column index regardless of creation order', async() => {
+    handsontable({
+      data: createSpreadsheetData(100, 10),
+      fixedColumnsStart: 2,
+      hiddenColumns: {
+        columns: [7, 8, 9],
+      },
+      columns: [
+        { type: 'text' },
+        { type: 'text' },
+        { type: 'text' },
+        { type: 'dropdown', source: ['Loaded', 'Unloaded'] },
+        { type: 'dropdown', source: ['Overlay', 'Attached'] },
+        { type: 'text' },
+        { type: 'text' },
+        { type: 'text' },
+        { type: 'text' },
+        { type: 'text' },
+      ],
+    });
+
+    [3, 4, 0, 1, 2, 5, 6, 7, 8, 9].forEach(column => getCellMeta(50, column));
+
+    const rowOfMeta = getCellMetaAtRow(50);
+
+    expect(rowOfMeta.map(meta => meta.col)).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    expect(rowOfMeta.map(meta => meta.visualCol)).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  });
 });

--- a/handsontable/test/e2e/core/getCellMetaAtRow.spec.js
+++ b/handsontable/test/e2e/core/getCellMetaAtRow.spec.js
@@ -35,32 +35,24 @@ describe('Core.getCellMetaAtRow', () => {
     expect(rowOfMeta[4].prop).toBe(4);
   });
 
-  it('should return meta sorted by physical/visual column index regardless of creation order', async() => {
+  it('should return meta sorted by physical/visual column index regardless of internal storage order', async() => {
     handsontable({
-      data: createSpreadsheetData(100, 10),
-      fixedColumnsStart: 2,
-      hiddenColumns: {
-        columns: [7, 8, 9],
-      },
-      columns: [
-        { type: 'text' },
-        { type: 'text' },
-        { type: 'text' },
-        { type: 'dropdown', source: ['Loaded', 'Unloaded'] },
-        { type: 'dropdown', source: ['Overlay', 'Attached'] },
-        { type: 'text' },
-        { type: 'text' },
-        { type: 'text' },
-        { type: 'text' },
-        { type: 'text' },
+      data: createSpreadsheetData(5, 5),
+      cell: [
+        { row: 0, col: 1, myId: 1 },
+        { row: 1, col: 1, myId: 2 },
+        { row: 2, col: 1, myId: 3 },
+        { row: 3, col: 1, myId: 4 },
+        { row: 4, col: 1, myId: 5 },
       ],
     });
 
-    [3, 4, 0, 1, 2, 5, 6, 7, 8, 9].forEach(column => getCellMeta(50, column));
+    await spliceCellsMeta(3, 1);
 
-    const rowOfMeta = getCellMetaAtRow(50);
+    const rowOfMeta = getCellMetaAtRow(2);
 
-    expect(rowOfMeta.map(meta => meta.col)).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
-    expect(rowOfMeta.map(meta => meta.visualCol)).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    expect(rowOfMeta.map(meta => meta.col)).toEqual([0, 1, 2, 3, 4]);
+    expect(rowOfMeta.map(meta => meta.visualCol)).toEqual([0, 1, 2, 3, 4]);
+    expect(rowOfMeta.find(meta => meta.col === 1).myId).toBe(3);
   });
 });

--- a/handsontable/test/e2e/core/spliceCellsMeta.spec.js
+++ b/handsontable/test/e2e/core/spliceCellsMeta.spec.js
@@ -35,11 +35,11 @@ describe('Core.spliceCellsMeta', () => {
 
     let metaAtRow = getCellMetaAtRow(2);
 
-    expect(metaAtRow[0].myId).toBe(3);
+    expect(metaAtRow.find(meta => meta.col === 1).myId).toBe(3);
 
     metaAtRow = getCellMetaAtRow(3);
 
-    expect(metaAtRow[0].myId).toBe(5);
+    expect(metaAtRow.find(meta => meta.col === 1).myId).toBe(5);
   });
 
   it('should remove cell meta objects from the collection', async() => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Context
This PR addresses bug #12082, where `getCellMetaAtRow()` returned cell metadata in an inconsistent order (based on creation/internal storage) rather than by the physical column index. The change ensures that `getCellMetaAtRow()` now consistently returns cell metadata sorted by the physical column index, providing a deterministic and expected order.

### How has this been tested?
- **Unit Tests:** A new unit test (`handsontable/src/dataMap/metaManager/metaLayers/__tests__/cellMeta.unit.js`) was added to specifically verify the correct sorting of cell metadata by column index, even when metadata is created out of order.
- **E2E Tests:** A new E2E regression test (`handsontable/test/e2e/core/getCellMetaAtRow.spec.js`) was added to confirm the end-to-end behavior of `Core.getCellMetaAtRow` under conditions that previously triggered the bug, asserting that `col` and `visualCol` properties are correctly ordered.
- **Linting:** All modified files passed ESLint checks.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #12082

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

---
<p><a href="https://cursor.com/agents/bc-b1169cd8-6e22-44a5-b084-874c46d8bfb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1169cd8-6e22-44a5-b084-874c46d8bfb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->