### PR TITLE
Fix argos visual tests examples

### DIFF
--- a/examples/next/visual-tests/js/demo/src/demos/default/index.js
+++ b/examples/next/visual-tests/js/demo/src/demos/default/index.js
@@ -101,14 +101,16 @@ export function init() {
         data: 8,
         renderer: progressBarRenderer,
         editor: false,
-        className: "htMiddle"
+        className: "htMiddle",
+        readOnly: true,
       },
       {
         data: 9,
         renderer: starRenderer,
         editor: false,
         className: "star htCenter",
-        headerClassName: "htCenter"
+        headerClassName: "htCenter",
+        readOnly: true,
       },
       { data: 5, type: "text" },
       { data: 2, type: "text" }

--- a/examples/next/visual-tests/react-wrapper/demo/src/DataGrid.tsx
+++ b/examples/next/visual-tests/react-wrapper/demo/src/DataGrid.tsx
@@ -56,8 +56,8 @@ const DataGrid = () => {
       <HotColumn data={4} type="date" allowInvalid={false} />
       <HotColumn data={6} type="checkbox" className="htCenter" headerClassName="htCenter" />
       <HotColumn data={7} type="numeric" headerClassName="htRight" />
-      <HotColumn data={8} editor={false} className="htMiddle" renderer={ProgressBarRenderer}/>
-      <HotColumn data={9} editor={false} className="htCenter" headerClassName="htCenter" renderer={StarsRenderer} />
+      <HotColumn data={8} editor={false} className="htMiddle" renderer={ProgressBarRenderer} readOnly={true} />
+      <HotColumn data={9} editor={false} className="htCenter" headerClassName="htCenter" renderer={StarsRenderer} readOnly={true} />
       <HotColumn data={5} />
       <HotColumn data={2} />
     </HotTable>

--- a/visual-tests/tests/multi-frameworks/editors/textEditor/redo-multiline-text.spec.ts
+++ b/visual-tests/tests/multi-frameworks/editors/textEditor/redo-multiline-text.spec.ts
@@ -14,16 +14,25 @@ test(__filename, async({ tablePage }) => {
   const cellEditor = await selectEditor();
 
   await cellEditor.press('Control+Enter');
+  await tablePage.waitForTimeout(20);
   await cellEditor.press('Control+Enter');
+  await tablePage.waitForTimeout(20);
   await cellEditor.press('Control+Enter');
+  await tablePage.waitForTimeout(20);
 
   await cell.press('Control+Z');
+  await tablePage.waitForTimeout(20);
   await cell.press('Control+Z');
+  await tablePage.waitForTimeout(20);
   await cell.press('Control+Shift+Z');
+
+  await tablePage.waitForTimeout(100);
 
   await tablePage.screenshot({ path: helpers.screenshotPath() });
 
   await cell.press('Control+Shift+Z');
+
+  await tablePage.waitForTimeout(100);
 
   await tablePage.screenshot({ path: helpers.screenshotPath() });
 });

--- a/visual-tests/tests/multi-frameworks/editors/textEditor/undo-multiline-text.spec.ts
+++ b/visual-tests/tests/multi-frameworks/editors/textEditor/undo-multiline-text.spec.ts
@@ -17,13 +17,19 @@ test(__filename, async({ tablePage }) => {
   await cellEditor.press('Control+Enter');
   await cellEditor.press('Control+Enter');
 
-  await tablePage.screenshot({ path: helpers.screenshotPath() });
-
-  await cell.press('Control+Z');
+  await tablePage.waitForTimeout(100);
 
   await tablePage.screenshot({ path: helpers.screenshotPath() });
 
   await cell.press('Control+Z');
+
+  await tablePage.waitForTimeout(100);
+
+  await tablePage.screenshot({ path: helpers.screenshotPath() });
+
+  await cell.press('Control+Z');
+
+  await tablePage.waitForTimeout(100);
 
   await tablePage.screenshot({ path: helpers.screenshotPath() });
 });

--- a/visual-tests/tests/multi-frameworks/editors/textEditor/undo-multiline-text.spec.ts
+++ b/visual-tests/tests/multi-frameworks/editors/textEditor/undo-multiline-text.spec.ts
@@ -14,7 +14,9 @@ test(__filename, async({ tablePage }) => {
   const cellEditor = await selectEditor();
 
   await cellEditor.press('Control+Enter');
+  await tablePage.waitForTimeout(20);
   await cellEditor.press('Control+Enter');
+  await tablePage.waitForTimeout(20);
   await cellEditor.press('Control+Enter');
 
   await tablePage.waitForTimeout(100);


### PR DESCRIPTION
### Context
This PR includes fixes to the visual test examples to fix the differences between the JS and wrapper examples.

### How has this been tested?
Locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to visual-test demos and Playwright-based visual specs, mainly tightening read-only configuration and adding timing waits to reduce flakiness.
> 
> **Overview**
> Marks the progress-bar and star-rating columns as explicitly `readOnly` (in both the vanilla JS and React wrapper visual-test demos) to avoid editability differences during snapshots.
> 
> Stabilizes multiline text editor undo/redo visual tests by inserting short `waitForTimeout` delays between key presses and before screenshots, reducing race conditions in Argos captures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2bd7cc6a71833886a4c04d184b1ca83f20187b75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->