### PR TITLE
Bug resolution

### DIFF
--- a/.changelogs/12149.json
+++ b/.changelogs/12149.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed the main theme column menu icon hover background color.",
+  "type": "fixed",
+  "issueOrPR": 12149,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/themes/__tests__/mainThemeTokens.unit.js
+++ b/handsontable/src/themes/__tests__/mainThemeTokens.unit.js
@@ -1,0 +1,7 @@
+import { mainTheme } from '../theme/main';
+
+describe('main theme tokens', () => {
+  it('should keep a translucent dropdown menu icon hover background', () => {
+    expect(mainTheme.tokens.iconButtonHoverBackgroundColor).toBe('#22222266');
+  });
+});

--- a/handsontable/src/themes/static/css/theme/ht-theme-main-no-icons.css
+++ b/handsontable/src/themes/static/css/theme/ht-theme-main-no-icons.css
@@ -164,7 +164,7 @@
   --ht-icon-button-icon-color: light-dark(var(--ht-colors-palette-300), var(--ht-colors-palette-400));
   --ht-icon-button-hit-area-size: var(--ht-sizing-size-6);
   --ht-icon-button-hover-border-color: light-dark(var(--ht-colors-palette-200), var(--ht-colors-palette-600));
-  --ht-icon-button-hover-background-color: light-dark(var(--ht-colors-palette-200), var(--ht-colors-palette-600));
+  --ht-icon-button-hover-background-color: #22222266;
   --ht-icon-button-hover-icon-color: light-dark(var(--ht-colors-palette-300), var(--ht-colors-palette-400));
   --ht-icon-button-active-border-color: light-dark(var(--ht-colors-primary-400), var(--ht-colors-primary-200));
   --ht-icon-button-active-background-color: var(--ht-accent-color);

--- a/handsontable/src/themes/static/css/theme/ht-theme-main.css
+++ b/handsontable/src/themes/static/css/theme/ht-theme-main.css
@@ -164,7 +164,7 @@
   --ht-icon-button-icon-color: light-dark(var(--ht-colors-palette-300), var(--ht-colors-palette-400));
   --ht-icon-button-hit-area-size: var(--ht-sizing-size-6);
   --ht-icon-button-hover-border-color: light-dark(var(--ht-colors-palette-200), var(--ht-colors-palette-600));
-  --ht-icon-button-hover-background-color: light-dark(var(--ht-colors-palette-200), var(--ht-colors-palette-600));
+  --ht-icon-button-hover-background-color: #22222266;
   --ht-icon-button-hover-icon-color: light-dark(var(--ht-colors-palette-300), var(--ht-colors-palette-400));
   --ht-icon-button-active-border-color: light-dark(var(--ht-colors-primary-400), var(--ht-colors-primary-200));
   --ht-icon-button-active-background-color: var(--ht-accent-color);

--- a/handsontable/src/themes/static/variables/tokens/main.js
+++ b/handsontable/src/themes/static/variables/tokens/main.js
@@ -117,7 +117,7 @@ export default {
   iconButtonIconColor: ['colors.palette.300', 'colors.palette.400'],
   iconButtonHitAreaSize: 'sizing.size_6',
   iconButtonHoverBorderColor: ['colors.palette.200', 'colors.palette.600'],
-  iconButtonHoverBackgroundColor: ['colors.palette.200', 'colors.palette.600'],
+  iconButtonHoverBackgroundColor: '#22222266',
   iconButtonHoverIconColor: ['colors.palette.300', 'colors.palette.400'],
   iconButtonActiveBorderColor: ['colors.primary.400', 'colors.primary.200'],
   iconButtonActiveBackgroundColor: 'tokens.accentColor',

--- a/handsontable/test/e2e/mobile/filters.spec.js
+++ b/handsontable/test/e2e/mobile/filters.spec.js
@@ -39,4 +39,20 @@ describe('Filters', () => {
 
     expect(document.activeElement).toBe(input);
   });
+
+  it.forTheme('main')('should apply the correct hover background token to the column menu icon', async() => {
+    handsontable({
+      data: createSpreadsheetObjectData(3, 3),
+      filters: true,
+      colHeaders: true,
+      dropdownMenu: true,
+    });
+
+    await sleep(50);
+
+    const button = getCell(-1, 0).querySelector('.changeType');
+    const hoverBackgroundToken = getComputedStyle(button).getPropertyValue('--ht-icon-button-hover-background-color');
+
+    expect(hoverBackgroundToken.trim()).toBe('#22222266');
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Context
This change fixes a regression where the column menu icon's hover background color was incorrect in the main theme. The hover state now correctly applies `#22222266`.

### How has this been tested?
- Added a unit regression test for the main theme token value.
- Added an E2E mobile regression test asserting the column menu icon hover token value in runtime DOM styles.
- Verified theme bundle compilation (`build:themes-umd`).
- Performed manual GUI verification to confirm the visual fix.
- Linted changed JS and CSS files.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. ClickUp: 86c8rfkq2

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<div><a href="https://cursor.com/agents/bc-3b4746f8-3acb-4fd5-ac6b-a0efaf25e54c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b4746f8-3acb-4fd5-ac6b-a0efaf25e54c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->