### PR TITLE
Clean up changelog entries already released in `17.0.0`

### DIFF
--- a/.changelogs/12049.json
+++ b/.changelogs/12049.json
@@ -1,8 +1,0 @@
-{
-  "issuesOrigin": "private",
-  "title": "Removed the `languages` folder from git + updated the `17.0+` release workflow.",
-  "type": "removed",
-  "issueOrPR": 12049,
-  "breaking": false,
-  "framework": "none"
-}

--- a/.changelogs/12058.json
+++ b/.changelogs/12058.json
@@ -1,8 +1,0 @@
-{
-  "issuesOrigin": "private",
-  "title": "Fixed and issue with column headers styles",
-  "type": "fixed",
-  "issueOrPR": 12058,
-  "breaking": false,
-  "framework": "none"
-}

--- a/.changelogs/12091.json
+++ b/.changelogs/12091.json
@@ -1,8 +1,0 @@
-{
-  "issuesOrigin": "private",
-  "title": "Fixed a problem with the Angular wrapper that broke builds done with a disabled `skipLibCheck`.",
-  "type": "fixed",
-  "issueOrPR": 12091,
-  "breaking": false,
-  "framework": "angular"
-}


### PR DESCRIPTION
### Context
  Removes three `.changelogs/` entries that were already included in the `17.0.0` release and should not appear in the next release's changelog:                                                                                 
                                                                                                                                                                                                                                 
  - [#12049](https://github.com/handsontable/handsontable/pull/12049) – Removed the `languages` folder from git ([381a086](https://github.com/handsontable/handsontable/commit/381a086dbb10110da9e8fc6c1f18dd6834f59a8a))        
  - [#12058](https://github.com/handsontable/handsontable/pull/12058) – Fixed column header styles issue ([aa429c5](https://github.com/handsontable/handsontable/commit/aa429c5c0a557fc0bc98ead818941931e6ca001e))               
  - [#12091](https://github.com/handsontable/handsontable/pull/12091) – Angular: Fixed `skipLibCheck` build problem ([c30e804](https://github.com/handsontable/handsontable/commit/c30e804ec8296c846f8732d49b9c71fe20d76088))    
            

  ### How has this been tested?
  N/A — no source code changes.

  ### Types of changes
  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature or improvement (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Additional language file or change to the existing one (translations)

  ### Related issue(s):
  1.

  ### Affected project(s):
  - [ ] `handsontable`
  - [ ] `@handsontable/angular-wrapper`
  - [ ] `@handsontable/react-wrapper`
  - [ ] `@handsontable/vue3`

  ### Checklist:
  - [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
  - [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
  - [ ] My change requires a change to the documentation.

  [skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cleanup that only deletes three temporary `.changelogs/*.json` files; no runtime or build logic changes.
> 
> **Overview**
> Removes three stale `.changelogs` JSON entries (`12049`, `12058`, `12091`) that were already included in the `17.0.0` release so they won’t be re-consumed into the next release changelog.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 453158127caa875ac8933c5c89d5a576edc72fb9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->