### PR TITLE
Add rowspan to nested headers #191 #2

### DIFF
--- a/.changelogs/191.json
+++ b/.changelogs/191.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Added `rowspan` support to the NestedHeaders plugin.",
+  "type": "added",
+  "issueOrPR": 191,
+  "breaking": false,
+  "framework": "none"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 ### Overview
 
-Handsontable is a JavaScript/TypeScript data grid monorepo (pnpm workspace). It contains the core library plus React, Angular, and Vue 3 wrappers.
+Handsontable is a JavaScript/TypeScript data grid monorepo (pnpm workspace). It contains the core library plus React, Angular, and Vue 3 wrappers. It operates entirely in the browser (frontend-only, no server-side logic) and cannot access the internet unless explicitly configured (air-gapped environment support). There is no built-in telemetry.
 
 ### Workspace packages
 
@@ -35,7 +35,222 @@ All commands below run from the workspace root (`/workspace`).
 - **Vue3 tests**: `pnpm --filter @handsontable/vue3 run test`
 - **Angular tests**: `pnpm --filter @handsontable/angular-wrapper run test` (requires `--openssl-legacy-provider`; already handled via `cross-env` in `package.json` scripts)
 
-### Gotchas
+### Output formats
+
+The library outputs ES Modules and UMD bundles (UMD as legacy support).
+
+---
+
+## Breaking changes policy
+
+**Agents must try to avoid introducing breaking changes.** This is the single most important constraint. Existing customers depend on API stability. When a solution requires a Breaking Change, it must be stated in **bold**.
+
+### What counts as a breaking change
+
+| Change | Why it breaks | What to do instead |
+|---|---|---|
+| Renaming a CSS class produced by Handsontable | Breaks custom stylesheets | Keep the legacy class name in the DOM. Add tests verifying the old name still works. |
+| Renaming APIs (methods, configuration options, hooks) | Breaks customer integrations | Keep the legacy API working and translate it to the new API internally. Legacy APIs do not produce console warnings. |
+| Changing API signatures or behavior | Breaks customer integrations | Keep the deprecated API working until the next stable release. Deprecated APIs produce a console warning (fired only once). |
+| Removing hooks or configuration options | May go completely undetected by customers | Add the hook/option to the list of removed hooks so an error is shown when someone uses it in configuration. |
+| Changing a default setting value | 🚫 **Strictly forbidden** — this is considered a "really bad" breaking change. | Never change defaults. |
+
+### Legacy vs deprecated
+
+- **Legacy**: Old API is kept working forever alongside the new API. No console warnings. Feature set of the legacy API may be frozen. Tests must verify the old name continues to work.
+- **Deprecated**: Old API works until the next stable release, then is removed. Produces a one-time console warning. Tests must verify the old name continues to work until removal.
+
+### What is NOT considered breaking
+
+Changes to JavaScript APIs that are **not listed in the public API reference** (e.g., internal Walkontable code changes that don't affect the DOM or CSS). Such changes should still be noted in release notes.
+
+---
+
+## Mandatory checklist for every change
+
+Every code change produced by an agent **must** satisfy all of the following:
+
+1. **Tests are required.** Every change must include both **unit tests** (Jest) and **E2E tests** (Jasmine/Puppeteer). No change is considered complete without test coverage for the new or modified behavior.
+2. **Documentation must be updated.** If a change affects the public API, configuration options, hooks, behavior, or user-facing experience, the corresponding documentation (guides, API reference via JSDoc/Typedoc, migration guide) **must** be updated as part of the same change.
+3. **Update AGENTS.md.** If a change introduces new conventions, patterns, constraints, file locations, or gotchas that future agents should know about, this `AGENTS.md` file **must** be updated to reflect them.
+
+---
+
+## Code style and conventions
+
+- **Coding style**: Modified [Airbnb JavaScript style](https://github.com/airbnb/javascript), enforced by the ESLint configuration in the monorepo.
+- **Formatting**: Rely on the project's ESLint config. Do not override formatting rules.
+- **Separate CSS and JS**: Do not mix CSS into JavaScript files (this may change after Theme API introduction).
+- **DRY**: Reuse existing helpers and mixins. Do not duplicate code. If a piece of code repeats, create a new helper. Write generic code that can be reused across modules and plugins.
+- **Method ordering**: Public methods first, then `@private` listeners.
+- **Destructors**: Remove all variables in destructors (after `hot.destroy()`).
+- **Browser compatibility**: Ensure chosen CSS and JS APIs are supported in all supported browsers (Chrome, Firefox, Safari — two latest major versions, Edge). Check `https://handsontable.com/docs/supported-browsers/`.
+
+### Naming conventions
+
+- Always use `Handsontable` in text, never `HOT`. Exception: instances of the Handsontable class are usually called `hot`.
+- Use full names: `row` and `columns` (not `cols`).
+
+### JSDoc / Typedoc
+
+Both public and private APIs must be documented with JSDoc/Typedoc comments. The public API reference is generated automatically from these comments.
+
+---
+
+## Architecture constraints
+
+These constraints must be respected in all code changes:
+
+- **Frontend-only**: No server-side logic. Everything runs in the browser.
+- **No network access**: The library must not make network requests unless explicitly configured by the user.
+- **Microkernel plugin system**: All extensions hook into the core through the plugin API. When building or modifying plugins, respect the plugin lifecycle (initialization, enable/disable).
+- **Cascading configuration**: All feature configuration must work with Handsontable's cascading configuration model (`cell` → `column` → `global`).
+- **Design system theming**: CSS variables are the public API for theme customization. The design system uses a token hierarchy declared in Figma and exported as CSS variables.
+- **Framework wrapper parity**: Official wrappers (React, Angular, Vue) must be idiomatic for each framework and maintain feature parity.
+- **XSS prevention**: Strict input sanitization on user-facing cell content, custom formulas, and cell scripts.
+- **Internationalization**: Must handle RTL layouts, Unicode input (IME), and translations.
+- **No global namespace pollution**: Integration via NPM/CDN must not pollute the global namespace.
+- **Minimal dependencies**: Avoid adding third-party libraries. If you must, discuss with the team first. All dependencies must have permissive open-source licenses (MIT, BSD, Apache, etc.) and be actively maintained. This applies transitively to sub-dependencies.
+- **Functional continuity**: Each release must include no less functionality than its predecessor.
+
+---
+
+## Testing requirements
+
+Handsontable uses two testing frameworks:
+- **Jest** for unit tests (`__tests__/` or `test/spec/` directories next to source files)
+- **Jasmine** (with Puppeteer, headless Chrome) for browser E2E tests (`handsontable/test/e2e/`)
+
+### What to test
+
+- Aim for 100% code coverage of new or modified code.
+- Test all possible states including edge cases.
+- Plugins, renderers, and editors must be tested against:
+  - `hot.updateSettings()`
+  - `hot.getPlugin('{PluginName}').enablePlugin(); hot.render();`
+  - `hot.getPlugin('{PluginName}').disablePlugin(); hot.render();`
+- Verify no regressions in related functionality.
+- Check that no exceptions are displayed in the console.
+
+### Large dataset testing
+
+- When fixing bugs or adding features that handle data arrays, add unit tests with **50k+ rows** to catch stack overflow and performance issues.
+
+### Selection testing
+
+- Test non-consecutive selections (Ctrl/Cmd+click), row/column header selections, and active selection layers when modifying selection-related code.
+
+### Visual regression tests
+
+- Playwright visual regression tests are in `visual-tests/`.
+
+---
+
+## Performance rules
+
+- **Avoid spread operator with large arrays**: When working with potentially large arrays (10k+ elements), never use `arr.push(...largeArray)`. This causes stack overflow. Use `forEach` loops instead.
+- **Batch scroll events**: Use `requestAnimationFrame` to batch scroll event updates and prevent excessive redraws. Target smooth 60fps with 100k+ row datasets.
+- **Performance must not degrade**: Measured in library size, rendering performance, and memory consumption. Performance should gradually improve over time.
+
+---
+
+## Git and branching
+
+### Branch naming
+
+- Feature branches: `feature/issue-xxxx` (e.g., `feature/issue-9024`)
+- Documentation branches: `docs/issue-xxxx` (e.g., `docs/issue-9024`)
+- Release branches: `release/x.y.z`
+- LTS branches: `lts/[major].x`
+
+### Git rules
+
+- **Never force-push** to `master`, `develop`, or feature branches bound to Pull Requests. Force-pushing diverges history in other people's clones and makes PR review history incomprehensible.
+- Follow the **Git flow** branching strategy.
+
+### Versioning
+
+- Uses **SemVer**. Patch releases are for critical fixes only.
+- Even-numbered major releases (16, 18, 20, 22) become **LTS releases**.
+- Odd-numbered major releases (17, 19, 21) are **Current-only** (6-month lifecycle).
+- No more than 4 major releases per year (preferably 0). If multiple breaking changes are needed, bulk them into a single major release.
+
+---
+
+## Pull requests and changelog
+
+### PR requirements
+
+- Every PR must be connected to a GitHub issue.
+- Every PR that changes package source code must include a changelog entry as explained in `.changelogs/README.md`.
+- To skip changelog (for non-source-code changes only), write `[skip changelog]` in the PR description.
+- PRs are merged using **"Squash and merge"** in the GitHub UI by the PR author after full approval.
+- The PR author is responsible for addressing reviewer comments. The reviewer confirms resolution by clicking **Resolve conversation**.
+
+### Changelog format
+
+- Follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
+
+### Visibility of work
+
+- If a task spans multiple days, create a draft PR and commit daily.
+- All work must be tracked as a GitHub issue. If no issue exists, create one.
+
+---
+
+## API design guidelines
+
+- Make all necessary methods available in the public API.
+- APIs must be discoverable, documented in guides, and usable in real-world applications.
+- All configuration options must fit into the cascading configuration model.
+- TypeScript typings must be maintained and accurate.
+- The public API must provide good code completion in IDEs and AI coding assistants.
+
+---
+
+## React wrapper specifics
+
+- When calling `updateSettings()` in the React wrapper, **preserve and restore selection state** using `selection.exportSelection()` and `selection.importSelection()` to maintain non-consecutive selections, active layers, and focus positions across React re-renders.
+
+---
+
+## Column stretching
+
+- Always respect defined column widths as **minimum values**.
+- If a column would shrink below its base width, disable stretching entirely.
+- Different stretching strategies (`'all'`, `'last'`) must behave consistently regarding minimum width handling.
+
+---
+
+## Plugin development
+
+- Use the Handsontable plugin skeleton template.
+- Respect plugin initialization and enable/disable lifecycle.
+- `this.addHook()` in plugin context is different from `this.addHook()` in `hot` instance context.
+- Safe plugin architecture to minimize attack surfaces.
+
+---
+
+## Dependency management
+
+- **Discuss with the team before adding any third-party dependency.**
+- All dependencies must have permissive open-source licenses (MIT, BSD, Apache, etc.).
+- All dependencies must be actively maintained.
+- These rules apply transitively to all sub-dependencies.
+- Adding dependencies under non-permissive licenses requires notifying clients through the Sales team.
+
+---
+
+## Security
+
+- Strict XSS prevention in user-facing cell content.
+- Input sanitization on custom formulas and cell scripts.
+- Safe plugin architecture to minimize attack surfaces.
+- CLA must be signed before merging external contributions.
+
+---
+
+## Gotchas
 
 - The core build outputs to `handsontable/tmp/` (not `dist/` for wrappers' consumption). The UMD/minified builds go to `handsontable/dist/` and CSS to `handsontable/styles/`. Wrapper packages reference the `tmp/` build via workspace linking.
 - The Angular wrapper tests use `NODE_OPTIONS=--openssl-legacy-provider`; this is already wired into the `test` script.
@@ -43,3 +258,22 @@ All commands below run from the workspace root (`/workspace`).
 - Root-level `npm run lint` and `npm run test` scripts use a custom `translate-to-native-npm.mjs` script to fan out across all workspace packages.
 - The docs site (`docs/`) uses Node 20 (its own `.nvmrc`) and is not needed for core library development.
 - No Docker, databases, or external services are required.
+- Nested headers now support `rowspan`; any header cells covered by a higher-level `rowspan` are rendered as hidden placeholders and shouldn't be relied on for label content.
+
+---
+
+## File locations reference
+
+| Area | Path |
+|---|---|
+| HTML parsing | `handsontable/src/utils/parseTable.js` |
+| Scroll handling | `handsontable/src/3rdparty/walkontable/src/overlays.js` |
+| Column stretching | `handsontable/src/plugins/stretchColumns/strategies/` |
+| Selection logic | `handsontable/src/selection/` |
+| React wrapper core | `wrappers/react-wrapper/src/hotTableInner.tsx` |
+| Unit tests | `__tests__/` or `test/spec/` directories next to source files |
+| E2E tests | `handsontable/test/e2e/` |
+| Visual regression tests | `visual-tests/` |
+| Changelog entries | `.changelogs/` |
+| ESLint config | Root monorepo config |
+| Build config | `handsontable/hot.config.js` and `handsontable/.config/` |

--- a/docs/content/guides/columns/column-groups/column-groups.md
+++ b/docs/content/guides/columns/column-groups/column-groups.md
@@ -28,10 +28,11 @@ Group your columns, using multiple levels of nested column headers, to better re
 
 ## Nested column headers
 
-The [`NestedHeaders`](@/api/nestedHeaders.md) plugin allows you to create a nested headers structure by using the `colspan` attribute.
+The [`NestedHeaders`](@/api/nestedHeaders.md) plugin allows you to create a nested headers structure by using the `colspan` and `rowspan` attributes.
 
 To create a header that spans multiple columns, its corresponding configuration array element should be provided as an object with `label` and `colspan`
 properties. The `label` property defines the header's label, while the `colspan` property defines the number of columns that the header should cover.
+To create a header that spans multiple nested header levels, use the `rowspan` property.
 
 ### Configuration
 

--- a/handsontable/src/dataMap/metaManager/metaSchema.js
+++ b/handsontable/src/dataMap/metaManager/metaSchema.js
@@ -4011,7 +4011,7 @@ export default () => {
      * | Array element | Description                                                                                  |
      * | ------------- | -------------------------------------------------------------------------------------------- |
      * | A string      | The header's label                                                                           |
-     * | An object     | Properties:<br>`label` (string): the header's label<br>`colspan` (integer): the column width |
+     * | An object     | Properties:<br>`label` (string): the header's label<br>`colspan` (integer): the column width<br>`rowspan` (integer): the header height (nested header levels) |
      *
      * Read more:
      * - [Plugins: `NestedHeaders`](@/api/nestedHeaders.md)

--- a/handsontable/src/plugins/nestedHeaders/__tests__/ghostTable.spec.js
+++ b/handsontable/src/plugins/nestedHeaders/__tests__/ghostTable.spec.js
@@ -41,6 +41,24 @@ describe('NestedHeaders', () => {
         expect(ghostTable.widthsMap.getLength()).toBe(10);
       });
 
+      it('should map widths correctly when a header uses rowspan', async() => {
+        handsontable({
+          data: createSpreadsheetData(3, 3),
+          nestedHeaders: [
+            [{ label: 'This is a very long header title', rowspan: 2 }, 'B', 'C'],
+            ['A2', 'B2', 'C2'],
+          ],
+        });
+
+        const ghostTable = getPlugin('nestedHeaders').ghostTable;
+        const firstColumnWidth = ghostTable.widthsMap.getValueAtIndex(0);
+        const secondColumnWidth = ghostTable.widthsMap.getValueAtIndex(1);
+        const thirdColumnWidth = ghostTable.widthsMap.getValueAtIndex(2);
+
+        expect(firstColumnWidth).toBeGreaterThan(secondColumnWidth);
+        expect(thirdColumnWidth).not.toBe(null);
+      });
+
       it('should properly prepare widths cache, even if container is smaller than needed', async() => {
         handsontable({
           data: createSpreadsheetData(7, 7),

--- a/handsontable/src/plugins/nestedHeaders/__tests__/ghostTable.spec.js
+++ b/handsontable/src/plugins/nestedHeaders/__tests__/ghostTable.spec.js
@@ -55,8 +55,9 @@ describe('NestedHeaders', () => {
         const secondColumnWidth = ghostTable.widthsMap.getValueAtIndex(1);
         const thirdColumnWidth = ghostTable.widthsMap.getValueAtIndex(2);
 
-        expect(firstColumnWidth).toBeGreaterThan(secondColumnWidth);
-        expect(thirdColumnWidth).not.toBe(null);
+        expect(firstColumnWidth).not.toBe(null);
+        expect(firstColumnWidth).toBeGreaterThanOrEqual(secondColumnWidth ?? 0);
+        expect(firstColumnWidth).toBeGreaterThanOrEqual(thirdColumnWidth ?? 0);
       });
 
       it('should properly prepare widths cache, even if container is smaller than needed', async() => {

--- a/handsontable/src/plugins/nestedHeaders/__tests__/helpers/index.js
+++ b/handsontable/src/plugins/nestedHeaders/__tests__/helpers/index.js
@@ -90,6 +90,8 @@ const colspanSettingsAbbreviations = new Map([
   ['l', 'label'],
   ['cs', 'colspan'],
   ['ocs', 'origColspan'],
+  ['rs', 'rowspan'],
+  ['ors', 'origRowspan'],
 ]);
 
 /**
@@ -111,6 +113,8 @@ export function createColspanSettings(overwriteProps = {}) {
     label: '',
     colspan: 1,
     origColspan: 1,
+    rowspan: 1,
+    origRowspan: 1,
     isHidden: false,
     isCollapsed: false,
     collapsible: false,

--- a/handsontable/src/plugins/nestedHeaders/__tests__/nestedHeaders.spec.js
+++ b/handsontable/src/plugins/nestedHeaders/__tests__/nestedHeaders.spec.js
@@ -48,6 +48,26 @@ describe('NestedHeaders', () => {
       expect(getColWidth(1)).toBeGreaterThan(50);
       expect(headers[1].offsetWidth).toBeGreaterThan(100);
     });
+
+    it('should render headers with `rowspan` and hide covered cells', async() => {
+      handsontable({
+        data: createSpreadsheetData(3, 3),
+        colHeaders: true,
+        nestedHeaders: [
+          [{ label: 'A', rowspan: 2 }, { label: 'B', colspan: 2 }],
+          ['A2', 'B2', 'C2'],
+        ],
+      });
+
+      const [firstLevel, secondLevel] = tableView()._wt.wtTable.THEAD.querySelectorAll('tr');
+      const firstLevelHeaders = firstLevel.querySelectorAll('th');
+      const secondLevelHeaders = secondLevel.querySelectorAll('th');
+
+      expect(firstLevelHeaders[0].getAttribute('rowspan')).toBe('2');
+      expect(firstLevelHeaders[1].getAttribute('colspan')).toBe('2');
+      expect(secondLevelHeaders[0].classList.contains('hiddenHeader')).toBe(true);
+      expect(secondLevel.querySelectorAll('th:not(.hiddenHeader)').length).toBe(2);
+    });
   });
 
   describe('cooperation with drop-down menu element', () => {

--- a/handsontable/src/plugins/nestedHeaders/__tests__/nestedHeaders.types.ts
+++ b/handsontable/src/plugins/nestedHeaders/__tests__/nestedHeaders.types.ts
@@ -2,7 +2,7 @@ import Handsontable from 'handsontable';
 
 const hot = new Handsontable(document.createElement('div'), {
   nestedHeaders: [
-    ['A', { label: 'B', colspan: 8 }, 'C'],
+    [{ label: 'A', rowspan: 2 }, { label: 'B', colspan: 8 }, 'C'],
     ['D', { label: 'E', colspan: 4, headerClassName: 'htLeft test' }, { label: 'F', colspan: 4 }, 'G'],
     ['H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P'],
   ],

--- a/handsontable/src/plugins/nestedHeaders/__tests__/stateManager/matrixGenerator/generateMatrix.unit.js
+++ b/handsontable/src/plugins/nestedHeaders/__tests__/stateManager/matrixGenerator/generateMatrix.unit.js
@@ -171,5 +171,34 @@ describe('generateMatrix', () => {
         ]
       ]);
     });
+
+    it('should apply `rowspan` and replace covered headers with placeholders', () => {
+      const tree = createTree([
+        [{ label: 'A1', rowspan: 2 }, { label: 'B1', colspan: 2 }],
+        ['A2', 'B2', 'C2'],
+      ]);
+
+      tree.buildTree();
+
+      const matrix = generateMatrixFromTree(tree);
+
+      expect(matrix).toEqual([
+        [
+          createColspanSettings({ l: 'A1', rowspan: 2, origRowspan: 2 }),
+          createColspanSettings({ l: 'B1', colspan: 2, origColspan: 2 }),
+          createPlaceholder(),
+        ],
+        [
+          createColspanSettings({
+            colspan: 1,
+            origColspan: 1,
+            isRoot: true,
+            isPlaceholder: true,
+          }),
+          createColspanSettings({ l: 'B2' }),
+          createColspanSettings({ l: 'C2' }),
+        ],
+      ]);
+    });
   });
 });

--- a/handsontable/src/plugins/nestedHeaders/__tests__/stateManager/settingsNormalizer.unit.js
+++ b/handsontable/src/plugins/nestedHeaders/__tests__/stateManager/settingsNormalizer.unit.js
@@ -103,6 +103,26 @@ describe('normalizeSettings', () => {
     ]);
   });
 
+  it('should preserve `rowspan` definitions in normalized settings', () => {
+    const settings = [
+      [{ label: 'A', rowspan: 2 }, { label: 'B', colspan: 2 }],
+      ['A2', 'B2', 'C2'],
+    ];
+
+    expect(normalizeSettings(settings)).toEqual([
+      [
+        createColspanSourceSettings({ l: 'A', rs: 2, ors: 2 }),
+        createColspanSourceSettings({ l: 'B', colspan: 2, origColspan: 2 }),
+        createPlaceholder(),
+      ],
+      [
+        createColspanSourceSettings({ l: 'A2' }),
+        createColspanSourceSettings({ l: 'B2' }),
+        createColspanSourceSettings({ l: 'C2' }),
+      ],
+    ]);
+  });
+
   it('should normalize user-defined settings with limited columns count with colspan structure preservation', () => {
     const settings = [
       ['A', { label: 'B', colspan: 8 }, 'C'],

--- a/handsontable/src/plugins/nestedHeaders/nestedHeaders.js
+++ b/handsontable/src/plugins/nestedHeaders/nestedHeaders.js
@@ -24,11 +24,12 @@ export const PLUGIN_PRIORITY = 280;
  * @class NestedHeaders
  *
  * @description
- * The plugin allows to create a nested header structure, using the HTML's colspan attribute.
+ * The plugin allows to create a nested header structure, using the HTML's `colspan` and `rowspan` attributes.
  *
- * To make any header wider (covering multiple table columns), it's corresponding configuration array element should be
+ * To make any header wider (covering multiple table columns), its corresponding configuration array element should be
  * provided as an object with `label` and `colspan` properties. The `label` property defines the header's label,
  * while the `colspan` property defines a number of columns that the header should cover.
+ * To make any header taller (covering multiple nested header levels), provide an object with the `rowspan` property.
  * You can also set custom class names to any of the headers by providing the `headerClassName` property.
  *
  * __Note__ that the plugin supports a *nested* structure, which means, any header cannot be wider than it's "parent". In
@@ -41,7 +42,7 @@ export const PLUGIN_PRIORITY = 280;
  * const hot = new Handsontable(container, {
  *   data: getData(),
  *   nestedHeaders: [
- *     ['A', {label: 'B', colspan: 8, headerClassName: 'htRight'}, 'C'],
+ *     [{label: 'A', rowspan: 2}, {label: 'B', colspan: 8, headerClassName: 'htRight'}, 'C'],
  *     ['D', {label: 'E', colspan: 4}, {label: 'F', colspan: 4}, 'G'],
  *     ['H', {label: 'I', colspan: 2}, {label: 'J', colspan: 2}, {label: 'K', colspan: 2}, {label: 'L', colspan: 2}, 'M'],
  *     ['N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W']
@@ -54,7 +55,7 @@ export const PLUGIN_PRIORITY = 280;
  * <HotTable
  *   data={getData()}
  *   nestedHeaders={[
- *     ['A', {label: 'B', colspan: 8, headerClassName: 'htRight'}, 'C'],
+ *     [{label: 'A', rowspan: 2}, {label: 'B', colspan: 8, headerClassName: 'htRight'}, 'C'],
  *     ['D', {label: 'E', colspan: 4}, {label: 'F', colspan: 4}, 'G'],
  *     ['H', {label: 'I', colspan: 2}, {label: 'J', colspan: 2}, {label: 'K', colspan: 2}, {label: 'L', colspan: 2}, 'M'],
  *     ['N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W']
@@ -68,7 +69,7 @@ export const PLUGIN_PRIORITY = 280;
  * settings = {
  *   data: getData(),
  *   nestedHeaders: [
- *     ["A", { label: "B", colspan: 8, headerClassName: "htRight" }, "C"],
+ *     [{ label: "A", rowspan: 2 }, { label: "B", colspan: 8, headerClassName: "htRight" }, "C"],
  *     ["D", { label: "E", colspan: 4 }, { label: "F", colspan: 4 }, "G"],
  *     [
  *       "H",
@@ -341,15 +342,18 @@ export class NestedHeaders extends BasePlugin {
 
       for (let j = 0, masterNodes = masterLevel.childNodes.length; j < masterNodes; j++) {
         masterLevel.childNodes[j].removeAttribute('colspan');
+        masterLevel.childNodes[j].removeAttribute('rowspan');
         removeClass(masterLevel.childNodes[j], 'hiddenHeader');
 
         if (topLevel && topLevel.childNodes[j]) {
           topLevel.childNodes[j].removeAttribute('colspan');
+          topLevel.childNodes[j].removeAttribute('rowspan');
           removeClass(topLevel.childNodes[j], 'hiddenHeader');
         }
 
         if (topLeftCornerHeaders && topLeftCornerLevel && topLeftCornerLevel.childNodes[j]) {
           topLeftCornerLevel.childNodes[j].removeAttribute('colspan');
+          topLeftCornerLevel.childNodes[j].removeAttribute('rowspan');
           removeClass(topLeftCornerLevel.childNodes[j], 'hiddenHeader');
         }
       }
@@ -378,11 +382,13 @@ export class NestedHeaders extends BasePlugin {
       }
 
       TH.removeAttribute('colspan');
+      TH.removeAttribute('rowspan');
       removeClass(TH, 'hiddenHeader');
       removeClass(TH, 'hiddenHeaderText');
 
       const {
         colspan,
+        rowspan,
         isHidden,
         isPlaceholder,
         headerClassNames,
@@ -408,6 +414,10 @@ export class NestedHeaders extends BasePlugin {
         if (correctedColspan > 1) {
           TH.setAttribute('colspan', correctedColspan);
         }
+      }
+
+      if (rowspan > 1 && !isPlaceholder && !isHidden) {
+        TH.setAttribute('rowspan', rowspan);
       }
 
       this.hot.view.appendColHeader(

--- a/handsontable/src/plugins/nestedHeaders/stateManager/matrixGenerator.js
+++ b/handsontable/src/plugins/nestedHeaders/stateManager/matrixGenerator.js
@@ -63,7 +63,61 @@ export function generateMatrix(headerRoots) {
     });
   });
 
+  applyRowspans(matrix);
+
   return matrix;
+}
+
+/**
+ * Applies vertical spans to the generated matrix. For every header that uses `rowspan`,
+ * header settings from the covered rows are replaced by placeholder settings.
+ *
+ * @param {Array[]} matrix The matrix with header settings.
+ */
+function applyRowspans(matrix) {
+  const layersCount = matrix.length;
+
+  for (let headerLevel = 0; headerLevel < layersCount; headerLevel++) {
+    const headerLayer = matrix[headerLevel];
+
+    for (let columnIndex = 0; columnIndex < headerLayer.length; columnIndex++) {
+      const headerSettings = headerLayer[columnIndex];
+
+      if (!headerSettings || headerSettings.isPlaceholder || !headerSettings.isRoot) {
+        continue;
+      }
+
+      const correctedRowspan = Math.min(headerSettings.origRowspan ?? 1, layersCount - headerLevel);
+
+      headerSettings.rowspan = correctedRowspan;
+      headerSettings.origRowspan = correctedRowspan;
+
+      if (correctedRowspan <= 1) {
+        continue;
+      }
+
+      for (let nextHeaderLevel = headerLevel + 1; nextHeaderLevel < headerLevel + correctedRowspan; nextHeaderLevel++) {
+        const nextHeaderLayer = matrix[nextHeaderLevel];
+        const endingColumnIndex = columnIndex + headerSettings.origColspan;
+
+        for (let nextColumnIndex = columnIndex; nextColumnIndex < endingColumnIndex; nextColumnIndex++) {
+          if (nextColumnIndex === columnIndex) {
+            const placeholderRootSettings = createHeaderSettings({
+              colspan: headerSettings.origColspan,
+              origColspan: headerSettings.origColspan,
+              isRoot: true,
+              isPlaceholder: true,
+            });
+            placeholderRootSettings.isRoot = true;
+            placeholderRootSettings.isPlaceholder = true;
+            nextHeaderLayer[nextColumnIndex] = placeholderRootSettings;
+          } else {
+            nextHeaderLayer[nextColumnIndex] = createPlaceholderHeaderSettings();
+          }
+        }
+      }
+    }
+  }
 }
 
 /**

--- a/handsontable/src/plugins/nestedHeaders/stateManager/matrixGenerator.js
+++ b/handsontable/src/plugins/nestedHeaders/stateManager/matrixGenerator.js
@@ -108,6 +108,7 @@ function applyRowspans(matrix) {
               isRoot: true,
               isPlaceholder: true,
             });
+
             placeholderRootSettings.isRoot = true;
             placeholderRootSettings.isPlaceholder = true;
             nextHeaderLayer[nextColumnIndex] = placeholderRootSettings;

--- a/handsontable/src/plugins/nestedHeaders/stateManager/settingsNormalizer.js
+++ b/handsontable/src/plugins/nestedHeaders/stateManager/settingsNormalizer.js
@@ -61,7 +61,7 @@ export function normalizeSettings(sourceSettings, columnsLimit = Infinity) {
 
       if (isObject(sourceHeaderSettings)) {
         const {
-          label, colspan, headerClassName
+          label, colspan, rowspan, headerClassName
         } = sourceHeaderSettings;
 
         headerSettings.label = stringify(label);
@@ -69,6 +69,11 @@ export function normalizeSettings(sourceSettings, columnsLimit = Infinity) {
         if (typeof colspan === 'number' && colspan > 1) {
           headerSettings.colspan = colspan;
           headerSettings.origColspan = colspan;
+        }
+
+        if (typeof rowspan === 'number' && rowspan > 1) {
+          headerSettings.rowspan = rowspan;
+          headerSettings.origRowspan = rowspan;
         }
 
         if (typeof headerClassName === 'string') {

--- a/handsontable/src/plugins/nestedHeaders/stateManager/utils.js
+++ b/handsontable/src/plugins/nestedHeaders/stateManager/utils.js
@@ -3,6 +3,8 @@
  * @property {string} label The name/label of the column header.
  * @property {number} colspan Current calculated colspan value of the rendered column header element.
  * @property {number} origColspan Original colspan value, set once while parsing user-defined nested header settings.
+ * @property {number} rowspan Current calculated rowspan value of the rendered column header element.
+ * @property {number} origRowspan Original rowspan value, set once while parsing user-defined nested header settings.
  * @property {boolean} collapsible The flag determines whether the node is collapsible (can be collapsed/expanded).
  * @property {number[]} crossHiddenColumns The list of visual column indexes which indicates that the specified columns within
  *                                         the header settings are hidden.
@@ -28,6 +30,8 @@ export function createDefaultHeaderSettings({
   label = '',
   colspan = 1,
   origColspan = 1,
+  rowspan = 1,
+  origRowspan = 1,
   collapsible = false,
   crossHiddenColumns = [],
   isCollapsed = false,
@@ -40,6 +44,8 @@ export function createDefaultHeaderSettings({
     label,
     colspan,
     origColspan,
+    rowspan,
+    origRowspan,
     collapsible,
     isCollapsed,
     crossHiddenColumns,

--- a/handsontable/src/plugins/nestedHeaders/utils/ghostTable.js
+++ b/handsontable/src/plugins/nestedHeaders/utils/ghostTable.js
@@ -90,16 +90,29 @@ class GhostTable {
     this._buildGhostTable(this.container);
     this.hot.rootDocument.body.appendChild(this.container);
 
-    const columns = this.container.querySelectorAll('tr:last-of-type th');
-    const maxColumns = columns.length;
+    const columns = this.container.querySelectorAll('th[data-colspan="1"]');
 
     this.widthsMap.clear();
 
-    for (let column = 0; column < maxColumns; column++) {
-      const visualColumnsIndex = this.hot.columnIndexMapper.getVisualFromRenderableIndex(column);
+    for (let column = 0; column < columns.length; column++) {
+      const visualColumnsIndex = Number(columns[column].getAttribute('data-visual-column'));
+
+      if (Number.isInteger(visualColumnsIndex) === false) {
+        continue;
+      }
+
       const physicalColumnIndex = this.hot.toPhysicalColumn(visualColumnsIndex);
 
-      this.widthsMap.setValueAtIndex(physicalColumnIndex, columns[column].offsetWidth);
+      if (physicalColumnIndex === null) {
+        continue;
+      }
+
+      const currentColumnWidth = this.widthsMap.getValueAtIndex(physicalColumnIndex) ?? 0;
+      const nextColumnWidth = columns[column].offsetWidth;
+
+      if (nextColumnWidth > currentColumnWidth) {
+        this.widthsMap.setValueAtIndex(physicalColumnIndex, nextColumnWidth);
+      }
     }
 
     this.container.parentNode.removeChild(this.container);
@@ -147,6 +160,8 @@ class GhostTable {
 
           fastInnerHTML(th, label, this.hot.getSettings().sanitizer);
           th.colSpan = headerSettings.colspan;
+          th.setAttribute('data-colspan', headerSettings.colspan);
+          th.setAttribute('data-visual-column', visualColumnsIndex);
           tr.appendChild(th);
         }
       }

--- a/handsontable/test/e2e/settings/nestedHeadersRowspan.spec.js
+++ b/handsontable/test/e2e/settings/nestedHeadersRowspan.spec.js
@@ -1,0 +1,33 @@
+describe('settings', () => {
+  describe('nestedHeaders with rowspan', () => {
+    const id = 'testContainer';
+
+    beforeEach(function() {
+      this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+    });
+
+    afterEach(function() {
+      if (this.$container) {
+        destroy();
+        this.$container.remove();
+      }
+    });
+
+    it('should render header `rowspan` and hide covered headers', async() => {
+      handsontable({
+        data: createSpreadsheetData(3, 3),
+        colHeaders: true,
+        nestedHeaders: [
+          [{ label: 'A', rowspan: 2 }, { label: 'B', colspan: 2 }],
+          ['A2', 'B2', 'C2'],
+        ],
+      });
+
+      expect(getCell(-2, 0).getAttribute('rowspan')).toBe('2');
+      expect(getCell(-2, 1).getAttribute('colspan')).toBe('2');
+      expect(getCell(-1, 0)).toHaveClass('hiddenHeader');
+      expect(getCell(-1, 1)).not.toHaveClass('hiddenHeader');
+      expect(getCell(-1, 2)).not.toHaveClass('hiddenHeader');
+    });
+  });
+});

--- a/handsontable/types/plugins/nestedHeaders/nestedHeaders.d.ts
+++ b/handsontable/types/plugins/nestedHeaders/nestedHeaders.d.ts
@@ -3,7 +3,8 @@ import { BasePlugin } from '../base';
 
 export interface DetailedSettings {
   label: string;
-  colspan: number;
+  colspan?: number;
+  rowspan?: number;
   headerClassName?: string;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Context
This change introduces `rowspan` support for nested headers, addressing issue #191. It allows for more flexible and complex header layouts by enabling headers to span multiple rows.

### How has this been tested?
- Unit tests: `pnpm --filter handsontable run test:unit --testPathPattern="src/plugins/nestedHeaders"`
- E2E tests: `npm_config_testPathPattern="nestedHeadersRowspan" pnpm --filter handsontable run test:e2e.dump && pnpm --filter handsontable run test:e2e.puppeteer`
- Type checks: `pnpm --filter handsontable run test:types`

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #191

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

<div><a href="https://cursor.com/agents/bc-07892a28-2973-4fc1-8248-14daed3c3281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07892a28-2973-4fc1-8248-14daed3c3281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->