### PR TITLE
Add arguments to the puppeteer config in the examples' smoke tests.

### DIFF
--- a/examples/next/docs/angular-wrapper/basic-example/spec/Smoke.spec.js
+++ b/examples/next/docs/angular-wrapper/basic-example/spec/Smoke.spec.js
@@ -9,7 +9,7 @@ describe('Smoke check', () => {
   beforeEach(async () => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 100000;
     // browser = await puppeteer.launch({ headless: false, slowMo: 250, devtools: true });
-    browser = await puppeteer.launch();
+    browser = await puppeteer.launch({ args: ['--no-sandbox', '--disable-setuid-sandbox'] });
     page = await browser.newPage();
     await page.goto(BASE_URL);
   }, 90000);

--- a/examples/next/docs/angular-wrapper/demo/spec/Smoke.spec.js
+++ b/examples/next/docs/angular-wrapper/demo/spec/Smoke.spec.js
@@ -9,7 +9,7 @@ describe('Smoke check', () => {
     beforeEach(async () => {
         jasmine.DEFAULT_TIMEOUT_INTERVAL = 100000;
         // browser = await puppeteer.launch({ headless: false, slowMo: 250, devtools: true });
-        browser = await puppeteer.launch();
+        browser = await puppeteer.launch({ args: ['--no-sandbox', '--disable-setuid-sandbox'] });
         page = await browser.newPage();
         await page.goto(BASE_URL);
     }, 90000);

--- a/examples/next/docs/js/accessibility/spec/Smoke.spec.cjs
+++ b/examples/next/docs/js/accessibility/spec/Smoke.spec.cjs
@@ -9,7 +9,7 @@ describe('Smoke check', () => {
   beforeEach(async () => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 100000;
     // browser = await puppeteer.launch({ headless: false, slowMo: 250, devtools: true });
-    browser = await puppeteer.launch();
+    browser = await puppeteer.launch({ args: ["--no-sandbox", "--disable-setuid-sandbox"] });
     page = await browser.newPage();
     await page.goto(BASE_URL);
   }, 90000);

--- a/examples/next/docs/js/basic-example/spec/Smoke.spec.js
+++ b/examples/next/docs/js/basic-example/spec/Smoke.spec.js
@@ -9,7 +9,7 @@ describe('Smoke check', () => {
   beforeEach(async () => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 100000;
     // browser = await puppeteer.launch({ headless: false, slowMo: 250, devtools: true });
-    browser = await puppeteer.launch();
+    browser = await puppeteer.launch({ args: ['--no-sandbox', '--disable-setuid-sandbox'] });
     page = await browser.newPage();
     await page.goto(BASE_URL);
   }, 90000);

--- a/examples/next/docs/js/demo/spec/Smoke.spec.js
+++ b/examples/next/docs/js/demo/spec/Smoke.spec.js
@@ -9,7 +9,7 @@ describe('Smoke check', () => {
   beforeEach(async () => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 100000;
     // browser = await puppeteer.launch({ headless: false, slowMo: 250, devtools: true });
-    browser = await puppeteer.launch();
+    browser = await puppeteer.launch({ args: ['--no-sandbox', '--disable-setuid-sandbox'] });
     page = await browser.newPage();
     await page.goto(BASE_URL);
   }, 90000);

--- a/examples/next/docs/react-wrapper/accessibility/spec/Smoke.spec.cjs
+++ b/examples/next/docs/react-wrapper/accessibility/spec/Smoke.spec.cjs
@@ -9,7 +9,7 @@ describe('Smoke check', () => {
   beforeEach(async () => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 100000;
     // browser = await puppeteer.launch({ headless: false, slowMo: 250, devtools: true });
-    browser = await puppeteer.launch();
+    browser = await puppeteer.launch({ args: ["--no-sandbox", "--disable-setuid-sandbox"] });
     page = await browser.newPage();
     await page.goto(BASE_URL);
   }, 90000);

--- a/examples/next/docs/react-wrapper/basic-example/spec/Smoke.spec.js
+++ b/examples/next/docs/react-wrapper/basic-example/spec/Smoke.spec.js
@@ -9,7 +9,7 @@ describe('Smoke check', () => {
   beforeEach(async () => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 100000;
     // browser = await puppeteer.launch({ headless: false, slowMo: 250, devtools: true });
-    browser = await puppeteer.launch();
+    browser = await puppeteer.launch({ args: ['--no-sandbox', '--disable-setuid-sandbox'] });
     page = await browser.newPage();
     await page.goto(BASE_URL);
   }, 90000);

--- a/examples/next/docs/react-wrapper/demo/spec/Smoke.spec.js
+++ b/examples/next/docs/react-wrapper/demo/spec/Smoke.spec.js
@@ -9,7 +9,7 @@ describe('Smoke check', () => {
   beforeEach(async () => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 100000;
     // browser = await puppeteer.launch({ headless: false, slowMo: 250, devtools: true });
-    browser = await puppeteer.launch();
+    browser = await puppeteer.launch({ args: ['--no-sandbox', '--disable-setuid-sandbox'] });
     page = await browser.newPage();
     await page.goto(BASE_URL);
   }, 90000);

--- a/examples/next/docs/vue3/basic-example/spec/Smoke.spec.cjs
+++ b/examples/next/docs/vue3/basic-example/spec/Smoke.spec.cjs
@@ -9,7 +9,7 @@ describe('Smoke check', () => {
   beforeEach(async () => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 100000;
     // browser = await puppeteer.launch({ headless: false, slowMo: 250, devtools: true });
-    browser = await puppeteer.launch();
+    browser = await puppeteer.launch({ args: ["--no-sandbox", "--disable-setuid-sandbox"] });
     page = await browser.newPage();
     await page.goto(BASE_URL);
   }, 90000);

--- a/examples/next/docs/vue3/demo/spec/Smoke.spec.cjs
+++ b/examples/next/docs/vue3/demo/spec/Smoke.spec.cjs
@@ -9,7 +9,7 @@ describe('Smoke check', () => {
   beforeEach(async () => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 100000;
     // browser = await puppeteer.launch({ headless: false, slowMo: 250, devtools: true });
-    browser = await puppeteer.launch();
+    browser = await puppeteer.launch({ args: ["--no-sandbox", "--disable-setuid-sandbox"] });
     page = await browser.newPage();
     await page.goto(BASE_URL);
   }, 90000);

--- a/examples/next/visual-tests/angular-wrapper/basic-example/spec/Smoke.spec.js
+++ b/examples/next/visual-tests/angular-wrapper/basic-example/spec/Smoke.spec.js
@@ -9,7 +9,7 @@ describe('Smoke check', () => {
   beforeEach(async () => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 100000;
     // browser = await puppeteer.launch({ headless: false, slowMo: 250, devtools: true });
-    browser = await puppeteer.launch();
+    browser = await puppeteer.launch({ args: ["--no-sandbox", "--disable-setuid-sandbox"] });
     page = await browser.newPage();
     await page.goto(BASE_URL);
   }, 90000);

--- a/examples/next/visual-tests/angular-wrapper/demo/spec/Smoke.spec.js
+++ b/examples/next/visual-tests/angular-wrapper/demo/spec/Smoke.spec.js
@@ -9,7 +9,7 @@ describe('Smoke check', () => {
     beforeEach(async () => {
         jasmine.DEFAULT_TIMEOUT_INTERVAL = 100000;
         // browser = await puppeteer.launch({ headless: false, slowMo: 250, devtools: true });
-        browser = await puppeteer.launch();
+        browser = await puppeteer.launch({ args: ["--no-sandbox", "--disable-setuid-sandbox"] });
         page = await browser.newPage();
         await page.goto(BASE_URL);
     }, 90000);

--- a/examples/next/visual-tests/js/basic-example/spec/Smoke.spec.js
+++ b/examples/next/visual-tests/js/basic-example/spec/Smoke.spec.js
@@ -9,7 +9,7 @@ describe('Smoke check', () => {
   beforeEach(async () => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 100000;
     // browser = await puppeteer.launch({ headless: false, slowMo: 250, devtools: true });
-    browser = await puppeteer.launch();
+    browser = await puppeteer.launch({ args: ["--no-sandbox", "--disable-setuid-sandbox"] });
     page = await browser.newPage();
     await page.goto(BASE_URL);
   }, 90000);

--- a/examples/next/visual-tests/js/demo/spec/Smoke.spec.js
+++ b/examples/next/visual-tests/js/demo/spec/Smoke.spec.js
@@ -9,7 +9,7 @@ describe('Smoke check', () => {
   beforeEach(async () => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 100000;
     // browser = await puppeteer.launch({ headless: false, slowMo: 250, devtools: true });
-    browser = await puppeteer.launch();
+    browser = await puppeteer.launch({ args: ["--no-sandbox", "--disable-setuid-sandbox"] });
     page = await browser.newPage();
     await page.goto(BASE_URL);
   }, 90000);

--- a/examples/next/visual-tests/react-wrapper/basic-example/spec/Smoke.spec.js
+++ b/examples/next/visual-tests/react-wrapper/basic-example/spec/Smoke.spec.js
@@ -9,7 +9,7 @@ describe('Smoke check', () => {
   beforeEach(async () => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 100000;
     // browser = await puppeteer.launch({ headless: false, slowMo: 250, devtools: true });
-    browser = await puppeteer.launch();
+    browser = await puppeteer.launch({ args: ["--no-sandbox", "--disable-setuid-sandbox"] });
     page = await browser.newPage();
     await page.goto(BASE_URL);
   }, 90000);

--- a/examples/next/visual-tests/react-wrapper/demo/spec/Smoke.spec.js
+++ b/examples/next/visual-tests/react-wrapper/demo/spec/Smoke.spec.js
@@ -9,7 +9,7 @@ describe('Smoke check', () => {
   beforeEach(async () => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 100000;
     // browser = await puppeteer.launch({ headless: false, slowMo: 250, devtools: true });
-    browser = await puppeteer.launch();
+    browser = await puppeteer.launch({ args: ["--no-sandbox", "--disable-setuid-sandbox"] });
     page = await browser.newPage();
     await page.goto(BASE_URL);
   }, 90000);

--- a/examples/next/visual-tests/vue3/basic-example/spec/Smoke.spec.js
+++ b/examples/next/visual-tests/vue3/basic-example/spec/Smoke.spec.js
@@ -9,7 +9,7 @@ describe('Smoke check', () => {
   beforeEach(async () => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 100000;
     // browser = await puppeteer.launch({ headless: false, slowMo: 250, devtools: true });
-    browser = await puppeteer.launch();
+    browser = await puppeteer.launch({ args: ["--no-sandbox", "--disable-setuid-sandbox"] });
     page = await browser.newPage();
     await page.goto(BASE_URL);
   }, 90000);

--- a/examples/next/visual-tests/vue3/demo/spec/Smoke.spec.js
+++ b/examples/next/visual-tests/vue3/demo/spec/Smoke.spec.js
@@ -9,7 +9,7 @@ describe('Smoke check', () => {
   beforeEach(async () => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 100000;
     // browser = await puppeteer.launch({ headless: false, slowMo: 250, devtools: true });
-    browser = await puppeteer.launch();
+    browser = await puppeteer.launch({ args: ["--no-sandbox", "--disable-setuid-sandbox"] });
     page = await browser.newPage();
     await page.goto(BASE_URL);
   }, 90000);

--- a/examples/templates/js/spec/Smoke.spec.js
+++ b/examples/templates/js/spec/Smoke.spec.js
@@ -9,7 +9,7 @@ describe('Smoke check', () => {
     beforeEach(async () => {
         jasmine.DEFAULT_TIMEOUT_INTERVAL = 100000;
         // browser = await puppeteer.launch({ headless: false, slowMo: 250, devtools: true });
-        browser = await puppeteer.launch();
+        browser = await puppeteer.launch({ args: ["--no-sandbox", "--disable-setuid-sandbox"] });
         page = await browser.newPage();
         await page.goto(BASE_URL);
     }, 90000);

--- a/examples/templates/react-wrapper/spec/Smoke.spec.js
+++ b/examples/templates/react-wrapper/spec/Smoke.spec.js
@@ -9,7 +9,7 @@ describe('Smoke check', () => {
     beforeEach(async () => {
         jasmine.DEFAULT_TIMEOUT_INTERVAL = 100000;
         // browser = await puppeteer.launch({ headless: false, slowMo: 250, devtools: true });
-        browser = await puppeteer.launch();
+        browser = await puppeteer.launch({ args: ["--no-sandbox", "--disable-setuid-sandbox"] });
         page = await browser.newPage();
         await page.goto(BASE_URL);
     }, 90000);


### PR DESCRIPTION
### Context                                                                                                                                                                                                                    
  The `Publish` workflow's "Run Examples tests" step was failing in CI because Chrome's sandbox requires unprivileged user namespaces, which are restricted on the GitHub Actions Ubuntu runners. The example smoke tests called  `puppeteer.launch()` with no arguments, unlike the core E2E test runner (`run-puppeteer.mjs`) which already passes `--no-sandbox` and `--disable-setuid-sandbox`. This fix aligns all six example `Smoke.spec.js` files with the existing pattern.

[skip changelog]
                                                                                                                                                                                        
  ### How has this been tested?                                                                                                                                                                                                  
  No automated tests — this is a CI configuration fix verified against the existing smoke test setup.
                                                                                                                                                                                                                                 
  ### Types of changes
  - [x] Bug fix (non-breaking change which fixes an issue)                                                                                                                                                                       
                  
  ### Related issue(s):
  1.
                                                                                                                                                                                                                                 
  ### Affected project(s):                                                                                                                                                                                                       
  - [ ] `handsontable`                                                                                                                                                                                                           
  - [ ] `@handsontable/angular-wrapper`                                                                                                                                                                                          
  - [ ] `@handsontable/react-wrapper`
  - [ ] `@handsontable/vue3`
                                                                                                                                                                                                                                 
  ### Checklist:
  - [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.         
  - [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)                                                           
  - [ ] My change requires a change to the documentation.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates Puppeteer launch flags in example/visual smoke tests to improve CI compatibility, without changing application logic.
> 
> **Overview**
> Updates all example and visual-test `Smoke.spec.*` Puppeteer setups to launch Chrome with `--no-sandbox` and `--disable-setuid-sandbox`, aligning the examples’ smoke tests with CI runner restrictions and reducing workflow flakiness.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ccc08d136f40d2335186fbf2031f16879becc5b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->