### PR TITLE
Preserve the column width after collapsing

### DIFF
--- a/handsontable/src/plugins/collapsibleColumns/__tests__/collapsibleColumns.spec.js
+++ b/handsontable/src/plugins/collapsibleColumns/__tests__/collapsibleColumns.spec.js
@@ -2266,6 +2266,94 @@ describe('CollapsibleColumns', () => {
         horizon.toBe(107);
       });
     });
+
+    it('should not change the first child column width after collapsing a parent header (#dev-2151)', async() => {
+      handsontable({
+        data: createSpreadsheetData(10, 10),
+        nestedHeaders: [
+          ['A1', { label: 'B1', colspan: 4 }, 'F1', 'G1', 'H1', 'I1', 'J1'],
+          ['A2', { label: 'B2', colspan: 2 }, { label: 'D2', colspan: 2 }, 'F2', 'G2', 'H2', 'I2', 'J2'],
+          ['A3', 'B3', 'C3', 'D3', 'E3', 'F3', 'G3', 'H3', 'I3', 'J3'],
+        ],
+        collapsibleColumns: true,
+      });
+
+      const widthBeforeCollapse = getColWidth(1);
+
+      const plugin = getPlugin('collapsibleColumns');
+
+      plugin.collapseSection({ row: -3, col: 1 });
+
+      expect(getColWidth(1)).toBe(widthBeforeCollapse);
+    });
+
+    it('should not change the first child column width after collapsing a deeply nested header (#dev-2151)', async() => {
+      handsontable({
+        data: createSpreadsheetData(10, 10),
+        nestedHeaders: [
+          [{ label: 'A1', colspan: 10 }],
+          [{ label: 'A2', colspan: 5 }, { label: 'F2', colspan: 5 }],
+          ['A3', { label: 'B3', colspan: 4 }, 'F3', 'G3', 'H3', 'I3', 'J3'],
+          ['A4', 'B4', 'C4', 'D4', 'E4', 'F4', 'G4', 'H4', 'I4', 'J4'],
+        ],
+        collapsibleColumns: true,
+      });
+
+      const widthBeforeCollapse = getColWidth(0);
+
+      const plugin = getPlugin('collapsibleColumns');
+
+      plugin.collapseSection({ row: -4, col: 0 });
+
+      expect(getColWidth(0)).toBe(widthBeforeCollapse);
+    });
+
+    it('should not change the first child column width after collapsing and expanding a header (#dev-2151)', async() => {
+      handsontable({
+        data: createSpreadsheetData(10, 10),
+        nestedHeaders: [
+          ['A1', { label: 'B1', colspan: 4 }, 'F1', 'G1', 'H1', 'I1', 'J1'],
+          ['A2', { label: 'B2', colspan: 2 }, { label: 'D2', colspan: 2 }, 'F2', 'G2', 'H2', 'I2', 'J2'],
+          ['A3', 'B3', 'C3', 'D3', 'E3', 'F3', 'G3', 'H3', 'I3', 'J3'],
+        ],
+        collapsibleColumns: true,
+      });
+
+      const widthBeforeCollapse = getColWidth(1);
+
+      const plugin = getPlugin('collapsibleColumns');
+
+      plugin.collapseSection({ row: -3, col: 1 });
+
+      expect(getColWidth(1)).toBe(widthBeforeCollapse);
+
+      plugin.expandSection({ row: -3, col: 1 });
+
+      expect(getColWidth(1)).toBe(widthBeforeCollapse);
+    });
+
+    it('should not change the first child column width after collapsing a header with a hidden column (#dev-2151)', async() => {
+      handsontable({
+        data: createSpreadsheetData(10, 10),
+        nestedHeaders: [
+          ['A1', { label: 'B1', colspan: 4 }, 'F1', 'G1', 'H1', 'I1', 'J1'],
+          ['A2', { label: 'B2', colspan: 2 }, { label: 'D2', colspan: 2 }, 'F2', 'G2', 'H2', 'I2', 'J2'],
+          ['A3', 'B3', 'C3', 'D3', 'E3', 'F3', 'G3', 'H3', 'I3', 'J3'],
+        ],
+        collapsibleColumns: true,
+        hiddenColumns: {
+          columns: [2],
+        },
+      });
+
+      const widthBeforeCollapse = getColWidth(1);
+
+      const plugin = getPlugin('collapsibleColumns');
+
+      plugin.collapseSection({ row: -3, col: 1 });
+
+      expect(getColWidth(1)).toBe(widthBeforeCollapse);
+    });
   });
 
   describe('expanding headers functionality', () => {

--- a/handsontable/src/plugins/dropdownMenu/__tests__/keyboardShortcuts/metaEnter.spec.js
+++ b/handsontable/src/plugins/dropdownMenu/__tests__/keyboardShortcuts/metaEnter.spec.js
@@ -300,7 +300,7 @@ describe('DropdownMenu keyboard shortcut', () => {
           main.toBeCloseTo(cellOffset.top + cell.clientHeight - 1, 0);
           horizon.toBeCloseTo(cellOffset.top + cell.clientHeight - 5, 0);
         });
-        expect(menuOffset.left).toBeCloseTo(buttonOffset.left, 0);
+        expect(menuOffset.left).toBeAroundValue(buttonOffset.left);
         expect(getSelectedRange()).toEqualCellRange(['highlight: -1,2 from: -1,1 to: 2,3']);
       });
     });

--- a/handsontable/src/plugins/dropdownMenu/__tests__/keyboardShortcuts/shiftOptionArrowDown.spec.js
+++ b/handsontable/src/plugins/dropdownMenu/__tests__/keyboardShortcuts/shiftOptionArrowDown.spec.js
@@ -451,7 +451,7 @@ describe('DropdownMenu keyboard shortcut', () => {
           main.toBeCloseTo(cellOffset.top + cell.clientHeight - 1, 0);
           horizon.toBeCloseTo(cellOffset.top + cell.clientHeight - 5, 0);
         });
-        expect(menuOffset.left).toBeCloseTo(buttonOffset.left, 0);
+        expect(menuOffset.left).toBeAroundValue(buttonOffset.left);
         expect(getSelectedRange()).toEqualCellRange(['highlight: -1,3 from: -1,1 to: 2,3']);
       });
     });

