### PR TITLE
Server-Side Row Model filtering

### DIFF
--- a/handsontable/src/plugins/dataProvider/__tests__/dataProvider.spec.js
+++ b/handsontable/src/plugins/dataProvider/__tests__/dataProvider.spec.js
@@ -221,7 +221,7 @@ describe('DataProvider', () => {
     expect(plugin.getQueryParameters().filters).toEqual({ col: 0, value: 'x' });
   });
 
-  it('should preserve current page when setSort or setFilters is called', async() => {
+  it('should preserve current page when setSort is called', async() => {
     const fetchParams = [];
 
     handsontable({
@@ -251,13 +251,70 @@ describe('DataProvider', () => {
     expect(plugin.getQueryParameters().page).toBe(2);
     expect(plugin.getQueryParameters().sort).toEqual({ column: 0, sortOrder: 'asc' });
     expect(fetchParams[fetchParams.length - 1].page).toBe(2);
+  });
 
-    await plugin.setFilters({ col: 1, value: 'z' });
+  it('should reset to page 1 when setFilters is called', async() => {
+    const fetchParams = [];
+
+    handsontable({
+      dataProvider: async(params) => {
+        fetchParams.push({ ...params });
+
+        return {
+          rows: createSpreadsheetData(params.pageSize || 10, 3),
+          totalRows: 100,
+        };
+      },
+      columns: 3,
+      pagination: { pageSize: 5 },
+    });
+
+    await sleep(100);
+
+    const plugin = getPlugin('dataProvider');
+
+    await plugin.goToPage(2);
+    await sleep(50);
+    expect(plugin.getQueryParameters().page).toBe(2);
+
+    await plugin.setFilters([{ column: 1, operation: 'conjunction', conditions: [{ name: 'contains', args: ['z'] }] }]);
     await sleep(50);
 
-    expect(plugin.getQueryParameters().page).toBe(2);
-    expect(plugin.getQueryParameters().filters).toEqual({ col: 1, value: 'z' });
-    expect(fetchParams[fetchParams.length - 1].page).toBe(2);
+    expect(plugin.getQueryParameters().page).toBe(1);
+    expect(plugin.getQueryParameters().filters).toBeDefined();
+    expect(fetchParams[fetchParams.length - 1].page).toBe(1);
+  });
+
+  it('should call dataProvider with filters null when setFilters(null) clears filters', async() => {
+    const fetchParams = [];
+
+    handsontable({
+      dataProvider: async(params) => {
+        fetchParams.push({ ...params });
+
+        return {
+          rows: createSpreadsheetData(params.pageSize || 10, 3),
+          totalRows: 100,
+        };
+      },
+      columns: 3,
+      pagination: true,
+    });
+
+    await sleep(100);
+
+    const plugin = getPlugin('dataProvider');
+
+    await plugin.setFilters([{ column: 0, operation: 'conjunction', conditions: [{ name: 'eq', args: ['a'] }] }]);
+    await sleep(50);
+    expect(plugin.getQueryParameters().filters).not.toBe(null);
+
+    await plugin.setFilters(null);
+    await sleep(50);
+
+    expect(plugin.getQueryParameters().filters).toBe(null);
+    expect(plugin.getQueryParameters().page).toBe(1);
+    expect(fetchParams[fetchParams.length - 1].filters).toBe(null);
   });
 
   it('should trigger dataProvider fetch with sort when columnSorting sort is used', async() => {

--- a/handsontable/src/plugins/dataProvider/dataProvider.js
+++ b/handsontable/src/plugins/dataProvider/dataProvider.js
@@ -327,13 +327,13 @@ export class DataProvider extends BasePlugin {
   }
 
   /**
-   * Updates filters and refetches.
+   * Updates filters and refetches. Resets to page 1 when filters change.
    *
-   * @param {object|null} filters Filter state to send to the provider.
+   * @param {object|null} filters Filter state to send to the provider (e.g. from Filters plugin export).
    * @returns {Promise<void>}
    */
   async setFilters(filters) {
-    await this.fetchData({ filters });
+    await this.fetchData({ filters, page: 1 });
   }
 
   /**

--- a/handsontable/src/plugins/filters/__tests__/conditionCollection.unit.js
+++ b/handsontable/src/plugins/filters/__tests__/conditionCollection.unit.js
@@ -392,6 +392,51 @@ describe('ConditionCollection', () => {
     });
   });
 
+  describe('importAllConditions', () => {
+    beforeEach(() => {
+      conditions.eq = { condition: () => {}, descriptor: {} };
+      conditions.contains = { condition: () => {}, descriptor: {} };
+      conditions.begins_with = { condition: () => {}, descriptor: {} };
+    });
+
+    afterEach(() => {
+      delete conditions.eq;
+      delete conditions.contains;
+      delete conditions.begins_with;
+    });
+
+    it('should preserve operation type when importing conditions (e.g. disjunction)', () => {
+      const conditionCollection = new ConditionCollection(hotMock, false);
+
+      conditionCollection.importAllConditions([{
+        column: 1,
+        operation: 'disjunction',
+        conditions: [
+          { name: 'contains', args: ['a'] },
+          { name: 'begins_with', args: ['b'] },
+        ],
+      }]);
+
+      expect(conditionCollection.getOperation(1)).toBe('disjunction');
+      const exported = conditionCollection.exportAllConditions();
+
+      expect(exported.length).toBe(1);
+      expect(exported[0].operation).toBe('disjunction');
+      expect(exported[0].conditions.map(c => c.name)).toEqual(['contains', 'begins_with']);
+    });
+
+    it('should default to conjunction when operation is missing (backward compatibility)', () => {
+      const conditionCollection = new ConditionCollection(hotMock, false);
+
+      conditionCollection.importAllConditions([{
+        column: 2,
+        conditions: [{ name: 'eq', args: ['x'] }],
+      }]);
+
+      expect(conditionCollection.getOperation(2)).toBe(OPERATION_AND);
+    });
+  });
+
   describe('getConditions', () => {
     it('should return conditions at specified index otherwise should return empty array', () => {
       const conditionCollection = new ConditionCollection(hotMock, false); // Second arguments is `false` - not registering map

--- a/handsontable/src/plugins/filters/__tests__/plugins/dataProvider.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/plugins/dataProvider.spec.js
@@ -291,6 +291,7 @@ describe('Filters integration with DataProvider', () => {
 
     expect(conditionsAfterFirstFetch.length).toBe(1);
     expect(conditionsAfterFirstFetch[0].column).toBe(0);
+    expect(conditionsAfterFirstFetch[0].operation).toBe('conjunction');
     expect(conditionsAfterFirstFetch[0].conditions[0].name).toBe('contains');
     expect(conditionsAfterFirstFetch[0].conditions[0].args).toEqual(['a']);
 
@@ -301,6 +302,7 @@ describe('Filters integration with DataProvider', () => {
 
     expect(conditionsAfterPageChange.length).toBe(1);
     expect(conditionsAfterPageChange[0].column).toBe(0);
+    expect(conditionsAfterPageChange[0].operation).toBe('conjunction');
     expect(conditionsAfterPageChange[0].conditions[0].name).toBe('contains');
     expect(conditionsAfterPageChange[0].conditions[0].args).toEqual(['a']);
 
@@ -311,7 +313,50 @@ describe('Filters integration with DataProvider', () => {
 
     expect(conditionsAfterReturnToPage1.length).toBe(1);
     expect(conditionsAfterReturnToPage1[0].column).toBe(0);
+    expect(conditionsAfterReturnToPage1[0].operation).toBe('conjunction');
     expect(conditionsAfterReturnToPage1[0].conditions[0].name).toBe('contains');
     expect(conditionsAfterReturnToPage1[0].conditions[0].args).toEqual(['a']);
+  });
+
+  it('should preserve filter operation type (disjunction) after dataProvider fetch', async() => {
+    handsontable({
+      dataProvider: async(params) => {
+        return {
+          rows: createSpreadsheetData(params.pageSize || 10, 3),
+          totalRows: params.filters ? 5 : 50,
+        };
+      },
+      columns: 3,
+      dropdownMenu: true,
+      filters: true,
+      pagination: { pageSize: 10 },
+    });
+
+    await sleep(100);
+
+    const filtersPlugin = getPlugin('filters');
+    const pagination = getPlugin('pagination');
+
+    filtersPlugin.addCondition(0, 'contains', ['a'], 'disjunction');
+    filtersPlugin.addCondition(0, 'begins_with', ['b'], 'disjunction');
+    filtersPlugin.filter();
+
+    await sleep(150);
+
+    expect(filtersPlugin.exportConditions()[0].operation).toBe('disjunction');
+
+    pagination.setPage(2);
+    await sleep(150);
+
+    const conditionsAfterPageChange = filtersPlugin.exportConditions();
+
+    expect(conditionsAfterPageChange.length).toBe(1);
+    expect(conditionsAfterPageChange[0].operation).toBe('disjunction');
+    expect(conditionsAfterPageChange[0].conditions.map(c => c.name)).toEqual(['contains', 'begins_with']);
+
+    pagination.setPage(1);
+    await sleep(150);
+
+    expect(filtersPlugin.exportConditions()[0].operation).toBe('disjunction');
   });
 });

--- a/handsontable/src/plugins/filters/__tests__/plugins/dataProvider.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/plugins/dataProvider.spec.js
@@ -1,0 +1,317 @@
+describe('Filters integration with DataProvider', () => {
+  beforeEach(function() {
+    this.$container = $('<div id="testContainer"></div>').appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should trigger dataProvider with filters model when filter is applied', async() => {
+    const fetchParams = [];
+
+    handsontable({
+      dataProvider: async(params) => {
+        fetchParams.push({ ...params });
+
+        return {
+          rows: createSpreadsheetData(params.pageSize || 10, 3),
+          totalRows: params.filters ? 5 : 50,
+        };
+      },
+      columns: 3,
+      dropdownMenu: true,
+      filters: true,
+      pagination: true,
+    });
+
+    await sleep(100);
+
+    const filtersPlugin = getPlugin('filters');
+    const dataProvider = getPlugin('dataProvider');
+
+    filtersPlugin.addCondition(0, 'contains', ['a']);
+    filtersPlugin.filter();
+
+    await sleep(150);
+
+    const lastCall = fetchParams[fetchParams.length - 1];
+
+    expect(lastCall.filters).not.toBe(null);
+    expect(Array.isArray(lastCall.filters)).toBe(true);
+    expect(lastCall.filters.length).toBe(1);
+    expect(lastCall.filters[0].column).toBe(0);
+    expect(lastCall.filters[0].operation).toBe('conjunction');
+    expect(lastCall.filters[0].conditions).toEqual([{ name: 'contains', args: ['a'] }]);
+    expect(lastCall.page).toBe(1);
+    expect(dataProvider.getQueryParameters().page).toBe(1);
+    expect(dataProvider.getQueryParameters().filters).toEqual(lastCall.filters);
+  });
+
+  it('should reset page to 1 when filter is applied', async() => {
+    const fetchParams = [];
+
+    handsontable({
+      dataProvider: async(params) => {
+        fetchParams.push({ ...params });
+
+        return {
+          rows: createSpreadsheetData(params.pageSize || 10, 3),
+          totalRows: 30,
+        };
+      },
+      columns: 3,
+      dropdownMenu: true,
+      filters: true,
+      pagination: { pageSize: 10 },
+    });
+
+    await sleep(100);
+
+    const pagination = getPlugin('pagination');
+    const filtersPlugin = getPlugin('filters');
+
+    pagination.setPage(2);
+    await sleep(100);
+
+    expect(fetchParams[fetchParams.length - 1].page).toBe(2);
+
+    filtersPlugin.addCondition(1, 'eq', ['x']);
+    filtersPlugin.filter();
+
+    await sleep(150);
+
+    expect(fetchParams[fetchParams.length - 1].page).toBe(1);
+    expect(getPlugin('dataProvider').getQueryParameters().page).toBe(1);
+  });
+
+  it('should trigger dataProvider with filters null when all filters are cleared', async() => {
+    const fetchParams = [];
+
+    handsontable({
+      dataProvider: async(params) => {
+        fetchParams.push({ ...params });
+
+        return {
+          rows: createSpreadsheetData(params.pageSize || 10, 3),
+          totalRows: 50,
+        };
+      },
+      columns: 3,
+      dropdownMenu: true,
+      filters: true,
+      pagination: true,
+    });
+
+    await sleep(100);
+
+    const filtersPlugin = getPlugin('filters');
+    const dataProvider = getPlugin('dataProvider');
+
+    filtersPlugin.addCondition(0, 'contains', ['a']);
+    filtersPlugin.filter();
+    await sleep(100);
+
+    expect(fetchParams[fetchParams.length - 1].filters).not.toBe(null);
+
+    filtersPlugin.clearConditions();
+    filtersPlugin.filter();
+    await sleep(150);
+
+    const lastCall = fetchParams[fetchParams.length - 1];
+
+    expect(lastCall.filters).toBe(null);
+    expect(dataProvider.getQueryParameters().filters).toBe(null);
+  });
+
+  it('should combine multiple column filters correctly in the filters object', async() => {
+    const fetchParams = [];
+
+    handsontable({
+      dataProvider: async(params) => {
+        fetchParams.push({ ...params });
+
+        return {
+          rows: createSpreadsheetData(params.pageSize || 10, 4),
+          totalRows: 20,
+        };
+      },
+      columns: 4,
+      dropdownMenu: true,
+      filters: true,
+      pagination: true,
+    });
+
+    await sleep(100);
+
+    const filtersPlugin = getPlugin('filters');
+
+    filtersPlugin.addCondition(0, 'begins_with', ['a']);
+    filtersPlugin.addCondition(1, 'gt', [10]);
+    filtersPlugin.addCondition(2, 'contains', ['z']);
+    filtersPlugin.filter();
+
+    await sleep(150);
+
+    const lastCall = fetchParams[fetchParams.length - 1];
+
+    expect(lastCall.filters).not.toBe(null);
+    expect(lastCall.filters.length).toBe(3);
+    expect(lastCall.filters[0]).toEqual({
+      column: 0,
+      operation: 'conjunction',
+      conditions: [{ name: 'begins_with', args: ['a'] }],
+    });
+    expect(lastCall.filters[1]).toEqual({
+      column: 1,
+      operation: 'conjunction',
+      conditions: [{ name: 'gt', args: [10] }],
+    });
+    expect(lastCall.filters[2]).toEqual({
+      column: 2,
+      operation: 'conjunction',
+      conditions: [{ name: 'contains', args: ['z'] }],
+    });
+  });
+
+  it('should update pagination total to reflect totalRows from filtered response', async() => {
+    const totalUnfiltered = 100;
+    const totalFiltered = 12;
+
+    handsontable({
+      dataProvider: async(params) => {
+        const total = params.filters && params.filters.length > 0 ? totalFiltered : totalUnfiltered;
+
+        return {
+          rows: createSpreadsheetData(params.pageSize || 10, 3),
+          totalRows: total,
+        };
+      },
+      columns: 3,
+      dropdownMenu: true,
+      filters: true,
+      pagination: { pageSize: 10 },
+    });
+
+    await sleep(100);
+
+    const dataProvider = getPlugin('dataProvider');
+    const filtersPlugin = getPlugin('filters');
+
+    expect(dataProvider.getTotalRows()).toBe(totalUnfiltered);
+
+    filtersPlugin.addCondition(0, 'contains', ['x']);
+    filtersPlugin.filter();
+
+    await sleep(150);
+
+    expect(dataProvider.getTotalRows()).toBe(totalFiltered);
+  });
+
+  it('should not use server-side filtering when dataProvider is not set (client-side filtering unaffected)', async() => {
+    const data = createSpreadsheetData(20, 5);
+
+    handsontable({
+      data,
+      columns: 5,
+      dropdownMenu: true,
+      filters: true,
+      width: 500,
+      height: 300,
+    });
+
+    const plugin = getPlugin('filters');
+
+    expect(getPlugin('dataProvider').isEnabled()).toBe(false);
+
+    plugin.addCondition(0, 'eq', ['A1']);
+    plugin.filter();
+
+    const filteredData = getData();
+
+    expect(filteredData.length).toBe(1);
+    expect(filteredData[0][0]).toBe('A1');
+  });
+
+  it('should hide "Filter by value" section in the dropdown menu when dataProvider is enabled', async() => {
+    handsontable({
+      dataProvider: async params => ({
+        rows: createSpreadsheetData(params.pageSize || 10, 3),
+        totalRows: 50,
+      }),
+      columns: 3,
+      dropdownMenu: true,
+      filters: true,
+      pagination: true,
+    });
+
+    await sleep(100);
+
+    getPlugin('dropdownMenu').open({ top: 100, left: 100 });
+    await sleep(100);
+
+    const menuRoot = dropdownMenuRootElement();
+
+    expect(menuRoot).not.toBeNull();
+    expect(menuRoot.querySelector('.htFiltersMenuValue')).toBeNull();
+  });
+
+  it('should preserve filter conditions after dataProvider fetch completes', async() => {
+    const fetchParams = [];
+
+    handsontable({
+      dataProvider: async(params) => {
+        fetchParams.push({ ...params });
+
+        return {
+          rows: createSpreadsheetData(params.pageSize || 10, 3),
+          totalRows: params.filters ? 5 : 50,
+        };
+      },
+      columns: 3,
+      dropdownMenu: true,
+      filters: true,
+      pagination: { pageSize: 10 },
+    });
+
+    await sleep(100);
+
+    const filtersPlugin = getPlugin('filters');
+    const pagination = getPlugin('pagination');
+
+    filtersPlugin.addCondition(0, 'contains', ['a']);
+    filtersPlugin.filter();
+
+    await sleep(150);
+
+    const conditionsAfterFirstFetch = filtersPlugin.exportConditions();
+
+    expect(conditionsAfterFirstFetch.length).toBe(1);
+    expect(conditionsAfterFirstFetch[0].column).toBe(0);
+    expect(conditionsAfterFirstFetch[0].conditions[0].name).toBe('contains');
+    expect(conditionsAfterFirstFetch[0].conditions[0].args).toEqual(['a']);
+
+    pagination.setPage(2);
+    await sleep(150);
+
+    const conditionsAfterPageChange = filtersPlugin.exportConditions();
+
+    expect(conditionsAfterPageChange.length).toBe(1);
+    expect(conditionsAfterPageChange[0].column).toBe(0);
+    expect(conditionsAfterPageChange[0].conditions[0].name).toBe('contains');
+    expect(conditionsAfterPageChange[0].conditions[0].args).toEqual(['a']);
+
+    pagination.setPage(1);
+    await sleep(150);
+
+    const conditionsAfterReturnToPage1 = filtersPlugin.exportConditions();
+
+    expect(conditionsAfterReturnToPage1.length).toBe(1);
+    expect(conditionsAfterReturnToPage1[0].column).toBe(0);
+    expect(conditionsAfterReturnToPage1[0].conditions[0].name).toBe('contains');
+    expect(conditionsAfterReturnToPage1[0].conditions[0].args).toEqual(['a']);
+  });
+});

--- a/handsontable/src/plugins/filters/__tests__/plugins/dataProvider.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/plugins/dataProvider.spec.js
@@ -359,4 +359,53 @@ describe('Filters integration with DataProvider', () => {
 
     expect(filtersPlugin.exportConditions()[0].operation).toBe('disjunction');
   });
+
+  it('should restore previous filter state when dataProvider fetch fails', async() => {
+    let fetchCallCount = 0;
+
+    handsontable({
+      dataProvider: async(params) => {
+        fetchCallCount += 1;
+
+        if (fetchCallCount === 3) {
+          throw new Error('Network error');
+        }
+
+        return {
+          rows: createSpreadsheetData(params.pageSize || 10, 3),
+          totalRows: params.filters ? 5 : 50,
+        };
+      },
+      columns: 3,
+      dropdownMenu: true,
+      filters: true,
+      pagination: true,
+    });
+
+    await sleep(100);
+
+    const filtersPlugin = getPlugin('filters');
+
+    filtersPlugin.addCondition(0, 'contains', ['a']);
+    filtersPlugin.filter();
+    await sleep(150);
+
+    const conditionsAfterFirstFetch = filtersPlugin.exportConditions();
+
+    expect(conditionsAfterFirstFetch.length).toBe(1);
+    expect(conditionsAfterFirstFetch[0].conditions[0].name).toBe('contains');
+    expect(conditionsAfterFirstFetch[0].conditions[0].args).toEqual(['a']);
+
+    filtersPlugin.addCondition(1, 'eq', ['x']);
+    filtersPlugin.filter();
+
+    await sleep(150);
+
+    const conditionsAfterFailedFetch = filtersPlugin.exportConditions();
+
+    expect(conditionsAfterFailedFetch.length).toBe(1);
+    expect(conditionsAfterFailedFetch[0].column).toBe(0);
+    expect(conditionsAfterFailedFetch[0].conditions[0].name).toBe('contains');
+    expect(conditionsAfterFailedFetch[0].conditions[0].args).toEqual(['a']);
+  });
 });

--- a/handsontable/src/plugins/filters/component/value.js
+++ b/handsontable/src/plugins/filters/component/value.js
@@ -8,6 +8,7 @@ import { BaseComponent } from './_base';
 import { MultipleSelectUI } from '../ui/multipleSelect';
 import { CONDITION_BY_VALUE, CONDITION_NONE } from '../constants';
 import { getConditionDescriptor } from '../conditionRegisterer';
+import { PLUGIN_KEY as DATA_PROVIDER_PLUGIN_KEY } from '../../dataProvider';
 
 /**
  * @private
@@ -194,6 +195,19 @@ export class ValueComponent extends BaseComponent {
    */
   getMultipleSelectElement() {
     return this.elements.filter(element => element instanceof MultipleSelectUI)[0];
+  }
+
+  /**
+   * Check if component is hidden. The "Filter by value" section is hidden when the dataProvider plugin
+   * is enabled, because filtering is then performed server-side and the value list is not available.
+   *
+   * @returns {boolean}
+   */
+  isHidden() {
+    const dataProvider = this.hot.getPlugin(DATA_PROVIDER_PLUGIN_KEY);
+    const isDataProviderEnabled = dataProvider?.isEnabled?.() === true;
+
+    return super.isHidden() || isDataProviderEnabled;
   }
 
   /**

--- a/handsontable/src/plugins/filters/component/value.js
+++ b/handsontable/src/plugins/filters/component/value.js
@@ -204,10 +204,14 @@ export class ValueComponent extends BaseComponent {
    * @returns {boolean}
    */
   isHidden() {
+    if (super.isHidden()) {
+      return true;
+    }
+
     const dataProvider = this.hot.getPlugin(DATA_PROVIDER_PLUGIN_KEY);
     const isDataProviderEnabled = dataProvider?.isEnabled?.() === true;
 
-    return super.isHidden() || isDataProviderEnabled;
+    return isDataProviderEnabled;
   }
 
   /**

--- a/handsontable/src/plugins/filters/conditionCollection.js
+++ b/handsontable/src/plugins/filters/conditionCollection.js
@@ -215,7 +215,9 @@ class ConditionCollection {
     this.clean();
 
     conditions.forEach((stack) => {
-      stack.conditions.forEach(condition => this.addCondition(stack.column, condition));
+      const operation = stack.operation ?? OPERATION_AND;
+
+      stack.conditions.forEach(condition => this.addCondition(stack.column, condition, operation));
     });
   }
 

--- a/handsontable/src/plugins/filters/filters.js
+++ b/handsontable/src/plugins/filters/filters.js
@@ -26,6 +26,7 @@ import {
   OPERATION_OR_THEN_VARIABLE
 } from './constants';
 import { TrimmingMap } from '../../translations';
+import { PLUGIN_KEY as DATA_PROVIDER_PLUGIN_KEY } from '../dataProvider';
 
 export const PLUGIN_KEY = 'filters';
 export const PLUGIN_PRIORITY = 250;
@@ -171,6 +172,13 @@ export class Filters extends BasePlugin {
    * @type {Array}
    */
   #previousConditionStack = [];
+  /**
+   * When loadData is called by the dataProvider plugin, initIndexMappers clears the condition
+   * collection. We save conditions in beforeLoadData and restore them in afterLoadData.
+   *
+   * @type {Array|null}
+   */
+  #savedConditionsForDataProvider = null;
 
   constructor(hotInstance) {
     super(hotInstance);
@@ -283,6 +291,8 @@ export class Filters extends BasePlugin {
     this.addHook('afterDropdownMenuShow', () => this.#onAfterDropdownMenuShow());
     this.addHook('afterDropdownMenuHide', () => this.#onAfterDropdownMenuHide());
     this.addHook('afterChange', changes => this.#onAfterChange(changes));
+    this.addHook('beforeLoadData', (data, firstRun, source) => this.#onBeforeLoadData(source));
+    this.addHook('afterLoadData', (data, firstRun, source) => this.#onAfterLoadData(source));
 
     // Temp. solution (extending menu items bug in contextMenu/dropdownMenu)
     if (this.hot.getSettings().dropdownMenu && this.dropdownMenuPlugin) {
@@ -365,6 +375,7 @@ export class Filters extends BasePlugin {
       this.conditionCollection.destroy();
       this.conditionCollection = null;
       this.hot.rowIndexMapper.unregisterMap(this.pluginName);
+      this.#savedConditionsForDataProvider = null;
     }
 
     this.unregisterShortcuts();
@@ -675,6 +686,40 @@ export class Filters extends BasePlugin {
       this.#previousConditionStack
     );
 
+    const dataProvider = this.hot.getPlugin(DATA_PROVIDER_PLUGIN_KEY);
+    const isServerSideMode = dataProvider?.isEnabled?.() === true;
+
+    if (isServerSideMode && allowFiltering !== false) {
+      const filtersForProvider = needToFilter
+        ? conditions.map(({ column, operation, conditions: conds }) => ({
+          column: this.hot.toVisualColumn(column),
+          operation,
+          conditions: conds.map(({ name, args }) => ({ name, args: [...args] })),
+        }))
+        : null;
+
+      dataProvider.setFilters(filtersForProvider).catch(() => {});
+
+      this.#previousConditionStack = this.exportConditions();
+
+      if (!needToFilter) {
+        this.filtersRowsMap.clear();
+      }
+
+      if (this.hot.selection.isSelected()) {
+        this.hot.selectCell(
+          navigableHeaders ? -1 : 0,
+          this.hot.getSelectedRangeActive().highlight.col,
+        );
+      }
+
+      this.hot.runHooks('afterFilter', conditions);
+      this.hot.view.adjustElementsSize();
+      this.hot.render();
+
+      return;
+    }
+
     if (allowFiltering !== false && needToFilter) {
       const dataFilter = this._createDataFilter();
       const trimmedRows = [];
@@ -806,6 +851,45 @@ export class Filters extends BasePlugin {
         }
       });
     }
+  }
+
+  /**
+   * Before loadData: when the source is the dataProvider plugin, save current filter conditions
+   * so they can be restored after loadData (initIndexMappers clears the condition collection).
+   *
+   * @private
+   * @param {string} [source] The source of the loadData call.
+   */
+  #onBeforeLoadData(source) {
+    if (source !== DATA_PROVIDER_PLUGIN_KEY) {
+      return;
+    }
+
+    const dataProvider = this.hot.getPlugin(DATA_PROVIDER_PLUGIN_KEY);
+
+    if (!dataProvider?.isEnabled?.()) {
+      return;
+    }
+
+    if (!this.conditionCollection.isEmpty()) {
+      this.#savedConditionsForDataProvider = this.exportConditions();
+    }
+  }
+
+  /**
+   * After loadData: when the source is the dataProvider plugin, restore filter conditions
+   * that were cleared by initIndexMappers.
+   *
+   * @private
+   * @param {string} [source] The source of the loadData call.
+   */
+  #onAfterLoadData(source) {
+    if (source !== DATA_PROVIDER_PLUGIN_KEY || this.#savedConditionsForDataProvider === null) {
+      return;
+    }
+
+    this.importConditions(this.#savedConditionsForDataProvider);
+    this.#savedConditionsForDataProvider = null;
   }
 
   /**

--- a/handsontable/src/plugins/filters/filters.js
+++ b/handsontable/src/plugins/filters/filters.js
@@ -179,6 +179,13 @@ export class Filters extends BasePlugin {
    * @type {Array|null}
    */
   #savedConditionsForDataProvider = null;
+  /**
+   * Conditions in effect before the last dataProvider fetch was triggered. Restored when the
+   * fetch fails (afterDataProviderFetchError) so the user keeps the previous filter state.
+   *
+   * @type {Array|null}
+   */
+  #conditionsBeforeDataProviderFetch = null;
 
   constructor(hotInstance) {
     super(hotInstance);
@@ -293,6 +300,8 @@ export class Filters extends BasePlugin {
     this.addHook('afterChange', changes => this.#onAfterChange(changes));
     this.addHook('beforeLoadData', (data, firstRun, source) => this.#onBeforeLoadData(source));
     this.addHook('afterLoadData', (data, firstRun, source) => this.#onAfterLoadData(source));
+    this.addHook('afterDataProviderFetch', () => this.#onAfterDataProviderFetch());
+    this.addHook('afterDataProviderFetchError', () => this.#onAfterDataProviderFetchError());
 
     // Temp. solution (extending menu items bug in contextMenu/dropdownMenu)
     if (this.hot.getSettings().dropdownMenu && this.dropdownMenuPlugin) {
@@ -376,6 +385,7 @@ export class Filters extends BasePlugin {
       this.conditionCollection = null;
       this.hot.rowIndexMapper.unregisterMap(this.pluginName);
       this.#savedConditionsForDataProvider = null;
+      this.#conditionsBeforeDataProviderFetch = null;
     }
 
     this.unregisterShortcuts();
@@ -698,6 +708,9 @@ export class Filters extends BasePlugin {
         }))
         : null;
 
+      this.#conditionsBeforeDataProviderFetch = this.#previousConditionStack.length > 0
+        ? this.#previousConditionStack.slice()
+        : [];
       dataProvider.setFilters(filtersForProvider).catch(() => {});
 
       this.#previousConditionStack = this.exportConditions();
@@ -890,6 +903,33 @@ export class Filters extends BasePlugin {
 
     this.importConditions(this.#savedConditionsForDataProvider);
     this.#savedConditionsForDataProvider = null;
+  }
+
+  /**
+   * After a successful dataProvider fetch: clear the backup so we do not restore it on a later error.
+   *
+   * @private
+   */
+  #onAfterDataProviderFetch() {
+    this.#conditionsBeforeDataProviderFetch = null;
+  }
+
+  /**
+   * After a failed dataProvider fetch: restore the filter conditions that were in effect before
+   * the fetch so the user keeps the previous state.
+   *
+   * @private
+   */
+  #onAfterDataProviderFetchError() {
+    if (this.#conditionsBeforeDataProviderFetch === null) {
+      return;
+    }
+
+    this.importConditions(this.#conditionsBeforeDataProviderFetch);
+    this.#previousConditionStack = this.#conditionsBeforeDataProviderFetch.slice();
+    this.#conditionsBeforeDataProviderFetch = null;
+    this.hot.view.adjustElementsSize();
+    this.hot.render();
   }
 
   /**

--- a/handsontable/types/index.d.ts
+++ b/handsontable/types/index.d.ts
@@ -178,6 +178,10 @@ import {
   DataProviderFetchResult,
   DataProviderOptions,
   DataProviderFunction,
+  DataProviderFilters,
+  FilterCondition,
+  FilterConditionOperator,
+  ColumnFilterStack,
 } from './plugins/dataProvider';
 import {
   DragToScroll as _DragToScroll,
@@ -550,6 +554,10 @@ declare namespace Handsontable {
       export { DataProviderFetchResult as FetchResult };
       export { DataProviderOptions as Options };
       export { DataProviderFunction };
+      export { DataProviderFilters as Filters };
+      export { FilterCondition };
+      export { FilterConditionOperator };
+      export { ColumnFilterStack };
     }
 
     export namespace DragToScroll {

--- a/handsontable/types/plugins/dataProvider/dataProvider.d.ts
+++ b/handsontable/types/plugins/dataProvider/dataProvider.d.ts
@@ -3,13 +3,50 @@ import { BasePlugin } from '../base';
 import { CellValue } from '../../common';
 
 /**
+ * Filter condition operators supported in queryParameters.filters when using server-side filtering.
+ */
+export type FilterConditionOperator =
+  | 'eq'
+  | 'neq'
+  | 'gt'
+  | 'gte'
+  | 'lt'
+  | 'lte'
+  | 'contains'
+  | 'not_contains'
+  | 'begins_with'
+  | 'ends_with';
+
+/**
+ * A single filter condition (operator + value/args) for one column.
+ */
+export interface FilterCondition {
+  name: FilterConditionOperator | string;
+  args: unknown[];
+}
+
+/**
+ * Filter stack for one column: column index (visual), logical operation, and conditions.
+ */
+export interface ColumnFilterStack {
+  column: number;
+  operation: 'conjunction' | 'disjunction' | 'disjunctionWithExtraCondition';
+  conditions: FilterCondition[] | null;
+}
+
+/**
+ * Filters model passed to the dataProvider: array of column filter stacks, or null when no filters.
+ */
+export type DataProviderFilters = ColumnFilterStack[] | null;
+
+/**
  * Query parameters passed to the dataProvider function and hooks.
  */
 export interface DataProviderQueryParameters {
   page: number;
   pageSize: number;
   sort: object | null;
-  filters: object | null;
+  filters: DataProviderFilters;
 }
 
 /**
@@ -50,5 +87,5 @@ export class DataProvider extends BasePlugin {
   goToPage(page: number): Promise<void>;
   setPageSize(pageSize: number): Promise<void>;
   setSort(sort: object | null): Promise<void>;
-  setFilters(filters: object | null): Promise<void>;
+  setFilters(filters: DataProviderFilters): Promise<void>;
 }

--- a/handsontable/types/plugins/dataProvider/index.d.ts
+++ b/handsontable/types/plugins/dataProvider/index.d.ts
@@ -5,5 +5,9 @@ export {
   DataProviderFetchResult,
   DataProviderOptions,
   DataProviderFunction,
+  DataProviderFilters,
+  FilterCondition,
+  FilterConditionOperator,
+  ColumnFilterStack,
   Settings,
 } from './dataProvider';


### PR DESCRIPTION

## Summary

Integrate Filters plugin with DataProvider: hide "Filter by value" when using server-side data, and preserve filter conditions across dataProvider fetches.

## Changes

### Features

- **Hide "Filter by value" when DataProvider is enabled**  
  When the table uses the DataProvider plugin, the "Filter by value" section and the whole `htFiltersMenuValue` block are hidden in the column filter dropdown. Filtering is done server-side, so the value list is not available.

- **Preserve filter conditions after DataProvider fetch**  
  When DataProvider loads data via `loadData()`, the core re-initializes index mappers and clears the Filters condition collection. The Filters plugin now saves conditions in `beforeLoadData` (when `source === 'dataProvider'`) and restores them in `afterLoadData`, so applied filters no longer disappear after a fetch (e.g. pagination or refetch).

### Code

- **`handsontable/src/plugins/filters/component/value.js`**
  - Import `PLUGIN_KEY as DATA_PROVIDER_PLUGIN_KEY` from the dataProvider plugin.
  - Override `isHidden()` to return `true` when the DataProvider plugin is enabled.

- **`handsontable/src/plugins/filters/filters.js`**
  - Add private `#savedConditionsForDataProvider` to hold conditions when a dataProvider load is in progress.
  - Subscribe to `beforeLoadData` and `afterLoadData`; in handlers, when `source === 'dataProvider'` and the dataProvider plugin is enabled, save conditions before load and restore them after.
  - Clear `#savedConditionsForDataProvider` in `disablePlugin()` to avoid stale state.

- **`handsontable/src/core/hooks/constants.js`**
  - Document `beforeLoadData` and `afterLoadData`: `source` param is optional and can be `'dataProvider'` when the DataProvider plugin loads data after a fetch.

- **`handsontable/types/core/hooks/index.d.ts`**
  - Add short JSDoc on `beforeLoadData` and `afterLoadData` noting that `source` is `'dataProvider'` when the DataProvider plugin loads data.

### Tests

- **`handsontable/src/plugins/filters/__tests__/plugins/dataProvider.spec.js`**
  - **"should hide 'Filter by value' section when dataProvider is enabled"** – open dropdown via API, assert `.htFiltersMenuValue` is not present.
  - **"should preserve filter conditions after dataProvider fetch completes"** – apply filter, change page twice, assert `exportConditions()` is unchanged after each fetch.
  - **"should update pagination total..."** – use `dataProvider.getTotalRows()` instead of `pagination.getPaginationData().totalRows` (totalRows not on getPaginationData).
  - **"should not use server-side filtering when dataProvider is not set"** – use `eq` + `['A1']` so only one row matches (avoids `begins_with ['A1']` matching A1, A10–A19).
  - **"should hide 'Filter by value'..."** – open dropdown with `getPlugin('dropdownMenu').open()`, assert menu root exists and `.htFiltersMenuValue` is null.

## Notes

- No new public API. Filters still use `importConditions` / `exportConditions` with existing `ColumnConditions` type.
- DataProvider continues to call `hot.loadData(rows, PLUGIN_KEY)`; Filters react via the existing `beforeLoadData` / `afterLoadData` hooks and the `source` argument.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes filtering behavior when `dataProvider` is enabled by routing filter actions to server-side fetches and resetting pagination to page 1, which can affect existing integrations and UI expectations. Adds state-save/restore around `loadData` and error recovery paths that could impact filter persistence if edge cases are missed.
> 
> **Overview**
> Enables **server-side filtering** when `dataProvider` is active: `Filters#filter()` now translates the current filter model into a `DataProvider` `filters` payload (or `null` when cleared) and triggers `dataProvider.setFilters(...)` instead of doing client-side row trimming.
> 
> Adjusts paging semantics so `DataProvider#setFilters()` **always resets to page 1** (while `setSort()` preserves the current page), and updates the Filters UI by hiding the *“Filter by value”* section when server-side mode is on.
> 
> Improves robustness by preserving/restoring filter conditions across `dataProvider`-driven `loadData` cycles and restoring the previous filter state after `afterDataProviderFetchError`. Types are updated to expose a structured `DataProviderFilters` model, and new/updated tests cover the integration and pagination/reset behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 846461bd73b6bcd97fb73144cbf014315b681838. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->