### PR TITLE
Missing afterGetCellMeta hook

### DIFF
--- a/.changelogs/10556.json
+++ b/.changelogs/10556.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed an issue where the Nested Rows plugin was disabled after calling updateSettings with an empty data array.",
+  "type": "fixed",
+  "issueOrPR": 10556,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/nestedRows/__tests__/initialization.spec.js
+++ b/handsontable/src/plugins/nestedRows/__tests__/initialization.spec.js
@@ -54,6 +54,35 @@ describe('NestedRows', () => {
       expect(getPlugin('nestedRows').enabled).toBe(false);
     });
 
+    it('should keep the plugin enabled when updating data to an empty array', async() => {
+      const nestedData = [{
+        label: 'Parent',
+        __children: [
+          { label: 'Child' },
+        ],
+      }];
+
+      handsontable({
+        data: nestedData,
+        nestedRows: true,
+      });
+
+      expect(getPlugin('nestedRows').enabled).toBe(true);
+      expect(countRows()).toBe(2);
+
+      await updateSettings({ data: [] });
+
+      expect(getPlugin('nestedRows').enabled).toBe(true);
+      expect(countRows()).toBe(0);
+
+      await updateSettings({ data: nestedData });
+
+      expect(getPlugin('nestedRows').enabled).toBe(true);
+      expect(countRows()).toBe(2);
+      expect(getDataAtCell(0, 0)).toBe('Parent');
+      expect(getDataAtCell(1, 0)).toBe('Child');
+    });
+
     it('should render the row header in correct width (based on the deepest dataset length)', async() => {
       handsontable({
         data: [{

--- a/handsontable/src/plugins/nestedRows/__tests__/utils/isValidDataSource.unit.js
+++ b/handsontable/src/plugins/nestedRows/__tests__/utils/isValidDataSource.unit.js
@@ -1,0 +1,23 @@
+import { isValidDataSource } from '../../utils/isValidDataSource';
+
+describe('NestedRows utils', () => {
+  describe('isValidDataSource', () => {
+    it('should return `true` for an empty array', () => {
+      expect(isValidDataSource([])).toBe(true);
+    });
+
+    it('should return `true` for an array of objects', () => {
+      expect(isValidDataSource([{ value: 'A1' }, { value: 'A2' }])).toBe(true);
+    });
+
+    it('should return `false` for an array of arrays', () => {
+      expect(isValidDataSource([['A1'], ['A2']])).toBe(false);
+    });
+
+    it('should return `false` for non-arrays', () => {
+      expect(isValidDataSource(undefined)).toBe(false);
+      expect(isValidDataSource(null)).toBe(false);
+      expect(isValidDataSource({})).toBe(false);
+    });
+  });
+});

--- a/handsontable/src/plugins/nestedRows/nestedRows.js
+++ b/handsontable/src/plugins/nestedRows/nestedRows.js
@@ -3,8 +3,8 @@ import DataManager from './data/dataManager';
 import CollapsingUI from './ui/collapsing';
 import HeadersUI from './ui/headers';
 import ContextMenuUI from './ui/contextMenu';
+import { isValidDataSource } from './utils/isValidDataSource';
 import { error } from '../../helpers/console';
-import { isArrayOfObjects } from '../../helpers/data';
 import { TrimmingMap } from '../../translations';
 import { EDITOR_EDIT_GROUP as SHORTCUTS_GROUP_EDITOR } from '../../shortcutContexts';
 import RowMoveController from './utils/rowMoveController';
@@ -490,7 +490,7 @@ export class NestedRows extends BasePlugin {
    * @param {Array} data The source data.
    */
   #onBeforeLoadData(data) {
-    if (!isArrayOfObjects(data)) {
+    if (!isValidDataSource(data)) {
       error(WRONG_DATA_TYPE_ERROR);
 
       this.hot.getSettings()[PLUGIN_KEY] = false;

--- a/handsontable/src/plugins/nestedRows/utils/isValidDataSource.js
+++ b/handsontable/src/plugins/nestedRows/utils/isValidDataSource.js
@@ -1,0 +1,11 @@
+import { isArrayOfObjects } from '../../../helpers/data';
+
+/**
+ * Checks whether the provided dataset can be handled by the Nested Rows plugin.
+ *
+ * @param {*} data Dataset to be checked.
+ * @returns {boolean}
+ */
+export function isValidDataSource(data) {
+  return Array.isArray(data) && (data.length === 0 || isArrayOfObjects(data));
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Context
This change addresses issue #10556, where the `nestedRows` plugin would incorrectly disable itself when `updateSettings({ data: [] })` was called. This prevented the plugin from re-enabling and rendering nested data on subsequent data loads.

### How has this been tested?
The changes have been tested with:
- ESLint for code style and quality.
- Unit tests for the new `isValidDataSource` utility, covering valid object arrays, empty arrays, and invalid inputs.
- A new E2E regression test that simulates the `filled -> empty -> filled` data sequence reported in the issue, verifying that nested children correctly render after updating data to an empty array and then back to a filled array.
- The E2E tests were run against a fresh UMD build to ensure accurate behavior.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #10556

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<div><a href="https://cursor.com/agents/bc-86bad8ab-d06b-4b42-ad7d-69bee83f4828"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86bad8ab-d06b-4b42-ad7d-69bee83f4828"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->