--- a/handsontable/src/plugins/nestedHeaders/__tests__/ghostTable.spec.js
+++ b/handsontable/src/plugins/nestedHeaders/__tests__/ghostTable.spec.js
@@ -55,13 +55,13 @@ describe('NestedHeaders', () => {
         const ghostTable = getPlugin('nestedHeaders').ghostTable;
 
         expect(ghostTable.widthsMap.getValueAtIndex(0)).forThemes(({ classic, main, horizon }) => {
-          classic.toBeAroundValue(99);
-          main.toBeAroundValue(111);
+          classic.toBeAroundValue(100);
+          main.toBeAroundValue(110);
           horizon.toBeAroundValue(119);
         });
         expect(ghostTable.widthsMap.getValueAtIndex(1)).forThemes(({ classic, main, horizon }) => {
-          classic.toBeAroundValue(99);
-          main.toBeAroundValue(111);
+          classic.toBeAroundValue(100);
+          main.toBeAroundValue(110);
           horizon.toBeAroundValue(119);
         });
         expect(ghostTable.widthsMap.getValueAtIndex(2)).forThemes(({ classic, main, horizon }) => {
@@ -113,7 +113,7 @@ describe('NestedHeaders', () => {
         });
         expect(ghostTable.widthsMap.getValueAtIndex(1)).forThemes(({ classic, main, horizon }) => {
           classic.toBeAroundValue(24);
-          main.toBeAroundValue(29);
+          main.toBeAroundValue(28);
           horizon.toBeAroundValue(37);
         });
         expect(ghostTable.widthsMap.getValueAtIndex(2)).forThemes(({ classic, main, horizon }) => {
@@ -123,12 +123,12 @@ describe('NestedHeaders', () => {
         });
         expect(ghostTable.widthsMap.getValueAtIndex(3)).forThemes(({ classic, main, horizon }) => {
           classic.toBeAroundValue(23);
-          main.toBeAroundValue(28);
+          main.toBeAroundValue(27);
           horizon.toBeAroundValue(36);
         });
         expect(ghostTable.widthsMap.getValueAtIndex(4)).forThemes(({ classic, main, horizon }) => {
           classic.toBeAroundValue(22);
-          main.toBeAroundValue(26);
+          main.toBeAroundValue(27);
           horizon.toBeAroundValue(35);
         });
         expect(ghostTable.widthsMap.getValueAtIndex(5)).forThemes(({ classic, main, horizon }) => {
@@ -139,16 +139,16 @@ describe('NestedHeaders', () => {
         expect(ghostTable.widthsMap.getValueAtIndex(6)).forThemes(({ classic, main, horizon }) => {
           classic.toBeAroundValue(21);
           main.toBeAroundValue(26);
-          horizon.toBeAroundValue(35);
+          horizon.toBeAroundValue(33);
         });
         expect(ghostTable.widthsMap.getValueAtIndex(7)).forThemes(({ classic, main, horizon }) => {
           classic.toBeAroundValue(101);
-          main.toBeAroundValue(110);
+          main.toBeAroundValue(111);
           horizon.toBeAroundValue(114);
         });
         expect(ghostTable.widthsMap.getValueAtIndex(8)).forThemes(({ classic, main, horizon }) => {
           classic.toBeAroundValue(98);
-          main.toBeAroundValue(107);
+          main.toBeAroundValue(108);
           horizon.toBeAroundValue(111);
         });
         expect(ghostTable.widthsMap.getValueAtIndex(9)).forThemes(({ classic, main, horizon }) => {
@@ -221,7 +221,7 @@ describe('NestedHeaders', () => {
         expect(ghostTable.widthsMap.getValueAtIndex(0)).toBe(null);
         expect(ghostTable.widthsMap.getValueAtIndex(1)).forThemes(({ classic, main, horizon }) => {
           classic.toBeAroundValue(24);
-          main.toBeAroundValue(29);
+          main.toBeAroundValue(28);
           horizon.toBeAroundValue(37);
         });
         expect(ghostTable.widthsMap.getValueAtIndex(2)).toBe(null);
@@ -232,7 +232,7 @@ describe('NestedHeaders', () => {
         });
         expect(ghostTable.widthsMap.getValueAtIndex(4)).forThemes(({ classic, main, horizon }) => {
           classic.toBeAroundValue(22);
-          main.toBeAroundValue(26);
+          main.toBeAroundValue(27);
           horizon.toBeAroundValue(35);
         });
         expect(ghostTable.widthsMap.getValueAtIndex(5)).forThemes(({ classic, main, horizon }) => {
@@ -243,16 +243,16 @@ describe('NestedHeaders', () => {
         expect(ghostTable.widthsMap.getValueAtIndex(6)).forThemes(({ classic, main, horizon }) => {
           classic.toBeAroundValue(21);
           main.toBeAroundValue(26);
-          horizon.toBeAroundValue(35);
+          horizon.toBeAroundValue(33);
         });
         expect(ghostTable.widthsMap.getValueAtIndex(7)).forThemes(({ classic, main, horizon }) => {
           classic.toBeAroundValue(101);
-          main.toBeAroundValue(110);
+          main.toBeAroundValue(111);
           horizon.toBeAroundValue(114);
         });
         expect(ghostTable.widthsMap.getValueAtIndex(8)).forThemes(({ classic, main, horizon }) => {
           classic.toBeAroundValue(98);
-          main.toBeAroundValue(107);
+          main.toBeAroundValue(108);
           horizon.toBeAroundValue(111);
         });
         expect(ghostTable.widthsMap.getValueAtIndex(9)).toBe(null);
@@ -272,6 +272,7 @@ describe('NestedHeaders', () => {
         });
 
         getPlugin('hiddenColumns').hideColumns([1, 3, 7]);
+        await render();
 
         const ghostTable = getPlugin('nestedHeaders').ghostTable;
 
@@ -289,7 +290,7 @@ describe('NestedHeaders', () => {
         expect(ghostTable.widthsMap.getValueAtIndex(3)).toBe(null);
         expect(ghostTable.widthsMap.getValueAtIndex(4)).forThemes(({ classic, main, horizon }) => {
           classic.toBeAroundValue(22);
-          main.toBeAroundValue(26);
+          main.toBeAroundValue(27);
           horizon.toBeAroundValue(35);
         });
         expect(ghostTable.widthsMap.getValueAtIndex(5)).forThemes(({ classic, main, horizon }) => {
@@ -327,6 +328,7 @@ describe('NestedHeaders', () => {
         });
 
         getPlugin('hiddenColumns').showColumns([2, 4, 7, 8]);
+        await render();
 
         const ghostTable = getPlugin('nestedHeaders').ghostTable;
 
@@ -340,19 +342,19 @@ describe('NestedHeaders', () => {
         expect(ghostTable.widthsMap.getValueAtIndex(3)).toBe(null);
         expect(ghostTable.widthsMap.getValueAtIndex(4)).forThemes(({ classic, main, horizon }) => {
           classic.toBeAroundValue(23);
-          main.toBeAroundValue(27);
+          main.toBeAroundValue(28);
           horizon.toBeAroundValue(36);
         });
         expect(ghostTable.widthsMap.getValueAtIndex(5)).toBe(null);
         expect(ghostTable.widthsMap.getValueAtIndex(6)).toBe(null);
         expect(ghostTable.widthsMap.getValueAtIndex(7)).forThemes(({ classic, main, horizon }) => {
           classic.toBeAroundValue(101);
-          main.toBeAroundValue(110);
+          main.toBeAroundValue(111);
           horizon.toBeAroundValue(114);
         });
         expect(ghostTable.widthsMap.getValueAtIndex(8)).forThemes(({ classic, main, horizon }) => {
           classic.toBeAroundValue(98);
-          main.toBeAroundValue(107);
+          main.toBeAroundValue(108);
           horizon.toBeAroundValue(111);
         });
         expect(ghostTable.widthsMap.getValueAtIndex(9)).toBe(null);

--- a/handsontable/src/plugins/nestedHeaders/__tests__/ghostTable.spec.js
+++ b/handsontable/src/plugins/nestedHeaders/__tests__/ghostTable.spec.js
@@ -57,12 +57,12 @@ describe('NestedHeaders', () => {
         expect(ghostTable.widthsMap.getValueAtIndex(0)).forThemes(({ classic, main, horizon }) => {
           classic.toBeAroundValue(100);
           main.toBeAroundValue(110);
-          horizon.toBeAroundValue(119);
+          horizon.toBeAroundValue(117);
         });
         expect(ghostTable.widthsMap.getValueAtIndex(1)).forThemes(({ classic, main, horizon }) => {
           classic.toBeAroundValue(100);
           main.toBeAroundValue(110);
-          horizon.toBeAroundValue(119);
+          horizon.toBeAroundValue(117);
         });
         expect(ghostTable.widthsMap.getValueAtIndex(2)).forThemes(({ classic, main, horizon }) => {
           classic.toBeAroundValue(99);
@@ -114,7 +114,7 @@ describe('NestedHeaders', () => {
         expect(ghostTable.widthsMap.getValueAtIndex(1)).forThemes(({ classic, main, horizon }) => {
           classic.toBeAroundValue(24);
           main.toBeAroundValue(28);
-          horizon.toBeAroundValue(37);
+          horizon.toBeAroundValue(36);
         });
         expect(ghostTable.widthsMap.getValueAtIndex(2)).forThemes(({ classic, main, horizon }) => {
           classic.toBeAroundValue(22);
@@ -142,14 +142,14 @@ describe('NestedHeaders', () => {
           horizon.toBeAroundValue(33);
         });
         expect(ghostTable.widthsMap.getValueAtIndex(7)).forThemes(({ classic, main, horizon }) => {
-          classic.toBeAroundValue(101);
+          classic.toBeAroundValue(102);
           main.toBeAroundValue(111);
           horizon.toBeAroundValue(114);
         });
         expect(ghostTable.widthsMap.getValueAtIndex(8)).forThemes(({ classic, main, horizon }) => {
           classic.toBeAroundValue(98);
           main.toBeAroundValue(108);
-          horizon.toBeAroundValue(111);
+          horizon.toBeAroundValue(112);
         });
         expect(ghostTable.widthsMap.getValueAtIndex(9)).forThemes(({ classic, main, horizon }) => {
           classic.toBeAroundValue(25);
@@ -193,7 +193,7 @@ describe('NestedHeaders', () => {
 
         expect(widthAfterUpdate).not.toBe(widthBeforeUpdate);
         expect(widthAfterUpdate).forThemes(({ classic, main, horizon }) => {
-          classic.toBeAroundValue(137);
+          classic.toBeAroundValue(135);
           main.toBeAroundValue(150);
           horizon.toBeAroundValue(158);
         });
@@ -222,7 +222,7 @@ describe('NestedHeaders', () => {
         expect(ghostTable.widthsMap.getValueAtIndex(1)).forThemes(({ classic, main, horizon }) => {
           classic.toBeAroundValue(24);
           main.toBeAroundValue(28);
-          horizon.toBeAroundValue(37);
+          horizon.toBeAroundValue(36);
         });
         expect(ghostTable.widthsMap.getValueAtIndex(2)).toBe(null);
         expect(ghostTable.widthsMap.getValueAtIndex(3)).forThemes(({ classic, main, horizon }) => {
@@ -246,14 +246,14 @@ describe('NestedHeaders', () => {
           horizon.toBeAroundValue(33);
         });
         expect(ghostTable.widthsMap.getValueAtIndex(7)).forThemes(({ classic, main, horizon }) => {
-          classic.toBeAroundValue(101);
+          classic.toBeAroundValue(102);
           main.toBeAroundValue(111);
           horizon.toBeAroundValue(114);
         });
         expect(ghostTable.widthsMap.getValueAtIndex(8)).forThemes(({ classic, main, horizon }) => {
           classic.toBeAroundValue(98);
           main.toBeAroundValue(108);
-          horizon.toBeAroundValue(111);
+          horizon.toBeAroundValue(112);
         });
         expect(ghostTable.widthsMap.getValueAtIndex(9)).toBe(null);
       });
@@ -348,14 +348,14 @@ describe('NestedHeaders', () => {
         expect(ghostTable.widthsMap.getValueAtIndex(5)).toBe(null);
         expect(ghostTable.widthsMap.getValueAtIndex(6)).toBe(null);
         expect(ghostTable.widthsMap.getValueAtIndex(7)).forThemes(({ classic, main, horizon }) => {
-          classic.toBeAroundValue(101);
+          classic.toBeAroundValue(102);
           main.toBeAroundValue(111);
           horizon.toBeAroundValue(114);
         });
         expect(ghostTable.widthsMap.getValueAtIndex(8)).forThemes(({ classic, main, horizon }) => {
           classic.toBeAroundValue(98);
           main.toBeAroundValue(108);
-          horizon.toBeAroundValue(111);
+          horizon.toBeAroundValue(112);
         });
         expect(ghostTable.widthsMap.getValueAtIndex(9)).toBe(null);
       });

--- a/handsontable/src/plugins/nestedHeaders/__tests__/resizingColumns.spec.js
+++ b/handsontable/src/plugins/nestedHeaders/__tests__/resizingColumns.spec.js
@@ -38,9 +38,9 @@ describe('NestedHeaders', () => {
       $resizer.simulate('mouseup');
 
       expect(colWidth(spec().$container, 1)).forThemes(({ classic, main, horizon }) => {
-        classic.toBe(27);
-        main.toBe(36);
-        horizon.toBe(44);
+        classic.toBe(26);
+        main.toBe(35);
+        horizon.toBe(43);
       });
     });
 

--- a/handsontable/src/plugins/nestedHeaders/__tests__/resizingColumns.spec.js
+++ b/handsontable/src/plugins/nestedHeaders/__tests__/resizingColumns.spec.js
@@ -38,9 +38,9 @@ describe('NestedHeaders', () => {
       $resizer.simulate('mouseup');
 
       expect(colWidth(spec().$container, 1)).forThemes(({ classic, main, horizon }) => {
-        classic.toBe(28);
-        main.toBe(37);
-        horizon.toBe(45);
+        classic.toBe(27);
+        main.toBe(36);
+        horizon.toBe(44);
       });
     });
 

--- a/handsontable/src/plugins/nestedHeaders/nestedHeaders.js
+++ b/handsontable/src/plugins/nestedHeaders/nestedHeaders.js
@@ -131,6 +131,12 @@ export class NestedHeaders extends BasePlugin {
    */
   #recentlyHighlightCoords = null;
   /**
+   * Determines if the widths map should be updated.
+   *
+   * @type {boolean}
+   */
+  #updateWidthsMap = false;
+  /**
    * Custom helper for getting widths of the nested headers.
    *
    * @private
@@ -190,11 +196,7 @@ export class NestedHeaders extends BasePlugin {
     this.addHook('beforeHighlightingColumnHeader', (...args) => this.#onBeforeHighlightingColumnHeader(...args));
     this.addHook('beforeCopy', (...args) => this.#onBeforeCopy(...args));
     this.addHook('beforeSelectColumns', (...args) => this.#onBeforeSelectColumns(...args));
-    this.addHook('beforeViewRender', () => {
-      this.ghostTable
-        .setLayersCount(this.getLayersCount())
-        .buildWidthsMap();
-    });
+    this.addHook('beforeViewRender', () => this.#onBeforeViewRender());
     this.addHook(
       'afterViewportColumnCalculatorOverride',
       (...args) => this.#onAfterViewportColumnCalculatorOverride(...args)
@@ -261,9 +263,7 @@ export class NestedHeaders extends BasePlugin {
         });
     }
 
-    // this.ghostTable
-    //   .setLayersCount(this.getLayersCount())
-    //   .buildWidthsMap();
+    this.#updateWidthsMap = true;
 
     super.updatePlugin();
   }
@@ -1010,6 +1010,18 @@ export class NestedHeaders extends BasePlugin {
   #onAfterLoadData(sourceData, initialLoad) {
     if (!initialLoad) {
       this.updatePlugin();
+    }
+  }
+
+  /**
+   * Builds the widths map before the view is rendered.
+   */
+  #onBeforeViewRender() {
+    if (this.#updateWidthsMap) {
+      this.ghostTable
+        .setLayersCount(this.getLayersCount())
+        .buildWidthsMap();
+      this.#updateWidthsMap = false;
     }
   }
 

--- a/handsontable/src/plugins/nestedHeaders/nestedHeaders.js
+++ b/handsontable/src/plugins/nestedHeaders/nestedHeaders.js
@@ -137,7 +137,10 @@ export class NestedHeaders extends BasePlugin {
    * @type {GhostTable}
    */
   // @TODO This should be changed after refactor handsontable/utils/ghostTable.
-  ghostTable = new GhostTable(this.hot, (row, column) => this.getHeaderSettings(row, column));
+  ghostTable = new GhostTable({
+    hot: this.hot,
+    headersStateManager: this.#stateManager,
+  });
   /**
    * The flag which determines that the nested header settings contains overlapping headers
    * configuration.
@@ -187,6 +190,11 @@ export class NestedHeaders extends BasePlugin {
     this.addHook('beforeHighlightingColumnHeader', (...args) => this.#onBeforeHighlightingColumnHeader(...args));
     this.addHook('beforeCopy', (...args) => this.#onBeforeCopy(...args));
     this.addHook('beforeSelectColumns', (...args) => this.#onBeforeSelectColumns(...args));
+    this.addHook('beforeViewRender', () => {
+      this.ghostTable
+        .setLayersCount(this.getLayersCount())
+        .buildWidthsMap();
+    });
     this.addHook(
       'afterViewportColumnCalculatorOverride',
       (...args) => this.#onAfterViewportColumnCalculatorOverride(...args)
@@ -253,9 +261,9 @@ export class NestedHeaders extends BasePlugin {
         });
     }
 
-    this.ghostTable
-      .setLayersCount(this.getLayersCount())
-      .buildWidthsMap();
+    // this.ghostTable
+    //   .setLayersCount(this.getLayersCount())
+    //   .buildWidthsMap();
 
     super.updatePlugin();
   }

--- a/handsontable/src/plugins/nestedHeaders/utils/ghostTable.js
+++ b/handsontable/src/plugins/nestedHeaders/utils/ghostTable.js
@@ -82,9 +82,6 @@ class GhostTable {
 
     this.#buildGhostTable(this.container);
 
-    // todo
-    this.hot.rootDocument.querySelectorAll('.htGhostTable').forEach(element => element.remove());
-
     this.hot.rootDocument.body.appendChild(this.container);
 
     const fullTable = this.container.querySelector('[data-ghost-table="full"]');

--- a/handsontable/src/plugins/nestedHeaders/utils/ghostTable.js
+++ b/handsontable/src/plugins/nestedHeaders/utils/ghostTable.js
@@ -1,5 +1,3 @@
-import { html } from '../../../helpers/templateLiteralTag';
-
 /**
  * The class generates the nested headers structure in the DOM and reads the column width for
  * each column. The hierarchy is built only for visible, non-hidden columns. Each time the
@@ -16,6 +14,13 @@ class GhostTable {
    * @type {Handsontable}
    */
   hot;
+  /**
+   * The state manager for the nested headers.
+   *
+   * @private
+   * @type {StateManager}
+   */
+  headersStateManager;
   /**
    * The value that holds information about the number of the nested header layers (header rows).
    *
@@ -71,6 +76,8 @@ class GhostTable {
    * Build cache of the headers widths.
    */
   buildWidthsMap() {
+    const collapsedPhysicalColumns = this.#getCollapsedPhysicalColumns();
+    const hasCollapsedGroups = collapsedPhysicalColumns.size > 0;
     const currentThemeName = this.hot.getCurrentThemeName();
 
     this.container = this.hot.rootDocument.createElement('div');
@@ -80,26 +87,18 @@ class GhostTable {
       this.container.classList.add(currentThemeName);
     }
 
-    this.#buildGhostTable(this.container);
+    this.#buildGhostTable(this.container, hasCollapsedGroups);
 
     this.hot.rootDocument.body.appendChild(this.container);
 
-    const fullTable = this.container.querySelector('[data-ghost-table="full"]');
+    const fullWidthByPhysical = hasCollapsedGroups
+      ? this.#measureFullTable()
+      : null;
+
     const renderedTable = this.container.querySelector('[data-ghost-table="rendered"]');
-    const fullColumns = fullTable.querySelectorAll('tr:last-of-type th');
     const renderedColumns = renderedTable.querySelectorAll('tr:last-of-type th');
 
     this.widthsMap.clear();
-
-    const fullWidthByPhysical = new Map();
-
-    for (let column = 0; column < fullColumns.length; column++) {
-      const visualColumnIndex = Number.parseInt(fullColumns[column].dataset.column, 10);
-      const physicalColumnIndex = this.hot.toPhysicalColumn(visualColumnIndex);
-      const width = fullColumns[column].getBoundingClientRect().width;
-
-      fullWidthByPhysical.set(physicalColumnIndex, width);
-    }
 
     for (let column = 0; column < renderedColumns.length; column++) {
       const visualColumnIndex = Number.parseInt(renderedColumns[column].dataset.column, 10);
@@ -109,28 +108,19 @@ class GhostTable {
         continue;
       }
 
-      const fullWidth = fullWidthByPhysical.get(physicalColumnIndex);
+      let width;
 
-      if (fullWidth === undefined) {
-        continue;
+      if (hasCollapsedGroups && collapsedPhysicalColumns.has(physicalColumnIndex)) {
+        const fullWidth = fullWidthByPhysical.get(physicalColumnIndex);
+
+        if (fullWidth !== undefined) {
+          width = fullWidth;
+        }
       }
 
-      const renderedWidth = renderedColumns[column].getBoundingClientRect().width;
-      const treeNode = this.headersStateManager.getHeaderTreeNode(-1, visualColumnIndex);
-
-      let isAnyAncestorCollapsed = false;
-
-      if (treeNode) {
-        treeNode.walkUp((node) => {
-          if (node.data.isCollapsed === true) {
-            isAnyAncestorCollapsed = true;
-
-            return false;
-          }
-        });
+      if (width === undefined) {
+        width = renderedColumns[column].getBoundingClientRect().width;
       }
-
-      const width = isAnyAncestorCollapsed ? fullWidth : renderedWidth;
 
       this.widthsMap.setValueAtIndex(physicalColumnIndex, width);
     }
@@ -140,124 +130,156 @@ class GhostTable {
   }
 
   /**
+   * Measure widths from the full (uncollapsed) ghost table.
+   *
+   * @returns {Map<number, number>} Map of physical column index to width.
+   */
+  #measureFullTable() {
+    const fullTable = this.container.querySelector('[data-ghost-table="full"]');
+    const fullColumns = fullTable.querySelectorAll('tr:last-of-type th');
+    const fullWidthByPhysical = new Map();
+
+    for (let column = 0; column < fullColumns.length; column++) {
+      const visualColumnIndex = Number.parseInt(fullColumns[column].dataset.column, 10);
+      const physicalColumnIndex = this.hot.toPhysicalColumn(visualColumnIndex);
+
+      fullWidthByPhysical.set(physicalColumnIndex, fullColumns[column].getBoundingClientRect().width);
+    }
+
+    return fullWidthByPhysical;
+  }
+
+  /**
+   * Pre-compute the set of physical column indexes that have any collapsed ancestor.
+   * This avoids repeated walkUp() calls per column during measurement.
+   *
+   * @returns {Set<number>} Set of physical column indexes under collapsed ancestors.
+   */
+  #getCollapsedPhysicalColumns() {
+    const collapsedPhysicals = new Set();
+    const maxColumnsCount = this.hot.countCols();
+
+    for (let col = 0; col < maxColumnsCount; col++) {
+      const treeNode = this.headersStateManager.getHeaderTreeNode(-1, col);
+
+      if (!treeNode) {
+        continue;
+      }
+
+      let found = false;
+
+      treeNode.walkUp((node) => {
+        if (node.data.isCollapsed === true) {
+          found = true;
+
+          return false;
+        }
+      });
+
+      if (found) {
+        collapsedPhysicals.add(this.hot.toPhysicalColumn(col));
+      }
+    }
+
+    return collapsedPhysicals;
+  }
+
+  /**
    * Build temporary tables for getting minimal columns widths. Builds two tables:
    * - Full: one TH per column (no collapse/hidden), to store width of the first column of a collapsed
-   *   group and fix jump on collapse/uncollapse.
+   *   group and fix jump on collapse/uncollapse. Only built when collapsed groups exist.
    * - Rendered: same structure as the main table (colspans, only visible roots), for width when a
    *   column has children and one is hidden (parent gets the width of the visible one).
    *
    * @param {HTMLElement} container The element where the DOM nodes are injected.
+   * @param {boolean} hasCollapsedGroups Whether any collapsed groups exist.
    */
-  #buildGhostTable(container) {
-    const { rootDocument } = this.hot;
+  #buildGhostTable(container, hasCollapsedGroups) {
     const isDropdownEnabled = !!this.hot.getSettings().dropdownMenu;
     const maxColumnsCount = this.hot.countCols();
+    const sanitizer = this.hot.getSettings().sanitizer;
 
-    container.appendChild(this.#buildFullColumnsTable(rootDocument, maxColumnsCount, isDropdownEnabled));
-    container.appendChild(this.#buildRenderedTable(rootDocument, maxColumnsCount, isDropdownEnabled));
+    if (hasCollapsedGroups) {
+      container.innerHTML = this.#buildFullColumnsTableHTML(maxColumnsCount, isDropdownEnabled, sanitizer) +
+        this.#buildRenderedTableHTML(maxColumnsCount, isDropdownEnabled, sanitizer);
+    } else {
+      container.innerHTML = this.#buildRenderedTableHTML(maxColumnsCount, isDropdownEnabled, sanitizer);
+    }
   }
 
   /**
-   * Build table with one TH per column (colspan 1), regardless of hidden/collapsed state.
-   * Used to store the width of the first column of a collapsed group.
+   * Build HTML string for a table with one TH per column (colspan = origColspan),
+   * regardless of hidden/collapsed state.
    *
-   * @param {Document} rootDocument Document to create elements in.
    * @param {number} maxColumnsCount Total column count.
    * @param {boolean} isDropdownEnabled Whether dropdown menu is enabled.
-   * @returns {HTMLTableElement}
+   * @param {Function|undefined} sanitizer The sanitizer function.
+   * @returns {string} HTML string for the full table.
    */
-  #buildFullColumnsTable(rootDocument, maxColumnsCount, isDropdownEnabled) {
-    const table = rootDocument.createElement('table');
-
-    table.dataset.ghostTable = 'full';
-
-    const thead = rootDocument.createElement('thead');
+  #buildFullColumnsTableHTML(maxColumnsCount, isDropdownEnabled, sanitizer) {
+    let rowsHTML = '';
 
     for (let row = 0; row < this.layersCount; row++) {
-      const tr = rootDocument.createElement('tr');
+      let cellsHTML = '';
 
       for (let col = 0; col < maxColumnsCount; col++) {
         const headerSettings = this.headersStateManager.getHeaderTreeNodeData(row, col);
 
-        if (
-          headerSettings && headerSettings.isRoot
-        ) {
-          const th = rootDocument.createElement('th');
-          const label = this.#buildHeaderLabel(headerSettings, isDropdownEnabled);
-
-          th.dataset.column = col;
-          th.colSpan = headerSettings.origColspan;
-
-          th.appendChild(label);
-          tr.appendChild(th);
+        if (headerSettings && headerSettings.isRoot) {
+          cellsHTML += `<th data-column="${col}" colspan="${headerSettings.origColspan}">${
+            this.#buildHeaderLabelHTML(headerSettings, isDropdownEnabled, sanitizer)
+          }</th>`;
         }
       }
 
-      thead.appendChild(tr);
+      rowsHTML += `<tr>${cellsHTML}</tr>`;
     }
 
-    table.appendChild(thead);
-
-    return table;
+    return `<table data-ghost-table="full"><thead>${rowsHTML}</thead></table>`;
   }
 
   /**
-   * Build table that mirrors the main table (colspans, only roots; placeholders/hidden not rendered).
-   * Used when a column has children and one is hidden - parent width is the width of the visible one.
+   * Build HTML string for a table that mirrors the main table (colspans, only visible roots).
    *
-   * @private
-   * @param {Document} rootDocument Document to create elements in.
    * @param {number} maxColumnsCount Total column count.
    * @param {boolean} isDropdownEnabled Whether dropdown menu is enabled.
-   * @returns {HTMLTableElement}
+   * @param {Function|undefined} sanitizer The sanitizer function.
+   * @returns {string} HTML string for the rendered table.
    */
-  #buildRenderedTable(rootDocument, maxColumnsCount, isDropdownEnabled) {
-    const table = rootDocument.createElement('table');
-
-    table.dataset.ghostTable = 'rendered';
-
-    const thead = rootDocument.createElement('thead');
+  #buildRenderedTableHTML(maxColumnsCount, isDropdownEnabled, sanitizer) {
+    let rowsHTML = '';
 
     for (let row = 0; row < this.layersCount; row++) {
-      const tr = rootDocument.createElement('tr');
+      let cellsHTML = '';
 
       for (let col = 0; col < maxColumnsCount; col++) {
         const headerSettings = this.headersStateManager.getHeaderSettings(row, col);
 
         if (
           headerSettings &&
-          (
-            !headerSettings.isPlaceholder && !headerSettings.isHidden
-          )
+          !headerSettings.isPlaceholder && !headerSettings.isHidden
         ) {
-          const th = rootDocument.createElement('th');
-          const label = this.#buildHeaderLabel(headerSettings, isDropdownEnabled);
-
-          th.colSpan = headerSettings.colspan;
-          th.dataset.column = col;
-
-          th.appendChild(label);
-          tr.appendChild(th);
+          cellsHTML += `<th data-column="${col}" colspan="${headerSettings.colspan}">${
+            this.#buildHeaderLabelHTML(headerSettings, isDropdownEnabled, sanitizer)
+          }</th>`;
         }
       }
 
-      thead.appendChild(tr);
+      rowsHTML += `<tr>${cellsHTML}</tr>`;
     }
 
-    table.appendChild(thead);
-
-    return table;
+    return `<table data-ghost-table="rendered"><thead>${rowsHTML}</thead></table>`;
   }
 
   /**
-   * Build header cell content for the ghost table as DOM nodes.
+   * Build header cell content HTML string.
    *
    * @param {object} headerSettings Header settings (label, colspan, etc).
    * @param {boolean} isDropdownEnabled Whether dropdown menu is enabled.
-   * @returns {DocumentFragment} Fragment containing the wrapper div.relative with header content.
+   * @param {Function|undefined} sanitizer The sanitizer function.
+   * @returns {string} HTML string for the header label.
    */
-  #buildHeaderLabel(headerSettings, isDropdownEnabled) {
-    const sanitizer = this.hot.getSettings().sanitizer;
+  #buildHeaderLabelHTML(headerSettings, isDropdownEnabled, sanitizer) {
     const label = typeof sanitizer === 'function'
       ? sanitizer(headerSettings.label, 'innerHTML')
       : headerSettings.label;
@@ -265,15 +287,8 @@ class GhostTable {
     const indicatorHtml = headerSettings.collapsible
       ? '<div class="collapsibleIndicator expanded">-</div>'
       : '';
-    const { fragment } = html`
-      <div class="relative">
-        <span class="colHeader">${label}</span>
-        ${dropdownHtml}
-        ${indicatorHtml}
-      </div>
-    `;
 
-    return fragment;
+    return `<div class="relative"><span class="colHeader">${label}</span>${dropdownHtml}${indicatorHtml}</div>`;
   }
 
   /**

--- a/handsontable/src/plugins/nestedHeaders/utils/ghostTable.js
+++ b/handsontable/src/plugins/nestedHeaders/utils/ghostTable.js
@@ -1,4 +1,4 @@
-import { fastInnerHTML } from '../../../helpers/dom/element';
+import { html } from '../../../helpers/templateLiteralTag';
 
 /**
  * The class generates the nested headers structure in the DOM and reads the column width for
@@ -17,13 +17,6 @@ class GhostTable {
    */
   hot;
   /**
-   * The function for retrieving the nested headers settings.
-   *
-   * @private
-   * @type {Function}
-   */
-  nestedHeaderSettingsGetter;
-  /**
    * The value that holds information about the number of the nested header layers (header rows).
    *
    * @private
@@ -38,16 +31,16 @@ class GhostTable {
    */
   container;
   /**
-   * PhysicalIndexToValueMap to keep and track of the columns' widths.
+   * PhysicalIndexToValueMap to keep and track of the columns' widths (as rendered in the main table).
    *
    * @private
    * @type {PhysicalIndexToValueMap}
    */
   widthsMap;
 
-  constructor(hot, nestedHeaderSettingsGetter) {
+  constructor({ hot, headersStateManager }) {
     this.hot = hot;
-    this.nestedHeaderSettingsGetter = nestedHeaderSettingsGetter;
+    this.headersStateManager = headersStateManager;
     this.widthsMap = this.hot.columnIndexMapper
       .createAndRegisterIndexMap('nestedHeaders.widthsMap', 'physicalIndexToValue');
   }
@@ -65,7 +58,7 @@ class GhostTable {
   }
 
   /**
-   * Gets the column width based on the visual column index.
+   * Gets the column width based on the visual column index (as rendered in the main table).
    *
    * @param {number} visualColumn Visual column index.
    * @returns {number|null}
@@ -81,81 +74,209 @@ class GhostTable {
     const currentThemeName = this.hot.getCurrentThemeName();
 
     this.container = this.hot.rootDocument.createElement('div');
-    this.container.classList.add('handsontable', 'htGhostTable', 'htAutoSize');
+    this.container.classList.add('handsontable', 'htGhostTable', 'htAutoSize', 'htNestedHeaders');
 
     if (currentThemeName) {
       this.container.classList.add(currentThemeName);
     }
 
-    this._buildGhostTable(this.container);
+    this.#buildGhostTable(this.container);
+
+    // todo
+    this.hot.rootDocument.querySelectorAll('.htGhostTable').forEach(element => element.remove());
+
     this.hot.rootDocument.body.appendChild(this.container);
 
-    const columns = this.container.querySelectorAll('tr:last-of-type th');
-    const maxColumns = columns.length;
+    const fullTable = this.container.querySelector('[data-ghost-table="full"]');
+    const renderedTable = this.container.querySelector('[data-ghost-table="rendered"]');
+    const fullColumns = fullTable.querySelectorAll('tr:last-of-type th');
+    const renderedColumns = renderedTable.querySelectorAll('tr:last-of-type th');
 
     this.widthsMap.clear();
 
-    for (let column = 0; column < maxColumns; column++) {
-      const visualColumnsIndex = this.hot.columnIndexMapper.getVisualFromRenderableIndex(column);
-      const physicalColumnIndex = this.hot.toPhysicalColumn(visualColumnsIndex);
+    const fullWidthByPhysical = new Map();
 
-      this.widthsMap.setValueAtIndex(physicalColumnIndex, columns[column].offsetWidth);
+    for (let column = 0; column < fullColumns.length; column++) {
+      const visualColumnIndex = Number.parseInt(fullColumns[column].dataset.column, 10);
+      const physicalColumnIndex = this.hot.toPhysicalColumn(visualColumnIndex);
+      const width = fullColumns[column].getBoundingClientRect().width;
+
+      fullWidthByPhysical.set(physicalColumnIndex, width);
     }
 
-    this.container.parentNode.removeChild(this.container);
+    for (let column = 0; column < renderedColumns.length; column++) {
+      const visualColumnIndex = Number.parseInt(renderedColumns[column].dataset.column, 10);
+      const physicalColumnIndex = this.hot.toPhysicalColumn(visualColumnIndex);
+
+      if (this.hot.columnIndexMapper.isHidden(physicalColumnIndex)) {
+        continue;
+      }
+
+      const fullWidth = fullWidthByPhysical.get(physicalColumnIndex);
+
+      if (fullWidth === undefined) {
+        continue;
+      }
+
+      const renderedWidth = renderedColumns[column].getBoundingClientRect().width;
+      const treeNode = this.headersStateManager.getHeaderTreeNode(-1, visualColumnIndex);
+
+      let isAnyAncestorCollapsed = false;
+
+      if (treeNode) {
+        treeNode.walkUp((node) => {
+          if (node.data.isCollapsed === true) {
+            isAnyAncestorCollapsed = true;
+
+            return false;
+          }
+        });
+      }
+
+      const width = isAnyAncestorCollapsed ? fullWidth : renderedWidth;
+
+      this.widthsMap.setValueAtIndex(physicalColumnIndex, width);
+    }
+
+    this.container.remove();
     this.container = null;
   }
 
   /**
-   * Build temporary table for getting minimal columns widths.
+   * Build temporary tables for getting minimal columns widths. Builds two tables:
+   * - Full: one TH per column (no collapse/hidden), to store width of the first column of a collapsed
+   *   group and fix jump on collapse/uncollapse.
+   * - Rendered: same structure as the main table (colspans, only visible roots), for width when a
+   *   column has children and one is hidden (parent gets the width of the visible one).
    *
-   * @private
    * @param {HTMLElement} container The element where the DOM nodes are injected.
    */
-  _buildGhostTable(container) {
-    const { rootDocument, columnIndexMapper } = this.hot;
-    const fragment = rootDocument.createDocumentFragment();
-    const table = rootDocument.createElement('table');
+  #buildGhostTable(container) {
+    const { rootDocument } = this.hot;
     const isDropdownEnabled = !!this.hot.getSettings().dropdownMenu;
-    const maxRenderedCols = columnIndexMapper.getRenderableIndexesLength();
+    const maxColumnsCount = this.hot.countCols();
+
+    container.appendChild(this.#buildFullColumnsTable(rootDocument, maxColumnsCount, isDropdownEnabled));
+    container.appendChild(this.#buildRenderedTable(rootDocument, maxColumnsCount, isDropdownEnabled));
+  }
+
+  /**
+   * Build table with one TH per column (colspan 1), regardless of hidden/collapsed state.
+   * Used to store the width of the first column of a collapsed group.
+   *
+   * @param {Document} rootDocument Document to create elements in.
+   * @param {number} maxColumnsCount Total column count.
+   * @param {boolean} isDropdownEnabled Whether dropdown menu is enabled.
+   * @returns {HTMLTableElement}
+   */
+  #buildFullColumnsTable(rootDocument, maxColumnsCount, isDropdownEnabled) {
+    const table = rootDocument.createElement('table');
+
+    table.dataset.ghostTable = 'full';
+
+    const thead = rootDocument.createElement('thead');
 
     for (let row = 0; row < this.layersCount; row++) {
       const tr = rootDocument.createElement('tr');
 
-      for (let col = 0; col < maxRenderedCols; col++) {
-        let visualColumnsIndex = columnIndexMapper.getVisualFromRenderableIndex(col);
-
-        if (visualColumnsIndex === null) {
-          visualColumnsIndex = col;
-        }
-
-        const th = rootDocument.createElement('th');
-        const headerSettings = this.nestedHeaderSettingsGetter(row, visualColumnsIndex);
+      for (let col = 0; col < maxColumnsCount; col++) {
+        const headerSettings = this.headersStateManager.getHeaderTreeNodeData(row, col);
 
         if (
-          headerSettings &&
-          (
-            (!headerSettings.isPlaceholder && !headerSettings.isCollapsed) ||
-            headerSettings.isHidden
-          )
+          headerSettings && headerSettings.isRoot
         ) {
-          let label = headerSettings.label;
+          const th = rootDocument.createElement('th');
+          const label = this.#buildHeaderLabel(headerSettings, isDropdownEnabled);
 
-          if (isDropdownEnabled) {
-            label += '<button class="changeType"></button>';
-          }
+          th.dataset.column = col;
+          th.colSpan = headerSettings.origColspan;
 
-          fastInnerHTML(th, label, this.hot.getSettings().sanitizer);
-          th.colSpan = headerSettings.colspan;
+          th.appendChild(label);
           tr.appendChild(th);
         }
       }
 
-      table.appendChild(tr);
+      thead.appendChild(tr);
     }
 
-    fragment.appendChild(table);
-    container.appendChild(fragment);
+    table.appendChild(thead);
+
+    return table;
+  }
+
+  /**
+   * Build table that mirrors the main table (colspans, only roots; placeholders/hidden not rendered).
+   * Used when a column has children and one is hidden - parent width is the width of the visible one.
+   *
+   * @private
+   * @param {Document} rootDocument Document to create elements in.
+   * @param {number} maxColumnsCount Total column count.
+   * @param {boolean} isDropdownEnabled Whether dropdown menu is enabled.
+   * @returns {HTMLTableElement}
+   */
+  #buildRenderedTable(rootDocument, maxColumnsCount, isDropdownEnabled) {
+    const table = rootDocument.createElement('table');
+
+    table.dataset.ghostTable = 'rendered';
+
+    const thead = rootDocument.createElement('thead');
+
+    for (let row = 0; row < this.layersCount; row++) {
+      const tr = rootDocument.createElement('tr');
+
+      for (let col = 0; col < maxColumnsCount; col++) {
+        const headerSettings = this.headersStateManager.getHeaderSettings(row, col);
+
+        if (
+          headerSettings &&
+          (
+            !headerSettings.isPlaceholder && !headerSettings.isHidden
+          )
+        ) {
+          const th = rootDocument.createElement('th');
+          const label = this.#buildHeaderLabel(headerSettings, isDropdownEnabled);
+
+          th.colSpan = headerSettings.colspan;
+          th.dataset.column = col;
+
+          th.appendChild(label);
+          tr.appendChild(th);
+        }
+      }
+
+      thead.appendChild(tr);
+    }
+
+    table.appendChild(thead);
+
+    return table;
+  }
+
+  /**
+   * Build header cell content for the ghost table as DOM nodes.
+   *
+   * @param {object} headerSettings Header settings (label, colspan, etc).
+   * @param {boolean} isDropdownEnabled Whether dropdown menu is enabled.
+   * @returns {DocumentFragment} Fragment containing the wrapper div.relative with header content.
+   */
+  #buildHeaderLabel(headerSettings, isDropdownEnabled) {
+    const sanitizer = this.hot.getSettings().sanitizer;
+    const label = typeof sanitizer === 'function'
+      ? sanitizer(headerSettings.label, 'innerHTML')
+      : headerSettings.label;
+    const dropdownHtml = isDropdownEnabled ? '<button class="changeType"></button>' : '';
+    const indicatorHtml = headerSettings.collapsible
+      ? '<div class="collapsibleIndicator expanded">-</div>'
+      : '';
+    const { fragment } = html`
+      <div class="relative">
+        <span class="colHeader">${label}</span>
+        ${dropdownHtml}
+        ${indicatorHtml}
+      </div>
+    `;
+
+    return fragment;
   }
 
   /**

--- a/handsontable/src/styles/base/_base.scss
+++ b/handsontable/src/styles/base/_base.scss
@@ -110,6 +110,11 @@
     // Force the ghost table to ignore the additional 1px border for the first rows in the table
     &.htGhostTable {
       table {
+        &.htNestedHeaders {
+          border-spacing: 0;
+          border-collapse: collapse;
+        }
+
         thead {
           th {
             border-bottom-width: 0;

--- a/handsontable/src/styles/base/_base.scss
+++ b/handsontable/src/styles/base/_base.scss
@@ -109,12 +109,12 @@
 
     // Force the ghost table to ignore the additional 1px border for the first rows in the table
     &.htGhostTable {
-      table {
-        &.htNestedHeaders {
-          border-spacing: 0;
-          border-collapse: collapse;
-        }
+      &.htNestedHeaders table {
+        border-spacing: 0;
+        border-collapse: collapse;
+      }
 
+      table {
         thead {
           th {
             border-bottom-width: 0;


### PR DESCRIPTION
### Context
This PR is a continuation of the work started in https://github.com/handsontable/dev-handsontable/issues/2151. It fixes column width not being preserved when collapsing nested header groups in the _NestedHeaders_ plugin. The ghost table used for width calculation now receives the headers state manager and builds two DOM tables: a full one (one TH per column, no collapse) and a rendered one (same structure as the main table, with colspans and only visible roots). The widths map is filled from the full table for columns under a collapsed ancestor and from the rendered table otherwise, so collapse/expand no longer causes width jumps.

Also, the PR fixes the text elipsis that was forced by miscaluclations of the column widths.

### Before
<img width="362" height="206" alt="image" src="https://github.com/user-attachments/assets/66ffe7eb-a28e-4665-978a-a0fbc378b0c9" />

### After
<img width="360" height="213" alt="image" src="https://github.com/user-attachments/assets/a3549cbf-921a-4ac6-a9f1-399b1079bfd0" />

_[skip changelog]_

### How has this been tested?
I tested the changes locally and I covered the fix with new tests.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. fixes https://github.com/handsontable/dev-handsontable/issues/2151 (continuation of the work from this issue)

### Affected project(s):
- [x] `handsontable`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core nested header width measurement and the timing of widths-map rebuilds, which can affect column sizing/layout across themes and when using hidden/collapsed columns.
> 
> **Overview**
> Fixes a nested headers regression where collapsing/expanding header groups could cause **column width “jumps”** (notably on the first child column) by reworking the `GhostTable` width calculation.
> 
> `GhostTable` now consumes the nested headers `StateManager` and, when collapsed groups exist, builds **two ghost tables** (full vs rendered) to measure stable widths for columns under collapsed ancestors while still handling hidden/visible-root rendering correctly. Width-map rebuilding is deferred to `beforeViewRender` via a new `#updateWidthsMap` flag.
> 
> Updates styles for the nested-headers ghost table and adjusts/extends tests: adds new collapsible-columns cases for width preservation, updates multiple ghost-table/resizing expectations, and relaxes dropdown-menu positioning assertions to be less pixel-fragile.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91a23317a92b794eea159659c1736986a3ea0654. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->