### PR TITLE
Scrolling performance bottlenecks

### DIFF
--- a/.changelogs/12142.json
+++ b/.changelogs/12142.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Improved scrolling performance for large datasets with uniform row heights.",
+  "type": "changed",
+  "issueOrPR": 12142,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/src/__tests__/rowHeightSumOptimization.unit.js
+++ b/handsontable/src/3rdparty/walkontable/src/__tests__/rowHeightSumOptimization.unit.js
@@ -1,0 +1,50 @@
+import { getUniformRowHeightSum } from '../overlay/utils/rowHeights';
+
+describe('Walkontable row height sum optimization', () => {
+  it('should provide precomputed sum for uniform-height rows', () => {
+    const wtSettings = {
+      getSetting(key) {
+        if (key === 'uniformRowHeight') {
+          return 23;
+        }
+
+        return undefined;
+      },
+    };
+    const wtViewport = {
+      oversizedRows: [],
+    };
+
+    expect(getUniformRowHeightSum(wtSettings, wtViewport, 0, 100001)).toBe(2300023);
+  });
+
+  it('should skip fast path when oversized rows are present', () => {
+    const wtSettings = {
+      getSetting(key) {
+        if (key === 'uniformRowHeight') {
+          return 23;
+        }
+
+        return undefined;
+      },
+    };
+    const wtViewport = {
+      oversizedRows: [undefined, 40],
+    };
+
+    expect(getUniformRowHeightSum(wtSettings, wtViewport, 0, 100001)).toBeNull();
+  });
+
+  it('should skip fast path when there is no uniform row height', () => {
+    const wtSettings = {
+      getSetting() {
+        return undefined;
+      },
+    };
+    const wtViewport = {
+      oversizedRows: [],
+    };
+
+    expect(getUniformRowHeightSum(wtSettings, wtViewport, 0, 100001)).toBeNull();
+  });
+});

--- a/handsontable/src/3rdparty/walkontable/src/overlay/bottom.js
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/bottom.js
@@ -9,6 +9,7 @@ import {
 } from '../../../../helpers/dom/element';
 import BottomOverlayTable from './../table/bottom';
 import { Overlay } from './_base';
+import { getUniformRowHeightSum } from './utils/rowHeights';
 import {
   CLONE_BOTTOM,
 } from './constants';
