### PR TITLE
 regression where revealing a hidden column under multi-level headers caused overlay/layer misalignment after vertical scroll.

### DIFF
--- a/.changelogs/12155.json
+++ b/.changelogs/12155.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed nested-header overlay misalignment after showing a hidden column",
+  "type": "fixed",
+  "issueOrPR": 12155,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/src/table.js
+++ b/handsontable/src/3rdparty/walkontable/src/table.js
@@ -403,17 +403,19 @@ class Table {
     }
 
     const shouldSynchronizeColumnHeaders = this.dataAccessObject.wtViewport.shouldSynchronizeColumnHeaders === true;
+    const visibleRowHeadersCount = this.wtSettings.getSetting('rowHeaders').length;
+    const inlineStartOverlayTable = this.isMaster ? wtOverlays.inlineStartOverlay?.clone?.wtTable : null;
+    const hasHeaderHeightMismatch = this.isMaster &&
+      visibleRowHeadersCount > 0 &&
+      inlineStartOverlayTable &&
+      columnHeadersCount > 0 &&
+      outerHeight(this.THEAD) !== outerHeight(inlineStartOverlayTable.THEAD);
 
-    if (this.isMaster && (positionChanged || shouldSynchronizeColumnHeaders)) {
+    if (this.isMaster && (positionChanged || shouldSynchronizeColumnHeaders || hasHeaderHeightMismatch)) {
       // Reset the one-time sync flag before triggering overlays refresh to avoid recursive redraw loops.
       this.dataAccessObject.wtViewport.shouldSynchronizeColumnHeaders = false;
-      const inlineStartOverlayTable = wtOverlays.inlineStartOverlay?.clone?.wtTable;
-      const shouldResyncHeaderHeights = shouldSynchronizeColumnHeaders || (
-        positionChanged ||
-        inlineStartOverlayTable &&
-        columnHeadersCount > 0 &&
-        outerHeight(this.THEAD) !== outerHeight(inlineStartOverlayTable.THEAD)
-      );
+      const shouldResyncHeaderHeights = visibleRowHeadersCount > 0 &&
+        (shouldSynchronizeColumnHeaders || hasHeaderHeightMismatch);
 
       if (shouldResyncHeaderHeights) {
         // Recalculate and sync column header heights only when overlays are actually desynchronized.
@@ -483,7 +485,7 @@ class Table {
         /* eslint-disable no-continue */
         continue;
       }
-      currentHeaderHeight = outerHeight(currentHeader);
+      currentHeaderHeight = innerHeight(currentHeader);
 
       if (!previousColHeaderHeight &&
           defaultRowHeight < currentHeaderHeight || previousColHeaderHeight < currentHeaderHeight) {

--- a/handsontable/src/3rdparty/walkontable/src/table.js
+++ b/handsontable/src/3rdparty/walkontable/src/table.js
@@ -402,17 +402,42 @@ class Table {
       }
     }
 
-    if (positionChanged) {
-      // The `innerBorderTop` / `innerBorderInlineStart` class toggle can change the effective
-      // column header height by 1px. Recalculate the oversized headers cache before refreshing overlays.
-      this.dataAccessObject.wtViewport.resetHasOversizedColumnHeadersMarked();
-      this.markOversizedColumnHeaders();
-      this.adjustColumnHeaderHeights();
-      wtOverlays.getOverlays().forEach((overlay) => {
-        if (overlay?.clone?.wtTable) {
-          overlay.clone.wtTable.adjustColumnHeaderHeights();
+    const shouldSynchronizeColumnHeaders = this.dataAccessObject.wtViewport.shouldSynchronizeColumnHeaders === true;
+
+    if (this.isMaster && (positionChanged || shouldSynchronizeColumnHeaders)) {
+      // Reset the one-time sync flag before triggering overlays refresh to avoid recursive redraw loops.
+      this.dataAccessObject.wtViewport.shouldSynchronizeColumnHeaders = false;
+      const inlineStartOverlayTable = wtOverlays.inlineStartOverlay?.clone?.wtTable;
+      const shouldResyncHeaderHeights = shouldSynchronizeColumnHeaders || (
+        inlineStartOverlayTable &&
+        columnHeadersCount > 0 &&
+        outerHeight(this.THEAD) !== outerHeight(inlineStartOverlayTable.THEAD)
+      );
+
+      if (shouldResyncHeaderHeights) {
+        // Recalculate and sync column header heights only when overlays are actually desynchronized.
+        this.dataAccessObject.wtViewport.resetHasOversizedColumnHeadersMarked();
+        this.markOversizedColumnHeaders();
+        this.adjustColumnHeaderHeights();
+        wtOverlays.getOverlays().forEach((overlay) => {
+          if (overlay?.clone?.wtTable) {
+            overlay.clone.wtTable.adjustColumnHeaderHeights();
+          }
+        });
+
+        if (inlineStartOverlayTable && columnHeadersCount > 0) {
+          const masterHeaderRows = this.THEAD?.childNodes ?? [];
+          const overlayHeaderRows = inlineStartOverlayTable.THEAD?.childNodes ?? [];
+
+          for (let rowIndex = 0; rowIndex < Math.min(masterHeaderRows.length, overlayHeaderRows.length); rowIndex++) {
+            const overlayHeaderInner = overlayHeaderRows[rowIndex]?.childNodes?.[0];
+
+            if (overlayHeaderInner) {
+              overlayHeaderInner.style.height = `${outerHeight(masterHeaderRows[rowIndex])}px`;
+            }
+          }
         }
-      });
+      }
 
       // It refreshes the cells borders caused by a 1px shift (introduced by overlays which add or
       // remove `innerBorderTop` and `innerBorderInlineStart` CSS classes to the DOM element. This happens
@@ -440,11 +465,8 @@ class Table {
   markIfOversizedColumnHeader(col) {
     const sourceColIndex = this.columnFilter.renderedToSource(col);
     let level = this.wtSettings.getSetting('columnHeaders').length;
-    const columnHeadersCount = level;
     const stylesHandler = this.wtSettings.getSetting('stylesHandler');
     const defaultRowHeight = stylesHandler.getDefaultRowHeight();
-    const borderBoxSizing = stylesHandler.areCellsBorderBox();
-    const columnHeaderHeightFn = borderBoxSizing ? outerHeight : innerHeight;
     let previousColHeaderHeight;
     let currentHeader;
     let currentHeaderHeight;
@@ -460,11 +482,7 @@ class Table {
         /* eslint-disable no-continue */
         continue;
       }
-      currentHeaderHeight = columnHeaderHeightFn(currentHeader);
-
-      if (!borderBoxSizing && level === columnHeadersCount - 1) {
-        currentHeaderHeight += 1;
-      }
+      currentHeaderHeight = innerHeight(currentHeader);
 
       if (!previousColHeaderHeight &&
           defaultRowHeight < currentHeaderHeight || previousColHeaderHeight < currentHeaderHeight) {

--- a/handsontable/src/3rdparty/walkontable/src/table.js
+++ b/handsontable/src/3rdparty/walkontable/src/table.js
@@ -403,6 +403,17 @@ class Table {
     }
 
     if (positionChanged) {
+      // The `innerBorderTop` / `innerBorderInlineStart` class toggle can change the effective
+      // column header height by 1px. Recalculate the oversized headers cache before refreshing overlays.
+      this.dataAccessObject.wtViewport.resetHasOversizedColumnHeadersMarked();
+      this.markOversizedColumnHeaders();
+      this.adjustColumnHeaderHeights();
+      wtOverlays.getOverlays().forEach((overlay) => {
+        if (overlay?.clone?.wtTable) {
+          overlay.clone.wtTable.adjustColumnHeaderHeights();
+        }
+      });
+
       // It refreshes the cells borders caused by a 1px shift (introduced by overlays which add or
       // remove `innerBorderTop` and `innerBorderInlineStart` CSS classes to the DOM element. This happens
       // when there is a switch between rendering from 0 to N rows/columns and vice versa).
@@ -429,7 +440,6 @@ class Table {
   markIfOversizedColumnHeader(col) {
     const sourceColIndex = this.columnFilter.renderedToSource(col);
     let level = this.wtSettings.getSetting('columnHeaders').length;
-    const columnHeadersCount = level;
     const stylesHandler = this.wtSettings.getSetting('stylesHandler');
     const defaultRowHeight = stylesHandler.getDefaultRowHeight();
     let previousColHeaderHeight;
@@ -447,12 +457,7 @@ class Table {
         /* eslint-disable no-continue */
         continue;
       }
-      // The collapsed table border should be compensated only once for the whole header stack.
-      currentHeaderHeight = innerHeight(currentHeader);
-
-      if (level === columnHeadersCount - 1) {
-        currentHeaderHeight += 1;
-      }
+      currentHeaderHeight = outerHeight(currentHeader);
 
       if (!previousColHeaderHeight &&
           defaultRowHeight < currentHeaderHeight || previousColHeaderHeight < currentHeaderHeight) {

--- a/handsontable/src/3rdparty/walkontable/src/table.js
+++ b/handsontable/src/3rdparty/walkontable/src/table.js
@@ -429,7 +429,9 @@ class Table {
   markIfOversizedColumnHeader(col) {
     const sourceColIndex = this.columnFilter.renderedToSource(col);
     let level = this.wtSettings.getSetting('columnHeaders').length;
-    const defaultRowHeight = this.wtSettings.getSetting('stylesHandler').getDefaultRowHeight();
+    const stylesHandler = this.wtSettings.getSetting('stylesHandler');
+    const defaultRowHeight = stylesHandler.getDefaultRowHeight();
+    const borderCompensation = stylesHandler.areCellsBorderBox() ? 0 : 1;
     let previousColHeaderHeight;
     let currentHeader;
     let currentHeaderHeight;
@@ -445,7 +447,7 @@ class Table {
         /* eslint-disable no-continue */
         continue;
       }
-      currentHeaderHeight = innerHeight(currentHeader);
+      currentHeaderHeight = innerHeight(currentHeader) + borderCompensation;
 
       if (!previousColHeaderHeight &&
           defaultRowHeight < currentHeaderHeight || previousColHeaderHeight < currentHeaderHeight) {

--- a/handsontable/src/3rdparty/walkontable/src/table.js
+++ b/handsontable/src/3rdparty/walkontable/src/table.js
@@ -440,8 +440,11 @@ class Table {
   markIfOversizedColumnHeader(col) {
     const sourceColIndex = this.columnFilter.renderedToSource(col);
     let level = this.wtSettings.getSetting('columnHeaders').length;
+    const columnHeadersCount = level;
     const stylesHandler = this.wtSettings.getSetting('stylesHandler');
     const defaultRowHeight = stylesHandler.getDefaultRowHeight();
+    const borderBoxSizing = stylesHandler.areCellsBorderBox();
+    const columnHeaderHeightFn = borderBoxSizing ? outerHeight : innerHeight;
     let previousColHeaderHeight;
     let currentHeader;
     let currentHeaderHeight;
@@ -457,7 +460,11 @@ class Table {
         /* eslint-disable no-continue */
         continue;
       }
-      currentHeaderHeight = outerHeight(currentHeader);
+      currentHeaderHeight = columnHeaderHeightFn(currentHeader);
+
+      if (!borderBoxSizing && level === columnHeadersCount - 1) {
+        currentHeaderHeight += 1;
+      }
 
       if (!previousColHeaderHeight &&
           defaultRowHeight < currentHeaderHeight || previousColHeaderHeight < currentHeaderHeight) {

--- a/handsontable/src/3rdparty/walkontable/src/table.js
+++ b/handsontable/src/3rdparty/walkontable/src/table.js
@@ -429,6 +429,7 @@ class Table {
   markIfOversizedColumnHeader(col) {
     const sourceColIndex = this.columnFilter.renderedToSource(col);
     let level = this.wtSettings.getSetting('columnHeaders').length;
+    const columnHeadersCount = level;
     const stylesHandler = this.wtSettings.getSetting('stylesHandler');
     const defaultRowHeight = stylesHandler.getDefaultRowHeight();
     let previousColHeaderHeight;
@@ -446,7 +447,12 @@ class Table {
         /* eslint-disable no-continue */
         continue;
       }
-      currentHeaderHeight = outerHeight(currentHeader);
+      // The collapsed table border should be compensated only once for the whole header stack.
+      currentHeaderHeight = innerHeight(currentHeader);
+
+      if (level === columnHeadersCount - 1) {
+        currentHeaderHeight += 1;
+      }
 
       if (!previousColHeaderHeight &&
           defaultRowHeight < currentHeaderHeight || previousColHeaderHeight < currentHeaderHeight) {

--- a/handsontable/src/3rdparty/walkontable/src/table.js
+++ b/handsontable/src/3rdparty/walkontable/src/table.js
@@ -431,7 +431,6 @@ class Table {
     let level = this.wtSettings.getSetting('columnHeaders').length;
     const stylesHandler = this.wtSettings.getSetting('stylesHandler');
     const defaultRowHeight = stylesHandler.getDefaultRowHeight();
-    const borderCompensation = stylesHandler.areCellsBorderBox() ? 0 : 1;
     let previousColHeaderHeight;
     let currentHeader;
     let currentHeaderHeight;
@@ -447,7 +446,7 @@ class Table {
         /* eslint-disable no-continue */
         continue;
       }
-      currentHeaderHeight = innerHeight(currentHeader) + borderCompensation;
+      currentHeaderHeight = outerHeight(currentHeader);
 
       if (!previousColHeaderHeight &&
           defaultRowHeight < currentHeaderHeight || previousColHeaderHeight < currentHeaderHeight) {

--- a/handsontable/src/3rdparty/walkontable/src/table.js
+++ b/handsontable/src/3rdparty/walkontable/src/table.js
@@ -409,6 +409,7 @@ class Table {
       this.dataAccessObject.wtViewport.shouldSynchronizeColumnHeaders = false;
       const inlineStartOverlayTable = wtOverlays.inlineStartOverlay?.clone?.wtTable;
       const shouldResyncHeaderHeights = shouldSynchronizeColumnHeaders || (
+        positionChanged ||
         inlineStartOverlayTable &&
         columnHeadersCount > 0 &&
         outerHeight(this.THEAD) !== outerHeight(inlineStartOverlayTable.THEAD)
@@ -482,7 +483,7 @@ class Table {
         /* eslint-disable no-continue */
         continue;
       }
-      currentHeaderHeight = innerHeight(currentHeader);
+      currentHeaderHeight = outerHeight(currentHeader);
 
       if (!previousColHeaderHeight &&
           defaultRowHeight < currentHeaderHeight || previousColHeaderHeight < currentHeaderHeight) {

--- a/handsontable/src/3rdparty/walkontable/test/spec/settings/columnHeaders.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/settings/columnHeaders.spec.js
@@ -85,7 +85,7 @@ describe('columnHeaders option', () => {
 
     wt.draw();
 
-    expect(spec().$wrapper.find('.ht_clone_top thead tr').height()).toBe(43);
+    expect(spec().$wrapper.find('.ht_clone_top thead tr').height()).toBe(44);
     style.remove();
   });
 

--- a/handsontable/src/3rdparty/walkontable/test/spec/settings/columnHeaders.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/settings/columnHeaders.spec.js
@@ -85,7 +85,7 @@ describe('columnHeaders option', () => {
 
     wt.draw();
 
-    expect(spec().$wrapper.find('.ht_clone_top thead tr').height()).toBe(44);
+    expect(spec().$wrapper.find('.ht_clone_top thead tr').height()).toBe(43);
     style.remove();
   });
 

--- a/handsontable/src/plugins/hiddenColumns/__tests__/publicAPI.spec.js
+++ b/handsontable/src/plugins/hiddenColumns/__tests__/publicAPI.spec.js
@@ -61,21 +61,33 @@ describe('HiddenColumns', () => {
         getPlugin('hiddenColumns').showColumn(0);
         await render();
 
-        const getAlignmentDelta = () => {
-          const firstRenderedRow = hot().view._wt.wtTable.getFirstRenderedRow();
-          const rowHeader = hot().view._wt.wtOverlays.inlineStartOverlay.clone.wtTable
-            .getRowHeader(firstRenderedRow, 0);
-          const rowCell = getCell(firstRenderedRow, 0);
-          const rowHeaderTop = rowHeader.getBoundingClientRect().top;
-          const rowCellTop = rowCell.getBoundingClientRect().top;
+        const getVisibleFirstRowAlignmentDelta = () => {
+          const rowHeader = spec().$container.find('.ht_clone_inline_start tbody tr:eq(0) th:eq(0)')[0];
+          const rowCell = spec().$container.find('.ht_master tbody tr:eq(0) td:eq(0)')[0];
 
-          return rowHeaderTop - rowCellTop;
+          return rowHeader.getBoundingClientRect().top - rowCell.getBoundingClientRect().top;
+        };
+        const getHeaderHeightDelta = () => {
+          const masterThead = spec().$container.find('.ht_master thead')[0];
+          const inlineStartThead = spec().$container.find('.ht_clone_inline_start thead')[0];
+
+          return masterThead.getBoundingClientRect().height - inlineStartThead.getBoundingClientRect().height;
         };
 
-        expect(getAlignmentDelta()).toBe(0);
+        expect(getVisibleFirstRowAlignmentDelta()).toBe(0);
+        expect(getHeaderHeightDelta()).toBe(0);
 
-        await scrollViewportVertically(350);
-        expect(getAlignmentDelta()).toBe(0);
+        await scrollViewportTo({ row: 11, col: 0, verticalSnap: 'top' });
+        expect(getVisibleFirstRowAlignmentDelta()).toBe(0);
+        expect(getHeaderHeightDelta()).toBe(0);
+
+        await scrollViewportTo({ row: 20, col: 0, verticalSnap: 'top' });
+        expect(getVisibleFirstRowAlignmentDelta()).toBe(0);
+        expect(getHeaderHeightDelta()).toBe(0);
+
+        await scrollViewportTo({ row: 120, col: 0, verticalSnap: 'top' });
+        expect(getVisibleFirstRowAlignmentDelta()).toBe(0);
+        expect(getHeaderHeightDelta()).toBe(0);
       });
     });
 

--- a/handsontable/src/plugins/hiddenColumns/__tests__/publicAPI.spec.js
+++ b/handsontable/src/plugins/hiddenColumns/__tests__/publicAPI.spec.js
@@ -45,6 +45,29 @@ describe('HiddenColumns', () => {
 
         expect(getCell(0, 1).innerText).toBe('B1');
       });
+
+      it('should keep row headers vertically aligned with row cells after showing the first hidden column', async() => {
+        handsontable({
+          data: createSpreadsheetData(200, 200),
+          height: 300,
+          hiddenColumns: {
+            columns: [0],
+          },
+          contextMenu: true,
+          rowHeaders: true,
+          colHeaders: ['A<br>BA<br>BA<br>BA<br>BA<br>BA<br>BA<br>BA<br>BA<br>BA<br>BA'],
+        });
+
+        getPlugin('hiddenColumns').showColumn(0);
+        await render();
+
+        const rowHeader = spec().$container.find('.ht_clone_inline_start tr:eq(1) th:eq(0)')[0];
+        const rowCell = getCell(0, 0);
+        const rowHeaderTop = rowHeader.getBoundingClientRect().top;
+        const rowCellTop = rowCell.getBoundingClientRect().top;
+
+        expect(rowHeaderTop - rowCellTop).toBe(0);
+      });
     });
 
     describe('showColumns', () => {

--- a/handsontable/src/plugins/hiddenColumns/__tests__/publicAPI.spec.js
+++ b/handsontable/src/plugins/hiddenColumns/__tests__/publicAPI.spec.js
@@ -61,12 +61,21 @@ describe('HiddenColumns', () => {
         getPlugin('hiddenColumns').showColumn(0);
         await render();
 
-        const rowHeader = spec().$container.find('.ht_clone_inline_start tr:eq(1) th:eq(0)')[0];
-        const rowCell = getCell(0, 0);
-        const rowHeaderTop = rowHeader.getBoundingClientRect().top;
-        const rowCellTop = rowCell.getBoundingClientRect().top;
+        const getAlignmentDelta = () => {
+          const firstRenderedRow = hot().view._wt.wtTable.getFirstRenderedRow();
+          const rowHeader = hot().view._wt.wtOverlays.inlineStartOverlay.clone.wtTable
+            .getRowHeader(firstRenderedRow, 0);
+          const rowCell = getCell(firstRenderedRow, 0);
+          const rowHeaderTop = rowHeader.getBoundingClientRect().top;
+          const rowCellTop = rowCell.getBoundingClientRect().top;
 
-        expect(rowHeaderTop - rowCellTop).toBe(0);
+          return rowHeaderTop - rowCellTop;
+        };
+
+        expect(getAlignmentDelta()).toBe(0);
+
+        await scrollViewportVertically(350);
+        expect(getAlignmentDelta()).toBe(0);
       });
     });
 

--- a/handsontable/src/plugins/hiddenColumns/__tests__/showingColumns.unit.js
+++ b/handsontable/src/plugins/hiddenColumns/__tests__/showingColumns.unit.js
@@ -44,7 +44,7 @@ describe('HiddenColumns', () => {
       container.remove();
     });
 
-    it('should use inner height in oversized column header measurement', () => {
+    it('should use outer height in oversized column header measurement', () => {
       registerPlugin(HiddenColumns);
 
       const container = document.createElement('div');
@@ -74,7 +74,7 @@ describe('HiddenColumns', () => {
 
       wtTable.markIfOversizedColumnHeader(0);
 
-      expect(hot.view._wt.wtViewport.oversizedColumnHeaders[0]).toBe(120);
+      expect(hot.view._wt.wtViewport.oversizedColumnHeaders[0]).toBe(121);
 
       hot.destroy();
       container.remove();

--- a/handsontable/src/plugins/hiddenColumns/__tests__/showingColumns.unit.js
+++ b/handsontable/src/plugins/hiddenColumns/__tests__/showingColumns.unit.js
@@ -44,7 +44,7 @@ describe('HiddenColumns', () => {
       container.remove();
     });
 
-    it('should use inner height in oversized column header measurement', () => {
+    it('should reset oversized markers and request header sync when showing hidden columns with row headers', () => {
       registerPlugin(HiddenColumns);
 
       const container = document.createElement('div');
@@ -62,19 +62,86 @@ describe('HiddenColumns', () => {
         },
         licenseKey: 'non-commercial-and-evaluation',
       });
-      const wtTable = hot.view._wt.wtTable;
-      const stylesHandler = wtTable.wtSettings.getSetting('stylesHandler');
-      const mockedHeader = document.createElement('div');
+      const viewport = hot.view._wt.wtViewport;
 
-      Object.defineProperty(mockedHeader, 'clientHeight', { value: 120 });
-      Object.defineProperty(mockedHeader, 'offsetHeight', { value: 121 });
+      hot.render();
 
-      jest.spyOn(stylesHandler, 'getDefaultRowHeight').mockReturnValue(23);
-      jest.spyOn(wtTable, 'getColumnHeader').mockReturnValue(mockedHeader);
+      viewport.hasOversizedColumnHeadersMarked.master = true;
+      viewport.shouldSynchronizeColumnHeaders = false;
 
-      wtTable.markIfOversizedColumnHeader(0);
+      hot.getPlugin('hiddenColumns').showColumns([0]);
 
-      expect(hot.view._wt.wtViewport.oversizedColumnHeaders[0]).toBe(120);
+      expect(viewport.hasOversizedColumnHeadersMarked.master).toBeUndefined();
+      expect(viewport.shouldSynchronizeColumnHeaders).toBe(true);
+
+      hot.destroy();
+      container.remove();
+    });
+
+    it('should not reset markers or request sync for no-op/invalid showColumns calls', () => {
+      registerPlugin(HiddenColumns);
+
+      const container = document.createElement('div');
+
+      document.body.appendChild(container);
+
+      const hot = new Handsontable(container, {
+        data: Array.from({ length: 5 }, (__, rowIndex) => {
+          return Array.from({ length: 5 }, (___, columnIndex) => `r${rowIndex}c${columnIndex}`);
+        }),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenColumns: {
+          columns: [0],
+        },
+        licenseKey: 'non-commercial-and-evaluation',
+      });
+      const viewport = hot.view._wt.wtViewport;
+
+      hot.render();
+
+      viewport.hasOversizedColumnHeadersMarked.master = true;
+      viewport.shouldSynchronizeColumnHeaders = false;
+
+      hot.getPlugin('hiddenColumns').showColumns([]);
+      hot.getPlugin('hiddenColumns').showColumns([99]);
+
+      expect(viewport.hasOversizedColumnHeadersMarked.master).toBe(true);
+      expect(viewport.shouldSynchronizeColumnHeaders).toBe(false);
+
+      hot.destroy();
+      container.remove();
+    });
+
+    it('should not request header sync when row headers are disabled', () => {
+      registerPlugin(HiddenColumns);
+
+      const container = document.createElement('div');
+
+      document.body.appendChild(container);
+
+      const hot = new Handsontable(container, {
+        data: Array.from({ length: 5 }, (__, rowIndex) => {
+          return Array.from({ length: 5 }, (___, columnIndex) => `r${rowIndex}c${columnIndex}`);
+        }),
+        rowHeaders: false,
+        colHeaders: true,
+        hiddenColumns: {
+          columns: [0],
+        },
+        licenseKey: 'non-commercial-and-evaluation',
+      });
+      const viewport = hot.view._wt.wtViewport;
+
+      hot.render();
+
+      viewport.hasOversizedColumnHeadersMarked.master = true;
+      viewport.shouldSynchronizeColumnHeaders = false;
+
+      hot.getPlugin('hiddenColumns').showColumns([0]);
+
+      expect(viewport.hasOversizedColumnHeadersMarked.master).toBeUndefined();
+      expect(viewport.shouldSynchronizeColumnHeaders).toBe(false);
 
       hot.destroy();
       container.remove();

--- a/handsontable/src/plugins/hiddenColumns/__tests__/showingColumns.unit.js
+++ b/handsontable/src/plugins/hiddenColumns/__tests__/showingColumns.unit.js
@@ -44,7 +44,7 @@ describe('HiddenColumns', () => {
       container.remove();
     });
 
-    it('should use outer height in oversized column header measurement', () => {
+    it('should use inner height in oversized column header measurement', () => {
       registerPlugin(HiddenColumns);
 
       const container = document.createElement('div');
@@ -74,7 +74,7 @@ describe('HiddenColumns', () => {
 
       wtTable.markIfOversizedColumnHeader(0);
 
-      expect(hot.view._wt.wtViewport.oversizedColumnHeaders[0]).toBe(121);
+      expect(hot.view._wt.wtViewport.oversizedColumnHeaders[0]).toBe(120);
 
       hot.destroy();
       container.remove();

--- a/handsontable/src/plugins/hiddenColumns/__tests__/showingColumns.unit.js
+++ b/handsontable/src/plugins/hiddenColumns/__tests__/showingColumns.unit.js
@@ -43,5 +43,41 @@ describe('HiddenColumns', () => {
 
       container.remove();
     });
+
+    it('should include border compensation in oversized column header measurement', () => {
+      registerPlugin(HiddenColumns);
+
+      const container = document.createElement('div');
+
+      document.body.appendChild(container);
+
+      const hot = new Handsontable(container, {
+        data: Array.from({ length: 5 }, (__, rowIndex) => {
+          return Array.from({ length: 5 }, (___, columnIndex) => `r${rowIndex}c${columnIndex}`);
+        }),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenColumns: {
+          columns: [0],
+        },
+        licenseKey: 'non-commercial-and-evaluation',
+      });
+      const wtTable = hot.view._wt.wtTable;
+      const stylesHandler = wtTable.wtSettings.getSetting('stylesHandler');
+      const mockedHeader = document.createElement('div');
+
+      Object.defineProperty(mockedHeader, 'clientHeight', { value: 120 });
+
+      jest.spyOn(stylesHandler, 'getDefaultRowHeight').mockReturnValue(23);
+      jest.spyOn(stylesHandler, 'areCellsBorderBox').mockReturnValue(false);
+      jest.spyOn(wtTable, 'getColumnHeader').mockReturnValue(mockedHeader);
+
+      wtTable.markIfOversizedColumnHeader(0);
+
+      expect(hot.view._wt.wtViewport.oversizedColumnHeaders[0]).toBe(121);
+
+      hot.destroy();
+      container.remove();
+    });
   });
 });

--- a/handsontable/src/plugins/hiddenColumns/__tests__/showingColumns.unit.js
+++ b/handsontable/src/plugins/hiddenColumns/__tests__/showingColumns.unit.js
@@ -1,0 +1,47 @@
+import Handsontable from 'handsontable/base';
+import {
+  registerPlugin,
+  HiddenColumns,
+  NestedHeaders,
+} from 'handsontable/plugins';
+
+describe('HiddenColumns', () => {
+  describe('showColumns', () => {
+    it('should reset oversized column header markers after showing columns', () => {
+      registerPlugin(HiddenColumns);
+      registerPlugin(NestedHeaders);
+
+      const container = document.createElement('div');
+
+      document.body.appendChild(container);
+
+      const hot = new Handsontable(container, {
+        data: Array.from({ length: 20 }, (__, rowIndex) => {
+          return Array.from({ length: 4 }, (___, columnIndex) => `r${rowIndex}c${columnIndex}`);
+        }),
+        rowHeaders: true,
+        colHeaders: true,
+        nestedHeaders: [
+          ['A', 'A very very long nested header label', 'C', 'D'],
+          ['A1', 'B1', 'C1', 'D1'],
+        ],
+        hiddenColumns: {
+          columns: [1],
+        },
+        licenseKey: 'non-commercial-and-evaluation',
+      });
+
+      hot.render();
+
+      expect(hot.view._wt.wtViewport.hasOversizedColumnHeadersMarked.master).toBe(true);
+
+      hot.getPlugin('hiddenColumns').showColumns([1]);
+
+      expect(hot.view._wt.wtViewport.hasOversizedColumnHeadersMarked.master).toBeUndefined();
+
+      hot.destroy();
+
+      container.remove();
+    });
+  });
+});

--- a/handsontable/src/plugins/hiddenColumns/__tests__/showingColumns.unit.js
+++ b/handsontable/src/plugins/hiddenColumns/__tests__/showingColumns.unit.js
@@ -44,7 +44,7 @@ describe('HiddenColumns', () => {
       container.remove();
     });
 
-    it('should include border compensation in oversized column header measurement', () => {
+    it('should use inner height in oversized column header measurement', () => {
       registerPlugin(HiddenColumns);
 
       const container = document.createElement('div');
@@ -74,7 +74,7 @@ describe('HiddenColumns', () => {
 
       wtTable.markIfOversizedColumnHeader(0);
 
-      expect(hot.view._wt.wtViewport.oversizedColumnHeaders[0]).toBe(121);
+      expect(hot.view._wt.wtViewport.oversizedColumnHeaders[0]).toBe(120);
 
       hot.destroy();
       container.remove();

--- a/handsontable/src/plugins/hiddenColumns/__tests__/showingColumns.unit.js
+++ b/handsontable/src/plugins/hiddenColumns/__tests__/showingColumns.unit.js
@@ -67,9 +67,9 @@ describe('HiddenColumns', () => {
       const mockedHeader = document.createElement('div');
 
       Object.defineProperty(mockedHeader, 'clientHeight', { value: 120 });
+      Object.defineProperty(mockedHeader, 'offsetHeight', { value: 121 });
 
       jest.spyOn(stylesHandler, 'getDefaultRowHeight').mockReturnValue(23);
-      jest.spyOn(stylesHandler, 'areCellsBorderBox').mockReturnValue(false);
       jest.spyOn(wtTable, 'getColumnHeader').mockReturnValue(mockedHeader);
 
       wtTable.markIfOversizedColumnHeader(0);

--- a/handsontable/src/plugins/hiddenColumns/hiddenColumns.js
+++ b/handsontable/src/plugins/hiddenColumns/hiddenColumns.js
@@ -309,6 +309,7 @@ export class HiddenColumns extends BasePlugin {
 
     if (wtViewport) {
       wtViewport.resetHasOversizedColumnHeadersMarked();
+      wtViewport.shouldSynchronizeColumnHeaders = true;
     }
 
     // @TODO Should call once per render cycle, currently fired separately in different plugins

--- a/handsontable/src/plugins/hiddenColumns/hiddenColumns.js
+++ b/handsontable/src/plugins/hiddenColumns/hiddenColumns.js
@@ -276,6 +276,7 @@ export class HiddenColumns extends BasePlugin {
     let destinationHideConfig = currentHideConfig;
     const hidingMapValues = this.#hiddenColumnsMap.getValues().slice();
     const isAnyColumnShowed = columns.length > 0;
+    const wtViewport = this.hot.view && this.hot.view._wt && this.hot.view._wt.wtViewport;
 
     if (isValidConfig && isAnyColumnShowed) {
       const physicalColumns = columns.map(visualColumn => this.hot.toPhysicalColumn(visualColumn));
@@ -304,6 +305,10 @@ export class HiddenColumns extends BasePlugin {
 
     if (isValidConfig && isAnyColumnShowed) {
       this.#hiddenColumnsMap.setValues(hidingMapValues);
+    }
+
+    if (wtViewport) {
+      wtViewport.resetHasOversizedColumnHeadersMarked();
     }
 
     // @TODO Should call once per render cycle, currently fired separately in different plugins

--- a/handsontable/src/plugins/hiddenColumns/hiddenColumns.js
+++ b/handsontable/src/plugins/hiddenColumns/hiddenColumns.js
@@ -305,11 +305,11 @@ export class HiddenColumns extends BasePlugin {
 
     if (isValidConfig && isAnyColumnShowed) {
       this.#hiddenColumnsMap.setValues(hidingMapValues);
-    }
 
-    if (wtViewport) {
-      wtViewport.resetHasOversizedColumnHeadersMarked();
-      wtViewport.shouldSynchronizeColumnHeaders = true;
+      if (wtViewport) {
+        wtViewport.resetHasOversizedColumnHeadersMarked();
+        wtViewport.shouldSynchronizeColumnHeaders = this.hot.countRowHeaders() > 0;
+      }
     }
 
     // @TODO Should call once per render cycle, currently fired separately in different plugins

--- a/handsontable/src/plugins/nestedHeaders/__tests__/showingColumns.spec.js
+++ b/handsontable/src/plugins/nestedHeaders/__tests__/showingColumns.spec.js
@@ -2022,6 +2022,35 @@ describe('NestedHeaders', () => {
           </tbody>
           `);
       });
+
+      it('should reset oversized column header marker when showing a high-header hidden column (fixedRowsTop)', async() => {
+        handsontable({
+          data: createSpreadsheetData(80, 4),
+          width: 260,
+          height: 240,
+          rowHeaders: true,
+          colHeaders: true,
+          fixedRowsTop: 2,
+          colWidths: [60, 40, 60, 60],
+          nestedHeaders: [
+            ['A', 'A very very long nested header label', 'C', 'D'],
+            ['A1', 'B1', 'C1', 'D1'],
+          ],
+          hiddenColumns: {
+            columns: [1],
+          },
+          viewportRowRenderingOffset: 0,
+        });
+
+        expect(hot().view._wt.wtViewport.hasOversizedColumnHeadersMarked.master).toBe(true);
+
+        getPlugin('hiddenColumns').showColumns([1]);
+        expect(hot().view._wt.wtViewport.hasOversizedColumnHeadersMarked.master).toBeUndefined();
+
+        await render();
+        await scrollViewportVertically(350);
+        expect(hot().view._wt.wtViewport.hasOversizedColumnHeadersMarked.master).toBe(true);
+      });
     });
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Context
This PR fixes a regression where revealing hidden columns could desynchronize overlay header measurements and cause layer misalignment after scrolling.

Follow-up to reviewer feedback:
- Fixed the remaining row-header/body misalignment when scrolling down past row 10 after `showColumn(0)` with long multiline column headers.
- Added robust post-show/post-scroll resync in Walkontable when a master vs inline-start header-height mismatch is detected.
- Kept Walkontable oversized-column-header measurement on `innerHeight` to avoid broad UMD/Walkontable regressions.
- Limited forced header synchronization to scenarios with row headers (the reported broken path), preventing regressions in non-row-header flows.
- Moved oversized-header-marker reset/sync-flag updates under the actual `showColumns()`-changed branch to avoid unnecessary work for no-op/invalid calls.
- Strengthened `HiddenColumns.showColumns` unit coverage to validate the PR behavior directly (marker reset/sync request when showing columns, no-op/invalid call path, and row-header-disabled path).

### How has this been tested?
- **Linting:**
  - `pnpm --filter handsontable run eslint -- src/3rdparty/walkontable/src/table.js src/plugins/hiddenColumns/hiddenColumns.js src/plugins/hiddenColumns/__tests__/publicAPI.spec.js src/plugins/hiddenColumns/__tests__/showingColumns.unit.js`
- **Targeted E2E (reviewer repro + related UMD regressions):**
  - `npm_config_testPathPattern='test/e2e/Core_reCreate.spec.js|test/e2e/settings/fixedRowsBottom.spec.js|test/e2e/settings/fixedRowsTop.spec.js|test/e2e/keyboardShortcuts/viewportScroll.spec.js|src/plugins/comments/__tests__/keyboardShortcuts.spec.js|hiddenColumns/__tests__/publicAPI.spec.js' pnpm --filter handsontable run test:e2e`
- **Walkontable tests:**
  - `pnpm --filter handsontable run test:walkontable`
- **Unit tests:**
  - `npm_config_testPathPattern=src/plugins/hiddenColumns/__tests__/showingColumns.unit.js pnpm --filter handsontable run test:unit`

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s)
1. handsontable/dev-handsontable#292

### Affected project(s)
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->