### PR TITLE
Add information about known limitation for the `skipRowsOnPaste`  and `skipColumnsOnPaste` options

### DIFF
--- a/handsontable/src/dataMap/metaManager/metaSchema.js
+++ b/handsontable/src/dataMap/metaManager/metaSchema.js
@@ -5077,7 +5077,7 @@ export default () => {
      * @description
      * The `skipColumnOnPaste` option determines whether you can paste data into a given column.
      *
-     * You can only apply the `skipColumnOnPaste` option to an entire column, using the [`columns`](#columns) option.
+     * You can only apply the `skipColumnOnPaste` option to an entire column, using the [`columns`](#columns) option. This option is not supported for the global table level settings.
      *
      * You can set the `skipColumnOnPaste` option to one of the following:
      *

--- a/handsontable/src/dataMap/metaManager/metaSchema.js
+++ b/handsontable/src/dataMap/metaManager/metaSchema.js
@@ -5111,7 +5111,7 @@ export default () => {
      *
      * The `skipRowOnPaste` option determines whether you can paste data into a given row.
      *
-     * You can only apply the `skipRowOnPaste` option to an entire row, using the [`cells`](#cells) option.
+     * You can only apply the `skipRowOnPaste` option to an entire row, using the [`cells`](#cells) option. This option is not supported for the global table level settings.
      *
      * You can set the `skipRowOnPaste` option to one of the following:
      *


### PR DESCRIPTION
### Context

This PR adds a note to the `skipRowsOnPaste` and `skipColumnsOnPaste` option descriptions that they are not supported at the global configuration level.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/188
2. 
### Affected project(s):
- [X] `handsontable`
- [X] `@handsontable/angular-wrapper`
- [X] `@handsontable/react-wrapper`
- [X] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change clarifying configuration limitations; no runtime behavior is modified.
> 
> **Overview**
> Clarifies in `metaSchema.js` docs that `skipColumnOnPaste` and `skipRowOnPaste` can only be configured per-column (`columns`) or per-row (`cells`) and are *not* supported at the global table settings level.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 782d0976d2a860ea1ff086f029ad38f44fba35d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->