### PR TITLE
Sync the React examples' configs with their JS counterparts.

### DIFF
--- a/docs/content/guides/cell-types/multiselect-cell-type/react/example1.jsx
+++ b/docs/content/guides/cell-types/multiselect-cell-type/react/example1.jsx
@@ -19,10 +19,16 @@ const shipmentCategories = [
 
 const data = [
   ['Los Angeles International Airport', ['Electronics and Gadgets', 'Medical Supplies']],
-  ['Chicago O\'Hare International Airport', ['Auto Parts', 'Fresh Produce']],
+  ["Chicago O'Hare International Airport", ['Auto Parts', 'Fresh Produce']],
   ['Charles de Gaulle Airport', ['Textiles', 'Industrial Equipment']],
   ['Tokyo Haneda Airport', ['Pharmaceuticals', 'Consumer Goods']],
   ['Singapore Changi Airport', ['Machine Parts', 'Food Products']],
+  ['Luton Airport', ['Electronics and Gadgets', 'Pharmaceuticals']],
+  ['Frankfurt Airport', ['Industrial Equipment', 'Auto Parts', 'Consumer Goods']],
+  ['Sydney Kingsford Smith Airport', ['Fresh Produce', 'Food Products']],
+  ['Toronto Pearson International Airport', ['Medical Supplies', 'Textiles']],
+  ['Hong Kong International Airport', ['Machine Parts', 'Electronics and Gadgets', 'Industrial Equipment']],
+  ['Heathrow Airport', ['Textiles', 'Consumer Goods']],
 ];
 
 const ExampleComponent = () => {
@@ -42,8 +48,9 @@ const ExampleComponent = () => {
           title: 'Shipment',
         },
       ]}
-      preventOverflow="horizontal"
-      colWidths={300}
+      height="auto"
+      stretchH="last"
+      width="100%"
     />
   );
 };

--- a/docs/content/guides/cell-types/multiselect-cell-type/react/example2.jsx
+++ b/docs/content/guides/cell-types/multiselect-cell-type/react/example2.jsx
@@ -18,26 +18,85 @@ const shipmentCategories = [
 ];
 
 const data = [
-  ['Los Angeles International Airport', [
-    { key: 'electronics', value: 'Electronics and Gadgets' },
-    { key: 'medical', value: 'Medical Supplies' },
-  ]],
-  ['Chicago O\'Hare International Airport', [
-    { key: 'auto-parts', value: 'Auto Parts' },
-    { key: 'fresh-produce', value: 'Fresh Produce' },
-  ]],
-  ['Charles de Gaulle Airport', [
-    { key: 'textiles', value: 'Textiles' },
-    { key: 'industrial', value: 'Industrial Equipment' },
-  ]],
-  ['Tokyo Haneda Airport', [
-    { key: 'pharmaceuticals', value: 'Pharmaceuticals' },
-    { key: 'consumer', value: 'Consumer Goods' },
-  ]],
-  ['Singapore Changi Airport', [
-    { key: 'machine-parts', value: 'Machine Parts' },
-    { key: 'food', value: 'Food Products' },
-  ]],
+  [
+    'Los Angeles International Airport',
+    [
+      { key: 'electronics', value: 'Electronics and Gadgets' },
+      { key: 'medical', value: 'Medical Supplies' },
+    ],
+  ],
+  [
+    "Chicago O'Hare International Airport",
+    [
+      { key: 'auto-parts', value: 'Auto Parts' },
+      { key: 'fresh-produce', value: 'Fresh Produce' },
+    ],
+  ],
+  [
+    'Charles de Gaulle Airport',
+    [
+      { key: 'textiles', value: 'Textiles' },
+      { key: 'industrial', value: 'Industrial Equipment' },
+    ],
+  ],
+  [
+    'Tokyo Haneda Airport',
+    [
+      { key: 'pharmaceuticals', value: 'Pharmaceuticals' },
+      { key: 'consumer', value: 'Consumer Goods' },
+    ],
+  ],
+  [
+    'Singapore Changi Airport',
+    [
+      { key: 'machine-parts', value: 'Machine Parts' },
+      { key: 'food', value: 'Food Products' },
+    ],
+  ],
+  [
+    'Luton Airport',
+    [
+      { key: 'electronics', value: 'Electronics and Gadgets' },
+      { key: 'pharmaceuticals', value: 'Pharmaceuticals' },
+    ],
+  ],
+  [
+    'Frankfurt Airport',
+    [
+      { key: 'industrial', value: 'Industrial Equipment' },
+      { key: 'auto-parts', value: 'Auto Parts' },
+      { key: 'consumer', value: 'Consumer Goods' },
+    ],
+  ],
+  [
+    'Sydney Kingsford Smith Airport',
+    [
+      { key: 'fresh-produce', value: 'Fresh Produce' },
+      { key: 'food', value: 'Food Products' },
+    ],
+  ],
+  [
+    'Toronto Pearson International Airport',
+    [
+      { key: 'medical', value: 'Medical Supplies' },
+      { key: 'textiles', value: 'Textiles' },
+    ],
+  ],
+  [
+    'Hong Kong International Airport',
+    [
+      { key: 'machine-parts', value: 'Machine Parts' },
+      { key: 'electronics', value: 'Electronics and Gadgets' },
+      { key: 'industrial', value: 'Industrial Equipment' },
+    ],
+  ],
+  [
+    'Heathrow Airport',
+    [
+      { key: 'textiles', value: 'Textiles' },
+      { key: 'consumer', value: 'Consumer Goods' },
+    ],
+  ],
 ];
 
 const ExampleComponent = () => {
@@ -57,8 +116,9 @@ const ExampleComponent = () => {
           title: 'Shipment',
         },
       ]}
