### PR TITLE
Server-Side Row Model sorting

### DIFF
--- a/handsontable/src/plugins/dataProvider/__tests__/dataProvider.spec.js
+++ b/handsontable/src/plugins/dataProvider/__tests__/dataProvider.spec.js
@@ -221,6 +221,108 @@ describe('DataProvider', () => {
     expect(plugin.getQueryParameters().filters).toEqual({ col: 0, value: 'x' });
   });
 
+  it('should preserve current page when setSort or setFilters is called', async() => {
+    const fetchParams = [];
+
+    handsontable({
+      dataProvider: async(params) => {
+        fetchParams.push({ ...params });
+
+        return {
+          rows: createSpreadsheetData(params.pageSize || 10, 3),
+          totalRows: 100,
+        };
+      },
+      columns: 3,
+      pagination: { pageSize: 5 },
+    });
+
+    await sleep(100);
+
+    const plugin = getPlugin('dataProvider');
+
+    await plugin.goToPage(2);
+    await sleep(50);
+    expect(plugin.getQueryParameters().page).toBe(2);
+
+    await plugin.setSort({ column: 0, sortOrder: 'asc' });
+    await sleep(50);
+
+    expect(plugin.getQueryParameters().page).toBe(2);
+    expect(plugin.getQueryParameters().sort).toEqual({ column: 0, sortOrder: 'asc' });
+    expect(fetchParams[fetchParams.length - 1].page).toBe(2);
+
+    await plugin.setFilters({ col: 1, value: 'z' });
+    await sleep(50);
+
+    expect(plugin.getQueryParameters().page).toBe(2);
+    expect(plugin.getQueryParameters().filters).toEqual({ col: 1, value: 'z' });
+    expect(fetchParams[fetchParams.length - 1].page).toBe(2);
+  });
+
+  it('should trigger dataProvider fetch with sort when columnSorting sort is used', async() => {
+    const fetchParams = [];
+
+    handsontable({
+      dataProvider: async(params) => {
+        fetchParams.push({ ...params });
+
+        return {
+          rows: createSpreadsheetData(params.pageSize || 10, 3),
+          totalRows: 50,
+        };
+      },
+      columns: 3,
+      colHeaders: true,
+      columnSorting: true,
+      pagination: true,
+    });
+
+    await sleep(100);
+
+    const columnSorting = getPlugin('columnSorting');
+    const dataProvider = getPlugin('dataProvider');
+
+    columnSorting.sort({ column: 0, sortOrder: 'asc' });
+    await sleep(100);
+
+    const lastCall = fetchParams[fetchParams.length - 1];
+
+    expect(lastCall.sort).toEqual({ column: 0, sortOrder: 'asc' });
+    expect(dataProvider.getQueryParameters().sort).toEqual({ column: 0, sortOrder: 'asc' });
+    expect(columnSorting.getSortConfig()).toEqual([{ column: 0, sortOrder: 'asc' }]);
+  });
+
+  it('should sync columnSorting state after fetch completes (setSort and clearSort)', async() => {
+    handsontable({
+      dataProvider: async params => ({
+        rows: createSpreadsheetData(params.pageSize || 10, 3),
+        totalRows: 50,
+      }),
+      columns: 3,
+      colHeaders: true,
+      columnSorting: true,
+      pagination: true,
+    });
+
+    await sleep(100);
+
+    const columnSorting = getPlugin('columnSorting');
+    const dataProvider = getPlugin('dataProvider');
+
+    await dataProvider.setSort({ column: 1, sortOrder: 'desc' });
+    await sleep(50);
+
+    expect(dataProvider.getQueryParameters().sort).toEqual({ column: 1, sortOrder: 'desc' });
+    expect(columnSorting.getSortConfig()).toEqual([{ column: 1, sortOrder: 'desc' }]);
+
+    await dataProvider.setSort(null);
+    await sleep(50);
+
+    expect(dataProvider.getQueryParameters().sort).toBe(null);
+    expect(columnSorting.getSortConfig()).toEqual([]);
+  });
+
   it('should disable plugin and remove hooks on updateSettings without dataProvider', async() => {
     handsontable({
       dataProvider: async() => ({ rows: createSpreadsheetData(5, 3), totalRows: 10 }),

--- a/handsontable/src/plugins/dataProvider/dataProvider.js
+++ b/handsontable/src/plugins/dataProvider/dataProvider.js
@@ -1,6 +1,7 @@
 import { isFunction } from '../../helpers/function';
 import { BasePlugin } from '../base';
 import { PLUGIN_KEY as PAGINATION_PLUGIN_KEY } from '../pagination';
+import { PLUGIN_KEY as COLUMN_SORTING_PLUGIN_KEY } from '../columnSorting';
 
 export const PLUGIN_KEY = 'dataProvider';
 export const PLUGIN_PRIORITY = 950;
@@ -110,8 +111,21 @@ export class DataProvider extends BasePlugin {
       }
     }
 
+    const columnSorting = this.hot.getPlugin(COLUMN_SORTING_PLUGIN_KEY);
+
+    if (columnSorting?.enabled) {
+      const sortConfig = columnSorting.getSortConfig();
+
+      if (Array.isArray(sortConfig) && sortConfig.length > 0) {
+        this.#queryParameters.sort = sortConfig[0];
+      } else if (sortConfig && typeof sortConfig === 'object' && 'column' in sortConfig) {
+        this.#queryParameters.sort = sortConfig;
+      }
+    }
+
     this.addHook('afterInit', this.#onAfterInitBound);
     this.addHook('modifyRowHeader', this.#onModifyRowHeaderBound);
+    this.addHook('beforeColumnSort', this.#onBeforeColumnSortBound);
 
     super.enablePlugin();
   }
@@ -138,6 +152,49 @@ export class DataProvider extends BasePlugin {
    * @returns {void}
    */
   #onAfterInitBound = () => this.#onAfterInit();
+
+  /**
+   * Bound handler for beforeColumnSort (so it can be removed in disablePlugin).
+   *
+   * @private
+   * @param {Array} currentSortConfig Previous sort config.
+   * @param {Array} destinationSortConfigs New sort config (single column for columnSorting).
+   * @param {boolean} sortPossible Whether the sort request is valid.
+   * @returns {boolean|undefined} `false` to block the default in-memory sort; otherwise undefined.
+   */
+  #onBeforeColumnSortBound = (currentSortConfig, destinationSortConfigs, sortPossible) =>
+    this.#onBeforeColumnSort(currentSortConfig, destinationSortConfigs, sortPossible);
+
+  /**
+   * When columnSorting triggers a sort, block in-memory sort and drive a dataProvider fetch with the new sort.
+   * Updates columnSorting's config so the header indicator is correct.
+   *
+   * @private
+   * @param {Array} currentSortConfig Previous sort config.
+   * @param {Array} destinationSortConfigs New sort config (single column for columnSorting).
+   * @param {boolean} sortPossible Whether the sort request is valid.
+   * @returns {boolean|undefined} `false` to block the default in-memory sort; otherwise undefined.
+   */
+  #onBeforeColumnSort(currentSortConfig, destinationSortConfigs, sortPossible) {
+    if (!this.isEnabled() || !sortPossible) {
+      return;
+    }
+
+    const columnSorting = this.hot.getPlugin(COLUMN_SORTING_PLUGIN_KEY);
+
+    if (columnSorting?.enabled) {
+      columnSorting.setSortConfig(destinationSortConfigs);
+    }
+
+    const sortParam =
+      Array.isArray(destinationSortConfigs) && destinationSortConfigs.length > 0
+        ? destinationSortConfigs[0]
+        : null;
+
+    this.setSort(sortParam);
+
+    return false;
+  }
 
   /**
    * Hook handler: maps visual row index (0-based within current page) to global 0-based row index
@@ -218,6 +275,7 @@ export class DataProvider extends BasePlugin {
       this.#queryParameters = params;
       this.#totalRows = totalRows;
       this.hot.loadData(rows, PLUGIN_KEY);
+      this.#syncColumnSortingState();
       this.hot.runHooks('afterDataProviderFetch', { ...result, rows, totalRows, queryParameters: params });
 
       return { rows, totalRows };
@@ -265,7 +323,7 @@ export class DataProvider extends BasePlugin {
    * @returns {Promise<void>}
    */
   async setSort(sort) {
-    await this.fetchData({ sort, page: 1 });
+    await this.fetchData({ sort });
   }
 
   /**
@@ -275,7 +333,7 @@ export class DataProvider extends BasePlugin {
    * @returns {Promise<void>}
    */
   async setFilters(filters) {
-    await this.fetchData({ filters, page: 1 });
+    await this.fetchData({ filters });
   }
 
   /**
@@ -294,6 +352,24 @@ export class DataProvider extends BasePlugin {
    */
   getQueryParameters() {
     return { ...this.#queryParameters };
+  }
+
+  /**
+   * Syncs the columnSorting plugin's sort config to match the current query parameters after a successful fetch.
+   *
+   * @private
+   */
+  #syncColumnSortingState() {
+    const columnSorting = this.hot.getPlugin(COLUMN_SORTING_PLUGIN_KEY);
+
+    if (!columnSorting?.enabled) {
+      return;
+    }
+
+    const sort = this.#queryParameters.sort;
+    const sortConfig = sort && typeof sort === 'object' && 'column' in sort ? sort : [];
+
+    columnSorting.setSortConfig(sortConfig);
   }
 
   /**
@@ -316,6 +392,7 @@ export class DataProvider extends BasePlugin {
   disablePlugin() {
     this.hot.removeHook('afterInit', this.#onAfterInitBound);
     this.hot.removeHook('modifyRowHeader', this.#onModifyRowHeaderBound);
+    this.hot.removeHook('beforeColumnSort', this.#onBeforeColumnSortBound);
 
     if (this.#abortController) {
       this.#abortController.abort();

--- a/handsontable/src/plugins/multiColumnSorting/__tests__/multiColumnSorting.spec.js
+++ b/handsontable/src/plugins/multiColumnSorting/__tests__/multiColumnSorting.spec.js
@@ -49,6 +49,49 @@ describe('MultiColumnSorting', () => {
     ['Robert', 'Evans', '07/24/2020', 30500, undefined]
   ];
 
+  describe('dataProvider conflict', () => {
+    it('should be disabled with warning when both multiColumnSorting and dataProvider are set', async() => {
+      spyOn(console, 'warn');
+
+      handsontable({
+        data: arrayOfObjects(),
+        multiColumnSorting: true,
+        dataProvider: async() => ({ rows: [], totalRows: 0 }),
+        columns: [{ data: 'id' }, { data: 'name' }, { data: 'lastName' }],
+      });
+
+      // eslint-disable-next-line no-console
+      expect(console.warn).toHaveBeenCalledWith(
+        'The `multiColumnSorting` plugin cannot be used with the `dataProvider` option. ' +
+        'This combination is not supported. The plugin will remain disabled.'
+      );
+      expect(getPlugin('multiColumnSorting').isEnabled()).toBe(false);
+    });
+
+    it('should disable and warn when dataProvider is added via updateSettings', async() => {
+      spyOn(console, 'warn');
+
+      handsontable({
+        data: arrayOfObjects(),
+        multiColumnSorting: true,
+        columns: [{ data: 'id' }, { data: 'name' }, { data: 'lastName' }],
+      });
+
+      expect(getPlugin('multiColumnSorting').isEnabled()).toBe(true);
+
+      await updateSettings({
+        dataProvider: async() => ({ rows: [], totalRows: 0 }),
+      });
+
+      // eslint-disable-next-line no-console
+      expect(console.warn).toHaveBeenCalledWith(
+        'The `multiColumnSorting` plugin cannot be used with the `dataProvider` option. ' +
+        'This combination is not supported. The plugin will remain disabled.'
+      );
+      expect(getPlugin('multiColumnSorting').isEnabled()).toBe(false);
+    });
+  });
+
   it('should sort table by first visible column', async() => {
     handsontable({
       data: [

--- a/handsontable/src/plugins/multiColumnSorting/multiColumnSorting.js
+++ b/handsontable/src/plugins/multiColumnSorting/multiColumnSorting.js
@@ -5,12 +5,15 @@ import {
 import { registerRootComparator } from '../columnSorting/sortService';
 import { wasHeaderClickedProperly } from '../columnSorting/utils';
 import { addClass, removeClass } from '../../helpers/dom/element';
+import { toSingleLine } from '../../helpers/templateLiteralTag';
+import { warn } from '../../helpers/console';
 import { rootComparator } from './rootComparator';
 import { getClassesToAdd, getClassesToRemove } from './domHelpers';
 import { EDITOR_EDIT_GROUP as SHORTCUTS_GROUP_EDITOR } from '../../shortcutContexts';
 
 export const PLUGIN_KEY = 'multiColumnSorting';
 export const PLUGIN_PRIORITY = 170;
+const SETTING_KEYS = ['dataProvider'];
 const SHORTCUTS_GROUP = PLUGIN_KEY;
 
 registerRootComparator(PLUGIN_KEY, rootComparator);
@@ -76,6 +79,13 @@ export class MultiColumnSorting extends ColumnSorting {
     return PLUGIN_PRIORITY;
   }
 
+  static get SETTING_KEYS() {
+    return [
+      PLUGIN_KEY,
+      ...SETTING_KEYS
+    ];
+  }
+
   /**
    * Main settings key designed for the plugin.
    *
@@ -87,11 +97,23 @@ export class MultiColumnSorting extends ColumnSorting {
   /**
    * Checks if the plugin is enabled in the Handsontable settings. This method is executed in {@link Hooks#beforeInit}
    * hook and if it returns `true` then the {@link MultiColumnSorting#enablePlugin} method is called.
+   * Disabled when `dataProvider` is used (server-side data); a warning is emitted in that case.
    *
    * @returns {boolean}
    */
   isEnabled() {
-    return !!(this.hot.getSettings()[this.pluginKey]);
+    const settings = this.hot.getSettings();
+    const pluginEnabled = !!settings[this.pluginKey];
+    const dataProviderEnabled = !!settings.dataProvider;
+
+    if (pluginEnabled && dataProviderEnabled) {
+      warn(toSingleLine`The \`multiColumnSorting\` plugin cannot be used with the \`dataProvider\` option.\x20
+        This combination is not supported. The plugin will remain disabled.`);
+
+      return false;
+    }
+
+    return pluginEnabled;
   }
 
   /**

--- a/handsontable/src/plugins/pagination/__tests__/plugins/dataProvider.spec.js
+++ b/handsontable/src/plugins/pagination/__tests__/plugins/dataProvider.spec.js
@@ -314,4 +314,84 @@ describe('Pagination integration with DataProvider', () => {
     expect(pagination.getPaginationData().pageSize).toBe(initialPageSize);
     expect(dataProvider.getQueryParameters().pageSize).toBe(initialPageSize);
   });
+
+  it('should keep columnSorting state in sync after page change when sort is active', async() => {
+    const pageSize = 10;
+
+    handsontable({
+      dataProvider: async(params) => {
+        const start = (params.page - 1) * params.pageSize;
+        const rows = createSpreadsheetData(params.pageSize, 2).map((row, i) =>
+          [`Row ${start + i + 1}`, row[1]]
+        );
+
+        return { rows, totalRows: 25 };
+      },
+      columns: 2,
+      rowHeaders: true,
+      colHeaders: true,
+      columnSorting: true,
+      pagination: { pageSize },
+    });
+
+    await sleep(100);
+
+    const pagination = getPlugin('pagination');
+    const dataProvider = getPlugin('dataProvider');
+    const columnSorting = getPlugin('columnSorting');
+
+    columnSorting.sort({ column: 0, sortOrder: 'desc' });
+    await sleep(100);
+
+    expect(dataProvider.getQueryParameters().sort).toEqual({ column: 0, sortOrder: 'desc' });
+    expect(columnSorting.getSortConfig()).toEqual([{ column: 0, sortOrder: 'desc' }]);
+
+    pagination.setPage(2);
+    await sleep(100);
+
+    expect(dataProvider.getQueryParameters().page).toBe(2);
+    expect(dataProvider.getQueryParameters().sort).toEqual({ column: 0, sortOrder: 'desc' });
+    expect(columnSorting.getSortConfig()).toEqual([{ column: 0, sortOrder: 'desc' }]);
+  });
+
+  it('should preserve current page when sort is applied from page 2', async() => {
+    const fetchParams = [];
+    const pageSize = 10;
+
+    handsontable({
+      dataProvider: async(params) => {
+        fetchParams.push({ page: params.page, sort: params.sort });
+        const start = (params.page - 1) * params.pageSize;
+        const rows = createSpreadsheetData(params.pageSize, 2).map((row, i) =>
+          [`Row ${start + i + 1}`, row[1]]
+        );
+
+        return { rows, totalRows: 25 };
+      },
+      columns: 2,
+      colHeaders: true,
+      columnSorting: true,
+      pagination: { pageSize },
+    });
+
+    await sleep(100);
+
+    const pagination = getPlugin('pagination');
+    const dataProvider = getPlugin('dataProvider');
+    const columnSorting = getPlugin('columnSorting');
+
+    pagination.setPage(2);
+    await sleep(100);
+
+    expect(pagination.getPaginationData().currentPage).toBe(2);
+    expect(dataProvider.getQueryParameters().page).toBe(2);
+
+    columnSorting.sort({ column: 0, sortOrder: 'asc' });
+    await sleep(100);
+
+    expect(pagination.getPaginationData().currentPage).toBe(2);
+    expect(dataProvider.getQueryParameters().page).toBe(2);
+    expect(dataProvider.getQueryParameters().sort).toEqual({ column: 0, sortOrder: 'asc' });
+    expect(fetchParams[fetchParams.length - 1].page).toBe(2);
+  });
 });


### PR DESCRIPTION
### Context

This change introduces a **dataProvider** option so Handsontable can load data from an async source (e.g. REST API) with query parameters for pagination, sorting, and filtering—enabling a server-side row model. When `dataProvider` is set, the table requests only the current page (and optional sort/filter state) from the server instead of holding the full dataset in memory.

**Problems solved:**

- **Large datasets:** Load only the visible page; pagination, sort, and filter are server-driven.
- **Sorting:** ColumnSorting is wired to the dataProvider so header sort triggers a fetch with `sort` in query params; sort state is synced on the client after each successful fetch.
- **Pagination:** Integrates with the existing Pagination plugin; on fetch failure, pagination and data revert to the previous state.
- **Conflicts:** ManualRowMove, TrimRows, and MultiColumnSorting are disabled with a console warning when `dataProvider` is set.

### Summary of changes

#### DataProvider plugin

- **Option:** `dataProvider` – async function `(queryParameters, { signal }) => Promise<{ rows, totalRows }>`.
- **Query parameters:** `{ page, pageSize, sort, filters }`; `signal` is an `AbortSignal` for cancelling in-flight requests.
- **Initial load:** When `dataProvider` is set, core skips loading from `data`; the DataProvider plugin runs the first fetch after init. Reads initial `pageSize` / `initialPage` from Pagination settings or from `settings.pagination` when the Pagination plugin is not yet enabled.
- **Row headers:** `modifyRowHeader` hook maps visual row index to global 1-based index (e.g. page 2 starts at 11).
- **API:** `fetchData(overrides?)`, `goToPage(page)`, `setPageSize(pageSize)`, `setSort(sort)`, `setFilters(filters)`, `getTotalRows()`, `getQueryParameters()`. `setSort` and `setFilters` preserve the current page (no reset to 1).
- **Hooks:** `beforeDataProviderFetch`, `afterDataProviderFetch`, `afterDataProviderFetchError`. Errors are rethrown after the error hook so callers that await `fetchData()` can handle them.
- **AbortController:** New fetch aborts the previous one with a descriptive reason; aborted requests are ignored.

#### ColumnSorting + DataProvider

- **beforeColumnSort:** DataProvider registers a handler that blocks the default in-memory sort (returns `false`), updates columnSorting’s config via `setSortConfig`, and calls `dataProvider.setSort(sortParam)` so the server is queried with the new sort.
- **Sync after fetch:** After every successful fetch, `#syncColumnSortingState()` updates the columnSorting plugin’s sort config from `#queryParameters.sort`, so header indicators and client state match the loaded data.
- **Initial sort:** On enable, DataProvider reads columnSorting’s `getSortConfig()` (if enabled) and sets `#queryParameters.sort` so the first fetch uses the configured sort.

#### MultiColumnSorting

- Disabled when `dataProvider` is set (same pattern as TrimRows/ManualRowMove): `isEnabled()` returns `false` and a console warning is shown; `SETTING_KEYS` includes `'dataProvider'` so adding dataProvider via `updateSettings` re-evaluates and keeps the plugin disabled.

#### Pagination integration

- **DataProvider mode:** Pagination uses `dataProvider.getTotalRows()` and drives page/size via `dataProvider.goToPage()` / `setPageSize()`. `goToPage` and `setPageSize` promises are caught so fetch failures do not cause unhandled rejections.
- **Revert on fetch error:** On failure, pagination state is reverted (`#revertPageOnFetchError`, `#revertPageSizeOnFetchError`) and `#refreshUI()` is called so the table and pagination UI stay consistent with the last successful state.
- **#onAfterDataProviderFetch:** Updates pagination’s internal page/pageSize from `result.queryParameters` and uses `createPaginatorStrategy('fixed')` (dataProvider always uses numeric pageSize).
- **getPaginationData:** When dataProvider is active, first/last visible row and total rendered rows reflect the dataProvider’s total and current page.

#### Plugin conflicts

- **ManualRowMove** and **TrimRows:** Disabled with warning when `dataProvider` is set; `SETTING_KEYS` includes `'dataProvider'`.
- **MultiColumnSorting:** Disabled with warning when `dataProvider` is set; `SETTING_KEYS` includes `'dataProvider'`.

#### Core / config

- `core.js`: When `dataProvider` is present, initial data is not loaded from `data`.
- `metaSchema.js`: `dataProvider` option documented.
- `constants.js`: Hooks `beforeDataProviderFetch`, `afterDataProviderFetch`, `afterDataProviderFetchError` (single registration in the “before” section).

#### TypeScript

- DataProvider: `DataProviderQueryParameters`, `DataProviderFetchResult`, `DataProviderOptions`, `DataProviderFunction`, plugin class and `Settings`.
- `GridSettings` and `Events` extended; `settings.types.ts` updated for new option and hooks.

### How has this been tested?

- **Unit / spec:** DataProvider spec (enable/disable, initial load, hooks, cancel fetch, error path, abort, goToPage/setPageSize/setSort/setFilters, columnSorting sort triggers fetch, sync columnSorting state after fetch, preserve page on setSort/setFilters). Pagination + DataProvider spec (both enabled, page change, revert on setPage/setPageSize failure, row headers, preserve page when sort applied from page 2). ManualRowMove, TrimRows, and MultiColumnSorting conflict specs (disabled + warning on init and on updateSettings with dataProvider).
- **Types:** `pnpm --filter handsontable run test:types`; `settings.types.ts` includes the new option and hooks.
- **E2E:** `npm run test:e2e --testPathPattern=DataProvider` (and related specs) run via Puppeteer.

### Types of changes

- [x] New feature or improvement (non-breaking change which adds functionality)
### Related issue(s)

1. PRO-1065

### Affected project(s)

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: changes core sorting behavior when `dataProvider` is enabled by intercepting `beforeColumnSort` and altering pagination/sort state syncing, which can affect existing sorting workflows and plugin interoperability.
> 
> **Overview**
> **Server-side sorting is now driven by `dataProvider`.** The `DataProvider` plugin now reads initial sort state from `columnSorting`, intercepts `beforeColumnSort` to block in-memory sorting and trigger a provider fetch with the new sort, and re-syncs `columnSorting` indicators/state after each successful fetch.
> 
> **Pagination behavior changes for sort/filter updates.** `dataProvider.setSort()` and `setFilters()` no longer force `page: 1`, preserving the current page while still refetching.
> 
> **Unsupported plugin combination is enforced.** `multiColumnSorting` is automatically disabled (with a warning) when `dataProvider` is configured, including when `dataProvider` is added via `updateSettings`.
> 
> Tests were expanded to cover page preservation, `columnSorting` → fetch wiring, post-fetch state sync, and the `multiColumnSorting` conflict.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a5b23182fb75e4aff77f39ae3b3db5f45feb584. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->