@@ -153,6 +154,12 @@ export class BottomOverlay extends Overlay {
    * @returns {number} Height sum.
    */
   sumCellSizes(from, to) {
+    const precomputedRowsHeight = getUniformRowHeightSum(this.wtSettings, this.wot.wtViewport, from, to);
+
+    if (precomputedRowsHeight !== null) {
+      return precomputedRowsHeight;
+    }
+
     const { wtTable, wtSettings } = this.wot;
     const defaultRowHeight = wtSettings.getSetting('stylesHandler').getDefaultRowHeight();
 

--- a/handsontable/src/3rdparty/walkontable/src/overlay/top.js
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/top.js
@@ -13,6 +13,7 @@ import {
 import TopOverlayTable from './../table/top';
 import { Overlay } from './_base';
 import { getCornerStyle } from '../selection';
+import { getUniformRowHeightSum } from './utils/rowHeights';
 import {
   CLONE_TOP,
 } from './constants';
@@ -154,6 +155,12 @@ export class TopOverlay extends Overlay {
    * @returns {number} Height sum.
    */
   sumCellSizes(from, to) {
+    const precomputedRowsHeight = getUniformRowHeightSum(this.wtSettings, this.wot.wtViewport, from, to);
+
+    if (precomputedRowsHeight !== null) {
+      return precomputedRowsHeight;
+    }
+
     const defaultRowHeight = this.wtSettings.getSetting('stylesHandler').getDefaultRowHeight();
     let row = from;
     let sum = 0;

--- a/handsontable/src/3rdparty/walkontable/src/overlay/utils/rowHeights.js
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/utils/rowHeights.js
@@ -1,0 +1,19 @@
+/**
+ * Get the precomputed row-height sum for uniform-height datasets.
+ *
+ * @param {Settings} wtSettings The Walkontable settings.
+ * @param {Viewport} wtViewport The viewport instance.
+ * @param {number} from The starting row index.
+ * @param {number} to The ending row index.
+ * @returns {number|null}
+ */
+export function getUniformRowHeightSum(wtSettings, wtViewport, from, to) {
+  const uniformRowHeight = wtSettings.getSetting('uniformRowHeight');
+  const hasOversizedRows = wtViewport.oversizedRows.length > 0;
+
+  if (Number.isFinite(uniformRowHeight) && !hasOversizedRows) {
+    return (to - from) * uniformRowHeight;
+  }
+
+  return null;
+}

--- a/handsontable/src/3rdparty/walkontable/src/settings.js
+++ b/handsontable/src/3rdparty/walkontable/src/settings.js
@@ -33,6 +33,7 @@ import { throwWithCause } from '../../../helpers/errors';
  * @property {Option} rowHeaders Option `rowHeaders`.
  * @property {Option} rowHeightOption `rowHeight`.
  * @property {Option} rowHeightByOverlayName Option `rowHeightByOverlayName`.
+ * @property {Option} uniformRowHeight Option `uniformRowHeight`.
  * @property {Option} shouldRenderBottomOverlay Option `shouldRenderBottomOverlay`.
  * @property {Option} shouldRenderInlineStartOverlay Option `shouldRenderInlineStartOverlay`.
  * @property {Option} shouldRenderTopOverlay Option `shouldRenderTopOverlay`.
@@ -190,6 +191,9 @@ export default class Settings {
       },
       rowHeightByOverlayName() {
         // return undefined means use default size for the rendered cell content
+      },
+      uniformRowHeight() {
+        // return undefined means there is no reliable, uniform row height.
       },
       defaultColumnWidth: 50,
       selections: null,

--- a/handsontable/src/3rdparty/walkontable/test/spec/scrollPerformance.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/scrollPerformance.spec.js
@@ -1,0 +1,40 @@
+describe('Walkontable scroll performance', () => {
+  beforeEach(function() {
+    this.$wrapper = $('<div></div>').addClass('handsontable').css({ overflow: 'hidden' });
+    this.$container = $('<div></div>');
+    this.$table = $('<table></table>').addClass('htCore');
+    this.$wrapper.append(this.$container);
+    this.$container.append(this.$table);
+    this.$wrapper.appendTo('body');
+  });
+
+  afterEach(function() {
+    $('.wtHolder').remove();
+    this.$wrapper.remove();
+
+    if (this.wotInstance) {
+      this.wotInstance.destroy();
+    }
+  });
+
+  it('should avoid per-row height lookup for large uniform ranges', async function() {
+    const totalRows = 100001;
+    const wt = walkontable({
+      data: () => 'x',
+      totalRows: () => totalRows,
+      totalColumns: () => 5,
+      uniformRowHeight: 23,
+    });
+
+    this.wotInstance = wt;
+    wt.draw();
+
+    spyOn(wt.wtTable, 'getRowHeight').and.callThrough();
+    wt.wtTable.getRowHeight.calls.reset();
+
+    const sum = wt.wtOverlays.topOverlay.sumCellSizes(0, totalRows);
+
+    expect(sum).toBe(totalRows * 23);
+    expect(wt.wtTable.getRowHeight).not.toHaveBeenCalled();
+  });
+});

--- a/handsontable/src/tableView.js
+++ b/handsontable/src/tableView.js
@@ -798,6 +798,33 @@ class TableView {
 
         return this.hot.getRowHeight(visualIndex === null ? renderedRowIndex : visualIndex);
       },
+      uniformRowHeight: () => {
+        const settings = this.hot.getSettings();
+        const rowHeights = settings.rowHeights;
+        const hasDynamicRowHeightHooks = this.hot.hasHook('modifyRowHeight');
+
+        if (hasDynamicRowHeightHooks || settings.autoRowSize || settings.manualRowResize) {
+          return undefined;
+        }
+
+        const defaultRowHeight = this.hot.stylesHandler.getDefaultRowHeight();
+
+        if (rowHeights === undefined || rowHeights === null) {
+          return defaultRowHeight;
+        }
+        if (typeof rowHeights === 'number') {
+          return Math.max(rowHeights, defaultRowHeight);
+        }
+        if (typeof rowHeights === 'string') {
+          const parsedRowHeight = Number.parseInt(rowHeights, 10);
+
+          if (!Number.isNaN(parsedRowHeight)) {
+            return Math.max(parsedRowHeight, defaultRowHeight);
+          }
+        }
+
+        return undefined;
+      },
       rowHeightByOverlayName: (renderedRowIndex, overlayType) => {
         const visualIndex = this.hot.rowIndexMapper.getVisualFromRenderableIndex(renderedRowIndex);
         const visualRowIndex = visualIndex === null ? renderedRowIndex : visualIndex;

--- a/handsontable/test/e2e/core/scrollViewportTo.spec.js
+++ b/handsontable/test/e2e/core/scrollViewportTo.spec.js
@@ -10,6 +10,27 @@ describe('Core.scrollViewportTo', () => {
     }
   });
 
+  it('should avoid linear row-height calls for 100k rows with default row height', async() => {
+    const totalRows = 100001;
+    const hot = handsontable({
+      data: Array.from({ length: totalRows }, (_, index) => [index]),
+      width: 300,
+      height: 300,
+    });
+
+    await render();
+
+    const defaultRowHeight = hot.stylesHandler.getDefaultRowHeight();
+
+    spyOn(hot, 'getRowHeight').and.callThrough();
+    hot.getRowHeight.calls.reset();
+
+    const rowsHeight = tableView()._wt.wtOverlays.topOverlay.sumCellSizes(0, totalRows);
+
+    expect(rowsHeight).toBe(totalRows * defaultRowHeight);
+    expect(hot.getRowHeight).not.toHaveBeenCalled();
+  });
+
   using('configuration object', [
     { htmlDir: 'rtl' },
     { htmlDir: 'ltr' },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Context
Scrolling performance with large datasets (100k+ rows) was poor due to `O(N)` linear row-height summations in Walkontable's hot scroll paths, specifically in `TopOverlay.sumCellSizes()`, `BottomOverlay.sumCellSizes()`, and `TopOverlay.scrollTo(..., bottomEdge=true)`.

This change introduces a safe fast path for uniform row heights, leveraging a new `uniformRowHeight` setting. This optimization avoids expensive per-row lookups in common large-dataset scenarios, significantly improving scroll throughput while maintaining correctness for dynamic row heights.

### How has this been tested?
Runtime profiling was used to identify and confirm the bottlenecks.
The changes have been validated with:
- A new dedicated unit test suite: `rowHeightSumOptimization.unit.js`.
- A new Walkontable spec: `scrollPerformance.spec.js`.
- An extended existing E2E test: `core/scrollViewportTo.spec.js`.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. N/A

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[Slack Thread](https://handsoncode.slack.com/archives/D0AKSFNH1JQ/p1773303301288669?thread_ts=1773303301.288669&cid=D0AKSFNH1JQ)

<div><a href="https://cursor.com/agents/bc-29fa9d63-41ef-5001-ac0e-0fe659f6d404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29fa9d63-41ef-5001-ac0e-0fe659f6d404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->