### PR TITLE
Add all of the conditions examples to the filters API

### DIFF
--- a/handsontable/src/plugins/filters/filters.js
+++ b/handsontable/src/plugins/filters/filters.js
@@ -458,23 +458,89 @@ export class Filters extends BasePlugin {
    * // access to filters plugin instance
    * const filtersPlugin = hot.getPlugin('filters');
    *
+   * // add filter "Begins with" with value "de" to column at index 1
+   * filtersPlugin.addCondition(1, 'begins_with', ['de']);
+   * filtersPlugin.filter();
+   *
+   * // add filter "Between" 10 and 50 to column at index 1
+   * filtersPlugin.addCondition(1, 'between', [10, 50]);
+   * filtersPlugin.filter();
+   *
+   * // add filter "By value" to column at index 1
+   * // in this case all values that don't match will be filtered
+   * filtersPlugin.addCondition(1, 'by_value', [['ing', 'ed', 'as', 'on']]);
+   * filtersPlugin.filter();
+   *
+   * // add filter "Contains" with value "ing" to column at index 1
+   * filtersPlugin.addCondition(1, 'contains', ['ing']);
+   * filtersPlugin.filter();
+   *
+   * // add filter "After a date" with value "1/1/2023" to column at index 1
+   * filtersPlugin.addCondition(1, 'date_after', ['1/1/2023']);
+   * filtersPlugin.filter();
+   *
+   * // add filter "Before a date" with value "1/1/2023" to column at index 1
+   * filtersPlugin.addCondition(1, 'date_before', ['1/1/2023']);
+   * filtersPlugin.filter();
+   *
+   * // add filter "Today" with no arguments to column at index 1
+   * filtersPlugin.addCondition(1, 'date_today', []);
+   * filtersPlugin.filter();
+   *
+   * // add filter "Tomorrow" with no arguments to column at index 1
+   * filtersPlugin.addCondition(1, 'date_tomorrow', []);
+   * filtersPlugin.filter();
+   *
+   * // add filter "Yesterday" with no arguments to column at index 1
+   * filtersPlugin.addCondition(1, 'date_yesterday', []);
+   * filtersPlugin.filter();
+   *
+   * // add filter "Empty" with no arguments to column at index 1
+   * filtersPlugin.addCondition(1, 'empty', []);
+   * filtersPlugin.filter();
+   *
+   * // add filter "Ends with" with value "ing" to column at index 1
+   * filtersPlugin.addCondition(1, 'ends_with', ['ing']);
+   * filtersPlugin.filter();
+   *
+   * // add filter "Equal" with value "John" to column at index 1
+   * filtersPlugin.addCondition(1, 'eq', ['John']);
+   * filtersPlugin.filter();
+   *
    * // add filter "Greater than" 95 to column at index 1
    * filtersPlugin.addCondition(1, 'gt', [95]);
    * filtersPlugin.filter();
    *
-   * // add filter "By value" to column at index 1
-   * // in this case all value's that don't match will be filtered.
-   * filtersPlugin.addCondition(1, 'by_value', [['ing', 'ed', 'as', 'on']]);
+   * // add filter "Greater than or equal" 95 to column at index 1
+   * filtersPlugin.addCondition(1, 'gte', [95]);
    * filtersPlugin.filter();
    *
-   * // add filter "Begins with" with value "de" AND "Not contains" with value "ing"
-   * filtersPlugin.addCondition(1, 'begins_with', ['de'], 'conjunction');
-   * filtersPlugin.addCondition(1, 'not_contains', ['ing'], 'conjunction');
+   * // add filter "Less than" 10 to column at index 1
+   * filtersPlugin.addCondition(1, 'lt', [10]);
    * filtersPlugin.filter();
    *
-   * // add filter "Begins with" with value "de" OR "Not contains" with value "ing"
-   * filtersPlugin.addCondition(1, 'begins_with', ['de'], 'disjunction');
-   * filtersPlugin.addCondition(1, 'not_contains', ['ing'], 'disjunction');
+   * // add filter "Less than or equal" 10 to column at index 1
+   * filtersPlugin.addCondition(1, 'lte', [10]);
+   * filtersPlugin.filter();
+   *
+   * // add filter "None" with no arguments to column at index 1
+   * filtersPlugin.addCondition(1, 'none', []);
+   * filtersPlugin.filter();
+   *
+   * // add filter "Not between" 10 and 50 to column at index 1
+   * filtersPlugin.addCondition(1, 'not_between', [10, 50]);
+   * filtersPlugin.filter();
+   *
+   * // add filter "Not contains" with value "ing" to column at index 1
+   * filtersPlugin.addCondition(1, 'not_contains', ['ing']);
+   * filtersPlugin.filter();
+   *
+   * // add filter "Not empty" with no arguments to column at index 1
+   * filtersPlugin.addCondition(1, 'not_empty', []);
+   * filtersPlugin.filter();
+   *
+   * // add filter "Not equal" with value "John" to column at index 1
+   * filtersPlugin.addCondition(1, 'neq', ['John']);
    * filtersPlugin.filter();
    * ```
    * :::
@@ -495,23 +561,89 @@ export class Filters extends BasePlugin {
    * const hot = hotRef.current.hotInstance;
    * const filtersPlugin = hot.getPlugin('filters');
    *
+   * // add filter "Begins with" with value "de" to column at index 1
+   * filtersPlugin.addCondition(1, 'begins_with', ['de']);
+   * filtersPlugin.filter();
+   *
+   * // add filter "Between" 10 and 50 to column at index 1
+   * filtersPlugin.addCondition(1, 'between', [10, 50]);
+   * filtersPlugin.filter();
+   *
+   * // add filter "By value" to column at index 1
+   * // in this case all values that don't match will be filtered
+   * filtersPlugin.addCondition(1, 'by_value', [['ing', 'ed', 'as', 'on']]);
+   * filtersPlugin.filter();
+   *
+   * // add filter "Contains" with value "ing" to column at index 1
+   * filtersPlugin.addCondition(1, 'contains', ['ing']);
+   * filtersPlugin.filter();
+   *
+   * // add filter "After a date" with value "1/1/2023" to column at index 1
+   * filtersPlugin.addCondition(1, 'date_after', ['1/1/2023']);
+   * filtersPlugin.filter();
+   *
+   * // add filter "Before a date" with value "1/1/2023" to column at index 1
+   * filtersPlugin.addCondition(1, 'date_before', ['1/1/2023']);
+   * filtersPlugin.filter();
+   *
+   * // add filter "Today" with no arguments to column at index 1
+   * filtersPlugin.addCondition(1, 'date_today', []);
+   * filtersPlugin.filter();
+   *
+   * // add filter "Tomorrow" with no arguments to column at index 1
+   * filtersPlugin.addCondition(1, 'date_tomorrow', []);
+   * filtersPlugin.filter();
+   *
+   * // add filter "Yesterday" with no arguments to column at index 1
+   * filtersPlugin.addCondition(1, 'date_yesterday', []);
+   * filtersPlugin.filter();
+   *
+   * // add filter "Empty" with no arguments to column at index 1
+   * filtersPlugin.addCondition(1, 'empty', []);
+   * filtersPlugin.filter();
+   *
+   * // add filter "Ends with" with value "ing" to column at index 1
+   * filtersPlugin.addCondition(1, 'ends_with', ['ing']);
+   * filtersPlugin.filter();
+   *
+   * // add filter "Equal" with value "John" to column at index 1
+   * filtersPlugin.addCondition(1, 'eq', ['John']);
+   * filtersPlugin.filter();
+   *
    * // add filter "Greater than" 95 to column at index 1
    * filtersPlugin.addCondition(1, 'gt', [95]);
    * filtersPlugin.filter();
    *
-   * // add filter "By value" to column at index 1
-   * // in this case all value's that don't match will be filtered.
-   * filtersPlugin.addCondition(1, 'by_value', [['ing', 'ed', 'as', 'on']]);
+   * // add filter "Greater than or equal" 95 to column at index 1
+   * filtersPlugin.addCondition(1, 'gte', [95]);
    * filtersPlugin.filter();
    *
-   * // add filter "Begins with" with value "de" AND "Not contains" with value "ing"
-   * filtersPlugin.addCondition(1, 'begins_with', ['de'], 'conjunction');
-   * filtersPlugin.addCondition(1, 'not_contains', ['ing'], 'conjunction');
+   * // add filter "Less than" 10 to column at index 1
+   * filtersPlugin.addCondition(1, 'lt', [10]);
    * filtersPlugin.filter();
    *
-   * // add filter "Begins with" with value "de" OR "Not contains" with value "ing"
-   * filtersPlugin.addCondition(1, 'begins_with', ['de'], 'disjunction');
-   * filtersPlugin.addCondition(1, 'not_contains', ['ing'], 'disjunction');
+   * // add filter "Less than or equal" 10 to column at index 1
+   * filtersPlugin.addCondition(1, 'lte', [10]);
+   * filtersPlugin.filter();
+   *
+   * // add filter "None" with no arguments to column at index 1
+   * filtersPlugin.addCondition(1, 'none', []);
+   * filtersPlugin.filter();
+   *
+   * // add filter "Not between" 10 and 50 to column at index 1
+   * filtersPlugin.addCondition(1, 'not_between', [10, 50]);
+   * filtersPlugin.filter();
+   *
+   * // add filter "Not contains" with value "ing" to column at index 1
+   * filtersPlugin.addCondition(1, 'not_contains', ['ing']);
+   * filtersPlugin.filter();
+   *
+   * // add filter "Not empty" with no arguments to column at index 1
+   * filtersPlugin.addCondition(1, 'not_empty', []);
+   * filtersPlugin.filter();
+   *
+   * // add filter "Not equal" with value "John" to column at index 1
+   * filtersPlugin.addCondition(1, 'neq', ['John']);
    * filtersPlugin.filter();
    * ```
    * :::
@@ -547,8 +679,12 @@ export class Filters extends BasePlugin {
    *     const hot = this.hotTable.hotInstance;
    *     const filtersPlugin = hot.getPlugin("filters");
    *
-   *     // Add filter "Greater than" 95 to column at index 1
-   *     filtersPlugin.addCondition(1, "gt", [95]);
+   *     // Add filter "Begins with" with value "de" to column at index 1
+   *     filtersPlugin.addCondition(1, "begins_with", ["de"]);
+   *     filtersPlugin.filter();
+   *
+   *     // Add filter "Between" 10 and 50 to column at index 1
+   *     filtersPlugin.addCondition(1, "between", [10, 50]);
    *     filtersPlugin.filter();
    *
    *     // Add filter "By value" to column at index 1
@@ -556,14 +692,76 @@ export class Filters extends BasePlugin {
    *     filtersPlugin.addCondition(1, "by_value", [["ing", "ed", "as", "on"]]);
    *     filtersPlugin.filter();
    *
-   *     // Add filter "Begins with" with value "de" AND "Not contains" with value "ing"
-   *     filtersPlugin.addCondition(1, "begins_with", ["de"], "conjunction");
-   *     filtersPlugin.addCondition(1, "not_contains", ["ing"], "conjunction");
+   *     // Add filter "Contains" with value "ing" to column at index 1
+   *     filtersPlugin.addCondition(1, "contains", ["ing"]);
    *     filtersPlugin.filter();
    *
-   *     // Add filter "Begins with" with value "de" OR "Not contains" with value "ing"
-   *     filtersPlugin.addCondition(1, "begins_with", ["de"], "disjunction");
-   *     filtersPlugin.addCondition(1, "not_contains", ["ing"], "disjunction");
+   *     // Add filter "After a date" with value "1/1/2023" to column at index 1
+   *     filtersPlugin.addCondition(1, "date_after", ["1/1/2023"]);
+   *     filtersPlugin.filter();
+   *
+   *     // Add filter "Before a date" with value "1/1/2023" to column at index 1
+   *     filtersPlugin.addCondition(1, "date_before", ["1/1/2023"]);
+   *     filtersPlugin.filter();
+   *
+   *     // Add filter "Today" with no arguments to column at index 1
+   *     filtersPlugin.addCondition(1, "date_today", []);
+   *     filtersPlugin.filter();
+   *
+   *     // Add filter "Tomorrow" with no arguments to column at index 1
+   *     filtersPlugin.addCondition(1, "date_tomorrow", []);
+   *     filtersPlugin.filter();
+   *
+   *     // Add filter "Yesterday" with no arguments to column at index 1
+   *     filtersPlugin.addCondition(1, "date_yesterday", []);
+   *     filtersPlugin.filter();
+   *
+   *     // Add filter "Empty" with no arguments to column at index 1
+   *     filtersPlugin.addCondition(1, "empty", []);
+   *     filtersPlugin.filter();
+   *
+   *     // Add filter "Ends with" with value "ing" to column at index 1
+   *     filtersPlugin.addCondition(1, "ends_with", ["ing"]);
+   *     filtersPlugin.filter();
+   *
+   *     // Add filter "Equal" with value "John" to column at index 1
+   *     filtersPlugin.addCondition(1, "eq", ["John"]);
+   *     filtersPlugin.filter();
+   *
+   *     // Add filter "Greater than" 95 to column at index 1
+   *     filtersPlugin.addCondition(1, "gt", [95]);
+   *     filtersPlugin.filter();
+   *
+   *     // Add filter "Greater than or equal" 95 to column at index 1
+   *     filtersPlugin.addCondition(1, "gte", [95]);
+   *     filtersPlugin.filter();
+   *
+   *     // Add filter "Less than" 10 to column at index 1
+   *     filtersPlugin.addCondition(1, "lt", [10]);
+   *     filtersPlugin.filter();
+   *
+   *     // Add filter "Less than or equal" 10 to column at index 1
+   *     filtersPlugin.addCondition(1, "lte", [10]);
+   *     filtersPlugin.filter();
+   *
+   *     // Add filter "None" with no arguments to column at index 1
+   *     filtersPlugin.addCondition(1, "none", []);
+   *     filtersPlugin.filter();
+   *
+   *     // Add filter "Not between" 10 and 50 to column at index 1
+   *     filtersPlugin.addCondition(1, "not_between", [10, 50]);
+   *     filtersPlugin.filter();
+   *
+   *     // Add filter "Not contains" with value "ing" to column at index 1
+   *     filtersPlugin.addCondition(1, "not_contains", ["ing"]);
+   *     filtersPlugin.filter();
+   *
+   *     // Add filter "Not empty" with no arguments to column at index 1
+   *     filtersPlugin.addCondition(1, "not_empty", []);
+   *     filtersPlugin.filter();
+   *
+   *     // Add filter "Not equal" with value "John" to column at index 1
+   *     filtersPlugin.addCondition(1, "neq", ["John"]);
    *     filtersPlugin.filter();
    *   }
    *


### PR DESCRIPTION
### Context

This PR adds the missing examples for all available filter conditions. 

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/122

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates JSDoc examples/comments for the Filters plugin without changing runtime logic.
> 
> **Overview**
> **Expands the `Filters#addCondition` API documentation examples** to cover all available built-in filter conditions (text, numeric, date, empty/none, and negated variants) across the JavaScript, React, and Angular snippets.
> 
> Also makes small wording/grammar tweaks in the example comments (e.g., “values” vs “value's”).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d61dd93c375e5c649c01c68c3285a5f7c556c18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->