### PR TITLE
Column headers function rendering

### DIFF
--- a/.changelogs/534.json
+++ b/.changelogs/534.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "dev-handsontable",
+  "title": "Fixed vertical keyboard scrolling after updateSettings when preventOverflow is enabled.",
+  "type": "fixed",
+  "issueOrPR": 534,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/534.json
+++ b/.changelogs/534.json
@@ -1,5 +1,5 @@
 {
-  "issuesOrigin": "dev-handsontable",
+  "issuesOrigin": "private",
   "title": "Fixed vertical keyboard scrolling after updateSettings when preventOverflow is enabled.",
   "type": "fixed",
   "issueOrPR": 534,

--- a/handsontable/src/3rdparty/walkontable/src/overlay/__tests__/_base.unit.js
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/__tests__/_base.unit.js
@@ -1,0 +1,74 @@
+import { Overlay } from '../_base';
+import { CLONE_INLINE_START, CLONE_TOP } from '../constants';
+
+function createOverlayMock({ type, preventOverflow, overflow = 'clip' }) {
+  const rootWindow = {
+    getComputedStyle() {
+      return {
+        getPropertyValue() {
+          return overflow;
+        },
+      };
+    },
+  };
+  const holder = {};
+  const TABLE = {};
+  const wtRootElement = { parentNode: {} };
+  const overlay = Object.create(Overlay.prototype);
+
+  overlay.type = type;
+  overlay.wot = {
+    wtTable: {
+      holder,
+      TABLE,
+      wtRootElement,
+    },
+  };
+  overlay.domBindings = { rootWindow };
+  overlay.wtSettings = {
+    getSetting(settingName) {
+      if (settingName === 'preventOverflow') {
+        return preventOverflow;
+      }
+    },
+  };
+
+  return { overlay, holder, rootWindow };
+}
+
+describe('Overlay', () => {
+  describe('updateMainScrollableElement', () => {
+    it('should keep `window` as the main scrollable element for the top overlay when `preventOverflow` is set to `horizontal`', () => {
+      const { overlay, rootWindow } = createOverlayMock({
+        type: CLONE_TOP,
+        preventOverflow: 'horizontal',
+      });
+
+      overlay.updateMainScrollableElement();
+
+      expect(overlay.mainTableScrollableElement).toBe(rootWindow);
+    });
+
+    it('should keep `window` as the main scrollable element for the inline-start overlay when `preventOverflow` is set to `vertical`', () => {
+      const { overlay, rootWindow } = createOverlayMock({
+        type: CLONE_INLINE_START,
+        preventOverflow: 'vertical',
+      });
+
+      overlay.updateMainScrollableElement();
+
+      expect(overlay.mainTableScrollableElement).toBe(rootWindow);
+    });
+
+    it('should keep holder as the main scrollable element for the top overlay when `preventOverflow` is set to `vertical`', () => {
+      const { overlay, holder } = createOverlayMock({
+        type: CLONE_TOP,
+        preventOverflow: 'vertical',
+      });
+
+      overlay.updateMainScrollableElement();
+
+      expect(overlay.mainTableScrollableElement).toBe(holder);
+    });
+  });
+});

--- a/handsontable/src/3rdparty/walkontable/src/overlay/_base.js
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/_base.js
@@ -119,16 +119,34 @@ export class Overlay {
    * Update the main scrollable element.
    */
   updateMainScrollableElement() {
+    this.mainTableScrollableElement = this.getMainTableScrollableElement();
+  }
+
+  /**
+   * Resolve the main table scrollable element for the current overlay.
+   *
+   * @returns {HTMLElement|Window}
+   */
+  getMainTableScrollableElement() {
     const { wtTable } = this.wot;
     const { rootWindow } = this.domBindings;
-    const computedOverflow = rootWindow.getComputedStyle(wtTable.wtRootElement.parentNode)
-      .getPropertyValue('overflow');
+    const tableParent = wtTable.wtRootElement.parentNode;
+    const preventOverflow = this.wtSettings.getSetting('preventOverflow');
+    const computedOverflow = rootWindow.getComputedStyle(tableParent).getPropertyValue('overflow');
+
+    if (
+      preventOverflow === true ||
+      (preventOverflow === 'horizontal' && this.type === CLONE_TOP) ||
+      (preventOverflow === 'vertical' && this.type === CLONE_INLINE_START)
+    ) {
+      return rootWindow;
+    }
 
     if (computedOverflow === 'hidden' || computedOverflow === 'clip') {
-      this.mainTableScrollableElement = this.wot.wtTable.holder;
-    } else {
-      this.mainTableScrollableElement = getScrollableElement(wtTable.TABLE);
+      return wtTable.holder;
     }
+
+    return getScrollableElement(wtTable.TABLE);
   }
 
   /**
@@ -287,7 +305,7 @@ export class Overlay {
       wtTable,
       wtSettings
     } = this.wot;
-    const { rootDocument, rootWindow } = this.domBindings;
+    const { rootDocument } = this.domBindings;
     const clone = rootDocument.createElement('div');
     const clonedTable = rootDocument.createElement('table');
     const tableParent = wtTable.wtRootElement.parentNode;
@@ -323,21 +341,7 @@ export class Overlay {
 
     tableParent.appendChild(clone);
 
-    const preventOverflow = this.wtSettings.getSetting('preventOverflow');
-    const computedOverflow = rootWindow.getComputedStyle(tableParent)
-      .getPropertyValue('overflow');
-
-    if (preventOverflow === true ||
-      preventOverflow === 'horizontal' && this.type === CLONE_TOP ||
-      preventOverflow === 'vertical' && this.type === CLONE_INLINE_START) {
-      this.mainTableScrollableElement = rootWindow;
-
-    } else if (computedOverflow === 'hidden' || computedOverflow === 'clip') {
-      this.mainTableScrollableElement = wtTable.holder;
-
-    } else {
-      this.mainTableScrollableElement = getScrollableElement(wtTable.TABLE);
-    }
+    this.mainTableScrollableElement = this.getMainTableScrollableElement();
 
     // Create a new instance of the Walkontable class
     return new Clone(clonedTable, this.wtSettings, { // todo ioc factory

--- a/handsontable/test/e2e/settings/preventOverflow.spec.js
+++ b/handsontable/test/e2e/settings/preventOverflow.spec.js
@@ -55,5 +55,36 @@ describe('settings', () => {
 
       document.body.style.marginLeft = origMarginLeft;
     });
+
+    it('should keep vertical keyboard scrolling after `updateSettings()` when `horizontal` option is used', async() => {
+      const rootWindow = spec().$container[0].ownerDocument.defaultView;
+
+      handsontable({
+        data: createSpreadsheetData(200, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        width: 400,
+        preventOverflow: 'horizontal',
+      });
+
+      await selectCell(20, 0);
+
+      const topOverlay = tableView()._wt.wtOverlays.topOverlay;
+      const initialScrollY = rootWindow.scrollY;
+
+      expect(topOverlay.mainTableScrollableElement).toBe(rootWindow);
+
+      await updateSettings({
+        className: 'after-update-settings',
+      });
+
+      expect(topOverlay.mainTableScrollableElement).toBe(rootWindow);
+
+      for (let i = 0; i < 10; i++) {
+        await keyDownUp('arrowdown');
+      }
+
+      expect(rootWindow.scrollY).toBeGreaterThan(initialScrollY);
+    });
   });
 });

--- a/handsontable/test/e2e/settings/preventOverflow.spec.js
+++ b/handsontable/test/e2e/settings/preventOverflow.spec.js
@@ -58,33 +58,44 @@ describe('settings', () => {
 
     it('should keep vertical keyboard scrolling after `updateSettings()` when `horizontal` option is used', async() => {
       const rootWindow = spec().$container[0].ownerDocument.defaultView;
+      const originalMarginTop = document.body.style.marginTop;
 
-      handsontable({
-        data: createSpreadsheetData(200, 5),
-        rowHeaders: true,
-        colHeaders: true,
-        width: 400,
-        preventOverflow: 'horizontal',
-      });
+      document.body.style.marginTop = '2000px';
+      try {
+        const hot = handsontable({
+          data: createSpreadsheetData(200, 5),
+          rowHeaders: true,
+          colHeaders: true,
+          width: 400,
+          preventOverflow: 'horizontal',
+        });
 
-      await selectCell(20, 0);
+        rootWindow.scrollTo(0, 100);
+        hot.selectCell(20, 0);
 
-      const topOverlay = tableView()._wt.wtOverlays.topOverlay;
-      const initialScrollY = rootWindow.scrollY;
+        const topOverlay = tableView()._wt.wtOverlays.topOverlay;
 
-      expect(topOverlay.mainTableScrollableElement).toBe(rootWindow);
+        expect(topOverlay.mainTableScrollableElement).toBe(rootWindow);
 
-      await updateSettings({
-        className: 'after-update-settings',
-      });
+        hot.updateSettings({
+          className: 'after-update-settings',
+        });
 
-      expect(topOverlay.mainTableScrollableElement).toBe(rootWindow);
+        expect(topOverlay.mainTableScrollableElement).toBe(rootWindow);
 
-      for (let i = 0; i < 10; i++) {
-        await keyDownUp('arrowdown');
+        const initialScrollY = rootWindow.scrollY;
+        const keyCode = Handsontable.helper.KEY_CODES.ARROW_DOWN;
+        const keyboardProxy = hot.rootElement.querySelector('textarea.handsontableInput');
+
+        for (let i = 0; i < 10; i++) {
+          $(keyboardProxy).simulate('keydown', { keyCode, key: 'ArrowDown' });
+          $(keyboardProxy).simulate('keyup', { keyCode, key: 'ArrowDown' });
+        }
+
+        expect(rootWindow.scrollY).toBeGreaterThan(initialScrollY);
+      } finally {
+        document.body.style.marginTop = originalMarginTop;
       }
-
-      expect(rootWindow.scrollY).toBeGreaterThan(initialScrollY);
     });
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Context
This change addresses issue #534, where keyboard-driven vertical scrolling stopped working after calling `updateSettings()` when `preventOverflow` was set to `'horizontal'`. The root cause was identified as the overlay scrollable element resolution not consistently respecting the `preventOverflow` setting after `updateSettings()`, leading to incorrect scrollable container determination. The fix centralizes the logic for determining the main table's scrollable element to ensure consistent behavior.

### How has this been tested?
- **Unit tests**: Added a new unit test for `src/3rdparty/walkontable/src/overlay/_base.js` to specifically validate the overlay scroll-element selection across different `preventOverflow` modes.
- **E2E tests**: Added an E2E regression test within `test/e2e/settings/preventOverflow.spec.js` to verify that vertical keyboard scrolling continues to function correctly after `updateSettings()` when `preventOverflow: 'horizontal'`.
- **Linting**: Verified lint compliance for all touched source and test files using `eslint`.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #534

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<div><a href="https://cursor.com/agents/bc-7842cdb6-48e6-44dd-b974-b8b25929589e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7842cdb6-48e6-44dd-b974-b8b25929589e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->