### PR TITLE
Sync the same review rules as for bugbot as the /review command

### DIFF
--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,9 +1,14 @@
 Review the current staged changes as a Handsontable maintainer.
 
-Focus on: [handsontable/.cursor/BUGBOT.md](handsontable/.cursor/BUGBOT.md).
+Focus on:
+ - When changes touch Handsontable core (`/handsontable/**`), follow the review rules defined in [handsontable/.cursor/BUGBOT.md](handsontable/.cursor/BUGBOT.md).
+ - Missing changelog entry in `/.changelogs/*.json` when package source code changed (test-only or docs-only changes do not require a changelog entry).
+ - Missing test coverage — every source code change must include unit tests (`*.unit.js`) and/or E2E tests (`*.spec.js`).
+ - Wrapper architecture violations — `/wrappers/**` must not contain business logic (e.g., data transformation, validation, or direct cell manipulation) that belongs in `/handsontable/src/**`.
+ - Risky performance changes (large data handling, virtualization, unnecessary renders).
 
 Output format:
-1. Numbered findings by severity (Critical, High, Medium, Low).
-2. Include `file:line` for each finding.
-3. Include a short "Open questions" section if assumptions are needed.
-4. If no blocking issues are found, output exactly: `No blocking issues found.`
+ - Numbered findings by severity (Critical, High, Medium, Low).
+ - Include `file:line` for each finding.
+ - Include an "Open questions" section only if assumptions were needed.
+ - If no blocking issues are found, output exactly: `No blocking issues found.`

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,13 +1,6 @@
 Review the current staged changes as a Handsontable maintainer.
 
-Focus on:
-- Breaking API behavior without a legacy/deprecation path.
-- Missing changelog entry in `/.changelogs/*.json` when source code changed.
-- Missing tests for behavior changes (`*.unit.js` and `*.spec.js`).
-- Missing JSDoc for new public methods/options (`@experimental` for experimental APIs).
-- Wrapper architecture violations (`/wrappers/**` containing business logic that belongs in `/handsontable/src/**`).
-- Accessibility regressions (keyboard navigation, header focus flow, ARIA/screen reader semantics).
-- Risky performance changes (large data handling, virtualization, unnecessary renders).
+Focus on: [handsontable/.cursor/BUGBOT.md](handsontable/.cursor/BUGBOT.md).
 
 Output format:
 1. Numbered findings by severity (Critical, High, Medium, Low).

--- a/handsontable/.cursor/BUGBOT.md
+++ b/handsontable/.cursor/BUGBOT.md
@@ -12,7 +12,7 @@ Apply these checks when changed files are in `/handsontable/**`.
 
 - **Core language boundary**: Core source is JavaScript. Do not add TypeScript files under `/handsontable/src/`.
 - **Code style**:
-  - Prefer arrow functions over bound method fields (e.g., prefer `this.#onX = () => { ... }` over `this.#onXBound = this.#handleX.bind(this)`).
+  - For hook/event callbacks, use arrow-function class fields (`#onAfterX = () => { ... }`) instead of `.bind(this)` references — avoids the extra bound field.
   - Extract duplicated code blocks into shared methods — do not repeat logic across the same file or plugin.
   - Silent `catch` blocks must include a comment explaining why the error is swallowed.
 - **Bundle size awareness**:
@@ -59,6 +59,15 @@ Apply these checks when changed files are in `/handsontable/**`.
 - **Type definitions**:
   - Do not duplicate type definitions across plugins. Import types from their source plugin (e.g., filter condition types come from Filters, not redefined in DataProvider).
   - Avoid bare `object` in `.d.ts` files — use or import specific types.
+
+## Accessibility
+
+- **WCAG conformance**: Changes to DOM rendering, selection, headers, frozen areas, hidden rows/columns, or merged cells must preserve WCAG 2.1 AA conformance.
+- **Keyboard navigation**: Do not regress keyboard-only navigation. Both navigation modes must keep working:
+  - Spreadsheet mode (default): `navigableHeaders: false`, `tabNavigation: true`.
+  - Data grid mode: `navigableHeaders: true`, `tabNavigation: false`.
+- **ARIA semantics**: Verify that ARIA attributes (`role`, `aria-label`, `aria-selected`, `aria-colspan`, etc.) remain correct after rendering or selection changes. Screen readers (NVDA, JAWS, VoiceOver) rely on these.
+- **Tag existence**: New UI elements (buttons, icons, overlays) must use semantic HTML. Verify sufficient color contrast and no flashing/blinking content.
 
 ## Testing
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Sync the rules and add an accessibility section.

_[skip changelog]_

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates to review guidelines with no runtime code changes.
> 
> **Overview**
> Aligns the `.claude/commands/review.md` `/review` prompt with the Handsontable core `BUGBOT.md` review rules, tightening requirements around changelogs, test coverage, wrapper boundaries, and performance.
> 
> Updates `handsontable/.cursor/BUGBOT.md` wording for callback binding guidance and adds a new **Accessibility** section covering WCAG, keyboard navigation modes, ARIA semantics, and semantic HTML expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bcee48d734a300a0673900fc4259dd1906dbf6a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->