### PR TITLE
 a new `serverSideData` core plugin 

### DIFF
--- a/.changelogs/13001.json
+++ b/.changelogs/13001.json
@@ -4,5 +4,5 @@
   "type": "added",
   "issueOrPR": 13001,
   "breaking": false,
-  "framework": "core"
+  "framework": "none"
 }

--- a/.changelogs/13001.json
+++ b/.changelogs/13001.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Added server-side data mode with dataProvider-driven pagination, sorting, filtering, and CRUD refresh APIs.",
+  "type": "added",
+  "issueOrPR": 13001,
+  "breaking": false,
+  "framework": "core"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -643,4 +643,7 @@ Follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format. See `.c
 - Root-level `npm run lint` and `npm run test` scripts use a custom `translate-to-native-npm.mjs` script to fan out across all workspace packages.
 - The docs site (`docs/`) uses Node 20 (its own `.nvmrc`) and is not needed for core library development.
 - Walkontable (the rendering engine) lives inside `src/3rdparty/walkontable/` and has its **own test runner** — do not mix Walkontable tests with main E2E tests.
+- Server-side row model MVP logic lives in `handsontable/src/plugins/serverSideData/`. Use that plugin for `dataProvider` orchestration instead of adding ad-hoc fetch logic in sorting/filtering/pagination plugins.
+- In server-side mode, `Pagination` uses `setServerPaginationData()` and does not slice client data. Keep page counters in sync with `totalRows` returned by `dataProvider`.
+- In server-side mode, `Filters.filter()` intentionally skips local filtering and emits `afterFilter` so server queries can be triggered without losing filter state.
 - No Docker, databases, or external services are required.

--- a/docs/content/guides/columns/column-filter/column-filter.md
+++ b/docs/content/guides/columns/column-filter/column-filter.md
@@ -597,6 +597,10 @@ filtering doesn't affect them.
 You can decide to use Handsontable as an intuitive filtering interface, but perform the actual
 filtering on the server.
 
+If you use [`dataProvider`](@/api/options.md#dataprovider), Handsontable sends a normalized filter
+model to your backend automatically, together with pagination and sorting query parameters. See
+[Server-side data](@/guides/rows/server-side-data/server-side-data.md).
+
 To help you with that, Handsontable's [`beforeFilter()`](@/api/hooks.md#beforefilter) hook allows
 you to:
 

--- a/docs/content/guides/rows/rows-pagination/rows-pagination.md
+++ b/docs/content/guides/rows/rows-pagination/rows-pagination.md
@@ -39,7 +39,12 @@ The pagination component splits the data into a range of pages, allowing users t
 
 With pagination, large data sets are divided into smaller pages, significantly improving usability and rendering performance. Users can navigate pages using built-in UI controls such as page navigation buttons, a page size selector, and a page counter, or you can manage pages programmatically via Handsontable's API.
 
-Pagination operates fully on the client side, requiring all data to be loaded into Handsontable.
+Pagination supports two modes:
+
+- Client-side mode (using `data`) – all rows are loaded in the browser.
+- Server-side mode (using `dataProvider`) – page changes trigger remote fetches.
+
+To learn server-side mode, see the [Server-side data guide](@/guides/rows/server-side-data/server-side-data.md).
 
 Whenever rows are added, removed, hidden, unhidden, filtered, or otherwise modified, pagination automatically recomputes total pages and adjusts the currently visible slice of data.
 
@@ -93,6 +98,8 @@ const configurationOptions = {
   pagination: {
     pageSize: 10,
     pageSizeList: ['auto', 5, 10, 20, 50, 100],
+    // or use pageSizeOptions (alias)
+    pageSizeOptions: ['auto', 5, 10, 20, 50, 100],
     initialPage: 1,
     showPageSize: true,
     showCounter: true,
@@ -118,6 +125,8 @@ const configurationOptions = {
     pageSize: 20,
     // Provide a list of selectable page sizes
     pageSizeList: ['auto', 10, 20, 50],
+    // Alias for pageSizeList
+    pageSizeOptions: ['auto', 10, 20, 50],
     // Set the initial page when the grid loads
     initialPage: 2,
     // Show or hide the page size section

--- a/docs/content/guides/rows/rows-sorting/rows-sorting.md
+++ b/docs/content/guides/rows/rows-sorting/rows-sorting.md
@@ -861,6 +861,9 @@ You can run your code before or after sorting, using the following [Handsontable
 For example, you can use [`beforeColumnSort()`](@/api/hooks.md#beforecolumnsort) for server-side sorting, or use
 [`afterColumnSort()`](@/api/hooks.md#aftercolumnsort) to [exclude rows from sorting](#exclude-rows-from-sorting).
 
+If you use [`dataProvider`](@/api/options.md#dataprovider), Handsontable handles this automatically and sends the
+current sort model to your backend. See [Server-side data](@/guides/rows/server-side-data/server-side-data.md).
+
 ::: only-for javascript
 
 ```js

