### PR TITLE
Column header context menu

### DIFF
--- a/.changelogs/2626.json
+++ b/.changelogs/2626.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed dropdown menu header misalignment after diagonal scrolling",
+  "type": "fixed",
+  "issueOrPR": 2626,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/468.json
+++ b/.changelogs/468.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed updating currentRowClassName through updateSettings",
+  "type": "fixed",
+  "issueOrPR": 468,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -2760,6 +2760,11 @@ export default function Core(rootContainer, userSettings, rootInstanceSymbol = f
    */
   this.updateSettings = function(settings, init = false) {
     const dataUpdateFunction = (firstRun ? instance.loadData : instance.updateData).bind(this);
+    const shouldUpdateSelectionClassNames =
+      hasOwnProperty(settings, 'currentHeaderClassName') ||
+      hasOwnProperty(settings, 'activeHeaderClassName') ||
+      hasOwnProperty(settings, 'currentRowClassName') ||
+      hasOwnProperty(settings, 'currentColClassName');
     let columnsAsFunc = false;
     let i;
     let j;
@@ -2808,6 +2813,19 @@ export default function Core(rootContainer, userSettings, rootInstanceSymbol = f
       } else if (!init && hasOwnProperty(settings, i)) { // Update settings
         globalMeta[i] = settings[i];
       }
+    }
+
+    if (shouldUpdateSelectionClassNames) {
+      selection.updateHighlightClassNames({
+        currentHeaderClassName: hasOwnProperty(settings, 'currentHeaderClassName') ?
+          settings.currentHeaderClassName : selection.highlight.options.headerClassName,
+        activeHeaderClassName: hasOwnProperty(settings, 'activeHeaderClassName') ?
+          settings.activeHeaderClassName : selection.highlight.options.activeHeaderClassName,
+        currentRowClassName: hasOwnProperty(settings, 'currentRowClassName') ?
+          settings.currentRowClassName : selection.highlight.options.rowClassName,
+        currentColClassName: hasOwnProperty(settings, 'currentColClassName') ?
+          settings.currentColClassName : selection.highlight.options.columnClassName,
+      });
     }
 
     const rootContainerThemeClassName = getThemeClassName(instance.rootContainer);

--- a/handsontable/src/plugins/dropdownMenu/__tests__/scrollGuard.spec.js
+++ b/handsontable/src/plugins/dropdownMenu/__tests__/scrollGuard.spec.js
@@ -41,4 +41,50 @@ describe('DropdownMenu', () => {
 
     expect(inlineStartOverlay().getScrollPosition()).not.toBe(initialScrollPosition);
   });
+
+  it('should keep top overlay and master horizontally synchronized after diagonal wheel scroll and opening header menu', async() => {
+    handsontable({
+      data: createSpreadsheetData(50, 20),
+      width: 300,
+      height: 220,
+      colWidths: 100,
+      colHeaders: true,
+      rowHeaders: true,
+      dropdownMenu: true,
+    });
+
+    await scrollViewportTo({ row: 0, col: 8 });
+
+    const wheelEvt = new WheelEvent('wheel', {
+      bubbles: true,
+      cancelable: true,
+      view: window,
+      deltaMode: 0,
+      deltaX: 120,
+      deltaY: 120,
+    });
+    const isChromeLowDensity = /Chrome/.test(navigator.userAgent) &&
+      /Google/.test(navigator.vendor) &&
+      !(tableView()._wt.rootWindow.devicePixelRatio && tableView()._wt.rootWindow.devicePixelRatio > 1);
+
+    if (isChromeLowDensity) {
+      getTopInlineStartClone().find('.wtHolder')[0].dispatchEvent(wheelEvt);
+    } else {
+      tableView()._wt.wtTable.wtRootElement.dispatchEvent(wheelEvt);
+    }
+
+    const partiallyVisibleHeader = getMaster().find('thead th')[7];
+    const button = partiallyVisibleHeader.querySelector('.changeType');
+
+    button.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
+    button.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, cancelable: true }));
+    button.focus();
+    button.click();
+
+    const masterHolder = getMaster().find('.wtHolder')[0];
+    const topHolder = getTopClone().find('.wtHolder')[0];
+
+    expect(getPlugin('dropdownMenu').menu.isOpened()).toBe(true);
+    expect(topHolder.scrollLeft).toBe(masterHolder.scrollLeft);
+  });
 });

--- a/handsontable/src/plugins/dropdownMenu/__tests__/scrollGuard.spec.js
+++ b/handsontable/src/plugins/dropdownMenu/__tests__/scrollGuard.spec.js
@@ -87,4 +87,168 @@ describe('DropdownMenu', () => {
     expect(getPlugin('dropdownMenu').menu.isOpened()).toBe(true);
     expect(topHolder.scrollLeft).toBe(masterHolder.scrollLeft);
   });
