### PR TITLE
Update the description of the `countSourceCols()` method

### DIFF
--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -4352,7 +4352,7 @@ export default function Core(rootContainer, userSettings, rootInstanceSymbol = f
   };
 
   /**
-   * Returns the total number of columns in the data source.
+   * Returns the total number of columns in the data source. It will take value either from schema, columns settings or the first row from the data set.
    *
    * @memberof Core#
    * @function countSourceCols

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -4352,7 +4352,7 @@ export default function Core(rootContainer, userSettings, rootInstanceSymbol = f
   };
 
   /**
-   * Returns the total number of columns in the data source. It will take value either from schema, columns settings or the first row from the data set.
+   * Returns the total number of columns in the data source. It will take value either from schema, columns settings or the first row from the data set. Unlike [countCols()](@/api/core.md#countcols), this value is not affected by the columns configuration option.
    *
    * @memberof Core#
    * @function countSourceCols
@@ -4374,7 +4374,7 @@ export default function Core(rootContainer, userSettings, rootInstanceSymbol = f
   };
 
   /**
-   * Returns the total number of visible columns in the table.
+   * Returns the total number of rendered columns. If the columns option is defined, it returns the number of columns set in that configuration, not the number of columns in the data source.
    *
    * @memberof Core#
    * @function countCols


### PR DESCRIPTION
### Context

This PR updates the`countSourceCols()` method about its behavior.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/350

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring-only updates in `core.js`; no runtime logic changes, so functional risk is minimal.
> 
> **Overview**
> Clarifies the API documentation for column counting in `Core`.
> 
> Updates the `countSourceCols()` description to explain that it derives its value from schema/`columns` settings/first data row and is *not* affected by the `columns` configuration option, and tweaks `countCols()` docs to emphasize it returns the number of rendered columns (and may reflect the `columns` option rather than the underlying data source).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9fc6c2558c9f5876ce5287d84ec68a5f3291698. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->