### PR TITLE
Fix Filters condition registration with Vite tree-shaking (#12165)

### DIFF
--- a/.changelogs/12165.json
+++ b/.changelogs/12165.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "github",
+  "title": "Fixed an issue where filter conditions could be tree-shaken and break Filters in Vite 8 builds.",
+  "type": "fixed",
+  "issueOrPR": 12165,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/12165.json
+++ b/.changelogs/12165.json
@@ -1,5 +1,5 @@
 {
-  "issuesOrigin": "github",
+  "issuesOrigin": "public",
   "title": "Fixed an issue where filter conditions could be tree-shaken and break Filters in Vite 8 builds.",
   "type": "fixed",
   "issueOrPR": 12165,

--- a/handsontable/package.json
+++ b/handsontable/package.json
@@ -274,7 +274,8 @@
   },
   "sideEffects": [
     "**/*.css",
-    "./languages/*"
+    "./languages/*",
+    "./plugins/filters/condition/**"
   ],
   "publishConfig": {
     "directory": "tmp",

--- a/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
@@ -1798,6 +1798,25 @@ describe('Filters UI', () => {
     expect(onErrorSpy).not.toHaveBeenCalled();
   });
 
+  it('should not throw an error while selecting "Is equal to" condition (#12165)', async() => {
+    const onErrorSpy = spyOn(window, 'onerror').and.returnValue(true);
+
+    handsontable({
+      data: getDataForFilters(),
+      columns: getColumnsForFilters(),
+      dropdownMenu: true,
+      filters: true,
+      width: 500,
+      height: 300
+    });
+
+    await dropdownMenu(1);
+    await openDropdownByConditionMenu();
+    await selectDropdownByConditionMenuOption('Is equal to');
+
+    expect(onErrorSpy).not.toHaveBeenCalled();
+  });
+
   it('should adjust the dropdown height to the currently displayed content', async() => {
     handsontable({
       data: getDataForFilters(),

--- a/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
@@ -1798,25 +1798,6 @@ describe('Filters UI', () => {
     expect(onErrorSpy).not.toHaveBeenCalled();
   });
 
-  it('should not throw an error while selecting "Is equal to" condition (#12165)', async() => {
-    const onErrorSpy = spyOn(window, 'onerror').and.returnValue(true);
-
-    handsontable({
-      data: getDataForFilters(),
-      columns: getColumnsForFilters(),
-      dropdownMenu: true,
-      filters: true,
-      width: 500,
-      height: 300
-    });
-
-    await dropdownMenu(1);
-    await openDropdownByConditionMenu();
-    await selectDropdownByConditionMenuOption('Is equal to');
-
-    expect(onErrorSpy).not.toHaveBeenCalled();
-  });
-
   it('should adjust the dropdown height to the currently displayed content', async() => {
     handsontable({
       data: getDataForFilters(),

--- a/handsontable/src/plugins/filters/__tests__/packageMetadata.unit.js
+++ b/handsontable/src/plugins/filters/__tests__/packageMetadata.unit.js
@@ -1,0 +1,13 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('package metadata', () => {
+  it('should mark filter condition modules as side effects', () => {
+    const packageJSONPath = path.resolve(__dirname, '../../../../package.json');
+    const packageJSON = JSON.parse(fs.readFileSync(packageJSONPath, 'utf8'));
+
+    expect(packageJSON.sideEffects).toEqual(expect.arrayContaining([
+      './plugins/filters/condition/**'
+    ]));
+  });
+});

--- a/handsontable/src/plugins/filters/__tests__/treeShaking.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/treeShaking.spec.js
@@ -1,0 +1,31 @@
+describe('Filters metadata and tree-shaking (#12165)', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should not throw an error while selecting "Is equal to" condition', async() => {
+    const onErrorSpy = spyOn(window, 'onerror').and.returnValue(true);
+
+    handsontable({
+      data: createSpreadsheetData(10, 5),
+      colHeaders: true,
+      dropdownMenu: true,
+      filters: true,
+    });
+
+    await dropdownMenu(0);
+    await openDropdownByConditionMenu();
+    await selectDropdownByConditionMenuOption('Is equal to');
+
+    expect(onErrorSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Context
This change fixes a regression reported in #12165 where Filters fail with `Filter condition "eq" does not exist.` in Vite 8 builds. The root cause is package metadata: `handsontable/package.json` did not mark `plugins/filters/condition/**` as side-effectful, so bundlers could tree-shake out condition-registration side effects.

### How has this been tested?
- `npm_config_testPathPattern=src/plugins/filters/__tests__/packageMetadata.unit.js npm run test:unit`
- `npm_config_testPathPattern=treeShaking.spec.js npm run test:e2e.dump && npm_config_testPathPattern=treeShaking.spec.js npm run test:e2e.puppeteer`
- `npm_config_testPathPattern=treeShaking.spec.js npm run test:e2e.dump && npm run test:e2e.puppeteer -- verbose`
- `bin/changelog consume --date 2050-01-01 --dry-run`

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #12165
2.
3.

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54716013-701d-4b01-8e64-423a1b02838f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54716013-701d-4b01-8e64-423a1b02838f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

