### PR TITLE
Change the `HTMLTableCellElement`description for all `beforeOnCellMouseXXX` hooks

### DIFF
--- a/handsontable/src/core/hooks/constants.js
+++ b/handsontable/src/core/hooks/constants.js
@@ -1505,7 +1505,7 @@ export const REGISTERED_HOOKS = [
    * @event Hooks#beforeOnCellMouseDown
    * @param {Event} event The `mousedown` event object.
    * @param {CellCoords} coords Cell coords object containing the visual coordinates of the clicked cell.
-   * @param {HTMLTableCellElement} TD TD element.
+   * @param {HTMLTableCellElement} TD Cell's TD (or TH) element.
    * @param {object} controller An object with properties `row`, `column` and `cell`. Each property contains
    *                            a boolean value that allows or disallows changing the selection for that particular area.
    */
@@ -1517,7 +1517,7 @@ export const REGISTERED_HOOKS = [
    * @event Hooks#beforeOnCellMouseUp
    * @param {Event} event The `mouseup` event object.
    * @param {CellCoords} coords Cell coords object containing the visual coordinates of the clicked cell.
-   * @param {HTMLTableCellElement} TD TD element.
+   * @param {HTMLTableCellElement} TD Cell's TD (or TH) element.
    */
   'beforeOnCellMouseUp',
 
@@ -1528,7 +1528,7 @@ export const REGISTERED_HOOKS = [
    * @since 4.1.0
    * @param {Event} event The `contextmenu` event object.
    * @param {CellCoords} coords Cell coords object containing the visual coordinates of the clicked cell.
-   * @param {HTMLTableCellElement} TD TD element.
+   * @param {HTMLTableCellElement} TD Cell's TD (or TH) element.
    */
   'beforeOnCellContextMenu',
 
@@ -1538,7 +1538,7 @@ export const REGISTERED_HOOKS = [
    * @event Hooks#beforeOnCellMouseOver
    * @param {Event} event The `mouseover` event object.
    * @param {CellCoords} coords CellCoords object containing the visual coordinates of the clicked cell.
-   * @param {HTMLTableCellElement} TD TD element.
+   * @param {HTMLTableCellElement} TD Cell's TD (or TH) element.
    * @param {object} controller An object with properties `row`, `column` and `cell`. Each property contains
    *                            a boolean value that allows or disallows changing the selection for that particular area.
    */
@@ -1550,7 +1550,7 @@ export const REGISTERED_HOOKS = [
    * @event Hooks#beforeOnCellMouseOut
    * @param {Event} event The `mouseout` event object.
    * @param {CellCoords} coords CellCoords object containing the visual coordinates of the leaved cell.
-   * @param {HTMLTableCellElement} TD TD element.
+   * @param {HTMLTableCellElement} TD Cell's TD (or TH) element.
    */
   'beforeOnCellMouseOut',
 


### PR DESCRIPTION
### Context

This PR changes the current description of the `HTMLTableCellElement` from `TD element` to `TD Cell's TD (or TH) element.`

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/185

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only JSDoc wording updates; no runtime behavior or API signatures change.
> 
> **Overview**
> Clarifies the JSDoc for the `HTMLTableCellElement` (`TD`) parameter across `beforeOnCellMouseDown`, `beforeOnCellMouseUp`, `beforeOnCellContextMenu`, `beforeOnCellMouseOver`, and `beforeOnCellMouseOut`, updating the description from a generic “TD element” to explicitly indicate it can be a cell `TD` *or* header `TH` element.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29177adda6b565fd14976c43be209dbbe5063c49. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->