### PR TITLE
Fix main theme dropdown menu icon hover color

### DIFF
--- a/.changelogs/170.json
+++ b/.changelogs/170.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed the hover color of the column menu icon in the main theme.",
+  "type": "fixed",
+  "issueOrPR": 170,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/dropdownMenu/__tests__/UI.spec.js
+++ b/handsontable/src/plugins/dropdownMenu/__tests__/UI.spec.js
@@ -47,5 +47,18 @@ describe('DropdownMenu', () => {
 
       expect(hot().rootElement.querySelectorAll('.ht_master table button.changeType[type=button]').length).toBe(5);
     });
+
+    it.forTheme('main')('should render the hovered menu icon with the expected color', async() => {
+      handsontable({
+        dropdownMenu: true,
+        colHeaders: true,
+      });
+
+      const button = getCell(-1, 0).querySelector('.changeType');
+
+      await mouseOver(button);
+
+      expect(window.getComputedStyle(button, ':before').backgroundColor).toBe('rgba(34, 34, 34, 0.4)');
+    });
   });
 });

--- a/handsontable/src/themes/engine/__tests__/builder.unit.js
+++ b/handsontable/src/themes/engine/__tests__/builder.unit.js
@@ -12,6 +12,12 @@ describe('ThemeBuilder', () => {
     ...overrides,
   });
 
+  describe('main theme tokens', () => {
+    it('should keep the dropdown menu icon hover color semitransparent', () => {
+      expect(mainTokens.iconButtonHoverIconColor).toEqual(['#22222266', '#c7c7c766']);
+    });
+  });
+
   describe('createTheme', () => {
     it('should create a ThemeBuilder instance', () => {
       const theme = createTheme(createValidConfig());

--- a/handsontable/src/themes/static/css/theme/ht-theme-main-no-icons.css
+++ b/handsontable/src/themes/static/css/theme/ht-theme-main-no-icons.css
@@ -165,7 +165,7 @@
   --ht-icon-button-hit-area-size: var(--ht-sizing-size-6);
   --ht-icon-button-hover-border-color: light-dark(var(--ht-colors-palette-200), var(--ht-colors-palette-600));
   --ht-icon-button-hover-background-color: light-dark(var(--ht-colors-palette-200), var(--ht-colors-palette-600));
-  --ht-icon-button-hover-icon-color: light-dark(var(--ht-colors-palette-300), var(--ht-colors-palette-400));
+  --ht-icon-button-hover-icon-color: light-dark(#22222266, #c7c7c766);
   --ht-icon-button-active-border-color: light-dark(var(--ht-colors-primary-400), var(--ht-colors-primary-200));
   --ht-icon-button-active-background-color: var(--ht-accent-color);
   --ht-icon-button-active-icon-color: var(--ht-colors-white);

--- a/handsontable/src/themes/static/css/theme/ht-theme-main.css
+++ b/handsontable/src/themes/static/css/theme/ht-theme-main.css
@@ -165,7 +165,7 @@
   --ht-icon-button-hit-area-size: var(--ht-sizing-size-6);
   --ht-icon-button-hover-border-color: light-dark(var(--ht-colors-palette-200), var(--ht-colors-palette-600));
   --ht-icon-button-hover-background-color: light-dark(var(--ht-colors-palette-200), var(--ht-colors-palette-600));
-  --ht-icon-button-hover-icon-color: light-dark(var(--ht-colors-palette-300), var(--ht-colors-palette-400));
+  --ht-icon-button-hover-icon-color: light-dark(#22222266, #c7c7c766);
   --ht-icon-button-active-border-color: light-dark(var(--ht-colors-primary-400), var(--ht-colors-primary-200));
   --ht-icon-button-active-background-color: var(--ht-accent-color);
   --ht-icon-button-active-icon-color: var(--ht-colors-white);

--- a/handsontable/src/themes/static/variables/tokens/main.js
+++ b/handsontable/src/themes/static/variables/tokens/main.js
@@ -118,7 +118,7 @@ export default {
   iconButtonHitAreaSize: 'sizing.size_6',
   iconButtonHoverBorderColor: ['colors.palette.200', 'colors.palette.600'],
   iconButtonHoverBackgroundColor: ['colors.palette.200', 'colors.palette.600'],
-  iconButtonHoverIconColor: ['colors.palette.300', 'colors.palette.400'],
+  iconButtonHoverIconColor: ['#22222266', '#c7c7c766'],
   iconButtonActiveBorderColor: ['colors.primary.400', 'colors.primary.200'],
   iconButtonActiveBackgroundColor: 'tokens.accentColor',
   iconButtonActiveIconColor: 'colors.white',


### PR DESCRIPTION
### Context
Title: [17.0] Main theme - fix menu icon hover background color
Body:
Problem: Hovering the column menu icon in main theme used incorrect color (#A3A3A3)
Fix: Set main theme icon hover color to #22222266 (dark mode counterpart #c7c7c766)
Tests:
Unit: src/themes/engine/__tests__/builder.unit.js
E2E: src/plugins/dropdownMenu/__tests__/UI.spec.js
Changelog: .changelogs/170.json

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only change updating a CSS token/variable for icon hover color, with added tests to prevent regressions.
> 
> **Overview**
> Fixes the main theme’s dropdown/column menu icon hover styling by changing `iconButtonHoverIconColor` to a semi-transparent value (`#22222266` / `#c7c7c766`) across the generated token (`tokens/main.js`) and both main theme CSS outputs (`ht-theme-main.css`, `ht-theme-main-no-icons.css`).
> 
> Adds coverage via a new theme-token unit assertion and a theme-scoped dropdown menu UI test that verifies the hovered icon pseudo-element renders the expected computed color. Includes a changelog entry in `.changelogs/170.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23dc1194427c8b769aaf6737d18fe25ceef4c08b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->