+
+  it('should block native wheel scrolling while menu is opened from header button', async() => {
+    handsontable({
+      data: createSpreadsheetData(50, 20),
+      width: 300,
+      height: 220,
+      colWidths: 100,
+      colHeaders: true,
+      rowHeaders: true,
+      dropdownMenu: true,
+      filters: true,
+    });
+
+    await scrollViewportTo({ row: 0, col: 1 });
+
+    const headerCell = getTopClone().find('thead th')[2];
+    const button = headerCell.querySelector('.changeType');
+    const masterHolder = getMaster().find('.wtHolder')[0];
+    const topHolder = getTopClone().find('.wtHolder')[0];
+    const initialMasterScrollLeft = masterHolder.scrollLeft;
+
+    button.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
+    button.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, cancelable: true }));
+    button.click();
+
+    const wheelEvt = new WheelEvent('wheel', {
+      bubbles: true,
+      cancelable: true,
+      view: window,
+      deltaMode: 0,
+      deltaX: 120,
+      deltaY: 120,
+    });
+
+    tableView()._wt.wtTable.wtRootElement.dispatchEvent(wheelEvt);
+    await sleep(100);
+
+    expect(getPlugin('dropdownMenu').menu.isOpened()).toBe(true);
+    expect(masterHolder.scrollLeft).toBe(initialMasterScrollLeft);
+    expect(topHolder.scrollLeft).toBe(masterHolder.scrollLeft);
+  });
+
+  it('should keep header and body aligned after diagonal wheel scroll and opening first column filter menu', async() => {
+    handsontable({
+      data: createSpreadsheetData(100, 8),
+      height: 450,
+      colWidths: [180, 220, 140, 120, 120, 120, 140],
+      colHeaders: [
+        'Company Name',
+        'Name',
+        'Sell date',
+        'In stock',
+        'Quantity',
+        'Order ID',
+        'Country',
+      ],
+      columns: [
+        {
+          data: 1,
+          type: 'text',
+          headerClassName: 'htLeft',
+        },
+        {
+          data: 3,
+          type: 'text',
+          headerClassName: 'htLeft',
+        },
+        {
+          data: 4,
+          type: 'date',
+          dateFormat: 'DD/MM/YYYY',
+          headerClassName: 'htLeft',
+        },
+        {
+          data: 6,
+          type: 'checkbox',
+          className: 'htCenter',
+          headerClassName: 'htLeft',
+        },
+        {
+          data: 7,
+          type: 'numeric',
+          headerClassName: 'htLeft',
+        },
+        {
+          data: 5,
+          type: 'text',
+          headerClassName: 'htLeft',
+        },
+        {
+          data: 2,
+          type: 'text',
+          headerClassName: 'htLeft',
+        },
+      ],
+      contextMenu: [
+        'cut',
+        'copy',
+        '---------',
+        'row_above',
+        'row_below',
+        'remove_row',
+        '---------',
+        'alignment',
+        'make_read_only',
+        'clear_column',
+      ],
+      dropdownMenu: true,
+      hiddenColumns: {
+        indicators: true,
+      },
+      multiColumnSorting: true,
+      filters: true,
+      rowHeaders: true,
+      manualRowMove: true,
+      autoWrapRow: true,
+      autoWrapCol: true,
+      manualRowResize: true,
+      manualColumnResize: true,
+      navigableHeaders: true,
+      headerClassName: 'htLeft',
+    });
+
+    const wheelEvt = new WheelEvent('wheel', {
+      bubbles: true,
+      cancelable: true,
+      view: window,
+      deltaMode: 0,
+      deltaX: 120,
+      deltaY: 120,
+    });
+    const isChromeLowDensity = /Chrome/.test(navigator.userAgent) &&
+      /Google/.test(navigator.vendor) &&
+      !(tableView()._wt.rootWindow.devicePixelRatio && tableView()._wt.rootWindow.devicePixelRatio > 1);
+
+    if (isChromeLowDensity) {
+      getTopInlineStartClone().find('.wtHolder')[0].dispatchEvent(wheelEvt);
+    } else {
+      tableView()._wt.wtTable.wtRootElement.dispatchEvent(wheelEvt);
+    }
+
+    const firstColumnHeader = getTopClone().find('thead th')[1];
+    const button = firstColumnHeader.querySelector('.changeType');
+    const firstHeaderLeft = firstColumnHeader.getBoundingClientRect().left;
+    const firstBodyCellLeft = getMaster().find('tbody tr:first td:first')[0].getBoundingClientRect().left;
+    const initialOffset = Math.round(firstHeaderLeft - firstBodyCellLeft);
+
+    button.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
+    button.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, cancelable: true }));
+    button.focus();
+    button.click();
+
+    await sleep(100);
+
+    const masterHolder = getMaster().find('.wtHolder')[0];
+    const topHolder = getTopClone().find('.wtHolder')[0];
+    const finalHeaderLeft = firstColumnHeader.getBoundingClientRect().left;
+    const finalBodyCellLeft = getMaster().find('tbody tr:first td:first')[0].getBoundingClientRect().left;
+    const finalOffset = Math.round(finalHeaderLeft - finalBodyCellLeft);
+
+    expect(getPlugin('dropdownMenu').menu.isOpened()).toBe(true);
+    expect(topHolder.scrollLeft).toBe(masterHolder.scrollLeft);
+    expect(finalOffset).toBe(initialOffset);
+  });
 });

