### PR TITLE
pasting very large datasets

### DIFF
--- a/.changelogs/11784.json
+++ b/.changelogs/11784.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed a stack overflow error when pasting large datasets (50,000+ rows) by optimizing array operations in the HTML table parser.",
+  "type": "fixed",
+  "issueOrPR": 11784,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/copyPaste/__tests__/paste.spec.js
+++ b/handsontable/src/plugins/copyPaste/__tests__/paste.spec.js
@@ -919,5 +919,73 @@ describe('CopyPaste', () => {
       expect(getDataAtCell(1, 1)).toEqual('test2');
       expect(getCopyableSourceData(1, 1)).toEqual({ sth: 1, label: 'test2' });
     });
+
+    it('should handle pasting very large HTML tables without stack overflow (issue #11784)', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        copyPaste: true,
+      });
+
+      // Create a large HTML table (50,000 rows) to test the fix
+      const rowCount = 50000;
+      let htmlTable = '<table><tbody>';
+
+      for (let i = 0; i < rowCount; i++) {
+        htmlTable += `<tr><td>Row${i}Col0</td><td>Row${i}Col1</td><td>Row${i}Col2</td></tr>`;
+      }
+      htmlTable += '</tbody></table>';
+
+      const plugin = getPlugin('CopyPaste');
+      const event = getClipboardEvent('text/html', htmlTable);
+
+      await selectCell(0, 0);
+
+      // This should not throw "Maximum call stack size exceeded"
+      expect(() => {
+        plugin.onPaste(event);
+      }).not.toThrow();
+
+      // The table should have been pasted successfully (though it may be limited by settings)
+      // Just verify the first few rows to ensure the paste worked
+      expect(getDataAtCell(0, 0)).toBe('Row0Col0');
+      expect(getDataAtCell(1, 0)).toBe('Row1Col0');
+      expect(getDataAtCell(2, 0)).toBe('Row2Col0');
+    });
+
+    it('should handle pasting HTML tables with multiple tbody sections without stack overflow', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        copyPaste: true,
+      });
+
+      // Create HTML table with multiple tbody sections (25,000 rows each)
+      const rowsPerSection = 25000;
+      let htmlTable = '<table>';
+
+      for (let section = 0; section < 2; section++) {
+        htmlTable += '<tbody>';
+        for (let i = 0; i < rowsPerSection; i++) {
+          const rowNum = section * rowsPerSection + i;
+
+          htmlTable += `<tr><td>S${section}R${rowNum}</td></tr>`;
+        }
+        htmlTable += '</tbody>';
+      }
+      htmlTable += '</table>';
+
+      const plugin = getPlugin('CopyPaste');
+      const event = getClipboardEvent('text/html', htmlTable);
+
+      await selectCell(0, 0);
+
+      // This should not throw "Maximum call stack size exceeded"
+      expect(() => {
+        plugin.onPaste(event);
+      }).not.toThrow();
+
+      // Verify the paste worked
+      expect(getDataAtCell(0, 0)).toBe('S0R0');
+      expect(getDataAtCell(1, 0)).toBe('S0R1');
+    });
   });
 });

