### PR TITLE
update issue template config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,10 +1,10 @@
 contact_links:
-  - name: Feature requests and questions
-    url: https://github.com/handsontable/handsontable/discussions
-    about: Start a new discussion about your idea.
-  - name: Discuss on Forum
-    url: https://forum.handsontable.com/
-    about: Start a discussion with the community on our Developers’ Forum.
+  - name: Feature requests
+    url: https://forum.handsontable.com/c/feature-requests/
+    about: Submit feature requests and vote on ideas on our forum.
+  - name: Questions and discussions
+    url: https://forum.handsontable.com/c/questions/
+    about: Ask questions and discuss ideas on our forum.
   - name: Support request
     url: https://handsontable.com/contact?category=technical_support
     about: Report your issue to our technical support team.


### PR DESCRIPTION
**Summary**

  - Redirect feature requests to the dedicated forum category instead of GitHub Discussions
  - Redirect questions and discussions to the forum Q&A category instead of GitHub Discussions
  - GitHub Issues remain for bug reports only

**Motivation**

Consolidate community discussions on the forum where feature requests can be properly tracked and voted on. GitHub Discussions will be disabled separately in repo settings.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/config change that only affects where GitHub’s issue creation UI routes users for support and discussions.
> 
> **Overview**
> Updates `.github/ISSUE_TEMPLATE/config.yml` to **redirect “Feature requests” and “Questions and discussions”** from GitHub Discussions to dedicated forum categories, keeping GitHub Issues focused on bug reports/support requests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f67f097baa51d97d7fc08a3dda137f060aaf898. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->