-      preventOverflow="horizontal"
-      colWidths={300}
+      height="auto"
+      stretchH="last"
+      width="100%"
     />
   );
 };

--- a/docs/content/guides/cell-types/multiselect-cell-type/react/example3.jsx
+++ b/docs/content/guides/cell-types/multiselect-cell-type/react/example3.jsx
@@ -17,6 +17,15 @@ const data = [
   [['Phone', 'Keys'], ['First aid kit', 'Snacks', 'Umbrella'], ['Nature']],
   [['Wallet', 'Phone'], [], ['Food', 'Shopping']],
   [['Passport', 'Tickets'], ['Book'], ['Art', 'History']],
+  [['Phone', 'Keys'], ['First aid kit', 'Snacks', 'Umbrella'], ['Nature']],
+  [['Wallet', 'Phone'], [], ['Food', 'Shopping']],
+  [['Passport', 'Tickets'], ['Book'], ['Art', 'History']],
+  [['Phone', 'Keys'], ['First aid kit', 'Snacks', 'Umbrella'], ['Nature']],
+  [['Wallet', 'Phone'], [], ['Food', 'Shopping']],
+  [['Passport', 'Tickets'], ['Book'], ['Art', 'History']],
+  [['Phone', 'Keys'], ['First aid kit', 'Snacks', 'Umbrella'], ['Nature']],
+  [['Wallet', 'Phone'], [], ['Food', 'Shopping']],
+  [['Passport', 'Tickets'], ['Book'], ['Art', 'History']],
 ];
 
 const ExampleComponent = () => {
@@ -51,8 +60,9 @@ const ExampleComponent = () => {
           filteringCaseSensitive: true,
         },
       ]}
-      preventOverflow="horizontal"
-      colWidths={200}
+      height="auto"
+      stretchH="last"
+      width="100%"
     />
   );
 };


### PR DESCRIPTION
 ### Context                                                                                                                                                                                                                    
  The React examples for the `multiselect` cell type were out of sync with their JavaScript counterparts. This PR aligns them by:                                                                                                
                                                                                                                                                                                                                                 
  - Replacing `preventOverflow="horizontal"` + `colWidths` with `height="auto"`, `stretchH="last"`, and `width="100%"` in all three examples.                                                                                    
  - Adding extra data rows to `example1`, `example2`, and `example3` to match the JS versions.                                                                                                                                 
  - Reformatting the `example2` data array for consistency (multi-line object entries).

[skip changelog]

  ### How has this been tested?
  No test changes — docs-only update.

  ### Checklist:
  - [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/develop/CONTRIBUTING.md)
  - [x] I have signed the [Contributor License Agreement](https://github.com/handsontable/handsontable/blob/develop/LICENSE)
  - [x] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes that adjust example configuration and sample data; no runtime/library logic is modified.
> 
> **Overview**
> Updates the React `multiselect` cell type guide examples to match the JavaScript versions by switching table sizing/overflow options from `preventOverflow` + `colWidths` to `height="auto"`, `stretchH="last"`, and `width="100%"`.
> 
> Expands the sample datasets in `example1`, `example2`, and `example3` (and reformats `example2`’s nested data for readability/consistency), so the rendered tables show the same rows and structure as the JS docs examples.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b089528055121091330b27eb797f228230d07d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->