--- a/handsontable/src/plugins/copyPaste/__tests__/paste.spec.js
+++ b/handsontable/src/plugins/copyPaste/__tests__/paste.spec.js
@@ -936,7 +936,9 @@ describe('CopyPaste', () => {
       htmlTable += '</tbody></table>';
 
       const plugin = getPlugin('CopyPaste');
-      const event = getClipboardEvent('text/html', htmlTable);
+      const event = getClipboardEvent();
+
+      event.clipboardData.setData('text/html', htmlTable);
 
       await selectCell(0, 0);
 
@@ -975,7 +977,9 @@ describe('CopyPaste', () => {
       htmlTable += '</table>';
 
       const plugin = getPlugin('CopyPaste');
-      const event = getClipboardEvent('text/html', htmlTable);
+      const event = getClipboardEvent();
+
+      event.clipboardData.setData('text/html', htmlTable);
 
       await selectCell(0, 0);
 

--- a/handsontable/src/plugins/copyPaste/__tests__/paste.spec.js
+++ b/handsontable/src/plugins/copyPaste/__tests__/paste.spec.js
@@ -964,8 +964,9 @@ describe('CopyPaste', () => {
 
       for (let section = 0; section < 2; section++) {
         htmlTable += '<tbody>';
+
         for (let i = 0; i < rowsPerSection; i++) {
-          const rowNum = section * rowsPerSection + i;
+          const rowNum = (section * rowsPerSection) + i;
 
           htmlTable += `<tr><td>S${section}R${rowNum}</td></tr>`;
         }

--- a/handsontable/src/utils/__tests__/parseTable.spec.js
+++ b/handsontable/src/utils/__tests__/parseTable.spec.js
@@ -41,4 +41,82 @@ describe('parseTable', () => {
       expect(testElem[matchesMethod]).toHaveBeenCalledTimes(3);
     });
   });
+
+  describe('htmlToGridSettings', () => {
+    it('should parse a simple HTML table', () => {
+      const html = '<table><tbody><tr><td>A1</td><td>B1</td></tr><tr><td>A2</td><td>B2</td></tr></tbody></table>';
+      const result = Handsontable.helper.htmlToGridSettings(html);
+
+      expect(result.data).toEqual([
+        ['A1', 'B1'],
+        ['A2', 'B2']
+      ]);
+    });
+
+    it('should parse HTML table with column headers', () => {
+      const html = '<table><thead><tr><th>Col A</th><th>Col B</th></tr></thead><tbody><tr><td>A1</td><td>B1</td></tr></tbody></table>';
+      const result = Handsontable.helper.htmlToGridSettings(html);
+
+      expect(result.colHeaders).toEqual(['Col A', 'Col B']);
+      expect(result.data).toEqual([['A1', 'B1']]);
+    });
+
+    it('should handle large datasets without stack overflow (issue #11784)', () => {
+      // Create a large HTML table with many rows to test the fix for the stack overflow issue
+      const rowCount = 50000;
+      let html = '<table><tbody>';
+
+      for (let i = 0; i < rowCount; i++) {
+        html += `<tr><td>Cell${i}-A</td><td>Cell${i}-B</td><td>Cell${i}-C</td></tr>`;
+      }
+      html += '</tbody></table>';
+
+      // This should not throw "Maximum call stack size exceeded"
+      const result = Handsontable.helper.htmlToGridSettings(html);
+
+      expect(result.data.length).toBe(rowCount);
+      expect(result.data[0]).toEqual(['Cell0-A', 'Cell0-B', 'Cell0-C']);
+      expect(result.data[rowCount - 1]).toEqual([`Cell${rowCount - 1}-A`, `Cell${rowCount - 1}-B`, `Cell${rowCount - 1}-C`]);
+    });
+
+    it('should handle very large datasets with multiple tbody sections', () => {
+      // Test with multiple tbody sections to ensure all are processed correctly
+      const rowsPerSection = 25000;
+      let html = '<table>';
+
+      for (let section = 0; section < 2; section++) {
+        html += '<tbody>';
+        for (let i = 0; i < rowsPerSection; i++) {
+          const rowNum = section * rowsPerSection + i;
+
+          html += `<tr><td>S${section}R${rowNum}</td></tr>`;
+        }
+        html += '</tbody>';
+      }
+      html += '</table>';
+
+      const result = Handsontable.helper.htmlToGridSettings(html);
+
+      expect(result.data.length).toBe(rowsPerSection * 2);
+      expect(result.data[0][0]).toBe('S0R0');
+      expect(result.data[rowsPerSection][0]).toBe(`S1R${rowsPerSection}`);
+    });
+
+    it('should handle table with thead, tbody, and tfoot', () => {
+      const html = `
+        <table>
+          <thead><tr><th>Header</th></tr></thead>
+          <tbody><tr><td>Body</td></tr></tbody>
+          <tfoot><tr><td>Footer</td></tr></tfoot>
+        </table>
+      `;
+      const result = Handsontable.helper.htmlToGridSettings(html);
+
+      expect(result.colHeaders).toEqual(['Header']);
+      expect(result.data.length).toBe(2);
+      expect(result.data[0][0]).toBe('Body');
+      expect(result.data[1][0]).toBe('Footer');
+      expect(result.fixedRowsBottom).toBe(1);
+    });
+  });
 });

--- a/handsontable/src/utils/__tests__/parseTable.spec.js
+++ b/handsontable/src/utils/__tests__/parseTable.spec.js
@@ -43,7 +43,7 @@ describe('parseTable', () => {
   });
 
   describe('htmlToGridSettings', () => {
-    it('should parse a simple HTML table', () => {
+    it('should parse a simple HTML table', async() => {
       const html = '<table><tbody><tr><td>A1</td><td>B1</td></tr><tr><td>A2</td><td>B2</td></tr></tbody></table>';
       const result = Handsontable.helper.htmlToGridSettings(html);
 
@@ -53,15 +53,16 @@ describe('parseTable', () => {
       ]);
     });
 
-    it('should parse HTML table with column headers', () => {
-      const html = '<table><thead><tr><th>Col A</th><th>Col B</th></tr></thead><tbody><tr><td>A1</td><td>B1</td></tr></tbody></table>';
+    it('should parse HTML table with column headers', async() => {
+      const html = '<table><thead><tr><th>Col A</th><th>Col B</th></tr></thead>' +
+        '<tbody><tr><td>A1</td><td>B1</td></tr></tbody></table>';
       const result = Handsontable.helper.htmlToGridSettings(html);
 
       expect(result.colHeaders).toEqual(['Col A', 'Col B']);
       expect(result.data).toEqual([['A1', 'B1']]);
     });
 
-    it('should handle large datasets without stack overflow (issue #11784)', () => {
+    it('should handle large datasets without stack overflow (issue #11784)', async() => {
       // Create a large HTML table with many rows to test the fix for the stack overflow issue
       const rowCount = 50000;
       let html = '<table><tbody>';
@@ -76,18 +77,23 @@ describe('parseTable', () => {
 
       expect(result.data.length).toBe(rowCount);
       expect(result.data[0]).toEqual(['Cell0-A', 'Cell0-B', 'Cell0-C']);
-      expect(result.data[rowCount - 1]).toEqual([`Cell${rowCount - 1}-A`, `Cell${rowCount - 1}-B`, `Cell${rowCount - 1}-C`]);
+      expect(result.data[rowCount - 1]).toEqual([
+        `Cell${rowCount - 1}-A`,
+        `Cell${rowCount - 1}-B`,
+        `Cell${rowCount - 1}-C`
+      ]);
     });
 
-    it('should handle very large datasets with multiple tbody sections', () => {
+    it('should handle very large datasets with multiple tbody sections', async() => {
       // Test with multiple tbody sections to ensure all are processed correctly
       const rowsPerSection = 25000;
       let html = '<table>';
 
       for (let section = 0; section < 2; section++) {
         html += '<tbody>';
+
         for (let i = 0; i < rowsPerSection; i++) {
-          const rowNum = section * rowsPerSection + i;
+          const rowNum = (section * rowsPerSection) + i;
 
           html += `<tr><td>S${section}R${rowNum}</td></tr>`;
         }
@@ -102,7 +108,7 @@ describe('parseTable', () => {
       expect(result.data[rowsPerSection][0]).toBe(`S1R${rowsPerSection}`);
     });
 
-    it('should handle table with thead, tbody, and tfoot', () => {
+    it('should handle table with thead, tbody, and tfoot', async() => {
       const html = `
         <table>
           <thead><tr><th>Header</th></tr></thead>

--- a/handsontable/src/utils/parseTable.js
+++ b/handsontable/src/utils/parseTable.js
@@ -350,9 +350,9 @@ export function htmlToGridSettings(element, rootDocument = document) {
   const dataRows = [
     ...fixedRowsTop,
     ...Array.from(checkElement.tBodies).reduce((sections, section) => {
-      for (const row of section.rows) {
+      Array.from(section.rows).forEach((row) => {
         sections.push(row);
-      }
+      });
 
       return sections;
     }, []),

--- a/handsontable/src/utils/parseTable.js
+++ b/handsontable/src/utils/parseTable.js
@@ -350,7 +350,9 @@ export function htmlToGridSettings(element, rootDocument = document) {
   const dataRows = [
     ...fixedRowsTop,
     ...Array.from(checkElement.tBodies).reduce((sections, section) => {
-      sections.push(...Array.from(section.rows));
+      for (const row of section.rows) {
+        sections.push(row);
+      }
 
       return sections;
     }, []),


### PR DESCRIPTION
### Context
This PR fixes a stack overflow error that occurred when pasting very large datasets (50,000+ rows) into Handsontable.
 
### Problem
When pasting a large dataset, Chrome would throw a `RangeError: Maximum call stack size exceeded` error, causing the application to crash. This occurred in the `htmlToGridSettings` function in `parseTable.js` when using the spread operator to push potentially hundreds of thousands of elements into an array.
 
### Solution
Replaced the problematic spread operator with a `forEach` loop that pushes rows individually:
 
```javascript
// Before (causes stack overflow):
sections.push(...Array.from(section.rows));
 
// After (safe for large datasets):
Array.from(section.rows).forEach((row) => {
  sections.push(row);
});
```

This approach avoids creating excessive function arguments while maintaining the same functionality.

### Tests Added

-   **Unit tests**  (`src/utils/__tests__/parseTable.spec.js`):
    
    -   Simple HTML table parsing
    -   HTML table with column headers
    -   Large datasets without stack overflow (50,000 rows)
    -   Multiple tbody sections (50,000 rows total)
    -   Table with thead, tbody, and tfoot
-   **Integration tests**  (`src/plugins/copyPaste/__tests__/paste.spec.js`):
    
    -   Pasting very large HTML tables (50,000 rows)
    -   Pasting HTML tables with multiple tbody sections

### How has this been tested?

All unit tests pass (2,232+ tests). The fix has been tested with datasets of 50,000+ rows.

### Types of changes

-   Bug fix (non-breaking change which fixes an issue)

### Related issue(s):

Closes #11784

### Affected project(s):

-   `handsontable`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core HTML table parsing path used by copy/paste; while the logic change is small, it affects large clipboard payload handling and could impact paste behavior/performance across browsers.
> 
> **Overview**
> Fixes a `Maximum call stack size exceeded` crash when pasting very large HTML tables by changing `htmlToGridSettings` (`parseTable.js`) to collect `tbody` rows without using a spread push of huge arrays.
> 
> Adds unit and CopyPaste integration coverage for 50,000-row tables (including multiple `tbody` sections and `thead`/`tfoot` handling) and includes a changelog entry for issue `#11784`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f0d91017706af2cec0292c08c8b41115fee2cea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->