--- a/docs/content/guides/rows/server-side-data/server-side-data.md
+++ b/docs/content/guides/rows/server-side-data/server-side-data.md
@@ -1,0 +1,243 @@
+---
+id: ir3m4x8n
+title: Server-side data
+metaTitle: Server-side data - JavaScript Data Grid | Handsontable
+description: Use Handsontable with server-side pagination, sorting, filtering, and CRUD operations through dataProvider.
+permalink: /server-side-data
+canonicalUrl: /server-side-data
+tags:
+  - server-side data
+  - dataProvider
+  - pagination
+  - sorting
+  - filtering
+  - CRUD
+react:
+  id: v0r3w4kz
+  metaTitle: Server-side data - React Data Grid | Handsontable
+angular:
+  id: m4o9p1jt
+  metaTitle: Server-side data - Angular Data Grid | Handsontable
+searchCategory: Guides
+category: Rows
+menuTag: new
+---
+
+# Server-side data
+
+Use `dataProvider` to fetch data from your backend on demand. Handsontable builds query parameters and calls your function when pagination, sorting, or filtering changes.
+
+[[toc]]
+
+## Overview
+
+When `dataProvider` is set, Handsontable switches to server-side mode:
+
+- Pagination requests use `page` and `pageSize`.
+- Sorting updates `sort`.
+- Filtering updates `filters`.
+- `refreshData()` re-fetches the current server-side view.
+
+`data` and `dataProvider` can coexist in configuration, but Handsontable prioritizes `dataProvider`.
+
+## REST example (JavaScript)
+
+```js
+const hot = new Handsontable(container, {
+  dataProvider: async(queryParameters, { signal }) => {
+    const { page, pageSize, sort, filters } = queryParameters;
+    const params = new URLSearchParams({
+      page: String(page),
+      pageSize: String(pageSize),
+    });
+
+    if (sort) {
+      params.set('sortBy', sort.column);
+      params.set('sortDir', sort.direction);
+    }
+
+    if (filters) {
+      params.set('filters', JSON.stringify(filters));
+    }
+
+    const response = await fetch(`/api/products?${params.toString()}`, { signal });
+    const json = await response.json();
+
+    return {
+      rows: json.rows,
+      totalRows: json.totalRows,
+    };
+  },
+  rowId: 'id',
+  pagination: {
+    pageSize: 20,
+    pageSizeOptions: [10, 20, 50, 100],
+  },
+  columnSorting: true,
+  filters: true,
+  dropdownMenu: true,
+  columns: [
+    { data: 'id', readOnly: true },
+    { data: 'name' },
+    { data: 'price', type: 'numeric' },
+    { data: 'category' },
+  ],
+});
+```
+
+## GraphQL example (JavaScript)
+
+```js
+const hot = new Handsontable(container, {
+  dataProvider: async(queryParameters, { signal }) => {
+    const query = `
+      query Products($page: Int!, $pageSize: Int!, $sort: SortInput, $filters: FilterInput) {
+        products(page: $page, pageSize: $pageSize, sort: $sort, filters: $filters) {
+          rows { id name price category }
+          totalRows
+        }
+      }
+    `;
+    const response = await fetch('/graphql', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      signal,
+      body: JSON.stringify({
+        query,
+        variables: queryParameters,
+      }),
+    });
+    const json = await response.json();
+
+    return json.data.products;
+  },
+  rowId: 'id',
+  pagination: true,
+  columnSorting: true,
+  filters: true,
+  columns: [
+    { data: 'id', readOnly: true },
+    { data: 'name' },
+    { data: 'price' },
+    { data: 'category' },
+  ],
+});
+```
+
+## CRUD callbacks
+
+Use async callbacks for server-side mutations:
+
+```js
+const hot = new Handsontable(container, {
+  dataProvider,
+  rowId: 'id',
+  onRowCreate: async(row) => {
+    await api.createProduct(row);
+  },
+  onRowUpdate: async(id, changes, rowData) => {
+    await api.updateProduct(id, changes, rowData);
+  },
+  onRowRemove: async(id) => {
+    await api.deleteProduct(id);
+  },
+});
+
+await hot.createRow({ name: 'New product', price: 0 });
+await hot.updateRow(42, { price: 19.99 });
+await hot.removeRow(42);
+```
+
+Handsontable refreshes server-side data after each successful mutation.
+
+## React example
+
+```jsx
+import { HotTable } from '@handsontable/react-wrapper';
+
+<HotTable
+  dataProvider={async(queryParameters, options) => fetchProducts(queryParameters, options)}
+  rowId="id"
+  pagination={{ pageSize: 20, pageSizeOptions: [10, 20, 50] }}
+  columnSorting={true}
+  filters={true}
+  dropdownMenu={true}
+  columns={[
+    { data: 'id', readOnly: true },
+    { data: 'name' },
+    { data: 'price' },
+    { data: 'category' },
+  ]}
+/>;
+```
+
+## Angular example
+
+```ts
+hotSettings = {
+  dataProvider: async(queryParameters, options) => {
+    return this.productsService.fetch(queryParameters, options.signal);
+  },
+  rowId: 'id',
+  pagination: { pageSize: 20, pageSizeOptions: [10, 20, 50] },
+  columnSorting: true,
+  filters: true,
+  dropdownMenu: true,
+  columns: [
+    { data: 'id', readOnly: true },
+    { data: 'name' },
+    { data: 'price' },
+    { data: 'category' },
+  ],
+};
+```
+
+## Vue 3 example
+
+```vue
+<template>
+  <HotTable :settings="settings" />
+</template>
+
+<script setup>
+import { HotTable } from '@handsontable/vue3';
+
+const settings = {
+  dataProvider: async(queryParameters, options) => fetchProducts(queryParameters, options),
+  rowId: 'id',
+  pagination: { pageSize: 20, pageSizeOptions: [10, 20, 50] },
+  columnSorting: true,
+  filters: true,
+  dropdownMenu: true,
+  columns: [
+    { data: 'id', readOnly: true },
+    { data: 'name' },
+    { data: 'price' },
+    { data: 'category' },
+  ],
+};
+</script>
+```
+
+## Related API reference
+
+- Options:
+  - [`dataProvider`](@/api/options.md#dataprovider)
+  - [`dataProviderParams`](@/api/options.md#dataproviderparams)
+  - [`rowId`](@/api/options.md#rowid)
+  - [`onRowCreate`](@/api/options.md#onrowcreate)
+  - [`onRowUpdate`](@/api/options.md#onrowupdate)
+  - [`onRowRemove`](@/api/options.md#onrowremove)
+- Core methods:
+  - [`refreshData()`](@/api/core.md#refreshdata)
+  - [`getQueryParameters()`](@/api/core.md#getqueryparameters)
+  - [`createRow()`](@/api/core.md#createrow)
+  - [`updateRow()`](@/api/core.md#updaterow)
+  - [`removeRow()`](@/api/core.md#removerow)
+- Hooks:
+  - [`beforeDataProviderRequest()`](@/api/hooks.md#beforedataproviderrequest)
+  - [`afterDataProviderResponse()`](@/api/hooks.md#afterdataproviderresponse)
+  - [`afterDataProviderError()`](@/api/hooks.md#afterdataprovidererror)
+  - [`beforeRowMutation()`](@/api/hooks.md#beforerowmutation)
+  - [`afterRowMutation()`](@/api/hooks.md#afterrowmutation)
+  - [`afterRowMutationError()`](@/api/hooks.md#afterrowmutationerror)

--- a/docs/content/guides/sidebar.js
+++ b/docs/content/guides/sidebar.js
@@ -60,6 +60,7 @@ const rowsItems = [
   { path: 'guides/rows/row-virtualization/row-virtualization' },
   { path: 'guides/rows/rows-sorting/rows-sorting' },
   { path: 'guides/rows/rows-pagination/rows-pagination' },
+  { path: 'guides/rows/server-side-data/server-side-data' },
   { path: 'guides/rows/row-trimming/row-trimming' },
   { path: 'guides/rows/row-prepopulating/row-prepopulating' },
 ];

--- a/docs/content/guides/upgrade-and-migration/migrating-from-16.2-to-17.0/migrating-from-16.2-to-17.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-16.2-to-17.0/migrating-from-16.2-to-17.0.md
@@ -26,6 +26,69 @@ For a detailed list of changes in this release, see the [Changelog](@/guides/upg
 
 [[toc]]
 
+## 0. Optional: migrate to the new server-side data mode
+
+Version 17.0 introduces server-side mode through `dataProvider`.
+
+### Who this affects
+
+This affects teams that currently implement server-side pagination, sorting, filtering, or CRUD manually around `loadData()`.
+
+### Why migrate
+
+You can move custom state orchestration into Handsontable and keep your backend as the single source of truth.
+
+### What changed
+
+Handsontable adds:
+
+- `dataProvider`, `dataProviderParams`, and `rowId` options.
+- Server-side mutation callbacks: `onRowCreate`, `onRowUpdate`, and `onRowRemove`.
+- New Core methods: `refreshData()`, `getQueryParameters()`, `createRow()`, `updateRow()`, and `removeRow()`.
+
+### Migration steps
+
+1. Replace `data` initialization with `dataProvider`.
+2. Return `{ rows, totalRows }` from your provider.
+3. Keep `pagination`, `columnSorting`, and `filters` enabled.
+4. Add mutation callbacks if you need server-side CRUD.
+
+### Before
+
+```js
+const hot = new Handsontable(container, {
+  data: localRows,
+  pagination: true,
+  columnSorting: true,
+  filters: true,
+});
+```
+
+### After
+
+```js
+const hot = new Handsontable(container, {
+  dataProvider: async(queryParameters, { signal }) => {
+    const response = await fetch(buildUrl(queryParameters), { signal });
+    const json = await response.json();
+
+    return {
+      rows: json.rows,
+      totalRows: json.totalRows,
+    };
+  },
+  rowId: 'id',
+  pagination: { pageSize: 20 },
+  columnSorting: true,
+  filters: true,
+});
+```
+
+### Related docs
+
+- [Server-side data guide](@/guides/rows/server-side-data/server-side-data.md)
+- [Rows pagination guide](@/guides/rows/rows-pagination/rows-pagination.md)
+
 ## 1. Legacy styles have been removed
 
 Starting from **version 17.0.0**, the legacy stylesheet (`dist/handsontable.full.min.css`) has been completely removed from Handsontable. If you're upgrading from an earlier version and still using the legacy styles, you must migrate to a theme.

--- a/handsontable/src/__tests__/core/settings.types.ts
+++ b/handsontable/src/__tests__/core/settings.types.ts
@@ -117,6 +117,24 @@ const allSettings: Required<Handsontable.GridSettings> = {
   currentRowClassName: 'foo',
   customBorders: true,
   data: oneOf([{}, {}, {}], [[], [], []]),
+  dataProvider: async(queryParameters, options) => ({
+    rows: [{ id: 1, name: 'A' }],
+    totalRows: 1,
+  }),
+  dataProviderParams: {
+    page: 1,
+    pageSize: 20,
+    sort: {
+      column: 'name',
+      direction: 'asc',
+    },
+    filters: {
+      name: {
+        operator: 'contains',
+        value: 'A',
+      },
+    },
+  },
   dataDotNotation: oneOf(true),
   dataSchema: oneOf({}, [[]], (index: number) => oneOf([index], { index })),
   dateFormat: 'foo',
@@ -224,6 +242,7 @@ const allSettings: Required<Handsontable.GridSettings> = {
   ),
   rowHeaders: oneOf(true, ['1', '2', '3'], (index: number) => `Row ${index}`),
   rowHeaderWidth: oneOf(25, [25, 30, 55]),
+  rowId: 'id',
   rowHeights: oneOf(100, '100px', [100, 120, 90], (index: number) => index * 10),
   sanitizer: (content: string, source: 'innerHTML' | 'CopyPaste.paste') => content,
   search: true,
@@ -253,6 +272,9 @@ const allSettings: Required<Handsontable.GridSettings> = {
   themeName: 'ht-theme-some-theme',
   theme: '',
   title: 'foo',
+  onRowCreate: async(row) => {},
+  onRowUpdate: async(id, changes, rowData) => {},
+  onRowRemove: async(id) => {},
   trimDropdown: true,
   trimRows: true,
   trimWhitespace: true,
@@ -487,6 +509,10 @@ const allSettings: Required<Handsontable.GridSettings> = {
   afterPageNavigationVisibilityChange(isVisible) {
     const _isVisible: boolean = isVisible;
   },
+  afterDataProviderResponse: (response, queryParameters) => {},
+  afterDataProviderError: (error, queryParameters) => {},
+  afterRowMutation: (type, payload) => {},
+  afterRowMutationError: (type, error, payload) => {},
   afterPaste: (data, coords) => {},
   afterPluginsInitialized: () => {},
   afterRedo: (action) => {},
@@ -635,6 +661,8 @@ const allSettings: Required<Handsontable.GridSettings> = {
 
     return true;
   },
+  beforeDataProviderRequest: (queryParameters, source) => {},
+  beforeRowMutation: (type, payload) => {},
   beforePaste: (data, coords) => { data.splice(0, 1); return false; },
   beforeRedo: (action) => {},
   beforeRedoStackChange: (undoneActions) => {},

--- a/handsontable/src/__tests__/registry/registerAllPlugins.unit.js
+++ b/handsontable/src/__tests__/registry/registerAllPlugins.unit.js
@@ -22,6 +22,7 @@ describe('`registerAllPlugins`', () => {
       'Autofill',
       'ManualRowResize',
       'AutoRowSize',
+      'ServerSideData',
       'ColumnSorting',
       'Comments',
       'ContextMenu',

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -2587,6 +2587,100 @@ export default function Core(rootContainer, userSettings, rootInstanceSymbol = f
   };
 
   /**
+   * In server-side mode, forces a fresh call to `dataProvider()` with the current query parameters.
+   *
+   * @memberof Core#
+   * @function refreshData
+   * @returns {Promise<void>}
+   */
+  this.refreshData = function() {
+    const serverSideDataPlugin = this.getPlugin('serverSideData');
+
+    if (!serverSideDataPlugin?.enabled) {
+      return Promise.resolve();
+    }
+
+    return serverSideDataPlugin.refreshData();
+  };
+
+  /**
+   * In server-side mode, gets the current query parameters sent to `dataProvider()`.
+   *
+   * @memberof Core#
+   * @function getQueryParameters
+   * @returns {{page: number, pageSize: number, sort: object | null, filters: object | null}}
+   */
+  this.getQueryParameters = function() {
+    const serverSideDataPlugin = this.getPlugin('serverSideData');
+
+    if (!serverSideDataPlugin?.enabled) {
+      return {
+        page: 1,
+        pageSize: 20,
+        sort: null,
+        filters: null,
+      };
+    }
+
+    return serverSideDataPlugin.getQueryParameters();
+  };
+
+  /**
+   * In server-side mode, creates a row by calling the `onRowCreate` callback.
+   *
+   * @memberof Core#
+   * @function createRow
+   * @param {object} rowData The row payload to send to the server.
+   * @returns {Promise<void>}
+   */
+  this.createRow = function(rowData) {
+    const serverSideDataPlugin = this.getPlugin('serverSideData');
+
+    if (!serverSideDataPlugin?.enabled) {
+      throwWithCause('The `createRow()` method is available only when `dataProvider` is enabled.');
+    }
+
+    return serverSideDataPlugin.createRow(rowData);
+  };
+
+  /**
+   * In server-side mode, updates a row by calling the `onRowUpdate` callback.
+   *
+   * @memberof Core#
+   * @function updateRow
+   * @param {string|number} rowId The row identifier.
+   * @param {object} changes The row changes payload.
+   * @returns {Promise<void>}
+   */
+  this.updateRow = function(rowId, changes) {
+    const serverSideDataPlugin = this.getPlugin('serverSideData');
+
+    if (!serverSideDataPlugin?.enabled) {
+      throwWithCause('The `updateRow()` method is available only when `dataProvider` is enabled.');
+    }
+
+    return serverSideDataPlugin.updateRow(rowId, changes);
+  };
+
+  /**
+   * In server-side mode, removes a row by calling the `onRowRemove` callback.
+   *
+   * @memberof Core#
+   * @function removeRow
+   * @param {string|number} rowId The row identifier.
+   * @returns {Promise<void>}
+   */
+  this.removeRow = function(rowId) {
+    const serverSideDataPlugin = this.getPlugin('serverSideData');
+
+    if (!serverSideDataPlugin?.enabled) {
+      throwWithCause('The `removeRow()` method is available only when `dataProvider` is enabled.');
+    }
+
+    return serverSideDataPlugin.removeRow(rowId);
+  };
+
+  /**
    * Gets the initial column count, calculated based on the `columns` setting.
    *
    * @private

--- a/handsontable/src/core/hooks/constants.js
+++ b/handsontable/src/core/hooks/constants.js
@@ -2641,6 +2641,63 @@ export const REGISTERED_HOOKS = [
   'afterPageNavigationVisibilityChange',
 
   /**
+   * Fired before calling `dataProvider()` in server-side mode.
+   *
+   * @event Hooks#beforeDataProviderRequest
+   * @param {object} queryParameters Query parameters that are about to be used for the request.
+   * @param {string} source Source of the request.
+   * @returns {object|boolean|void} Return `false` to cancel the request, or return an object to override query parameters.
+   */
+  'beforeDataProviderRequest',
+
+  /**
+   * Fired after `dataProvider()` resolves in server-side mode.
+   *
+   * @event Hooks#afterDataProviderResponse
+   * @param {object} response Response returned from `dataProvider()`.
+   * @param {object} queryParameters Query parameters used for the request.
+   */
+  'afterDataProviderResponse',
+
+  /**
+   * Fired when `dataProvider()` rejects in server-side mode.
+   *
+   * @event Hooks#afterDataProviderError
+   * @param {Error} error The error thrown by `dataProvider()`.
+   * @param {object} queryParameters Query parameters used for the request.
+   */
+  'afterDataProviderError',
+
+  /**
+   * Fired before a server-side CRUD mutation callback is called.
+   *
+   * @event Hooks#beforeRowMutation
+   * @param {'create'|'update'|'remove'} type Mutation type.
+   * @param {object} payload Mutation payload.
+   * @returns {boolean|void} Return `false` to cancel the mutation.
+   */
+  'beforeRowMutation',
+
+  /**
+   * Fired after a server-side CRUD mutation callback resolves.
+   *
+   * @event Hooks#afterRowMutation
+   * @param {'create'|'update'|'remove'} type Mutation type.
+   * @param {object} payload Mutation payload.
+   */
+  'afterRowMutation',
+
+  /**
+   * Fired when a server-side CRUD mutation callback rejects.
+   *
+   * @event Hooks#afterRowMutationError
+   * @param {'create'|'update'|'remove'} type Mutation type.
+   * @param {Error} error The error thrown by the mutation callback.
+   * @param {object} payload Mutation payload.
+   */
+  'afterRowMutationError',
+
+  /**
    * Fired by the {@link Formulas} plugin, when any cell value changes.
    *
    * Returns an array of objects that contains:

--- a/handsontable/src/dataMap/metaManager/metaSchema.js
+++ b/handsontable/src/dataMap/metaManager/metaSchema.js
@@ -1602,6 +1602,69 @@ export default () => {
     data: undefined,
 
     /**
+     * The `dataProvider` option enables server-side mode by providing a function that fetches table rows.
+     *
+     * When this option is set, Handsontable calls the function with current query parameters (`page`, `pageSize`,
+     * `sort`, and `filters`) and expects a Promise resolving to `{ rows, totalRows }`.
+     *
+     * @memberof Options#
+     * @type {Function}
+     * @default undefined
+     * @category Core
+     */
+    dataProvider: undefined,
+
+    /**
+     * The `dataProviderParams` option sets initial query parameters for server-side mode.
+     *
+     * @memberof Options#
+     * @type {object}
+     * @default undefined
+     * @category Core
+     */
+    dataProviderParams: undefined,
+
+    /**
+     * The `rowId` option defines which property in your row object is treated as its unique identifier.
+     *
+     * @memberof Options#
+     * @type {string}
+     * @default 'id'
+     * @category Core
+     */
+    rowId: 'id',
+
+    /**
+     * The `onRowCreate` option defines an async callback for server-side row creation.
+     *
+     * @memberof Options#
+     * @type {Function}
+     * @default undefined
+     * @category Core
+     */
+    onRowCreate: undefined,
+
+    /**
+     * The `onRowUpdate` option defines an async callback for server-side row updates.
+     *
+     * @memberof Options#
+     * @type {Function}
+     * @default undefined
+     * @category Core
+     */
+    onRowUpdate: undefined,
+
+    /**
+     * The `onRowRemove` option defines an async callback for server-side row removal.
+     *
+     * @memberof Options#
+     * @type {Function}
+     * @default undefined
+     * @category Core
+     */
+    onRowRemove: undefined,
+
+    /**
      * @description
      * If `true`, Handsontable will interpret the dots in the columns mapping as a nested object path. If your dataset contains
      * the dots in the object keys and you don't want Handsontable to interpret them as a nested object path, set this option to `false`.

--- a/handsontable/src/plugins/__tests__/builtInPlugins.unit.js
+++ b/handsontable/src/plugins/__tests__/builtInPlugins.unit.js
@@ -8,6 +8,7 @@ describe('built-in plugins', () => {
       'Autofill',
       'ManualRowResize',
       'AutoRowSize',
+      'ServerSideData',
       'ColumnSorting',
       'Comments',
       'ContextMenu',

--- a/handsontable/src/plugins/filters/filters.js
+++ b/handsontable/src/plugins/filters/filters.js
@@ -669,11 +669,25 @@ export class Filters extends BasePlugin {
     const { navigableHeaders } = this.hot.getSettings();
     const needToFilter = !this.conditionCollection.isEmpty();
     const conditions = this.exportConditions();
+    const isServerSideMode = typeof this.hot.getSettings().dataProvider === 'function';
     const allowFiltering = this.hot.runHooks(
       'beforeFilter',
       conditions,
       this.#previousConditionStack
     );
+
+    if (isServerSideMode) {
+      if (allowFiltering !== false) {
+        this.#previousConditionStack = this.exportConditions();
+        this.hot.runHooks('afterFilter', conditions);
+        this.hot.view.adjustElementsSize();
+        this.hot.render();
+      } else {
+        this.importConditions(this.#previousConditionStack);
+      }
+
+      return;
+    }
 
     if (allowFiltering !== false && needToFilter) {
       const dataFilter = this._createDataFilter();

--- a/handsontable/src/plugins/index.js
+++ b/handsontable/src/plugins/index.js
@@ -29,6 +29,7 @@ import { NestedHeaders } from './nestedHeaders';
 import { NestedRows } from './nestedRows';
 import { Pagination } from './pagination';
 import { Search } from './search';
+import { ServerSideData } from './serverSideData';
 import { StretchColumns } from './stretchColumns';
 import { TouchScroll } from './touchScroll';
 import { TrimRows } from './trimRows';
@@ -73,6 +74,7 @@ export function registerAllPlugins() {
   registerPlugin(NestedHeaders);
   registerPlugin(NestedRows);
   registerPlugin(Pagination);
+  registerPlugin(ServerSideData);
   registerPlugin(Search);
   registerPlugin(StretchColumns);
   registerPlugin(TouchScroll);
@@ -114,6 +116,7 @@ export {
   NestedHeaders,
   NestedRows,
   Pagination,
+  ServerSideData,
   Search,
   StretchColumns,
   TouchScroll,

--- a/handsontable/src/plugins/manualRowMove/manualRowMove.js
+++ b/handsontable/src/plugins/manualRowMove/manualRowMove.js
@@ -86,7 +86,7 @@ export class ManualRowMove extends BasePlugin {
    * @returns {boolean}
    */
   isEnabled() {
-    return !!this.hot.getSettings()[PLUGIN_KEY];
+    return !!this.hot.getSettings()[PLUGIN_KEY] && typeof this.hot.getSettings().dataProvider !== 'function';
   }
 
   /**

--- a/handsontable/src/plugins/multiColumnSorting/multiColumnSorting.js
+++ b/handsontable/src/plugins/multiColumnSorting/multiColumnSorting.js
@@ -91,7 +91,7 @@ export class MultiColumnSorting extends ColumnSorting {
    * @returns {boolean}
    */
   isEnabled() {
-    return !!(this.hot.getSettings()[this.pluginKey]);
+    return !!this.hot.getSettings()[this.pluginKey] && typeof this.hot.getSettings().dataProvider !== 'function';
   }
 
   /**

--- a/handsontable/src/plugins/pagination/pagination.js
+++ b/handsontable/src/plugins/pagination/pagination.js
@@ -102,6 +102,7 @@ export class Pagination extends BasePlugin {
     return {
       pageSize: 10,
       pageSizeList: ['auto', 5, 10, 20, 50, 100],
+      pageSizeOptions: ['auto', 5, 10, 20, 50, 100],
       initialPage: 1,
       showPageSize: true,
       showCounter: true,
@@ -144,6 +145,18 @@ export class Pagination extends BasePlugin {
    */
   #calcStrategy = null;
   /**
+   * Indicates if pagination works in server-side mode.
+   *
+   * @type {boolean}
+   */
+  #isServerSideMode = false;
+  /**
+   * The total number of rows available on the server.
+   *
+   * @type {number}
+   */
+  #serverTotalRows = 0;
+  /**
    * Flag indicating if the plugin is in the process of updating the index cache (execution operation).
    * Prevents circular calls when the index cache is updated.
    *
@@ -183,12 +196,18 @@ export class Pagination extends BasePlugin {
 
     const settings = this.hot.getSettings()[PLUGIN_KEY];
 
+    if (settings?.pageSizeOptions !== undefined && settings?.pageSizeList === undefined) {
+      settings.pageSizeList = settings.pageSizeOptions;
+    }
+
     if (settings?.initialPage !== undefined) {
       this.#currentPage = this.getSetting('initialPage');
     }
     if (settings?.pageSize !== undefined) {
       this.#pageSize = this.getSetting('pageSize');
     }
+    this.#isServerSideMode = typeof this.hot.getSettings().dataProvider === 'function';
+    this.#serverTotalRows = 0;
 
     this.#pagedRowsMap = this.hot.rowIndexMapper.createAndRegisterIndexMap(this.pluginName, 'hiding', false);
 
@@ -245,6 +264,12 @@ export class Pagination extends BasePlugin {
    * Updates the plugin state. This method is executed when {@link Core#updateSettings} is invoked.
    */
   updatePlugin() {
+    const settings = this.hot.getSettings()[PLUGIN_KEY];
+
+    if (settings?.pageSizeOptions !== undefined && settings?.pageSizeList === undefined) {
+      settings.pageSizeList = settings.pageSizeOptions;
+    }
+
     this.disablePlugin();
     this.enablePlugin();
 
@@ -265,6 +290,8 @@ export class Pagination extends BasePlugin {
 
     this.#ui.destroy();
     this.#ui = null;
+    this.#isServerSideMode = false;
+    this.#serverTotalRows = 0;
 
     super.disablePlugin();
   }
@@ -301,25 +328,34 @@ export class Pagination extends BasePlugin {
       startIndex,
     } = this.#calcStrategy.getState(this.#currentPage);
 
-    const countRows = this.hot.countRows();
-    let visibleCount = 0;
+    if (this.#isServerSideMode) {
+      const countRows = this.hot.countRows();
 
-    for (let rowIndex = startIndex; visibleCount < pageSize; rowIndex++) {
-      if (rowIndex >= countRows) {
-        break;
+      if (countRows > 0) {
+        firstVisibleRowIndex = 0;
+        lastVisibleRowIndex = countRows - 1;
       }
+    } else {
+      const countRows = this.hot.countRows();
+      let visibleCount = 0;
 
-      if (this.hot.rowIndexMapper.isHidden(this.hot.toPhysicalRow(rowIndex))) {
-        // eslint-disable-next-line no-continue
-        continue;
+      for (let rowIndex = startIndex; visibleCount < pageSize; rowIndex++) {
+        if (rowIndex >= countRows) {
+          break;
+        }
+
+        if (this.hot.rowIndexMapper.isHidden(this.hot.toPhysicalRow(rowIndex))) {
+          // eslint-disable-next-line no-continue
+          continue;
+        }
+
+        if (firstVisibleRowIndex === -1) {
+          firstVisibleRowIndex = rowIndex;
+        }
+
+        lastVisibleRowIndex = rowIndex;
+        visibleCount += 1;
       }
-
-      if (firstVisibleRowIndex === -1) {
-        firstVisibleRowIndex = rowIndex;
-      }
-
-      lastVisibleRowIndex = rowIndex;
-      visibleCount += 1;
     }
 
     return {
@@ -481,6 +517,28 @@ export class Pagination extends BasePlugin {
   }
 
   /**
+   * Synchronizes pagination with server-side totals and page details.
+   *
+   * @param {object} options Server-side pagination data.
+   * @param {number} options.currentPage Current page number.
+   * @param {number} options.pageSize Page size.
+   * @param {number} options.totalRows Total number of rows available on the server.
+   */
+  setServerPaginationData({ currentPage, pageSize, totalRows }) {
+    if (!this.#isServerSideMode) {
+      return;
+    }
+
+    this.#currentPage = currentPage;
+    this.#pageSize = pageSize;
+    this.#serverTotalRows = totalRows;
+
+    this.#computeAndApplyState();
+    this.hot.view.adjustElementsSize();
+    this.hot.render();
+  }
+
+  /**
    * Shows the page size section in the pagination UI.
    *
    * @fires Hooks#afterPageSizeVisibilityChange
@@ -572,11 +630,12 @@ export class Pagination extends BasePlugin {
 
     const renderableIndexes = this.hot.rowIndexMapper.getRenderableIndexes();
     const renderableRowsLength = renderableIndexes.length;
+    const totalItems = this.#isServerSideMode ? this.#serverTotalRows : renderableRowsLength;
     const { stylesHandler } = this.hot;
 
     this.#calcStrategy.calculate({
       pageSize: this.#pageSize,
-      totalItems: renderableRowsLength,
+      totalItems,
       viewportSizeProvider: () => {
         const { view } = this.hot;
 
@@ -613,19 +672,23 @@ export class Pagination extends BasePlugin {
 
     this.#currentPage = clamp(this.#currentPage, 1, totalPages);
 
-    if (renderableIndexes.length > 0) {
-      const {
-        startIndex,
-        pageSize,
-      } = this.#calcStrategy.getState(this.#currentPage);
+    if (!this.#isServerSideMode) {
+      if (renderableIndexes.length > 0) {
+        const {
+          startIndex,
+          pageSize,
+        } = this.#calcStrategy.getState(this.#currentPage);
 
-      renderableIndexes.splice(startIndex, pageSize);
-    }
+        renderableIndexes.splice(startIndex, pageSize);
+      }
 
-    if (renderableIndexes.length > 0) {
-      this.hot.batchExecution(() => {
-        renderableIndexes.forEach(index => this.#pagedRowsMap.setValueAtIndex(index, true));
-      }, true);
+      if (renderableIndexes.length > 0) {
+        this.hot.batchExecution(() => {
+          renderableIndexes.forEach(index => this.#pagedRowsMap.setValueAtIndex(index, true));
+        }, true);
+      } else {
+        this.hot.rowIndexMapper.updateCache(true);
+      }
     } else {
       this.hot.rowIndexMapper.updateCache(true);
     }
@@ -634,9 +697,27 @@ export class Pagination extends BasePlugin {
 
     const paginationData = this.getPaginationData();
 
+    let counterStartIndex = paginationData.firstVisibleRowIndex;
+    let counterEndIndex = paginationData.lastVisibleRowIndex;
+    let totalRenderedRows = renderableRowsLength;
+
+    if (this.#isServerSideMode) {
+      const {
+        startIndex,
+      } = this.#calcStrategy.getState(this.#currentPage);
+      const currentPageRowsCount = this.hot.countRows();
+
+      counterStartIndex = currentPageRowsCount > 0 ? startIndex : -1;
+      counterEndIndex = currentPageRowsCount > 0 ?
+        Math.min(startIndex + currentPageRowsCount - 1, Math.max(totalItems - 1, 0)) : -1;
+      totalRenderedRows = totalItems;
+    }
+
     this.#ui.updateState({
       ...paginationData,
-      totalRenderedRows: renderableRowsLength,
+      firstVisibleRowIndex: counterStartIndex,
+      lastVisibleRowIndex: counterEndIndex,
+      totalRenderedRows,
     });
   }
 
@@ -647,6 +728,10 @@ export class Pagination extends BasePlugin {
    * @returns {boolean} Returns `true` if the pagination UI should have a top border, `false` otherwise.
    */
   #computeNeedsBorder() {
+    if (this.#isServerSideMode) {
+      return true;
+    }
+
     if (!this.hot.view) {
       return true;
     }

--- a/handsontable/src/plugins/serverSideData/__tests__/serverSideData.spec.js
+++ b/handsontable/src/plugins/serverSideData/__tests__/serverSideData.spec.js
@@ -1,0 +1,192 @@
+describe('ServerSideData', () => {
+  beforeEach(function() {
+    this.$container = $('<div id="testContainer"></div>').appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should call dataProvider on init and on refreshData()', async() => {
+    const dataProvider = jasmine.createSpy('dataProvider').and.callFake(async queryParameters => ({
+      rows: [{ id: 1, name: `Row ${queryParameters.page}` }],
+      totalRows: 1,
+    }));
+
+    handsontable({
+      colHeaders: true,
+      columns: [
+        { data: 'id' },
+        { data: 'name' },
+      ],
+      pagination: true,
+      dataProvider,
+      dataProviderParams: {
+        pageSize: 15,
+      },
+    });
+
+    expect(getPlugin('serverSideData')).toBeDefined();
+    expect(getPlugin('serverSideData').enabled).toBe(true);
+    expect(getSettings().dataProvider).toBe(dataProvider);
+
+    await sleep(150);
+
+    expect(dataProvider.calls.count()).toBe(1);
+    expect(dataProvider.calls.argsFor(0)[0]).toEqual({
+      page: 1,
+      pageSize: 15,
+      sort: null,
+      filters: null,
+    });
+
+    await hot().refreshData();
+
+    expect(dataProvider.calls.count()).toBe(2);
+  });
+
+  it('should fetch data on server-side pagination change', async() => {
+    const dataProvider = jasmine.createSpy('dataProvider').and.callFake(async() => ({
+      rows: createSpreadsheetData(10, 2),
+      totalRows: 35,
+    }));
+
+    handsontable({
+      pagination: true,
+      colHeaders: true,
+      columns: [{ data: 0 }, { data: 1 }],
+      dataProvider,
+    });
+
+    await sleep(150);
+    getPlugin('pagination').setPage(2);
+    await sleep(200);
+
+    expect(dataProvider.calls.mostRecent().args[0].page).toBe(2);
+    expect(getPlugin('pagination').getPaginationData().currentPage).toBe(2);
+  });
+
+  it('should fetch data on server-side sorting change', async() => {
+    const dataProvider = jasmine.createSpy('dataProvider').and.callFake(async() => ({
+      rows: [
+        { id: 1, name: 'A' },
+        { id: 2, name: 'B' },
+      ],
+      totalRows: 2,
+    }));
+
+    handsontable({
+      colHeaders: true,
+      columnSorting: true,
+      columns: [
+        { data: 'id' },
+        { data: 'name' },
+      ],
+      dataProvider,
+      pagination: true,
+    });
+
+    await sleep(150);
+    getPlugin('columnSorting').sort({ column: 1, sortOrder: 'asc' });
+    await sleep(200);
+
+    expect(dataProvider.calls.mostRecent().args[0].sort).toEqual({
+      column: 'name',
+      direction: 'asc',
+    });
+    expect(dataProvider.calls.mostRecent().args[0].page).toBe(1);
+  });
+
+  it('should fetch data on server-side filter change', async() => {
+    const dataProvider = jasmine.createSpy('dataProvider').and.callFake(async() => ({
+      rows: [
+        { id: 1, name: 'Alice' },
+        { id: 2, name: 'Bob' },
+      ],
+      totalRows: 2,
+    }));
+
+    handsontable({
+      colHeaders: true,
+      dropdownMenu: true,
+      filters: true,
+      columns: [
+        { data: 'id' },
+        { data: 'name' },
+      ],
+      dataProvider,
+      pagination: true,
+    });
+
+    await sleep(150);
+    getPlugin('filters').addCondition(1, 'contains', ['A']);
+    getPlugin('filters').filter();
+    await sleep(200);
+
+    expect(dataProvider.calls.mostRecent().args[0].filters).toEqual({
+      name: {
+        operator: 'contains',
+        value: 'a',
+      },
+    });
+    expect(dataProvider.calls.mostRecent().args[0].page).toBe(1);
+  });
+
+  it('should call onRowUpdate and refresh after editing a cell', async() => {
+    const onRowUpdate = jasmine.createSpy('onRowUpdate').and.callFake(async() => undefined);
+    const dataProvider = jasmine.createSpy('dataProvider').and.callFake(async() => ({
+      rows: [{ id: 1, name: 'Alice' }],
+      totalRows: 1,
+    }));
+
+    handsontable({
+      colHeaders: true,
+      columns: [
+        { data: 'id', readOnly: true },
+        { data: 'name' },
+      ],
+      dataProvider,
+      onRowUpdate,
+      rowId: 'id',
+    });
+
+    await sleep(150);
+    await setDataAtCell(0, 1, 'Alicia', 'edit');
+    await sleep(250);
+
+    expect(onRowUpdate.calls.count()).toBe(1);
+    expect(onRowUpdate.calls.argsFor(0)[0]).toBe(1);
+    expect(onRowUpdate.calls.argsFor(0)[1]).toEqual({ name: 'Alicia' });
+    expect(dataProvider.calls.count()).toBe(2);
+  });
+
+  it('should revert edited value when onRowUpdate rejects', async() => {
+    const onRowUpdate = jasmine.createSpy('onRowUpdate').and.callFake(async() => {
+      return Promise.reject(new Error('Update failed'));
+    });
+    const dataProvider = jasmine.createSpy('dataProvider').and.callFake(async() => ({
+      rows: [{ id: 1, name: 'Alice' }],
+      totalRows: 1,
+    }));
+
+    handsontable({
+      colHeaders: true,
+      columns: [
+        { data: 'id', readOnly: true },
+        { data: 'name' },
+      ],
+      dataProvider,
+      onRowUpdate,
+      rowId: 'id',
+    });
+
+    await sleep(150);
+    await setDataAtCell(0, 1, 'Alicia', 'edit');
+    await sleep(250);
+
+    expect(getDataAtCell(0, 1)).toBe('Alice');
+  });
+});

--- a/handsontable/src/plugins/serverSideData/__tests__/serverSideData.unit.js
+++ b/handsontable/src/plugins/serverSideData/__tests__/serverSideData.unit.js
@@ -1,0 +1,58 @@
+import {
+  cloneQueryParameters,
+  normalizePage,
+  normalizePageSize,
+} from '../serverSideData';
+
+describe('ServerSideData (unit)', () => {
+  describe('normalizePage', () => {
+    it('should return a positive integer page number', () => {
+      expect(normalizePage('3')).toBe(3);
+      expect(normalizePage(2)).toBe(2);
+    });
+
+    it('should return fallback for invalid values', () => {
+      expect(normalizePage(0, 7)).toBe(7);
+      expect(normalizePage(-1, 7)).toBe(7);
+      expect(normalizePage('foo', 7)).toBe(7);
+    });
+  });
+
+  describe('normalizePageSize', () => {
+    it('should return a positive integer page size', () => {
+      expect(normalizePageSize('25')).toBe(25);
+      expect(normalizePageSize(50)).toBe(50);
+    });
+
+    it('should return fallback for invalid values', () => {
+      expect(normalizePageSize(0, 40)).toBe(40);
+      expect(normalizePageSize(-10, 40)).toBe(40);
+      expect(normalizePageSize('foo', 40)).toBe(40);
+    });
+  });
+
+  describe('cloneQueryParameters', () => {
+    it('should return a shallow-cloned query object', () => {
+      const queryParameters = {
+        page: 2,
+        pageSize: 50,
+        sort: {
+          column: 'price',
+          direction: 'asc',
+        },
+        filters: {
+          category: {
+            operator: 'contains',
+            value: 'books',
+          },
+        },
+      };
+      const clonedQueryParameters = cloneQueryParameters(queryParameters);
+
+      expect(clonedQueryParameters).toEqual(queryParameters);
+      expect(clonedQueryParameters).not.toBe(queryParameters);
+      expect(clonedQueryParameters.sort).not.toBe(queryParameters.sort);
+      expect(clonedQueryParameters.filters).not.toBe(queryParameters.filters);
+    });
+  });
+});

--- a/handsontable/src/plugins/serverSideData/index.js
+++ b/handsontable/src/plugins/serverSideData/index.js
@@ -1,0 +1,5 @@
+export {
+  PLUGIN_KEY,
+  PLUGIN_PRIORITY,
+  ServerSideData,
+} from './serverSideData';

--- a/handsontable/src/plugins/serverSideData/serverSideData.js
+++ b/handsontable/src/plugins/serverSideData/serverSideData.js
@@ -1,0 +1,673 @@
+import { BasePlugin } from '../base';
+import { warn, info, error } from '../../helpers/console';
+import { isFunction } from '../../helpers/function';
+import { isObject } from '../../helpers/object';
+import { throwWithCause } from '../../helpers/errors';
+
+export const PLUGIN_KEY = 'serverSideData';
+export const PLUGIN_PRIORITY = 45;
+const REQUEST_DEBOUNCE_MS = 100;
+
+/**
+ * Clone query parameters object.
+ *
+ * @param {object} queryParameters Query parameters to clone.
+ * @returns {{page: number, pageSize: number, sort: object | null, filters: object | null}}
+ */
+export function cloneQueryParameters(queryParameters) {
+  return {
+    page: queryParameters.page,
+    pageSize: queryParameters.pageSize,
+    sort: queryParameters.sort ? { ...queryParameters.sort } : null,
+    filters: queryParameters.filters ? { ...queryParameters.filters } : null,
+  };
+}
+
+/**
+ * Normalize page number.
+ *
+ * @param {number|string} value Candidate page number.
+ * @param {number} [fallbackValue=1] Fallback page number.
+ * @returns {number}
+ */
+export function normalizePage(value, fallbackValue = 1) {
+  const normalizedValue = Number.parseInt(value, 10);
+
+  return Number.isInteger(normalizedValue) && normalizedValue > 0 ? normalizedValue : fallbackValue;
+}
+
+/**
+ * Normalize page size.
+ *
+ * @param {number|string} value Candidate page size.
+ * @param {number} [fallbackValue=20] Fallback page size.
+ * @returns {number}
+ */
+export function normalizePageSize(value, fallbackValue = 20) {
+  const normalizedValue = Number.parseInt(value, 10);
+
+  return Number.isInteger(normalizedValue) && normalizedValue > 0 ? normalizedValue : fallbackValue;
+}
+
+/**
+ * @plugin ServerSideData
+ * @class ServerSideData
+ */
+export class ServerSideData extends BasePlugin {
+  static get PLUGIN_KEY() {
+    return PLUGIN_KEY;
+  }
+
+  static get PLUGIN_PRIORITY() {
+    return PLUGIN_PRIORITY;
+  }
+
+  static get SETTING_KEYS() {
+    return [
+      'dataProvider',
+      'dataProviderParams',
+      'rowId',
+      'onRowCreate',
+      'onRowUpdate',
+      'onRowRemove',
+      'pagination',
+    ];
+  }
+
+  #queryParameters = {
+    page: 1,
+    pageSize: 20,
+    sort: null,
+    filters: null,
+  };
+  #totalRows = 0;
+  #requestController = null;
+  #requestId = 0;
+  #activeRequestId = 0;
+  #requestDebounceTimer = null;
+  #isDestroyed = false;
+  #mutationQueue = Promise.resolve();
+
+  isEnabled() {
+    return isFunction(this.hot.getSettings().dataProvider);
+  }
+
+  enablePlugin() {
+    if (this.enabled) {
+      return;
+    }
+
+    if (this.hot.getSettings().data !== undefined) {
+      warn('Both `data` and `dataProvider` are set. Handsontable will prioritize `dataProvider` in server-side mode.');
+    }
+
+    this.#initializeQueryParameters();
+
+    this.addHook('afterInit', () => this.refreshData('serverSideData.init'));
+    this.addHook('beforePageChange', (...args) => this.#onBeforePageChange(...args), -100);
+    this.addHook('beforePageSizeChange', (...args) => this.#onBeforePageSizeChange(...args), -100);
+    this.addHook('beforeColumnSort', (...args) => this.#onBeforeColumnSort(...args), -100);
+    this.addHook('afterFilter', (...args) => this.#onAfterFilter(...args), 100);
+    this.addHook('afterChange', (...args) => this.#onAfterChange(...args), 100);
+    this.addHook('beforeCreateRow', (...args) => this.#onBeforeCreateRow(...args), -100);
+    this.addHook('beforeRemoveRow', (...args) => this.#onBeforeRemoveRow(...args), -100);
+    this.addHook('beforeContextMenuSetItems', (...args) => this.#onBeforeContextMenuSetItems(...args), -100);
+
+    if (this.hot.getSettings().manualRowMove) {
+      info('`manualRowMove` is disabled in server-side mode because row order is controlled by the server.');
+    }
+    if (this.hot.getSettings().trimRows) {
+      info('`trimRows` is disabled in server-side mode because row visibility is controlled by the server.');
+    }
+    if (this.hot.getSettings().multiColumnSorting) {
+      info('`multiColumnSorting` is disabled in server-side mode. Use single-column sorting with `dataProvider`.');
+    }
+
+    super.enablePlugin();
+  }
+
+  updatePlugin(newSettings) {
+    if (!this.isEnabled()) {
+      this.disablePlugin();
+
+      return;
+    }
+
+    if (newSettings?.pagination || newSettings?.dataProviderParams) {
+      this.#initializeQueryParameters();
+      this.refreshData('serverSideData.updateSettings');
+    }
+
+    super.updatePlugin();
+  }
+
+  disablePlugin() {
+    if (this.#requestController) {
+      this.#requestController.abort();
+      this.#requestController = null;
+    }
+
+    if (this.#requestDebounceTimer !== null) {
+      this.hot.rootWindow.clearTimeout(this.#requestDebounceTimer);
+      this.#requestDebounceTimer = null;
+    }
+
+    super.disablePlugin();
+  }
+
+  getQueryParameters() {
+    return cloneQueryParameters(this.#queryParameters);
+  }
+
+  refreshData(source = 'serverSideData.refreshData') {
+    if (!this.enabled || this.#isDestroyed) {
+      return Promise.resolve();
+    }
+
+    return this.#fetchData(source);
+  }
+
+  createRow(row = {}) {
+    const onRowCreate = this.hot.getSettings().onRowCreate;
+
+    if (!isFunction(onRowCreate)) {
+      throwWithCause('The `createRow()` method requires the `onRowCreate` callback to be defined.');
+    }
+
+    return this.#enqueueMutation(
+      'create',
+      row,
+      async() => {
+        await onRowCreate(row);
+        await this.#refreshAfterMutation('create');
+      }
+    );
+  }
+
+  updateRow(id, changes = {}) {
+    const onRowUpdate = this.hot.getSettings().onRowUpdate;
+
+    if (!isFunction(onRowUpdate)) {
+      throwWithCause('The `updateRow()` method requires the `onRowUpdate` callback to be defined.');
+    }
+
+    const rowIdKey = this.hot.getSettings().rowId;
+    const visualRow = this.#findVisualRowById(id);
+    const currentRowData = visualRow >= 0 ? this.hot.getSourceDataAtRow(visualRow) : {};
+    const rowData = isObject(currentRowData) ? { ...currentRowData, ...changes } : { ...changes, [rowIdKey]: id };
+
+    return this.#enqueueMutation(
+      'update',
+      { id, changes, rowData },
+      async() => {
+        await onRowUpdate(id, changes, rowData);
+        await this.#refreshAfterMutation('update');
+      }
+    );
+  }
+
+  removeRow(id) {
+    const onRowRemove = this.hot.getSettings().onRowRemove;
+
+    if (!isFunction(onRowRemove)) {
+      throwWithCause('The `removeRow()` method requires the `onRowRemove` callback to be defined.');
+    }
+
+    return this.#enqueueMutation(
+      'remove',
+      { id },
+      async() => {
+        await onRowRemove(id);
+        await this.#refreshAfterMutation('remove');
+      }
+    );
+  }
+
+  #initializeQueryParameters() {
+    const {
+      dataProviderParams,
+      pagination,
+    } = this.hot.getSettings();
+    const defaultPageSize = typeof pagination === 'object' && pagination?.pageSize !== 'auto' ?
+      normalizePageSize(pagination?.pageSize, 20) : 20;
+    const nextQueryParameters = {
+      page: 1,
+      pageSize: defaultPageSize,
+      sort: null,
+      filters: null,
+    };
+
+    if (isObject(dataProviderParams)) {
+      if (dataProviderParams.page !== undefined) {
+        nextQueryParameters.page = normalizePage(dataProviderParams.page, nextQueryParameters.page);
+      }
+      if (dataProviderParams.pageSize !== undefined) {
+        nextQueryParameters.pageSize = normalizePageSize(dataProviderParams.pageSize, nextQueryParameters.pageSize);
+      }
+      if (dataProviderParams.sort !== undefined) {
+        nextQueryParameters.sort = dataProviderParams.sort ?? null;
+      }
+      if (dataProviderParams.filters !== undefined) {
+        nextQueryParameters.filters = dataProviderParams.filters ?? null;
+      }
+    }
+
+    this.#queryParameters = nextQueryParameters;
+  }
+
+  #fetchData(source) {
+    const dataProvider = this.hot.getSettings().dataProvider;
+
+    if (!isFunction(dataProvider)) {
+      return Promise.resolve();
+    }
+
+    if (this.#requestController) {
+      this.#requestController.abort();
+    }
+
+    const requestController = new AbortController();
+
+    this.#requestController = requestController;
+
+    this.#requestId += 1;
+
+    const requestId = this.#requestId;
+
+    this.#activeRequestId = requestId;
+    this.#showLoadingState();
+
+    let queryParameters = cloneQueryParameters(this.#queryParameters);
+
+    try {
+      const modifiedQueryParameters = this.hot.runHooks('beforeDataProviderRequest', queryParameters, source);
+
+      if (modifiedQueryParameters === false) {
+        return Promise.resolve();
+      }
+      if (isObject(modifiedQueryParameters)) {
+        queryParameters = {
+          ...queryParameters,
+          ...modifiedQueryParameters,
+        };
+      }
+
+      const fetchPromise = Promise.resolve(
+        dataProvider(queryParameters, { signal: this.#requestController.signal })
+      );
+
+      return fetchPromise.then((response) => {
+        if (requestController.signal.aborted || requestId !== this.#activeRequestId) {
+          return;
+        }
+
+        if (!isObject(response) || !Array.isArray(response.rows)) {
+          throwWithCause('`dataProvider` must resolve to an object containing a `rows` array.');
+        }
+
+        const totalRows = Number.parseInt(response.totalRows, 10);
+
+        if (!Number.isInteger(totalRows) || totalRows < 0) {
+          throwWithCause('`dataProvider` must resolve with a non-negative integer `totalRows`.');
+        }
+
+        this.#totalRows = totalRows;
+
+        this.hot.loadData(response.rows, 'serverSideData.dataProvider');
+        this.#syncPaginationState();
+        this.hot.runHooks('afterDataProviderResponse', response, cloneQueryParameters(queryParameters));
+      }).catch((fetchError) => {
+        if (requestController.signal.aborted) {
+          return;
+        }
+
+        this.hot.runHooks('afterDataProviderError', fetchError, cloneQueryParameters(queryParameters));
+        error(fetchError);
+      }).finally(() => {
+        if (requestId === this.#activeRequestId) {
+          this.#hideLoadingState();
+        }
+      });
+    } catch (hookError) {
+      this.#hideLoadingState();
+      this.hot.runHooks('afterDataProviderError', hookError, cloneQueryParameters(queryParameters));
+      error(hookError);
+
+      return Promise.reject(hookError);
+    }
+  }
+
+  #syncPaginationState() {
+    const paginationPlugin = this.hot.getPlugin('pagination');
+
+    if (paginationPlugin?.enabled && isFunction(paginationPlugin.setServerPaginationData)) {
+      paginationPlugin.setServerPaginationData({
+        currentPage: this.#queryParameters.page,
+        pageSize: this.#queryParameters.pageSize,
+        totalRows: this.#totalRows,
+      });
+    }
+  }
+
+  #showLoadingState() {
+    const loadingPlugin = this.hot.getPlugin('loading');
+
+    if (loadingPlugin?.enabled) {
+      loadingPlugin.show();
+    }
+  }
+
+  #hideLoadingState() {
+    const loadingPlugin = this.hot.getPlugin('loading');
+
+    if (loadingPlugin?.enabled) {
+      loadingPlugin.hide();
+    }
+  }
+
+  #scheduleFetch(source) {
+    if (this.#requestDebounceTimer !== null) {
+      this.hot.rootWindow.clearTimeout(this.#requestDebounceTimer);
+    }
+
+    this.#requestDebounceTimer = this.hot.rootWindow.setTimeout(() => {
+      this.#requestDebounceTimer = null;
+      this.#fetchData(source);
+    }, REQUEST_DEBOUNCE_MS);
+  }
+
+  #onBeforePageChange(_oldPage, newPage) {
+    this.#queryParameters.page = normalizePage(newPage, this.#queryParameters.page);
+    this.#scheduleFetch('serverSideData.pageChange');
+
+    return false;
+  }
+
+  #onBeforePageSizeChange(_oldPageSize, newPageSize) {
+    if (newPageSize === 'auto') {
+      warn('The `auto` pagination page size is not supported in server-side mode.');
+
+      return false;
+    }
+
+    this.#queryParameters.pageSize = normalizePageSize(newPageSize, this.#queryParameters.pageSize);
+    this.#queryParameters.page = 1;
+    this.#scheduleFetch('serverSideData.pageSizeChange');
+
+    return false;
+  }
+
+  #onBeforeColumnSort(_currentSortConfig, destinationSortConfigs) {
+    const sortingConfig = Array.isArray(destinationSortConfigs) ? destinationSortConfigs[0] : destinationSortConfigs;
+    const columnSortingPlugin = this.hot.getPlugin('columnSorting');
+
+    if (isFunction(columnSortingPlugin?.setSortConfig)) {
+      columnSortingPlugin.setSortConfig(sortingConfig ? [sortingConfig] : []);
+    }
+
+    if (sortingConfig && Number.isInteger(sortingConfig.column) && sortingConfig.sortOrder) {
+      const columnProp = this.hot.colToProp(sortingConfig.column);
+
+      this.#queryParameters.sort = {
+        column: `${columnProp}`,
+        direction: sortingConfig.sortOrder,
+      };
+    } else {
+      this.#queryParameters.sort = null;
+    }
+
+    this.#queryParameters.page = 1;
+    this.hot.render();
+    this.#scheduleFetch('serverSideData.sortChange');
+
+    return false;
+  }
+
+  #onAfterFilter(conditionsStack) {
+    const filterModel = {};
+
+    conditionsStack.forEach((columnConditions) => {
+      const firstCondition = columnConditions.conditions?.[0];
+      const operator = firstCondition?.name ?? firstCondition?.command?.key;
+
+      if (!operator) {
+        return;
+      }
+
+      const columnProp = this.hot.colToProp(columnConditions.column);
+
+      filterModel[columnProp] = {
+        operator,
+        value: firstCondition?.args?.[0] ?? null,
+      };
+    });
+
+    this.#queryParameters.filters = Object.keys(filterModel).length > 0 ? filterModel : null;
+    this.#queryParameters.page = 1;
+    this.#scheduleFetch('serverSideData.filterChange');
+  }
+
+  #onAfterChange(changes, source) {
+    const onRowUpdate = this.hot.getSettings().onRowUpdate;
+
+    if (!Array.isArray(changes) || !isFunction(onRowUpdate) || this.#isInternalSource(source)) {
+      return;
+    }
+
+    const groupedChanges = new Map();
+
+    changes.forEach(([visualRow, prop, oldValue, newValue]) => {
+      if (oldValue === newValue || visualRow < 0) {
+        return;
+      }
+
+      const visualColumn = this.hot.propToCol(prop);
+      const rowData = this.hot.getSourceDataAtRow(visualRow);
+      const rowId = this.#extractRowId(rowData);
+
+      if (rowId === undefined) {
+        warn('Skipping `onRowUpdate` call because row identifier is missing.');
+
+        return;
+      }
+
+      if (!groupedChanges.has(visualRow)) {
+        groupedChanges.set(visualRow, {
+          id: rowId,
+          rowData,
+          changes: {},
+          revertStack: [],
+        });
+      }
+
+      const groupedChange = groupedChanges.get(visualRow);
+
+      groupedChange.changes[prop] = newValue;
+      groupedChange.revertStack.push([visualRow, visualColumn, oldValue]);
+    });
+
+    groupedChanges.forEach((payload) => {
+      this.#enqueueMutation(
+        'update',
+        {
+          id: payload.id,
+          changes: payload.changes,
+          rowData: payload.rowData,
+        },
+        async() => {
+          await onRowUpdate(payload.id, payload.changes, payload.rowData);
+          await this.#refreshAfterMutation('update');
+        },
+        (mutationError) => {
+          payload.revertStack.forEach(([row, column, oldValue]) => {
+            this.hot.setDataAtCell(row, column, oldValue, 'serverSideData.revert');
+          });
+          this.hot.runHooks('afterDataProviderError', mutationError, this.getQueryParameters());
+          this.hot.render();
+        }
+      );
+    });
+  }
+
+  #onBeforeCreateRow(_index, amount = 1, source = 'edit') {
+    const onRowCreate = this.hot.getSettings().onRowCreate;
+
+    if (source.startsWith('serverSideData.')) {
+      return;
+    }
+
+    if (!isFunction(onRowCreate)) {
+      return false;
+    }
+
+    for (let rowOffset = 0; rowOffset < amount; rowOffset += 1) {
+      const rowPayload = {};
+
+      this.#enqueueMutation(
+        'create',
+        rowPayload,
+        async() => {
+          await onRowCreate(rowPayload);
+          await this.#refreshAfterMutation('create');
+        }
+      );
+    }
+
+    return false;
+  }
+
+  #onBeforeRemoveRow(index, amount = 1, _physicalRows, source = 'edit') {
+    const onRowRemove = this.hot.getSettings().onRowRemove;
+
+    if (source.startsWith('serverSideData.')) {
+      return;
+    }
+
+    if (!isFunction(onRowRemove)) {
+      return false;
+    }
+
+    const rowIds = [];
+
+    for (let visualRow = index; visualRow < index + amount; visualRow += 1) {
+      const rowData = this.hot.getSourceDataAtRow(visualRow);
+      const rowId = this.#extractRowId(rowData);
+
+      if (rowId !== undefined) {
+        rowIds.push(rowId);
+      }
+    }
+
+    if (rowIds.length === 0) {
+      warn('Skipping `onRowRemove` call because selected rows do not have identifiers.');
+
+      return false;
+    }
+
+    this.#enqueueMutation(
+      'remove',
+      { ids: rowIds },
+      async() => {
+        await Promise.all(rowIds.map(rowId => onRowRemove(rowId)));
+        await this.#refreshAfterMutation('remove');
+      }
+    );
+
+    return false;
+  }
+
+  #onBeforeContextMenuSetItems(menuItems) {
+    const hasCreate = isFunction(this.hot.getSettings().onRowCreate);
+    const hasRemove = isFunction(this.hot.getSettings().onRowRemove);
+
+    menuItems.forEach((menuItem) => {
+      if (!isObject(menuItem)) {
+        return;
+      }
+
+      if (menuItem.key === 'row_above' || menuItem.key === 'row_below') {
+        if (!hasCreate) {
+          menuItem.hidden = true;
+        }
+      }
+
+      if (menuItem.key === 'remove_row' && !hasRemove) {
+        menuItem.hidden = true;
+      }
+    });
+  }
+
+  #isInternalSource(source) {
+    return source === 'loadData' ||
+      source === 'updateData' ||
+      (typeof source === 'string' && source.startsWith('serverSideData.'));
+  }
+
+  #extractRowId(rowData) {
+    const rowIdKey = this.hot.getSettings().rowId;
+
+    if (isObject(rowData)) {
+      return rowData[rowIdKey];
+    }
+    if (Array.isArray(rowData)) {
+      return rowData[rowIdKey];
+    }
+
+    return undefined;
+  }
+
+  #findVisualRowById(id) {
+    const rowIdKey = this.hot.getSettings().rowId;
+
+    for (let visualRow = 0; visualRow < this.hot.countRows(); visualRow += 1) {
+      const rowData = this.hot.getSourceDataAtRow(visualRow);
+
+      if ((isObject(rowData) || Array.isArray(rowData)) && rowData[rowIdKey] === id) {
+        return visualRow;
+      }
+    }
+
+    return -1;
+  }
+
+  #refreshAfterMutation(type) {
+    if (type === 'remove' && this.hot.countRows() <= 1 && this.#queryParameters.page > 1) {
+      this.#queryParameters.page -= 1;
+    }
+
+    return this.refreshData(`serverSideData.mutation.${type}`);
+  }
+
+  #enqueueMutation(type, payload, callback, onError) {
+    const queuedMutation = this.#mutationQueue.then(async() => {
+      const shouldProceed = this.hot.runHooks('beforeRowMutation', type, payload);
+
+      if (shouldProceed === false) {
+        return;
+      }
+
+      try {
+        await callback();
+        this.hot.runHooks('afterRowMutation', type, payload);
+      } catch (mutationError) {
+        this.hot.runHooks('afterRowMutationError', type, mutationError, payload);
+
+        if (isFunction(onError)) {
+          onError(mutationError);
+        }
+
+        throw mutationError;
+      }
+    });
+
+    this.#mutationQueue = queuedMutation.catch(() => undefined);
+
+    return queuedMutation;
+  }
+
+  destroy() {
+    this.#isDestroyed = true;
+    this.disablePlugin();
+    super.destroy();
+  }
+}

--- a/handsontable/src/plugins/trimRows/trimRows.js
+++ b/handsontable/src/plugins/trimRows/trimRows.js
@@ -177,7 +177,7 @@ export class TrimRows extends BasePlugin {
    * @returns {boolean}
    */
   isEnabled() {
-    return !!this.hot.getSettings()[PLUGIN_KEY];
+    return !!this.hot.getSettings()[PLUGIN_KEY] && typeof this.hot.getSettings().dataProvider !== 'function';
   }
 
   /**

--- a/handsontable/test/e2e/core/serverSideData.spec.js
+++ b/handsontable/test/e2e/core/serverSideData.spec.js
@@ -1,0 +1,161 @@
+describe('Core: server-side data mode', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should pass pagination, sorting, and filtering query parameters to dataProvider', async() => {
+    const queryHistory = [];
+    const sourceRows = [
+      { id: 1, name: 'Alpha', category: 'a' },
+      { id: 2, name: 'Bravo', category: 'b' },
+      { id: 3, name: 'Charlie', category: 'a' },
+      { id: 4, name: 'Delta', category: 'b' },
+      { id: 5, name: 'Echo', category: 'a' },
+      { id: 6, name: 'Foxtrot', category: 'b' },
+    ];
+    const dataProvider = async(queryParameters) => {
+      queryHistory.push(queryParameters);
+
+      let rows = sourceRows.slice();
+
+      if (queryParameters.filters?.category) {
+        rows = rows.filter(row => row.category.includes(queryParameters.filters.category.value));
+      }
+      if (queryParameters.sort?.column) {
+        const directionFactor = queryParameters.sort.direction === 'asc' ? 1 : -1;
+
+        rows.sort((rowA, rowB) => {
+          if (rowA[queryParameters.sort.column] > rowB[queryParameters.sort.column]) {
+            return directionFactor;
+          }
+          if (rowA[queryParameters.sort.column] < rowB[queryParameters.sort.column]) {
+            return -directionFactor;
+          }
+
+          return 0;
+        });
+      }
+
+      const start = (queryParameters.page - 1) * queryParameters.pageSize;
+      const end = start + queryParameters.pageSize;
+
+      return {
+        rows: rows.slice(start, end),
+        totalRows: rows.length,
+      };
+    };
+
+    handsontable({
+      colHeaders: true,
+      columns: [
+        { data: 'id' },
+        { data: 'name' },
+        { data: 'category' },
+      ],
+      pagination: {
+        pageSize: 2,
+      },
+      columnSorting: true,
+      filters: true,
+      dropdownMenu: true,
+      dataProvider,
+    });
+
+    await sleep(150);
+    expect(queryHistory[0]).toEqual({
+      page: 1,
+      pageSize: 2,
+      sort: null,
+      filters: null,
+    });
+
+    getPlugin('pagination').setPage(2);
+    await sleep(180);
+    expect(queryHistory[queryHistory.length - 1].page).toBe(2);
+
+    getPlugin('columnSorting').sort({ column: 1, sortOrder: 'desc' });
+    await sleep(180);
+    expect(queryHistory[queryHistory.length - 1].sort).toEqual({
+      column: 'name',
+      direction: 'desc',
+    });
+    expect(queryHistory[queryHistory.length - 1].page).toBe(1);
+
+    getPlugin('filters').addCondition(2, 'contains', ['a']);
+    getPlugin('filters').filter();
+    await sleep(180);
+    expect(queryHistory[queryHistory.length - 1].filters).toEqual({
+      category: {
+        operator: 'contains',
+        value: 'a',
+      },
+    });
+  });
+
+  it('should support server-side create/update/remove API methods', async() => {
+    let sourceRows = [
+      { id: 1, name: 'Alice', category: 'x' },
+      { id: 2, name: 'Bob', category: 'y' },
+    ];
+    const onRowCreate = jasmine.createSpy('onRowCreate').and.callFake(async(rowData) => {
+      sourceRows.push({
+        id: 3,
+        name: rowData.name ?? 'Created',
+        category: rowData.category ?? 'z',
+      });
+    });
+    const onRowUpdate = jasmine.createSpy('onRowUpdate').and.callFake(async(idToUpdate, changes) => {
+      sourceRows = sourceRows.map((row) => {
+        if (row.id === idToUpdate) {
+          return { ...row, ...changes };
+        }
+
+        return row;
+      });
+    });
+    const onRowRemove = jasmine.createSpy('onRowRemove').and.callFake(async(idToRemove) => {
+      sourceRows = sourceRows.filter(row => row.id !== idToRemove);
+    });
+    const dataProvider = async() => ({
+      rows: sourceRows.slice(),
+      totalRows: sourceRows.length,
+    });
+
+    handsontable({
+      colHeaders: true,
+      columns: [
+        { data: 'id' },
+        { data: 'name' },
+        { data: 'category' },
+      ],
+      dataProvider,
+      rowId: 'id',
+      onRowCreate,
+      onRowUpdate,
+      onRowRemove,
+    });
+
+    await sleep(150);
+
+    await hot().createRow({ name: 'Carla', category: 'z' });
+    expect(onRowCreate).toHaveBeenCalledWith({ name: 'Carla', category: 'z' });
+    expect(getDataAtCell(2, 1)).toBe('Carla');
+
+    await hot().updateRow(2, { name: 'Bobby' });
+    expect(onRowUpdate).toHaveBeenCalledWith(2, { name: 'Bobby' }, jasmine.any(Object));
+    expect(getDataAtCell(1, 1)).toBe('Bobby');
+
+    await hot().removeRow(1);
+    expect(onRowRemove).toHaveBeenCalledWith(1);
+    expect(getDataAtCell(0, 0)).toBe(2);
+  });
+});

--- a/handsontable/types/core.d.ts
+++ b/handsontable/types/core.d.ts
@@ -10,6 +10,7 @@ import {
   CellMeta,
   CellProperties,
   ColumnSettings,
+  QueryParameters,
 } from './settings';
 import CellCoords from './3rdparty/walkontable/src/cell/coords';
 import CellRange from './3rdparty/walkontable/src/cell/range';
@@ -82,6 +83,7 @@ export default class Core {
   getDataAtRow(row: number): CellValue[];
   getDataAtRowProp(row: number, prop: string): CellValue;
   getDataType(rowFrom: number, columnFrom: number, rowTo: number, columnTo: number): CellType | 'mixed';
+  getQueryParameters(): QueryParameters;
   getDirectionFactor(): 1 | -1;
   getFirstFullyVisibleColumn(): number | null;
   getFirstFullyVisibleRow(): number | null;
@@ -141,6 +143,7 @@ export default class Core {
     endColumn?: number, source?: string, method?: 'shift_down' | 'shift_right' | 'overwrite'): void;
   propToCol<T extends number | string>(prop: string | number): T;
   refreshDimensions(): void;
+  refreshData(): Promise<void>;
   removeCellMeta(row: number, column: number, key: (keyof CellMeta) | string): void;
   removeHook<K extends keyof Events>(key: K, callback: Events[K]): void;
   render(): void;
@@ -185,6 +188,9 @@ export default class Core {
   toVisualRow(row: number): number;
   unlisten(): void;
   updateData(data: CellValue[][] | RowObject[], source?: string): void;
+  createRow(rowData: object): Promise<void>;
+  removeRow(rowId: string | number): Promise<void>;
+  updateRow(rowId: string | number, changes: object): Promise<void>;
   updateSettings(settings: GridSettings, init?: boolean): void;
   useTheme(themeName: string|boolean|undefined): void;
   validateCell(value: any, cellProperties: CellProperties, callback: (valid: boolean) => void, source: string): void;

--- a/handsontable/types/core/hooks/index.d.ts
+++ b/handsontable/types/core/hooks/index.d.ts
@@ -124,6 +124,33 @@ export interface Events {
   afterPageNavigationVisibilityChange?: (isVisible: boolean) => void;
   afterPageSizeChange?: (oldPageSize: number | 'auto', newPageSize: number | 'auto') => void;
   afterPageSizeVisibilityChange?: (isVisible: boolean) => void;
+  afterDataProviderResponse?: (
+    response: { rows: RowObject[], totalRows: number },
+    queryParameters: {
+      page: number,
+      pageSize: number,
+      sort: { column: string, direction: 'asc' | 'desc' } | null,
+      filters: Record<string, { operator: string, value: unknown }> | null
+    }
+  ) => void;
+  afterDataProviderError?: (
+    error: Error,
+    queryParameters: {
+      page: number,
+      pageSize: number,
+      sort: { column: string, direction: 'asc' | 'desc' } | null,
+      filters: Record<string, { operator: string, value: unknown }> | null
+    }
+  ) => void;
+  afterRowMutation?: (
+    type: 'create' | 'update' | 'remove',
+    payload: object
+  ) => void;
+  afterRowMutationError?: (
+    type: 'create' | 'update' | 'remove',
+    error: Error,
+    payload: object
+  ) => void;
   afterPaste?: (data: CellValue[][], coords: RangeType[]) => void;
   afterPluginsInitialized?: () => void;
   afterRedo?: (action: UndoRedoAction) => void;
@@ -219,6 +246,19 @@ export interface Events {
   beforeOnCellMouseUp?: (event: MouseEvent, coords: CellCoords, TD: HTMLTableCellElement) => void;
   beforePageChange?: (oldPage: number, newPage: number) => void | boolean;
   beforePageSizeChange?: (oldPageSize: number | 'auto', newPageSize: number | 'auto') => void | boolean;
+  beforeDataProviderRequest?: (
+    queryParameters: {
+      page: number,
+      pageSize: number,
+      sort: { column: string, direction: 'asc' | 'desc' } | null,
+      filters: Record<string, { operator: string, value: unknown }> | null
+    },
+    source: string
+  ) => object | boolean | void;
+  beforeRowMutation?: (
+    type: 'create' | 'update' | 'remove',
+    payload: object
+  ) => void | boolean;
   beforePaste?: (data: CellValue[][], coords: RangeType[]) => void | boolean;
   beforeRedo?: (action: UndoRedoAction) => void;
   beforeRedoStackChange?: (undoneActions: UndoRedoAction[]) => void;

--- a/handsontable/types/index.d.ts
+++ b/handsontable/types/index.d.ts
@@ -13,6 +13,12 @@ import {
   ColumnSettings,
   CellMeta,
   CellProperties,
+  DataProvider,
+  DataProviderResponse,
+  QueryParameters,
+  OnRowCreate,
+  OnRowUpdate,
+  OnRowRemove,
 } from './settings';
 import {
   ThemeConfig,
@@ -249,6 +255,9 @@ import {
   Settings as PaginationSettings,
 } from './plugins/pagination';
 import {
+  ServerSideData as _ServerSideData,
+} from './plugins/serverSideData';
+import {
   Search as _Search,
   Settings as SearchSettings,
   SearchCallback,
@@ -316,6 +325,12 @@ declare namespace Handsontable {
     ColumnSettings,
     GridSettings,
     NumericFormatOptions,
+    DataProvider,
+    DataProviderResponse,
+    QueryParameters,
+    OnRowCreate,
+    OnRowUpdate,
+    OnRowRemove,
     // themes
     ThemeConfig,
     ThemeColorScheme,
@@ -469,6 +484,7 @@ declare namespace Handsontable {
     export class NestedHeaders extends _NestedHeaders {}
     export class NestedRows extends _NestedRows {}
     export class Pagination extends _Pagination {}
+    export class ServerSideData extends _ServerSideData {}
     export class Search extends _Search {}
     export class TouchScroll extends _TouchScroll {}
     export class TrimRows extends _TrimRows {}
@@ -609,6 +625,15 @@ declare namespace Handsontable {
 
     export namespace Pagination {
       export { PaginationSettings as Settings };
+    }
+
+    export namespace ServerSideData {
+      export { DataProvider };
+      export { DataProviderResponse };
+      export { QueryParameters };
+      export { OnRowCreate };
+      export { OnRowUpdate };
+      export { OnRowRemove };
     }
 
     export namespace Search {

--- a/handsontable/types/plugins/index.d.ts
+++ b/handsontable/types/plugins/index.d.ts
@@ -29,6 +29,7 @@ import { NestedHeaders } from './nestedHeaders';
 import { NestedRows } from './nestedRows';
 import { Pagination } from './pagination';
 import { Search } from './search';
+import { ServerSideData } from './serverSideData';
 import { StretchColumns } from './stretchColumns';
 import { TouchScroll } from './touchScroll';
 import { TrimRows } from './trimRows';
@@ -68,6 +69,7 @@ export interface Plugins {
   nestedHeaders: NestedHeaders;
   nestedRows: NestedRows;
   pagination: Pagination;
+  serverSideData: ServerSideData;
   search: Search;
   stretchColumns: StretchColumns;
   touchScroll: TouchScroll;
@@ -112,6 +114,7 @@ export {
   NestedHeaders,
   NestedRows,
   Pagination,
+  ServerSideData,
   Search,
   StretchColumns,
   TouchScroll,

--- a/handsontable/types/plugins/pagination/pagination.d.ts
+++ b/handsontable/types/plugins/pagination/pagination.d.ts
@@ -6,6 +6,7 @@ type PageSizeOption = number | 'auto';
 export interface DetailedSettings {
   pageSize?: PageSizeOption;
   pageSizeList?: Array<PageSizeOption>;
+  pageSizeOptions?: Array<PageSizeOption>;
   initialPage?: number;
   showPageSize?: boolean;
   showCounter?: boolean;
@@ -49,4 +50,5 @@ export class Pagination extends BasePlugin {
   hidePageCounterSection(): void;
   showPageNavigationSection(): void;
   hidePageNavigationSection(): void;
+  setServerPaginationData(options: { currentPage: number, pageSize: number, totalRows: number }): void;
 }

--- a/handsontable/types/plugins/serverSideData/index.d.ts
+++ b/handsontable/types/plugins/serverSideData/index.d.ts
@@ -1,0 +1,1 @@
+export * from './serverSideData';

--- a/handsontable/types/plugins/serverSideData/serverSideData.d.ts
+++ b/handsontable/types/plugins/serverSideData/serverSideData.d.ts
@@ -1,0 +1,29 @@
+import Core from '../../core';
+import { BasePlugin } from '../base';
+import {
+  DataProvider,
+  DataProviderResponse,
+  QueryParameters,
+  OnRowCreate,
+  OnRowUpdate,
+  OnRowRemove,
+} from '../../settings';
+
+export {
+  DataProvider,
+  DataProviderResponse,
+  QueryParameters,
+  OnRowCreate,
+  OnRowUpdate,
+  OnRowRemove,
+};
+
+export class ServerSideData extends BasePlugin {
+  constructor(hotInstance: Core);
+
+  getQueryParameters(): QueryParameters;
+  refreshData(source?: string): Promise<void>;
+  createRow(row?: object): Promise<void>;
+  updateRow(id: string | number, changes?: object): Promise<void>;
+  removeRow(id: string | number): Promise<void>;
+}

--- a/handsontable/types/settings.d.ts
+++ b/handsontable/types/settings.d.ts
@@ -97,6 +97,49 @@ export interface CellSettings extends CellMeta {
   col: number;
 }
 
+export interface SortModel {
+  column: string;
+  direction: 'asc' | 'desc';
+}
+
+export interface FilterCondition {
+  operator: string;
+  value: unknown;
+}
+
+export interface FilterModel {
+  [column: string]: FilterCondition;
+}
+
+export interface QueryParameters {
+  page: number;
+  pageSize: number;
+  sort: SortModel | null;
+  filters: FilterModel | null;
+}
+
+export interface FetchOptions {
+  signal: AbortSignal;
+}
+
+export interface DataProviderResponse<TRow = RowObject> {
+  rows: TRow[];
+  totalRows: number;
+}
+
+export type DataProvider<TRow = RowObject> = (
+  queryParameters: QueryParameters,
+  options: FetchOptions
+) => Promise<DataProviderResponse<TRow>>;
+
+export type OnRowCreate<TRow = RowObject> = (row: Partial<TRow>) => Promise<void>;
+export type OnRowUpdate<TRow = RowObject> = (
+  id: string | number,
+  changes: Partial<TRow>,
+  rowData: TRow
+) => Promise<void>;
+export type OnRowRemove = (id: string | number) => Promise<void>;
+
 /**
  * Base table settings that will cascade to columns and cells.
  */
@@ -137,6 +180,8 @@ export interface GridSettings extends Events {
   currentRowClassName?: string;
   customBorders?: CustomBordersSettings;
   data?: CellValue[][] | RowObject[];
+  dataProvider?: DataProvider;
+  dataProviderParams?: Partial<QueryParameters>;
   dataDotNotation?: boolean;
   dataSchema?: RowObject | CellValue[] | ((row: number) => RowObject | CellValue[]);
   dateFormat?: string;
@@ -207,6 +252,7 @@ export interface GridSettings extends Events {
   renderer?: RendererType | string | BaseRenderer;
   rowHeaders?: boolean | string[] | ((index: number) => string);
   rowHeaderWidth?: number | number[];
+  rowId?: string;
   rowHeights?: number | string | number[] | string[] | undefined[] | Array<number | string | undefined> | ((index: number) => string | number | undefined);
   sanitizer?: (content: string, source: 'innerHTML' | 'CopyPaste.paste') => string;
   search?: SearchSettings;
@@ -228,6 +274,9 @@ export interface GridSettings extends Events {
   theme?: ThemeBuilder | BaseTheme | string;
   themeName?: string;
   title?: string;
+  onRowCreate?: OnRowCreate;
+  onRowRemove?: OnRowRemove;
+  onRowUpdate?: OnRowUpdate;
   trimDropdown?: boolean;
   trimRows?: TrimRowsSettings;
   trimWhitespace?: boolean;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Context
This PR introduces a new `serverSideData` core plugin to enable comprehensive server-side data handling within Handsontable. It provides a robust framework for managing server-driven pagination, sorting, filtering, and CRUD operations, along with new core APIs and hooks for seamless integration with remote data sources.

### How has this been tested?
The changes have been thoroughly tested through:
- **Unit tests**: Covering the new plugin's utilities, registration, and core logic.
- **Integration tests**: Validating interactions with existing plugins like pagination, sorting, and filters in a server-side context.
- **End-to-end (E2E) tests (Puppeteer)**: Ensuring full functionality of the server-side data flow, including public CRUD and query APIs, under browser execution.
- **Type declaration tests**: Confirming the correctness of new settings, hooks, and API typings.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. N/A

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

<div><a href="https://cursor.com/agents/bc-99125a95-980f-48ab-b8dd-012674751b3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99125a95-980f-48ab-b8dd-012674751b3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->