### PR TITLE
Handsontable cell is focusing, when focus in another input 

### DIFF
--- a/.changelogs/12131.json
+++ b/.changelogs/12131.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed a bug where Handsontable stole focus from external inputs when `outsideClickDeselects` was set to `false` and focus moved programmatically.",
+  "type": "fixed",
+  "issueOrPR": 401,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/tableView.js
+++ b/handsontable/src/tableView.js
@@ -358,7 +358,8 @@ class TableView {
     });
 
     this.eventManager.addEventListener(documentElement, 'focusin', (event) => {
-      if (isOutsideInput(event.target)) {
+      if (isOutsideInput(event.target) &&
+          !(rootWrapperElement ?? rootElement).contains(event.target)) {
         this.hot.unlisten();
       }
     });

--- a/handsontable/src/tableView.js
+++ b/handsontable/src/tableView.js
@@ -357,6 +357,12 @@ class TableView {
       }
     });
 
+    this.eventManager.addEventListener(documentElement, 'focusin', (event) => {
+      if (isOutsideInput(event.target)) {
+        this.hot.unlisten();
+      }
+    });
+
     this.eventManager.addEventListener(documentElement, 'contextmenu', (event) => {
       if (selection.isInProgress() && isRightClick(event)) {
         selection.finish();

--- a/handsontable/test/e2e/settings/outsideClickDeselects.spec.js
+++ b/handsontable/test/e2e/settings/outsideClickDeselects.spec.js
@@ -257,7 +257,7 @@ describe('settings', () => {
       textarea.remove();
     });
 
-    xit('should allow to type in external input after opening cell editor', async() => {
+    it('should allow to type in external input after opening cell editor', async() => {
       const textarea = $('<textarea></textarea>').prependTo($('body'));
       let keyPressed;
 
@@ -337,6 +337,115 @@ describe('settings', () => {
       expect(getDataAtCell(0, 0)).toEqual('Foo');
 
       textarea.remove();
+    });
+
+    it('should stop listening when focus moves programmatically to an external input (outsideClickDeselects: false)', async() => {
+      const input = $('<input type="text">').prependTo($('body'));
+
+      handsontable({
+        outsideClickDeselects: false,
+        data: createSpreadsheetData(5, 5),
+      });
+
+      await selectCell(0, 0);
+
+      expect(isListening()).toBe(true);
+
+      input[0].focus();
+
+      expect(isListening()).toBe(false);
+      expect(document.activeElement).toBe(input[0]);
+      expect(getSelected()).toEqual([[0, 0, 0, 0]]);
+
+      input.remove();
+    });
+
+    it('should not open the cell editor when typing in a programmatically focused external input (outsideClickDeselects: false)', async() => {
+      const input = $('<input type="text">').prependTo($('body'));
+
+      handsontable({
+        outsideClickDeselects: false,
+        data: createSpreadsheetData(5, 5),
+      });
+
+      await selectCell(0, 0);
+
+      input[0].focus();
+
+      await keyDownUp('a');
+      await keyDownUp('b');
+
+      expect(document.activeElement).toBe(input[0]);
+      expect(getSelected()).toEqual([[0, 0, 0, 0]]);
+      expect(getDataAtCell(0, 0)).toBe('A1');
+
+      input.remove();
+    });
+
+    it('should not open the cell editor when typing in a programmatically focused external textarea (outsideClickDeselects: false)', async() => {
+      const textarea = $('<textarea></textarea>').prependTo($('body'));
+
+      handsontable({
+        outsideClickDeselects: false,
+        data: createSpreadsheetData(5, 5),
+      });
+
+      await selectCell(0, 0);
+
+      textarea[0].focus();
+
+      await keyDownUp('a');
+      await keyDownUp('b');
+
+      expect(document.activeElement).toBe(textarea[0]);
+      expect(getSelected()).toEqual([[0, 0, 0, 0]]);
+      expect(getDataAtCell(0, 0)).toBe('A1');
+
+      textarea.remove();
+    });
+
+    it('should not open the cell editor when typing in a programmatically focused external input (outsideClickDeselects as function)', async() => {
+      const input = $('<input type="text">').prependTo($('body'));
+
+      handsontable({
+        outsideClickDeselects: () => false,
+        data: createSpreadsheetData(5, 5),
+      });
+
+      await selectCell(0, 0);
+
+      input[0].focus();
+
+      await keyDownUp('a');
+      await keyDownUp('b');
+
+      expect(document.activeElement).toBe(input[0]);
+      expect(getSelected()).toEqual([[0, 0, 0, 0]]);
+      expect(getDataAtCell(0, 0)).toBe('A1');
+
+      input.remove();
+    });
+
+    it('should resume listening when focus returns to the grid after being on an external input', async() => {
+      const input = $('<input type="text">').prependTo($('body'));
+
+      handsontable({
+        outsideClickDeselects: false,
+        data: createSpreadsheetData(5, 5),
+      });
+
+      await selectCell(0, 0);
+
+      input[0].focus();
+
+      expect(isListening()).toBe(false);
+
+      await selectCell(1, 1);
+
+      expect(isListening()).toBe(true);
+      expect(getSelected()).toEqual([[1, 1, 1, 1]]);
+
+      input.remove();
     });
 
     it('should not re-render all the rows when outsideClickDeselects is set as false and the user toggles the visibility' +


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Context
This change addresses bug https://github.com/handsontable/handsontable/issues/401. When `outsideClickDeselects: false` is set, and focus moves to an external input via Tab or programmatic `.focus()`, `unlisten()` was not called. This caused the Handsontable instance to remain "listening" and process keyboard events, leading to the editor opening and stealing focus from the external input.

The fix adds a `focusin` event listener on `documentElement` in `tableView.js`. This listener calls `unlisten()` when focus moves to an external input (not marked with `data-hot-input`), mirroring the existing `mouseup` handler behavior but covering programmatic and Tab-based focus changes.

### How has this been tested?
- Re-enabled a previously disabled E2E test (`xit` -> `it`) in `outsideClickDeselects.spec.js`.
- Added 5 new E2E tests covering programmatic focus with `outsideClickDeselects: false` (boolean and function variants), verifying `isListening()` state, and verifying focus resume when returning to the grid.
- Ran comprehensive E2E tests for `outsideClickDeselects`, `enterMoves`, `tabMoves`, `textEditor`, and `listen` related specs.
- Ran unit tests for `element` helpers.
- Performed a manual GUI test with a video demonstration to confirm the fix end-to-end.
- Confirmed pre-existing `ScopeManager` test failures are unrelated to this change.
- Ran ESLint checks.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/401

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<div><a href="https://cursor.com/agents/bc-719c3705-f501-476f-b5d6-c1426b07b8f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-719c3705-f501-476f-b5d6-c1426b07b8f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->