--- a/handsontable/src/plugins/dropdownMenu/__tests__/scrollGuard.spec.js
+++ b/handsontable/src/plugins/dropdownMenu/__tests__/scrollGuard.spec.js
@@ -129,104 +129,52 @@ describe('DropdownMenu', () => {
     expect(topHolder.scrollLeft).toBe(masterHolder.scrollLeft);
   });
 
-  it('should keep header and body aligned after diagonal wheel scroll and opening first column filter menu', async() => {
+  it('should keep first column header and body aligned after small diagonal scroll and opening first column menu button', async() => {
     handsontable({
-      data: createSpreadsheetData(100, 8),
-      height: 450,
-      colWidths: [180, 220, 140, 120, 120, 120, 140],
-      colHeaders: [
-        'Company Name',
-        'Name',
-        'Sell date',
-        'In stock',
-        'Quantity',
-        'Order ID',
-        'Country',
-      ],
-      columns: [
-        {
-          data: 1,
-          type: 'text',
-          headerClassName: 'htLeft',
-        },
-        {
-          data: 3,
-          type: 'text',
-          headerClassName: 'htLeft',
-        },
-        {
-          data: 4,
-          type: 'date',
-          dateFormat: 'DD/MM/YYYY',
-          headerClassName: 'htLeft',
-        },
-        {
-          data: 6,
-          type: 'checkbox',
-          className: 'htCenter',
-          headerClassName: 'htLeft',
-        },
-        {
-          data: 7,
-          type: 'numeric',
-          headerClassName: 'htLeft',
-        },
-        {
-          data: 5,
-          type: 'text',
-          headerClassName: 'htLeft',
-        },
-        {
-          data: 2,
-          type: 'text',
-          headerClassName: 'htLeft',
-        },
-      ],
-      contextMenu: [
-        'cut',
-        'copy',
-        '---------',
-        'row_above',
-        'row_below',
-        'remove_row',
-        '---------',
-        'alignment',
-        'make_read_only',
-        'clear_column',
-      ],
+      data: createSpreadsheetData(120, 12),
+      width: 420,
+      height: 260,
+      colWidths: 120,
+      colHeaders: true,
+      rowHeaders: true,
+      themeName: 'ht-theme-horizon',
       dropdownMenu: true,
+      filters: true,
       hiddenColumns: {
+        columns: [1],
         indicators: true,
       },
       multiColumnSorting: true,
-      filters: true,
-      rowHeaders: true,
-      manualRowMove: true,
-      autoWrapRow: true,
-      autoWrapCol: true,
-      manualRowResize: true,
+      manualColumnMove: true,
       manualColumnResize: true,
-      navigableHeaders: true,
-      headerClassName: 'htLeft',
+      manualRowMove: true,
+      manualRowResize: true,
     });
 
-    const wheelEvt = new WheelEvent('wheel', {
-      bubbles: true,
-      cancelable: true,
-      view: window,
-      deltaMode: 0,
-      deltaX: 120,
-      deltaY: 120,
-    });
+    const masterHolder = getMaster().find('.wtHolder')[0];
+    const topHolder = getTopClone().find('.wtHolder')[0];
     const isChromeLowDensity = /Chrome/.test(navigator.userAgent) &&
       /Google/.test(navigator.vendor) &&
       !(tableView()._wt.rootWindow.devicePixelRatio && tableView()._wt.rootWindow.devicePixelRatio > 1);
 
-    if (isChromeLowDensity) {
-      getTopInlineStartClone().find('.wtHolder')[0].dispatchEvent(wheelEvt);
-    } else {
-      tableView()._wt.wtTable.wtRootElement.dispatchEvent(wheelEvt);
+    for (let wheelStep = 0; wheelStep < 4; wheelStep += 1) {
+      const wheelEvt = new WheelEvent('wheel', {
+        bubbles: true,
+        cancelable: true,
+        view: window,
+        deltaMode: 0,
+        deltaX: 20,
+        deltaY: 20,
+      });
+
+      if (isChromeLowDensity) {
+        getTopInlineStartClone().find('.wtHolder')[0].dispatchEvent(wheelEvt);
+      } else {
+        tableView()._wt.wtTable.wtRootElement.dispatchEvent(wheelEvt);
+      }
     }
+
+    await sleep(100);
 
     const firstColumnHeader = getTopClone().find('thead th')[1];
     const button = firstColumnHeader.querySelector('.changeType');
@@ -241,12 +189,12 @@ describe('DropdownMenu', () => {
 
     await sleep(100);
 
-    const masterHolder = getMaster().find('.wtHolder')[0];
-    const topHolder = getTopClone().find('.wtHolder')[0];
     const finalHeaderLeft = firstColumnHeader.getBoundingClientRect().left;
     const finalBodyCellLeft = getMaster().find('tbody tr:first td:first')[0].getBoundingClientRect().left;
     const finalOffset = Math.round(finalHeaderLeft - finalBodyCellLeft);
 
+    expect(masterHolder.scrollLeft).toBeGreaterThan(0);
+    expect(masterHolder.scrollTop).toBeGreaterThan(0);
     expect(getPlugin('dropdownMenu').menu.isOpened()).toBe(true);
     expect(topHolder.scrollLeft).toBe(masterHolder.scrollLeft);
     expect(finalOffset).toBe(initialOffset);

--- a/handsontable/src/plugins/dropdownMenu/__tests__/scrollGuard.spec.js
+++ b/handsontable/src/plugins/dropdownMenu/__tests__/scrollGuard.spec.js
@@ -1,0 +1,44 @@
+describe('DropdownMenu', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should block delayed horizontal viewport scroll after opening menu from a partially visible header button', async() => {
+    handsontable({
+      data: createSpreadsheetData(10, 20),
+      width: 300,
+      height: 300,
+      colWidths: 100,
+      colHeaders: true,
+      rowHeaders: true,
+      dropdownMenu: true
+    });
+
+    await scrollViewportTo({ row: 0, col: 8 }); // make the column `G` partially visible
+
+    const initialScrollPosition = inlineStartOverlay().getScrollPosition();
+
+    await dropdownMenu(6);
+
+    expect(getPlugin('dropdownMenu').menu.isOpened()).toBe(true);
+
+    await scrollViewportTo({ row: 0, col: 6, horizontalSnap: 'start' });
+
+    expect(inlineStartOverlay().getScrollPosition()).toBe(initialScrollPosition);
+
+    getPlugin('dropdownMenu').close();
+
+    await scrollViewportTo({ row: 0, col: 6, horizontalSnap: 'start' });
+
+    expect(inlineStartOverlay().getScrollPosition()).not.toBe(initialScrollPosition);
+  });
+});

--- a/handsontable/src/plugins/dropdownMenu/__tests__/scrollGuard.unit.js
+++ b/handsontable/src/plugins/dropdownMenu/__tests__/scrollGuard.unit.js
@@ -113,5 +113,51 @@ describe('DropdownMenu', () => {
       hot.destroy();
       container.remove();
     });
+
+    it('should synchronize master scroll with top overlay after menu-open RAF cycle', () => {
+      const container = document.createElement('div');
+
+      document.body.appendChild(container);
+
+      const hot = new Handsontable(container, {
+        data: Array.from({ length: 20 }, (_rowValue, row) =>
+          Array.from({ length: 20 }, (_colValue, col) => `${row}:${col}`)),
+        width: 300,
+        height: 220,
+        colWidths: 100,
+        colHeaders: true,
+        rowHeaders: true,
+        dropdownMenu: true,
+        licenseKey: 'non-commercial-and-evaluation',
+      });
+      const button = hot.rootElement.querySelector('.changeType');
+      const masterHolder = hot.view._wt.wtTable.holder;
+      const topHolder = hot.view._wt.wtOverlays.topOverlay.clone.wtTable.holder;
+      const rafQueue = [];
+      const originalRaf = hot.rootWindow.requestAnimationFrame;
+
+      hot.rootWindow.requestAnimationFrame = (callback) => {
+        rafQueue.push(callback);
+
+        return rafQueue.length;
+      };
+
+      button.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
+      button.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, cancelable: true }));
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+
+      masterHolder.scrollLeft = 80;
+      topHolder.scrollLeft = 51;
+
+      while (rafQueue.length) {
+        rafQueue.shift()();
+      }
+
+      expect(masterHolder.scrollLeft).toBe(51);
+
+      hot.rootWindow.requestAnimationFrame = originalRaf;
+      hot.destroy();
+      container.remove();
+    });
   });
 });

