### PR TITLE
Dataprovider initial fetch

### DIFF
--- a/.changelogs/12134.json
+++ b/.changelogs/12134.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Added the experimental `dataProvider` option for loading initial grid data from a function.",
+  "type": "added",
+  "issueOrPR": 12134,
+  "breaking": false,
+  "framework": "none"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -516,6 +516,34 @@ Follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format. See `.c
 
 ---
 
+## dataProvider (experimental)
+
+The `dataProvider` option lets users supply a function that returns data instead of a static `data` array. The function receives a request object `{ type: 'all' }` and can return data synchronously (an array) or asynchronously (a `Promise` that resolves to an array).
+
+### Key rules
+
+- `dataProvider` is defined in `metaSchema.js` as a grid-level option (`undefined` by default).
+- When both `data` and `dataProvider` are set, `dataProvider` takes precedence.
+- Integration lives in `core.js` inside `updateSettings()`, in the data loading section.
+- Synchronous return values are passed directly to `loadData`/`updateData`.
+- Asynchronous return values (thenables) cause the grid to initialize empty; when the `Promise` resolves, `loadData` is called with source `'dataProvider'`.
+- The `dataProvider` key is skipped in the `updateSettings` settings loop (alongside `data` and `language`) and handled in the data loading block.
+- TypeScript type: `(request: { type: string }) => CellValue[][] | RowObject[] | Promise<CellValue[][] | RowObject[]>`.
+- `ColumnSettings` excludes `dataProvider` (grid-level only).
+
+### File locations
+
+| Area | Path |
+|---|---|
+| Option definition (JSDoc) | `handsontable/src/dataMap/metaManager/metaSchema.js` |
+| Core integration | `handsontable/src/core.js` (inside `updateSettings`) |
+| TypeScript types | `handsontable/types/settings.d.ts` |
+| Unit tests | `handsontable/src/dataMap/__tests__/dataProvider.unit.js` |
+| E2E tests | `handsontable/test/e2e/settings/dataProvider.spec.js` |
+| Type tests | `handsontable/src/dataMap/__tests__/dataProvider.types.ts` |
+
+---
+
 ## Dependency management
 
 - **Discuss with the team before adding any third-party dependency.**

--- a/handsontable/src/__tests__/core/settings.types.ts
+++ b/handsontable/src/__tests__/core/settings.types.ts
@@ -117,6 +117,7 @@ const allSettings: Required<Handsontable.GridSettings> = {
   currentRowClassName: 'foo',
   customBorders: true,
   data: oneOf([{}, {}, {}], [[], [], []]),
+  dataProvider: (request: { type: string }) => oneOf([['a']], [{ id: 1 }], Promise.resolve([['a']])),
   dataDotNotation: oneOf(true),
   dataSchema: oneOf({}, [[]], (index: number) => oneOf([index], { index })),
   dateFormat: 'foo',

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -2782,8 +2782,8 @@ export default function Core(rootContainer, userSettings, rootInstanceSymbol = f
 
     // eslint-disable-next-line no-restricted-syntax
     for (i in settings) {
-      if (i === 'data' || i === 'language') {
-        // Do nothing. loadData and language change will be triggered later
+      if (i === 'data' || i === 'language' || i === 'dataProvider') {
+        // Do nothing. loadData, language change, and dataProvider will be triggered later
 
       } else if (i === 'className') {
         setClassName('className', settings.className);
@@ -2886,7 +2886,30 @@ export default function Core(rootContainer, userSettings, rootInstanceSymbol = f
     }
 
     // Load data or create data map
-    if (settings.data === undefined && tableMeta.data === undefined) {
+    const hasDataProvider = settings.dataProvider !== undefined
+      ? isFunction(settings.dataProvider)
+      : isFunction(tableMeta.dataProvider);
+
+    if (hasDataProvider) {
+      const provider = settings.dataProvider ?? tableMeta.dataProvider;
+
+      if (settings.dataProvider !== undefined) {
+        globalMeta.dataProvider = settings.dataProvider;
+      }
+
+      const result = provider({ type: 'all' });
+
+      if (result !== null && result !== undefined && isFunction(result.then)) {
+        dataUpdateFunction(null, 'updateSettings');
+
+        result.then((resolvedData) => {
+          instance.loadData(resolvedData, 'dataProvider');
+        });
+      } else {
+        dataUpdateFunction(result, 'updateSettings');
+      }
+
+    } else if (settings.data === undefined && tableMeta.data === undefined) {
       dataUpdateFunction(null, 'updateSettings'); // data source created just now
 
     } else if (settings.data !== undefined) {

--- a/handsontable/src/dataMap/__tests__/dataProvider.types.ts
+++ b/handsontable/src/dataMap/__tests__/dataProvider.types.ts
@@ -1,0 +1,43 @@
+import Handsontable from 'handsontable';
+
+// Synchronous dataProvider returning array of arrays.
+new Handsontable(document.createElement('div'), {
+  dataProvider(request: { type: string }) {
+    return [
+      ['A1', 'B1'],
+      ['A2', 'B2'],
+    ];
+  },
+});
+
+// Synchronous dataProvider returning array of objects.
+new Handsontable(document.createElement('div'), {
+  dataProvider(request: { type: string }) {
+    return [
+      { id: 1, name: 'Alice' },
+      { id: 2, name: 'Bob' },
+    ];
+  },
+});
+
+// Asynchronous dataProvider returning a Promise.
+new Handsontable(document.createElement('div'), {
+  dataProvider(request: { type: string }) {
+    return Promise.resolve([
+      ['A1', 'B1'],
+      ['A2', 'B2'],
+    ]);
+  },
+});
+
+// dataProvider alongside other options.
+new Handsontable(document.createElement('div'), {
+  dataProvider(request: { type: string }) {
+    return [['A1']];
+  },
+  colHeaders: true,
+  rowHeaders: true,
+});
+
+// dataProvider is optional.
+new Handsontable(document.createElement('div'), {});

--- a/handsontable/src/dataMap/__tests__/dataProvider.unit.js
+++ b/handsontable/src/dataMap/__tests__/dataProvider.unit.js
@@ -1,0 +1,18 @@
+import metaSchemaFactory from '../metaManager/metaSchema';
+
+describe('dataProvider option', () => {
+  it('should be defined in the meta schema with a default value of `undefined`', () => {
+    const schema = metaSchemaFactory();
+
+    expect(schema.dataProvider).toBeUndefined();
+  });
+
+  it('should accept a function value', () => {
+    const schema = metaSchemaFactory();
+    const provider = () => [];
+
+    schema.dataProvider = provider;
+
+    expect(schema.dataProvider).toBe(provider);
+  });
+});

--- a/handsontable/src/dataMap/metaManager/metaSchema.js
+++ b/handsontable/src/dataMap/metaManager/metaSchema.js
@@ -1603,6 +1603,45 @@ export default () => {
 
     /**
      * @description
+     * The `dataProvider` option lets you load data into Handsontable from a function.
+     *
+     * Set `dataProvider` to a function that receives a request object and returns
+     * an [array of arrays](@/guides/getting-started/binding-to-data/binding-to-data.md#array-of-arrays),
+     * an [array of objects](@/guides/getting-started/binding-to-data/binding-to-data.md#array-of-objects),
+     * or a `Promise` that resolves to one of those types.
+     *
+     * On initialization, Handsontable calls `dataProvider` with `{ type: 'all' }`.
+     * If the function returns a `Promise`, the grid renders empty first
+     * and loads the resolved data when the `Promise` settles.
+     *
+     * When both [`data`](#data) and `dataProvider` are set, `dataProvider` takes precedence.
+     *
+     * @experimental
+     * @memberof Options#
+     * @type {Function}
+     * @default undefined
+     * @category Core
+     *
+     * @example
+     * ```js
+     * // synchronous data provider
+     * dataProvider(request) {
+     *   return [
+     *     ['A1', 'B1'],
+     *     ['A2', 'B2'],
+     *   ];
+     * },
+     *
+     * // asynchronous data provider
+     * dataProvider(request) {
+     *   return fetch('/api/data').then(response => response.json());
+     * },
+     * ```
+     */
+    dataProvider: undefined,
+
+    /**
+     * @description
      * If `true`, Handsontable will interpret the dots in the columns mapping as a nested object path. If your dataset contains
      * the dots in the object keys and you don't want Handsontable to interpret them as a nested object path, set this option to `false`.
      *

--- a/handsontable/test/e2e/settings/dataProvider.spec.js
+++ b/handsontable/test/e2e/settings/dataProvider.spec.js
@@ -1,0 +1,266 @@
+describe('settings', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  describe('dataProvider', () => {
+    it('should be `undefined` by default', async() => {
+      handsontable({
+        data: createSpreadsheetData(3, 3),
+      });
+
+      expect(getSettings().dataProvider).toBeUndefined();
+    });
+
+    it('should render data returned synchronously from the dataProvider function', async() => {
+      handsontable({
+        dataProvider() {
+          return [
+            ['A1', 'B1', 'C1'],
+            ['A2', 'B2', 'C2'],
+            ['A3', 'B3', 'C3'],
+          ];
+        },
+      });
+
+      expect(countRows()).toBe(3);
+      expect(countCols()).toBe(3);
+      expect(getDataAtCell(0, 0)).toBe('A1');
+      expect(getDataAtCell(1, 1)).toBe('B2');
+      expect(getDataAtCell(2, 2)).toBe('C3');
+    });
+
+    it('should render data returned asynchronously from the dataProvider function', async() => {
+      const data = [
+        ['A1', 'B1', 'C1'],
+        ['A2', 'B2', 'C2'],
+      ];
+
+      handsontable({
+        dataProvider() {
+          return new Promise((resolve) => {
+            setTimeout(() => resolve(data), 50);
+          });
+        },
+      });
+
+      // Initially the grid is empty.
+      expect(countRows()).toBe(5);
+      expect(getDataAtCell(0, 0)).toBeNull();
+
+      await sleep(200);
+
+      expect(countRows()).toBe(2);
+      expect(countCols()).toBe(3);
+      expect(getDataAtCell(0, 0)).toBe('A1');
+      expect(getDataAtCell(1, 2)).toBe('C2');
+    });
+
+    it('should call the dataProvider function with a request object containing type "all"', async() => {
+      const providerSpy = jasmine.createSpy('dataProvider').and.returnValue(
+        createSpreadsheetData(2, 2)
+      );
+
+      handsontable({
+        dataProvider: providerSpy,
+      });
+
+      expect(providerSpy).toHaveBeenCalledTimes(1);
+      expect(providerSpy).toHaveBeenCalledWith({ type: 'all' });
+    });
+
+    it('should take precedence over the `data` option', async() => {
+      handsontable({
+        data: [
+          ['X1', 'X2'],
+        ],
+        dataProvider() {
+          return [
+            ['A1', 'B1'],
+            ['A2', 'B2'],
+          ];
+        },
+      });
+
+      expect(countRows()).toBe(2);
+      expect(getDataAtCell(0, 0)).toBe('A1');
+      expect(getDataAtCell(1, 1)).toBe('B2');
+    });
+
+    it('should support array of objects as data source', async() => {
+      handsontable({
+        dataProvider() {
+          return [
+            { id: 1, name: 'Alice' },
+            { id: 2, name: 'Bob' },
+          ];
+        },
+        columns: [
+          { data: 'id' },
+          { data: 'name' },
+        ],
+      });
+
+      expect(countRows()).toBe(2);
+      expect(getDataAtCell(0, 0)).toBe(1);
+      expect(getDataAtCell(0, 1)).toBe('Alice');
+      expect(getDataAtCell(1, 0)).toBe(2);
+      expect(getDataAtCell(1, 1)).toBe('Bob');
+    });
+
+    it('should fire `beforeLoadData` and `afterLoadData` hooks with synchronous provider', async() => {
+      const beforeLoadDataSpy = jasmine.createSpy('beforeLoadData');
+      const afterLoadDataSpy = jasmine.createSpy('afterLoadData');
+
+      handsontable({
+        dataProvider() {
+          return createSpreadsheetData(2, 2);
+        },
+        beforeLoadData: beforeLoadDataSpy,
+        afterLoadData: afterLoadDataSpy,
+      });
+
+      expect(beforeLoadDataSpy).toHaveBeenCalled();
+      expect(afterLoadDataSpy).toHaveBeenCalled();
+    });
+
+    it('should fire `beforeLoadData` and `afterLoadData` hooks with async provider', async() => {
+      const afterLoadDataCalls = [];
+
+      handsontable({
+        dataProvider() {
+          return new Promise((resolve) => {
+            setTimeout(() => resolve(createSpreadsheetData(2, 2)), 50);
+          });
+        },
+        afterLoadData(data, initialLoad, source) {
+          afterLoadDataCalls.push({ data, initialLoad, source });
+        },
+      });
+
+      await sleep(200);
+
+      const dataProviderCall = afterLoadDataCalls.find(call => call.source === 'dataProvider');
+
+      expect(dataProviderCall).toBeDefined();
+      expect(dataProviderCall.data.length).toBe(2);
+    });
+
+    it('should update data when `dataProvider` is changed via `updateSettings`', async() => {
+      handsontable({
+        dataProvider() {
+          return createSpreadsheetData(2, 2);
+        },
+      });
+
+      expect(countRows()).toBe(2);
+      expect(getDataAtCell(0, 0)).toBe('A1');
+
+      await updateSettings({
+        dataProvider() {
+          return [
+            ['X1', 'Y1', 'Z1'],
+            ['X2', 'Y2', 'Z2'],
+            ['X3', 'Y3', 'Z3'],
+          ];
+        },
+      });
+
+      expect(countRows()).toBe(3);
+      expect(countCols()).toBe(3);
+      expect(getDataAtCell(0, 0)).toBe('X1');
+      expect(getDataAtCell(2, 2)).toBe('Z3');
+    });
+
+    it('should update data when async `dataProvider` is changed via `updateSettings`', async() => {
+      handsontable({
+        dataProvider() {
+          return createSpreadsheetData(2, 2);
+        },
+      });
+
+      expect(countRows()).toBe(2);
+
+      await updateSettings({
+        dataProvider() {
+          return new Promise((resolve) => {
+            setTimeout(() => resolve([
+              ['X1', 'Y1'],
+              ['X2', 'Y2'],
+              ['X3', 'Y3'],
+              ['X4', 'Y4'],
+            ]), 50);
+          });
+        },
+      });
+
+      await sleep(200);
+
+      expect(countRows()).toBe(4);
+      expect(getDataAtCell(0, 0)).toBe('X1');
+      expect(getDataAtCell(3, 1)).toBe('Y4');
+    });
+
+    it('should render an empty grid when the synchronous provider returns `null`', async() => {
+      handsontable({
+        dataProvider() {
+          return null;
+        },
+      });
+
+      expect(countRows()).toBe(5);
+      expect(countCols()).toBe(5);
+      expect(getDataAtCell(0, 0)).toBeNull();
+    });
+
+    it('should work with `colHeaders` option', async() => {
+      handsontable({
+        dataProvider() {
+          return createSpreadsheetData(3, 3);
+        },
+        colHeaders: true,
+      });
+
+      expect(countRows()).toBe(3);
+      expect(countCols()).toBe(3);
+      expect(getColHeader(0)).toBe('A');
+      expect(getDataAtCell(0, 0)).toBe('A1');
+    });
+
+    it('should work with `rowHeaders` option', async() => {
+      handsontable({
+        dataProvider() {
+          return createSpreadsheetData(3, 3);
+        },
+        rowHeaders: true,
+      });
+
+      expect(countRows()).toBe(3);
+      expect(getCell(0, -1).textContent).toBe('1');
+      expect(getDataAtCell(0, 0)).toBe('A1');
+    });
+
+    it('should be callable only once during initialization', async() => {
+      let callCount = 0;
+
+      handsontable({
+        dataProvider() {
+          callCount += 1;
+
+          return createSpreadsheetData(2, 2);
+        },
+      });
+
+      expect(callCount).toBe(1);
+    });
+  });
+});

--- a/handsontable/types/settings.d.ts
+++ b/handsontable/types/settings.d.ts
@@ -84,7 +84,7 @@ export type Omit<T, K extends keyof T> = Pick<T, ({ [P in keyof T]: P } & { [P i
 /**
  * Column settings inherit grid settings but overload the meaning of `data` to be specific to each column.
  */
-export interface ColumnSettings extends Omit<GridSettings, "data"> {
+export interface ColumnSettings extends Omit<GridSettings, "data" | "dataProvider"> {
   data?: string | number | ColumnDataGetterSetterFunction;
   /**
    * Column and cell meta data is extensible, developers can add any properties they want.
@@ -137,6 +137,7 @@ export interface GridSettings extends Events {
   currentRowClassName?: string;
   customBorders?: CustomBordersSettings;
   data?: CellValue[][] | RowObject[];
+  dataProvider?: (request: { type: string }) => CellValue[][] | RowObject[] | Promise<CellValue[][] | RowObject[]>;
   dataDotNotation?: boolean;
   dataSchema?: RowObject | CellValue[] | ((row: number) => RowObject | CellValue[]);
   dateFormat?: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Context
This PR introduces the `dataProvider` option, allowing Handsontable to fetch initial grid data from a function instead of a static array. This enables dynamic data loading, supporting both synchronous and asynchronous (Promise-based) data retrieval. It provides a flexible alternative to the existing `data` option for initial data population.

### How has this been tested?
*   **Unit Tests**: New unit tests (`dataProvider.unit.js`) cover metaSchema default values. All 2234 existing unit tests passed.
*   **E2E Tests**: A comprehensive suite of 13 new E2E tests (`dataProvider.spec.js`) covers synchronous and asynchronous data fetching, precedence over the `data` option, array-of-objects data, integration with hooks, `updateSettings` behavior, null returns, header handling, and single-call guarantees. All 8719 existing E2E specs passed, with 2 unrelated, pre-existing failures in `MultiSelectEditor`.
*   **Type Tests**: New type tests (`dataProvider.types.ts`) and updates to `settings.types.ts` ensure correct TypeScript definitions for `dataProvider`. All type checks passed.
*   **Linting**: ESLint checks passed without errors.
*   No manual GUI testing was performed as the feature is fully covered by automated E2E tests.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

<div><a href="https://cursor.com/agents/bc-12cfbcc6-d846-4760-9161-9a7246e1a1a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12cfbcc6-d846-4760-9161-9a7246e1a1a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->