### PR TITLE
Fix `ThemeBuilder` false unknown token warning for `iconButtonHitAreaSize`.

### DIFF
--- a/.changelogs/12146.json
+++ b/.changelogs/12146.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fix ThemeBuilder false unknown token warning on initialization",
+  "type": "fixed",
+  "issueOrPR": 12146,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/themes/engine/__tests__/builder.unit.js
+++ b/handsontable/src/themes/engine/__tests__/builder.unit.js
@@ -96,6 +96,24 @@ describe('ThemeBuilder', () => {
       consoleSpy.mockRestore();
     });
 
+    it('should not warn for iconButtonHitAreaSize token key in createTheme', () => {
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      createTheme(createValidConfig({
+        tokens: {
+          ...mainTokens,
+          iconButtonHitAreaSize: 'sizing.size_6',
+        },
+      }));
+
+      expect(consoleSpy).not.toHaveBeenCalledWith(
+        '[ThemeBuilder] Unknown token key: "iconButtonHitAreaSize" in themeConfig.tokens. ' +
+        'This may be a custom token or a typo.'
+      );
+
+      consoleSpy.mockRestore();
+    });
+
     it('should warn for missing icon keys in createTheme', () => {
       const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 

--- a/handsontable/src/themes/engine/__tests__/builder.unit.js
+++ b/handsontable/src/themes/engine/__tests__/builder.unit.js
@@ -96,20 +96,18 @@ describe('ThemeBuilder', () => {
       consoleSpy.mockRestore();
     });
 
-    it('should not warn for iconButtonHitAreaSize token key in createTheme', () => {
+    it('should not warn for unknown token keys when using built-in tokens in createTheme', () => {
       const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
       createTheme(createValidConfig({
-        tokens: {
-          ...mainTokens,
-          iconButtonHitAreaSize: 'sizing.size_6',
-        },
+        tokens: mainTokens,
       }));
 
-      expect(consoleSpy).not.toHaveBeenCalledWith(
-        '[ThemeBuilder] Unknown token key: "iconButtonHitAreaSize" in themeConfig.tokens. ' +
-        'This may be a custom token or a typo.'
-      );
+      const unknownTokenWarnings = consoleSpy.mock.calls
+        .map(([message]) => message)
+        .filter(message => message.startsWith('[ThemeBuilder] Unknown token key:'));
+
+      expect(unknownTokenWarnings).toEqual([]);
 
       consoleSpy.mockRestore();
     });

--- a/handsontable/src/themes/engine/utils/validation.js
+++ b/handsontable/src/themes/engine/utils/validation.js
@@ -228,6 +228,7 @@ const VALID_TOKEN_KEYS = new Set([
   'iconButtonBorderColor',
   'iconButtonBackgroundColor',
   'iconButtonIconColor',
+  'iconButtonHitAreaSize',
   'iconButtonHoverBorderColor',
   'iconButtonHoverBackgroundColor',
   'iconButtonHoverIconColor',

--- a/handsontable/test/e2e/core/themeManager.spec.js
+++ b/handsontable/test/e2e/core/themeManager.spec.js
@@ -58,6 +58,22 @@ describe('Core.themeManager', () => {
       expect(hot.themeManager.getClassName()).toBe('ht-theme-plain-config-theme');
     });
 
+    it('should not warn for iconButtonHitAreaSize token key on initialization', async() => {
+      const expectedWarning = '[ThemeBuilder] Unknown token key: "iconButtonHitAreaSize" in themeConfig.tokens. ' +
+        'This may be a custom token or a typo.';
+
+      // eslint-disable-next-line no-console
+      spyOn(console, 'warn');
+
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        theme: createValidThemeConfig({ name: 'plain-hit-area-theme' }),
+      }, true);
+
+      // eslint-disable-next-line no-console
+      expect(console.warn).not.toHaveBeenCalledWith(expectedWarning);
+    });
+
     it('should set the correct theme class when passing a plain theme config object', async() => {
       const plainThemeConfig = createValidThemeConfig({ name: 'plain-class-theme' });
 

--- a/handsontable/test/e2e/core/themeManager.spec.js
+++ b/handsontable/test/e2e/core/themeManager.spec.js
@@ -58,10 +58,7 @@ describe('Core.themeManager', () => {
       expect(hot.themeManager.getClassName()).toBe('ht-theme-plain-config-theme');
     });
 
-    it('should not warn for iconButtonHitAreaSize token key on initialization', async() => {
-      const expectedWarning = '[ThemeBuilder] Unknown token key: "iconButtonHitAreaSize" in themeConfig.tokens. ' +
-        'This may be a custom token or a typo.';
-
+    it('should not warn for unknown token keys on initialization', async() => {
       // eslint-disable-next-line no-console
       spyOn(console, 'warn');
 
@@ -71,7 +68,11 @@ describe('Core.themeManager', () => {
       }, true);
 
       // eslint-disable-next-line no-console
-      expect(console.warn).not.toHaveBeenCalledWith(expectedWarning);
+      const unknownTokenWarnings = console.warn.calls.allArgs()
+        .map(([message]) => message)
+        .filter(message => message.startsWith('[ThemeBuilder] Unknown token key:'));
+
+      expect(unknownTokenWarnings).toEqual([]);
     });
 
     it('should set the correct theme class when passing a plain theme config object', async() => {

--- a/handsontable/types/themes.d.ts
+++ b/handsontable/types/themes.d.ts
@@ -240,6 +240,7 @@ export type TokenKey =
   | 'iconButtonBorderColor'
   | 'iconButtonBackgroundColor'
   | 'iconButtonIconColor'
+  | 'iconButtonHitAreaSize'
   | 'iconButtonHoverBorderColor'
   | 'iconButtonHoverBackgroundColor'
   | 'iconButtonHoverIconColor'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Context
This change addresses a warning `[ThemeBuilder] Unknown token key: "iconButtonHitAreaSize"` that appeared on Handsontable initialization. The warning was caused by the `iconButtonHitAreaSize` token being present in theme definitions but missing from the `VALID_TOKEN_KEYS` allowlist in the theme engine's validator.

### How has this been tested?
- A new unit test was added to `handsontable/src/themes/engine/__tests__/builder.unit.js` to verify that `createTheme()` does not emit a warning for `iconButtonHitAreaSize`.
- An E2E test was added to `handsontable/test/e2e/core/themeManager.spec.js` to confirm that Handsontable initialization no longer emits the unknown-token warning.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://app.clickup.com/t/86c8teput

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[Slack Thread](https://handsoncode.slack.com/archives/D0ALH60DZ9N/p1773316358344549?thread_ts=1773316358.344549&cid=D0ALH60DZ9N)

<div><a href="https://cursor.com/agents/bc-a931944c-b9fb-5494-b4e1-961e980cb1e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a931944c-b9fb-5494-b4e1-961e980cb1e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->