--- a/handsontable/src/plugins/dropdownMenu/__tests__/scrollGuard.unit.js
+++ b/handsontable/src/plugins/dropdownMenu/__tests__/scrollGuard.unit.js
@@ -1,0 +1,43 @@
+import Handsontable from 'handsontable/base';
+import {
+  registerPlugin,
+  AutoColumnSize,
+  DropdownMenu,
+} from 'handsontable/plugins';
+
+describe('DropdownMenu', () => {
+  describe('horizontal scroll guard', () => {
+    beforeAll(() => {
+      registerPlugin(AutoColumnSize);
+      registerPlugin(DropdownMenu);
+    });
+
+    it('should block horizontal viewport scroll while the menu is opened by button click', () => {
+      const container = document.createElement('div');
+
+      document.body.appendChild(container);
+
+      const hot = new Handsontable(container, {
+        data: [['A1', 'B1'], ['A2', 'B2']],
+        colHeaders: true,
+        dropdownMenu: true,
+        licenseKey: 'non-commercial-and-evaluation',
+      });
+      const dropdownMenu = hot.getPlugin('dropdownMenu');
+      const button = hot.rootElement.querySelector('.changeType');
+
+      button.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
+      button.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, cancelable: true }));
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+
+      expect(dropdownMenu.menu.isOpened()).toBe(true);
+      expect(hot.runHooks('beforeViewportScrollHorizontally', 1, { value: 'auto' })).toBe(null);
+
+      dropdownMenu.close();
+      expect(hot.runHooks('beforeViewportScrollHorizontally', 1, { value: 'auto' })).toBe(1);
+
+      hot.destroy();
+      container.remove();
+    });
+  });
+});

