### PR TITLE
Add optional chaining usage guideline to BUGBOT.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,7 @@ These custom rules are enforced and will cause lint failures if violated:
 - **Method ordering**: Public methods first, then `@private` listeners.
 - **Destructors**: Remove all variables in destructors (after `hot.destroy()`).
 - **Browser compatibility**: Ensure chosen CSS and JS APIs are supported in all supported browsers (Chrome, Firefox, Safari — two latest major versions, Edge).
+- **Optional chaining (`?.`)**: Use only when a value is genuinely optional by design, not as a blanket safety net. If a value is guaranteed by the data contract (e.g., parallel arrays from the same iterator, or APIs like `getCellMeta()` that always return an object), access it directly without `?.`. Unnecessary optional chaining hides bugs and misleads contributors into assuming a value can be null when it cannot.
 
 ### Naming conventions
 

--- a/handsontable/.cursor/BUGBOT.md
+++ b/handsontable/.cursor/BUGBOT.md
@@ -15,6 +15,10 @@ Apply these checks when changed files are in `/handsontable/**`.
   - For hook/event callbacks, use arrow-function class fields (`#onAfterX = () => { ... }`) instead of `.bind(this)` references — avoids the extra bound field.
   - Extract duplicated code blocks into shared methods — do not repeat logic across the same file or plugin.
   - Silent `catch` blocks must include a comment explaining why the error is swallowed.
+- **Optional chaining (`?.`) usage**:
+  - Use optional chaining only when a value is genuinely optional by design — not as a blanket safety net for values that should always exist.
+  - If a value is guaranteed by the data contract (e.g., parallel arrays built by the same iterator, or APIs like `getCellMeta()` that always return an object), access it directly without `?.`.
+  - Unnecessary optional chaining silently swallows errors, hides broken assumptions, and misleads future contributors into thinking a value can be null when it cannot.
 - **Bundle size awareness**:
   - Where possible, prefer JavaScript grammar that produces smaller output in compressed (minified/gzipped) bundles. For example, prefer `===` over verbose truthiness helpers, use short-circuit evaluation instead of full `if` blocks for simple assignments, and avoid unnecessary intermediate variables.
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Update the BUGBOT files with the knowledge gained from the recent code review.

_[skip changelog]_

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates that adjust coding guidance; no runtime, build, or API behavior changes.
> 
> **Overview**
> Clarifies project guidelines to discourage using optional chaining (`?.`) as a blanket safety net when values are guaranteed by contract.
> 
> This rule is added to `AGENTS.md` general conventions and expanded in `handsontable/.cursor/BUGBOT.md` with rationale about avoiding hidden bugs and misleading nullability assumptions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4bc2410d8cf35d8f37021d861ec50884210e9d97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->