### PR TITLE
`setSourceDataAtCell()` would incorrectly update a parent row instead of the intended nested child row when the `nestedRows` option was enabled

### DIFF
--- a/.changelogs/10657.json
+++ b/.changelogs/10657.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed `setSourceDataAtCell()` updating parent rows instead of nested child rows when `nestedRows` is enabled.",
+  "type": "fixed",
+  "issueOrPR": 10657,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/dataMap/__tests__/dataSource.unit.js
+++ b/handsontable/src/dataMap/__tests__/dataSource.unit.js
@@ -1,0 +1,42 @@
+import DataSource from 'handsontable/dataMap/dataSource';
+
+describe('DataSource', () => {
+  function createHotMock(modifyRowData = null) {
+    return {
+      hasHook(hookName) {
+        return hookName === 'modifyRowData' && modifyRowData !== null;
+      },
+      runHooks(hookName, rowIndex) {
+        if (hookName === 'modifyRowData') {
+          return modifyRowData(rowIndex);
+        }
+      },
+    };
+  }
+
+  describe('setAtCell', () => {
+    it('should set value for a row based on the `modifyRowData` hook result', () => {
+      const data = [
+        {
+          artist: 'Parent',
+          __children: [
+            { artist: 'Child' },
+          ],
+        },
+        { artist: 'Second parent' },
+      ];
+      const dataSource = new DataSource(createHotMock((rowIndex) => {
+        if (rowIndex === 1) {
+          return data[0].__children[0];
+        }
+
+        return data[rowIndex];
+      }), data);
+
+      dataSource.setAtCell(1, 'artist', 'Updated child');
+
+      expect(data[0].__children[0].artist).toBe('Updated child');
+      expect(data[1].artist).toBe('Second parent');
+    });
+  });
+});

--- a/handsontable/src/dataMap/dataSource.js
+++ b/handsontable/src/dataMap/dataSource.js
@@ -212,11 +212,17 @@ class DataSource {
       return;
     }
 
+    const dataRow = this.modifyRowData(row);
+
+    if (dataRow === undefined || dataRow === null) {
+      return;
+    }
+
     if (!Number.isInteger(column)) {
       // column argument is the prop name
-      setProperty(this.data[row], column, value);
+      setProperty(dataRow, column, value);
     } else {
-      this.data[row][column] = value;
+      dataRow[column] = value;
     }
   }
 

--- a/handsontable/src/dataMap/dataSource.js
+++ b/handsontable/src/dataMap/dataSource.js
@@ -214,10 +214,6 @@ class DataSource {
 
     const dataRow = this.modifyRowData(row);
 
-    if (dataRow === undefined || dataRow === null) {
-      return;
-    }
-
     if (!Number.isInteger(column)) {
       // column argument is the prop name
       setProperty(dataRow, column, value);

--- a/handsontable/test/e2e/core/setSourceDataAtCell.spec.js
+++ b/handsontable/test/e2e/core/setSourceDataAtCell.spec.js
@@ -49,6 +49,30 @@ describe('Core.setSourceDataAtCell', () => {
     expect(getSourceData()[2].lorem).toBe('amet');
   });
 
+  it('should set a child row value when nested rows plugin is enabled', async() => {
+    const sourceData = [
+      {
+        artist: 'Parent',
+        __children: [
+          { artist: 'Child' },
+        ],
+      },
+      {
+        artist: 'Second parent',
+      },
+    ];
+
+    handsontable({
+      data: sourceData,
+      nestedRows: true,
+    });
+
+    await setSourceDataAtCell(1, 'artist', 'Updated child');
+
+    expect(sourceData[0].__children[0].artist).toBe('Updated child');
+    expect(sourceData[1].artist).toBe('Second parent');
+  });
+
   it('should trigger table render cycle after changing the data', async() => {
     const hot = handsontable({
       data: [[1, 2, 3], ['a', 'b', 'c']],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Context
This change addresses an issue where `setSourceDataAtCell()` would incorrectly update a parent row instead of the intended nested child row when the `nestedRows` option was enabled. The `DataSource.setAtCell()` method now correctly writes to the row object resolved by the `modifyRowData` hook, ensuring accurate updates for nested data structures.

### How has this been tested?
- **Unit tests:** A new unit test was added to `dataSource.unit.js` to verify that `DataSource.setAtCell()` correctly writes through hook-resolved row objects, ensuring proper data layer updates for nested-like data.
- **E2E tests:** An E2E regression test was added to `setSourceDataAtCell.spec.js` to confirm that `Core.setSourceDataAtCell` with `nestedRows: true` correctly updates child data while leaving sibling parents unchanged.
- **Linting:** All modified files passed lint checks.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #10657

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<div><a href="https://cursor.com/agents/bc-2dbb18f9-c44c-44a3-8d73-4ab0fcb8b9aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2dbb18f9-c44c-44a3-8d73-4ab0fcb8b9aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->