--- a/handsontable/src/plugins/dropdownMenu/__tests__/scrollGuard.unit.js
+++ b/handsontable/src/plugins/dropdownMenu/__tests__/scrollGuard.unit.js
@@ -39,5 +39,40 @@ describe('DropdownMenu', () => {
       hot.destroy();
       container.remove();
     });
+
+    it('should synchronize top overlay scroll position with master before opening menu', () => {
+      const container = document.createElement('div');
+
+      document.body.appendChild(container);
+
+      const hot = new Handsontable(container, {
+        data: Array.from({ length: 20 }, (_rowValue, row) =>
+          Array.from({ length: 20 }, (_colValue, col) => `${row}:${col}`)),
+        width: 300,
+        height: 220,
+        colWidths: 100,
+        colHeaders: true,
+        rowHeaders: true,
+        dropdownMenu: true,
+        licenseKey: 'non-commercial-and-evaluation',
+      });
+      const dropdownMenu = hot.getPlugin('dropdownMenu');
+      const masterHolder = hot.view._wt.wtTable.holder;
+      const topHolder = hot.view._wt.wtOverlays.topOverlay.clone.wtTable.holder;
+      const button = hot.rootElement.querySelector('.changeType');
+
+      masterHolder.scrollLeft = 180;
+      topHolder.scrollLeft = 120;
+
+      button.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
+      button.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, cancelable: true }));
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+
+      expect(dropdownMenu.menu.isOpened()).toBe(true);
+      expect(topHolder.scrollLeft).toBe(masterHolder.scrollLeft);
+
+      hot.destroy();
+      container.remove();
+    });
   });
 });

--- a/handsontable/src/plugins/dropdownMenu/__tests__/scrollGuard.unit.js
+++ b/handsontable/src/plugins/dropdownMenu/__tests__/scrollGuard.unit.js
@@ -74,5 +74,44 @@ describe('DropdownMenu', () => {
       hot.destroy();
       container.remove();
     });
+
+    it('should block wheel scrolling while menu is opened by button click', () => {
+      const container = document.createElement('div');
+
+      document.body.appendChild(container);
+
+      const hot = new Handsontable(container, {
+        data: Array.from({ length: 20 }, (_rowValue, row) =>
+          Array.from({ length: 20 }, (_colValue, col) => `${row}:${col}`)),
+        width: 300,
+        height: 220,
+        colWidths: 100,
+        colHeaders: true,
+        rowHeaders: true,
+        dropdownMenu: true,
+        licenseKey: 'non-commercial-and-evaluation',
+      });
+      const button = hot.rootElement.querySelector('.changeType');
+
+      button.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
+      button.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, cancelable: true }));
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+
+      const wheelEvent = new WheelEvent('wheel', {
+        bubbles: true,
+        cancelable: true,
+        deltaX: 120,
+        deltaY: 120,
+      });
+
+      hot.rootElement.dispatchEvent(wheelEvent);
+
+      expect(wheelEvent.defaultPrevented).toBe(true);
+
+      hot.getPlugin('dropdownMenu').close();
+
+      hot.destroy();
+      container.remove();
+    });
   });
 });

--- a/handsontable/src/plugins/dropdownMenu/dropdownMenu.js
+++ b/handsontable/src/plugins/dropdownMenu/dropdownMenu.js
@@ -625,9 +625,29 @@ export class DropdownMenu extends BasePlugin {
    * @fires Hooks#afterDropdownMenuShow
    */
   #onMenuAfterOpen() {
+    const rootWindow = this.hot?.rootWindow;
+
+    if (!rootWindow) {
+      return;
+    }
     this.hot.runHooks('afterDropdownMenuShow', this);
 
     this.#addCustomShortcuts(this.menu);
+
+    if (this.#isMenuOpenedByButtonClick) {
+      const reconcileMasterWithTopOverlay = () => {
+        if (!this.#isMenuOpenedByButtonClick || !(this.menu?.isOpened() ?? false)) {
+          return;
+        }
+
+        this.#syncMasterScrollPositionWithTopOverlay();
+      };
+
+      rootWindow.requestAnimationFrame(() => {
+        reconcileMasterWithTopOverlay();
+        rootWindow.requestAnimationFrame(reconcileMasterWithTopOverlay);
+      });
+    }
   }
 
   /**
@@ -679,6 +699,35 @@ export class DropdownMenu extends BasePlugin {
   #onBeforeOnCellMouseDown(event) {
     if (hasClass(event.target, BUTTON_CLASS_NAME)) {
       this.#isButtonClicked = true;
+    }
+  }
+
+  /**
+   * Synchronizes the master holder horizontal scroll position with the top overlay holder.
+   *
+   * It handles post-open layout adjustments that can clamp the top overlay scroll position.
+   */
+  #syncMasterScrollPositionWithTopOverlay() {
+    if (!this.hot) {
+      return;
+    }
+
+    const wt = this.hot.view?._wt;
+
+    if (!wt) {
+      return;
+    }
+
+    const masterHolder = wt.wtTable.holder;
+    const topHolder = wt.wtOverlays.topOverlay.clone.wtTable.holder;
+    const topScrollLeft = topHolder.scrollLeft;
+
+    if (masterHolder.scrollLeft !== topScrollLeft) {
+      masterHolder.scrollLeft = topScrollLeft;
+    }
+
+    if (wt.wtOverlays.bottomOverlay.needFullRender) {
+      wt.wtOverlays.bottomOverlay.clone.wtTable.holder.scrollLeft = topScrollLeft;
     }
   }
 

