### PR TITLE
Change the `strict` option in `bindingRowsWithHeaders` example to `true` to match the description

### DIFF
--- a/docs/content/guides/rows/row-header/angular/example1.ts
+++ b/docs/content/guides/rows/row-header/angular/example1.ts
@@ -21,7 +21,7 @@ export class AppComponent implements OnInit {
     height: 'auto',
     contextMenu: true,
     manualRowMove: true,
-    bindRowsWithHeaders: 'strict',
+    bindRowsWithHeaders: true,
     autoWrapRow: true,
     autoWrapCol: true,
   };

--- a/docs/content/guides/rows/row-header/javascript/example1.js
+++ b/docs/content/guides/rows/row-header/javascript/example1.js
@@ -26,7 +26,7 @@ new Handsontable(container, {
   height: 'auto',
   contextMenu: true,
   manualRowMove: true,
-  bindRowsWithHeaders: 'strict',
+  bindRowsWithHeaders: true,
   autoWrapRow: true,
   autoWrapCol: true,
   licenseKey: 'non-commercial-and-evaluation',

--- a/docs/content/guides/rows/row-header/javascript/example1.ts
+++ b/docs/content/guides/rows/row-header/javascript/example1.ts
@@ -27,7 +27,7 @@ new Handsontable(container, {
   height: 'auto',
   contextMenu: true,
   manualRowMove: true,
-  bindRowsWithHeaders: 'strict',
+  bindRowsWithHeaders: true,
   autoWrapRow: true,
   autoWrapCol: true,
   licenseKey: 'non-commercial-and-evaluation',

--- a/docs/content/guides/rows/row-header/react/example1.jsx
+++ b/docs/content/guides/rows/row-header/react/example1.jsx
@@ -26,7 +26,7 @@ const ExampleComponent = () => {
       height="auto"
       contextMenu={true}
       manualRowMove={true}
-      bindRowsWithHeaders="strict"
+      bindRowsWithHeaders={true}
       autoWrapRow={true}
       autoWrapCol={true}
       licenseKey="non-commercial-and-evaluation"

--- a/docs/content/guides/rows/row-header/react/example1.tsx
+++ b/docs/content/guides/rows/row-header/react/example1.tsx
@@ -27,7 +27,7 @@ const ExampleComponent = () => {
       height="auto"
       contextMenu={true}
       manualRowMove={true}
-      bindRowsWithHeaders="strict"
+      bindRowsWithHeaders={true}
       autoWrapRow={true}
       autoWrapCol={true}
       licenseKey="non-commercial-and-evaluation"

--- a/docs/content/guides/rows/row-header/row-header.md
+++ b/docs/content/guides/rows/row-header/row-header.md
@@ -43,6 +43,13 @@ You can bind row numbers with row headers. This is used mostly to differentiate 
 
 To enable the plugin, set the [`bindRowsWithHeaders`](@/api/options.md#bindrowswithheaders) property to `true`. Move the rows in the example below to see what this plugin does.
 
+Possible values:
+
+- `true` - Enables the plugin.
+- `strict` - Enables the plugin and the order of indexes is not reorganized after the operation such as hiding or moving rows.
+- `loose` -  Enables the plugin and the order of indexes is re-organized after the operation such as hiding or moving rows.
+
+
 ::: only-for javascript
 
 ::: example #example1 --js 1 --ts 2


### PR DESCRIPTION
### Context

Change the `strict` option in `bindingRowsWithHeaders` example to `true` to match the description and add the list of possible options to the guide.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/73

### Affected project(s):
- [X] `handsontable`
- [X] `@handsontable/angular-wrapper`
- [X] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates example configuration values; no runtime/library code is modified.
> 
> **Overview**
> Updates the row header guide examples (JS/TS, React, Angular) to set `bindRowsWithHeaders` to `true` instead of `'strict'`, matching the guide’s “Basic example” description.
> 
> Expands the guide text to explicitly document the supported `bindRowsWithHeaders` values (`true`, `strict`, `loose`) and what each means.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 46287d64034371b44cfb4a0751fa984027696a90. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->