### PR TITLE
docs: Update AGENTS.md with bug fix learnings and best practices

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 ### Overview
 
-Handsontable is a JavaScript/TypeScript data grid monorepo (pnpm workspace). It contains the core library plus React, Angular, and Vue 3 wrappers.
+Handsontable is a JavaScript/TypeScript data grid monorepo (pnpm workspace). It contains the core library plus React, Angular, and Vue 3 wrappers. It operates entirely in the browser (frontend-only, no server-side logic) and cannot access the internet unless explicitly configured (air-gapped environment support). There is no built-in telemetry.
 
 ### Workspace packages
 
@@ -35,7 +35,222 @@ All commands below run from the workspace root (`/workspace`).
 - **Vue3 tests**: `pnpm --filter @handsontable/vue3 run test`
 - **Angular tests**: `pnpm --filter @handsontable/angular-wrapper run test` (requires `--openssl-legacy-provider`; already handled via `cross-env` in `package.json` scripts)
 
-### Gotchas
+### Output formats
+
+The library outputs ES Modules and UMD bundles (UMD as legacy support).
+
+---
+
+## Breaking changes policy
+
+**Agents must try to avoid introducing breaking changes.** This is the single most important constraint. Existing customers depend on API stability. When a solution requires a Breaking Change, it must be stated in **bold**.
+
+### What counts as a breaking change
+
+| Change | Why it breaks | What to do instead |
+|---|---|---|
+| Renaming a CSS class produced by Handsontable | Breaks custom stylesheets | Keep the legacy class name in the DOM. Add tests verifying the old name still works. |
+| Renaming APIs (methods, configuration options, hooks) | Breaks customer integrations | Keep the legacy API working and translate it to the new API internally. Legacy APIs do not produce console warnings. |
+| Changing API signatures or behavior | Breaks customer integrations | Keep the deprecated API working until the next stable release. Deprecated APIs produce a console warning (fired only once). |
+| Removing hooks or configuration options | May go completely undetected by customers | Add the hook/option to the list of removed hooks so an error is shown when someone uses it in configuration. |
+| Changing a default setting value | 🚫 **Strictly forbidden** — this is considered a "really bad" breaking change. | Never change defaults. |
+
+### Legacy vs deprecated
+
+- **Legacy**: Old API is kept working forever alongside the new API. No console warnings. Feature set of the legacy API may be frozen. Tests must verify the old name continues to work.
+- **Deprecated**: Old API works until the next stable release, then is removed. Produces a one-time console warning. Tests must verify the old name continues to work until removal.
+
+### What is NOT considered breaking
+
+Changes to JavaScript APIs that are **not listed in the public API reference** (e.g., internal Walkontable code changes that don't affect the DOM or CSS). Such changes should still be noted in release notes.
+
+---
+
+## Mandatory checklist for every change
+
+Every code change produced by an agent **must** satisfy all of the following:
+
+1. **Tests are required.** Every change must include both **unit tests** (Jest) and **E2E tests** (Jasmine/Puppeteer). No change is considered complete without test coverage for the new or modified behavior.
+2. **Documentation must be updated.** If a change affects the public API, configuration options, hooks, behavior, or user-facing experience, the corresponding documentation (guides, API reference via JSDoc/Typedoc, migration guide) **must** be updated as part of the same change.
+3. **Update AGENTS.md.** If a change introduces new conventions, patterns, constraints, file locations, or gotchas that future agents should know about, this `AGENTS.md` file **must** be updated to reflect them.
+
+---
+
+## Code style and conventions
+
+- **Coding style**: Modified [Airbnb JavaScript style](https://github.com/airbnb/javascript), enforced by the ESLint configuration in the monorepo.
+- **Formatting**: Rely on the project's ESLint config. Do not override formatting rules.
+- **Separate CSS and JS**: Do not mix CSS into JavaScript files (this may change after Theme API introduction).
+- **DRY**: Reuse existing helpers and mixins. Do not duplicate code. If a piece of code repeats, create a new helper. Write generic code that can be reused across modules and plugins.
+- **Method ordering**: Public methods first, then `@private` listeners.
+- **Destructors**: Remove all variables in destructors (after `hot.destroy()`).
+- **Browser compatibility**: Ensure chosen CSS and JS APIs are supported in all supported browsers (Chrome, Firefox, Safari — two latest major versions, Edge). Check `https://handsontable.com/docs/supported-browsers/`.
+
+### Naming conventions
+
+- Always use `Handsontable` in text, never `HOT`. Exception: instances of the Handsontable class are usually called `hot`.
+- Use full names: `row` and `columns` (not `cols`).
+
+### JSDoc / Typedoc
+
+Both public and private APIs must be documented with JSDoc/Typedoc comments. The public API reference is generated automatically from these comments.
+
+---
+
+## Architecture constraints
+
+These constraints must be respected in all code changes:
+
+- **Frontend-only**: No server-side logic. Everything runs in the browser.
+- **No network access**: The library must not make network requests unless explicitly configured by the user.
+- **Microkernel plugin system**: All extensions hook into the core through the plugin API. When building or modifying plugins, respect the plugin lifecycle (initialization, enable/disable).
+- **Cascading configuration**: All feature configuration must work with Handsontable's cascading configuration model (`cell` → `column` → `global`).
+- **Design system theming**: CSS variables are the public API for theme customization. The design system uses a token hierarchy declared in Figma and exported as CSS variables.
+- **Framework wrapper parity**: Official wrappers (React, Angular, Vue) must be idiomatic for each framework and maintain feature parity.
+- **XSS prevention**: Strict input sanitization on user-facing cell content, custom formulas, and cell scripts.
+- **Internationalization**: Must handle RTL layouts, Unicode input (IME), and translations.
+- **No global namespace pollution**: Integration via NPM/CDN must not pollute the global namespace.
+- **Minimal dependencies**: Avoid adding third-party libraries. If you must, discuss with the team first. All dependencies must have permissive open-source licenses (MIT, BSD, Apache, etc.) and be actively maintained. This applies transitively to sub-dependencies.
+- **Functional continuity**: Each release must include no less functionality than its predecessor.
+
+---
+
+## Testing requirements
+
+Handsontable uses two testing frameworks:
+- **Jest** for unit tests (`__tests__/` or `test/spec/` directories next to source files)
+- **Jasmine** (with Puppeteer, headless Chrome) for browser E2E tests (`handsontable/test/e2e/`)
+
+### What to test
+
+- Aim for 100% code coverage of new or modified code.
+- Test all possible states including edge cases.
+- Plugins, renderers, and editors must be tested against:
+  - `hot.updateSettings()`
+  - `hot.getPlugin('{PluginName}').enablePlugin(); hot.render();`
+  - `hot.getPlugin('{PluginName}').disablePlugin(); hot.render();`
+- Verify no regressions in related functionality.
+- Check that no exceptions are displayed in the console.
+
+### Large dataset testing
+
+- When fixing bugs or adding features that handle data arrays, add unit tests with **50k+ rows** to catch stack overflow and performance issues.
+
+### Selection testing
+
+- Test non-consecutive selections (Ctrl/Cmd+click), row/column header selections, and active selection layers when modifying selection-related code.
+
+### Visual regression tests
+
+- Playwright visual regression tests are in `visual-tests/`.
+
+---
+
+## Performance rules
+
+- **Avoid spread operator with large arrays**: When working with potentially large arrays (10k+ elements), never use `arr.push(...largeArray)`. This causes stack overflow. Use `forEach` loops instead.
+- **Batch scroll events**: Use `requestAnimationFrame` to batch scroll event updates and prevent excessive redraws. Target smooth 60fps with 100k+ row datasets.
+- **Performance must not degrade**: Measured in library size, rendering performance, and memory consumption. Performance should gradually improve over time.
+
+---
+
+## Git and branching
+
+### Branch naming
+
+- Feature branches: `feature/issue-xxxx` (e.g., `feature/issue-9024`)
+- Documentation branches: `docs/issue-xxxx` (e.g., `docs/issue-9024`)
+- Release branches: `release/x.y.z`
+- LTS branches: `lts/[major].x`
+
+### Git rules
+
+- **Never force-push** to `master`, `develop`, or feature branches bound to Pull Requests. Force-pushing diverges history in other people's clones and makes PR review history incomprehensible.
+- Follow the **Git flow** branching strategy.
+
+### Versioning
+
+- Uses **SemVer**. Patch releases are for critical fixes only.
+- Even-numbered major releases (16, 18, 20, 22) become **LTS releases**.
+- Odd-numbered major releases (17, 19, 21) are **Current-only** (6-month lifecycle).
+- No more than 4 major releases per year (preferably 0). If multiple breaking changes are needed, bulk them into a single major release.
+
+---
+
+## Pull requests and changelog
+
+### PR requirements
+
+- Every PR must be connected to a GitHub issue.
+- Every PR that changes package source code must include a changelog entry as explained in `.changelogs/README.md`.
+- To skip changelog (for non-source-code changes only), write `[skip changelog]` in the PR description.
+- PRs are merged using **"Squash and merge"** in the GitHub UI by the PR author after full approval.
+- The PR author is responsible for addressing reviewer comments. The reviewer confirms resolution by clicking **Resolve conversation**.
+
+### Changelog format
+
+- Follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
+
+### Visibility of work
+
+- If a task spans multiple days, create a draft PR and commit daily.
+- All work must be tracked as a GitHub issue. If no issue exists, create one.
+
+---
+
+## API design guidelines
+
+- Make all necessary methods available in the public API.
+- APIs must be discoverable, documented in guides, and usable in real-world applications.
+- All configuration options must fit into the cascading configuration model.
+- TypeScript typings must be maintained and accurate.
+- The public API must provide good code completion in IDEs and AI coding assistants.
+
+---
+
+## React wrapper specifics
+
+- When calling `updateSettings()` in the React wrapper, **preserve and restore selection state** using `selection.exportSelection()` and `selection.importSelection()` to maintain non-consecutive selections, active layers, and focus positions across React re-renders.
+
+---
+
+## Column stretching
+
+- Always respect defined column widths as **minimum values**.
+- If a column would shrink below its base width, disable stretching entirely.
+- Different stretching strategies (`'all'`, `'last'`) must behave consistently regarding minimum width handling.
+
+---
+
+## Plugin development
+
+- Use the Handsontable plugin skeleton template.
+- Respect plugin initialization and enable/disable lifecycle.
+- `this.addHook()` in plugin context is different from `this.addHook()` in `hot` instance context.
+- Safe plugin architecture to minimize attack surfaces.
+
+---
+
+## Dependency management
+
+- **Discuss with the team before adding any third-party dependency.**
+- All dependencies must have permissive open-source licenses (MIT, BSD, Apache, etc.).
+- All dependencies must be actively maintained.
+- These rules apply transitively to all sub-dependencies.
+- Adding dependencies under non-permissive licenses requires notifying clients through the Sales team.
+
+---
+
+## Security
+
+- Strict XSS prevention in user-facing cell content.
+- Input sanitization on custom formulas and cell scripts.
+- Safe plugin architecture to minimize attack surfaces.
+- CLA must be signed before merging external contributions.
+
+---
+
+## Gotchas
 
 - The core build outputs to `handsontable/tmp/` (not `dist/` for wrappers' consumption). The UMD/minified builds go to `handsontable/dist/` and CSS to `handsontable/styles/`. Wrapper packages reference the `tmp/` build via workspace linking.
 - The Angular wrapper tests use `NODE_OPTIONS=--openssl-legacy-provider`; this is already wired into the `test` script.
@@ -44,26 +259,20 @@ All commands below run from the workspace root (`/workspace`).
 - The docs site (`docs/`) uses Node 20 (its own `.nvmrc`) and is not needed for core library development.
 - No Docker, databases, or external services are required.
 
-### Common pitfalls & best practices
+---
 
-#### Large dataset handling
-- **Avoid spread operator with large arrays**: When working with potentially large arrays (10k+ elements), avoid using the spread operator to push elements (e.g., `arr.push(...largeArray)`). This creates excessive function arguments and can cause stack overflow errors. Use `forEach` loops instead.
-- **Batch scroll events**: When handling scroll events that may fire rapidly (e.g., trackpad scrolling), use `requestAnimationFrame` to batch updates and prevent excessive redraws. This ensures smooth 60fps performance even with 100k+ row datasets.
-- **Test with large datasets**: When fixing bugs or adding features that handle data arrays, add unit tests with 50k+ rows to catch stack overflow and performance issues.
+## File locations reference
 
-#### Selection and state preservation
-- **React wrapper state updates**: When calling `updateSettings()` in the React wrapper, preserve and restore the selection state using `selection.exportSelection()` and `selection.importSelection()` to maintain non-consecutive selections, active layers, and focus positions across React re-renders.
-- **Selection testing**: Test non-consecutive selections (Ctrl/Cmd+click), row/column header selections, and active selection layers when modifying selection-related code.
-
-#### Column stretching
-- **Respect minimum widths**: When implementing column stretching strategies, always respect the defined column widths as minimum values. If a column would shrink below its base width, disable stretching entirely rather than allowing unusable column widths.
-- **Strategy parity**: Different stretching strategies (`'all'`, `'last'`) should behave consistently regarding minimum width handling.
-
-#### File locations reference
-- **HTML parsing**: `handsontable/src/utils/parseTable.js`
-- **Scroll handling**: `handsontable/src/3rdparty/walkontable/src/overlays.js`
-- **Column stretching**: `handsontable/src/plugins/stretchColumns/strategies/`
-- **Selection logic**: `handsontable/src/selection/`
-- **React wrapper core**: `wrappers/react-wrapper/src/hotTableInner.tsx`
-- **Unit tests**: `__tests__/` or `test/spec/` directories next to source files
-- **E2E tests**: `handsontable/test/e2e/`
+| Area | Path |
+|---|---|
+| HTML parsing | `handsontable/src/utils/parseTable.js` |
+| Scroll handling | `handsontable/src/3rdparty/walkontable/src/overlays.js` |
+| Column stretching | `handsontable/src/plugins/stretchColumns/strategies/` |
+| Selection logic | `handsontable/src/selection/` |
+| React wrapper core | `wrappers/react-wrapper/src/hotTableInner.tsx` |
+| Unit tests | `__tests__/` or `test/spec/` directories next to source files |
+| E2E tests | `handsontable/test/e2e/` |
+| Visual regression tests | `visual-tests/` |
+| Changelog entries | `.changelogs/` |
+| ESLint config | Root monorepo config |
+| Build config | `handsontable/hot.config.js` and `handsontable/.config/` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,31 @@
 # AGENTS.md
 
-## Cursor Cloud specific instructions
-
-### Overview
+## Overview
 
 Handsontable is a JavaScript/TypeScript data grid monorepo (pnpm workspace). It contains the core library plus React, Angular, and Vue 3 wrappers. It operates entirely in the browser (frontend-only, no server-side logic) and cannot access the internet unless explicitly configured (air-gapped environment support). There is no built-in telemetry.
 
-### Workspace packages
+**The core package (`handsontable/`) is JavaScript, not TypeScript.** Type definitions are hand-authored `.d.ts` files in `handsontable/types/`. Do not create `.ts` files in the core package.
+
+---
+
+## Common pitfalls
+
+These are the most frequent mistakes. Read this section first.
+
+| Pitfall | What to do instead |
+|---|---|
+| `throw new Error('...')` | Use `throwWithCause('...', cause)` from `src/helpers/errors.js`. Enforced by ESLint rule `handsontable/no-native-error-throw`. |
+| Using `window`, `document`, `console` as globals | Use `this.hot.rootWindow`, `this.hot.rootDocument`, and helpers from `src/helpers/console.js`. Enforced by ESLint rule `no-restricted-globals`. |
+| Importing from barrel index files (`plugins/index`, `editors/index`, `renderers/index`, `validators/index`, `cellTypes/index`, `i18n/index`) | Import from the specific submodule path (e.g., `import { HiddenColumns } from '../plugins/hiddenColumns/hiddenColumns'`). Enforced by ESLint rule `handsontable/restricted-module-imports`. The only exception is `src/registry.js`. |
+| Writing `it('should ...', () => { ... })` in spec files | All `it()` callbacks in `*.spec.js` that call HOT rendering APIs **must** be `async` and the API calls must be `await`-ed. Enforced by ESLint rule `handsontable/require-async-in-it`. |
+| `arr.push(...largeArray)` with large arrays | Causes stack overflow with 10k+ elements. Use `forEach` loop instead. |
+| Confusing physical, visual, and renderable coordinates | See [Three coordinate systems](#three-coordinate-systems). |
+| Creating `.ts` files in `handsontable/src/` | Core is JavaScript. TypeScript definitions live in `handsontable/types/` as `.d.ts` files. |
+| Forgetting `super.enablePlugin()` / `super.disablePlugin()` in plugins | See [Plugin lifecycle](#plugin-lifecycle). |
+
+---
+
+## Workspace packages
 
 | Package | Directory | Purpose |
 |---|---|---|
@@ -18,26 +37,48 @@ Handsontable is a JavaScript/TypeScript data grid monorepo (pnpm workspace). It 
 | `handsontable-examples-internal` | `examples/` | Code examples |
 | `handsontable-documentation` | `docs/` | VuePress docs site (requires Node 20) |
 
-### Prerequisites
+---
+
+## Prerequisites
 
 - **Node.js 22** (see `.nvmrc`)
 - **pnpm 10.30.2** (see `packageManager` in root `package.json`); activate via `corepack enable && corepack prepare pnpm@10.30.2 --activate`
 
-### Build, lint, test
+---
 
-All commands below run from the workspace root (`/workspace`).
+## Build, lint, test
+
+**Monorepo-level commands** use `pnpm` from the workspace root:
 
 - **Build core**: `pnpm --filter handsontable run build` (must be done before wrapper tests, since wrappers depend on the built `tmp/` output)
 - **Lint core**: `pnpm --filter handsontable run eslint` and `pnpm --filter handsontable run stylelint`
 - **Unit tests (core)**: `pnpm --filter handsontable run test:unit` (Jest, ~2200 tests)
 - **E2E tests (core)**: `pnpm --filter handsontable run test:e2e` (Puppeteer/Jasmine, headless Chrome)
+- **Walkontable tests**: `pnpm --filter handsontable run test:walkontable` (separate pipeline)
 - **React tests**: `pnpm --filter @handsontable/react-wrapper run test`
 - **Vue3 tests**: `pnpm --filter @handsontable/vue3 run test`
-- **Angular tests**: `pnpm --filter @handsontable/angular-wrapper run test` (requires `--openssl-legacy-provider`; already handled via `cross-env` in `package.json` scripts)
+- **Angular tests**: `pnpm --filter @handsontable/angular-wrapper run test` (uses `--openssl-legacy-provider` automatically)
 
-### Output formats
+**Inside individual packages** (e.g., `cd handsontable`), use `npm run ...` directly.
 
-The library outputs ES Modules and UMD bundles (UMD as legacy support).
+### Build outputs
+
+The library outputs ES Modules and UMD bundles (UMD as legacy support). Two build variants exist:
+
+- `handsontable.js` — base build, external dependencies not bundled
+- `handsontable.full.js` — includes HyperFormula bundled in
+
+Build scripts require environment variables injected via `env-cmd -f ../hot.config.js`.
+
+| Output | Path |
+|---|---|
+| UMD / minified bundles | `handsontable/dist/` |
+| ES and CJS modules (used by wrappers via workspace linking) | `handsontable/tmp/` |
+| Compiled CSS | `handsontable/styles/` |
+
+### CSS themes
+
+Three themes are available: `ht-theme-main`, `ht-theme-classic`, `ht-theme-horizon` (each with `-no-icons` variants). The theme CSS class is applied to the root container element.
 
 ---
 
@@ -70,7 +111,7 @@ Changes to JavaScript APIs that are **not listed in the public API reference** (
 
 Every code change produced by an agent **must** satisfy all of the following:
 
-1. **Tests are required.** Every change must include both **unit tests** (Jest) and **E2E tests** (Jasmine/Puppeteer). No change is considered complete without test coverage for the new or modified behavior.
+1. **Tests are required.** Every change must include both **unit tests** (Jest, `*.unit.js`) and **E2E tests** (Jasmine/Puppeteer, `*.spec.js`). No change is considered complete without test coverage for the new or modified behavior.
 2. **Documentation must be updated.** If a change affects the public API, configuration options, hooks, behavior, or user-facing experience, the corresponding documentation (guides, API reference via JSDoc/Typedoc, migration guide) **must** be updated as part of the same change.
 3. **Update AGENTS.md.** If a change introduces new conventions, patterns, constraints, file locations, or gotchas that future agents should know about, this `AGENTS.md` file **must** be updated to reflect them.
 
@@ -78,13 +119,34 @@ Every code change produced by an agent **must** satisfy all of the following:
 
 ## Code style and conventions
 
-- **Coding style**: Modified [Airbnb JavaScript style](https://github.com/airbnb/javascript), enforced by the ESLint configuration in the monorepo.
-- **Formatting**: Rely on the project's ESLint config. Do not override formatting rules.
-- **Separate CSS and JS**: Do not mix CSS into JavaScript files (this may change after Theme API introduction).
+### Formatting rules (enforced by ESLint)
+
+- **Style base**: Modified [Airbnb JavaScript style](https://github.com/airbnb/javascript)
+- **Indentation**: 2 spaces
+- **Quotes**: Single quotes only
+- **Max line length**: 120 characters (ignores comments and long `it()` test names)
+- **JSDoc**: `jsdoc/require-jsdoc` is set to `error` — all exported functions require JSDoc comments
+
+### Handsontable-specific ESLint rules
+
+These custom rules are enforced and will cause lint failures if violated:
+
+| Rule | What it enforces |
+|---|---|
+| `handsontable/no-native-error-throw` | Must use `throwWithCause()` from `src/helpers/errors.js`, not `throw new Error()` |
+| `handsontable/restricted-module-imports` | No imports from barrel index files (`plugins/index`, `editors/index`, `renderers/index`, `validators/index`, `cellTypes/index`, `i18n/index`) |
+| `handsontable/require-async-in-it` | All `it()` in `*.spec.js` calling HOT rendering APIs must be `async` |
+| `handsontable/require-await` | Specific HOT API calls must be `await`-ed |
+| `no-restricted-globals` | `window`, `document`, `console`, `Handsontable` are banned as globals |
+| `compat/compat` | Browser API compatibility enforced against supported browser list |
+
+### General conventions
+
+- **Separate CSS and JS**: Do not mix CSS into JavaScript files.
 - **DRY**: Reuse existing helpers and mixins. Do not duplicate code. If a piece of code repeats, create a new helper. Write generic code that can be reused across modules and plugins.
 - **Method ordering**: Public methods first, then `@private` listeners.
 - **Destructors**: Remove all variables in destructors (after `hot.destroy()`).
-- **Browser compatibility**: Ensure chosen CSS and JS APIs are supported in all supported browsers (Chrome, Firefox, Safari — two latest major versions, Edge). Check `https://handsontable.com/docs/supported-browsers/`.
+- **Browser compatibility**: Ensure chosen CSS and JS APIs are supported in all supported browsers (Chrome, Firefox, Safari — two latest major versions, Edge).
 
 ### Naming conventions
 
@@ -93,33 +155,248 @@ Every code change produced by an agent **must** satisfy all of the following:
 
 ### JSDoc / Typedoc
 
-Both public and private APIs must be documented with JSDoc/Typedoc comments. The public API reference is generated automatically from these comments.
+Both public and private APIs must be documented with JSDoc/Typedoc comments. The public API reference is generated automatically from these comments. Allowed custom tags: `@plugin`, `@util`, `@experimental`, `@deprecated`, `@preserve`, `@core`, `@TODO`, `@category`.
+
+#### Typedoc formatting rules
+
+- Avoid HTML tags (`<strong>`, `<br>`, etc.) inside descriptions — use Markdown instead.
+- For line breaks use an **empty line**, never `<br>`.
+- Links must use `[[MY_LINK]]` syntax, not `{@link MY_LINK}`.
+- End every sentence with a full stop.
+- Comment blocks start with `/**` — do not leave a blank line below the opening.
+- Comment blocks end with `*/` — do not leave a blank line above the closing.
+- Do not hardcode parameter values in descriptions — use `@param` tags.
+- Group tags of the same type on consecutive lines.
+
+#### Typedoc template
+
+```
+/**
+ * Brief description of the method.
+ *
+ * Additional notes if needed.
+ *
+ * @param {string} paramName - description of the parameter
+ * @param {number} anotherParam - description
+ *
+ * @fires [[eventName]] when triggered
+ *
+ * @throws [[ErrorType]] when condition is met
+ *
+ * @returns description of the return value
+ *
+ * @category CategoryName
+ */
+```
 
 ---
 
-## Architecture constraints
+## Documentation rules
 
-These constraints must be respected in all code changes:
+### What counts as documentation
 
-- **Frontend-only**: No server-side logic. Everything runs in the browser.
-- **No network access**: The library must not make network requests unless explicitly configured by the user.
-- **Microkernel plugin system**: All extensions hook into the core through the plugin API. When building or modifying plugins, respect the plugin lifecycle (initialization, enable/disable).
-- **Cascading configuration**: All feature configuration must work with Handsontable's cascading configuration model (`cell` → `column` → `global`).
-- **Design system theming**: CSS variables are the public API for theme customization. The design system uses a token hierarchy declared in Figma and exported as CSS variables.
-- **Framework wrapper parity**: Official wrappers (React, Angular, Vue) must be idiomatic for each framework and maintain feature parity.
-- **XSS prevention**: Strict input sanitization on user-facing cell content, custom formulas, and cell scripts.
-- **Internationalization**: Must handle RTL layouts, Unicode input (IME), and translations.
-- **No global namespace pollution**: Integration via NPM/CDN must not pollute the global namespace.
-- **Minimal dependencies**: Avoid adding third-party libraries. If you must, discuss with the team first. All dependencies must have permissive open-source licenses (MIT, BSD, Apache, etc.) and be actively maintained. This applies transitively to sub-dependencies.
-- **Functional continuity**: Each release must include no less functionality than its predecessor.
+Handsontable documentation includes: guides and code examples on the docs portal, the API reference (generated from JSDoc/Typedoc), code comments, changelog entries, release notes, migration guides, and README files across the monorepo.
+
+### When documentation is required
+
+- Any change to a public API (methods, options, hooks, plugins, typings, errors) **must** update the corresponding JSDoc/Typedoc comments and guides.
+- Any change to user-facing behavior or look-and-feel **must** be documented.
+- Any breaking change **must** include a migration guide step (see below).
+- New documentation pages should be included in the changelog (do not use `[skip changelog]` for new pages).
+
+### Documentation branch conventions
+
+- Documentation branches for features: `docs/issue-xxxx` (e.g., `docs/issue-9024`), branched from the feature branch or `develop`.
+- Documentation branches for releases: `release/x.y.z-docs`, branched from `release/x.y.z`.
+- Documentation-only PRs use `[skip changelog]` in the PR description, **unless** the PR adds a new documentation page.
+
+### Writing style rules
+
+All documentation text (guides, JSDoc comments, changelog entries, migration guides, PR descriptions) must follow these rules:
+
+1. **Short sentences.** Split longer sentences in two.
+2. **Active voice.** Never passive. ("Configure the parameters" not "The parameters should be configured.")
+3. **Simple verb syntax.** ("To ensure performance…" not "In order to ensure that the system will be capable of…")
+4. **American English spelling.** (`recognize`, `program`, `behavior`, not `recognise`, `programme`, `behaviour`.)
+5. **Commonized forms.** `frontend`, `backend`, `webhook`, `internet` (not `front-end`, `back end`, `web hook`, `Internet`).
+6. **Use "you" not "we".** ("In this example, you can see…" not "In this example, we can see…")
+7. **Oxford comma.** Use a comma before `and`/`or` in lists of 3+ items. ("berries, apples, and bacon.")
+8. **No evaluative adjectives.** Eliminate "easy", "simple", "obvious", "straightforward" from explanations.
+9. **Do not assume user background knowledge.** Bridge the gap between specialists and non-specialists.
+10. **Max 3 adjectives before a noun.**
+11. **Use en dashes (–) to separate clauses**, not hyphens.
+12. **Consistent 3rd-party naming.** Use official capitalization: `Node.js`, `webpack`, `GitLab`, `TypeScript`.
+13. **PR descriptions**: Use plain, concise language. Avoid literary wording — developers need to parse it quickly.
+
+### Migration guide requirements
+
+A migration guide is required for every major release and some minor releases. Each breaking change must have a separate migration guide step that includes:
+
+1. Who the breaking change affects.
+2. A brief reason for the change (what the user gains).
+3. A brief description of the change itself.
+4. What the user needs to do (step-by-step, with substeps if needed).
+5. Code examples (before/after).
+6. Links to more detailed information (new pages, PRs).
+
+The structure must follow previous migration guides for consistency.
+
+### Trademark rules
+
+- Any documentation page mentioning "Excel" must include the Microsoft/Excel trademark disclaimer.
+- If the page also mentions "Google Sheets", use the expanded disclaimer covering both trademarks.
+- Avoid third-party trademarks in documentation unless practically necessary (e.g., to describe compatibility or integration).
+
+### Documentation file locations
+
+| Content | Location |
+|---|---|
+| Guides and examples | `docs/content/` |
+| API reference source | JSDoc/Typedoc comments in source files |
+| Changelog | `CHANGELOG.md` (root) |
+| Changelog entry mechanism | `.changelogs/README.md` |
+| Changelog CLI | `bin/changelog` |
+| Docs editing guide | `docs/README-EDITING.md` |
+| Docs deployment guide | `docs/README-DEPLOYMENT.md` |
+| Broken link redirects | `docs/netlify/netlify/edge-functions/` |
+| Migration guides | `docs/content/guides/upgrade-and-migration/` |
+
+---
+
+## Three coordinate systems
+
+This is fundamental to working with the codebase. Three distinct index spaces exist:
+
+| Coordinate type | Description | Example |
+|---|---|---|
+| **Physical** | Position in the source data array | Row 5 in the original dataset |
+| **Visual** | Position in the DataMap (after trimming) | Row 3 if rows 0-1 were trimmed |
+| **Renderable** | Position in the DOM (after hiding) | Row 2 if one visual row is hidden |
+
+Plugins must correctly translate between these systems using `IndexMapper` (`hot.rowIndexMapper` / `hot.columnIndexMapper`).
+
+### HidingMap vs TrimmingMap
+
+| Map type | Effect |
+|---|---|
+| `HidingMap` | Index stays in DataMap but is **not rendered** in the DOM |
+| `TrimmingMap` | Index is **removed from DataMap** entirely |
+
+Plugins register maps via:
+```js
+hot.rowIndexMapper.registerMap('pluginName', new TrimmingMap());
+hot.columnIndexMapper.registerMap('pluginName', new HidingMap());
+```
+
+---
+
+## Plugin lifecycle
+
+All plugins extend `BasePlugin` from `src/plugins/base/base.js`.
+
+### Required static properties
+
+```js
+class MyPlugin extends BasePlugin {
+  static get PLUGIN_KEY() { return 'myPlugin'; }          // Key in settings
+  static get PLUGIN_PRIORITY() { return 150; }             // Init order (lower = first)
+  static get SETTING_KEYS() { return ['myPlugin']; }       // Keys that trigger updatePlugin()
+  static get PLUGIN_DEPS() { return ['plugin:AutoRowSize']; } // Dependencies
+}
+```
+
+### Method lifecycle (in order)
+
+1. `constructor(hotInstance)` — receives HOT instance as `this.hot`
+2. `isEnabled()` — return truthy/falsy based on `this.hot.getSettings()[PLUGIN_KEY]`
+3. `enablePlugin()` — set up hooks via `this.addHook()`, register IndexMapper maps. **Call `super.enablePlugin()` at the end.**
+4. `updatePlugin()` — typical pattern: `this.disablePlugin(); this.enablePlugin(); super.updatePlugin();`
+5. `disablePlugin()` — **Call `super.disablePlugin()` (clears EventManager and hooks).** Then clean up plugin-specific state.
+6. `destroy()` — final teardown. **Call `super.destroy()` at the end.**
+
+### Hook registration
+
+Plugins that introduce new hooks register them globally **at module level, outside the class**:
+
+```js
+import Hooks from '../../core/hooks';
+
+Hooks.getSingleton().register('beforeMyAction');
+Hooks.getSingleton().register('afterMyAction');
+
+export class MyPlugin extends BasePlugin {
+  // ...
+}
+```
+
+### Important distinction
+
+`this.addHook()` in a plugin context (BasePlugin) is different from `this.hot.addHook()`. The plugin version auto-cleans hooks on `disablePlugin()`.
+
+### File structure convention
+
+Each plugin directory exports from an `index.js`:
+```js
+export { PLUGIN_KEY, PLUGIN_PRIORITY, MyPlugin } from './myPlugin';
+```
 
 ---
 
 ## Testing requirements
 
-Handsontable uses two testing frameworks:
-- **Jest** for unit tests (`__tests__/` or `test/spec/` directories next to source files)
-- **Jasmine** (with Puppeteer, headless Chrome) for browser E2E tests (`handsontable/test/e2e/`)
+Handsontable uses three test pipelines:
+- **Jest** for unit tests (`*.unit.js` files, `__tests__/` directories next to source files)
+- **Jasmine** (with Puppeteer, headless Chrome) for browser E2E tests (`*.spec.js` files, `handsontable/test/e2e/`)
+- **Walkontable** has its own separate test pipeline (`npm run test:walkontable`)
+
+### Test file naming
+
+| Type | Pattern | Framework | Location |
+|---|---|---|---|
+| Unit test | `*.unit.js` | Jest (jsdom) | `src/**/__tests__/` |
+| E2E test | `*.spec.js` | Jasmine (Puppeteer) | `test/e2e/` and `src/plugins/**/__tests__/` |
+| Type test | `*.types.ts` | `tsc` only | `test/types/` |
+
+### Standard E2E test boilerplate
+
+```js
+describe('MyPlugin', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should do something', async() => {
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+      myPlugin: true,
+    });
+
+    await selectCell(0, 0);
+
+    expect(getDataAtCell(0, 0)).toBe('A1');
+  });
+});
+```
+
+### Global test helpers
+
+`test/helpers/common.js` exposes all HOT API methods as global test functions — **no imports needed** in spec files:
+
+- `handsontable(options)` — creates a HOT instance
+- `createSpreadsheetData(rows, cols)` — generates mock data (`'A1'`, `'B2'`, etc.)
+- `selectCell()`, `getCell()`, `getDataAtCell()`, `getData()`, `getPlugin()`, `render()`, `destroy()`, `updateSettings()`, etc.
+- `spec()` — returns the current test's HOT instance
+
+Additional helpers: `test/helpers/mouseEvents.js`, `test/helpers/keyboardEvents.js` (DOM event simulation), `test/helpers/asciiTable.js` (selection pattern assertions).
 
 ### What to test
 
@@ -134,15 +411,30 @@ Handsontable uses two testing frameworks:
 
 ### Large dataset testing
 
-- When fixing bugs or adding features that handle data arrays, add unit tests with **50k+ rows** to catch stack overflow and performance issues.
+When fixing bugs or adding features that handle data arrays, add unit tests with **50k+ rows** to catch stack overflow and performance issues.
 
 ### Selection testing
 
-- Test non-consecutive selections (Ctrl/Cmd+click), row/column header selections, and active selection layers when modifying selection-related code.
+Test non-consecutive selections (Ctrl/Cmd+click), row/column header selections, and active selection layers when modifying selection-related code.
 
 ### Visual regression tests
 
-- Playwright visual regression tests are in `visual-tests/`.
+Playwright visual regression tests are in `visual-tests/`.
+
+---
+
+## Architecture constraints
+
+- **Frontend-only**: No server-side logic. Everything runs in the browser. No network requests unless explicitly configured by the user.
+- **Microkernel plugin system**: All extensions hook into the core through the plugin API. Respect the plugin lifecycle (see [Plugin lifecycle](#plugin-lifecycle)).
+- **Cascading configuration**: All feature configuration must work with Handsontable's cascading configuration model (`cell` → `column` → `global`).
+- **Design system theming**: CSS variables are the public API for theme customization. The design system uses a token hierarchy declared in Figma and exported as CSS variables.
+- **Framework wrapper parity**: Official wrappers (React, Angular, Vue) must be idiomatic for each framework and maintain feature parity.
+- **XSS prevention**: Strict input sanitization on user-facing cell content, custom formulas, and cell scripts. Safe plugin architecture to minimize attack surfaces.
+- **Internationalization**: Must handle RTL layouts, Unicode input (IME), and translations.
+- **No global namespace pollution**: Integration via NPM/CDN must not pollute the global namespace.
+- **Minimal dependencies**: Avoid adding third-party libraries. If you must, discuss with the team first. All dependencies must have permissive open-source licenses (MIT, BSD, Apache, etc.) and be actively maintained. This applies transitively to sub-dependencies.
+- **Functional continuity**: Each release must include no less functionality than its predecessor.
 
 ---
 
@@ -150,6 +442,7 @@ Handsontable uses two testing frameworks:
 
 - **Avoid spread operator with large arrays**: When working with potentially large arrays (10k+ elements), never use `arr.push(...largeArray)`. This causes stack overflow. Use `forEach` loops instead.
 - **Batch scroll events**: Use `requestAnimationFrame` to batch scroll event updates and prevent excessive redraws. Target smooth 60fps with 100k+ row datasets.
+- **Use `batch()` / `batchRender()` / `suspendRender()` / `resumeRender()`** when performing multiple operations that trigger rendering to avoid unnecessary redraws.
 - **Performance must not degrade**: Measured in library size, rendering performance, and memory consumption. Performance should gradually improve over time.
 
 ---
@@ -182,14 +475,15 @@ Handsontable uses two testing frameworks:
 ### PR requirements
 
 - Every PR must be connected to a GitHub issue.
-- Every PR that changes package source code must include a changelog entry as explained in `.changelogs/README.md`.
+- Every PR that changes package source code must include a changelog entry.
+- To create a changelog entry, run: `bin/changelog entry` (interactive CLI).
 - To skip changelog (for non-source-code changes only), write `[skip changelog]` in the PR description.
 - PRs are merged using **"Squash and merge"** in the GitHub UI by the PR author after full approval.
 - The PR author is responsible for addressing reviewer comments. The reviewer confirms resolution by clicking **Resolve conversation**.
 
 ### Changelog format
 
-- Follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
+Follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format. See `.changelogs/README.md` for full details.
 
 ### Visibility of work
 
@@ -203,7 +497,7 @@ Handsontable uses two testing frameworks:
 - Make all necessary methods available in the public API.
 - APIs must be discoverable, documented in guides, and usable in real-world applications.
 - All configuration options must fit into the cascading configuration model.
-- TypeScript typings must be maintained and accurate.
+- TypeScript typings in `handsontable/types/` must be maintained and accurate.
 - The public API must provide good code completion in IDEs and AI coding assistants.
 
 ---
@@ -219,15 +513,6 @@ Handsontable uses two testing frameworks:
 - Always respect defined column widths as **minimum values**.
 - If a column would shrink below its base width, disable stretching entirely.
 - Different stretching strategies (`'all'`, `'last'`) must behave consistently regarding minimum width handling.
-
----
-
-## Plugin development
-
-- Use the Handsontable plugin skeleton template.
-- Respect plugin initialization and enable/disable lifecycle.
-- `this.addHook()` in plugin context is different from `this.addHook()` in `hot` instance context.
-- Safe plugin architecture to minimize attack surfaces.
 
 ---
 
@@ -250,29 +535,112 @@ Handsontable uses two testing frameworks:
 
 ---
 
+## File locations reference
+
+### Core
+
+| Area | Path |
+|---|---|
+| Core class | `handsontable/src/core.js` |
+| Full entry point | `handsontable/src/index.js` |
+| Base (tree-shakeable) entry | `handsontable/src/base.js` |
+| Module registry | `handsontable/src/registry.js` |
+| TableView (Core ↔ Walkontable bridge) | `handsontable/src/tableView.js` |
+
+### Plugins
+
+| Area | Path |
+|---|---|
+| Plugin base class | `handsontable/src/plugins/base/base.js` |
+| Plugin registry | `handsontable/src/plugins/registry.js` |
+| All plugins index | `handsontable/src/plugins/index.js` |
+| Column stretching strategies | `handsontable/src/plugins/stretchColumns/strategies/` |
+
+### Data and meta
+
+| Area | Path |
+|---|---|
+| Data mapping | `handsontable/src/dataMap/` |
+| Cell meta system | `handsontable/src/dataMap/metaManager/` |
+| Index translations (IndexMapper) | `handsontable/src/translations/` |
+
+### Selection
+
+| Area | Path |
+|---|---|
+| Selection logic | `handsontable/src/selection/` |
+| Highlight system | `handsontable/src/selection/highlight/` |
+| Selection transformations | `handsontable/src/selection/transformation/` |
+
+### Rendering (Walkontable)
+
+| Area | Path |
+|---|---|
+| Walkontable engine | `handsontable/src/3rdparty/walkontable/src/` |
+| Overlays | `handsontable/src/3rdparty/walkontable/src/overlay/` |
+| Viewport calculators | `handsontable/src/3rdparty/walkontable/src/calculator/` |
+| Scroll handling | `handsontable/src/3rdparty/walkontable/src/scroll.js` |
+| Walkontable tests | `handsontable/src/3rdparty/walkontable/test/` |
+
+### Hooks and helpers
+
+| Area | Path |
+|---|---|
+| Hooks system | `handsontable/src/core/hooks/` |
+| Error helpers (`throwWithCause`) | `handsontable/src/helpers/errors.js` |
+| Console helpers | `handsontable/src/helpers/console.js` |
+| HTML parsing | `handsontable/src/utils/parseTable.js` |
+
+### Types and config
+
+| Area | Path |
+|---|---|
+| TypeScript definitions | `handsontable/types/` |
+| Webpack configs | `handsontable/.config/` |
+| Babel config | `handsontable/babel.config.js` |
+| Build env variables | `hot.config.js` (root) |
+| ESLint config | `.eslintrc.js` (root) and `handsontable/.eslintrc.js` |
+
+### Tests
+
+| Area | Path |
+|---|---|
+| E2E tests | `handsontable/test/e2e/` |
+| Test helpers | `handsontable/test/helpers/` |
+| Test bootstrap | `handsontable/test/bootstrap.js` |
+| Type tests | `handsontable/test/types/` |
+| Visual regression tests | `visual-tests/` |
+
+### Wrappers
+
+| Area | Path |
+|---|---|
+| React wrapper core | `wrappers/react-wrapper/src/hotTableInner.tsx` |
+| Angular wrapper core | `wrappers/angular-wrapper/projects/hot-table/src/lib/` |
+| Vue 3 wrapper | `wrappers/vue3/` |
+
+### CI/CD, changelog, and docs
+
+| Area | Path |
+|---|---|
+| CI workflows | `.github/workflows/` |
+| Changelog entries | `.changelogs/` |
+| Changelog CLI | `bin/changelog` |
+| Guides and examples | `docs/content/` |
+| Docs editing guide | `docs/README-EDITING.md` |
+| Docs deployment guide | `docs/README-DEPLOYMENT.md` |
+| Broken link redirects | `docs/netlify/netlify/edge-functions/` |
+| Migration guides | `docs/content/guides/upgrade-and-migration/` |
+
+---
+
 ## Gotchas
 
 - The core build outputs to `handsontable/tmp/` (not `dist/` for wrappers' consumption). The UMD/minified builds go to `handsontable/dist/` and CSS to `handsontable/styles/`. Wrapper packages reference the `tmp/` build via workspace linking.
+- Two Handsontable builds exist: `handsontable.js` (base, external deps) and `handsontable.full.js` (includes HyperFormula). When testing, ensure both variants work.
 - The Angular wrapper tests use `NODE_OPTIONS=--openssl-legacy-provider`; this is already wired into the `test` script.
 - The `pnpm-workspace.yaml` has `ignoredBuiltDependencies` and `onlyBuiltDependencies` lists. If pnpm warns about ignored build scripts (e.g., `less`), this is expected.
 - Root-level `npm run lint` and `npm run test` scripts use a custom `translate-to-native-npm.mjs` script to fan out across all workspace packages.
 - The docs site (`docs/`) uses Node 20 (its own `.nvmrc`) and is not needed for core library development.
+- Walkontable (the rendering engine) lives inside `src/3rdparty/walkontable/` and has its **own test runner** — do not mix Walkontable tests with main E2E tests.
 - No Docker, databases, or external services are required.
-
----
-
-## File locations reference
-
-| Area | Path |
-|---|---|
-| HTML parsing | `handsontable/src/utils/parseTable.js` |
-| Scroll handling | `handsontable/src/3rdparty/walkontable/src/overlays.js` |
-| Column stretching | `handsontable/src/plugins/stretchColumns/strategies/` |
-| Selection logic | `handsontable/src/selection/` |
-| React wrapper core | `wrappers/react-wrapper/src/hotTableInner.tsx` |
-| Unit tests | `__tests__/` or `test/spec/` directories next to source files |
-| E2E tests | `handsontable/test/e2e/` |
-| Visual regression tests | `visual-tests/` |
-| Changelog entries | `.changelogs/` |
-| ESLint config | Root monorepo config |
-| Build config | `handsontable/hot.config.js` and `handsontable/.config/` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,3 +43,27 @@ All commands below run from the workspace root (`/workspace`).
 - Root-level `npm run lint` and `npm run test` scripts use a custom `translate-to-native-npm.mjs` script to fan out across all workspace packages.
 - The docs site (`docs/`) uses Node 20 (its own `.nvmrc`) and is not needed for core library development.
 - No Docker, databases, or external services are required.
+
+### Common pitfalls & best practices
+
+#### Large dataset handling
+- **Avoid spread operator with large arrays**: When working with potentially large arrays (10k+ elements), avoid using the spread operator to push elements (e.g., `arr.push(...largeArray)`). This creates excessive function arguments and can cause stack overflow errors. Use `forEach` loops instead.
+- **Batch scroll events**: When handling scroll events that may fire rapidly (e.g., trackpad scrolling), use `requestAnimationFrame` to batch updates and prevent excessive redraws. This ensures smooth 60fps performance even with 100k+ row datasets.
+- **Test with large datasets**: When fixing bugs or adding features that handle data arrays, add unit tests with 50k+ rows to catch stack overflow and performance issues.
+
+#### Selection and state preservation
+- **React wrapper state updates**: When calling `updateSettings()` in the React wrapper, preserve and restore the selection state using `selection.exportSelection()` and `selection.importSelection()` to maintain non-consecutive selections, active layers, and focus positions across React re-renders.
+- **Selection testing**: Test non-consecutive selections (Ctrl/Cmd+click), row/column header selections, and active selection layers when modifying selection-related code.
+
+#### Column stretching
+- **Respect minimum widths**: When implementing column stretching strategies, always respect the defined column widths as minimum values. If a column would shrink below its base width, disable stretching entirely rather than allowing unusable column widths.
+- **Strategy parity**: Different stretching strategies (`'all'`, `'last'`) should behave consistently regarding minimum width handling.
+
+#### File locations reference
+- **HTML parsing**: `handsontable/src/utils/parseTable.js`
+- **Scroll handling**: `handsontable/src/3rdparty/walkontable/src/overlays.js`
+- **Column stretching**: `handsontable/src/plugins/stretchColumns/strategies/`
+- **Selection logic**: `handsontable/src/selection/`
+- **React wrapper core**: `wrappers/react-wrapper/src/hotTableInner.tsx`
+- **Unit tests**: `__tests__/` or `test/spec/` directories next to source files
+- **E2E tests**: `handsontable/test/e2e/`


### PR DESCRIPTION
# AGENTS.md

## Overview

Handsontable is a JavaScript/TypeScript data grid monorepo (pnpm workspace). It contains the core library plus React, Angular, and Vue 3 wrappers. It operates entirely in the browser (frontend-only, no server-side logic) and cannot access the internet unless explicitly configured (air-gapped environment support). There is no built-in telemetry.

**The core package (`handsontable/`) is JavaScript, not TypeScript.** Type definitions are hand-authored `.d.ts` files in `handsontable/types/`. Do not create `.ts` files in the core package.

---

## Common pitfalls

These are the most frequent mistakes. Read this section first.

| Pitfall | What to do instead |
|---|---|
| `throw new Error('...')` | Use `throwWithCause('...', cause)` from `src/helpers/errors.js`. Enforced by ESLint rule `handsontable/no-native-error-throw`. |
| Using `window`, `document`, `console` as globals | Use `this.hot.rootWindow`, `this.hot.rootDocument`, and helpers from `src/helpers/console.js`. Enforced by ESLint rule `no-restricted-globals`. |
| Importing from barrel index files (`plugins/index`, `editors/index`, `renderers/index`, `validators/index`, `cellTypes/index`, `i18n/index`) | Import from the specific submodule path (e.g., `import { HiddenColumns } from '../plugins/hiddenColumns/hiddenColumns'`). Enforced by ESLint rule `handsontable/restricted-module-imports`. The only exception is `src/registry.js`. |
| Writing `it('should ...', () => { ... })` in spec files | All `it()` callbacks in `*.spec.js` that call HOT rendering APIs **must** be `async` and the API calls must be `await`-ed. Enforced by ESLint rule `handsontable/require-async-in-it`. |
| `arr.push(...largeArray)` with large arrays | Causes stack overflow with 10k+ elements. Use `forEach` loop instead. |
| Confusing physical, visual, and renderable coordinates | See [Three coordinate systems](#three-coordinate-systems). |
| Creating `.ts` files in `handsontable/src/` | Core is JavaScript. TypeScript definitions live in `handsontable/types/` as `.d.ts` files. |
| Forgetting `super.enablePlugin()` / `super.disablePlugin()` in plugins | See [Plugin lifecycle](#plugin-lifecycle). |

---

## Workspace packages

| Package | Directory | Purpose |
|---|---|---|
| `handsontable` | `handsontable/` | Core data grid (vanilla JS) |
| `@handsontable/react-wrapper` | `wrappers/react-wrapper/` | React wrapper |
| `@handsontable/angular-wrapper` | `wrappers/angular-wrapper/` | Angular wrapper |
| `@handsontable/vue3` | `wrappers/vue3/` | Vue 3 wrapper |
| `handsontable-visual-tests` | `visual-tests/` | Playwright visual regression tests |
| `handsontable-examples-internal` | `examples/` | Code examples |
| `handsontable-documentation` | `docs/` | VuePress docs site (requires Node 20) |

---

## Prerequisites

- **Node.js 22** (see `.nvmrc`)
- **pnpm 10.30.2** (see `packageManager` in root `package.json`); activate via `corepack enable && corepack prepare pnpm@10.30.2 --activate`

---

## Build, lint, test

**Monorepo-level commands** use `pnpm` from the workspace root:

- **Build core**: `pnpm --filter handsontable run build` (must be done before wrapper tests, since wrappers depend on the built `tmp/` output)
- **Lint core**: `pnpm --filter handsontable run eslint` and `pnpm --filter handsontable run stylelint`
- **Unit tests (core)**: `pnpm --filter handsontable run test:unit` (Jest, ~2200 tests)
- **E2E tests (core)**: `pnpm --filter handsontable run test:e2e` (Puppeteer/Jasmine, headless Chrome)
- **Walkontable tests**: `pnpm --filter handsontable run test:walkontable` (separate pipeline)
- **React tests**: `pnpm --filter @handsontable/react-wrapper run test`
- **Vue3 tests**: `pnpm --filter @handsontable/vue3 run test`
- **Angular tests**: `pnpm --filter @handsontable/angular-wrapper run test` (uses `--openssl-legacy-provider` automatically)

**Inside individual packages** (e.g., `cd handsontable`), use `npm run ...` directly.

### Build outputs

The library outputs ES Modules and UMD bundles (UMD as legacy support). Two build variants exist:

- `handsontable.js` — base build, external dependencies not bundled
- `handsontable.full.js` — includes HyperFormula bundled in

Build scripts require environment variables injected via `env-cmd -f ../hot.config.js`.

| Output | Path |
|---|---|
| UMD / minified bundles | `handsontable/dist/` |
| ES and CJS modules (used by wrappers via workspace linking) | `handsontable/tmp/` |
| Compiled CSS | `handsontable/styles/` |

### CSS themes

Three themes are available: `ht-theme-main`, `ht-theme-classic`, `ht-theme-horizon` (each with `-no-icons` variants). The theme CSS class is applied to the root container element.

---

## Breaking changes policy

**Agents must try to avoid introducing breaking changes.** This is the single most important constraint. Existing customers depend on API stability. When a solution requires a Breaking Change, it must be stated in **bold**.

### What counts as a breaking change

| Change | Why it breaks | What to do instead |
|---|---|---|
| Renaming a CSS class produced by Handsontable | Breaks custom stylesheets | Keep the legacy class name in the DOM. Add tests verifying the old name still works. |
| Renaming APIs (methods, configuration options, hooks) | Breaks customer integrations | Keep the legacy API working and translate it to the new API internally. Legacy APIs do not produce console warnings. |
| Changing API signatures or behavior | Breaks customer integrations | Keep the deprecated API working until the next stable release. Deprecated APIs produce a console warning (fired only once). |
| Removing hooks or configuration options | May go completely undetected by customers | Add the hook/option to the list of removed hooks so an error is shown when someone uses it in configuration. |
| Changing a default setting value | 🚫 **Strictly forbidden** — this is considered a "really bad" breaking change. | Never change defaults. |

### Legacy vs deprecated

- **Legacy**: Old API is kept working forever alongside the new API. No console warnings. Feature set of the legacy API may be frozen. Tests must verify the old name continues to work.
- **Deprecated**: Old API works until the next stable release, then is removed. Produces a one-time console warning. Tests must verify the old name continues to work until removal.

### What is NOT considered breaking

Changes to JavaScript APIs that are **not listed in the public API reference** (e.g., internal Walkontable code changes that don't affect the DOM or CSS). Such changes should still be noted in release notes.

---

## Mandatory checklist for every change

Every code change produced by an agent **must** satisfy all of the following:

1. **Tests are required.** Every change must include both **unit tests** (Jest, `*.unit.js`) and **E2E tests** (Jasmine/Puppeteer, `*.spec.js`). No change is considered complete without test coverage for the new or modified behavior.
2. **Documentation must be updated.** If a change affects the public API, configuration options, hooks, behavior, or user-facing experience, the corresponding documentation (guides, API reference via JSDoc/Typedoc, migration guide) **must** be updated as part of the same change.
3. **Update AGENTS.md.** If a change introduces new conventions, patterns, constraints, file locations, or gotchas that future agents should know about, this `AGENTS.md` file **must** be updated to reflect them.

---

## Code style and conventions

### Formatting rules (enforced by ESLint)

- **Style base**: Modified [Airbnb JavaScript style](https://github.com/airbnb/javascript)
- **Indentation**: 2 spaces
- **Quotes**: Single quotes only
- **Max line length**: 120 characters (ignores comments and long `it()` test names)
- **JSDoc**: `jsdoc/require-jsdoc` is set to `error` — all exported functions require JSDoc comments

### Handsontable-specific ESLint rules

These custom rules are enforced and will cause lint failures if violated:

| Rule | What it enforces |
|---|---|
| `handsontable/no-native-error-throw` | Must use `throwWithCause()` from `src/helpers/errors.js`, not `throw new Error()` |
| `handsontable/restricted-module-imports` | No imports from barrel index files (`plugins/index`, `editors/index`, `renderers/index`, `validators/index`, `cellTypes/index`, `i18n/index`) |
| `handsontable/require-async-in-it` | All `it()` in `*.spec.js` calling HOT rendering APIs must be `async` |
| `handsontable/require-await` | Specific HOT API calls must be `await`-ed |
| `no-restricted-globals` | `window`, `document`, `console`, `Handsontable` are banned as globals |
| `compat/compat` | Browser API compatibility enforced against supported browser list |

### General conventions

- **Separate CSS and JS**: Do not mix CSS into JavaScript files.
- **DRY**: Reuse existing helpers and mixins. Do not duplicate code. If a piece of code repeats, create a new helper. Write generic code that can be reused across modules and plugins.
- **Method ordering**: Public methods first, then `@private` listeners.
- **Destructors**: Remove all variables in destructors (after `hot.destroy()`).
- **Browser compatibility**: Ensure chosen CSS and JS APIs are supported in all supported browsers (Chrome, Firefox, Safari — two latest major versions, Edge).

### Naming conventions

- Always use `Handsontable` in text, never `HOT`. Exception: instances of the Handsontable class are usually called `hot`.
- Use full names: `row` and `columns` (not `cols`).

### JSDoc / Typedoc

Both public and private APIs must be documented with JSDoc/Typedoc comments. The public API reference is generated automatically from these comments. Allowed custom tags: `@plugin`, `@util`, `@experimental`, `@deprecated`, `@preserve`, `@core`, `@TODO`, `@category`.

#### Typedoc formatting rules

- Avoid HTML tags (`<strong>`, `<br>`, etc.) inside descriptions — use Markdown instead.
- For line breaks use an **empty line**, never `<br>`.
- Links must use `[[MY_LINK]]` syntax, not `{@link MY_LINK}`.
- End every sentence with a full stop.
- Comment blocks start with `/**` — do not leave a blank line below the opening.
- Comment blocks end with `*/` — do not leave a blank line above the closing.
- Do not hardcode parameter values in descriptions — use `@param` tags.
- Group tags of the same type on consecutive lines.

#### Typedoc template

```
/**
 * Brief description of the method.
 *
 * Additional notes if needed.
 *
 * @param {string} paramName - description of the parameter
 * @param {number} anotherParam - description
 *
 * @fires [[eventName]] when triggered
 *
 * @throws [[ErrorType]] when condition is met
 *
 * @returns description of the return value
 *
 * @category CategoryName
 */
```

---

## Documentation rules

### What counts as documentation

Handsontable documentation includes: guides and code examples on the docs portal, the API reference (generated from JSDoc/Typedoc), code comments, changelog entries, release notes, migration guides, and README files across the monorepo.

### When documentation is required

- Any change to a public API (methods, options, hooks, plugins, typings, errors) **must** update the corresponding JSDoc/Typedoc comments and guides.
- Any change to user-facing behavior or look-and-feel **must** be documented.
- Any breaking change **must** include a migration guide step (see below).
- New documentation pages should be included in the changelog (do not use `[skip changelog]` for new pages).

### Documentation branch conventions

- Documentation branches for features: `docs/issue-xxxx` (e.g., `docs/issue-9024`), branched from the feature branch or `develop`.
- Documentation branches for releases: `release/x.y.z-docs`, branched from `release/x.y.z`.
- Documentation-only PRs use `[skip changelog]` in the PR description, **unless** the PR adds a new documentation page.

### Writing style rules

All documentation text (guides, JSDoc comments, changelog entries, migration guides, PR descriptions) must follow these rules:

1. **Short sentences.** Split longer sentences in two.
2. **Active voice.** Never passive. ("Configure the parameters" not "The parameters should be configured.")
3. **Simple verb syntax.** ("To ensure performance…" not "In order to ensure that the system will be capable of…")
4. **American English spelling.** (`recognize`, `program`, `behavior`, not `recognise`, `programme`, `behaviour`.)
5. **Commonized forms.** `frontend`, `backend`, `webhook`, `internet` (not `front-end`, `back end`, `web hook`, `Internet`).
6. **Use "you" not "we".** ("In this example, you can see…" not "In this example, we can see…")
7. **Oxford comma.** Use a comma before `and`/`or` in lists of 3+ items. ("berries, apples, and bacon.")
8. **No evaluative adjectives.** Eliminate "easy", "simple", "obvious", "straightforward" from explanations.
9. **Do not assume user background knowledge.** Bridge the gap between specialists and non-specialists.
10. **Max 3 adjectives before a noun.**
11. **Use en dashes (–) to separate clauses**, not hyphens.
12. **Consistent 3rd-party naming.** Use official capitalization: `Node.js`, `webpack`, `GitLab`, `TypeScript`.
13. **PR descriptions**: Use plain, concise language. Avoid literary wording — developers need to parse it quickly.

### Migration guide requirements

A migration guide is required for every major release and some minor releases. Each breaking change must have a separate migration guide step that includes:

1. Who the breaking change affects.
2. A brief reason for the change (what the user gains).
3. A brief description of the change itself.
4. What the user needs to do (step-by-step, with substeps if needed).
5. Code examples (before/after).
6. Links to more detailed information (new pages, PRs).

The structure must follow previous migration guides for consistency.

### Trademark rules

- Any documentation page mentioning "Excel" must include the Microsoft/Excel trademark disclaimer.
- If the page also mentions "Google Sheets", use the expanded disclaimer covering both trademarks.
- Avoid third-party trademarks in documentation unless practically necessary (e.g., to describe compatibility or integration).

### Documentation file locations

| Content | Location |
|---|---|
| Guides and examples | `docs/content/` |
| API reference source | JSDoc/Typedoc comments in source files |
| Changelog | `CHANGELOG.md` (root) |
| Changelog entry mechanism | `.changelogs/README.md` |
| Changelog CLI | `bin/changelog` |
| Docs editing guide | `docs/README-EDITING.md` |
| Docs deployment guide | `docs/README-DEPLOYMENT.md` |
| Broken link redirects | `docs/netlify/netlify/edge-functions/` |
| Migration guides | `docs/content/guides/upgrade-and-migration/` |

---

## Three coordinate systems

This is fundamental to working with the codebase. Three distinct index spaces exist:

| Coordinate type | Description | Example |
|---|---|---|
| **Physical** | Position in the source data array | Row 5 in the original dataset |
| **Visual** | Position in the DataMap (after trimming) | Row 3 if rows 0-1 were trimmed |
| **Renderable** | Position in the DOM (after hiding) | Row 2 if one visual row is hidden |

Plugins must correctly translate between these systems using `IndexMapper` (`hot.rowIndexMapper` / `hot.columnIndexMapper`).

### HidingMap vs TrimmingMap

| Map type | Effect |
|---|---|
| `HidingMap` | Index stays in DataMap but is **not rendered** in the DOM |
| `TrimmingMap` | Index is **removed from DataMap** entirely |

Plugins register maps via:
```js
hot.rowIndexMapper.registerMap('pluginName', new TrimmingMap());
hot.columnIndexMapper.registerMap('pluginName', new HidingMap());
```

---

## Plugin lifecycle

All plugins extend `BasePlugin` from `src/plugins/base/base.js`.

### Required static properties

```js
class MyPlugin extends BasePlugin {
  static get PLUGIN_KEY() { return 'myPlugin'; }          // Key in settings
  static get PLUGIN_PRIORITY() { return 150; }             // Init order (lower = first)
  static get SETTING_KEYS() { return ['myPlugin']; }       // Keys that trigger updatePlugin()
  static get PLUGIN_DEPS() { return ['plugin:AutoRowSize']; } // Dependencies
}
```

### Method lifecycle (in order)

1. `constructor(hotInstance)` — receives HOT instance as `this.hot`
2. `isEnabled()` — return truthy/falsy based on `this.hot.getSettings()[PLUGIN_KEY]`
3. `enablePlugin()` — set up hooks via `this.addHook()`, register IndexMapper maps. **Call `super.enablePlugin()` at the end.**
4. `updatePlugin()` — typical pattern: `this.disablePlugin(); this.enablePlugin(); super.updatePlugin();`
5. `disablePlugin()` — **Call `super.disablePlugin()` (clears EventManager and hooks).** Then clean up plugin-specific state.
6. `destroy()` — final teardown. **Call `super.destroy()` at the end.**

### Hook registration

Plugins that introduce new hooks register them globally **at module level, outside the class**:

```js
import Hooks from '../../core/hooks';

Hooks.getSingleton().register('beforeMyAction');
Hooks.getSingleton().register('afterMyAction');

export class MyPlugin extends BasePlugin {
  // ...
}
```

### Important distinction

`this.addHook()` in a plugin context (BasePlugin) is different from `this.hot.addHook()`. The plugin version auto-cleans hooks on `disablePlugin()`.

### File structure convention

Each plugin directory exports from an `index.js`:
```js
export { PLUGIN_KEY, PLUGIN_PRIORITY, MyPlugin } from './myPlugin';
```

---

## Testing requirements

Handsontable uses three test pipelines:
- **Jest** for unit tests (`*.unit.js` files, `__tests__/` directories next to source files)
- **Jasmine** (with Puppeteer, headless Chrome) for browser E2E tests (`*.spec.js` files, `handsontable/test/e2e/`)
- **Walkontable** has its own separate test pipeline (`npm run test:walkontable`)

### Test file naming

| Type | Pattern | Framework | Location |
|---|---|---|---|
| Unit test | `*.unit.js` | Jest (jsdom) | `src/**/__tests__/` |
| E2E test | `*.spec.js` | Jasmine (Puppeteer) | `test/e2e/` and `src/plugins/**/__tests__/` |
| Type test | `*.types.ts` | `tsc` only | `test/types/` |

### Standard E2E test boilerplate

```js
describe('MyPlugin', () => {
  const id = 'testContainer';

  beforeEach(function() {
    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
  });

  afterEach(function() {
    if (this.$container) {
      destroy();
      this.$container.remove();
    }
  });

  it('should do something', async() => {
    handsontable({
      data: createSpreadsheetData(5, 5),
      myPlugin: true,
    });

    await selectCell(0, 0);

    expect(getDataAtCell(0, 0)).toBe('A1');
  });
});
```

### Global test helpers

`test/helpers/common.js` exposes all HOT API methods as global test functions — **no imports needed** in spec files:

- `handsontable(options)` — creates a HOT instance
- `createSpreadsheetData(rows, cols)` — generates mock data (`'A1'`, `'B2'`, etc.)
- `selectCell()`, `getCell()`, `getDataAtCell()`, `getData()`, `getPlugin()`, `render()`, `destroy()`, `updateSettings()`, etc.
- `spec()` — returns the current test's HOT instance

Additional helpers: `test/helpers/mouseEvents.js`, `test/helpers/keyboardEvents.js` (DOM event simulation), `test/helpers/asciiTable.js` (selection pattern assertions).

### What to test

- Aim for 100% code coverage of new or modified code.
- Test all possible states including edge cases.
- Plugins, renderers, and editors must be tested against:
  - `hot.updateSettings()`
  - `hot.getPlugin('{PluginName}').enablePlugin(); hot.render();`
  - `hot.getPlugin('{PluginName}').disablePlugin(); hot.render();`
- Verify no regressions in related functionality.
- Check that no exceptions are displayed in the console.

### Large dataset testing

When fixing bugs or adding features that handle data arrays, add unit tests with **50k+ rows** to catch stack overflow and performance issues.

### Selection testing

Test non-consecutive selections (Ctrl/Cmd+click), row/column header selections, and active selection layers when modifying selection-related code.

### Visual regression tests

Playwright visual regression tests are in `visual-tests/`.

---

## Architecture constraints

- **Frontend-only**: No server-side logic. Everything runs in the browser. No network requests unless explicitly configured by the user.
- **Microkernel plugin system**: All extensions hook into the core through the plugin API. Respect the plugin lifecycle (see [Plugin lifecycle](#plugin-lifecycle)).
- **Cascading configuration**: All feature configuration must work with Handsontable's cascading configuration model (`cell` → `column` → `global`).
- **Design system theming**: CSS variables are the public API for theme customization. The design system uses a token hierarchy declared in Figma and exported as CSS variables.
- **Framework wrapper parity**: Official wrappers (React, Angular, Vue) must be idiomatic for each framework and maintain feature parity.
- **XSS prevention**: Strict input sanitization on user-facing cell content, custom formulas, and cell scripts. Safe plugin architecture to minimize attack surfaces.
- **Internationalization**: Must handle RTL layouts, Unicode input (IME), and translations.
- **No global namespace pollution**: Integration via NPM/CDN must not pollute the global namespace.
- **Minimal dependencies**: Avoid adding third-party libraries. If you must, discuss with the team first. All dependencies must have permissive open-source licenses (MIT, BSD, Apache, etc.) and be actively maintained. This applies transitively to sub-dependencies.
- **Functional continuity**: Each release must include no less functionality than its predecessor.

---

## Performance rules

- **Avoid spread operator with large arrays**: When working with potentially large arrays (10k+ elements), never use `arr.push(...largeArray)`. This causes stack overflow. Use `forEach` loops instead.
- **Batch scroll events**: Use `requestAnimationFrame` to batch scroll event updates and prevent excessive redraws. Target smooth 60fps with 100k+ row datasets.
- **Use `batch()` / `batchRender()` / `suspendRender()` / `resumeRender()`** when performing multiple operations that trigger rendering to avoid unnecessary redraws.
- **Performance must not degrade**: Measured in library size, rendering performance, and memory consumption. Performance should gradually improve over time.

---

## Git and branching

### Branch naming

- Feature branches: `feature/issue-xxxx` (e.g., `feature/issue-9024`)
- Documentation branches: `docs/issue-xxxx` (e.g., `docs/issue-9024`)
- Release branches: `release/x.y.z`
- LTS branches: `lts/[major].x`

### Git rules

- **Never force-push** to `master`, `develop`, or feature branches bound to Pull Requests. Force-pushing diverges history in other people's clones and makes PR review history incomprehensible.
- Follow the **Git flow** branching strategy.

### Versioning

- Uses **SemVer**. Patch releases are for critical fixes only.
- Even-numbered major releases (16, 18, 20, 22) become **LTS releases**.
- Odd-numbered major releases (17, 19, 21) are **Current-only** (6-month lifecycle).
- No more than 4 major releases per year (preferably 0). If multiple breaking changes are needed, bulk them into a single major release.

---

## Pull requests and changelog

### PR requirements

- Every PR must be connected to a GitHub issue.
- Every PR that changes package source code must include a changelog entry.
- To create a changelog entry, run: `bin/changelog entry` (interactive CLI).
- To skip changelog (for non-source-code changes only), write `[skip changelog]` in the PR description.
- PRs are merged using **"Squash and merge"** in the GitHub UI by the PR author after full approval.
- The PR author is responsible for addressing reviewer comments. The reviewer confirms resolution by clicking **Resolve conversation**.

### Changelog format

Follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format. See `.changelogs/README.md` for full details.

### Visibility of work

- If a task spans multiple days, create a draft PR and commit daily.
- All work must be tracked as a GitHub issue. If no issue exists, create one.

---

## API design guidelines

- Make all necessary methods available in the public API.
- APIs must be discoverable, documented in guides, and usable in real-world applications.
- All configuration options must fit into the cascading configuration model.
- TypeScript typings in `handsontable/types/` must be maintained and accurate.
- The public API must provide good code completion in IDEs and AI coding assistants.

---

## React wrapper specifics

- When calling `updateSettings()` in the React wrapper, **preserve and restore selection state** using `selection.exportSelection()` and `selection.importSelection()` to maintain non-consecutive selections, active layers, and focus positions across React re-renders.

---

## Column stretching

- Always respect defined column widths as **minimum values**.
- If a column would shrink below its base width, disable stretching entirely.
- Different stretching strategies (`'all'`, `'last'`) must behave consistently regarding minimum width handling.

---

## Dependency management

- **Discuss with the team before adding any third-party dependency.**
- All dependencies must have permissive open-source licenses (MIT, BSD, Apache, etc.).
- All dependencies must be actively maintained.
- These rules apply transitively to all sub-dependencies.
- Adding dependencies under non-permissive licenses requires notifying clients through the Sales team.

---

## Security

- Strict XSS prevention in user-facing cell content.
- Input sanitization on custom formulas and cell scripts.
- Safe plugin architecture to minimize attack surfaces.
- CLA must be signed before merging external contributions.

---

## File locations reference

### Core

| Area | Path |
|---|---|
| Core class | `handsontable/src/core.js` |
| Full entry point | `handsontable/src/index.js` |
| Base (tree-shakeable) entry | `handsontable/src/base.js` |
| Module registry | `handsontable/src/registry.js` |
| TableView (Core ↔ Walkontable bridge) | `handsontable/src/tableView.js` |

### Plugins

| Area | Path |
|---|---|
| Plugin base class | `handsontable/src/plugins/base/base.js` |
| Plugin registry | `handsontable/src/plugins/registry.js` |
| All plugins index | `handsontable/src/plugins/index.js` |
| Column stretching strategies | `handsontable/src/plugins/stretchColumns/strategies/` |

### Data and meta

| Area | Path |
|---|---|
| Data mapping | `handsontable/src/dataMap/` |
| Cell meta system | `handsontable/src/dataMap/metaManager/` |
| Index translations (IndexMapper) | `handsontable/src/translations/` |

### Selection

| Area | Path |
|---|---|
| Selection logic | `handsontable/src/selection/` |
| Highlight system | `handsontable/src/selection/highlight/` |
| Selection transformations | `handsontable/src/selection/transformation/` |

### Rendering (Walkontable)

| Area | Path |
|---|---|
| Walkontable engine | `handsontable/src/3rdparty/walkontable/src/` |
| Overlays | `handsontable/src/3rdparty/walkontable/src/overlay/` |
| Viewport calculators | `handsontable/src/3rdparty/walkontable/src/calculator/` |
| Scroll handling | `handsontable/src/3rdparty/walkontable/src/scroll.js` |
| Walkontable tests | `handsontable/src/3rdparty/walkontable/test/` |

### Hooks and helpers

| Area | Path |
|---|---|
| Hooks system | `handsontable/src/core/hooks/` |
| Error helpers (`throwWithCause`) | `handsontable/src/helpers/errors.js` |
| Console helpers | `handsontable/src/helpers/console.js` |
| HTML parsing | `handsontable/src/utils/parseTable.js` |

### Types and config

| Area | Path |
|---|---|
| TypeScript definitions | `handsontable/types/` |
| Webpack configs | `handsontable/.config/` |
| Babel config | `handsontable/babel.config.js` |
| Build env variables | `hot.config.js` (root) |
| ESLint config | `.eslintrc.js` (root) and `handsontable/.eslintrc.js` |

### Tests

| Area | Path |
|---|---|
| E2E tests | `handsontable/test/e2e/` |
| Test helpers | `handsontable/test/helpers/` |
| Test bootstrap | `handsontable/test/bootstrap.js` |
| Type tests | `handsontable/test/types/` |
| Visual regression tests | `visual-tests/` |

### Wrappers

| Area | Path |
|---|---|
| React wrapper core | `wrappers/react-wrapper/src/hotTableInner.tsx` |
| Angular wrapper core | `wrappers/angular-wrapper/projects/hot-table/src/lib/` |
| Vue 3 wrapper | `wrappers/vue3/` |

### CI/CD, changelog, and docs

| Area | Path |
|---|---|
| CI workflows | `.github/workflows/` |
| Changelog entries | `.changelogs/` |
| Changelog CLI | `bin/changelog` |
| Guides and examples | `docs/content/` |
| Docs editing guide | `docs/README-EDITING.md` |
| Docs deployment guide | `docs/README-DEPLOYMENT.md` |
| Broken link redirects | `docs/netlify/netlify/edge-functions/` |
| Migration guides | `docs/content/guides/upgrade-and-migration/` |

---

## Gotchas

- The core build outputs to `handsontable/tmp/` (not `dist/` for wrappers' consumption). The UMD/minified builds go to `handsontable/dist/` and CSS to `handsontable/styles/`. Wrapper packages reference the `tmp/` build via workspace linking.
- Two Handsontable builds exist: `handsontable.js` (base, external deps) and `handsontable.full.js` (includes HyperFormula). When testing, ensure both variants work.
- The Angular wrapper tests use `NODE_OPTIONS=--openssl-legacy-provider`; this is already wired into the `test` script.
- The `pnpm-workspace.yaml` has `ignoredBuiltDependencies` and `onlyBuiltDependencies` lists. If pnpm warns about ignored build scripts (e.g., `less`), this is expected.
- Root-level `npm run lint` and `npm run test` scripts use a custom `translate-to-native-npm.mjs` script to fan out across all workspace packages.
- The docs site (`docs/`) uses Node 20 (its own `.nvmrc`) and is not needed for core library development.
- Walkontable (the rendering engine) lives inside `src/3rdparty/walkontable/` and has its **own test runner** — do not mix Walkontable tests with main E2E tests.
- No Docker, databases, or external services are required.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no runtime code paths, builds, or tests are modified.
> 
> **Overview**
> Extensively rewrites and expands `AGENTS.md` from a short set of notes into a comprehensive contributor/agent guide, adding sections on common pitfalls, breaking-change policy, mandatory test/doc checklist, coding and Typedoc conventions, testing requirements, performance/security rules, and a detailed file-location reference.
> 
> Also clarifies/updates build and test instructions (including Walkontable and Angular notes) and adds additional project gotchas (e.g., dual build variants and Walkontable’s separate test runner).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5803d1da6e7ac2702fbbcf950125438f9fec3eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->