--- a/handsontable/src/plugins/dropdownMenu/dropdownMenu.js
+++ b/handsontable/src/plugins/dropdownMenu/dropdownMenu.js
@@ -343,6 +343,9 @@ export class DropdownMenu extends BasePlugin {
    */
   registerEvents() {
     this.eventManager.addEventListener(this.hot.rootElement, 'click', event => this.#onTableClick(event));
+    this.eventManager.addEventListener(this.hot.rootElement, 'wheel', event => this.#onTableWheel(event), {
+      passive: false,
+    });
   }
 
   /**
@@ -464,6 +467,21 @@ export class DropdownMenu extends BasePlugin {
         above: 0,
         below: 3,
       });
+    }
+  }
+
+  /**
+   * Table wheel listener.
+   *
+   * @private
+   * @param {WheelEvent} event The wheel event object.
+   */
+  #onTableWheel(event) {
+    const isMenuOpened = this.menu?.isOpened() ?? false;
+
+    if (this.#isMenuOpenedByButtonClick && isMenuOpened) {
+      this.#syncOverlayScrollPositionsWithMaster();
+      event.preventDefault();
     }
   }
 

--- a/handsontable/src/plugins/dropdownMenu/dropdownMenu.js
+++ b/handsontable/src/plugins/dropdownMenu/dropdownMenu.js
@@ -446,6 +446,8 @@ export class DropdownMenu extends BasePlugin {
    */
   #onTableClick(event) {
     if (hasClass(event.target, BUTTON_CLASS_NAME)) {
+      this.#syncOverlayScrollPositionsWithMaster();
+
       const offset = getDocumentOffsetByElement(this.menu.container, this.hot.rootDocument);
       const buttonRect = this.#getButtonRect(event.target);
 
@@ -462,6 +464,33 @@ export class DropdownMenu extends BasePlugin {
         above: 0,
         below: 3,
       });
+    }
+  }
+
+  /**
+   * Synchronizes overlay holders with the current master holder scroll position.
+   *
+   * This prevents opening the dropdown menu while an in-flight native wheel scroll left
+   * the top overlay out of sync with the main table.
+   */
+  #syncOverlayScrollPositionsWithMaster() {
+    const wt = this.hot.view?._wt;
+
+    if (!wt) {
+      return;
+    }
+
+    const masterHolder = wt.wtTable.holder;
+    const masterScrollLeft = masterHolder.scrollLeft;
+    const masterScrollTop = masterHolder.scrollTop;
+    const topHolder = wt.wtOverlays.topOverlay.clone.wtTable.holder;
+    const inlineStartHolder = wt.wtOverlays.inlineStartOverlay.clone.wtTable.holder;
+
+    topHolder.scrollLeft = masterScrollLeft;
+    inlineStartHolder.scrollTop = masterScrollTop;
+
+    if (wt.wtOverlays.bottomOverlay.needFullRender) {
+      wt.wtOverlays.bottomOverlay.clone.wtTable.holder.scrollLeft = masterScrollLeft;
     }
   }
 
@@ -615,8 +644,9 @@ export class DropdownMenu extends BasePlugin {
    */
   #onBeforeViewportScrollHorizontally(visualColumn) {
     const isMenuOpened = this.menu?.isOpened() ?? false;
+    const shouldBlockScroll = this.#isButtonClicked || (this.#isMenuOpenedByButtonClick && isMenuOpened);
 
-    if (this.#isButtonClicked || (this.#isMenuOpenedByButtonClick && isMenuOpened)) {
+    if (shouldBlockScroll) {
       return null;
     }
 

--- a/handsontable/src/plugins/dropdownMenu/dropdownMenu.js
+++ b/handsontable/src/plugins/dropdownMenu/dropdownMenu.js
@@ -157,6 +157,13 @@ export class DropdownMenu extends BasePlugin {
    * @type {boolean}
    */
   #isButtonClicked = false;
+  /**
+   * Flag which determines if the currently opened menu was opened from the
+   * header button click.
+   *
+   * @type {boolean}
+   */
+  #isMenuOpenedByButtonClick = false;
 
   constructor(hotInstance) {
     super(hotInstance);
@@ -444,6 +451,7 @@ export class DropdownMenu extends BasePlugin {
 
       event.stopPropagation();
       this.#isButtonClicked = false;
+      this.#isMenuOpenedByButtonClick = true;
 
       this.open({
         left: buttonRect.left + offset.left,
@@ -592,6 +600,7 @@ export class DropdownMenu extends BasePlugin {
    * @fires Hooks#afterDropdownMenuHide
    */
   #onMenuAfterClose() {
+    this.#isMenuOpenedByButtonClick = false;
     this.hot.listen();
     this.hot.runHooks('afterDropdownMenuHide', this);
   }
@@ -605,7 +614,13 @@ export class DropdownMenu extends BasePlugin {
    * @returns {number | null}
    */
   #onBeforeViewportScrollHorizontally(visualColumn) {
-    return this.#isButtonClicked ? null : visualColumn;
+    const isMenuOpened = this.menu?.isOpened() ?? false;
+
+    if (this.#isButtonClicked || (this.#isMenuOpenedByButtonClick && isMenuOpened)) {
+      return null;
+    }
+
+    return visualColumn;
   }
 
   /**

--- a/handsontable/src/selection/__tests__/selection.unit.js
+++ b/handsontable/src/selection/__tests__/selection.unit.js
@@ -1,0 +1,68 @@
+import Selection from '../selection';
+
+function createSettings() {
+  return {
+    currentHeaderClassName: 'initial-header',
+    activeHeaderClassName: 'initial-active-header',
+    currentRowClassName: 'initial-row',
+    currentColClassName: 'initial-column',
+    selectionMode: 'single',
+    navigableHeaders: false,
+    fixedRowsBottom: 0,
+    minSpareRows: 0,
+    minSpareCols: 0,
+    autoWrapRow: false,
+    autoWrapCol: false,
+    fillHandle: false,
+  };
+}
+
+function createTableProps() {
+  return {
+    rowIndexMapper: {},
+    columnIndexMapper: {},
+    isDisabledCellSelection: () => false,
+    createCellCoords: (row, col) => ({ row, col }),
+    createCellRange: () => null,
+    visualToRenderableCoords: coords => coords,
+    renderableToVisualCoords: coords => coords,
+    countRenderableRows: () => 0,
+    countRenderableColumns: () => 0,
+    countRenderableRowsInRange: () => 0,
+    countRenderableColumnsInRange: () => 0,
+    countRowHeaders: () => 0,
+    countColHeaders: () => 0,
+  };
+}
+
+describe('Selection', () => {
+  describe('updateHighlightClassNames', () => {
+    it('should update class names for all highlight instances from the current settings', () => {
+      const settings = createSettings();
+      const selection = new Selection(settings, createTableProps());
+
+      const rowHighlight = selection.highlight.createRowHighlight();
+      const columnHighlight = selection.highlight.createColumnHighlight();
+      const rowHeaderHighlight = selection.highlight.createRowHeader();
+      const columnHeaderHighlight = selection.highlight.createColumnHeader();
+      const activeRowHeaderHighlight = selection.highlight.createActiveRowHeader();
+      const activeColumnHeaderHighlight = selection.highlight.createActiveColumnHeader();
+      const activeCornerHeaderHighlight = selection.highlight.createActiveCornerHeader();
+
+      settings.currentHeaderClassName = 'updated-header';
+      settings.activeHeaderClassName = 'updated-active-header';
+      settings.currentRowClassName = undefined;
+      settings.currentColClassName = 'updated-column';
+
+      selection.updateHighlightClassNames();
+
+      expect(rowHighlight.settings.className).toBeUndefined();
+      expect(columnHighlight.settings.className).toBe('updated-column');
+      expect(rowHeaderHighlight.settings.className).toBe('updated-header');
+      expect(columnHeaderHighlight.settings.className).toBe('updated-header');
+      expect(activeRowHeaderHighlight.settings.className).toBe('updated-active-header');
+      expect(activeColumnHeaderHighlight.settings.className).toBe('updated-active-header');
+      expect(activeCornerHeaderHighlight.settings.className).toBe('updated-active-header');
+    });
+  });
+});

--- a/handsontable/src/selection/selection.js
+++ b/handsontable/src/selection/selection.js
@@ -189,6 +189,52 @@ class Selection {
   }
 
   /**
+   * Updates class names used by selection highlights.
+   *
+   * @param {object} [classNames=this.settings] Class names to apply.
+   * @param {string} [classNames.currentHeaderClassName] Header class name.
+   * @param {string} [classNames.activeHeaderClassName] Active header class name.
+   * @param {string} [classNames.currentRowClassName] Row class name.
+   * @param {string} [classNames.currentColClassName] Column class name.
+   * @returns {void}
+   */
+  updateHighlightClassNames(classNames = this.settings) {
+    const {
+      currentHeaderClassName,
+      activeHeaderClassName,
+      currentRowClassName,
+      currentColClassName,
+    } = classNames;
+
+    this.highlight.options.headerClassName = currentHeaderClassName;
+    this.highlight.options.activeHeaderClassName = activeHeaderClassName;
+    this.highlight.options.rowClassName = currentRowClassName;
+    this.highlight.options.columnClassName = currentColClassName;
+
+    arrayEach(this.highlight.getRowHighlights(), (highlight) => {
+      highlight.settings.className = currentRowClassName;
+    });
+    arrayEach(this.highlight.getColumnHighlights(), (highlight) => {
+      highlight.settings.className = currentColClassName;
+    });
+    arrayEach(this.highlight.getRowHeaders(), (highlight) => {
+      highlight.settings.className = currentHeaderClassName;
+    });
+    arrayEach(this.highlight.getColumnHeaders(), (highlight) => {
+      highlight.settings.className = currentHeaderClassName;
+    });
+    arrayEach(this.highlight.getActiveRowHeaders(), (highlight) => {
+      highlight.settings.className = activeHeaderClassName;
+    });
+    arrayEach(this.highlight.getActiveColumnHeaders(), (highlight) => {
+      highlight.settings.className = activeHeaderClassName;
+    });
+    arrayEach(this.highlight.getActiveCornerHeaders(), (highlight) => {
+      highlight.settings.className = activeHeaderClassName;
+    });
+  }
+
+  /**
    * Gets all selection range layers of the selection.
    *
    * @returns {SelectionRange}

--- a/handsontable/test/e2e/settings/currentRowClassName.spec.js
+++ b/handsontable/test/e2e/settings/currentRowClassName.spec.js
@@ -35,6 +35,42 @@ describe('settings', () => {
 
       expect(spec().$container.find('td.currentRowClassName').length).toEqual(0);
     });
+
+    it('should update currentRowClassName after updateSettings', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 7),
+        currentRowClassName: 'initial-row-highlight'
+      });
+
+      await selectCell(2, 2);
+
+      expect(spec().$container.find('td.initial-row-highlight').length).toEqual(7);
+      expect(spec().$container.find('td.updated-row-highlight').length).toEqual(0);
+
+      await updateSettings({
+        currentRowClassName: 'updated-row-highlight'
+      });
+
+      expect(spec().$container.find('td.initial-row-highlight').length).toEqual(0);
+      expect(spec().$container.find('td.updated-row-highlight').length).toEqual(7);
+    });
+
+    it('should remove currentRowClassName after updateSettings sets it to undefined', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 7),
+        currentRowClassName: 'current-row-highlight'
+      });
+
+      await selectCell(2, 2);
+
+      expect(spec().$container.find('td.current-row-highlight').length).toEqual(7);
+
+      await updateSettings({
+        currentRowClassName: undefined
+      });
+
+      expect(spec().$container.find('td.current-row-highlight').length).toEqual(0);
+    });
   });
 
   describe('currentColClassName', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Context
This PR fixes a timing-related header misalignment in the **column dropdown menu** path (3-dot button in column headers, Horizon theme).

After a small diagonal touchpad/wheel scroll, opening the **first column** dropdown menu could desynchronize the top overlay and master holder scroll positions. The fix now reconciles scroll state after menu open (including post-open animation frames) and guards wheel-driven drift while the header-opened menu is active.

### How has this been tested?
- ✅ `pnpm --filter handsontable exec eslint src/plugins/dropdownMenu/dropdownMenu.js src/plugins/dropdownMenu/__tests__/scrollGuard.spec.js src/plugins/dropdownMenu/__tests__/scrollGuard.unit.js`
- ✅ `pnpm --filter handsontable exec cross-env-shell BABEL_ENV=commonjs env-cmd -f ../hot.config.js jest --testPathPattern=src/plugins/dropdownMenu/__tests__/scrollGuard.unit.js`
- ✅ `npm_config_testpathpattern="%scrollGuard\.spec\.js%" pnpm --filter handsontable run test:e2e.dump`
- ✅ `node test/scripts/run-puppeteer.mjs "test/E2ERunner.html?spec=should%20keep%20first%20column%20header%20and%20body%20aligned%20after%20small%20diagonal%20scroll%20and%20opening%20first%20column%20menu%20button"`
- ✅ `node test/scripts/run-puppeteer.mjs "test/E2ERunner.html?spec=should%20block%20delayed%20horizontal%20viewport%20scroll%20after%20opening%20menu%20from%20a%20partially%20visible%20header%20button"`
- ✅ `node test/scripts/run-puppeteer.mjs "test/E2ERunner.html?spec=should%20keep%20top%20overlay%20and%20master%20horizontally%20synchronized%20after%20diagonal%20wheel%20scroll%20and%20opening%20header%20menu"`
- ✅ `node test/scripts/run-puppeteer.mjs "test/E2ERunner.html?spec=should%20block%20native%20wheel%20scrolling%20while%20menu%20is%20opened%20from%20header%20button"`
- ✅ Manual UI verification recorded for the first-column scenario (Horizon theme, first column menu button, small diagonal scroll) with visible PASS state.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. Internal tracker issue (same bug context as discussed in review thread).

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->